### PR TITLE
fix(semantics): support multiple Compose roots

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.ViewRootForTest
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
@@ -655,13 +657,30 @@ class RenderEngine(
                 recordOptions =
                   RoborazziOptions.RecordOptions(applyDeviceCrop = isRound && !flattenWearScroll)
               )
+            // A preview may install more than one Compose owner (Wear empty-state scaffolds and
+            // popup/dialog-like content do this). `onRoot()` asserts that exactly one node matches
+            // `isRoot`, so using it independently for capture and every data product drops the
+            // whole render as soon as a second owner appears. Resolve one owner once: prefer the
+            // owner attached to the activity's rendered window, then prefer the richest tree. Use
+            // that same interaction for pixels and its unmerged root for every structured export.
+            val rootInteractions = rule.onAllNodes(isRoot(), useUnmergedTree = true)
+            val semanticsRoots =
+              rootInteractions.fetchSemanticsNodes(atLeastOneRootRequired = false)
+            val resolvedSemanticsRoot =
+              selectRenderedSurfaceSemanticsRoot(
+                roots = semanticsRoots,
+                activityDecorView = rule.activity.window.decorView,
+              ) ?: error("No semantics root was produced for '${spec.outputBaseName}'")
+            val resolvedRootIndex = semanticsRoots.indexOf(resolvedSemanticsRoot)
+            val resolvedRootInteraction = rootInteractions[resolvedRootIndex]
             System.err.println(
               "compose-ai-daemon: [render] phase=captureRoboImage.start outputBaseName=${spec.outputBaseName}"
             )
