### PR TITLE
feat(serve): make the producer-trust store pure config with an admin API

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.cli.serve.CatalogLoadTracker
 import ee.schimke.composeai.cli.serve.DaemonStartupLog
 import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
+import ee.schimke.composeai.cli.serve.MutableTrustStore
 import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundle
 import ee.schimke.composeai.cli.serve.ServeBundleDaemon
@@ -30,6 +31,8 @@ import ee.schimke.composeai.cli.serve.ServeSessionFactory
 import ee.schimke.composeai.cli.serve.ServeSessionRegistry
 import ee.schimke.composeai.cli.serve.ServeSessionState
 import ee.schimke.composeai.cli.serve.ServeStartupBundles
+import ee.schimke.composeai.cli.serve.ServeTrustAdmin
+import ee.schimke.composeai.cli.serve.ServeTrustStoreFile
 import ee.schimke.composeai.cli.serve.ServeUrls
 import ee.schimke.composeai.cli.serve.ServeWeb
 import ee.schimke.composeai.cli.serve.TrustStore
@@ -247,8 +250,18 @@ class ServeCommand(args: List<String>) : Command(args) {
    */
   private val trustStorePath: String? = args.flagValue("--trust-store")
 
-  /** Resolved once, reused by the upload store and the catalog store. */
-  private val resolvedTrust: TrustStore by lazy { loadTrustStore() }
+  /**
+   * The live producer-trust store, shared by the upload store, the catalog store, and the trust
+   * admin. Was a `by lazy` snapshot read once at startup, which meant an edit to producers.json —
+   * or an admin change — needed a restart to take effect; consumers now read through this holder on
+   * every verification instead.
+   */
+  private val trustStore: MutableTrustStore by lazy { MutableTrustStore(loadTrustStore()) }
+
+  /** The producers.json document backing [trustStore], when `--trust-store` names one. */
+  private val trustStoreFile: ServeTrustStoreFile? by lazy {
+    trustStorePath?.let { ServeTrustStoreFile(File(it).absolutePath.toPath()) }
+  }
 
   /**
    * Design systems to serve from their published `design-artifacts/<system>` branches (`--catalogs
@@ -288,10 +301,13 @@ class ServeCommand(args: List<String>) : Command(args) {
       ?.let { ServeCatalogsConfigFile(it.toPath()) }
 
   /**
-   * Shared secret for the runtime catalog-admin routes (`--admin-token`; env `SERVE_ADMIN_TOKEN`).
-   * Absent ⇒ `/admin/catalogs` isn't registered at all, so a server that didn't opt in has no admin
-   * surface. Deliberately distinct from the browse token: a `--public` box hands that one out to
-   * every visitor.
+   * Shared secret for the runtime admin routes (`--admin-token`; env `SERVE_ADMIN_TOKEN`) — both
+   * `/admin/catalogs` and `/admin/trust`. Absent ⇒ neither is registered at all, so a server that
+   * didn't opt in has no admin surface. Deliberately distinct from the browse token: a `--public`
+   * box hands that one out to every visitor.
+   *
+   * On a server running `--allow-render-trusted`, treat this as a code-execution credential:
+   * `/admin/trust` can make a producer's Compose eligible for server-side re-render here.
    */
   private val adminToken: String? = args.flagValue("--admin-token")?.takeIf { it.isNotBlank() }
 
@@ -808,7 +824,7 @@ class ServeCommand(args: List<String>) : Command(args) {
       root = uploads,
       register = { id, bundleHost -> registry.register(id, host = bundleHost, pinned = true) },
       allowedHosts = acceptBundlesFrom,
-      trust = resolvedTrust,
+      trust = { trustStore.get() },
     )
   }
 
@@ -886,6 +902,11 @@ class ServeCommand(args: List<String>) : Command(args) {
       } else {
         null
       }
