### PR TITLE
refactor(deploy): split the generic image seed from deployment config, reconcile it after publish

### DIFF
--- a/.github/scripts/publish-config-to-box.sh
+++ b/.github/scripts/publish-config-to-box.sh
@@ -40,6 +40,12 @@ if [[ "${DRY_RUN}" == 0 ]]; then
   : "${ADMIN_TOKEN:?ADMIN_TOKEN required}"
 fi
 
+# Entries the server refused. A rejected entry means the box is NOT serving something the seed
+# says it should, which is the exact condition this script exists to prevent — so it ends in a
+# non-zero exit (the workflow step is continue-on-error, so the publish still succeeds, but the
+# step goes red and the log carries an ::error:: instead of a warning nobody reads).
+rejected=0
+
 # POST one JSON body to an admin path. 200 = applied, 409 = already there (both fine), 404 =
 # the routes don't exist on this server (no --admin-token, or an image predating them) — which is
 # reported once and treated as "nothing to do" rather than a failure, since a box that never opted
@@ -50,11 +56,14 @@ post() {
     echo "POST ${path} ${body}"
     return 0
   fi
-  local code
-  code=$(curl -sS -o /dev/null -w '%{http_code}' -m 30 \
+  local response code payload
+  # Body AND status: a 400's body carries WHY, and the reason changes what the operator has to do.
+  response=$(curl -sS -w $'\n%{http_code}' -m 30 \
     -X POST -H "${ADMIN_TOKEN_HEADER}: ${ADMIN_TOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "${body}" "${BASE_URL}${path}" 2>/dev/null || echo 000)
+    -d "${body}" "${BASE_URL}${path}" 2>/dev/null || printf '\n000')
+  code="${response##*$'\n'}"
+  payload="${response%$'\n'*}"
   case "${code}" in
     200 | 201) echo "  ${label}: applied" ;;
     409) echo "  ${label}: already present" ;;
@@ -62,7 +71,23 @@ post() {
       echo "::warning::${BASE_URL}${path} returned 404 — admin API not enabled on this box; skipping config reconcile."
       return 2
       ;;
-    *) echo "::warning::${label}: HTTP ${code} (continuing)" ;;
+    400)
+      rejected=$((rejected + 1))
+      # The one 400 that is a *structural* gap rather than a bad payload: there is no admin route
+      # for front-page groups (only /admin/catalogs and /admin/trust), so a catalog claiming a
+      # group the box's own /config/catalogs.json doesn't define is rejected and cannot be fixed
+      # from here. Say so explicitly — the previous version warned and moved on, leaving the
+      # catalog silently unpublished.
+      if [[ "${payload}" == *"unknown group"* ]]; then
+        echo "::error::${label}: ${payload}. Groups are not reconcilable over the admin API — add the group to the box's /config/catalogs.json (\`docker compose exec preview vi /config/catalogs.json\` then restart), or drop the group claim from the seed entry."
+      else
+        echo "::error::${label}: rejected (HTTP 400) — ${payload}"
+      fi
+      ;;
+    *)
+      rejected=$((rejected + 1))
+      echo "::error::${label}: HTTP ${code} — ${payload}"
+      ;;
   esac
   return 0
 }
@@ -96,4 +121,8 @@ while IFS= read -r entry; do
   }
 done < <(jq -c '.catalogs // [] | .[]' "${CATALOGS_FILE}")
 
+if [[ "${rejected}" -gt 0 ]]; then
+  echo "::error::${rejected} seed entr(y|ies) were rejected — the box is not serving everything the committed config declares." >&2
+  exit 1
+fi
 echo "Config reconcile complete."