-            rule.onRoot().also {
-              trace.section("render:captureRoboImage") {
-                it.captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
-              }
+            trace.section("render:captureRoboImage") {
+              resolvedRootInteraction.captureRoboImage(
+                file = outputFile,
+                roborazziOptions = roborazziOptions,
+              )
             }
             System.err.println(
               "compose-ai-daemon: [render] phase=captureRoboImage.done outputBaseName=${spec.outputBaseName}"
@@ -683,10 +702,7 @@ class RenderEngine(
 
             // Pull per-node theme facts while the composition is still alive so theme consumer
             // attribution (#1847) can run after the rule tears the scene down.
-            capturedThemeFacts =
-              ThemeConsumerCapture.extractFacts(
-                runCatching { rule.onRoot(useUnmergedTree = true).fetchSemanticsNode() }.getOrNull()
-              )
+            capturedThemeFacts = ThemeConsumerCapture.extractFacts(resolvedSemanticsRoot)
 
             // Always-on data-artifact extensions (fonts, resources, semantics, layout-inspector,
             // i18n, etc). Each extension owns its own recorder lifecycle (installed during
@@ -695,9 +711,7 @@ class RenderEngine(
             // post-capture context (rootDir, previewId, semantics root, layout-inspector
             // preview context, locale) and lets each extension decide what to write.
             if (dataDir != null && builtDataArtifactExtensions.isNotEmpty()) {
-              val resolvedSemanticsRoot =
-                runCatching { rule.onRoot(useUnmergedTree = true).fetchSemanticsNode() }.getOrNull()
-              val layoutInspectorPreviewContext = resolvedSemanticsRoot?.let { semanticsRoot ->
+              val layoutInspectorPreviewContext =
                 PreviewContext.Builder(
                     previewId = spec.previewId,
                     backend = PreviewBackends.ANDROID,
@@ -714,9 +728,8 @@ class RenderEngine(
                   )
                   .parameterInformationCollected()
                   .addSlotTables(slotTableCapture.snapshot())
-                  .rootForTest(semanticsRoot.root)
+                  .rootForTest(resolvedSemanticsRoot.root)
                   .build()
-              }
               val artifactContextData =
                 buildList<ExtensionContextValue<*>> {
                   add(RenderDataArtifactContextKeys.RootDir provides dataDir)
@@ -725,20 +738,22 @@ class RenderEngine(
                   spec.localeTag
                     ?.takeIf { it.isNotBlank() }
                     ?.let { add(RenderDataArtifactContextKeys.RenderedLocale provides it) }
-                  resolvedSemanticsRoot?.let {
-                    add(RenderDataArtifactContextKeys.SemanticsRoot provides it)
-                  }
+                  add(RenderDataArtifactContextKeys.SemanticsRoot provides resolvedSemanticsRoot)
                   add(RenderDataArtifactContextKeys.Density provides spec.density)
                   add(RenderDataArtifactContextKeys.SlotTables provides slotTableCapture.snapshot())
                   add(RenderDataArtifactContextKeys.FontScale provides (spec.fontScale ?: 1.0f))
                   add(RenderDataArtifactContextKeys.OutputPng provides outputFile)
                   add(RenderDataArtifactContextKeys.HeldActivity provides rule.activity)
-                  layoutInspectorPreviewContext?.let {
-                    add(RenderDataArtifactContextKeys.LayoutInspectorPreviewContext provides it)
-                    // Round-Wear clip for the shared figma-svg export — the same
-                    // `previewContext.device.isRound` the inline Android extension read.
-                    add(RenderDataArtifactContextKeys.RoundClip provides it.device.isRound)
-                  }
+                  add(
+                    RenderDataArtifactContextKeys.LayoutInspectorPreviewContext provides
+                      layoutInspectorPreviewContext
+                  )
+                  // Round-Wear clip for the shared figma-svg export — the same
+                  // `previewContext.device.isRound` the inline Android extension read.
+                  add(
+                    RenderDataArtifactContextKeys.RoundClip provides
+                      layoutInspectorPreviewContext.device.isRound
+                  )
                 }
               val extensionContextData =
                 ExtensionContextData.of(*artifactContextData.toTypedArray())
@@ -787,7 +802,7 @@ class RenderEngine(
               )
               try {
                 trace.section("a11y:dataProducts") {
-                  val view = (rule.onRoot().fetchSemanticsNode().root as ViewRootForTest).view
+                  val view = (resolvedSemanticsRoot.root as ViewRootForTest).view
                   // Hierarchy + ATF come from a typed extension instead of a direct
                   // AccessibilityChecker.analyze call. The extension owns the platform-specific
                   // ATF walk; downstream consumers (TouchTargets, Overlay) read declared inputs
@@ -843,7 +858,6 @@ class RenderEngine(
             if (dataDir != null) {
               try {
                 trace.section("uia:hierarchy") {
-                  val rootNode = rule.onRoot(useUnmergedTree = false).fetchSemanticsNode()
                   val uiaExtension = UiAutomatorHierarchyExtension()
                   val uiaStore = RecordingDataProductStore()
                   uiaExtension.process(
@@ -854,7 +868,8 @@ class RenderEngine(
                       products = uiaStore.scopedFor(uiaExtension),
                       data =
                         ExtensionContextData.of(
-                          UiAutomatorHierarchyContextKeys.SemanticsRoot provides rootNode
+                          UiAutomatorHierarchyContextKeys.SemanticsRoot provides
+                            resolvedSemanticsRoot
                         ),
                     )
                   )
@@ -1941,6 +1956,33 @@ internal fun isRoundDevice(device: String?): Boolean {
   val lower = device.lowercase()
   return lower.contains("_round") || lower.contains("isround=true") || lower.contains("shape=round")
 }
+
+/**
+ * Select the Compose semantics root representing the activity surface being captured.
+ *
+ * Multiple owners are valid (for example, a popup or Wear scaffold may add another root). Prefer
+ * owners whose Android view belongs to the activity window; if more than one does, prefer the tree
+ * with the most semantic content. Callers request the unmerged roots up front, so the selected node
+ * retains the detailed tree all structured data products need.
+ */
+internal fun selectRenderedSurfaceSemanticsRoot(
+  roots: List<SemanticsNode>,
+  activityDecorView: android.view.View,
+): SemanticsNode? =
+  roots.maxWithOrNull(
+    compareBy<SemanticsNode>(
+      { if (it.belongsToWindow(activityDecorView)) 1 else 0 },
+      { it.descendantCount() },
+      { it.boundsInRoot.width * it.boundsInRoot.height },
+    )
+  )
+
+private fun SemanticsNode.belongsToWindow(decorView: android.view.View): Boolean =
+  runCatching { (root as? ViewRootForTest)?.view?.rootView === decorView.rootView }
+    .getOrDefault(false)
+
+private fun SemanticsNode.descendantCount(): Int =
+  runCatching { 1 + children.sumOf { it.descendantCount() } }.getOrDefault(1)
 
 /**
  * Tiny @Composable trampoline that invokes [composableMethod] reflectively against the current

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/MultipleSemanticsRootsRenderTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/MultipleSemanticsRootsRenderTest.kt
@@ -1,0 +1,73 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/** Regression coverage for multiple valid Compose owner/root nodes (issue #2871). */
+class MultipleSemanticsRootsRenderTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun rendersAndExportsDataFromTheActivitySurfaceWhenAPopupAddsAnotherRoot() {
+    val outputDir = tempFolder.newFolder("renders-multiple-roots")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val previewId = "multiple-roots"
+    val host =
+      PreviewManifestRouter(
+        manifest =
+          PreviewManifest(
+            previews =
+              listOf(
+                PreviewManifestEntry(
+                  id = previewId,
+                  className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+                  functionName = "MultipleSemanticsRoots",
+                  params = PreviewParamsEntry(widthDp = 96, heightDp = 96, density = 1.0f),
+                )
+              )
+          )
+      )
+
+    host.start()
+    try {
+      val result =
+        host.submit(
+          RenderRequest.Render(payload = "previewId=$previewId"),
+          timeoutMs = 120_000,
+        )
+      assertNotNull("PNG path must be populated", result.pngPath)
+      assertTrue("rendered PNG must exist", File(result.pngPath!!).isFile)
+
+      val previewDataDir = outputDir.parentFile!!.resolve("data/$previewId")
+      val rootDependentProducts =
+        listOf(
+          "compose-semantics.json",
+          "compose-semantics-wireframe.svg",
+          "layout-inspector.json",
+          "compose-figma.svg",
+          "i18n-translations.json",
+          "uia-hierarchy.json",
+        )
+      for (name in rootDependentProducts) {
+        assertTrue(
+          "$name must survive the additional root; wrote ${previewDataDir.list()?.toList()}",
+          previewDataDir.resolve(name).isFile,
+        )
+      }
+      val semantics = previewDataDir.resolve("compose-semantics.json")
+      val payload = semantics.readText()
+      assertTrue(
+        "the selected tree must be the activity surface: $payload",
+        "activity-surface" in payload,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+}

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -51,6 +51,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -58,6 +60,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
 
 /**
  * Test fixtures for [RenderEngineTest] and the D-harness.v2 Android real-mode scenarios. Lives in
@@ -78,6 +81,25 @@ import androidx.compose.ui.unit.sp
 @Composable
 fun RedSquare() {
   Box(modifier = Modifier.fillMaxSize().background(Color(0xFFEF5350)))
+}
+
+/** Two-owner fixture: the activity surface plus a popup-owned semantics root. */
+@Composable
+fun MultipleSemanticsRoots() {
+  Box(
+    modifier =
+      Modifier.fillMaxSize()
+        .background(Color(0xFFEF5350))
+        .semantics { contentDescription = "activity-surface" }
+  )
+  Popup {
+    Box(
+      modifier =
+        Modifier.size(24.dp)
+          .background(Color(0xFF42A5F5))
+          .semantics { contentDescription = "popup-surface" }
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- resolve all valid Compose semantics roots once per render instead of assuming `onRoot()` is unique
- prefer the owner attached to the activity window, with semantic tree size and bounds as deterministic fallbacks
- use the same selected root for pixel capture, theme facts, accessibility, UI Automator, layout inspector, Figma, i18n, and semantics outputs
- add an end-to-end popup fixture proving every root-dependent artifact survives a second owner

## Testing

- `./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.MultipleSemanticsRootsRenderTest`
- `./gradlew :daemon:android:ktfmtCheck`
- `git diff --check`

The aggregate Android daemon suite was also attempted, but the 32 GB local runner exhausted memory and cascaded into unrelated `FileSystemAlreadyExistsException`, native renderer loading, and I/O failures. The isolated end-to-end regression passes.

Fixes #2871