### PR TITLE
feat(trust): trust yschimke/horologist design-artifacts branches

### DIFF
--- a/deploy/image/trust/producers.json
+++ b/deploy/image/trust/producers.json
@@ -22,6 +22,10 @@
       "branch": "design-artifacts/*"
     },
     {
+      "repo": "yschimke/horologist",
+      "branch": "design-artifacts/*"
+    },
+    {
       "repo": "joreilly/Confetti",
       "branch": "design-artifacts/*"
     },

--- a/trust/producers.json
+++ b/trust/producers.json
@@ -28,6 +28,10 @@
     {
       "repo": "yschimke/compose-samples",
       "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/horologist",
+      "branch": "design-artifacts/*"
     }
   ],
   "oidc": [


### PR DESCRIPTION
Adds `yschimke/horologist` + `design-artifacts/*` as a branch (origin) trust producer.

Edited **both** copies, per the warning in `trust/producers.json`:
- `deploy/image/trust/producers.json` — the one actually baked into the `preview-host` image (`COPY trust/ /trust/` with build context `deploy/image`), i.e. what preview.coo.ee uses.
- `trust/producers.json` — the reference/example copy for operators running their own server with `--trust-store`.

Non-visual change (trust config only), so no render evidence.

### Note on sequencing

There is no `design-artifacts/horologist` branch in `yschimke/horologist` yet — its only preview-related branch is `compose-preview/main`, which carries `renders/` + `baselines.json` (the @Preview render bot's output), not a catalog bundle. So this PR only makes the trust entry ready; registering a `horologist` catalog will 502 until that delivery branch is published.

Trust is baked into the image, so the entry reaches preview.coo.ee on the next `preview-host-image` publish, not on merge.

### Test plan

- `python3 -json.tool` parse check on both files; branch lists verified to contain `yschimke/horologist`.
- CI (`No Agent Attribution`, build) on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FdJsCmxDm9dXv8iEsxVYgs)_