### PR TITLE
fix(android): preserve preview wrappers in all render modes

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/PreviewWrapperClass.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/PreviewWrapperClass.kt
@@ -22,6 +22,37 @@ package ee.schimke.composeai.preview
  * androidx-free `preview-annotations` artifact (it has no compile dependency on
  * `ui-tooling-preview` and its `PreviewWrapperProvider`). Consumers that want to use the annotation
  * depend on `ee.schimke.composeai:preview-annotations`.
+ *
+ * A wrapper is also the supported way to install **app-owned** preview environment. The renderer
+ * provides standard Compose locals, but it cannot discover arbitrary locals declared by an app. For
+ * example, an app whose screens require its own `LocalSharedTransitionScope` and
+ * `LocalAnimatedVisibilityScope` can create real AndroidX scopes compositionally and map them to
+ * those locals once:
+ * ```
+ * class SharedTransitionPreviewWrapper : PreviewWrapperProvider {
+ *   @Composable
+ *   override fun Wrap(content: @Composable () -> Unit) {
+ *     SharedTransitionLayout {
+ *       AnimatedVisibility(visible = true) {
+ *         CompositionLocalProvider(
+ *           LocalSharedTransitionScope provides this@SharedTransitionLayout,
+ *           LocalAnimatedVisibilityScope provides this,
+ *           content = content,
+ *         )
+ *       }
+ *     }
+ *   }
+ * }
+ *
+ * @Preview
+ * @PreviewWrapperClass("com.example.app.SharedTransitionPreviewWrapper")
+ * @Composable
+ * fun HomePreview() = HomeScreen()
+ * ```
+ *
+ * Keep a required app local non-null with a descriptive throwing default; the app host and preview
+ * wrapper should both provide a valid value. Make it nullable only when the composable deliberately
+ * supports running without that environment—for example, by omitting shared-element modifiers.
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -1149,7 +1149,15 @@ class RenderEngine(
                 .toTypedArray()
             CompositionLocalProvider(*provided) {
               Box(modifier = Modifier.fillMaxSize().background(Color(bgArgb))) {
-                InvokeComposable(composableMethod)
+                // A scrolling preview has the same composition contract as its default capture.
+                // In particular, app-owned environment such as SharedTransition scopes is often
+                // installed by a PreviewWrapperProvider. Bypassing the wrapper here made the
+                // default PNG succeed while LONG/GIF failed during composition.
+                InvokeWithOptionalWrapper(
+                  composableMethod = composableMethod,
+                  wrapperFqnFromSpec = spec.wrapperClassName,
+                  themeProviderFqn = spec.overrides?.themeProvider,
+                )
               }
             }
           }
@@ -1970,7 +1978,7 @@ private fun InvokeComposable(composableMethod: ComposableMethod) {
  * `RemoteOverridablePreviewWrapper`) apply transparently.
  */
 @Composable
-private fun InvokeWithOptionalWrapper(
+internal fun InvokeWithOptionalWrapper(
   composableMethod: ComposableMethod,
   wrapperFqnFromSpec: String?,
   themeProviderFqn: String? = null,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1339,8 +1339,14 @@ open class RobolectricHost(
             null -> null
           },
         inspectionMode = inspectionMode,
+        // Preserve the preview's declared wrapper in held/live mode. This is part of the preview's
+        // composition contract, not decoration: wrappers may provide required app locals.
+        wrapperClassName = spec.wrapperClassName,
+        // Theme providers use the same PreviewWrapperProvider machinery and replace the declared
+        // wrapper when they resolve, matching the one-shot render path.
+        themeProviderFqn = spec.overrides?.themeProvider,
         // Decomposed `spec.overrides.touchOverlay` so the held-rule loop can wrap
-        // `InvokeHeldComposable` with the touch-overlay planner output. Other override fields
+        // the preview with the touch-overlay planner output. Other override fields
         // stay on the host side; only the ones planners actually read on the interactive path
         // get threaded across the sandbox boundary (see the field's doc on
         // `InteractiveCommand.Start`).
@@ -2612,7 +2618,15 @@ open class RobolectricHost(
                               classLoader = classLoader,
                             )
                           } else {
-                            InvokeHeldComposable(composableMethod!!)
+                            // The held composition must obey the same app environment contract as a
+                            // one-shot render. A PreviewWrapperProvider may install required
+                            // composition locals (for example app-owned SharedTransition scopes),
+                            // and a selected theme provider replaces it on the same terms.
+                            InvokeWithOptionalWrapper(
+                              composableMethod = composableMethod!!,
+                              wrapperFqnFromSpec = start.wrapperClassName,
+                              themeProviderFqn = start.themeProviderFqn,
+                            )
                           }
                         }
                       }
