### PR TITLE
fix(lottie): settle each swept APNG frame before capturing

### DIFF
--- a/.github/actions/apply/lib/post-comment.sh
+++ b/.github/actions/apply/lib/post-comment.sh
@@ -56,8 +56,14 @@ COMMENT_ID=$(gh api \
   | head -1)
 
 if [ -n "$COMMENT_ID" ]; then
+  # `-F`, not `-f`: only `--field` expands a leading `@` into the file's
+  # contents. `--raw-field` sends the value verbatim, so `-f body=@file`
+  # PATCHed the sticky comment to the literal string "@_comment_body.md",
+  # wiping the rendered diff off every PR whose comment already existed
+  # (issue #2868). The first post is unaffected — it goes through
+  # `gh pr comment --body-file` below.
   gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
-    -X PATCH -f "body=@${BODY_FILE}"
+    -X PATCH -F "body=@${BODY_FILE}"
 else
   gh pr comment "$PR_NUMBER" --body-file "$BODY_FILE"
 fi

--- a/.github/actions/apply/lib/test-post-comment.sh
+++ b/.github/actions/apply/lib/test-post-comment.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Self-test for `post-comment.sh`, the sticky-comment upsert every preview
+# pipeline posts through.
+#
+# The regression it guards (issue #2868): the PATCH branch passed the body as
+# `gh api -f body=@FILE`. `--raw-field` sends its value verbatim, so the
+# sticky comment was rewritten to the literal string "@_comment_body.md" —
+# silently destroying the rendered preview diff on every PR whose comment
+# already existed. Only `--field` (`-F`) expands a leading `@` into the file's
+# contents. The fake `gh` below models exactly that distinction, so this test
+# fails if the flag ever regresses.
+#
+# Pure bash + a stub `gh` on PATH; no network, no gh CLI required.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+UNDER_TEST="$SCRIPT_DIR/post-comment.sh"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+FAILURES=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "ok - $*"
+}
+
+# --- stub gh -----------------------------------------------------------------
+# Models the three calls post-comment.sh makes:
+#   gh api repos/O/R/issues/N/comments --paginate --jq ...   → prints $GH_EXISTING_ID
+#   gh api repos/O/R/issues/comments/ID -X PATCH -F body=... → records the body
+#   gh pr comment N --body-file FILE                         → records the body
+# `-F name=@file` reads the file; `-f name=@file` does not. That asymmetry is
+# the whole point of the fixture.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+record() { printf '%s' "$1" > "$GH_RECORDED_BODY"; }
+
+case "${1:-}" in
+  api)
+    shift
+    # Listing call: `--jq` present and no `-X PATCH`.
+    if [[ " $* " == *" --paginate "* ]]; then
+      printf '%s\n' "${GH_EXISTING_ID:-}"
+      exit 0
+    fi
+    echo "PATCH" > "$GH_RECORDED_METHOD"
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -F)
+          value="${2#*=}"
+          # --field: a leading @ means "read from this file".
+          if [ "${value:0:1}" = "@" ]; then
+            record "$(cat "${value:1}")"
+          else
+            record "$value"
+          fi
+          shift 2
+          ;;
+        -f)
+          # --raw-field: verbatim, @ and all. This is the bug shape.
+          record "${2#*=}"
+          shift 2
+          ;;
+        *) shift ;;
+      esac
+    done
+    ;;
+  pr)
+    shift # pr
+    shift # comment
+    echo "POST" > "$GH_RECORDED_METHOD"
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --body-file) record "$(cat "$2")"; shift 2 ;;
+        --body) record "$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    ;;
+  *)
+    echo "stub gh: unexpected command: $*" >&2
+    exit 64
+    ;;
+esac
+STUB
+chmod +x "$WORK/bin/gh"
+export PATH="$WORK/bin:$PATH"
+
+export REPO="acme/widgets"
+export PR_NUMBER="42"
+export MARKER="<!-- preview-diff -->"
+export GH_TOKEN="stub-token"
+export GH_RECORDED_BODY="$WORK/body.out"
+export GH_RECORDED_METHOD="$WORK/method.out"
+
+run_under_test() {
+  : > "$GH_RECORDED_BODY"
+  : > "$GH_RECORDED_METHOD"
+  bash "$UNDER_TEST" > /dev/null
+}
+
+# --- 1. updating an existing comment sends the file's contents ---------------
+BODY_FILE="$WORK/comment_body.md"
+export BODY_FILE
+{
+  echo "$MARKER"
+  echo "## Preview Diff"
+  echo
+  echo "| Preview | Before | After |"
+  echo "| --- | --- | --- |"
+  echo "| LottieSpin | ![](a.png) | ![](b.png) |"
+} > "$BODY_FILE"
+
+GH_EXISTING_ID="991122" run_under_test
+if [ "$(cat "$GH_RECORDED_METHOD")" != "PATCH" ]; then
+  fail "an existing sticky comment should be PATCHed, got $(cat "$GH_RECORDED_METHOD")"
+elif [ "$(cat "$GH_RECORDED_BODY")" != "$(cat "$BODY_FILE")" ]; then
+  fail "PATCH body should be the file's contents, got: $(cat "$GH_RECORDED_BODY")"
+elif [ "$(cat "$GH_RECORDED_BODY")" = "@$BODY_FILE" ]; then
+  fail "PATCH body is the literal @path — the -f/-F regression is back"
+else
+  pass "PATCH sends the body file's contents, not its path"
+fi
+
+# --- 2. a first-time comment posts the same contents -------------------------
+GH_EXISTING_ID="" run_under_test
+if [ "$(cat "$GH_RECORDED_METHOD")" != "POST" ]; then
+  fail "with no existing comment a fresh one should be posted"
+elif [ "$(cat "$GH_RECORDED_BODY")" != "$(cat "$BODY_FILE")" ]; then
+  fail "POST body should be the file's contents, got: $(cat "$GH_RECORDED_BODY")"
+else
+  pass "POST sends the body file's contents"
+fi
+
+# --- 3. an over-long body is truncated, still by file ------------------------
+BIG_FILE="$WORK/big_body.md"
+export BODY_FILE="$BIG_FILE"
+{
+  echo "$MARKER"
+  for _ in $(seq 1 4000); do
+    echo "a padding line that exists purely to blow past the byte budget......"
+  done
+} > "$BIG_FILE"
+
+COMMENT_MAX_BYTES=5000 GH_EXISTING_ID="991122" run_under_test
+sent_bytes=$(wc -c < "$GH_RECORDED_BODY")
+if [ "$sent_bytes" -ge 5000 ]; then
+  fail "over-long body should be truncated under the budget, sent $sent_bytes bytes"
+elif ! head -1 "$GH_RECORDED_BODY" | grep -qF "$MARKER"; then
+  fail "truncated body should keep the marker on the first line"
+elif ! grep -qF "truncated" "$GH_RECORDED_BODY"; then
+  fail "truncated body should carry the truncation notice"
+else
+  pass "over-long body is truncated, keeps its marker, and is still sent by file"
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo "post-comment self-test: $FAILURES failure(s)" >&2
+  exit 1
+fi
+echo "post-comment self-test: all checks passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,6 +574,8 @@ jobs:
         run: python3 .github/actions/lib/test_xr_gallery.py -v
       - name: Run apply skew-guard tests
         run: python3 .github/actions/apply/test_check_skew.py -v
