### PR TITLE
fix(figma-svg): only unwrap painters that alter nothing about the paint

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -481,33 +481,48 @@ internal object ModifierTokenResolver {
       // the pixels exactly, so those stop the descent. Inert bookkeeping (a cached
       // `intrinsicSize`, a measured extent) doesn't change the paint and is allowed through.
       if (own.any { altersPaint(it) }) return current
-      val delegates = own.filter {
+      val painterFields = own.filter {
         isPainterType(it.type) && it.type.name != current.javaClass.name
       }
-      // Two painters: which one is the fill would be a guess, so leave it alone as well.
+      // Two painters: which one is the fill would be a guess, so leave it alone as well. A local
+      // or anonymous painter that *captures* another painter (an overlay drawn by its `onDraw`)
+      // holds it in a compiler-generated field, so captures count here too — otherwise a captured
+      // second painter would be invisible and the one declared delegate would be reported as the
+      // fill even though the capture changes what is drawn.
+      if (painterFields.size != 1) return current
+      // The delegate itself is a declared field, though: a capture is never the thing the wrapper
+      // forwards to.
       val next =
-        delegates.singleOrNull()?.let { field ->
-          runCatching {
-              field.isAccessible = true
-              field.get(current)
-            }
-            .getOrNull()
-        } ?: return current
+        painterFields
+          .single()
+          .takeUnless { it.isSynthetic }
+          ?.let { field ->
+            runCatching {
+                field.isAccessible = true
+                field.get(current)
+              }
+              .getOrNull()
+          } ?: return current
       current = next
     }
     return current
   }
 
   /**
-   * A painter's own instance state: the fields declared below `Painter` in its hierarchy. Skips
-   * `Painter`'s own bookkeeping (its cached paint, layout direction and the like) and the
-   * static/synthetic fields Kotlin emits, none of which say anything about what a painter draws.
+   * A painter's own instance state: the fields declared below `Painter` in its hierarchy, skipping
+   * `Painter`'s own bookkeeping (its cached paint, layout direction and the like).
+   *
+   * Compiler-generated fields are **kept**. A local or anonymous painter holds whatever it captured
+   * in a synthetic field, and a captured `Painter` or `ColorFilter` affects the pixels exactly as
+   * much as a declared one does — filtering synthetics out would hide that state from both the
+   * paint-altering check and the ambiguity check. Only statics are dropped, since they are shared
+   * class state rather than this instance's.
    */
   private fun ownFields(type: Class<*>): List<Field> =
     generateSequence(type as Class<*>?) { it.superclass }
       .takeWhile { it.name != "androidx.compose.ui.graphics.painter.Painter" }
       .flatMap { it.declaredFields.asSequence() }
