### PR TITLE
feat(serve): playground preview-token store and REST DTOs

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire types for the **playground** REST surface — the Stage-1 "compile a snippet, get a result +
+ * an expiring preview token" contract described in
+ * [docs/design/PLAYGROUND.md](../../../../../../../../docs/design/PLAYGROUND.md).
+ *
+ * The request/response shapes are deliberately a **superset** of the `kotlin-compiler-server`
+ * `/api/{version}/compiler/run` contract that a stock `kotlin-playground` frontend speaks, so an
+ * unmodified editor can POST to us: it sends `{ args, files, confType }` and reads `{ text,
+ * exception, errors }`. The two fields it does **not** know about — [PlaygroundRunResponse.image]
+ * and [PlaygroundRunResponse.previewToken] — are additive; a stock frontend ignores them and ours
+ * surfaces them as the still frame + the "Open live preview →" handoff.
+ *
+ * These are pure data types with no server behaviour; the route handler and the compile/render
+ * plumbing live elsewhere.
+ */
+
+/** Which renderer + permalink target a snippet compiles for. See PLAYGROUND.md §3. */
+@Serializable
+enum class PlaygroundMode {
+  /** Compose Multiplatform, desktop (Skiko) daemon → live streaming session. */
+  @SerialName("compose-cmp") CMP,
+  /** Jetpack Compose, Robolectric daemon → live streaming session. */
+  @SerialName("compose-android") ANDROID,
+  /** Snippet emits a RemoteDocument → `/d/<id>` document permalink, played client-side. */
+  @SerialName("remote-compose") REMOTE_COMPOSE;
+
+  companion object {
+    /**
+     * Resolve the request's `confType` to a mode. Accepts our own ids (the [SerialName]s above) and
+     * tolerates the stock `kotlin-playground` target ids so an unmodified frontend still lands on a
+     * sensible mode: `canvas`/`js`/`wasm`/`compose-wasm` (its in-browser Compose targets) map to
+     * [CMP], everything else defaults to [CMP] as well — the one mode a from-source box can always
+     * serve. An empty/absent `confType` is [CMP].
+     */
+    fun fromConfType(confType: String?): PlaygroundMode =
+      when (confType?.trim()?.lowercase()) {
+        "compose-android",
+        "android" -> ANDROID
+        "remote-compose",
+        "remotecompose",
+        "rc" -> REMOTE_COMPOSE
+        else -> CMP
+      }
+  }
+}
+
+/** One editor file in a run request. `publicId` is carried through but unused server-side. */
+@Serializable
+data class PlaygroundFile(val name: String, val text: String, val publicId: String = "")
+
+/**
+ * A Stage-1 run request. Mirrors the `kotlin-compiler-server` body so a stock frontend fits; [args]
+ * is accepted and ignored (a preview has no argv), and the mode comes from [confType] via
+ * [PlaygroundMode.fromConfType].
+ */
+@Serializable
+data class PlaygroundRunRequest(
+  val args: String = "",
+  val files: List<PlaygroundFile> = emptyList(),
+  val confType: String = "",
+)
+
+/** Severity of a compiler diagnostic, spelled the way the editor's highlight lane expects. */
+@Serializable
+enum class PlaygroundSeverity {
+  @SerialName("error") ERROR,
+  @SerialName("warning") WARNING,
+  @SerialName("info") INFO,
+}
+
+/**
+ * One compiler diagnostic. Line/char positions are **0-based** to match CodeMirror (what
+ * `kotlin-playground` renders against); a null position is a file-level diagnostic with no anchor.
+ */
+@Serializable
+data class PlaygroundDiagnostic(
+  val severity: PlaygroundSeverity,
+  val message: String,
+  val file: String? = null,
+  val line: Int? = null,
+  val ch: Int? = null,
+  val endLine: Int? = null,
+  val endCh: Int? = null,
+)
+
+/**
+ * The Stage-1 result.
+ *
+ * On a clean compile: [diagnostics] carries any warnings, [image] is the first-frame render as a
+ * `data:image/png;base64,…` URI, and [previewToken] / [previewUrl] are the handoff to the live
+ * Stage-2 session. On a compile error: [diagnostics] carries the errors and **no** token is minted
+ * ([previewToken] stays null). [exception] is reserved for a server-side failure that isn't a user
+ * compile error (e.g. the render subprocess died).
+ */
+@Serializable
+data class PlaygroundRunResponse(
+  val diagnostics: List<PlaygroundDiagnostic> = emptyList(),
+  val text: String = "",
+  val exception: String? = null,
+  val image: String? = null,
+  val previewToken: String? = null,
+  val previewUrl: String? = null,
+)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStore.kt
@@ -1,0 +1,193 @@
+package ee.schimke.composeai.cli.serve
+
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import okio.FileSystem
+import okio.Path
+
+/**
+ * The expiring **preview-token** capability behind `/pg/<token>` — the Stage-1 → Stage-2 handoff in
+ * [docs/design/PLAYGROUND.md](../../../../../../../../docs/design/PLAYGROUND.md).
+ *
+ * Sibling of [ServeDocStore]: where that holds a client-uploaded *document* and hands back a
+ * `/d/<id>` playback link, this holds a **just-compiled snippet** ([PlaygroundSnippet]) and hands
+ * back a `/pg/<id>` link that redeems into a live daemon session (CMP/Android) or a document
+ * permalink (Remote Compose). A token is minted only after a *clean* compile, so possessing one
+ * means "there are real classes on disk ready to render".
+ *
+ * Safety model mirrors [ServeDocStore]:
+ * - **Id is the capability.** 128 bits of [SecureRandom], base64url, `pg_`-prefixed. Unguessable,
+ *   so a link is safe to hand to one person without listing it.
+ * - **Expiring.** After [ttlSeconds] the token is dropped and `/pg/<id>` 404s without disclosing
+ *   whether the id ever existed.
+ * - **Bounded.** A [maxTokens] cap evicts nearest-expiry first on overflow. Each token owns a temp
+ *   work directory ([PlaygroundSnippet.workDir]); dropping the token **deletes that directory**, so
+ *   the cap bounds disk, not just the map.
+ *
+ * Unlike [ServeDocStore] this store owns on-disk state, so every removal path (expiry, overflow,
+ * explicit [remove], [clear]) routes through [disposeSnippet] to delete the work dir. The delete is
+ * best-effort — a failure is swallowed so one undeletable directory can't wedge purging.
+ */
+class PlaygroundTokenStore(
+  /** How long a preview token stays redeemable. Short by design — minutes, not hours. */
+  val ttlSeconds: Long = DEFAULT_TTL_SECONDS,
+  private val maxTokens: Int = DEFAULT_MAX_TOKENS,
+  /** Injected per the repo's Okio-everywhere rule; tests pass a `FakeFileSystem`. */
+  private val fileSystem: FileSystem = FileSystem.SYSTEM,
+  /** Injected so tests can drive expiry without sleeping. */
+  private val clock: () -> Long = System::currentTimeMillis,
+  private val mintId: () -> String = ::randomId,
+) {
+
+  /**
+   * A compiled snippet a token points at — everything Stage 2 needs to stand up (or, for Remote
+   * Compose, replay) the preview without recompiling.
+   */
+  data class PlaygroundSnippet(
+    val mode: PlaygroundMode,
+    /** Temp root for this snippet; **deleted** when its token is dropped. */
+    val workDir: Path,
+    /** Compiled `.class` output, on [classpath] for the render. */
+    val classesDir: Path,
+    /** Full render classpath (catalog live-bundle jars + [classesDir]). */
+    val classpath: List<Path>,
+    /** Kotlin `MODULE_NAME` the snippet compiled under. */
+    val moduleName: String,
+    /** The `@Preview` id Stage 2 renders/streams. */
+    val previewId: String,
+  )
+
+  /** One minted token and its lifetime. */
+  data class Token(
+    val id: String,
+    val snippet: PlaygroundSnippet,
+    val createdAtMillis: Long,
+    val expiresAtMillis: Long,
+  ) {
+    /** The redeem path — the id is the capability, so this is the whole share. */
+    val path: String
+      get() = "/pg/$id"
+
+    fun secondsUntilExpiry(nowMillis: Long): Long =
+      ((expiresAtMillis - nowMillis) / 1000).coerceAtLeast(0)
+
+    // Keyed by id, like ServeDocStore.Doc — array/path-reference equality would be surprising.
+    override fun equals(other: Any?): Boolean = other is Token && other.id == id
+
+    override fun hashCode(): Int = id.hashCode()
+  }
+
+  private val tokens = ConcurrentHashMap<String, Token>()
+
+  /**
+   * Mint a token for [snippet] and return it. The store now owns [snippet]'s [workDir] and will
+   * delete it on expiry/eviction/[remove]. [isSecurityChecked] is the greppable audit marker
+   * [ServeDocStore.add] uses (no runtime enforcement): the caller passes `true` only once the
+   * request has cleared the playground route's gate.
+   */
+  fun add(snippet: PlaygroundSnippet, isSecurityChecked: Boolean): Token {
+    val now = clock()
+    purgeExpired(now)
+    val token =
+      Token(
+        id = mintId(),
+        snippet = snippet,
+        createdAtMillis = now,
+        expiresAtMillis = now + ttlSeconds * 1000,
+      )
+    tokens[token.id] = token
+    evictOverflow()
+    return token
+  }
+
+  /** The live token for [id], or null when it's unknown **or expired** (expired ⇒ dropped). */
+  fun get(id: String): Token? {
+    val now = clock()
+    purgeExpired(now)
+    return tokens[id]?.takeIf { it.expiresAtMillis > now }
+  }
+
+  /**
+   * Seconds left on [token], measured on the **store's** clock — the one that decides expiry.
+   * Callers must not read the wall clock themselves.
+   */
+  fun remainingSeconds(token: Token): Long = token.secondsUntilExpiry(clock())
+
+  /** Explicitly drop [id] (and delete its work dir); returns true if it was present. */
+  fun remove(id: String): Boolean {
+    val removed = tokens.remove(id) ?: return false
+    disposeSnippet(removed.snippet)
+    return true
+  }
+
+  /** Drop every token whose TTL has run out (deleting each work dir); returns how many went. */
+  fun purgeExpired(nowMillis: Long = clock()): Int {
+    var dropped = 0
+    val it = tokens.entries.iterator()
+    while (it.hasNext()) {
+      val entry = it.next()
+      if (entry.value.expiresAtMillis <= nowMillis) {
+        it.remove()
+        disposeSnippet(entry.value.snippet)
+        dropped++
+      }
+    }
+    return dropped
+  }
+
+  /** Live tokens, soonest expiry first — for the status page. */
+  fun snapshot(): List<Token> {
+    val now = clock()
+    purgeExpired(now)
+    return tokens.values.sortedBy { it.expiresAtMillis }
+  }
+
+  /** Drop everything (deleting every work dir) — for host shutdown. */
+  fun clear() {
+    val all = tokens.values.toList()
+    tokens.clear()
+    all.forEach { disposeSnippet(it.snippet) }
+  }
+
+  /**
+   * Enforce the count cap by dropping the tokens closest to expiry first — a burst evicts the
+   * oldest shares (deleting their work dirs) rather than being refused, so disk + heap stay
+   * bounded.
+   */
+  private fun evictOverflow() {
+    while (tokens.size > maxTokens) {
+      val oldest = tokens.values.minByOrNull { it.expiresAtMillis } ?: return
+      tokens.remove(oldest.id)?.let { disposeSnippet(it.snippet) }
+    }
+  }
+
+  /** Best-effort delete of a dropped snippet's work dir; a failure must not wedge purging. */
+  private fun disposeSnippet(snippet: PlaygroundSnippet) {
+    try {
+      fileSystem.deleteRecursively(snippet.workDir, mustExist = false)
+    } catch (_: Exception) {
+      // The directory may already be gone, or held open on Windows; leaking one temp dir is
+      // strictly better than throwing out of a purge and stranding the rest.
+    }
+  }
+
+  companion object {
+    /** Ten minutes: long enough to click through and refresh a tab, short enough to not linger. */
+    const val DEFAULT_TTL_SECONDS = 600L
+
+    const val DEFAULT_MAX_TOKENS = 64
+
+    /** 128 bits of [SecureRandom], base64url, `pg_`-prefixed — the id IS the capability. */
+    private val random = SecureRandom()
+
+    fun randomId(): String {
+      val bytes = ByteArray(16)
+      random.nextBytes(bytes)
+      return "pg_" + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    /** True when [id] could be one of ours — cheap shape check before a map lookup. */
+    fun isWellFormedId(id: String): Boolean = id.matches(Regex("pg_[A-Za-z0-9_-]{16,64}"))
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStoreTest.kt
@@ -1,0 +1,123 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+/**
+ * The expiring preview-token store behind `/pg/<token>`: mint, redeem, TTL, caps, and work-dir
+ * cleanup.
+ */
+class PlaygroundTokenStoreTest {
+
+  private var now = 1_000_000L
+  private var ids = 0
+  private val fs = FakeFileSystem()
+
+  private fun store(ttlSeconds: Long = 600, maxTokens: Int = 8) =
+    PlaygroundTokenStore(
+      ttlSeconds = ttlSeconds,
+      maxTokens = maxTokens,
+      fileSystem = fs,
+      clock = { now },
+      mintId = { "pg_${(++ids).toString().padStart(16, '0')}" },
+    )
+
+  /** A snippet whose work dir actually exists on the fake FS, so cleanup is observable. */
+  private fun snippet(
+    name: String,
+    mode: PlaygroundMode = PlaygroundMode.CMP,
+  ): PlaygroundTokenStore.PlaygroundSnippet {
+    val work = "/work/$name".toPath()
+    val classes = work / "classes"
+    fs.createDirectories(classes)
+    fs.write(classes / "Snippet.class") { writeUtf8("cafebabe") }
+    return PlaygroundTokenStore.PlaygroundSnippet(
+      mode = mode,
+      workDir = work,
+      classesDir = classes,
+      classpath = listOf(classes),
+      moduleName = "playground-$name",
+      previewId = "com.example.$name.Preview",
+    )
+  }
+
+  @Test
+  fun `a minted token redeems until it expires, then is gone`() {
+    val store = store(ttlSeconds = 600)
+
+    val token = store.add(snippet("a"), isSecurityChecked = true)
+    assertEquals("/pg/${token.id}", token.path)
+    assertTrue(PlaygroundTokenStore.isWellFormedId(token.id), token.id)
+    assertEquals(600, token.secondsUntilExpiry(now))
+    assertEquals(token.id, store.get(token.id)?.id)
+
+    now += 599_000
+    assertEquals(token.id, store.get(token.id)?.id, "still redeemable one second before expiry")
+
+    now += 2_000
+    assertNull(store.get(token.id), "the link stops resolving once the TTL is up")
+    assertTrue(store.snapshot().isEmpty())
+    assertFalse(fs.exists("/work/a".toPath()), "and the work dir is deleted, not merely hidden")
+  }
+
+  @Test
+  fun `the snippet's mode and preview id survive the round trip`() {
+    val store = store()
+    val token = store.add(snippet("wear", mode = PlaygroundMode.ANDROID), isSecurityChecked = true)
+    val got = store.get(token.id)!!.snippet
+    assertEquals(PlaygroundMode.ANDROID, got.mode)
+    assertEquals("com.example.wear.Preview", got.previewId)
+  }
+
+  @Test
+  fun `overflow evicts the nearest-expiry token and deletes its work dir`() {
+    val store = store(maxTokens = 2)
+
+    val first = store.add(snippet("first"), isSecurityChecked = true)
+    now += 1_000
+    store.add(snippet("second"), isSecurityChecked = true)
+    now += 1_000
+    store.add(snippet("third"), isSecurityChecked = true) // pushes over the cap of 2
+
+    assertNull(store.get(first.id), "the oldest token is evicted on overflow")
+    assertFalse(fs.exists("/work/first".toPath()), "and its work dir is cleaned up")
+    assertEquals(2, store.snapshot().size)
+  }
+
+  @Test
+  fun `explicit remove drops the token and its work dir`() {
+    val store = store()
+    val token = store.add(snippet("gone"), isSecurityChecked = true)
+
+    assertTrue(store.remove(token.id))
+    assertNull(store.get(token.id))
+    assertFalse(fs.exists("/work/gone".toPath()))
+    assertFalse(store.remove(token.id), "removing an unknown id is a no-op")
+  }
+
+  @Test
+  fun `clear drops every token and work dir`() {
+    val store = store()
+    store.add(snippet("x"), isSecurityChecked = true)
+    store.add(snippet("y"), isSecurityChecked = true)
+
+    store.clear()
+    assertTrue(store.snapshot().isEmpty())
+    assertFalse(fs.exists("/work/x".toPath()))
+    assertFalse(fs.exists("/work/y".toPath()))
+  }
+
+  @Test
+  fun `confType maps to the right mode`() {
+    assertEquals(PlaygroundMode.CMP, PlaygroundMode.fromConfType("compose-cmp"))
+    assertEquals(PlaygroundMode.ANDROID, PlaygroundMode.fromConfType("compose-android"))
+    assertEquals(PlaygroundMode.REMOTE_COMPOSE, PlaygroundMode.fromConfType("remote-compose"))
+    assertEquals(PlaygroundMode.CMP, PlaygroundMode.fromConfType("canvas"), "stock frontend target")
+    assertEquals(PlaygroundMode.CMP, PlaygroundMode.fromConfType(null), "absent confType")
+  }
+}


### PR DESCRIPTION
## Summary

First implementation slice for the Compose playground designed in [`docs/design/PLAYGROUND.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/PLAYGROUND.md) (merged in #2984). Two self-contained, unit-tested foundation pieces — no route wiring yet, so nothing is reachable from a running server until the follow-ups land.

- **`PlaygroundApi.kt`** — the Stage-1 run request/response wire types. A deliberate **superset** of the `kotlin-compiler-server` `/compiler/run` contract so a stock `kotlin-playground` frontend can POST to us unmodified (`{ args, files, confType }` → `{ text, exception, diagnostics }`), plus the two **additive** handoff fields it ignores and ours surfaces: `image` (first-frame `data:` PNG) and `previewToken`. Includes `PlaygroundMode` (CMP / Compose-Android / Remote-Compose) with `confType` resolution that tolerates the stock frontend's target ids.
- **`PlaygroundTokenStore.kt`** — the expiring `/pg/<token>` capability that hands a compiled snippet off to a live session, modelled directly on `ServeDocStore`: 128-bit `SecureRandom` `pg_`-prefixed ids, TTL expiry, a count cap with nearest-expiry eviction. Unlike the doc store it owns **on-disk** state, so every drop path (expiry, overflow, `remove`, `clear`) deletes the snippet's temp work dir through an **injected Okio `FileSystem`** (per the repo's Okio-everywhere rule). Best-effort delete so one undeletable dir can't wedge a purge.

### Where this sits in the plan

Phase 1 (token-gated, CMP, single snippet) from the design doc. Still to come as follow-ups: the `/api/{v}/compiler/run` route + compile handler (over the shipped `BtaCompileSession`), the first-frame render, and the `/pg/<token>` redemption into the existing live streaming session. Isolation (Phase 4) remains the gate to any `--public` exposure and is untouched here.

## Test plan

- [x] `./gradlew :cli:test --tests "ee.schimke.composeai.cli.serve.PlaygroundTokenStoreTest"` — green (6 cases: redeem-until-expiry, mode/preview-id round-trip, overflow eviction + work-dir cleanup, explicit remove, clear, confType mapping). Work-dir deletion is asserted against a `FakeFileSystem`.
- [x] `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` — clean.
- Non-visual change (server-side data types + capability store); no rendered surface touched, so no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_