### PR TITLE
refactor(rc-embedded): decouple the player's state helpers from Android

### DIFF
--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -24,7 +24,8 @@ inside it. Vendoring is the only way to depend on it.
 
 ## What is vendored
 
-The player proper: the package root plus `layout/`, `modifier/`, and `state/` (42 files). Upstream's
+The player proper: the package root plus `layout/`, `modifier/`, and `state/` (42 upstream files,
+43 here — one was split in two, see "Done: `state/` decoupled" below). Upstream's
 `demos/`, `integration/previews/`, and the `androidx.wear.compose.remote.material3.previews` sample
 previews that live in the same source set are **not** vendored — they are demo/test scaffolding for
 the integration-test app, and they drag in Wear Material3 and `remote-creation-compose` capture.
@@ -98,6 +99,13 @@ revert to upstream verbatim.
   Worth reporting upstream on its own — any out-of-tree consumer following the documented
   downloadable-fonts pattern against the published artifact hits this, not just this player.
 
+- **`rememberRemoteBitmapAsState` moved to its own file** (`state/RcPlayerBitmapState.kt`, out of
+  `state/RcPlayerState.kt`). Not a behaviour change and not an upstream gap — a refactor in service
+  of the CMP split, recorded here because it is the one place the snapshot is no longer file-for-file
+  with upstream, so a refresh `diff -r` will flag both files. The function body is verbatim; re-apply
+  the move after a refresh rather than treating the diff as a conflict. Rationale under
+  "Done: `state/` decoupled" below.
+
 ### Not a source delta, but required to build
 
 `androidResources` has to be enabled explicitly in `build.gradle.kts` — AGP 9 defaults it to `false`