-      .filterNot { it.isSynthetic || Modifier.isStatic(it.modifiers) }
+      .filterNot { Modifier.isStatic(it.modifiers) }
       .toList()
 
   /**

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.layout.ModifierInfo
 import androidx.compose.ui.platform.InspectableValue
 import androidx.compose.ui.unit.Dp
 import ee.schimke.composeai.data.layoutinspector.PlaceholderModifiers
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -454,21 +456,35 @@ internal object ModifierTokenResolver {
    * nothing (the common case) — so a real `ColorPainter`, `BitmapPainter` or `VectorPainter` is
    * handed back as-is and classified normally by the caller.
    *
-   * A wrapper carrying **more than one** painter field is left alone: which one is the fill is a
-   * guess, and guessing wrong would paint the container in the wrong colour — worse than the raster
-   * fallback. Depth is bounded so a self-referential painter can't spin.
+   * Only a **pure pass-through** wrapper is followed: one whose sole piece of own state is that
+   * delegate painter. A wrapper that also holds a shape, a `ColorFilter`, a `Brush`, a
+   * `BorderStroke`, an alpha — or a second painter, where which one is the fill would be a guess —
+   * is left alone, because each of those changes what the render actually painted and a flat fill
+   * recovered past them would be a rectangle in the wrong colour. Wrong colours are worse than the
+   * raster fallback, which reproduces the pixels exactly.
+   *
+   * Reflection can see a painter's *state* but not its `onDraw`, so this cannot prove a wrapper
+   * forwards its delegate — a stateless painter that draws something else entirely would still be
+   * followed. That residue is accepted: a painter whose only field is another painter and which
+   * then ignores it is not a shape any Compose library ships. Depth is bounded so a
+   * self-referential painter can't spin.
    */
   private fun unwrapDelegatingPainter(painter: Any): Any {
     var current = painter
     repeat(MAX_PAINTER_UNWRAP_DEPTH) {
       if (current.javaClass.simpleName == "ColorPainter") return current
-      val delegates =
-        generateSequence(current.javaClass as Class<*>?) { it.superclass }
-          .flatMap { it.declaredFields.asSequence() }
-          .filter { field ->
-            field.type.name != current.javaClass.name && isPainterType(field.type)
-          }
-          .toList()
+      val own = ownFields(current.javaClass)
+      // A wrapper that also holds paint-altering state — a shape to clip with, a
+      // `ColorFilter`/`Brush` to re-tint with, a `BorderStroke`, an alpha — does not paint what
+      // its delegate paints, so a flat fill recovered past it would be a rectangle in a colour
+      // the render never drew. Wrong colours are worse than the raster fallback, which reproduces
+      // the pixels exactly, so those stop the descent. Inert bookkeeping (a cached
+      // `intrinsicSize`, a measured extent) doesn't change the paint and is allowed through.
+      if (own.any { altersPaint(it) }) return current
+      val delegates = own.filter {
+        isPainterType(it.type) && it.type.name != current.javaClass.name
+      }
+      // Two painters: which one is the fill would be a guess, so leave it alone as well.
       val next =
         delegates.singleOrNull()?.let { field ->
           runCatching {
@@ -481,6 +497,54 @@ internal object ModifierTokenResolver {
     }
     return current
   }
+
+  /**
+   * A painter's own instance state: the fields declared below `Painter` in its hierarchy. Skips
+   * `Painter`'s own bookkeeping (its cached paint, layout direction and the like) and the
+   * static/synthetic fields Kotlin emits, none of which say anything about what a painter draws.
+   */
+  private fun ownFields(type: Class<*>): List<Field> =
+    generateSequence(type as Class<*>?) { it.superclass }
+      .takeWhile { it.name != "androidx.compose.ui.graphics.painter.Painter" }
+      .flatMap { it.declaredFields.asSequence() }
+      .filterNot { it.isSynthetic || Modifier.isStatic(it.modifiers) }
+      .toList()
+
+  /**
+   * True when [field] is state that changes what a painter puts on screen relative to what it
+   * delegates to.
+   *
+   * Detected two ways, because Compose spells these both as objects and as inlined value classes:
+   * by *type* for the paint concepts that have one (`Brush`, `ColorFilter`, `Shape`, …), and by
+   * *name* for the scalars that don't — a `Color` and a `Size` are both an inlined `long`, so only
+   * the name distinguishes a tint from a cached extent.
+   */
+  private fun altersPaint(field: Field): Boolean {
+    if (supertypes(field.type).any { it in PAINT_ALTERING_TYPES }) return true
+    val name = field.name.lowercase(Locale.US)
+    return PAINT_KNOB_NAMES.any { name.contains(it) }
+  }
+
+  /** [type] and every class/interface it inherits from, by binary name. */
+  private fun supertypes(type: Class<*>): Sequence<String> = sequence {
+    yield(type.name)
+    type.superclass?.let { yieldAll(supertypes(it)) }
+    type.interfaces.forEach { yieldAll(supertypes(it)) }
+  }
+
+  private val PAINT_ALTERING_TYPES =
+    setOf(
+      "androidx.compose.ui.graphics.Brush",
+      "androidx.compose.ui.graphics.ColorFilter",
+      "androidx.compose.ui.graphics.ColorProducer",
+      "androidx.compose.ui.graphics.Outline",
+      "androidx.compose.ui.graphics.Paint",
+      "androidx.compose.ui.graphics.Shape",
+      "androidx.compose.foundation.BorderStroke",
+    )
+
+  private val PAINT_KNOB_NAMES =
+    listOf("alpha", "opacity", "tint", "color", "colour", "filter", "brush", "shape", "border")
 
   /** True when [type] is (or extends) Compose's `Painter`. */
   private fun isPainterType(type: Class<*>): Boolean =

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/DelegatingPainterUnwrapTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/DelegatingPainterUnwrapTest.kt
@@ -108,6 +108,28 @@ class DelegatingPainterUnwrapTest {
     assertNull(resolve(painter))
   }
 
+  /**
+   * A painter that forwards to one painter and draws a second one it *captured*. Kotlin keeps a
+   * capture in a compiler-generated field, so a scan that skipped those would see a single clean
+   * delegate and report its colour — while the overlay it draws on top is what the render actually
+   * shows.
+   */
+  private fun capturingPainter(delegate: Painter, overlay: Painter): Painter =
+    object : Painter() {
+      override val intrinsicSize: Size = Size.Unspecified
+
+      override fun DrawScope.onDraw() {
+        with(delegate) { draw(size) }
+        with(overlay) { draw(size) }
+      }
+    }
+
+  @Test
+  fun `a captured second painter still counts as ambiguous`() {
+    val painter = capturingPainter(ColorPainter(Color(0xFF112233)), ColorPainter(Color(0xFF445566)))
+    assertNull("a captured overlay changes the pixels and must not be ignored", resolve(painter))
+  }
+
   @Test
   fun `extra state anywhere in the chain stops the descent`() {
     val painter = WrappingPainter(TintingPainter(ColorPainter(Color(0xFF112233)), tint = 0L))

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/DelegatingPainterUnwrapTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/DelegatingPainterUnwrapTest.kt
@@ -1,10 +1,15 @@
 package ee.schimke.composeai.daemon
 
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -21,15 +26,44 @@ import org.junit.Test
  */
 class DelegatingPainterUnwrapTest {
 
-  /** A painter that delegates its drawing to exactly one other painter. */
+  /** A painter that delegates its drawing to exactly one other painter, and holds nothing else. */
   private class WrappingPainter(@JvmField val delegate: Painter) : Painter() {
+    override val intrinsicSize: Size = delegate.intrinsicSize
+
+    override fun DrawScope.onDraw() {
+      with(delegate) { draw(size) }
+    }
+  }
+
+  /** A wrapper holding two painters — which one is the fill is a guess, so it must not resolve. */
+  private class AmbiguousPainter(@JvmField val a: Painter, @JvmField val b: Painter) : Painter() {
     override val intrinsicSize: Size = Size.Unspecified
 
     override fun DrawScope.onDraw() = Unit
   }
 
-  /** A wrapper holding two painters — which one is the fill is a guess, so it must not resolve. */
-  private class AmbiguousPainter(@JvmField val a: Painter, @JvmField val b: Painter) : Painter() {
+  /**
+   * A wrapper that also re-tints what it forwards. The inner colour is *not* what the render
+   * painted, so recovering it would draw the container in the wrong colour.
+   */
+  private class TintingPainter(@JvmField val delegate: Painter, @JvmField val tint: Long) :
+    Painter() {
+    override val intrinsicSize: Size = Size.Unspecified
+
+    override fun DrawScope.onDraw() = Unit
+  }
+
+  /**
+   * A minimal [Shape] — this module is deliberately foundation-free, so no `RoundedCornerShape`.
+   */
+  private object BoxShape : Shape {
+    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density) =
+      Outline.Rectangle(Rect(0f, 0f, size.width, size.height))
+  }
+
+  /** A wrapper that clips what it forwards to its own shape. */
+  private class ShapingPainter(@JvmField val delegate: Painter, @JvmField val outline: Shape) :
+    Painter() {
     override val intrinsicSize: Size = Size.Unspecified
 
     override fun DrawScope.onDraw() = Unit
@@ -58,6 +92,26 @@ class DelegatingPainterUnwrapTest {
   fun `a wrapper with two painter fields is left for the raster fallback`() {
     val painter = AmbiguousPainter(ColorPainter(Color(0xFF112233)), ColorPainter(Color(0xFF445566)))
     assertNull("ambiguous delegate must not be guessed at", resolve(painter))
+  }
+
+  @Test
+  fun `a wrapper carrying paint-altering state is left for the raster fallback`() {
+    val painter = TintingPainter(ColorPainter(Color(0xFF112233)), tint = 0x7F000000L)
+    assertNull("a re-tinting wrapper's inner colour is not what the render drew", resolve(painter))
+  }
+
+  @Test
+  fun `a wrapper that clips to its own shape is left for the raster fallback`() {
+    // The type-based half of the check: a `Shape` field is a paint concept with a real type, so
+    // it's caught without relying on the field's name.
+    val painter = ShapingPainter(ColorPainter(Color(0xFF112233)), BoxShape)
+    assertNull(resolve(painter))
+  }
+
+  @Test
+  fun `extra state anywhere in the chain stops the descent`() {
+    val painter = WrappingPainter(TintingPainter(ColorPainter(Color(0xFF112233)), tint = 0L))
+    assertNull(resolve(painter))
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #2918, addressing the P1 Codex left on it after it merged.

## The concern, and why it's right

#2918 follows a delegating painter down to the `ColorPainter` it draws, keyed on finding a single painter-typed field. That heuristic is too permissive: a wrapper can hold exactly one painter and *also* clip, tint, apply alpha to, or border what it forwards. Unwrapping past that reports a flat fill the render never painted — and because a non-null `backgroundColor` is exactly what makes `FigmaSvgModel.toLayer` skip the raster fallback, the wrong colour gets drawn where correct pixels used to be. That's a worse failure than the one #2918 fixed.

## The fix

The descent now stops at any wrapper carrying paint-altering state. Compose spells those two ways, so both are checked:

- **by type** for the paint concepts that have one — `Brush`, `ColorFilter`, `Shape`, `Outline`, `Paint`, `BorderStroke`, `ColorProducer`;
- **by field name** for the scalars that don't — a `Color` and a `Size` are both an inlined `long`, so only the name separates a tint from a cached extent.

Inert bookkeeping such as `intrinsicSize` still passes. That distinction matters: nearly every real wrapper has an `intrinsicSize` backing field, so the stricter "exactly one own field" rule I tried first disabled the unwrap entirely and re-broke #2615. The two-painter bail-out from #2918 is unchanged.

## What this still doesn't do

Reflection can read a painter's state but not its `onDraw`, so this cannot *prove* a wrapper forwards its delegate — a stateless painter that draws something else entirely would still be followed. Codex's example of that was the PR's own `WrappingPainter` fixture, whose `onDraw` was empty. That residue is documented at the call site and accepted: a painter whose only state is another painter, which it then ignores, is not a shape any Compose library ships. I've also fixed the fixture to actually draw its delegate, so it stops being a misleading example of the very thing being guarded against.

I could not verify the real Wear wrapper classes here — `wear-compose-material3` isn't resolvable in this container — so the exact wrappers Jetcaster Wear uses remain unconfirmed. If the next catalog rerun shows #2615's surfaces still rasterising, the wrapper carries state this now (correctly) refuses, and the answer is to handle that wrapper's semantics explicitly rather than to loosen this check again.

## Test plan

- `./gradlew :data-layoutinspector-connector:test` — green (full module).
- New cases: a re-tinting wrapper (name-detected), a shape-clipping wrapper (type-detected), and extra state appearing partway down a chain — all resolve null and keep the raster fallback. The existing pass-through and two-painter cases still hold.

Text-only PR: this is capture-side resolver logic with no rendered surface of its own.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AbWyewkWvbY9pb5VS7FBWr)_