### PR TITLE
refactor(fonts): extract Google Fonts resolution into a shared module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,10 @@ val androidFunctionalTestPublishTargets =
     // The renderer + data modules read/write files through Okio's `:common-io` (its file-IO
     // foundation), so it's part of the closure the synthetic project must resolve from mavenLocal.
     ":common-io",
+    // Downloadable-font resolution, an `api` dep of `:renderer-android` — so it is in the published
+    // metadata the synthetic consumer resolves, and the development version exists nowhere but
+    // mavenLocal.
+    ":data-fonts-google",
   )
 
 tasks.register("functionalTestWithAndroid") {

--- a/data/fonts/google/build.gradle.kts
+++ b/data/fonts/google/build.gradle.kts
@@ -1,0 +1,40 @@
+// Google Fonts resolution: the CSS-API queries, the TTF download, and the machine-local cache.
+//
+// Extracted from `:renderers-android` because two independent lanes need the *same* resolution, and
+// a second copy would be worse than a shared module: `downloadFromGoogleFonts` encodes a
+// stage-1/stage-2 contract whose failure mode is a silently wrong typeface cached under the right
+// filename (see its KDoc). Two implementations would drift into resolving the same family to
+// differently-metricked faces.
+//
+// The consumers are the Robolectric renderer's downloadable-font shadow (a Compose
+// `Font(GoogleFont(...))` request) and the Remote Compose connector's typeface resolver (a
+// `RemoteFontFamily.Named("google:…")` in an `.rc` document). Neither Compose nor Remote Compose
+// types appear here — the whole surface is `(family, weight, italic) -> File` — which is what lets
+// a
+// pure-JVM module sit under an Android renderer and a Compose connector alike.
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+  implementation(project(":common-io"))
+  implementation(libs.okhttp)
+  // `api` so consumers writing a custom downloader get Okio's `FileSystem` without re-declaring it.
+  api(libs.okio)
+
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-fonts-google",
+    displayName = "Compose Preview — Google Fonts",
+    description =
+      "Google Fonts CSS-API resolution and machine-local TTF cache, keyed by (family, weight, " +
+        "italic). Shared by the Robolectric downloadable-font shadow and the Remote Compose " +
+        "typeface resolver so both lanes resolve a family to the same file.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/fonts/google/src/main/kotlin/ee/schimke/composeai/fonts/google/GoogleFonts.kt
+++ b/data/fonts/google/src/main/kotlin/ee/schimke/composeai/fonts/google/GoogleFonts.kt
@@ -1,0 +1,216 @@
+package ee.schimke.composeai.fonts.google
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * A single resolved Google font file keyed by family + axes. Serialised on disk as
+ * `<slug>-<weight>[-italic].ttf` so the cache is human-readable under `~/.cache/composeai/fonts/`.
+ *
+ * [weight] is a plain CSS numeric weight rather than a Compose `FontWeight`: the two render lanes
+ * that resolve fonts through here reach it from different worlds — one from a Compose
+ * `Font(GoogleFont(...))` request, one from a `RemoteFontFamily.Named` string in an `.rc` document
+ * — and neither should have to adopt the other's type to ask for a file.
+ */
+data class GoogleFontKey(val name: String, val weight: Int, val italic: Boolean) {
+  fun fileName(): String {
+    val slug = slugify(name)
+    val italicPart = if (italic) "-italic" else ""
+    return "$slug-$weight$italicPart.ttf"
+  }
+
+  companion object {
+    /** Lowercase + replace non-alphanumerics with `-`, no leading/trailing hyphens. */
+    fun slugify(name: String): String =
+      buildString {
+          var prevDash = true
+          for (ch in name) {
+            val lower = ch.lowercaseChar()
+            if (lower in 'a'..'z' || lower in '0'..'9') {
+              append(lower)
+              prevDash = false
+            } else if (!prevDash) {
+              append('-')
+              prevDash = true
+            }
+          }
+        }
+        .trim('-')
+        // A name with no alphanumerics at all would otherwise slug to "", giving every such family
+        // the same `-400.ttf` cache filename.
+        .ifEmpty { "font" }
+  }
+}
+
+/** Where a resolved font file comes from. Swappable so tests never touch the network. */
+interface GoogleFontSource {
+  fun load(key: GoogleFontKey): File?
+}
+
+/**
+ * A machine-local cache of resolved TTFs, downloading on a miss.
+ *
+ * The cache is shared across projects on purpose — a font keyed by `(family, weight, italic)` is
+ * identical everywhere — so it resolves once per machine and every later render reuses it.
+ * [offline] turns a miss into a null rather than a fetch, for deliberately air-gapped renders.
+ */
+class GoogleFontCache(
+  private val cacheDir: File,
+  private val offline: Boolean = false,
+  private val downloader: (GoogleFontKey, File) -> Boolean = ::downloadFromGoogleFonts,
+) : GoogleFontSource {
+
+  override fun load(key: GoogleFontKey): File? {
+    val file = File(cacheDir, key.fileName())
+    if (file.exists() && file.length() > 0) return file
+    if (offline) return null
+    cacheDir.mkdirs()
+    val tmp = File(cacheDir, "${file.name}.tmp")
+    val ok = runCatching { downloader(key, tmp) }.getOrDefault(false)
+    if (!ok || !tmp.exists() || tmp.length() == 0L) {
+      tmp.delete()
+      return null
+    }
+    if (!tmp.renameTo(file)) {
+      // Atomic rename can fail across filesystems. Fall back to copy.
+      tmp.copyTo(file, overwrite = true)
+      tmp.delete()
+    }
+    return file
+  }
+}
+
+/**
+ * Fetches a TTF for [key] into [destination]. Returns `true` on success.
+ *
+ * Two-stage lookup:
+ * 1. Try `wght@<exact>` — works for static families (Roboto, Lobster Two) and for the default
+ *    weight of variable families.
+ * 2. If that request *succeeded but carried no TTF URL* (purely-variable fonts like Roboto Flex
+ *    reject single-weight requests at non-default weights), retry with `wght@<min>..<max>` covering
+ *    the full 1–1000 range. For variable fonts the response is a single `@font-face` pointing at
+ *    the variable TTF; for static fonts it's multiple blocks and we pick the closest to the
+ *    requested weight.
+ *
+ * The stage-1/stage-2 distinction is load-bearing for reproducibility, which is why a *failed*
+ * stage-1 request returns false rather than falling through. The two stages can legitimately
+ * resolve the same `(family, weight, italic)` to different faces — a static sub-font at the exact
+ * weight vs the family's variable TTF — and those have different text metrics. Falling through on a
+ * network error therefore let a transient blip resolve a key to the other face, and because the
+ * result is cached under the same filename, that face then stuck for every later render on the
+ * machine. Consumers saw it as a whole-text-layer sub-pixel shift appearing and disappearing
+ * between CI runs on unrelated commits. Failing instead routes through the caller's usual
+ * unresolved-font path.
+ *
+ * The CSS2 endpoint serves WOFF2 by default (Android doesn't parse WOFF2 natively), so we send an
+ * Android-2.3 User-Agent — one of the few UAs for which the API still returns TrueType. Same
+ * mechanism `google-webfonts-helper` and similar offline caches rely on.
+ */
+fun downloadFromGoogleFonts(
+  key: GoogleFontKey,
+  destination: File,
+  fileSystem: FileSystem = SystemFileSystem,
+): Boolean {
+  // A null here is a *failed request*, not "this family has no TTF at this weight" — don't let it
+  // silently pick up the range query's (differently-metricked) answer. See the KDoc.
+  val exactCss = httpGet(buildCssUrl(key), TTF_USER_AGENT) ?: return false
+  val url =
+    extractFirstTruetypeUrl(exactCss)
+      ?: run {
+        val rangeCss = httpGet(buildRangeCssUrl(key), TTF_USER_AGENT) ?: return false
+        pickClosestTruetypeUrl(rangeCss, key.weight) ?: return false
+      }
+  val bytes = httpGetBytes(url, userAgent = TTF_USER_AGENT) ?: return false
+  if (bytes.isEmpty()) return false
+  destination.parentFile?.mkdirs()
+  fileSystem.write(destination.path.toPath()) { write(bytes) }
+  return true
+}
+
+// The CSS2 endpoint picks the `src: url(...) format(...)` format based on
+// User-Agent capabilities. Modern UAs get WOFF2 (Android can't parse it
+// natively); IE11 gets WOFF (same problem); the only UAs that reliably
+// produce `format('truetype')` are pre-KitKat Android variants — legacy
+// devices predating native WOFF2 support. Using a fixed Android 2.3 UA is
+// the same approach `google-webfonts-helper` settled on for its "TTF only"
+// download mode.
+private const val TTF_USER_AGENT =
+  "Mozilla/5.0 (Linux; U; Android 2.3.3; en-us) AppleWebKit/533.1 (KHTML, like Gecko)"
+
+fun buildCssUrl(key: GoogleFontKey): String =
+  buildCssUrlForAxis(key, if (key.italic) "ital,wght@1,${key.weight}" else "wght@${key.weight}")
+
+/**
+ * Range-query variant. Returns a CSS response with either one `@font-face` (variable font) or many
+ * (static families with multiple pre-rendered weights). Used as a fallback when [buildCssUrl]
+ * produced no TTF URL — purely variable families like Roboto Flex reject single-weight queries at
+ * non-default weights.
+ *
+ * `100..1000` is the conventional Google Fonts wght axis range and works for Roboto Flex (wght
+ * 100..1000), Google Sans Flex (wght 100..1000), and other variable families. Ranges outside a
+ * family's declared axis bounds (e.g. `1..1000` on Roboto Flex) return a 400 "Font family not
+ * found" HTML page, which our TTF regex correctly treats as a miss.
+ */
+fun buildRangeCssUrl(key: GoogleFontKey): String =
+  buildCssUrlForAxis(key, if (key.italic) "ital,wght@1,100..1000" else "wght@100..1000")
+
+private fun buildCssUrlForAxis(key: GoogleFontKey, axis: String): String {
+  // `URLEncoder.encode(s, Charset)` is API 33+. The renderer runs inside
+  // Robolectric on JDK 17 where both overloads exist, but the library's
+  // `minSdk = 24` trips `lint`. The legacy `encode(s, charsetName)`
+  // overload is unchanged and the round-trip is identical.
+  @Suppress("DEPRECATION") val family = URLEncoder.encode(key.name, "UTF-8").replace("+", "%20")
+  return "https://fonts.googleapis.com/css2?family=$family:$axis&display=swap"
+}
+
+fun extractFirstTruetypeUrl(css: String): String? {
+  // Matches `url(...) format('truetype')` inside an `@font-face` block.
+  val regex = Regex("""url\((https://[^)]+)\)\s*format\(['"]truetype['"]\)""")
+  return regex.find(css)?.groupValues?.get(1)
+}
+
+/**
+ * Parse a CSS response with one-or-many `@font-face` blocks and pick the TTF URL whose declared
+ * `font-weight` is closest to [requestedWeight].
+ *
+ * - Variable-font responses have a single block with `font-weight: 400` but the TTF itself supports
+ *   the full axis range — just return that URL.
+ * - Static-family range responses carry one block per discrete weight (100, 200, …, 900); pick the
+ *   nearest and the consumer's text renders in the closest existing static sub-font.
+ */
+fun pickClosestTruetypeUrl(css: String, requestedWeight: Int): String? {
+  val blockRegex =
+    Regex("""font-weight:\s*(\d+)[\s\S]*?url\((https://[^)]+)\)\s*format\(['"]truetype['"]\)""")
+  val matches = blockRegex.findAll(css).toList()
+  if (matches.isEmpty()) return extractFirstTruetypeUrl(css)
+  if (matches.size == 1) return matches[0].groupValues[2]
+  return matches
+    .minByOrNull { kotlin.math.abs(it.groupValues[1].toInt() - requestedWeight) }
+    ?.groupValues
+    ?.get(2)
+}
+
+private val fontHttpClient: OkHttpClient by lazy {
+  OkHttpClient.Builder()
+    .connectTimeout(10, TimeUnit.SECONDS)
+    .readTimeout(15, TimeUnit.SECONDS)
+    .build()
+}
+
+private fun httpGet(url: String, userAgent: String): String? =
+  httpGetBytes(url, userAgent)?.toString(Charsets.UTF_8)
+
+private fun httpGetBytes(url: String, userAgent: String): ByteArray? =
+  runCatching {
+      val request = Request.Builder().url(url).header("User-Agent", userAgent).build()
+      fontHttpClient.newCall(request).execute().use { response ->
+        if (response.isSuccessful) response.body?.bytes() else null
+      }
+    }
+    .getOrNull()

--- a/data/fonts/google/src/test/kotlin/ee/schimke/composeai/fonts/google/GoogleFontsTest.kt
+++ b/data/fonts/google/src/test/kotlin/ee/schimke/composeai/fonts/google/GoogleFontsTest.kt
@@ -1,0 +1,217 @@
+package ee.schimke.composeai.fonts.google
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The Google Fonts resolution surface: CSS-API query shapes, TTF extraction, and cache behaviour.
+ *
+ * These moved here with the code when it was extracted from `:renderers-android`, because two lanes
+ * now resolve through it — the Robolectric downloadable-font shadow and the Remote Compose typeface
+ * resolver — and a regression in the query shape or the cache would silently give one of them the
+ * wrong typeface.
+ */
+class GoogleFontsTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  @Test
+  fun `slugify lowercases and replaces non-alphanumerics with hyphens`() {
+    assertEquals("roboto-mono", GoogleFontKey.slugify("Roboto Mono"))
+    assertEquals("ibm-plex-sans", GoogleFontKey.slugify("IBM Plex Sans"))
+    assertEquals("noto-serif", GoogleFontKey.slugify("  Noto--Serif  "))
+    assertEquals("font", GoogleFontKey.slugify("!!!"))
+  }
+
+  @Test
+  fun `fileName encodes weight and italic axis`() {
+    assertEquals(
+      "roboto-mono-400.ttf",
+      GoogleFontKey("Roboto Mono", 400, italic = false).fileName(),
+    )
+    assertEquals(
+      "roboto-mono-700-italic.ttf",
+      GoogleFontKey("Roboto Mono", 700, italic = true).fileName(),
+    )
+  }
+
+  @Test
+  fun `buildCssUrl encodes family name with spaces and weight axis`() {
+    val url = buildCssUrl(GoogleFontKey("Roboto Mono", 500, italic = false))
+    assertEquals(
+      "https://fonts.googleapis.com/css2?family=Roboto%20Mono:wght@500&display=swap",
+      url,
+    )
+  }
+
+  @Test
+  fun `buildCssUrl encodes italic axis`() {
+    val url = buildCssUrl(GoogleFontKey("Inter", 400, italic = true))
+    assertEquals("https://fonts.googleapis.com/css2?family=Inter:ital,wght@1,400&display=swap", url)
+  }
+
+  @Test
+  fun `extractFirstTruetypeUrl picks the truetype-formatted entry only`() {
+    val css =
+      """
+      @font-face {
+        font-family: 'Inter';
+        src: url(https://fonts.gstatic.com/foo.woff2) format('woff2');
+      }
+      @font-face {
+        font-family: 'Inter';
+        src: url(https://fonts.gstatic.com/foo.ttf) format('truetype');
+      }
+      """
+        .trimIndent()
+    assertEquals("https://fonts.gstatic.com/foo.ttf", extractFirstTruetypeUrl(css))
+  }
+
+  @Test
+  fun `extractFirstTruetypeUrl returns null when no truetype source is present`() {
+    val css =
+      """
+      @font-face {
+        src: url(https://fonts.gstatic.com/foo.woff2) format('woff2');
+      }
+      """
+        .trimIndent()
+    assertNull(extractFirstTruetypeUrl(css))
+  }
+
+  @Test
+  fun `buildRangeCssUrl spans the conventional 100-1000 variable-axis range`() {
+    val url = buildRangeCssUrl(GoogleFontKey("Roboto Flex", 100, italic = false))
+    assertEquals(
+      "https://fonts.googleapis.com/css2?family=Roboto%20Flex:wght@100..1000&display=swap",
+      url,
+    )
+  }
+
+  @Test
+  fun `pickClosestTruetypeUrl returns the single URL for a variable-font response`() {
+    // Range query on a purely-variable family like Roboto Flex returns
+    // one @font-face block whose font-weight says "400" but whose TTF is
+    // the axis-range-covering variable font.
+    val css =
+      """
+      @font-face {
+        font-family: 'Roboto Flex';
+        font-weight: 400;
+        src: url(https://fonts.gstatic.com/flex.ttf) format('truetype');
+      }
+      """
+        .trimIndent()
+    assertEquals(
+      "https://fonts.gstatic.com/flex.ttf",
+      pickClosestTruetypeUrl(css, requestedWeight = 100),
+    )
+  }
+
+  @Test
+  fun `pickClosestTruetypeUrl picks the nearest declared weight from a static family`() {
+    val css =
+      """
+      @font-face { font-family: 'X'; font-weight: 300;
+        src: url(https://fonts.gstatic.com/x-300.ttf) format('truetype'); }
+      @font-face { font-family: 'X'; font-weight: 500;
+        src: url(https://fonts.gstatic.com/x-500.ttf) format('truetype'); }
+      @font-face { font-family: 'X'; font-weight: 700;
+        src: url(https://fonts.gstatic.com/x-700.ttf) format('truetype'); }
+      """
+        .trimIndent()
+    // 550 is strictly closer to 500 than 300 or 700.
+    assertEquals(
+      "https://fonts.gstatic.com/x-500.ttf",
+      pickClosestTruetypeUrl(css, requestedWeight = 550),
+    )
+    // 900 pulls to 700, the heaviest declared static sub-font.
+    assertEquals(
+      "https://fonts.gstatic.com/x-700.ttf",
+      pickClosestTruetypeUrl(css, requestedWeight = 900),
+    )
+  }
+
+  @Test
+  fun `GoogleFontCache returns cached file when it already exists`() {
+    val dir = tempDir.newFolder("fonts")
+    val key = GoogleFontKey("Roboto Mono", 400, italic = false)
+    val existing = File(dir, key.fileName())
+    existing.writeBytes(FAKE_TTF_BYTES)
+    var downloaderCalls = 0
+    val cache =
+      GoogleFontCache(
+        dir,
+        offline = false,
+        downloader = { _, _ ->
+          downloaderCalls++
+          true
+        },
+      )
+    val file = cache.load(key)
+    assertEquals(existing, file)
+    assertEquals(0, downloaderCalls)
+  }
+
+  @Test
+  fun `GoogleFontCache invokes downloader on miss and caches the result`() {
+    val dir = tempDir.newFolder("fonts")
+    val key = GoogleFontKey("Inter", 400, italic = false)
+    var downloaderCalls = 0
+    val cache =
+      GoogleFontCache(
+        dir,
+        offline = false,
+        downloader = { _, dest ->
+          downloaderCalls++
+          dest.writeBytes(FAKE_TTF_BYTES)
+          true
+        },
+      )
+    val file1 = cache.load(key)
+    assertNotNull(file1)
+    assertTrue(FAKE_TTF_BYTES.contentEquals(file1!!.readBytes()))
+    assertEquals(1, downloaderCalls)
+
+    // Second call hits cache — downloader not invoked again.
+    val file2 = cache.load(key)
+    assertEquals(file1, file2)
+    assertEquals(1, downloaderCalls)
+  }
+
+  @Test
+  fun `GoogleFontCache returns null on miss when offline is true`() {
+    val dir = tempDir.newFolder("fonts")
+    val key = GoogleFontKey("Inter", 400, italic = false)
+    val cache =
+      GoogleFontCache(
+        dir,
+        offline = true,
+        downloader = { _, _ -> error("offline mode must not invoke the downloader") },
+      )
+    assertNull(cache.load(key))
+  }
+
+  @Test
+  fun `GoogleFontCache returns null and leaves no file when downloader fails`() {
+    val dir = tempDir.newFolder("fonts")
+    val key = GoogleFontKey("Ghost", 400, italic = false)
+    val cache = GoogleFontCache(dir, offline = false, downloader = { _, _ -> false })
+    assertNull(cache.load(key))
+    assertFalse(File(dir, key.fileName()).exists())
+  }
+
+  companion object {
+    // Minimum byte sequence the cache round-trips. No need to be a valid
+    // TTF — the unit tests never parse the file, only the
+    // shadow/end-to-end path hands it to `Typeface.createFromFile`.
+    private val FAKE_TTF_BYTES = byteArrayOf(0, 1, 0, 0, 0, 0)
+  }
+}

