### PR TITLE
fix(figma-svg): stop squashing a clipped vector to its drawn box

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawCaptureExtractor.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawCaptureExtractor.kt
@@ -92,6 +92,9 @@ internal object DrawCaptureExtractor {
       viewportWidth = width.toFloat(),
       viewportHeight = height.toFloat(),
       paths = rec.paths.toList(),
+      // These paths *are* the draw modifier's output, so the export must not also treat that
+      // modifier as an unrepresented overlay and raster the node (issue #2852).
+      fromDrawCapture = true,
     )
   }
 

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -85,7 +85,13 @@ object LayoutInspectorProduct {
   // item shrunk toward the curved edge). `bounds` already carries the scaled rect; `transform` says
   // the shrink is real, so a consumer doesn't grow the node back to its measured `size`. Additive —
   // older entries decode with `transform = null`.
-  const val SCHEMA_VERSION: Int = 9
+  // v10 (#2852): a `vectorGraphic` says whether its paths came from the node's own draw lambda
+  // (`fromDrawCapture`) or from an `ImageVector`. The export needs the distinction to read a draw
+  // modifier on a vector node: for a captured draw the modifier *is* those paths, while on an
+  // `ImageVector` it's an unrepresented overlay (Jetsnack's blend-mode gradient icon tint) that has
+  // to raster instead of exporting the untinted glyph. Additive — older entries decode with
+  // `fromDrawCapture = false`, which is the `ImageVector` reading they all had.
+  const val SCHEMA_VERSION: Int = 10
   const val FILE: String = "layout-inspector.json"
 }
 