@@ -3845,17 +3859,4 @@ open class RobolectricHost(
       private val UNRESOLVED_REASON_JSON: Json = Json { encodeDefaults = true }
     }
   }
-}
-
-/**
- * Tiny @Composable trampoline — same shape as `RenderEngine.kt`'s top-level private
- * `InvokeComposable`, duplicated here because Kotlin top-level `private` is file-scoped and the
- * held-rule loop in `SandboxRunner` lives in this file. Reflectively invokes a
- * [androidx.compose.runtime.reflect.ComposableMethod] so the held composition can host any
- *
- * @Preview-shaped function the user resolves.
- */
-@androidx.compose.runtime.Composable
-private fun InvokeHeldComposable(method: androidx.compose.runtime.reflect.ComposableMethod) {
-  method.invoke(androidx.compose.runtime.currentComposer, null)
 }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -407,8 +407,19 @@ sealed interface InteractiveCommand {
     /** Held-session `LocalInspectionMode`; `null` preserves the runtime-like default (`false`). */
     val inspectionMode: Boolean? = null,
     /**
+     * FQN of the preview's app-declared `PreviewWrapperProvider`. Held/live rendering must preserve
+     * the same wrapper as the one-shot render; wrappers commonly install required app composition
+     * locals such as shared-transition scopes.
+     */
+    val wrapperClassName: String? = null,
+    /**
+     * Optional app-declared theme `PreviewWrapperProvider` selected by a live override. Like the
+     * one-shot path, a provider that resolves successfully replaces [wrapperClassName].
+     */
+    val themeProviderFqn: String? = null,
+    /**
      * Decomposed `spec.overrides.touchOverlay`. When `true`, the held-rule loop wraps
-     * `InvokeHeldComposable` with the planner output that includes `TouchOverlayExtension`, so a
+     * the preview with the planner output that includes `TouchOverlayExtension`, so a
      * panel-driven `interactive/input` with multi-touch dispatch paints the visualization rings on
      * the streamed frames. Threaded as a primitive (not the full `PreviewOverrides` bag) because
      * the protocol's nested types live in the instrumented daemon package and don't cross the

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
@@ -544,6 +544,40 @@ class AndroidInteractiveSessionTest {
   }
 
   @Test
+  fun heldSessionPreservesRequiredPreviewWrapper() {
+    System.setProperty(
+      RenderEngine.OUTPUT_DIR_PROP,
+      tempFolder.newFolder("interactive-wrapper").absolutePath,
+    )
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      // WrapperRequiredFixturePreview throws during composition unless the app-owned environment
+      // local is installed. Before the fix, InteractiveCommand.Start dropped wrapperClassName and
+      // acquireInteractiveSession surfaced that throw as a failed start reply.
+      val session =
+        host.acquireInteractiveSession(
+          previewId = WRAPPER_REQUIRED_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      try {
+        val image = decode(File(session.render(RenderHost.nextRequestId()).pngPath!!))
+        val green = pixelMatchPct(image, GREEN_RGB, perChannelTolerance = 8)
+        assertTrue(
+          "held frame should be rendered by the wrapper-backed preview (got " +
+            "${"%.2f".format(green * 100)}% green)",
+          green >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun acquireWithoutResolverThrowsUnsupported() {
     val host = RobolectricHost(sandboxCount = 2)
     assertFalse(
@@ -1102,6 +1136,17 @@ class AndroidInteractiveSessionTest {
           // dedicated strategy in the held loop instead of `getDeclaredComposableMethod`.
           kind = RenderEngine.NOTIFICATION_KIND,
         )
+      WRAPPER_REQUIRED_PREVIEW_ID ->
+        RenderSpec(
+          className = "ee.schimke.composeai.daemon.PreviewWrapperResolutionFixturesKt",
+          functionName = "WrapperRequiredFixturePreview",
+          widthPx = INTERACTIVE_WIDTH_PX,
+          heightPx = INTERACTIVE_HEIGHT_PX,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = "interactive-wrapper",
+          wrapperClassName = "ee.schimke.composeai.daemon.RequiredCompositionLocalWrapper",
+        )
       else -> null
     }
   }
@@ -1150,6 +1195,7 @@ class AndroidInteractiveSessionTest {
     private const val RELEASE_POSITION_PREVIEW_ID = "interactive-release-position"
     private const val ROTARY_PREVIEW_ID = "interactive-rsb"
     private const val NOTIFICATION_PREVIEW_ID = "interactive-notification"
+    private const val WRAPPER_REQUIRED_PREVIEW_ID = "interactive-wrapper-required"
     private const val MISSING_RESOURCE_PREVIEW_ID = "interactive-missing-resource"
     private const val INTERACTIVE_WIDTH_PX = 96
     private const val INTERACTIVE_HEIGHT_PX = 96

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionFixtures.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionFixtures.kt
@@ -3,8 +3,13 @@ package ee.schimke.composeai.daemon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.PreviewWrapper
@@ -41,4 +46,52 @@ fun WrappedFixturePreview() {
 @Composable
 fun UnwrappedFixturePreview() {
   Box(modifier = Modifier)
+}
+
+/**
+ * App-owned preview environment used to model required locals such as
+ * `LocalSharedTransitionScope`. The renderer cannot provide an app-specific local itself; it must
+ * preserve the preview's declared wrapper in every render mode.
+ */
+private val LocalRequiredPreviewEnvironment = staticCompositionLocalOf { false }
+
+class RequiredCompositionLocalWrapper {
+  @Composable
+  fun Wrap(content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalRequiredPreviewEnvironment provides true, content = content)
+  }
+}
+
+/**
+ * Fails before drawing unless [RequiredCompositionLocalWrapper] ran. Used by held/live regression
+ * coverage, where the wrapper FQN crosses the non-instrumented bridge as part of `Start`.
+ */
+@Composable
+fun WrapperRequiredFixturePreview() {
+  check(LocalRequiredPreviewEnvironment.current) {
+    "Required app preview environment was not installed"
+  }
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFF66BB6A)))
+}
+
+/**
+ * Scrollable twin of [WrapperRequiredFixturePreview]. The LONG/GIF path owns a separate
+ * `setContent` call and historically invoked the body directly, so its wrapper contract needs an
+ * independent end-to-end guard.
+ */
+@Composable
+fun WrapperRequiredScrollableFixturePreview() {
+  check(LocalRequiredPreviewEnvironment.current) {
+    "Required app preview environment was not installed"
+  }
+  LazyColumn(modifier = Modifier.fillMaxSize()) {
+    items(30) { index ->
+      Box(
+        modifier =
+          Modifier.fillMaxWidth()
+            .height(24.dp)
+            .background(if (index % 2 == 0) Color(0xFFEF5350) else Color(0xFF1B5E20))
+      )
+    }
+  }
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/WrappedPreviewRenderTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/WrappedPreviewRenderTest.kt
@@ -88,6 +88,86 @@ class WrappedPreviewRenderTest {
     }
   }
 
