### PR TITLE
fix(figma-svg): read alpha from lambda-form graphicsLayer blocks

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -282,14 +282,37 @@ internal object ModifierTokenResolver {
     recorded[property]?.let {
       return it
     }
+    GRAPHICS_LAYER_DEFAULTS[property]?.let {
+      return it
+    }
     return when (type) {
-      java.lang.Float.TYPE -> if (property == "density" || property == "fontScale") 1f else 0f
+      java.lang.Float.TYPE -> 0f
       java.lang.Boolean.TYPE -> false
       java.lang.Integer.TYPE -> 0
       java.lang.Long.TYPE -> 0L
       else -> null
     }
   }
+
+  /**
+   * `GraphicsLayerScope`'s own identity defaults, for a property the block **reads before
+   * writing**.
+   *
+   * A relative assignment (`graphicsLayer { alpha *= fade }`) starts from Compose's default, not
+   * from zero — answering 0 there would record `alpha = 0` for every non-zero fade and make the
+   * node vanish from the export, which is the same class of bug this evaluator exists to fix.
+   * Anything not listed keeps the type's zero, which is the identity for translation and rotation.
+   */
+  private val GRAPHICS_LAYER_DEFAULTS: Map<String, Any> =
+    mapOf(
+      "alpha" to 1f,
+      "scaleX" to 1f,
+      "scaleY" to 1f,
+      // Compose's `DefaultCameraDistance`.
+      "cameraDistance" to 8f,
+      "density" to 1f,
+      "fontScale" to 1f,
+    )
 
   private fun reflectedFloat(instance: Any, name: String): Float? =
     reflectedField(instance, name)?.let(::floatValue)

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -174,21 +174,121 @@ internal object ModifierTokenResolver {
   }
 
   /**
-   * Effective alpha of one graphics-layer modifier. Lambda-based `graphicsLayer { … }` elements
-   * only expose the block itself, but their [ModifierInfo.coordinates] coordinator retains the
-   * evaluated `ReusableGraphicsLayerScope`; direct overloads may expose `alpha` on the element.
+   * Effective alpha of one graphics-layer modifier.
+   *
+   * Three shapes, probed in order of how much we can trust them:
+   * 1. The **named-parameter** overload (`graphicsLayer(alpha = 0f)`) keeps `alpha` as a real field
+   *    on the element, and the inspector also exposes it as a property.
+   * 2. The **lambda** overload (`graphicsLayer { alpha = … }`) keeps only the opaque block, so we
+   *    evaluate it ourselves against a recording scope ([evaluateLayerBlockAlpha]).
+   * 3. Only if neither answered, the coordinator's `graphicsLayerScope`.
+   *
+   * The ordering is the fix for issue #2853. Probing the coordinator *first* looked like it covered
+   * the lambda case, but `graphicsLayerScope` is a **shared static** on `NodeCoordinator` that
+   * Compose reuses for whichever layer it updated most recently — so it reports some other node's
+   * alpha, and for Jetchat's `RecordButton` (`graphicsLayer { alpha = containerAlpha.value }`, zero
+   * when idle) it read back 1 and the export drew an opaque blue circle the PNG doesn't have.
+   * Evaluating the block is per-node and exact, which is why it now runs before that fallback
+   * rather than after it.
    */
   internal fun graphicsLayerAlpha(info: ModifierInfo): Double? {
-    val scope = reflectedField(info.coordinates, "graphicsLayerScope")
     val effective =
-      scope?.let { reflectedFloat(it, "alpha") }
-        ?: reflectedFloat(info.modifier, "alpha")
+      reflectedFloat(info.modifier, "alpha")
         ?: (info.modifier as? InspectableValue)
           ?.inspectableElements
           ?.firstOrNull { it.name == "alpha" }
           ?.value
           ?.let(::floatValue)
+        ?: evaluateLayerBlockAlpha(info.modifier)
+        ?: reflectedField(info.coordinates, "graphicsLayerScope")?.let {
+          reflectedFloat(it, "alpha")
+        }
     return effective?.coerceIn(0f, 1f)?.toDouble()
+  }
+
+  /**
+   * Runs a lambda-form `graphicsLayer { … }` block against a recording scope and returns the alpha
+   * it assigned, or null when [modifier] carries no such block (or the block can't be run).
+   *
+   * The scope is a [java.lang.reflect.Proxy] over whatever interface the block expects rather than
+   * a hand-written `GraphicsLayerScope` implementation: that interface has gained members across
+   * Compose releases, and a proxy records the setters it actually sees while answering every other
+   * call with a type-appropriate default. So this keeps working when the interface grows.
+   *
+   * Re-running the block is safe and is what makes the value *current*: a `graphicsLayer` block is
+   * a series of property assignments, and reading the animation state it closes over gives exactly
+   * the alpha the frame was drawn with.
+   */
+  internal fun evaluateLayerBlockAlpha(modifier: Any): Float? {
+    val block = layerBlock(modifier) ?: return null
+    val recorded = HashMap<String, Any?>()
+    // The scope interface by name, not from the lambda's generic signature: a Kotlin lambda erases
+    // to a raw `Function1`, so there is no type argument to read back off it.
+    val iface =
+      runCatching {
+          Class.forName(
+            "androidx.compose.ui.graphics.GraphicsLayerScope",
+            false,
+            modifier.javaClass.classLoader,
+          )
+        }
+        .getOrNull()
+        ?.takeIf { it.isInterface } ?: return null
+    val scope =
+      runCatching {
+          java.lang.reflect.Proxy.newProxyInstance(iface.classLoader, arrayOf(iface)) { _, m, args
+            ->
+            val name = m.name
+            when {
+              name.startsWith("set") && args != null && args.size == 1 -> {
+                recorded[name.removePrefix("set").replaceFirstChar { it.lowercase() }] = args[0]
+                null
+              }
+              // Getters (and anything else) answer with a harmless default so a block that reads
+              // back a property it just set, or consults `density`, doesn't blow up mid-evaluation.
+              else -> defaultFor(m.returnType, name, recorded)
+            }
+          }
+        }
+        .getOrNull() ?: return null
+    @Suppress("UNCHECKED_CAST") val invoke = block as? Function1<Any?, Any?> ?: return null
+    runCatching { invoke(scope) }.getOrNull() ?: return null
+    return recorded["alpha"] as? Float
+  }
+
+  /** The `GraphicsLayerScope.() -> Unit` a lambda-form `graphicsLayer` element holds, if any. */
+  private fun layerBlock(modifier: Any): Any? =
+    generateSequence(modifier.javaClass as Class<*>?) { it.superclass }
+      .flatMap { it.declaredFields.asSequence() }
+      .firstOrNull { field ->
+        kotlin.jvm.functions.Function1::class.java.isAssignableFrom(field.type) &&
+          (field.name == "block" || field.name == "layerBlock")
+      }
+      ?.let { field ->
+        runCatching {
+            field.isAccessible = true
+            field.get(modifier)
+          }
+          .getOrNull()
+      }
+
+  /**
+   * A benign return value for a proxied scope call: whatever the block already assigned when it
+   * reads a property back, else the type's zero. `density`/`fontScale` answer 1 so a block that
+   * converts dp inside itself divides by something sane rather than zero.
+   */
+  private fun defaultFor(type: Class<*>, name: String, recorded: Map<String, Any?>): Any? {
+    val property = name.removePrefix("get").replaceFirstChar { it.lowercase() }
+    recorded[property]?.let {
+      return it
+    }
+    return when (type) {
+      java.lang.Float.TYPE -> if (property == "density" || property == "fontScale") 1f else 0f
+      java.lang.Boolean.TYPE -> false
+      java.lang.Integer.TYPE -> 0
+      java.lang.Long.TYPE -> 0L
+      else -> null
+    }
   }
 
   private fun reflectedFloat(instance: Any, name: String): Float? =

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/GraphicsLayerBlockAlphaTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/GraphicsLayerBlockAlphaTest.kt
@@ -1,0 +1,68 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.graphics.GraphicsLayerScope
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #2853: the **lambda** form of `graphicsLayer` hides its alpha inside an opaque block.
+ *
+ * `graphicsLayer(alpha = 0f)` keeps `alpha` as a field, so the previous synthetic fixtures passed
+ * while Jetchat's `RecordButton` — which writes `graphicsLayer { alpha = containerAlpha.value }` —
+ * kept exporting an opaque circle its PNG doesn't show. The coordinator fallback that was supposed
+ * to cover the lambda case reads a *shared static* scope belonging to whichever layer Compose
+ * updated last, so it answered with some other node's alpha.
+ *
+ * These drive the block evaluator directly with real `GraphicsLayerScope` lambdas, which is the
+ * shape the app code actually uses.
+ */
+class GraphicsLayerBlockAlphaTest {
+
+  /** Stands in for a lambda-form `graphicsLayer` element: it holds only the block. */
+  private class BlockLayerElement(@JvmField val block: GraphicsLayerScope.() -> Unit)
+
+  /** …and for the named-parameter form, which carries a real `alpha` field. */
+  @Suppress("unused") private class FieldLayerElement(@JvmField val alpha: Float)
+
+  @Test
+  fun `a zero alpha assigned inside the block is recovered`() {
+    val element = BlockLayerElement { alpha = 0f }
+    assertEquals(0f, ModifierTokenResolver.evaluateLayerBlockAlpha(element))
+  }
+
+  @Test
+  fun `a partial alpha assigned alongside other layer properties is recovered`() {
+    // The real RecordButton shape: alpha and scale set together from animation state.
+    val containerAlpha = 0.35f
+    val scale = 0.8f
+    val element = BlockLayerElement {
+      alpha = containerAlpha
+      scaleX = scale
+      scaleY = scale
+    }
+    assertEquals(0.35f, ModifierTokenResolver.evaluateLayerBlockAlpha(element))
+  }
+
+  @Test
+  fun `a block that sets no alpha reports none rather than inventing one`() {
+    val element = BlockLayerElement { scaleX = 0.5f }
+    assertNull(ModifierTokenResolver.evaluateLayerBlockAlpha(element))
+  }
+
+  @Test
+  fun `a block that reads a property back mid-evaluation still yields its alpha`() {
+    // The proxy answers getters with whatever was already assigned, so a block that computes from
+    // its own earlier writes evaluates instead of throwing.
+    val element = BlockLayerElement {
+      scaleX = 0.5f
+      alpha = scaleX
+    }
+    assertEquals(0.5f, ModifierTokenResolver.evaluateLayerBlockAlpha(element))
+  }
+
+  @Test
+  fun `an element with no block is left to the field path`() {
+    assertNull(ModifierTokenResolver.evaluateLayerBlockAlpha(FieldLayerElement(0f)))
+  }
+}

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/GraphicsLayerBlockAlphaTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/GraphicsLayerBlockAlphaTest.kt
@@ -62,6 +62,21 @@ class GraphicsLayerBlockAlphaTest {
   }
 
   @Test
