### PR TITLE
fix(rc-embedded): stop the guard certifying a file that can't move yet

### DIFF
--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -171,10 +171,23 @@ true *today*, before any restructure: this is a plain android library, so a file
 can be re-coupled by the next edit with nothing to notice.
 
 `RcSemanticsExtractionTest`'s neighbour `PlatformNeutralSourcesTest` is that missing constraint. It
-holds the list of files claimed ready for `jvmCommonMain` and fails if any of them imports one of
-the four prefixes. Each declaration split below adds its file to that list; when the restructure
-lands, the list is the move order, and the test retires once the `jvm` target enforces the same
-thing by compiling.
+keeps two lists, because moving a file needs two things and they are worth not conflating:
+
+- **`IMPORT_CLEAN`** — the file imports no Android platform API. This is what a declaration split
+  buys, and the list exists so a later edit can't quietly undo one.
+- **`READY_FOR_JVM_COMMON`** — additionally, the file imports nothing that stays in `androidMain`,
+  which `jvmCommonMain` would not be able to see. Only these can actually move.
+
+Import-freedom alone does **not** make a file movable, and `state/RcPlayerState.kt` is the case in
+point: it is import-clean after the split below, but its helpers read `LocalGraphContext`, whose type
+extends `AndroidRemoteContext`. It graduates when the `GraphContext` chain in the table above is
+split — which is the same thing that unblocks the rest of the state path.
+
+The second check works on imports, so it catches *cross-package* references only: the player splits
+into `embedded`, `embedded.layout`, `embedded.modifier` and `embedded.state`, so a file in a
+sub-package must import what it uses from the root package. References within the root package need
+no import and this test cannot see them — the chain table above is the record for those. The whole
+test retires once a `jvm` target enforces both halves by compiling.
 
 #### Done: `state/` decoupled
 
