### PR TITLE
refactor(rc-embedded): draw the texture shader with multiplatform ImageShader

### DIFF
--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -130,6 +130,17 @@ revert to upstream verbatim.
   sole contract method that does is `loadBitmap` — which `GraphContext` already stubbed. Worth
   reporting upstream alongside their issue #12: the split they describe is close to mechanical.
 
+- **`PaintBundle.TEXTURE` uses multiplatform `ImageShader` instead of `BitmapShader`**
+  (`RcPlayerPaint.kt`). The texture path built a framework `BitmapShader` and needed a parallel
+  `nativeTileMode` table to feed it — a second tile-mode mapping alongside the Compose `mapTileMode`
+  the same file already used everywhere else. `ImageShader` is the multiplatform equivalent and takes
+  the Compose `TileMode` directly, so the duplicate table is gone and the bitmap goes through
+  `asImageBitmap()`.
+
+  Behaviour-preserving: same tile modes, same image, still wrapped as a `ShaderBrush`. Note the
+  *other* `BitmapShader` in this file stays — it binds a bitmap uniform inside `buildRuntimeShader`,
+  so it belongs to the AGSL path, which is deferred (issue #2954).
+
 - **`RcImageSource` extracted, and `mapEasing` split out of `RcPlayer.kt`** (`RcImageSource.kt`,
   `RcPlayerEasing.kt`). Two small deltas with the same shape: a neutral declaration was living inside
   an Android-coupled one, so everything that touched it inherited coupling it never used.
@@ -399,7 +410,7 @@ single-target milestone it cannot be verified. It splits into 1a/1b.
    isolated enough to postpone): **particles** — `RcPlayerParticles.kt` is the only
    `AndroidPaintContext` user, so deferring it avoids a Skia `PaintContext` port entirely, at the
    cost of a small seam where `RcPlayerPaint.kt`/`RcPlayerDrawing.kt` dispatch into it; **AGSL
-   shaders** (`RcPlayerPaint.kt`, `RcPlayer.kt`); and **downloadable fonts**
+   shaders** (`RcPlayerPaint.kt`, `RcPlayer.kt`, tracked as issue #2954); and **downloadable fonts**
    (`RcPlayerTextLayout.kt`). What is *not* deferrable is framework `Paint` and bitmaps — those are
    the draw path itself.
 2. **1b — restructure to KMP, android target only,** moving the (now much larger) clean set into

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerPaint.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerPaint.kt
@@ -34,11 +34,13 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageShader
 import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.font.FontStyle
 
@@ -141,14 +143,6 @@ internal fun mapTileMode(mode: Int): TileMode =
         1 -> TileMode.Repeated
         2 -> TileMode.Mirror
         else -> TileMode.Clamp
-    }
-
-/** Maps a packed tile-mode index to a framework [Shader.TileMode]. */
-private fun nativeTileMode(index: Int): Shader.TileMode =
-    when (index) {
-        1 -> Shader.TileMode.REPEAT
-        2 -> Shader.TileMode.MIRROR
-        else -> Shader.TileMode.CLAMP
     }
 
 /** Wraps a framework [Shader] as a Compose [Brush] for the DrawScope paint path. */
@@ -362,12 +356,15 @@ internal fun updatePaintFromBundle(
                 i++ // filter/maxAnisotropy word (filtering managed by Compose; consumed to stay
                 // synced)
                 val bitmap = resolveBitmap(remoteContext, bitmapId)
+                // `ImageShader` is the multiplatform equivalent of a framework `BitmapShader`, and
+                // it takes the Compose `TileMode` the file already maps for every other path — so
+                // this needs neither `android.graphics` nor the parallel `nativeTileMode` table.
                 val shader =
                     bitmap?.let {
-                        BitmapShader(
-                            it,
-                            nativeTileMode(tileModes and 0xF),
-                            nativeTileMode((tileModes shr 16) and 0xF),
+                        ImageShader(
+                            it.asImageBitmap(),
+                            mapTileMode(tileModes and 0xF),
+                            mapTileMode((tileModes shr 16) and 0xF),
                         )
                     }
                 paintState.nativeShader = shader


### PR DESCRIPTION
One API swapped for its portable equivalent, on the way to a single-implementation paint path.

## What changed

`PaintBundle.TEXTURE` built a framework `BitmapShader`, which forced a **second tile-mode mapping** — `nativeTileMode`, returning `android.graphics.Shader.TileMode` — sitting right next to the Compose `mapTileMode` the same file already used for every other path.

`ImageShader` is the multiplatform equivalent and takes the Compose `TileMode` directly:

```kotlin
ImageShader(
    it.asImageBitmap(),
    mapTileMode(tileModes and 0xF),
    mapTileMode((tileModes shr 16) and 0xF),
)
```

Same tile modes, same image, still wrapped as a `ShaderBrush`. The duplicate table is deleted.

## Why the other `BitmapShader` stays

Worth being precise, because the file has two and only one is portable. The other binds a **bitmap uniform inside `buildRuntimeShader`** — it belongs to the AGSL path, not the texture path.

AGSL has no multiplatform equivalent: desktop Compose exposes SkSL `RuntimeEffect`, a different shading language *and* a different uniform-binding API. So that path keeps `RuntimeShader`, `BitmapShader`, `Matrix` and the API-33 `Build` guard until it gets a seam — deferred deliberately and tracked as **#2954**.

## Test plan

- `:third-party-rc-embedded-player:check` — green (compile, Robolectric render harness, guard).
- `:third-party-rc-embedded-player-jvm:check` — green.

This is a behaviour-preserving swap, not a rendering change: `ImageShader` and `BitmapShader` are the same Skia construct reached through different type names, and the tile modes map one-for-one. No visual evidence embedded for that reason — but it is on the draw path, so the rc-compare lane is the place it would show up if that reasoning is wrong.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYTmD9R6gf92mATchtq461)_