### PR TITLE
feat(serve): register Jetcaster Wear catalog

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1658,7 +1658,16 @@ object ServeWeb {
       )
     val isAndroidSample =
       published(
-        ids = setOf("jetnews", "jetcaster", "jetchat", "jetsnack", "jetlagged", "reply"),
+        ids =
+          setOf(
+            "jetnews",
+            "jetcaster",
+            "jetcaster-wear",
+            "jetchat",
+            "jetsnack",
+            "jetlagged",
+            "reply",
+          ),
         // The preview branches currently live in the fork; both spellings are Android's samples.
         repos = setOf("android/compose-samples", "yschimke/compose-samples"),
       )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
@@ -85,7 +85,8 @@ class ServeWebThumbCropTest {
 
   @Test
   fun `all compose sample catalogs are attributed to android and shown on the homepage`() {
-    val sampleIds = listOf("jetnews", "jetcaster", "jetchat", "jetsnack", "jetlagged", "reply")
+    val sampleIds =
+      listOf("jetnews", "jetcaster", "jetcaster-wear", "jetchat", "jetsnack", "jetlagged", "reply")
     val systems = sampleIds.map { id ->
       ServeWeb.HomeSystem(
         system = id,

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
       # The catalog set is BAKED INTO THE IMAGE (entrypoint): the front-page systems
       # (compose-m3, wear-m3, remote-m3) and the app systems fetched from their own repos
-      # (MeshCore Mobile, Home Assistant Remote Compose, the six compose-samples apps, and the two
+      # (MeshCore Mobile, Home Assistant Remote Compose, the seven compose-samples catalogs, and the two
       # Confetti apps); Cadence is served unlisted. Leave these empty to inherit the baked defaults
       # — so a bare image pull self-heals without editing this compose. setup.sh removes the exact
       # legacy three-compose-samples override, which would otherwise shadow that complete default.

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 # The published catalog set is BAKED INTO THE IMAGE (same `:=` + `none` convention
 # as SERVE_TRUST_STORE below), so a bare `docker pull` / Watchtower auto-update
 # self-heals without editing the box's compose. Front-page systems:
-: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,jetnews@yschimke/compose-samples,jetcaster@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetsnack@yschimke/compose-samples,jetlagged@yschimke/compose-samples,reply@yschimke/compose-samples,confetti-wear@joreilly/Confetti,confetti-mobile@joreilly/Confetti}"
+: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,jetnews@yschimke/compose-samples,jetcaster@yschimke/compose-samples,jetcaster-wear@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetsnack@yschimke/compose-samples,jetlagged@yschimke/compose-samples,reply@yschimke/compose-samples,confetti-wear@joreilly/Confetti,confetti-mobile@joreilly/Confetti}"
 [[ "${SERVE_CATALOGS}" != "none" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
 # …and cadence, served UNLISTED from its own repo — reachable at /cadence/ (and ?session=cadence)
 # but kept OFF the front-page index. (meshcore-mobile / homeassistant-remotecompose are LISTED above

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       # serves the in-browser CMP tier from the image's local wasm build via
       # SERVE_WASM_DIR. For a token-gated box, set SERVE_PUBLIC=0 + SERVE_TOKEN.
       SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
-      SERVE_CATALOGS: "${SERVE_CATALOGS:-compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,jetnews@yschimke/compose-samples,jetcaster@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetsnack@yschimke/compose-samples,jetlagged@yschimke/compose-samples,reply@yschimke/compose-samples}"
+      SERVE_CATALOGS: "${SERVE_CATALOGS:-compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,jetnews@yschimke/compose-samples,jetcaster@yschimke/compose-samples,jetcaster-wear@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetsnack@yschimke/compose-samples,jetlagged@yschimke/compose-samples,reply@yschimke/compose-samples}"
       # cadence is served UNLISTED from its own repo — reachable at /cadence/ (and ?session=cadence)
       # but kept OFF the front-page index. (meshcore-mobile / homeassistant-remotecompose are LISTED
       # above so they DO show on the front page.) <system>@<owner>/<repo> points serve at each app's

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -236,10 +236,11 @@ Both container profiles take this config from env (the entrypoint maps `SERVE_PU
 `SERVE_CATALOGS`, `SERVE_CATALOGS_UNLISTED`, `SERVE_TRUST_STORE`, `SERVE_WASM_DIR`,
 `SERVE_ACCEPT_BUNDLES` → flags) and put **Caddy** in front for TLS. They default to the **open public
 profile** (`SERVE_PUBLIC=1`, catalogs `compose-m3,wear-m3,remote-m3` plus the app systems `meshcore-mobile`,
-`homeassistant-remotecompose`, and all six compose-samples apps (`jetnews`, `jetcaster`, `jetchat`, `jetsnack`,
-`jetlagged`, and `reply`) on the front-page index; `cadence` is served unlisted at `/cadence/` — off the front
-page — via `SERVE_CATALOGS_UNLISTED`). The prebuilt `deploy/image` profile additionally includes the two
-Confetti apps. Set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a token-gated box.
+`homeassistant-remotecompose`, and all seven compose-samples catalogs (`jetnews`, `jetcaster`,
+`jetcaster-wear`, `jetchat`, `jetsnack`, `jetlagged`, and `reply`) on the front-page index; `cadence` is
+served unlisted at `/cadence/` — off the front page — via `SERVE_CATALOGS_UNLISTED`). The prebuilt
+`deploy/image` profile additionally includes the two Confetti apps. Set `SERVE_PUBLIC=0` +
+`SERVE_TOKEN` for a token-gated box.
 
 The prebuilt `deploy/image` **bakes a branch-trust store** at `/trust/producers.json` (trusting
 `design-artifacts/*` on `yschimke/compose-ai-tools`, `yschimke/meshcore-mobile`, and
@@ -250,8 +251,8 @@ Mount your own over that path (or set `SERVE_TRUST_STORE` to it) to pin differen
 out — which also means a bare image pull self-heals a box without editing its compose.)
 
 The **catalog set is baked into the image the same way**: the entrypoint defaults `SERVE_CATALOGS`
-to the three built-in design systems, MeshCore Mobile, Home Assistant Remote Compose, all six
-`yschimke/compose-samples` apps, and both Confetti apps (front-page index), and defaults
+to the three built-in design systems, MeshCore Mobile, Home Assistant Remote Compose, all seven
+`yschimke/compose-samples` catalogs, and both Confetti apps (front-page index), and defaults
 `SERVE_CATALOGS_UNLISTED` to `cadence@yschimke/cadence` (served at `/cadence/`, off the front page).
 So a bare `docker pull` / Watchtower update serves them
 without editing the box's compose. Override either with your own comma list, or `none` to serve none


### PR DESCRIPTION
## Summary

- register `jetcaster-wear@yschimke/compose-samples` in the baked image and from-source VPS catalog defaults
- group the Wear catalog with the other `android/compose-samples` catalogs on the public home page
- update the public-server documentation and homepage attribution coverage

## Why

The Jetcaster Wear catalog is published on `design-artifacts/jetcaster-wear`, but `preview.coo.ee` does not request that catalog. This leaves `/jetcaster-wear/` unavailable even though the existing compose-samples trust wildcard already covers its artifact branch.

## Impact

After this reaches the preview-host deployment, Jetcaster Wear will appear on the front page under `android/compose-samples` and be served at `/jetcaster-wear/`.

## Test plan

- [x] `./gradlew ktfmtFormat`
- [x] `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.ServeWebThumbCropTest'`
- [x] `bash -n deploy/image/entrypoint.sh`
- [x] `DOMAIN=preview.coo.ee docker compose -f deploy/vps/docker-compose.yml config --quiet`
- [x] `DOMAIN=preview.coo.ee docker compose -f deploy/image/docker-compose.yml config --quiet`