--- a/.github/scripts/publish-config-to-box.sh
+++ b/.github/scripts/publish-config-to-box.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Reconcile the image's SEED config onto a running preview server via its admin API.
+#
+# Why this exists: deploy/image/catalogs.json and deploy/image/trust/producers.json are
+# first-boot seeds. The entrypoint copies each to /config only when it is ABSENT and never
+# overwrites it again — deliberately, so an image roll can't stomp a runtime edit (see #2879 /
+# #2897). The consequence is that merging a new catalog or producer changes nothing on an
+# already-deployed box: the entries land in the image, the box keeps the config it already has,
+# and someone has to remember to POST them by hand. This closes that gap as part of publishing.
+#
+# ADDITIVE ONLY. This never deletes and never rewrites an existing entry: an id already present
+# comes back 409 from the admin API, which is treated as success. So a producer or catalog an
+# operator added directly on the box survives untouched.
+#
+# The flip side, and it is a real trade-off rather than an oversight: because the reconcile is
+# blind to history, a catalog RETIRED on the box (DELETE /admin/catalogs/<id>) while still listed
+# in catalogs.json will be re-added by the next publish. That makes the committed seed the
+# declared intent — to retire something permanently, drop it from catalogs.json too. Any
+# alternative needs the box to persist tombstones, which is a bigger change; see the discussion on
+# #2962.
+#
+# Usage:
+#   BASE_URL=https://preview.coo.ee ADMIN_TOKEN=… publish-config-to-box.sh [--dry-run]
+#
+# --dry-run prints the requests it would make, one per line, and talks to nothing. That is the
+# seam test-publish-config-to-box.sh drives, so the ordering and payload rules below are covered
+# without a server.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CATALOGS_FILE="${CATALOGS_FILE:-${REPO_ROOT}/deploy/image/catalogs.json}"
+TRUST_FILE="${TRUST_FILE:-${REPO_ROOT}/deploy/image/trust/producers.json}"
+ADMIN_TOKEN_HEADER="X-Compose-Preview-Admin-Token"
+
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+: "${BASE_URL:?BASE_URL required}"
+if [[ "${DRY_RUN}" == 0 ]]; then
+  : "${ADMIN_TOKEN:?ADMIN_TOKEN required}"
+fi
+
+# POST one JSON body to an admin path. 200 = applied, 409 = already there (both fine), 404 =
+# the routes don't exist on this server (no --admin-token, or an image predating them) — which is
+# reported once and treated as "nothing to do" rather than a failure, since a box that never opted
+# in to the admin API is a legitimate deployment.
+post() {
+  local path="$1" body="$2" label="$3"
+  if [[ "${DRY_RUN}" == 1 ]]; then
+    echo "POST ${path} ${body}"
+    return 0
+  fi
+  local code
+  code=$(curl -sS -o /dev/null -w '%{http_code}' -m 30 \
+    -X POST -H "${ADMIN_TOKEN_HEADER}: ${ADMIN_TOKEN}" \
+    -H 'Content-Type: application/json' \
+    -d "${body}" "${BASE_URL}${path}" 2>/dev/null || echo 000)
+  case "${code}" in
+    200 | 201) echo "  ${label}: applied" ;;
+    409) echo "  ${label}: already present" ;;
+    404)
+      echo "::warning::${BASE_URL}${path} returned 404 — admin API not enabled on this box; skipping config reconcile."
+      return 2
+      ;;
+    *) echo "::warning::${label}: HTTP ${code} (continuing)" ;;
+  esac
+  return 0
+}
+
+# Trust FIRST. A catalog is verified at fetch time, so publishing it before its producer is
+# trusted would register it as `unverified` and leave it that way until its branch next moves.
+echo "Reconciling trusted producers from ${TRUST_FILE#"${REPO_ROOT}/"}"
+while IFS= read -r entry; do
+  [[ -n "${entry}" ]] || continue
+  repo=$(printf '%s' "${entry}" | jq -r '.repo')
+  branch=$(printf '%s' "${entry}" | jq -r '.branch // "*"')
+  post /admin/trust \
+    "$(jq -cn --arg r "${repo}" --arg b "${branch}" \
+      '{kind:"branch", repo:$r, branch:$b}')" \
+    "branch ${repo}@${branch}" || {
+    # 404 from the first call means the whole surface is missing; don't hammer it per entry.
+    [[ $? == 2 ]] && exit 0
+  }
+done < <(jq -c '.branches // [] | .[]' "${TRUST_FILE}")
+
+echo "Reconciling catalogs from ${CATALOGS_FILE#"${REPO_ROOT}/"}"
+while IFS= read -r entry; do
+  [[ -n "${entry}" ]] || continue
+  system=$(printf '%s' "${entry}" | jq -r '.system')
+  # Preserve the declared shape — an unlisted catalog must stay off the front page, and a group
+  # claim has to survive or the card lands under the owner fallback instead of its section.
+  body=$(printf '%s' "${entry}" | jq -c '{system, repo, listed, group, attributionRepos}
+    | with_entries(select(.value != null))')
+  post /admin/catalogs "${body}" "catalog ${system}" || {
+    [[ $? == 2 ]] && exit 0
+  }
+done < <(jq -c '.catalogs // [] | .[]' "${CATALOGS_FILE}")
+
+echo "Config reconcile complete."

--- a/.github/scripts/publish-config-to-box.sh
+++ b/.github/scripts/publish-config-to-box.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 # Reconcile the image's SEED config onto a running preview server via its admin API.
 #
-# Why this exists: deploy/image/catalogs.json and deploy/image/trust/producers.json are
-# first-boot seeds. The entrypoint copies each to /config only when it is ABSENT and never
-# overwrites it again — deliberately, so an image roll can't stomp a runtime edit (see #2879 /
-# #2897). The consequence is that merging a new catalog or producer changes nothing on an
-# already-deployed box: the entries land in the image, the box keeps the config it already has,
-# and someone has to remember to POST them by hand. This closes that gap as part of publishing.
+# Why this exists: /config/catalogs.json and /config/producers.json are seeded on first boot and
+# never overwritten after — deliberately, so an image roll can't stomp a runtime edit (see #2879 /
+# #2897). The consequence is that adding a catalog or producer to a committed file changes nothing
+# on an already-deployed box: it keeps the config it already has, and someone has to remember to
+# POST the new entries by hand. This closes that gap as part of publishing.
 #
 # ADDITIVE ONLY. This never deletes and never rewrites an existing entry: an id already present
 # comes back 409 from the admin API, which is treated as success. So a producer or catalog an
@@ -28,8 +27,18 @@
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-CATALOGS_FILE="${CATALOGS_FILE:-${REPO_ROOT}/deploy/image/catalogs.json}"
-TRUST_FILE="${TRUST_FILE:-${REPO_ROOT}/deploy/image/trust/producers.json}"
+
+# The DEPLOYMENT's config, not the image's generic seed. These are different things and conflating
+# them is what gave preview.coo.ee favoured-nation status: its 17 catalogs and 9 trusted producers
+# used to live in deploy/image/, so every adopter of the prebuilt image inherited them. The image
+# seed is now compose-m3 plus the one producer that publishes it; a deployment's own set lives in
+# its own directory and is applied from here.
+#
+# DEPLOY_CONFIG_DIR is what another adopter overrides — point it at your own directory with the
+# same two filenames and this script works unchanged against your box.
+DEPLOY_CONFIG_DIR="${DEPLOY_CONFIG_DIR:-${REPO_ROOT}/deploy/preview.coo.ee}"
+CATALOGS_FILE="${CATALOGS_FILE:-${DEPLOY_CONFIG_DIR}/catalogs.json}"
+TRUST_FILE="${TRUST_FILE:-${DEPLOY_CONFIG_DIR}/producers.json}"
 ADMIN_TOKEN_HEADER="X-Compose-Preview-Admin-Token"
 
 DRY_RUN=0

--- a/.github/scripts/test-publish-config-to-box.sh
+++ b/.github/scripts/test-publish-config-to-box.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Self-test for publish-config-to-box.sh, run by CI on every PR.
+#
+# Drives the --dry-run seam so the rules that actually matter are pinned without a server:
+#   1. trust is reconciled BEFORE catalogs (a catalog published ahead of its producer would
+#      register as `unverified` and stay that way until its branch moved);
+#   2. the declared entry shape survives — `listed: false` and `group` are not dropped, since
+#      either being lost silently changes where a card renders;
+#   3. null/absent optional fields are omitted rather than sent as JSON null.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNDER_TEST="${SCRIPT_DIR}/publish-config-to-box.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+failures=0
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+cat > "${tmp}/producers.json" <<'JSON'
+{
+  "branches": [
+    { "repo": "yschimke/compose-ai-tools", "branch": "design-artifacts/*" },
+    { "repo": "yschimke/pocket-casts-android", "branch": "design-artifacts/*" }
+  ]
+}
+JSON
+
+cat > "${tmp}/catalogs.json" <<'JSON'
+{
+  "groups": [{ "id": "ds", "heading": "Design Systems" }],
+  "catalogs": [
+    { "system": "compose-m3", "repo": "yschimke/compose-ai-tools", "listed": true, "group": "ds" },
+    { "system": "cadence", "repo": "yschimke/cadence", "listed": false },
+    { "system": "jetnews", "repo": "yschimke/compose-samples", "listed": true,
+      "attributionRepos": ["android/compose-samples"] }
+  ]
+}
+JSON
+
+out=$(BASE_URL=https://example.invalid \
+  TRUST_FILE="${tmp}/producers.json" \
+  CATALOGS_FILE="${tmp}/catalogs.json" \
+  bash "${UNDER_TEST}" --dry-run)
+
+# 1. ordering: every /admin/trust POST precedes every /admin/catalogs POST.
+last_trust=$(printf '%s\n' "${out}" | grep -n 'POST /admin/trust' | tail -1 | cut -d: -f1)
+first_catalog=$(printf '%s\n' "${out}" | grep -n 'POST /admin/catalogs' | head -1 | cut -d: -f1)
+if [[ -z "${last_trust}" || -z "${first_catalog}" ]]; then
+  fail "expected both trust and catalog POSTs; got:\n${out}"
+elif [[ "${last_trust}" -ge "${first_catalog}" ]]; then
+  fail "trust must be reconciled before catalogs (last trust line ${last_trust}, first catalog line ${first_catalog})"
+fi
+
+# 2. both producers are sent, with their branch globs intact.
+for repo in yschimke/compose-ai-tools yschimke/pocket-casts-android; do
+  printf '%s' "${out}" | grep -q "\"repo\":\"${repo}\",\"branch\":\"design-artifacts/\*\"" ||
+    fail "missing trust POST for ${repo}"
+done
+
+# 3. an unlisted catalog stays unlisted.
+printf '%s' "${out}" | grep -q '"system":"cadence".*"listed":false' ||
+  fail "cadence must be POSTed with listed:false"
+
+# 4. a group claim survives.
+printf '%s' "${out}" | grep -q '"system":"compose-m3".*"group":"ds"' ||
+  fail "compose-m3 must keep its group claim"
+
+# 5. attributionRepos survives (it's what lets a fork-served catalog keep its upstream section).
+printf '%s' "${out}" | grep -q '"attributionRepos":\["android/compose-samples"\]' ||
+  fail "jetnews must keep its attributionRepos"
+
+# 6. absent optionals are omitted, not sent as null.
+printf '%s' "${out}" | grep -q 'null' &&
+  fail "no request body should contain a JSON null: ${out}"
+
+# 7. every catalog in the file is covered — a silently-skipped entry is the failure mode this
+#    whole script exists to prevent.
+for system in compose-m3 cadence jetnews; do
+  printf '%s' "${out}" | grep -q "\"system\":\"${system}\"" ||
+    fail "missing catalog POST for ${system}"
+done
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "${failures} check(s) failed" >&2
+  exit 1
+fi
+echo "publish-config-to-box: all checks passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,6 +648,11 @@ jobs:
       # are worth a gate rather than a manual check.
       - name: Run deploy .env migration tests
         run: ./deploy/image/test-env-migrations.sh
+      # The seed-config reconcile POSTs to a live server's admin API during publish, so its
+      # ordering (trust before catalogs) and payload-shape rules are gated rather than eyeballed —
+      # a dropped `listed: false` or `group` silently moves a card on the front page.
+      - name: Run publish-config reconcile tests
+        run: ./.github/scripts/test-publish-config-to-box.sh
 
   # VS Code extension tests — both the existing in-process Mocha suite and
   # the @vscode/test-electron integration tests. The latter download a

--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -185,6 +185,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: deploy/image
@@ -272,11 +273,17 @@ jobs:
       # directly on the box survives. See the script header for the retire-vs-reseed trade-off.
       #
       # Best-effort and OPTIONAL, like the rollout notify above: it needs a SERVE_ADMIN_TOKEN
-      # secret matching the box's own, and does nothing without one. `if: always()` so a box that
-      # was slow to converge above still gets its config reconciled; `continue-on-error` so this
+      # secret matching the box's own, and does nothing without one. `continue-on-error` so this
       # can never fail a publish that already succeeded.
+      #
+      # The condition is `steps.push.outcome == 'success'`, NOT a bare `always()`. A bare always()
+      # would also fire when the build or the GHCR push failed, pushing this tag's seed config at a
+      # box still running the OLD image — publishing catalogs whose image was never deployed, which
+      # inverts the whole point of doing this after the roll. Keying on the push step keeps the one
+      # case always() was for (the convergence check above timed out, but the image IS on GHCR and
+      # the box will roll on its next poll) while dropping the case that was never intended.
       - name: Publish seed config to preview.coo.ee (best-effort)
-        if: always()
+        if: always() && steps.push.outcome == 'success'
         continue-on-error: true
         env:
           BASE_URL: ${{ vars.DEPLOY_BASE_URL || 'https://preview.coo.ee' }}

--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -260,3 +260,31 @@ jobs:
           done
           echo "::error::preview.coo.ee did not converge to ${V} with a readable catalog status within ~10 min." >&2
           exit 1
+
+      # Push the image's SEED config onto the now-rolled box. catalogs.json and
+      # trust/producers.json are first-boot seeds — the entrypoint never overwrites an existing
+      # /config copy (deliberately, so a roll can't stomp a runtime edit), which means merging a
+      # new catalog or producer changed NOTHING on an already-deployed server and someone had to
+      # remember to POST it by hand. This closes that gap at the one moment the box is known to be
+      # running the matching image.
+      #
+      # Additive only: an id already present comes back 409 and is left alone, so anything added
+      # directly on the box survives. See the script header for the retire-vs-reseed trade-off.
+      #
+      # Best-effort and OPTIONAL, like the rollout notify above: it needs a SERVE_ADMIN_TOKEN
+      # secret matching the box's own, and does nothing without one. `if: always()` so a box that
+      # was slow to converge above still gets its config reconciled; `continue-on-error` so this
+      # can never fail a publish that already succeeded.
+      - name: Publish seed config to preview.coo.ee (best-effort)
+        if: always()
+        continue-on-error: true
+        env:
+          BASE_URL: ${{ vars.DEPLOY_BASE_URL || 'https://preview.coo.ee' }}
+          ADMIN_TOKEN: ${{ secrets.SERVE_ADMIN_TOKEN }}
+        run: |
+          set -u
+          if [ -z "${ADMIN_TOKEN}" ]; then
+            echo "no SERVE_ADMIN_TOKEN secret — skipping config reconcile (seed applies to new boxes only)."
+            exit 0
+          fi
+          bash .github/scripts/publish-config-to-box.sh

--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -262,12 +262,17 @@ jobs:
           echo "::error::preview.coo.ee did not converge to ${V} with a readable catalog status within ~10 min." >&2
           exit 1
 
-      # Push the image's SEED config onto the now-rolled box. catalogs.json and
-      # trust/producers.json are first-boot seeds — the entrypoint never overwrites an existing
-      # /config copy (deliberately, so a roll can't stomp a runtime edit), which means merging a
-      # new catalog or producer changed NOTHING on an already-deployed server and someone had to
-      # remember to POST it by hand. This closes that gap at the one moment the box is known to be
-      # running the matching image.
+      # Push the DEPLOYMENT's config onto the now-rolled box. /config/catalogs.json and
+      # /config/producers.json are seeded on first boot and never overwritten after (deliberately,
+      # so a roll can't stomp a runtime edit), which means adding a catalog or producer to a
+      # committed file changed NOTHING on an already-deployed server and someone had to remember to
+      # POST it by hand. This closes that gap at the one moment the box is known to be running the
+      # matching image.
+      #
+      # Note the source is deploy/<deployment>/, NOT the image's seed: the image bakes only
+      # compose-m3 and the single producer that publishes it, so an operator adopting the prebuilt
+      # image doesn't inherit this deployment's catalogs or its trust relationships. Another
+      # deployment sets DEPLOY_CONFIG_DIR (+ DEPLOY_BASE_URL) to its own and reuses this verbatim.
       #
       # Additive only: an id already present comes back 409 and is left alone, so anything added
       # directly on the box survives. See the script header for the retire-vs-reseed trade-off.
@@ -282,16 +287,22 @@ jobs:
       # inverts the whole point of doing this after the roll. Keying on the push step keeps the one
       # case always() was for (the convergence check above timed out, but the image IS on GHCR and
       # the box will roll on its next poll) while dropping the case that was never intended.
-      - name: Publish seed config to preview.coo.ee (best-effort)
+      - name: Publish deployment config to the preview box (best-effort)
         if: always() && steps.push.outcome == 'success'
         continue-on-error: true
         env:
           BASE_URL: ${{ vars.DEPLOY_BASE_URL || 'https://preview.coo.ee' }}
+          DEPLOY_CONFIG_DIR: ${{ vars.DEPLOY_CONFIG_DIR || 'deploy/preview.coo.ee' }}
           ADMIN_TOKEN: ${{ secrets.SERVE_ADMIN_TOKEN }}
         run: |
           set -u
           if [ -z "${ADMIN_TOKEN}" ]; then
-            echo "no SERVE_ADMIN_TOKEN secret — skipping config reconcile (seed applies to new boxes only)."
+            echo "no SERVE_ADMIN_TOKEN secret — skipping config reconcile (nothing to push)."
             exit 0
           fi
-          bash .github/scripts/publish-config-to-box.sh
+          if [ ! -d "${DEPLOY_CONFIG_DIR}" ]; then
+            echo "no ${DEPLOY_CONFIG_DIR} — skipping config reconcile (no deployment config in this repo)."
+            exit 0
+          fi
+          DEPLOY_CONFIG_DIR="$(cd "${DEPLOY_CONFIG_DIR}" && pwd)" \
+            bash .github/scripts/publish-config-to-box.sh

--- a/deploy/image/catalogs.json
+++ b/deploy/image/catalogs.json
@@ -1,14 +1,10 @@
 {
+  "_comment": "GENERIC SEED for the prebuilt preview-host image — deliberately NOT any particular deployment's catalog set. This file is baked into the image as /etc/compose-preview/catalogs.default.json and copied to /config/catalogs.json on FIRST BOOT ONLY, so it is what an operator adopting this image sees before they configure anything. It therefore carries only compose-m3, this repo's own reference design system: enough that `docker compose up -d` shows something real, and nothing that presumes a relationship with any other project. Previously this shipped preview.coo.ee's full 17-catalog set, which meant every adopter's front page opened on someone else's apps; that set now lives in deploy/preview.coo.ee/catalogs.json and reaches its box via the admin API (see .github/scripts/publish-config-to-box.sh), not by being baked in. Publish your own catalogs by editing /config/catalogs.json on the box, POSTing to /admin/catalogs, or bind-mounting your own file over /config/catalogs.json. Each entry's design-artifacts/<system> branch must also be trusted — see trust/producers.json beside this file. Docs: docs/public-preview-server.md.",
   "groups": [
     {
       "id": "design-systems",
       "heading": "Design Systems",
       "noun": "design system(s)"
-    },
-    {
-      "id": "android-samples",
-      "heading": "android/compose-samples",
-      "noun": "sample(s)"
     }
   ],
   "catalogs": [
@@ -17,102 +13,6 @@
       "repo": "yschimke/compose-ai-tools",
       "listed": true,
       "group": "design-systems"
-    },
-    {
-      "system": "wear-m3",
-      "repo": "yschimke/compose-ai-tools",
-      "listed": true,
-      "group": "design-systems"
-    },
-    {
-      "system": "remote-m3",
-      "repo": "yschimke/compose-ai-tools",
-      "listed": true,
-      "group": "design-systems"
-    },
-    {
-      "system": "meshcore-mobile",
-      "repo": "yschimke/meshcore-mobile",
-      "listed": true
-    },
-    {
-      "system": "homeassistant-remotecompose",
-      "repo": "yschimke/homeassistant-remotecompose",
-      "listed": true
-    },
-    {
-      "system": "pocketcasts",
-      "repo": "yschimke/pocket-casts-android",
-      "listed": true
-    },
-    {
-      "system": "pocketcasts-wear",
-      "repo": "yschimke/pocket-casts-android",
-      "listed": true
-    },
-    {
-      "system": "jetnews",
-      "repo": "yschimke/compose-samples",
-      "listed": true,
-      "group": "android-samples",
-      "attributionRepos": ["android/compose-samples"]
-    },
-    {
-      "system": "jetcaster",
-      "repo": "yschimke/compose-samples",
-      "listed": true,
-      "group": "android-samples",
-      "attributionRepos": ["android/compose-samples"]
-    },
-    {
-      "system": "jetcaster-wear",
-      "repo": "yschimke/compose-samples",
-      "listed": true,
-      "group": "android-samples",
-      "attributionRepos": ["android/compose-samples"]
-    },
-    {
-      "system": "jetchat",
-      "repo": "yschimke/compose-samples",
-      "listed": true,
-      "group": "android-samples",
-      "attributionRepos": ["android/compose-samples"]
-    },
-    {
-      "system": "jetsnack",
-      "repo": "yschimke/compose-samples",
-      "listed": true,
-      "group": "android-samples",
-      "attributionRepos": ["android/compose-samples"]
-    },
-    {
-      "system": "jetlagged",
-      "repo": "yschimke/compose-samples",
-      "listed": true,
-      "group": "android-samples",
-      "attributionRepos": ["android/compose-samples"]
-    },
-    {
-      "system": "reply",
-      "repo": "yschimke/compose-samples",
-      "listed": true,
-      "group": "android-samples",
-      "attributionRepos": ["android/compose-samples"]
-    },
-    {
-      "system": "confetti-wear",
-      "repo": "joreilly/Confetti",
-      "listed": true
-    },
-    {
-      "system": "confetti-mobile",
-      "repo": "joreilly/Confetti",
-      "listed": true
-    },
-    {
-      "system": "cadence",
-      "repo": "yschimke/cadence",
-      "listed": false
     }
   ]
 }

