### PR TITLE
feat(design-artifacts): drive the per-preview-id filter from modePriority end to end

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -290,11 +290,41 @@ jobs:
             args+=(--no-live-bundle)
           fi
           node compose-ai-tools/scripts/design-artifacts/validate-catalog-spec.mjs "${args[@]}" \
-            --render-filter-out "$GITHUB_WORKSPACE/render-filter.txt"
+            --render-filter-out "$GITHUB_WORKSPACE/render-filter.txt" \
+            --deferred-modes-out "$GITHUB_WORKSPACE/deferred-modes.txt"
           # The `--preview` patterns that render just the required entries. EMPTY for every
           # spec that defers no entry — i.e. all of them today — in which case the render
           # step below sees an empty property and renders everything, exactly as before.
           echo "render-filter=$(cat "$GITHUB_WORKSPACE/render-filter.txt")" >> "$GITHUB_OUTPUT"
+          # The deferred MODE names. Only the gate for the discovery step below (issue #2966):
+          # the mode axis is skipped per preview ID, and the ids only exist after discovery, so
+          # the extra Gradle invocation is worth paying only when a mode is actually deferred.
+          echo "deferred-modes=$(cat "$GITHUB_WORKSPACE/deferred-modes.txt")" >> "$GITHUB_OUTPUT"
+
+      # Per-mode render filter (issue #2966). `modePriority` thins a fan-out that lives INSIDE one
+      # `@Preview` function, so unlike the entry-level filter above it can't be expressed as function
+      # names — it needs the discovered preview ids (`FilledButton_Dark`, a `@PreviewParameter` row).
+      # `compose-preview list --json` runs `composePreviewDiscover` to get them; that compile is
+      # shared with the render below (same Gradle build, warm caches), so the extra invocation costs
+      # discovery, not a second compile. Skipped entirely when the spec defers no mode, which is the
+      # state of every catalog that hasn't opted in.
+      - name: Derive per-mode render exclusions
+        id: mode-filter
+        if: ${{ steps.validate-spec.outputs.deferred-modes != '' }}
+        working-directory: ${{ inputs.working-directory || '.' }}
+        env:
+          SPEC: ${{ inputs.spec }}
+        run: |
+          set -euo pipefail
+          compose-preview list --json --module "${{ inputs.module }}" \
+            > "$GITHUB_WORKSPACE/discovered-previews.json"
+          node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/deferred-preview-ids.mjs" \
+            --spec "$GITHUB_WORKSPACE/$SPEC" \
+            --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
+            --out "$GITHUB_WORKSPACE/mode-filter.txt"
+          # Exclusion polarity: a pattern that matches nothing renders MORE, never less, so a spec
+          # that has drifted ahead of the code wastes time instead of dropping a sticker.
+          echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter.txt")" >> "$GITHUB_OUTPUT"
 
       # Stage bundled fallback fonts into fontconfig before any render, so a
       # desktop (Skiko) render resolves glyphs a preview's FontFamily doesn't
@@ -358,12 +388,19 @@ jobs:
           # this catalog's spec, and the filter fails fast when it matches nothing — an extra
           # module whose previews are all deferred would sink the render rather than skip it.
           ORG_GRADLE_PROJECT_composePreview.filter: ${{ steps.validate-spec.outputs.render-filter }}
+          # Per-mode exclusions (issue #2966), as a CLI flag rather than an env var because the
+          # SEMANTICS capture is driven by the CLI itself, not by Gradle: an env var would thin the
+          # render and leave that pass at full width, which is half the axis saving. The flag does
+          # both — it forwards `-PcomposePreview.idExclude` to the render and skips the same ids in
+          # the daemon capture. Empty ⇒ the flag is omitted ⇒ render + capture everything.
+          EXCLUDE_PREVIEW_IDS: ${{ steps.mode-filter.outputs.exclude-ids }}
         run: |
           set -euo pipefail
           run() { if [ "${{ inputs.desktop-render }}" = "true" ]; then xvfb-run -a -s "-screen 0 2000x1400x24" "$@"; else "$@"; fi; }
           embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
+          exclude=(); if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS"); fi
           run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics \
-            "${embed[@]}" -o "$GITHUB_WORKSPACE/bundle.png" --timeout 600
+            "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" --timeout 600
 
       - name: Render extra module
         if: ${{ inputs.extra-module != '' }}

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -282,12 +282,35 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/design-artifacts/validate-catalog-spec.mjs --spec "${{ matrix.spec }}" \
-            --render-filter-out "$GITHUB_WORKSPACE/render-filter.txt"
+            --render-filter-out "$GITHUB_WORKSPACE/render-filter.txt" \
+            --deferred-modes-out "$GITHUB_WORKSPACE/deferred-modes.txt"
           # Render priority (issue #2950): the `--preview` patterns that render just the
           # entries this spec still needs baked. EMPTY unless the spec marks entries
           # `priority: "deferred"` — no catalog here does today, so the render set is
           # unchanged. Consumed by the render step below.
           echo "render-filter=$(cat "$GITHUB_WORKSPACE/render-filter.txt")" >> "$GITHUB_OUTPUT"
+          # Gate for the per-mode exclusion step below (issue #2966): that one needs discovered
+          # preview ids, so it costs an extra Gradle invocation and only runs when a mode is
+          # actually deferred.
+          echo "deferred-modes=$(cat "$GITHUB_WORKSPACE/deferred-modes.txt")" >> "$GITHUB_OUTPUT"
+
+      # Per-mode render exclusions (issue #2966). `modePriority` thins the palette fan-out INSIDE one
+      # `@Preview` function, so it can't be named as function patterns like the entry-level filter
+      # above — it needs the discovered ids (`FilledButton_Dark`). `compose-preview list --json` runs
+      # `composePreviewDiscover` for them; the compile it does is shared with the render below, so the
+      # extra invocation costs discovery rather than a second build. Skipped when nothing is deferred.
+      - name: Derive per-mode render exclusions
+        id: mode-filter
+        if: ${{ steps.validate-spec.outputs.deferred-modes != '' }}
+        run: |
+          set -euo pipefail
+          compose-preview list --json --module "${{ matrix.module }}" \
+            > "$GITHUB_WORKSPACE/discovered-previews.json"
+          node scripts/design-artifacts/deferred-preview-ids.mjs \
+            --spec "${{ matrix.spec }}" \
+            --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
+            --out "$GITHUB_WORKSPACE/mode-filter.txt"
+          echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter.txt")" >> "$GITHUB_OUTPUT"
 
       # Published previews pin their preview-runtimes to a RELEASED version
       # (`composeaiReleasedRuntimeVersion`, bumped by release-please on each release). Sonatype →
@@ -349,6 +372,11 @@ jobs:
           # `bundle pack` with no CLI flag. Empty ⇒ no filter ⇒ render everything, which
           # is what every catalog here gets today.
           ORG_GRADLE_PROJECT_composePreview.filter: ${{ steps.validate-spec.outputs.render-filter }}
+          # Per-mode exclusions (issue #2966). Passed as a CLI flag, not an env var, because it must
+          # also thin the CLI-driven `--with-semantics` capture — filtering only the Gradle render
+          # would leave that (per-preview daemon) pass at full width. Empty ⇒ flag omitted ⇒
+          # everything renders, which is what every catalog here gets today.
+          EXCLUDE_PREVIEW_IDS: ${{ steps.mode-filter.outputs.exclude-ids }}
         run: |
           set -euo pipefail
           # Run under a virtual framebuffer so the Skiko desktop daemon has a
