### PR TITLE
fix(design-artifacts): defer a component's variants with it, so a mixed entry can't drop coverage

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -391,6 +391,13 @@ What each form actually saves:
   every consumer (the join, the variant split, the render filter), so the render set and
   the published set can't disagree about which entries are baked.
 
+  **Deferring a component defers its `variants` with it** (`variantPriority`), whatever
+  they say — each gets its own `deferred[]` record so it stays live-routable. A variant's
+  sticker is normally *folded onto* its component's images, so once the component is
+  deferred there is no `components[]` entry left to fold onto: a variant left at the
+  `required` default would be rendered and then neither baked nor recorded anywhere. The
+  useful direction — a required component with one deferred variant — works as written.
+
 Caveats worth knowing before reaching for it:
 
 - **A live path is required.** Deferring with neither `--publish-live-bundle` nor

--- a/scripts/design-artifacts/catalog-priority.mjs
+++ b/scripts/design-artifacts/catalog-priority.mjs
@@ -59,6 +59,24 @@ export function entryPriority(entry) {
 }
 
 /**
+ * The priority of one `variants` entry, which **inherits its component's deferral**: a variant of a
+ * deferred component is deferred whatever it says, because a variant's sticker is folded onto the
+ * component's images and there is no `components[]` record left to fold it onto.
+ *
+ * Without the inheritance a mixed-priority component loses coverage silently: the driver
+ * short-circuits a deferred component before reaching its variants, so a variant left at the
+ * `required` default would be rendered (the render filter keeps its function), then neither baked,
+ * nor recorded in `deferred[]`, nor reported by the completeness gate. Inheriting instead keeps it
+ * addressable through the live lane, which is what deferral means everywhere else.
+ *
+ * A variant can still be deferred on its own while its component stays required — that direction is
+ * the useful one, and it is what [splitDeferredVariants] folds out.
+ */
+export function variantPriority(component, variant) {
+  return entryPriority(component) === DEFERRED ? DEFERRED : entryPriority(variant);
+}
+
+/**
  * The priority the spec declares for one mode (theme) of the sticker sheet, from `modePriority`:
  * an exact key wins, then the `*` wildcard, then the `required` default.
  */
@@ -132,7 +150,7 @@ export function specDefersAnything(spec) {
   return components(spec).some(
     ({ component }) =>
       entryPriority(component) === DEFERRED ||
-      (component?.variants ?? []).some((v) => entryPriority(v) === DEFERRED),
+      (component?.variants ?? []).some((v) => variantPriority(component, v) === DEFERRED),
   );
 }
 