@@ -112,8 +120,8 @@ software-canvas ambiguity that made the shader finding hard to attribute (see th
 ### Measured surface
 
 **32 of the 42 vendored files reference nothing platform-specific** — no `android.*`, no
-`androidx.core.*`, no `player.core.platform.*`, no `ui.text.googlefonts`. They move as-is. The
-remaining 10, with what actually couples them:
+`androidx.core.*`, no `player.core.platform.*`, no `ui.text.googlefonts`. The remaining 10, with
+what actually couples them:
 
 | file | coupling |
 | --- | --- |
@@ -122,11 +130,67 @@ remaining 10, with what actually couples them:
 | `RcPlayer.kt` | `SuppressLint`, `PendingIntent`, `AndroidRemoteContext` |
 | `EmbeddedPlayerTypefaceResolver.kt` | `Typeface`, `Handler`, `Looper`, `Log`, `FontRequest`, `FontsContractCompat`, `AndroidRemoteContext`, `TypefaceResolver`, `FontInstance` |
 | `RcImageLoader.kt` | `Bitmap`, `drawable`, `content.res` |
-| `state/RcPlayerState.kt` | `Bitmap` |
+| `state/RcPlayerBitmapState.kt` | `Bitmap` (split out of `RcPlayerState.kt` — see below) |
 | `GraphContext.kt` | extends `AndroidRemoteContext` |
 | `RcPlayerParticles.kt` | `AndroidPaintContext` |
 | `RcPlayerTextLayout.kt` | `googlefonts.Font`, `googlefonts.GoogleFont` |
 | `DrawablePainter.kt` | `drawable.Drawable` — Android-only by definition, no jvm counterpart needed |
+
+#### 32/10 is a coupling *surface*, not a partition
+
+That table counts files by what they **import**. It does not describe a source-set split, and reading
+it as one is the mistake to avoid: a source set can only hold a file whose *callees* are also
+visible to it, and the 32 call into the 10 constantly. Following the references transitively — mark
+the 10 as `androidMain`, then repeatedly pull in anything referencing a declaration that lives
+there — the partition collapses to roughly **five** files in `jvmCommonMain`. The chains that do it,
+each verifiable by grep:
+
+| declaration | lives in (Android-coupled) | pulls in |
+| --- | --- | --- |
+| `rememberRemote*AsState` (14 helpers) | `state/RcPlayerState.kt` | 19 files outside `state/` |
+| `RcPlayerChildren` | `RcPlayer.kt` | 5 of the 8 `layout/` files |
+| `RcPlayerComponent` | `RcPlayer.kt` | `layout/RcPlayerStateLayout.kt` |
+| `executeOperations` | `RcPlayerDrawing.kt` | `RcPlayerCanvas.kt`, `RcPlayerModifiers.kt` |
+| `GraphContext` (extends `AndroidRemoteContext`) | `GraphContext.kt` | the state + expression path |
+| `RcImageLoader` (`Drawable`-typed) | `RcImageLoader.kt` | `layout/RcPlayerImageLayout.kt`, `RcPlayerCustom.kt` |
+
+So the unit of work is a **declaration**, not a file. Some of those splits are nearly free — the
+`rememberRemote*AsState` row was the largest single blocker and its whole Android coupling was *one*
+function (see the note below). Others are the `expect`/`actual` seams the sequencing already
+names — `GraphContext`/`RemoteContext`, image decode, the `Drawable`-typed loader — which means
+the original "step 1 needs no `expect`/`actual`" is only true for a `jvmCommonMain` of about five
+files. Anything larger pulls step 2 forward.
+
+#### A single android target cannot enforce the split
+
+Worth knowing before treating step 1 as done: with only the android target configured,
+`jvmCommonMain` is compiled *as part of the android compilation* and has the Android SDK on its
+classpath. Nothing rejects an `android.*` import that lands in "common" code — the separation is
+convention, not a constraint, until a second target exists to contradict it. The same is already
+true *today*, before any restructure: this is a plain android library, so a file decoupled by hand
+can be re-coupled by the next edit with nothing to notice.
+
+`RcSemanticsExtractionTest`'s neighbour `PlatformNeutralSourcesTest` is that missing constraint. It
+holds the list of files claimed ready for `jvmCommonMain` and fails if any of them imports one of
+the four prefixes. Each declaration split below adds its file to that list; when the restructure
+lands, the list is the move order, and the test retires once the `jvm` target enforces the same
+thing by compiling.
+
+#### Done: `state/` decoupled
+
+`state/RcPlayerState.kt` held all fourteen `rememberRemote*AsState` helpers *and* one Android-typed
+one, `rememberRemoteBitmapAsState` (`State<Bitmap?>`, decoding via `resolveBitmap`) — which coupled
+the entire file, and through it the 19 files above. That one function now lives in
+`state/RcPlayerBitmapState.kt`; `RcPlayerState.kt` no longer imports anything Android. The function
+body is verbatim and it had **no call sites** in the vendored subset (upstream API surface only), so
+this is a file move, not a behaviour change. The largest chain in the table above is cleared, and
+`RcPlayerState.kt` is now held that way by `PlatformNeutralSourcesTest` — along with
+`CoreDataAccessors.kt`, `CoreDataModel.kt` and `SnapshotRemoteComposeState.kt`, which were already
+platform-neutral as vendored and are pinned so they stay that way.
+
+Verified by compile and by the module's `check`. **Not** verified by a render: the rc-compare lane
+needs a staged catalog (see the sequencing note below), so the claim here is "no behaviour change by
+construction", not "the 24-document render is unchanged".
 
 ### The source-set shape is `jvmCommon`, not `common`
 
@@ -177,14 +241,31 @@ Android-only in a first cut rather than forcing a Skia `PaintContext` port.
 
 ### Sequencing
 
-1. Restructure to KMP with **only** the android target, moving the 32/10 split into
-   `jvmCommonMain`/`androidMain`. No `expect`/`actual` needed yet — `androidMain` sees
-   `jvmCommonMain` directly. Verify by re-running the 24-document render and confirming the numbers
-   are unchanged.
-2. Add the `jvm` target and the `expect`/`actual` seams, starting with `RemoteContext` and image
-   decode.
-3. Port text off framework `Paint`.
-4. Shaders last, after the Android-side shader divergence is understood.
+Revised after the measurement above: the original step 1 ("move the 32/10 split into
+`jvmCommonMain`/`androidMain`, no `expect`/`actual` needed") is not a pure source-set move, and as a
+single-target milestone it cannot be verified. It splits into 1a/1b.
 
-Step 1 is the safe, verifiable milestone: it is a pure source-set move whose success criterion is
-"the existing render output does not change".
+1. **1a — declaration splits, still a plain android library.** Peel the platform-neutral
+   declarations out of the coupled files so a `jvmCommonMain` worth having exists *before* the build
+   is restructured. Each split is behaviour-preserving and verified by a compile, so they land
+   independently and bisect cleanly. Highest-leverage first, by the table above: `state/` (**done**),
+   then `RcPlayerChildren`/`RcPlayerComponent`/`mapEasing` out of `RcPlayer.kt`, then the
+   bitmap-typed helpers out of `RcPlayerDrawing.kt` so `executeOperations`' dispatcher can follow.
+2. **1b — restructure to KMP, android target only,** moving the (now much larger) clean set into
+   `jvmCommonMain`. Ship it with the forbidden-import guard from above, since the target itself
+   enforces nothing. Two build-level unknowns to settle first, both about the module's existing
+   requirements rather than the sources: whether `com.android.kotlin.multiplatform.library` under
+   AGP 9 supports `androidResources` (the module carries its own resource table — the GMS font
+   certs) and Robolectric unit tests with merged resources (`RcEmbeddedRenderHarness`). If it does
+   not, 1b waits and 1a continues to be useful on its own.
+3. Add the `jvm` target and the `expect`/`actual` seams, starting with `RemoteContext`
+   (`GraphContext`'s `AndroidRemoteContext` base) and image decode. This is where the remaining
+   chains in the table are actually paid for, not step 1.
+4. Port text off framework `Paint`.
+5. Shaders last, after the Android-side shader divergence is understood.
+
+**On the success criterion.** "The existing render output does not change" is the right test for
+every step here, but it needs a staged catalog: `RcEmbeddedRenderHarness` skips unless
+`rc-compare.mjs --stage-embedded` has written `<id>.rc` + `manifest.json`, and no `.rc` fixtures are
+committed. So a compile-only check is what a working tree gives you; the render comparison is a CI /
+full-capture step, and a step-1a split should not be called verified on a compile alone.

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/state/RcPlayerBitmapState.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/state/RcPlayerBitmapState.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("RestrictedApiAndroidX")
+
+package androidx.compose.remote.player.compose.embedded.state
+
+import android.graphics.Bitmap
+import androidx.compose.remote.player.compose.embedded.LocalCoreDocument
+import androidx.compose.remote.player.compose.embedded.LocalRemoteContext
+import androidx.compose.remote.player.compose.embedded.resolveBitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+
+/*
+ * Split out of `RcPlayerState.kt`, which is otherwise platform-neutral. This is the *only*
+ * Android-typed reactive resolver in the `state/` package — it names `android.graphics.Bitmap` in
+ * its return type and decodes through `resolveBitmap`. Keeping it in its own file is what lets the
+ * remaining sixteen `rememberRemote*AsState` helpers move to `jvmCommonMain` under the CMP split
+ * (see the "Planned: CMP android/jvm" section of PROVENANCE.md) — those sixteen are referenced by
+ * fifteen of the module's otherwise platform-free files, so they are the single largest blocker to
+ * a real source-set partition.
+ *
+ * Not a source delta against upstream in any behavioural sense: the function body is verbatim, only
+ * the file it lives in changed.
+ */
+
+@Composable
+internal fun rememberRemoteBitmapAsState(id: Int): State<Bitmap?> {
+    val document = LocalCoreDocument.current
+    val remoteContext = LocalRemoteContext.current
+    // Lazy decode: an Image component composing here is the "drawn" trigger. Decode once in a keyed
+    // remember (the snapshot write happens here, outside the derived read), then track the
+    // snapshot-backed data store so a later host swap of the bitmap recomposes — no listener
+    // bridge.
+    remember(document, id) { resolveBitmap(remoteContext, id) }
+    return remember(document, id) {
+        derivedStateOf { remoteContext.mRemoteComposeState.getFromId(id) as? Bitmap }
+    }
+}

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/state/RcPlayerState.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/state/RcPlayerState.kt
@@ -18,7 +18,6 @@
 
 package androidx.compose.remote.player.compose.embedded.state
 
-import android.graphics.Bitmap
 import androidx.compose.remote.core.RemoteContext
 import androidx.compose.remote.core.VariableSupport
 import androidx.compose.remote.core.operations.Utils
@@ -30,7 +29,6 @@ import androidx.compose.remote.player.compose.embedded.LocalRemoteContext
 import androidx.compose.remote.player.compose.embedded.getFloatExpressionsReflection
 import androidx.compose.remote.player.compose.embedded.getRemoteContextReflection
 import androidx.compose.remote.player.compose.embedded.getVariableIdReflection
-import androidx.compose.remote.player.compose.embedded.resolveBitmap
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.MutableState
@@ -203,20 +201,6 @@ internal fun rememberRemoteColorAsState(id: Int): State<Color> {
     }
     // Plain variable: reactive read of the snapshot-backed color store.
     return remember(document, id) { derivedStateOf { Color(context.getColor(id)) } }
-}
-
-@Composable
-internal fun rememberRemoteBitmapAsState(id: Int): State<Bitmap?> {
-    val document = LocalCoreDocument.current
-    val remoteContext = LocalRemoteContext.current
-    // Lazy decode: an Image component composing here is the "drawn" trigger. Decode once in a keyed
-    // remember (the snapshot write happens here, outside the derived read), then track the
-    // snapshot-backed data store so a later host swap of the bitmap recomposes — no listener
-    // bridge.
-    remember(document, id) { resolveBitmap(remoteContext, id) }
-    return remember(document, id) {
-        derivedStateOf { remoteContext.mRemoteComposeState.getFromId(id) as? Bitmap }
-    }
 }
 
 @Composable

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the platform-neutral half of the CMP android/jvm split (see `PROVENANCE.md`).
+ *
+ * Files listed in [PLATFORM_NEUTRAL] have been deliberately decoupled from the Android platform so
+ * they can move to `jvmCommonMain` when the module is restructured. Nothing in the *current* build
+ * enforces that: the module is a plain android library, so every source file has the Android SDK on
+ * its classpath and an `android.*` import in any of them compiles happily. It would keep compiling
+ * after the restructure too — with only the android target configured, `jvmCommonMain` is compiled
+ * as part of the android compilation. The coupling would only surface much later, when the `jvm`
+ * target is added and the file no longer resolves.
+ *
+ * So this test is the constraint standing in for the missing target. It is deliberately a *source*
+ * scan rather than a bytecode one: the question is which source set a file may live in, which is a
+ * question about its imports.
+ *
+ * Adding a file here is a claim that it is ready for `jvmCommonMain`. Removing one is a decision to
+ * give up on that, and belongs in `PROVENANCE.md` with a reason.
+ */
+class PlatformNeutralSourcesTest {
+
+  /**
+   * Import prefixes that tie a file to the Android platform — the same four the CMP measurement in
+   * `PROVENANCE.md` counts.
+   */
+  private val forbiddenPrefixes =
+    listOf(
+      "android.",
+      "androidx.core.",
+      "androidx.compose.remote.player.core.platform.",
+      "androidx.compose.ui.text.googlefonts.",
+    )
+
+  @Test
+  fun platformNeutralSourcesImportNothingAndroid() {
+    val root = playerSourceRoot()
+    val offenders = mutableListOf<String>()
+    for (relative in PLATFORM_NEUTRAL) {
+      val file = File(root, relative)
+      // A rename that silently drops a file from the guard is the failure this catches.
+      assertTrue("declared platform-neutral but missing: $relative", file.isFile)
+      file.readLines()
+        .filter { it.startsWith("import ") }
+        .forEach { line ->
+          val imported = line.removePrefix("import ").trim()
+          if (forbiddenPrefixes.any { imported.startsWith(it) }) {
+            offenders += "$relative: $line"
+          }
+        }
+    }
+    assertEquals(
+      "These files are declared ready for jvmCommonMain (PROVENANCE.md, 'CMP android/jvm') but " +
+        "import Android platform APIs. Either drop the import or remove the file from " +
+        "PLATFORM_NEUTRAL and say why in PROVENANCE.md.",
+      emptyList<String>(),
+      offenders,
+    )
+  }
+
+  /**
+   * Locates `src/main/kotlin/androidx/compose/remote/player/compose/embedded`, walking up from the
+   * working directory so the test does not depend on which directory Gradle runs it from. Failing
+   * to find it fails the test — a guard that silently finds no files to check is worse than none.
+   */
+  private fun playerSourceRoot(): File {
+    val suffix = "src/main/kotlin/androidx/compose/remote/player/compose/embedded"
+    var dir: File? = File("").absoluteFile
+    while (dir != null) {
+      val candidate = File(dir, suffix)
+      if (candidate.isDirectory) return candidate
+      dir = dir.parentFile
+    }
+    throw AssertionError("could not locate $suffix from ${File("").absolutePath}")
+  }
+
+  private companion object {
+    /**
+     * Files decoupled from the Android platform so far. This is not yet the whole `jvmCommonMain`
+     * set — `PROVENANCE.md` tracks which chains are still to be split, and each split adds its file
+     * here.
+     */
+    val PLATFORM_NEUTRAL =
+      listOf(
+        // Decoupled by moving `rememberRemoteBitmapAsState` to `state/RcPlayerBitmapState.kt`.
+        // Its fourteen sibling helpers are referenced by 19 files outside `state/`, which makes
+        // this the single highest-leverage file in the split.
+        "state/RcPlayerState.kt",
+        // Platform-neutral as vendored — the reflective `CoreDocument` accessors and the document
+        // data model are plain `remote-core` types.
+        "CoreDataAccessors.kt",
+        "CoreDataModel.kt",
+        "SnapshotRemoteComposeState.kt",
+      )
+  }
+}


### PR DESCRIPTION
Continues the "Planned: CMP android/jvm" work in `third_party/rc-embedded-player/PROVENANCE.md` — with a correction to the plan, because its central measurement doesn't survive contact.

## The plan was reading a coupling surface as a partition

PROVENANCE measured **32 of the 42** vendored files as importing nothing platform-specific, and read that as a source-set split: step 1 was "a pure source-set move" whose success criterion was "the render output doesn't change", needing no `expect`/`actual`.

That count is correct but it isn't a partition. A source set can only hold a file whose *callees* are visible to it, and the 32 call into the 10 constantly. Following the references transitively — mark the 10 `androidMain`, then repeatedly pull in anything referencing a declaration living there — `jvmCommonMain` collapses to roughly **five** files. The chains that do it, each checkable by grep:

| declaration | lives in (Android-coupled) | pulls in |
| --- | --- | --- |
| `rememberRemote*AsState` (14 helpers) | `state/RcPlayerState.kt` | 19 files outside `state/` |
| `RcPlayerChildren` | `RcPlayer.kt` | 5 of the 8 `layout/` files |
| `RcPlayerComponent` | `RcPlayer.kt` | `layout/RcPlayerStateLayout.kt` |
| `executeOperations` | `RcPlayerDrawing.kt` | `RcPlayerCanvas.kt`, `RcPlayerModifiers.kt` |
| `GraphContext` (extends `AndroidRemoteContext`) | `GraphContext.kt` | the state + expression path |
| `RcImageLoader` (`Drawable`-typed) | `RcImageLoader.kt` | `layout/RcPlayerImageLayout.kt`, `RcPlayerCustom.kt` |

So the unit of work is a **declaration**, not a file — and the seams the plan deferred to step 2 (`RemoteContext`, image decode) are what most of these chains need, so "step 1 needs no `expect`/`actual`" only holds for a `jvmCommonMain` of about five files.

## Take the largest chain first

`state/RcPlayerState.kt` held all fourteen `rememberRemote*AsState` helpers **and** one Android-typed one — `rememberRemoteBitmapAsState` (`State<Bitmap?>`, decoding via `resolveBitmap`) — which coupled the whole file, and through it those 19 callers.

It moves to `state/RcPlayerBitmapState.kt`. The body is verbatim and it has **no call sites** in the vendored subset (upstream API surface only), so this is a file move, not a behaviour change. `RcPlayerState.kt` now imports nothing Android.

## The split needed something to hold it

Nothing in the build enforced this before, and nothing would after the restructure either: with only the android target configured, `jvmCommonMain` compiles *as part of* the android compilation and has the SDK on its classpath. An `android.*` import in "common" code would compile fine and only surface much later, when the `jvm` target is added. That makes the original step-1 criterion unfalsifiable.

`PlatformNeutralSourcesTest` stands in for the missing target: it holds the list of files claimed ready for `jvmCommonMain` and fails if any imports one of the four Android prefixes. Each future split adds its file to the list; it retires once a `jvm` target enforces the same thing by compiling.

PROVENANCE also re-sequences step 1 into **1a** (declaration splits, still a plain android library — each behaviour-preserving and independently landable) and **1b** (the KMP restructure), and records the two build unknowns 1b has to settle first: whether `com.android.kotlin.multiplatform.library` under AGP 9 supports `androidResources` (this module carries its own resource table — the GMS font certs) and Robolectric unit tests with merged resources.

## Test plan

- `:third-party-rc-embedded-player:check` — green, including `PlatformNeutralSourcesTest` (1 test, 0 skipped — confirmed it isn't silently no-op'ing).
- **Negative test of the guard**: put `import android.graphics.Bitmap` back into `RcPlayerState.kt` and the test fails as intended (`1 test completed, 1 failed`); reverted.
- PROVENANCE's own copyright-header check passes over the new files.

**Not verified by a render, deliberately.** `RcEmbeddedRenderHarness` skips unless `rc-compare.mjs --stage-embedded` has staged a catalog, and no `.rc` fixtures are committed — so a working tree can only offer a compile-level check. The claim here is "no behaviour change by construction" (a verbatim, uncalled function moved between files), not "the 24-document render is unchanged". PROVENANCE now says this explicitly so a later 1a split isn't called verified on a compile alone.

No visual surface changes — no rendered output, preview, or webview is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYTmD9R6gf92mATchtq461)_