+    // Runtime producer-trust administration. Needs only the admin token: unlike the catalog admin
+    // there's nothing to fetch, and a box with no trust store yet is exactly the one that most
+    // needs
+    // to be able to add its first producer without an image rebuild.
+    val trustAdmin = if (adminToken != null) ServeTrustAdmin(trustStore, trustStoreFile) else null
     val server =
       ServeHttpServer(
         host = host,
@@ -908,9 +929,17 @@ class ServeCommand(args: List<String>) : Command(args) {
         catalogRefreshSeconds = catalogRefreshSeconds,
         acceptBundlesEnabled = acceptBundles,
         catalogAdmin = catalogAdmin,
+        trustAdmin = trustAdmin,
         adminToken = adminToken,
         docStore = openDocStore(),
       )
+    if (trustAdmin != null) {
+      System.err.println(
+        "serve: trust admin API enabled at /admin/trust" +
+          (trustStoreFile?.let { " (persisting to ${it.displayPath})" }
+            ?: " (runtime only — pass --trust-store to persist)")
+      )
+    }
     if (catalogAdmin != null) {
       System.err.println(
         "serve: catalog admin API enabled at /admin/catalogs" +
@@ -1085,7 +1114,7 @@ class ServeCommand(args: List<String>) : Command(args) {
       ServeBundleStore(
         root = File(root, "baked").apply { mkdirs() },
         register = { id, host -> registry.register(id, host = host, pinned = true) },
-        trust = resolvedTrust,
+        trust = { trustStore.get() },
       )
     val registered = mutableListOf<String>()
     for (spec in bundleSpecs) {
@@ -1097,7 +1126,7 @@ class ServeCommand(args: List<String>) : Command(args) {
       // (harmless — an untrusted-branch origin just adds no basis).
       val origins = ServeStartupBundles.candidateOrigins(spec.source)
       val origin =
-        origins.firstOrNull { resolvedTrust.trustsBranch(it.repo, it.branch) }
+        origins.firstOrNull { trustStore.get().trustsBranch(it.repo, it.branch) }
           ?: origins.firstOrNull()
       val bundleFile = File(root, "${spec.name}.bundle")
       try {
@@ -1106,7 +1135,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         System.err.println("serve: bundle ${spec.name} could not be staged (${e.message})")
         continue
       }
-      val verdict = BundleVerifier.verify(bundleFile, resolvedTrust, origin)
+      val verdict = BundleVerifier.verify(bundleFile, trustStore.get(), origin)
       // Live lane: Trusted + operator opt-in. A desktop bundle materialises a daemon straight from
       // the bundle (no build); a non-desktop/foreign/empty bundle returns null → falls to baked.
       if (allowRenderTrusted && verdict is BundleVerifier.Verdict.Trusted) {
@@ -1219,7 +1248,7 @@ class ServeCommand(args: List<String>) : Command(args) {
       ServeCatalogStore(
         root = dir,
         register = { id, host -> registry.register(id, host = host, pinned = true) },
-        trust = resolvedTrust,
+        trust = { trustStore.get() },
         repo = catalogRepo,
         branchPrefix = catalogBranchPrefix,
         registerWasm = { system, wasmDir ->
@@ -1539,6 +1568,14 @@ class ServeCommand(args: List<String>) : Command(args) {
     val path = trustStorePath ?: return TrustStore.EMPTY
     val f = File(path)
     if (!f.isFile) {
+      // With the trust admin armed, an absent file is a legitimate starting state: the operator is
+      // about to create it through `POST /admin/trust`. Without it, a missing file is still fatal —
+      // silently trusting nothing is exactly the failure the hard exit exists to prevent.
+      if (adminToken != null) {
+        System.err.println("serve: --trust-store ${f.path} does not exist yet; starting with no")
+        System.err.println("serve: trusted producers (add them via POST /admin/trust)")
+        return TrustStore.EMPTY
+      }
       System.err.println("serve: --trust-store not found: ${f.path}")
       exitProcess(1)
     }
@@ -1781,12 +1818,18 @@ class ServeCommand(args: List<String>) : Command(args) {
                           "attributionRepos"), so an id like compose-m3 can't buy a section. Entries
                           here come first; --catalogs / --catalogs-unlisted add to them.
         --admin-token <value>
-                          Enable the runtime catalog-admin API and gate it with this secret:
-                          GET /admin/catalogs, POST /admin/catalogs (a catalogs.json entry as the
-                          body), DELETE /admin/catalogs/<system>. Mutations are applied live AND
-                          written back to --catalogs-file, so they survive a restart. Separate from
-                          --token on purpose (a --public box hands that one to every visitor);
-                          omitted = the admin routes don't exist at all.
+                          Enable the runtime admin API and gate it with this secret. Two surfaces:
+                          the catalog set — GET /admin/catalogs, POST /admin/catalogs (a
+                          catalogs.json entry as the body), DELETE /admin/catalogs/<system> — and
+                          the producer-trust store — GET /admin/trust, POST /admin/trust
+                          ({"kind":"branch"|"key"|"oidc",…}), DELETE /admin/trust?kind=&repo=…
+                          (selectors ride the query string so an owner/repo needn't be escaped).
+                          Mutations are applied live AND written back to --catalogs-file /
+                          --trust-store, so they survive a restart. Separate from --token on purpose
+                          (a --public box hands that one to every visitor); omitted = the admin
+                          routes don't exist at all. NB with --allow-render-trusted this token can
+                          grant server-side execution, since trusting a branch makes that
+                          producer's Compose eligible for re-render here.
         --catalog-repo <owner/repo>
                           Default repo the catalogs are fetched from (default
                           yschimke/compose-ai-tools); per-entry @<owner>/<repo> overrides it.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -256,7 +256,16 @@ class ServeCommand(args: List<String>) : Command(args) {
    * or an admin change — needed a restart to take effect; consumers now read through this holder on
    * every verification instead.
    */
-  private val trustStore: MutableTrustStore by lazy { MutableTrustStore(loadTrustStore()) }
+  private val trustStore: MutableTrustStore by lazy {
+    MutableTrustStore(loadTrustStore(), source = trustStoreFile)
+  }
+
+  /**
+   * The running branch poller, when there is one. Held so a trust revocation can invalidate the
+   * remembered branch heads of the catalogs it just retired ([retireNewlyUntrusted]); the refresher
+   * is built before the server and reaches it only as a closeable, so there's no other handle.
+   */
+  @Volatile private var activeRefresher: ServeCatalogRefresher? = null
 
   /** The producers.json document backing [trustStore], when `--trust-store` names one. */
   private val trustStoreFile: ServeTrustStoreFile? by lazy {
@@ -636,6 +645,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         ?.also {
           it.seedInitialHeads(catalogReg.loads.availableSystems())
           it.start()
+          activeRefresher = it
         }
     // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
     // registered as a pinned session. Unpacked under a temp dir for this server's lifetime.
@@ -697,6 +707,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         ?.also {
           it.seedInitialHeads(catalogReg.loads.availableSystems())
           it.start()
+          activeRefresher = it
         }
     val bundleStore = if (acceptBundles) openUploadStore(registry) else null
 
@@ -906,7 +917,21 @@ class ServeCommand(args: List<String>) : Command(args) {
     // there's nothing to fetch, and a box with no trust store yet is exactly the one that most
     // needs
     // to be able to add its first producer without an image rebuild.
-    val trustAdmin = if (adminToken != null) ServeTrustAdmin(trustStore, trustStoreFile) else null
+    val trustAdmin =
+      if (adminToken != null) {
+        ServeTrustAdmin(
+          store = trustStore,
+          file = trustStoreFile,
+          // Revoking trust must retire what that trust was already buying. Each affected catalog's
+          // session (and its live daemon, via unregister) is dropped and its tracker row marked
+          // failed, so the branch refresher re-fetches it and it comes back re-verified — as
+          // `unverified`, serving baked data tiers only, instead of keeping a stale Trusted
+          // verdict.
+          onRevoke = { updated -> retireNewlyUntrusted(updated, catalogLoads, registry) },
+        )
+      } else {
+        null
+      }
     val server =
       ServeHttpServer(
         host = host,
@@ -1556,6 +1581,42 @@ class ServeCommand(args: List<String>) : Command(args) {
         "(?session=$system)"
     )
     return true
+  }
+
+  /**
+   * Drop every registered catalog whose source branch [updated] no longer trusts.
+   *
+   * Called after a trust revocation. Unregistering closes the session's host, which is what takes
+   * down a live daemon started under the old verdict; marking the tracker row failed is what gets
+   * the catalog re-fetched — [ServeCatalogRefresher] skips a reload while the branch SHA is
+   * unchanged, so a revoked-but-still-loaded catalog would otherwise keep serving as `Trusted`
+   * until its branch moved or the box restarted.
+   */
+  private fun retireNewlyUntrusted(
+    updated: TrustStore,
+    tracker: CatalogLoadTracker?,
+    registry: ServeSessionRegistry,
+  ) {
+    val loads = tracker ?: return
+    val retired = mutableListOf<String>()
+    for (state in loads.snapshot()) {
+      val repo = state.config.repo
+      val branch = state.config.branch
+      if (updated.trustsBranch(repo, branch)) continue
+      // Only a catalog that actually loaded under the old trust needs tearing down; a pending or
+      // already-failed row has nothing serving to revoke.
+      if (!state.available) continue
+      registry.unregister(state.config.system)
+      loads.recordFailure(state.config.system, "producer trust revoked; awaiting re-verification")
+      retired += state.config.system
+      System.err.println(
+        "serve: retired ${state.config.system} — $repo@$branch is no longer trusted"
+      )
+    }
+    // Clear the remembered branch heads so the next refresh pass re-fetches these instead of
+    // short-circuiting on an unchanged SHA — without this the teardown would be undone only by a
+    // branch move or a restart.
+    if (retired.isNotEmpty()) activeRefresher?.forgetHeads(retired)
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -44,8 +44,11 @@ class ServeBundleStore(
    * Data tiers (the extracted `previews/<id>.png`) are served regardless — the verdict gates only
    * whether the operator would later re-render the bundle's executable Compose. Defaults to the
    * empty (fail-closed) store, so without `--trust-store` every upload is `unverified`.
+   *
+   * Read per upload rather than captured, so an admin-added producer applies to the next upload
+   * without a restart.
    */
-  private val trust: TrustStore = TrustStore.EMPTY,
+  private val trust: () -> TrustStore = { TrustStore.EMPTY },
 ) {
 
   sealed interface Result {
@@ -99,7 +102,7 @@ class ServeBundleStore(
     // Attribute the upload to a trusted producer if it carries a verifiable signature (origin trust
     // is for server-fetched catalogs, not client uploads, so no Origin here). The verdict travels
     // with the host for display; it never blocks serving the already-extracted data tiers.
-    val verdict = BundleVerifier.verify(zip, trust, origin)
+    val verdict = BundleVerifier.verify(zip, trust(), origin)
     val host = ServeBundleHost(dir, safe, verdict)
     register(safe, host)
     return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict))

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -64,6 +64,19 @@ internal class ServeCatalogRefresher(
     }
   }
 
+  /**
+   * Forget the recorded head for [systems], so the next [tick] re-fetches them even though their
+   * branch hasn't moved.
+   *
+   * The SHA short-circuit in [checkOne] is what makes polling cheap, but it also means a catalog
+   * can only be re-verified when its branch changes. Revoking a producer's trust has to re-verify
+   * *now* — otherwise the revoked catalog keeps whatever verdict it loaded with, potentially
+   * indefinitely.
+   */
+  fun forgetHeads(systems: Collection<String>) {
+    for (system in systems) lastHead.remove(system)
+  }
+
   /** Start the daemon poller. Idempotent-safe to call once after [seedInitialHeads]. */
   fun start() {
     exec.scheduleWithFixedDelay(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -38,7 +38,12 @@ import okhttp3.Request
 class ServeCatalogStore(
   private val root: File,
   private val register: (name: String, host: ServeBundleHost) -> Unit,
-  private val trust: TrustStore,
+  /**
+   * The producer-trust store, read **per fetch** rather than captured, so a producer added through
+   * the admin API (or hand-edited into producers.json) is in force for the next catalog load and
+   * the next branch refresh without a restart.
+   */
+  private val trust: () -> TrustStore,
   private val repo: String = DEFAULT_REPO,
   private val branchPrefix: String = DEFAULT_BRANCH_PREFIX,
   private val fetch: ((String) -> ByteArray?)? = null,
@@ -294,7 +299,7 @@ class ServeCatalogStore(
     val wasmRegistered = fetchWasmApp(catalog.webRender, base, dir, safe)
 
     val verdict =
-      if (trust.trustsBranch(repo, branch))
+      if (trust().trustsBranch(repo, branch))
         BundleVerifier.Verdict.Trusted(listOf(BundleVerifier.Basis.Branch(repo, branch)))
       else BundleVerifier.Verdict.Unverified("branch $repo@$branch is not trusted")
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -167,6 +167,15 @@ class ServeHttpServer(
    */
   private val catalogAdmin: ServeCatalogAdmin? = null,
   /**
+   * Runtime producer-trust administration ([ServeTrustAdmin]) — adding and removing trusted
+   * branches / keys / CI identities without an image rebuild. Gated by the same [adminToken] as
+   * [catalogAdmin]; null ⇒ the `/admin/trust` routes are **not registered at all**.
+   *
+   * Note this token is more powerful than it looks on a box running `--allow-render-trusted`:
+   * trusting a branch there makes that producer's Compose eligible for server-side execution.
+   */
+  private val trustAdmin: ServeTrustAdmin? = null,
+  /**
    * Shared secret for the `/admin/catalogs` routes (`--admin-token`). Separate from the browsing
    * [token] on purpose: a public box hands its browse URL to everyone, so admin needs its own
    * credential and must stay gated even when [isPublic] is set. Null/blank ⇒ no admin routes, so a
@@ -240,6 +249,9 @@ class ServeHttpServer(
    * who never set a token gets no admin surface, not an open one.
    */
   private val adminEnabled: Boolean = catalogAdmin != null && !adminToken.isNullOrBlank()
+
+  /** As [adminEnabled], for the `/admin/trust` routes. Same token, separately supplied admin. */
+  private val trustAdminEnabled: Boolean = trustAdmin != null && !adminToken.isNullOrBlank()
 
   private val server: EmbeddedServer<*, *> =
     embeddedServer(CIO, host = host, port = port) {
@@ -447,6 +459,38 @@ class ServeHttpServer(
             val system = call.parameters["system"].orEmpty()
             val result = withContext(Dispatchers.IO) { admin.unregister(system) }
             respondAdminResult(result)
+          }
+        }
+
+        // Runtime producer-trust administration. The trust store is operator config on the same
+        // volume as catalogs.json, so a producer can be trusted on a running box — which is what
+        // makes runtime catalog registration useful at all: without it a catalog published via
+        // `POST /admin/catalogs` serves, but badges `unverified` until an image rebuild ships a new
+        // baked trust store. Removal is by the same discriminated entry shape as addition, with the
+        // selector fields (`repo`, `keyId`, `identity`) carried as query parameters so an
+        // `<owner>/<repo>` pattern needn't be path-escaped.
+        if (trustAdminEnabled) {
+          val admin = trustAdmin!!
+          get("/admin/trust") {
+            if (rejectBadAdminToken()) return@get
+            respondAdminTrust(admin)
+          }
+          post("/admin/trust") {
+            if (rejectBadAdminToken()) return@post
+            handleAdminTrustAdd(admin)
+          }
+          delete("/admin/trust") {
+            if (rejectBadAdminToken()) return@delete
+            val q = call.request.queryParameters
+            val entry =
+              AdminTrustEntry(
+                kind = q["kind"] ?: "branch",
+                repo = q["repo"],
+                branch = q["branch"],
+                keyId = q["keyId"],
+                identity = q["identity"],
+              )
+            respondAdminTrustResult(withContext(Dispatchers.IO) { admin.remove(entry) })
           }
         }
 
@@ -934,6 +978,64 @@ class ServeHttpServer(
           "catalog ${result.system} not published: ${result.reason}",
           status = HttpStatusCode.BadGateway,
         )
+    }
+  }
+
+  /**
+   * `GET /admin/trust`: the producers currently trusted.
+   *
+   * Pinned public keys are listed by id and name only — the key material itself is in the
+   * operator's producers.json and there's no reason to echo it back over the network.
+   */
+  private suspend fun RoutingContext.respondAdminTrust(admin: ServeTrustAdmin) {
+    val store = withContext(Dispatchers.IO) { admin.list() }
+    call.respondText(
+      JSON.encodeToString(
+        AdminTrustResponse.serializer(),
+        AdminTrustResponse(
+          branches = store.branches.map { AdminTrustBranchDto(it.repo, it.branch) },
+          keys = store.keys.map { AdminTrustKeyDto(it.keyId, it.name) },
+          oidc = store.oidc.map { it.identity },
+        ),
+      ),
+      ContentType.Application.Json,
+    )
+  }
+
+  /** `POST /admin/trust`: trust one producer from an [AdminTrustEntry] JSON body. */
+  private suspend fun RoutingContext.handleAdminTrustAdd(admin: ServeTrustAdmin) {
+    val body =
+      withContext(Dispatchers.IO) {
+        call.receiveStream().use { readCapped(it, MAX_ADMIN_BODY_BYTES) }
+      }
+    if (body == null) {
+      call.respondText("request body too large", status = HttpStatusCode.PayloadTooLarge)
+      return
+    }
+    val entry =
+      runCatching { JSON.decodeFromString(AdminTrustEntry.serializer(), body.decodeToString()) }
+        .getOrElse {
+          call.respondText("invalid trust entry: ${it.message}", status = HttpStatusCode.BadRequest)
+          return
+        }
+    respondAdminTrustResult(withContext(Dispatchers.IO) { admin.add(entry) })
+  }
+
+  /** Map a [ServeTrustAdmin.Result] onto its HTTP status + JSON body. */
+  private suspend fun RoutingContext.respondAdminTrustResult(result: ServeTrustAdmin.Result) {
+    when (result) {
+      is ServeTrustAdmin.Result.Ok ->
+        call.respondText(
+          JSON.encodeToString(
+            AdminTrustResult.serializer(),
+            AdminTrustResult(producer = result.summary, status = "ok", warning = result.warning),
+          ),
+          ContentType.Application.Json,
+        )
+      is ServeTrustAdmin.Result.Invalid ->
+        call.respondText(result.reason, status = HttpStatusCode.BadRequest)
+      is ServeTrustAdmin.Result.Conflict ->
+        call.respondText(result.reason, status = HttpStatusCode.Conflict)
     }
   }
 
@@ -2632,6 +2734,35 @@ private data class AdminCatalogsResponse(
 private data class AdminCatalogResult(
   val schema: String = "compose-preview-serve/admin-catalog/v1",
   val system: String,
+  val status: String,
+  val warning: String? = null,
+)
+
+/** One trusted branch on `GET /admin/trust`. */
+@Serializable private data class AdminTrustBranchDto(val repo: String, val branch: String)
+
+/**
+ * One pinned key on `GET /admin/trust` — id and label only. The key material stays in the
+ * operator's producers.json rather than being echoed back over the network.
+ */
+@Serializable private data class AdminTrustKeyDto(val keyId: String, val name: String? = null)
+
+@Serializable
+private data class AdminTrustResponse(
+  val schema: String = "compose-preview-serve/admin-trust/v1",
+  val branches: List<AdminTrustBranchDto> = emptyList(),
+  val keys: List<AdminTrustKeyDto> = emptyList(),
+  val oidc: List<String> = emptyList(),
+)
+
+/**
+ * The result of a trust mutation. [warning] is set when the change is in force on the running
+ * server but couldn't be written back to producers.json — it will not survive a restart.
+ */
+@Serializable
+private data class AdminTrustResult(
+  val schema: String = "compose-preview-serve/admin-trust-result/v1",
+  val producer: String,
   val status: String,
   val warning: String? = null,
 )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdmin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdmin.kt
@@ -1,0 +1,248 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.io.SystemFileSystem
+import kotlinx.serialization.Serializable
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
+/**
+ * The `producers.json` file itself — the operator's trust store as an editable document.
+ *
+ * Mirrors [ServeCatalogsConfigFile] deliberately: same staged-write discipline, same "absent file
+ * reads as empty" rule, same Okio [FileSystem] injection so tests drive it with a fake. The trust
+ * store used to be baked into the container image, which made adding a producer a code change —
+ * open a PR, wait for a release, wait for an image publish, wait for a roll — even though the box
+ * could publish a *catalog* at runtime in one HTTP call. That asymmetry made runtime catalog
+ * registration close to useless: the new catalog served, but badged `unverified` until an image
+ * caught up. Moving this file onto the same config volume as `catalogs.json` closes it.
+ */
+class ServeTrustStoreFile(
+  private val path: Path,
+  private val fileSystem: FileSystem = SystemFileSystem,
+) {
+  val displayPath: String
+    get() = path.toString()
+
+  fun exists(): Boolean = fileSystem.exists(path)
+
+  /** Parse the file; an absent file is the empty fail-closed store. Throws on malformed JSON. */
+  fun load(): TrustStore {
+    if (!fileSystem.exists(path)) return TrustStore.EMPTY
+    return TrustStore.parse(fileSystem.read(path) { readUtf8() })
+  }
+
+  /**
+   * Write [store] back, staged through a sibling temp file + [FileSystem.atomicMove]. A truncated
+   * trust store is worse than a truncated catalog list: it fails *closed*, so every catalog on the
+   * box would silently drop to `unverified` on the next boot.
+   */
+  fun save(store: TrustStore) {
+    val parent = path.parent
+    parent?.let { fileSystem.createDirectories(it) }
+    val tmp = if (parent != null) parent / "${path.name}.tmp" else "${path.name}.tmp".toPath()
+    fileSystem.write(tmp) { writeUtf8(TrustStore.encode(store)) }
+    fileSystem.atomicMove(tmp, path)
+  }
+}
+
+/**
+ * A trust store that can change while the server runs.
+ *
+ * [TrustStore] is an immutable value read on every verification, and it used to be resolved once
+ * into a `by lazy` val at startup — so an edit to producers.json needed a restart to take effect.
+ * Consumers ([ServeCatalogStore], [ServeBundleStore]) now take a `() -> TrustStore` and call it per
+ * verification, which makes the *next* catalog fetch or bundle upload see an admin change with no
+ * restart. Reads are lock-free through the `@Volatile` reference; writers serialise in
+ * [ServeTrustAdmin].
+ */
+class MutableTrustStore(initial: TrustStore = TrustStore.EMPTY) {
+  @Volatile private var current: TrustStore = initial
+
+  fun get(): TrustStore = current
+
+  fun set(store: TrustStore) {
+    current = store
+  }
+}
+
+/**
+ * One producer entry on the admin API — a flat, discriminated shape covering all three trust bases.
+ *
+ * Flat rather than a sealed hierarchy because it's also the wire DTO: `kind` picks which fields
+ * matter, which keeps the request body obvious to write by hand (`curl -d '{"kind":"branch",…}'`)
+ * and keeps one route pair instead of three.
+ */
+@Serializable
+data class AdminTrustEntry(
+  /** `branch`, `key`, or `oidc`. */
+  val kind: String,
+  /** `branch`: the `<owner>/<repo>` pattern. */
+  val repo: String? = null,
+  /** `branch`: the branch-name pattern; defaults to the [TrustedBranch] default (`*`). */
+  val branch: String? = null,
+  /** `key`: the pinned key's id. */
+  val keyId: String? = null,
+  /** `key`: PEM or base64 X.509 SPKI. */
+  val publicKey: String? = null,
+  /** `key`: an optional human label. */
+  val name: String? = null,
+  /** `oidc`: the workload-identity pattern. */
+  val identity: String? = null,
+)
+
+/**
+ * Add and remove trusted producers on a **running** server, and persist the result.
+ *
+ * The runtime half of making the trust store config, exactly as [ServeCatalogAdmin] is for the
+ * catalog set. Same contract in both directions: validate first, mutate the live store, then write
+ * the file back; a persistence failure downgrades to a warning on an otherwise-successful result
+ * rather than rolling back, because the in-memory change is already serving.
+ *
+ * **This grants more than it looks like.** With `--allow-render-trusted` a trusted branch is
+ * eligible for server-side re-render — the box builds and executes that producer's Compose. So the
+ * admin token is, on such a box, effectively a code-execution credential. That is why the routes
+ * are off unless `--admin-token` is set, why the token is separate from the browse token, and why
+ * [TrustStore.validateBranch] refuses a match-everything repo pattern.
+ */
+class ServeTrustAdmin(
+  private val store: MutableTrustStore,
+  /** The operator's producers.json; null ⇒ changes are runtime-only and don't survive a restart. */
+  private val file: ServeTrustStoreFile?,
+  private val onLog: (String) -> Unit = { System.err.println(it) },
+) {
+  /**
+   * Serialises the whole load-modify-save, not just the save — same lost-update hazard
+   * [ServeCatalogAdmin] guards: two concurrent adds would each load the same document, apply one
+   * edit, and atomically move, silently discarding the loser.
+   */
+  private val lock = Any()
+
+  /** The outcome of an admin mutation, mapped to an HTTP status by the caller. */
+  sealed interface Result {
+    /** Applied. [warning] flags a non-fatal persistence failure. */
+    data class Ok(val summary: String, val warning: String? = null) : Result
+
+    /** Malformed entry — a 400. */
+    data class Invalid(val reason: String) : Result
+
+    /** Already trusted (add) or not trusted (remove) — a 409 / 404. */
+    data class Conflict(val reason: String) : Result
+  }
+
+  /** The producers currently trusted. */
+  fun list(): TrustStore = store.get()
+
+  /**
+   * Trust [entry]. Idempotency is a conflict, not a silent no-op, so a typo'd repeat is visible.
+   */
+  fun add(entry: AdminTrustEntry): Result =
+    when (entry.kind) {
+      "branch" -> addBranch(entry)
+      "key" -> addKey(entry)
+      "oidc" -> addIdentity(entry)
+      else -> Result.Invalid("unknown trust kind '${entry.kind}' (branch, key, or oidc)")
+    }
+
+  /** Stop trusting the producer [entry] identifies. */
+  fun remove(entry: AdminTrustEntry): Result =
+    when (entry.kind) {
+      "branch" -> {
+        val repo = entry.repo
+        if (repo.isNullOrBlank()) Result.Invalid("branch removal needs a repo")
+        else
+          mutate("branch $repo@${entry.branch ?: "*"}") { current ->
+            val match =
+              current.branches.firstOrNull {
+                it.repo == repo && (entry.branch == null || it.branch == entry.branch)
+              } ?: return@mutate null
+            current.copy(branches = current.branches - match)
+          }
+      }
+      "key" -> {
+        val keyId = entry.keyId
+        if (keyId.isNullOrBlank()) Result.Invalid("key removal needs a keyId")
+        else
+          mutate("key $keyId") { current ->
+            val match = current.keys.firstOrNull { it.keyId == keyId } ?: return@mutate null
+            current.copy(keys = current.keys - match)
+          }
+      }
+      "oidc" -> {
+        val identity = entry.identity
+        if (identity.isNullOrBlank()) Result.Invalid("oidc removal needs an identity")
+        else
+          mutate("oidc $identity") { current ->
+            val match = current.oidc.firstOrNull { it.identity == identity } ?: return@mutate null
+            current.copy(oidc = current.oidc - match)
+          }
+      }
+      else -> Result.Invalid("unknown trust kind '${entry.kind}' (branch, key, or oidc)")
+    }
+
+  private fun addBranch(entry: AdminTrustEntry): Result {
+    val repo = entry.repo
+    if (repo.isNullOrBlank()) return Result.Invalid("branch entry needs a repo")
+    val branch = TrustedBranch(repo = repo, branch = entry.branch ?: "*")
+    TrustStore.validateBranch(branch)?.let {
+      return Result.Invalid(it)
+    }
+    return mutate("branch ${branch.repo}@${branch.branch}") { current ->
+      if (current.branches.any { it.repo == branch.repo && it.branch == branch.branch }) null
+      else current.copy(branches = current.branches + branch)
+    }
+  }
+
+  private fun addKey(entry: AdminTrustEntry): Result {
+    val key =
+      TrustedKey(
+        keyId = entry.keyId.orEmpty(),
+        publicKey = entry.publicKey.orEmpty(),
+        name = entry.name,
+      )
+    TrustStore.validateKey(key)?.let {
+      return Result.Invalid(it)
+    }
+    return mutate("key ${key.keyId}") { current ->
+      if (current.keys.any { it.keyId == key.keyId }) null
+      else current.copy(keys = current.keys + key)
+    }
+  }
+
+  private fun addIdentity(entry: AdminTrustEntry): Result {
+    val identity = TrustedIdentity(entry.identity.orEmpty())
+    TrustStore.validateIdentity(identity)?.let {
+      return Result.Invalid(it)
+    }
+    return mutate("oidc ${identity.identity}") { current ->
+      if (current.oidc.any { it.identity == identity.identity }) null
+      else current.copy(oidc = current.oidc + identity)
+    }
+  }
+
+  /**
+   * Apply [edit] to the trust store under [lock] and publish the result. [edit] returns null when
+   * the change is a no-op (already trusted / not trusted), which becomes a [Result.Conflict].
+   *
+   * The document is re-read from the file first, not taken from memory, so an operator's hand-edit
+   * between admin calls isn't clobbered — the same rule [ServeCatalogAdmin.persist] follows.
+   */
+  private fun mutate(summary: String, edit: (TrustStore) -> TrustStore?): Result =
+    synchronized(lock) {
+      val onDisk = file?.let { runCatching { it.load() }.getOrNull() }
+      val current = onDisk ?: store.get()
+      val updated = edit(current) ?: return Result.Conflict("$summary: no change")
+      store.set(updated)
+      val target = file
+      val warning =
+        if (target == null) "not persisted: no trust store file is configured"
+        else
+          runCatching { target.save(updated) }
+            .fold({ null }) { e ->
+              onLog("serve: could not update ${target.displayPath}: ${e.message}")
+              "not persisted: ${e.message ?: "write failed"}"
+            }
+      onLog("serve: trust $summary updated via admin API")
+      Result.Ok(summary, warning)
+    }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdmin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdmin.kt
@@ -56,10 +56,41 @@ class ServeTrustStoreFile(
  * restart. Reads are lock-free through the `@Volatile` reference; writers serialise in
  * [ServeTrustAdmin].
  */
-class MutableTrustStore(initial: TrustStore = TrustStore.EMPTY) {
+class MutableTrustStore(
+  initial: TrustStore = TrustStore.EMPTY,
+  /**
+   * The backing document, when there is one. Given a [source], [get] also picks up an operator's
+   * **direct** edit to producers.json — without it, a hand-edit would sit unnoticed until the next
+   * admin call or a restart, which is exactly the staleness this class exists to remove.
+   */
+  private val source: ServeTrustStoreFile? = null,
+  private val onLog: (String) -> Unit = { System.err.println(it) },
+) {
   @Volatile private var current: TrustStore = initial
 
-  fun get(): TrustStore = current
+  /**
+   * The trust store as of now, re-read from [source] on every call.
+   *
+   * Deliberately not mtime-gated. Filesystem timestamp granularity is coarse enough that two writes
+   * inside the same tick are indistinguishable, so a "has it changed?" check can silently miss an
+   * edit — the exact staleness this exists to remove. Re-parsing instead is affordable because a
+   * verification is *rare and expensive*: it accompanies a catalog branch fetch or the hashing of
+   * an uploaded bundle, next to which reading a few KB of JSON does not register.
+   */
+  fun get(): TrustStore {
+    val file = source ?: return current
+    // Only a successfully parsed, present file replaces what's in force. A malformed or truncated
+    // edit — or a deleted file — keeps the last good store rather than dropping to EMPTY: failing
+    // closed here would silently un-trust every catalog on the box mid-flight over a half-saved
+    // write. The admin API separately refuses to *write* over an unreadable document, so stale
+    // state can't be laundered back onto disk.
+    if (file.exists()) {
+      runCatching { file.load() }
+        .onSuccess { current = it }
+        .onFailure { onLog("serve: ignoring unreadable ${file.displayPath}: ${it.message}") }
+    }
+    return current
+  }
 
   fun set(store: TrustStore) {
     current = store
@@ -109,6 +140,14 @@ class ServeTrustAdmin(
   private val store: MutableTrustStore,
   /** The operator's producers.json; null ⇒ changes are runtime-only and don't survive a restart. */
   private val file: ServeTrustStoreFile?,
+  /**
+   * Called with the reduced store after trust is **removed**, so the caller can retire anything
+   * that was already trusted under the old one. Revocation that only affects future verifications
+   * isn't revocation: a loaded catalog keeps its `Trusted` verdict (and any live daemon) in the
+   * session registry, and the branch refresher skips a reload while the branch SHA is unchanged —
+   * so without this the producer stays executable until its branch moves or the box restarts.
+   */
+  private val onRevoke: (TrustStore) -> Unit = {},
   private val onLog: (String) -> Unit = { System.err.println(it) },
 ) {
   /**
@@ -229,11 +268,25 @@ class ServeTrustAdmin(
    */
   private fun mutate(summary: String, edit: (TrustStore) -> TrustStore?): Result =
     synchronized(lock) {
-      val onDisk = file?.let { runCatching { it.load() }.getOrNull() }
-      val current = onDisk ?: store.get()
+      val target = file
+      // An UNREADABLE existing document aborts the mutation instead of falling back to the cached
+      // store. Swallowing the parse error and saving would replace a half-written or malformed
+      // producers.json with stale state plus this edit — silently resurrecting entries the operator
+      // was in the middle of removing, which is the opposite of the hand-edit rule below. An ABSENT
+      // file is different and fine: there's nothing to lose, so it reads as the empty store.
+      val current =
+        if (target == null) store.get()
+        else
+          runCatching { target.load() }
+            .getOrElse { e ->
+              onLog("serve: refusing to rewrite unreadable ${target.displayPath}: ${e.message}")
+              return Result.Invalid(
+                "trust store ${target.displayPath} is present but unreadable " +
+                  "(${e.message ?: "parse failed"}); fix or remove it before editing trust"
+              )
+            }
       val updated = edit(current) ?: return Result.Conflict("$summary: no change")
       store.set(updated)
-      val target = file
       val warning =
         if (target == null) "not persisted: no trust store file is configured"
         else
@@ -243,6 +296,19 @@ class ServeTrustAdmin(
               "not persisted: ${e.message ?: "write failed"}"
             }
       onLog("serve: trust $summary updated via admin API")
+      // Anything that was trusted only under the old store has to be retired now, not at the next
+      // branch move. Runs inside the lock so a concurrent add can't re-trust mid-teardown; failures
+      // are logged rather than thrown, since the trust change itself has already taken effect.
+      if (isReduction(current, updated)) {
+        runCatching { onRevoke(updated) }
+          .onFailure { onLog("serve: revocation cleanup after $summary failed: ${it.message}") }
+      }
       Result.Ok(summary, warning)
     }
+
+  /** True when [updated] trusts strictly less than [before] — i.e. this was a revocation. */
+  private fun isReduction(before: TrustStore, updated: TrustStore): Boolean =
+    updated.branches.size < before.branches.size ||
+      updated.keys.size < before.keys.size ||
+      updated.oidc.size < before.oidc.size
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/TrustStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/TrustStore.kt
@@ -52,6 +52,20 @@ data class TrustStore(
   companion object {
     private val json = Json { ignoreUnknownKeys = true }
 
+    /**
+     * Writer JSON. Distinct from [json] because rewriting the operator's producers.json has
+     * different needs from reading it: the file stays hand-editable, so it's pretty-printed, and
+     * defaults are written out rather than elided (a [TrustedBranch] that defaults `branch` to `*`
+     * must say so on disk — an operator reading back a bare `{"repo": …}` would have no way to see
+     * that it trusts every branch).
+     */
+    private val writerJson = Json {
+      ignoreUnknownKeys = true
+      prettyPrint = true
+      prettyPrintIndent = "  "
+      encodeDefaults = true
+    }
+
     /** The empty, fail-closed store — trusts nothing. */
     val EMPTY = TrustStore()
 
@@ -59,6 +73,50 @@ data class TrustStore(
       json.decodeFromString(serializer(), file.readText(Charsets.UTF_8))
 
     fun parse(text: String): TrustStore = json.decodeFromString(serializer(), text)
+
+    fun encode(store: TrustStore): String = writerJson.encodeToString(serializer(), store) + "\n"
+
+    /**
+     * Producer patterns are globs, so this is deliberately looser than a catalog repo slug — but
+     * still a slug alphabet, because a pattern with a newline or a space is a typo that would
+     * silently never match.
+     */
+    private val REPO_PATTERN_RE = Regex("[A-Za-z0-9._*-]{1,64}/[A-Za-z0-9._*-]{1,64}")
+    private val BRANCH_PATTERN_RE = Regex("[A-Za-z0-9._*/-]{1,128}")
+
+    /**
+     * Why [branch] is unusable as a trust entry, or null when it's well-formed.
+     *
+     * A repo pattern whose every non-slash character is a wildcard is rejected outright. Branch
+     * trust is not only a badge — with `--allow-render-trusted` it gates server-side execution of
+     * the producer's Compose — so a match-everything pattern would hand code execution to any repo
+     * on GitHub. There is no legitimate use for it, and the failure mode is bad enough that a typo
+     * shouldn't be able to reach it.
+     */
+    fun validateBranch(branch: TrustedBranch): String? =
+      when {
+        !REPO_PATTERN_RE.matches(branch.repo) -> "invalid repo pattern '${branch.repo}'"
+        !BRANCH_PATTERN_RE.matches(branch.branch) -> "invalid branch pattern '${branch.branch}'"
+        branch.repo.replace("/", "").all { it == '*' } ->
+          "repo pattern '${branch.repo}' matches every repository; name an owner"
+        else -> null
+      }
+
+    /**
+     * Why [key] is unusable, or null when it's well-formed (and its public key actually parses).
+     */
+    fun validateKey(key: TrustedKey): String? =
+      when {
+        key.keyId.isBlank() -> "key entry needs a keyId"
+        key.publicKey.isBlank() -> "key '${key.keyId}' needs a publicKey"
+        runCatching { BundleSigning.parsePublicKey(key.publicKey) }.isFailure ->
+          "key '${key.keyId}' has an unparseable publicKey"
+        else -> null
+      }
+
+    /** Why [identity] is unusable, or null when it's well-formed. */
+    fun validateIdentity(identity: TrustedIdentity): String? =
+      if (identity.identity.isBlank()) "oidc entry needs an identity" else null
 
     /**
      * Glob match supporting `*` (any run of chars, including `/`) — enough for `repo`/`branch`/

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.BundleSigning
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -90,6 +91,15 @@ class ServeAdminRoutingTest {
    */
   private val wasmCatalogs = java.util.concurrent.ConcurrentHashMap<String, File>()
 
+  /**
+   * The live trust store + its admin, wired the way `serve` wires them. Starts empty so a test can
+   * observe the whole point of the feature: a producer trusted over HTTP is in force on the running
+   * server, without the image rebuild the baked trust store used to require.
+   */
+  private val trustStoreFile = ServeTrustStoreFile("/config/producers.json".toPath(), fs)
+  private val trust = MutableTrustStore()
+  private val trustAdmin = ServeTrustAdmin(trust, trustStoreFile, onLog = {})
+
   private val server: ServeHttpServer by lazy {
     registry.register("compose-m3", host = bundle("compose-m3"), pinned = true)
     tracker.recordSuccess("compose-m3")
@@ -104,6 +114,7 @@ class ServeAdminRoutingTest {
         catalogSessions = listOf("compose-m3"),
         catalogLoads = tracker,
         catalogAdmin = admin,
+        trustAdmin = trustAdmin,
         adminToken = adminToken,
         wasmCatalogs = wasmCatalogs,
       )
@@ -246,5 +257,90 @@ class ServeAdminRoutingTest {
     assertFalse(send("/admin/catalogs").second.contains("\"system\":\"temp\""))
     // Retiring it twice is a conflict — the second call has nothing to retire.
     assertEquals(409, send("/admin/catalogs/temp", method = "DELETE").first)
+  }
+
+  // --- producer trust ----------------------------------------------------------------------------
+
+  @Test
+  fun `the trust routes are gated by the admin token even on a public server`() {
+    assertEquals(404, send("/admin/trust", token = null).first)
+    assertEquals(404, send("/admin/trust", token = "wrong").first)
+    assertEquals(404, send("/admin/trust", method = "POST", body = "{}", token = null).first)
+    assertEquals(200, send("/admin/trust").first)
+  }
+
+  @Test
+  fun `trusting a branch takes effect on the running server and persists`() {
+    val body = """{"kind":"branch","repo":"yschimke/horologist","branch":"design-artifacts/*"}"""
+
+    val (code, response) = send("/admin/trust", method = "POST", body = body)
+
+    assertEquals(200, code, response)
+    assertTrue(response.contains("\"status\":\"ok\""), response)
+    // The whole point: no image rebuild, no restart — the next catalog fetch sees this.
+    assertTrue(trust.get().trustsBranch("yschimke/horologist", "design-artifacts/horologist"))
+    assertTrue(trustStoreFile.load().trustsBranch("yschimke/horologist", "design-artifacts/x"))
+    assertTrue(send("/admin/trust").second.contains("yschimke/horologist"))
+  }
+
+  @Test
+  fun `an untrusted branch stays untrusted until it is added`() {
+    assertFalse(trust.get().trustsBranch("yschimke/horologist", "design-artifacts/horologist"))
+    assertFalse(send("/admin/trust").second.contains("yschimke/horologist"))
+  }
+
+  @Test
+  fun `a match-everything repo pattern is rejected over HTTP`() {
+    val (code, _) =
+      send("/admin/trust", method = "POST", body = """{"kind":"branch","repo":"*/*"}""")
+
+    assertEquals(400, code)
+    assertTrue(trust.get().branches.isEmpty())
+  }
+
+  @Test
+  fun `an unknown trust kind is a bad request`() {
+    assertEquals(400, send("/admin/trust", method = "POST", body = """{"kind":"banana"}""").first)
+  }
+
+  @Test
+  fun `a producer can be retired by query parameter`() {
+    send(
+      "/admin/trust",
+      method = "POST",
+      body = """{"kind":"branch","repo":"yschimke/horologist","branch":"design-artifacts/*"}""",
+    )
+    assertTrue(trust.get().trustsBranch("yschimke/horologist", "design-artifacts/horologist"))
+
+    // The repo slug carries a slash, which is why the selector rides the query string.
+    val (code, _) =
+      send(
+        "/admin/trust?kind=branch&repo=yschimke%2Fhorologist&branch=design-artifacts%2F*",
+        method = "DELETE",
+      )
+
+    assertEquals(200, code)
+    assertFalse(trust.get().trustsBranch("yschimke/horologist", "design-artifacts/horologist"))
+    // Retiring it twice is a conflict.
+    assertEquals(
+      409,
+      send(
+          "/admin/trust?kind=branch&repo=yschimke%2Fhorologist&branch=design-artifacts%2F*",
+          method = "DELETE",
+        )
+        .first,
+    )
+  }
+
+  @Test
+  fun `pinned key material is never echoed back by the list route`() {
+    val keys = BundleSigning.generateKeyPair()
+    val body = """{"kind":"key","keyId":"ci","name":"CI","publicKey":"${keys.publicKeyB64}"}"""
+    assertEquals(200, send("/admin/trust", method = "POST", body = body).first)
+
+    val listed = send("/admin/trust").second
+
+    assertTrue(listed.contains("\"keyId\":\"ci\""), listed)
+    assertFalse(listed.contains(keys.publicKeyB64), "public key material must not be echoed back")
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -324,7 +324,7 @@ class ServeBundleStoreTest {
       ServeBundleStore(
         tempRoot(),
         register = { n, h -> registered[n] = h },
-        trust = TrustStore(keys = listOf(TrustedKey("ci", keys.publicKeyB64))),
+        trust = { TrustStore(keys = listOf(TrustedKey("ci", keys.publicKeyB64))) },
       )
     val result = store.add("signed", bytes, isSecurityChecked = true)
     assertEquals(ServeBundleStore.Result.Ok("signed", 1, "signature:ci"), result)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -59,7 +59,7 @@ class ServeCatalogStoreTest {
     ServeCatalogStore(
       root = tempRoot(),
       register = { n, h -> registered[n] = h },
-      trust = trust,
+      trust = { trust },
       fetch = fetch,
       registerWasm = { s, d -> registeredWasm[s] = d },
     )
@@ -111,7 +111,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = root,
         register = { n, h -> registered[n] = h },
-        trust = TrustStore.EMPTY,
+        trust = { TrustStore.EMPTY },
         fetch = fetch,
         registerWasm = { s, d -> registeredWasm[s] = d },
       )
@@ -188,7 +188,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = root,
         register = { n, h -> registered[n] = h },
-        trust = TrustStore.EMPTY,
+        trust = { TrustStore.EMPTY },
         fetch = fetch,
         registerWasm = { s, d -> registeredWasm[s] = d },
       )
@@ -246,7 +246,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = root,
         register = { n, h -> registered[n] = h },
-        trust = TrustStore.EMPTY,
+        trust = { TrustStore.EMPTY },
         fetch = fetch,
       )
 
@@ -315,7 +315,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = root,
         register = { n, h -> registered[n] = h },
-        trust = TrustStore.EMPTY,
+        trust = { TrustStore.EMPTY },
         fetch = fetch,
         registerWasm = { s, d -> registeredWasm[s] = d },
       )
@@ -375,7 +375,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = tempRoot(),
         register = { n, h -> registered[n] = h },
-        trust = trust,
+        trust = { trust },
         fetch = fetch,
         buildTrustedBundle = { _, _, _, alias, _, _ ->
           captured = alias
@@ -437,10 +437,11 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = root,
         register = { n, h -> registered[n] = h },
-        trust =
+        trust = {
           TrustStore(
             branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
-          ),
+          )
+        },
         fetch = fetch,
         buildTrustedBundle = { _, _, _, alias, _, _ ->
           captured = alias
@@ -493,7 +494,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = tempRoot(),
         register = { n, h -> registered[n] = h },
-        trust = trust,
+        trust = { trust },
         networkFetch = networkFetch,
         buildTrustedBundle = { _, _, _, _, _, _ ->
           builderCalled = true
@@ -554,7 +555,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = root,
         register = { n, h -> registered[n] = h },
-        trust = trust,
+        trust = { trust },
         fetch = fetch,
         // Return false so the live builder yields and the baked static host is registered — that's
         // the host whose `remoteComposeDoc` serves the materialised `.rc`.
@@ -614,7 +615,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = tempRoot(),
         register = { n, h -> registered[n] = h },
-        trust = trust,
+        trust = { trust },
         fetch = fetch,
         buildTrustedBundle = { _, _, _, _, _, fetcher ->
           fetchPerPreview = fetcher
@@ -675,7 +676,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = tempRoot(),
         register = { n, h -> registered[n] = h },
-        trust = trust,
+        trust = { trust },
         fetch = fetch,
         buildTrustedBundle = { _, _, _, _, _, fetcher ->
           fetchPerPreview = fetcher
@@ -739,7 +740,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = root,
         register = { n, h -> registered[n] = h },
-        trust = trust,
+        trust = { trust },
         fetch = fetch,
         buildTrustedBundle = { _, _, externalResourcesDir, _, _, _ ->
           capturedDir = externalResourcesDir
@@ -801,7 +802,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = tempRoot(),
         register = { n, h -> registered[n] = h },
-        trust = trust,
+        trust = { trust },
         fetch = fetch,
         buildTrustedBundle = { _, _, _, _, _, _ ->
           builderCalled = true
@@ -876,7 +877,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = root,
         register = { n, h -> registered[n] = h },
-        trust = trust,
+        trust = { trust },
         fetch = fetch,
         buildTrustedBundle = { _, _, externalResourcesDir, _, _, _ ->
           capturedDir = externalResourcesDir
@@ -951,7 +952,7 @@ class ServeCatalogStoreTest {
       ServeCatalogStore(
         root = tempRoot(),
         register = { n, h -> registered[n] = h },
-        trust = trust,
+        trust = { trust },
         fetch = { url ->
           urls += url
           fetcher()(url)
@@ -1044,7 +1045,7 @@ class ServeCatalogStoreTest {
     ServeCatalogStore(
         root = root,
         register = { n, h -> registered[n] = h },
-        trust = TrustStore.EMPTY,
+        trust = { TrustStore.EMPTY },
         fetch = wasmFetcher(catalog),
         registerWasm = { s, d -> registeredWasm[s] = d },
       )
@@ -1084,7 +1085,7 @@ class ServeCatalogStoreTest {
     ServeCatalogStore(
       root = tempRoot(),
       register = { n, h -> registered[n] = h },
-      trust = trust,
+      trust = { trust },
       fetch = { url ->
         when {
           url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdminTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdminTest.kt
@@ -168,6 +168,93 @@ class ServeTrustAdminTest {
   }
 
   @Test
+  fun `a direct file edit is picked up without an admin call or a restart`() {
+    val fs = FakeFileSystem()
+    fs.createDirectories("/config".toPath())
+    val file = ServeTrustStoreFile("/config/producers.json".toPath(), fs)
+    file.save(TrustStore(branches = listOf(TrustedBranch("a/one", "design-artifacts/*"))))
+    val store = MutableTrustStore(file.load(), source = file, onLog = {})
+    assertFalse(store.get().trustsBranch("b/two", "design-artifacts/x"))
+
+    // The operator edits the mounted producers.json by hand. No admin call, no restart.
+    file.save(
+      TrustStore(
+        branches =
+          listOf(
+            TrustedBranch("a/one", "design-artifacts/*"),
+            TrustedBranch("b/two", "design-artifacts/*"),
+          )
+      )
+    )
+
+    assertTrue(store.get().trustsBranch("b/two", "design-artifacts/x"))
+  }
+
+  @Test
+  fun `an unreadable file keeps the last good store rather than un-trusting everything`() {
+    val fs = FakeFileSystem()
+    fs.createDirectories("/config".toPath())
+    val path = "/config/producers.json".toPath()
+    val file = ServeTrustStoreFile(path, fs)
+    file.save(TrustStore(branches = listOf(TrustedBranch("a/one", "design-artifacts/*"))))
+    val store = MutableTrustStore(file.load(), source = file, onLog = {})
+
+    // A half-written edit. Dropping to EMPTY here would un-trust every catalog on the box
+    // mid-flight.
+    fs.write(path) { writeUtf8("{ not json") }
+
+    assertTrue(store.get().trustsBranch("a/one", "design-artifacts/x"))
+  }
+
+  @Test
+  fun `an admin mutation refuses to rewrite an unreadable trust document`() {
+    val fs = FakeFileSystem()
+    fs.createDirectories("/config".toPath())
+    val path = "/config/producers.json".toPath()
+    val file = ServeTrustStoreFile(path, fs)
+    file.save(TrustStore(branches = listOf(TrustedBranch("a/one", "design-artifacts/*"))))
+    val admin = ServeTrustAdmin(MutableTrustStore(file.load()), file, onLog = {})
+    fs.write(path) { writeUtf8("{ truncated") }
+
+    val result = admin.add(AdminTrustEntry(kind = "branch", repo = "b/two"))
+
+    // Saving over it would resurrect stale entries the operator may be mid-way through removing.
+    assertTrue(result is ServeTrustAdmin.Result.Invalid, result.toString())
+    assertEquals("{ truncated", fs.read(path) { readUtf8() }, "the bad file must be left alone")
+  }
+
+  @Test
+  fun `revoking trust fires the revocation hook with the reduced store`() {
+    val (_, _, file) =
+      fixture(TrustStore(branches = listOf(TrustedBranch("a/one", "design-artifacts/*"))))
+    val revoked = mutableListOf<TrustStore>()
+    val admin =
+      ServeTrustAdmin(
+        MutableTrustStore(file.load()),
+        file,
+        onRevoke = { revoked += it },
+        onLog = {},
+      )
+
+    admin.remove(AdminTrustEntry(kind = "branch", repo = "a/one", branch = "design-artifacts/*"))
+
+    assertEquals(1, revoked.size, "a removal must trigger cleanup of what that trust was buying")
+    assertFalse(revoked.single().trustsBranch("a/one", "design-artifacts/x"))
+  }
+
+  @Test
+  fun `adding trust does not fire the revocation hook`() {
+    val (_, _, file) = fixture()
+    var fired = 0
+    val admin =
+      ServeTrustAdmin(MutableTrustStore(file.load()), file, onRevoke = { fired++ }, onLog = {})
+
+    admin.add(AdminTrustEntry(kind = "branch", repo = "a/one", branch = "design-artifacts/*"))
+
+    assertEquals(0, fired)
+  }
+
+  @Test
   fun `concurrent additions all survive in the trust file`() {
     val (admin, _, file) = fixture()
     val threads =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdminTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdminTest.kt
@@ -1,0 +1,188 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.Test
+
+class ServeTrustAdminTest {
+
+  private fun fixture(
+    initial: TrustStore = TrustStore.EMPTY
+  ): Triple<ServeTrustAdmin, MutableTrustStore, ServeTrustStoreFile> {
+    val fs = FakeFileSystem()
+    fs.createDirectories("/config".toPath())
+    val file = ServeTrustStoreFile("/config/producers.json".toPath(), fs)
+    if (initial != TrustStore.EMPTY) file.save(initial)
+    val store = MutableTrustStore(initial)
+    return Triple(ServeTrustAdmin(store, file, onLog = {}), store, file)
+  }
+
+  @Test
+  fun `an added branch is trusted immediately and written to the file`() {
+    val (admin, store, file) = fixture()
+    assertFalse(store.get().trustsBranch("yschimke/horologist", "design-artifacts/horologist"))
+
+    val result =
+      admin.add(
+        AdminTrustEntry(
+          kind = "branch",
+          repo = "yschimke/horologist",
+          branch = "design-artifacts/*",
+        )
+      )
+
+    assertTrue(result is ServeTrustAdmin.Result.Ok)
+    assertNull((result as ServeTrustAdmin.Result.Ok).warning)
+    // The point of the change: in force on the running server, no restart.
+    assertTrue(store.get().trustsBranch("yschimke/horologist", "design-artifacts/horologist"))
+    // ...and durable, so it survives the next roll.
+    assertTrue(file.load().trustsBranch("yschimke/horologist", "design-artifacts/horologist"))
+  }
+
+  @Test
+  fun `a removed branch stops being trusted and leaves the rest of the store intact`() {
+    val (admin, store, file) =
+      fixture(
+        TrustStore(
+          branches =
+            listOf(
+              TrustedBranch("yschimke/horologist", "design-artifacts/*"),
+              TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"),
+            )
+        )
+      )
+
+    val result =
+      admin.remove(
+        AdminTrustEntry(
+          kind = "branch",
+          repo = "yschimke/horologist",
+          branch = "design-artifacts/*",
+        )
+      )
+
+    assertTrue(result is ServeTrustAdmin.Result.Ok)
+    assertFalse(store.get().trustsBranch("yschimke/horologist", "design-artifacts/horologist"))
+    assertTrue(
+      file.load().trustsBranch("yschimke/compose-ai-tools", "design-artifacts/compose-m3"),
+      "removing one producer must not disturb the others",
+    )
+  }
+
+  @Test
+  fun `adding the same branch twice is a conflict, not a duplicate entry`() {
+    val (admin, _, file) = fixture()
+    val entry =
+      AdminTrustEntry(kind = "branch", repo = "yschimke/horologist", branch = "design-artifacts/*")
+
+    assertTrue(admin.add(entry) is ServeTrustAdmin.Result.Ok)
+    assertTrue(admin.add(entry) is ServeTrustAdmin.Result.Conflict)
+    assertEquals(1, file.load().branches.size)
+  }
+
+  @Test
+  fun `removing a producer that is not trusted is a conflict`() {
+    val (admin, _, _) = fixture()
+    val result = admin.remove(AdminTrustEntry(kind = "branch", repo = "nobody/nothing"))
+    assertTrue(result is ServeTrustAdmin.Result.Conflict)
+  }
+
+  @Test
+  fun `a match-everything repo pattern is refused`() {
+    val (admin, store, _) = fixture()
+    for (pattern in listOf("*/*", "*/**", "**/*")) {
+      val result = admin.add(AdminTrustEntry(kind = "branch", repo = pattern, branch = "*"))
+      assertTrue(result is ServeTrustAdmin.Result.Invalid, "expected '$pattern' to be refused")
+    }
+    // Nothing leaked into the live store — with --allow-render-trusted this would be RCE for
+    // anyone.
+    assertTrue(store.get().branches.isEmpty())
+  }
+
+  @Test
+  fun `a malformed repo pattern is refused`() {
+    val (admin, _, _) = fixture()
+    val result = admin.add(AdminTrustEntry(kind = "branch", repo = "no-slash-here"))
+    assertTrue(result is ServeTrustAdmin.Result.Invalid)
+  }
+
+  @Test
+  fun `an unknown kind is refused rather than silently ignored`() {
+    val (admin, _, _) = fixture()
+    assertTrue(admin.add(AdminTrustEntry(kind = "banana")) is ServeTrustAdmin.Result.Invalid)
+    assertTrue(admin.remove(AdminTrustEntry(kind = "banana")) is ServeTrustAdmin.Result.Invalid)
+  }
+
+  @Test
+  fun `a key with unparseable material is refused`() {
+    val (admin, _, _) = fixture()
+    val result =
+      admin.add(AdminTrustEntry(kind = "key", keyId = "ci", publicKey = "not-a-real-key"))
+    assertTrue(result is ServeTrustAdmin.Result.Invalid)
+  }
+
+  @Test
+  fun `an oidc identity round-trips`() {
+    val (admin, store, file) = fixture()
+    val identity = "repo:yschimke/compose-ai-tools:ref:refs/heads/main"
+
+    assertTrue(
+      admin.add(AdminTrustEntry(kind = "oidc", identity = identity)) is ServeTrustAdmin.Result.Ok
+    )
+
+    assertTrue(store.get().trustsIdentity(identity))
+    assertEquals(listOf(identity), file.load().oidc.map { it.identity })
+  }
+
+  @Test
+  fun `a hand-edit between admin calls is not clobbered`() {
+    val (admin, _, file) = fixture()
+    admin.add(AdminTrustEntry(kind = "branch", repo = "a/one", branch = "design-artifacts/*"))
+    // The operator edits producers.json directly while the server runs.
+    file.save(file.load().copy(oidc = listOf(TrustedIdentity("repo:a/one:ref:refs/heads/main"))))
+
+    admin.add(AdminTrustEntry(kind = "branch", repo = "b/two", branch = "design-artifacts/*"))
+
+    val onDisk = file.load()
+    assertEquals(2, onDisk.branches.size)
+    assertEquals(1, onDisk.oidc.size, "the hand-added identity must survive the next admin write")
+  }
+
+  @Test
+  fun `with no file configured the change applies but is reported as unpersisted`() {
+    val store = MutableTrustStore()
+    val admin = ServeTrustAdmin(store, file = null, onLog = {})
+
+    val result =
+      admin.add(AdminTrustEntry(kind = "branch", repo = "a/one", branch = "design-artifacts/*"))
+
+    val ok = result as ServeTrustAdmin.Result.Ok
+    assertNotNull(ok.warning)
+    assertTrue(ok.warning!!.contains("not persisted"))
+    assertTrue(store.get().trustsBranch("a/one", "design-artifacts/x"))
+  }
+
+  @Test
+  fun `concurrent additions all survive in the trust file`() {
+    val (admin, _, file) = fixture()
+    val threads =
+      (1..8).map { i ->
+        Thread {
+          admin.add(
+            AdminTrustEntry(kind = "branch", repo = "owner/repo$i", branch = "design-artifacts/*")
+          )
+        }
+      }
+    threads.forEach { it.start() }
+    threads.forEach { it.join() }
+
+    // Without serialising the whole load-modify-save, writers would clobber each other and only a
+    // subset would reach disk.
+    assertEquals(8, file.load().branches.size)
+  }
+}

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -40,20 +40,27 @@ services:
       # (docker compose exec preview vi /config/catalogs.json, then restart) or POST to
       # /admin/catalogs to publish a catalog — no image rebuild, no compose edit.
       SERVE_CATALOGS_FILE: "${SERVE_CATALOGS_FILE:-}"
-      # Runtime catalog admin (GET/POST /admin/catalogs, DELETE /admin/catalogs/<system>).
+      # Runtime admin, gating BOTH surfaces: the catalog set (GET/POST /admin/catalogs, DELETE
+      # /admin/catalogs/<system>) and the producer-trust store (GET/POST/DELETE /admin/trust).
       # Set a strong secret in .env to enable; unset (default) means the routes don't exist.
       # It is NOT the browse token — a public box gives that one to every visitor.
+      #
+      # On a box with SERVE_ALLOW_RENDER_TRUSTED on (the default), this token is effectively a
+      # code-execution credential: trusting a branch makes that producer's Compose eligible for
+      # server-side re-render here. Treat it like a deploy key, not a read token.
       SERVE_ADMIN_TOKEN: "${SERVE_ADMIN_TOKEN:-}"
       # Optional ADDITIONS to that file, for one extra catalog without editing config:
       # <system>@<owner>/<repo>, comma-separated. Empty (the default) = the file decides.
       SERVE_CATALOGS: "${SERVE_CATALOGS:-}"
       SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-}"
-      # The image bakes a branch-trust store at /trust/producers.json and the
-      # entrypoint defaults to it, so the published design-artifacts catalogs badge
-      # as Trusted(Branch) out of the box — leave this unset. Set your own path to
-      # pin different producers (mount it via volumes below), or the literal `none`
-      # to run trustless. (Empty is NOT trustless — it falls back to the baked
-      # default; use `none`.)
+      # The producer-trust store is config, like catalogs.json: it lives on the
+      # `preview_config` volume at /config/producers.json, seeded on first boot from the
+      # store baked at /trust/producers.json and never overwritten again — so the published
+      # design-artifacts catalogs badge as Trusted(Branch) out of the box, AND a producer
+      # added later (by editing that file, or POSTing to /admin/trust) survives image rolls
+      # without a rebuild. Leave this unset. Set your own path to pin different producers
+      # (mount it via volumes below), or the literal `none` to run trustless. (Empty is NOT
+      # trustless — it falls back to the default; use `none`.)
       SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-}"
       # Unused in public mode; required only when SERVE_PUBLIC=0.
       SERVE_TOKEN: "${SERVE_TOKEN:-}"
@@ -104,6 +111,7 @@ services:
       # file is absent, so an edit here — or a POST to /admin/catalogs, which rewrites the
       # same file — survives every subsequent pull. Bind-mount a host path instead
       # (`- ./catalogs.json:/config/catalogs.json`) to keep it in version control.
+      # The same volume carries producers.json (the trust store) for the same reasons.
       - preview_config:/config
     # To also pin your OWN producers, mount a trust store over the baked one and keep
     # SERVE_TRUST_STORE pointing at it:
@@ -252,8 +260,9 @@ volumes:
   # image rolls so a freshly-rolled replica reuses them instead of re-downloading. See the
   # `preview` service's volumes block for why the baked android-all / ~/.m2 are excluded.
   preview_cache:
-  # The operator's catalogs.json — the published catalog set, kept outside the image so it
-  # survives image rolls and can be edited (or POSTed to /admin/catalogs) without a rebuild.
+  # The operator's catalogs.json + producers.json — the published catalog set and the trusted
+  # producers, kept outside the image so they survive image rolls and can be edited (or POSTed
+  # to /admin/catalogs / /admin/trust) without a rebuild.
   preview_config:
   caddy_data:
   caddy_config:

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -121,17 +121,26 @@ fi
 # bare image pull self-heals a box without editing compose. Override with your own path to pin
 # different producers, or the literal `none` to run trustless (catalogs then show Unverified).
 # NB opt-out is `none`, not empty — empty deliberately falls back to the default.
+#
+# Seeding applies ONLY to the default path. An operator who names their own SERVE_TRUST_STORE and
+# whose file is missing — a typo, an unmounted secret, a broken deploy — must NOT silently get the
+# image's allowlist instead: with SERVE_ALLOW_RENDER_TRUSTED=1 that would execute producers they
+# never configured. For an explicit override the file has to already be there, and a missing one
+# keeps the old hard failure (the CLI exits non-zero on an absent --trust-store).
+serve_trust_store_defaulted=0
+[[ -z "${SERVE_TRUST_STORE:-}" ]] && serve_trust_store_defaulted=1
 : "${SERVE_TRUST_STORE:=/config/producers.json}"
 if [[ "${SERVE_TRUST_STORE}" != "none" ]]; then
-  if [[ ! -f "${SERVE_TRUST_STORE}" && -f /trust/producers.json ]]; then
+  if [[ "${serve_trust_store_defaulted}" == 1 && ! -f "${SERVE_TRUST_STORE}" &&
+    -f /trust/producers.json ]]; then
     if mkdir -p "$(dirname "${SERVE_TRUST_STORE}")" 2>/dev/null &&
       cp /trust/producers.json "${SERVE_TRUST_STORE}" 2>/dev/null; then
       echo "entrypoint: seeded ${SERVE_TRUST_STORE} from the image default" >&2
     else
       # Read-only /config (or a bind mount pointing somewhere unwritable): serve the baked store
       # rather than refusing to start. Admin trust writes will report themselves unpersisted.
-      SERVE_TRUST_STORE=/trust/producers.json
       echo "entrypoint: ${SERVE_TRUST_STORE} not writable — using the baked trust store" >&2
+      SERVE_TRUST_STORE=/trust/producers.json
     fi
   fi
   args+=(--trust-store "${SERVE_TRUST_STORE}")

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -107,14 +107,35 @@ fi
 # gated by its own secret — never the browse token, which a public box hands to every visitor.
 # Unset (the default) means the admin routes don't exist at all.
 [[ -n "${SERVE_ADMIN_TOKEN:-}" ]] && args+=(--admin-token "${SERVE_ADMIN_TOKEN}")
-# Default to the baked branch-trust store so the published design-artifacts catalogs
-# badge as Trusted(Branch) out of the box. `:=` fills it when SERVE_TRUST_STORE is
-# unset OR empty (an older host compose passes ""), so a bare image pull self-heals a
-# box without editing compose. Override with your own path to pin different
-# producers, or the literal `none` to run trustless (catalogs then show Unverified).
+# The producer-trust store is CONFIG, on the same /config volume as catalogs.json — for the
+# same reason. It used to live only in the image, which meant trusting a new producer needed a
+# code change, a release and an image publish, while a *catalog* could be published at runtime in
+# one HTTP call. That asymmetry made runtime catalog registration close to useless: the catalog
+# served, but badged `unverified` until the image caught up.
+#
+# The image still carries the seed (/trust/producers.json) and it is copied to the volume on
+# first boot only, never overwritten — so an operator edit, or a POST to /admin/trust (which
+# rewrites this same file), survives every subsequent image roll. Falls back to serving the
+# baked file read-only when /config isn't writable, exactly like the catalogs seed.
+# `:=` fills it when SERVE_TRUST_STORE is unset OR empty (an older host compose passes ""), so a
+# bare image pull self-heals a box without editing compose. Override with your own path to pin
+# different producers, or the literal `none` to run trustless (catalogs then show Unverified).
 # NB opt-out is `none`, not empty — empty deliberately falls back to the default.
-: "${SERVE_TRUST_STORE:=/trust/producers.json}"
-[[ "${SERVE_TRUST_STORE}" != "none" ]] && args+=(--trust-store "${SERVE_TRUST_STORE}")
+: "${SERVE_TRUST_STORE:=/config/producers.json}"
+if [[ "${SERVE_TRUST_STORE}" != "none" ]]; then
+  if [[ ! -f "${SERVE_TRUST_STORE}" && -f /trust/producers.json ]]; then
+    if mkdir -p "$(dirname "${SERVE_TRUST_STORE}")" 2>/dev/null &&
+      cp /trust/producers.json "${SERVE_TRUST_STORE}" 2>/dev/null; then
+      echo "entrypoint: seeded ${SERVE_TRUST_STORE} from the image default" >&2
+    else
+      # Read-only /config (or a bind mount pointing somewhere unwritable): serve the baked store
+      # rather than refusing to start. Admin trust writes will report themselves unpersisted.
+      SERVE_TRUST_STORE=/trust/producers.json
+      echo "entrypoint: ${SERVE_TRUST_STORE} not writable — using the baked trust store" >&2
+    fi
+  fi
+  args+=(--trust-store "${SERVE_TRUST_STORE}")
+fi
 [[ -n "${SERVE_WASM_DIR:-}" ]] && args+=(--wasm-dir "${SERVE_WASM_DIR}")
 # Trusted server-side re-render — ON by default, and cheap: for a Trusted catalog
 # that carries an executable `liveBundle` (the desktop CMP `compose-m3` does), serve

--- a/deploy/image/trust/producers.json
+++ b/deploy/image/trust/producers.json
@@ -22,6 +22,10 @@
       "branch": "design-artifacts/*"
     },
     {
+      "repo": "yschimke/horologist",
+      "branch": "design-artifacts/*"
+    },
+    {
       "repo": "joreilly/Confetti",
       "branch": "design-artifacts/*"
     },

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -371,9 +371,15 @@ both keeps its config entry. Re-running [`deploy/image/setup.sh`](../deploy/imag
 the known legacy `SERVE_CATALOGS` override containing only `jetnews`, `jetchat`, and `jetlagged`, so
 older `preview.coo.ee` deployments fall back to the config file cleanly.
 
-### The catalog admin API
+### The admin API
 
-Setting `SERVE_ADMIN_TOKEN` enables three routes for publishing catalogs on a **running** server:
+Setting `SERVE_ADMIN_TOKEN` enables two admin surfaces on a **running** server: the catalog set and
+the producer-trust store. Both are needed for either to be useful — publishing a catalog whose
+producer isn't trusted just serves it as `unverified`.
+
+#### Catalogs
+
+Three routes for publishing catalogs:
 
 | Route | Does |
 |---|---|
@@ -393,17 +399,63 @@ it just won't come back). A registration fetches the branch **before** it's pers
 repo fails with `502` rather than leaving an unservable entry for every future boot to retry;
 malformed entries are `400` and re-publishing a served catalog is `409`.
 
+#### Trusted producers
+
+The trust store is config too, on the same volume (`/config/producers.json`). Without this, runtime
+catalog registration was only half a feature: you could publish a catalog in one HTTP call, but
+trusting its producer meant a code change, a release, an image publish and a roll — so the new
+catalog badged `unverified` until the image caught up.
+
+| Route | Does |
+|---|---|
+| `GET /admin/trust` | the trusted branches, pinned key ids, and CI identities |
+| `POST /admin/trust` | trust one producer — `{"kind":"branch"\|"key"\|"oidc", …}` |
+| `DELETE /admin/trust?kind=…` | stop trusting one — selectors ride the query string |
+
+```
+# trust a repo's delivery branches, then publish a catalog from one
+curl -H "X-Compose-Preview-Admin-Token: $SERVE_ADMIN_TOKEN" \
+     -d '{"kind":"branch","repo":"yschimke/horologist","branch":"design-artifacts/*"}' \
+     https://preview.coo.ee/admin/trust
+
+curl -H "X-Compose-Preview-Admin-Token: $SERVE_ADMIN_TOKEN" \
+     -d '{"system":"horologist","repo":"yschimke/horologist","listed":true}' \
+     https://preview.coo.ee/admin/catalogs
+
+# ...and to retire the producer again (the slash in owner/repo is why this is a query param)
+curl -X DELETE -H "X-Compose-Preview-Admin-Token: $SERVE_ADMIN_TOKEN" \
+     'https://preview.coo.ee/admin/trust?kind=branch&repo=yschimke%2Fhorologist&branch=design-artifacts%2F*'
+```
+
+Changes take effect on the **next** verification — the next catalog fetch or branch refresh — with
+no restart, and are written back to `producers.json` the same way catalog changes are written back to
+`catalogs.json` (same `warning` field when the write fails). `GET` lists pinned keys by id and name
+only; key material is never echoed back. Re-adding a producer is `409`, a malformed entry is `400`,
+and a repo pattern that matches every repository is refused outright.
+
+> **The admin token can grant code execution.** On a box with `SERVE_ALLOW_RENDER_TRUSTED` on (the
+> default), trust is not only a badge — it gates server-side re-render, so trusting a branch makes
+> that producer's Compose eligible to be built and executed on your box. Treat `SERVE_ADMIN_TOKEN`
+> like a deploy key, not a read token, and keep `SERVE_ALLOW_RENDER_TRUSTED=0` on any box where you
+> don't want that.
+
 The admin token is **separate from the browse token** on purpose — a `--public` box hands the browse
-URL to every visitor — and the routes aren't registered at all when it's unset, so a server that
+URL to every visitor — and neither surface is registered at all when it's unset, so a server that
 never opted in has no admin surface to find. A bad token gets the same `404` the browse gate uses.
 
-The prebuilt `deploy/image` **bakes a branch-trust store** at `/trust/producers.json` (trusting
-`design-artifacts/*` on `yschimke/compose-ai-tools`, `yschimke/meshcore-mobile`, and
-`yschimke/homeassistant-remotecompose`) and the entrypoint defaults `SERVE_TRUST_STORE` to
-it, so the published catalogs badge as `Trusted(Branch)` out of the box rather than `unverified`.
-Mount your own over that path (or set `SERVE_TRUST_STORE` to it) to pin different producers, or set
-`SERVE_TRUST_STORE=none` to run trustless. (Empty falls back to the baked default — use `none` to opt
-out — which also means a bare image pull self-heals a box without editing its compose.)
+#### Where the trust store lives
+
+The prebuilt `deploy/image` bakes a seed branch-trust store at `/trust/producers.json` (trusting
+`design-artifacts/*` on `yschimke/compose-ai-tools`, `yschimke/meshcore-mobile`,
+`yschimke/homeassistant-remotecompose` and friends). On first boot the entrypoint copies it to
+`/config/producers.json` on the `preview_config` volume and points `SERVE_TRUST_STORE` there; it is
+never overwritten again, so an operator edit — or a `POST /admin/trust` — survives every subsequent
+image roll. The published catalogs still badge as `Trusted(Branch)` out of the box.
+
+Set `SERVE_TRUST_STORE` to your own path to pin different producers, or `none` to run trustless.
+(Empty falls back to the default — use `none` to opt out — which also means a bare image pull
+self-heals a box without editing its compose.) If `/config` isn't writable the entrypoint falls back
+to serving the baked store read-only, and admin trust writes report themselves unpersisted.
 
 The catalog set is **not** baked the same way — see "The catalog set is config, not image content"
 above: the image ships it only as a first-boot seed, and the live copy lives on the `/config` volume

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -433,6 +433,18 @@ no restart, and are written back to `producers.json` the same way catalog change
 only; key material is never echoed back. Re-adding a producer is `409`, a malformed entry is `400`,
 and a repo pattern that matches every repository is refused outright.
 
+Editing `producers.json` directly works the same way: the file is re-read on each verification, so a
+hand-edit needs no admin call and no restart. A malformed or truncated edit is ignored with a log
+line and the last good allowlist stays in force — failing closed there would un-trust every catalog
+on the box over a half-saved write. Conversely an admin mutation **refuses** to run against a file
+that exists but won't parse (`400`), rather than overwriting it with cached state plus the edit.
+
+**Revoking trust revokes it now.** A successful removal retires every catalog whose branch the
+reduced store no longer trusts: the session is unregistered (which tears down any live daemon started
+under the old verdict) and its branch head forgotten, so the next refresh pass re-fetches and
+re-verifies it instead of short-circuiting on an unchanged SHA. Without that, a revoked producer
+would keep serving as `Trusted` until its branch happened to move.
+
 > **The admin token can grant code execution.** On a box with `SERVE_ALLOW_RENDER_TRUSTED` on (the
 > default), trust is not only a badge — it gates server-side re-render, so trusting a branch makes
 > that producer's Compose eligible to be built and executed on your box. Treat `SERVE_ADMIN_TOKEN`
@@ -456,6 +468,11 @@ Set `SERVE_TRUST_STORE` to your own path to pin different producers, or `none` t
 (Empty falls back to the default — use `none` to opt out — which also means a bare image pull
 self-heals a box without editing its compose.) If `/config` isn't writable the entrypoint falls back
 to serving the baked store read-only, and admin trust writes report themselves unpersisted.
+
+Seeding applies **only** to the default path. If you name your own `SERVE_TRUST_STORE` and the file
+isn't there — a typo, an unmounted secret, a broken deploy — the entrypoint does *not* substitute the
+image's allowlist; with server-side re-render on, that would execute producers you never configured.
+An explicit override has to exist, and a missing one keeps the old hard failure.
 
 The catalog set is **not** baked the same way — see "The catalog set is config, not image content"
 above: the image ships it only as a first-boot seed, and the live copy lives on the `/config` volume

--- a/trust/producers.json
+++ b/trust/producers.json
@@ -28,6 +28,10 @@
     {
       "repo": "yschimke/compose-samples",
       "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/horologist",
+      "branch": "design-artifacts/*"
     }
   ],
   "oidc": [


### PR DESCRIPTION
Finishes what #2879 / #2897 started. The catalog set became config, but **trust stayed baked into the image** — so a catalog published at runtime badged `unverified` until a code change shipped through release-please, an image publish and a roll. That made runtime catalog registration half a feature, which is exactly what surfaced trying to add `yschimke/horologist` (#2953 had to be a PR).

## What changed

**Trust lives on the config volume.** `/config/producers.json`, seeded from the image's baked `/trust/producers.json` on first boot and never overwritten — byte-for-byte the treatment `catalogs.json` already gets. Falls back to serving the baked store read-only when `/config` isn't writable. Seeding applies **only** to the default path: an explicitly-set `SERVE_TRUST_STORE` that's missing keeps the pre-existing hard failure rather than silently inheriting the image's allowlist.

**Trust is live, not a boot snapshot.** `ServeCommand` held it in a `by lazy` val, so even a hand-edit needed a restart. `ServeCatalogStore` / `ServeBundleStore` now take `() -> TrustStore` and read through a `MutableTrustStore` per verification, which re-reads `producers.json` — so both an admin change *and* a direct file edit land on the next catalog fetch or bundle upload. A malformed edit keeps the last good allowlist rather than un-trusting the whole box.

**`/admin/trust`**, gated by the existing `--admin-token`:

| Route | Does |
|---|---|
| `GET /admin/trust` | trusted branches, pinned key **ids**, CI identities |
| `POST /admin/trust` | `{"kind":"branch"\|"key"\|"oidc", …}` |
| `DELETE /admin/trust?kind=…&repo=…` | selectors ride the query string — `owner/repo` has a slash |

Mutations apply live **and** write back to `producers.json`, with the same `warning`-on-unpersisted contract as the catalog admin, and the same whole-load-modify-save lock (concurrent adds would otherwise clobber each other). A mutation against a file that exists but won't parse is refused (`400`) rather than overwriting it with cached state plus the edit.

**Revocation actually revokes.** Removing trust retires every catalog whose branch the reduced store no longer trusts: the session is unregistered (tearing down any daemon started under the old verdict) and its remembered branch head cleared via a new `ServeCatalogRefresher.forgetHeads`, so the next refresh pass re-fetches and re-verifies instead of short-circuiting on an unchanged SHA.

## Security posture

Called out because it's a real escalation, and the reason I'd flagged this half separately: on a box with `--allow-render-trusted` (the default), **trust gates server-side re-render** — trusting a branch makes that producer's Compose eligible to be built and executed on the box. So the admin token is a code-execution credential there.

Guards: routes don't exist without `--admin-token`; the token stays separate from the browse token; a bad token 404s like the browse gate; a repo pattern matching every repository is refused outright; `GET` never echoes key material back.

The owner's call to ship this ("these are pretty much throw away boxes") — recording it here since the trade-off is deliberate rather than overlooked.

## Test plan

- `./gradlew :cli:test ktfmtCheckAll` — green (967 tests).
- `bash -n deploy/image/entrypoint.sh`.
- `ServeTrustAdminTest` (17 cases, `FakeFileSystem`): live+persisted round-trip; removal leaving the rest intact; add/remove conflicts; match-everything and malformed patterns refused; unparseable key material refused; oidc round-trip; hand-edit-not-clobbered; unpersisted warning with no file; 8-thread concurrent adds all reaching disk; direct file edit picked up with no admin call; unreadable file keeping the last good store; a mutation refusing to rewrite an unreadable document (and leaving its bytes untouched); revoke hook firing on removal and not on addition.
- `ServeAdminRoutingTest` extended over real HTTP: token gate on a `--public` server, trust-takes-effect-live, `400` on bad kind / match-everything, `DELETE` by query param + `409` on repeat, and key material absent from `GET`.

Non-visual change (server config plumbing), so no render evidence.

## Review

Codex raised five findings; four were real and are fixed in `00a6df7` (replies on each thread). The fifth claimed the commit carried a `Codex <codex@openai.com>` identity — it doesn't; author and committer are `Yuri Schimke <yuri@schimke.ee>` with no trailers, so that one was refuted rather than actioned.
