### PR TITLE
feat(serve): add page-aware link unfurling

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -13,6 +13,8 @@ import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.origin
+import io.ktor.server.request.queryString
 import io.ktor.server.request.receiveStream
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondBytes
@@ -473,6 +475,34 @@ class ServeHttpServer(
   }
 
   /**
+   * Browser-visible origin for absolute Open Graph image URLs. Caddy preserves `Host` and supplies
+   * `X-Forwarded-Proto` while terminating TLS; direct/local serve requests fall back to Ktor's
+   * connection scheme and Host header. Only the first proxy value is relevant when a request
+   * crossed more than one hop.
+   */
+  private fun RoutingContext.externalOrigin(): String {
+    fun firstHeader(name: String): String? =
+      call.request.headers[name]?.substringBefore(',')?.trim()?.takeIf { it.isNotEmpty() }
+
+    val forwardedScheme = firstHeader("X-Forwarded-Proto")
+    val scheme =
+      forwardedScheme?.takeIf { it.equals("http", true) || it.equals("https", true) }
+        ?: call.request.origin.scheme
+    val authority =
+      firstHeader("X-Forwarded-Host")
+        ?: firstHeader(HttpHeaders.Host)
+        ?: "${call.request.origin.serverHost}:${call.request.origin.serverPort}"
+    return "${scheme.lowercase()}://$authority"
+  }
+
+  /** Raw request query, including its leading `?` only when non-empty. */
+  private fun RoutingContext.requestQuerySuffix(): String =
+    call.request.queryString().let { if (it.isEmpty()) "" else "?$it" }
+
+  /** Absolute externally visible URL for the current page (including its query). */
+  private fun RoutingContext.externalPageUrl(): String = externalOrigin() + call.request.origin.uri
+
+  /**
    * Resolve the tenant for [sessionId] and run [block] with its host while holding a
    * [ServeSessionRegistry.Lease] for the request's whole duration — so the reaper can't suspend the
    * daemon mid-request (e.g. a long `/bundle.zip` that renders every preview). Responds 404 when
@@ -507,7 +537,12 @@ class ServeHttpServer(
    */
   private suspend fun RoutingContext.respondNotFoundHtml(message: String) {
     call.respondText(
-      ServeWeb.notFoundPage(message, token, isPublic),
+      ServeWeb.notFoundPage(
+        message,
+        token,
+        isPublic,
+        unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
+      ),
       ContentType.Text.Html,
       HttpStatusCode.NotFound,
     )
@@ -545,6 +580,15 @@ class ServeHttpServer(
       selectedSessionId(sessionInPath),
       onMissing = { respondNotFoundHtml("That design system was not found on this server.") },
     ) { renderHost ->
+      val heroId =
+        catalogBundleHost(renderHost)?.declaredHeroPreviewId
+          ?: ServeWeb.representativePreviewId(renderHost.previews)
+      val heroUrl = heroId?.let {
+        externalOrigin() +
+          basePath +
+          "/render/${WebEscaping.urlEncodeSegment(it)}.png" +
+          requestQuerySuffix()
+      }
       markGeneration("static-page", pageCacheControl())
       call.respondText(
         ServeWeb.landingPage(
@@ -573,6 +617,7 @@ class ServeHttpServer(
           // Why the catalog is snapshot-only, when it is (no live bundle, unverified, …) — shown as
           // a banner under the header so a browser sees it before opening a preview.
           degradations = renderHost.degradations,
+          unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl(), imageUrl = heroUrl),
         ),
         ContentType.Text.Html,
       )
@@ -601,9 +646,29 @@ class ServeHttpServer(
    */
   private suspend fun RoutingContext.handleHomeIndex() {
     val systems = withContext(Dispatchers.IO) { homeSystemsFor(catalogSessions) }
+    // Match the first card a visitor actually sees after the homepage's publisher grouping, not
+    // merely the operator's input order.
+    val featured =
+      ServeWeb.homeSections(systems)
+        .asSequence()
+        .flatMap { it.systems.asSequence() }
+        .firstOrNull { it.heroImage != null || it.heroPreviewId != null }
+    val featuredPath =
+      featured?.heroImage?.path
+        ?: featured?.heroPreviewId?.let {
+          "/${WebEscaping.urlEncodeSegment(featured.system)}/render/" +
+            "${WebEscaping.urlEncodeSegment(it)}.png"
+        }
+    val featuredUrl = featuredPath?.let { externalOrigin() + it + requestQuerySuffix() }
     markGeneration("static-page", pageCacheControl())
     call.respondText(
-      ServeWeb.homeIndexPage(systems, token, isPublic = isPublic, version = BUNDLE_VERSION),
+      ServeWeb.homeIndexPage(
+        systems,
+        token,
+        isPublic = isPublic,
+        version = BUNDLE_VERSION,
+        unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl(), imageUrl = featuredUrl),
+      ),
       ContentType.Text.Html,
     )
   }
@@ -655,7 +720,14 @@ class ServeHttpServer(
         ContentType.Application.Json,
       )
     } else {
-      call.respondText(ServeWeb.statusPage(data.toView(), token), ContentType.Text.Html)
+      call.respondText(
+        ServeWeb.statusPage(
+          data.toView(),
+          token,
+          unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
+        ),
+        ContentType.Text.Html,
+      )
     }
   }
 
