### PR TITLE
fix(serve): reject a themeProvider the catalog never declared

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1652,11 +1652,16 @@ class ServeHttpServer(
         ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, overrideParams)
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
+      // Reject a themeProvider this catalog never declared instead of quietly rendering the
+      // default theme under its name (see ServeOverrides.parse).
+      val declaredThemeFqns = renderHost.declaredThemes.map { it.providerFqn }.toSet()
       // `?format=svg` serves the figma-svg export as an inert svg <img> (vector, for DOM-capture
       // visual tools); default (png) inlines the raster. SVG is daemon-only, so a static bundle
       // 404s.
       val wantSvg = call.request.queryParameters["format"]?.lowercase() == "svg"
-      when (val parsed = ServeOverrides.parse(normalizedOverrideParams, knobKinds)) {
+      when (
+        val parsed = ServeOverrides.parse(normalizedOverrideParams, knobKinds, declaredThemeFqns)
+      ) {
         is OverrideParse.Invalid ->
           call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
         is OverrideParse.Ok ->
@@ -1911,7 +1916,12 @@ class ServeHttpServer(
       // `<kind>:<value>` still wins) so the viewer never has to spell the type in the URL.
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
-      when (val parsed = ServeOverrides.parse(normalizedOverrideParams, knobKinds)) {
+      // Reject a themeProvider this catalog never declared instead of quietly rendering the
+      // default theme under its name (see ServeOverrides.parse).
+      val declaredThemeFqns = renderHost.declaredThemes.map { it.providerFqn }.toSet()
+      when (
+        val parsed = ServeOverrides.parse(normalizedOverrideParams, knobKinds, declaredThemeFqns)
+      ) {
         is OverrideParse.Invalid ->
           call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
         is OverrideParse.Ok -> {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
@@ -40,7 +40,10 @@ private constructor(
     when (val message = ServeStreamProtocol.parseClient(text)) {
       is ServeStreamProtocol.ClientMessage.SetOverrides -> {
         val normalized = normalize(message.overrides)
-        when (val parsed = ServeOverrides.parse(normalized, knobKindsFor(previewId))) {
+        when (
+          val parsed =
+            ServeOverrides.parse(normalized, knobKindsFor(previewId), declaredThemeFqns())
+        ) {
           is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
           is OverrideParse.Ok -> {
             // stream/start fixes overrides for the held session, so an override change restarts it.
@@ -99,7 +102,10 @@ private constructor(
   private fun switchTo(message: ServeStreamProtocol.ClientMessage.Switch) {
     val nextOverrides = message.overrides?.let(::normalize) ?: overrides
     val parsed =
-      when (val p = ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId))) {
+      when (
+        val p =
+          ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId), declaredThemeFqns())
+      ) {
         is OverrideParse.Invalid -> {
           send(ServeStreamProtocol.errorMessage(p.message))
           return
@@ -124,6 +130,13 @@ private constructor(
   private fun knobKindsFor(id: String): Map<String, String> =
     ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == id })
 
+  /**
+   * The session's declared `@ThemeCatalog` provider FQNs, so a `themeProvider` this catalog never
+   * declared is reported as an error rather than silently rendering the default theme.
+   */
+  private fun declaredThemeFqns(): Set<String> =
+    renderHost.declaredThemes.map { it.providerFqn }.toSet()
+
   private fun onFrame(frame: StreamFrameParams) {
     // `unchanged` heartbeats carry no payload — nothing to paint.
     val payload = frame.payloadBase64 ?: return
@@ -146,9 +159,11 @@ private constructor(
       }
 
     /**
-     * Try to open a daemon-backed live stream. Returns `null` when streaming is unsupported, so the
-     * caller falls back to the snapshot lane. An invalid initial-overrides query degrades to the
-     * preview's defaults (the bad value would otherwise block the whole live session at connect).
+     * Try to open a daemon-backed live stream. Returns `null` when streaming is unsupported, or
+     * when the initial-overrides query is invalid — in both cases the caller falls back to the
+     * snapshot lane, which re-parses the same overrides and reports the reason once. The invalid
+     * case used to degrade to the preview's defaults and subscribe anyway; that quietly served a
+     * default-themed stream to a client that had asked for something else.
      */
     fun tryStart(
       renderHost: ServeHost,
@@ -164,9 +179,29 @@ private constructor(
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
       val normalizedOverrides = ServeWeb.SystemDisplay.normalizeOverrideParams(system, overrides)
+      // Validate the socket's *initial* query too, not just the later `setOverrides` / `switch`
+      // messages. Degrading an invalid parse to `PreviewOverrides()` here would subscribe the
+      // client to a stream rendered under the default theme while it believes it asked for another
+      // one — the exact silent-default this validation exists to stop, and worse on a live stream
+      // than on a snapshot because a later frame would clear the viewer's error overlay while the
+      // wrong stream kept running. Refuse to start instead: the reason goes out through
+      // [onUnavailable], and the caller's fallback to [ServeStreamSession] re-parses the same
+      // overrides and reports it once, rather than this lane and that one both sending it.
       val initial =
-        (ServeOverrides.parse(normalizedOverrides, knobKinds) as? OverrideParse.Ok)?.overrides
-          ?: PreviewOverrides()
+        when (
+          val parsed =
+            ServeOverrides.parse(
+              normalizedOverrides,
+              knobKinds,
+              renderHost.declaredThemes.map { it.providerFqn }.toSet(),
+            )
+        ) {
+          is OverrideParse.Invalid -> {
+            onUnavailable?.invoke(parsed.message)
+            return null
+          }
+          is OverrideParse.Ok -> parsed.overrides
+        }
       val session =
         ServeLiveSession(renderHost, previewId, normalizedOverrides, codec, maxFps, send, system)
       session.handle =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -184,10 +184,21 @@ object ServeOverrides {
    * [knobKinds] maps a knob's `wireKey` to its declared kind so a bare `knob.<key>=<value>` is
    * typed without the caller spelling it (see [declaredKnobKinds]); an explicit `<kind>:<value>`
    * prefix still wins, and an undeclared key with a bare value falls back to a string.
+   *
+   * [declaredThemeFqns] is the session's `@ThemeCatalog` provider FQNs
+   * ([ServeHost.declaredThemes]). A `themeProvider` outside that set is rejected here rather than
+   * passed down: the renderer's `loadWrapperByFqnOrNull` logs to stderr and returns null on a class
+   * it can't load, so a misspelled or stale FQN used to come back HTTP 200 with a
+   * **default-themed** PNG — visually indistinguishable from a theme that genuinely renders the
+   * same, and therefore the kind of failure a caller can stare straight through. `null` (the
+   * default) means "the caller doesn't know this session's themes" and skips the check; an **empty
+   * set** means the session declares none, so any `themeProvider` is rejected — nothing could apply
+   * it.
    */
   fun parse(
     params: Map<String, String>,
     knobKinds: Map<String, String> = emptyMap(),
+    declaredThemeFqns: Set<String>? = null,
   ): OverrideParse {
     fun blank(key: String): Boolean = params[key]?.isBlank() ?: true
 
@@ -519,6 +530,19 @@ object ServeOverrides {
         }
     }
 
+    val themeProvider = params["themeProvider"]?.takeIf { it.isNotBlank() }
+    if (themeProvider != null && declaredThemeFqns != null && themeProvider !in declaredThemeFqns) {
+      return OverrideParse.Invalid(
+        if (declaredThemeFqns.isEmpty()) {
+          "themeProvider '$themeProvider' cannot be applied: this catalog declares no " +
+            "@ThemeCatalog providers"
+        } else {
+          "unknown themeProvider '$themeProvider'; this catalog declares " +
+            declaredThemeFqns.sorted().joinToString(", ")
+        }
+      )
+    }
+
     // Fold the two Remote Compose facets into one override, or leave null when neither is present
     // so
     // an rc-free render carries no `remoteCompose` payload (identical wire shape to before).
@@ -545,7 +569,7 @@ object ServeOverrides {
         placeholderActive = placeholderActive,
         talkBack = talkBack,
         touchOverlay = touchOverlay,
-        themeProvider = params["themeProvider"]?.takeIf { it.isNotBlank() },
+        themeProvider = themeProvider,
         focus = focus,
         gestures = gestures,
         clearBackground = clearBackground,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -56,7 +56,10 @@ class ServeStreamSession(
         // Validate before committing: a bad override message is reported but must not poison the
         // session — the previous (valid) overrides stay in effect for subsequent frames.
         val normalized = normalize(message.overrides)
-        when (val parsed = ServeOverrides.parse(normalized, knobKindsFor(previewId))) {
+        when (
+          val parsed =
+            ServeOverrides.parse(normalized, knobKindsFor(previewId), declaredThemeFqns())
+        ) {
           is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
           is OverrideParse.Ok -> {
             overrides = normalized
@@ -90,7 +93,10 @@ class ServeStreamSession(
     // lane.
     val nextOverrides = message.overrides?.let(::normalize) ?: overrides
     val parsed =
-      when (val p = ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId))) {
+      when (
+        val p =
+          ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId), declaredThemeFqns())
+      ) {
         is OverrideParse.Invalid -> {
           send(ServeStreamProtocol.errorMessage(p.message))
           return
@@ -109,6 +115,13 @@ class ServeStreamSession(
     ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == id })
 
   /**
+   * The session's declared `@ThemeCatalog` provider FQNs, so a `themeProvider` this catalog never
+   * declared is reported as an error rather than silently rendering the default theme.
+   */
+  private fun declaredThemeFqns(): Set<String> =
+    renderHost.declaredThemes.map { it.providerFqn }.toSet()
+
+  /**
    * The message for an [input][ServeStreamProtocol.ClientMessage.Input] the snapshot lane can't
    * dispatch. When the live lane's original failure was captured, surface it so the user sees *why*
    * (e.g. "…: the daemon could not hold an interactive session for this preview") instead of a bare
@@ -119,7 +132,9 @@ class ServeStreamSession(
     else "input requires a live stream — unavailable: $liveUnavailableReason"
 
   private fun renderCurrent() {
-    when (val parsed = ServeOverrides.parse(overrides, knobKindsFor(previewId))) {
+    when (
+      val parsed = ServeOverrides.parse(overrides, knobKindsFor(previewId), declaredThemeFqns())
+    ) {
       is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
       is OverrideParse.Ok -> sendFrame(parsed.overrides)
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
@@ -107,6 +107,64 @@ class ServeLiveSessionTest {
   }
 
   @Test
+  fun `tryStart refuses an undeclared themeProvider in the opening query`() {
+    // The socket's *initial* overrides are validated too, not just later setOverrides / switch
+    // messages — otherwise a direct WebSocket client asking for a theme this catalog never
+    // declared would be silently subscribed to a default-themed stream, and a later frame would
+    // clear the viewer's error overlay while the wrong stream kept running (Codex #2923 review).
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    val themed =
+      ServeRenderHost(
+        session,
+        listOf(ServePreview(previewId, "Red")),
+        declaredThemes = listOf(ServeTheme("Brand Dark", "com.example.BrandDarkThemeCatalog")),
+        renderTimeoutSeconds = 30,
+      )
+    themed.use { h ->
+      var reason: String? = null
+      assertNull(
+        ServeLiveSession.tryStart(
+          h,
+          previewId,
+          mapOf("themeProvider" to "com.example.NopeThemeCatalog"),
+          send = {},
+          system = "compose-m3",
+          onUnavailable = { reason = it },
+        )
+      )
+      assertNotNull(reason)
+      assertTrue(
+        reason.contains("com.example.NopeThemeCatalog"),
+        "expected the rejected provider in the reason, got: $reason",
+      )
+    }
+  }
+
+  @Test
+  fun `tryStart accepts a declared themeProvider in the opening query`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    val themed =
+      ServeRenderHost(
+        session,
+        listOf(ServePreview(previewId, "Red")),
+        declaredThemes = listOf(ServeTheme("Brand Dark", "com.example.BrandDarkThemeCatalog")),
+        renderTimeoutSeconds = 30,
+      )
+    themed.use { h ->
+      val live =
+        ServeLiveSession.tryStart(
+          h,
+          previewId,
+          mapOf("themeProvider" to "com.example.BrandDarkThemeCatalog"),
+          send = {},
+          system = "compose-m3",
+        )
+      assertNotNull(live)
+      live.close()
+    }
+  }
+
+  @Test
   fun `daemon-pushed frames are forwarded as frame messages`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -43,6 +43,58 @@ class ServeOverridesTest {
   }
 
   @Test
+  fun `a themeProvider the catalog declares is accepted`() {
+    val parsed =
+      ServeOverrides.parse(
+        mapOf("themeProvider" to "com.example.BrandDarkThemeCatalog"),
+        declaredThemeFqns =
+          setOf("com.example.BrandLightThemeCatalog", "com.example.BrandDarkThemeCatalog"),
+      )
+    assertTrue(parsed is OverrideParse.Ok, "expected Ok, got $parsed")
+    assertEquals("com.example.BrandDarkThemeCatalog", parsed.overrides.themeProvider)
+  }
+
+  @Test
+  fun `a themeProvider the catalog does not declare is rejected, not silently defaulted`() {
+    val parsed =
+      ServeOverrides.parse(
+        mapOf("themeProvider" to "com.example.TotallyBogusThemeCatalog"),
+        declaredThemeFqns = setOf("com.example.BrandDarkThemeCatalog"),
+      )
+    assertTrue(parsed is OverrideParse.Invalid, "expected Invalid, got $parsed")
+    assertTrue(
+      parsed.message.contains("com.example.TotallyBogusThemeCatalog"),
+      "message should name the rejected provider: ${parsed.message}",
+    )
+    assertTrue(
+      parsed.message.contains("com.example.BrandDarkThemeCatalog"),
+      "message should list what the catalog does declare: ${parsed.message}",
+    )
+  }
+
+  @Test
+  fun `a themeProvider against a catalog that declares none is rejected`() {
+    val parsed =
+      ServeOverrides.parse(
+        mapOf("themeProvider" to "com.example.BrandDarkThemeCatalog"),
+        declaredThemeFqns = emptySet(),
+      )
+    assertTrue(parsed is OverrideParse.Invalid, "expected Invalid, got $parsed")
+    assertTrue(
+      parsed.message.contains("declares no"),
+      "message should say the catalog declares none: ${parsed.message}",
+    )
+  }
+
+  @Test
+  fun `a caller that does not know the session themes skips validation`() {
+    // `declaredThemeFqns = null` is the default — the pre-existing behaviour for callers with no
+    // session in hand. Covered so the back-compat default can't be tightened by accident.
+    val o = ok(mapOf("themeProvider" to "com.example.AnythingThemeCatalog"))
+    assertEquals("com.example.AnythingThemeCatalog", o.themeProvider)
+  }
+
+  @Test
   fun `focus tab index maps to a focus override with the overlay drawn`() {
     val o = ok(mapOf("focus" to "2"))
     assertEquals(2, o.focus?.tabIndex)


### PR DESCRIPTION
## Summary

A `themeProvider` the catalog never declared came back **HTTP 200 with a default-themed PNG**. No error, no badge, nothing in the response to say the theme had not been applied — and a default-themed render is visually indistinguishable from a theme that genuinely renders the same, so it is the kind of failure a caller stares straight through.

Reproduced against the live server with a deliberately fabricated FQCN:

```
GET /confetti-mobile/render/colorscheme__…__light__compact.png
      ?themeProvider=dev.johnoreilly.confetti.ui.TotallyBogusThemeCatalog
→ 200 · x-compose-preview-generation: daemon
→ pixels identical to every real provider's render
```

The cause is `loadWrapperByFqnOrNull` in both `RenderEngine`s: it logs to stderr and returns `null` on a class it cannot load, then falls back to the preview's declared wrapper. That fallback is deliberate and correct — dropping a required `@PreviewWrapper` would misrender — but it means a bad `themeProvider` is only ever reported to a daemon log nobody is reading. The same silence covers a provider that was real and has since been renamed.

So this rejects it one level up, at the serve boundary, where the session already knows what the catalog declares. `ServeOverrides.parse` gains a `declaredThemeFqns` parameter and returns `OverrideParse.Invalid` for a `themeProvider` outside that set. That is exactly the contract `parse` already documents for every other override — *"returns `Invalid` with a human reason on malformed values rather than rendering with a silent default"* — and every lane (HTTP `/render`, storybook iframe, stream, live) already routes `Invalid` to a 400 / error frame, so no new error plumbing was needed.

Three-state parameter, so the check is never guessing:

| `declaredThemeFqns` | meaning | behaviour |
|---|---|---|
| `null` (default) | caller does not know this session's themes | skipped, as before |
| non-empty | the session's declared providers | anything outside the set is rejected, and the message lists what *is* declared |
| empty | the session declares none | any `themeProvider` is rejected — nothing could apply it |

### The live lane's opening query (Codex P1)

`ServeLiveSession.tryStart` parsed the socket's initial query without validation and degraded an invalid parse to `PreviewOverrides()`, then subscribed anyway. A direct WebSocket client asking for an undeclared theme was handed a default-themed **stream** under the name of the theme it asked for — worse than the snapshot lane, because the bundled viewer's replay reports the error but a later frame clears the overlay while the wrong stream keeps running.

It now validates the opening query too and refuses to start, reporting through `onUnavailable`. The caller's existing fallback to `ServeStreamSession` re-parses the same overrides and surfaces the reason exactly once, rather than both lanes sending it.

## Not included

This does not make a *declared* provider actually change the pixels. On `confetti-mobile` all 14 declared providers also render identically, but for a different, catalog-side reason: `compose-preview` applies a `themeProvider` **in place of** a preview's `@PreviewWrapper`, and those previews install their theme inside the function body instead, where an outer wrapper cannot reach it. That is a fix for the catalog, not for this repo — raised on the Confetti side.

## Test plan

- Four new cases in `ServeOverridesTest`: a declared provider is accepted; an undeclared one is `Invalid` and the message names both the rejected provider and what the catalog does declare; a `themeProvider` against a catalog declaring none is `Invalid`; and `null` still skips validation, so the back-compat default cannot be tightened by accident.
- Two new cases in `ServeLiveSessionTest` covering the opening query: an undeclared provider returns `null` with the reason on `onUnavailable`, a declared one starts normally.
- `./gradlew :cli:test --tests "*ServeOverridesTest*" --tests "*ServeLiveSessionTest*" --tests "*ServeStreamSessionTest*"` — green.

Text-only PR — no rendered output changes.

## Note on the force-push

The first push of this branch was cut from a stale base and silently reverted work that had landed on `main` in between (~200 lines of `ServeHttpServer.kt`, plus `ServeWeb.kt` and others). The branch has been rebuilt on current `main` by applying only this change's edits; the diff is now purely additive.