### PR TITLE
feat(plugin): per-preview-id render filter, so a deferred catalog palette skips its render

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewNameFilter.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewNameFilter.kt
@@ -48,6 +48,25 @@ object PreviewNameFilter {
     return if (pkg.isEmpty()) functionName else "$pkg.$functionName"
   }
 
+  /**
+   * True when a preview **id** matches at least one of [patterns], or when [patterns] is empty.
+   *
+   * The id-level counterpart of [matches], for selecting individual members of one `@Preview`
+   * function's fan-out (issue #2966). A multipreview member or `@PreviewParameter` row is its own
+   * `PreviewInfo` with a distinct `id` (`FilledButton_Light` / `FilledButton_Dark`) but the *same*
+   * `functionName`, so [matches] can only ever keep or drop the whole function — which is why a
+   * catalog's `modePriority` could thin its published sticker set but not its render.
+   *
+   * Ids are opaque strings rather than named code, so only one candidate is compared (no FQN
+   * variant), but the glob-vs-substring rules are deliberately identical to [matches] so a single
+   * documented pattern syntax covers both filters.
+   */
+  fun matchesId(patterns: Collection<String>, id: String): Boolean {
+    val cleaned = patterns.map(String::trim).filter(String::isNotEmpty)
+    if (cleaned.isEmpty()) return true
+    return cleaned.any { matchOne(it, id, id) }
+  }
+
   private fun matchOne(pattern: String, simpleName: String, fqName: String): Boolean =
     if (pattern.any { it == '*' || it == '?' }) {
       val regex = globToRegex(pattern)

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewNameFilterTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewNameFilterTest.kt
@@ -99,4 +99,31 @@ class PreviewNameFilterTest {
   fun `fqName falls back to the bare function name in the default package`() {
     assertThat(PreviewNameFilter.fqName("FooKt", "BarPreview")).isEqualTo("BarPreview")
   }
+
+  @Test
+  fun `matchesId with an empty filter keeps every id`() {
+    assertThat(PreviewNameFilter.matchesId(emptyList(), "FilledButton_Dark")).isTrue()
+    assertThat(PreviewNameFilter.matchesId(listOf("  ", ""), "FilledButton_Dark")).isTrue()
+  }
+
+  @Test
+  fun `matchesId globs a fan-out suffix`() {
+    // The catalog case: keep one palette per component, defer the rest to the live preview server.
+    assertThat(PreviewNameFilter.matchesId(listOf("*_Light"), "FilledButton_Light")).isTrue()
+    assertThat(PreviewNameFilter.matchesId(listOf("*_Light"), "FilledButton_Dark")).isFalse()
+  }
+
+  @Test
+  fun `matchesId treats a glob-free pattern as equality-or-substring, like matches`() {
+    assertThat(PreviewNameFilter.matchesId(listOf("FilledButton_Dark"), "FilledButton_Dark"))
+      .isTrue()
+    assertThat(PreviewNameFilter.matchesId(listOf("Filled"), "FilledButton_Dark")).isTrue()
+    assertThat(PreviewNameFilter.matchesId(listOf("Outlined"), "FilledButton_Dark")).isFalse()
+  }
+
+  @Test
+  fun `matchesId does not treat a dot in an id as a wildcard`() {
+    // Ids can carry package-qualified forms; `.` must stay literal, as it does for fqName matching.
+    assertThat(PreviewNameFilter.matchesId(listOf("com.example.Foo"), "comXexampleXFoo")).isFalse()
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -257,6 +257,10 @@ internal object ComposePreviewTasks {
         // repeatable `--preview` CLI option overrides it. Comma-separated so a single `-P` can name
         // several previews.
         previewFilters.convention(previewFilterProperty(project))
+        // `composePreview.idFilter` convention for the `--preview-id` fan-out-member filter (issue
+        // #2966); the repeatable `--preview-id` CLI option overrides it.
+        previewIdFilters.convention(previewIdFilterProperty(project))
+        previewIdExcludes.convention(previewIdExcludeProperty(project))
         displayFilterFilters.set(AndroidPreviewSupport.resolveDisplayFilterFilters(project))
         deviceFrameDevice.set(AndroidPreviewSupport.resolveDeviceFrameDevice(project))
         renderClasspath.from(sourceClassDirs)
@@ -1287,6 +1291,39 @@ internal object ComposePreviewTasks {
   internal fun previewFilterProperty(project: Project): Provider<List<String>> =
     project.providers
       .gradleProperty("composePreview.filter")
+      .map { v -> v.split(",").map(String::trim).filter(String::isNotEmpty) }
+      .orElse(emptyList())
+
+  /**
+   * `Provider<List<String>>` for the `composePreview.idFilter` Gradle property — the `--preview-id`
+   * filter's project-property form (issue #2966). Selects individual members of a `@Preview`
+   * function's fan-out by discovered **id**, which `composePreview.filter` can't: a multipreview
+   * member / `@PreviewParameter` row has its own id but shares its `functionName`.
+   *
+   * Same shape as [previewFilterProperty] — comma-separated, blanks dropped, absent ⇒ empty list
+   * ("render every preview") — so the design-artifacts pipeline can set it the same way, via
+   * `ORG_GRADLE_PROJECT_composePreview.idFilter`, and reach `composePreviewRender` through `bundle
+   * pack` with no CLI flag. Lazy through `project.providers` so reading it doesn't invalidate the
+   * configuration cache when the property flips between runs.
+   */
+  internal fun previewIdFilterProperty(project: Project): Provider<List<String>> =
+    project.providers
+      .gradleProperty("composePreview.idFilter")
+      .map { v -> v.split(",").map(String::trim).filter(String::isNotEmpty) }
+      .orElse(emptyList())
+
+  /**
+   * `Provider<List<String>>` for the `composePreview.idExclude` Gradle property — the
+   * `--exclude-preview-id` form, and the one a design catalog's deferred palettes actually use
+   * (issue #2966): the ids to *keep* aren't a matchable set, since the untagged primary stickers
+   * carry no theme suffix, so the deferral is expressed as what to skip.
+   *
+   * Set by the design-artifacts pipeline as `ORG_GRADLE_PROJECT_composePreview.idExclude` so it
+   * reaches `composePreviewRender` through `bundle pack` with no CLI flag.
+   */
+  internal fun previewIdExcludeProperty(project: Project): Provider<List<String>> =
+    project.providers
+      .gradleProperty("composePreview.idExclude")
       .map { v -> v.split(",").map(String::trim).filter(String::isNotEmpty) }
       .orElse(emptyList())
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1305,6 +1305,13 @@ internal object ComposePreviewTasks {
    * `ORG_GRADLE_PROJECT_composePreview.idFilter`, and reach `composePreviewRender` through `bundle
    * pack` with no CLI flag. Lazy through `project.providers` so reading it doesn't invalidate the
    * configuration cache when the property flips between runs.
+   *
+   * Wired only onto the DESKTOP `composePreviewRender` ([RenderPreviewsTask]). On an Android module
+   * that task name is a Robolectric `Test` task registered by [AndroidPreviewSupport], which reads
+   * neither this nor [previewFilterProperty] — so a filter is INERT on an Android render (it
+   * renders everything, the historical behaviour) rather than wrong. Extending the Robolectric path
+   * is tracked separately; until then a catalog's render-time saving only lands on a desktop/CMP
+   * module.
    */
   internal fun previewIdFilterProperty(project: Project): Provider<List<String>> =
     project.providers
@@ -1319,7 +1326,8 @@ internal object ComposePreviewTasks {
    * carry no theme suffix, so the deferral is expressed as what to skip.
    *
    * Set by the design-artifacts pipeline as `ORG_GRADLE_PROJECT_composePreview.idExclude` so it
-   * reaches `composePreviewRender` through `bundle pack` with no CLI flag.
+   * reaches `composePreviewRender` through `bundle pack` with no CLI flag — on a desktop module.
+   * Inert on an Android render for the reason given on [previewIdFilterProperty].
    */
   internal fun previewIdExcludeProperty(project: Project): Provider<List<String>> =
     project.providers

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -80,6 +80,14 @@ abstract class RenderPreviewsTask : DefaultTask() {
    * as a convention, from the `composePreview.idFilter` Gradle property wired at registration.
    * Matching (glob `*`/`?` or substring) lives in [PreviewNameFilter.matchesId]. `@Input` so a
    * filter change re-runs the render.
+   *
+   * **Scope: this task only, i.e. the desktop/JVM render backend.** On an Android module
+   * `composePreviewRender` is a Robolectric `Test` task registered by [AndroidPreviewSupport],
+   * which reads none of these properties — so neither this nor [previewIdExcludes] (nor the
+   * pre-existing [previewFilters]) narrows an Android render. They are inert there rather than
+   * wrong: an absent filter means "render everything", the historical behaviour. Extending the
+   * Robolectric path is tracked separately; until then a catalog's render-time saving from a filter
+   * only lands on a desktop/CMP module.
    */
   @get:Input abstract val previewIdFilters: ListProperty<String>
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -71,6 +71,65 @@ abstract class RenderPreviewsTask : DefaultTask() {
   }
 
   /**
+   * Preview **id** filter (issue #2966) — narrows the render to individual members of a `@Preview`
+   * function's fan-out, which [previewFilters] cannot: a multipreview member / `@PreviewParameter`
+   * row has its own `id` but shares its `functionName`. Applied AFTER the name filter, so the two
+   * compose. Empty (the default) renders every preview the name filter kept.
+   *
+   * Populated from the repeatable `--preview-id` task option (see [setPreviewIdFilterOption]) or,
+   * as a convention, from the `composePreview.idFilter` Gradle property wired at registration.
+   * Matching (glob `*`/`?` or substring) lives in [PreviewNameFilter.matchesId]. `@Input` so a
+   * filter change re-runs the render.
+   */
+  @get:Input abstract val previewIdFilters: ListProperty<String>
+
+  /**
+   * Backs the repeatable `--preview-id` CLI option. Setting it overrides the
+   * `composePreview.idFilter` convention rather than merging with it, matching how `--preview`
+   * relates to `composePreview.filter`.
+   */
+  @Option(
+    option = "preview-id",
+    description =
+      "Render only previews whose discovered id matches this pattern (repeatable; supports " +
+        "'*'/'?' globs or a plain substring). Selects individual members of a multipreview / " +
+        "@PreviewParameter fan-out, which --preview cannot. Applied after --preview. No match " +
+        "fails the task. Overrides -PcomposePreview.idFilter.",
+  )
+  fun setPreviewIdFilterOption(values: List<String>) {
+    previewIdFilters.set(values)
+  }
+
+  /**
+   * Preview **id** exclusions (issue #2966) — drops individual fan-out members, keeping everything
+   * else. The polarity a *deferral* needs, and not interchangeable with [previewIdFilters]:
+   *
+   * A catalog that bakes one palette per component and defers the rest can't express that as a
+   * positive filter, because the ids it wants are not a matchable set. `*_light` would keep the
+   * light members but also drop every preview whose id carries no theme suffix at all — the
+   * untagged primary stickers, i.e. most of the catalog. `--exclude-preview-id *_dark` says what it
+   * means.
+   *
+   * Exclusion also fails safe under a stale spec: a pattern that matches nothing renders *more*
+   * than intended (a wasted render, caught by the publish), where a positive filter that matches
+   * nothing renders none. Applied after [previewIdFilters]. Empty (the default) excludes nothing.
+   */
+  @get:Input abstract val previewIdExcludes: ListProperty<String>
+
+  /** Backs the repeatable `--exclude-preview-id` CLI option; overrides the property convention. */
+  @Option(
+    option = "exclude-preview-id",
+    description =
+      "Skip previews whose discovered id matches this pattern (repeatable; '*'/'?' globs or a " +
+        "plain substring), rendering everything else. The polarity a deferred catalog palette " +
+        "needs. Applied after --preview-id. Excluding every preview fails the task. Overrides " +
+        "-PcomposePreview.idExclude.",
+  )
+  fun setPreviewIdExcludeOption(values: List<String>) {
+    previewIdExcludes.set(values)
+  }
+
+  /**
    * Render-tier filter. When `"fast"` the desktop path skips any preview whose representative
    * capture is heavier than [HEAVY_COST_THRESHOLD] (TOP / static stay in; LONG / GIF / animated
    * fall out). Default `"full"` keeps the historical behaviour (every preview rendered).
@@ -129,6 +188,10 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // Empty default = "render every preview". The plugin registration overrides this convention
     // with the `composePreview.filter` Gradle property; a `--preview` option overrides both.
     previewFilters.convention(emptyList())
+    // Same story one axis down: empty = "render every preview the name filter kept". Overridden at
+    // registration with the `composePreview.idFilter` property; `--preview-id` overrides both.
+    previewIdFilters.convention(emptyList())
+    previewIdExcludes.convention(emptyList())
     // Caching is intentionally gated on `tier=full` AND an empty `--preview` filter — a run is only
     // cacheable when its `outputDir` is the module's *complete* render set. A `tier=fast` run
     // writes
@@ -142,9 +205,18 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // filtered inputs (issue #2066 review). Up-to-date checks still apply, so a re-run with no
     // input
     // changes is a no-op and the renders directory stays as-is regardless of tier or filter.
+    // An id filter is partial for exactly the same reason a name filter is — it renders a subset
+    // and
+    // leaves every other (possibly stale) PNG in place — so it disqualifies caching too. Missing
+    // this
+    // would let a one-palette catalog render be stored and later restored as if it were the
+    // module's
+    // complete set.
     outputs.cacheIf("composePreviewRender caches full, unfiltered runs only") {
       tier.get().equals("full", ignoreCase = true) &&
-        previewFilters.getOrElse(emptyList()).none { it.isNotBlank() }
+        previewFilters.getOrElse(emptyList()).none { it.isNotBlank() } &&
+        previewIdFilters.getOrElse(emptyList()).none { it.isNotBlank() } &&
+        previewIdExcludes.getOrElse(emptyList()).none { it.isNotBlank() }
     }
   }
 
@@ -162,6 +234,16 @@ abstract class RenderPreviewsTask : DefaultTask() {
     val nameFiltered =
       selectNamedPreviews(rawManifest.previews, previewFilters.getOrElse(emptyList()))
 
+    // Id filter (issue #2966) — narrows to individual fan-out members within the functions the name
+    // filter kept, which is the granularity a catalog's per-theme `modePriority` needs to skip the
+    // renders it isn't going to publish. Runs immediately after the name filter so both are applied
+    // before tier/kind/catalog filtering, and so `--preview Foo --preview-id *_Light` composes.
+    val idFiltered =
+      excludePreviewIds(
+        selectPreviewIds(nameFiltered, previewIdFilters.getOrElse(emptyList())),
+        previewIdExcludes.getOrElse(emptyList()),
+      )
+
     // Tier filter — drop previews whose representative capture is heavy
     // when running in `fast` mode. The desktop path renders just the
     // first capture per preview, so the decision is per-preview rather
@@ -172,9 +254,9 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // with its badge.
     val isFastTier = tier.get().equals("fast", ignoreCase = true)
     val tierFiltered =
-      if (!isFastTier) nameFiltered
+      if (!isFastTier) idFiltered
       else
-        nameFiltered.filter {
+        idFiltered.filter {
           val firstCost = it.captures.firstOrNull()?.cost ?: STATIC_COST
           !isHeavyCost(firstCost)
         }
@@ -211,7 +293,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
     renderWithCompose(manifest, rawManifest, outDir)
 
     val tierTag =
-      if (isFastTier) " (fast tier; ${nameFiltered.size - manifest.previews.size} heavy skipped)"
+      if (isFastTier) " (fast tier; ${idFiltered.size - manifest.previews.size} heavy skipped)"
       else ""
     logger.lifecycle("Rendered ${manifest.previews.size} preview(s)$tierTag")
   }
@@ -521,6 +603,84 @@ internal fun selectNamedPreviews(
         }
       }
     }
+  )
+}
+
+/**
+ * Narrows [previews] to those whose **id** matches [filters] (issue #2966) — the per-fan-out-member
+ * counterpart of [selectNamedPreviews].
+ *
+ * Exists because the name filter can't reach inside a `@Preview` function. A multipreview member or
+ * a `@PreviewParameter` row is its own [PreviewInfo] with a distinct `id` (`FilledButton_Light` /
+ * `FilledButton_Dark`) but the same `functionName`, so a name filter keeps or drops all of them
+ * together. A design catalog that bakes one palette per component and leaves the rest to the live
+ * preview server (`modePriority` in `catalog.spec.json`) needs exactly this granularity to skip the
+ * renders it isn't publishing — without it that deferral shrinks the published bundle but not the
+ * build.
+ *
+ * Same select-or-fail policy as [selectNamedPreviews], and for the same reason: a filter that
+ * matches nothing is a typo or a stale spec, and rendering zero previews silently would surface
+ * much later as a bundle full of missing stickers. Both filters compose — the name filter runs
+ * first, so `--preview Foo --preview-id *_Light` means "Foo's light member".
+ */
+internal fun selectPreviewIds(
+  previews: List<PreviewInfo>,
+  filters: List<String>,
+): List<PreviewInfo> {
+  val cleaned = filters.map(String::trim).filter(String::isNotEmpty)
+  if (cleaned.isEmpty()) return previews
+
+  val matched = previews.filter { PreviewNameFilter.matchesId(cleaned, it.id) }
+  if (matched.isNotEmpty()) return matched
+
+  val available = previews.map { it.id }.distinct().sorted()
+  throw GradleException(
+    buildString {
+      append("composePreviewRender --preview-id matched no previews for ")
+      append(cleaned.joinToString(", ") { "'$it'" })
+      append(".")
+      if (available.isEmpty()) {
+        append(" This module has no discovered previews — run composePreviewDiscover to confirm.")
+      } else {
+        append(" Available preview ids:")
+        available.take(MAX_SUGGESTED_PREVIEW_NAMES).forEach { append("\n  ").append(it) }
+        val more = available.size - MAX_SUGGESTED_PREVIEW_NAMES
+        if (more > 0) {
+          append("\n  … and ")
+          append(more)
+          append(" more (run composePreviewDiscover for the full list).")
+        }
+      }
+    }
+  )
+}
+
+/**
+ * Drops previews whose **id** matches [excludes], keeping the rest (issue #2966).
+ *
+ * The deferral polarity — see [RenderPreviewsTask.previewIdExcludes] for why a positive filter
+ * can't express "bake one palette per component, defer the others": the ids to keep aren't a
+ * matchable set, because the untagged primary stickers carry no theme suffix to match on.
+ *
+ * A pattern matching nothing is a no-op on purpose (it renders more than intended, which the
+ * publish catches, rather than less). Excluding *everything* still throws: the render would write
+ * no PNGs at all and the pack that follows would produce a catalog of missing stickers, which is
+ * precisely the silent failure the select-or-fail policy exists to prevent.
+ */
+internal fun excludePreviewIds(
+  previews: List<PreviewInfo>,
+  excludes: List<String>,
+): List<PreviewInfo> {
+  val cleaned = excludes.map(String::trim).filter(String::isNotEmpty)
+  if (cleaned.isEmpty() || previews.isEmpty()) return previews
+
+  val kept = previews.filterNot { PreviewNameFilter.matchesId(cleaned, it.id) }
+  if (kept.isNotEmpty()) return kept
+
+  throw GradleException(
+    "composePreviewRender --exclude-preview-id excluded every one of the ${previews.size} " +
+      "preview(s) for ${cleaned.joinToString(", ") { "'$it'" }} — nothing would render. Narrow the " +
+      "pattern; a render with no outputs packs a bundle of missing stickers."
   )
 }
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectPreviewIdsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectPreviewIdsTest.kt
@@ -1,0 +1,164 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.PreviewInfo
+import org.gradle.api.GradleException
+import org.junit.Test
+
+/**
+ * Unit tests for the preview-**id** filter (issue #2966), the per-fan-out-member counterpart of
+ * [selectNamedPreviews].
+ *
+ * The fixture is the shape that motivates the filter: one `@Preview` function fanned out over
+ * several themes. All three ids share `functionName`, so a name filter can only keep or drop the
+ * whole set — which is why a design catalog deferring every palette but the primary could thin its
+ * published bundle but not its render.
+ */
+class SelectPreviewIdsTest {
+
+  private fun preview(id: String, functionName: String, pkg: String = "com.example.preview") =
+    PreviewInfo(id = id, functionName = functionName, className = "$pkg.PreviewsKt")
+
+  private val all =
+    listOf(
+      preview("FilledButton_Light", "FilledButton"),
+      preview("FilledButton_Dark", "FilledButton"),
+      preview("FilledButton_HighContrast", "FilledButton"),
+      preview("OutlinedButton_Light", "OutlinedButton"),
+      preview("OutlinedButton_Dark", "OutlinedButton"),
+    )
+
+  @Test
+  fun `empty filter returns every preview`() {
+    assertThat(selectPreviewIds(all, emptyList())).isEqualTo(all)
+  }
+
+  @Test
+  fun `blank-only filter returns every preview`() {
+    assertThat(selectPreviewIds(all, listOf("  ", ""))).isEqualTo(all)
+  }
+
+  @Test
+  fun `glob selects one member per function across the whole module`() {
+    // The catalog case: bake the light palette, leave the rest to the live preview server.
+    val selected = selectPreviewIds(all, listOf("*_Light"))
+    assertThat(selected.map { it.id }).containsExactly("FilledButton_Light", "OutlinedButton_Light")
+  }
+
+  @Test
+  fun `id filter splits a single function's fan-out, which a name filter cannot`() {
+    val byId = selectPreviewIds(all, listOf("FilledButton_Dark"))
+    assertThat(byId.map { it.id }).containsExactly("FilledButton_Dark")
+    // Contrast: the name filter keeps every member of the function, all three palettes.
+    val byName = selectNamedPreviews(all, listOf("FilledButton"))
+    assertThat(byName.map { it.id })
+      .containsExactly("FilledButton_Light", "FilledButton_Dark", "FilledButton_HighContrast")
+  }
+
+  @Test
+  fun `plain pattern matches as a substring`() {
+    val selected = selectPreviewIds(all, listOf("Outlined"))
+    assertThat(selected.map { it.id })
+      .containsExactly("OutlinedButton_Light", "OutlinedButton_Dark")
+  }
+
+  @Test
+  fun `several patterns are OR-ed`() {
+    val selected = selectPreviewIds(all, listOf("FilledButton_Light", "OutlinedButton_Dark"))
+    assertThat(selected.map { it.id }).containsExactly("FilledButton_Light", "OutlinedButton_Dark")
+  }
+
+  @Test
+  fun `composes with the name filter, most-specific last`() {
+    // What `--preview FilledButton --preview-id *_Light` does: the name filter runs first.
+    val selected =
+      selectPreviewIds(selectNamedPreviews(all, listOf("FilledButton")), listOf("*_Light"))
+    assertThat(selected.map { it.id }).containsExactly("FilledButton_Light")
+  }
+
+  @Test
+  fun `no match fails fast and lists available ids`() {
+    // Same select-or-fail policy as the name filter: a stale spec or a typo'd glob must be loud,
+    // not
+    // a silent zero-preview render that surfaces later as a bundle of missing stickers.
+    val thrown =
+      try {
+        selectPreviewIds(all, listOf("*_Sepia"))
+        null
+      } catch (e: GradleException) {
+        e
+      }
+    assertThat(thrown).isNotNull()
+    val message = thrown!!.message!!
+    assertThat(message).contains("--preview-id matched no previews")
+    assertThat(message).contains("'*_Sepia'")
+    assertThat(message).contains("Available preview ids:")
+    assertThat(message).contains("FilledButton_Light")
+  }
+
+  @Test
+  fun `no match with no discovered previews explains the empty module`() {
+    val thrown =
+      try {
+        selectPreviewIds(emptyList(), listOf("Anything"))
+        null
+      } catch (e: GradleException) {
+        e
+      }
+    assertThat(thrown!!.message).contains("no discovered previews")
+  }
+
+  @Test
+  fun `exclusion drops the named members and keeps everything else`() {
+    // The deferral case: bake every primary, skip the dark palettes.
+    val kept = excludePreviewIds(all, listOf("*_Dark"))
+    assertThat(kept.map { it.id })
+      .containsExactly("FilledButton_Light", "FilledButton_HighContrast", "OutlinedButton_Light")
+  }
+
+  @Test
+  fun `exclusion is the only polarity that can express a deferred palette`() {
+    // A component's untagged primary sticker carries no theme suffix, so a positive `*_Light`
+    // filter
+    // would drop it along with the deferred palettes — the failure exclusion exists to avoid.
+    val withUntagged = all + preview("PlainCard", "PlainCard")
+    assertThat(selectPreviewIds(withUntagged, listOf("*_Light")).map { it.id })
+      .doesNotContain("PlainCard")
+    assertThat(excludePreviewIds(withUntagged, listOf("*_Dark")).map { it.id })
+      .contains("PlainCard")
+  }
+
+  @Test
+  fun `an empty or blank exclusion list is a no-op`() {
+    assertThat(excludePreviewIds(all, emptyList())).isEqualTo(all)
+    assertThat(excludePreviewIds(all, listOf(" ", ""))).isEqualTo(all)
+  }
+
+  @Test
+  fun `an exclusion matching nothing is a no-op, not a failure`() {
+    // Fails safe: a stale pattern renders more than intended (caught by the publish) rather than
+    // silently rendering none.
+    assertThat(excludePreviewIds(all, listOf("*_Sepia"))).isEqualTo(all)
+  }
+
+  @Test
+  fun `excluding every preview fails loudly`() {
+    val thrown =
+      try {
+        excludePreviewIds(all, listOf("*Button*"))
+        null
+      } catch (e: GradleException) {
+        e
+      }
+    assertThat(thrown).isNotNull()
+    assertThat(thrown!!.message).contains("excluded every one of the 5 preview(s)")
+    assertThat(thrown.message).contains("nothing would render")
+  }
+
+  @Test
+  fun `exclusion applies after the id filter`() {
+    val kept =
+      excludePreviewIds(selectPreviewIds(all, listOf("FilledButton*")), listOf("*_HighContrast"))
+    assertThat(kept.map { it.id }).containsExactly("FilledButton_Light", "FilledButton_Dark")
+  }
+}


### PR DESCRIPTION
Closes #2966 (plugin half). Follow-up to #2950 / #2959.

## Why

`--preview` / `-PcomposePreview.filter` matches `functionName`, so it can only keep or drop a whole `@Preview`. A multipreview member or a `@PreviewParameter` row is its own `PreviewInfo` with a distinct `id` but the **same** `functionName` — which is why a catalog's per-theme `modePriority` could thin its published sticker set but not its build. Per #2950's measurements that axis is the bigger lever: against `yschimke/pocket-casts-android@feffc631` (61 componentIds, nine themes) deferring every palette beyond the primary is **−59%** of 339 renders, vs −37% for deferring all variants.

## What

Id-level granularity, in **both** polarities — they are not interchangeable:

| flag | property | semantics |
| --- | --- | --- |
| `--preview-id` | `composePreview.idFilter` | select by id; select-or-fail |
| `--exclude-preview-id` | `composePreview.idExclude` | skip by id, keep the rest |

Exclusion is the one a deferral needs. A positive `*_light` **cannot** express "bake one palette per component": it would also drop every preview whose id carries no theme suffix — the untagged primary stickers, i.e. most of the catalog. There's a test pinning exactly that asymmetry.

The two polarities also fail in opposite directions, deliberately:

- a positive filter that matches nothing **throws**, listing available ids — a stale spec must be loud, not a silent zero-preview render that resurfaces later as a bundle of missing stickers (same policy as `selectNamedPreviews`);
- an exclusion that matches nothing is a **no-op** — it renders more than intended, which the publish catches. Excluding *every* preview still throws, since that packs a bundle of missing stickers.

Both compose with the name filter, which runs first: `--preview FilledButton --preview-id *_Light`.

Both are `@Input`, and both disqualify build-cache storage for the same reason the name filter does — `outputDir` is then not the module's complete render set, so a partial snapshot must never be restorable over a full one (see the existing comment block at `RenderPreviewsTask.kt:132-148`).

The property forms are what make this reachable from the design-artifacts pipeline: Gradle sources project properties from `ORG_GRADLE_PROJECT_*`, so `ORG_GRADLE_PROJECT_composePreview.idExclude` reaches `composePreviewRender` through `bundle pack` with no new CLI flag — the same route #2959 already uses for the name filter.

## Not in this PR

- **Deriving the exclusions from `modePriority`.** The ids come from discovery (`previews.json`), which the build-free pre-flight doesn't have, so the driver side needs either an extra `composePreviewDiscover` pass or spec-expressible globs. Left for the export-side half of #2966 so this is reviewable and testable on its own.
- **Semantics capture.** `bundle pack --with-semantics` captures per preview via `packSemanticsBlob`, which is where #2948's fixed 180s deadline actually bites. Filtering the render alone doesn't shrink that pass, so the axis saving stays partial until it's filtered too. Noted on #2966.
- Deferred previews must stay listed in the bundle's `previews.json` (the bundle task already carries every selected preview and omits only the PNG) — that listing is what keeps them addressable for the serve host's live lane. So this filters the **render**, never the pack.

## Test plan

- `:gradle-plugin:test` and `:gradle-plugin:preview-discovery:test` — **BUILD SUCCESSFUL**, full suites, not just the new classes.
- `./gradlew ktfmtCheckAll` — **BUILD SUCCESSFUL** (the CI format gate).
- New `SelectPreviewIdsTest` (13 cases): glob/substring/OR matching, splitting one function's fan-out where a name filter can't, composition with the name filter, both failure policies, and the polarity asymmetry above. New `matchesId` cases in `PreviewNameFilterTest`, including that a `.` in an id stays literal.

Non-visual (build wiring), so text-only evidence is the right form here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016azcVhRhQze6Y91gMT4BeF

---
_Generated by [Claude Code](https://claude.ai/code/session_016azcVhRhQze6Y91gMT4BeF)_