+  @Test
+  fun scrollLongPreservesRequiredPreviewWrapper() {
+    val outputDir = tempFolder.newFolder("renders-wrapped-scroll")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val priorIndex = System.getProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+    val previewIndex =
+      tempFolder.newFile("previews-wrapped-scroll.json").apply {
+        writeText(
+          """
+          {
+            "previews": [
+              {
+                "id": "wrapped-scroll",
+                "className": "ee.schimke.composeai.daemon.PreviewWrapperResolutionFixturesKt",
+                "functionName": "WrapperRequiredScrollableFixturePreview",
+                "dataProducts": [
+                  {
+                    "kind": "render/scroll/long",
+                    "scroll": {
+                      "mode": "LONG",
+                      "axis": "VERTICAL",
+                      "maxScrollPx": 2000,
+                      "frameIntervalMs": 0
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+          """
+            .trimIndent()
+        )
+      }
+    System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, previewIndex.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "wrapped-scroll",
+              className = "ee.schimke.composeai.daemon.PreviewWrapperResolutionFixturesKt",
+              functionName = "WrapperRequiredScrollableFixturePreview",
+              params =
+                PreviewParamsEntry(
+                  widthDp = 64,
+                  heightDp = 96,
+                  density = 1.0f,
+                  wrapperClassName =
+                    "ee.schimke.composeai.daemon.RequiredCompositionLocalWrapper",
+                ),
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      // The body throws before drawing unless its app-owned local was installed by the wrapper.
+      // Before the fix, runScrollScenario called InvokeComposable directly and this submit failed.
+      val result =
+        host.submit(
+          RenderRequest.Render(payload = "previewId=wrapped-scroll;mode=scroll-long"),
+          timeoutMs = 120_000,
+        )
+      assertNotNull("scroll-long must return its stitched PNG", result.pngPath)
+      val image = renderAndDecode(result.pngPath!!, "wrapped scroll-long")
+      assertTrue(
+        "stitched LONG capture should exceed one 96px viewport (was ${image.height}px)",
+        image.height > 96,
+      )
+    } finally {
+      host.shutdown()
+      if (priorIndex == null) {
+        System.clearProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+      } else {
+        System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, priorIndex)
+      }
+    }
+  }
+
   private fun renderAndDecode(
     host: PreviewManifestRouter,
     payload: String,
@@ -97,6 +177,13 @@ class WrappedPreviewRenderTest {
     val result = host.submit(request, timeoutMs = 120_000)
     assertNotNull("$label: pngPath must be populated", result.pngPath)
     val pngFile = File(result.pngPath!!)
+    assertTrue("$label: rendered PNG must exist", pngFile.exists())
+    return ByteArrayInputStream(pngFile.readBytes()).use { ImageIO.read(it) }
+      ?: error("$label: PNG failed to decode")
+  }
+
+  private fun renderAndDecode(path: String, label: String): BufferedImage {
+    val pngFile = File(path)
     assertTrue("$label: rendered PNG must exist", pngFile.exists())
     return ByteArrayInputStream(pngFile.readBytes()).use { ImageIO.read(it) }
       ?: error("$label: PNG failed to decode")

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
@@ -64,6 +64,8 @@ class InteractiveCommandTest {
         outputBaseName = "stream-A-frame",
         replyLatch = startLatch,
         replyError = startError,
+        wrapperClassName = "com.example.SharedTransitionPreviewWrapper",
+        themeProviderFqn = "com.example.DarkThemePreviewWrapper",
       )
     val dispatch =
       InteractiveCommand.Dispatch(
@@ -101,6 +103,11 @@ class InteractiveCommandTest {
     assertSame(startLatch, drainedStart.replyLatch)
     assertSame(startError, drainedStart.replyError)
     assertNull("replyError defaults to null", drainedStart.replyError.get())
+    assertEquals(
+      "com.example.SharedTransitionPreviewWrapper",
+      drainedStart.wrapperClassName,
+    )
+    assertEquals("com.example.DarkThemePreviewWrapper", drainedStart.themeProviderFqn)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- preserve declared `PreviewWrapperProvider` and theme wrappers in Android held/live sessions
- apply wrappers to scroll LONG/GIF captures, matching normal renders
- document the supported wrapper pattern for app-owned SharedTransition composition locals

## Root cause

Normal Android rendering honored `wrapperClassName`, but scroll rendering invoked the composable directly and held sessions dropped wrapper metadata from the interactive start command. Required app-owned composition locals installed by a wrapper therefore worked in normal renders but failed in alternate render modes.

The renderer cannot provide arbitrary app-defined locals itself, so the consumer wrapper remains the explicit integration point.

## Test plan

- `./gradlew :daemon:android:testDebugUnitTest --tests 'ee.schimke.composeai.daemon.PreviewWrapperResolutionTest' --tests 'ee.schimke.composeai.daemon.WrappedPreviewRenderTest' --tests 'ee.schimke.composeai.daemon.AndroidInteractiveSessionTest.heldSessionPreservesRequiredPreviewWrapper' --tests 'ee.schimke.composeai.daemon.bridge.InteractiveCommandTest' --no-daemon`
- `./gradlew :preview-annotations:ktfmtFormat :preview-annotations:check --no-daemon`
- `./gradlew ktfmtFormat --no-daemon`
- `git diff --check`

Fixes #2795