### PR TITLE
feat(serve): publish the pocketcasts and pocketcasts-wear catalogs

### DIFF
--- a/deploy/image/catalogs.json
+++ b/deploy/image/catalogs.json
@@ -41,6 +41,16 @@
       "listed": true
     },
     {
+      "system": "pocketcasts",
+      "repo": "yschimke/pocket-casts-android",
+      "listed": true
+    },
+    {
+      "system": "pocketcasts-wear",
+      "repo": "yschimke/pocket-casts-android",
+      "listed": true
+    },
+    {
       "system": "jetnews",
       "repo": "yschimke/compose-samples",
       "listed": true,

--- a/deploy/image/trust/producers.json
+++ b/deploy/image/trust/producers.json
@@ -26,6 +26,10 @@
       "branch": "design-artifacts/*"
     },
     {
+      "repo": "yschimke/pocket-casts-android",
+      "branch": "design-artifacts/*"
+    },
+    {
       "repo": "joreilly/Confetti",
       "branch": "design-artifacts/*"
     },

--- a/trust/producers.json
+++ b/trust/producers.json
@@ -32,6 +32,10 @@
     {
       "repo": "yschimke/horologist",
       "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/pocket-casts-android",
+      "branch": "design-artifacts/*"
     }
   ],
   "oidc": [


### PR DESCRIPTION
Adds `yschimke/pocket-casts-android` as a trusted producer and publishes the two catalogs it carries.

## Trust

`yschimke/pocket-casts-android` + `design-artifacts/*` as a branch (origin) trust producer, in **both** copies per the warning in `trust/producers.json`:
- `deploy/image/trust/producers.json` — the one baked into the `preview-host` image (`COPY trust/ /trust/` with build context `deploy/image`), i.e. what preview.coo.ee seeds from.
- `trust/producers.json` — the reference/example copy for operators running their own server with `--trust-store`.

## Catalogs

Registered in the image's `catalogs.json` seed:

| system | repo | listed |
|---|---|---|
| `pocketcasts` | `yschimke/pocket-casts-android` | yes |
| `pocketcasts-wear` | `yschimke/pocket-casts-android` | yes |

Both delivery branches exist and carry real bundles — `design-artifacts/pocketcasts` (`da9e2aa`) and `design-artifacts/pocketcasts-wear` (`ce85d3f`), each with `catalog.json`, `bundle/`, `images/`, plus the figma/code-connect/token exports. So unlike the horologist entry in #2953, these are immediately servable rather than staged ahead of a branch that doesn't exist yet.

Left **ungrouped**, so they render under the `yschimke org` owner-fallback heading alongside `meshcore-mobile` and `homeassistant-remotecompose`. Adding a Pocket Casts section (or attributing them upstream to `Automattic/pocket-casts-android` the way the jet\* catalogs attribute to `android/compose-samples`) is a one-line `catalogs.json` change if you'd prefer that — say so and I'll follow up.

## How this reaches preview.coo.ee

Neither file is live on merge:
- **Trust** is baked, so it arrives on the next `preview-host-image` publish.
- **`catalogs.json`** is a *first-boot seed only* — the entrypoint never overwrites an existing `/config/producers.json` / `/config/catalogs.json`, so the running box keeps the catalog set it already has.

With #2961 merged, the box's live set can be updated without waiting for either:

```
curl -H "X-Compose-Preview-Admin-Token: $SERVE_ADMIN_TOKEN" \
     -d '{"system":"pocketcasts","repo":"yschimke/pocket-casts-android","listed":true}' \
     https://preview.coo.ee/admin/catalogs
```
That needs the trust entry present on the box first, though — otherwise the catalog serves as `unverified`.

## Test plan

- `json.load` parse check on all three edited files; branch lists and the 17-entry catalog set verified.
- Both delivery branches confirmed to exist and contain `catalog.json` + `bundle/`.
- CI (`No Agent Attribution`, `Format Check`, build) on this PR.

Non-visual change (trust + catalog config only), so no render evidence.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FdJsCmxDm9dXv8iEsxVYgs)_