### PR TITLE
fix(catalog): preserve declared Wear breakpoints

### DIFF
--- a/scripts/design-artifacts/catalog-breakpoints.mjs
+++ b/scripts/design-artifacts/catalog-breakpoints.mjs
@@ -1,0 +1,50 @@
+/**
+ * Apply a catalog spec's named width breakpoints to candidate images.
+ *
+ * The candidate reader classifies numeric `widthDp` values with Material window
+ * size classes (`compact` / `medium` / `expanded`). Catalog specs may declare a
+ * more useful vocabulary for their domain, such as Wear's `smallRound` and
+ * `largeRound`. Re-tag matching images after the bundle has been read so those
+ * declared names become the catalog's size axis.
+ *
+ * @param {Array<{previewId?: string, componentId: string, images?: Array<object>}>} candidates
+ * @param {Array<{id: string, params?: object, captures?: Array<{params?: object}>}>} previews
+ * @param {Array<{size: string, widthDp: number}> | undefined} breakpoints
+ * @returns {number} number of images assigned a declared breakpoint name
+ */
+export function applySpecBreakpoints(candidates, previews, breakpoints) {
+  const sizeByWidth = new Map(
+    (breakpoints ?? [])
+      .filter(
+        ({ size, widthDp }) =>
+          typeof size === "string" &&
+          size.length > 0 &&
+          typeof widthDp === "number" &&
+          Number.isFinite(widthDp),
+      )
+      .map(({ size, widthDp }) => [widthDp, size]),
+  );
+  if (sizeByWidth.size === 0) return 0;
+
+  const previewById = new Map(previews.map((preview) => [preview.id, preview]));
+  let applied = 0;
+  for (const candidate of candidates) {
+    const preview = previewById.get(candidate.previewId ?? candidate.componentId);
+    if (!preview) continue;
+    const captures =
+      Array.isArray(preview.captures) && preview.captures.length > 0
+        ? preview.captures
+        : [{}];
+    for (let index = 0; index < (candidate.images ?? []).length; index += 1) {
+      const params = {
+        ...(preview.params ?? {}),
+        ...(captures[index]?.params ?? {}),
+      };
+      const size = sizeByWidth.get(params.widthDp);
+      if (size === undefined) continue;
+      candidate.images[index].size = size;
+      applied += 1;
+    }
+  }
+  return applied;
+}