@@ -611,6 +617,18 @@ data class LayoutInspectorVectorGraphic(
   val viewportWidth: Float,
   val viewportHeight: Float,
   val paths: List<LayoutInspectorVectorPath>,
+  /**
+   * True when these paths were recorded from the node's own imperative draw lambda (the
+   * `DrawCaptureExtractor` path: a slider groove, a progress arc) rather than reflected off an
+   * `ImageVector` painter.
+   *
+   * The export needs the distinction to know what a draw modifier on the same node means. For a
+   * captured draw the modifier *is* these paths, and everything it painted is already represented.
+   * For an `ImageVector` the draw modifier is a separate overlay that nothing here accounts for —
+   * Jetsnack tints its icons with `drawWithContent { drawContent(); drawRect(brush, blendMode) }` —
+   * so the layer has to raster instead of emitting the untinted icon (issue #2852).
+   */
+  val fromDrawCapture: Boolean = false,
 )
 
 /**

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -488,15 +488,21 @@ object FigmaLayeredSvg {
       scaleX = if (vec.viewportWidth > 0f) layer.width / vec.viewportWidth.toDouble() else 1.0
       scaleY = if (vec.viewportHeight > 0f) layer.height / vec.viewportHeight.toDouble() else 1.0
     } else {
+      // Fit the vector's own viewport into its layout slot, uniformly — an icon keeps its aspect
+      // ratio.
       val layoutScale =
         minOf(
           layoutWidth / vec.viewportWidth.toDouble(),
           layoutHeight / vec.viewportHeight.toDouble(),
         )
-      val placedScaleX = if (layoutWidth > 0.0) layer.width / layoutWidth else 1.0
-      val placedScaleY = if (layoutHeight > 0.0) layer.height / layoutHeight else 1.0
-      scaleX = layoutScale * placedScaleX
-      scaleY = layoutScale * placedScaleY
+      // Then apply the node's *captured* draw-time scale, not the ratio of its drawn box to its
+      // layout slot. Those two disagree whenever a node is clipped rather than scaled, and the
+      // ratio reading squashed a square icon in an animating container to `scale(0.49 0.13)`
+      // (issue #2853): Jetsnack's FAB shrinks the box it draws its icon into, but the icon itself
+      // is never distorted — it's cropped, and it stays square right up to the point it vanishes.
+      // A real non-uniform layer scale still reads correctly, because the capture reports it.
+      scaleX = layoutScale * vec.scaleX
+      scaleY = layoutScale * vec.scaleY
     }
     val fittedWidth = vec.viewportWidth.toDouble() * scaleX
     val fittedHeight = vec.viewportHeight.toDouble() * scaleY

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -495,14 +495,28 @@ object FigmaLayeredSvg {
           layoutWidth / vec.viewportWidth.toDouble(),
           layoutHeight / vec.viewportHeight.toDouble(),
         )
-      // Then apply the node's *captured* draw-time scale, not the ratio of its drawn box to its
-      // layout slot. Those two disagree whenever a node is clipped rather than scaled, and the
-      // ratio reading squashed a square icon in an animating container to `scale(0.49 0.13)`
-      // (issue #2853): Jetsnack's FAB shrinks the box it draws its icon into, but the icon itself
-      // is never distorted — it's cropped, and it stays square right up to the point it vanishes.
-      // A real non-uniform layer scale still reads correctly, because the capture reports it.
-      scaleX = layoutScale * vec.scaleX
-      scaleY = layoutScale * vec.scaleY
+      if (vec.fromDrawCapture) {
+        // A draw capture's viewport is already in *placed* px — the recorder is sized to the node's
+        // drawn bounds, not its layout slot — so the drawn/slot ratio is what maps it back, and it
+        // cancels `layoutScale` to 1 in the usual case. A `RadioButton`/`Checkbox` relies on this:
+        // it records a ~20px viewport while measuring to a 48dp touch target, and dropping the
+        // ratio would draw the control at 2.4× over its own box.
+        val placedScaleX = if (layoutWidth > 0.0) layer.width / layoutWidth else 1.0
+        val placedScaleY = if (layoutHeight > 0.0) layer.height / layoutHeight else 1.0
+        scaleX = layoutScale * placedScaleX
+        scaleY = layoutScale * placedScaleY
+      } else {
+        // An `ImageVector`'s viewport is the icon's own space, so after fitting it to the layout
+        // slot the only thing left to apply is the node's *captured* draw-time scale — not the
+        // ratio of its drawn box to that slot. Those two disagree whenever a node is clipped
+        // rather than scaled, and the ratio reading squashed a square icon in an animating
+        // container to `scale(0.49 0.13)` (issue #2853): Jetsnack's FAB shrinks the box it draws
+        // its icon into, but the icon is never distorted — it's cropped, and stays square right up
+        // to the point it vanishes. A real non-uniform layer scale still reads correctly, because
+        // the capture reports it.
+        scaleX = layoutScale * vec.scaleX
+        scaleY = layoutScale * vec.scaleY
+      }
     }
     val fittedWidth = vec.viewportWidth.toDouble() * scaleX
     val fittedHeight = vec.viewportHeight.toDouble() * scaleY

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -153,6 +153,12 @@ data class FigmaSvgVector(
    */
   val scaleX: Double = 1.0,
   val scaleY: Double = 1.0,
+  /**
+   * True when the paths were recorded from the node's own draw lambda rather than an `ImageVector`
+   * — which also decides what coordinate space [viewportWidth]/[viewportHeight] are in, and so how
+   * the emitter scales them. See [FigmaLayeredSvg]'s vector placement.
+   */
+  val fromDrawCapture: Boolean = false,
   val paths: List<FigmaSvgVectorPath>,
 )
 