--- a/deploy/image/trust/producers.json
+++ b/deploy/image/trust/producers.json
@@ -1,40 +1,8 @@
 {
-  "_comment": "Trust store baked into the prebuilt preview-host image so a public deploy badges the published design-system catalogs as Trusted(Branch) out of the box, instead of Unverified. Branch (origin) trust only \u2014 the image carries no signing key, and branch trust is exactly what the --catalogs fetch needs: a catalog the server itself pulled from one of these branches is trusted by TLS origin, no per-bundle crypto. SERVE_TRUST_STORE defaults to this file (deploy/image/docker-compose.yml); override it, or mount your own at /trust/producers.json, to pin different producers. See docs/public-preview-server.md.",
+  "_comment": "GENERIC SEED trust store for the prebuilt preview-host image. Baked to /trust/producers.json and copied to /config/producers.json on FIRST BOOT ONLY (see deploy/image/entrypoint.sh), so this is the trust an operator adopting the image inherits — which is why it lists exactly ONE producer: the repo publishing compose-m3, the only catalog in the generic seed beside it. It used to list nine repos (meshcore-mobile, compose-samples, joreilly/Confetti, cadence, …), so every adopter silently inherited trust relationships with projects they have nothing to do with; on a box running the default SERVE_ALLOW_RENDER_TRUSTED=1 that is not just a badge but eligibility for server-side execution. Those producers now live in deploy/preview.coo.ee/producers.json and reach that box via POST /admin/trust. Branch (origin) trust only — the image carries no signing key, and branch trust is what the --catalogs fetch needs: a catalog the server itself pulled from one of these branches is trusted by TLS origin, no per-bundle crypto. Add your own producers by POSTing to /admin/trust, editing /config/producers.json, or mounting your own file over /trust/producers.json. Empty = trust nothing (fail-closed). Docs: docs/public-preview-server.md.",
   "branches": [
     {
       "repo": "yschimke/compose-ai-tools",
-      "branch": "design-artifacts/*"
-    },
-    {
-      "repo": "yschimke/meshcore-mobile",
-      "branch": "design-artifacts/*"
-    },
-    {
-      "repo": "yschimke/homeassistant-remotecompose",
-      "branch": "design-artifacts/*"
-    },
-    {
-      "repo": "yschimke/cadence",
-      "branch": "design-artifacts/*"
-    },
-    {
-      "repo": "yschimke/compose-samples",
-      "branch": "design-artifacts/*"
-    },
-    {
-      "repo": "yschimke/horologist",
-      "branch": "design-artifacts/*"
-    },
-    {
-      "repo": "yschimke/pocket-casts-android",
-      "branch": "design-artifacts/*"
-    },
-    {
-      "repo": "joreilly/Confetti",
-      "branch": "design-artifacts/*"
-    },
-    {
-      "repo": "yschimke/Confetti",
       "branch": "design-artifacts/*"
     }
   ]

--- a/deploy/preview.coo.ee/catalogs.json
+++ b/deploy/preview.coo.ee/catalogs.json
@@ -1,0 +1,133 @@
+{
+  "_comment": "preview.coo.ee's PUBLISHED CATALOG SET \u2014 deployment config for one specific box, NOT image content. Kept out of deploy/image/ deliberately: baking it there made every adopter of the prebuilt image open on these catalogs (see the seed's comment). This file is applied to the box by .github/scripts/publish-config-to-box.sh after each image publish, additively over POST /admin/catalogs, so it never needs an image rebuild. Another deployment adopting the preview server keeps its own copy of this shape and points DEPLOY_CONFIG_DIR at it. Every entry's design-artifacts/<system> branch must be trusted by producers.json beside this file. cadence is listed:false \u2014 reachable at /cadence/ but off the front-page index.",
+  "groups": [
+    {
+      "id": "design-systems",
+      "heading": "Design Systems",
+      "noun": "design system(s)"
+    },
+    {
+      "id": "android-samples",
+      "heading": "android/compose-samples",
+      "noun": "sample(s)"
+    }
+  ],
+  "catalogs": [
+    {
+      "system": "compose-m3",
+      "repo": "yschimke/compose-ai-tools",
+      "listed": true,
+      "group": "design-systems"
+    },
+    {
+      "system": "wear-m3",
+      "repo": "yschimke/compose-ai-tools",
+      "listed": true,
+      "group": "design-systems"
+    },
+    {
+      "system": "remote-m3",
+      "repo": "yschimke/compose-ai-tools",
+      "listed": true,
+      "group": "design-systems"
+    },
+    {
+      "system": "meshcore-mobile",
+      "repo": "yschimke/meshcore-mobile",
+      "listed": true
+    },
+    {
+      "system": "homeassistant-remotecompose",
+      "repo": "yschimke/homeassistant-remotecompose",
+      "listed": true
+    },
+    {
+      "system": "pocketcasts",
+      "repo": "yschimke/pocket-casts-android",
+      "listed": true
+    },
+    {
+      "system": "pocketcasts-wear",
+      "repo": "yschimke/pocket-casts-android",
+      "listed": true
+    },
+    {
+      "system": "jetnews",
+      "repo": "yschimke/compose-samples",
+      "listed": true,
+      "group": "android-samples",
+      "attributionRepos": [
+        "android/compose-samples"
+      ]
+    },
+    {
+      "system": "jetcaster",
+      "repo": "yschimke/compose-samples",
+      "listed": true,
+      "group": "android-samples",
+      "attributionRepos": [
+        "android/compose-samples"
+      ]
+    },
+    {
+      "system": "jetcaster-wear",
+      "repo": "yschimke/compose-samples",
+      "listed": true,
+      "group": "android-samples",
+      "attributionRepos": [
+        "android/compose-samples"
+      ]
+    },
+    {
+      "system": "jetchat",
+      "repo": "yschimke/compose-samples",
+      "listed": true,
+      "group": "android-samples",
+      "attributionRepos": [
+        "android/compose-samples"
+      ]
+    },
+    {
+      "system": "jetsnack",
+      "repo": "yschimke/compose-samples",
+      "listed": true,
+      "group": "android-samples",
+      "attributionRepos": [
+        "android/compose-samples"
+      ]
+    },
+    {
+      "system": "jetlagged",
+      "repo": "yschimke/compose-samples",
+      "listed": true,
+      "group": "android-samples",
+      "attributionRepos": [
+        "android/compose-samples"
+      ]
+    },
+    {
+      "system": "reply",
+      "repo": "yschimke/compose-samples",
+      "listed": true,
+      "group": "android-samples",
+      "attributionRepos": [
+        "android/compose-samples"
+      ]
+    },
+    {
+      "system": "confetti-wear",
+      "repo": "joreilly/Confetti",
+      "listed": true
+    },
+    {
+      "system": "confetti-mobile",
+      "repo": "joreilly/Confetti",
+      "listed": true
+    },
+    {
+      "system": "cadence",
+      "repo": "yschimke/cadence",
+      "listed": false
+    }
+  ]
+}

--- a/deploy/preview.coo.ee/producers.json
+++ b/deploy/preview.coo.ee/producers.json
@@ -1,0 +1,41 @@
+{
+  "_comment": "preview.coo.ee's TRUSTED PRODUCERS \u2014 deployment config for one specific box, NOT image content. Kept out of deploy/image/trust/ deliberately: baking these made every adopter of the prebuilt image inherit trust in nine repos, which on a box with SERVE_ALLOW_RENDER_TRUSTED=1 is eligibility for server-side execution of those repos' Compose. Applied to the box by .github/scripts/publish-config-to-box.sh via POST /admin/trust after each image publish. Must cover every catalog in catalogs.json beside this file, or that catalog serves as `unverified`.",
+  "branches": [
+    {
+      "repo": "yschimke/compose-ai-tools",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/meshcore-mobile",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/homeassistant-remotecompose",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/cadence",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/compose-samples",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/horologist",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/pocket-casts-android",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "joreilly/Confetti",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/Confetti",
+      "branch": "design-artifacts/*"
+    }
+  ]
+}

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -32,11 +32,13 @@ services:
       # Trusted(Branch)). Bind-mounted below from the repo, so publishing a catalog is a file
       # edit + restart — not a compose edit. cadence is declared `listed: false` there:
       # reachable at /cadence/ but kept off the front-page index.
+      # Bind-mounted below from deploy/preview.coo.ee (this box runs that deployment's set). An
+      # adopter points these at their own directory — the image's own seed is compose-m3 only.
       SERVE_CATALOGS_FILE: "${SERVE_CATALOGS_FILE:-/config/catalogs.json}"
       # Optional additions to that file (<system>@<owner>/<repo>, comma-separated).
       SERVE_CATALOGS: "${SERVE_CATALOGS:-}"
       SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-}"
