### PR TITLE
feat(serve): publish horologist, attribute pocketcasts to Automattic

### DIFF
--- a/deploy/preview.coo.ee/catalogs.json
+++ b/deploy/preview.coo.ee/catalogs.json
@@ -10,6 +10,11 @@
       "id": "android-samples",
       "heading": "android/compose-samples",
       "noun": "sample(s)"
+    },
+    {
+      "id": "pocket-casts",
+      "heading": "Automattic/pocket-casts-android",
+      "noun": "app(s)"
     }
   ],
   "catalogs": [
@@ -44,11 +49,24 @@
     {
       "system": "pocketcasts",
       "repo": "yschimke/pocket-casts-android",
-      "listed": true
+      "listed": true,
+      "group": "pocket-casts",
+      "attributionRepos": [
+        "Automattic/pocket-casts-android"
+      ]
     },
     {
       "system": "pocketcasts-wear",
       "repo": "yschimke/pocket-casts-android",
+      "listed": true,
+      "group": "pocket-casts",
+      "attributionRepos": [
+        "Automattic/pocket-casts-android"
+      ]
+    },
+    {
+      "system": "horologist",
+      "repo": "yschimke/horologist",
       "listed": true
     },
     {


### PR DESCRIPTION
## horologist

#2953 added trust for `yschimke/horologist` but never a catalog entry, because `design-artifacts/horologist` didn't exist — its only preview branch was `compose-preview/main` (render-bot output, not a bundle). **That branch now exists** (`1df0a14`), so the entry can finally be published. Trust already shipped, so this is just the catalog.

## pocketcasts → Automattic

Both entries move under an `Automattic/pocket-casts-android` section — upstream confirmed as `Automattic/pocket-casts-android` (2.8k stars, Kotlin), not a guess at the spelling.

This mirrors how the jet\* catalogs are credited to `android/compose-samples` while actually being fetched from a fork: `group` + `attributionRepos`. The section is a **provenance-checked claim**, not a label — `ServeWeb.homeSections` honours it only when the fetched bytes came from the entry's own `repo` or one of its `attributionRepos`. Satisfied here by `yschimke/pocket-casts-android`, so a third party serving the id `pocketcasts` still can't present it as Automattic's.

Front page goes from `pocketcasts`/`pocketcasts-wear` under the `yschimke org` owner fallback to their own `Automattic/pocket-casts-android` section; `horologist` lands under `yschimke org`.

## Known limitation this change runs straight into

**Groups are not reconcilable over the admin API** — the flaw I documented on #2967. There is no `/admin/groups` route, and `ServeCatalogAdmin.register` checks the group *before* the duplicate check, so on the live box (where both pocketcasts entries are already registered ungrouped) the reconcile will hit `400 unknown group 'pocket-casts'` rather than a harmless 409. That's now a loud `::error::` with an actionable message rather than a swallowed warning, so it won't pass silently — but it does mean **the new section needs a one-time hand edit** of the box's `/config/catalogs.json` (add the group, add `group`/`attributionRepos` to the two entries) plus a restart. `horologist` needs no such thing and will register cleanly.

If that manual step is unwelcome, the alternative is dropping the group claim and letting both sit under `yschimke org` — or adding a groups admin route, which is the real fix and a separate change.

## Test plan

- `.github/scripts/test-publish-config-to-box.sh` — passes.
- `--dry-run` inspected: `horologist` trust + catalog posted, both pocketcasts entries carry `group` and `attributionRepos` intact.
- `deploy/preview.coo.ee/catalogs.json` parses; 18 catalogs, 3 groups.
- `design-artifacts/horologist` confirmed to exist at `1df0a14`.

Non-visual in the diff (config only) — the front-page effect is described above and can't be rendered from here, since the grouping is computed from a live box's fetched provenance.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FdJsCmxDm9dXv8iEsxVYgs)_