@@ -1398,6 +1470,9 @@ class ServeHttpServer(
       // Fail-closed: any session without a verifiable trusted verdict gets opaque (false).
       val wasmSameOrigin =
         catalogBundleHost(renderHost)?.let { it.trust is BundleVerifier.Verdict.Trusted } ?: false
+      val origin = externalOrigin()
+      val imageUrl =
+        "$origin$basePath/render/${WebEscaping.urlEncodeSegment(preview.id)}.png${requestQuerySuffix()}"
       markGeneration("static-page", pageCacheControl())
       call.respondText(
         ServeWeb.viewerPage(
@@ -1439,6 +1514,7 @@ class ServeHttpServer(
           // the
           // catalog-level reason (no live bundle, unverified, …) alongside the per-control note.
           degradations = renderHost.degradations,
+          unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl(), imageUrl = imageUrl),
         ),
         ContentType.Text.Html,
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -16,6 +16,15 @@ import kotlinx.serialization.json.JsonPrimitive
  */
 object ServeWeb {
 
+  /**
+   * Absolute URLs advertised to link unfurlers for a browser-facing page. [imageUrl] is the thing
+   * that page represents (a featured catalog hero, catalog component, or exact viewer render);
+   * utility/error pages leave it null and get an honest text-only card. Kept explicit rather than
+   * derived here because only the HTTP layer knows the externally visible scheme/host (notably when
+   * Caddy terminates TLS).
+   */
+  data class UnfurlMetadata(val pageUrl: String, val imageUrl: String? = null)
+
   private val STYLE =
     """
     :root { color-scheme: light dark; }
@@ -1525,6 +1534,8 @@ object ServeWeb {
      * fixture golden passes a fixed string so a release never churns the committed HTML.
      */
     version: String? = null,
+    /** Absolute page + representative hero URLs for Open Graph/Twitter link previews. */
+    unfurl: UnfurlMetadata? = null,
   ): String {
     val about = if (isPublic) aboutSection(version) + "\n" else ""
     // Public routes are open — no token param on the cards; a token-gated box keeps it.
@@ -1600,6 +1611,10 @@ object ServeWeb {
       }
     return document(
       title = "Design systems — compose-preview",
+      unfurlTitle = "Compose previews",
+      unfurlDescription =
+        "Browse ${systems.size} published Compose design system and app catalogs.",
+      unfurl = unfurl,
       body =
         """
         $about$body
@@ -1670,10 +1685,17 @@ object ServeWeb {
    * render / API lanes keep their plain-text 404; this is only for the HTML page routes. The back
    * link is built like [backButton] so it keeps the token on a gated ([isPublic] false) server.
    */
-  fun notFoundPage(message: String, token: String, isPublic: Boolean): String {
+  fun notFoundPage(
+    message: String,
+    token: String,
+    isPublic: Boolean,
+    unfurl: UnfurlMetadata? = null,
+  ): String {
     val suffix = querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
     return document(
       title = "Not found — compose-preview",
+      unfurlDescription = message,
+      unfurl = unfurl,
       body =
         """
         <h1 class="cp-head">Not found</h1>
@@ -1771,7 +1793,7 @@ object ServeWeb {
    * 404; a `--public` server drops it (the routes need none). The always-ungated `/version` /
    * `/healthz` links stay bare either way.
    */
-  fun statusPage(view: StatusView, token: String): String {
+  fun statusPage(view: StatusView, token: String, unfurl: UnfurlMetadata? = null): String {
     fun esc(s: String) = WebEscaping.htmlEscape(s)
     // Gated-link suffix: token-gated ⇒ carry the token; public ⇒ nothing (routes are open).
     val suffix = if (view.public) "" else "?token=" + WebEscaping.urlEncodeSegment(token)
@@ -1912,7 +1934,13 @@ object ServeWeb {
       """
         .trimIndent()
 
-    return document(title = "Server status — compose-preview", body = body)
+    return document(
+      title = "Server status — compose-preview",
+      body = body,
+      unfurlDescription =
+        "Live catalog, render-daemon, and deployment status for this compose-preview server.",
+      unfurl = unfurl,
+    )
   }
 
   /**
@@ -2089,6 +2117,8 @@ object ServeWeb {
      * a plain module). See [ServeDegradation] / [degradeBanner].
      */
     degradations: List<ServeDegradation> = emptyList(),
+    /** Absolute page + representative preview URLs for Open Graph/Twitter link previews. */
+    unfurl: UnfurlMetadata? = null,
   ): String {
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
     // A dark-first system (Wear) puts every unthemed card on the dark stage; explicit light/dark
@@ -2270,6 +2300,9 @@ object ServeWeb {
       else ""
     return document(
       title = "$moduleLabel — compose-preview",
+      unfurlTitle = moduleLabel,
+      unfurlDescription = "${previews.size} Compose previews in $moduleLabel",
+      unfurl = unfurl,
       body =
         """
         $back<h1 class="cp-head">${WebEscaping.htmlEscape(moduleLabel)}${trustBadge(trust)}</h1>
@@ -2400,6 +2433,8 @@ object ServeWeb {
      * [degradeBanner].
      */
     degradations: List<ServeDegradation> = emptyList(),
+    /** Absolute viewer + PNG URLs for Open Graph/Twitter link previews. */
+    unfurl: UnfurlMetadata? = null,
   ): String {
     val idSeg = WebEscaping.urlEncodeSegment(preview.id)
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
@@ -2838,7 +2873,13 @@ object ServeWeb {
       <script>${backendBadgeScript()}</script>
       """
         .trimIndent()
-    return document(title = "$label — compose-preview", body = body)
+    return document(
+      title = "${preview.label} — compose-preview",
+      body = body,
+      unfurlTitle = preview.label,
+      unfurlDescription = "Compose preview for ${preview.label}",
+      unfurl = unfurl,
+    )
   }
 
   /**
@@ -4332,13 +4373,59 @@ object ServeWeb {
     """
       .trimIndent()
 
-  private fun document(title: String, body: String): String =
-    """
+  private fun document(
+    title: String,
+    body: String,
+    unfurlTitle: String? = null,
+    unfurlDescription: String? = null,
+    unfurl: UnfurlMetadata? = null,
+  ): String {
+    val unfurlHtml =
+      if (unfurl == null) ""
+      else {
+        val metaTitle = WebEscaping.htmlEscape(unfurlTitle ?: title)
+        val description =
+          WebEscaping.htmlEscape(unfurlDescription ?: "Compose preview rendered by compose-preview")
+        val pageUrl = WebEscaping.htmlEscape(unfurl.pageUrl)
+        val imageUrl = unfurl.imageUrl?.let(WebEscaping::htmlEscape)
+        val imageHtml =
+          if (imageUrl == null) ""
+          else
+            """
+            <meta property="og:image" content="$imageUrl">
+            <meta property="og:image:type" content="image/png">
+            <meta property="og:image:alt" content="$metaTitle">
+            """
+              .trimIndent()
+        val twitterImageHtml =
+          if (imageUrl == null) ""
+          else
+            """
+            <meta name="twitter:image" content="$imageUrl">
+            <meta name="twitter:image:alt" content="$metaTitle">
+            """
+              .trimIndent()
+        """
+        <meta property="og:type" content="website">
+        <meta property="og:site_name" content="compose-preview">
+        <meta property="og:title" content="$metaTitle">
+        <meta property="og:description" content="$description">
+        <meta property="og:url" content="$pageUrl">
+        $imageHtml
+        <meta name="twitter:card" content="${if (imageUrl == null) "summary" else "summary_large_image"}">
+        <meta name="twitter:title" content="$metaTitle">
+        <meta name="twitter:description" content="$description">
+        $twitterImageHtml
+        """
+          .trimIndent()
+      }
+    val unfurlBlock = if (unfurlHtml.isEmpty()) "" else "\n${unfurlHtml.prependIndent("        ")}"
+    return """
     <!doctype html>
     <html lang="en">
       <head>
         <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="viewport" content="width=device-width, initial-scale=1">$unfurlBlock
         <title>${WebEscaping.htmlEscape(title)}</title>
         <style>$STYLE</style>
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
@@ -4352,6 +4439,7 @@ object ServeWeb {
     </html>
     """
       .trimIndent() + "\n"
+  }
 
   /**
    * The copyable direct-link panel: the `/render/<id>.png` (and, when [hasSvgExport], `.svg`) URL

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -260,6 +260,93 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `viewer unfurl metadata uses the external origin and preserves render overrides`() {
+    val request =
+      Request.Builder()
+        .url(
+          "http://127.0.0.1:${server.port}/compose-m3/p/$previewId" + "?fontScale=1.5&locale=en-US"
+        )
+        .header("Host", "preview.coo.ee")
+        .header("X-Forwarded-Proto", "https")
+        .build()
+
+    client.newCall(request).execute().use { response ->
+      assertEquals(200, response.code)
+      val html = response.body?.string().orEmpty()
+      assertTrue(
+        html.contains(
+          "<meta property=\"og:url\" content=\"https://preview.coo.ee/compose-m3/p/" +
+            "$previewId?fontScale=1.5&amp;locale=en-US\">"
+        ),
+        "canonical external viewer URL: $html",
+      )
+      val imageUrl =
+        "https://preview.coo.ee/compose-m3/render/$previewId.png?" +
+          "fontScale=1.5&amp;locale=en-US"
+      assertTrue(
+        html.contains("<meta property=\"og:image\" content=\"$imageUrl\">"),
+        "Open Graph points at the matching render: $html",
+      )
+      assertTrue(
+        html.contains("<meta name=\"twitter:image\" content=\"$imageUrl\">"),
+        "Twitter points at the matching render: $html",
+      )
+    }
+  }
+
+  @Test
+  fun `each browse page unfurls the content expected for that page`() {
+    fun proxied(path: String): Pair<Int, String> {
+      val request =
+        Request.Builder()
+          .url("http://127.0.0.1:${server.port}$path")
+          .header("Host", "preview.coo.ee")
+          .header("X-Forwarded-Proto", "https")
+          .build()
+      client.newCall(request).execute().use { response ->
+        return response.code to response.body.string()
+      }
+    }
+
+    val (homeCode, home) = proxied("/")
+    assertEquals(200, homeCode)
+    assertTrue(
+      Regex(
+          """<meta property="og:image" content="https://preview\.coo\.ee/""" +
+            """(?:hero/compose-m3/[a-f0-9]+\.png|compose-m3/render/[^"]+\.png)">"""
+        )
+        .containsMatchIn(home),
+      "the server index uses its first published catalog hero: $home",
+    )
+
+    val (catalogCode, catalog) = proxied("/compose-m3/")
+    assertEquals(200, catalogCode)
+    assertTrue(
+      catalog.contains(
+        "<meta property=\"og:image\" content=\"https://preview.coo.ee/compose-m3/render/" +
+          "$previewId.png\">"
+      ),
+      "a catalog landing uses its representative preview: $catalog",
+    )
+
+    val (statusCode, status) = proxied("/status")
+    assertEquals(200, statusCode)
+    assertTrue(
+      status.contains("<meta name=\"twitter:card\" content=\"summary\">"),
+      "the utility page gets an accurate text card",
+    )
+    assertTrue(!status.contains("<meta property=\"og:image\""), "status does not claim a component")
+
+    val (missingCode, missing) = proxied("/compose-m3/p/does-not-exist")
+    assertEquals(404, missingCode)
+    assertTrue(
+      missing.contains("<meta property=\"og:title\" content=\"Not found — compose-preview\">"),
+      "the error page describes itself",
+    )
+    assertTrue(!missing.contains("<meta property=\"og:image\""), "404 does not claim a component")
+  }
+
+  @Test
   fun `public browse pages and baked previews advertise static generation`() {
     val homeReq = Request.Builder().url("http://127.0.0.1:${server.port}/").build()
     client.newCall(homeReq).execute().use { response ->

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -247,4 +247,45 @@ class ServeWebTest {
       "no variant switcher for a component without props variants",
     )
   }
+
+  @Test
+  fun `viewer advertises its rendered png to link unfurlers`() {
+    val html =
+      ServeWeb.viewerPage(
+        preview = ServePreview("red", "Red & \"Blue\""),
+        token = "unused",
+        unfurl =
+          ServeWeb.UnfurlMetadata(
+            pageUrl = "https://preview.example/p/red?theme=dark&fontScale=1.5",
+            imageUrl = "https://preview.example/render/red.png?theme=dark&fontScale=1.5",
+          ),
+      )
+
+    assertTrue(
+      html.contains("<meta property=\"og:title\" content=\"Red &amp; &quot;Blue&quot;\">"),
+      "Open Graph title is present and escaped",
+    )
+    assertTrue(
+      html.contains(
+        "<meta property=\"og:image\" content=\"https://preview.example/render/red.png?" +
+          "theme=dark&amp;fontScale=1.5\">"
+      ),
+      "Open Graph image points at the rendered PNG",
+    )
+    assertTrue(
+      html.contains("<meta name=\"twitter:card\" content=\"summary_large_image\">"),
+      "large-image Twitter card is present",
+    )
+    assertTrue(
+      html.contains(
+        "<meta name=\"twitter:image\" content=\"https://preview.example/render/red.png?" +
+          "theme=dark&amp;fontScale=1.5\">"
+      ),
+      "Twitter card uses the same rendered PNG",
+    )
+    assertTrue(
+      html.contains("<title>Red &amp; &quot;Blue&quot; — compose-preview</title>"),
+      "document title is escaped exactly once",
+    )
+  }
 }


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card metadata to browser-facing serve pages
- unfurl the first visible catalog hero on the server index
- unfurl a catalog's representative component on catalog landings
- unfurl the exact preview PNG, including URL overrides, on preview viewer links
- use accurate text-only cards for status and not-found pages
- derive absolute HTTPS URLs correctly behind the preview.coo.ee Caddy proxy

## Why
The serve HTML only exposed a document title, so chat and social clients could not discover the rendered preview associated with a shared link. The HTTP layer also had no browser-visible origin handling for TLS terminated by Caddy.

## User impact
Shared preview.coo.ee links now expand to the content represented by that page instead of a generic link card. Token/session and render override query parameters are retained where required.

## Validation
- `./gradlew :cli:ktfmtCheck :cli:test --no-daemon` (884 tests)
- post-rebase routing, escaping, and fixture-sync tests

This is metadata-only and does not change visible page rendering, so there is no before/after UI image.

Fixes #2867