### PR TITLE
feat(rc-embedded): run the player's value layer on the desktop JVM

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -557,6 +557,16 @@ include(":third-party-rc-embedded-player")
 
 project(":third-party-rc-embedded-player").projectDir = file("third_party/rc-embedded-player")
 
+// The desktop half of the same player: a plain Kotlin/JVM module that compiles the *platform-neutral
+// subset* of the module above against Compose Desktop instead of the Android artifacts. It shares
+// those sources by path rather than copying them, so there is one copy of each file. This is what
+// makes "platform-neutral" a compiled fact rather than a claim — see the CMP section of
+// `third_party/rc-embedded-player/PROVENANCE.md`.
+include(":third-party-rc-embedded-player-jvm")
+
+project(":third-party-rc-embedded-player-jvm").projectDir =
+  file("third_party/rc-embedded-player-jvm")
+
 include(":data-remotecompose-core")
 
 project(":data-remotecompose-core").projectDir = file("data/remotecompose/core")

--- a/third_party/rc-embedded-player-jvm/build.gradle.kts
+++ b/third_party/rc-embedded-player-jvm/build.gradle.kts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// `:third-party-rc-embedded-player-jvm` — the **desktop half** of the embedded Remote Compose
+// player, and the first thing in this repo to run any of it off Android.
+//
+// It compiles a subset of `:third-party-rc-embedded-player`'s sources against Compose Desktop
+// rather than the Android artifacts. Nothing is copied: the files are shared from the Android
+// module's source tree by path, so there is exactly one copy of each and no chance of the two
+// drifting.
+//
+// **Why a separate module rather than converting the Android one to KMP.** The CMP plan
+// (`PROVENANCE.md`) has the Android module eventually becoming multiplatform, but that conversion
+// carries an unsettled risk — whether `com.android.kotlin.multiplatform.library` under AGP 9
+// supports the Robolectric unit tests the render harness depends on. This module needs none of that
+// resolved: it is a plain `kotlin("jvm")` module that proves the shared sources genuinely compile
+// and run on a JVM, today, and it does so *without touching the Android module's build at all*.
+// When the KMP conversion happens, this module's file list is the migration order — and until then
+// it is the thing that keeps the "platform-neutral" claim honest, because a file that isn't really
+// neutral fails to compile here rather than passing a source scan.
+//
+// The list below is deliberately explicit rather than a directory glob. Adding a file is a claim
+// that it is platform-neutral, and it should be a decision someone makes, not something a wildcard
+// makes for them.
+
+plugins {
+  id("composeai.base-conventions")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+}
+
+/**
+ * Sources shared from the Android module, relative to its `src/main/kotlin`.
+ *
+ * Keep in sync with `PlatformNeutralSourcesTest`: that test scans imports, this compiles them. The
+ * scan is the fast signal, this is the real one.
+ */
+val sharedPlayerSources =
+  listOf(
+    // Reflective `CoreDocument` accessors + the document data model — plain `remote-core` types.
+    "androidx/compose/remote/player/compose/embedded/CoreDataAccessors.kt",
+    "androidx/compose/remote/player/compose/embedded/CoreDataModel.kt",
+    // Snapshot-backed store: `RemoteComposeState` over Compose's `SnapshotStateMap`.
+    "androidx/compose/remote/player/compose/embedded/SnapshotRemoteComposeState.kt",
+    // The platform-neutral `RemoteContext` — ported from `AndroidRemoteContext` minus `loadBitmap`.
+    "androidx/compose/remote/player/compose/embedded/StoreBackedRemoteContext.kt",
+    // Opaque image-loader handle, so the evaluator can carry one without naming `Drawable`.
+    "androidx/compose/remote/player/compose/embedded/RcImageSource.kt",
+    // The expression evaluator itself, and the composition locals the state path reads.
+    "androidx/compose/remote/player/compose/embedded/GraphContext.kt",
+    "androidx/compose/remote/player/compose/embedded/RcPlayerCompositionLocals.kt",
+    // Core easing constant -> Compose easing; split out of `RcPlayer.kt` so the expression
+    // evaluator below doesn't inherit that file's Android coupling for a six-line `when`.
+    "androidx/compose/remote/player/compose/embedded/RcPlayerEasing.kt",
+    // The `rememberRemote*AsState` family, and the expression/animation evaluator behind it.
+    "androidx/compose/remote/player/compose/embedded/state/RcPlayerState.kt",
+    "androidx/compose/remote/player/compose/embedded/state/RcPlayerExpression.kt",
+  )
+
+kotlin {
+  sourceSets["main"].kotlin.apply {
+    srcDir("../rc-embedded-player/src/main/kotlin")
+    // `include` filters every srcDir of this source set, so this module's own sources need a
+    // pattern too — otherwise the explicit list above would silently exclude them.
+    include(sharedPlayerSources + "ee/**")
+  }
+}
+
+// The shared sources are AOSP-formatted (4-space) and must stay a verbatim snapshot, so they are
+// exempt from this repo's Google-style ktfmt — same as in the Android module, where AGP's source
+// sets happen not to be picked up at all. Only this module's own sources are formatted.
+tasks
+  .withType<org.gradle.api.tasks.SourceTask>()
+  .matching { it.name.startsWith("ktfmt") }
+  .configureEach { exclude("androidx/**") }
+
+dependencies {
+  // Document model + operation tree. A plain `java-library` upstream, which is the whole reason a
+  // jvm target is possible at all.
+  api(libs.compose.remote.core)
+
+  // Compose Desktop, not the Android artifacts — the point of this module.
+  @Suppress("DEPRECATION") implementation(compose.runtime)
+  @Suppress("DEPRECATION") implementation(compose.foundation)
+
+  testImplementation(libs.junit)
+}

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/DesktopRemoteContextTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/DesktopRemoteContextTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded.jvm
+
+import androidx.compose.remote.core.RemoteComposeState
+import androidx.compose.remote.core.SystemClock
+import androidx.compose.remote.player.compose.embedded.SnapshotRemoteComposeState
+import androidx.compose.remote.player.compose.embedded.StoreBackedRemoteContext
+import androidx.compose.runtime.snapshots.Snapshot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Runs the embedded player's value layer on a **plain desktop JVM** — no Android, no Robolectric.
+ *
+ * This is the first execution of any of this player off Android, and it is what the CMP split in
+ * `PROVENANCE.md` exists to reach. Compiling is most of the claim (the module wouldn't build if a
+ * shared file secretly needed the platform), but compiling isn't running:
+ * `SnapshotRemoteComposeState` is backed by Compose's snapshot system, and this asserts that
+ * machinery actually works under the Desktop runtime rather than merely resolving against it.
+ *
+ * Scope is honest about where the port has got to: the value/expression layer runs, the draw path
+ * does not exist here yet. See the sequencing in `PROVENANCE.md`.
+ */
+class DesktopRemoteContextTest {
+
+  /** Minimal concrete context; the clock only matters to the time-variable ids, unused here. */
+  private class TestContext(state: RemoteComposeState) : StoreBackedRemoteContext(SystemClock()) {
+    init {
+      mRemoteComposeState = state
+    }
+  }
+
+  private fun newContext(): TestContext = TestContext(SnapshotRemoteComposeState())
+
+  @Test
+  fun readsAndWritesFloatsThroughTheSharedStore() {
+    val context = newContext()
+    context.loadFloat(42, 1.5f)
+    assertEquals(1.5f, context.getFloat(42), 0f)
+
+    context.loadFloat(42, 2.5f)
+    assertEquals("a second write should replace, not accumulate", 2.5f, context.getFloat(42), 0f)
+  }
+
+  @Test
+  fun readsAndWritesIntegersAndColors() {
+    val context = newContext()
+    context.loadInteger(43, 7)
+    context.loadColor(44, 0xFF102030.toInt())
+    assertEquals(7, context.getInteger(43))
+    assertEquals(0xFF102030.toInt(), context.getColor(44))
+  }
+
+  @Test
+  fun textRoundTripsThroughTheDataStore() {
+    val context = newContext()
+    // `loadText` distinguishes first write from update — the branch is worth exercising both ways.
+    context.loadText(45, "hello")
+    assertEquals("hello", context.getText(45))
+    context.loadText(45, "goodbye")
+    assertEquals("goodbye", context.getText(45))
+  }
+
+  @Test
+  fun unknownIdReadsDoNotThrow() {
+    // The evaluator reads speculatively, so an absent id must be answerable rather than fatal.
+    assertNull(newContext().getText(9999))
+  }
+
+  /**
+   * The reason this store exists: reads must register with Compose's snapshot system so a
+   * `derivedStateOf` over them recomputes. Without this, [GraphContext]'s whole
+   * dependency-discovery design silently degrades to "never invalidates" — and nothing else in this
+   * test would notice.
+   */
+  @Test
+  fun storeReadsAreObservedBySnapshots() {
+    val context = newContext()
+    context.loadFloat(50, 1f)
+
+    val observed = mutableSetOf<Any>()
+    val snapshot = Snapshot.takeMutableSnapshot(readObserver = { observed.add(it) })
+    try {
+      snapshot.enter { context.getFloat(50) }
+    } finally {
+      snapshot.dispose()
+    }
+
+    assertTrue(
+      "reading the store recorded no snapshot dependency — derivedStateOf would never invalidate",
+      observed.isNotEmpty(),
+    )
+  }
+}

--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -130,6 +130,21 @@ revert to upstream verbatim.
   sole contract method that does is `loadBitmap` — which `GraphContext` already stubbed. Worth
   reporting upstream alongside their issue #12: the split they describe is close to mechanical.
 
+- **`RcImageSource` extracted, and `mapEasing` split out of `RcPlayer.kt`** (`RcImageSource.kt`,
+  `RcPlayerEasing.kt`). Two small deltas with the same shape: a neutral declaration was living inside
+  an Android-coupled one, so everything that touched it inherited coupling it never used.
+
+  `RcImageSource` is an **empty** supertype of `RcImageLoader`. `GraphContext` only ever *carried* a
+  loader — `RcPlayer` sets one, the canvas draw path reads it back — so it now carries the neutral
+  type, and the single site that actually loads casts back to `RcImageLoader`. Narrowing rather than
+  generalising is the point: the interface has no members, so nothing pretends image decode is
+  platform-neutral. `mapEasing` is a six-line `when` from a core easing constant to a Compose one,
+  whose only caller is the expression evaluator; leaving it in `RcPlayer.kt` pinned that whole
+  evaluator to `SuppressLint`/`PendingIntent`.
+
+  Together these are what let `GraphContext`, `RcPlayerState.kt` and `RcPlayerExpression.kt` compile
+  for the jvm target — see "Done: it runs on the desktop JVM" below.
+
 - **`rememberRemoteBitmapAsState` moved to its own file** (`state/RcPlayerBitmapState.kt`, out of
   `state/RcPlayerState.kt`). Not a behaviour change and not an upstream gap — a refactor in service
   of the CMP split, recorded here because it is the one place the snapshot is no longer file-for-file
@@ -248,6 +263,35 @@ Verified by compile and by the module's `check`. **Not** verified by a render: t
 needs a staged catalog (see the sequencing note below), so the claim here is "no behaviour change by
 construction", not "the 24-document render is unchanged".
 
+#### Done: it runs on the desktop JVM
+
+`:third-party-rc-embedded-player-jvm` compiles the neutral subset of this module's sources against
+**Compose Desktop** and runs them on a plain JVM — no Android, no Robolectric. `DesktopRemoteContextTest`
+exercises the value layer there: float/int/colour/text round-trips through the shared store, and —
+the one that actually matters — that a store read registers with Compose's snapshot system, without
+which `GraphContext`'s whole `derivedStateOf` design would silently degrade to "never invalidates".
+
+The sources are **shared by path, not copied**: the jvm module adds the Android module's
+`src/main/kotlin` as a source directory and names an explicit file list. So there is one copy of each
+file, and no possibility of the two drifting.
+
+This inverts what `PlatformNeutralSourcesTest` is for. The scan was standing in for a missing
+compiler; now the compiler is here, and a file that isn't really neutral fails to build rather than
+passing a source scan. The test remains as the fast check with the precise message, and
+`readyFilesAreActuallyCompiledForTheJvm` ties its `READY_FOR_JVM_COMMON` list to the build file's, so
+a file cannot be claimed ready without something having actually compiled it off Android.
+
+**What runs, and what doesn't.** The value/expression layer runs: the store, the neutral
+`RemoteContext`, `GraphContext`, the `rememberRemote*AsState` family, and the expression/animation
+evaluator. The draw path does not exist here — that is `RcPlayerPaint`/`RcPlayerDrawing` and the rest
+of the sequencing below. Ten of the module's files still import Android; nine did before this, so the
+remaining work is the draw path, not the value layer.
+
+**This also makes 1b optional rather than blocking.** A separate jvm module was chosen precisely
+because converting the Android module to KMP still has an unsettled risk (Robolectric under the
+KMP-Android plugin), and nothing here needs that resolved. If the conversion happens, this module's
+file list is the migration order; if it never does, the desktop lane still works.
+
 ### The source-set shape is `jvmCommon`, not `common`
 
 `remote-core` — the document and operation model the player reads throughout — is a plain
@@ -311,12 +355,15 @@ single-target milestone it cannot be verified. It splits into 1a/1b.
      was step 2's `RemoteContext` seam, pulled forward because it gated most of 1a; it turned out to
      need no `expect`/`actual` at all, since `RemoteContext` is itself platform-neutral (42 abstract
      members, not one naming an Android type — even `loadBitmap` takes a `byte[]`).
-   - **Next: `RcImageLoader`.** It is now the single thing pinning `GraphContext` (which holds one)
-     and therefore `RcPlayerState.kt` behind it. The interface is `Drawable`-typed; making it
-     generic over a platform image handle, or narrowing what `GraphContext` needs from it, graduates
-     the state + expression path in one move.
-   - Then `RcPlayerChildren`/`RcPlayerComponent`/`mapEasing` out of `RcPlayer.kt`, then the
+   - `RcImageLoader` pinning `GraphContext` — **done**, via the empty `RcImageSource` supertype.
+     `GraphContext` only ever *carried* a loader, so it now carries the neutral type and the one
+     site that loads casts back. Narrowing beat generalising here: the interface has no members, so
+     nothing pretends image decode is platform-neutral.
+   - `mapEasing` out of `RcPlayer.kt` — **done** (`RcPlayerEasing.kt`), which is what let
+     `RcPlayerExpression.kt` and `RcPlayerState.kt` compile for the jvm target.
+   - **Next: the draw path.** `RcPlayerChildren`/`RcPlayerComponent` out of `RcPlayer.kt`, then the
      bitmap-typed helpers out of `RcPlayerDrawing.kt` so `executeOperations`' dispatcher can follow.
+     This is the large remaining piece and where the deferrals below start to matter.
 
    **Import-clean and movable are different things**, and 1a keeps tripping over the difference —
    `GraphContext` imports nothing Android yet still cannot move, because of an ordinary in-package

--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -111,6 +111,25 @@ revert to upstream verbatim.
   Worth reporting upstream on its own — any out-of-tree consumer following the documented
   downloadable-fonts pattern against the published artifact hits this, not just this player.
 
+- **`GraphContext` reparented off `AndroidRemoteContext`** (`GraphContext.kt`, plus the new
+  `StoreBackedRemoteContext.kt`). Upstream's `GraphContext` extends `AndroidRemoteContext`, which
+  pinned it — and through `LocalGraphContext`, the whole state/expression path — to Android for
+  behaviour it never used: it overrides every platform-bound member away (`loadBitmap`, `loadShader`
+  are empty bodies) and shares the store explicitly.
+
+  `StoreBackedRemoteContext` is a platform-neutral `RemoteContext` **ported from
+  `AndroidRemoteContext` at the pinned commit**, method for method, minus the one method that cannot
+  come along. That framing is deliberate: `GraphContext`'s leaf reads call `super.getFloat`/
+  `getText`/…, so a reimplementation that diverged would change every computed value — which is every
+  pixel. The bodies are upstream's, not ours. (`getText` reads via `getFromId`, not a typed getter —
+  exactly the sort of thing a from-signatures guess gets wrong.)
+
+  This is only viable because `AndroidRemoteContext` is barely an Android class: of its 63 methods,
+  **five** touch the platform, and four of those (`setAndroidContext`, `setBitmapLoader`,
+  `setTypefaceResolver`, `useCanvas`) are its own API rather than the `RemoteContext` contract. The
+  sole contract method that does is `loadBitmap` — which `GraphContext` already stubbed. Worth
+  reporting upstream alongside their issue #12: the split they describe is close to mechanical.
+
 - **`rememberRemoteBitmapAsState` moved to its own file** (`state/RcPlayerBitmapState.kt`, out of
   `state/RcPlayerState.kt`). Not a behaviour change and not an upstream gap — a refactor in service
   of the CMP split, recorded here because it is the one place the snapshot is no longer file-for-file
@@ -170,8 +189,8 @@ each verifiable by grep:
 | `RcPlayerChildren` | `RcPlayer.kt` | 5 of the 8 `layout/` files |
 | `RcPlayerComponent` | `RcPlayer.kt` | `layout/RcPlayerStateLayout.kt` |
 | `executeOperations` | `RcPlayerDrawing.kt` | `RcPlayerCanvas.kt`, `RcPlayerModifiers.kt` |
-| `GraphContext` (extends `AndroidRemoteContext`) | `GraphContext.kt` | the state + expression path |
-| `RcImageLoader` (`Drawable`-typed) | `RcImageLoader.kt` | `layout/RcPlayerImageLayout.kt`, `RcPlayerCustom.kt` |
+| ~~`GraphContext` (extends `AndroidRemoteContext`)~~ — **resolved**, see below | `GraphContext.kt` | the state + expression path |
+| `RcImageLoader` (`Drawable`-typed) | `RcImageLoader.kt` | `layout/RcPlayerImageLayout.kt`, `RcPlayerCustom.kt`, **`GraphContext.kt`** |
 
 So the unit of work is a **declaration**, not a file. Some of those splits are nearly free — the
 `rememberRemote*AsState` row was the largest single blocker and its whole Android coupling was *one*
@@ -285,15 +304,31 @@ single-target milestone it cannot be verified. It splits into 1a/1b.
 1. **1a — declaration splits, still a plain android library.** Peel the platform-neutral
    declarations out of the coupled files so a `jvmCommonMain` worth having exists *before* the build
    is restructured. Each split is behaviour-preserving and verified by a compile, so they land
-   independently and bisect cleanly. Order by the table above: `state/`'s Android *import* is gone
-   (**done**), but the chain it sits on runs through `GraphContext`, so that is the next one — split
-   the `RemoteContext` seam and the whole state + expression path graduates at once. Then
-   `RcPlayerChildren`/`RcPlayerComponent`/`mapEasing` out of `RcPlayer.kt`, then the bitmap-typed
-   helpers out of `RcPlayerDrawing.kt` so `executeOperations`' dispatcher can follow.
+   independently and bisect cleanly. Progress so far, in the order the table above implies:
 
-   Note this reorders against the original plan: `GraphContext` is the `RemoteContext` seam that was
-   step 2's first item, and it turns out to gate most of 1a. Splitting it early is what makes a
-   `jvmCommonMain` larger than a handful of files reachable at all.
+   - `state/`'s Android *import* — **done**, by splitting out `rememberRemoteBitmapAsState`.
+   - `GraphContext`'s `AndroidRemoteContext` base — **done**, via `StoreBackedRemoteContext`. This
+     was step 2's `RemoteContext` seam, pulled forward because it gated most of 1a; it turned out to
+     need no `expect`/`actual` at all, since `RemoteContext` is itself platform-neutral (42 abstract
+     members, not one naming an Android type — even `loadBitmap` takes a `byte[]`).
+   - **Next: `RcImageLoader`.** It is now the single thing pinning `GraphContext` (which holds one)
+     and therefore `RcPlayerState.kt` behind it. The interface is `Drawable`-typed; making it
+     generic over a platform image handle, or narrowing what `GraphContext` needs from it, graduates
+     the state + expression path in one move.
+   - Then `RcPlayerChildren`/`RcPlayerComponent`/`mapEasing` out of `RcPlayer.kt`, then the
+     bitmap-typed helpers out of `RcPlayerDrawing.kt` so `executeOperations`' dispatcher can follow.
+
+   **Import-clean and movable are different things**, and 1a keeps tripping over the difference —
+   `GraphContext` imports nothing Android yet still cannot move, because of an ordinary in-package
+   reference. `PlatformNeutralSourcesTest` tracks the two as separate lists for exactly this reason.
+
+   **Deferred deliberately** (niche surfaces the jvm target does not need in a first cut, each
+   isolated enough to postpone): **particles** — `RcPlayerParticles.kt` is the only
+   `AndroidPaintContext` user, so deferring it avoids a Skia `PaintContext` port entirely, at the
+   cost of a small seam where `RcPlayerPaint.kt`/`RcPlayerDrawing.kt` dispatch into it; **AGSL
+   shaders** (`RcPlayerPaint.kt`, `RcPlayer.kt`); and **downloadable fonts**
+   (`RcPlayerTextLayout.kt`). What is *not* deferrable is framework `Paint` and bitmaps — those are
+   the draw path itself.
 2. **1b — restructure to KMP, android target only,** moving the (now much larger) clean set into
    `jvmCommonMain`. Ship it with the forbidden-import guard from above, since the target itself
    enforces nothing. One build-level unknown left: whether `com.android.kotlin.multiplatform.library`

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/GraphContext.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/GraphContext.kt
@@ -86,7 +86,8 @@ internal class GraphContext(
      * isn't a composable, so can't read [LocalRcImageLoader]) needs it to resolve document image
      * draws through the same pluggable loader the composable Image layout uses.
      */
-    internal var imageLoader: RcImageLoader? = null
+    /** Carried for the draw path, never called here — see [RcImageSource]. */
+    internal var imageLoader: RcImageSource? = null
 
     // Capture bookkeeping is per-thread: `derivedStateOf` may be evaluated on whichever thread
     // reads

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/GraphContext.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/GraphContext.kt
@@ -25,7 +25,6 @@ import androidx.compose.remote.core.VariableSupport
 import androidx.compose.remote.core.operations.FloatExpression
 import androidx.compose.remote.core.operations.ShaderData
 import androidx.compose.remote.core.operations.utilities.ArrayAccess
-import androidx.compose.remote.player.core.platform.AndroidRemoteContext
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 
@@ -49,17 +48,19 @@ import androidx.compose.runtime.derivedStateOf
  * handled by save/restore.
  *
  * Conceptually this is a [androidx.compose.remote.core.RemoteReadContext] (a value view) that
