### PR TITLE
feat(serve): add /admin/groups so front-page sections are runtime config too

### DIFF
--- a/.github/scripts/publish-config-to-box.sh
+++ b/.github/scripts/publish-config-to-box.sh
@@ -82,13 +82,11 @@ post() {
       ;;
     400)
       rejected=$((rejected + 1))
-      # The one 400 that is a *structural* gap rather than a bad payload: there is no admin route
-      # for front-page groups (only /admin/catalogs and /admin/trust), so a catalog claiming a
-      # group the box's own /config/catalogs.json doesn't define is rejected and cannot be fixed
-      # from here. Say so explicitly — the previous version warned and moved on, leaving the
-      # catalog silently unpublished.
+      # `unknown group` should now be unreachable: the group loop above defines every section before
+      # any catalog claims one. If it still happens, the group POST silently failed or the box
+      # predates /admin/groups — worth saying rather than a generic "rejected".
       if [[ "${payload}" == *"unknown group"* ]]; then
-        echo "::error::${label}: ${payload}. Groups are not reconcilable over the admin API — add the group to the box's /config/catalogs.json (\`docker compose exec preview vi /config/catalogs.json\` then restart), or drop the group claim from the seed entry."
+        echo "::error::${label}: ${payload}. Groups are reconciled first, so this means the /admin/groups POST did not take — check the group lines above, or whether this box predates the route."
       else
         echo "::error::${label}: rejected (HTTP 400) — ${payload}"
       fi
@@ -116,6 +114,18 @@ while IFS= read -r entry; do
     [[ $? == 2 ]] && exit 0
   }
 done < <(jq -c '.branches // [] | .[]' "${TRUST_FILE}")
+
+# Groups BEFORE catalogs, for the same reason trust comes before both: a catalog claiming a section
+# the server hasn't been told about is rejected outright, and until /admin/groups existed that
+# rejection was unfixable from here.
+echo "Reconciling front-page groups from ${CATALOGS_FILE#"${REPO_ROOT}/"}"
+while IFS= read -r group; do
+  [[ -n "${group}" ]] || continue
+  id=$(printf '%s' "${group}" | jq -r '.id')
+  post /admin/groups "${group}" "group ${id}" || {
+    [[ $? == 2 ]] && exit 0
+  }
+done < <(jq -c '.groups // [] | .[]' "${CATALOGS_FILE}")
 
 echo "Reconciling catalogs from ${CATALOGS_FILE#"${REPO_ROOT}/"}"
 while IFS= read -r entry; do

--- a/.github/scripts/test-publish-config-to-box.sh
+++ b/.github/scripts/test-publish-config-to-box.sh
@@ -46,14 +46,26 @@ out=$(BASE_URL=https://example.invalid \
   CATALOGS_FILE="${tmp}/catalogs.json" \
   bash "${UNDER_TEST}" --dry-run)
 
-# 1. ordering: every /admin/trust POST precedes every /admin/catalogs POST.
+# 1. ordering: trust, then groups, then catalogs. Both hops matter — a catalog posted before its
+#    producer is trusted registers `unverified`; one posted before its section exists is rejected
+#    outright as an unknown group.
 last_trust=$(printf '%s\n' "${out}" | grep -n 'POST /admin/trust' | tail -1 | cut -d: -f1)
+first_group=$(printf '%s\n' "${out}" | grep -n 'POST /admin/groups' | head -1 | cut -d: -f1)
+last_group=$(printf '%s\n' "${out}" | grep -n 'POST /admin/groups' | tail -1 | cut -d: -f1)
 first_catalog=$(printf '%s\n' "${out}" | grep -n 'POST /admin/catalogs' | head -1 | cut -d: -f1)
-if [[ -z "${last_trust}" || -z "${first_catalog}" ]]; then
-  fail "expected both trust and catalog POSTs; got:\n${out}"
-elif [[ "${last_trust}" -ge "${first_catalog}" ]]; then
-  fail "trust must be reconciled before catalogs (last trust line ${last_trust}, first catalog line ${first_catalog})"
+if [[ -z "${last_trust}" || -z "${first_group}" || -z "${first_catalog}" ]]; then
+  fail "expected trust, group and catalog POSTs; got:\n${out}"
+else
+  [[ "${last_trust}" -lt "${first_group}" ]] ||
+    fail "trust must precede groups (last trust ${last_trust}, first group ${first_group})"
+  [[ "${last_group}" -lt "${first_catalog}" ]] ||
+    fail "groups must precede catalogs (last group ${last_group}, first catalog ${first_catalog})"
 fi
