### PR TITLE
docs(upstream): report the Remote Compose TypefaceResolver API gap

### DIFF
--- a/docs/upstream/remote-compose-typeface-resolver-gap.md
+++ b/docs/upstream/remote-compose-typeface-resolver-gap.md
@@ -1,0 +1,131 @@
+# A custom `TypefaceResolver` can only replace the default, never delegate to it
+
+**Component:** `androidx.compose.remote:remote-player-core` / `remote-player-compose`
+**Versions checked:** artifacts `1.0.0-alpha15`; source read at `androidx-main`
+**Type:** API gap (no workaround available through public API)
+
+## Summary
+
+`RemoteDocumentPlayer` accepts a `typefaceResolver`, and `RemoteComposePlayer` exposes
+`get`/`setTypefaceResolver`. But there is no way to install a resolver that handles *some* requests
+and forwards the rest to the stock behaviour:
+
+- `AndroidRemoteContext.getTypefaceResolver()` returns `null` until someone calls the setter — there
+  is no default instance to read back and delegate to.
+- Reimplementing the default requires a `RemoteContext`, and the only accessor
+  (`RemoteComposePlayer.getRemoteContext()`) is `private`.
+
+So a caller who wants to add one behaviour — resolving a `RemoteFontFamily.Named` value the host
+knows how to fetch — must replace the whole resolver and cannot reproduce the part of the default
+that reads document-embedded fonts.
+
+## Why the obvious approaches don't work
+
+### 1. Decorating in the `init` callback
+
+`RemoteDocumentPlayer.kt` builds the player like this:
+
+```kotlin
+RemoteComposePlayer(it).apply {
+    doOnPreDraw { fullyDrawnReporter?.removeReporter() }
+    init(this)
+    bitmapLoader?.let(::setBitmapLoader)
+    typefaceResolver?.let(::setTypefaceResolver)
+}
+```
+
+`init(this)` runs **before** `setTypefaceResolver`, so:
+
+```kotlin
+init = { player ->
+    val current = player.getTypefaceResolver()   // always null here
+    if (current != null) player.setTypefaceResolver(MyResolver(current))
+}
+```
+
+never fires. And if it did, the `typefaceResolver` parameter would overwrite it one line later.
+
+### 2. Reading the current resolver at any point
+
+`RemoteComposePlayer` forwards both accessors to the context:
+
+```java
+public void setTypefaceResolver(@NonNull TypefaceResolver typefaceResolver) {
+    ((AndroidRemoteContext) mInner.getRemoteContext()).setTypefaceResolver(typefaceResolver);
+}
+
+public @Nullable TypefaceResolver getTypefaceResolver() {
+    return ((AndroidRemoteContext) mInner.getRemoteContext()).getTypefaceResolver();
+}
+```
+
+and `AndroidRemoteContext` stores it with no lazy default:
+
+```java
+private TypefaceResolver mTypefaceResolver;
+
+public @Nullable TypefaceResolver getTypefaceResolver() {
+    return mTypefaceResolver;
+}
+```
+
+The stock behaviour is constructed inside `AndroidPaintContext` when the context has no resolver, so
+it is never observable through the public API. `getTypefaceResolver()` returns `null` for the entire
+lifetime of a player nobody has called the setter on — which is exactly the case where a caller would
+want to wrap it.
+
+### 3. Constructing `DefaultTypefaceResolver` to delegate to
+
+`DefaultTypefaceResolver`'s constructor takes a `RemoteContext`, and reads it in one place — the
+`fontType` overload, to find document-embedded font data:
+
+```java
+RemoteContext.FontInfo fi = (RemoteContext.FontInfo) mContext.getObject(fontType);
+```
+
+A caller cannot obtain that context: `RemoteComposePlayer.getRemoteContext()` is `private`, and
+`RemoteDocumentPlayer` exposes only the `RemoteComposePlayer` (via `init`) and the `CoreDocument`
+(which the caller supplies and which has no context accessor).
+
+Passing a freshly-constructed `AndroidRemoteContext` compiles, but it is a *different* context from
+the one playing the document, so `getObject(fontType)` misses and every document-embedded font
+silently falls back. That is a correctness regression, not a workaround.
+
+## Impact
+
+Any host that can resolve a font the player cannot has to choose between:
+
+- **not resolving it** — named families render in the platform default, silently, and (because a
+  Remote Compose document carries geometry measured by the authoring renderer) with the wrong
+  metrics as well; or
+- **replacing the resolver wholesale** — losing document-embedded `FontData` for every document that
+  host plays.
+
+Neither is acceptable for a library that plays arbitrary third-party documents.
+
+## Concrete use case
+
+A snapshot renderer plays `.rc` documents that carry `RemoteFontFamily.Named("…")`. The host already
+has the face on disk (it resolves the same families for Compose's own
+`Font(GoogleFont(...))` requests through a local cache). It needs to answer *just* the named-family
+lookups and leave generic typeface ids, system families, and embedded fonts to the stock resolver.
+That is currently impossible.
+
+## Reproduction
+
+```kotlin
+RemoteDocumentPlayer(
+    document = document,
+    documentWidth = w,
+    documentHeight = h,
+    init = { player ->
+        // Prints null, always: nothing has set a resolver, and there is no lazy default.
+        println("resolver = ${player.getTypefaceResolver()}")
+    },
+)
+```
+
+Expected: a resolver instance that a caller can wrap.
+Actual: `null`, with the stock behaviour living inside `AndroidPaintContext`, unreachable.
+
+See the companion proposal for the suggested fix.