--- a/renderers/android/build.gradle.kts
+++ b/renderers/android/build.gradle.kts
@@ -44,6 +44,9 @@ android {
 
 dependencies {
   implementation(project(":common-io"))
+  // Google Fonts CSS-API + TTF cache, shared with the Remote Compose typeface resolver so both
+  // lanes resolve a family to the same file rather than to two drifting copies of the downloader.
+  api(project(":data-fonts-google"))
   // Google Fonts CSS/TTF fetch in GoogleFontInterceptor (replaces java.net.HttpURLConnection).
   implementation(libs.okhttp)
   // D2.2 — `AccessibilityChecker`, `AccessibilityOverlay`, and the

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
@@ -1,15 +1,10 @@
 package ee.schimke.composeai.renderer
 
-import androidx.compose.ui.text.font.FontWeight
-import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.fonts.google.GoogleFontCache
+import ee.schimke.composeai.fonts.google.GoogleFontKey
+import ee.schimke.composeai.fonts.google.GoogleFontSource
 import java.io.File
 import java.net.URLDecoder
-import java.net.URLEncoder
-import java.util.concurrent.TimeUnit
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okio.FileSystem
-import okio.Path.Companion.toPath
 
 /**
  * Cache and CSS-API helpers that underpin [ShadowFontsContractCompat].
@@ -51,7 +46,7 @@ internal object GoogleFontCacheAccess {
   }
 
   fun load(name: String, weight: Int, italic: Boolean): File? =
-    cache?.load(GoogleFontKey(name, FontWeight(weight), italic))
+    cache?.load(GoogleFontKey(name, weight, italic))
 }
 
 /**
@@ -76,7 +71,7 @@ object GoogleFontFiles {
    */
   fun cached(family: String, weight: Int, italic: Boolean): File? {
     val dir = System.getProperty("composeai.fonts.cacheDir")?.takeIf { it.isNotBlank() } ?: return null
-    val file = File(dir, GoogleFontKey(family, FontWeight(weight), italic).fileName())
+    val file = File(dir, GoogleFontKey(family, weight, italic).fileName())
     return file.takeIf { it.isFile && it.length() > 0 }
   }
 }
@@ -147,7 +142,7 @@ object FontResolutionDiagnostics {
    * [reason]. Adds it to the current preview's buffer and emits a de-duplicated stderr line.
    */
   internal fun recordFallback(key: GoogleFontKey, reason: String) {
-    val fallback = FontFallback(key.name, key.weight.weight, key.italic, reason)
+    val fallback = FontFallback(key.name, key.weight, key.italic, reason)
     currentPreview.add(fallback)
     if (warnedThisProcess.add(key.fileName())) System.err.println(describe(fallback))
   }
@@ -209,213 +204,6 @@ class FontFallbackException(
   )
 
 /**
- * Represents a single resolved Google font file keyed by family + axes. Serialised on disk as
- * `<slug>-<weight>[-italic].ttf` so the cache is human-readable under `~/.cache/composeai/fonts/`.
- */
-internal data class GoogleFontKey(val name: String, val weight: FontWeight, val italic: Boolean) {
-  fun fileName(): String {
-    val slug = slugify(name)
-    val italicPart = if (italic) "-italic" else ""
-    return "$slug-${weight.weight}$italicPart.ttf"
-  }
-
-  companion object {
-    /** Lowercase + replace non-alphanumerics with `-`, no leading/trailing hyphens. */
-    fun slugify(name: String): String =
-      buildString {
-          var prevDash = true
-          for (ch in name) {
-            val lower = ch.lowercaseChar()
-            if (lower in 'a'..'z' || lower in '0'..'9') {
-              append(lower)
-              prevDash = false
-            } else if (!prevDash) {
-              append('-')
-              prevDash = true
-            }
-          }
-        }
-        .trim('-')
-        .ifEmpty { "font" }
-  }
-}
-
-/**
- * Abstraction over "hand me a cached TTF for `(name, weight, italic)`" so tests can stub the
- * download path with a preseeded directory.
- */
-internal interface GoogleFontSource {
-  fun load(key: GoogleFontKey): File?
-}
-
-/**
- * Disk-backed [GoogleFontSource]. Downloads missing TTFs from the Google Fonts CSS API on first
- * access, then reuses the on-disk copy forever.
- *
- * Two knobs, both off the same system-property surface the rest of the renderer uses:
- * - `composeai.fonts.cacheDir` — directory root.
- * - `composeai.fonts.offline` — when `true`, skip network on cache miss so the render shows the
- *   fallback font instead of silently fetching from a non-deterministic endpoint.
- */
-internal class GoogleFontCache(
-  private val cacheDir: File,
-  private val offline: Boolean = false,
-  private val downloader: (GoogleFontKey, File) -> Boolean = ::downloadFromGoogleFonts,
-) : GoogleFontSource {
-
-  override fun load(key: GoogleFontKey): File? {
-    val file = File(cacheDir, key.fileName())
-    if (file.exists() && file.length() > 0) return file
-    if (offline) return null
-    cacheDir.mkdirs()
-    val tmp = File(cacheDir, "${file.name}.tmp")
-    val ok = runCatching { downloader(key, tmp) }.getOrDefault(false)
-    if (!ok || !tmp.exists() || tmp.length() == 0L) {
-      tmp.delete()
-      return null
-    }
-    if (!tmp.renameTo(file)) {
-      // Atomic rename can fail across filesystems. Fall back to copy.
-      tmp.copyTo(file, overwrite = true)
-      tmp.delete()
-    }
-    return file
-  }
-}
-
-/**
- * Fetches a TTF for [key] into [destination]. Returns `true` on success.
- *
- * Two-stage lookup:
- * 1. Try `wght@<exact>` — works for static families (Roboto, Lobster Two) and for the default
- *    weight of variable families.
- * 2. If that request *succeeded but carried no TTF URL* (purely-variable fonts like Roboto Flex
- *    reject single-weight requests at non-default weights), retry with `wght@<min>..<max>` covering
- *    the full 1–1000 range. For variable fonts the response is a single `@font-face` pointing at the
- *    variable TTF; for static fonts it's multiple blocks and we pick the closest to the requested
- *    weight.
- *
- * The stage-1/stage-2 distinction is load-bearing for reproducibility, which is why a *failed*
- * stage-1 request returns false rather than falling through. The two stages can legitimately resolve
- * the same `(family, weight, italic)` to different faces — a static sub-font at the exact weight vs
- * the family's variable TTF — and those have different text metrics. Falling through on a network
- * error therefore let a transient blip resolve a key to the other face, and because the result is
- * cached under the same filename, that face then stuck for every later render on the machine.
- * Consumers saw it as a whole-text-layer sub-pixel shift appearing and disappearing between CI runs
- * on unrelated commits. Failing instead routes through the usual unresolved-font path, which is
- * fatal per-preview by default (see [FontResolutionDiagnostics.failOnFallback]) and says so.
- *
- * The CSS2 endpoint serves WOFF2 by default (Android doesn't parse WOFF2 natively), so we send an
- * Android-2.3 User-Agent — one of the few UAs for which the API still returns TrueType. Same
- * mechanism `google-webfonts-helper` and similar offline caches rely on.
- */
-internal fun downloadFromGoogleFonts(
-  key: GoogleFontKey,
-  destination: File,
-  fileSystem: FileSystem = SystemFileSystem,
-): Boolean {
-  // A null here is a *failed request*, not "this family has no TTF at this weight" — don't let it
-  // silently pick up the range query's (differently-metricked) answer. See the KDoc.
-  val exactCss = httpGet(buildCssUrl(key), TTF_USER_AGENT) ?: return false
-  val url =
-    extractFirstTruetypeUrl(exactCss)
-      ?: run {
-        val rangeCss = httpGet(buildRangeCssUrl(key), TTF_USER_AGENT) ?: return false
-        pickClosestTruetypeUrl(rangeCss, key.weight.weight) ?: return false
-      }
-  val bytes = httpGetBytes(url, userAgent = TTF_USER_AGENT) ?: return false
-  if (bytes.isEmpty()) return false
-  destination.parentFile?.mkdirs()
-  fileSystem.write(destination.path.toPath()) { write(bytes) }
-  return true
-}
-
-// The CSS2 endpoint picks the `src: url(...) format(...)` format based on
-// User-Agent capabilities. Modern UAs get WOFF2 (Android can't parse it
-// natively); IE11 gets WOFF (same problem); the only UAs that reliably
-// produce `format('truetype')` are pre-KitKat Android variants — legacy
-// devices predating native WOFF2 support. Using a fixed Android 2.3 UA is
-// the same approach `google-webfonts-helper` settled on for its "TTF only"
-// download mode.
-private const val TTF_USER_AGENT =
-  "Mozilla/5.0 (Linux; U; Android 2.3.3; en-us) AppleWebKit/533.1 (KHTML, like Gecko)"
-
-internal fun buildCssUrl(key: GoogleFontKey): String =
-  buildCssUrlForAxis(
-    key,
-    if (key.italic) "ital,wght@1,${key.weight.weight}" else "wght@${key.weight.weight}",
-  )
-
-/**
- * Range-query variant. Returns a CSS response with either one `@font-face` (variable font) or many
- * (static families with multiple pre-rendered weights). Used as a fallback when [buildCssUrl]
- * produced no TTF URL — purely variable families like Roboto Flex reject single-weight queries at
- * non-default weights.
- *
- * `100..1000` is the conventional Google Fonts wght axis range and works for Roboto Flex (wght
- * 100..1000), Google Sans Flex (wght 100..1000), and other variable families. Ranges outside a
- * family's declared axis bounds (e.g. `1..1000` on Roboto Flex) return a 400 "Font family not
- * found" HTML page, which our TTF regex correctly treats as a miss.
- */
-internal fun buildRangeCssUrl(key: GoogleFontKey): String =
-  buildCssUrlForAxis(key, if (key.italic) "ital,wght@1,100..1000" else "wght@100..1000")
-
-private fun buildCssUrlForAxis(key: GoogleFontKey, axis: String): String {
-  // `URLEncoder.encode(s, Charset)` is API 33+. The renderer runs inside
-  // Robolectric on JDK 17 where both overloads exist, but the library's
-  // `minSdk = 24` trips `lint`. The legacy `encode(s, charsetName)`
-  // overload is unchanged and the round-trip is identical.
-  @Suppress("DEPRECATION") val family = URLEncoder.encode(key.name, "UTF-8").replace("+", "%20")
-  return "https://fonts.googleapis.com/css2?family=$family:$axis&display=swap"
-}
-
-internal fun extractFirstTruetypeUrl(css: String): String? {
-  // Matches `url(...) format('truetype')` inside an `@font-face` block.
-  val regex = Regex("""url\((https://[^)]+)\)\s*format\(['"]truetype['"]\)""")
-  return regex.find(css)?.groupValues?.get(1)
-}
-
-/**
- * Parse a CSS response with one-or-many `@font-face` blocks and pick the TTF URL whose declared
- * `font-weight` is closest to [requestedWeight].
- *
- * - Variable-font responses have a single block with `font-weight: 400` but the TTF itself supports
- *   the full axis range — just return that URL.
- * - Static-family range responses carry one block per discrete weight (100, 200, …, 900); pick the
- *   nearest and the consumer's text renders in the closest existing static sub-font.
- */
-internal fun pickClosestTruetypeUrl(css: String, requestedWeight: Int): String? {
-  val blockRegex =
-    Regex("""font-weight:\s*(\d+)[\s\S]*?url\((https://[^)]+)\)\s*format\(['"]truetype['"]\)""")
-  val matches = blockRegex.findAll(css).toList()
-  if (matches.isEmpty()) return extractFirstTruetypeUrl(css)
-  if (matches.size == 1) return matches[0].groupValues[2]
-  return matches
-    .minByOrNull { kotlin.math.abs(it.groupValues[1].toInt() - requestedWeight) }
-    ?.groupValues
-    ?.get(2)
-}
-
-private val fontHttpClient: OkHttpClient by lazy {
-  OkHttpClient.Builder()
-    .connectTimeout(10, TimeUnit.SECONDS)
-    .readTimeout(15, TimeUnit.SECONDS)
-    .build()
-}
-
-private fun httpGet(url: String, userAgent: String): String? =
-  httpGetBytes(url, userAgent)?.toString(Charsets.UTF_8)
-
-private fun httpGetBytes(url: String, userAgent: String): ByteArray? =
-  runCatching {
-      val request = Request.Builder().url(url).header("User-Agent", userAgent).build()
-      fontHttpClient.newCall(request).execute().use { response ->
-        if (response.isSuccessful) response.body?.bytes() else null
-      }
-    }
-    .getOrNull()
-
-/**
  * Parses the `FontRequest.query` wire format that Compose's `GoogleFont.kt` builds into a
  * [GoogleFontKey].
  *
@@ -443,5 +231,5 @@ internal fun parseFontRequestQuery(query: String?): GoogleFontKey? {
   val name = pairs["name"]?.takeIf { it.isNotBlank() } ?: return null
   val weight = pairs["weight"]?.toIntOrNull() ?: 400
   val italic = pairs["italic"]?.toFloatOrNull()?.let { it >= 0.5f } ?: false
-  return GoogleFontKey(name, FontWeight(weight), italic)
+  return GoogleFontKey(name, weight, italic)
 }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PixelSystemFontAliases.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PixelSystemFontAliases.kt
@@ -1,7 +1,9 @@
 package ee.schimke.composeai.renderer
 
 import android.graphics.Typeface
-import androidx.compose.ui.text.font.FontWeight
+import ee.schimke.composeai.fonts.google.GoogleFontCache
+import ee.schimke.composeai.fonts.google.GoogleFontKey
+import ee.schimke.composeai.fonts.google.GoogleFontSource
 
 /**
  * Maps Android system-font family slugs (the names consumers pass to
@@ -149,7 +151,7 @@ object PixelSystemFontAliases {
       when {
         lookup != null -> lookup
         cache != null -> { n, w, i ->
-          cache.load(GoogleFontKey(n, FontWeight(w), i))
+          cache.load(GoogleFontKey(n, w, i))
         }
         else -> { n, w, i ->
           GoogleFontCacheAccess.load(n, w, i)

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ShadowFontsContractCompat.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ShadowFontsContractCompat.kt
@@ -70,7 +70,7 @@ class ShadowFontsContractCompat {
         )
         return
       }
-      val file: File? = GoogleFontCacheAccess.load(key.name, key.weight.weight, key.italic)
+      val file: File? = GoogleFontCacheAccess.load(key.name, key.weight, key.italic)
       if (file == null) {
         // The cache couldn't produce a TTF (offline / no cache dir / failed download / no such
         // face). Record the fallback so the render loop can fail or warn on it — text would
@@ -85,7 +85,7 @@ class ShadowFontsContractCompat {
         return
       }
       val typeface =
-        runCatching { buildTypefaceFromFile(file, key.weight.weight, key.italic) }.getOrNull()
+        runCatching { buildTypefaceFromFile(file, key.weight, key.italic) }.getOrNull()
       if (typeface == null) {
         FontResolutionDiagnostics.recordFallback(
           key,

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FontResolutionDiagnosticsTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FontResolutionDiagnosticsTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.renderer
 
-import androidx.compose.ui.text.font.FontWeight
+import ee.schimke.composeai.fonts.google.GoogleFontKey
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
@@ -41,7 +41,7 @@ class FontResolutionDiagnosticsTest {
   }
 
   private fun key(name: String, weight: Int = 400, italic: Boolean = false) =
-    GoogleFontKey(name, FontWeight(weight), italic)
+    GoogleFontKey(name, weight, italic)
 
   @Test
   fun `failOnFallback defaults to true and honours the opt-out`() {

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptorTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptorTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.renderer
 
-import androidx.compose.ui.text.font.FontWeight
+import ee.schimke.composeai.fonts.google.GoogleFontKey
 import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptorTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptorTest.kt
@@ -20,133 +20,13 @@ import org.junit.rules.TemporaryFolder
  * exercised end-to-end via `:samples:android:composePreviewRenderAll`.
  */
 class GoogleFontInterceptorTest {
-
-  @get:Rule val tempDir = TemporaryFolder()
-
-  @Test
-  fun `slugify lowercases and replaces non-alphanumerics with hyphens`() {
-    assertEquals("roboto-mono", GoogleFontKey.slugify("Roboto Mono"))
-    assertEquals("ibm-plex-sans", GoogleFontKey.slugify("IBM Plex Sans"))
-    assertEquals("noto-serif", GoogleFontKey.slugify("  Noto--Serif  "))
-    assertEquals("font", GoogleFontKey.slugify("!!!"))
-  }
-
-  @Test
-  fun `fileName encodes weight and italic axis`() {
-    assertEquals(
-      "roboto-mono-400.ttf",
-      GoogleFontKey("Roboto Mono", FontWeight(400), italic = false).fileName(),
-    )
-    assertEquals(
-      "roboto-mono-700-italic.ttf",
-      GoogleFontKey("Roboto Mono", FontWeight(700), italic = true).fileName(),
-    )
-  }
-
-  @Test
-  fun `buildCssUrl encodes family name with spaces and weight axis`() {
-    val url = buildCssUrl(GoogleFontKey("Roboto Mono", FontWeight(500), italic = false))
-    assertEquals(
-      "https://fonts.googleapis.com/css2?family=Roboto%20Mono:wght@500&display=swap",
-      url,
-    )
-  }
-
-  @Test
-  fun `buildCssUrl encodes italic axis`() {
-    val url = buildCssUrl(GoogleFontKey("Inter", FontWeight(400), italic = true))
-    assertEquals("https://fonts.googleapis.com/css2?family=Inter:ital,wght@1,400&display=swap", url)
-  }
-
-  @Test
-  fun `extractFirstTruetypeUrl picks the truetype-formatted entry only`() {
-    val css =
-      """
-      @font-face {
-        font-family: 'Inter';
-        src: url(https://fonts.gstatic.com/foo.woff2) format('woff2');
-      }
-      @font-face {
-        font-family: 'Inter';
-        src: url(https://fonts.gstatic.com/foo.ttf) format('truetype');
-      }
-      """
-        .trimIndent()
-    assertEquals("https://fonts.gstatic.com/foo.ttf", extractFirstTruetypeUrl(css))
-  }
-
-  @Test
-  fun `extractFirstTruetypeUrl returns null when no truetype source is present`() {
-    val css =
-      """
-      @font-face {
-        src: url(https://fonts.gstatic.com/foo.woff2) format('woff2');
-      }
-      """
-        .trimIndent()
-    assertNull(extractFirstTruetypeUrl(css))
-  }
-
-  @Test
-  fun `buildRangeCssUrl spans the conventional 100-1000 variable-axis range`() {
-    val url = buildRangeCssUrl(GoogleFontKey("Roboto Flex", FontWeight(100), italic = false))
-    assertEquals(
-      "https://fonts.googleapis.com/css2?family=Roboto%20Flex:wght@100..1000&display=swap",
-      url,
-    )
-  }
-
-  @Test
-  fun `pickClosestTruetypeUrl returns the single URL for a variable-font response`() {
-    // Range query on a purely-variable family like Roboto Flex returns
-    // one @font-face block whose font-weight says "400" but whose TTF is
-    // the axis-range-covering variable font.
-    val css =
-      """
-      @font-face {
-        font-family: 'Roboto Flex';
-        font-weight: 400;
-        src: url(https://fonts.gstatic.com/flex.ttf) format('truetype');
-      }
-      """
-        .trimIndent()
-    assertEquals(
-      "https://fonts.gstatic.com/flex.ttf",
-      pickClosestTruetypeUrl(css, requestedWeight = 100),
-    )
-  }
-
-  @Test
-  fun `pickClosestTruetypeUrl picks the nearest declared weight from a static family`() {
-    val css =
-      """
-      @font-face { font-family: 'X'; font-weight: 300;
-        src: url(https://fonts.gstatic.com/x-300.ttf) format('truetype'); }
-      @font-face { font-family: 'X'; font-weight: 500;
-        src: url(https://fonts.gstatic.com/x-500.ttf) format('truetype'); }
-      @font-face { font-family: 'X'; font-weight: 700;
-        src: url(https://fonts.gstatic.com/x-700.ttf) format('truetype'); }
-      """
-        .trimIndent()
-    // 550 is strictly closer to 500 than 300 or 700.
-    assertEquals(
-      "https://fonts.gstatic.com/x-500.ttf",
-      pickClosestTruetypeUrl(css, requestedWeight = 550),
-    )
-    // 900 pulls to 700, the heaviest declared static sub-font.
-    assertEquals(
-      "https://fonts.gstatic.com/x-700.ttf",
-      pickClosestTruetypeUrl(css, requestedWeight = 900),
-    )
-  }
-
   @Test
   fun `parseFontRequestQuery reads the Compose GoogleFont wire format`() {
     val query = "name=Roboto%20Mono&weight=500&width=100.0&italic=0.0&besteffort=true"
     val key = parseFontRequestQuery(query)
     assertNotNull(key)
     assertEquals("Roboto Mono", key!!.name)
-    assertEquals(500, key.weight.weight)
+    assertEquals(500, key.weight)
     assertFalse(key.italic)
   }
 
@@ -155,14 +35,14 @@ class GoogleFontInterceptorTest {
     val key = parseFontRequestQuery("name=Inter&weight=700&italic=1.0&besteffort=true")
     assertNotNull(key)
     assertTrue(key!!.italic)
-    assertEquals(700, key.weight.weight)
+    assertEquals(700, key.weight)
   }
 
   @Test
   fun `parseFontRequestQuery defaults missing weight to 400 and italic to false`() {
     val key = parseFontRequestQuery("name=Inter&besteffort=true")
     assertNotNull(key)
-    assertEquals(400, key!!.weight.weight)
+    assertEquals(400, key!!.weight)
     assertFalse(key.italic)
   }
 
@@ -171,81 +51,5 @@ class GoogleFontInterceptorTest {
     assertNull(parseFontRequestQuery(null))
     assertNull(parseFontRequestQuery("weight=400&italic=0.0"))
     assertNull(parseFontRequestQuery("name=&weight=400"))
-  }
-
-  @Test
-  fun `GoogleFontCache returns cached file when it already exists`() {
-    val dir = tempDir.newFolder("fonts")
-    val key = GoogleFontKey("Roboto Mono", FontWeight(400), italic = false)
-    val existing = File(dir, key.fileName())
-    existing.writeBytes(FAKE_TTF_BYTES)
-    var downloaderCalls = 0
-    val cache =
-      GoogleFontCache(
-        dir,
-        offline = false,
-        downloader = { _, _ ->
-          downloaderCalls++
-          true
-        },
-      )
-    val file = cache.load(key)
-    assertEquals(existing, file)
-    assertEquals(0, downloaderCalls)
-  }
-
-  @Test
-  fun `GoogleFontCache invokes downloader on miss and caches the result`() {
-    val dir = tempDir.newFolder("fonts")
-    val key = GoogleFontKey("Inter", FontWeight(400), italic = false)
-    var downloaderCalls = 0
-    val cache =
-      GoogleFontCache(
-        dir,
-        offline = false,
-        downloader = { _, dest ->
-          downloaderCalls++
-          dest.writeBytes(FAKE_TTF_BYTES)
-          true
-        },
-      )
-    val file1 = cache.load(key)
-    assertNotNull(file1)
-    assertTrue(FAKE_TTF_BYTES.contentEquals(file1!!.readBytes()))
-    assertEquals(1, downloaderCalls)
-
-    // Second call hits cache — downloader not invoked again.
-    val file2 = cache.load(key)
-    assertEquals(file1, file2)
-    assertEquals(1, downloaderCalls)
-  }
-
-  @Test
-  fun `GoogleFontCache returns null on miss when offline is true`() {
-    val dir = tempDir.newFolder("fonts")
-    val key = GoogleFontKey("Inter", FontWeight(400), italic = false)
-    val cache =
-      GoogleFontCache(
-        dir,
-        offline = true,
-        downloader = { _, _ -> error("offline mode must not invoke the downloader") },
-      )
-    assertNull(cache.load(key))
-  }
-
-  @Test
-  fun `GoogleFontCache returns null and leaves no file when downloader fails`() {
-    val dir = tempDir.newFolder("fonts")
-    val key = GoogleFontKey("Ghost", FontWeight(400), italic = false)
-    val cache = GoogleFontCache(dir, offline = false, downloader = { _, _ -> false })
-    assertNull(cache.load(key))
-    assertFalse(File(dir, key.fileName()).exists())
-  }
-
-  companion object {
-    // Minimum byte sequence the cache round-trips. No need to be a valid
-    // TTF — the unit tests never parse the file, only the
-    // shadow/end-to-end path hands it to `Typeface.createFromFile`.
-    private val FAKE_TTF_BYTES = byteArrayOf(0, 1, 0, 0, 0, 0)
   }
 }

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PixelSystemFontAliasesTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PixelSystemFontAliasesTest.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.renderer
 
 import android.graphics.Typeface
-import androidx.compose.ui.text.font.FontWeight
+import ee.schimke.composeai.fonts.google.GoogleFontKey
 import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -163,7 +163,7 @@ class PixelSystemFontAliasesTest {
     // which is identical to the GoogleFont("Roboto Flex") cache entry —
     // so the two entry points share bytes instead of double-downloading.
     val systemAliasFile =
-      GoogleFontKey(name = "Roboto Flex", weight = FontWeight(400), italic = false).fileName()
+      GoogleFontKey(name = "Roboto Flex", weight = 400, italic = false).fileName()
     assertEquals("roboto-flex-400.ttf", systemAliasFile)
   }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -367,6 +367,12 @@ include(":data-navigation-connector")
 
 project(":data-navigation-connector").projectDir = file("data/navigation/connector")
 
+// Google Fonts resolution + machine-local TTF cache. Shared by the Robolectric downloadable-font
+// shadow and the Remote Compose typeface resolver so both lanes resolve a family to the same file.
+include(":data-fonts-google")
+
+project(":data-fonts-google").projectDir = file("data/fonts/google")
+
 include(":data-render-core")
 
 project(":data-render-core").projectDir = file("data/render/core")


### PR DESCRIPTION
Groundwork for resolving `RemoteFontFamily.Named("google:…")` in the snapshot renderer — the open half of #2919. **This PR is the extraction only**; the resolver itself is not here (see below).

## Why extract rather than copy

`GoogleFontKey`, `GoogleFontCache` and `downloadFromGoogleFonts` lived inside `:renderer-android` as `internal`, reachable only from the Robolectric downloadable-font shadow. The Remote Compose connector needs the same resolution, and it is a sibling module — neither depends on the other — so it currently cannot see any of it.

A second copy would be actively dangerous. `downloadFromGoogleFonts` encodes a stage-1/stage-2 contract whose failure mode is subtle and *permanent*: falling through to the range query on a network error can resolve a key to the family's variable TTF rather than its static sub-font, and because the result is cached under the same filename, that differently-metricked face then sticks for every later render on the machine. That's the bug the existing KDoc describes as "a whole-text-layer sub-pixel shift appearing and disappearing between CI runs on unrelated commits". Two implementations would drift into exactly it.

So it moves to `:data-fonts-google`, a pure-JVM module (okio + okhttp) that both an Android renderer and a Compose connector can depend on. The whole surface is `(family, weight, italic) -> File`, which is what keeps it platform-free: `weight` is a plain CSS numeric rather than a Compose `FontWeight`, because the two callers reach it from different worlds and neither should adopt the other's type just to ask for a file.

## No behaviour change

Pure relocation. The tests for the moved surface move with it, and earned their keep immediately: transcribing `slugify` dropped its `.ifEmpty { "font" }` tail, which would have given every family with no alphanumerics the same `-400.ttf` cache filename. The moved test caught it before it could be committed — which is the argument for moving the tests rather than leaving them behind.

## Test plan

- `:data-fonts-google:test` — 13 cases (CSS-API query shapes, TTF extraction, nearest-weight selection, cache hit/miss/offline/failure), green.
- `:renderer-android:compileDebugKotlin` green against the extracted module; the four remaining `parseFontRequestQuery` cases stay with the shadow they test.
- No render output changes, so no visual evidence: this PR moves code between modules and touches no drawing path.

## What is deliberately *not* in this PR

I wrote the resolver (`RemoteNamedFontResolver`, decorating the player's own `TypefaceResolver`) and it compiles, but re-rendering the catalog showed **it does not yet take effect** — the branded sticker still bakes as Roboto and no `orbitron-*.ttf` appears in the font cache, so the resolver's `load` is never reached.

Diagnosis: `RemoteDocumentPlayer`'s `init` callback runs inside the same factory that installs the player's own resolver, so `getTypefaceResolver()` is still null when `init` fires and the decoration is skipped. The supported seam is the `typefaceResolver` constructor parameter, but constructing the default resolver to delegate to needs a `RemoteContext` the player owns and does not expose. That needs resolving properly rather than guessed at, so it is left out rather than shipped as dead code.

Until it lands, the `Text/Branded` row on the PNG↔Remote-Compose parity page still reads high and the browser render still clips, both for the reason documented in `third_party/remote-compose-player/PROVENANCE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6SvmYX83WejJUsHYoCHM1

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6SvmYX83WejJUsHYoCHM1)_