+
+# 1b. the group's heading and noun reach the wire intact — a dropped heading would silently rename
+#     a front-page section.
+printf '%s' "${out}" | grep -q '"id":"ds".*"heading":"Design Systems"' ||
+  fail "group ds must be POSTed with its heading"
 
 # 2. both producers are sent, with their branch globs intact.
 for repo in yschimke/compose-ai-tools yschimke/pocket-casts-android; do

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1885,6 +1885,10 @@ class ServeCommand(args: List<String>) : Command(args) {
                           the producer-trust store — GET /admin/trust, POST /admin/trust
                           ({"kind":"branch"|"key"|"oidc",…}), DELETE /admin/trust?kind=&repo=…
                           (selectors ride the query string so an owner/repo needn't be escaped).
+                          the front-page sections — GET /admin/groups, POST /admin/groups
+                          ({"id","heading","noun"}), DELETE /admin/groups/<id>. Defining a section
+                          also regroups catalogs already registered, and re-POSTing a published
+                          catalog converges its listing (group / listed) in place.
                           Mutations are applied live AND written back to --catalogs-file /
                           --trust-store, so they survive a restart. Separate from --token on purpose
                           (a --public box hands that one to every visitor); omitted = the admin

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
@@ -82,6 +82,32 @@ class CatalogLoadTracker(
       true
     }
 
+  /**
+   * Replace [system]'s **listing** metadata — where it appears, not where it comes from — keeping
+   * its load state and its registered content untouched. Returns false when it isn't tracked.
+   *
+   * Needed because a catalog's front-page placement is resolved once, at registration, into a
+   * [ServeWeb.HomeGroup] snapshot. So a group defined *after* a catalog was published would never
+   * reach it: the group table would gain the entry while the already-registered catalog kept `group
+   * = null` and stayed under the owner fallback. [ServeCatalogAdmin] calls this to re-resolve every
+   * claim whenever the group table changes, which is what makes a group edit take effect without a
+   * restart or a re-fetch.
+   *
+   * Deliberately cannot change [Config.repo] or [Config.branch] — those decide what bytes get
+   * served, and changing them behind a live registration would leave the served content disagreeing
+   * with its own provenance (and its trust verdict). Re-pointing a catalog is a retire plus a
+   * publish.
+   */
+  fun relist(system: String, listed: Boolean, group: ServeWeb.HomeGroup?): Boolean =
+    synchronized(lock) {
+      val existing = states[system] ?: return false
+      val updated = existing.config.copy(listed = listed, group = group)
+      states[system] = existing.copy(config = updated)
+      val at = ordered.indexOfFirst { it.system == system }
+      if (at >= 0) ordered[at] = updated
+      true
+    }
+
   /** Retire a catalog. Returns false when it wasn't configured. */
   fun remove(system: String): Boolean =
     synchronized(lock) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdmin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdmin.kt
@@ -71,6 +71,65 @@ class ServeCatalogAdmin(
   /** The currently configured catalogs, in front-page order. */
   fun list(): List<CatalogLoadTracker.State> = tracker.snapshot()
 
+  /** The front-page sections a catalog entry may claim. */
+  fun listGroups(): List<ServeCatalogsConfig.Group> = groups
+
+  /**
+   * Define [group], or update the heading/noun of one that already exists.
+   *
+   * Groups used to be the one part of the catalog config with no runtime path at all: adding a
+   * section meant editing the box's `catalogs.json` and restarting, and a catalog claiming a
+   * section the server didn't know about was rejected outright. That made a committed config
+   * genuinely unable to converge — the gap flagged on #2967.
+   */
+  fun upsertGroup(group: ServeCatalogsConfig.Group): Result {
+    ServeCatalogsConfig.validateGroup(group)?.let {
+      return Result.Invalid(it)
+    }
+    if (groups.any { it == group }) {
+      return Result.Conflict("group '${group.id}' is already defined identically")
+    }
+    val warning = persist { it.withGroup(group) }
+    // Re-resolve the claims of catalogs ALREADY registered: a section defined after its catalogs
+    // were published must still collect them, or defining it does nothing visible.
+    val moved = reapplyGroupClaims()
+    onLog("serve: group ${group.id} defined via admin API (regrouped $moved catalog(s))")
+    return Result.Ok(group.id, warning)
+  }
+
+  /** Delete group [id]. Catalogs claiming it fall back to their source repo's owner heading. */
+  fun removeGroup(id: String): Result {
+    if (groups.none { it.id == id }) {
+      return Result.Conflict("group '$id' is not defined here")
+    }
+    val warning = persist { it.withoutGroup(id) }
+    val moved = reapplyGroupClaims()
+    onLog("serve: group $id removed via admin API (regrouped $moved catalog(s))")
+    return Result.Ok(id, warning)
+  }
+
+  /**
+   * Re-resolve every registered catalog's front-page placement against the current group table and
+   * the persisted entry that declares it. Returns how many changed.
+   *
+   * Reads the entries from the config file rather than the tracker, because the tracker holds the
+   * *resolved* [ServeWeb.HomeGroup] and not the `group` id that produced it — so the declared claim
+   * only survives on disk. A catalog with no config entry (a `--catalogs` flag addition, say)
+   * declares no group and is left alone.
+   */
+  private fun reapplyGroupClaims(): Int {
+    val declared = configFile?.let { runCatching { it.load() }.getOrNull() } ?: return 0
+    val table = groups
+    var changed = 0
+    for (entry in declared.catalogs) {
+      val current = tracker.configFor(entry.system) ?: continue
+      val resolved = homeGroup(entry, current.repo, table)
+      if (current.group == resolved && current.listed == entry.listed) continue
+      if (tracker.relist(entry.system, listed = entry.listed, group = resolved)) changed++
+    }
+    return changed
+  }
+
   /**
    * Publish [entry]. The catalog is fetched before it's persisted, so a typo'd repo fails loudly
    * instead of leaving an unservable entry in the config for every future boot to retry.
@@ -85,10 +144,29 @@ class ServeCatalogAdmin(
     if (entry.group != null && declared.none { g -> g.id == entry.group }) {
       return Result.Invalid("unknown group '${entry.group}'")
     }
-    if (tracker.configFor(entry.system) != null) {
-      return Result.Conflict("catalog '${entry.system}' is already published")
-    }
     val repo = entry.repo?.takeIf { it.isNotBlank() } ?: defaultRepo
+    // Already published? Converge its LISTING rather than refusing outright. A flat conflict here
+    // is
+    // what made a committed config unable to catch up with a running box: re-posting an entry whose
+    // group or listed flag had changed was rejected, so the box kept its original placement
+    // forever.
+    // The content is untouched — no re-fetch, no dropped load state — and a repo change is still
+    // refused, since that decides what bytes get served (retire and re-publish for that).
+    tracker.configFor(entry.system)?.let { current ->
+      if (current.repo != repo) {
+        return Result.Conflict(
+          "catalog '${entry.system}' is published from ${current.repo}; retire it before " +
+            "re-publishing from $repo"
+        )
+      }
+      val resolved = homeGroup(entry, repo, declared)
+      if (current.group == resolved && current.listed == entry.listed) {
+        return Result.Conflict("catalog '${entry.system}' is already published")
+      }
+      tracker.relist(entry.system, listed = entry.listed, group = resolved)
+      onLog("serve: catalog ${entry.system} listing updated via admin API")
+      return Result.Ok(entry.system, persist { it.withEntry(entry.copy(repo = repo)) })
+    }
     val config = configOf(entry, repo, declared)
     if (!tracker.add(config)) {
       return Result.Conflict("catalog '${entry.system}' is already published")
@@ -170,6 +248,22 @@ class ServeCatalogAdmin(
     }
   }
 }
+
+/** This config with [group] added, or replacing a same-id group, preserving section order. */
+internal fun ServeCatalogsConfig.withGroup(group: ServeCatalogsConfig.Group): ServeCatalogsConfig {
+  val known = groups.any { it.id == group.id }
+  val updated = if (known) groups.map { if (it.id == group.id) group else it } else groups + group
+  return copy(groups = updated)
+}
+
+/**
+ * This config with group [id] removed. Entries claiming it are left declaring it: an unknown group
+ * id is already a tolerated condition ([ServeCatalogsConfig.problems] reports it, and the card
+ * falls back to its owner heading), and silently rewriting an operator's catalog entries because a
+ * section was deleted would lose the claim they'd have to retype if the group came back.
+ */
+internal fun ServeCatalogsConfig.withoutGroup(id: String): ServeCatalogsConfig =
+  copy(groups = groups.filterNot { it.id == id })
 
 /** This config with [entry] added (or replacing a same-system entry), preserving order. */
 internal fun ServeCatalogsConfig.withEntry(entry: ServeCatalogsConfig.Entry): ServeCatalogsConfig {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfig.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfig.kt
@@ -125,6 +125,25 @@ data class ServeCatalogsConfig(
     fun encode(config: ServeCatalogsConfig): String =
       JSON.encodeToString(serializer(), config) + "\n"
 
+    /**
+     * A group id is referenced by catalog entries and never appears in a URL, so it only needs to
+     * be a stable slug. The heading and noun ARE rendered, so they're length-capped — they reach
+     * the page HTML-escaped ([ServeWeb.section]), but an operator pasting a novel into a heading
+     * should get told, not silently produce an unreadable front page.
+     */
+    private val GROUP_ID_RE = Regex("[A-Za-z0-9][A-Za-z0-9._-]{0,63}")
+
+    /** Why [group] is unusable as a front-page section, or null when it's well-formed. */
+    fun validateGroup(group: Group): String? =
+      when {
+        !GROUP_ID_RE.matches(group.id) -> "invalid group id '${group.id}'"
+        group.heading.isBlank() -> "group '${group.id}' needs a heading"
+        group.heading.length > 120 -> "group '${group.id}' heading is too long (max 120)"
+        group.noun.isBlank() -> "group '${group.id}' needs a noun"
+        group.noun.length > 60 -> "group '${group.id}' noun is too long (max 60)"
+        else -> null
+      }
+
     /** Why [entry] is unusable, or null when it's well-formed. */
     fun validateEntry(entry: Entry): String? =
       when {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -460,6 +460,25 @@ class ServeHttpServer(
             val result = withContext(Dispatchers.IO) { admin.unregister(system) }
             respondAdminResult(result)
           }
+          // Front-page sections. The last part of the catalog config with no runtime path: a
+          // section
+          // could only be added by editing the box's catalogs.json and restarting, and a catalog
+          // claiming an undefined one was rejected — so a committed config could not converge.
+          // Defining a section also re-resolves the claims of catalogs ALREADY registered, or
+          // defining it would collect nothing.
+          get("/admin/groups") {
+            if (rejectBadAdminToken()) return@get
+            respondAdminGroups(admin)
+          }
+          post("/admin/groups") {
+            if (rejectBadAdminToken()) return@post
+            handleAdminGroupUpsert(admin)
+          }
+          delete("/admin/groups/{id}") {
+            if (rejectBadAdminToken()) return@delete
+            val id = call.parameters["id"].orEmpty()
+            respondAdminResult(withContext(Dispatchers.IO) { admin.removeGroup(id) })
+          }
         }
 
         // Runtime producer-trust administration. The trust store is operator config on the same
@@ -979,6 +998,39 @@ class ServeHttpServer(
           status = HttpStatusCode.BadGateway,
         )
     }
+  }
+
+  /** `GET /admin/groups`: the front-page sections a catalog entry may claim. */
+  private suspend fun RoutingContext.respondAdminGroups(admin: ServeCatalogAdmin) {
+    val groups = withContext(Dispatchers.IO) { admin.listGroups() }
+    call.respondText(
+      JSON.encodeToString(
+        AdminGroupsResponse.serializer(),
+        AdminGroupsResponse(groups = groups.map { AdminGroupDto(it.id, it.heading, it.noun) }),
+      ),
+      ContentType.Application.Json,
+    )
+  }
+
+  /** `POST /admin/groups`: define a section, or restyle one that exists. */
+  private suspend fun RoutingContext.handleAdminGroupUpsert(admin: ServeCatalogAdmin) {
+    val body =
+      withContext(Dispatchers.IO) {
+        call.receiveStream().use { readCapped(it, MAX_ADMIN_BODY_BYTES) }
+      }
+    if (body == null) {
+      call.respondText("request body too large", status = HttpStatusCode.PayloadTooLarge)
+      return
+    }
+    val group =
+      runCatching {
+          JSON.decodeFromString(ServeCatalogsConfig.Group.serializer(), body.decodeToString())
+        }
+        .getOrElse {
+          call.respondText("invalid group: ${it.message}", status = HttpStatusCode.BadRequest)
+          return
+        }
+    respondAdminResult(withContext(Dispatchers.IO) { admin.upsertGroup(group) })
   }
 
   /**
@@ -2746,6 +2798,16 @@ private data class AdminCatalogResult(
   val system: String,
   val status: String,
   val warning: String? = null,
+)
+
+/** One front-page section on `GET /admin/groups`. */
+@Serializable
+private data class AdminGroupDto(val id: String, val heading: String, val noun: String)
+
+@Serializable
+private data class AdminGroupsResponse(
+  val schema: String = "compose-preview-serve/admin-groups/v1",
+  val groups: List<AdminGroupDto> = emptyList(),
 )
 
 /** One trusted branch on `GET /admin/trust`. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
@@ -259,6 +259,152 @@ class ServeAdminRoutingTest {
     assertEquals(409, send("/admin/catalogs/temp", method = "DELETE").first)
   }
 
+  // --- front-page groups -------------------------------------------------------------------------
+
+  @Test
+  fun `the group routes are gated by the admin token even on a public server`() {
+    assertEquals(404, send("/admin/groups", token = null).first)
+    assertEquals(404, send("/admin/groups", token = "wrong").first)
+    assertEquals(200, send("/admin/groups").first)
+  }
+
+  @Test
+  fun `a group defined after its catalogs still collects them`() {
+    // The whole reason /admin/groups exists. Publish first, ungrouped...
+    send(
+      "/admin/catalogs",
+      method = "POST",
+      body = """{"system":"pocketcasts","repo":"someorg/pocket-casts-android"}""",
+    )
+    assertEquals(null, tracker.configFor("pocketcasts")?.group)
+
+    // ...then define the section and re-post the entry claiming it.
+    val group =
+      """{"id":"pocket-casts","heading":"Automattic/pocket-casts-android","noun":"app(s)"}"""
+    assertEquals(200, send("/admin/groups", method = "POST", body = group).first)
+    val (code, _) =
+      send(
+        "/admin/catalogs",
+        method = "POST",
+        body =
+          """{"system":"pocketcasts","repo":"someorg/pocket-casts-android","group":"pocket-casts"}""",
+      )
+
+    // Converged in place: no re-fetch, no retire, and the card moves.
+    assertEquals(200, code)
+    assertEquals(
+      "Automattic/pocket-casts-android",
+      tracker.configFor("pocketcasts")?.group?.heading,
+    )
+  }
+
+  @Test
+  fun `defining a group regroups an already-claiming catalog with no second post`() {
+    // A catalog whose config entry ALREADY claims a group the server doesn't know yet: rejected on
+    // publish, so publish it plain, persist the claim, then define the group.
+    send(
+      "/admin/catalogs",
+      method = "POST",
+      body = """{"system":"newcat","repo":"someorg/newcat"}""",
+    )
+    configFile.save(
+      configFile
+        .load()
+        .withEntry(
+          ServeCatalogsConfig.Entry(system = "newcat", repo = "someorg/newcat", group = "later")
+        )
+    )
+
+    val (code, _) =
+      send(
+        "/admin/groups",
+        method = "POST",
+        body = """{"id":"later","heading":"Defined Later","noun":"thing(s)"}""",
+      )
+
+    assertEquals(200, code)
+    assertEquals("Defined Later", tracker.configFor("newcat")?.group?.heading)
+  }
+
+  @Test
+  fun `removing a group drops its catalogs back to the owner fallback`() {
+    send(
+      "/admin/groups",
+      method = "POST",
+      body = """{"id":"ds2","heading":"Temporary","noun":"thing(s)"}""",
+    )
+    send(
+      "/admin/catalogs",
+      method = "POST",
+      body = """{"system":"grouped","repo":"someorg/grouped","group":"ds2"}""",
+    )
+    assertEquals("Temporary", tracker.configFor("grouped")?.group?.heading)
+
+    assertEquals(200, send("/admin/groups/ds2", method = "DELETE").first)
+
+    assertEquals(null, tracker.configFor("grouped")?.group)
+    assertFalse(send("/admin/groups").second.contains("Temporary"))
+  }
+
+  @Test
+  fun `an unchanged group is a conflict and an unknown one cannot be removed`() {
+    val body = """{"id":"dupe","heading":"Dupe","noun":"x"}"""
+    assertEquals(200, send("/admin/groups", method = "POST", body = body).first)
+    assertEquals(409, send("/admin/groups", method = "POST", body = body).first)
+    assertEquals(409, send("/admin/groups/nosuch", method = "DELETE").first)
+  }
+
+  @Test
+  fun `a group heading can be restyled without touching its catalogs`() {
+    send("/admin/groups", method = "POST", body = """{"id":"ds3","heading":"Before","noun":"x"}""")
+    send(
+      "/admin/catalogs",
+      method = "POST",
+      body = """{"system":"restyled","repo":"someorg/restyled","group":"ds3"}""",
+    )
+
+    assertEquals(
+      200,
+      send("/admin/groups", method = "POST", body = """{"id":"ds3","heading":"After","noun":"x"}""")
+        .first,
+    )
+
+    assertEquals("After", tracker.configFor("restyled")?.group?.heading)
+    assertEquals("loaded", tracker.snapshot().first { it.config.system == "restyled" }.loadState)
+  }
+
+  @Test
+  fun `a malformed group is refused`() {
+    assertEquals(
+      400,
+      send("/admin/groups", method = "POST", body = """{"id":"bad id","heading":"H"}""").first,
+    )
+    assertEquals(
+      400,
+      send("/admin/groups", method = "POST", body = """{"id":"ok","heading":""}""").first,
+    )
+  }
+
+  @Test
+  fun `re-publishing an unchanged catalog is still a conflict`() {
+    val body = """{"system":"same","repo":"someorg/same","listed":true}"""
+    assertEquals(200, send("/admin/catalogs", method = "POST", body = body).first)
+    // Convergence must not turn a genuine duplicate into a silent success.
+    assertEquals(409, send("/admin/catalogs", method = "POST", body = body).first)
+  }
+
+  @Test
+  fun `re-publishing from a different repo is refused rather than silently re-pointed`() {
+    send("/admin/catalogs", method = "POST", body = """{"system":"moved","repo":"someorg/one"}""")
+
+    val (code, msg) =
+      send("/admin/catalogs", method = "POST", body = """{"system":"moved","repo":"someorg/two"}""")
+
+    assertEquals(409, code)
+    assertTrue(msg.contains("retire"), msg)
+    assertEquals("someorg/one", tracker.configFor("moved")?.repo)
+  }
+
   // --- producer trust ----------------------------------------------------------------------------
 
   @Test

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -416,6 +416,29 @@ it just won't come back). A registration fetches the branch **before** it's pers
 repo fails with `502` rather than leaving an unservable entry for every future boot to retry;
 malformed entries are `400` and re-publishing a served catalog is `409`.
 
+#### Front-page groups
+
+| Route | Does |
+|---|---|
+| `GET /admin/groups` | the sections a catalog entry may claim |
+| `POST /admin/groups` | define a section, or restyle one that exists — `{"id","heading","noun"}` |
+| `DELETE /admin/groups/<id>` | delete it; its catalogs fall back to their owner heading |
+
+Defining a section also **re-resolves the claims of catalogs already registered**. That matters
+because a catalog's placement is resolved once, at registration, into a snapshot — so without this,
+defining a section after its catalogs were published would collect nothing, and the cards would sit
+under the owner fallback until a restart.
+
+For the same reason `POST /admin/catalogs` on an id that's already published **converges its
+listing** rather than refusing: re-posting an entry whose `group` or `listed` has changed updates it
+in place, with no re-fetch and no dropped load state. Re-posting an *unchanged* entry is still `409`,
+so a duplicate stays visible, and a changed `repo` is still refused — that decides what bytes get
+served, so re-pointing a catalog is a retire plus a publish.
+
+Groups were the last part of the catalog config with no runtime path: a section could only be added
+by editing the box's `catalogs.json` and restarting, and a catalog claiming an undefined one was
+rejected outright — which meant a committed config genuinely could not converge. It can now.
+
 #### Trusted producers
 
 The trust store is config too, on the same volume (`/config/producers.json`). Without this, runtime


### PR DESCRIPTION
Closes the last gap between "committed config" and "the box converges on its own" — the one #2967 documented and #2975 walked straight into.

Front-page groups were the only part of the catalog config with **no runtime path at all**: a section could only be added by editing the box's `catalogs.json` and restarting, and a catalog claiming an undefined one was rejected outright. So the `Automattic/pocket-casts-android` section from #2975 needed a hand edit plus a restart.

## Three pieces, because one route isn't enough

**1. The routes**

| Route | Does |
|---|---|
| `GET /admin/groups` | the sections a catalog entry may claim |
| `POST /admin/groups` | define a section, or restyle one — `{"id","heading","noun"}` |
| `DELETE /admin/groups/<id>` | delete it; its catalogs fall back to their owner heading |

**2. Re-resolving catalogs that are already registered.** A catalog's placement is resolved *once*, at registration, into a `ServeWeb.HomeGroup` snapshot. So a route alone would have been useless: defining a section after its catalogs were published would have collected nothing, because those entries still held `group = null`. `upsertGroup` / `removeGroup` now re-resolve every declared claim against the new table, via a new `CatalogLoadTracker.relist` that swaps *listing* metadata while keeping load state and registered content intact. `relist` deliberately cannot change `repo`/`branch` — those decide what bytes get served, and changing them behind a live registration would leave content disagreeing with its own trust verdict.

**3. `POST /admin/catalogs` converges an existing listing** instead of a flat 409. Re-posting an entry whose `group` or `listed` changed updates it in place — no re-fetch, no dropped load state. Without this the reconcile still couldn't fix pocketcasts, because those entries are already registered ungrouped. Guarded so it doesn't become sloppy:
- unchanged entry → still `409`, so a genuine duplicate stays visible
- changed `repo` → still refused, with a message saying to retire first

## Reconcile ordering

`publish-config-to-box.sh` now posts **trust → groups → catalogs**. Both hops are load-bearing: a catalog posted before its producer is trusted registers `unverified`; one posted before its section exists is rejected. The `unknown group` error path is kept but reworded — it should now be unreachable, so if it fires it means the group POST didn't take or the box predates the route.

## Test plan

- `./gradlew :cli:test ktfmtCheckAll` — green.
- 9 new cases in `ServeAdminRoutingTest`, over real HTTP. The two that matter most:
  - **`a group defined after its catalogs still collects them`** — publish ungrouped, define the section, re-post claiming it, assert the card moved. This is the exact pocketcasts situation.
  - **`defining a group regroups an already-claiming catalog with no second post`** — entry already declares a group the server doesn't know; defining it regroups with no further call.
  - plus: token gate; delete drops to owner fallback; unchanged group `409`; unknown group delete `409`; restyle preserves load state; malformed group `400`; unchanged catalog still `409`; repo change refused and not re-pointed.
- `test-publish-config-to-box.sh` extended to pin the three-way ordering and that a group's heading reaches the wire.
- `--dry-run` against the real deployment config: `9 trust → 3 groups → 18 catalogs`.

Non-visual in the diff; the front-page effect is asserted through `tracker.configFor(...).group.heading` rather than a render, since grouping is computed from a live box's fetched provenance.

## After this ships

The `pocket-casts` section needs no hand edit — the next publish's reconcile defines the group and converges both entries. The manual `docker compose cp` dance I gave earlier can be dropped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FdJsCmxDm9dXv8iEsxVYgs)_