### PR TITLE
feat(design-artifacts): act on entry-level render priority now the serve host routes it

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -372,28 +372,24 @@ What each form actually saves:
   compile is shared with the render that follows. Measured against a nine-theme catalog
   this is the bigger lever: deferring every palette beyond the primary drops ~59% of
   renders, versus ~37% for deferring all variants.
-- **Per entry** (`priority` on a component or variant) — **authorable now, inert
-  until [#2965](https://github.com/yschimke/compose-ai-tools/issues/2965).** A
-  wholly-deferred entry has no `images[]` record, and `ServeCatalogStore` builds
-  both its registration and its catalog-id → daemon-id alias from
-  `components[].images` alone (it never decodes `deferred[]`), so acting on the
-  deferral today would make the entry *absent* from `serve --catalogs` rather than
-  rendered on demand.
+- **Per entry** (`priority` on a component or variant) — **usable now**, since
+  [#2965](https://github.com/yschimke/compose-ai-tools/issues/2965) gave the deferred
+  records a live lane. A wholly-deferred entry has no `images[]` record at all, so it
+  reaches a viewer only through that lane: the export writes it to `catalog.json`'s
+  top-level `deferred[]` (with the `path` it *would* have baked, so the route id is the
+  same either way), and `ServeCatalogStore` decodes those records — aliasing each to its
+  daemon `previewId` and registering it with no baked PNG. A session with **no** live
+  lane hides them and says why (`deferred-not-served`) rather than showing broken cards.
 
-  So the annotation is currently honoured as `required`: the entry renders and bakes
-  exactly as it would without it, the published catalog is unchanged, and the driver
-  logs a warning naming the entries whose deferral is recorded but not yet acted on.
-  A spec can therefore be annotated ahead of the server without either being blocked
-  or quietly losing coverage. One constant — `ENTRY_DEFERRAL_SERVED` in
-  [`catalog-priority.mjs`](../../scripts/design-artifacts/catalog-priority.mjs) —
-  drives every consumer, so the render set and the published set can't disagree
-  about which entries are baked; flipping it is the last step of #2965.
-
-  The render-time half is already built behind that switch: the pre-flight emits the
-  `--preview` patterns for the still-required functions (`--render-filter-out
+  It is also the form that saves whole renders, not just published bytes: the pre-flight
+  emits the `--preview` patterns for the still-required functions (`--render-filter-out
   <file>`), and both design-artifacts workflows feed them to the render as
   `ORG_GRADLE_PROJECT_composePreview.filter`. A function is only droppable when
-  **nothing required points at it** — two entries can name the same `@Preview`.
+  **nothing required points at it** — two entries can name the same `@Preview`. One
+  reader — `entryPriority` in
+  [`catalog-priority.mjs`](../../scripts/design-artifacts/catalog-priority.mjs) — drives
+  every consumer (the join, the variant split, the render filter), so the render set and
+  the published set can't disagree about which entries are baked.
 
 Caveats worth knowing before reaching for it:
 

--- a/scripts/design-artifacts/catalog-priority.mjs
+++ b/scripts/design-artifacts/catalog-priority.mjs
@@ -11,26 +11,26 @@
  *     the serve host, which re-renders it from the carried live bundle / buildable source); it is
  *     simply not rasterised in CI.
  *
- * Two forms, because they buy different things — and, right now, because only one of them takes
- * effect:
+ * Two forms, because they buy different things:
  *
- *   - **per axis** — `modePriority: { "light": "required", "*": "deferred" }`. **Active today.** Bakes
- *     one sticker per component and leaves the remaining palettes to the (already interactive) theme
- *     switcher on the serve host. Measured against a nine-theme catalog this is the bigger lever,
- *     because the fan-out lives in the BASE entries rather than the variants. Degrades safely: the
- *     component keeps its untagged primary sticker in `components[]`, so the served catalog browses as
- *     before with one fewer baked palette.
- *   - **per entry** — `priority` on a component or one of its `variants`. **Recorded but not yet acted
- *     on** — see [ENTRY_DEFERRAL_SERVED]. Once the serve host can route it, a wholly-deferred entry
- *     names a `@Preview` function nothing else needs, so it can be dropped from the render itself (see
- *     [renderFilterPatterns]) — real build time, not just a smaller bundle.
+ *   - **per axis** — `modePriority: { "light": "required", "*": "deferred" }`. Bakes one sticker per
+ *     component and leaves the remaining palettes to the (already interactive) theme switcher on the
+ *     serve host. Measured against a nine-theme catalog this is the bigger lever, because the fan-out
+ *     lives in the BASE entries rather than the variants. Degrades safely: the component keeps its
+ *     untagged primary sticker in `components[]`, so the served catalog browses as before with one
+ *     fewer baked palette. The mode axis is skipped at render time by the **id** filter (#2966).
+ *   - **per entry** — `priority` on a component or one of its `variants`. A wholly-deferred entry names
+ *     a `@Preview` function nothing else needs, so it is dropped from the render itself (see
+ *     [renderFilterPatterns]) — real build time, not just a smaller bundle. Such an entry has no
+ *     `images[]` record at all, so it reaches a viewer only through the serve host's live lane
+ *     (`catalog.json` `deferred[]` → `ServeCatalogStore`, compose-ai-tools#2965).
  *
  * Deferral is always explicit and always opt-in: the default stays `required`, so a spec that says
- * nothing behaves exactly as it did. Deferral that TAKES EFFECT also needs a live path (a carried live
- * bundle or a buildable `source`), or the deferred entries would just be coverage silently dropped
- * from the published sheet — the driver enforces that, and `validateSpec` mirrors it when the caller
- * knows. The requirement is keyed on the *effective* priority, so an inert entry-level annotation
- * imposes nothing.
+ * nothing behaves exactly as it did. Deferral needs a live path (a carried live bundle or a buildable
+ * `source`), or the deferred entries would just be coverage silently dropped from the published
+ * sheet — the driver enforces that, and `validateSpec` mirrors it when the caller knows. A server with
+ * no live path still degrades explicably rather than showing broken cards: it reports
+ * `deferred-not-served` and omits them.
  *
  * Pure and dependency-free (node built-ins only, no `@design-parity/*`, no I/O) so it unit-tests
  * without an `npm ci`, like its sibling `catalog-variants.mjs` / `catalog-spec.mjs`.
@@ -46,80 +46,16 @@ export const PRIORITIES = Object.freeze([REQUIRED, DEFERRED]);
 export const MODE_WILDCARD = "*";
 
 /**
- * Whether the preview server can serve an ENTRY-level deferral yet.
- *
- * `false` until compose-ai-tools#2965 lands. `ServeCatalogStore` builds both its preview
- * registration and its catalog-id → daemon-id alias from `components[].images` alone — it doesn't
- * decode the `deferred[]` records — so a wholly-deferred entry or variant, which has no `images[]`
- * record at all, would be *absent* from `serve --catalogs` rather than rendered on demand.
- *
- * While it is `false` the declared deferral is honoured as `required`: the entry renders and bakes
- * exactly as it would without the annotation. That is deliberately the *inert* reading rather than
- * either extreme — refusing the publish would block a catalog for annotating ahead of the server,
- * and honouring the deferral would quietly drop the entry from the served sheet. A spec can be
- * authored now, causes no change in the meantime, and starts actually deferring when this flips.
- * The gap is reported by [declaredEntryDeferrals] so it can't go unnoticed.
- *
- * ONE switch drives every consumer — [effectivePriority] below, and through it the render filter,
- * the variant split and the driver's join — so the render set and the published set can never
- * disagree about which entries are baked. Flipping it to `true` is the last step of #2965.
- *
- * The AXIS form (`modePriority`) is unaffected and active today: a mode-deferred image leaves its
- * component in `components[]` with the untagged primary sticker, so the served catalog browses as
- * before with one fewer baked palette — a reduction the catalog asked for, not a missing entry.
- */
-export const ENTRY_DEFERRAL_SERVED = false;
-
-/**
- * The priority a component / variant entry **declares**, defaulting to `required`.
+ * The priority a component / variant entry declares, defaulting to `required`.
  * An unrecognised value also reads as `required` — validation rejects it up front, and failing
  * *closed* (bake it) is the safe reading if one ever slips through.
  *
- * This is the authored value, for validation and reporting. Everything that decides whether an
- * entry is actually rendered/baked must use [effectivePriority] instead.
+ * This one reader is what every decision point uses — the driver's join, the variant split,
+ * [specDefersAnything] and the render-filter derivation — so the render set and the published set
+ * can't disagree about which entries are baked.
  */
 export function entryPriority(entry) {
   return entry?.priority === DEFERRED ? DEFERRED : REQUIRED;
-}
-
-/**
- * The priority an entry is actually treated with: its declared value once the serve host can route
- * a deferred entry, else `required` (see [ENTRY_DEFERRAL_SERVED]).
- */
-export function effectivePriority(entry) {
-  return ENTRY_DEFERRAL_SERVED ? entryPriority(entry) : REQUIRED;
-}
-
-/**
- * Entries and variants whose declared `priority: "deferred"` is currently being ignored because the
- * serve host can't route it yet. Empty once [ENTRY_DEFERRAL_SERVED] flips. The driver logs these so
- * a catalog author sees that the annotation is recorded but not yet acted on — a tracked gap rather
- * than a silent one.
- *
- * @returns {Array<{componentId: string, preview: string, kind: "entry"|"variant"}>}
- */
-export function declaredEntryDeferrals(spec) {
-  if (ENTRY_DEFERRAL_SERVED) return [];
-  const out = [];
-  for (const { component } of components(spec)) {
-    if (entryPriority(component) === DEFERRED) {
-      out.push({
-        componentId: component.componentId,
-        preview: component.preview,
-        kind: "entry",
-      });
-    }
-    for (const variant of component?.variants ?? []) {
-      if (entryPriority(variant) === DEFERRED) {
-        out.push({
-          componentId: component.componentId,
-          preview: variant.preview,
-          kind: "variant",
-        });
-      }
-    }
-  }
-  return out;
 }
 
 /**
@@ -188,17 +124,15 @@ function components(spec) {
 }
 
 /**
- * True when the spec defers anything that actually takes effect — a mode, or (once the serve host
- * can route it) an entry or variant. Deliberately keyed on the EFFECTIVE priority: this gates the
- * live-path requirement, and demanding a live bundle for a deferral that is currently inert would
- * block a publish for no benefit.
+ * True when the spec defers anything at all — a mode, an entry or a variant. This is what gates the
+ * live-path requirement, since anything deferred is coverage the published bundle no longer carries.
  */
 export function specDefersAnything(spec) {
   if (deferredModes(spec).length > 0) return true;
   return components(spec).some(
     ({ component }) =>
-      effectivePriority(component) === DEFERRED ||
-      (component?.variants ?? []).some((v) => effectivePriority(v) === DEFERRED),
+      entryPriority(component) === DEFERRED ||
+      (component?.variants ?? []).some((v) => entryPriority(v) === DEFERRED),
   );
 }
 
@@ -234,14 +168,13 @@ export function previewNamesByPriority(spec) {
     if (typeof preview !== "string" || preview.length === 0) return;
     (priority === DEFERRED ? deferred : required).add(preview);
   };
-  // EFFECTIVE priority, so the render filter can never drop a preview the driver is still going to
-  // bake — the failure that would leave a "required" entry with no PNG and trip the completeness
-  // gate. While [ENTRY_DEFERRAL_SERVED] is false nothing is deferred, so `deferred` comes back empty
-  // and [renderFilterPatterns] returns no filter at all.
+  // Same [entryPriority] reader the driver's join uses, so the render filter can never drop a preview
+  // the driver is still going to bake — the failure that would leave a "required" entry with no PNG
+  // and trip the completeness gate.
   for (const { component } of components(spec)) {
-    note(component?.preview, effectivePriority(component));
+    note(component?.preview, entryPriority(component));
     for (const variant of component?.variants ?? []) {
-      note(variant?.preview, effectivePriority(variant));
+      note(variant?.preview, entryPriority(variant));
     }
   }
   for (const name of required) deferred.delete(name);
@@ -299,10 +232,10 @@ export function splitDeferredImages(images, spec) {
  */
 export function splitDeferredVariants(component) {
   const variants = component?.variants ?? [];
-  const deferredVariants = variants.filter((v) => effectivePriority(v) === DEFERRED);
+  const deferredVariants = variants.filter((v) => entryPriority(v) === DEFERRED);
   if (deferredVariants.length === 0) return { component, deferredVariants: [] };
   return {
-    component: { ...component, variants: variants.filter((v) => effectivePriority(v) === REQUIRED) },
+    component: { ...component, variants: variants.filter((v) => entryPriority(v) === REQUIRED) },
     deferredVariants,
   };
 }
@@ -341,9 +274,9 @@ export function deferralPlan(spec) {
   let entries = 0;
   let variants = 0;
   for (const { component } of components(spec)) {
-    if (effectivePriority(component) === DEFERRED) entries += 1;
+    if (entryPriority(component) === DEFERRED) entries += 1;
     for (const variant of component?.variants ?? []) {
-      if (effectivePriority(variant) === DEFERRED) variants += 1;
+      if (entryPriority(variant) === DEFERRED) variants += 1;
     }
   }
   const { required, deferred } = previewNamesByPriority(spec);
@@ -355,8 +288,5 @@ export function deferralPlan(spec) {
     requiredPreviews: required,
     renderFilter: renderFilterPatterns(spec),
     defersAnything: specDefersAnything(spec),
-    // Declared-but-inert entry deferrals, so the pre-flight's `--json` surfaces the tracked gap
-    // alongside the effective counts above.
-    ignoredEntryDeferrals: declaredEntryDeferrals(spec),
   };
 }

--- a/scripts/design-artifacts/catalog-priority.test.mjs
+++ b/scripts/design-artifacts/catalog-priority.test.mjs
@@ -4,11 +4,8 @@ import assert from "node:assert/strict";
 import {
   DEFERRED,
   REQUIRED,
-  ENTRY_DEFERRAL_SERVED,
-  declaredEntryDeferrals,
   deferralPlan,
   deferredModes,
-  effectivePriority,
   entryPriority,
   isImageDeferred,
   modePriority,
@@ -65,40 +62,6 @@ test("deferredModes expands the wildcard over declared modes", () => {
   assert.deepEqual(deferredModes(spec([])), []);
 });
 
-test("effectivePriority keeps entry deferral inert until the serve host can route it", () => {
-  // #2965: `ServeCatalogStore` registers and aliases from `components[].images` alone, so honouring
-  // an entry deferral today would drop the entry from the served catalog. Declared value is still
-  // reported; the effective one is what every decision point uses.
-  const deferredEntry = { componentId: "A", preview: "Alpha", priority: "deferred" };
-  assert.equal(entryPriority(deferredEntry), DEFERRED, "the declared value is preserved");
-  assert.equal(
-    effectivePriority(deferredEntry),
-    ENTRY_DEFERRAL_SERVED ? DEFERRED : REQUIRED,
-    "the effective value follows the serve-side switch",
-  );
-});
-
-test("declaredEntryDeferrals names the annotations that are recorded but not acted on", () => {
-  const s = spec([
-    { componentId: "A", preview: "Alpha" },
-    { componentId: "B", preview: "Beta", priority: "deferred" },
-    {
-      componentId: "C",
-      preview: "Gamma",
-      variants: [{ preview: "GammaOff", state: "off", priority: "deferred" }],
-    },
-  ]);
-  const ignored = declaredEntryDeferrals(s);
-  if (ENTRY_DEFERRAL_SERVED) {
-    assert.deepEqual(ignored, [], "nothing is ignored once the serve host can route it");
-  } else {
-    assert.deepEqual(ignored, [
-      { componentId: "B", preview: "Beta", kind: "entry" },
-      { componentId: "C", preview: "GammaOff", kind: "variant" },
-    ]);
-  }
-});
-
 test("previewNamesByPriority only defers a function nothing required points at", () => {
   const { required, deferred } = previewNamesByPriority(
     spec([
@@ -116,15 +79,9 @@ test("previewNamesByPriority only defers a function nothing required points at",
       },
     ]),
   );
-  if (ENTRY_DEFERRAL_SERVED) {
-    assert.deepEqual(required, ["Alpha", "Delta", "DeltaPressed"]);
-    // "Alpha" is required by componentId A even though C defers it, so it must still render.
-    assert.deepEqual(deferred, ["Beta", "DeltaDisabled"]);
-  } else {
-    // Inert: every declared entry deferral reads as required, so nothing is droppable.
-    assert.deepEqual(required, ["Alpha", "Beta", "Delta", "DeltaDisabled", "DeltaPressed"]);
-    assert.deepEqual(deferred, []);
-  }
+  assert.deepEqual(required, ["Alpha", "Delta", "DeltaPressed"]);
+  // "Alpha" is required by componentId A even though C defers it, so it must still render.
+  assert.deepEqual(deferred, ["Beta", "DeltaDisabled"]);
 });
 
 test("renderFilterPatterns is empty when nothing is deferred, and positive when it is", () => {
@@ -147,9 +104,9 @@ test("renderFilterPatterns is empty when nothing is deferred, and positive when 
         { componentId: "B", preview: "Beta", priority: "deferred" },
       ]),
     ),
-    // No filter while entry deferral is inert — the driver still bakes "Beta", so dropping it from
-    // the render would leave a required entry with no PNG. The two MUST agree.
-    ENTRY_DEFERRAL_SERVED ? ["Alpha"] : [],
+    // Positive list: render what is still required. The driver drops "Beta" from the publish too, so
+    // the render set and the published set agree — the invariant this whole module exists to keep.
+    ["Alpha"],
   );
 });
 
@@ -189,33 +146,22 @@ test("splitDeferredVariants folds out the deferred variants", () => {
     ],
   };
   const { component: trimmed, deferredVariants } = splitDeferredVariants(component);
-  if (ENTRY_DEFERRAL_SERVED) {
-    assert.deepEqual(
-      trimmed.variants.map((v) => v.preview),
-      ["P"],
-    );
-    assert.deepEqual(
-      deferredVariants.map((v) => v.preview),
-      ["D"],
-    );
-  } else {
-    assert.deepEqual(
-      trimmed.variants.map((v) => v.preview),
-      ["P", "D"],
-      "inert: the deferred variant is still folded and baked",
-    );
-    assert.deepEqual(deferredVariants, []);
-  }
+  assert.deepEqual(
+    trimmed.variants.map((v) => v.preview),
+    ["P"],
+  );
+  assert.deepEqual(
+    deferredVariants.map((v) => v.preview),
+    ["D"],
+  );
   assert.equal(component.variants.length, 2, "the input spec is not mutated");
 });
 
 test("specDefersAnything sees entries, variants and modes", () => {
   assert.equal(specDefersAnything(spec([{ componentId: "A", preview: "Alpha" }])), false);
-  // Entry/variant deferral only counts once it takes effect — the live-path requirement it gates
-  // must not block a publish for a deferral that is currently inert.
   assert.equal(
     specDefersAnything(spec([{ componentId: "A", preview: "Alpha", priority: "deferred" }])),
-    ENTRY_DEFERRAL_SERVED,
+    true,
   );
   assert.equal(
     specDefersAnything(
@@ -227,7 +173,7 @@ test("specDefersAnything sees entries, variants and modes", () => {
         },
       ]),
     ),
-    ENTRY_DEFERRAL_SERVED,
+    true,
   );
   assert.equal(
     specDefersAnything(spec([], { modes: ["light", "dark"], modePriority: { "*": "deferred" } })),
@@ -251,25 +197,11 @@ test("deferralPlan summarises what a spec defers", () => {
     ),
   );
   assert.deepEqual(plan.modes, ["dark"]);
-  // The mode axis is active today, so the plan always reports the deferral; the entry counts and the
-  // render filter follow the serve-side switch.
   assert.equal(plan.defersAnything, true);
-  if (ENTRY_DEFERRAL_SERVED) {
-    assert.equal(plan.entries, 1);
-    assert.equal(plan.variants, 1);
-    assert.deepEqual(plan.deferredPreviews, ["Beta", "GammaOff"]);
-    assert.deepEqual(plan.renderFilter, ["Alpha", "Gamma"]);
-    assert.deepEqual(plan.ignoredEntryDeferrals, []);
-  } else {
-    assert.equal(plan.entries, 0);
-    assert.equal(plan.variants, 0);
-    assert.deepEqual(plan.deferredPreviews, []);
-    assert.deepEqual(plan.renderFilter, []);
-    assert.deepEqual(
-      plan.ignoredEntryDeferrals.map((d) => d.preview),
-      ["Beta", "GammaOff"],
-    );
-  }
+  assert.equal(plan.entries, 1);
+  assert.equal(plan.variants, 1);
+  assert.deepEqual(plan.deferredPreviews, ["Beta", "GammaOff"]);
+  assert.deepEqual(plan.renderFilter, ["Alpha", "Gamma"]);
 });
 
 test("previewForImage resolves a variant's sticker back to the variant's own @Preview", () => {

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -706,10 +706,9 @@ test("validateSpec warns when modePriority defers every declared mode", () => {
   assert.ok(warnings.some((w) => /defers every declared mode/.test(w)));
 });
 
-test("validateSpec rejects deferral when the publish has no live path", () => {
-  // Keyed on the AXIS form, which is what actually takes effect today. `modePriority` genuinely
-  // thins the published set, so publishing it without a live path would drop coverage no serve host
-  // could produce.
+test("validateSpec rejects axis deferral when the publish has no live path", () => {
+  // `modePriority` genuinely thins the published set, so publishing it without a live path would drop
+  // coverage no serve host could produce.
   const spec = prioritySpec([{ componentId: "A", preview: "Alpha" }], {
     modes: ["light", "dark"],
     modePriority: { light: "required", dark: "deferred" },
@@ -722,14 +721,27 @@ test("validateSpec rejects deferral when the publish has no live path", () => {
   assert.deepEqual(validateSpec(spec).errors, []);
 });
 
-test("validateSpec does not demand a live path for a deferral that is currently inert", () => {
-  // Entry-level deferral is recorded but not acted on until the serve host can route it (#2965), so
-  // requiring `--publish-live-bundle` for it would block a publish for no benefit.
+test("validateSpec rejects entry deferral when the publish has no live path", () => {
+  // An entry-deferred component has no `images[]` record at all, so the live lane
+  // (`catalog.json` `deferred[]` → `ServeCatalogStore`, #2965) is the ONLY way a viewer reaches it.
+  // Without a live path it is coverage dropped outright, which is the one thing deferral must not be.
   const spec = prioritySpec([
     { componentId: "A", preview: "Alpha" },
     { componentId: "B", preview: "Beta", priority: "deferred" },
   ]);
-  assert.deepEqual(validateSpec(spec, { liveBundle: false }).errors, []);
+  const { errors } = validateSpec(spec, { liveBundle: false });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /no live path/);
+  assert.deepEqual(validateSpec(spec, { liveBundle: true }).errors, []);
+  // A variant-level deferral is the same trade, and gated the same way.
+  const variantSpec = prioritySpec([
+    {
+      componentId: "A",
+      preview: "Alpha",
+      variants: [{ preview: "AlphaOff", state: "off", priority: "deferred" }],
+    },
+  ]);
+  assert.match(validateSpec(variantSpec, { liveBundle: false }).errors[0], /no live path/);
 });
 
 test("validateSpec still resolves a deferred entry's preview name against the module", () => {

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -47,9 +47,8 @@ import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 import { foldVariants } from "./catalog-variants.mjs";
 import {
   DEFERRED,
-  declaredEntryDeferrals,
   deferralPlan,
-  effectivePriority,
+  entryPriority,
   modeOfPreviewId,
   modePriority,
   previewForImage,
@@ -390,7 +389,7 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       // A wholly-deferred entry is never rendered (its `@Preview` may not even have been packed
       // with a PNG), so it short-circuits before the candidate lookup — reporting it missing is
       // exactly the false failure this feature exists to remove.
-      if (effectivePriority(specComponent) === DEFERRED) {
+      if (entryPriority(specComponent) === DEFERRED) {
         deferred.push({
           componentId: specComponent.componentId,
           group: group.name,
@@ -818,32 +817,6 @@ if (deferred.length > 0) {
   );
 }
 
-// Entry-level deferral is declared-but-inert until the serve host can route it (#2965) — see
-// `ENTRY_DEFERRAL_SERVED`. `entryPriority` still reports what the spec asked for, but every decision
-// point (the join above, the variant split, the render filter) reads `effectivePriority`, which
-// currently answers `required` — so these entries render and bake exactly as they would without the
-// annotation, and the published catalog is byte-for-byte what it was before.
-//
-// Inert rather than either extreme, on purpose. Refusing the publish would block a catalog for
-// annotating ahead of the server; honouring the deferral would quietly drop the entry from the
-// served sheet, because `ServeCatalogStore` registers and aliases from `components[].images` alone
-// and never decodes `deferred[]`. Neither is a good trade for a gap we're tracking. Say so loudly
-// instead, so the gap is visible in the build log rather than a surprise when the render bill
-// doesn't drop.
-const ignoredDeferrals = declaredEntryDeferrals(spec);
-if (ignoredDeferrals.length > 0) {
-  const shown = [...new Set(ignoredDeferrals.map((d) => d.componentId))].slice(0, 8).join(", ");
-  const more = ignoredDeferrals.length > 8 ? `, +${ignoredDeferrals.length - 8} more` : "";
-  console.warn(
-    `[${spec.system}] ${ignoredDeferrals.length} entry/variant-level \`priority: "deferred"\` ` +
-      `annotation(s) are RECORDED BUT NOT YET ACTED ON — rendered and baked as \`required\` for ` +
-      `now: ${shown}${more}. The preview server does not read catalog.json's \`deferred[]\` yet, so ` +
-      `honouring them would drop these entries from \`serve --catalogs\` instead of rendering them ` +
-      `on demand. They start deferring (and dropping out of the render) when the serve-side lane ` +
-      `lands — https://github.com/yschimke/compose-ai-tools/issues/2965. \`modePriority\` is ` +
-      `unaffected and takes effect today.`,
-  );
-}
 if (
   !values["allow-incomplete"] &&
   (missing.length > 0 || withoutSemantics.length > 0)

--- a/scripts/design-artifacts/validate-catalog-spec.mjs
+++ b/scripts/design-artifacts/validate-catalog-spec.mjs
@@ -165,23 +165,6 @@ if (values.json) {
           : " No @Preview function is wholly deferred, so the render set is unchanged."),
     );
   }
-  // The tracked gap: entry-level deferral is recorded but not yet acted on (#2965). Reported here as
-  // well as by the driver so an author sees it in the fast pre-flight, not only after a long render.
-  if (plan.ignoredEntryDeferrals.length > 0) {
-    const shown = plan.ignoredEntryDeferrals
-      .slice(0, 8)
-      .map((d) => `${d.componentId} (${d.kind})`)
-      .join(", ");
-    const more =
-      plan.ignoredEntryDeferrals.length > 8
-        ? `, +${plan.ignoredEntryDeferrals.length - 8} more`
-        : "";
-    console.log(
-      `  note:    ${plan.ignoredEntryDeferrals.length} entry/variant \`priority: "deferred"\` ` +
-        `annotation(s) are recorded but NOT yet acted on — rendered and baked as \`required\` until ` +
-        `the preview server can route them (compose-ai-tools#2965): ${shown}${more}`,
-    );
-  }
   for (const w of warnings) console.log(`  warning: ${w}`);
   for (const e of errors) console.log(`  error:   ${e}`);
   console.log(


### PR DESCRIPTION
Closes #2965 (the last step of it). Follow-up to #2950 / #2959 / #2972 / #2979.

## Why

Entry-level `priority: "deferred"` has been **declared but inert** since #2959, and #2972 restored that inertness after #2959 merged without it. The reason was concrete: a wholly-deferred entry has no `images[]` record, and `ServeCatalogStore` built both its registration and its catalog-id → daemon-id alias from `components[].images` alone. Acting on the deferral would have made the entry *absent* from `serve --catalogs` rather than rendered on demand.

**#2979 gave those records a live lane** — `catalog.json`'s `deferred[]` is decoded, each record aliased to its daemon `previewId` and registered with no baked PNG, and a session with no live lane hides them behind an explicit `deferred-not-served` degradation instead of showing broken cards. So `ENTRY_DEFERRAL_SERVED` has nothing left to guard.

## What

Rather than flip the constant and leave a dead lever behind, this removes it. `entryPriority` becomes the single reader every decision point uses — the driver's spec→candidate join, the variant split, `specDefersAnything`, and the render-filter derivation — which preserves the invariant the switch existed to protect: **the render set and the published set cannot disagree about which entries are baked.** A mismatch there is what would leave a `required` entry with no PNG and trip the completeness gate.

Behaviour that changes, all of it the intended end state:

| | before | after |
| --- | --- | --- |
| deferred entry/variant | rendered and baked as `required` | recorded in `deferred[]`, skipped by the completeness gate |
| its `@Preview` | always rendered | dropped from the render when nothing `required` points at it |
| live-path rule | axis deferral only | axis **and** entry deferral |

The render saving flows through machinery already on `main`: the pre-flight's `--render-filter-out` patterns, which both design-artifacts workflows feed to the render as `ORG_GRADLE_PROJECT_composePreview.filter`. A function is only droppable when **nothing required points at it** — two entries can name the same `@Preview`.

The live-path rule now biting for entry deferral is the point, not a side effect: an entry with no baked PNG is reachable *only* through the live lane, so deferring one with neither `--publish-live-bundle` nor a buildable `--source-module` would be coverage dropped outright.

Also removed, because they are no longer true: the driver's "recorded but not yet acted on" warning and the pre-flight's matching `note:` line.

## Blast radius

**No committed spec declares `priority` or `modePriority` yet** (`rg '"priority"|modePriority' samples/**/*.json` → no matches), so no published catalog changes shape from this merge. The first spec to use it gets the behaviour above.

Verified the deferred entry still reaches the serve host: `BundlePreviewTask` reads `previews.json` from `DiscoverPreviewsTask` (not from the render), packs a filtered copy listing every *selected* preview, and omits only the PNG — "the reader treats an absent entry as not rendered yet". So the id survives for `daemonPreviewIdsByFunction` → `deferred[].previewIds` → the live route.

## Test plan

- All 30 `scripts/design-artifacts/*.test.mjs` suites — **pass**. `catalog-priority` 12/12, `catalog-spec` 50/50. (`rc-round-clip` / `rc-webfonts` self-skip: `chromium unavailable` in this container, unrelated and unchanged.)
- The both-sides-of-the-switch branches are gone from the tests, replaced by direct assertions on the served behaviour — that's what those branches were written to survive into.
- `validateSpec` now has one test per polarity: axis deferral and entry deferral each rejected without a live path, entry test also covering a variant-level deferral.
- End-to-end pre-flight smoke on a synthetic spec (1 deferred entry `BannerPreview`, 1 deferred variant `CardPressed`):
  ```
  Render priority: 1 deferred entry/entries, 1 deferred variant(s), deferred mode(s): none.
    Render filter: 2 required @Preview function(s).
  OK — 0 warning(s), 0 errors.
  $ cat filter.txt
  ButtonPreview,CardPreview
  ```
  and with `--no-live-bundle`: `FAILED — 1 error(s)` … `the publish has no live path`.

Non-visual (export-driver logic, docs, tests), so text-only evidence is the right form here. The serve-side rendering this unblocks already carries its before/after in #2979.

## Still open

#2977 — neither the name nor the id filter reaches the Android/Robolectric render path, so the render saving above is desktop-only. Harmless (an absent filter means "render everything") but it means an Android catalog trims its publish without trimming its build, and the motivating pocket-casts −59% needs that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016azcVhRhQze6Y91gMT4BeF)_