### PR TITLE
fix(catalog): reject GIF-only previews in spec validation

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -237,6 +237,17 @@ gap by scanning the module's Kotlin source directly (no Gradle build, no render)
   …). The authoritative check remains the render + completeness gate; this is the
   fast local/CI pre-flight.
 
+  It also rejects a `preview` that resolves to a **PNG-less** function — one whose
+  only capture is an animated GIF or a scroll data product (`@AnimatedPreview`,
+  `@FocusedPreview(gif = true)`, or `@ScrollingPreview` with only `ScrollMode.LONG`
+  / `ScrollMode.GIF`). Those render fine, but the export represents every catalog
+  entry as a static sticker: `candidatePreviewBundle()` drops anything without
+  `previews/<id>.png` from the candidate join, and the completeness gate then
+  reports the component missing. Catalogue a static `@Preview` sibling instead and
+  let the GIF travel in the bundle as its own artifact. `init-catalog-spec` skips
+  these functions when scaffolding, and the validator's discovery line names them
+  so you know why they're absent.
+
 The spec shape is described by
 [`scripts/design-artifacts/catalog.spec.schema.json`](../../scripts/design-artifacts/catalog.spec.schema.json)
 (referenced via `$schema` in each sample spec for editor validation).

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -238,9 +238,10 @@ gap by scanning the module's Kotlin source directly (no Gradle build, no render)
   fast local/CI pre-flight.
 
   It also rejects a `preview` that resolves to a **PNG-less** function — one whose
-  only capture is an animated GIF or a scroll data product (`@AnimatedPreview`,
-  `@FocusedPreview(gif = true)`, or `@ScrollingPreview` with only `ScrollMode.LONG`
-  / `ScrollMode.GIF`). Those render fine, but the export represents every catalog
+  only capture is an animated GIF or a scroll data product (`@AnimatedPreview`, a
+  multi-step `@FocusedPreview(gif = true)`, or `@ScrollingPreview` with only
+  `ScrollMode.LONG` / `ScrollMode.GIF`). Those render fine, but the export
+  represents every catalog
   entry as a static sticker: `candidatePreviewBundle()` drops anything without
   `previews/<id>.png` from the candidate join, and the completeness gate then
   reports the component missing. Catalogue a static `@Preview` sibling instead and

