### PR TITLE
fix(figma-svg): unwrap delegating painters so Wear surfaces stay vectorised

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -326,6 +326,55 @@ internal object ModifierTokenResolver {
   }
 
   /**
+   * Follows a delegating painter down to the concrete painter it ultimately draws, by looking for a
+   * single field that is itself a `Painter`. Returns [painter] unchanged when it delegates to
+   * nothing (the common case) — so a real `ColorPainter`, `BitmapPainter` or `VectorPainter` is
+   * handed back as-is and classified normally by the caller.
+   *
+   * A wrapper carrying **more than one** painter field is left alone: which one is the fill is a
+   * guess, and guessing wrong would paint the container in the wrong colour — worse than the raster
+   * fallback. Depth is bounded so a self-referential painter can't spin.
+   */
+  private fun unwrapDelegatingPainter(painter: Any): Any {
+    var current = painter
+    repeat(MAX_PAINTER_UNWRAP_DEPTH) {
+      if (current.javaClass.simpleName == "ColorPainter") return current
+      val delegates =
+        generateSequence(current.javaClass as Class<*>?) { it.superclass }
+          .flatMap { it.declaredFields.asSequence() }
+          .filter { field ->
+            field.type.name != current.javaClass.name && isPainterType(field.type)
+          }
+          .toList()
+      val next =
+        delegates.singleOrNull()?.let { field ->
+          runCatching {
+              field.isAccessible = true
+              field.get(current)
+            }
+            .getOrNull()
+        } ?: return current
+      current = next
+    }
+    return current
+  }
+
+  /** True when [type] is (or extends) Compose's `Painter`. */
+  private fun isPainterType(type: Class<*>): Boolean =
+    generateSequence(type as Class<*>?) { it.superclass }
+      .any { it.name == "androidx.compose.ui.graphics.painter.Painter" }
+
+  /** Bound on [unwrapDelegatingPainter]'s descent; real wrappers nest one or two deep. */
+  private const val MAX_PAINTER_UNWRAP_DEPTH = 4
+
+  /**
+   * Test seam for [painterColorHex]'s painter half: resolves the flat fill a `Modifier.paint`
+   * painter would contribute, with no modifier element map to fall back on.
+   */
+  internal fun painterFillHexForTest(painter: Any): String? =
+    painterColorHex(mapOf("painter" to painter), Any())
+
+  /**
    * Resolves a painter-based container fill (`Modifier.paint(painter, alpha, colorFilter)`) as ARGB
    * hex. Only a solid [androidx.compose.ui.graphics.painter.ColorPainter] yields a colour — the
    * fill Wear M3 surfaces apply for their container — while bitmap / vector / gradient painters (an
@@ -393,7 +442,15 @@ internal object ModifierTokenResolver {
           }
           .getOrNull() ?: return null
       } else {
-        painter
+        // Any *other* delegating painter is unwrapped structurally rather than by name (issue
+        // #2615). Wear's scaling list wraps a surface's fill in more than one shape depending on
+        // the component — a `FilledIconButton` or a transformed `SurfaceTransformation` card does
+        // not necessarily arrive as `BackgroundPainter` — and each unrecognised wrapper collapsed
+        // its whole container to a raster, taking the editable subtree with it: exactly the
+        // "transformed surfaces absent, reduced to isolated raster/icon leaves" symptom. Following
+        // a single painter-typed field down to a `ColorPainter` recovers the flat fill without
+        // needing to know the wrapper's class.
+        unwrapDelegatingPainter(painter)
       }
     if (fillPainter.javaClass.simpleName != "ColorPainter") return null
     val baseArgb =

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/DelegatingPainterUnwrapTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/DelegatingPainterUnwrapTest.kt
@@ -1,0 +1,75 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #2615: a Wear surface whose fill arrives wrapped in a painter the resolver doesn't
+ * recognise resolves no colour, so its container collapses to a whole-layer raster and takes the
+ * editable subtree with it — the "transformed surfaces absent, reduced to isolated raster/icon
+ * leaves" symptom on Jetcaster Wear's `TransformingLazyColumn` + `SurfaceTransformation` screens.
+ *
+ * `BackgroundPainter` was already unwrapped by name. These pin the *structural* unwrap that covers
+ * whatever wrapper a given Wear component actually uses, without the resolver having to know its
+ * class.
+ */
+class DelegatingPainterUnwrapTest {
+
+  /** A painter that delegates its drawing to exactly one other painter. */
+  private class WrappingPainter(@JvmField val delegate: Painter) : Painter() {
+    override val intrinsicSize: Size = Size.Unspecified
+
+    override fun DrawScope.onDraw() = Unit
+  }
+
+  /** A wrapper holding two painters — which one is the fill is a guess, so it must not resolve. */
+  private class AmbiguousPainter(@JvmField val a: Painter, @JvmField val b: Painter) : Painter() {
+    override val intrinsicSize: Size = Size.Unspecified
+
+    override fun DrawScope.onDraw() = Unit
+  }
+
+  private fun resolve(painter: Painter): String? =
+    ModifierTokenResolver.painterFillHexForTest(painter)
+
+  @Test
+  fun `a bare ColorPainter still resolves`() {
+    assertEquals("#FF112233", resolve(ColorPainter(Color(0xFF112233))))
+  }
+
+  @Test
+  fun `a single-level wrapper resolves to the colour it delegates to`() {
+    assertEquals("#FF112233", resolve(WrappingPainter(ColorPainter(Color(0xFF112233)))))
+  }
+
+  @Test
+  fun `a nested wrapper resolves through both levels`() {
+    val painter = WrappingPainter(WrappingPainter(ColorPainter(Color(0xFF445566))))
+    assertEquals("#FF445566", resolve(painter))
+  }
+
+  @Test
+  fun `a wrapper with two painter fields is left for the raster fallback`() {
+    val painter = AmbiguousPainter(ColorPainter(Color(0xFF112233)), ColorPainter(Color(0xFF445566)))
+    assertNull("ambiguous delegate must not be guessed at", resolve(painter))
+  }
+
+  @Test
+  fun `a wrapper that bottoms out in a non-solid painter stays unresolved`() {
+    // Nothing flat to recover — the raster fallback is the correct outcome here.
+    val painter = WrappingPainter(WrappingPainter(NonSolidPainter()))
+    assertNull(resolve(painter))
+  }
+
+  private class NonSolidPainter : Painter() {
+    override val intrinsicSize: Size = Size.Unspecified
+
+    override fun DrawScope.onDraw() = Unit
+  }
+}


