### PR TITLE
fix(daemon): degrade missing drawables read via getDrawableForDensity to a placeholder

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PlaceholderFallbackResources.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PlaceholderFallbackResources.kt
@@ -35,11 +35,18 @@ import android.graphics.drawable.Drawable
  * a later `String.format` with args leaves it unchanged. Value resources ([getColor], the dimension
  * family, [getDrawable]) don't route through a shared accessor, so each is guarded directly. The
  * base class's `AssetManager` / `DisplayMetrics` / `Configuration` are reused, so every *resolvable*
- * resource still takes the normal Android path.
+ * resource still takes the normal Android path. Drawables are guarded on **all four**
+ * `loadDrawable` entry points — `getDrawable(id)`, `getDrawable(id, theme)`, and both
+ * `getDrawableForDensity(...)` overloads — because a density-aware caller
+ * (`ResourcesCompat.getDrawableForDensity`, RemoteViews / ImageView inflation, image loaders)
+ * reaches the throwing `ResourcesImpl.loadDrawable` without funnelling through the plain
+ * `getDrawable`, so guarding only the latter left the miss to abort the render (issue #2976).
  *
- * Not (yet) covered: `getValue`-based paths such as Compose `painterResource(...)` — a missing
- * drawable id read that way still throws. Tracked as a follow-up; the string family is the common
- * crash the live server hits (`wear-m3` stickers use `stringResource`).
+ * Not (yet) covered: raw `getValue` / `openRawResource` decode paths (e.g. a bitmap whose id
+ * resolves but whose backing file is absent) can't be substituted at the `Resources` seam without
+ * fabricating a `TypedValue` / stream, so a miss read that way still throws. The value families
+ * above (`getText`, `getColor`, the dimension family) and every `getDrawable*` overload are the
+ * common crashes the live server hits.
  */
 @Suppress("DEPRECATION")
 internal class PlaceholderFallbackResources(base: Resources) :
@@ -111,6 +118,28 @@ internal class PlaceholderFallbackResources(base: Resources) :
   override fun getDrawable(id: Int): Drawable =
     try {
       super.getDrawable(id)
+    } catch (_: NotFoundException) {
+      placeholderDrawable()
+    }
+
+  // The density-aware variants are a *separate* entry into `ResourcesImpl.loadDrawable` — the same
+  // method that throws `NotFoundException: Drawable <pkg>:drawable/<name> with resource ID #0x…`.
+  // `getDrawable(id[, theme])` funnels here internally, so overriding those two catches an app-code
+  // `getDrawable(...)`; but a caller that reaches `getDrawableForDensity(...)` directly (density-aware
+  // image-loading paths, `ResourcesCompat.getDrawableForDensity`, RemoteViews/ImageView inflation)
+  // bypasses those overrides and the miss escapes as a hard render abort (issue #2976:
+  // `splash_background` on the `pocketcasts-wear` live server). Guard both overloads too so every
+  // `loadDrawable` path degrades to the placeholder.
+  override fun getDrawableForDensity(id: Int, density: Int): Drawable? =
+    try {
+      super.getDrawableForDensity(id, density)
+    } catch (_: NotFoundException) {
+      placeholderDrawable()
+    }
+
+  override fun getDrawableForDensity(id: Int, density: Int, theme: Theme?): Drawable? =
+    try {
+      super.getDrawableForDensity(id, density, theme)
     } catch (_: NotFoundException) {
       placeholderDrawable()
     }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PlaceholderFallbackResourcesTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PlaceholderFallbackResourcesTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import android.content.res.Resources
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -60,6 +61,27 @@ class PlaceholderFallbackResourcesTest {
   fun `a resolvable framework color is returned untouched`() {
     val real = base.getColor(android.R.color.white, null)
     assertEquals(real, fallback.getColor(android.R.color.white, null))
+  }
+
+  @Test
+  fun `a missing drawable id falls back to a placeholder instead of throwing`() {
+    // `getDrawable(id[, theme])` is the plain entry `Resources.getDrawable` funnels through.
+    assertNotNull(fallback.getDrawable(missingId, null))
+    @Suppress("DEPRECATION") assertNotNull(fallback.getDrawable(missingId))
+  }
+
+  @Test
+  fun `a missing drawable id read via getDrawableForDensity also falls back`() {
+    // Regression for issue #2976: a density-aware caller (image loaders, RemoteViews / ImageView
+    // inflation, `ResourcesCompat.getDrawableForDensity`) reaches `ResourcesImpl.loadDrawable`
+    // without funnelling through the plain `getDrawable`, so guarding only the latter let the miss
+    // abort the whole render (`NotFoundException: Drawable …/splash_background with resource ID …`).
+    @Suppress("DEPRECATION")
+    assertNotNull("2-arg density variant must degrade to a placeholder", fallback.getDrawableForDensity(missingId, 160))
+    assertNotNull(
+      "3-arg density+theme variant must degrade to a placeholder",
+      fallback.getDrawableForDensity(missingId, 160, null),
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes #2976.

The live serve daemon rendered `pocketcasts-wear/playback-marquee-media-display` with:

```
render failed: NotFoundException: Drawable au.com.shiftyjelly.pocketcasts.debug:drawable/splash_background with resource ID #0x7f0806b5
```

`PlaceholderFallbackResources` is meant to turn a **missing** app-resource lookup into an obvious magenta placeholder rather than letting `Resources.NotFoundException` abort the whole preview render. It already guards the string/color/dimension families and `getDrawable(id)` / `getDrawable(id, theme)` — but **not** the density-aware `getDrawableForDensity(...)` overloads.

That exact `"Drawable <pkg>:drawable/<name> with resource ID #0x…"` message is produced only by `ResourcesImpl.loadDrawable`. The plain `getDrawable(...)` overloads funnel into `loadDrawable` (and were caught), but a caller that reaches `getDrawableForDensity(...)` **directly** — density-aware image loaders, `ResourcesCompat.getDrawableForDensity`, RemoteViews / `ImageView` inflation — enters `loadDrawable` without passing through the guarded methods, so the miss still threw and aborted the render even though the fallback was enabled (serve sets `composeai.render.placeholderMissingResources=true`).

## Change

- Override both `getDrawableForDensity(id, density)` and `getDrawableForDensity(id, density, theme)` in `PlaceholderFallbackResources` to catch `NotFoundException` and return the same magenta placeholder, so **all four** `loadDrawable` entry points degrade gracefully.
- Update the class doc's "not (yet) covered" note: drawables are now guarded on every `loadDrawable` path; only raw `getValue` / `openRawResource` decode paths (which can't be substituted at the `Resources` seam without fabricating a `TypedValue` / stream) remain a theoretical gap.
- Add unit coverage for the density-aware misses in `PlaceholderFallbackResourcesTest`.

## Test plan

- `./gradlew :daemon:android:testDebugUnitTest --tests "ee.schimke.composeai.daemon.PlaceholderFallbackResourcesTest"` — **BUILD SUCCESSFUL** (new density-variant tests pass alongside the existing coverage).
- `./gradlew :daemon:android:ktfmtCheck` — **BUILD SUCCESSFUL**.

Non-visual change (resource-fallback plumbing in the render engine), so no rendered before/after evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTUqnZfpeTGS82tWZFpfQc)_