@@ -359,9 +387,10 @@ jobs:
           # `composeaiUseReleasedRuntimes` gate (job env) + `composeaiReleasedRuntimeVersion`
           # (gradle.properties, release-please-managed); the "Wait for released preview-runtimes"
           # step above guarantees that version is resolvable on Central before we render.
+          exclude=(); if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS"); fi
           xvfb-run -a -s "-screen 0 2000x1400x24" \
             compose-preview bundle pack --module "$MODULE" --with-semantics \
-              -o "$GITHUB_WORKSPACE/$SYSTEM-bundle.png"
+              "${exclude[@]}" -o "$GITHUB_WORKSPACE/$SYSTEM-bundle.png"
 
       # Android-only supplement (Robolectric): render the previews that need androidx
       # material3 APIs with no CMP equivalent (the inset focus ring). Robolectric

--- a/cli/completions/compose-preview.fish
+++ b/cli/completions/compose-preview.fish
@@ -7,8 +7,8 @@
 
 function __compose_preview_needs_command
     set -l cmd (commandline -opc)
-    set -l valued_flags --module --filter --id --output --timeout --plugin-version \
-        --fail-on --desc --branch --remote --pr-number --message \
+    set -l valued_flags --module --filter --id --exclude-preview-id --output --timeout \
+        --plugin-version --fail-on --desc --branch --remote --pr-number --message \
         --with-extension --with --project --antigravity-config --codex-config \
         --replicas-per-daemon
     set -l i 2
@@ -31,8 +31,8 @@ end
 
 function __compose_preview_command
     set -l cmd (commandline -opc)
-    set -l valued_flags --module --filter --id --output --timeout --plugin-version \
-        --fail-on --desc --branch --remote --pr-number --message \
+    set -l valued_flags --module --filter --id --exclude-preview-id --output --timeout \
+        --plugin-version --fail-on --desc --branch --remote --pr-number --message \
         --with-extension --with --project --antigravity-config --codex-config \
         --replicas-per-daemon
     set -l i 2
@@ -284,6 +284,9 @@ complete -c compose-preview -x -n '__compose_preview_using_bundle_sub pack' \
 complete -c compose-preview -x -n '__compose_preview_using_bundle_sub pack' \
     -l id -a '(__compose_preview_bundle_pack_ids)' \
     -d 'Preview id to include (repeatable; first is cover)'
