### PR TITLE
feat(preview-image): bake Google Sans Flex into the font cache

### DIFF
--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -150,18 +150,19 @@ RUN set -eu; \
 # fonts.googleapis.com, and the same bytes CI rendered the PNGs with.
 #
 # LICENSING — this stage REDISTRIBUTES font binaries in a published image, which is a different act
-# from the runtime fetch it replaces. Every family below is in the google/fonts open corpus under
-# OFL-1.1 or Apache-2.0, which permit redistribution. `Google Sans Flex` is deliberately ABSENT: the
-# CSS2 endpoint serves it, but it is not in google/fonts under any license dir, so its
-# redistribution terms are unclear. It keeps working exactly as before (fetched at runtime on first
-# use) — it is only not baked. Add it to FONT_PREWARM_FAMILIES yourself if you have cleared the
-# licensing for your deployment.
+# from the runtime fetch it replaces. All but one family below are in the google/fonts open corpus
+# under OFL-1.1 or Apache-2.0, which permit redistribution. `Google Sans Flex` is the exception: the
+# CSS2 endpoint serves it, but it is in no license directory of that repo, so its terms can't be
+# read off the corpus. It is baked here because the project owner confirmed redistribution is
+# cleared for this deployment — if you fork this image, that clearance is NOT inherited, so re-check
+# it or drop the family from FONT_PREWARM_FAMILIES. Dropping it only forgoes the baked copy; the
+# renderer still fetches it at runtime, exactly as every family did before this stage existed.
 #
-# The list mirrors `PixelSystemFontAliases.ALIASES` minus that exclusion; extend both together.
+# The list mirrors `PixelSystemFontAliases.ALIASES`; extend both together.
 # ---------------------------------------------------------------------------
 FROM base AS fonts
 COPY prewarm-fonts.sh /usr/local/bin/prewarm-fonts.sh
-ARG FONT_PREWARM_FAMILIES="Roboto|Roboto Flex|Noto Sans|Noto Serif|Noto Sans Mono|Cutive Mono|Coming Soon|Dancing Script|Carrois Gothic SC"
+ARG FONT_PREWARM_FAMILIES="Roboto|Roboto Flex|Google Sans Flex|Noto Sans|Noto Serif|Noto Sans Mono|Cutive Mono|Coming Soon|Dancing Script|Carrois Gothic SC"
 # `IFS='|'` + an unquoted expansion is how the pipe-separated list becomes one argument per family;
 # family names contain spaces, so splitting on whitespace would be wrong.
 RUN set -eu; \

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -266,12 +266,14 @@ should never show two different typefaces.
   *its* cache, not this host), so an entry left by an earlier runtime fetch is unknown-provenance
   and an upgrade must be able to correct it. Replacement is temp + `mv`, before serve starts.
   Faces the image doesn't ship are left alone.
-- **Licensing.** Baking redistributes font binaries, which the runtime fetch did not. Every baked
-  family is in the [google/fonts](https://github.com/google/fonts) corpus under OFL-1.1 or
-  Apache-2.0. **`Google Sans Flex` is deliberately not baked** — the CSS2 endpoint serves it, but it
-  is not in that repo under any license directory, so its redistribution terms are unclear. It still
-  works exactly as before (fetched at runtime on first use). Override `FONT_PREWARM_FAMILIES` at
-  build time to change the set.
+- **Licensing.** Baking redistributes font binaries, which the runtime fetch did not. All baked
+  families except one are in the [google/fonts](https://github.com/google/fonts) corpus under
+  OFL-1.1 or Apache-2.0. **`Google Sans Flex` is the exception** — the CSS2 endpoint serves it, but
+  it is in no license directory of that repo, so its terms can't be read off the corpus; it is baked
+  because the project owner confirmed redistribution is cleared for this deployment. **A fork does
+  not inherit that clearance** — re-check it, or drop the family from `FONT_PREWARM_FAMILIES`.
+  Dropping it only forgoes the baked copy; the renderer still fetches it at runtime, as every family
+  did before this stage existed. Override `FONT_PREWARM_FAMILIES` at build time to change the set.
 
 ## Notes / caveats
 


### PR DESCRIPTION
Follow-up to #2909, which baked the downloadable-font cache into the preview-host image but left
`Google Sans Flex` out.

## Why it's worth baking

`google-sans-flex` is a `PixelSystemFontAliases` slug, so it gets the same parity win as Roboto
Flex: a preview using it renders in the live daemon from a pinned, deterministic face instead of
depending on runtime egress to `fonts.googleapis.com` — and, on a miss, silently falling back to
Roboto while the baked catalog PNG shows the real face.

## Test plan

- Ran the real prewarm with the new list: all 10 families resolve, `Google Sans Flex` →
  `google-sans-flex-400.ttf` (127,900 bytes). That filename is exactly the cache key
  `seedSystemFontMap` looks up for the `google-sans-flex` alias, so the renderer will actually find
  it — a mismatch here would silently re-download instead.
- Validated the file is real TrueType (`sfnt` magic `00010000`, `glyf` present), not an HTML error
  page — the failure mode the script's two-stage lookup guards against.
- `deploy/image/test-prewarm-fonts.sh` — 14 passed, 0 failed.
- Baked cache: 1.8 MB → 1.9 MB.

Not visually verified: no Docker daemon or Android SDK 37 in this environment. Config-and-docs
change to an existing, tested mechanism — the image build in CI is the check.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GSzA2iRKuasMeQGtK73jD3)_