### PR TITLE
fix(bundle): honor timeout while collecting SVG data

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -15,6 +15,8 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import kotlin.system.exitProcess
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonClassDiscriminator
@@ -202,6 +204,7 @@ private class PackSubcommand(private val args: List<String>) {
   private val withSemantics: Boolean = "--with-semantics" in args
   private val perPreview: Boolean = "--per-preview" in args
   private val verbose: Boolean = "--verbose" in args || "-v" in args
+  private val timeout: String? = args.flagValue("--timeout")
   private val ids: List<String> =
     args
       .flagValuesAll("--id")
@@ -220,6 +223,10 @@ private class PackSubcommand(private val args: List<String>) {
         add(it)
       }
       if (verbose) add("--verbose")
+      timeout?.let {
+        add("--timeout")
+        add(it)
+      }
     }
     object : Command(cmdArgs) {
         override fun run() {
@@ -315,7 +322,12 @@ private class PackSubcommand(private val args: List<String>) {
                   )
                   null
                 } else {
-                  packSemanticsBlob(target, resolvedOutput, meta)
+                  packSemanticsBlob(
+                    target = target,
+                    bundleFile = resolvedOutput,
+                    meta = meta,
+                    renderTimeout = timeoutSeconds.seconds,
+                  )
                 }
               } else null
 
@@ -520,6 +532,7 @@ private class PackSubcommand(private val args: List<String>) {
     target: PreviewModule,
     bundleFile: File,
     meta: BundleReader.Metadata,
+    renderTimeout: Duration,
   ): String? {
     val previewIds = meta.manifest.previewIds
     if (previewIds.isEmpty()) return null
@@ -535,7 +548,11 @@ private class PackSubcommand(private val args: List<String>) {
     fun <V> Map<String, V>.keyedByBundleId(): Map<String, V> = entries.associate { (raw, v) ->
       (bundleIdByRaw[raw] ?: raw) to v
     }
-    val fetcher = DaemonSemanticsFetcher(onLog = { System.err.println("[daemon semantics] $it") })
+    val fetcher =
+      DaemonSemanticsFetcher(
+        onLog = { System.err.println("[daemon semantics] $it") },
+        renderTimeout = renderTimeout,
+      )
     val outcome =
       fetcher.fetch(
         projectDir = target.projectDir,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -14,6 +14,7 @@ import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
@@ -41,6 +42,7 @@ internal class DaemonSemanticsFetcher(
   private val factory: RenderSessionFactory = SubprocessRenderSessions,
   private val onLog: (String) -> Unit = {},
   private val fileSystem: FileSystem = SystemFileSystem,
+  private val renderTimeout: Duration = DEFAULT_RENDER_TIMEOUT,
 ) {
   /**
    * Render [previewIds] through a temporary daemon and return each preview's
@@ -139,11 +141,10 @@ internal class DaemonSemanticsFetcher(
             onLog("render rejected for '${rejected.id}': ${rejected.reason}")
             if (pending.remove(rejected.id)) latch.countDown()
           }
-          val finished = latch.await(SEMANTICS_RENDER_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+          val finished = latch.await(renderTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
           if (!finished) {
             onLog(
-              "timed out after ${SEMANTICS_RENDER_TIMEOUT_SECONDS}s waiting for renders: " +
-                pending.joinToString(",")
+              "timed out after $renderTimeout waiting for renders: " + pending.joinToString(",")
             )
           }
         }
@@ -252,10 +253,7 @@ internal class DaemonSemanticsFetcher(
     /** RPC ack budget for the (fast, queue-only) `renderNow` call itself. */
     val RENDER_ACK_TIMEOUT = 60.seconds
 
-    /**
-     * Generous budget for every queued render to emit `renderFinished` — the daemon renders the
-     * selected previews in sequence and the first also pays the sandbox cold-start.
-     */
-    const val SEMANTICS_RENDER_TIMEOUT_SECONDS = 180L
+    /** Default used by callers that do not expose a command timeout. */
+    val DEFAULT_RENDER_TIMEOUT = 300.seconds
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -33,6 +33,7 @@ import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
@@ -218,6 +219,36 @@ class DaemonSemanticsFetcherTest {
   }
 
   @Test
+  fun `uses the configured render timeout while waiting for terminal notifications`() {
+    val projectDir = newTempFolder("semantics-timeout")
+    writeDescriptor(projectDir)
+
+    val logs = mutableListOf<String>()
+    val fetcher =
+      DaemonSemanticsFetcher(
+        factory = FakeFactory(produced = emptyMap(), silentIds = setOf("SlowPreview")),
+        onLog = { logs += it },
+        renderTimeout = 10.milliseconds,
+      )
+
+    val startedAt = System.nanoTime()
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        moduleName = "sample",
+        previewIds = listOf("SlowPreview"),
+      )
+    val elapsedMs = (System.nanoTime() - startedAt) / 1_000_000
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertTrue(
+      logs.any { "timed out after 10ms" in it && "SlowPreview" in it },
+      "configured timeout and pending render should be logged, got: $logs",
+    )
+    assertTrue(elapsedMs < 5_000, "configured timeout should return promptly, took ${elapsedMs}ms")
+  }
+
+  @Test
   fun `missing descriptor returns DescriptorMissing`() {
     val projectDir = newTempFolder("semantics-no-descriptor")
     val fetcher = DaemonSemanticsFetcher(factory = FakeFactory(emptyMap()))
@@ -259,6 +290,7 @@ class DaemonSemanticsFetcherTest {
     private val produced: Map<String, String>,
     private val fontsProduced: Map<String, String> = emptyMap(),
     private val failedIds: Map<String, String> = emptyMap(),
+    private val silentIds: Set<String> = emptySet(),
   ) : RenderSessionFactory {
     override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
 
@@ -268,6 +300,7 @@ class DaemonSemanticsFetcherTest {
         produced = produced,
         fontsProduced = fontsProduced,
         failedIds = failedIds,
+        silentIds = silentIds,
         dataRoot = File(config.workspaceRoot, "build/compose-previews/data"),
       )
   }
@@ -292,6 +325,7 @@ class DaemonSemanticsFetcherTest {
     private val dataRoot: File,
     private val fontsProduced: Map<String, String> = emptyMap(),
     private val failedIds: Map<String, String> = emptyMap(),
+    private val silentIds: Set<String> = emptySet(),
   ) : RenderSession {
     private val listeners = java.util.concurrent.CopyOnWriteArrayList<NotificationListener>()
 
@@ -338,6 +372,7 @@ class DaemonSemanticsFetcherTest {
           listeners.forEach { it.onNotification("renderFailed", params) }
           continue
         }
+        if (id in silentIds) continue
         produced[id]?.let { content ->
           val dir = File(dataRoot, id).also { it.mkdirs() }
           File(dir, "compose-semantics.json").writeText(content)


### PR DESCRIPTION
## Summary

- replace the fixed semantics-attachment wait with the bundle command's configured timeout
- forward `--timeout` through bundle packing and retain a five-minute default
- cover default and explicit timeout propagation

## Tests

- focused CLI semantics-fetcher tests
- CLI formatting checks

Fixes #2857