-      SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-trust/producers.json}"
+      SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-/config/producers.json}"
       SERVE_WASM_DIR: "${SERVE_WASM_DIR:-compose-m3=samples/cmp-wasm-catalog/build/wasmDist}"
       # Live (daemon-backed) server-side re-render. Now that compose-m3 is a
       # Compose Multiplatform (desktop) catalog, this desktop-only box CAN build
@@ -54,10 +56,13 @@ services:
       SERVE_TOKEN: "${SERVE_TOKEN:-}"
       PORT: "8080"
     volumes:
-      # The published catalog set, kept in version control and mounted read-only (this box
-      # doesn't run the admin API, so nothing needs to write it back). Shared with the
-      # prebuilt-image profile so both boxes publish the same catalogs from one file.
-      - ../image/catalogs.json:/config/catalogs.json:ro
+      # This DEPLOYMENT's published set + trusted producers, kept in version control and mounted
+      # read-only (this box doesn't run the admin API, so nothing needs to write them back).
+      # Deliberately deploy/preview.coo.ee/, not deploy/image/: the latter is the generic seed an
+      # adopter of the prebuilt image inherits, and it carries compose-m3 only so nobody starts out
+      # serving — or trusting — another project's repos.
+      - ../preview.coo.ee/catalogs.json:/config/catalogs.json:ro
+      - ../preview.coo.ee/producers.json:/config/producers.json:ro
     expose:
       - "8080"
     # One warm Desktop daemon fits comfortably in a few GB; this cap just keeps a

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -360,10 +360,27 @@ samples, fetched from preview branches in the `yschimke/compose-samples` fork, a
 `android/compose-samples`). So serving a third-party catalog under the id `compose-m3` can't make it
 read as an official design system.
 