### PR DESCRIPTION
## Summary

Wear M3's `surface()` fills a container via `Modifier.paint(painter)`. Under `TransformingLazyColumn` + `SurfaceTransformation` that painter arrives **wrapped**, and `ModifierTokenResolver.painterColorHex` only knew how to unwrap one wrapper — `BackgroundPainter`, matched by class name.

Every *other* wrapper left `backgroundColor` null. A null fill marks the layer as carrying unvectorizable paint, which collapses the whole container — title, subtitle and all — into a single opaque `<image>`. That is exactly the reopened symptom on #2615: *"FilledIconButton groups and transformed episode/library card surfaces are absent or reduced to isolated raster/icon leaves."*

The fix follows a delegating painter **structurally** rather than by class name: descend through a *single* painter-typed field until a `ColorPainter` is reached, and read the flat fill from there. No knowledge of the wrapper's class is needed, so a future Wear wrapper is covered without a new name match.

Guardrails, matching the "recover it semantically where possible, otherwise fall back to raster" policy:

- A wrapper carrying **more than one** painter field is left unresolved — which one is the fill would be a guess, and guessing wrong paints the container the wrong colour, which is worse than the raster fallback.
- Depth is bounded (`MAX_PAINTER_UNWRAP_DEPTH = 4`) so a self-referential painter can't spin.
- A wrapper that bottoms out in a bitmap / vector / gradient painter still resolves nothing and correctly keeps the raster path.
- The existing `BackgroundPainter` branch (with its bordered-wrapper bail-out) is untouched and still takes precedence.

## Test plan

New `DelegatingPainterUnwrapTest` (5 cases) pins each behaviour:

| case | expected |
| --- | --- |
| bare `ColorPainter` | resolves (no regression) |
| single-level wrapper | resolves to the delegate's colour |
| nested wrapper | resolves through both levels |
| wrapper with two painter fields | **unresolved** — left to raster |
| wrapper bottoming out in a non-solid painter | **unresolved** — left to raster |

- `./gradlew :data-layoutinspector-connector:test` — green (the full module suite, not just the new class).
- Non-vacuousness verified: reverting the one-line `unwrapDelegatingPainter(painter)` hook back to `painter` makes 2 of the 5 new tests fail; restoring it makes them pass again.

No visual evidence embedded: this change is capture-side plumbing in the modifier→token resolver, and reproducing the before/after pixels needs a real Jetcaster Wear `TransformingLazyColumn` render, which this headless container can't produce. The observable effect is verified downstream — the real-world catalog rerun that reopened #2615 is the acceptance test, and the CI visual-diff bot renders any Wear surface fixture on subsequent PRs.

Fixes #2615


---
_Generated by [Claude Code](https://claude.ai/code/session_01AbWyewkWvbY9pb5VS7FBWr)_