### PR TITLE
fix(figma-svg): raster an icon a blend-mode tint draws over

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawCaptureExtractor.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawCaptureExtractor.kt
@@ -92,6 +92,9 @@ internal object DrawCaptureExtractor {
       viewportWidth = width.toFloat(),
       viewportHeight = height.toFloat(),
       paths = rec.paths.toList(),
+      // These paths *are* the draw modifier's output, so the export must not also treat that
+      // modifier as an unrepresented overlay and raster the node (issue #2852).
+      fromDrawCapture = true,
     )
   }
 

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -85,7 +85,13 @@ object LayoutInspectorProduct {
   // item shrunk toward the curved edge). `bounds` already carries the scaled rect; `transform` says
   // the shrink is real, so a consumer doesn't grow the node back to its measured `size`. Additive —
   // older entries decode with `transform = null`.
-  const val SCHEMA_VERSION: Int = 9
+  // v10 (#2852): a `vectorGraphic` says whether its paths came from the node's own draw lambda
+  // (`fromDrawCapture`) or from an `ImageVector`. The export needs the distinction to read a draw
+  // modifier on a vector node: for a captured draw the modifier *is* those paths, while on an
+  // `ImageVector` it's an unrepresented overlay (Jetsnack's blend-mode gradient icon tint) that has
+  // to raster instead of exporting the untinted glyph. Additive — older entries decode with
+  // `fromDrawCapture = false`, which is the `ImageVector` reading they all had.
+  const val SCHEMA_VERSION: Int = 10
   const val FILE: String = "layout-inspector.json"
 }
 
@@ -611,6 +617,18 @@ data class LayoutInspectorVectorGraphic(
   val viewportWidth: Float,
   val viewportHeight: Float,
   val paths: List<LayoutInspectorVectorPath>,
+  /**
+   * True when these paths were recorded from the node's own imperative draw lambda (the
+   * `DrawCaptureExtractor` path: a slider groove, a progress arc) rather than reflected off an
+   * `ImageVector` painter.
+   *
+   * The export needs the distinction to know what a draw modifier on the same node means. For a
+   * captured draw the modifier *is* these paths, and everything it painted is already represented.
+   * For an `ImageVector` the draw modifier is a separate overlay that nothing here accounts for —
+   * Jetsnack tints its icons with `drawWithContent { drawContent(); drawRect(brush, blendMode) }` —
+   * so the layer has to raster instead of emitting the untinted icon (issue #2852).
+   */
+  val fromDrawCapture: Boolean = false,
 )
 
 /**

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -662,7 +662,7 @@ data class FigmaSvgModel(
       // the recorder just made. Hybrid mode only — with no frame to crop from, the untinted vector
       // still beats a broken `<image>` reference.
       if (ctx.captureCanvasDraws && vectorGraphic?.fromDrawCapture == false && hasCustomDraw()) {
-        val region = drawnOverlayRegion()
+        val region = drawnOverlayRegion(bounds)
         val href = ctx.rasterHref(nodeId)
         ctx.rasterTargets.add(
           FigmaSvgRasterTarget(nodeId, href, region.left, region.top, region.right, region.bottom)
@@ -1233,14 +1233,24 @@ data class FigmaSvgModel(
      * — the icon underneath still has to be inside the crop, and a tint pass that reports no bounds
      * covers the whole node.
      */