--- a/docs/upstream/remote-compose-typeface-resolver-gap.md
+++ b/docs/upstream/remote-compose-typeface-resolver-gap.md
@@ -43,7 +43,12 @@ init = { player ->
 }
 ```
 
-never fires. And if it did, the `typefaceResolver` parameter would overwrite it one line later.
+never fires — `getTypefaceResolver()` is null here for the reason in §2 — and had the caller also
+passed the `typefaceResolver` parameter, it would have overwritten the result one line later.
+
+The ordering is a wrinkle rather than the root cause: give the getter a lazy default (see the
+proposal's Option A) and this shape starts working, provided the caller leaves the `typefaceResolver`
+parameter unset. The blocking problems are §2 and §3.
 
 ### 2. Reading the current resolver at any point
 

--- a/docs/upstream/remote-compose-typeface-resolver-proposal.md
+++ b/docs/upstream/remote-compose-typeface-resolver-proposal.md
@@ -1,0 +1,107 @@
+# Proposal: make the stock `TypefaceResolver` reachable so callers can delegate
+
+Companion to `remote-compose-typeface-resolver-gap.md`. Three options, cheapest first. Any one of
+them unblocks the case; they are not mutually exclusive.
+
+## Option A — give `AndroidRemoteContext` a lazy default (smallest change)
+
+Make the getter return the resolver the player would otherwise build, instead of `null`:
+
+```java
+public @NonNull TypefaceResolver getTypefaceResolver() {
+    if (mTypefaceResolver == null) {
+        mTypefaceResolver = new DefaultTypefaceResolver(this);
+    }
+    return mTypefaceResolver;
+}
+```
+
+Callers can then wrap:
+
+```kotlin
+player.setTypefaceResolver(MyResolver(delegate = player.getTypefaceResolver()))
+```
+
+**Pros:** a few lines; no new API surface; `AndroidPaintContext` can keep its own fallback for the
+case where the context is absent.
+
+**Cons:** on its own it is not enough for `RemoteDocumentPlayer` callers, because `init` still runs
+before `setTypefaceResolver` — see Option C. It works today for direct `RemoteComposePlayer` users.
+
+**Compatibility:** the getter's return type narrows from `@Nullable` to `@NonNull`. Source-compatible
+for Kotlin callers that already null-checked; worth confirming against the API-tracking rules.
+
+## Option B — let a resolver decline, and fall back
+
+Give `TypefaceResolver` a way to say "not mine", so a caller can add behaviour without owning the
+whole contract:
+
+```java
+public interface TypefaceResolver {
+    /** Return null to defer to the platform default. */
+    @Nullable FontInstance resolve(int fontType, int weight, boolean italic,
+                                   @Nullable Typeface fallback, int flags, boolean bestEffort);
+
+    @Nullable FontInstance resolve(String name, int weight, boolean italic,
+                                   @Nullable Typeface fallback, int flags, boolean bestEffort);
+}
+```
+
+`AndroidPaintContext` then tries the installed resolver and, on `null`, uses its own
+`DefaultTypefaceResolver`.
+
+**Pros:** the most expressive option and the one that scales to several independent contributors of
+font knowledge; a caller never has to reimplement anything it does not care about.
+
+**Cons:** changes an existing interface's nullability contract — a breaking change for anyone already
+implementing it.
+
+## Option C — apply `typefaceResolver` before `init`
+
+Independent of A and B, and worth doing regardless: in `RemoteDocumentPlayer`, install the resolver
+(and the bitmap loader) *before* handing the player to `init`:
+
+```kotlin
+RemoteComposePlayer(it).apply {
+    doOnPreDraw { fullyDrawnReporter?.removeReporter() }
+    bitmapLoader?.let(::setBitmapLoader)
+    typefaceResolver?.let(::setTypefaceResolver)
+    init(this)
+}
+```
+
+Today `init` sees a player whose declared configuration has not been applied yet, and any
+configuration `init` performs is silently overwritten a line later. Applying the declared parameters
+first makes `init` a genuine customisation hook rather than one whose effect depends on which
+parameters the caller also passed.
+
+**Pros:** two moved lines; removes a surprising ordering dependency.
+
+**Cons:** behaviour change for anyone (unknowingly) relying on `init` running first.
+
+## Suggested combination
+
+**A + C** is the smallest set that fixes the reported case: `getTypefaceResolver()` returns something
+to wrap, and `init` can wrap it without being overwritten. **B** is the better long-term shape if the
+interface can still take a breaking change at alpha.
+
+## What a caller would then write
+
+```kotlin
+class NamedFamilyResolver(private val delegate: TypefaceResolver) : TypefaceResolver {
+
+    // Generic typeface ids and embedded fonts are none of our business.
+    override fun resolve(fontType: Int, weight: Int, italic: Boolean,
+                         fallback: Typeface?, flags: Int, bestEffort: Boolean) =
+        delegate.resolve(fontType, weight, italic, fallback, flags, bestEffort)
+
+    override fun resolve(name: String, weight: Int, italic: Boolean,
+                         fallback: Typeface?, flags: Int, bestEffort: Boolean): FontInstance {
+        hostFontCache.lookup(name, weight, italic)?.let { return SimpleFontInstance(it) }
+        return delegate.resolve(name, weight, italic, fallback, flags, bestEffort)
+    }
+}
+```
+
+which is the shape the API already implies — it just isn't constructible today, because `delegate`
+cannot be obtained.

--- a/docs/upstream/remote-compose-typeface-resolver-proposal.md
+++ b/docs/upstream/remote-compose-typeface-resolver-proposal.md
@@ -1,7 +1,7 @@
 # Proposal: make the stock `TypefaceResolver` reachable so callers can delegate
 
-Companion to `remote-compose-typeface-resolver-gap.md`. Three options, cheapest first. Any one of
-them unblocks the case; they are not mutually exclusive.
+Companion to `remote-compose-typeface-resolver-gap.md`. Three options, cheapest first. **Option A
+alone unblocks the reported case**; B and C are improvements on top, not prerequisites.
 
 ## Option A — give `AndroidRemoteContext` a lazy default (smallest change)
 
@@ -23,10 +23,23 @@ player.setTypefaceResolver(MyResolver(delegate = player.getTypefaceResolver()))
 ```
 
 **Pros:** a few lines; no new API surface; `AndroidPaintContext` can keep its own fallback for the