--- a/scripts/design-artifacts/catalog-breakpoints.test.mjs
+++ b/scripts/design-artifacts/catalog-breakpoints.test.mjs
@@ -1,0 +1,82 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applySpecBreakpoints } from "./catalog-breakpoints.mjs";
+
+test("declared Wear breakpoints replace canonical compact sizes", () => {
+  const candidates = [
+    {
+      componentId: "PodcastScreenPreview",
+      previewId: "PodcastScreenPreview_Small_Round",
+      images: [{ size: "compact" }, { size: "compact" }],
+    },
+  ];
+  const previews = [
+    {
+      id: "PodcastScreenPreview_Small_Round",
+      params: { widthDp: 192, heightDp: 192 },
+      captures: [
+        {},
+        { params: { widthDp: 227, heightDp: 227 } },
+      ],
+    },
+  ];
+
+  const applied = applySpecBreakpoints(candidates, previews, [
+    { size: "smallRound", widthDp: 192 },
+    { size: "largeRound", widthDp: 227 },
+  ]);
+
+  assert.equal(applied, 2);
+  assert.deepEqual(
+    candidates[0].images.map((image) => image.size),
+    ["smallRound", "largeRound"],
+  );
+});
+
+test("capture params override preview params when resolving a breakpoint", () => {
+  const candidates = [
+    {
+      componentId: "Screen",
+      previewId: "Screen_Large",
+      images: [{ size: "compact" }],
+    },
+  ];
+  const previews = [
+    {
+      id: "Screen_Large",
+      params: { widthDp: 192 },
+      captures: [{ params: { widthDp: 227 } }],
+    },
+  ];
+
+  applySpecBreakpoints(candidates, previews, [
+    { size: "smallRound", widthDp: 192 },
+    { size: "largeRound", widthDp: 227 },
+  ]);
+
+  assert.equal(candidates[0].images[0].size, "largeRound");
+});
+
+test("undeclared widths keep the candidate reader's canonical size", () => {
+  const candidates = [
+    {
+      componentId: "TabletPreview",
+      previewId: "TabletPreview",
+      images: [{ size: "medium" }],
+    },
+  ];
+  const previews = [
+    {
+      id: "TabletPreview",
+      params: { widthDp: 700 },
+    },
+  ];
+
+  const applied = applySpecBreakpoints(candidates, previews, [
+    { size: "compactPhone", widthDp: 360 },
+  ]);
+
+  assert.equal(applied, 0);
+  assert.equal(candidates[0].images[0].size, "medium");
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -74,6 +74,7 @@ import {
 import { candidatePreviewBundle } from "./bundle-previews.mjs";
 import { bridgeLivePreviewIds } from "./bridge-live-preview-ids.mjs";
 import { applySpecSections } from "./apply-spec-sections.mjs";
+import { applySpecBreakpoints } from "./catalog-breakpoints.mjs";
 
 /**
  * Best-effort fetch + parse of a JSON URL, with a short timeout. Returns null on
@@ -129,7 +130,7 @@ async function listFilesRecursive(dir) {
  * ships to npm and the pin is bumped, this can revert to a plain
  * `loadPreviewBundle(path, resolver)`.
  */
-async function loadCandidates(path) {
+async function loadCandidates(path, breakpoints) {
   const bundle = await readPreviewBundle(path);
   for (const preview of bundle.previews) {
     sanitizeNullSizes(preview.params);
@@ -151,6 +152,15 @@ async function loadCandidates(path) {
   const candidates = bundleToCandidates(
     candidateBundle,
     (entry) => entry.functionName ?? entry.id,
+  );
+  // The published candidate reader classifies every numeric width with Material
+  // window classes. Give this catalog's declared names precedence so domain
+  // breakpoints such as Wear's 192 dp `smallRound` and 227 dp `largeRound` remain
+  // distinct output axes instead of both collapsing to `compact`.
+  applySpecBreakpoints(
+    candidates,
+    candidateBundle.previews,
+    breakpoints,
   );
   // `@OverrideVariant` synthetic previews share their base's `functionName`, so `mergeByFunction`
   // (below) folds their images into the parent candidate. Stamp each one's `_VARIANT_<name>` suffix
@@ -442,7 +452,10 @@ const spec = JSON.parse(await readFile(specPath, "utf8"));
 // the join folds a function's theme/size multipreview variants (whose ids differ
 // only by an appended `_<mode>`) onto one component. See `loadCandidates` (which
 // also works around the published null-widthDp crash) and the vendored join.
-const { candidates, bundle } = await loadCandidates(rendersPath);
+const { candidates, bundle } = await loadCandidates(
+  rendersPath,
+  spec.breakpoints,
+);
 
 // Fold a supplementary render bundle in, overriding same-named functions. Lets an
 // Android-only render (the material3 1.5.0-alpha inset focus ring, which CMP can't
@@ -456,6 +469,7 @@ let extraBundle = null;
 if (values["extra-renders"]) {
   const { candidates: extra, bundle: extraRenderBundle } = await loadCandidates(
     resolve(values["extra-renders"]),
+    spec.breakpoints,
   );
   extraBundle = extraRenderBundle;
   const overridden = new Set(extra.map(functionOf));


### PR DESCRIPTION
## Summary

- apply catalog-spec breakpoint names to rendered candidate images
- preserve capture-level width overrides when resolving the size axis
- leave undeclared widths on the existing canonical Material size path

## Root cause

The candidate reader normalizes every numeric `widthDp` through Material window classes. Both 192 dp and 227 dp Wear renders therefore became `compact`, producing duplicate catalog output axes even though the spec declared `smallRound` and `largeRound`.

## Impact

Wear multipreviews can now be used as the primary catalog preview without their device variants colliding during design-catalog generation.

## Validation

- `cd scripts/design-artifacts && npm test` (22/22 test files pass)
- `git diff --check`

Fixes #2870