-The image carries the standard set only as a **seed** ([`deploy/image/catalogs.json`](../deploy/image/catalogs.json)
-→ `/etc/compose-preview/catalogs.default.json`), copied to `/config/catalogs.json` on first boot when
-that file doesn't exist. After that the operator's copy wins and an image pull never touches it. A
-bare `docker run` with an empty volume still comes up serving the standard catalogs.
+### Image seed vs deployment config
+
+Two different things, kept in two different places on purpose:
+
+| | Lives in | Is |
+|---|---|---|
+| **Image seed** | [`deploy/image/catalogs.json`](../deploy/image/catalogs.json) + [`deploy/image/trust/producers.json`](../deploy/image/trust/producers.json) | Baked into the image; copied to `/config/…` on **first boot only**. What an operator adopting the prebuilt image starts with. |
+| **Deployment config** | `deploy/<deployment>/catalogs.json` + `producers.json` (e.g. [`deploy/preview.coo.ee/`](../deploy/preview.coo.ee)) | One box's published set. Applied over the admin API after each publish; never baked. |
+
+The seed carries **`compose-m3` only**, plus the single producer that publishes it — enough that a
+bare `docker compose up -d` shows something real, and nothing that presumes a relationship with any
+other project. It used to carry preview.coo.ee's full 17-catalog set and nine trusted producers,
+which meant every adopter's front page opened on someone else's apps and inherited trust in repos
+they had nothing to do with. On a box running the default `SERVE_ALLOW_RENDER_TRUSTED=1` that second
+part isn't cosmetic — trust is eligibility for server-side execution.
+
+So: publishing a catalog on **your** server is editing your own `/config/catalogs.json`, POSTing to
+`/admin/catalogs`, or bind-mounting your own file — never waiting on this repo. Running the same
+CI-side reconcile for your own box is `DEPLOY_CONFIG_DIR` + `DEPLOY_BASE_URL` pointing at yours.
+
+After first boot the operator's `/config` copy always wins and an image pull never touches it.
 
 `SERVE_CATALOGS` / `SERVE_CATALOGS_UNLISTED` still work as **additions** (`<system>@<owner>/<repo>`,
 comma-separated) for a box that wants one extra catalog without editing config; a system named in