+complete -c compose-preview -x -n '__compose_preview_using_bundle_sub pack' \
+    -l exclude-preview-id -a '(__compose_preview_bundle_pack_ids)' \
+    -d 'Preview id (or glob) to skip rendering + semantics (repeatable)'
 complete -c compose-preview -F -n '__compose_preview_using_bundle_sub pack' \
     -l output -s o -d 'Output .png polyglot path'
 complete -c compose-preview -f -n '__compose_preview_using_bundle_sub pack' \

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -126,6 +126,18 @@ class BundleCommand(args: List<String>) : Command(args) {
 
       Pack flags:
         --id <preview-id>   Preview to include. Repeatable. First is the cover. Default: all.
+        --exclude-preview-id <id|glob>
+                            Skip rendering (and semantics-capturing) previews whose discovered id
+                            matches. Repeatable and comma-separated; '*'/'?' globs or a plain
+                            substring, matching composePreviewRender --exclude-preview-id.
+                            Unlike --id (which selects whole previews to PACK) this thins the RENDER
+                            of one function's multipreview / multi-annotation fan-out — a design
+                            catalog deferring a palette to its live server passes the deferred ids
+                            here. Excluded previews stay listed in the bundle (addressable, just
+                            without a baked PNG). Forwarded to Gradle as
+                            -PcomposePreview.idExclude; also read from the
+                            ORG_GRADLE_PROJECT_composePreview.idExclude env var when the flag is
+                            absent, so an env-only setup thins the semantics pass too.
         --per-preview       Emit one valid single-preview bundle per preview (<out-dir>/<id>.png)
                             instead of a single sheet — the addressable-preview unit, each openable /
                             re-renderable on its own. Renders once, then packs each (minimized to its
@@ -212,6 +224,15 @@ private class PackSubcommand(private val args: List<String>) {
       .map { it.trim() }
       .filter { it.isNotEmpty() }
 
+  /**
+   * `--exclude-preview-id` patterns (issue #2966) — the previews this pack must NOT render or
+   * semantics-capture. Falls back to the `ORG_GRADLE_PROJECT_composePreview.idExclude` env var so a
+   * caller that only sets the env var (the way the design-artifacts workflow passes the name filter
+   * through to `composePreviewRender`) still gets the semantics pass thinned, which the env var
+   * alone cannot do — the CLI, not Gradle, drives that capture.
+   */
+  private val excludePreviewIds: List<String> = PackPreviewIdExclusions.fromArgs(args)
+
   fun run() {
     if (perPreview) {
       runPerPreview()
@@ -247,6 +268,15 @@ private class PackSubcommand(private val args: List<String>) {
             val gradleArgs = buildList {
               if (ids.isNotEmpty())
                 add("-PbundlePreviewIds=${ids.joinToString(",") { encodePreviewId(it) }}")
+              // Thin the RENDER itself (issue #2966): `composePreviewRender` reads this as the
+              // `--exclude-preview-id` convention. Passed explicitly rather than relying on the
+              // inherited env var so `--exclude-preview-id` works from any shell, and so the
+              // patterns the semantics pass below skips are provably the same ones the render did.
+              if (excludePreviewIds.isNotEmpty())
+                add(
+                  "-P${PackPreviewIdExclusions.GRADLE_PROPERTY}=" +
+                    excludePreviewIds.joinToString(",")
+                )
               if (embedDeps) add("-PbundleEmbedDeps=true")
               if (includeDataExtensions) add("-PbundleIncludeDataExtensions=true")
               add("-PbundleOutput=${resolvedOutput.absolutePath}")
@@ -548,6 +578,27 @@ private class PackSubcommand(private val args: List<String>) {
     fun <V> Map<String, V>.keyedByBundleId(): Map<String, V> = entries.associate { (raw, v) ->
       (bundleIdByRaw[raw] ?: raw) to v
     }
+    // The other half of the deferral saving (issue #2966): this capture is a daemon render per
+    // preview, so filtering only `composePreviewRender` would leave the axis cost here untouched.
+    // Excluded previews stay listed in the bundle (they must, to stay addressable on the serve host
+    // — see #2965) and simply carry no semantics/layout/figma-svg sidecar, exactly as they carry no
+    // PNG.
+    val captureIds = PackPreviewIdExclusions.retain(rawIds, excludePreviewIds)
+    val excludedFromCapture = rawIds.size - captureIds.size
+    if (excludedFromCapture > 0) {
+      System.err.println(
+        "bundle pack: --with-semantics skipping $excludedFromCapture excluded preview(s) " +
+          "(--exclude-preview-id); ${captureIds.size} to capture."
+      )
+    }
+    if (captureIds.isEmpty()) {
+      System.err.println(
+        "bundle pack: --exclude-preview-id excluded every preview from the semantics capture; " +
+          "bundle written without previews/<id>$BUNDLE_SEMANTICS_SUFFIX."
+      )
+      return null
+    }
+    val captureCount = captureIds.size
     val fetcher =
       DaemonSemanticsFetcher(
         onLog = { System.err.println("[daemon semantics] $it") },
@@ -557,7 +608,7 @@ private class PackSubcommand(private val args: List<String>) {
       fetcher.fetch(
         projectDir = target.projectDir,
         moduleName = target.gradlePath,
-        previewIds = rawIds,
+        previewIds = captureIds,
       )
     when (outcome) {
       is DaemonSemanticsFetcher.Outcome.Ok -> {
@@ -569,7 +620,7 @@ private class PackSubcommand(private val args: List<String>) {
           return null
         }
         val written = injectSemanticsIntoBundle(bundleFile, outcome.semanticsById.keyedByBundleId())
-        val missing = previewIds.size - written
+        val missing = captureCount - written
         // The layout-inspector tree rides alongside the semantics blob (best-effort): a preview
         // that produced a tree gets `previews/<id>.layout.json` so a consumer can build slot-level
         // redlines/wireframes. Injected after semantics so its byte count is reflected too.
@@ -588,23 +639,23 @@ private class PackSubcommand(private val args: List<String>) {
         val figmaRasterWritten =
           injectFigmaRasterIntoBundle(bundleFile, outcome.figmaRasterById.keyedByBundleId())
         val semanticsLine =
-          "  semantics:     $written / ${previewIds.size} preview(s) carried as " +
+          "  semantics:     $written / $captureCount preview(s) carried as " +
             "previews/<id>$BUNDLE_SEMANTICS_SUFFIX" +
             if (missing > 0) " ($missing without a captured tree)" else ""
         val extraLines = buildString {
           if (layoutWritten > 0)
             append(
-              "\n  layout:        $layoutWritten / ${previewIds.size} preview(s) carried " +
+              "\n  layout:        $layoutWritten / $captureCount preview(s) carried " +
                 "as previews/<id>$BUNDLE_LAYOUT_SUFFIX"
             )
           if (fontsWritten > 0)
             append(
-              "\n  fonts:         $fontsWritten / ${previewIds.size} preview(s) carried " +
+              "\n  fonts:         $fontsWritten / $captureCount preview(s) carried " +
                 "as previews/<id>$BUNDLE_FONTS_SUFFIX"
             )
           if (figmaSvgWritten > 0)
             append(
-              "\n  figma-svg:     $figmaSvgWritten / ${previewIds.size} preview(s) carried " +
+              "\n  figma-svg:     $figmaSvgWritten / $captureCount preview(s) carried " +
                 "as previews/<id>$BUNDLE_FIGMA_SVG_SUFFIX"
             )
           if (figmaRasterWritten > 0)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -30,6 +30,7 @@ internal object CliFlags {
       "--module",
       "--filter",
       "--id",
+      "--exclude-preview-id",
       "--output",
       "--timeout",
       "--plugin-version",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
@@ -1,0 +1,87 @@
+package ee.schimke.composeai.cli
+
+/**
+ * `bundle pack --exclude-preview-id` (issue #2966): the preview **ids** a pack must neither render
+ * nor semantics-capture.
+ *
+ * Two consumers, one list, which is the point of collecting it here:
+ * - the **render**, via `-PcomposePreview.idExclude` on the Gradle invocation (the
+ *   `composePreviewRender` task's `--exclude-preview-id` convention);
+ * - the **semantics capture**, which the CLI drives itself over the daemon — a Gradle property
+ *   can't reach it, so filtering the render alone would leave that pass at full width and only half
+ *   the deferral saving would land.
+ *
+ * Matching mirrors the plugin's `PreviewNameFilter.matchesId` — the authority, since it is what
+ * actually skips the render: an anchored `*`/`?` glob when the pattern carries one, else equality
+ * OR substring, case-sensitive. The two MUST agree, or a plain pattern would thin the render and
+ * not the semantics pass (or the reverse). The logic is restated here rather than shared because
+ * the plugin's `preview-discovery` module lives in a separate Gradle build the CLI does not depend
+ * on — the same split the VS Code extension's `previewFilter.ts` lives with. Keep them in step:
+ * both are covered by unit tests that spell the semantics out.
+ */
+internal object PackPreviewIdExclusions {
+
+  /** The Gradle property `composePreviewRender` reads the same patterns from. */
+  const val GRADLE_PROPERTY = "composePreview.idExclude"
+
+  /** Env form of [GRADLE_PROPERTY] — how Gradle sources project properties from the environment. */
+  const val ENV_VAR = "ORG_GRADLE_PROJECT_$GRADLE_PROPERTY"
+
+  /**
+   * The patterns for this invocation: every `--exclude-preview-id` value (repeatable, and each
+   * value may itself be comma-separated), or — when the flag is absent entirely — the [ENV_VAR]
+   * value.
+   *
+   * The env fallback exists because a caller can already thin the *render* by exporting [ENV_VAR]
+   * alone (Gradle picks it up inside the pack's own invocation) and would otherwise silently keep
+   * paying for the full semantics pass. An explicit flag wins outright rather than merging, so a
+   * command line can narrow an inherited environment.
+   */
+  fun fromArgs(args: List<String>, env: (String) -> String? = System::getenv): List<String> {
+    val flagValues = args.flagValuesAll("--exclude-preview-id")
+    val raw = if (flagValues.isNotEmpty()) flagValues else listOfNotNull(env(ENV_VAR))
+    return raw.flatMap { it.split(',') }.map { it.trim() }.filter { it.isNotEmpty() }
+  }
+
+  /** [ids] with every entry matching [patterns] removed. An empty pattern list keeps everything. */
+  fun retain(ids: List<String>, patterns: List<String>): List<String> {
+    val cleaned = patterns.map { it.trim() }.filter { it.isNotEmpty() }
+    if (cleaned.isEmpty()) return ids
+    return ids.filterNot { id -> cleaned.any { matches(it, id) } }
+  }
+
+  private fun matches(pattern: String, id: String): Boolean =
+    if (pattern.any { it == '*' || it == '?' }) globToRegex(pattern).matches(id)
+    else id == pattern || id.contains(pattern)
+
+  /**
+   * Anchored regex for a `*`/`?` glob, escaping every other character so a `.` in a
+   * package-qualified id is a literal dot. Literal runs go through [Regex.escape] so a
+   * metacharacter in an id can never leak into the pattern.
+   */
+  private fun globToRegex(glob: String): Regex {
+    val out = StringBuilder()
+    val literal = StringBuilder()
+    fun flushLiteral() {
+      if (literal.isNotEmpty()) {
+        out.append(Regex.escape(literal.toString()))
+        literal.clear()
+      }
+    }
+    for (c in glob) {
+      when (c) {
+        '*' -> {
+          flushLiteral()
+          out.append(".*")
+        }
+        '?' -> {
+          flushLiteral()
+          out.append(".")
+        }
+        else -> literal.append(c)
+      }
+    }
+    flushLiteral()
+    return Regex(out.toString())
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
@@ -1,0 +1,104 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PackPreviewIdExclusionsTest {
+
+  private val noEnv: (String) -> String? = { null }
+
+  private fun envWith(value: String): (String) -> String? = { name ->
+    if (name == PackPreviewIdExclusions.ENV_VAR) value else null
+  }
+
+  @Test
+  fun `no flag and no env yields no patterns`() {
+    assertEquals(
+      emptyList(),
+      PackPreviewIdExclusions.fromArgs(listOf("pack", "--module", "app"), noEnv),
+    )
+  }
+
+  @Test
+  fun `repeatable flag collects every value`() {
+    val args = listOf("--exclude-preview-id", "Foo_Dark", "--exclude-preview-id", "Bar_Dark")
+    assertEquals(listOf("Foo_Dark", "Bar_Dark"), PackPreviewIdExclusions.fromArgs(args, noEnv))
+  }
+
+  @Test
+  fun `one value may be comma-separated`() {
+    val args = listOf("--exclude-preview-id", "Foo_Dark, Bar_Dark ,")
+    assertEquals(listOf("Foo_Dark", "Bar_Dark"), PackPreviewIdExclusions.fromArgs(args, noEnv))
+  }
+
+  @Test
+  fun `env var is used when the flag is absent`() {
+    assertEquals(
+      listOf("Foo_Dark", "Bar_Dark"),
+      PackPreviewIdExclusions.fromArgs(listOf("pack"), envWith("Foo_Dark,Bar_Dark")),
+    )
+  }
+
+  @Test
+  fun `an explicit flag wins over the env var rather than merging`() {
+    assertEquals(
+      listOf("Foo_Dark"),
+      PackPreviewIdExclusions.fromArgs(
+        listOf("--exclude-preview-id", "Foo_Dark"),
+        envWith("Everything_Dark"),
+      ),
+    )
+  }
+
+  @Test
+  fun `env var name is the Gradle property's ORG_GRADLE_PROJECT form`() {
+    assertEquals("ORG_GRADLE_PROJECT_composePreview.idExclude", PackPreviewIdExclusions.ENV_VAR)
+  }
+
+  private val ids = listOf("Foo_Light", "Foo_Dark", "FooLarge_Dark", "Bar_Light")
+
+  @Test
+  fun `no patterns retains every id`() {
+    assertEquals(ids, PackPreviewIdExclusions.retain(ids, emptyList()))
+    assertEquals(ids, PackPreviewIdExclusions.retain(ids, listOf(" ", "")))
+  }
+
+  @Test
+  fun `an exact pattern drops that id`() {
+    assertEquals(
+      listOf("Foo_Light", "FooLarge_Dark", "Bar_Light"),
+      PackPreviewIdExclusions.retain(ids, listOf("Foo_Dark")),
+    )
+  }
+
+  @Test
+  fun `a plain pattern also matches as a substring, like the plugin's matchesId`() {
+    // The render-side filter (PreviewNameFilter.matchesId) substring-matches a glob-free pattern,
+    // so
+    // this must too — otherwise a plain pattern would thin the render but not the semantics pass.
+    assertEquals(
+      listOf("Foo_Light", "Bar_Light"),
+      PackPreviewIdExclusions.retain(ids, listOf("_Dark")),
+    )
+  }
+
+  @Test
+  fun `a glob drops the whole family`() {
+    assertEquals(
+      listOf("Foo_Light", "Bar_Light"),
+      PackPreviewIdExclusions.retain(ids, listOf("*_Dark")),
+    )
+  }
+
+  @Test
+  fun `matching is case-sensitive`() {
+    assertEquals(ids, PackPreviewIdExclusions.retain(ids, listOf("foo_dark")))
+  }
+
+  @Test
+  fun `a substring pattern is as wide as it reads`() {
+    // `Foo` matches `Foo_Light`, `Foo_Dark` AND `FooLarge_Dark` — the same width the render-side
+    // filter gives it. Reach for a glob (`Foo_*`) when that's not what you meant.
+    assertEquals(listOf("Bar_Light"), PackPreviewIdExclusions.retain(ids, listOf("Foo")))
+  }
+}

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -355,15 +355,23 @@ letting a catalog explicitly opt the long tail out.
 
 What each form actually saves:
 
-- **Per axis** (`modePriority`) — **usable now.** Thins what is *published*: the
-  deferred palettes are not written to `images/`, not exported as `figma/*.svg`, and
-  not carried into the Figma import. Every component stays in `catalog.json`'s
-  `components[]` with its untagged primary sticker, so the served catalog browses as
-  before with one fewer baked palette. It does not yet shrink the *render*, because
-  the fan-out it removes lives *inside* one `@Preview` function (a multipreview
-  member or a `@PreviewParameter` row) and the renderer's filter selects whole
-  functions — [#2966](https://github.com/yschimke/compose-ai-tools/issues/2966) adds
-  the per-preview-id filter that makes it a build-time win too.
+- **Per axis** (`modePriority`) — **usable now, and now a build-time win too.** Thins
+  what is *published*: the deferred palettes are not written to `images/`, not exported
+  as `figma/*.svg`, and not carried into the Figma import. Every component stays in
+  `catalog.json`'s `components[]` with its untagged primary sticker, so the served
+  catalog browses as before with one fewer baked palette. They are also **not rendered
+  and not semantics-captured**: the fan-out lives *inside* one `@Preview` function (a
+  multipreview member, or one of several `@Preview` annotations), so naming functions
+  can't express it and the skip is per preview **id** — `composePreviewRender
+  --exclude-preview-id` / `-PcomposePreview.idExclude`, plus `bundle pack
+  --exclude-preview-id`, which forwards the patterns to the render *and* skips the same
+  ids in the CLI-driven daemon semantics pass. Ids only exist after discovery, so both
+  design-artifacts workflows run `compose-preview list --json` first and derive them with
+  [`deferred-preview-ids.mjs`](../../scripts/design-artifacts/deferred-preview-ids.mjs);
+  that extra Gradle invocation is gated on the spec actually deferring a mode, and its
+  compile is shared with the render that follows. Measured against a nine-theme catalog
+  this is the bigger lever: deferring every palette beyond the primary drops ~59% of
+  renders, versus ~37% for deferring all variants.
 - **Per entry** (`priority` on a component or variant) — **authorable now, inert
   until [#2965](https://github.com/yschimke/compose-ai-tools/issues/2965).** A
   wholly-deferred entry has no `images[]` record, and `ServeCatalogStore` builds
@@ -401,7 +409,23 @@ Caveats worth knowing before reaching for it:
 - **The primary sticker is never deferrable by mode.** Only a render that *names* a
   theme is eligible, so every published component keeps baked pixels. A component
   whose every render is mode-deferred is treated as a misconfiguration and fails the
-  gate rather than publishing with no pixels.
+  gate rather than publishing with no pixels. The render-side filter mirrors that: a
+  function whose *every* discovered id resolves to a deferred mode keeps all of them
+  (and says so in the log), so a bad `modePriority` surfaces as a gate failure rather
+  than as a component silently rendered away.
+- **Two shapes get the publish saving but not the render saving** (both still correct, just
+  not cheaper to build). A mode axis supplied by a **`@PreviewParameter` provider** has no
+  per-row id to skip: discovery emits one entry for the parameterized function and the
+  renderer expands the rows itself. And an **Android/Robolectric** catalog
+  (`design-catalog-wear-m3`, `design-catalog-remote-m3`) renders through a `Test` task that
+  reads the manifest directly and honours neither the id filter nor `--preview` — the same
+  backend gap #2066 left open for the name filter. The `--with-semantics` saving *does* land
+  there, since the CLI drives that pass. Wiring the Robolectric path is the follow-up.
+- **A skipped render is still declared.** Deferred previews stay listed in the bundle's
+  `previews.json` — the bundle task carries every selected preview and simply omits the
+  PNG for one that didn't render — which is what keeps them addressable on the serve
+  host's live lane. `catalog.json`'s `deferred[]` records the mode-deferred coverage from
+  that listing, so the declaration doesn't disappear along with the pixels.
 
 ## Components with no static sticker (`capture: "none"`)
 

--- a/scripts/design-artifacts/catalog-priority.mjs
+++ b/scripts/design-artifacts/catalog-priority.mjs
@@ -136,6 +136,41 @@ export function modePriority(spec, mode) {
 }
 
 /**
+ * The declared mode a **daemon preview id** renders in, or null when the id names none.
+ *
+ * The theme fan-out lives inside one `@Preview` function — a multipreview member (`@CatalogModes` →
+ * `Foo_Light` / `Foo_Dark`) or one of several `@Preview` annotations — and the mode's name is the
+ * only trace of
+ * it on the id, appended as a trailing segment. So this reads that segment back and resolves it
+ * against the modes the spec declares, which is what lets the render-side id filter (issue #2966)
+ * skip a deferred palette instead of merely leaving it out of the publish.
+ *
+ * Matched case-insensitively (`modes: ["light"]` vs the annotation's `name = "Light"`), longest mode
+ * first so `dark` can't shadow a declared `highContrastDark`, and only at a segment boundary — the
+ * mode must be the whole id, follow a separator (`_`, `-`, `.`, space), or start at an upper-case
+ * letter (`FooLight`). Without the boundary rule a mode named `on` would match `ButtonSwitchOn`'s
+ * unrelated tail and silently defer a required render.
+ */
+export function modeOfPreviewId(id, modes) {
+  const text = String(id ?? "");
+  if (text.length === 0) return null;
+  const declared = (modes ?? [])
+    .filter((m) => typeof m === "string" && m.length > 0)
+    .sort((a, b) => b.length - a.length);
+  const lower = text.toLowerCase();
+  for (const mode of declared) {
+    const suffix = mode.toLowerCase();
+    if (!lower.endsWith(suffix)) continue;
+    const start = text.length - suffix.length;
+    if (start === 0) return mode;
+    const before = text[start - 1];
+    const boundary = /[^A-Za-z0-9]/.test(before) || /[A-Z]/.test(text[start]);
+    if (boundary) return mode;
+  }
+  return null;
+}
+
+/**
  * Whether a rendered image's mode is deferred. Only an image that *names* a theme can be deferred:
  * the untagged sticker is the component's primary render (the one the grid shows and the Figma
  * import carries), so `modePriority` can thin the palette fan-out without ever leaving a component
@@ -226,9 +261,12 @@ export function previewNamesByPriority(spec) {
  * deferred entry may then be rasterised anyway, costing time but never correctness: the export keys
  * deferral off the spec, not off whether a PNG happens to exist.
  *
- * Mode-level deferral contributes nothing here. The fan-out it thins lives *inside* one `@Preview`
- * function (a multipreview member or a `@PreviewParameter` row), and the render filter selects whole
- * functions — so `modePriority` currently thins what is published, not what is rendered.
+ * Mode-level deferral contributes nothing here, and can't: the fan-out it thins lives *inside* one
+ * `@Preview` function (a multipreview member, or one of several `@Preview` annotations), and this
+ * filter selects
+ * whole functions. The mode axis is skipped by the sibling **id** filter instead — see
+ * `deferred-preview-ids.mjs`, which needs the discovered ids and therefore runs after discovery
+ * rather than in the build-free pre-flight (issue #2966).
  */
 export function renderFilterPatterns(spec) {
   const { required, deferred } = previewNamesByPriority(spec);

--- a/scripts/design-artifacts/deferred-preview-ids.mjs
+++ b/scripts/design-artifacts/deferred-preview-ids.mjs
@@ -1,0 +1,146 @@
+/**
+ * The **preview ids** a catalog's render may skip because `modePriority` defers their mode
+ * (issue #2966).
+ *
+ * `renderFilterPatterns` (issue #2959) can drop a wholly-deferred `@Preview` *function* from the
+ * render, but the palette fan-out `modePriority` thins lives inside one function — a `@CatalogModes`
+ * member, or one of several `@Preview` annotations — where every combination is its own discovered
+ * preview with a distinct `id` and the same `functionName`. Only an id-level filter reaches those, so
+ * the render savings for the mode axis (measured at −59% of renders on a nine-theme catalog, vs −37%
+ * for deferring variants) needs exact ids, which only discovery knows. Hence the shape of this
+ * module: the caller runs `compose-preview list --json` (which runs `composePreviewDiscover`) and
+ * feeds the result in.
+ *
+ * Two shapes it deliberately can't thin, both because the ids don't exist at this point:
+ *  - a mode axis supplied by a **`@PreviewParameter` provider** — discovery emits ONE preview for the
+ *    parameterized function and the renderer expands the rows into `<stem>_<label>` outputs later, so
+ *    there is no per-row id to exclude (such a catalog still gets the entry-level filter);
+ *  - an **Android/Robolectric** module — its `composePreviewRender` is a `Test` task reading the
+ *    manifest directly, and honours neither this filter nor `--preview`. The semantics-capture saving
+ *    (CLI-driven) does land there; the raster saving does not, until that path grows the same filter.
+ *
+ * Two invariants make this safe to hand to a render:
+ *
+ *  1. **Never leave a function with nothing to render.** A function whose every id resolves to a
+ *     deferred mode keeps all of them. That mirrors "the primary sticker is never deferrable by mode"
+ *     on the publish side — a component with no baked pixels at all is a spec misconfiguration the
+ *     completeness gate is meant to catch, not something to silently turn into a skipped render.
+ *  2. **Only functions the spec actually references.** An id belonging to no spec entry is left
+ *     alone: the sheet may not catalogue it, but something else in the module (the wireframe pass, a
+ *     token sheet) may still need its pixels.
+ *
+ * Exclusion polarity throughout: the caller names what must NOT render, so a spec that has drifted
+ * ahead of the code renders too much (wasted time) rather than too little (a missing sticker).
+ *
+ * Pure and dependency-free apart from its sibling `catalog-priority.mjs` (node built-ins only, no
+ * `@design-parity/*`) so it unit-tests without an `npm ci`. The `--spec`/`--previews` CLI wrapper at
+ * the bottom only runs when this file is executed directly.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import { DEFERRED, modeOfPreviewId, modePriority } from "./catalog-priority.mjs";
+
+/** Every `@Preview` function name a spec references, from components and their variants. */
+export function specPreviewFunctions(spec) {
+  const out = new Set();
+  for (const group of spec?.groups ?? []) {
+    for (const component of group?.components ?? []) {
+      if (typeof component?.preview === "string") out.add(component.preview);
+      for (const variant of component?.variants ?? []) {
+        if (typeof variant?.preview === "string") out.add(variant.preview);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * The ids whose render this spec can skip.
+ *
+ * @param {object} spec parsed `catalog.spec.json`.
+ * @param {Array<{id: string, functionName?: string}>} previews discovered previews (from
+ *   `compose-preview list --json`, or a `previews.json` manifest — both carry `id` + `functionName`).
+ * @returns {{ ids: string[], keptByGuard: string[] }} `ids` sorted and unique; `keptByGuard` names
+ *   the functions whose every id was mode-deferred and which were therefore left alone, so the caller
+ *   can log the (spec-level) misconfiguration instead of hiding it behind a smaller render.
+ */
+export function deferredPreviewIds(spec, previews) {
+  const referenced = specPreviewFunctions(spec);
+  const modes = spec?.modes ?? [];
+  const byFunction = new Map();
+  for (const preview of previews ?? []) {
+    const id = preview?.id;
+    if (typeof id !== "string" || id.length === 0) continue;
+    const fn = preview.functionName ?? id;
+    if (!referenced.has(fn)) continue;
+    const list = byFunction.get(fn) ?? [];
+    list.push(id);
+    byFunction.set(fn, list);
+  }
+
+  const ids = new Set();
+  const keptByGuard = [];
+  for (const [fn, fnIds] of byFunction) {
+    const deferredIds = fnIds.filter(
+      (id) => modePriority(spec, modeOfPreviewId(id, modes)) === DEFERRED,
+    );
+    if (deferredIds.length === 0) continue;
+    if (deferredIds.length === fnIds.length) {
+      keptByGuard.push(fn);
+      continue;
+    }
+    for (const id of deferredIds) ids.add(id);
+  }
+  return { ids: [...ids].sort(), keptByGuard: keptByGuard.sort() };
+}
+
+/**
+ * Pull the preview list out of whatever JSON the caller captured: `compose-preview list --json`
+ * (`{ previews: [...] }` or a bare array) or a module's discovery manifest (`previews.json`, also
+ * `{ previews: [...] }`). Anything else yields an empty list, which means "exclude nothing".
+ */
+export function previewsFromJson(parsed) {
+  if (Array.isArray(parsed)) return parsed;
+  if (Array.isArray(parsed?.previews)) return parsed.previews;
+  if (Array.isArray(parsed?.results)) return parsed.results;
+  return [];
+}
+
+// --- CLI ----------------------------------------------------------------------
+// `node deferred-preview-ids.mjs --spec catalog.spec.json --previews previews.json [--out ids.txt]`
+// Prints (and optionally writes) the comma-separated exclusion list the render consumes as
+// `compose-preview bundle pack --exclude-preview-id` / `-PcomposePreview.idExclude`. Empty output
+// is the normal case for a spec that defers no mode, and means "render everything".
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { values } = parseArgs({
+    options: {
+      spec: { type: "string" },
+      previews: { type: "string" },
+      out: { type: "string" },
+    },
+  });
+  if (!values.spec || !values.previews) {
+    console.error(
+      "usage: deferred-preview-ids.mjs --spec <catalog.spec.json> --previews <list.json> [--out <file>]",
+    );
+    process.exit(2);
+  }
+  const spec = JSON.parse(readFileSync(values.spec, "utf8"));
+  const previews = previewsFromJson(JSON.parse(readFileSync(values.previews, "utf8")));
+  const { ids, keptByGuard } = deferredPreviewIds(spec, previews);
+  for (const fn of keptByGuard) {
+    console.error(
+      `[${spec.system}] ${fn}: every discovered preview renders a DEFERRED mode — keeping all of ` +
+        `them so the component still has pixels. Check \`modePriority\` against the modes this ` +
+        `function actually renders.`,
+    );
+  }
+  console.error(
+    `[${spec.system}] mode deferral: ${ids.length} preview id(s) excluded from the render` +
+      (ids.length > 0 ? ` (${ids.slice(0, 5).join(", ")}${ids.length > 5 ? ", …" : ""})` : ""),
+  );
+  const line = ids.join(",");
+  if (values.out) writeFileSync(values.out, line);
+  console.log(line);
+}

--- a/scripts/design-artifacts/deferred-preview-ids.test.mjs
+++ b/scripts/design-artifacts/deferred-preview-ids.test.mjs
@@ -1,0 +1,164 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  deferredPreviewIds,
+  previewsFromJson,
+  specPreviewFunctions,
+} from "./deferred-preview-ids.mjs";
+import { modeOfPreviewId } from "./catalog-priority.mjs";
+
+/** A nine-theme-ish spec: light required, every other palette deferred. */
+const spec = {
+  system: "compose-m3",
+  modes: ["light", "dark", "highContrastDark"],
+  modePriority: { light: "required", "*": "deferred" },
+  groups: [
+    {
+      name: "Buttons",
+      components: [
+        { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        {
+          componentId: "Buttons/Outlined",
+          preview: "OutlinedButtonPreview",
+          variants: [
+            { preview: "OutlinedButtonDisabledPreview", state: "disabled" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const preview = (id, functionName) => ({ id, functionName });
+
+test("modeOfPreviewId reads the trailing mode segment case-insensitively", () => {
+  const modes = ["light", "dark"];
+  assert.equal(modeOfPreviewId("FilledButtonPreview_Dark", modes), "dark");
+  assert.equal(modeOfPreviewId("FilledButtonPreview_Light", modes), "light");
+  assert.equal(modeOfPreviewId("FilledButtonPreviewDark", modes), "dark");
+  assert.equal(modeOfPreviewId("FilledButtonPreview", modes), null);
+});
+
+test("modeOfPreviewId prefers the longest declared mode", () => {
+  const modes = ["dark", "highContrastDark"];
+  assert.equal(
+    modeOfPreviewId("FilledButtonPreview_HighContrastDark", modes),
+    "highContrastDark",
+  );
+});
+
+test("modeOfPreviewId only matches at a segment boundary", () => {
+  // A separator or a camel-case hump is a boundary (`Foo_Dark`, `FooDark`); a mode buried inside a
+  // word is not, so a mode named `ark` can never claim `FooDark`.
+  assert.equal(modeOfPreviewId("FooDark", ["ark"]), null);
+  assert.equal(modeOfPreviewId("Foo_ark", ["ark"]), "ark");
+  // The camel-hump rule is symmetric, so a short mode name does match a hump that spells it — a
+  // consequence worth knowing when naming modes, and bounded by the never-empty guard below.
+  assert.equal(modeOfPreviewId("SwitchOn", ["on"]), "on");
+});
+
+test("modeOfPreviewId with no declared modes matches nothing", () => {
+  assert.equal(modeOfPreviewId("FilledButtonPreview_Dark", []), null);
+  assert.equal(modeOfPreviewId("FilledButtonPreview_Dark", undefined), null);
+});
+
+test("specPreviewFunctions collects components and variants", () => {
+  assert.deepEqual([...specPreviewFunctions(spec)], [
+    "FilledButtonPreview",
+    "OutlinedButtonPreview",
+    "OutlinedButtonDisabledPreview",
+  ]);
+});
+
+test("deferred modes' ids are excluded, the required one is kept", () => {
+  const previews = [
+    preview("FilledButtonPreview_Light", "FilledButtonPreview"),
+    preview("FilledButtonPreview_Dark", "FilledButtonPreview"),
+    preview("FilledButtonPreview_HighContrastDark", "FilledButtonPreview"),
+  ];
+  const { ids, keptByGuard } = deferredPreviewIds(spec, previews);
+  assert.deepEqual(ids, [
+    "FilledButtonPreview_Dark",
+    "FilledButtonPreview_HighContrastDark",
+  ]);
+  assert.deepEqual(keptByGuard, []);
+});
+
+test("a function whose EVERY id is mode-deferred keeps all of them", () => {
+  // The publish-side rule is "the primary sticker is never deferrable by mode"; skipping the render
+  // here would turn a spec misconfiguration into a component with no pixels.
+  const previews = [
+    preview("FilledButtonPreview_Dark", "FilledButtonPreview"),
+    preview("FilledButtonPreview_HighContrastDark", "FilledButtonPreview"),
+  ];
+  const { ids, keptByGuard } = deferredPreviewIds(spec, previews);
+  assert.deepEqual(ids, []);
+  assert.deepEqual(keptByGuard, ["FilledButtonPreview"]);
+});
+
+test("previews the spec doesn't reference are left alone", () => {
+  const previews = [
+    preview("WireframeOnlyPreview_Dark", "WireframeOnlyPreview"),
+    preview("WireframeOnlyPreview_Light", "WireframeOnlyPreview"),
+  ];
+  assert.deepEqual(deferredPreviewIds(spec, previews).ids, []);
+});
+
+test("variant previews are filtered like component previews", () => {
+  const previews = [
+    preview("OutlinedButtonDisabledPreview_Light", "OutlinedButtonDisabledPreview"),
+    preview("OutlinedButtonDisabledPreview_Dark", "OutlinedButtonDisabledPreview"),
+  ];
+  assert.deepEqual(deferredPreviewIds(spec, previews).ids, [
+    "OutlinedButtonDisabledPreview_Dark",
+  ]);
+});
+
+test("a spec that defers no mode excludes nothing", () => {
+  const strict = { ...spec, modePriority: undefined };
+  const previews = [
+    preview("FilledButtonPreview_Light", "FilledButtonPreview"),
+    preview("FilledButtonPreview_Dark", "FilledButtonPreview"),
+  ];
+  assert.deepEqual(deferredPreviewIds(strict, previews).ids, []);
+});
+
+test("ids with no functionName fall back to the id itself", () => {
+  const flat = {
+    ...spec,
+    groups: [
+      {
+        name: "Buttons",
+        components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview_Dark" }],
+      },
+    ],
+  };
+  // Degenerate but real for a bundle/manifest that carries no functionName: the id IS the key, and a
+  // lone id that is itself mode-deferred hits the never-empty guard rather than being dropped.
+  const { ids, keptByGuard } = deferredPreviewIds(flat, [{ id: "FilledButtonPreview_Dark" }]);
+  assert.deepEqual(ids, []);
+  assert.deepEqual(keptByGuard, ["FilledButtonPreview_Dark"]);
+});
+
+test("ids are unique and sorted", () => {
+  const previews = [
+    preview("OutlinedButtonPreview_Light", "OutlinedButtonPreview"),
+    preview("OutlinedButtonPreview_Dark", "OutlinedButtonPreview"),
+    preview("FilledButtonPreview_Light", "FilledButtonPreview"),
+    preview("FilledButtonPreview_Dark", "FilledButtonPreview"),
+    preview("FilledButtonPreview_Dark", "FilledButtonPreview"),
+  ];
+  assert.deepEqual(deferredPreviewIds(spec, previews).ids, [
+    "FilledButtonPreview_Dark",
+    "OutlinedButtonPreview_Dark",
+  ]);
+});
+
+test("previewsFromJson accepts every shape the pipeline produces", () => {
+  const rows = [{ id: "A" }];
+  assert.deepEqual(previewsFromJson(rows), rows);
+  assert.deepEqual(previewsFromJson({ previews: rows }), rows);
+  assert.deepEqual(previewsFromJson({ results: rows }), rows);
+  assert.deepEqual(previewsFromJson({ nothing: true }), []);
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -50,6 +50,8 @@ import {
   declaredEntryDeferrals,
   deferralPlan,
   effectivePriority,
+  modeOfPreviewId,
+  modePriority,
   previewForImage,
   specDefersAnything,
   splitDeferredImages,
@@ -279,6 +281,25 @@ function functionOf(candidate) {
   return candidate.functionName ?? candidate.componentId;
 }
 
+/**
+ * Identity of one deferred sticker across every axis a `deferred[]` record can carry, so a
+ * recovered-from-the-bundle record (issue #2966) is deduped against the image-derived one for the
+ * SAME sticker and not against a sibling variant that merely shares its mode. `props` is
+ * key-sorted so two equal prop sets always produce the same key.
+ */
+function deferralAxisKey(theme, state, props, size) {
+  const propsPart = props
+    ? Object.entries(props)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${v}`)
+        .join(",")
+    : "";
+  // NUL-joined (like `bridge-live-preview-ids`' `variantKey`) so a state or prop value that
+  // contains the separator can never make two different stickers collide on one key.
+  const NUL = String.fromCharCode(0);
+  return [theme ?? "", state ?? "", propsPart, size ?? ""].join(NUL);
+}
+
 /** A semantics tree carries real signal (not the empty `{ root: {} }` fallback). */
 function hasSemantics(candidate) {
   const tree = candidate.semantics;
@@ -434,6 +455,54 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
           ...(image.props !== undefined ? { props: image.props } : {}),
           ...(image.size !== undefined ? { size: image.size } : {}),
         });
+      }
+      // Modes whose render was SKIPPED, not merely un-published (issue #2966). Once the render
+      // filter drops a deferred palette, its images never reach the candidate join (the join only
+      // sees previews that produced a PNG), so `splitDeferredImages` above has nothing to record and
+      // the coverage would vanish from `catalog.json` instead of being declared live-only. Recover it
+      // from the bundle's full preview list, which carries every SELECTED preview whether or not CI
+      // rasterised it — the same listing the live lane resolves against. Deduped against the modes
+      // already accounted for, so an unfiltered render (a local generate, say) records each once.
+      //
+      // Keyed by the FULL axis tuple, not by mode alone, and walked over the component's own
+      // `@Preview` plus each REQUIRED variant's: a required state/props variant whose function also
+      // fans out by mode has its deferred-mode ids excluded from the render too, and recording only
+      // the base function's would drop that variant's `state`/`props` from the declaration (a record
+      // an unfiltered run produced via `splitDeferredImages`). Deferred variants are already recorded
+      // above, so they are deliberately not revisited here.
+      const seenAxes = new Set(
+        [...deferredImages, ...baked]
+          .filter((image) => image.theme)
+          .map((image) => deferralAxisKey(image.theme, image.state, image.props, image.size)),
+      );
+      const modeSources = [
+        { preview: component.preview },
+        ...(component.variants ?? []).map((v) => ({
+          preview: v.preview,
+          state: v.state,
+          props: v.props,
+          size: v.size,
+        })),
+      ];
+      for (const source of modeSources) {
+        if (!source.preview) continue;
+        for (const previewId of opts.previewIdsByFunction?.get(source.preview) ?? []) {
+          const mode = modeOfPreviewId(previewId, spec.modes);
+          if (!mode || modePriority(spec, mode) !== DEFERRED) continue;
+          const key = deferralAxisKey(mode, source.state, source.props, source.size);
+          if (seenAxes.has(key)) continue;
+          seenAxes.add(key);
+          deferred.push({
+            componentId: component.componentId,
+            group: group.name,
+            preview: source.preview,
+            reason: "mode",
+            theme: mode,
+            ...(source.state !== undefined ? { state: source.state } : {}),
+            ...(source.props !== undefined ? { props: source.props } : {}),
+            ...(source.size !== undefined ? { size: source.size } : {}),
+          });
+        }
       }
       if (baked.length === 0) {
         // Every one of this component's renders was mode-deferred — it would publish as a
@@ -703,6 +772,10 @@ const { catalog, missing, noSticker, withoutSemantics, deferred } =
     ...(values.renderer ? { renderer: values.renderer } : {}),
     ...(designParityVersion() ? { designParity: designParityVersion() } : {}),
     ...(themeTokens ? { themeTokens } : {}),
+    // Every daemon preview id per function, from the bundles' FULL preview lists — including the
+    // deferred palettes whose render was skipped (#2966), which is how their live-only coverage still
+    // gets declared even though no image of them exists to fold.
+    previewIdsByFunction: daemonPreviewIdsByFunction([bundle, extraBundle]),
   });
 
 // Completeness gate: `bundle pack --with-semantics` is best-effort and exits 0

--- a/scripts/design-artifacts/validate-catalog-spec.mjs
+++ b/scripts/design-artifacts/validate-catalog-spec.mjs
@@ -48,6 +48,11 @@ const { values } = parseArgs({
     // defers no entry, which means "render everything" — so a caller can pass the contents straight
     // through unconditionally.
     "render-filter-out": { type: "string" },
+    // Write the deferred MODE names to <path> (comma-separated, no trailing newline). Empty when the
+    // spec defers no mode. The render-side counterpart needs exact preview ids, which only discovery
+    // knows (issue #2966), so a caller uses this as the cheap "is the extra discovery run worth it?"
+    // gate before running `compose-preview list --json` + `deferred-preview-ids.mjs`.
+    "deferred-modes-out": { type: "string" },
     json: { type: "boolean", default: false },
     help: { type: "boolean", default: false },
   },
@@ -57,7 +62,7 @@ if (values.help) {
   console.log(
     "usage: validate-catalog-spec --spec <catalog.spec.json> [--module-dir <dir> | --src <dir>…] " +
       "[--preview-annotation <Name>…] [--no-scan] [--live-bundle|--no-live-bundle] " +
-      "[--render-filter-out <file>] [--json]",
+      "[--render-filter-out <file>] [--deferred-modes-out <file>] [--json]",
   );
   process.exit(0);
 }
@@ -116,6 +121,9 @@ const { errors, warnings } = validateSpec(spec, {
 const plan = deferralPlan(spec);
 if (values["render-filter-out"]) {
   await writeFile(values["render-filter-out"], plan.renderFilter.join(","), "utf8");
+}
+if (values["deferred-modes-out"]) {
+  await writeFile(values["deferred-modes-out"], plan.modes.join(","), "utf8");
 }
 
 if (values.json) {

--- a/site/index.md
+++ b/site/index.md
@@ -99,6 +99,23 @@ can't poison the run:
 # or, as a Gradle property: -PcomposePreview.filter='*ExportHelpDialogPreview'
 ```
 
+`--preview` selects whole `@Preview` **functions**. To skip one member of a
+function's fan-out — a multipreview member, or one of several `@Preview`
+annotations, which share a function name but have distinct ids — exclude it by id
+instead:
+
+```sh
+./gradlew :desktopApp:composePreviewRender --exclude-preview-id '*_Dark'
+# or, as a Gradle property: -PcomposePreview.idExclude='*_Dark'
+```
+
+Ids take the same pattern syntax as `--preview` (a `*`/`?` glob, or a plain
+substring). `--preview-id` is the positive form ("render only these"); prefer
+`--exclude-preview-id` when you're deferring part of a fan-out, since a stale
+pattern then renders too much rather than dropping a preview you wanted. Either
+way a filtered run is never stored in the build cache, since its render directory
+is only part of the module's output.
+
 (Android modules render previews through a Robolectric test task; the `--preview`
 filter there is tracked as a follow-up.)
 


### PR DESCRIPTION
Closes #2966. **Rebased onto #2973, which landed the render-side half of this issue while this PR was open.** The plugin is now untouched here — this is the rest of the chain that turns `modePriority` into an actual build-time saving.

## What #2973 left open

`composePreviewRender --preview-id` / `--exclude-preview-id` exists on the desktop `RenderPreviewsTask`, but nothing computes the ids a deferred palette implies, passes them through `bundle pack`, or thins the semantics capture — so a catalog with `modePriority` still pays for a full render in CI.

## What this adds

**`deferred-preview-ids.mjs`** derives the exact ids from `compose-preview list --json` (which runs `composePreviewDiscover`) plus the spec's `modes` / `modePriority` — the robust option the issue asked for rather than fragile `*_dark` globs. Two invariants:

- a function whose *every* id resolves to a deferred mode keeps all of them — the render-side mirror of "the primary sticker is never deferrable by mode", so a bad `modePriority` still fails the completeness gate instead of quietly rendering a component away;
- ids belonging to no spec entry are left alone (the wireframe pass or a token sheet may still need those pixels).

**`bundle pack --exclude-preview-id`** forwards the patterns to the render as `-PcomposePreview.idExclude` *and* skips the same ids in the `--with-semantics` daemon capture. That pass is CLI-driven, so a Gradle property alone would leave #2948's per-preview deadline paying for palettes nothing bakes — half the axis saving. Falls back to `ORG_GRADLE_PROJECT_composePreview.idExclude` when the flag is absent. Its matcher restates `PreviewNameFilter.matchesId` (glob, else equality-or-substring) because `preview-discovery` lives in a build the CLI can't depend on — the same split `previewFilter.ts` lives with; both sides have tests spelling the semantics out so they can't drift.

**Workflows**: both design-artifacts workflows derive the ids before the pack, gated on a new `validate-catalog-spec --deferred-modes-out` output, so the extra Gradle invocation is only paid by a spec that actually defers a mode — and its compile is shared with the render that follows.

**`catalog.json` keeps declaring what it skipped.** A skipped render never reaches the candidate join (`candidatePreviewBundle` drops PNG-less previews), so the mode-deferred `deferred[]` records would have vanished along with the pixels — exactly the listing #2965's live lane needs. The generator now recovers them from the bundle's full preview list, walking the component's own function plus each required variant's, deduped on the full axis tuple (`deferralAxisKey`) so a variant's `state`/`props`/`size` survive too.

### Two shapes get the publish saving but not the render saving

Documented rather than papered over (`DESIGN_CATALOGS.md`, plus the derivation's header):

- a mode axis supplied by a **`@PreviewParameter` provider** — discovery emits one entry for the parameterized function and the renderer expands the rows into `<stem>_<label>` outputs later, so no per-row id exists (verified on `:samples:cmp`: one `SwatchPreview_Color Swatch` entry → four `_{Amber,Crimson,Teal,Violet}` renders);
- an **Android/Robolectric** catalog (`design-catalog-wear-m3`, `design-catalog-remote-m3`) — that `composePreviewRender` is a `Test` task reading the manifest directly and honours neither this filter nor `--preview`, the gap #2066 left open. The `--with-semantics` saving *does* land there. Wiring the Robolectric path (which should carry the name filter with it) is the follow-up.

## Test plan

- `:cli:test`, `ktfmtCheck` — green. New `PackPreviewIdExclusionsTest` (incl. a case pinning the CLI matcher to `matchesId`'s substring behaviour) and `deferred-preview-ids.test.mjs` (13 cases: mode resolution, the never-empty guard, variant functions, unreferenced ids, dedup).
- `node --test` in `scripts/design-artifacts` — the pre-existing `rc-compare-pixels.test.mjs` failure is a missing npm dep in this sandbox, untouched here.
- End-to-end against the **landed** plugin on `:samples:cmp`, which has two functions with a `_Night` fan-out sibling:

```
# unfiltered
Rendered 37 preview(s)   → 40 outputs, incl. Pixel8SystemUiPreview_Pixel_8_Night
                                        and ShowBackgroundNoSurfacePreview_Night

# -PcomposePreview.idExclude='*Night'
Rendered 35 preview(s)   → no *Night* output at all; both functions keep their
                           non-Night sibling
```

No visual evidence: nothing rendered changes shape — this is render *scheduling* plus CLI/driver plumbing. (PNG rasterisation can't complete in this sandbox at all: the Skiko fork can't resolve `libGL.so.1` even after installing Mesa, so the outputs above are the renderer's per-preview error sidecars. The scheduling counts and filenames are what this change controls; CI renders the pixels.)
