### PR TITLE
test(rc-embedded-player): settle the RC harnesses on waitForIdle()

### DIFF
--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcEmbeddedRenderHarness.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcEmbeddedRenderHarness.kt
@@ -62,6 +62,15 @@ import org.robolectric.annotation.GraphicsMode
  * plain JVM through Compose Desktop's Skia backend with no Android runtime. Until then
  * `@GraphicsMode(NATIVE)` gives real pixels.
  *
+ * **Why the capture still draws the view by hand.** Every harness here settles with `waitForIdle()`
+ * now that the player's frame loop lets the composition reach idle ([RcIdleProbeTest]), but the
+ * rasterization itself stays a direct `View.draw(Canvas(bitmap))` rather than `captureToImage()`.
+ * That is a Robolectric limit, not a player one: `captureToImage()` calls `forceRedraw`, which waits
+ * on a `ViewTreeObserver.OnDrawListener` Robolectric never fires, and times out after 2s for *any*
+ * content — [RobolectricCaptureToImageProbeTest] pins that with a bare `Box` and no player at all.
+ * When that probe starts failing, Robolectric has grown the draw pass and this can become a
+ * `captureToImage()`.
+ *
  * Density is pinned: the catalogs capture at dpi 320, so documents carry dp->px factors for density
  * 2.0 (a 200dp preview bakes to 400px). `xhdpi` is that density — rendering at another one
  * re-lays-out the document and every row would diff on geometry instead of renderer behaviour.