--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -177,20 +177,70 @@ function annotationNames(run) {
  * Source-level detection is sound here because all three annotations are
  * `@Target(FUNCTION)` — they can't hide inside a multipreview annotation class.
  */
+/** The comma-separated entries of a Kotlin array literal's inner text. */
+function arrayItems(inner) {
+  return inner
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** The inner text of an annotation argument's array literal — `name = [...]` when
+ *  named, else the first positional `[...]`. Returns null when there is none. */
+function arrayArg(args, name) {
+  const named = args.match(new RegExp(String.raw`\b${name}\s*=\s*\[([^\]]*)\]`));
+  if (named) return named[1];
+  // A positional array is only unambiguous when no other argument is named.
+  if (/\w+\s*=/.test(args)) return null;
+  return args.match(/\[([^\]]*)\]/)?.[1] ?? null;
+}
+
+/** The `ScrollMode` names a `@ScrollingPreview` argument list selects. Kotlin allows
+ *  both the qualified `ScrollMode.GIF` and a directly imported `GIF`, so accept
+ *  either — matching only inside the `modes` array keeps sibling arguments
+ *  (`frameIntervalMs = DEFAULT_GIF_FRAME_INTERVAL_MS`) from registering as modes. */
+function scrollModeList(args) {
+  const inner = arrayArg(args, "modes");
+  if (inner === null) return [];
+  return arrayItems(inner)
+    .map((item) => item.match(/(?:ScrollMode\s*\.\s*)?(TOP|END|LONG|GIF)$/)?.[1])
+    .filter(Boolean);
+}
+
+/** How many capture steps a `@FocusedPreview(gif = true)` yields — mirrors
+ *  `readFocusSteps`: the `traverse` directions when non-empty, else the distinct
+ *  non-negative `indices` (default `[0]`). `0` when the annotation isn't GIF-mode.
+ *  An `indices`/`traverse` value that isn't a literal array reads as the default,
+ *  which keeps an unparseable annotation on the PNG-capable (lenient) side. */
+function focusGifSteps(args) {
+  if (!/\bgif\s*=\s*true\b/.test(args)) return 0;
+  const traverse = arrayArg(args, "traverse");
+  if (traverse !== null && arrayItems(traverse).length > 0) return arrayItems(traverse).length;
+  const indices = arrayArg(args, "indices");
+  if (indices === null) return 1; // default `indices = [0]`
+  const values = arrayItems(indices)
+    .map((item) => Number(item))
+    .filter((n) => Number.isInteger(n) && n >= 0);
+  return new Set(values).size;
+}
+
 export function rendersStaticPng(run) {
   const entries = annotationEntries(run);
   const named = (name) => entries.filter((e) => e.name === name);
 
   const animated = named(ANIMATED_PREVIEW_ANNOTATION).length > 0;
   const focused = named(FOCUSED_PREVIEW_ANNOTATION);
-  const focusGif = focused.some((e) => /\bgif\s*=\s*true\b/.test(e.args));
+  // `extractFocusGifSpec` returns null below two steps — a one-frame GIF wouldn't
+  // animate — so a singleton `gif = true` (notably the default `indices = [0]`)
+  // falls back to the ordinary focus fan-out and DOES render a PNG.
+  const focusGif = focused.some((e) => focusGifSteps(e.args) >= 2);
   // `@FocusedPreview(gif = true)` supersedes the per-step focus fan-out (see
   // `effectiveFocuses` in PreviewDiscovery.kt), so focus steps only count when no
   // GIF-mode annotation is present.
   const focusSteps = !focusGif && focused.length > 0;
 
   const scrollModes = named(SCROLLING_PREVIEW_ANNOTATION).flatMap((e) => {
-    const modes = [...e.args.matchAll(/ScrollMode\.(\w+)/g)].map((m) => m[1]);
+    const modes = scrollModeList(e.args);
     // No explicit `modes` → the annotation default, `[ScrollMode.END]`.
     return modes.length > 0 ? modes : ["END"];
   });
@@ -198,9 +248,11 @@ export function rendersStaticPng(run) {
   const productScrolls = scrollModes.filter((m) => PRODUCT_SCROLL_MODES.has(m));
 
   // `@RoboComposePreviewOptions(manualClockOptions = [...])` fans the function out
-  // into one PNG per virtual-time stop.
-  const timings = named(ROBO_OPTIONS_ANNOTATION).some((e) =>
-    /\bmanualClockOptions\s*=/.test(e.args),
+  // into one PNG per virtual-time stop. `extractRoboTimings` reads each entry's
+  // `advanceTimeMillis`, so an empty (or stop-less) array yields no timings at all
+  // and doesn't hold the static cross-product open.
+  const timings = named(ROBO_OPTIONS_ANNOTATION).some(
+    (e) => /\bmanualClockOptions\s*=/.test(e.args) && /\badvanceTimeMillis\s*=/.test(e.args),
   );
 
   return (

--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -16,6 +16,27 @@
 // a spec `preview` can reference.
 const PREVIEW_ANNOTATION = "Preview";
 
+// Capture annotations that decide whether a preview function renders a static
+// `renders/<id>.png` at all. Mirrors `emitStaticCross` in PreviewDiscovery.kt
+// (gradle-plugin/preview-discovery): a function whose ONLY capture annotations are
+// single-output GIF producers (`@AnimatedPreview`, `@FocusedPreview(gif = true)`,
+// `@ScrollingPreview` with only the data-product modes LONG/GIF) suppresses the
+// static cross-product, so no PNG is written. `@ScrollingPreview(modes = [LONG])`
+// still writes a PNG (the stitched long shot IS the render), so only the GIF cases
+// end up PNG-less.
+//
+// This matters for the spec because the catalog export's `candidatePreviewBundle()`
+// keeps only previews carrying `previews/<id>.png` — a GIF-only preview is dropped
+// from the candidate join and then reported missing by the completeness gate. See
+// bundle-previews.mjs and issue #2865.
+const ANIMATED_PREVIEW_ANNOTATION = "AnimatedPreview";
+const FOCUSED_PREVIEW_ANNOTATION = "FocusedPreview";
+const SCROLLING_PREVIEW_ANNOTATION = "ScrollingPreview";
+const ROBO_OPTIONS_ANNOTATION = "RoboComposePreviewOptions";
+// `ScrollMode` values that are emitted as data products (a tall stitched PNG /
+// scrolling GIF) rather than as ordinary captures.
+const PRODUCT_SCROLL_MODES = new Set(["LONG", "GIF"]);
+
 // A leading run of Kotlin annotations, e.g. `@CatalogModes @Preview(name = "x") `.
 // Each annotation is `@Name` optionally followed by a `(...)` argument list. The
 // arg matcher allows one level of nested parens (`@Preview(widthDp = f(1))`);
@@ -122,17 +143,72 @@ export function blankStringContents(source) {
   return out;
 }
 
+/** The `@Name` / `@Name(args…)` entries of a leading-annotation run, each with its
+ *  simple name (`a.b.CatalogModes` → `CatalogModes`) — Kotlin call sites usually
+ *  import and use the short name, which is what a multipreview `annotation class`
+ *  is declared under — and its raw argument text (`""` when there is no arg list). */
+function annotationEntries(run) {
+  const entryRe = new RegExp(String.raw`@([\w.]+)(\s*\((?:[^()]|\([^()]*\))*\))?`, "g");
+  const entries = [];
+  for (const m of run.matchAll(entryRe)) {
+    const parts = m[1].split(".");
+    entries.push({ name: parts[parts.length - 1], args: m[2] ?? "" });
+  }
+  return entries;
+}
+
 /** The set of `@Name` identifiers named in a leading-annotation run. */
 function annotationNames(run) {
-  const names = new Set();
-  for (const m of run.matchAll(/@([\w.]+)/g)) {
-    // Keep only the simple name (`a.b.CatalogModes` → `CatalogModes`) — Kotlin
-    // call sites usually import and use the short name, which is what a
-    // multipreview `annotation class` is declared under.
-    const parts = m[1].split(".");
-    names.add(parts[parts.length - 1]);
-  }
-  return names;
+  return new Set(annotationEntries(run).map((e) => e.name));
+}
+
+/**
+ * Whether a function carrying this leading-annotation run renders a static
+ * `previews/<id>.png`.
+ *
+ * Mirrors `emitStaticCross` in PreviewDiscovery.kt: the scroll × time × focus
+ * cross-product normally emits at least one PNG capture, but it is suppressed when
+ * the function's only capture annotations are single-output producers —
+ * `@AnimatedPreview`, `@FocusedPreview(gif = true)`, or a `@ScrollingPreview` whose
+ * modes are all data products (LONG/GIF, which land under `data/…` rather than
+ * `previews/<id>.png`). Those functions render, but have no static sticker for the
+ * catalog export to join on.
+ *
+ * Source-level detection is sound here because all three annotations are
+ * `@Target(FUNCTION)` — they can't hide inside a multipreview annotation class.
+ */
+export function rendersStaticPng(run) {
+  const entries = annotationEntries(run);
+  const named = (name) => entries.filter((e) => e.name === name);
+
+  const animated = named(ANIMATED_PREVIEW_ANNOTATION).length > 0;
+  const focused = named(FOCUSED_PREVIEW_ANNOTATION);
+  const focusGif = focused.some((e) => /\bgif\s*=\s*true\b/.test(e.args));
+  // `@FocusedPreview(gif = true)` supersedes the per-step focus fan-out (see
+  // `effectiveFocuses` in PreviewDiscovery.kt), so focus steps only count when no
+  // GIF-mode annotation is present.
+  const focusSteps = !focusGif && focused.length > 0;
+
+  const scrollModes = named(SCROLLING_PREVIEW_ANNOTATION).flatMap((e) => {
+    const modes = [...e.args.matchAll(/ScrollMode\.(\w+)/g)].map((m) => m[1]);
+    // No explicit `modes` → the annotation default, `[ScrollMode.END]`.
+    return modes.length > 0 ? modes : ["END"];
+  });
+  const captureScrolls = scrollModes.filter((m) => !PRODUCT_SCROLL_MODES.has(m));
+  const productScrolls = scrollModes.filter((m) => PRODUCT_SCROLL_MODES.has(m));
+
+  // `@RoboComposePreviewOptions(manualClockOptions = [...])` fans the function out
+  // into one PNG per virtual-time stop.
+  const timings = named(ROBO_OPTIONS_ANNOTATION).some((e) =>
+    /\bmanualClockOptions\s*=/.test(e.args),
+  );
+
+  return (
+    captureScrolls.length > 0 ||
+    timings ||
+    focusSteps ||
+    (!animated && !focusGif && productScrolls.length === 0)
+  );
 }
 
 /**
@@ -144,9 +220,12 @@ function annotationNames(run) {
  * @param {string[]} [opts.extraAnnotations]  Extra multipreview annotation
  *   *simple names* to treat as preview markers — for annotations declared in
  *   another module (imported), which a source-only scan can't see meta-annotated.
- * @returns {{ previews: string[], annotations: string[] }}
+ * @returns {{ previews: string[], annotations: string[], pngLess: string[] }}
  *   `previews`: sorted unique function names. `annotations`: the multipreview
  *   annotation names recognised (built-in `Preview` + discovered + extra).
+ *   `pngLess`: the subset of `previews` that render no static `previews/<id>.png`
+ *   (GIF-only / data-product-only captures — see [rendersStaticPng]); the catalog
+ *   export drops these from the candidate join, so a spec must not reference them.
  */
 export function discoverPreviews(sources, opts = {}) {
   const texts = sources.map((s) => blankStringContents(stripComments(s)));
@@ -184,16 +263,25 @@ export function discoverPreviews(sources, opts = {}) {
   // Functions whose leading run references any marker are previews.
   const funRe = new RegExp(`${LEADING_ANNOTATIONS}${MODIFIERS}fun\\s+(\\w+)`, "g");
   const previews = new Set();
+  // A function name is PNG-less only when EVERY declaration of it is (an overload
+  // or same-named function in another file that does render a sticker keeps the
+  // name joinable).
+  const pngLess = new Set();
+  const staticNames = new Set();
   for (const text of texts) {
     for (const m of text.matchAll(funRe)) {
       const names = annotationNames(m[1]);
-      if ([...names].some((a) => markers.has(a))) previews.add(m[2]);
+      if (![...names].some((a) => markers.has(a))) continue;
+      previews.add(m[2]);
+      if (rendersStaticPng(m[1])) staticNames.add(m[2]);
+      else pngLess.add(m[2]);
     }
   }
 
   return {
     previews: [...previews].sort(),
     annotations: [...markers].sort(),
+    pngLess: [...pngLess].filter((name) => !staticNames.has(name)).sort(),
   };
 }
 
@@ -277,6 +365,10 @@ export function closest(name, candidates) {
  * @param {object} spec
  * @param {object} [opts]
  * @param {string[]|Set<string>} [opts.knownPreviews]
+ * @param {string[]|Set<string>} [opts.pngLessPreviews]  Discovered preview functions
+ *   that render no static `previews/<id>.png` (see [discoverPreviews]'s `pngLess`).
+ *   Referencing one is an error: `candidatePreviewBundle()` drops it from the
+ *   candidate join and the completeness gate then reports the component missing.
  * @returns {{ errors: string[], warnings: string[] }}
  */
 export function validateSpec(spec, opts = {}) {
@@ -390,11 +482,10 @@ export function validateSpec(spec, opts = {}) {
     }
   }
 
-  const known = opts.knownPreviews
-    ? opts.knownPreviews instanceof Set
-      ? opts.knownPreviews
-      : new Set(opts.knownPreviews)
-    : null;
+  const known = toSet(opts.knownPreviews);
+  // PNG-less previews are still legitimately discovered @Preview functions, so they
+  // resolve — but they can't be catalog entries.
+  const pngLess = toSet(opts.pngLessPreviews) ?? new Set();
   if (known) {
     for (const [preview, paths] of previewToPaths) {
       if (!known.has(preview)) {
@@ -403,10 +494,20 @@ export function validateSpec(spec, opts = {}) {
         errors.push(
           `preview "${preview}" (${paths[0]}) matches no @Preview function in the scanned module${suffix}`,
         );
+      } else if (pngLess.has(preview)) {
+        errors.push(
+          `preview "${preview}" (${paths[0]}) renders no static PNG — it is an animated/data-product ` +
+            `capture (@AnimatedPreview, @FocusedPreview(gif = true), or @ScrollingPreview with only ` +
+            `LONG/GIF modes). The catalog export drops PNG-less previews from the candidate join, so ` +
+            `this entry would be reported missing by the completeness gate. Point it at a static ` +
+            `@Preview function (a plain @Preview sibling of the animated one works).`,
+        );
       }
     }
     const referenced = new Set(previewToPaths.keys());
-    const orphans = [...known].filter((p) => !referenced.has(p));
+    // PNG-less previews can't be catalogued at all, so their absence isn't a
+    // coverage gap worth reporting.
+    const orphans = [...known].filter((p) => !referenced.has(p) && !pngLess.has(p));
     if (orphans.length > 0) {
       warnings.push(
         `${orphans.length} @Preview function(s) not in the catalog: ${orphans.slice(0, 12).join(", ")}${orphans.length > 12 ? ", …" : ""}`,
@@ -415,6 +516,12 @@ export function validateSpec(spec, opts = {}) {
   }
 
   return { errors, warnings };
+}
+
+/** Normalise an optional array-or-Set option to a Set, or null when absent. */
+function toSet(value) {
+  if (!value) return null;
+  return value instanceof Set ? value : new Set(value);
 }
 
 function pushMulti(map, key, value) {

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -299,3 +299,129 @@ test("buildSkeletonSpec produces an editable one-group spec", () => {
   const { errors } = validateSpec(spec, { knownPreviews: ["Alpha", "Beta"] });
   assert.deepEqual(errors, []);
 });
+
+test("discoverPreviews flags GIF-only captures as PNG-less", () => {
+  const src = `
+    @Preview(name = "Toggle")
+    @AnimatedPreview(durationMs = 1000, frameIntervalMs = 100)
+    @Composable fun ToggleAnimatedPreview() {}
+
+    @Preview @Composable fun Static() {}
+
+    @Preview
+    @FocusedPreview(gif = true)
+    @Composable fun FocusGif() {}
+
+    @Preview
+    @ScrollingPreview(modes = [ScrollMode.GIF])
+    @Composable fun ScrollGif() {}
+
+    @Preview
+    @ScrollingPreview(modes = [ScrollMode.LONG])
+    @Composable fun ScrollLong() {}
+  `;
+  const { previews, pngLess } = discoverPreviews([src]);
+  assert.deepEqual(previews, [
+    "FocusGif",
+    "ScrollGif",
+    "ScrollLong",
+    "Static",
+    "ToggleAnimatedPreview",
+  ]);
+  // LONG and GIF are both data products written under `data/…`, never
+  // `previews/<id>.png`, so neither is catalogable.
+  assert.deepEqual(pngLess, ["FocusGif", "ScrollGif", "ScrollLong", "ToggleAnimatedPreview"]);
+});
+
+test("discoverPreviews keeps previews whose GIF sits alongside a static capture", () => {
+  const src = `
+    @Preview
+    @AnimatedPreview
+    @ScrollingPreview(modes = [ScrollMode.END, ScrollMode.GIF])
+    @Composable fun ScrolledAndAnimated() {}
+
+    @Preview
+    @FocusedPreview(indices = [0, 1])
+    @Composable fun FocusSteps() {}
+
+    @Preview
+    @ScrollingPreview
+    @Composable fun DefaultScroll() {}
+
+    @Preview
+    @RoboComposePreviewOptions(manualClockOptions = [ManualClockOptions(advanceTimeMillis = 300)])
+    @AnimatedPreview
+    @Composable fun TimedAndAnimated() {}
+  `;
+  const { pngLess } = discoverPreviews([src]);
+  assert.deepEqual(pngLess, []);
+});
+
+test("discoverPreviews only calls a name PNG-less when every declaration is", () => {
+  const animated = `
+    @Preview @AnimatedPreview @Composable fun Shared() {}
+  `;
+  const stat = `
+    @Preview @Composable fun Shared() {}
+  `;
+  assert.deepEqual(discoverPreviews([animated, stat]).pngLess, []);
+});
+
+test("validateSpec rejects a component pointing at a PNG-less preview", () => {
+  const spec = {
+    system: "s",
+    title: "T",
+    groups: [
+      {
+        name: "Motion",
+        components: [{ componentId: "Motion/Toggle", preview: "ToggleAnimatedPreview" }],
+      },
+    ],
+  };
+  const { errors } = validateSpec(spec, {
+    knownPreviews: ["ToggleAnimatedPreview", "Static"],
+    pngLessPreviews: ["ToggleAnimatedPreview"],
+  });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes('preview "ToggleAnimatedPreview"'));
+  assert.ok(errors[0].includes("renders no static PNG"));
+});
+
+test("validateSpec rejects a PNG-less preview referenced from a variant", () => {
+  const spec = {
+    system: "s",
+    title: "T",
+    groups: [
+      {
+        name: "G",
+        components: [
+          {
+            componentId: "A",
+            preview: "Static",
+            variants: [{ state: "pressed", preview: "PressedGif" }],
+          },
+        ],
+      },
+    ],
+  };
+  const { errors } = validateSpec(spec, {
+    knownPreviews: ["Static", "PressedGif"],
+    pngLessPreviews: ["PressedGif"],
+  });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes("variants[0]"));
+});
+
+test("validateSpec does not report PNG-less previews as coverage orphans", () => {
+  const spec = {
+    system: "s",
+    title: "T",
+    groups: [{ name: "G", components: [{ componentId: "A", preview: "Static" }] }],
+  };
+  const { errors, warnings } = validateSpec(spec, {
+    knownPreviews: ["Static", "ToggleAnimatedPreview"],
+    pngLessPreviews: ["ToggleAnimatedPreview"],
+  });
+  assert.deepEqual(errors, []);
+  assert.deepEqual(warnings, []);
+});

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -309,7 +309,7 @@ test("discoverPreviews flags GIF-only captures as PNG-less", () => {
     @Preview @Composable fun Static() {}
 
     @Preview
-    @FocusedPreview(gif = true)
+    @FocusedPreview(gif = true, indices = [0, 1, 2])
     @Composable fun FocusGif() {}
 
     @Preview
@@ -424,4 +424,59 @@ test("validateSpec does not report PNG-less previews as coverage orphans", () =>
   });
   assert.deepEqual(errors, []);
   assert.deepEqual(warnings, []);
+});
+
+test("discoverPreviews keeps a singleton @FocusedPreview(gif = true) PNG-capable", () => {
+  // `extractFocusGifSpec` bails below two steps (a one-frame GIF wouldn't animate),
+  // so these fall back to the ordinary focus fan-out and do render a static PNG.
+  const src = `
+    @Preview @FocusedPreview(gif = true) @Composable fun DefaultIndex() {}
+    @Preview @FocusedPreview(gif = true, indices = [2]) @Composable fun OneIndex() {}
+    @Preview @FocusedPreview(gif = true, indices = [1, 1]) @Composable fun RepeatedIndex() {}
+    @Preview @FocusedPreview(gif = true, traverse = [FocusDirection.Next]) @Composable fun OneStep() {}
+  `;
+  assert.deepEqual(discoverPreviews([src]).pngLess, []);
+  // Two or more steps really is GIF-only, in either mode.
+  const gifs = `
+    @Preview @FocusedPreview(gif = true, indices = [0, 1]) @Composable fun TwoIndices() {}
+    @Preview
+    @FocusedPreview(gif = true, traverse = [FocusDirection.Next, FocusDirection.Previous])
+    @Composable fun TwoSteps() {}
+  `;
+  assert.deepEqual(discoverPreviews([gifs]).pngLess, ["TwoIndices", "TwoSteps"]);
+});
+
+test("discoverPreviews recognises directly imported ScrollMode entries", () => {
+  const src = `
+    import ee.schimke.composeai.preview.ScrollMode.GIF
+    @Preview @ScrollingPreview(modes = [GIF]) @Composable fun BareGif() {}
+    @Preview @ScrollingPreview(modes = [LONG]) @Composable fun BareLong() {}
+    @Preview @ScrollingPreview(modes = [END, GIF]) @Composable fun BareEndAndGif() {}
+    @Preview @ScrollingPreview([ScrollMode.GIF]) @Composable fun PositionalGif() {}
+  `;
+  const { pngLess } = discoverPreviews([src]);
+  assert.deepEqual(pngLess, ["BareGif", "BareLong", "PositionalGif"]);
+});
+
+test("discoverPreviews does not read a sibling argument as a scroll mode", () => {
+  // `DEFAULT_GIF_FRAME_INTERVAL_MS` must not register as ScrollMode.GIF, and the
+  // annotation still defaults to `[ScrollMode.END]` — a static capture.
+  const src = `
+    @Preview
+    @ScrollingPreview(frameIntervalMs = DEFAULT_GIF_FRAME_INTERVAL_MS, maxScrollPx = 800)
+    @Composable fun DefaultModeWithArgs() {}
+  `;
+  assert.deepEqual(discoverPreviews([src]).pngLess, []);
+});
+
+test("discoverPreviews ignores a manualClockOptions array with no stops", () => {
+  // `extractRoboTimings` reads each entry's `advanceTimeMillis`, so an empty array
+  // is zero timings — the animation still suppresses the static cross-product.
+  const src = `
+    @Preview
+    @RoboComposePreviewOptions(manualClockOptions = [])
+    @AnimatedPreview
+    @Composable fun EmptyClockStops() {}
+  `;
+  assert.deepEqual(discoverPreviews([src]).pngLess, ["EmptyClockStops"]);
 });

--- a/scripts/design-artifacts/init-catalog-spec.mjs
+++ b/scripts/design-artifacts/init-catalog-spec.mjs
@@ -57,13 +57,23 @@ if (sources.length === 0) {
   process.exit(1);
 }
 
-const { previews, annotations } = discoverPreviews(sources, {
+const { previews: discovered, annotations, pngLess } = discoverPreviews(sources, {
   extraAnnotations: values["preview-annotation"] ?? [],
 });
+// PNG-less previews (@AnimatedPreview / @FocusedPreview(gif = true) / LONG-GIF-only
+// @ScrollingPreview) render no static sticker, so the catalog export drops them and
+// the completeness gate reports them missing — scaffolding them in would produce a
+// spec that fails validation. See catalog-spec.mjs `rendersStaticPng`.
+const skipped = new Set(pngLess);
+const previews = discovered.filter((p) => !skipped.has(p));
 if (previews.length === 0) {
   console.error(
-    `init-catalog-spec: found no @Preview functions under ${dirs.join(", ")}. ` +
-      `If your previews use an imported multipreview annotation, pass it via --preview-annotation.`,
+    skipped.size > 0
+      ? `init-catalog-spec: every @Preview function under ${dirs.join(", ")} renders only an ` +
+          `animated GIF / scroll data product (${[...skipped].join(", ")}) — none can be a catalog ` +
+          `entry. Add a static @Preview sibling for the components you want catalogued.`
+      : `init-catalog-spec: found no @Preview functions under ${dirs.join(", ")}. ` +
+          `If your previews use an imported multipreview annotation, pass it via --preview-annotation.`,
   );
   process.exit(1);
 }
@@ -82,5 +92,9 @@ await writeFile(values.out, JSON.stringify(spec, null, 2) + "\n", "utf8");
 console.error(
   `Wrote ${values.out}: ${previews.length} component(s) in one "Components" group ` +
     `(recognised preview annotations: ${annotations.join(", ")}).\n` +
+    (skipped.size > 0
+      ? `Skipped ${skipped.size} PNG-less preview(s) — animated GIF / scroll data products the ` +
+        `catalog export can't join: ${[...skipped].join(", ")}.\n`
+      : "") +
     `Next: group/caption them, add variants, then \`node validate-catalog-spec.mjs --spec ${values.out}\`.`,
 );

--- a/scripts/design-artifacts/validate-catalog-spec.mjs
+++ b/scripts/design-artifacts/validate-catalog-spec.mjs
@@ -51,16 +51,18 @@ try {
 const srcDirs = values["module-dir"] ? [values["module-dir"], ...(values.src ?? [])] : values.src;
 
 let knownPreviews = null;
+let pngLessPreviews = [];
 let annotatedInventory = undefined;
 let scannedDirs = [];
 if (!values["no-scan"]) {
   scannedDirs = resolveSourceDirs({ srcDirs, spec, specPath: values.spec });
   if (scannedDirs.length > 0) {
     const sources = await collectKotlinSources(scannedDirs);
-    const { previews } = discoverPreviews(sources, {
+    const { previews, pngLess } = discoverPreviews(sources, {
       extraAnnotations: values["preview-annotation"] ?? [],
     });
     knownPreviews = previews;
+    pngLessPreviews = pngLess;
     // Only meaningful when a module was scanned; leaves `annotatedInventory` undefined (lenient) on
     // the structural-only path so a no-groups spec isn't wrongly rejected without source access.
     annotatedInventory = hasCatalogAnnotations(sources);
@@ -68,7 +70,7 @@ if (!values["no-scan"]) {
 }
 
 const { errors, warnings } = validateSpec(spec, {
-  ...(knownPreviews ? { knownPreviews } : {}),
+  ...(knownPreviews ? { knownPreviews, pngLessPreviews } : {}),
   ...(annotatedInventory !== undefined ? { annotatedInventory } : {}),
 });
 
@@ -79,6 +81,7 @@ if (values.json) {
         spec: values.spec,
         scannedDirs,
         discoveredPreviews: knownPreviews ? knownPreviews.length : null,
+        pngLessPreviews,
         errors,
         warnings,
         ok: errors.length === 0,
@@ -90,7 +93,10 @@ if (values.json) {
 } else {
   if (knownPreviews) {
     console.log(
-      `Scanned ${scannedDirs.length} source dir(s); discovered ${knownPreviews.length} @Preview function(s).`,
+      `Scanned ${scannedDirs.length} source dir(s); discovered ${knownPreviews.length} @Preview function(s)` +
+        (pngLessPreviews.length > 0
+          ? `, ${pngLessPreviews.length} of them PNG-less (not catalogable): ${pngLessPreviews.join(", ")}.`
+          : "."),
     );
   } else {
     console.log(

--- a/scripts/design-artifacts/validate-samples.test.mjs
+++ b/scripts/design-artifacts/validate-samples.test.mjs
@@ -29,12 +29,15 @@ for (const rel of SAMPLE_SPECS) {
     // the module directory here rather than relying on cwd-based derivation.
     const moduleDir = resolve(repoRoot, moduleToDir(spec.module));
     const sources = await collectKotlinSources([moduleDir]);
-    const { previews } = discoverPreviews(sources);
+    const { previews, pngLess } = discoverPreviews(sources);
     assert.ok(previews.length > 0, `discovered no @Preview functions for ${rel}`);
     // Pass whether the module carries @CatalogComponent annotations, so a cover-sheet-only spec
-    // (no `groups`) is accepted iff its inventory really is annotation-supplied.
+    // (no `groups`) is accepted iff its inventory really is annotation-supplied. `pngLess` catches
+    // the other half of the same class of bug: a spec entry pointing at a GIF-only capture the
+    // export drops (issue #2865).
     const { errors } = validateSpec(spec, {
       knownPreviews: previews,
+      pngLessPreviews: pngLess,
       annotatedInventory: hasCatalogAnnotations(sources),
     });
     assert.deepEqual(errors, [], `${rel} has spec errors:\n${errors.join("\n")}`);


### PR DESCRIPTION
Fixes #2865

## Problem

A `catalog.spec.json` component could point at a function whose only rendered capture is an animated GIF — `@Preview` + `@AnimatedPreview` being the case that surfaced in #2865. `validate-catalog-spec.mjs` reported the spec valid (the function *is* a discovered `@Preview`), but the export's `candidatePreviewBundle()` keeps only previews carrying `previews/<id>.png`, so the entry was dropped from the candidate join and the completeness gate reported the component missing — after the ~90-minute render.

This takes the issue's second option: align the fast validator with the completeness gate, so the failure lands in the build-free pre-flight instead of at publish time.

## Change

`discoverPreviews` now also returns `pngLess` — preview functions that render no static PNG. The rule mirrors `emitStaticCross` in `PreviewDiscovery.kt` rather than special-casing `@AnimatedPreview`, so it covers every way a function ends up sticker-less:

| annotations on the function | static PNG? |
| --- | --- |
| `@AnimatedPreview` alone | no |
| `@FocusedPreview(gif = true)` with **two or more** steps | no |
| `@FocusedPreview(gif = true)` with one step (e.g. the default `indices = [0]`) | **yes** — `extractFocusGifSpec` bails below two steps, so the ordinary focus fan-out runs |
| `@ScrollingPreview(modes = [GIF])` / `[LONG]` alone | no — those land under `data/…`, not `previews/<id>.png` |
| any GIF producer **plus** a TOP/END scroll, a real `advanceTimeMillis` stop, or a non-GIF `@FocusedPreview` | yes — the static cross-product still runs |

Mode names are read from the `modes` array and accept both `ScrollMode.GIF` and a directly imported `GIF`; scoping to that array keeps a sibling `frameIntervalMs = DEFAULT_GIF_FRAME_INTERVAL_MS` from reading as a mode. A `manualClockOptions` array only counts as a timing fan-out when it actually carries an `advanceTimeMillis` stop.

Source-level detection is sound because all three capture annotations are `@Target(FUNCTION)` — they can't hide inside a multipreview annotation class. A name is only called PNG-less when *every* declaration of it is, and any `indices` / `traverse` / `modes` value that isn't a literal array reads as the annotation default — an unparseable annotation stays on the PNG-capable side, since a missed error costs a late gate failure while a false one blocks a legitimate spec.

Then:

- `validateSpec` gains `pngLessPreviews` and errors when a component or variant references one, naming the annotation family and pointing at the static-sibling fix. It also stops listing them as coverage orphans — they can't be catalogued at all, so their absence isn't a gap.
- `validate-catalog-spec` passes the set through, names PNG-less previews on its discovery line, and reports them in `--json`.
- `init-catalog-spec` skips them when scaffolding, so a fresh spec can't be born invalid (with a clear error if *every* preview in the module is PNG-less).
- `validate-samples.test.mjs` — the committed-spec regression guard — now checks the same property.

## Test plan

- `node --test` in `scripts/design-artifacts/`: 233 passing, 0 failing (223 on `main`; `catalog-spec.test.mjs` goes 22 → 32). New cases cover the issue's exact repro, each PNG-less annotation shape, the singleton-vs-multi-step focus GIF boundary, imported/positional scroll modes, the stop-less `manualClockOptions` case, component + variant references, and the orphan-warning suppression.
- Ran the real CLI over the committed sample catalogs:

  ```
  $ node scripts/design-artifacts/validate-catalog-spec.mjs \
      --spec samples/design-catalog-wear-m3/catalog.spec.json --module-dir samples/design-catalog-wear-m3
  Scanned 1 source dir(s); discovered 31 @Preview function(s), 2 of them PNG-less
  (not catalogable): CardScalingScrollGif, IndeterminateCircularProgressGif.
  OK — 0 warning(s), 0 errors.

  $ node scripts/design-artifacts/validate-catalog-spec.mjs \
      --spec samples/design-catalog-m3/catalog.spec.json --module-dir samples/design-catalog-m3
  Scanned 1 source dir(s); discovered 39 @Preview function(s).
  OK — 0 warning(s), 0 errors.
  ```

  Those two wear previews are exactly the ones the export already logs as dropped — detected with no false positives across the three sample modules, and neither is referenced by a spec, so no committed catalog changes.

No visual surfaces touched — this is validator/scaffolder plumbing, so there's nothing to render. The other option in #2865 (making animated GIFs first-class `Animations` catalog entries) is a larger export/schema change and is not attempted here.