+  fun `a relative assignment starts from Compose's default alpha, not zero`() {
+    // `alpha *= fade` reads alpha before writing it. Answering 0 there would record 0 for every
+    // non-zero fade and blank the node — the same class of bug this evaluator exists to fix.
+    val fade = 0.4f
+    val element = BlockLayerElement { alpha *= fade }
+    assertEquals(0.4f, ModifierTokenResolver.evaluateLayerBlockAlpha(element))
+  }
+
+  @Test
+  fun `scale defaults to unity when read before assignment`() {
+    val element = BlockLayerElement { alpha = scaleX }
+    assertEquals(1f, ModifierTokenResolver.evaluateLayerBlockAlpha(element))
+  }
+
+  @Test
   fun `an element with no block is left to the field path`() {
     assertNull(ModifierTokenResolver.evaluateLayerBlockAlpha(FieldLayerElement(0f)))
   }


### PR DESCRIPTION
Addresses the alpha half of #2853 (reopened).

## Why the earlier fix missed the real component

There are two spellings of the same modifier, and only one of them keeps `alpha` where the resolver was looking:

- `Modifier.graphicsLayer(alpha = 0f)` — `alpha` is a real field on the element. The synthetic regression fixtures added with #2861 use this form, which is why they passed.
- `Modifier.graphicsLayer { alpha = … }` — the element keeps only an opaque block. **This is what real components write**, because the values come from animation state: Jetchat's `RecordButton` drives container alpha and scale together this way.