@@ -113,12 +122,6 @@ class RcEmbeddedRenderHarness(private val entry: Entry) {
   }
 
   private fun renderToBitmap(bytes: ByteArray): Bitmap {
-    // The player animates off the frame clock and only breaks its loop for a fully static document,
-    // so the composition never reaches idle and every Compose test API that waits for idle times
-    // out. Driving the clock manually avoids that, and makes the capture deterministic — an
-    // auto-advancing clock would sample time-driven content at an arbitrary moment.
-    composeRule.mainClock.autoAdvance = false
-
     composeRule.setContent {
       val density = LocalDensity.current
       Box(
@@ -138,7 +141,10 @@ class RcEmbeddedRenderHarness(private val entry: Entry) {
       }
     }
 
-    repeat(FRAMES) { composeRule.mainClock.advanceTimeByFrame() }
+    // The player's frame loop used to keep the composition busy forever, so this harness pumped a
+    // fixed number of frames off a manually driven clock. #2945 fixed that, so settling is now just
+    // `waitForIdle()` and the render is whatever the document itself came to rest at.
+    composeRule.waitForIdle()
 
     val root = composeRule.activity.findViewById<ViewGroup>(android.R.id.content)
     // Force measure/layout at the document's exact size before drawing, so the draw can't land at
@@ -157,9 +163,6 @@ class RcEmbeddedRenderHarness(private val entry: Entry) {
   companion object {
     private const val INPUT_PROPERTY = "rc.embedded.input"
     private const val OUTPUT_PROPERTY = "rc.embedded.output"
-
-    /** Recompose, lay out, and let the player's frame loop settle time-driven state. */
-    private const val FRAMES = 4
 
     private fun inputDir(): File? =
       System.getProperty(INPUT_PROPERTY)?.let(::File)?.takeIf { it.isDirectory }

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcFigmaSvgExportTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcFigmaSvgExportTest.kt
@@ -231,13 +231,13 @@ class RcFigmaSvgExportTest {
    * layout-inspector walk reflects over `LayoutNode.getZSortedChildren`, empty until a draw z-sorts
    * them), then runs the production capture + hybrid figma-svg export and reads the SVG back.
    *
-   * The frame PNG is drawn straight off the content view rather than through Roborazzi: `RcPlayer`
-   * animates off the frame clock and never reaches idle, so every wait-for-idle capture API times
-   * out — the same manual-clock + direct-draw workaround `RcEmbeddedRenderHarness` documents.
+   * The frame PNG is drawn straight off the content view rather than through `captureToImage()`,
+   * which under Robolectric times out waiting for a draw pass that never runs — see
+   * [RobolectricCaptureToImageProbeTest] and the note on [RcEmbeddedRenderHarness]. The composition
+   * still settles with `waitForIdle()`, the manual frame pumping having gone with #2945.
    */
   private fun export(name: String, doc: Doc, content: @Composable (ByteArray) -> Unit): Lane {
     val rootDir = Files.createTempDirectory("rc-figma-svg-$name").toFile()
-    composeRule.mainClock.autoAdvance = false
 
     val slotTables = mutableSetOf<CompositionData>()
     var density = 1f
@@ -254,7 +254,7 @@ class RcFigmaSvgExportTest {
         }
       }
     }
-    repeat(FRAMES) { composeRule.mainClock.advanceTimeByFrame() }
+    composeRule.waitForIdle()
 
     val view = composeRule.activity.findViewById<ViewGroup>(android.R.id.content)
     view.measure(
@@ -391,7 +391,6 @@ class RcFigmaSvgExportTest {
   private companion object {
     const val INPUT_PROPERTY = "rc.embedded.input"
     const val REPORT_PROPERTY = "rc.semantics.report"
-    const val FRAMES = 4
     const val FIXTURE = "rc-fixtures/TitleCardRemote-640x480.rc"
   }
 }

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcIdleProbeTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcIdleProbeTest.kt
@@ -37,10 +37,17 @@ import org.robolectric.annotation.GraphicsMode
  *
  * `RcPlayer` drives time from a `LaunchedEffect` that never returns for an animated or time-driven
  * document. Requested through `withFrameMillis` that is indistinguishable from ordinary pending
- * work, so `waitForIdle()` blocks forever and every wait-for-idle capture API times out — which is
- * why the render harnesses drive `mainClock` by hand and draw the view directly. Requested through
- * `withInfiniteAnimationFrameMillis` it goes via the `InfiniteAnimationPolicy` the test framework
- * installs, and idle is reachable.
+ * work, so `waitForIdle()` blocks forever and every wait-for-idle capture API times out. Requested
+ * through `withInfiniteAnimationFrameMillis` it goes via the `InfiniteAnimationPolicy` the test
+ * framework installs, and idle is reachable.
+ *
+ * This is load-bearing, not merely a property worth recording: [RcEmbeddedRenderHarness],
+ * [RcViewPlayerRenderHarness], [RcSemanticsExtractionTest] and [RcFigmaSvgExportTest] all settle on
+ * `waitForIdle()` now. They used to disable the clock and pump a fixed number of frames precisely
+ * because they couldn't; a regression here takes all four out with it.
+ *
+ * Their *capture* is still a direct `View.draw(Canvas(bitmap))` — that half is Robolectric's, not
+ * the player's, and [RobolectricCaptureToImageProbeTest] holds the receipt.
  *
  * This asserts the property directly: compose a real document and call `waitForIdle()`. If the loop
  * regresses to `withFrameMillis` this test hangs and the suite times out rather than failing

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcSemanticsExtractionTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcSemanticsExtractionTest.kt
@@ -136,7 +136,6 @@ class RcSemanticsExtractionTest {
   private data class Captured(val nodes: Int, val texts: List<String>)
 
   private fun capture(width: Int, height: Int, content: @Composable () -> Unit): Captured {
-    composeRule.mainClock.autoAdvance = false
     composeRule.setContent {
       val density = LocalDensity.current
       Box(
@@ -145,7 +144,7 @@ class RcSemanticsExtractionTest {
         content()
       }
     }
-    repeat(4) { composeRule.mainClock.advanceTimeByFrame() }
+    composeRule.waitForIdle()
 
     val texts = mutableListOf<String>()
     var count = 0

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcViewPlayerRenderHarness.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcViewPlayerRenderHarness.kt
@@ -42,7 +42,7 @@ import org.robolectric.annotation.GraphicsMode
 /**
  * The **control** for [RcEmbeddedRenderHarness]: rasterizes the same documents through the
  * `remote-player-view`-backed [RemoteDocumentPlayer] in an otherwise identical harness — same
- * Robolectric config, same density, same manual clock, same software-canvas capture.
+ * Robolectric config, same density, same `waitForIdle()` + software-canvas capture.
  *
  * This exists to make divergences *attributable*. A row where the embedded player disagrees with the
  * baked PNG has at least three possible causes:
@@ -94,8 +94,6 @@ class RcViewPlayerRenderHarness(private val entry: RcEmbeddedRenderHarness.Entry
   }
 
   private fun renderToBitmap(bytes: ByteArray): Bitmap {
-    composeRule.mainClock.autoAdvance = false
-
     composeRule.setContent {
       val density = LocalDensity.current
       Box(
@@ -114,7 +112,7 @@ class RcViewPlayerRenderHarness(private val entry: RcEmbeddedRenderHarness.Entry
       }
     }
 
-    repeat(FRAMES) { composeRule.mainClock.advanceTimeByFrame() }
+    composeRule.waitForIdle()
 
     val root = composeRule.activity.findViewById<ViewGroup>(android.R.id.content)
     root.measure(
@@ -131,7 +129,6 @@ class RcViewPlayerRenderHarness(private val entry: RcEmbeddedRenderHarness.Entry
   companion object {
     private const val INPUT_PROPERTY = "rc.embedded.input"
     private const val OUTPUT_PROPERTY = "rc.view.output"
-    private const val FRAMES = 4
 
     private fun inputDir(): File? =
       System.getProperty(INPUT_PROPERTY)?.let(::File)?.takeIf { it.isDirectory }

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RobolectricCaptureToImageProbeTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RobolectricCaptureToImageProbeTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeTimeoutException
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Why the render harnesses still rasterize with `View.draw(Canvas(bitmap))` instead of
+ * `captureToImage()` — and the tripwire for when they no longer have to.
+ *
+ * [RcIdleProbeTest] pins the half of the story that #2945 fixed: the composition reaches idle, so
+ * `waitForIdle()` works and the harnesses no longer drive `mainClock` by hand. The capture half did
+ * *not* follow, and the reason has nothing to do with the player. `captureToImage()` goes through
+ * `WindowCapture.forceRedraw`, which registers a `ViewTreeObserver.OnDrawListener`, invalidates, and
+ * waits 2s for a draw pass. Robolectric never runs one, so the call times out — for **any** content.
+ *
+ * This composes a 10dp red `Box` with no Remote Compose document anywhere near it and asserts the
+ * timeout, so the constraint is attributed to the environment rather than re-blamed on `RcPlayer` the
+ * next time someone reads the harnesses.
+ *
+ * **When this test fails, that is the good outcome**: Robolectric (or `compose-ui-test`) has grown
+ * the draw pass, and [RcEmbeddedRenderHarness], [RcViewPlayerRenderHarness] and [RcFigmaSvgExportTest]
+ * can drop the manual `measure`/`layout`/`draw` for a `captureToImage()` — with a fresh md5 sweep,
+ * since that changes how the reference pixels are produced.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [34], qualifiers = "xhdpi")
+class RobolectricCaptureToImageProbeTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun captureToImageStillCannotDrawUnderRobolectric() {
+    composeRule.setContent { Box(Modifier.testTag(TAG).size(10.dp).background(Color.Red)) }
+    composeRule.waitForIdle()
+
+    val failure =
+      runCatching { composeRule.onNodeWithTag(TAG).captureToImage() }.exceptionOrNull()
+
+    assert(failure is ComposeTimeoutException) {
+      "captureToImage() no longer times out under Robolectric (got ${failure ?: "a real image"}) — " +
+        "the render harnesses can stop drawing the view by hand; see this test's KDoc"
+    }
+  }
+
+  private companion object {
+    const val TAG = "probe"
+  }
+}


### PR DESCRIPTION
Closes #2947. Follow-up to #2945, which fixed the `RcPlayer` frame loop so an animated document's composition can reach idle.

## What moved

The four harnesses carried two things that looked like one workaround. Only one of them was the player's doing.

**The clock is gone.** `RcEmbeddedRenderHarness`, `RcViewPlayerRenderHarness`, `RcSemanticsExtractionTest` and `RcFigmaSvgExportTest` no longer set `mainClock.autoAdvance = false` or pump `repeat(FRAMES) { advanceTimeByFrame() }`. They call `waitForIdle()` and render whatever the document itself came to rest at. No harness needed an exception — all four settle.

**The direct `View.draw(Canvas(bitmap))` stays**, and that is the deliberate exception #2947 asks to be named. It is not the player: `captureToImage()` goes through `WindowCapture.forceRedraw`, which registers a `ViewTreeObserver.OnDrawListener`, invalidates, and waits 2s for a draw pass Robolectric never runs. Measured, not assumed — a bare `Box(Modifier.size(10.dp).background(Color.Red))` with no Remote Compose document anywhere near it fails identically:

```
androidx.compose.ui.test.ComposeTimeoutException: Condition still not satisfied after 2000 ms
	at androidx.compose.ui.test.android.WindowCapture_androidKt.forceRedraw(WindowCapture.android.kt:124)
	at androidx.compose.ui.test.AndroidImageHelpers_androidKt.captureToImage(AndroidImageHelpers.android.kt:101)
```

New `RobolectricCaptureToImageProbeTest` pins that with exactly that `Box`, so the constraint stays attributed to the environment instead of being re-blamed on `RcPlayer` — and **fails loudly when it stops being true**, which is the signal to unwind the hand-drawing. `RcIdleProbeTest`'s KDoc now points at it for the capture half and drops the "which is why the harnesses drive `mainClock` by hand" clause for the clock half.

## Fresh md5 sweep — 24/24 byte-identical, both lanes

Staged from `design-artifacts/remote-m3` and run at `78b59f7` (this PR's base) with and without the change:

```sh
node scripts/design-artifacts/rc-compare.mjs --bundle bundle.png --player … \
  --out out --stage-embedded /tmp/rc-in            # staged 24 document(s)
./gradlew :third-party-rc-embedded-player:testDebugUnitTest --no-daemon \
  -Prc.embedded.input=/tmp/rc-in -Prc.embedded.output=… -Prc.view.output=…
```

| lane | documents | md5 vs base | errors |
|---|---|---|---|
| embedded (`RcEmbeddedRenderHarness`) | 24 | **24/24 identical** | 0 |
| view control (`RcViewPlayerRenderHarness`) | 24 | **24/24 identical** | 0 |

Nothing to explain and nothing rebaselined: the manual four-frame pump was already landing on the frame the composition settles at, so swapping it for `waitForIdle()` reproduces the reference pixels bit for bit. Scored against the baked PNGs the control is **mean 0.00%** (14 of 24 at exactly 0.00%, the rest 0.01–0.02% sub-pixel AA) and the embedded lane **mean 4.18%**, in line with the 4.16% recorded in `docs/design/evidence/rc-compare-embedded-lane/`.

## Test plan

- `./gradlew :third-party-rc-embedded-player:testDebugUnitTest` — 58 tests, all pass (24 + 24 harness cases, `RcFigmaSvgExportTest` ×2, `RcSemanticsExtractionTest` ×2, `RcIdleProbeTest`, `RobolectricCaptureToImageProbeTest`, `PlatformNeutralSourcesTest` ×4).
- `RcFigmaSvgExportTest` and `RcSemanticsExtractionTest` pass unchanged in intent — same assertions, only the settling changed.
- `./gradlew :third-party-rc-embedded-player:ktfmtCheck` — clean.

No visual surface changes: the rendered output is byte-identical by measurement, and the table above is the evidence.


---
_Generated by [Claude Code](https://claude.ai/code/session_0182H8MN4nLUGfSBAqLvirRK)_