@@ -174,7 +192,7 @@ export function previewNamesByPriority(spec) {
   for (const { component } of components(spec)) {
     note(component?.preview, entryPriority(component));
     for (const variant of component?.variants ?? []) {
-      note(variant?.preview, entryPriority(variant));
+      note(variant?.preview, variantPriority(component, variant));
     }
   }
   for (const name of required) deferred.delete(name);
@@ -232,10 +250,13 @@ export function splitDeferredImages(images, spec) {
  */
 export function splitDeferredVariants(component) {
   const variants = component?.variants ?? [];
-  const deferredVariants = variants.filter((v) => entryPriority(v) === DEFERRED);
+  const deferredVariants = variants.filter((v) => variantPriority(component, v) === DEFERRED);
   if (deferredVariants.length === 0) return { component, deferredVariants: [] };
   return {
-    component: { ...component, variants: variants.filter((v) => entryPriority(v) === REQUIRED) },
+    component: {
+      ...component,
+      variants: variants.filter((v) => variantPriority(component, v) === REQUIRED),
+    },
     deferredVariants,
   };
 }
@@ -276,7 +297,7 @@ export function deferralPlan(spec) {
   for (const { component } of components(spec)) {
     if (entryPriority(component) === DEFERRED) entries += 1;
     for (const variant of component?.variants ?? []) {
-      if (entryPriority(variant) === DEFERRED) variants += 1;
+      if (variantPriority(component, variant) === DEFERRED) variants += 1;
     }
   }
   const { required, deferred } = previewNamesByPriority(spec);

--- a/scripts/design-artifacts/catalog-priority.test.mjs
+++ b/scripts/design-artifacts/catalog-priority.test.mjs
@@ -7,6 +7,7 @@ import {
   deferralPlan,
   deferredModes,
   entryPriority,
+  variantPriority,
   isImageDeferred,
   modePriority,
   previewForImage,
@@ -60,6 +61,54 @@ test("deferredModes expands the wildcard over declared modes", () => {
   // A wildcard with no `modes` list to expand over still reports as deferring.
   assert.deepEqual(deferredModes(spec([], { modePriority: { "*": "deferred" } })), ["*"]);
   assert.deepEqual(deferredModes(spec([])), []);
+});
+
+test("variantPriority inherits a deferred component, so a mixed component can't leak coverage", () => {
+  const deferredComponent = { componentId: "A", preview: "Alpha", priority: "deferred" };
+  const requiredComponent = { componentId: "B", preview: "Beta" };
+  // A variant left at the `required` default under a deferred component is deferred WITH it. The
+  // driver short-circuits a deferred component before folding variants, so treating this one as
+  // required would render it and then neither bake it nor record it anywhere.
+  assert.equal(variantPriority(deferredComponent, { preview: "AlphaOff", state: "off" }), DEFERRED);
+  assert.equal(
+    variantPriority(deferredComponent, { preview: "AlphaOn", state: "on", priority: "required" }),
+    DEFERRED,
+    "an explicit `required` under a deferred component does not resurrect it",
+  );
+  // The useful direction still works: a required component with one deferred variant.
+  assert.equal(variantPriority(requiredComponent, { preview: "BetaOff", state: "off" }), REQUIRED);
+  assert.equal(
+    variantPriority(requiredComponent, { preview: "BetaOff", state: "off", priority: "deferred" }),
+    DEFERRED,
+  );
+});
+
+test("a deferred component's variants stay out of the render filter", () => {
+  // The invariant: what the filter renders and what the driver bakes must agree. A variant of a
+  // deferred component is baked by nothing, so its function must not be kept alive here either.
+  const s = spec([
+    { componentId: "A", preview: "Alpha" },
+    {
+      componentId: "B",
+      preview: "Beta",
+      priority: "deferred",
+      variants: [{ preview: "BetaOff", state: "off" }],
+    },
+  ]);
+  const { required, deferred } = previewNamesByPriority(s);
+  assert.deepEqual(required, ["Alpha"]);
+  assert.deepEqual(deferred, ["Beta", "BetaOff"]);
+  assert.deepEqual(renderFilterPatterns(s), ["Alpha"]);
+  // splitDeferredVariants agrees, for a caller that reaches it with a deferred component.
+  const { deferredVariants } = splitDeferredVariants(s.groups[0].components[1]);
+  assert.deepEqual(
+    deferredVariants.map((v) => v.preview),
+    ["BetaOff"],
+  );
+  // And the plan counts it, so the pre-flight reports the variant rather than only the entry.
+  const plan = deferralPlan(s);
+  assert.equal(plan.entries, 1);
+  assert.equal(plan.variants, 1);
 });
 
 test("previewNamesByPriority only defers a function nothing required points at", () => {

--- a/scripts/design-artifacts/catalog-variants.mjs
+++ b/scripts/design-artifacts/catalog-variants.mjs
@@ -98,7 +98,7 @@ function recordOutputKey(seen, image, componentId) {
 }
 
 /** A short label for a variant, for the missing-render report: its state, props and/or theme. */
-function variantLabel(variant) {
+export function variantLabel(variant) {
   const parts = [
     ...(variant.state ? [variant.state] : []),
     ...Object.entries(variant.props ?? {}).map(([k, v]) => `${k}=${v}`),

--- a/scripts/design-artifacts/catalog-variants.test.mjs
+++ b/scripts/design-artifacts/catalog-variants.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { foldVariants } from "./catalog-variants.mjs";
+import { foldVariants, variantLabel } from "./catalog-variants.mjs";
 import { renderIndexHtml } from "./render-index-html.mjs";
 
 const img = (state, theme) => ({ state, theme, uri: "x", width: 100, height: 40 });
@@ -262,4 +262,14 @@ test("a content-axis (props) variant never wins the hero and is labelled in the 
   // The chip counts it as a variant (not a "state"), and the zoom view labels the axis.
   assert.match(html, /class="statechip"[^>]*>\+1 variant</);
   assert.match(html, /<figcaption>content=icon\+label<\/figcaption>/);
+});
+
+test("variantLabel is the shared label shape both lanes report noSticker under", () => {
+  // Exported because the driver's deferred branch reports `capture: "none"` variants as noSticker
+  // too, and must produce a label indistinguishable from the one foldVariants writes here — a
+  // reader of the report shouldn't be able to tell which lane the entry took.
+  assert.equal(variantLabel({ preview: "P", state: "off" }), "off");
+  assert.equal(variantLabel({ preview: "P", state: "on", props: { size: "sm" } }), "on, size=sm");
+  assert.equal(variantLabel({ preview: "P", theme: "dark" }), "dark");
+  assert.equal(variantLabel({ preview: "P" }), "P", "falls back to the preview name");
 });

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -44,7 +44,7 @@ import {
 } from "@design-parity/candidate";
 import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 
-import { foldVariants } from "./catalog-variants.mjs";
+import { foldVariants, variantLabel } from "./catalog-variants.mjs";
 import {
   DEFERRED,
   deferralPlan,
@@ -390,20 +390,36 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       // with a PNG), so it short-circuits before the candidate lookup — reporting it missing is
       // exactly the false failure this feature exists to remove.
       if (entryPriority(specComponent) === DEFERRED) {
-        deferred.push({
-          componentId: specComponent.componentId,
-          group: group.name,
-          ...(group.section !== undefined ? { section: group.section } : {}),
-          ...(specComponent.caption !== undefined ? { caption: specComponent.caption } : {}),
-          preview: specComponent.preview,
-          reason: "entry",
-        });
+        // `"capture": "none"` outranks deferral, for both the entry and its variants below. The two
+        // axes answer different questions — deferral picks the LANE (bake now vs. render on the serve
+        // host), `capture` says the preview yields no sticker on ANY lane — so a declared-uncapturable
+        // preview has nothing for the live lane to serve either. Recording it live-only would invent
+        // a card for coverage the spec says doesn't render, and the required path already classifies
+        // the identical entry as `noSticker` (foldVariants); the two must agree.
+        if (exportsNoSticker(specComponent)) {
+          noSticker.push(specComponent.componentId);
+        } else {
+          deferred.push({
+            componentId: specComponent.componentId,
+            group: group.name,
+            ...(group.section !== undefined ? { section: group.section } : {}),
+            ...(specComponent.caption !== undefined ? { caption: specComponent.caption } : {}),
+            preview: specComponent.preview,
+            reason: "entry",
+          });
+        }
         // Its variants are deferred with it (`variantPriority` inherits), and each needs its OWN
         // record: a variant's sticker is normally folded onto the component's images, and there is no
         // `components[]` entry left to fold onto. Recording them here is what keeps them reachable on
         // the live lane instead of dropping out of the publish unnoticed — the short-circuit below
         // means nothing else in this loop will see them.
         for (const variant of specComponent.variants ?? []) {
+          if (exportsNoSticker(variant)) {
+            // Same label shape `foldVariants` uses for the required path, from the same helper, so a
+            // reader can't tell from the report which lane the entry took.
+            noSticker.push(`${specComponent.componentId} [${variantLabel(variant)}]`);
+            continue;
+          }
           deferred.push({
             componentId: specComponent.componentId,
             group: group.name,

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -398,6 +398,23 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
           preview: specComponent.preview,
           reason: "entry",
         });
+        // Its variants are deferred with it (`variantPriority` inherits), and each needs its OWN
+        // record: a variant's sticker is normally folded onto the component's images, and there is no
+        // `components[]` entry left to fold onto. Recording them here is what keeps them reachable on
+        // the live lane instead of dropping out of the publish unnoticed — the short-circuit below
+        // means nothing else in this loop will see them.
+        for (const variant of specComponent.variants ?? []) {
+          deferred.push({
+            componentId: specComponent.componentId,
+            group: group.name,
+            ...(group.section !== undefined ? { section: group.section } : {}),
+            preview: variant.preview,
+            reason: "variant",
+            ...(variant.state !== undefined ? { state: variant.state } : {}),
+            ...(variant.props !== undefined ? { props: variant.props } : {}),
+            ...(variant.theme !== undefined ? { theme: variant.theme } : {}),
+          });
+        }
         continue;
       }
       // Fold only the REQUIRED variants; each deferred one is recorded live-only instead of being


### PR DESCRIPTION
Follow-up to #2987, which landed with this gap — it was raised in review while the PR was merging, so it lands as a fresh change off `main` rather than a fixup.

## The bug

The driver short-circuits a deferred component *before* folding its variants:

```js
if (entryPriority(specComponent) === DEFERRED) { deferred.push({…}); continue; }   // ← skips variants
const { component, deferredVariants } = splitDeferredVariants(specComponent);      // ← never reached
```

A variant left at the `required` default (i.e. any variant that doesn't say otherwise) therefore fell between the two paths:

- `previewNamesByPriority` read it as required, so its `@Preview` stayed in the render filter and **CI rendered it**;
- the join never baked it, never wrote a `deferred[]` record for it, and never reported it through the completeness gate.

So the coverage disappeared with nothing red anywhere — exactly the failure mode the single-reader invariant exists to prevent, and the invariant #2987's body claims to keep. Not currently reachable in practice (no committed spec declares `priority` yet), but it would bite the first spec that defers a component with variants.

## The fix

Deferral flows down. `variantPriority(component, variant)` reads `DEFERRED` whenever the component is deferred, whatever the variant declares, and the driver emits a `deferred[]` record per variant so each stays addressable on the live lane.

Inheriting is the right reading rather than a validation error, because a variant's sticker is folded **onto** its component's images — with the component deferred there is no `components[]` entry left to fold onto, so "required variant of a deferred component" has nothing it could mean. Rejecting it would only force the author to write `priority: "deferred"` on each variant to express the thing they already said.

The useful direction is untouched: a required component with one deferred variant still folds the required ones and records the rest live-only.

Every consumer routes through the new reader — the render filter, the variant split, `specDefersAnything`, the plan counts — so the render set and the published set still agree, which is the whole point.

## Second commit: `capture: "none"` outranks deferral

From review on this PR. The deferred branch emitted a record for every entry and variant unconditionally, including ones declaring `capture: "none"` — a record that later receives a path and preview id, so the serve host would register a live-only card for coverage the spec says produces no sticker. The required path, via `foldVariants`, classifies the identical entry as `noSticker` and omits it. Two paths, two answers.

The axes answer different questions: deferral picks the **lane** (bake now vs. serve live), `capture` says the preview yields no sticker on **any** lane. So `capture` wins, and both paths now report `noSticker`. Applied to the entry-level record too, not just the variants added here — it had the same defect, and fixing one lane while leaving the other would recreate the split this closes. `variantLabel` is exported and shared rather than reimplemented, so a `noSticker` line reads identically whichever lane produced it.

## Deliberately not fixed here: #2993

Also from review — an all-deferred catalog yields an empty render filter, which the workflows read as *render everything*, so it renders exactly what it meant to skip. Real, and this PR widens it slightly, but it costs render time only (never correctness) and is unreachable until a catalog declares `priority`. Fixing it needs a prior decision — is an all-deferred catalog legal at all? — so it's filed as #2993 rather than guessed at here.

## Test plan

- `catalog-priority`, `catalog-spec`, `catalog-variants`, `deferred-preview-ids` — **93/93 pass**.
- New cases:
  - `variantPriority` inherits a deferred component (including over an explicit `priority: "required"`), and leaves a required component's variants alone in both polarities;
  - the end-to-end shape: for a deferred component with one plain variant, `previewNamesByPriority` reports `deferred: ["Beta", "BetaOff"]`, `renderFilterPatterns` returns just `["Alpha"]`, `splitDeferredVariants` folds it out, and `deferralPlan` counts 1 entry + 1 variant so the pre-flight names it;
  - `variantLabel` produces the exact label shape both lanes report `noSticker` under.

The driver's record-emission itself has no unit test — `generate-design-catalog.mjs` needs `@design-parity/*` (no `node_modules` in this container), which is why its decision logic lives in the pure modules that are tested. Same coverage split as the rest of that file; `node --check` passes on the driver.

Non-visual (export-driver logic, docs, tests), so text-only evidence is the right form here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016azcVhRhQze6Y91gMT4BeF)_