-case where the context is absent.
+case where the context is absent. Sufficient on its own, for direct `RemoteComposePlayer` users *and*
+for `RemoteDocumentPlayer` callers: leave the nullable `typefaceResolver` argument unset and install
+from `init`, at which point the trailing `typefaceResolver?.let(::setTypefaceResolver)` is a no-op and
+cannot overwrite what `init` set.
 
-**Cons:** on its own it is not enough for `RemoteDocumentPlayer` callers, because `init` still runs
-before `setTypefaceResolver` — see Option C. It works today for direct `RemoteComposePlayer` users.
+```kotlin
+RemoteDocumentPlayer(
+    document = document,
+    documentWidth = w,
+    documentHeight = h,
+    // typefaceResolver deliberately omitted — see below.
+    init = { player -> player.setTypefaceResolver(MyResolver(player.getTypefaceResolver())) },
+)
+```
+
+**Cons:** the working call has to *avoid* the declared `typefaceResolver` parameter and use `init`
+instead, which is the opposite of what the API's shape suggests. Option C removes that wrinkle.
 
 **Compatibility:** the getter's return type narrows from `@Nullable` to `@NonNull`. Source-compatible
 for Kotlin callers that already null-checked; worth confirming against the API-tracking rules.
@@ -53,8 +66,12 @@ public interface TypefaceResolver {
 **Pros:** the most expressive option and the one that scales to several independent contributors of
 font knowledge; a caller never has to reimplement anything it does not care about.
 
-**Cons:** changes an existing interface's nullability contract — a breaking change for anyone already
-implementing it.
+**Cons:** changes an existing interface's nullability contract. Note the break is on the **call**
+side, not the implementation side: an existing implementation that returns a non-null `FontInstance`
+remains a valid covariant override, and Java implementations are unaffected — but every caller must
+now handle `FontInstance?`, which in Kotlin is a compile error until updated. In practice the only
+in-tree caller is `AndroidPaintContext`; the exposure is to any downstream code that invokes a
+resolver directly.
 
 ## Option C — apply `typefaceResolver` before `init`
 
@@ -77,13 +94,16 @@ parameters the caller also passed.
 
 **Pros:** two moved lines; removes a surprising ordering dependency.
 
-**Cons:** behaviour change for anyone (unknowingly) relying on `init` running first.
+**Cons:** behaviour change for anyone (unknowingly) relying on `init` running first. On its own it
+fixes nothing for this report — with no lazy default there is still no stock resolver to wrap, so C
+is only worth doing alongside A.
 
 ## Suggested combination
 
-**A + C** is the smallest set that fixes the reported case: `getTypefaceResolver()` returns something
-to wrap, and `init` can wrap it without being overwritten. **B** is the better long-term shape if the
-interface can still take a breaking change at alpha.
+**A** is the minimum, and is sufficient by itself. **C** on top makes the fix discoverable, so the
+declared `typefaceResolver` parameter and `init` compose instead of the caller having to know that
+passing the parameter defeats wrapping. **B** is the better long-term shape if the interface can
+still take a source-breaking change to its callers at alpha.
 
 ## What a caller would then write
 


### PR DESCRIPTION
Two markdown files, ready to file against AndroidX, recording why `RemoteFontFamily.Named("google:…")` still cannot be resolved in the snapshot renderer. The browser lane already resolves it (#2919); the shared font module it would resolve *through* already landed (#2927). This is the remaining blocker, and it is upstream.

## The gap

A custom `TypefaceResolver` can only **replace** the player's stock behaviour, never delegate to it — so a host that knows how to answer one kind of font request cannot add that without taking over all of them, including document-embedded fonts it knows nothing about.

Three approaches are ruled out, each for a different reason, and the report records which so nobody re-derives them:

- `AndroidRemoteContext` keeps the resolver in a plain field with **no lazy default**, so `getTypefaceResolver()` returns `null` for the whole lifetime of any player nobody has called the setter on — precisely the case where you would want to wrap it. The stock behaviour is built inside `AndroidPaintContext`, where it is not observable. **This is the root cause.**
- Reimplementing `DefaultTypefaceResolver` needs the `RemoteContext` it reads document-embedded `FontInfo` from, and `RemoteComposePlayer.getRemoteContext()` is `private`. Passing a fresh `AndroidRemoteContext` compiles but is a *different* context, so embedded fonts silently miss — a correctness regression, not a workaround.
- Secondarily, `RemoteDocumentPlayer` runs its `init` callback **before** it applies the `typefaceResolver` parameter, so a caller who passes both finds the parameter overwrites whatever `init` installed. This is a wrinkle rather than a blocker: with a lazy default in place, installing from `init` and leaving the parameter unset works.

## Files

- `docs/upstream/remote-compose-typeface-resolver-gap.md` — the report: summary, the three dead ends with quoted upstream code, impact, use case, and a three-line reproduction.
- `docs/upstream/remote-compose-typeface-resolver-proposal.md` — three fix options with compatibility trade-offs: (A) a lazy default in the getter; (B) a nullable "not mine" return so a resolver can decline; (C) applying the declared parameters before `init`. **A alone is sufficient**; C makes the fix discoverable rather than depending on the caller knowing that passing the parameter defeats wrapping; B is the better long-term shape while the API is still alpha.

Both are written for a reader with no knowledge of this repo — the use case is described generically, with no internal module names.

## Test plan

Docs only; nothing to build or render. Source claims were read at `androidx-main` and match the runtime behaviour observed while attempting the fix (a resolver installed via `init` never had its `load` reached, and no font file appeared in the cache).

Two caveats stated in the files rather than glossed: the source was read at `androidx-main` while our artifacts are `1.0.0-alpha15`, and option A narrows a `@Nullable` return to `@NonNull`, which may interact with AndroidX API-tracking rules.

Review found two errors in the first draft's analysis, both corrected in `55bf28b`: I had claimed A needed C (it doesn't — the ordering only bites a caller who also passes the parameter), and I had attributed option B's source break to implementers rather than callers (a non-null return remains a valid covariant override; it is callers who must handle `FontInstance?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6SvmYX83WejJUsHYoCHM1