-    private fun LayoutInspectorNode.drawnOverlayRegion(): LayoutInspectorBounds {
+    private fun LayoutInspectorNode.drawnOverlayRegion(
+      nodeBounds: LayoutInspectorBounds
+    ): LayoutInspectorBounds {
+      // [nodeBounds], not this node's raw `bounds`: a detached or not-yet-placed node (a vector
+      // inside a subcomposed Button/TextField) reports `(0,0,0,0)`, which `toLayer` has already
+      // reconstructed from its measured size. Reading the raw field back would crop a zero-sized
+      // region and the layer would come back as the transparent 1×1 fallback.
       val drawn = modifiers.filter { it.isCustomDraw() }.mapNotNull { it.bounds }
-      if (drawn.isEmpty()) return bounds
+      if (drawn.isEmpty()) return nodeBounds
+      // A draw modifier's own bounds are subject to the same detachment, so an empty one can't be
+      // allowed to drag the union back to the origin.
+      val placed = drawn.filter { it.right > it.left && it.bottom > it.top }
+      if (placed.isEmpty()) return nodeBounds
       return LayoutInspectorBounds(
-        left = minOf(bounds.left, drawn.minOf { it.left }),
-        top = minOf(bounds.top, drawn.minOf { it.top }),
-        right = maxOf(bounds.right, drawn.maxOf { it.right }),
-        bottom = maxOf(bounds.bottom, drawn.maxOf { it.bottom }),
+        left = minOf(nodeBounds.left, placed.minOf { it.left }),
+        top = minOf(nodeBounds.top, placed.minOf { it.top }),
+        right = maxOf(nodeBounds.right, placed.maxOf { it.right }),
+        bottom = maxOf(nodeBounds.bottom, placed.maxOf { it.bottom }),
       )
     }
 

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -651,6 +651,33 @@ data class FigmaSvgModel(
       // below. Placed before the raster branch so a vector-backed icon never rasterises; a
       // bitmap-backed one (no `vectorGraphic`) falls through and rasters as before. An empty/
       // gradient-only capture yields null and also falls through.
+      // …unless something draws *over* that icon which the vector model doesn't represent. Jetsnack
+      // tints its gradient icons with `Modifier.drawWithContent { drawContent(); drawRect(brush,
+      // blendMode = Plus/Darken) }`; a blend-mode composite over arbitrary content has no faithful
+      // SVG equivalent, and emitting the bare `ImageVector` painted the untinted (black) glyph the
+      // PNG never shows. Raster the node so the tint survives (issue #2852).
+      //
+      // Only for an `ImageVector`: when the paths were recorded *from* the draw lambda the modifier
+      // is already fully represented by them, and rastering would throw away the editable capture
+      // the recorder just made. Hybrid mode only — with no frame to crop from, the untinted vector
+      // still beats a broken `<image>` reference.
+      if (ctx.captureCanvasDraws && vectorGraphic?.fromDrawCapture == false && hasCustomDraw()) {
+        val region = drawnOverlayRegion()
+        val href = ctx.rasterHref(nodeId)
+        ctx.rasterTargets.add(
+          FigmaSvgRasterTarget(nodeId, href, region.left, region.top, region.right, region.bottom)
+        )
+        return FigmaSvgLayer(
+          name = layerName(),
+          left = region.left,
+          top = region.top,
+          right = region.right,
+          bottom = region.bottom,
+          raster = FigmaSvgRaster(href),
+          opacity = opacity,
+          contentOpacity = contentOpacity,
+        )
+      }
       vectorGraphic
         ?.toFigmaSvgVector(
           layoutWidth = size.width,
@@ -1197,6 +1224,23 @@ data class FigmaSvgModel(
         top = drawn.minOf { it.top },
         right = drawn.maxOf { it.right },
         bottom = drawn.maxOf { it.bottom },
+      )
+    }
+
+    /**
+     * The region an over-drawing modifier covers on a vector node: the union of the node box and
+     * the draw modifiers' own bounds. Unlike [drawnRegion] this never *shrinks* to the draw bounds
+     * — the icon underneath still has to be inside the crop, and a tint pass that reports no bounds
+     * covers the whole node.
+     */
+    private fun LayoutInspectorNode.drawnOverlayRegion(): LayoutInspectorBounds {
+      val drawn = modifiers.filter { it.isCustomDraw() }.mapNotNull { it.bounds }
+      if (drawn.isEmpty()) return bounds
+      return LayoutInspectorBounds(
+        left = minOf(bounds.left, drawn.minOf { it.left }),
+        top = minOf(bounds.top, drawn.minOf { it.top }),
+        right = maxOf(bounds.right, drawn.maxOf { it.right }),
+        bottom = maxOf(bounds.bottom, drawn.maxOf { it.bottom }),
       )
     }
 

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -597,6 +597,46 @@ class FigmaLayeredSvgTest {
     assertTrue("the untinted vector must not be emitted\n$svg", !svg.contains("M11 5h2v14h-2z"))
   }
 
+  /**
+   * A detached / not-yet-placed vector (inside a subcomposed Button or TextField) reports
+   * `(0,0,0,0)` bounds, which `toLayer` reconstructs from its measured size. The overlay raster has
+   * to crop that recovered box — cropping the raw zero-area one yields the transparent 1×1
+   * fallback, i.e. the icon disappears instead of being preserved.
+   */
+  @Test
+  fun anOverDrawnIconWithRecoveredBoundsRastersAtItsRecoveredSize() {
+    val model =
+      FigmaSvgModel.from(
+        layout =
+          LayoutInspectorPayload(
+            LayoutInspectorNode(
+              nodeId = "root",
+              component = "Box",
+              bounds = LayoutInspectorBounds(0, 0, 24, 24),
+              size = LayoutInspectorSize(24, 24),
+              children =
+                listOf(
+                  LayoutInspectorNode(
+                    nodeId = "icon",
+                    component = "Icon",
+                    bounds = LayoutInspectorBounds(0, 0, 0, 0),
+                    size = LayoutInspectorSize(24, 24),
+                    vectorGraphic = plusVector(fromDrawCapture = false),
+                    modifiers = listOf(tintModifier()),
+                  )
+                ),
+            )
+          ),
+        captureCanvasDraws = true,
+      )
+
+    val target = model.rasterTargets.single { it.nodeId == "icon" }
+    assertTrue(
+      "the raster must cover the recovered box, not a zero-area one: $target",
+      target.right > target.left && target.bottom > target.top,
+    )
+  }
+
   @Test
   fun anIconWithNoOverDrawStaysAnEditableVector() {
     val model =

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -551,6 +551,94 @@ class FigmaLayeredSvgTest {
     assertFalse(svg, svg.contains("""id="Box"""))
   }
 
+  private fun plusVector(fromDrawCapture: Boolean) =
+    LayoutInspectorVectorGraphic(
+      viewportWidth = 24f,
+      viewportHeight = 24f,
+      paths =
+        listOf(LayoutInspectorVectorPath(pathData = "M11 5h2v14h-2z", fillArgb = "#FF000000")),
+      fromDrawCapture = fromDrawCapture,
+    )
+
+  private fun tintModifier() =
+    LayoutInspectorModifier(name = "drawWithContent", properties = emptyMap())
+
+  private fun vectorNode(
+    vector: LayoutInspectorVectorGraphic,
+    modifiers: List<LayoutInspectorModifier>,
+  ) =
+    LayoutInspectorPayload(
+      LayoutInspectorNode(
+        nodeId = "icon",
+        component = "Icon",
+        bounds = LayoutInspectorBounds(0, 0, 24, 24),
+        size = LayoutInspectorSize(24, 24),
+        vectorGraphic = vector,
+        modifiers = modifiers,
+      )
+    )
+
+  /**
+   * Issue #2852: Jetsnack tints its gradient icons with `Modifier.drawWithContent { drawContent();
+   * drawRect(brush, blendMode = Plus/Darken) }`. A blend-mode composite over arbitrary content has
+   * no faithful SVG equivalent, and the export emitted the bare `ImageVector` — painting the
+   * untinted black glyph the PNG never shows. The node must raster so the tint survives.
+   */
+  @Test
+  fun anIconDrawnOverByABlendModeTintRastersInsteadOfLosingTheTint() {
+    val model =
+      FigmaSvgModel.from(
+        layout = vectorNode(plusVector(fromDrawCapture = false), listOf(tintModifier())),
+        captureCanvasDraws = true,
+      )
+
+    assertEquals(listOf("icon"), model.rasterTargets.map { it.nodeId })
+    val svg = FigmaLayeredSvg.render(model)
+    assertTrue("the untinted vector must not be emitted\n$svg", !svg.contains("M11 5h2v14h-2z"))
+  }
+
+  @Test
+  fun anIconWithNoOverDrawStaysAnEditableVector() {
+    val model =
+      FigmaSvgModel.from(
+        layout = vectorNode(plusVector(fromDrawCapture = false), emptyList()),
+        captureCanvasDraws = true,
+      )
+
+    assertTrue(model.rasterTargets.isEmpty())
+    assertTrue(FigmaLayeredSvg.render(model).contains("M11 5h2v14h-2z"))
+  }
+
+  /**
+   * The counterpart guard: when the paths were recorded *from* the draw lambda (a slider groove, a
+   * progress arc) the modifier is already fully represented by them, so rastering would throw away
+   * the editable capture the recorder just made.
+   */
+  @Test
+  fun aCapturedDrawKeepsItsVectorRatherThanRasteringItsOwnModifier() {
+    val model =
+      FigmaSvgModel.from(
+        layout = vectorNode(plusVector(fromDrawCapture = true), listOf(tintModifier())),
+        captureCanvasDraws = true,
+      )
+
+    assertTrue("a captured draw is its own vector", model.rasterTargets.isEmpty())
+    assertTrue(FigmaLayeredSvg.render(model).contains("M11 5h2v14h-2z"))
+  }
+
+  /** With no frame to crop from, the untinted vector still beats a broken `<image>` reference. */
+  @Test
+  fun withoutAFrameToCropTheOverDrawnIconKeepsItsVector() {
+    val model =
+      FigmaSvgModel.from(
+        layout = vectorNode(plusVector(fromDrawCapture = false), listOf(tintModifier())),
+        captureCanvasDraws = false,
+      )
+
+    assertTrue(model.rasterTargets.isEmpty())
+    assertTrue(FigmaLayeredSvg.render(model).contains("M11 5h2v14h-2z"))
+  }
+
   @Test
   fun inheritedDisplayNameIsNotUsedForOpaqueRasterMatching() {
     // Regression guard (#2469 follow-up): an IconButton's internal wrapper inherits the label


### PR DESCRIPTION
Closes out the remaining `Foundations/Icon button` reproduction on #2852 — the half #2916 deliberately left alone.

## The defect

Jetsnack tints its gradient icons with

```kotlin
Modifier.drawWithContent { drawContent(); drawRect(brush, blendMode = Plus/Darken) }
```

A blend-mode composite over arbitrary content has no faithful SVG equivalent, so that node should take the raster fallback — which is exactly what the issue asks for ("raster the complete affected draw layer when the brush cannot be vectorized"). Instead the export emitted the bare `ImageVector` and dropped the tint: a flat black plus against a PNG showing a cyan-to-purple glyph.

The cause is ordering, not detection. `toLayer` returns the vector layer *before* it ever looks at a draw modifier on the same node, so the over-draw was invisible to every check downstream — including `hasCustomDraw()`, which already existed and would have caught it.

## The fix

The vector branch now rasters when the node also carries a custom draw.

The subtlety is that a node's `vectorGraphic` has two possible origins, and they want **opposite** treatment:

| origin | draw modifier means | correct action |
| --- | --- | --- |
| reflected off an `ImageVector` | a separate, unrepresented overlay | raster |
| recorded from the draw lambda by `DrawCaptureExtractor` (slider groove, progress arc) | the modifier *is* those paths | keep the vector |

Rastering the second case would throw away the editable capture the recorder had just made. The wire model couldn't distinguish them, so `LayoutInspectorVectorGraphic` gains `fromDrawCapture` and the layout-inspector schema goes to **v10**. Additive — older entries decode it `false`, which is the `ImageVector` reading they all had.

Hybrid mode only: with no frame PNG to crop from, the untinted vector still beats a broken `<image>` reference.

This also fixes a quieter instance of the same bug — any `drawBehind` art *under* an icon (a coloured disc, a badge) was silently dropped for exactly the same reason, and now rasters.

## Test plan

- `:data-layoutinspector-core:test` and `:data-layoutinspector-connector:test` — green.
- Four new cases: the tinted icon rasters and the untinted path data is **absent** from the SVG; an icon with no over-draw stays an editable vector; a draw-captured vector keeps its paths rather than rastering its own modifier; and without a frame to crop, the vector is kept.
- Non-vacuousness verified: disabling the new gate fails `anIconDrawnOverByABlendModeTintRastersInsteadOfLosingTheTint` and nothing else, so the test pins this change specifically rather than passing incidentally.

No before/after images embedded: reproducing these pixels needs a full Jetsnack catalog render, which this headless container can't produce. The change is verified by the model-level assertions above — the exported layer switches from a vector carrying the untinted path to a raster target — and the catalog rerun on `preview.coo.ee` is the acceptance test, since `Foundations/Icon button` (20.3% before the border fix) is the tracked number this moves.

Fixes #2852


---
_Generated by [Claude Code](https://claude.ai/code/session_01AbWyewkWvbY9pb5VS7FBWr)_