@@ -591,6 +597,7 @@ data class FigmaSvgModel(
           fillBounds = fillBounds,
           scaleX = scaleX,
           scaleY = scaleY,
+          fromDrawCapture = fromDrawCapture,
           paths = emittable,
         )
     }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -662,7 +662,7 @@ data class FigmaSvgModel(
       // the recorder just made. Hybrid mode only — with no frame to crop from, the untinted vector
       // still beats a broken `<image>` reference.
       if (ctx.captureCanvasDraws && vectorGraphic?.fromDrawCapture == false && hasCustomDraw()) {
-        val region = drawnOverlayRegion()
+        val region = drawnOverlayRegion(bounds)
         val href = ctx.rasterHref(nodeId)
         ctx.rasterTargets.add(
           FigmaSvgRasterTarget(nodeId, href, region.left, region.top, region.right, region.bottom)
@@ -1233,14 +1233,24 @@ data class FigmaSvgModel(
      * — the icon underneath still has to be inside the crop, and a tint pass that reports no bounds
      * covers the whole node.
      */
-    private fun LayoutInspectorNode.drawnOverlayRegion(): LayoutInspectorBounds {
+    private fun LayoutInspectorNode.drawnOverlayRegion(
+      nodeBounds: LayoutInspectorBounds
+    ): LayoutInspectorBounds {
+      // [nodeBounds], not this node's raw `bounds`: a detached or not-yet-placed node (a vector
+      // inside a subcomposed Button/TextField) reports `(0,0,0,0)`, which `toLayer` has already
+      // reconstructed from its measured size. Reading the raw field back would crop a zero-sized
+      // region and the layer would come back as the transparent 1×1 fallback.
       val drawn = modifiers.filter { it.isCustomDraw() }.mapNotNull { it.bounds }
-      if (drawn.isEmpty()) return bounds
+      if (drawn.isEmpty()) return nodeBounds
+      // A draw modifier's own bounds are subject to the same detachment, so an empty one can't be
+      // allowed to drag the union back to the origin.
+      val placed = drawn.filter { it.right > it.left && it.bottom > it.top }
+      if (placed.isEmpty()) return nodeBounds
       return LayoutInspectorBounds(
-        left = minOf(bounds.left, drawn.minOf { it.left }),
-        top = minOf(bounds.top, drawn.minOf { it.top }),
-        right = maxOf(bounds.right, drawn.maxOf { it.right }),
-        bottom = maxOf(bounds.bottom, drawn.maxOf { it.bottom }),
+        left = minOf(nodeBounds.left, placed.minOf { it.left }),
+        top = minOf(nodeBounds.top, placed.minOf { it.top }),
+        right = maxOf(nodeBounds.right, placed.maxOf { it.right }),
+        bottom = maxOf(nodeBounds.bottom, placed.maxOf { it.bottom }),
       )
     }
 

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -651,6 +651,33 @@ data class FigmaSvgModel(
       // below. Placed before the raster branch so a vector-backed icon never rasterises; a
       // bitmap-backed one (no `vectorGraphic`) falls through and rasters as before. An empty/
       // gradient-only capture yields null and also falls through.
+      // …unless something draws *over* that icon which the vector model doesn't represent. Jetsnack
+      // tints its gradient icons with `Modifier.drawWithContent { drawContent(); drawRect(brush,
+      // blendMode = Plus/Darken) }`; a blend-mode composite over arbitrary content has no faithful
+      // SVG equivalent, and emitting the bare `ImageVector` painted the untinted (black) glyph the
+      // PNG never shows. Raster the node so the tint survives (issue #2852).
+      //
+      // Only for an `ImageVector`: when the paths were recorded *from* the draw lambda the modifier
+      // is already fully represented by them, and rastering would throw away the editable capture
+      // the recorder just made. Hybrid mode only — with no frame to crop from, the untinted vector
+      // still beats a broken `<image>` reference.
+      if (ctx.captureCanvasDraws && vectorGraphic?.fromDrawCapture == false && hasCustomDraw()) {
+        val region = drawnOverlayRegion()
+        val href = ctx.rasterHref(nodeId)
+        ctx.rasterTargets.add(
+          FigmaSvgRasterTarget(nodeId, href, region.left, region.top, region.right, region.bottom)
+        )
+        return FigmaSvgLayer(
+          name = layerName(),
+          left = region.left,
+          top = region.top,
+          right = region.right,
+          bottom = region.bottom,
+          raster = FigmaSvgRaster(href),
+          opacity = opacity,
+          contentOpacity = contentOpacity,
+        )
+      }
       vectorGraphic
         ?.toFigmaSvgVector(
           layoutWidth = size.width,
@@ -1197,6 +1224,23 @@ data class FigmaSvgModel(
         top = drawn.minOf { it.top },
         right = drawn.maxOf { it.right },
         bottom = drawn.maxOf { it.bottom },
+      )
+    }
+
+    /**
+     * The region an over-drawing modifier covers on a vector node: the union of the node box and
+     * the draw modifiers' own bounds. Unlike [drawnRegion] this never *shrinks* to the draw bounds
+     * — the icon underneath still has to be inside the crop, and a tint pass that reports no bounds
+     * covers the whole node.
+     */
+    private fun LayoutInspectorNode.drawnOverlayRegion(): LayoutInspectorBounds {
+      val drawn = modifiers.filter { it.isCustomDraw() }.mapNotNull { it.bounds }
+      if (drawn.isEmpty()) return bounds
+      return LayoutInspectorBounds(
+        left = minOf(bounds.left, drawn.minOf { it.left }),
+        top = minOf(bounds.top, drawn.minOf { it.top }),
+        right = maxOf(bounds.right, drawn.maxOf { it.right }),
+        bottom = maxOf(bounds.bottom, drawn.maxOf { it.bottom }),
       )
     }
 

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -141,6 +141,18 @@ data class FigmaSvgVector(
   val layoutWidth: Int,
   val layoutHeight: Int,
   val fillBounds: Boolean = false,
+  /**
+   * The node's captured draw-time `graphicsLayer` scale (`LayoutInspectorNode.transform`), 1 when
+   * it declared none.
+   *
+   * This is what separates a genuinely squashed vector from a merely *clipped* one. `bounds` alone
+   * can't: a node measured 24×24 and drawn into a 12×3 rect looks identical whether an ancestor
+   * scaled it or an animating container clipped it, and inferring a scale from that ratio squashed
+   * Jetsnack's square FAB icon to `scale(0.49 0.13)` (issue #2853). The capture states which it is,
+   * so the export stops guessing.
+   */
+  val scaleX: Double = 1.0,
+  val scaleY: Double = 1.0,
   val paths: List<FigmaSvgVectorPath>,
 )
 
@@ -549,6 +561,8 @@ data class FigmaSvgModel(
       layoutWidth: Int,
       layoutHeight: Int,
       fillBounds: Boolean,
+      scaleX: Double = 1.0,
+      scaleY: Double = 1.0,
     ): FigmaSvgVector? {
       if (viewportWidth <= 0f || viewportHeight <= 0f) return null
       val emittable =
@@ -575,6 +589,8 @@ data class FigmaSvgModel(
           layoutWidth = layoutWidth,
           layoutHeight = layoutHeight,
           fillBounds = fillBounds,
+          scaleX = scaleX,
+          scaleY = scaleY,
           paths = emittable,
         )
     }
@@ -683,6 +699,8 @@ data class FigmaSvgModel(
           layoutWidth = size.width,
           layoutHeight = size.height,
           fillBounds = hasFillBoundsContentScale(),
+          scaleX = transform?.scaleX?.toDouble() ?: 1.0,
+          scaleY = transform?.scaleY?.toDouble() ?: 1.0,
         )
         ?.let { vec ->
           return FigmaSvgLayer(

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -597,6 +597,46 @@ class FigmaLayeredSvgTest {
     assertTrue("the untinted vector must not be emitted\n$svg", !svg.contains("M11 5h2v14h-2z"))
   }
 
+  /**
+   * A detached / not-yet-placed vector (inside a subcomposed Button or TextField) reports
+   * `(0,0,0,0)` bounds, which `toLayer` reconstructs from its measured size. The overlay raster has
+   * to crop that recovered box — cropping the raw zero-area one yields the transparent 1×1
+   * fallback, i.e. the icon disappears instead of being preserved.
+   */
+  @Test
+  fun anOverDrawnIconWithRecoveredBoundsRastersAtItsRecoveredSize() {
+    val model =
+      FigmaSvgModel.from(
+        layout =
+          LayoutInspectorPayload(
+            LayoutInspectorNode(
+              nodeId = "root",
+              component = "Box",
+              bounds = LayoutInspectorBounds(0, 0, 24, 24),
+              size = LayoutInspectorSize(24, 24),
+              children =
+                listOf(
+                  LayoutInspectorNode(
+                    nodeId = "icon",
+                    component = "Icon",
+                    bounds = LayoutInspectorBounds(0, 0, 0, 0),
+                    size = LayoutInspectorSize(24, 24),
+                    vectorGraphic = plusVector(fromDrawCapture = false),
+                    modifiers = listOf(tintModifier()),
+                  )
+                ),
+            )
+          ),
+        captureCanvasDraws = true,
+      )
+
+    val target = model.rasterTargets.single { it.nodeId == "icon" }
+    assertTrue(
+      "the raster must cover the recovered box, not a zero-area one: $target",
+      target.right > target.left && target.bottom > target.top,
+    )
+  }
+
   @Test
   fun anIconWithNoOverDrawStaysAnEditableVector() {
     val model =

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -410,6 +410,38 @@ class FigmaLayeredSvgTest {
    * A uniformly shrunk node (Wear's curved-edge transform, #2615) still scales with its capture.
    */
   @Test
+  fun aDrawCapturedControlKeepsItsPlacedBoundsScale() {
+    // A draw-captured control records its viewport in *placed* px while measuring to its 48dp
+    // touch target, so the drawn/slot ratio is what maps it back — dropping it would draw a
+    // RadioButton at 2.4× over its own box. Only `ImageVector` nodes take the transform rule.
+    val node =
+      LayoutInspectorNode(
+        nodeId = "radio",
+        component = "RadioButton",
+        bounds = bounds(0, 0, 20, 20),
+        size = LayoutInspectorSize(48, 48),
+        vectorGraphic =
+          LayoutInspectorVectorGraphic(
+            viewportWidth = 20f,
+            viewportHeight = 20f,
+            fromDrawCapture = true,
+            paths =
+              listOf(
+                LayoutInspectorVectorPath(
+                  pathData = "M0,0 L20,0 L20,20 L0,20 Z",
+                  fillArgb = "#FF000000",
+                )
+              ),
+          ),
+      )
+
+    val svg = render(node)
+
+    assertTrue("the control must draw at its own size\n$svg", svg.contains("""scale(1 1)"""))
+    assertFalse("must not blow up to the touch target\n$svg", svg.contains("scale(2.4"))
+  }
+
+  @Test
   fun aUniformlyScaledVectorFollowsItsCapturedTransform() {
     val node =
       LayoutInspectorNode(

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -551,6 +551,94 @@ class FigmaLayeredSvgTest {
     assertFalse(svg, svg.contains("""id="Box"""))
   }
 
+  private fun plusVector(fromDrawCapture: Boolean) =
+    LayoutInspectorVectorGraphic(
+      viewportWidth = 24f,
+      viewportHeight = 24f,
+      paths =
+        listOf(LayoutInspectorVectorPath(pathData = "M11 5h2v14h-2z", fillArgb = "#FF000000")),
+      fromDrawCapture = fromDrawCapture,
+    )
+
+  private fun tintModifier() =
+    LayoutInspectorModifier(name = "drawWithContent", properties = emptyMap())
+
+  private fun vectorNode(
+    vector: LayoutInspectorVectorGraphic,
+    modifiers: List<LayoutInspectorModifier>,
+  ) =
+    LayoutInspectorPayload(
+      LayoutInspectorNode(
+        nodeId = "icon",
+        component = "Icon",
+        bounds = LayoutInspectorBounds(0, 0, 24, 24),
+        size = LayoutInspectorSize(24, 24),
+        vectorGraphic = vector,
+        modifiers = modifiers,
+      )
+    )
+
+  /**
+   * Issue #2852: Jetsnack tints its gradient icons with `Modifier.drawWithContent { drawContent();
+   * drawRect(brush, blendMode = Plus/Darken) }`. A blend-mode composite over arbitrary content has
+   * no faithful SVG equivalent, and the export emitted the bare `ImageVector` — painting the
+   * untinted black glyph the PNG never shows. The node must raster so the tint survives.
+   */
+  @Test
+  fun anIconDrawnOverByABlendModeTintRastersInsteadOfLosingTheTint() {
+    val model =
+      FigmaSvgModel.from(
+        layout = vectorNode(plusVector(fromDrawCapture = false), listOf(tintModifier())),
+        captureCanvasDraws = true,
+      )
+
+    assertEquals(listOf("icon"), model.rasterTargets.map { it.nodeId })
+    val svg = FigmaLayeredSvg.render(model)
+    assertTrue("the untinted vector must not be emitted\n$svg", !svg.contains("M11 5h2v14h-2z"))
+  }
+
+  @Test
+  fun anIconWithNoOverDrawStaysAnEditableVector() {
+    val model =
+      FigmaSvgModel.from(
+        layout = vectorNode(plusVector(fromDrawCapture = false), emptyList()),
+        captureCanvasDraws = true,
+      )
+
+    assertTrue(model.rasterTargets.isEmpty())
+    assertTrue(FigmaLayeredSvg.render(model).contains("M11 5h2v14h-2z"))
+  }
+
+  /**
+   * The counterpart guard: when the paths were recorded *from* the draw lambda (a slider groove, a
+   * progress arc) the modifier is already fully represented by them, so rastering would throw away
+   * the editable capture the recorder just made.
+   */
+  @Test
+  fun aCapturedDrawKeepsItsVectorRatherThanRasteringItsOwnModifier() {
+    val model =
+      FigmaSvgModel.from(
+        layout = vectorNode(plusVector(fromDrawCapture = true), listOf(tintModifier())),
+        captureCanvasDraws = true,
+      )
+
+    assertTrue("a captured draw is its own vector", model.rasterTargets.isEmpty())
+    assertTrue(FigmaLayeredSvg.render(model).contains("M11 5h2v14h-2z"))
+  }
+
+  /** With no frame to crop from, the untinted vector still beats a broken `<image>` reference. */
+  @Test
+  fun withoutAFrameToCropTheOverDrawnIconKeepsItsVector() {
+    val model =
+      FigmaSvgModel.from(
+        layout = vectorNode(plusVector(fromDrawCapture = false), listOf(tintModifier())),
+        captureCanvasDraws = false,
+      )
+
+    assertTrue(model.rasterTargets.isEmpty())
+    assertTrue(FigmaLayeredSvg.render(model).contains("M11 5h2v14h-2z"))
+  }
+
   @Test
   fun inheritedDisplayNameIsNotUsedForOpaqueRasterMatching() {
     // Regression guard (#2469 follow-up): an IconButton's internal wrapper inherits the label

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -341,12 +341,16 @@ class FigmaLayeredSvgTest {
 
   @Test
   fun vectorRetainsAnExplicitNonuniformLayoutTransform() {
+    // "Explicit" is the captured `transform`: the node really is drawn through a
+    // `graphicsLayer(scaleX = 2f)`, so the vector is stretched to match. The bounds agree with
+    // that scale (24 × 2 = 48 wide), but it's the transform — not the bounds ratio — that decides.
     val node =
       LayoutInspectorNode(
         nodeId = "icon",
         component = "Icon",
         bounds = bounds(10, 20, 58, 44),
         size = LayoutInspectorSize(24, 24),
+        transform = LayoutInspectorTransform(scaleX = 2f, scaleY = 1f),
         vectorGraphic =
           LayoutInspectorVectorGraphic(
             viewportWidth = 24f,
@@ -364,6 +368,71 @@ class FigmaLayeredSvgTest {
     val svg = render(node)
 
     assertTrue(svg, svg.contains("""transform="translate(10 20) scale(2 1)""""))
+  }
+
+  /**
+   * Issue #2853: Jetsnack's `Profile/Animating FAB content` draws a square icon into a box the
+   * animation has shrunk — the icon is *clipped*, never distorted. Inferring a scale from the ratio
+   * of drawn box to layout slot squashed it to `scale(0.49 0.13)`; with no captured `transform`
+   * there is no draw-time scale to apply, so it must stay square.
+   */
+  @Test
+  fun aClippedVectorStaysSquareInsteadOfBeingSquashedToItsDrawnBox() {
+    val node =
+      LayoutInspectorNode(
+        nodeId = "icon",
+        component = "Icon",
+        // 24×24 measured, drawn into ~12×3 by the animating container. No `transform`: nothing
+        // scaled it.
+        bounds = bounds(10, 20, 22, 23),
+        size = LayoutInspectorSize(24, 24),
+        vectorGraphic =
+          LayoutInspectorVectorGraphic(
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            paths =
+              listOf(
+                LayoutInspectorVectorPath(
+                  pathData = "M0,0 L24,0 L24,24 L0,24 Z",
+                  fillArgb = "#FF000000",
+                )
+              ),
+          ),
+      )
+
+    val svg = render(node)
+
+    assertTrue("the icon must stay square\n$svg", svg.contains("""scale(1 1)"""))
+    assertFalse("the drawn-box ratio must not become a scale\n$svg", svg.contains("scale(0.5 0.13"))
+  }
+
+  /**
+   * A uniformly shrunk node (Wear's curved-edge transform, #2615) still scales with its capture.
+   */
+  @Test
+  fun aUniformlyScaledVectorFollowsItsCapturedTransform() {
+    val node =
+      LayoutInspectorNode(
+        nodeId = "icon",
+        component = "Icon",
+        bounds = bounds(0, 0, 12, 12),
+        size = LayoutInspectorSize(24, 24),
+        transform = LayoutInspectorTransform(scaleX = 0.5f, scaleY = 0.5f),
+        vectorGraphic =
+          LayoutInspectorVectorGraphic(
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            paths =
+              listOf(
+                LayoutInspectorVectorPath(
+                  pathData = "M0,0 L24,0 L24,24 L0,24 Z",
+                  fillArgb = "#FF000000",
+                )
+              ),
+          ),
+      )
+
+    assertTrue(render(node).contains("""scale(0.5 0.5)"""))
   }
 
   @Test


### PR DESCRIPTION
Closes out the remaining half of #2853 — the part #2914 explicitly deferred rather than guessing at.

> **Stacked on #2924.** Review flagged that separating a clipped vector from a scaled one needs the same `fromDrawCapture` distinction #2924 introduces, so this branch is rebased onto it and its commits appear here. Merge #2924 first and this reduces to the two commits below.

## The defect

`Profile/Animating FAB content` emitted `scale(0.49 0.13)` for a square icon. The export inferred the vector's scale from the ratio of its **drawn box** to its **layout slot**, and an animating container shrinks that box by clipping. The icon is never distorted in the render — it's cropped, and stays square until it disappears.

## Why the obvious fix didn't work

Bounds and size alone can't tell the two cases apart. A node measured 24×24 and drawn into a 12×3 rect looks identical whether an ancestor scaled it or a container clipped it. That's why the uniform-fit attempt in #2914 broke `vectorRetainsAnExplicitNonuniformLayoutTransform` — a deliberate `scale(2 1)` — instead of fixing this.

## The fix

`transform` (layout-inspector v9) records the real draw-time `graphicsLayer` scale and is present *only* when it isn't the identity — exactly the "scaled, or merely clipped?" question, answered at capture time and already trusted elsewhere in this file (`scaleMean` for token geometry). The vector scales by that instead of the box ratio.

**But only for an `ImageVector`.** The two vector sources record their viewport in different coordinate spaces, so they need different treatment:

| source | viewport space | scale |
| --- | --- | --- |
| `ImageVector` | the icon's own | fit to layout slot × captured draw-time transform |
| draw capture | the node's *placed* px | fit to layout slot × drawn/slot ratio (unchanged) |

Review caught that applying the transform rule to draw captures is a real regression: a `RadioButton`/`Checkbox` records a ~20px viewport while measuring to a 48dp touch target, so dropping the ratio drew the control at **2.4×**, overflowing its own box with no clip to contain it. Draw-captured placement is now byte-for-byte what it was before; only `ImageVector` nodes take the new rule.

## A note on the changed test

`vectorRetainsAnExplicitNonuniformLayoutTransform` gains the `transform` its name always implied. It asserts an **explicit** non-uniform scale, but nothing in the fixture actually declared one — the 2× came from the bounds ratio the FAB case proves unreliable. Adding the transform makes the fixture mean what the test name says; the assertion is unchanged.

## Test plan

- `:data-layoutinspector-core:test` and `:data-layoutinspector-connector:test` — green (116 in the emitter suite).
- New: a 24×24 icon drawn into a ~12×3 box with **no** transform stays `scale(1 1)` and must not produce the drawn-box ratio; a uniformly shrunk node (Wear's curved-edge transform, #2615) still follows its captured `scale(0.5 0.5)`; a draw-captured 20px control in a 48dp slot stays `scale(1 1)` and must not reach `2.4`.
- Non-vacuousness verified: restoring the box-ratio formula fails `aClippedVectorStaysSquareInsteadOfBeingSquashedToItsDrawnBox` and nothing else.

No before/after images: this needs a Jetsnack catalog render to show, which this headless container can't produce. The emitted `transform` attribute is asserted directly instead, and `Profile/Animating FAB content` on `preview.coo.ee` is the acceptance test.

Fixes #2853
