### PR TITLE
fix(bundle): render Wear theme catalog semantics

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -154,6 +154,9 @@ class PreviewManifestRouter(
       (inbound["kind"] ?: resolved.kind)
         ?.takeIf { it.isNotBlank() }
         ?.let { append("kind=").append(it).append(';') }
+      resolved.name
+        ?.takeIf { it.isNotBlank() }
+        ?.let { append("previewName=").append(it).append(';') }
       // `@PreviewWrapper(SomeProvider::class)` FQN sourced from `previews.json` (the gradle
       // plugin's `extractWrapperFqn` reads it off the class-file annotation tables — the
       // upstream annotation is `AnnotationRetention.BINARY` and not visible via
@@ -210,6 +213,7 @@ private fun PreviewManifestEntry.renderSpec(): RenderSpec {
     device = resolved.device,
     outputBaseName = resolved.outputBaseName,
     kind = resolved.kind,
+    previewName = resolved.name,
     wrapperClassName = resolved.wrapperClassName,
     wrapWidth = resolved.wrapWidth,
     wrapHeight = resolved.wrapHeight,
@@ -279,6 +283,7 @@ data class PreviewManifestEntry(
     val density = density ?: p?.density ?: 2.0f
     val device = device ?: p?.device
     val kind = kind ?: p?.kind
+    val name = p?.name
     val uiMode = uiMode ?: p?.uiMode ?: 0
     // A preview that declares an explicit size — or is pinned to a fixed frame by a device or a
     // non-Compose surface (tile / notification / Glance, whose render helpers consume the concrete
@@ -313,6 +318,7 @@ data class PreviewManifestEntry(
       device = device,
       outputBaseName = outputBaseName ?: id,
       kind = kind,
+      name = name,
       wrapperClassName = wrapperClassName,
       wrapWidth = wrapWidth,
       wrapHeight = wrapHeight,
@@ -348,6 +354,7 @@ data class PreviewManifestEntry(
  */
 @Serializable
 data class PreviewParamsEntry(
+  val name: String? = null,
   val device: String? = null,
   val widthDp: Int? = null,
   val heightDp: Int? = null,
@@ -394,6 +401,7 @@ data class ResolvedRenderParams(
   val device: String?,
   val outputBaseName: String,
   val kind: String? = null,
+  val name: String? = null,
   val wrapperClassName: String? = null,
   /**
    * AS-parity wrap-content flags (see [RenderSpec.wrapWidth]). Set when the preview declares no

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -236,6 +236,8 @@ class RenderEngine(
     val isTile = spec.kind.equals(TILE_KIND, ignoreCase = true)
     val isNotification = spec.kind.equals(NOTIFICATION_KIND, ignoreCase = true)
     val isGlanceAppWidget = spec.kind.equals(GLANCE_APPWIDGET_KIND, ignoreCase = true)
+    val isThemeCatalog = spec.kind.equals(THEME_CATALOG_KIND, ignoreCase = true)
+    val isWearThemeCatalog = spec.kind.equals(WEAR_THEME_CATALOG_KIND, ignoreCase = true)
     // v5 IR replay: a bundle may carry this preview's intermediate representation, in which case
     // its
     // consumer class was dropped at pack time. We then inflate the IR via the matching runtime in
@@ -259,8 +261,9 @@ class RenderEngine(
     // An IR-backed preview's consumer class was dropped at pack time, so skip the reflective load
     // whenever we have a replay path for it (protolayout direct, or a resolved RC provider).
     val isIrReplay = isProtolayoutIr || rcReplayClass != null
+    val isSyntheticThemeCatalog = isThemeCatalog || isWearThemeCatalog
     val clazz =
-      if (isIrReplay) null
+      if (isIrReplay || isSyntheticThemeCatalog) null
       else
         trace.section("classloader:loadPreviewClass") {
           Class.forName(spec.className, true, classLoader)
@@ -277,7 +280,8 @@ class RenderEngine(
     // body that fails the moment a Glance composable touches the GlanceComposition applier. The
     // dedicated branches skip top-level composable resolution and paint the result through the
     // matching renderer helper in the setContent body below.
-    val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget || isIrReplay
+    val nonComposableInvocation =
+      isTile || isNotification || isGlanceAppWidget || isSyntheticThemeCatalog || isIrReplay
     val composableMethod: ComposableMethod? =
       if (nonComposableInvocation) null
       else
@@ -604,6 +608,19 @@ class RenderEngine(
                             widthDp = widthDp,
                             heightDp = heightDp,
                             classLoader = classLoader,
+                          )
+                        } else if (isSyntheticThemeCatalog) {
+                          // `@ThemeCatalog` / `@WearThemeCatalog` entries are synthetic sheets:
+                          // their functionName is a display label, not a consumer method. Reuse the
+                          // standalone renderer's canonical strategy so the provider wraps the
+                          // same canned specimen during daemon semantics/data capture.
+                          ee.schimke.composeai.renderer.ThemeCatalogPreview(
+                            previewId = spec.previewId ?: spec.outputBaseName,
+                            themeName = spec.previewName ?: spec.functionName,
+                            wrapperClassName = spec.wrapperClassName ?: spec.className,
+                            wear = isWearThemeCatalog,
+                            widthDp = pxToDp(spec.widthPx, spec.density),
+                            heightDp = pxToDp(spec.heightPx, spec.density),
                           )
                         } else {
                           InvokeWithOptionalWrapper(
@@ -1917,6 +1934,12 @@ class RenderEngine(
      */
     const val GLANCE_APPWIDGET_KIND: String = "GLANCE_APPWIDGET"
 
+    /** Synthetic `@ThemeCatalog` sheet rendered through the shared renderer strategy. */
+    const val THEME_CATALOG_KIND: String = "THEME_CATALOG"
+
+    /** Synthetic `@WearThemeCatalog` sheet rendered through the shared Wear renderer strategy. */
+    const val WEAR_THEME_CATALOG_KIND: String = "WEAR_THEME_CATALOG"
+
     /**
      * Virtual time to advance before capture in the paused-`mainClock` path, in milliseconds.
      * Mirrors `RobolectricRenderTest.CAPTURE_ADVANCE_MS` exactly so daemon-rendered PNGs match the
@@ -2238,13 +2261,14 @@ data class RenderSpec(
    */
   val overrides: PreviewOverrides? = null,
   /**
-   * Preview flavour, mirroring `ee.schimke.composeai.plugin.PreviewKind` (`"COMPOSE"` / `"TILE"` /
-   * `"NOTIFICATION"` / `"GLANCE_APPWIDGET"`). Drives renderer selection: `"TILE"` routes through
-   * [renderer.TilePreviewComposable], `"NOTIFICATION"` through `NotificationPreviewComposable`,
-   * `"GLANCE_APPWIDGET"` through `GlanceAppWidgetPreviewComposable`. `null` / `"COMPOSE"` render as
-   * a normal `@Composable`.
+   * Preview flavour, mirroring `ee.schimke.composeai.plugin.PreviewKind`. Drives renderer
+   * selection: `"TILE"`, `"NOTIFICATION"`, and `"GLANCE_APPWIDGET"` route through their dedicated
+   * renderer helpers; `"THEME_CATALOG"` and `"WEAR_THEME_CATALOG"` render synthetic specimens
+   * inside their declared provider. `null` / `"COMPOSE"` render as a normal `@Composable`.
    */
   val kind: String? = null,
+  /** Discovery-time display name for synthetic catalog sheets. */
+  val previewName: String? = null,
   /**
    * FQN of the `PreviewWrapperProvider` from `@PreviewWrapper(SomeProvider::class)` when the source
    * preview is annotated. Sourced from the gradle plugin's discovery JSON (`extractWrapperFqn`
@@ -2324,6 +2348,7 @@ data class RenderSpec(
         inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
         overrides = map["overrides"]?.decodePreviewOverrides(),
         kind = map["kind"]?.takeIf { it.isNotBlank() },
+        previewName = map["previewName"]?.takeIf { it.isNotBlank() },
         wrapperClassName = map["wrapperClassName"]?.takeIf { it.isNotBlank() },
       )
     }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterRoutingTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterRoutingTest.kt
@@ -197,6 +197,47 @@ class PreviewManifestRouterRoutingTest {
   }
 
   @Test
+  fun `routePayload preserves Wear theme catalog kind and display name`() {
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "wearthemecatalog__Dark",
+              className = "com.example.JetcasterWearDarkThemeCatalog",
+              functionName = "Dark theme",
+              params =
+                PreviewParamsEntry(
+                  name = "Dark",
+                  widthDp = 227,
+                  heightDp = 227,
+                  kind = "WEAR_THEME_CATALOG",
+                  wrapperClassName = "com.example.JetcasterWearDarkThemeCatalog",
+                ),
+            )
+          )
+      )
+
+    val routed =
+      PreviewManifestRouter(manifest = manifest)
+        .routePayload("previewId=wearthemecatalog__Dark")
+    val spec = RenderSpec.parseFromPayloadOrNull(routed)!!
+
+    assertTrue(
+      "Wear theme catalogs must retain their strategy kind. payload=$routed",
+      spec.kind == "WEAR_THEME_CATALOG",
+    )
+    assertTrue(
+      "the synthetic sheet's clean theme name must survive routing. payload=$routed",
+      spec.previewName == "Dark",
+    )
+    assertTrue(
+      "the provider FQN must survive routing. payload=$routed",
+      spec.wrapperClassName == "com.example.JetcasterWearDarkThemeCatalog",
+    )
+  }
+
+  @Test
   fun `routePayload derives uiMode=dark from the manifest night bit`() {
     // A `_Dark` multipreview variant differs from its `_Light` sibling ONLY by
     // `@Preview(uiMode = UI_MODE_NIGHT_YES)`. Dropping the bit rendered both variants identically

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/WrappedPreviewRenderTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/WrappedPreviewRenderTest.kt
@@ -89,6 +89,51 @@ class WrappedPreviewRenderTest {
   }
 
   @Test
+  fun wearThemeCatalogUsesSyntheticStrategyInsteadOfReflectingDisplayName() {
+    val outputDir = tempFolder.newFolder("renders-wear-theme-catalog")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val provider = "ee.schimke.composeai.daemon.GreenBorderWrapper"
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "wearthemecatalog__Dark",
+              className = provider,
+              // Synthetic catalog entries carry a display label here. It deliberately does not
+              // name a method: falling through to ordinary composable reflection reproduces the
+              // NoSuchMethodException from issue #2872.
+              functionName = "Dark theme",
+              params =
+                PreviewParamsEntry(
+                  name = "Dark",
+                  widthDp = 96,
+                  heightDp = 96,
+                  density = 1.0f,
+                  kind = "WEAR_THEME_CATALOG",
+                  wrapperClassName = provider,
+                ),
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val image =
+        renderAndDecode(
+          host = host,
+          payload = "previewId=wearthemecatalog__Dark",
+          label = "Wear theme catalog",
+        )
+      assertTrue("Wear theme catalog should render its requested width", image.width == 96)
+      assertTrue("Wear theme catalog should render its requested height", image.height == 96)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun scrollLongPreservesRequiredPreviewWrapper() {
     val outputDir = tempFolder.newFolder("renders-wrapped-scroll")
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -59,6 +59,44 @@ internal fun strategyFor(kind: PreviewKind): PreviewRenderStrategy =
   STRATEGIES[kind] ?: error("No render strategy registered for PreviewKind.$kind")
 
 /**
+ * Renders a synthetic `@ThemeCatalog` / `@WearThemeCatalog` entry outside the parameterized
+ * standalone renderer.
+ *
+ * The preview daemon receives the same discovery manifest, but owns its own render loop. Exposing
+ * this narrow bridge lets it reuse the canonical theme strategies instead of treating the
+ * synthetic display [themeName] as a consumer composable method.
+ */
+@Composable
+fun ThemeCatalogPreview(
+  previewId: String,
+  themeName: String,
+  wrapperClassName: String,
+  wear: Boolean,
+  widthDp: Int,
+  heightDp: Int,
+) {
+  val kind = if (wear) PreviewKind.WEAR_THEME_CATALOG else PreviewKind.THEME_CATALOG
+  strategyFor(kind)
+    .Render(
+      preview =
+        RenderPreviewEntry(
+          id = previewId,
+          className = wrapperClassName,
+          functionName = themeName,
+          params =
+            RenderPreviewParams(
+              name = themeName,
+              wrapperClassName = wrapperClassName,
+              kind = kind,
+            ),
+        ),
+      widthDp = widthDp,
+      heightDp = heightDp,
+      previewArgs = emptyList(),
+    )
+}
+
+/**
  * Default strategy: reflect the `@Composable` and invoke it through the Composer. Honours
  * `@PreviewWrapper` by looking up the provider's `Wrap(content)` method.
  *


### PR DESCRIPTION
## Summary

- route synthetic `THEME_CATALOG` and `WEAR_THEME_CATALOG` entries through the renderer's canonical theme strategies in daemon renders
- preserve the discovery-time theme display name through manifest routing
- skip ordinary composable method resolution for synthetic theme sheets

## Root cause

The manifest router already preserved `WEAR_THEME_CATALOG`, but the Android daemon only dispatched Tile, Notification, and Glance kinds. Theme-catalog entries therefore fell through to ordinary composable reflection, where their display `functionName` (for example `Dark theme`) was treated as a consumer method and failed with `NoSuchMethodException`.

## Impact

`bundle pack --with-semantics` can now capture semantics, layout, Figma SVG, translations, and hierarchy products for Wear theme catalog sheets using the same specimen/provider behavior as the ordinary Gradle renderer.

## Validation

- `./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.PreviewManifestRouterRoutingTest --tests ee.schimke.composeai.daemon.WrappedPreviewRenderTest`
- `./gradlew :renderer-android:testDebugUnitTest`
- `./gradlew :daemon:android:ktfmtCheck :renderer-android:ktfmtCheck`
- `git diff --check`

Fixes #2872