### PR TITLE
fix(daemon): carry themeProvider through the renderNow wire

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1117,6 +1117,18 @@ class JsonRpcServer(
           minHeightPx = overrides.minHeightPx,
           maxWidthPx = overrides.maxWidthPx,
           maxHeightPx = overrides.maxHeightPx,
+          // `themeProvider` rides the bag so `renderNow.overrides.themeProvider` reaches the
+          // renderer, which reads `spec.overrides.themeProvider` in `InvokeWithOptionalWrapper` to
+          // wrap the preview in an app-declared `@ThemeCatalog` / `@WearThemeCatalog`
+          // `PreviewWrapperProvider`. It is renderer-read rather than planner-read, but it has no
+          // typed wire token of its own, so without a slot here the one-shot `renderNow` path
+          // dropped it silently: every `?themeProvider=` render on the preview server came back
+          // with
+          // the preview's declared wrapper (the theme chips redrew identical pixels). The live
+          // `stream/start` path carries it separately as
+          // `InteractiveCommand.Start.themeProviderFqn`
+          // and was unaffected.
+          themeProvider = overrides.themeProvider,
         )
       if (
         extensionBag.material3Theme != null ||
@@ -1128,7 +1140,8 @@ class JsonRpcServer(
           extensionBag.minWidthPx != null ||
           extensionBag.minHeightPx != null ||
           extensionBag.maxWidthPx != null ||
-          extensionBag.maxHeightPx != null
+          extensionBag.maxHeightPx != null ||
+          !extensionBag.themeProvider.isNullOrBlank()
       ) {
         if (isNotEmpty()) append(';')
         append("overrides=")

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ThemeProviderOverrideEncodingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ThemeProviderOverrideEncodingTest.kt
@@ -1,0 +1,257 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.Base64
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression test for the wire-side leg of the app-declared theme axis (`@ThemeCatalog` /
+ * `@WearThemeCatalog`).
+ *
+ * [JsonRpcServer.encodeRenderPayload] serializes the render-affecting overrides that have no typed
+ * wire token of their own into a single base64 `overrides=<bag>` token. `themeProvider` was missing
+ * from that bag, so a one-shot `renderNow.overrides.themeProvider = <providerFqn>` was dropped on
+ * the wire: the renderer read `spec.overrides?.themeProvider == null` in
+ * `InvokeWithOptionalWrapper` and fell back to the preview's declared `@PreviewWrapper`. On the
+ * preview server that surfaced as a Theme picker whose chips redrew byte-identical (unthemed)
+ * pixels — every declared theme rendered the same. The live `stream/start` path was unaffected: it
+ * carries the FQN separately as `InteractiveCommand.Start.themeProviderFqn`.
+ *
+ * Drives a full JSON-RPC `initialize` → `renderNow` round-trip against a payload-capturing host and
+ * asserts the encoded payload carries the FQN inside the `overrides=<base64>` token. Sibling to
+ * [PermissionsOverrideEncodingTest] — same plumbing, different override field.
+ */
+class ThemeProviderOverrideEncodingTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test(timeout = 30_000)
+  fun themeProviderOverrideIsEncodedIntoTheExtensionBag() {
+    val captured =
+      renderAndCapturePayload(
+        overrides = """{"themeProvider":"com.example.designcatalogwearm3.WearTealThemeCatalog"}"""
+      )
+    val bag = decodeExtensionBag(captured)
+    assertEquals("com.example.designcatalogwearm3.WearTealThemeCatalog", bag.themeProvider)
+  }
+
+  @Test(timeout = 30_000)
+  fun themeProviderRidesAlongsideTheOtherBagFields() {
+    // The theme selection travels in the same single bag as the planner-driven fields rather than
+    // sprouting a token of its own.
+    val captured =
+      renderAndCapturePayload(
+        overrides =
+          """{
+                "themeProvider":"com.example.ThemeCatalog",
+                "material3Theme":{"sourceColor":"#FF3366FF"}
+              }"""
+      )
+    val bag = decodeExtensionBag(captured)
+    assertEquals("com.example.ThemeCatalog", bag.themeProvider)
+    assertNotNull("material3Theme must round-trip", bag.material3Theme)
+  }
+
+  @Test(timeout = 30_000)
+  fun blankThemeProviderDoesNotForceTheBag() {
+    // A blank FQN is "no theme selected" — it must not emit a bag on its own, matching the
+    // no-extension-field case in [PermissionsOverrideEncodingTest].
+    val captured = renderAndCapturePayload(overrides = """{"themeProvider":"","uiMode":"dark"}""")
+    assertTrue(
+      "overrides= bag must be omitted for a blank themeProvider: '$captured'",
+      "overrides=" !in captured,
+    )
+  }
+
+  private fun decodeExtensionBag(payload: String): PreviewOverrides {
+    val token =
+      payload.split(';').firstOrNull { it.trim().startsWith("overrides=") }
+        ?: error("payload must carry an overrides= token: '$payload'")
+    val b64 = token.substringAfter('=').trim()
+    val raw = String(Base64.getUrlDecoder().decode(b64), Charsets.UTF_8)
+    return json.decodeFromString(PreviewOverrides.serializer(), raw)
+  }
+
+  /**
+   * Spins up a [JsonRpcServer] backed by a payload-capturing host with a single-preview index, runs
+   * `initialize` → `renderNow` with the supplied overrides JSON, and returns the
+   * `RenderRequest.payload` string the host received. Mirrors [PermissionsOverrideEncodingTest]'s
+   * helper verbatim — kept file-local for the same reason.
+   */
+  private fun renderAndCapturePayload(overrides: String): String {
+    val sourceKt = java.nio.file.Files.createTempFile("theme-provider-override-test", ".kt")
+    java.nio.file.Files.writeString(sourceKt, "@Preview fun A() {}\n")
+    val previewDto =
+      PreviewInfoDto(
+        id = "preview-A",
+        className = "com.example.AKt",
+        methodName = "A",
+        sourceFile = sourceKt.toAbsolutePath().toString(),
+      )
+    val index = PreviewIndex.fromMap(path = sourceKt, byId = mapOf("preview-A" to previewDto))
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val host = PayloadCapturingThemeProviderHost()
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        previewIndex = index,
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val serverThread =
+      Thread({ server.run() }, "theme-provider-override-encoding-test").apply { isDaemon = true }
+    serverThread.start()
+
+    val reader = ContentLengthFramer(serverToClientIn)
+    val received = LinkedBlockingQueue<JsonObject>()
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "theme-provider-override-encoding-test-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    try {
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":t","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false}}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":2,"method":"renderNow","params":{
+              "previews":["preview-A"],"tier":"fast","overrides":$overrides}}""",
+      )
+      val finished =
+        pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+      assertNotNull("renderFinished must arrive within timeout", finished)
+
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"exit"}""")
+      assertTrue(exitLatch.await(5, TimeUnit.SECONDS))
+      return host.lastPayload.get() ?: error("host never received a render request")
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      try {
+        java.nio.file.Files.deleteIfExists(sourceKt)
+      } catch (_: Throwable) {}
+      serverThread.join(5_000)
+    }
+  }
+
+  private fun writeFrame(out: PipedOutputStream, jsonStr: String) {
+    val payload = jsonStr.toByteArray(Charsets.UTF_8)
+    out.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+    out.write(payload)
+    out.flush()
+  }
+
+  private fun pollUntil(
+    queue: LinkedBlockingQueue<JsonObject>,
+    timeoutMs: Long = 10_000,
+    matcher: (JsonObject) -> Boolean,
+  ): JsonObject? {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+      if (matcher(msg)) return msg
+    }
+    return null
+  }
+}
+
+/**
+ * Captures the [RenderRequest.Render.payload] string the daemon submits, then completes the render
+ * synchronously with a stub success result. File-local copy of the shape
+ * [PermissionsOverrideEncodingTest] uses, so the two tests take no cross-file dependency.
+ */
+private class PayloadCapturingThemeProviderHost : RenderHost {
+  val lastPayload: AtomicReference<String?> = AtomicReference(null)
+  private val queue = LinkedBlockingQueue<RenderRequest>()
+  private val results = LinkedBlockingQueue<RenderResult>()
+
+  @Volatile private var stopped = false
+
+  private val worker: Thread =
+    Thread(
+        {
+          while (!stopped) {
+            when (val req = queue.poll(50, TimeUnit.MILLISECONDS)) {
+              null -> continue
+              is RenderRequest.Render -> {
+                lastPayload.set(req.payload)
+                results.put(
+                  RenderResult(
+                    id = req.id,
+                    classLoaderHashCode = 0,
+                    classLoaderName = "theme-provider-override-encoding-test",
+                  )
+                )
+              }
+              RenderRequest.Shutdown -> return@Thread
+            }
+          }
+        },
+        "payload-capturing-theme-provider-host",
+      )
+      .apply { isDaemon = true }
+
+  override fun start() {
+    worker.start()
+  }
+
+  override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+    require(request is RenderRequest.Render)
+    queue.put(request)
+    return results.poll(timeoutMs, TimeUnit.MILLISECONDS)
+      ?: error("PayloadCapturingThemeProviderHost.submit timed out")
+  }
+
+  override fun shutdown(timeoutMs: Long) {
+    stopped = true
+    queue.put(RenderRequest.Shutdown)
+    worker.join(timeoutMs)
+  }
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeProviderWireIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeProviderWireIntegrationTest.kt
@@ -1,0 +1,240 @@
+package ee.schimke.composeai.daemon
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end regression test for the app-declared theme axis over the **real JSON-RPC wire**.
+ *
+ * [OverrideIntegrationTest.themeProviderOverrideWrapsPreviewInDeclaredTheme] already proves the
+ * renderer honours `spec.overrides.themeProvider` — but it hand-builds the `overrides=<base64>`
+ * token, so it never exercised `JsonRpcServer.encodeRenderPayload`. That encoder enumerates the
+ * fields it packs into the bag, and `themeProvider` was missing from the list: a
+ * `renderNow.overrides.themeProvider` was silently dropped between client and renderer, and every
+ * preview came back wrapped in its own `@PreviewWrapper` instead of the chosen theme. On
+ * preview.coo.ee that was the Theme picker whose chips all redrew identical pixels.
+ *
+ * This test closes the gap the two one-sided tests left between them: it drives a real
+ * [JsonRpcServer] (`initialize` → `renderNow` with `overrides.themeProvider`) against a real
+ * [PreviewManifestRouter] and asserts the *pixels* changed. The wire-shape assertion lives in
+ * `:daemon:core`'s `ThemeProviderOverrideEncodingTest`.
+ */
+class ThemeProviderWireIntegrationTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  /** The declared theme's primary — see `RedFixturePreviews.BluePrimaryThemeProvider`. */
+  private val themePrimaryRgb = 0x1565C0
+
+  @Test(timeout = 120_000)
+  fun themeProviderOverrideSurvivesTheRenderNowWire() {
+    val outputDir = tempFolder.newFolder("renders-theme-wire")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+
+    val default = renderOverJsonRpc(overridesJson = "{}")
+    val themed =
+      renderOverJsonRpc(
+        overridesJson =
+          """{"themeProvider":"ee.schimke.composeai.daemon.BluePrimaryThemeProvider"}"""
+      )
+
+    val themedBluePct = pixelMatchPct(themed, themePrimaryRgb, perChannelTolerance = 8)
+    assertTrue(
+      "a renderNow.overrides.themeProvider must reach the renderer and paint the declared " +
+        "theme's primary; got ${"%.2f".format(themedBluePct * 100)}% — the encoder dropped the " +
+        "field again",
+      themedBluePct >= 0.95,
+    )
+    assertNotEquals(
+      "the themed render must differ from the default-theme render",
+      default.getRGB(default.width / 2, default.height / 2),
+      themed.getRGB(themed.width / 2, themed.height / 2),
+    )
+
+    // Before/after PNGs for the PR's visual evidence, mirroring
+    // `OverrideIntegrationTest`'s `build/theme-evidence/`.
+    val evidenceDir = File("build/theme-wire-evidence").apply { mkdirs() }
+    ImageIO.write(default, "png", File(evidenceDir, "wire-theme-default.png"))
+    ImageIO.write(themed, "png", File(evidenceDir, "wire-theme-selected.png"))
+  }
+
+  /**
+   * Runs `initialize` → `initialized` → `renderNow(overrides = [overridesJson])` against a
+   * [JsonRpcServer] whose [RenderHost] is a real [PreviewManifestRouter], and returns the decoded
+   * PNG the render produced. Server output is drained rather than parsed — the recording host below
+   * signals completion, so the test needs no access to `:daemon:core`'s internal frame reader.
+   */
+  private fun renderOverJsonRpc(overridesJson: String): java.awt.image.BufferedImage {
+    val sourceKt = java.nio.file.Files.createTempFile("theme-provider-wire-test", ".kt")
+    java.nio.file.Files.writeString(sourceKt, "@Preview fun WallpaperAwareSquare() {}\n")
+    val previewId = "ambient-primary"
+    val index =
+      PreviewIndex.fromMap(
+        path = sourceKt,
+        byId =
+          mapOf(
+            previewId to
+              PreviewInfoDto(
+                id = previewId,
+                className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+                methodName = "WallpaperAwareSquare",
+                sourceFile = sourceKt.toAbsolutePath().toString(),
+              )
+          ),
+      )
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = previewId,
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "WallpaperAwareSquare",
+              widthPx = 200,
+              heightPx = 120,
+              density = 1.0f,
+              outputBaseName = previewId,
+            )
+          )
+      )
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val router = PreviewManifestRouter(manifest = manifest)
+    val host = RecordingRenderHost(router)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        previewIndex = index,
+        onExit = {},
+      )
+    val serverThread =
+      Thread({ server.run() }, "theme-provider-wire-test").apply { isDaemon = true }
+    serverThread.start()
+    // Drain the server's replies; nothing here needs to read them.
+    Thread(
+        {
+          try {
+            val buf = ByteArray(4096)
+            while (serverToClientIn.read(buf) >= 0) {}
+          } catch (_: Throwable) {}
+        },
+        "theme-provider-wire-test-drain",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    try {
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":t","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false}}}""",
+      )
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":2,"method":"renderNow","params":{
+              "previews":["$previewId"],"tier":"fast","overrides":$overridesJson}}""",
+      )
+      assertTrue(
+        "the render must complete within the timeout",
+        host.completed.await(90, TimeUnit.SECONDS),
+      )
+      val pngPath = host.lastResult.get()?.pngPath
+      assertNotNull("pngPath must be populated", pngPath)
+      val pngFile = File(pngPath!!)
+      assertTrue("rendered PNG must exist", pngFile.exists())
+      return ByteArrayInputStream(pngFile.readBytes()).use { ImageIO.read(it) }
+        ?: error("PNG failed to decode")
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      try {
+        java.nio.file.Files.deleteIfExists(sourceKt)
+      } catch (_: Throwable) {}
+      serverThread.join(5_000)
+    }
+  }
+
+  private fun writeFrame(out: PipedOutputStream, jsonStr: String) {
+    val payload = jsonStr.toByteArray(Charsets.UTF_8)
+    out.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+    out.write(payload)
+    out.flush()
+  }
+
+  /** Fraction of pixels within [perChannelTolerance] of the expected `0xRRGGBB`. */
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        if (
+          abs(((rgb shr 16) and 0xFF) - expR) <= perChannelTolerance &&
+            abs(((rgb shr 8) and 0xFF) - expG) <= perChannelTolerance &&
+            abs((rgb and 0xFF) - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    return matches.toDouble() / (img.width.toLong() * img.height.toLong()).toDouble()
+  }
+}
+
+/**
+ * Delegates to the real [PreviewManifestRouter] and records the [RenderResult] so the test can read
+ * the rendered PNG without parsing the daemon's `renderFinished` notification.
+ */
+private class RecordingRenderHost(private val delegate: PreviewManifestRouter) : RenderHost {
+  val lastResult: AtomicReference<RenderResult?> = AtomicReference(null)
+  val completed = CountDownLatch(1)
+
+  override fun start() = delegate.start()
+
+  override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+    try {
+      val result = delegate.submit(request, timeoutMs)
+      lastResult.set(result)
+      return result
+    } finally {
+      // Release the waiter on a throwing render too, so a broken render surfaces as a missing
+      // pngPath rather than as an opaque await timeout.
+      completed.countDown()
+    }
+  }
+
+  override fun shutdown(timeoutMs: Long) = delegate.shutdown(timeoutMs)
+}


### PR DESCRIPTION
The Theme picker on a published catalog does nothing: picking Coral / M3 / Teal on
[preview.coo.ee/wear-m3](https://preview.coo.ee/wear-m3/) re-requests every thumbnail with
`?themeProvider=<fqn>` and gets back the same unthemed pixels.

## Root cause

`JsonRpcServer.encodeRenderPayload` packs the render-affecting override fields that have no typed
wire token into a single base64 `overrides=<bag>` token — and it enumerates them explicitly.
`themeProvider` was missing from that list, so a `renderNow.overrides.themeProvider` was dropped
between client and renderer: `InvokeWithOptionalWrapper` saw a null FQN and fell back to the
preview's declared `@PreviewWrapper`. Every declared theme therefore rendered identically.

The live `stream/start` lane was unaffected — it carries the selection separately as
`InteractiveCommand.Start.themeProviderFqn`, which is why the viewer's live mode looked fine.

Two existing tests sat either side of the gap and neither could see it:

- `OverrideIntegrationTest.themeProviderOverrideWrapsPreviewInDeclaredTheme` proves the *renderer*
  honours `spec.overrides.themeProvider` — but it hand-builds the base64 bag, so it never touches
  the encoder.
- The encoder's own tests (`PermissionsOverrideEncodingTest`, `DeviceOverrideEncodingTest`) cover
  other fields only.

## Change

- `JsonRpcServer.encodeRenderPayload`: include `themeProvider` in the extension bag and in the gate
  that decides whether to emit the `overrides=` token at all (a blank FQN still emits nothing).
- New `:daemon:core` `ThemeProviderOverrideEncodingTest` — drives a real `initialize` → `renderNow`
  round trip and asserts the FQN survives inside the encoded token.
- New `:daemon:desktop` `ThemeProviderWireIntegrationTest` — the same round trip against a real
  `PreviewManifestRouter`, asserting the *pixels* repaint to the declared theme's primary. This is
  the test that would have caught the bug end to end.

## Evidence (production, pre-fix)

Same preview, three different `@WearThemeCatalog` themes requested from the live server — all
identical, and identical to the plain baked render:

| Requested theme | Render |
| --- | --- |
| none (baked) | [baked](https://preview.coo.ee/wear-m3/render/button-filled__ideal__default__largeround.png) |
| `WearCoralThemeCatalog` | [coral](``https://preview.coo.ee/wear-m3/render/button-filled__ideal__default__largeround.png?themeProvider=com.example.designcatalogwearm3.WearCoralThemeCatalog``) |
| `WearTealThemeCatalog` | [teal](``https://preview.coo.ee/wear-m3/render/button-filled__ideal__default__largeround.png?themeProvider=com.example.designcatalogwearm3.WearTealThemeCatalog``) |

The renders come back with `x-compose-preview-generation: daemon-cache`, so the daemon *did* run —
and the Coral and Teal bytes are identical to each other and to a plain `?density=2.0` daemon
render, while `?fontScale=1.5` on the same preview differs. The override lane works; only this one
field was being dropped. (These URLs render live, so they will show the *fixed* output once a
server carrying this change is deployed.)

**No after-pixels in this PR body.** The desktop renderer cannot run in this container —
`libskiko-linux-x64.so` fails to load (`libGL.so.1: cannot open shared object file`), which fails
all 13 pre-existing `OverrideIntegrationTest` render tests identically, not just the new one. The
new `ThemeProviderWireIntegrationTest` writes `wire-theme-default.png` / `wire-theme-selected.png`
to `daemon/desktop/build/theme-wire-evidence/` and asserts ≥95% of the themed render matches the
declared theme's primary, so CI (where Skia loads) is what confirms the after-state.

## Test plan

- `./gradlew :daemon:core:test --tests "*ThemeProviderOverrideEncodingTest" --tests
  "*PermissionsOverrideEncodingTest" --tests "*DeviceOverrideEncodingTest"` — pass.
- `./gradlew :daemon:core:test` — 134 tests, 0 failures. (The task still reports a non-zero test
  executor exit; reproduced on a clean tree without this change, so it is pre-existing here.)
- `./gradlew :daemon:desktop:test --tests "*ThemeProviderWireIntegrationTest"` — reaches the
  renderer (daemon log shows `renderNow received` → correct class/function dispatched) and then
  fails on the missing `libGL.so.1` described above. **Needs CI to confirm.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2uiiedP4EtBC7YqLiqv5j)_