The lambda case was nominally covered by reading `graphicsLayerScope` off the modifier's coordinator. That is a **shared static** on `NodeCoordinator` which Compose reuses for whichever layer it updated most recently, so it answers with an unrelated node's alpha. Idle `RecordButton` (alpha 0) read back 1, and the export drew the opaque blue recording circle that the PNG doesn't contain — the same leaked circle visible at the upper-right of `Conversation/Input`.

## The fix

The block is evaluated directly against a recording scope, per node, and that now runs **before** the coordinator fallback rather than after it.

The scope is a `java.lang.reflect.Proxy` over `GraphicsLayerScope` rather than a hand-written implementation: that interface has gained members across Compose releases, and a proxy records the setters it sees while answering everything else with a type-appropriate default — so this keeps working as the interface grows. Re-running the block is safe and is what makes the value current: it's a series of property assignments over state that is still live at capture time.

## Test plan

- `:data-layoutinspector-connector:test` and `:data-layoutinspector-core:test` — green.
- New `GraphicsLayerBlockAlphaTest` drives the evaluator with **real `GraphicsLayerScope` lambdas**, which is the shape the previous fixtures didn't cover: zero alpha, a partial alpha set alongside `scaleX`/`scaleY` (the `RecordButton` shape), a block that sets no alpha, a block that reads a property back mid-evaluation, and an element carrying no block at all.
- `ktfmtFormat` applied.

## What this PR does *not* fix

The issue's second symptom — `Profile/Animating FAB content` emitting `scale(0.49 0.13)` for a square vector — is **not** addressed here, and I'd rather say so than ship a guess.

I tried the obvious fix (fit the vector uniformly in its placed box) and it breaks `vectorRetainsAnExplicitNonuniformLayoutTransform`, an existing test that deliberately asserts `scale(2 1)` for a node measured 24×24 and *placed* 48×24. That case is a genuine non-uniform layer scale; the FAB case is a square icon that must stay square. From `bounds` + `size` alone the two are indistinguishable, so any change here either breaks the existing behaviour or hard-codes a heuristic.

The captured `transform` field (layout-inspector v9) looks like the right discriminator — it records the real draw-time `graphicsLayer` scale, which would be present for the deliberate case and absent when a node is merely clipped or animated to a smaller box. Confirming that needs the actual `layout-inspector.json` for `Profile/Animating FAB content`; if you can attach one from the failing run I'll finish that half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbWyewkWvbY9pb5VS7FBWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbWyewkWvbY9pb5VS7FBWr)_