+      - name: Run post-comment tests
+        run: bash .github/actions/apply/lib/test-post-comment.sh
       - name: Run apply change-scope tests
         run: python3 .github/actions/apply/test_compute_scope.py -v
       - name: Run change-scope classifier tests

--- a/docs/LOTTIE_PREVIEWS.md
+++ b/docs/LOTTIE_PREVIEWS.md
@@ -75,6 +75,14 @@ parse and Skia surface allocation happen once, not once per frame. Each RGBA fra
 PNG is stitched into the APNG by `renderer-desktop`'s pure-JVM `ApngEncoder`, which copies each
 frame's `IDAT` verbatim (no re-quantisation, so the alpha is preserved).
 
+Each step is captured only once its pixels have *settled*: Compottie publishes a new `progress` to
+its painter from another thread, so how many render passes the handoff needs varies run to run, and
+a fixed pass count let the capture keep the previous step's pixels now and then. A single duplicated
+frame rewrites the whole APNG, which is why the committed baseline flapped between two byte-states
+and the diff bot reported `lottie/spin.json` as changed on unrelated PRs (issue #2868). The capture
+therefore re-renders until three consecutive passes encode identically (bounded at eight) instead of
+trusting a pass count.
+
 The animated capture is **optional** in discovery: if a headless env can't encode it, the missing
 artefact never trips `composePreviewRenderAll`'s required-render gate — the still PNG remains the
 required baseline.

--- a/docs/LOTTIE_PREVIEWS.md
+++ b/docs/LOTTIE_PREVIEWS.md
@@ -80,8 +80,9 @@ its painter from another thread, so how many render passes the handoff needs var
 a fixed pass count let the capture keep the previous step's pixels now and then. A single duplicated
 frame rewrites the whole APNG, which is why the committed baseline flapped between two byte-states
 and the diff bot reported `lottie/spin.json` as changed on unrelated PRs (issue #2868). The capture
-therefore re-renders until three consecutive passes encode identically (bounded at eight) instead of
-trusting a pass count.
+therefore re-renders until the frame has both moved off the previous step's settled bytes — which is
+precisely what a stale capture would still be showing — and stopped changing, bounded at eight
+passes. Only a genuinely held frame reaches that bound.
 
 The animated capture is **optional** in discovery: if a headless env can't encode it, the missing
 artefact never trips `composePreviewRenderAll`'s required-render gate — the still PNG remains the

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopLottieRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopLottieRenderer.kt
@@ -48,10 +48,10 @@ const val MAX_LOTTIE_GIF_DURATION_MS: Int = 5000
  * round(durationMs / interval)` frames, progress stepped `i / frameCount` so the loop wraps
  * seamlessly. Holds a single [ImageComposeScene] and sweeps a snapshot-backed progress state across
  * it (`Snapshot.sendApplyNotifications()` flushes each step, then [renderSettledFrame] renders
- * until the pixels stop changing), so the Compottie parse + Skia surface allocation happen once.
- * Each captured frame is written as a PNG and stitched by [ApngEncoder], which copies each frame's
- * `IDAT` verbatim — so the RGBA (alpha-carrying) frames Skiko emits become an alpha-carrying APNG
- * with no re-quantisation.
+ * until that step has demonstrably reached the painter), so the Compottie parse + Skia surface
+ * allocation happen once. Each captured frame is written as a PNG and stitched by [ApngEncoder],
+ * which copies each frame's `IDAT` verbatim — so the RGBA (alpha-carrying) frames Skiko emits
+ * become an alpha-carrying APNG with no re-quantisation.
  *
  * Returns the written [outputFile], or throws (propagated by the caller) when the asset can't be
  * inflated or a frame can't be encoded.
@@ -97,11 +97,15 @@ fun renderLottieApng(
     }
     // Settle the first composition before sampling, mirroring the still + GIF paths.
     scene.render()
+    // The previous step's settled bytes double as the "stale" reference the next step must move
+    // off — see [renderSettledFrame].
+    var settled: ByteArray? = null
     for (i in 0 until frameCount) {
       progress.floatValue = i.toFloat() / frameCount
       Snapshot.sendApplyNotifications()
+      settled = renderSettledFrame(scene, i, settled)
       val frameFile = File(frameDir, "frame-%05d.png".format(i))
-      frameFile.writeBytes(renderSettledFrame(scene, i))
+      frameFile.writeBytes(settled)
       frameFiles += frameFile
     }
   } finally {
@@ -123,21 +127,16 @@ fun renderLottieApng(
 }
 
 /**
- * How many consecutive render passes must agree byte-for-byte before a swept frame is accepted as
- * settled. Three, not two: a single agreeing pair can still be two *stale* passes when the progress
- * step is late reaching the painter, and one duplicated frame is enough to rewrite the whole APNG.
- */
-private const val LOTTIE_SETTLE_AGREEMENTS: Int = 3
-
-/**
- * Upper bound on render passes per swept frame, so a pathological asset that never reaches
- * [LOTTIE_SETTLE_AGREEMENTS] agreeing passes still terminates with its most recent pixels rather
- * than spinning.
+ * Upper bound on render passes per swept frame. Reached only when a step's pixels genuinely equal
+ * the previous step's (a held segment of the timeline, where "has the new progress landed?" is
+ * unanswerable from the pixels because both answers look the same) — at which point the accumulated
+ * passes are themselves the evidence, and the held pixels are returned.
  */
 private const val MAX_LOTTIE_SETTLE_PASSES: Int = 8
 
 /**
- * Render [scene] repeatedly until the encoded PNG stops changing, and return the settled bytes.
+ * Render [scene] until the requested progress step has demonstrably reached the painter, and return
+ * the settled PNG bytes.
  *
  * Compottie routes a new `progress` to its painter through work that lands *after* the pass that
  * applied the snapshot — usually on the very next pass, but not always, because that work is
@@ -148,22 +147,39 @@ private const val MAX_LOTTIE_SETTLE_PASSES: Int = 8
  * committed APNG's bytes flipped between two states push after push and the diff bot reported
  * `lottie/spin.json` as changed on PRs that never touched it (issue #2868).
  *
- * Converging on the pixels instead makes the capture independent of how many passes the async
- * handoff needs. A step whose progress already landed on the first pass settles immediately at the
- * [LOTTIE_SETTLE_AGREEMENTS]th identical pass; a late one keeps rendering until the new pixels
- * appear and then agree. `render()` defaults to nanoTime 0, so the extra passes advance no
- * clock-driven animation — they only drain pending work.
+ * Counting agreeing passes alone doesn't fix it either: if the handoff is late enough, the first N
+ * passes can *all* carry the previous step's pixels and agree with each other, and the loop latches
+ * on the stale frame. What makes the stale case decidable is that the stale pixels are not just any
+ * pixels — they are exactly [previousFrame], the bytes the last step settled on. So a pass counts
+ * as settled only once it has both moved off [previousFrame] and stopped changing. A late handoff
+ * can no longer satisfy that by standing still, because standing still is the very thing being
+ * rejected.
+ *
+ * The one case the pixels can't decide is a genuinely held frame, where the new progress renders
+ * identically to the previous step. That runs to [MAX_LOTTIE_SETTLE_PASSES] and returns the held
+ * pixels, which is the right answer either way: the previous step itself only returned once *it*
+ * had settled, so no work was outstanding when this step began, and pumping the full pass allowance
+ * with nothing else pending leaves "the frame is genuinely identical" as the explanation.
+ * Continuously moving assets like `lottie/spin.json` never reach the cap.
+ *
+ * [previousFrame] is null for the first step, which has no predecessor to be stale against; it
+ * settles on two agreeing passes, matching the still-capture path. `render()` defaults to nanoTime
+ * 0, so the extra passes advance no clock-driven animation — they only drain pending work.
  */
-private fun renderSettledFrame(scene: ImageComposeScene, frameIndex: Int): ByteArray {
-  var previous: ByteArray? = null
-  var agreements = 1
+private fun renderSettledFrame(
+  scene: ImageComposeScene,
+  frameIndex: Int,
+  previousFrame: ByteArray?,
+): ByteArray {
+  var last: ByteArray? = null
   repeat(MAX_LOTTIE_SETTLE_PASSES) {
     val bytes =
       scene.render().encodeToData(EncodedImageFormat.PNG)?.bytes
         ?: error("Failed to encode Lottie APNG frame $frameIndex to PNG")
-    agreements = if (previous?.contentEquals(bytes) == true) agreements + 1 else 1
-    previous = bytes
-    if (agreements >= LOTTIE_SETTLE_AGREEMENTS) return bytes
+    val stable = last?.contentEquals(bytes) == true
+    val advanced = previousFrame == null || !bytes.contentEquals(previousFrame)
+    last = bytes
+    if (stable && advanced) return bytes
   }
-  return previous ?: error("Failed to render Lottie APNG frame $frameIndex")
+  return last ?: error("Failed to render Lottie APNG frame $frameIndex")
 }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopLottieRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopLottieRenderer.kt
@@ -47,9 +47,9 @@ const val MAX_LOTTIE_GIF_DURATION_MS: Int = 5000
  * Captures the asset's intrinsic-duration window sampled at [frameIntervalMs] into `frameCount =
  * round(durationMs / interval)` frames, progress stepped `i / frameCount` so the loop wraps
  * seamlessly. Holds a single [ImageComposeScene] and sweeps a snapshot-backed progress state across
- * it (`Snapshot.sendApplyNotifications()` flushes each step, then a settle pass lands it before the
- * capture — see the loop), so the Compottie parse + Skia surface allocation happen once. Each
- * captured frame is written as a PNG and stitched by [ApngEncoder], which copies each frame's
+ * it (`Snapshot.sendApplyNotifications()` flushes each step, then [renderSettledFrame] renders
+ * until the pixels stop changing), so the Compottie parse + Skia surface allocation happen once.
+ * Each captured frame is written as a PNG and stitched by [ApngEncoder], which copies each frame's
  * `IDAT` verbatim — so the RGBA (alpha-carrying) frames Skiko emits become an alpha-carrying APNG
  * with no re-quantisation.
  *
@@ -100,21 +100,8 @@ fun renderLottieApng(
     for (i in 0 until frameCount) {
       progress.floatValue = i.toFloat() / frameCount
       Snapshot.sendApplyNotifications()
-      // Two passes per step; the second one is the capture. Compottie routes the new progress to
-      // its painter through a snapshot observer that *usually* — but not always — lands before
-      // the same pass draws, so a single pass now and then captured the previous step's pixels.
-      // That surfaced as a random handful of duplicated frames per run (frames 3 and 21 in one CI
-      // render, frame 25 in the next, none in a third), which rewrote the committed APNG's bytes
-      // on every push and made the diff bot report `lottie/spin.json` as changed on every PR. The
-      // settle pass drains that pending work; `render()` defaults to nanoTime 0, so it advances no
-      // clock-driven animation. Same two-render settle every other desktop capture path uses (see
-      // DesktopRendererMain's still Lottie + SVG paths).
-      scene.render()
-      val png =
-        scene.render().encodeToData(EncodedImageFormat.PNG)
-          ?: error("Failed to encode Lottie APNG frame $i to PNG")
       val frameFile = File(frameDir, "frame-%05d.png".format(i))
-      frameFile.writeBytes(png.bytes)
+      frameFile.writeBytes(renderSettledFrame(scene, i))
       frameFiles += frameFile
     }
   } finally {
@@ -133,4 +120,50 @@ fun renderLottieApng(
   } finally {
     frameDir.deleteRecursively()
   }
+}
+
+/**
+ * How many consecutive render passes must agree byte-for-byte before a swept frame is accepted as
+ * settled. Three, not two: a single agreeing pair can still be two *stale* passes when the progress
+ * step is late reaching the painter, and one duplicated frame is enough to rewrite the whole APNG.
+ */
+private const val LOTTIE_SETTLE_AGREEMENTS: Int = 3
+
+/**
+ * Upper bound on render passes per swept frame, so a pathological asset that never reaches
+ * [LOTTIE_SETTLE_AGREEMENTS] agreeing passes still terminates with its most recent pixels rather
+ * than spinning.
+ */
+private const val MAX_LOTTIE_SETTLE_PASSES: Int = 8
+
+/**
+ * Render [scene] repeatedly until the encoded PNG stops changing, and return the settled bytes.
+ *
+ * Compottie routes a new `progress` to its painter through work that lands *after* the pass that
+ * applied the snapshot — usually on the very next pass, but not always, because that work is
+ * published from another thread and races the render. A fixed pass count therefore can't fix it:
+ * with one pass per step the capture reused the previous step's pixels outright, and with a fixed
+ * settle pass it still did so now and then. The duplicates fell on a different index each run
+ * (frame 35 in one CI render, none in the next, frames 3 and 21 in an earlier one), so the
+ * committed APNG's bytes flipped between two states push after push and the diff bot reported
+ * `lottie/spin.json` as changed on PRs that never touched it (issue #2868).
+ *
+ * Converging on the pixels instead makes the capture independent of how many passes the async
+ * handoff needs. A step whose progress already landed on the first pass settles immediately at the
+ * [LOTTIE_SETTLE_AGREEMENTS]th identical pass; a late one keeps rendering until the new pixels
+ * appear and then agree. `render()` defaults to nanoTime 0, so the extra passes advance no
+ * clock-driven animation — they only drain pending work.
+ */
+private fun renderSettledFrame(scene: ImageComposeScene, frameIndex: Int): ByteArray {
+  var previous: ByteArray? = null
+  var agreements = 1
+  repeat(MAX_LOTTIE_SETTLE_PASSES) {
+    val bytes =
+      scene.render().encodeToData(EncodedImageFormat.PNG)?.bytes
+        ?: error("Failed to encode Lottie APNG frame $frameIndex to PNG")
+    agreements = if (previous?.contentEquals(bytes) == true) agreements + 1 else 1
+    previous = bytes
+    if (agreements >= LOTTIE_SETTLE_AGREEMENTS) return bytes
+  }
+  return previous ?: error("Failed to render Lottie APNG frame $frameIndex")
 }

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopLottieRendererTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopLottieRendererTest.kt
@@ -95,12 +95,15 @@ class DesktopLottieRendererTest {
 
   @Test
   fun `sweeps a distinct frame per step and renders byte-identically twice`() {
-    // Regression guard for the flapping baseline: one `scene.render()` per progress step let
-    // Compottie's snapshot-driven progress land *after* the draw now and then, so the capture
-    // reused the previous step's pixels. The duplicated frames fell on random indices each run, so
-    // the committed APNG's bytes changed on every push and the preview diff bot reported
-    // `lottie/spin.json` as changed on every PR. The spinner rotates continuously, so no two
-    // adjacent steps may share pixels, and two renders of the same asset must agree byte for byte.
+    // Regression guard for the flapping baseline: Compottie's progress handoff lands *after* the
+    // pass that applied the snapshot, and how many passes it needs races another thread — so any
+    // fixed number of render passes per step now and then captured the previous step's pixels. The
+    // duplicated frames fell on a different index each run (frame 35 in the CI render that prompted
+    // issue #2868), so the committed APNG's bytes flipped between two states push after push and
+    // the preview diff bot reported `lottie/spin.json` as changed on PRs that never touched it.
+    // `renderSettledFrame` converges on the pixels instead. The spinner rotates continuously, so no
+    // two adjacent steps may share pixels, and two renders of the same asset must agree byte for
+    // byte.
     val renders = tempFolder.newFolder("renders")
     val first = File(renders, "spin-a_animated.png")
     val second = File(renders, "spin-b_animated.png")


### PR DESCRIPTION
## Summary

Two bugs, both visible on #2861's preview-diff comment.

**1. `lottie-spin` diffs on every PR.** `renderLottieApng` steps a snapshot-backed `progress` and renders a fixed number of passes before encoding each frame. Compottie publishes the new progress to its painter from another thread, so the handoff sometimes lands *after* the capture pass and the frame keeps the previous step's pixels. The duplicate falls on a different index each run, one duplicated frame rewrites the whole APNG, and the diff bot then reports `lottie/spin.json` as changed on PRs that never touched it.

Measured on the committed baseline `renders/samples:android/lottie__lottie_spin_animated.png`:

- **32 of the last 60** `compose-preview/main` commits rewrote that one render.
- It oscillates between exactly **two** byte-states — `0138f7f` and `7a7d26c` are byte-identical, `18e3deb` is the other state.
- Comparing those two states frame by frame (pixelmatch, the diff bot's own gate): **49 of 50 frames identical, frame 35 differs by 6668 px.** In the churned state frame 35 is a byte-for-byte duplicate of frame 34; in the good state it is its own frame. That is the stale capture, not a rendering change.

The fix uses the one thing that makes a stale capture *decidable*: the stale pixels are not arbitrary, they are exactly the bytes the previous step settled on. Each step now threads that frame in and counts as settled only once it has both **moved off it** and **stopped changing** — so a late handoff can't satisfy the condition by standing still, which is what a pure "N agreeing passes" counter would let it do. A genuinely held frame (new progress renders identically to its predecessor) can't be decided from pixels either way; it runs to the eight-pass cap and returns the held pixels, which is correct — the previous step only returned once it had itself settled, so nothing was outstanding when this one began. Continuously moving assets never reach the cap.

**2. The diff comment was being destroyed on update.** `post-comment.sh` PATCHed an existing sticky comment with `gh api -f body=@FILE`. `--raw-field` sends its value verbatim; only `--field` (`-F`) expands a leading `@` into the file's contents. So every re-render of a PR that already had a comment replaced the rendered diff with the literal string `@_comment_body.md` — which is exactly what #2861's `<!-- preview-diff -->` comment says right now ([run log](https://github.com/yschimke/compose-ai-tools/actions/runs/30386008356/job/90365364506), 18:24:03). The first post was unaffected, because that path goes through `gh pr comment --body-file`.

## Visual evidence

The two byte-states the baseline has been flapping between, both pinned to `compose-preview/main` commits (APNGs autoplay inline):

| State A (`0138f7f`, `7a7d26c`, …) | State B (`18e3deb`, …) — frame 35 duplicated |
| --- | --- |
| ![state A](https://raw.githubusercontent.com/yschimke/compose-ai-tools/7a7d26c/renders/samples%3Aandroid/lottie__lottie_spin_animated.png) | ![state B](https://raw.githubusercontent.com/yschimke/compose-ai-tools/18e3deb/renders/samples%3Aandroid/lottie__lottie_spin_animated.png) |

They look the same to the eye — that is the point. The difference is one stalled frame mid-rotation, which is invisible at 25fps but rewrites the artefact's bytes and so is not invisible to the diff bot.

**A head render is not embedded here, and that is a gap in this PR.** Skiko can't load in this container (`libskiko-linux-x64.so: libGL.so.1: cannot open shared object file`, and the Nix-provided JVM can't be pointed at the Debian `libGL`), so the animated Lottie capture cannot be re-run locally. The verification that matters is on this PR itself: the `Compose Preview` job re-renders `lottie__lottie_spin_animated.png` and the diff bot comments — and with fix 2 in place, that comment now survives its own update. If it lands with no `lottie-spin` entry on a run whose baseline is state B, the sweep is settled.

## Test plan

- `.github/actions/apply/lib/test-post-comment.sh` — new. Stubs `gh` on `PATH` and models the `-f`/`-F` distinction faithfully, so the fixture reproduces the production symptom. Verified it **fails** against the pre-fix script (`PATCH body should be the file's contents, got: @/tmp/.../comment_body.md`) and **passes** after. Covers the update path, the first-post path, and the >65,536-char truncation path. Wired into the `Actions Script Tests` CI job.
- `:renderer-desktop:test --tests DesktopLottieRendererTest` — the existing `sweeps a distinct frame per step and renders byte-identically twice` guard already asserts no adjacent frame is a duplicate and that two renders agree byte for byte; its comment now records the real (threading, not fixed-pass-count) cause. **Not run locally** — same skiko/`libGL` limitation as above; it runs on this PR's CI.
- `:renderer-desktop:compileKotlin`, `:renderer-desktop:compileTestKotlin`, `:renderer-desktop:ktfmtCheck` — pass.

Fixes #2868

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAKtnqptUgPmwkbVphUW2