### PR TITLE
fix(rc-embedded-player): let the composition reach idle, drop dead autoUpdate

### DIFF
--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -152,6 +152,32 @@ revert to upstream verbatim.
   the move after a refresh rather than treating the diff as a conflict. Rationale under
   "Done: `state/` decoupled" below.
 
+### Behaviour delta: the frame loop, and the dead `autoUpdate` knob
+
+Unlike everything above, this one *is* a fix rather than a build-gap workaround, so it is worth
+reporting upstream on its own.
+
+- **The time loop requests frames through `withInfiniteAnimationFrameMillis`, not `withFrameMillis`**
+  (`RcPlayer.kt`). `RcPlayer` drives document time from a `LaunchedEffect` whose `while (true)` loop
+  only breaks when the document has no animations, no time dependency, no particles and no `wakeIn` —
+  i.e. for any animated or time-driven document it never returns. Requested through `withFrameMillis`
+  that is indistinguishable from ordinary pending recomposition work, so **the composition never
+  reaches idle**: `ComposeTestRule.waitForIdle()` blocks forever, and with it every wait-for-idle
+  capture API. That is exactly what Compose's `InfiniteAnimationPolicy` exists to make visible, and
+  `withInfiniteAnimationFrameMillis` is how you opt into it. Outside a test no policy is installed
+  and the call degrades to `withFrameMillis`, so production timing is unchanged — confirmed by
+  re-rendering the 24-document `remote-m3` lane and comparing by md5: **24 identical, 0 differing**.
+  `RcIdleProbeTest` pins the property by composing a real document and asserting `waitForIdle()`
+  returns at all.
+
+- **`autoUpdate` removed** from both `RcPlayer` overloads and from
+  `ExperimentalRemoteDocumentPlayer`. Upstream declares the parameter, defaults it to `true`, and
+  forwards it down the wrapper chain — but **no body ever reads it**. It is dead, and worse than
+  dead: it reads exactly like the knob that stops the frame loop, so a host trying to render a still
+  frame passes `autoUpdate = false`, gets no error, and still hangs. The render harnesses here were
+  written around that misunderstanding. With the loop fixed the knob has nothing left to mean, so it
+  goes rather than being wired up.
+
 ### Not a source delta, but worth knowing about the build
 
 The module carries **no resource table** and leaves `androidResources` at AGP 9's default (`false`

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/ExperimentalRemoteDocumentPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/ExperimentalRemoteDocumentPlayer.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Modifier
 public fun ExperimentalRemoteDocumentPlayer(
     document: RemoteDocument,
     modifier: Modifier = Modifier,
-    autoUpdate: Boolean = true,
     namedColorOverrides: ObjectIntMap<String> = emptyObjectIntMap(),
     imageLoader: RcImageLoader? = null,
     isShaderValid: (shaderSource: String) -> Boolean = { true },
@@ -45,7 +44,6 @@ public fun ExperimentalRemoteDocumentPlayer(
     RcPlayer(
         document = document.document,
         modifier = modifier,
-        autoUpdate = autoUpdate,
         namedColorOverrides = namedColorOverrides,
         imageLoader = imageLoader,
         isShaderValid = isShaderValid,

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -31,6 +31,7 @@ import androidx.collection.IntObjectMap
 import androidx.collection.ObjectIntMap
 import androidx.collection.emptyIntObjectMap
 import androidx.collection.emptyObjectIntMap
+import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.remote.core.CoreDocument
@@ -91,7 +92,6 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.withFrameMillis
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.layout.onPlaced
@@ -131,7 +131,6 @@ import kotlin.math.abs
 public fun RcPlayer(
     document: CoreDocument,
     modifier: Modifier = Modifier,
-    autoUpdate: Boolean = true,
     namedColorOverrides: ObjectIntMap<String> = emptyObjectIntMap(),
     imageLoader: RcImageLoader? = null,
     isShaderValid: (shaderSource: String) -> Boolean = { true },
@@ -299,10 +298,18 @@ public fun RcPlayer(
     // instead.
     val hasWakeIn = remember(document) { containsWakeIn(document.getOperationsReflection()) }
 
+    // `withInfiniteAnimationFrameMillis`, not `withFrameMillis`: this loop never terminates for an
+    // animated / time-driven document, which is precisely what Compose means by an *infinite*
+    // animation. Requesting frames through the infinite-animation channel routes them via the
+    // `InfiniteAnimationPolicy` in the coroutine context, so a host that needs the composition to
+    // reach idle can see through it. Under `ComposeTestRule` that is the difference between
+    // `waitForIdle()` returning and hanging forever; under `@Preview` inspection it is what lets
+    // tooling pause the animation instead of spinning. Outside a test the policy is absent and this
+    // degrades to exactly `withFrameMillis`, so production timing is unchanged.
     LaunchedEffect(document, hasAnimations, isTimeDependent, hasParticles, hasWakeIn) {
-        val startMillis = withFrameMillis { it }
+        val startMillis = withInfiniteAnimationFrameMillis { it }
         while (true) {
-            val frameMillis = withFrameMillis { it } - startMillis
+            val frameMillis = withInfiniteAnimationFrameMillis { it } - startMillis
             // Pure time ticker. Updating currentTimeMillisState is the *only* per-frame work: every
             // reactive path keys off it. Expression display flows through the GraphContext
             // derivedStateOf graph and the float/int/color resolvers (which read this state for
@@ -476,7 +483,6 @@ public fun RcPlayer(
 public fun RcPlayer(
     capturedDocument: CapturedDocument,
     modifier: Modifier = Modifier,
-    autoUpdate: Boolean = true,
     namedColorOverrides: ObjectIntMap<String> = emptyObjectIntMap(),
     imageLoader: RcImageLoader? = null,
     isShaderValid: (shaderSource: String) -> Boolean = { true },
@@ -496,7 +502,6 @@ public fun RcPlayer(
     RcPlayer(
         document = coreDoc,
         modifier = modifier,
-        autoUpdate = autoUpdate,
         namedColorOverrides = namedColorOverrides,
         imageLoader = imageLoader,
         isShaderValid = isShaderValid,

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcEmbeddedRenderHarness.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcEmbeddedRenderHarness.kt
@@ -133,7 +133,6 @@ class RcEmbeddedRenderHarness(private val entry: Entry) {
         ExperimentalRemoteDocumentPlayer(
           document = document,
           // A still comparison against a still baked PNG.
-          autoUpdate = false,
           modifier = Modifier.fillMaxSize(),
         )
       }

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcFigmaSvgExportTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcFigmaSvgExportTest.kt
@@ -125,7 +125,6 @@ class RcFigmaSvgExportTest {
     val lane = export("embedded", doc) { bytes ->
       ExperimentalRemoteDocumentPlayer(
         document = remember { RemoteDocument(bytes) },
-        autoUpdate = false,
         modifier = Modifier.fillMaxSize(),
       )
     }

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcIdleProbeTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcIdleProbeTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayer
+import androidx.compose.remote.player.core.RemoteDocument
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The player's frame loop must not stop the composition reaching idle.
+ *
+ * `RcPlayer` drives time from a `LaunchedEffect` that never returns for an animated or time-driven
+ * document. Requested through `withFrameMillis` that is indistinguishable from ordinary pending
+ * work, so `waitForIdle()` blocks forever and every wait-for-idle capture API times out — which is
+ * why the render harnesses drive `mainClock` by hand and draw the view directly. Requested through
+ * `withInfiniteAnimationFrameMillis` it goes via the `InfiniteAnimationPolicy` the test framework
+ * installs, and idle is reachable.
+ *
+ * This asserts the property directly: compose a real document and call `waitForIdle()`. If the loop
+ * regresses to `withFrameMillis` this test hangs and the suite times out rather than failing
+ * cleanly — a loud failure either way, which is the point.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [34], qualifiers = "xhdpi")
+class RcIdleProbeTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test(timeout = 120_000)
+  fun compositionReachesIdleWithThePlayerRunning() {
+    val bytes =
+      checkNotNull(javaClass.getResourceAsStream("/rc-fixtures/TitleCardRemote-640x480.rc"))
+        .use { it.readBytes() }
+
+    composeRule.setContent {
+      Box(
+        Modifier.size(
+          with(LocalDensity.current) { 640.toDp() },
+          with(LocalDensity.current) { 480.toDp() },
+        )
+      ) {
+        ExperimentalRemoteDocumentPlayer(
+          document = RemoteDocument(bytes),
+          modifier = Modifier.fillMaxSize(),
+        )
+      }
+    }
+
+    // The assertion is that this returns at all.
+    composeRule.waitForIdle()
+  }
+}

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcSemanticsExtractionTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcSemanticsExtractionTest.kt
@@ -80,7 +80,6 @@ class RcSemanticsExtractionTest {
     val embedded = capture(width, height) {
       ExperimentalRemoteDocumentPlayer(
         document = remember { RemoteDocument(bytes) },
-        autoUpdate = false,
         modifier = Modifier.fillMaxSize(),
       )
     }


### PR DESCRIPTION
## Summary

Two related defects in the vendored embedded player, both reported by @yschimke.

**1. The frame loop blocks idle.** `RcPlayer` drives document time from a `LaunchedEffect` whose `while (true)` loop only breaks when the document has no animations, no time dependency, no particles and no `wakeIn` — i.e. for any animated or time-driven document it never returns. Requested through `withFrameMillis`, that is indistinguishable from ordinary pending recomposition work, so **the composition never reaches idle**: `ComposeTestRule.waitForIdle()` blocks forever and with it every wait-for-idle capture API. That is precisely what Compose's `InfiniteAnimationPolicy` exists to make visible, and `withInfiniteAnimationFrameMillis` is how you opt into it.

Outside a test no policy is installed and the call degrades to exactly `withFrameMillis`, so **production timing is unchanged** — see the test plan.

**2. `autoUpdate` is dead.** Upstream declares it on both `RcPlayer` overloads and on `ExperimentalRemoteDocumentPlayer`, defaults it to `true`, and forwards it down the wrapper chain — but no body ever reads it. Worse than dead: it reads exactly like the knob that stops the frame loop, so a host rendering a still frame passes `autoUpdate = false`, gets no error, and still hangs. The render harnesses in this repo were written around that misunderstanding. With the loop fixed the parameter has nothing left to mean, so it goes rather than being wired up.

Both are recorded as a new **"Behaviour delta"** section in `third_party/rc-embedded-player/PROVENANCE.md` — unlike the existing deltas these are fixes, not build-against-published-alpha workarounds, so they're prime upstream-report material.

## Test plan

- **New `RcIdleProbeTest`** composes a real document and calls `waitForIdle()`; the assertion is that it returns at all. Passes now; before this change it hangs (the test carries a 120 s timeout so a regression fails loudly rather than wedging CI).
- `:third-party-rc-embedded-player:testDebugUnitTest` green — `RcIdleProbeTest` 1/1, `PlatformNeutralSourcesTest` 3/3, `RcFigmaSvgExportTest` 2/2, `BUILD SUCCESSFUL`.
- `:third-party-rc-embedded-player:ktfmtCheck` clean.
- **No pixel change:** re-rendered the 24-document `remote-m3` embedded lane and compared the PNGs by md5 against the pre-change output — **24 identical, 0 differing**.

## Visual evidence

None embedded, deliberately: the render comparison above is the evidence, and its result is that **every rendered pixel is byte-identical** to `main`. There is no before/after to show — a diff image would be uniformly empty. The surfaces this touches (the `rc-compare` embedded lane) stay covered by the existing CI lane.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYQT3Sc9Vpfg4Fhfy6StKL)_