@@ -183,10 +196,15 @@ one, `rememberRemoteBitmapAsState` (`State<Bitmap?>`, decoding via `resolveBitma
 the entire file, and through it the 19 files above. That one function now lives in
 `state/RcPlayerBitmapState.kt`; `RcPlayerState.kt` no longer imports anything Android. The function
 body is verbatim and it had **no call sites** in the vendored subset (upstream API surface only), so
-this is a file move, not a behaviour change. The largest chain in the table above is cleared, and
-`RcPlayerState.kt` is now held that way by `PlatformNeutralSourcesTest` — along with
-`CoreDataAccessors.kt`, `CoreDataModel.kt` and `SnapshotRemoteComposeState.kt`, which were already
-platform-neutral as vendored and are pinned so they stay that way.
+this is a file move, not a behaviour change. `RcPlayerState.kt` is now held import-clean by
+`PlatformNeutralSourcesTest`, and `CoreDataAccessors.kt` / `CoreDataModel.kt` /
+`SnapshotRemoteComposeState.kt` — already platform-neutral as vendored — are pinned as genuinely
+movable.
+
+This clears the *import* half of the largest chain, not the whole chain: the fourteen helpers still
+read `LocalGraphContext`, so `state/` moves when `GraphContext` is split, not before. What the split
+buys now is that the 19 dependent files are no longer blocked on an `android.graphics.Bitmap` import
+that had nothing to do with them.
 
 Verified by compile and by the module's `check`. **Not** verified by a render: the rc-compare lane
 needs a staged catalog (see the sequencing note below), so the claim here is "no behaviour change by
@@ -248,9 +266,15 @@ single-target milestone it cannot be verified. It splits into 1a/1b.
 1. **1a — declaration splits, still a plain android library.** Peel the platform-neutral
    declarations out of the coupled files so a `jvmCommonMain` worth having exists *before* the build
    is restructured. Each split is behaviour-preserving and verified by a compile, so they land
-   independently and bisect cleanly. Highest-leverage first, by the table above: `state/` (**done**),
-   then `RcPlayerChildren`/`RcPlayerComponent`/`mapEasing` out of `RcPlayer.kt`, then the
-   bitmap-typed helpers out of `RcPlayerDrawing.kt` so `executeOperations`' dispatcher can follow.
+   independently and bisect cleanly. Order by the table above: `state/`'s Android *import* is gone
+   (**done**), but the chain it sits on runs through `GraphContext`, so that is the next one — split
+   the `RemoteContext` seam and the whole state + expression path graduates at once. Then
+   `RcPlayerChildren`/`RcPlayerComponent`/`mapEasing` out of `RcPlayer.kt`, then the bitmap-typed
+   helpers out of `RcPlayerDrawing.kt` so `executeOperations`' dispatcher can follow.
+
+   Note this reorders against the original plan: `GraphContext` is the `RemoteContext` seam that was
+   step 2's first item, and it turns out to gate most of 1a. Splitting it early is what makes a
+   `jvmCommonMain` larger than a handful of files reachable at all.
 2. **1b — restructure to KMP, android target only,** moving the (now much larger) clean set into
    `jvmCommonMain`. Ship it with the forbidden-import guard from above, since the target itself
    enforces nothing. Two build-level unknowns to settle first, both about the module's existing

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
@@ -82,18 +82,50 @@ class PlatformNeutralSourcesTest {
   fun jvmCommonReadyFilesImportNothingThatStaysInAndroidMain() {
     val offenders = mutableListOf<String>()
     forEachDeclaredFile(READY_FOR_JVM_COMMON) { relative, imported, line ->
-      val simpleName = imported.substringAfterLast('.')
-      if (imported.startsWith(PLAYER_PACKAGE) && simpleName in ANDROID_MAIN_DECLARATIONS) {
-        offenders += "$relative: $line"
+      if (imported.startsWith(PLAYER_PACKAGE)) {
+        val simpleName = importedSimpleName(imported)
+        // A star-import of the player package drags in whatever stays in `androidMain` and offers
+        // no name to check, so it is refused rather than waved through.
+        if (simpleName == "*" || simpleName in ANDROID_MAIN_DECLARATIONS) {
+          offenders += "$relative: $line"
+        }
       }
     }
     assertEquals(
       "These files are declared ready for jvmCommonMain but import a declaration that stays in " +
-        "androidMain, which jvmCommonMain cannot see — the move would not compile. Split the " +
-        "declaration first, or move the file back to IMPORT_CLEAN.",
+        "androidMain (or star-import the package it lives in), which jvmCommonMain cannot see — " +
+        "the move would not compile. Split the declaration first, or move the file back to " +
+        "IMPORT_CLEAN.",
       emptyList<String>(),
       offenders,
     )
+  }
+
+  /**
+   * The declaration name an `import` line actually binds, ignoring any `as` alias.
+   *
+   * The alias is a local rename, not part of the declaration's identity — `import …embedded.Foo as
+   * Bar` still depends on `Foo`. Taking the simple name off the raw line would compare
+   * `"Foo as Bar"` and match nothing, so an aliased import of an `androidMain` declaration would
+   * slip past. Not hypothetical: this vendored tree already aliases imports off this very package
+   * (`…embedded.R as GoogleFontR` in two files).
+   */
+  private fun importedSimpleName(imported: String): String =
+    imported.substringBefore(" as ").trim().substringAfterLast('.')
+
+  @Test
+  fun importedSimpleNameIgnoresAliases() {
+    assertEquals("LocalGraphContext", importedSimpleName("$PLAYER_PACKAGE.LocalGraphContext"))
+    assertEquals(
+      "LocalGraphContext",
+      importedSimpleName("$PLAYER_PACKAGE.LocalGraphContext as PlayerGraphContext"),
+    )
+    // The real aliased import in the tree today.
+    assertEquals("R", importedSimpleName("$PLAYER_PACKAGE.R as GoogleFontR"))
+    // Star-imports surface as `*` so the caller can refuse them.
+    assertEquals("*", importedSimpleName("$PLAYER_PACKAGE.*"))
+    // A name merely containing "as" is not an alias.
+    assertEquals("CanvasOperations", importedSimpleName("$PLAYER_PACKAGE.CanvasOperations"))
   }
 
   /** Feeds every `import` line of each declared file to [block] as (relative path, FQN, raw line). */

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
@@ -22,22 +22,32 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Guards the platform-neutral half of the CMP android/jvm split (see `PROVENANCE.md`).
+ * Guards the decoupling work behind the CMP android/jvm split (see `PROVENANCE.md`).
  *
- * Files listed in [PLATFORM_NEUTRAL] have been deliberately decoupled from the Android platform so
- * they can move to `jvmCommonMain` when the module is restructured. Nothing in the *current* build
- * enforces that: the module is a plain android library, so every source file has the Android SDK on
- * its classpath and an `android.*` import in any of them compiles happily. It would keep compiling
- * after the restructure too — with only the android target configured, `jvmCommonMain` is compiled
- * as part of the android compilation. The coupling would only surface much later, when the `jvm`
- * target is added and the file no longer resolves.
+ * Nothing in the build enforces any of this today: the module is a plain android library, so every
+ * source file has the Android SDK on its classpath and an `android.*` import compiles happily
+ * wherever it lands. It would keep compiling after the restructure too — with only the android
+ * target configured, `jvmCommonMain` is compiled as part of the android compilation. The coupling
+ * would only surface much later, when the `jvm` target is added. This test is the constraint
+ * standing in for the missing target.
  *
- * So this test is the constraint standing in for the missing target. It is deliberately a *source*
- * scan rather than a bytecode one: the question is which source set a file may live in, which is a
- * question about its imports.
+ * **Two things are required to move a file to `jvmCommonMain`, and this test checks one and a
+ * half.**
+ * 1. The file must not import an Android platform API. That is [IMPORT_CLEAN] below, checked for
+ *    every file listed.
+ * 2. The file must not reference a declaration that stays in `androidMain` — `jvmCommonMain` cannot
+ *    see those. Only files in [READY_FOR_JVM_COMMON] are checked for this, and only for
+ *    *cross-package* references: the vendored player splits into `embedded`, `embedded.layout`,
+ *    `embedded.modifier` and `embedded.state`, so a file in a sub-package must import anything it
+ *    uses from the root package and the import scan catches it. References *within* the root
+ *    package need no import and are invisible here — `PROVENANCE.md`'s chain table is the record for
+ *    those, not this test.
  *
- * Adding a file here is a claim that it is ready for `jvmCommonMain`. Removing one is a decision to
- * give up on that, and belongs in `PROVENANCE.md` with a reason.
+ * So [IMPORT_CLEAN] is the weaker claim ("the decoupling done to this file has not regressed") and
+ * [READY_FOR_JVM_COMMON] is the stronger one ("this file can move"). Keeping them apart matters:
+ * `state/RcPlayerState.kt` is import-clean but reads `LocalGraphContext`, whose type extends
+ * `AndroidRemoteContext`, so it cannot move until that chain is split. Listing it as ready would
+ * certify a move that will not compile.
  */
 class PlatformNeutralSourcesTest {
 
@@ -54,29 +64,52 @@ class PlatformNeutralSourcesTest {
     )
 
   @Test
-  fun platformNeutralSourcesImportNothingAndroid() {
-    val root = playerSourceRoot()
+  fun declaredFilesImportNothingAndroid() {
     val offenders = mutableListOf<String>()
-    for (relative in PLATFORM_NEUTRAL) {
-      val file = File(root, relative)
-      // A rename that silently drops a file from the guard is the failure this catches.
-      assertTrue("declared platform-neutral but missing: $relative", file.isFile)
-      file.readLines()
-        .filter { it.startsWith("import ") }
-        .forEach { line ->
-          val imported = line.removePrefix("import ").trim()
-          if (forbiddenPrefixes.any { imported.startsWith(it) }) {
-            offenders += "$relative: $line"
-          }
-        }
+    forEachDeclaredFile(IMPORT_CLEAN + READY_FOR_JVM_COMMON) { relative, imported, line ->
+      if (forbiddenPrefixes.any { imported.startsWith(it) }) offenders += "$relative: $line"
     }
     assertEquals(
-      "These files are declared ready for jvmCommonMain (PROVENANCE.md, 'CMP android/jvm') but " +
-        "import Android platform APIs. Either drop the import or remove the file from " +
-        "PLATFORM_NEUTRAL and say why in PROVENANCE.md.",
+      "These files were decoupled from the Android platform on purpose (PROVENANCE.md, " +
+        "'CMP android/jvm') and have picked an Android import back up. Either drop the import, or " +
+        "remove the file from this test and say why in PROVENANCE.md.",
       emptyList<String>(),
       offenders,
     )
+  }
+
+  @Test
+  fun jvmCommonReadyFilesImportNothingThatStaysInAndroidMain() {
+    val offenders = mutableListOf<String>()
+    forEachDeclaredFile(READY_FOR_JVM_COMMON) { relative, imported, line ->
+      val simpleName = imported.substringAfterLast('.')
+      if (imported.startsWith(PLAYER_PACKAGE) && simpleName in ANDROID_MAIN_DECLARATIONS) {
+        offenders += "$relative: $line"
+      }
+    }
+    assertEquals(
+      "These files are declared ready for jvmCommonMain but import a declaration that stays in " +
+        "androidMain, which jvmCommonMain cannot see — the move would not compile. Split the " +
+        "declaration first, or move the file back to IMPORT_CLEAN.",
+      emptyList<String>(),
+      offenders,
+    )
+  }
+
+  /** Feeds every `import` line of each declared file to [block] as (relative path, FQN, raw line). */
+  private fun forEachDeclaredFile(
+    files: List<String>,
+    block: (relative: String, imported: String, line: String) -> Unit,
+  ) {
+    val root = playerSourceRoot()
+    for (relative in files) {
+      val file = File(root, relative)
+      // A rename that silently drops a file from the guard is the failure this catches.
+      assertTrue("declared in this test but missing: $relative", file.isFile)
+      file.readLines()
+        .filter { it.startsWith("import ") }
+        .forEach { block(relative, it.removePrefix("import ").trim(), it) }
+    }
   }
 
   /**
@@ -85,7 +118,7 @@ class PlatformNeutralSourcesTest {
    * to find it fails the test — a guard that silently finds no files to check is worse than none.
    */
   private fun playerSourceRoot(): File {
-    val suffix = "src/main/kotlin/androidx/compose/remote/player/compose/embedded"
+    val suffix = "src/main/kotlin/${PLAYER_PACKAGE.replace('.', '/')}"
     var dir: File? = File("").absoluteFile
     while (dir != null) {
       val candidate = File(dir, suffix)
@@ -96,22 +129,62 @@ class PlatformNeutralSourcesTest {
   }
 
   private companion object {
+    const val PLAYER_PACKAGE = "androidx.compose.remote.player.compose.embedded"
+
     /**
-     * Files decoupled from the Android platform so far. This is not yet the whole `jvmCommonMain`
-     * set — `PROVENANCE.md` tracks which chains are still to be split, and each split adds its file
-     * here.
+     * Declarations that stay in `androidMain` — they name an Android type in their signature or
+     * supertype. Mirrors the chain table in `PROVENANCE.md`; splitting one is what lets its
+     * dependents graduate from [IMPORT_CLEAN] to [READY_FOR_JVM_COMMON].
      */
-    val PLATFORM_NEUTRAL =
-      listOf(
-        // Decoupled by moving `rememberRemoteBitmapAsState` to `state/RcPlayerBitmapState.kt`.
-        // Its fourteen sibling helpers are referenced by 19 files outside `state/`, which makes
-        // this the single highest-leverage file in the split.
-        "state/RcPlayerState.kt",
-        // Platform-neutral as vendored — the reflective `CoreDocument` accessors and the document
-        // data model are plain `remote-core` types.
-        "CoreDataAccessors.kt",
-        "CoreDataModel.kt",
-        "SnapshotRemoteComposeState.kt",
+    val ANDROID_MAIN_DECLARATIONS =
+      setOf(
+        // extends AndroidRemoteContext, and the composition local that hands it out
+        "GraphContext",
+        "LocalGraphContext",
+        // android.graphics.Bitmap / Rect / drawable on the canvas draw path
+        "executeOperations",
+        "resolveBitmap",
+        "resolveCanvasBitmap",
+        "rememberRemoteBitmapAsState",
+        // framework android.graphics.Paint + RuntimeShader
+        "ComposeLocalPaint",
+        "updatePaintFromBundle",
+        // Drawable-typed image loading
+        "RcImageLoader",
+        "EmbeddedRcImageLoader",
+        "LocalRcImageLoader",
+        "DrawablePainter",
+        // SuppressLint / PendingIntent / AndroidRemoteContext
+        "RcPlayer",
+        "RcPlayerChildren",
+        "RcPlayerComponent",
+        // googlefonts Font/GoogleFont, Typeface, FontRequest
+        "RcPlayerText",
+        "EmbeddedPlayerTypefaceResolver",
+        // AndroidPaintContext
+        "drawParticles",
+        "drawParticlesCompare",
       )
+
+    /**
+     * Import-clean, but still referencing something that stays in `androidMain`, so not yet movable.
+     * These are here to hold decoupling work that has already been done against regression.
+     */
+    val IMPORT_CLEAN =
+      listOf(
+        // Decoupled by moving `rememberRemoteBitmapAsState` to `state/RcPlayerBitmapState.kt`. Its
+        // fourteen sibling helpers are referenced by 19 files outside `state/`, which makes this the
+        // highest-leverage file in the split. Still blocked on the `GraphContext` chain: the
+        // helpers read `LocalGraphContext` to resolve computed ids.
+        "state/RcPlayerState.kt"
+      )
+
+    /**
+     * Import-clean *and* free of cross-package references into `androidMain` — these are the files
+     * that can actually move. Platform-neutral as vendored: the reflective `CoreDocument` accessors,
+     * the document data model, and the snapshot-backed state store are plain `remote-core` types.
+     */
+    val READY_FOR_JVM_COMMON =
+      listOf("CoreDataAccessors.kt", "CoreDataModel.kt", "SnapshotRemoteComposeState.kt")
   }
 }


### PR DESCRIPTION
Follow-up to #2934. The Codex review on it raised a correct finding that landed after the merge, so this is a fresh branch off `main` rather than a push to the merged one.

## The guard checked one thing and claimed another

`PlatformNeutralSourcesTest` verified that a file imports no Android platform API. Its list was named and documented as "ready for `jvmCommonMain`". Those are different claims, and `state/RcPlayerState.kt` is where they come apart.

After #2934 that file is import-clean — but its helpers read `LocalGraphContext`:

```kotlin
// RcPlayerCompositionLocals.kt:44
internal val LocalGraphContext: ProvidableCompositionLocal<GraphContext?> = ...
// GraphContext.kt:62
) : AndroidRemoteContext(clock) {
```

`jvmCommonMain` can't see a declaration left in `androidMain`, so the move the list certified wouldn't compile — and the import-prefix scan would have stayed green the entire way there. That's the worst shape for a guard: confidently wrong at exactly the moment it's relied on.

## Two lists, matching what a move actually requires

- **`IMPORT_CLEAN`** — imports no Android platform API. What a declaration split buys; the list stops a later edit quietly undoing one.
- **`READY_FOR_JVM_COMMON`** — additionally imports nothing that stays in `androidMain`, checked against the declarations named in PROVENANCE's chain table (`GraphContext`, `executeOperations`, `RcPlayerChildren`, the `Drawable`-typed loader, …). Only these can actually move.

`RcPlayerState.kt` moves to the weaker list — which is what it has earned. The three files platform-neutral as vendored (`CoreDataAccessors.kt`, `CoreDataModel.kt`, `SnapshotRemoteComposeState.kt`) stay in the stronger one.

## On the limits of the second check

It works on imports, so it catches **cross-package** references only. That isn't a coincidence of the encoding — the player splits into `embedded`, `embedded.layout`, `embedded.modifier`, `embedded.state`, so a file in a sub-package *must* import what it uses from the root package, which is precisely the `state/` → `GraphContext` case this is about. Root-package siblings need no import and stay invisible to it; PROVENANCE's chain table remains the record for those. The test says this plainly rather than implying more rigor than it has.

PROVENANCE drops the same overclaim in prose, and reorders step 1a: `GraphContext` was step 2's first item but gates most of 1a, so it goes first — splitting that seam graduates the whole state + expression path at once.

## Test plan

- `:third-party-rc-embedded-player:check` — green, `PlatformNeutralSourcesTest` at 2 tests, 0 skipped.
- **Negative run**: promote `RcPlayerState.kt` into `READY_FOR_JVM_COMMON` and `jvmCommonReadyFilesImportNothingThatStaysInAndroidMain` fails on `LocalGraphContext` — the exact case that prompted this. Reverted.

No visual surface changes — test and docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYTmD9R6gf92mATchtq461)_