### PR TITLE
docs: design proposal for a Compose playground over the preview server

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ specs the code actually depends on:
 - [design/SPATIAL_SCENE_CONTRACT.md](design/SPATIAL_SCENE_CONTRACT.md) — the XR scene wire format (schema-generated Kotlin/TS/C++ mirrors).
 - [design/DESIGN_CATALOGS.md](design/DESIGN_CATALOGS.md) — the code-led sticker-sheet catalog system.
 - [design/UI_BUILDER.md](design/UI_BUILDER.md) — **proposal**: assembling screens from catalog components (scaffold-first slots, a persisted composition document, Figma round-trip). Product analysis + phased plan; no code yet.
+- [design/PLAYGROUND.md](design/PLAYGROUND.md) — **proposal**: a hosted Kotlin/Compose editor over the `serve` preview server (compile-then-permalink handoff, CMP / Compose-Android / Remote-Compose modes, the preview-token capability, isolation requirements). Product analysis + phased plan; Phase 1 in progress.
 
 Component-level contracts (the XR semantics tree, `FigmaLayeredSvg`, the font
 preview wrapper, `@XrSubspacePreview`) now live as **KDoc on the owning class**,

--- a/docs/design/PLAYGROUND.md
+++ b/docs/design/PLAYGROUND.md
@@ -1,0 +1,318 @@
+# Playground — a Kotlin/Compose editor over the preview server
+
+Status: **design proposal** (2026-07). Product analysis + architecture for a
+hosted "edit Compose, get a live interactive preview" surface, built on the
+seams `compose-preview serve` already ships. This document scopes what exists,
+what's missing, the REST + handoff contract, the isolation requirements, and a
+phased plan. The first phase's implementation is landing alongside this doc; the
+later phases are not built yet.
+
+> **Thesis.** A Compose playground is mostly the *existing* serve viewer plus an
+> editor pane plus an ephemeral, per-session module. The three things that would
+> normally be the hard parts — **compiling Kotlin without Gradle**, **rendering a
+> preview headlessly**, and **streaming a live, clickable composition** — already
+> exist and run in production (`BtaCompileSession`, the desktop/Robolectric
+> daemons, the serve `input` WebSocket protocol). The genuinely new work is
+> **(1)** a two-stage *compile-then-permalink* flow that keeps a stock one-shot
+> editor frontend usable, **(2)** an expiring **preview-token** capability that
+> hands a compiled snippet off to a live session, and **(3)** the isolation a
+> host needs before it can run a stranger's code. Everything else is wiring seams
+> that already exist.
+
+---
+
+## 1. Product analysis
+
+### 1.1 The user story
+
+Someone — a docs author, an agent, a person kicking the tyres on Material 3 —
+wants to:
+
+1. Write a Compose snippet in the browser, against **our** component catalogs
+   (`compose-m3`, `wear-m3`, …) so `import`s resolve to the real library.
+2. Compile it and see errors inline, fast.
+3. See it **render**, and then **interact** with it — click a button, watch state
+   change, scroll a list — not just look at a static screenshot.
+4. Share a **link** to that running preview.
+
+…across three render modes:
+
+| Mode | What it is |
+|---|---|
+| **Compose (CMP)** | Compose Multiplatform, rendered by the desktop (Skiko) daemon. |
+| **Compose (Android)** | Jetpack Compose, rendered by the Robolectric daemon. |
+| **Remote Compose** | The snippet emits a `RemoteDocument` byte stream; the browser plays it. Android-authored today, CMP-authored later. |
+
+### 1.2 Prior art
+
+| Tool | What it is | Why it isn't the fit |
+|---|---|---|
+| **play.kotlinlang.org** (`kotlin-playground` + `kotlin-compiler-server`) | The canonical hosted Kotlin editor. Apache-2.0, both halves. `compose-wasm` target renders Compose **in the browser** via Kotlin/Wasm. | JVM/Wasm only. No Compose **Android** (no Robolectric), no **Remote Compose**, no server-driven **live render** of a JVM composition. Its model is one-shot `POST code → get result`; it has no streamed, clickable session. |
+| **Compose Playground / KMP web samples** | Prebuilt CMP-Wasm apps embedded in a page. | Fixed apps; they don't compile *new* snippets. This repo already ships one (`:samples:cmp-wasm-catalog`, served at `/wasm/<system>/`). |
+| **This repo's `serve` host** | Trusted catalogs, live daemon-backed sessions, an `input` protocol, `--accept-docs` document permalinks. | Everything except the **editor** and the **compile-arbitrary-source** entry point. That's the gap this doc closes. |
+
+**Verdict.** `kotlin-playground`'s Wasm path already covers "Compose in the
+browser, no server." What it structurally cannot do is render the Android
+runtime, or a JVM composition on a real Compose renderer, or a Remote Compose
+document — which is exactly the ground this repo's daemons already own. So the
+build is *not* "reimplement play.kotlinlang.org"; it's "put an editor in front of
+the renderer we already run."
+
+### 1.3 Why not just point `kotlin-playground`'s frontend at us (`data-server`)
+
+`kotlin-playground` supports a `data-server` attribute to redirect compilation at
+a custom backend — that's a first-class, documented feature, and its backend
+contract is small and known (see [§4](#4-the-rest-contract-stock-frontend-compatibility)).
+But its whole UI model is **one request in, one result out**: `POST` the code,
+render `{text | jsCode | testResults}` inline. Ours is **open a session, stream
+frames, send input** — a different transport, not a new result type. Bolting a
+persistent clickable canvas into a framework built around one-shot POSTs fights
+the framework the whole way.
+
+The **two-stage** decomposition below dissolves that conflict, and in doing so
+shrinks the frontend change from *rewrite the transport* to *surface one field in
+the response*. That is what makes reusing a stock editor viable again.
+
+---
+
+## 2. Architecture: two stages, one compile
+
+The insight is to **not** make the editor host the interactive preview. Split the
+work where the models already split:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ STAGE 1 — Playground (one-shot, the editor's native model)            │
+│                                                                        │
+│  editor ──POST source──▶ /api/{v}/compiler/run                         │
+│                            │  BtaCompileSession.compile (Compose plugin)│
+│                            │  one headless render (first frame)         │
+│                            ▼                                            │
+│  { diagnostics, image: data-URI PNG, previewToken: "pg_…" }           │
+│                                                                        │
+│  editor shows errors + the still frame + an "Open live preview →" link │
+└───────────────────────────────────────────┬────────────────────────────┘
+                                             │ user clicks (deliberate)
+                                             ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ STAGE 2 — Preview (the serve viewer we already ship)                  │
+│                                                                        │
+│  GET /pg/<token>  ── redeem ──▶ stand up / resume a live daemon session│
+│      viewer + WS  ◀── frames ──   (desktop or Robolectric)             │
+│      input events ──▶ dispatched into the composition (existing proto) │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Two properties fall out of this split:
+
+- **The compile that produces the Stage-1 result is the same compile that would
+  bootstrap the Stage-2 session.** So the permalink is nearly free: the `run`
+  response just carries a `previewToken`. A stock `kotlin-playground` frontend
+  ignores the unknown field; a one-line frontend addition turns it into a button.
+  (Zero-fork fallback: put the URL in the `text` output field — ugly, but works
+  with the unmodified component.)
+- **Session creation is a *redeemed* act, not a per-keystroke one.** Most compiles
+  never get a click, so Stage 1 does **not** stand up a streaming session — it
+  returns a token. Redeeming `/pg/<token>` is the deliberate, rate-limitable,
+  TTL'd step. This is the same capability model `--accept-docs` already uses for
+  documents (see [§5](#5-the-preview-token-capability)).
+
+### 2.1 What already exists (and where)
+
+| Capability | Where | Status |
+|---|---|---|
+| Compile Kotlin, no Gradle, with the Compose plugin + `sourceInformation` | `daemon/core/.../bta/BtaCompileSession.kt`, driven by `JsonRpcServer.compileSources` | **Shipped.** Incremental, content-hashed classpath snapshots, structured diagnostics (`DiagnosticCollector`). |
+| Compile arbitrary absolute source paths against a supplied classpath | `compileSources` takes `sources: List<Path>` with no source-set containment | **Shipped.** A snippet written to a temp file is a valid input today. |
+| Headless render → PNG (both backends) | `renderer-desktop` (Skiko), `renderer-android` (Robolectric) | **Shipped.** |
+| Live, daemon-backed streaming session | `cli/.../serve/ServeLiveSession.kt`, `ServeStreamSession.kt`, per-preview pool | **Shipped.** `compose-m3` (desktop) and `wear-m3` (Android) run live on `preview.coo.ee`. |
+| Interactive `input` protocol (click / pointer / rotary / key) | `docs/serve/SESSION-VIEWER-PROTOCOL.md` §`input`, `ServeStreamProtocol.parseClient` | **Shipped.** Dispatched into the live composition; snapshot lane ignores it. |
+| Expiring capability permalink (id = 128-bit `SecureRandom`, TTL, `private,no-store`) | `cli/.../serve/ServeDocStore.kt` | **Shipped.** The literal template for the preview-token store. |
+| Remote Compose document → browser playback | `--accept-docs`, `ServeDocFormats`, vendored `RcdPlayer` (`cli/src/main/resources/rc-player/`) | **Shipped.** RC-in-browser needs no server round-trip per interaction. |
+| Live-seat admission budget (desktop = 1 permit, Android = 2) | `cli/.../serve/LiveSeatLimiter.kt` | **Shipped**, but sized for *trusted catalogs* — see [§6](#6-isolation-the-actual-hard-part). |
+
+### 2.2 What is new
+
+1. **A `PlaygroundSession`** — an ephemeral, per-token module: a temp source dir,
+   a resolved compile classpath (borrowed from a chosen catalog's live bundle),
+   an output dir, and a daemon handle. Conceptually a bundle-backed session
+   (`ServeBundleDaemon`) whose classes come from a just-compiled snippet instead
+   of a fetched `.bundle`.
+2. **The REST shim** — enough of the `kotlin-compiler-server` contract that a
+   stock editor frontend talks to us ([§4](#4-the-rest-contract-stock-frontend-compatibility)).
+3. **The preview-token store + `/pg/<token>` redeem route** ([§5](#5-the-preview-token-capability)).
+4. **Isolation** — the part that gates going public ([§6](#6-isolation-the-actual-hard-part)).
+
+---
+
+## 3. The three modes → three permalink targets
+
+The modes differ only in Stage 2 — what the token redeems to:
+
+| Mode | Compile → | Stage-2 target | Per-interaction cost | Seat cost |
+|---|---|---|---|---|
+| **Compose (CMP)** | desktop daemon, `ImageComposeScene` | **live streaming session** | server re-render per event | 1 permit |
+| **Compose (Android)** | Robolectric daemon | **live streaming session** | server re-render per event | 2 permits |
+| **Remote Compose** | compile+run → `.rc` document | **document permalink** (`/d/<id>`) | **none** — played client-side | **0** (no daemon) |
+
+**Remote Compose is the architectural standout, and should ship to any
+public audience first.** An `.rc` document carries its own state machine
+(`data/remotecompose/connector`: `RemoteOverridableState`,
+`RemoteComposeController`), so once it reaches the browser the server is out of
+the loop — no live seat, no re-render, no round-trip. The two JVM modes each pin
+a live daemon for the session's lifetime; RC hands over bytes and lets go. Its
+serving side is already public-safe (the vendored player runs in the *viewer's*
+browser); only *producing* the document runs snippet code on the server, and that
+is the same isolation problem all three share.
+
+**On "CMP Remote Compose in future":** separate *authoring* from *playback*. The
+browser `RcdPlayer` is already platform-neutral — it plays a byte stream and does
+not care that the document was authored through Android APIs. So RC-in-browser
+works for a playground **now**; what is Android-bound is the *authoring* side of
+`data/remotecompose`. The playground's RC mode does not have to wait on
+CMP-authored Remote Compose — it can offer Android authoring today and pick up
+CMP authoring when the connector does. (There is also an AndroidX
+Compose-embedded player, `:third-party-rc-embedded-player`, used for CI fidelity
+diffs; the browser player is the one the playground uses.)
+
+---
+
+## 4. The REST contract (stock-frontend compatibility)
+
+To let an unmodified `kotlin-playground` component talk to us, we implement the
+subset of the `kotlin-compiler-server` contract its frontend actually calls. The
+frontend (`src/config.js`) builds **versioned** paths — `/api/{version}/compiler/…`
+— even though the upstream controller is mounted at unversioned `/api/compiler/…`;
+we mount the shim at the versioned path the frontend emits.
+
+| Path (as emitted by the frontend) | Method | We answer it with |
+|---|---|---|
+| `/api/{version}/compiler/run` | POST | BTA compile → diagnostics + first-frame PNG (`data:` URI) + `previewToken`. |
+| `/api/{version}/compiler/highlight` | POST | BTA diagnostics reshaped to the highlight schema (we compile anyway). |
+| `/versions` | GET | The single Kotlin/Compose version this host offers. |
+| `/api/{version}/compiler/complete` | POST | **Deferred.** BTA compiles; it does not complete. Returns `[]` in v1. Real completion needs a Kotlin analysis backend — out of scope until there's demand. |
+
+Request body is `{ args, files: [{ name, text, publicId }], confType }`; the
+`confType` selects the mode ([§3](#3-the-three-modes--three-permalink-targets)).
+Response reuses the upstream shape (`{ errors, text, exception, … }`) with two
+**additive** fields — `image` (first-frame `data:` PNG) and `previewToken` — that
+the upstream frontend ignores and ours surfaces.
+
+> **On reusing the frontend at all.** Implementing this contract is what keeps a
+> stock editor an option; it is not a commitment to ship theirs. `kotlin-playground`
+> is itself a CodeMirror wrapper, and a bespoke editor (CodeMirror/Monaco + our
+> own response shape, no contract to track) may win once completion and
+> mode-specific UI matter. The contract is cheap enough to keep the door open;
+> the decision of *which* editor ships is deferred and does not block Stage 1.
+
+---
+
+## 5. The preview-token capability
+
+Modelled directly on `ServeDocStore` — the same safety properties, a different
+payload:
+
+- **Id is the capability.** 128-bit `SecureRandom`, base64url, prefixed `pg_`.
+  Unguessable; a link is safe to hand to one person without listing it.
+- **Expiring.** A short TTL (minutes). After expiry `/pg/<token>` 404s without
+  disclosing whether the token ever existed.
+- **Bounded.** Count + total-memory caps; a burst evicts nearest-expiry first, as
+  `ServeDocStore` does. A token holds a temp source dir + compiled classes, so the
+  cap also bounds disk.
+- **Single redemption target.** A token names *one* compiled snippet and its mode.
+  Redeeming stands up (or resumes) exactly that session.
+
+A token is minted in Stage 1 *after* a clean compile (a compile error returns
+diagnostics and **no** token). The Stage-1 render and the Stage-2 session share
+the compiled output, so redemption never recompiles.
+
+---
+
+## 6. Isolation — the actual hard part
+
+Nothing above changes the one constraint the serve host is built around, stated
+in [`docs/public-preview-server.md`](../public-preview-server.md): *"Neither ever
+lets untrusted code run on the server."* Trust is fail-closed; `--revisions`
+(which runs Gradle) is off on public boxes; unverified bundles serve as baked
+PNGs with no re-render. **A playground inverts that premise** — its whole point is
+to execute code a stranger wrote.
+
+Concretely: `BtaCompileSession` compiles **in-process**, and a live session loads
+the result into a long-lived daemon JVM. On JDK 17+ there is no `SecurityManager`;
+a snippet gets filesystem, sockets, `System.exit`, process spawn, and unbounded
+heap, in a JVM other sessions may share. **RC mode does not dodge this** — its
+*serving* side is safe, but *producing* the `.rc` still runs the snippet on the
+server.
+
+`--live-seats` (`LiveSeatLimiter`) is **admission control, not a sandbox** — it
+bounds concurrent daemons for *trusted* catalogs; it does not contain hostile
+code. A public playground therefore needs a genuinely disposable per-session
+sandbox:
+
+- its own process/container, **killed** after a hard wall-clock TTL;
+- **no outbound network** (or a strict egress allowlist);
+- **read-only / ephemeral** filesystem, quota-bounded;
+- **memory + CPU caps** (cgroup), so one snippet can't starve the box;
+- **one snippet per JVM** — never hot-swap a stranger's classes into a shared,
+  long-lived daemon.
+
+This is a real ops project, not a flag. It is the gate between "internal /
+token-gated tool" and "open at `preview.coo.ee`", and the phased plan below is
+ordered so that everything valuable can be proven **behind a token** before any
+of it is exposed.
+
+---
+
+## 7. Phased plan
+
+Each phase is independently shippable and useful on its own.
+
+1. **Phase 1 — token-gated, CMP, single snippet (in progress).**
+   The `/api/{v}/compiler/run` shim → `BtaCompileSession` against `compose-m3`'s
+   live-bundle classpath → first-frame PNG + `previewToken` → `/pg/<token>`
+   redeems to the existing desktop live session with the existing `input`
+   protocol. Gated (`--playground`, refused under `--public`). Almost entirely
+   wiring over shipped parts; proves the loop feels right before any sandbox work.
+
+2. **Phase 2 — the Android backend.** Same loop, Robolectric daemon, 2 permits.
+   Compose Android snippets against `wear-m3` / an Android catalog classpath.
+
+3. **Phase 3 — Remote Compose mode.** Compile+run → `.rc` → hand off to the
+   existing `/d/<id>` document permalink and `RcdPlayer`. Reuses `ServeDocStore`,
+   `ServeDocFormats`, `rc-player`. No live seat. **This is the first mode safe to
+   expose to a wider (still gated) audience**, because its serving side already is.
+
+4. **Phase 4 — per-session sandbox.** Only once 1–3 have proven the product:
+   container isolation, no egress, read-only FS, memory/CPU/wall-clock caps, hard
+   TTL, one snippet per JVM. This is the gate to `--public`.
+
+5. **Editor decision (parallel, non-blocking).** Ship Stage 1 against the REST
+   contract with a stock `kotlin-playground` first; evaluate a bespoke
+   CodeMirror/Monaco editor once completion and per-mode UI justify owning it.
+
+### 7.1 Latency note
+
+Do **not** size expectations from the stage-0 numbers in
+[`docs/daemon/baseline-latency.md`](../daemon/baseline-latency.md) (≈9 s desktop
+`render` cold) — those are per-process Gradle forks, not the daemon path. The
+resident daemon renders at p50 ≈ 1.9 s warm (`/status.json` `renderStats`), and
+the stage-2 in-process BTA compile targets < 1 s warm on desktop. The playground
+rides the daemon path, so the warm edit→pixel loop is in that range, not the
+cold-fork range.
+
+---
+
+## 8. Open questions
+
+- **Classpath source per mode.** Phase 1 borrows `compose-m3`'s resolved
+  live-bundle classpath. Should a snippet be able to pick its catalog (and thus
+  its available components), or is one canonical classpath per mode enough for v1?
+- **Multi-file snippets.** The `run` contract carries `files: [...]`. Phase 1 can
+  accept one file; multi-file is a natural extension (all written to the temp
+  source dir, all passed to `compileSources`).
+- **`@Preview` discovery vs. an entrypoint.** Does the snippet declare a
+  `@Preview` we discover (reusing `previews.json` discovery), or a known
+  entrypoint we render directly? Discovery reuses more; a fixed entrypoint is
+  simpler to explain in an editor. Leaning discovery, to reuse the pipeline.
+- **Token TTL + redemption count.** One redemption or many within the TTL? Many is
+  friendlier (refresh the tab); one is tighter. Leaning many-within-TTL, matching
+  `ServeDocStore`.


### PR DESCRIPTION
## Summary

A design proposal (`docs/design/PLAYGROUND.md`) for a hosted Kotlin/Compose **playground** built on top of the `serve` preview host, rather than as a new stack.

The core idea is a **two-stage, compile-then-permalink** flow that keeps a stock one-shot editor frontend usable while still delivering a live, interactive preview:

- **Stage 1 (playground)** — the editor POSTs source to a `kotlin-compiler-server`-compatible `/run` shim. We compile via the shipped `BtaCompileSession` (no Gradle), return diagnostics + a first-frame PNG + an expiring **preview token**.
- **Stage 2 (preview)** — an "Open live preview →" link redeems `/pg/<token>`, standing up (or resuming) the existing daemon-backed streaming session with the existing `input` protocol (click / pointer / rotary / key).

This split shrinks the frontend change from *rewrite the transport* to *surface one additive field*, and makes session creation a deliberate, rate-limitable, TTL'd act instead of a per-keystroke one.

### Mode matrix

| Mode | Stage-2 target | Per-interaction cost | Seat cost |
|---|---|---|---|
| Compose (CMP) | live streaming session (desktop/Skiko daemon) | server re-render | 1 |
| Compose (Android) | live streaming session (Robolectric daemon) | server re-render | 2 |
| Remote Compose | `/d/<id>` document permalink, played client-side | **none** | 0 |

Remote Compose is the standout — its serving side is already public-safe, and the browser `RcdPlayer` is platform-neutral, so RC-in-browser works now even though CMP *authoring* of RC is future.

### What already exists vs. what's new

Most of the hard parts are shipped: in-process compile (`BtaCompileSession` / `compileSources`), headless render (both backends), the live streaming session, the `input` protocol, and the expiring-permalink capability (`ServeDocStore`, the literal template for the preview-token store). New work is the `PlaygroundSession`, the REST shim, the preview-token store + `/pg/<token>` route, and — the real gate to going public — per-session **isolation** (the doc is explicit that running a stranger's code inverts the serve host's "never run untrusted code on the server" invariant, and that `--live-seats` is admission control, not a sandbox).

### Phased plan

1. Token-gated, CMP, single snippet (**in progress**).
2. Android backend (Robolectric).
3. Remote Compose mode (reuses `ServeDocStore` / `rc-player`; first mode safe for a wider gated audience).
4. Per-session sandbox — the gate to `--public`.

Doc-only change; the Phase 1 implementation lands as follow-up commits on this branch.

## Test plan

- [x] Doc-only; no code paths touched.
- [x] Linked from `docs/README.md` design-tree index, mirroring `UI_BUILDER.md`.
- [x] Cross-references verified against the current tree (`ServeDocStore`, `BtaCompileSession`, `JsonRpcServer.compileSources`, `SESSION-VIEWER-PROTOCOL.md`, `LiveSeatLimiter`, `rc-player`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_