### PR TITLE
fix(deploy): don't abandon the config reconcile when one admin route is missing

### DIFF
--- a/.github/scripts/publish-config-to-box.sh
+++ b/.github/scripts/publish-config-to-box.sh
@@ -55,10 +55,18 @@ fi
 # step goes red and the log carries an ::error:: instead of a warning nobody reads).
 rejected=0
 
+# Sections skipped because the box lacks the route (an older image, e.g. one still mid-roll).
+groups_skipped=0
+catalogs_skipped=0
+
 # POST one JSON body to an admin path. 200 = applied, 409 = already there (both fine), 404 =
-# the routes don't exist on this server (no --admin-token, or an image predating them) — which is
-# reported once and treated as "nothing to do" rather than a failure, since a box that never opted
-# in to the admin API is a legitimate deployment.
+# that ROUTE doesn't exist on this box — returned as 2 so the caller can skip just its own section.
+#
+# A 404 is per-route, NOT "the admin API is off". This bit for real on the 0.19.8 publish: the box
+# was still rolling and answered as 0.19.7, which has /admin/trust but not the newer /admin/groups.
+# The groups 404 was treated as a global "admin not enabled" and aborted the run before the catalogs
+# loop, so a newly-added catalog (horologist) was silently never published. A missing groups route
+# only means catalogs land ungrouped — no reason to skip them.
 post() {
   local path="$1" body="$2" label="$3"
   if [[ "${DRY_RUN}" == 1 ]]; then
@@ -77,7 +85,7 @@ post() {
     200 | 201) echo "  ${label}: applied" ;;
     409) echo "  ${label}: already present" ;;
     404)
-      echo "::warning::${BASE_URL}${path} returned 404 — admin API not enabled on this box; skipping config reconcile."
+      echo "::warning::${path} returned 404 — route not available on this box; skipping the rest of this section."
       return 2
       ;;
     400)
@@ -110,8 +118,13 @@ while IFS= read -r entry; do
     "$(jq -cn --arg r "${repo}" --arg b "${branch}" \
       '{kind:"branch", repo:$r, branch:$b}')" \
     "branch ${repo}@${branch}" || {
-    # 404 from the first call means the whole surface is missing; don't hammer it per entry.
-    [[ $? == 2 ]] && exit 0
+    # /admin/trust is the oldest of the three routes, so a 404 HERE really does mean the admin API
+    # is off (no --admin-token, or a wrong token — both answer 404 by design). Nothing downstream
+    # can work, so stop rather than emit the same warning for every group and catalog.
+    if [[ $? == 2 ]]; then
+      echo "::warning::/admin/trust is unavailable — admin API not enabled on this box (or the token does not match); skipping the whole reconcile."
+      exit 0
+    fi
   }
 done < <(jq -c '.branches // [] | .[]' "${TRUST_FILE}")
 
@@ -123,7 +136,13 @@ while IFS= read -r group; do
   [[ -n "${group}" ]] || continue
   id=$(printf '%s' "${group}" | jq -r '.id')
   post /admin/groups "${group}" "group ${id}" || {
-    [[ $? == 2 ]] && exit 0
+    # Route missing (a box predating /admin/groups, e.g. one still mid-roll on an older image).
+    # Catalogs are still worth publishing — they just land under the owner-repo fallback heading
+    # until a later run can group them. Skipping them here is what silently lost horologist.
+    if [[ $? == 2 ]]; then
+      groups_skipped=1
+      break
+    fi
   }
 done < <(jq -c '.groups // [] | .[]' "${CATALOGS_FILE}")
 
