### PR TITLE
test: verify sticky-comment upsert after #2896 (do not merge)

### DIFF
--- a/samples/android/src/main/res/values/notification_strings.xml
+++ b/samples/android/src/main/res/values/notification_strings.xml
@@ -9,6 +9,6 @@
 <resources>
   <string name="app_name">Sample Android</string>
   <string name="notif_variant_title">Compose preview update</string>
-  <string name="notif_variant_text">Tap to read</string>
+  <string name="notif_variant_text">Tap to read it</string>
   <string name="notif_variant_big_text">Notifications now fan out across @Preview environment axes — theme, locale, font scale — through Compose\'s existing multi-preview machinery. One factory, many rendered variants.</string>
 </resources>

--- a/samples/android/src/main/res/values/notification_strings.xml
+++ b/samples/android/src/main/res/values/notification_strings.xml
@@ -9,6 +9,6 @@
 <resources>
   <string name="app_name">Sample Android</string>
   <string name="notif_variant_title">Compose preview update</string>
-  <string name="notif_variant_text">Tap to read it</string>
+  <string name="notif_variant_text">Tap to read now</string>
   <string name="notif_variant_big_text">Notifications now fan out across @Preview environment axes — theme, locale, font scale — through Compose\'s existing multi-preview machinery. One factory, many rendered variants.</string>
 </resources>


### PR DESCRIPTION
**Throwaway verification PR — do not merge. Will be closed and the branch deleted once observed.**

Live check that the #2869 fix (merged in #2896) actually holds on a real PR, since the unit tests only exercise a `gh` double.

The change edits one notification string in `samples/android`, which makes the notification and compose pipelines render a real diff and post their sticky comments.

### What's being verified

1. **Push 1** (`Tap to read` → `Tap to read it`) — sticky comments get **posted**. Record their comment ids.
2. **Push 2** (a second string change) — the same comment ids must be **PATCHed in place**, with their `<!-- notification-previews -->` / `<!-- preview-diff -->` markers intact.

The bug was that push 2 rewrote the body to the literal `@_comment_body.md`, destroying the marker, so push 3 onward posted a fresh comment every time. Pass condition: **one comment per marker after both pushes, same id, marker still at the start of the body.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8vh7y4fJQvLdLMKyyQqNi)_