- * captures the one write an op makes as its result. It still extends [AndroidRemoteContext] only
- * because the op contract (`apply`/`updateVariables`) takes the concrete `RemoteContext`; once that
- * contract is split onto the read/write interfaces (issue #12), this collapses to a lightweight
- * `RemoteReadContext` + capture sink with no platform subclass.
+ * captures the one write an op makes as its result. It extends [StoreBackedRemoteContext] — a
+ * platform-neutral `RemoteContext` — only because the op contract (`apply`/`updateVariables`) takes
+ * the concrete `RemoteContext`; once that contract is split onto the read/write interfaces
+ * (issue #12), this collapses to a lightweight `RemoteReadContext` + capture sink with no base at
+ * all. Upstream extends `AndroidRemoteContext` here, which pinned this class — and the whole
+ * state/expression path reaching it via `LocalGraphContext` — to Android for no reason it uses.
  */
 internal class GraphContext(
     private val realState: SnapshotRemoteComposeState,
     private val computedOps: Map<Int, Operation>,
     private val timeMillis: State<Float>,
     clock: RemoteClock,
-) : AndroidRemoteContext(clock) {
+) : StoreBackedRemoteContext(clock) {
 
     init {
         // Share the leaf store so collections/objects/paths and plain variables resolve against the

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcImageLoader.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcImageLoader.kt
@@ -47,7 +47,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
  * composable and the canvas observe the same value, and so an async completion updates both.
  */
 @Stable
-public fun interface RcImageLoader {
+public fun interface RcImageLoader : RcImageSource {
     /** A reactive holder for the [Drawable] of [bitmapId]; `null` until/unless one is available. */
     public fun loadImage(bitmapId: Int): State<Drawable?>
 }

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcImageSource.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcImageSource.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.remote.player.compose.embedded
+
+/**
+ * Platform-neutral supertype of [RcImageLoader], so code that only *carries* an image loader does
+ * not have to name its platform-typed API.
+ *
+ * [GraphContext] is the case this exists for. It holds a loader purely as a slot — `RcPlayer` sets
+ * one, the canvas draw path reads it back — and never calls it. But `RcImageLoader.loadImage`
+ * returns a `State<Drawable?>`, so naming that type pinned the evaluator, and the entire
+ * state/expression path reaching it through `LocalGraphContext`, to Android over a field it does not
+ * use.
+ *
+ * The narrowing is deliberate: this interface has no members. Anything that actually *loads* an
+ * image casts back to [RcImageLoader], which is honest — decoding an image is genuinely
+ * platform-bound, and pretending otherwise behind a neutral signature would just move the problem.
+ * When the jvm target grows a real image path, this is the seam it plugs into.
+ */
+public interface RcImageSource

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -31,11 +31,6 @@ import androidx.collection.IntObjectMap
 import androidx.collection.ObjectIntMap
 import androidx.collection.emptyIntObjectMap
 import androidx.collection.emptyObjectIntMap
-import androidx.compose.animation.core.Easing as ComposeEasing
-import androidx.compose.animation.core.FastOutLinearInEasing
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.remote.core.CoreDocument
@@ -75,7 +70,6 @@ import androidx.compose.remote.core.operations.layout.managers.TextLayout
 import androidx.compose.remote.core.operations.layout.modifiers.ComponentVisibilityOperation
 import androidx.compose.remote.core.operations.utilities.AnimatedFloatExpression
 import androidx.compose.remote.core.operations.utilities.NanMap
-import androidx.compose.remote.core.operations.utilities.easing.Easing as RemoteEasing
 import androidx.compose.remote.creation.compose.capture.CapturedDocument
 import androidx.compose.remote.player.compose.ExperimentalRemotePlayerApi
 import androidx.compose.remote.player.compose.embedded.layout.RcPlayerBox
@@ -745,12 +739,3 @@ private fun findComponent(operations: Collection<Operation>, id: Int): Component
     return null
 }
 
-internal fun mapEasing(type: Int): ComposeEasing {
-    return when (type) {
-        RemoteEasing.CUBIC_LINEAR -> LinearEasing
-        RemoteEasing.CUBIC_STANDARD -> FastOutSlowInEasing
-        RemoteEasing.CUBIC_ACCELERATE -> FastOutLinearInEasing
-        RemoteEasing.CUBIC_DECELERATE -> LinearOutSlowInEasing
-        else -> LinearEasing
-    }
-}

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerDrawing.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerDrawing.kt
@@ -135,7 +135,7 @@ internal fun resolveCanvasBitmap(
     remoteContext: RemoteContext,
     id: Int,
 ): Bitmap? {
-    val loaded = graph?.imageLoader?.loadImage(id)?.value
+    val loaded = (graph?.imageLoader as? RcImageLoader)?.loadImage(id)?.value
     if (loaded is BitmapDrawable) return loaded.bitmap
     return resolveBitmap(remoteContext, id)
 }

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerEasing.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerEasing.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.remote.player.compose.embedded
+
+import androidx.compose.animation.core.Easing as ComposeEasing
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.remote.core.operations.utilities.easing.Easing as RemoteEasing
+
+/*
+ * Split out of `RcPlayer.kt`, which is Android-coupled (`SuppressLint`, `PendingIntent`). This
+ * mapping is neither: it turns a core easing constant into a Compose one, and both sides are
+ * platform-neutral.
+ *
+ * Its only caller is `state/RcPlayerExpression.kt`'s animation path, so leaving it in `RcPlayer.kt`
+ * meant the whole expression evaluator inherited that file's Android coupling for a six-line `when`.
+ * Extracting it is what lets `RcPlayerExpression.kt` — and with it `RcPlayerState.kt` — compile for
+ * the jvm target. See the CMP section of PROVENANCE.md.
+ */
+
+internal fun mapEasing(type: Int): ComposeEasing {
+    return when (type) {
+        RemoteEasing.CUBIC_LINEAR -> LinearEasing
+        RemoteEasing.CUBIC_STANDARD -> FastOutSlowInEasing
+        RemoteEasing.CUBIC_ACCELERATE -> FastOutLinearInEasing
+        RemoteEasing.CUBIC_DECELERATE -> LinearOutSlowInEasing
+        else -> LinearEasing
+    }
+}

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/StoreBackedRemoteContext.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/StoreBackedRemoteContext.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("RestrictedApiAndroidX")
+
+package androidx.compose.remote.player.compose.embedded
+
+import androidx.compose.remote.core.RemoteClock
+import androidx.compose.remote.core.RemoteContext
+import androidx.compose.remote.core.VariableSupport
+import androidx.compose.remote.core.operations.FloatExpression
+import androidx.compose.remote.core.operations.ShaderData
+import androidx.compose.remote.core.operations.utilities.ArrayAccess
+import androidx.compose.remote.core.operations.utilities.DataMap
+import androidx.compose.remote.core.types.LongConstant
+
+/**
+ * A [RemoteContext] whose entire state lives in the shared [RemoteContext.mRemoteComposeState] store
+ * and the [RemoteContext.mDocument] — with **no platform dependency at all**.
+ *
+ * ## Why this exists
+ *
+ * [GraphContext] previously extended `AndroidRemoteContext`, which pinned it — and therefore the
+ * whole state/expression path that reaches it through `LocalGraphContext` — to `androidMain`. It
+ * never needed to: it overrides every platform-bound member away (`loadBitmap` and `loadShader` are
+ * empty bodies) and shares the store explicitly.
+ *
+ * ## Why this is a safe substitution
+ *
+ * `AndroidRemoteContext` is **not really an Android class**. Of its 63 methods, exactly five touch
+ * the platform, and four of those (`setAndroidContext`, `setBitmapLoader`, `setTypefaceResolver`,
+ * `useCanvas`) are its own API rather than the [RemoteContext] contract. The only *contract* method
+ * that touches Android is [loadBitmap], which decodes to an `android.graphics.Bitmap`.
+ *
+ * Everything else — the reads, the writes, the named-override family, `updateOps`, `listensTo`,
+ * `runAction`, `hapticEffect` — is delegation to the core store or the core document. So the bodies
+ * below are ports of upstream's, not reimplementations: each mirrors `AndroidRemoteContext` at the
+ * commit pinned in `PROVENANCE.md`, so a context built on this resolves values identically. That
+ * matters more than it looks — [GraphContext]'s leaf reads call `super.getFloat`/`getText`/… , so a
+ * divergence here would change every computed value, which is every pixel.
+ *
+ * [loadBitmap] is the one method that cannot come along; it defaults to a no-op here, which is what
+ * [GraphContext] already overrode it to. A subclass that genuinely needs image decode overrides it.
+ *
+ * Keep this in sync with upstream on a snapshot refresh, the same as the vendored sources.
+ */
+internal abstract class StoreBackedRemoteContext(clock: RemoteClock) : RemoteContext(clock) {
+
+    /** Variable-name registry backing [getVariableId] and the named-override family. */
+    private val varNames = HashMap<String, ArrayList<VarName>>()
+
+    private class VarName(@JvmField val name: String, @JvmField val id: Int, @JvmField val type: Int)
+
+    // ---------------------------------------------------------------- reads
+
+    override fun getFloat(id: Int): Float = mRemoteComposeState.getFloat(id)
+
+    override fun getInteger(id: Int): Int = mRemoteComposeState.getInteger(id)
+
+    override fun getColor(id: Int): Int = mRemoteComposeState.getColor(id)
+
+    override fun getText(id: Int): String? = mRemoteComposeState.getFromId(id) as String?
+
+    override fun getLong(id: Int): Long =
+        (mRemoteComposeState.getObject(id) as LongConstant).getValue()
+
+    override fun getObject(id: Int): Any? = mRemoteComposeState.getObject(id)
+
+    override fun getDataMap(id: Int): DataMap? = mRemoteComposeState.getDataMap(id)
+
+    override fun getShader(id: Int): ShaderData? = mRemoteComposeState.getFromId(id) as ShaderData?
+
+    override fun getPathData(instanceId: Int): FloatArray? =
+        mRemoteComposeState.getPathData(instanceId)
+
+    // --------------------------------------------------------------- writes
+
+    override fun loadFloat(id: Int, value: Float) {
+        mRemoteComposeState.updateFloat(id, value)
+    }
+
+    override fun loadInteger(id: Int, value: Int) {
+        mRemoteComposeState.updateInteger(id, value)
+    }
+
+    override fun loadColor(id: Int, color: Int) {
+        mRemoteComposeState.updateColor(id, color)
+    }
+
+    override fun loadText(id: Int, text: String) {
+        // Upstream distinguishes first write from update; `updateData` on an absent id would not
+        // register it.
+        if (!mRemoteComposeState.containsId(id)) {
+            mRemoteComposeState.cacheData(id, text)
+        } else {
+            mRemoteComposeState.updateData(id, text)
+        }
+    }
+
+    override fun loadPathData(instanceId: Int, winding: Int, floatPath: FloatArray) {
+        mRemoteComposeState.putPathData(instanceId, floatPath)
+        mRemoteComposeState.putPathWinding(instanceId, winding)
+    }
+
+    override fun loadShader(id: Int, value: ShaderData) {
+        mRemoteComposeState.cacheData(id, value)
+    }
+
+    override fun loadAnimatedFloat(id: Int, animatedFloat: FloatExpression) {
+        mRemoteComposeState.cacheData(id, animatedFloat)
+    }
+
+    override fun addCollection(id: Int, collection: ArrayAccess) {
+        mRemoteComposeState.addCollection(id, collection)
+    }
+
+    override fun putObject(id: Int, value: Any) {
+        mRemoteComposeState.updateObject(id, value)
+    }
+
+    override fun putDataMap(id: Int, map: DataMap) {
+        mRemoteComposeState.putDataMap(id, map)
+    }
+
+    /**
+     * No-op: decoding bytes to an image is the one genuinely platform-bound member of the contract.
+     * [GraphContext] overrides it to nothing anyway — it evaluates values and never paints.
+     */
+    override fun loadBitmap(
+        imageId: Int,
+        encoding: Short,
+        type: Short,
+        width: Int,
+        height: Int,
+        data: ByteArray,
+    ) {}
+
+    // ------------------------------------------------------------ evaluation
+
+    override fun listensTo(id: Int, variableSupport: VariableSupport) {
+        mRemoteComposeState.listenToVar(id, variableSupport)
+    }
+
+    override fun updateOps(): Int = mRemoteComposeState.getOpsToUpdate(this, currentTime)
+
+    override fun markVariableDirty(id: Int) {
+        mRemoteComposeState.markVariableDirty(id)
+    }
+
+    // -------------------------------------------------------------- overrides
+
+    override fun overrideFloat(id: Int, value: Float) {
+        mRemoteComposeState.overrideFloat(id, value)
+    }
+
+    override fun overrideInteger(id: Int, value: Int) {
+        mRemoteComposeState.overrideInteger(id, value)
+    }
+
+    override fun overrideText(id: Int, text: Int) {
+        mRemoteComposeState.overrideData(id, text)
+    }
+
+    private fun overrideData(id: Int, value: Any) {
+        mRemoteComposeState.overrideData(id, value)
+    }
+
+    private fun clearDataOverride(id: Int) {
+        mRemoteComposeState.clearDataOverride(id)
+    }
+
+    private fun clearFloatOverride(id: Int) {
+        mRemoteComposeState.clearFloatOverride(id)
+    }
+
+    private fun clearIntegerOverride(id: Int) {
+        mRemoteComposeState.clearIntegerOverride(id)
+    }
+
+    // --------------------------------------------------------- variable names
+
+    override fun loadVariableName(varName: String, varId: Int, varType: Int) {
+        val list = varNames.getOrPut(varName) { ArrayList() }
+        // Avoid duplicates if re-initializing the same document.
+        if (list.none { it.id == varId }) {
+            list.add(VarName(varName, varId, varType))
+        }
+    }
+
+    /** Not part of the [RemoteContext] contract — `AndroidRemoteContext`'s own API, mirrored here. */
+    fun clearVariables() {
+        varNames.clear()
+    }
+
+    /** Mirrors upstream, including throwing rather than returning a sentinel for an unknown name. */
+    fun getVariableId(name: String): Int {
+        val list = varNames[name]
+        if (list.isNullOrEmpty()) {
+            throw NoSuchElementException("Variable $name not found")
+        }
+        return list[0].id
+    }
+
+    private inline fun forEachNamed(name: String, action: (Int) -> Unit) {
+        varNames[name]?.forEach { action(it.id) }
+    }
+
+    override fun setNamedStringOverride(stringName: String, value: String) = forEachNamed(
+        stringName
+    ) { overrideData(it, value) }
+
+    override fun clearNamedStringOverride(stringName: String) = forEachNamed(stringName) {
+        clearDataOverride(it)
+    }
+
+    override fun setNamedFloatOverride(floatName: String, value: Float) = forEachNamed(floatName) {
+        mRemoteComposeState.overrideFloat(it, value)
+    }
+
+    override fun clearNamedFloatOverride(floatName: String) = forEachNamed(floatName) {
+        clearFloatOverride(it)
+    }
+
+    override fun setNamedIntegerOverride(integerName: String, value: Int) = forEachNamed(
+        integerName
+    ) { mRemoteComposeState.overrideInteger(it, value) }
+
+    override fun clearNamedIntegerOverride(integerName: String) = forEachNamed(integerName) {
+        clearIntegerOverride(it)
+    }
+
+    override fun setNamedBooleanOverride(booleanName: String, value: Boolean) =
+        setNamedIntegerOverride(booleanName, if (value) 1 else 0)
+
+    override fun clearNamedBooleanOverride(booleanName: String) =
+        clearNamedIntegerOverride(booleanName)
+
+    override fun setNamedColorOverride(colorName: String, color: Int) = forEachNamed(colorName) {
+        mRemoteComposeState.overrideColor(it, color)
+    }
+
+    override fun setNamedDataOverride(dataName: String, value: Any) = forEachNamed(dataName) {
+        overrideData(it, value)
+    }
+
+    override fun clearNamedDataOverride(dataName: String) = forEachNamed(dataName) {
+        clearDataOverride(it)
+    }
+
+    override fun setNamedLong(name: String, value: Long) = forEachNamed(name) {
+        (mRemoteComposeState.getObject(it) as LongConstant).setValue(value)
+    }
+
+    // ------------------------------------------------------------ host actions
+
+    override fun runAction(id: Int, metadata: String) {
+        mDocument.performClick(this, id, metadata)
+    }
+
+    override fun runNamedAction(id: Int, value: Any?) {
+        val text = getText(id)
+        if (text != null) {
+            mDocument.runNamedAction(text, value)
+        }
+    }
+
+    override fun addClickArea(
+        id: Int,
+        contentDescriptionId: Int,
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        metadataId: Int,
+    ) {
+        val contentDescription = mRemoteComposeState.getFromId(contentDescriptionId) as String?
+        val metadata = mRemoteComposeState.getFromId(metadataId) as String?
+        mDocument.addClickArea(id, contentDescription, left, top, right, bottom, metadata)
+    }
+
+    override fun hapticEffect(type: Int) {
+        mDocument.haptic(type)
+    }
+}

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
@@ -44,10 +44,15 @@ import org.junit.Test
  *    those, not this test.
  *
  * So [IMPORT_CLEAN] is the weaker claim ("the decoupling done to this file has not regressed") and
- * [READY_FOR_JVM_COMMON] is the stronger one ("this file can move"). Keeping them apart matters:
- * `state/RcPlayerState.kt` is import-clean but reads `LocalGraphContext`, whose type extends
- * `AndroidRemoteContext`, so it cannot move until that chain is split. Listing it as ready would
- * certify a move that will not compile.
+ * [READY_FOR_JVM_COMMON] is the stronger one ("this file can move"). Keeping them apart matters —
+ * `GraphContext` spent a while import-clean but still unmovable, because it held a `Drawable`-typed
+ * `RcImageLoader`; listing it as ready then would have certified a move that could not compile.
+ *
+ * **This test is now the fast check, not the real one.** `:third-party-rc-embedded-player-jvm`
+ * compiles every [READY_FOR_JVM_COMMON] file against Compose Desktop, which settles the question by
+ * construction — a file that isn't really neutral fails to build there. What this test still buys is
+ * speed and a precise message, plus [IMPORT_CLEAN] coverage for files not yet pulled into that
+ * module. [readyFilesAreActuallyCompiledForTheJvm] keeps the two from drifting apart.
  */
 class PlatformNeutralSourcesTest {
 
@@ -128,6 +133,37 @@ class PlatformNeutralSourcesTest {
     assertEquals("CanvasOperations", importedSimpleName("$PLAYER_PACKAGE.CanvasOperations"))
   }
 
+  /**
+   * Every file claimed ready must actually be compiled for the JVM by
+   * `:third-party-rc-embedded-player-jvm`.
+   *
+   * Without this the two lists drift, and they drift in the dangerous direction: a file added here
+   * but not there reads as "verified for the jvm target" while nothing has ever built it off
+   * Android. The build file's list is the source of truth precisely because a wrong entry there
+   * fails a compile rather than a scan.
+   */
+  @Test
+  fun readyFilesAreActuallyCompiledForTheJvm() {
+    // Walk up rather than count `..` segments — the same reason `playerSourceRoot` does.
+    var dir: File? = playerSourceRoot()
+    var buildFile: File? = null
+    while (dir != null && buildFile == null) {
+      val candidate = File(dir, "rc-embedded-player-jvm/build.gradle.kts")
+      if (candidate.isFile) buildFile = candidate
+      dir = dir.parentFile
+    }
+    assertTrue("could not locate the jvm module's build file by walking up", buildFile != null)
+    val declared = buildFile!!.readText()
+    val missing = READY_FOR_JVM_COMMON.filterNot { declared.contains("$PLAYER_PATH/$it") }
+    assertEquals(
+      "Declared ready for jvmCommonMain but not in :third-party-rc-embedded-player-jvm's " +
+        "sharedPlayerSources, so nothing has ever compiled them off Android. Add them there — and " +
+        "if they don't compile, they aren't ready.",
+      emptyList<String>(),
+      missing,
+    )
+  }
+
   /** Feeds every `import` line of each declared file to [block] as (relative path, FQN, raw line). */
   private fun forEachDeclaredFile(
     files: List<String>,
@@ -162,6 +198,7 @@ class PlatformNeutralSourcesTest {
 
   private companion object {
     const val PLAYER_PACKAGE = "androidx.compose.remote.player.compose.embedded"
+    val PLAYER_PATH = PLAYER_PACKAGE.replace('.', '/')
 
     /**
      * Declarations that stay in `androidMain` — they name an Android type in their signature or
@@ -170,11 +207,6 @@ class PlatformNeutralSourcesTest {
      */
     val ANDROID_MAIN_DECLARATIONS =
       setOf(
-        // No longer *imports* anything Android — it extends the neutral StoreBackedRemoteContext
-        // now — but it still holds an `RcImageLoader`, which is Drawable-typed. Import-clean and
-        // not yet movable are different things, and this is the difference.
-        "GraphContext",
-        "LocalGraphContext",
         // android.graphics.Bitmap / Rect / drawable on the canvas draw path
         "executeOperations",
         "resolveBitmap",
@@ -204,21 +236,7 @@ class PlatformNeutralSourcesTest {
      * Import-clean, but still referencing something that stays in `androidMain`, so not yet movable.
      * These are here to hold decoupling work that has already been done against regression.
      */
-    val IMPORT_CLEAN =
-      listOf(
-        // Decoupled by moving `rememberRemoteBitmapAsState` to `state/RcPlayerBitmapState.kt`. Its
-        // fourteen sibling helpers are referenced by 19 files outside `state/`, which makes this the
-        // highest-leverage file in the split. Still blocked behind `GraphContext` — the helpers read
-        // `LocalGraphContext` to resolve computed ids.
-        "state/RcPlayerState.kt",
-        // Reparented from `AndroidRemoteContext` onto the neutral `StoreBackedRemoteContext`, which
-        // is what freed the state/expression path of any *platform* dependency. What still pins it
-        // is an ordinary in-package one: it holds an `RcImageLoader` (Drawable-typed). Seam that and
-        // both this and `RcPlayerState.kt` graduate together.
-        "GraphContext.kt",
-        // Declares the composition locals the state path reads, `LocalGraphContext` among them.
-        "RcPlayerCompositionLocals.kt",
-      )
+    val IMPORT_CLEAN = listOf<String>()
 
     /**
      * Import-clean *and* free of cross-package references into `androidMain` — these are the files
@@ -233,6 +251,12 @@ class PlatformNeutralSourcesTest {
         // Written here rather than vendored: a platform-neutral `RemoteContext`, ported from
         // `AndroidRemoteContext` minus its one Android method. It touches nothing but `remote-core`.
         "StoreBackedRemoteContext.kt",
+        "RcImageSource.kt",
+        "GraphContext.kt",
+        "RcPlayerCompositionLocals.kt",
+        "RcPlayerEasing.kt",
+        "state/RcPlayerState.kt",
+        "state/RcPlayerExpression.kt",
       )
   }
 }

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
@@ -170,7 +170,9 @@ class PlatformNeutralSourcesTest {
      */
     val ANDROID_MAIN_DECLARATIONS =
       setOf(
-        // extends AndroidRemoteContext, and the composition local that hands it out
+        // No longer *imports* anything Android — it extends the neutral StoreBackedRemoteContext
+        // now — but it still holds an `RcImageLoader`, which is Drawable-typed. Import-clean and
+        // not yet movable are different things, and this is the difference.
         "GraphContext",
         "LocalGraphContext",
         // android.graphics.Bitmap / Rect / drawable on the canvas draw path
@@ -206,9 +208,16 @@ class PlatformNeutralSourcesTest {
       listOf(
         // Decoupled by moving `rememberRemoteBitmapAsState` to `state/RcPlayerBitmapState.kt`. Its
         // fourteen sibling helpers are referenced by 19 files outside `state/`, which makes this the
-        // highest-leverage file in the split. Still blocked on the `GraphContext` chain: the
-        // helpers read `LocalGraphContext` to resolve computed ids.
-        "state/RcPlayerState.kt"
+        // highest-leverage file in the split. Still blocked behind `GraphContext` — the helpers read
+        // `LocalGraphContext` to resolve computed ids.
+        "state/RcPlayerState.kt",
+        // Reparented from `AndroidRemoteContext` onto the neutral `StoreBackedRemoteContext`, which
+        // is what freed the state/expression path of any *platform* dependency. What still pins it
+        // is an ordinary in-package one: it holds an `RcImageLoader` (Drawable-typed). Seam that and
+        // both this and `RcPlayerState.kt` graduate together.
+        "GraphContext.kt",
+        // Declares the composition locals the state path reads, `LocalGraphContext` among them.
+        "RcPlayerCompositionLocals.kt",
       )
 
     /**
@@ -217,6 +226,13 @@ class PlatformNeutralSourcesTest {
      * the document data model, and the snapshot-backed state store are plain `remote-core` types.
      */
     val READY_FOR_JVM_COMMON =
-      listOf("CoreDataAccessors.kt", "CoreDataModel.kt", "SnapshotRemoteComposeState.kt")
+      listOf(
+        "CoreDataAccessors.kt",
+        "CoreDataModel.kt",
+        "SnapshotRemoteComposeState.kt",
+        // Written here rather than vendored: a platform-neutral `RemoteContext`, ported from
+        // `AndroidRemoteContext` minus its one Android method. It touches nothing but `remote-core`.
+        "StoreBackedRemoteContext.kt",
+      )
   }
 }


### PR DESCRIPTION
**The embedded Remote Compose player now runs off Android.** `:third-party-rc-embedded-player-jvm` compiles its platform-neutral subset against Compose Desktop and executes it on a plain JVM — no Android, no Robolectric. That's the thing the CMP plan in `PROVENANCE.md` exists to reach.

> Scope note: this PR grew after its first review. It opened as just the `GraphContext` reparent; that turned out to be one seam short of a working desktop build, so the rest is here. The reparent commit is unchanged — `4e545f8` — and the desktop module is `2e7d3a6`.

## The desktop module

```
:third-party-rc-embedded-player-jvm:test
  DesktopRemoteContextTest > 5 tests, 0 failures, 0 skipped
```

It exercises the value layer on the JVM: float/int/colour/text round-trips through the shared store, an absent id answering rather than throwing, and — the one that actually matters — that a store read **registers with Compose's snapshot system**. Without that, `GraphContext`'s whole `derivedStateOf` design degrades silently to "never invalidates", and nothing else in the suite would notice.

Sources are **shared by path, not copied**: the module adds the Android module's `src/main/kotlin` as a source directory and names an explicit file list. One copy of each file, no drift. The list is explicit rather than a glob because adding a file is a claim that it's neutral, and that should be a decision someone makes rather than something a wildcard makes for them.

**A separate module rather than converting the Android one to KMP**, deliberately. That conversion still carries an unsettled risk — Robolectric under `com.android.kotlin.multiplatform.library` — and nothing here needs it resolved. If the conversion happens, this file list is the migration order; if it never does, the desktop lane works anyway. It also touches the Android module's build not at all.

## How `GraphContext` got there (the original commit)

`GraphContext` extended `AndroidRemoteContext`, pinning it — and through `LocalGraphContext` the whole state/expression path — to Android for behaviour it never used. It now extends `StoreBackedRemoteContext`, a platform-neutral `RemoteContext` **ported from `AndroidRemoteContext` at the pinned commit**, method for method, minus the one method that can't come along.

This is viable because `AndroidRemoteContext` is barely an Android class — **5 of 63** methods touch the platform, and 4 of those are its own API, not the `RemoteContext` contract. The only contract method that does is `loadBitmap`, already stubbed by `GraphContext`. `RemoteContext` itself has 42 abstract members and **not one names an Android type**, so no `expect`/`actual` was needed at all.

Ported, not reimplemented, because `GraphContext`'s leaf reads call `super.getFloat`/`getText`/… — a divergence would change every computed value. Reading upstream caught what a from-signatures guess would have missed: `getText` reads via `getFromId`, and `RemoteComposeState` exposes no `getText` at all.

## Two seams to finish the path

Both the same shape — a neutral declaration living inside an Android-coupled one:

- **`RcImageSource`**, an *empty* supertype of `RcImageLoader`. `GraphContext` only ever *carried* a loader; it now carries the neutral type and the single site that loads casts back. Narrowing rather than generalising is the point: no members, so nothing pretends image decode is platform-neutral.
- **`mapEasing`** out of `RcPlayer.kt` — a six-line `when` whose only caller is the expression evaluator, which was inheriting `SuppressLint`/`PendingIntent` for it.

## The guard's role inverts

`PlatformNeutralSourcesTest`'s import scan was standing in for a missing compiler. The compiler is here now, so a file that isn't really neutral **fails to build** rather than passing a scan. The test stays as the fast check with the precise message, and a new `readyFilesAreActuallyCompiledForTheJvm` ties its ready list to the build file's — a file can no longer be called ready without something having compiled it off Android.

## Test plan

- `:third-party-rc-embedded-player-jvm:check` — green, 5 tests.
- `:third-party-rc-embedded-player:check` — green, including the Robolectric render harness and the guard at 4 tests.
- ktfmt scoped off the shared AOSP-formatted sources; verified the vendored files were **not** reflowed (diffs are 2–3 lines, indentation still 4-space).
- PROVENANCE copyright-header scan passes over both modules.

**Still not verified by a render.** The reparent swaps the base class every computed value flows through and is not behaviour-preserving by construction. The desktop tests assert the value layer behaves, but "the Android pixels are unchanged" needs the staged catalog in CI. Worth checking the rc-compare lane before relying on this.

Scope is the value/expression layer; the draw path is next and is where the deferrals (particles first) start to matter.