### PR TITLE
fix(catalog): route untagged stickers to the light annotation

### DIFF
--- a/scripts/design-artifacts/bridge-live-preview-ids.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.mjs
@@ -159,8 +159,20 @@ function pickVariantId(candidates, image, widthForSize) {
   let bestScore = -Infinity;
   for (const candidate of candidates) {
     let score = 0;
-    if (wantNight !== null && candidate.night !== null) {
-      score += candidate.night === wantNight ? 2 : -2;
+    if (wantNight !== null) {
+      if (candidate.night !== null) score += candidate.night === wantNight ? 2 : -2;
+    } else if (candidate.night === true) {
+      // A sticker that names NO theme is the catalog's default one — its path is
+      // `ideal__default__compact`, with no theme segment, precisely because light IS the default
+      // (only the dark sibling gets tagged). Treating that as "unconstrained" let it tie with the
+      // dark annotation and take whichever the bundle listed first, which is how Jetsnack's
+      // Snack/Card and Search/Categories kept shipping the DARK vector against a light PNG after
+      // the first pass at #2883. Same shape as the font-scale preference below: absent means
+      // "prefer the untagged annotation", scored ±1 so it breaks the tie without ever outvoting a
+      // matching width or an explicit theme.
+      score -= 1;
+    } else {
+      score += 1;
     }
     if (wantWidth !== null && candidate.widthDp !== null) {
       score += candidate.widthDp === wantWidth ? 2 : -2;

--- a/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
@@ -780,3 +780,94 @@ test("an explicit fontScale of 1 matches an annotation that omits it", () => {
     "app.FeedKt.FeedScreenPreview_default",
   );
 });
+
+test("an untagged (default) sticker takes the light annotation, not the dark one", () => {
+  // Reopened #2883. Jetsnack tags only its DARK stickers — the light one's path is
+  // `ideal__default__compact`, with no theme segment — so `image.theme` is undefined for it. The
+  // first pass scored an absent theme as "unconstrained", which let the light sticker tie with the
+  // dark annotation and take whichever the bundle listed first. With the dark preview listed
+  // first (as here), every light sticker shipped the dark vector against a light PNG.
+  const spec = {
+    system: "jetsnack",
+    groups: [
+      {
+        components: [
+          { componentId: "Snack/Card", preview: "SnackCardPreview", variants: [] },
+        ],
+      },
+    ],
+  };
+  const bundle = {
+    previews: [
+      // Dark deliberately first — that ordering is what the tie resolved to before.
+      {
+        id: "app.SnackKt.SnackCardPreview_dark",
+        functionName: "SnackCardPreview",
+        params: { widthDp: 412, uiMode: 0x20 },
+      },
+      {
+        id: "app.SnackKt.SnackCardPreview",
+        functionName: "SnackCardPreview",
+        params: { widthDp: 412 },
+      },
+    ],
+  };
+  const manifest = {
+    system: "jetsnack",
+    components: [
+      {
+        componentId: "Snack/Card",
+        images: [{ state: "default" }, { state: "default", theme: "dark" }],
+      },
+    ],
+  };
+
+  bridgeLivePreviewIds(manifest, spec, bundle, new Set());
+
+  assert.deepEqual(
+    manifest.components[0].images.map((i) => i.previewId),
+    ["app.SnackKt.SnackCardPreview", "app.SnackKt.SnackCardPreview_dark"],
+  );
+});
+
+test("an un-themed catalog is unaffected by the untagged-sticker preference", () => {
+  // wear-m3 / remote-m3 carry no theme on either side: the stickers are untagged AND the daemon
+  // ids don't end in light/dark, so every candidate scores the same +1 and the first still wins.
+  // This pins that the fix above can't disturb the state-variant catalogs.
+  const spec = {
+    system: "wear-m3",
+    groups: [
+      {
+        components: [
+          {
+            componentId: "Button/Filled",
+            preview: "FilledButton",
+            variants: [{ state: "pressed", preview: "ButtonPressed" }],
+          },
+        ],
+      },
+    ],
+  };
+  const bundle = {
+    previews: [
+      { id: "pkg.CatalogKt.FilledButton", functionName: "FilledButton" },
+      { id: "pkg.CatalogKt.ButtonPressed", functionName: "ButtonPressed" },
+    ],
+  };
+  const manifest = {
+    system: "wear-m3",
+    components: [
+      {
+        componentId: "Button/Filled",
+        images: [{ state: "default" }, { state: "pressed" }],
+      },
+    ],
+  };
+
+  bridgeLivePreviewIds(manifest, spec, bundle, new Set());
+
+  assert.deepEqual(
+    manifest.components[0].images.map((i) => i.previewId),
+    ["pkg.CatalogKt.FilledButton", "pkg.CatalogKt.ButtonPressed"],
+  );
+});


### PR DESCRIPTION
Fixes #2883 (reopened after #2894).

## What was still wrong

#2894 taught the variant scorer to compare a sticker's theme against each `@Preview` annotation's `uiMode` bits — but only when the sticker *names* a theme. Jetsnack tags only its **dark** stickers: the light one's path is `ideal__default__compact`, with no theme segment, because light is the catalog's default. So `image.theme` is `undefined` for it, the scorer read that as "unconstrained", and the light sticker tied with the dark annotation on every axis it did compare.

Ties resolve to the first candidate in bundle order. Where the dark preview happened to be listed first, the light sticker was handed the **dark** render — vector and raster crops alike. That's precisely the reported signature: `Snack/Card` and `Search/Categories` byte-identical to their dark siblings, a light PNG next to a dark SVG, at 74.0% and 30.0%.

Size routing did start working in #2894, which is why the report averages improved and the residue looked smaller than it was.

## The fix

An absent theme now expresses a *preference* rather than indifference: a candidate that is `night` scores −1, anything else +1. This is the same shape the `fontScale` axis already used (absent ⇒ prefer the unscaled annotation), and it is deliberately weighted below the ±2 of an explicit theme or a matching width, so it breaks a tie without ever outvoting a real constraint.

Un-themed catalogs are untouched by construction: in wear-m3 / remote-m3 neither the stickers nor the daemon ids carry a theme, so every candidate scores the same +1 and first-wins still applies.

## Test plan

- `scripts/design-artifacts` — 239/239 node tests pass.
- Two new cases: an untagged sticker takes the light annotation with the **dark preview listed first** (the ordering that previously produced the wrong answer), and an un-themed state-variant catalog is unaffected.
- I verified the first new test is not vacuous: reverting just the scorer hunk makes it fail with the untagged sticker taking the dark id, matching the issue report. With the fix, 19/19 in that file.

No visual evidence embedded: this is a routing change with no rendering of its own — it selects which already-correct vector a sticker receives. The observable proof is the catalog re-render, where the affected light stickers should stop being byte-identical to their dark siblings.

## Not addressed here

The other reopened issues from the 0.19.4 run (#2615 Wear transformed lists, #2852 gradient icon button, #2853 zero-alpha layers) and the new #2906 (downloadable Lato fonts) are separate exporter defects, not regressions from #2894, so they are deliberately out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbWyewkWvbY9pb5VS7FBWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbWyewkWvbY9pb5VS7FBWr)_