@@ -136,9 +155,20 @@ while IFS= read -r entry; do
   body=$(printf '%s' "${entry}" | jq -c '{system, repo, listed, group, attributionRepos}
     | with_entries(select(.value != null))')
   post /admin/catalogs "${body}" "catalog ${system}" || {
-    [[ $? == 2 ]] && exit 0
+    if [[ $? == 2 ]]; then
+      catalogs_skipped=1
+      break
+    fi
   }
 done < <(jq -c '.catalogs // [] | .[]' "${CATALOGS_FILE}")
+
+if [[ "${groups_skipped}" == 1 ]]; then
+  echo "::warning::front-page groups were not reconciled — this box predates /admin/groups. Catalogs are published ungrouped; the next publish against a newer image will group them."
+fi
+if [[ "${catalogs_skipped}" == 1 ]]; then
+  echo "::error::catalogs were not reconciled — /admin/catalogs is unavailable on this box."
+  rejected=$((rejected + 1))
+fi
 
 if [[ "${rejected}" -gt 0 ]]; then
   echo "::error::${rejected} seed entr(y|ies) were rejected — the box is not serving everything the committed config declares." >&2

--- a/.github/scripts/test-publish-config-to-box.sh
+++ b/.github/scripts/test-publish-config-to-box.sh
@@ -96,6 +96,52 @@ for system in compose-m3 cadence jetnews; do
     fail "missing catalog POST for ${system}"
 done
 
+# 8. A box missing ONE route must not lose the other sections. This is the regression that
+#    silently dropped a newly-added catalog on the 0.19.8 publish: the box was mid-roll and still
+#    answering as an older image, /admin/groups 404'd, and the whole run aborted before catalogs.
+#    Driven through a stubbed curl so no server is involved.
+shim="${tmp}/bin"
+mkdir -p "${shim}"
+cat > "${shim}/curl" <<'SH'
+#!/usr/bin/env bash
+# An older box: /admin/trust and /admin/catalogs exist, /admin/groups does not.
+for a in "$@"; do
+  case "$a" in
+    */admin/groups) printf 'not found\n404'; exit 0 ;;
+    */admin/catalogs) printf 'ok\n200'; exit 0 ;;
+    */admin/trust) printf 'ok\n200'; exit 0 ;;
+  esac
+done
+printf 'ok\n200'
+SH
+chmod +x "${shim}/curl"
+
+partial=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
+  TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs.json" \
+  bash "${UNDER_TEST}" 2>&1)
+
+printf '%s' "${partial}" | grep -q 'catalog compose-m3: applied' ||
+  fail "a missing /admin/groups must NOT stop catalogs being published:\n${partial}"
+printf '%s' "${partial}" | grep -q 'catalog cadence: applied' ||
+  fail "every catalog must still be attempted when groups are unavailable:\n${partial}"
+printf '%s' "${partial}" | grep -q 'front-page groups were not reconciled' ||
+  fail "skipping groups must be reported, not silent:\n${partial}"
+
+# 9. A 404 on /admin/trust — the oldest route — genuinely does mean the admin API is off, so it
+#    should stop early rather than emit one warning per entry.
+cat > "${shim}/curl" <<'SH'
+#!/usr/bin/env bash
+printf 'not found\n404'
+SH
+chmod +x "${shim}/curl"
+off=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
+  TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs.json" \
+  bash "${UNDER_TEST}" 2>&1)
+printf '%s' "${off}" | grep -q 'admin API not enabled' ||
+  fail "a 404 on /admin/trust should report the admin API as off:\n${off}"
+[[ $(printf '%s\n' "${off}" | grep -c 'returned 404') -le 1 ]] ||
+  fail "an admin-off box should warn once, not per entry:\n${off}"
+
 if [[ "${failures}" -gt 0 ]]; then
   echo "${failures} check(s) failed" >&2
   exit 1


### PR DESCRIPTION
A bug I introduced in #2967, caught by the 0.19.8 publish actually running it.

## What happened

`horologist` was merged into `deploy/preview.coo.ee/catalogs.json` in #2975 and never appeared on preview.coo.ee. The publish log ([run 30519030318](https://github.com/yschimke/compose-ai-tools/actions/runs/30519030318)) shows why:

```
Reconciling trusted producers from deploy/preview.coo.ee/producers.json
  branch yschimke/compose-ai-tools@design-artifacts/*: already present
  … all 9, including yschimke/horologist
Reconciling front-page groups from deploy/preview.coo.ee/catalogs.json
##[warning] https://preview.coo.ee/admin/groups returned 404 —
            admin API not enabled on this box; skipping config reconcile.
```

Then it exited 0. **The catalogs loop never ran.**

The box was still mid-roll: the convergence check immediately above had just timed out after 30 attempts, every one reading `version=0.19.7/0.19.8`. 0.19.7 has `/admin/trust` (#2961) but not `/admin/groups` (#2981, first in 0.19.8). My 404 handler read one missing route as "the whole admin API is off" and bailed out of everything downstream.

Two things made it invisible: the step reported **success** (the early exit was `exit 0`), and the job's failure was attributed to the *convergence* step above it.

## The fix

A 404 is now scoped to the route that returned it:

| Route 404s | Behaviour |
|---|---|
| `/admin/trust` | Genuinely means the admin API is off — it's the oldest of the three, and a missing/wrong token also answers 404. Stops with **one** warning instead of repeating it per entry. |
| `/admin/groups` | Skips **only** grouping. Catalogs still publish, landing under the owner-repo fallback until a later run against a newer image groups them. Reported as a warning. |
| `/admin/catalogs` | An `::error::` and a non-zero exit — that's the surface this script exists to drive. |

The ordering guarantee is unchanged: trust → groups → catalogs.

## Test plan

- `test-publish-config-to-box.sh` gains two cases, both driven through a stubbed `curl` on `PATH` so no server is involved:
  - **the exact regression** — a box where `/admin/groups` 404s but trust and catalogs work: asserts every catalog is still `applied` and that skipping groups is reported rather than silent. This test fails against the old script.
  - **admin genuinely off** — everything 404s: asserts it reports the API as off and warns *once*, not per entry.
- `bash -n` clean; all 9 pre-existing checks still pass.

## Remaining state on the box

preview.coo.ee is now on 0.19.8 (it rolled after the check gave up), so it has all three routes. `horologist` and the `pocket-casts` grouping are still absent and will be picked up by the next publish's reconcile. If you'd rather not wait, the two POSTs by hand will do it — but nothing further is needed for correctness.

Worth noting separately: the convergence check's ~10 min budget was too short for this roll, which is what put the reconcile in front of an old box in the first place. Not changed here, since a longer wait has its own cost and this fix makes the mismatch harmless.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FdJsCmxDm9dXv8iEsxVYgs)_