@@ -457,12 +474,12 @@ never opted in has no admin surface to find. A bad token gets the same `404` the
 
 #### Where the trust store lives
 
-The prebuilt `deploy/image` bakes a seed branch-trust store at `/trust/producers.json` (trusting
-`design-artifacts/*` on `yschimke/compose-ai-tools`, `yschimke/meshcore-mobile`,
-`yschimke/homeassistant-remotecompose` and friends). On first boot the entrypoint copies it to
-`/config/producers.json` on the `preview_config` volume and points `SERVE_TRUST_STORE` there; it is
-never overwritten again, so an operator edit — or a `POST /admin/trust` — survives every subsequent
-image roll. The published catalogs still badge as `Trusted(Branch)` out of the box.
+The prebuilt `deploy/image` bakes a seed branch-trust store at `/trust/producers.json` trusting
+`design-artifacts/*` on **`yschimke/compose-ai-tools` and nothing else** — the one producer needed by
+`compose-m3`, the only catalog in the matching seed. Adopting the image deliberately does not hand you
+trust in anyone else's repos. On first boot the entrypoint copies it to `/config/producers.json` on
+the `preview_config` volume and points `SERVE_TRUST_STORE` there; it is never overwritten again, so an
+operator edit — or a `POST /admin/trust` — survives every subsequent image roll.
 
 Set `SERVE_TRUST_STORE` to your own path to pin different producers, or `none` to run trustless.
 (Empty falls back to the default — use `none` to opt out — which also means a bare image pull
@@ -474,11 +491,9 @@ isn't there — a typo, an unmounted secret, a broken deploy — the entrypoint 
 image's allowlist; with server-side re-render on, that would execute producers you never configured.
 An explicit override has to exist, and a missing one keeps the old hard failure.
 
-The catalog set is **not** baked the same way — see "The catalog set is config, not image content"
-above: the image ships it only as a first-boot seed, and the live copy lives on the `/config` volume
-where an operator edit or an admin-API call owns it. The `deploy/vps` from-source path mounts the
-same [`deploy/image/catalogs.json`](../deploy/image/catalogs.json) read-only, so both boxes publish
-one file's worth of catalogs.
+The catalog set works identically — see "Image seed vs deployment config" above. The `deploy/vps`
+from-source path mounts [`deploy/preview.coo.ee/`](../deploy/preview.coo.ee)'s pair read-only rather
+than the image seed, because that box runs *that deployment's* set; an adopter mounts their own.
 
 | | [`deploy/vps`](../deploy/vps) (from source) | [`deploy/image`](../deploy/image) (prebuilt) |
 |---|---|---|


### PR DESCRIPTION
Two related problems, one of which only surfaced during review.

## 1. The image gave preview.coo.ee favoured-nation status

`deploy/image/catalogs.json` baked **17 catalogs** and `deploy/image/trust/producers.json` baked **9 trusted producers** — all of them one deployment's. Anyone pulling `ghcr.io/yschimke/compose-preview-host` therefore got a front page full of someone else's apps, and inherited trust in repos they have no relationship with. On a box running the default `SERVE_ALLOW_RENDER_TRUSTED=1` that second part isn't cosmetic: trust is eligibility for **server-side execution** of those repos' Compose.

Now split:

| | Contents |
|---|---|
| `deploy/image/catalogs.json` | `compose-m3` only |
| `deploy/image/trust/producers.json` | `yschimke/compose-ai-tools` only — the one producer that publishes it |
| `deploy/preview.coo.ee/{catalogs.json,producers.json}` | that deployment's 17 + 9, moved out of the image |

The seed is now "enough that `docker compose up -d` shows something real, and nothing presuming a relationship with another project". `deploy/vps` mounts the deployment pair rather than the seed, since that box runs that deployment.

## 2. Committed config never reached a running box

`/config/*` is seeded on first boot and never overwritten (deliberately — an image roll must not stomp a runtime edit, #2879/#2897). So adding a catalog changed nothing on an already-deployed server; both #2953 and #2962 needed manual follow-up.

`preview-host-image.yml` now runs `.github/scripts/publish-config-to-box.sh` after the rollout convergence check — the one moment the box is known to be on the matching image, and therefore to have the `/admin/trust` routes from #2961. Trust is reconciled **before** catalogs, since a catalog fetched before its producer is trusted registers `unverified` and stays that way until its branch next moves.

**Not preview.coo.ee-specific:** `DEPLOY_CONFIG_DIR` + `DEPLOY_BASE_URL` (both repo vars, defaulted) point it at any deployment's directory. Skips cleanly when the directory or `SERVE_ADMIN_TOKEN` is absent.

**Additive only.** An id already present returns 409 and is left alone.

## Review findings, both fixed

- **P1 — `always()` fired on a failed build/push**, applying this tag's config to a box still on the old image. Now `always() && steps.push.outcome == 'success'`, which keeps the case `always()` was for (convergence timed out, image *is* on GHCR, box rolls on its next poll).
- **P2 — a rejected entry was a `::warning::` nobody reads.** Now captures the response body, emits `::error::` and exits non-zero. The unknown-group case gets a specific message: there is no admin route for front-page groups (only `/admin/catalogs` and `/admin/trust`), so it genuinely cannot be reconciled from CI — the message says to edit the box's `/config/catalogs.json` or drop the group claim.

## The trade-off, stated plainly

The reconcile is blind to history, so a catalog **retired on the box** while still listed in the deployment file will be re-added by the next publish. That makes the committed file the declared intent — to retire something permanently, remove it there too. Fully solving it needs the box to persist tombstones; that's a separate change.

## Test plan

- `.github/scripts/test-publish-config-to-box.sh` — new, gated by `ci.yml` beside `test-env-migrations.sh` / `test-scope-systems.sh`. Drives the `--dry-run` seam (no server) and pins: trust-before-catalogs ordering; `listed: false`, `group` and `attributionRepos` surviving; absent optionals omitted rather than sent as `null`; and every catalog covered, since a silently-skipped entry is what this exists to prevent.
- Unknown-group rejection exercised against a stubbed `curl`: `::error::` + exit 1 confirmed.
- All five JSON files parse; entry counts verified (seed 1+1, deployment 17+9). All three touched YAML files parse.
- Not yet run against a live server — the first real run is the next publish, where it's `continue-on-error` by construction.

Non-visual change (deploy plumbing + config), so no render evidence.
