### PR TITLE
fix(figma-svg): embed the downloadable face the render resolved

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontResolverRecorder.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontResolverRecorder.kt
@@ -42,7 +42,16 @@ class FontResolverRecorder(private val context: Context? = null) {
     // below, which makes the export box the text and write its warning sidecar rather than
     // silently substituting Roboto.
     val resourceFamily = matched?.let(::recoverResourceFont)
-    FigmaSvgRenderedFonts.record(resourceFamily ?: matched?.let { displayFamilyName(fontLabel(it)) })
+    val displayName = matched?.let { displayFamilyName(fontLabel(it)) }
+    // A downloadable `Font(GoogleFont("Lato"), …)` resolved to a real TTF in the renderer's font
+    // cache for the PNG. Publish that file so the figma-svg export embeds the same bytes rather
+    // than re-fetching a WOFF2 by name — a second network hop that silently produced no
+    // `@font-face` on an offline or egress-closed catalog render, leaving the SVG on the browser's
+    // sans-serif while the PNG had the real face (issue #2906).
+    if (resourceFamily == null && matched != null && displayName != null) {
+      recoverDownloadableFont(matched, displayName, weight, style == "italic")
+    }
+    FigmaSvgRenderedFonts.record(resourceFamily ?: displayName)
     val key = listOf(requestedFamily, resolvedFamily, weight.toString(), style).joinToString("|")
     entries[key] =
       FontUsedEntry(
@@ -146,6 +155,35 @@ class FontResolverRecorder(private val context: Context? = null) {
     val family = fontFamilyOf(bytes) ?: return entryName
     FigmaResourceFonts.register(identity, target.absolutePath)
     return family
+  }
+
+  /**
+   * Publishes the cached TTF a downloadable [font] resolved to, under the family name the capture
+   * records for it (issue #2906).
+   *
+   * Gated on the `GoogleFont("…")` label so only a genuinely downloadable face is registered — a
+   * bundled or resource face reaches this method by a different route and must not have a
+   * family-keyed path attached to it. Registration is weight/style-qualified because the captured
+   * identity is the *family*: Lato 400 and Lato 600 are different files, and a bare-family
+   * registration would hand whichever resolved last to every weight the export asks about.
+   *
+   * A cache miss is deliberately silent: it means the render didn't draw with this face either
+   * (it fell back), which `FontResolutionDiagnostics` already reports on the render side.
+   */
+  private fun recoverDownloadableFont(
+    font: Font,
+    family: String,
+    weight: Int,
+    italic: Boolean,
+  ) {
+    if (GOOGLE_FONT_LABEL.find(fontLabel(font)) == null) return
+    if (FigmaResourceFonts.pathFor(family, weight, italic) != null) return
+    val file =
+      runCatching {
+          ee.schimke.composeai.renderer.GoogleFontFiles.cached(family, weight, italic)
+        }
+        .getOrNull() ?: return
+    FigmaResourceFonts.register(family, weight, italic, file.absolutePath)
   }
 
   /**

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -248,7 +248,7 @@ object ComposeFigmaSvgDataProducer {
     val faces = LinkedHashMap<String, FigmaSvgFontFace>()
     val overrides = HashMap<String, String>()
     fun add(captured: String?, weight: Int, italic: Boolean, codePoints: Set<Int>) {
-      val fontPath = captured?.let { fontFilePath(it, fileSystem) }
+      val fontPath = captured?.let { fontFilePath(it, weight, italic, fileSystem) }
       if (fontPath != null) {
         // Subset to a stable base charset (printable ASCII) plus whatever this face actually draws,
         // so every Latin sticker asks for the *same* subset — computed once, cached process-wide,
@@ -360,12 +360,20 @@ object ComposeFigmaSvgDataProducer {
    * `format('collection')` plus a face selection (the collection carries several faces), which we
    * don't emit — so a bare `truetype` src would be skipped and the text would silently fall back.
    */
-  private fun fontFilePath(family: String, fileSystem: FileSystem): okio.Path? {
-    // An Android resource-backed face reaches the capture as `res/font/<resId>` — a handle, not a
-    // path, and never a name a consumer could resolve. The render side extracts those bytes to a
-    // real file and publishes the mapping here, so the export embeds the actual face instead of
-    // emitting the numeric id as a CSS family with no `@font-face` behind it (issue #2886).
-    val candidate = FigmaResourceFonts.pathFor(family) ?: family
+  private fun fontFilePath(
+    family: String,
+    weight: Int,
+    italic: Boolean,
+    fileSystem: FileSystem,
+  ): okio.Path? {
+    // Two kinds of face reach the capture as a handle rather than a path, and both are published
+    // here by the render side — the only place their bytes are reachable:
+    //  - an Android resource face, as `res/font/<resId>` (issue #2886), and
+    //  - a downloadable `GoogleFont`, as its bare family name (issue #2906), registered per
+    //    weight/style because one family spans several files.
+    // Consulting the registry first means the export embeds the exact bytes the render drew with,
+    // instead of naming a family it provides no `@font-face` for.
+    val candidate = FigmaResourceFonts.pathFor(family, weight, italic) ?: family
     val lower = candidate.lowercase()
     if (!(lower.endsWith(".ttf") || lower.endsWith(".otf"))) return null
     val path = candidate.toPath()

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaResourceFonts.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaResourceFonts.kt
@@ -39,14 +39,39 @@ object FigmaResourceFonts {
    * Record that [identity] (a value from [identityFor]) is available on disk at [path] — an
    * absolute `.ttf`/`.otf` the export can read and subset. Later registrations for the same
    * identity win, so a re-extraction after a cleared temp dir heals the mapping.
+   *
+   * This face-agnostic form suits a per-face identity like `res/font/<resId>`, where the handle
+   * already names one concrete weight/style.
    */
   fun register(identity: String, path: String) {
     if (identity.isBlank() || path.isBlank()) return
     paths[identity] = path
   }
 
+  /**
+   * Weight/style-qualified registration, for an identity that names a **family** rather than a face
+   * — a downloadable `GoogleFont("Lato")` reaches the capture as the bare family, but Lato 400 and
+   * Lato 600 are different files with different metrics. Registering those under the bare name
+   * would embed whichever landed last for every weight the export asks about.
+   */
+  fun register(identity: String, weight: Int, italic: Boolean, path: String) {
+    if (identity.isBlank() || path.isBlank()) return
+    paths[key(identity, weight, italic)] = path
+  }
+
   /** The registered file for [identity], or null when nothing recovered that face. */
   fun pathFor(identity: String): String? = paths[identity]
+
+  /**
+   * The registered file for a specific face: the weight/style-qualified registration when one
+   * exists, else the face-agnostic one. The fallback is what keeps per-face identities
+   * (`res/font/<resId>`) resolving through the same lookup.
+   */
+  fun pathFor(identity: String, weight: Int, italic: Boolean): String? =
+    paths[key(identity, weight, italic)] ?: paths[identity]
+
+  private fun key(identity: String, weight: Int, italic: Boolean): String =
+    "$identity|$weight|$italic"
 
   /** Drop every registration. Tests only — production accumulates for the process's life. */
   fun clear() {

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaFontEmbedTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaFontEmbedTest.kt
@@ -426,6 +426,70 @@ class FigmaFontEmbedTest {
   }
 
   @Test
+  fun writeSvgEmbedsTheDownloadableFaceTheRenderResolvedRatherThanRefetchingIt() {
+    // Issue #2906. A downloadable `Font(GoogleFont("Lato"), …)` reaches the capture as the bare
+    // family name. The export used to hand that to the Google-Fonts WOFF2 resolver — a second
+    // network round-trip, independent of the TTF the render had already resolved — so a catalog
+    // whose font cache was warm but whose egress was closed produced an SVG with NO `@font-face`
+    // while its PNG carried the real face. The render now publishes the resolved file and the
+    // export embeds those exact bytes, with no resolver involvement at all.
+    val lato = File(dir, "lato-600.ttf").apply { writeBytes(byteArrayOf(11, 22, 33)) }
+    FigmaResourceFonts.register("Lato", 600, false, lato.absolutePath)
+    val semantics =
+      ComposeSemanticsPayload(
+        ComposeSemanticsNode(
+          nodeId = "root",
+          boundsInRoot = "0,0,200,100",
+          children =
+            listOf(
+              ComposeSemanticsNode(
+                nodeId = "Text",
+                boundsInRoot = "8,8,192,40",
+                text = "AVE TIME IN BED",
+                typography =
+                  ComposeSemanticsTypography(
+                    fontSize = "16.0sp",
+                    fontWeight = 600,
+                    fontFamily = "Lato",
+                  ),
+              )
+            ),
+        )
+      )
+    // The resolver must never be consulted for a face the render already resolved.
+    val resolver = FigmaFontResolver { _, _, _ -> error("must not re-fetch a resolved face") }
+
+    ComposeFigmaSvgDataProducer.writeSvg(
+      rootDir = dir,
+      previewId = "p",
+      layout = LayoutInspectorPayload(textNode()),
+      semantics = semantics,
+      fontResolver = resolver,
+    )
+
+    val svg = dir.resolve("p").resolve(ComposeFigmaSvgDataProducer.FILE_SVG).readText()
+    assertTrue("embeds the resolved face", svg.contains("format('truetype')"))
+    assertTrue("uses the render's own bytes", svg.contains("data:font/ttf;base64,CxYh"))
+    assertTrue("text names the embedded family", svg.contains("""font-family="lato-600"""))
+  }
+
+  @Test
+  fun aFamilyRegistrationIsScopedToItsWeight() {
+    // One family spans several files: Lato 400 and Lato 600 have different metrics. A bare-family
+    // registration would hand whichever resolved last to every weight, so the registry is
+    // weight/style-qualified and a lookup for an unregistered weight must miss rather than reuse.
+    val lato600 = File(dir, "lato-600.ttf").apply { writeBytes(byteArrayOf(1)) }
+    FigmaResourceFonts.register("Lato", 600, false, lato600.absolutePath)
+
+    assertEquals(lato600.absolutePath, FigmaResourceFonts.pathFor("Lato", 600, false))
+    assertEquals(null, FigmaResourceFonts.pathFor("Lato", 400, false))
+    assertEquals(null, FigmaResourceFonts.pathFor("Lato", 600, true))
+    // The face-agnostic form still resolves for a per-face identity like `res/font/<resId>`.
+    FigmaResourceFonts.register("res/font/42", lato600.absolutePath)
+    assertEquals(lato600.absolutePath, FigmaResourceFonts.pathFor("res/font/42", 700, false))
+  }
+
+  @Test
   fun writeSvgSkipsTtcCollectionsRatherThanEmbedThemAsTruetype() {
     // A `.ttc` collection can't be embedded as a bare `format('truetype')` src (it needs
     // `format('collection')` + a face selection we don't emit), so the file path is not treated as

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
@@ -55,6 +55,33 @@ internal object GoogleFontCacheAccess {
 }
 
 /**
+ * Read-only view of the downloadable-font cache for consumers that need the *file the render
+ * actually drew with* rather than a fresh resolution.
+ *
+ * The `compose/figma-svg` export used to embed a downloadable face by re-fetching a WOFF2 from
+ * Google by family name — a second network round-trip, independent of the TTF the render had
+ * already resolved. It failed exactly where it mattered: a catalog render whose font cache was
+ * warm (so the PNG is correct) but whose egress is closed, or which runs
+ * `composeai.fonts.offline`, produced an SVG with no `@font-face` at all, so browsers fell back to
+ * sans-serif and every glyph width, line break and ellipsis drifted from the PNG (issue #2906).
+ *
+ * Looking the already-resolved file up instead makes the embedded face the same bytes the raster
+ * used, by construction, and removes the network from the export path entirely.
+ */
+object GoogleFontFiles {
+  /**
+   * The cached TTF for `(family, weight, italic)`, or null when nothing has resolved it. Never
+   * downloads — a miss means the render didn't draw with this face either, and the export should
+   * degrade rather than fetch a face the raster never saw.
+   */
+  fun cached(family: String, weight: Int, italic: Boolean): File? {
+    val dir = System.getProperty("composeai.fonts.cacheDir")?.takeIf { it.isNotBlank() } ?: return null
+    val file = File(dir, GoogleFontKey(family, FontWeight(weight), italic).fileName())
+    return file.takeIf { it.isFile && it.length() > 0 }
+  }
+}
+
+/**
  * Render-time surfacing for downloadable-font resolution failures.
  *
  * A `Font(GoogleFont(...))` that can't be resolved — offline, no cache dir, a failed download, or a


### PR DESCRIPTION
Fixes #2906.

## Root cause

The two halves of the pipeline were resolving the same font independently.

The Android renderer resolves `Font(GoogleFont("Lato"), provider)` through `ShadowFontsContractCompat` → `GoogleFontCache`, landing a real TTF at `<composeai.fonts.cacheDir>/lato-600.ttf`, and draws the PNG with it. The figma-svg export then ignored that file entirely and asked `GoogleFontsWoff2Resolver` for a **WOFF2, by family name, over the network** — a second round-trip with its own cache, its own failure modes, and no guarantee of returning the same face.

That fails exactly where the catalog runs: a warm font cache (so the PNG is correct) plus closed egress or `composeai.fonts.offline` means the WOFF2 fetch returns null, the export logs a warning and emits no `@font-face`, and the browser falls back to sans-serif. Hence JetLagged's cluster — structurally correct, but every glyph width, line break and ellipsis off.

This is the downloadable-font counterpart of #2886: same "the bytes only exist on the render side" shape, different font family type.

## The fix

`GoogleFontFiles.cached(family, weight, italic)` exposes a **read-only** view of the renderer's font cache. `FontResolverRecorder` publishes the resolved file on `FigmaResourceFonts` as each face resolves, and the exporter consults that registry before its on-disk path check — so it embeds the exact bytes the raster drew with, and touches the network for it not at all.

Two deliberate details:

- **The lookup never downloads.** A cache miss means the render fell back too, which `FontResolutionDiagnostics` already reports on the render side; fetching there would embed a face the PNG never showed.
- **Registration is weight/style-qualified.** Unlike `res/font/<resId>`, which names one concrete face, a downloadable family spans several files — Lato 400 and Lato 600 have different metrics. A bare-family registration would hand whichever resolved last to every weight. The face-agnostic form is retained so `res/font/<resId>` keeps resolving through the same lookup.

## Test plan

- `:data-layoutinspector-connector:test --tests "*FigmaFontEmbedTest*"` — passes.
- New: a registered downloadable face is embedded with the render's own bytes, and the `FigmaFontResolver` is stubbed to **throw** so the test fails if anything still tries to re-fetch a resolved face.
- New: the registry is weight/style-scoped — a lookup for an unregistered weight or the italic variant misses rather than reusing, while a face-agnostic `res/font/<id>` registration still resolves at any weight.
- `:renderer-android:compileDebugKotlin`, `:data-layoutinspector-connector:compileKotlin`, `:daemon:android:compileDebugKotlin` clean; `ktfmtFormat` applied.

## Note on the requested fixture

The issue also asks for an Android end-to-end PNG/browser-SVG fidelity fixture using `androidx.compose.ui.text.googlefonts.Font` at a non-default weight. I have not added one here: it needs a warm downloadable-font cache in CI, which is the very condition that masks the bug — a fixture that only passes with egress available would not have caught this. The unit coverage above pins the actual contract (embed the resolved file, never re-fetch), and is deterministic offline. Happy to add the e2e fixture separately if you want it, but it should probably assert the **offline** case to be meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbWyewkWvbY9pb5VS7FBWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbWyewkWvbY9pb5VS7FBWr)_