### PR TITLE
feat(plugin): skip @PreviewParameter rows by label so a provider-supplied mode axis can defer

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -321,10 +321,14 @@ jobs:
           node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/deferred-preview-ids.mjs" \
             --spec "$GITHUB_WORKSPACE/$SPEC" \
             --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
-            --out "$GITHUB_WORKSPACE/mode-filter.txt"
+            --out "$GITHUB_WORKSPACE/mode-filter.txt" \
+            --rows-out "$GITHUB_WORKSPACE/mode-filter-rows.txt"
           # Exclusion polarity: a pattern that matches nothing renders MORE, never less, so a spec
           # that has drifted ahead of the code wastes time instead of dropping a sticker.
           echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter.txt")" >> "$GITHUB_OUTPUT"
+          # A mode that carries no discovered id is a @PreviewParameter row axis: discovery never
+          # sees those rows (the renderer expands the provider), so they're skipped by LABEL instead.
+          echo "exclude-rows=$(cat "$GITHUB_WORKSPACE/mode-filter-rows.txt")" >> "$GITHUB_OUTPUT"
 
       # Stage bundled fallback fonts into fontconfig before any render, so a
       # desktop (Skiko) render resolves glyphs a preview's FontFamily doesn't
@@ -394,11 +398,13 @@ jobs:
           # both — it forwards `-PcomposePreview.idExclude` to the render and skips the same ids in
           # the daemon capture. Empty ⇒ the flag is omitted ⇒ render + capture everything.
           EXCLUDE_PREVIEW_IDS: ${{ steps.mode-filter.outputs.exclude-ids }}
+          EXCLUDE_PREVIEW_ROWS: ${{ steps.mode-filter.outputs.exclude-rows }}
         run: |
           set -euo pipefail
           run() { if [ "${{ inputs.desktop-render }}" = "true" ]; then xvfb-run -a -s "-screen 0 2000x1400x24" "$@"; else "$@"; fi; }
           embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
           exclude=(); if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS"); fi
+          if [ -n "${EXCLUDE_PREVIEW_ROWS:-}" ]; then exclude+=(--exclude-preview-row "$EXCLUDE_PREVIEW_ROWS"); fi
           run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics \
             "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" --timeout 600
 

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -309,8 +309,12 @@ jobs:
           node scripts/design-artifacts/deferred-preview-ids.mjs \
             --spec "${{ matrix.spec }}" \
             --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
-            --out "$GITHUB_WORKSPACE/mode-filter.txt"
+            --out "$GITHUB_WORKSPACE/mode-filter.txt" \
+            --rows-out "$GITHUB_WORKSPACE/mode-filter-rows.txt"
           echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter.txt")" >> "$GITHUB_OUTPUT"
+          # Modes that carry no discovered id are a @PreviewParameter row axis — skipped by label
+          # inside the render instead, since discovery never sees those rows.
+          echo "exclude-rows=$(cat "$GITHUB_WORKSPACE/mode-filter-rows.txt")" >> "$GITHUB_OUTPUT"
 
       # Published previews pin their preview-runtimes to a RELEASED version
       # (`composeaiReleasedRuntimeVersion`, bumped by release-please on each release). Sonatype →
@@ -377,6 +381,7 @@ jobs:
           # would leave that (per-preview daemon) pass at full width. Empty ⇒ flag omitted ⇒
           # everything renders, which is what every catalog here gets today.
           EXCLUDE_PREVIEW_IDS: ${{ steps.mode-filter.outputs.exclude-ids }}
+          EXCLUDE_PREVIEW_ROWS: ${{ steps.mode-filter.outputs.exclude-rows }}
         run: |
           set -euo pipefail
           # Run under a virtual framebuffer so the Skiko desktop daemon has a
@@ -388,6 +393,7 @@ jobs:
           # (gradle.properties, release-please-managed); the "Wait for released preview-runtimes"
           # step above guarantees that version is resolvable on Central before we render.
           exclude=(); if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS"); fi
+          if [ -n "${EXCLUDE_PREVIEW_ROWS:-}" ]; then exclude+=(--exclude-preview-row "$EXCLUDE_PREVIEW_ROWS"); fi
           xvfb-run -a -s "-screen 0 2000x1400x24" \
             compose-preview bundle pack --module "$MODULE" --with-semantics \
               "${exclude[@]}" -o "$GITHUB_WORKSPACE/$SYSTEM-bundle.png"

--- a/cli/completions/compose-preview.fish
+++ b/cli/completions/compose-preview.fish
@@ -7,7 +7,7 @@
 
 function __compose_preview_needs_command
     set -l cmd (commandline -opc)
-    set -l valued_flags --module --filter --id --exclude-preview-id --output --timeout \
+    set -l valued_flags --module --filter --id --exclude-preview-id --exclude-preview-row --output --timeout \
         --plugin-version --fail-on --desc --branch --remote --pr-number --message \
         --with-extension --with --project --antigravity-config --codex-config \
         --replicas-per-daemon
@@ -31,7 +31,7 @@ end
 
 function __compose_preview_command
     set -l cmd (commandline -opc)
-    set -l valued_flags --module --filter --id --exclude-preview-id --output --timeout \
+    set -l valued_flags --module --filter --id --exclude-preview-id --exclude-preview-row --output --timeout \
         --plugin-version --fail-on --desc --branch --remote --pr-number --message \
         --with-extension --with --project --antigravity-config --codex-config \
         --replicas-per-daemon
@@ -287,6 +287,9 @@ complete -c compose-preview -x -n '__compose_preview_using_bundle_sub pack' \
 complete -c compose-preview -x -n '__compose_preview_using_bundle_sub pack' \
     -l exclude-preview-id -a '(__compose_preview_bundle_pack_ids)' \
     -d 'Preview id (or glob) to skip rendering + semantics (repeatable)'
+complete -c compose-preview -x -n '__compose_preview_using_bundle_sub pack' \
+    -l exclude-preview-row \
+    -d '@PreviewParameter row label (or glob) to skip rendering (repeatable)'
 complete -c compose-preview -F -n '__compose_preview_using_bundle_sub pack' \
     -l output -s o -d 'Output .png polyglot path'
 complete -c compose-preview -f -n '__compose_preview_using_bundle_sub pack' \

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -441,6 +441,22 @@ private class PackSubcommand(private val args: List<String>) {
             outDir.mkdirs()
 
             val sharedArgs = buildList {
+              // The render filters ride the shared render too, not just the single-sheet path
+              // above:
+              // `--per-preview` runs `composePreviewRender` once and packs each result, so leaving
+              // them off here would accept the flags and then render every excluded preview/row
+              // anyway. `--id` still selects which previews get *packed*; these thin what is
+              // *drawn*.
+              if (excludePreviewIds.isNotEmpty())
+                add(
+                  "-P${PackPreviewIdExclusions.GRADLE_PROPERTY}=" +
+                    excludePreviewIds.joinToString(",")
+                )
+              if (excludePreviewRows.isNotEmpty())
+                add(
+                  "-P${PackPreviewIdExclusions.ROW_GRADLE_PROPERTY}=" +
+                    excludePreviewRows.joinToString(",")
+                )
               if (embedDeps) add("-PbundleEmbedDeps=true")
               if (includeDataExtensions) add("-PbundleIncludeDataExtensions=true")
             }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -138,6 +138,15 @@ class BundleCommand(args: List<String>) : Command(args) {
                             -PcomposePreview.idExclude; also read from the
                             ORG_GRADLE_PROJECT_composePreview.idExclude env var when the flag is
                             absent, so an env-only setup thins the semantics pass too.
+        --exclude-preview-row <label|glob>
+                            Skip rendering the @PreviewParameter rows whose label matches — the fan-out
+                            --exclude-preview-id can't reach, because discovery never sees the rows
+                            (they exist only once the renderer enumerates the provider). Repeatable
+                            and comma-separated; an exact label or a '*'/'?' glob, case-insensitive,
+                            matched against the label in <stem>_<label>.png. Never empties a preview's
+                            rows. Forwarded as -PcomposePreview.rowExclude; also read from
+                            ORG_GRADLE_PROJECT_composePreview.rowExclude when the flag is absent.
+                            Desktop render path only (see issue #2977).
         --per-preview       Emit one valid single-preview bundle per preview (<out-dir>/<id>.png)
                             instead of a single sheet — the addressable-preview unit, each openable /
                             re-renderable on its own. Renders once, then packs each (minimized to its
@@ -233,6 +242,13 @@ private class PackSubcommand(private val args: List<String>) {
    */
   private val excludePreviewIds: List<String> = PackPreviewIdExclusions.fromArgs(args)
 
+  /**
+   * `--exclude-preview-row` labels — the `@PreviewParameter` rows this pack must not render. Render
+   * only: the semantics capture is per preview, so a parameterized preview costs one capture
+   * whatever its provider fans out to and there is nothing to thin there.
+   */
+  private val excludePreviewRows: List<String> = PackPreviewIdExclusions.rowsFromArgs(args)
+
   fun run() {
     if (perPreview) {
       runPerPreview()
@@ -276,6 +292,14 @@ private class PackSubcommand(private val args: List<String>) {
                 add(
                   "-P${PackPreviewIdExclusions.GRADLE_PROPERTY}=" +
                     excludePreviewIds.joinToString(",")
+                )
+              // Same for the `@PreviewParameter` row axis, which the render resolves one level
+              // deeper
+              // (the labels don't exist until the provider is enumerated inside the render JVM).
+              if (excludePreviewRows.isNotEmpty())
+                add(
+                  "-P${PackPreviewIdExclusions.ROW_GRADLE_PROPERTY}=" +
+                    excludePreviewRows.joinToString(",")
                 )
               if (embedDeps) add("-PbundleEmbedDeps=true")
               if (includeDataExtensions) add("-PbundleIncludeDataExtensions=true")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -31,6 +31,7 @@ internal object CliFlags {
       "--filter",
       "--id",
       "--exclude-preview-id",
+      "--exclude-preview-row",
       "--output",
       "--timeout",
       "--plugin-version",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
@@ -37,9 +37,34 @@ internal object PackPreviewIdExclusions {
    * paying for the full semantics pass. An explicit flag wins outright rather than merging, so a
    * command line can narrow an inherited environment.
    */
-  fun fromArgs(args: List<String>, env: (String) -> String? = System::getenv): List<String> {
-    val flagValues = args.flagValuesAll("--exclude-preview-id")
-    val raw = if (flagValues.isNotEmpty()) flagValues else listOfNotNull(env(ENV_VAR))
+  fun fromArgs(args: List<String>, env: (String) -> String? = System::getenv): List<String> =
+    patternsFor(args, "--exclude-preview-id", ENV_VAR, env)
+
+  /** The Gradle property carrying `@PreviewParameter` **row** label exclusions. */
+  const val ROW_GRADLE_PROPERTY = "composePreview.rowExclude"
+
+  /** Env form of [ROW_GRADLE_PROPERTY]. */
+  const val ROW_ENV_VAR = "ORG_GRADLE_PROJECT_$ROW_GRADLE_PROPERTY"
+
+  /**
+   * `--exclude-preview-row` labels, same flag-then-env resolution as [fromArgs].
+   *
+   * These are forwarded to the render and nowhere else: unlike an id exclusion, a row exclusion
+   * needs no matching skip in the semantics pass, because that capture is driven per *preview* over
+   * the daemon — a parameterized preview yields one capture whatever its provider fans out to, so
+   * there is no per-row cost there to save.
+   */
+  fun rowsFromArgs(args: List<String>, env: (String) -> String? = System::getenv): List<String> =
+    patternsFor(args, "--exclude-preview-row", ROW_ENV_VAR, env)
+
+  private fun patternsFor(
+    args: List<String>,
+    flag: String,
+    envVar: String,
+    env: (String) -> String?,
+  ): List<String> {
+    val flagValues = args.flagValuesAll(flag)
+    val raw = if (flagValues.isNotEmpty()) flagValues else listOfNotNull(env(envVar))
     return raw.flatMap { it.split(',') }.map { it.trim() }.filter { it.isNotEmpty() }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
@@ -55,6 +55,32 @@ class PackPreviewIdExclusionsTest {
     assertEquals("ORG_GRADLE_PROJECT_composePreview.idExclude", PackPreviewIdExclusions.ENV_VAR)
   }
 
+  @Test
+  fun `row labels come from their own flag and env var`() {
+    val args =
+      listOf("--exclude-preview-row", "Dark, ExtraDark", "--exclude-preview-id", "Foo_Dark")
+    assertEquals(listOf("Dark", "ExtraDark"), PackPreviewIdExclusions.rowsFromArgs(args, noEnv))
+    // The two axes are independent: an id pattern never lands in the row list, or a pack would skip
+    // rows it was only asked to skip whole previews for.
+    assertEquals(listOf("Foo_Dark"), PackPreviewIdExclusions.fromArgs(args, noEnv))
+  }
+
+  @Test
+  fun `row labels fall back to the row env var only`() {
+    val env = { name: String ->
+      when (name) {
+        PackPreviewIdExclusions.ROW_ENV_VAR -> "Dark"
+        PackPreviewIdExclusions.ENV_VAR -> "Foo_Dark"
+        else -> null
+      }
+    }
+    assertEquals(listOf("Dark"), PackPreviewIdExclusions.rowsFromArgs(listOf("pack"), env))
+    assertEquals(
+      "ORG_GRADLE_PROJECT_composePreview.rowExclude",
+      PackPreviewIdExclusions.ROW_ENV_VAR,
+    )
+  }
+
   private val ids = listOf("Foo_Light", "Foo_Dark", "FooLarge_Dark", "Bar_Light")
 
   @Test

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -413,14 +413,22 @@ Caveats worth knowing before reaching for it:
   function whose *every* discovered id resolves to a deferred mode keeps all of them
   (and says so in the log), so a bad `modePriority` surfaces as a gate failure rather
   than as a component silently rendered away.
-- **Two shapes get the publish saving but not the render saving** (both still correct, just
-  not cheaper to build). A mode axis supplied by a **`@PreviewParameter` provider** has no
-  per-row id to skip: discovery emits one entry for the parameterized function and the
-  renderer expands the rows itself. And an **Android/Robolectric** catalog
-  (`design-catalog-wear-m3`, `design-catalog-remote-m3`) renders through a `Test` task that
-  reads the manifest directly and honours neither the id filter nor `--preview` — the same
-  backend gap #2066 left open for the name filter. The `--with-semantics` saving *does* land
-  there, since the CLI drives that pass. Wiring the Robolectric path is the follow-up.
+- **A `@PreviewParameter` mode axis is skipped by label, not by id.** When the palettes come
+  from a provider rather than a multipreview, discovery emits ONE entry for the parameterized
+  function — it reads bytecode and can't instantiate the provider — and the rows only exist
+  once the renderer enumerates them. So there is no id to exclude, and the derivation emits
+  the deferred **mode names** instead (`--rows-out` → `bundle pack --exclude-preview-row` →
+  `-PcomposePreview.rowExclude`), which the renderer matches case-insensitively against the
+  label it puts in `<stem>_<label>.png`. A mode that *does* appear in an id stays with the id
+  filter, which is exact; only modes with no id become labels. Because labels are matched
+  module-wide, an unrelated parameterized preview whose row is labelled like a deferred mode
+  loses that row — the completeness gate then fails the publish for that component, which is
+  the loud outcome, and the renderer never empties a preview's rows.
+- **An Android/Robolectric catalog gets the publish saving but not the render saving**
+  (`design-catalog-wear-m3`, `design-catalog-remote-m3`): that `composePreviewRender` is a
+  `Test` task reading the manifest directly and honours none of these filters — the same
+  backend gap #2066 left open for the name filter, tracked in #2977. The `--with-semantics`
+  saving *does* land there, since the CLI drives that pass.
 - **A skipped render is still declared.** Deferred previews stay listed in the bundle's
   `previews.json` — the bundle task carries every selected preview and simply omits the
   PNG for one that didn't render — which is what keeps them addressable on the serve

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -419,11 +419,13 @@ Caveats worth knowing before reaching for it:
   once the renderer enumerates them. So there is no id to exclude, and the derivation emits
   the deferred **mode names** instead (`--rows-out` → `bundle pack --exclude-preview-row` →
   `-PcomposePreview.rowExclude`), which the renderer matches case-insensitively against the
-  label it puts in `<stem>_<label>.png`. A mode that *does* appear in an id stays with the id
-  filter, which is exact; only modes with no id become labels. Because labels are matched
-  module-wide, an unrelated parameterized preview whose row is labelled like a deferred mode
-  loses that row — the completeness gate then fails the publish for that component, which is
-  the loud outcome, and the renderer never empties a preview's rows.
+  label it puts in `<stem>_<label>.png`. The choice is made **per function**: a deferred mode
+  becomes a label when some spec-referenced *parameterized* function has no id carrying it, so
+  a catalog whose modes are all visible as ids gets no labels at all, while a mixed one still
+  gets the label its provider-backed component needs. Because labels are then matched
+  module-wide inside the render, an unrelated parameterized preview whose row is labelled like
+  a deferred mode loses that row — the completeness gate then fails the publish for that
+  component, which is the loud outcome, and the renderer never empties a preview's rows.
 - **An Android/Robolectric catalog gets the publish saving but not the render saving**
   (`design-catalog-wear-m3`, `design-catalog-remote-m3`): that `composePreviewRender` is a
   `Test` task reading the manifest directly and honours none of these filters — the same

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -261,6 +261,10 @@ internal object ComposePreviewTasks {
         // #2966); the repeatable `--preview-id` CLI option overrides it.
         previewIdFilters.convention(previewIdFilterProperty(project))
         previewIdExcludes.convention(previewIdExcludeProperty(project))
+        // `composePreview.rowExclude` — the `@PreviewParameter` row axis, forwarded to the render
+        // subprocess as a system property since the rows only exist once the provider is
+        // enumerated.
+        previewRowExcludes.convention(previewRowExcludeProperty(project))
         displayFilterFilters.set(AndroidPreviewSupport.resolveDisplayFilterFilters(project))
         deviceFrameDevice.set(AndroidPreviewSupport.resolveDeviceFrameDevice(project))
         renderClasspath.from(sourceClassDirs)
@@ -1332,6 +1336,23 @@ internal object ComposePreviewTasks {
   internal fun previewIdExcludeProperty(project: Project): Provider<List<String>> =
     project.providers
       .gradleProperty("composePreview.idExclude")
+      .map { v -> v.split(",").map(String::trim).filter(String::isNotEmpty) }
+      .orElse(emptyList())
+
+  /**
+   * `Provider<List<String>>` for the `composePreview.rowExclude` Gradle property — the
+   * `--exclude-preview-row` form, which skips `@PreviewParameter` rows by **label**.
+   *
+   * The axis the id filters can't express: discovery never sees the rows (it can't instantiate a
+   * provider), so a catalog whose palettes come from a `@PreviewParameter` provider had no way to
+   * stop rendering the ones it defers. Set by the design-artifacts pipeline as
+   * `ORG_GRADLE_PROJECT_composePreview.rowExclude`, so it reaches `composePreviewRender` through
+   * `bundle pack` with no CLI flag — on a desktop module. Inert on an Android render for the reason
+   * given on [previewIdFilterProperty].
+   */
+  internal fun previewRowExcludeProperty(project: Project): Provider<List<String>> =
+    project.providers
+      .gradleProperty("composePreview.rowExclude")
       .map { v -> v.split(",").map(String::trim).filter(String::isNotEmpty) }
       .orElse(emptyList())
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -138,6 +138,40 @@ abstract class RenderPreviewsTask : DefaultTask() {
   }
 
   /**
+   * `@PreviewParameter` **row** exclusions, by label — the one fan-out the id filters above cannot
+   * reach.
+   *
+   * Discovery emits ONE `PreviewInfo` per parameterized function (it reads bytecode, so it can't
+   * instantiate a provider to learn the values), and the rows only exist once the renderer has
+   * enumerated them and `PreviewParameterLabels` has named each `<stem>_<label>.png`. So no id
+   * pattern can name a row — which is why a design system whose theme axis is a `@PreviewParameter`
+   * provider (nine palettes on one provider, the shape behind #2966's measurement) still rendered
+   * every palette after `--exclude-preview-id` landed.
+   *
+   * Forwarded to the render subprocess as `composeai.preview.rowExclude` and applied by
+   * `PreviewRowFilter`: exclusion polarity like the id filter, matched case-insensitively (a label
+   * is user data — `"Dark"` — while the pattern is usually a spec's own spelling, `"dark"`), and
+   * never allowed to empty a preview's row set. Empty (the default) renders every row.
+   *
+   * Desktop-only, like the filters above (see [previewIdFilters]); the Android/Robolectric renderer
+   * expands its own rows and reads none of these — issue #2977.
+   */
+  @get:Input abstract val previewRowExcludes: ListProperty<String>
+
+  /** Backs the repeatable `--exclude-preview-row` CLI option; overrides the property convention. */
+  @Option(
+    option = "exclude-preview-row",
+    description =
+      "Skip @PreviewParameter rows whose label matches this pattern (repeatable; '*'/'?' globs or " +
+        "an exact label, case-insensitive), rendering the rest. Addresses one row of a " +
+        "parameterized preview, which --exclude-preview-id cannot. Never empties a preview's rows. " +
+        "Overrides -PcomposePreview.rowExclude.",
+  )
+  fun setPreviewRowExcludeOption(values: List<String>) {
+    previewRowExcludes.set(values)
+  }
+
+  /**
    * Render-tier filter. When `"fast"` the desktop path skips any preview whose representative
    * capture is heavier than [HEAVY_COST_THRESHOLD] (TOP / static stay in; LONG / GIF / animated
    * fall out). Default `"full"` keeps the historical behaviour (every preview rendered).
@@ -200,6 +234,9 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // registration with the `composePreview.idFilter` property; `--preview-id` overrides both.
     previewIdFilters.convention(emptyList())
     previewIdExcludes.convention(emptyList())
+    // And one axis further down again: empty = "render every row of every parameterized preview".
+    // Overridden at registration with `composePreview.rowExclude`; `--exclude-preview-row` wins.
+    previewRowExcludes.convention(emptyList())
     // Caching is intentionally gated on `tier=full` AND an empty `--preview` filter — a run is only
     // cacheable when its `outputDir` is the module's *complete* render set. A `tier=fast` run
     // writes
@@ -220,11 +257,14 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // would let a one-palette catalog render be stored and later restored as if it were the
     // module's
     // complete set.
+    // A row exclusion is the same kind of partial one level finer: the excluded rows' PNGs stay on
+    // disk from whatever ran last, so `outputDir` again isn't this module's complete render set.
     outputs.cacheIf("composePreviewRender caches full, unfiltered runs only") {
       tier.get().equals("full", ignoreCase = true) &&
         previewFilters.getOrElse(emptyList()).none { it.isNotBlank() } &&
         previewIdFilters.getOrElse(emptyList()).none { it.isNotBlank() } &&
-        previewIdExcludes.getOrElse(emptyList()).none { it.isNotBlank() }
+        previewIdExcludes.getOrElse(emptyList()).none { it.isNotBlank() } &&
+        previewRowExcludes.getOrElse(emptyList()).none { it.isNotBlank() }
     }
   }
 
@@ -450,6 +490,20 @@ abstract class RenderPreviewsTask : DefaultTask() {
       // composite the render into a device-art bezel (reading the cache the task action filled).
       // Empty string disables it (DeviceFrameConfig treats blank as "off").
       systemProperty("composeai.deviceframe.device", deviceFrameDevice.get())
+      // Forward the `@PreviewParameter` row exclusions so `PreviewRowFilter` can drop fan-out
+      // members
+      // by label — the rows don't exist until the subprocess has enumerated the provider, so this
+      // is
+      // the only place the filter can be applied. Set only when non-empty, keeping the render JVM's
+      // command line (and therefore every unfiltered run's inputs) exactly as it was.
+      previewRowExcludes
+        .getOrElse(emptyList())
+        .filter { it.isNotBlank() }
+        .let { rows ->
+          if (rows.isNotEmpty()) {
+            systemProperty("composeai.preview.rowExclude", rows.joinToString(","))
+          }
+        }
       if (deviceFrameDevice.get().isNotBlank()) {
         systemProperty(
           "composeai.deviceframe.cacheDir",

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -324,24 +324,50 @@ fun main(args: Array<String>) {
       return
     }
 
-  val suffixes: List<String> =
+  val allSuffixes: List<String> =
     if (values.size == 1 && values[0] === NO_PARAM) {
       listOf("")
     } else {
       PreviewParameterLabels.suffixesFor(values)
     }
-  val targetFiles = values.mapIndexed { idx, value ->
+  val allTargetFiles = values.mapIndexed { idx, value ->
     if (value === NO_PARAM) outputFile
-    else File(insertBeforeExtension(outputFile.path, suffixes[idx]))
+    else File(insertBeforeExtension(outputFile.path, allSuffixes[idx]))
   }
+  // Row filter (`--exclude-preview-row`, issue #2966 follow-up): drop the fan-out members the
+  // caller
+  // named by label. Applied AFTER labelling — the labels are the only handle on a row, and they
+  // don't
+  // exist until the provider has been enumerated, which is why this can't live in the id filters
+  // upstream. Kept out of `deleteStaleFanoutFiles` below on purpose: a skipped row's PNG from a
+  // prior
+  // full run stays on disk, exactly like a preview the id filter skipped, so an interactive panel
+  // still shows the (stale-badged) image instead of a hole.
+  val keptRows = PreviewRowFilter.keptRows(allSuffixes, PreviewRowFilter.patterns())
+  if (keptRows.size < allSuffixes.size) {
+    val skipped =
+      allSuffixes.filterIndexed { idx, _ -> idx !in keptRows }.map { it.removePrefix("_") }
+    System.err.println(
+      "@PreviewParameter on $functionName: skipping ${skipped.size} of ${allSuffixes.size} row(s) " +
+        "excluded by ${PreviewRowFilter.PROPERTY}: ${skipped.joinToString(", ")}"
+    )
+  }
+  val targetFiles = keptRows.map { allTargetFiles[it] }
+  val keptValues = keptRows.map { values[it] }
   // Renderer is authoritative about the fan-out — delete any
   // `<stem>_*<ext>` files from prior runs that aren't in this run's
   // expected output. Guards against provider renames and the
   // `_PARAM_<idx>` → `_<label>` migration leaving stale PNGs behind.
+  //
+  // Deliberately keyed on ALL of this run's rows, not just the kept ones: a row the filter skipped
+  // is
+  // still a row the current provider yields, so its previous PNG is stale-but-valid (badged in the
+  // panel), not orphaned. Passing the kept subset here would delete exactly the images the filter
+  // exists to avoid re-rendering.
   if (values.any { it !== NO_PARAM }) {
-    deleteStaleFanoutFiles(outputFile, targetFiles.map { it.name }.toSet(), fanoutSiblingStems)
+    deleteStaleFanoutFiles(outputFile, allTargetFiles.map { it.name }.toSet(), fanoutSiblingStems)
   }
-  for ((idx, value) in values.withIndex()) {
+  for ((idx, value) in keptValues.withIndex()) {
     val targetFile = targetFiles[idx]
     val previewArgs = if (value === NO_PARAM) emptyList() else listOf(value)
     // Per-value try/catch — the user-facing pain we're addressing is "one

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRowFilter.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRowFilter.kt
@@ -1,0 +1,91 @@
+package ee.schimke.composeai.renderer
+
+/**
+ * Skips individual `@PreviewParameter` **rows** of one preview, from the
+ * `composeai.preview.rowExclude` system property the Gradle plugin forwards (`composePreviewRender
+ * --exclude-preview-row` / `-PcomposePreview.rowExclude`).
+ *
+ * Why this exists as its own axis rather than reusing the id filters (#2966): discovery emits ONE
+ * `PreviewInfo` per parameterized function — it reads bytecode and can't instantiate a provider —
+ * and the rows only come into existence here, when [PreviewParameterLabels] labels the values this
+ * renderer just enumerated. So no id-level filter upstream can name a row, and a design system
+ * whose theme axis is a `@PreviewParameter` provider (the shape that motivated #2966's measurement:
+ * nine palettes on one provider) had no way to stop rendering the palettes it defers. A row is
+ * addressed by its **label** — the same token that ends up in `<stem>_<label>.png`, so what a
+ * caller reads off disk is what they exclude.
+ *
+ * Matching, per pattern: an anchored `*`/`?` glob when the pattern carries one, else equality.
+ * **Case-insensitive** either way, deliberately and unlike the id filters: a label comes from user
+ * data (a provider value's `name`/`toString()`, so `"Dark"`) while the pattern is usually a design
+ * spec's own spelling of the same axis (`"dark"`), and nothing reconciles the two.
+ * Case-insensitivity can only ever widen an *exclusion*, and [keptRows]' never-empty rule bounds
+ * what that can cost.
+ */
+internal object PreviewRowFilter {
+
+  /**
+   * System property the plugin forwards; comma-separated, blank/absent means "render every row".
+   */
+  const val PROPERTY = "composeai.preview.rowExclude"
+
+  /** Patterns from [PROPERTY] (or [raw] in tests), trimmed with blanks dropped. */
+  fun patterns(raw: String? = System.getProperty(PROPERTY)): List<String> =
+    raw?.split(',')?.map(String::trim)?.filter(String::isNotEmpty) ?: emptyList()
+
+  /**
+   * The indices of [suffixes] to render, in order.
+   *
+   * [suffixes] are [PreviewParameterLabels.suffixesFor]'s output — `"_Dark"`, or `"_PARAM_3"` for a
+   * value that couldn't be labelled — and the leading `_` is stripped before matching, so a caller
+   * writes `--exclude-preview-row Dark`, matching the filename they see.
+   *
+   * Two rules keep this from ever costing coverage silently:
+   * - a preview with no fan-out (the single `""` suffix) is never filtered — it has no rows, so a
+   *   row pattern must not be able to delete its only render;
+   * - if every row matches, none is skipped. A preview that rendered nothing at all would publish
+   *   as a component with no pixels, which is a misconfigured exclusion rather than a deferral —
+   *   the same never-empty rule the design-catalog derivation applies one level up.
+   */
+  fun keptRows(suffixes: List<String>, patterns: List<String>): List<Int> {
+    val all = suffixes.indices.toList()
+    if (patterns.isEmpty()) return all
+    if (suffixes.size == 1 && suffixes[0].isEmpty()) return all
+    val kept = all.filterNot { matchesAny(suffixes[it].removePrefix("_"), patterns) }
+    return if (kept.isEmpty()) all else kept
+  }
+
+  private fun matchesAny(label: String, patterns: List<String>): Boolean = patterns.any { pattern ->
+    if (pattern.any { it == '*' || it == '?' }) globToRegex(pattern).matches(label)
+    else label.equals(pattern, ignoreCase = true)
+  }
+
+  /**
+   * Anchored, case-insensitive regex for a `*`/`?` glob. Literal runs go through [Regex.escape] so
+   * a metacharacter in a label or pattern can't leak into the expression.
+   */
+  private fun globToRegex(glob: String): Regex {
+    val out = StringBuilder()
+    val literal = StringBuilder()
+    fun flushLiteral() {
+      if (literal.isNotEmpty()) {
+        out.append(Regex.escape(literal.toString()))
+        literal.clear()
+      }
+    }
+    for (c in glob) {
+      when (c) {
+        '*' -> {
+          flushLiteral()
+          out.append(".*")
+        }
+        '?' -> {
+          flushLiteral()
+          out.append(".")
+        }
+        else -> literal.append(c)
+      }
+    }
+    flushLiteral()
+    return Regex(out.toString(), RegexOption.IGNORE_CASE)
+  }
+}

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewRowFilterTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewRowFilterTest.kt
@@ -1,0 +1,79 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreviewRowFilterTest {
+
+  /** What `PreviewParameterLabels.suffixesFor` hands the render loop for a four-value provider. */
+  private val rows = listOf("_Amber", "_Crimson", "_Teal", "_Violet")
+
+  @Test
+  fun `no patterns keeps every row`() {
+    assertEquals(listOf(0, 1, 2, 3), PreviewRowFilter.keptRows(rows, emptyList()))
+  }
+
+  @Test
+  fun `an exact label drops that row`() {
+    assertEquals(listOf(0, 2, 3), PreviewRowFilter.keptRows(rows, listOf("Crimson")))
+  }
+
+  @Test
+  fun `the leading underscore is not part of the label`() {
+    // A caller writes what they read off the filename (`Foo_Crimson.png` → `Crimson`).
+    assertEquals(rows.indices.toList(), PreviewRowFilter.keptRows(rows, listOf("_Crimson")))
+  }
+
+  @Test
+  fun `labels match case-insensitively`() {
+    // The motivating case: a spec says `modePriority: { dark: deferred }` while the provider value
+    // labels itself `Dark`.
+    assertEquals(listOf(0, 1, 3), PreviewRowFilter.keptRows(rows, listOf("teal")))
+  }
+
+  @Test
+  fun `a glob drops a family of rows`() {
+    assertEquals(listOf(1, 3), PreviewRowFilter.keptRows(rows, listOf("?ea*", "Amber")))
+  }
+
+  @Test
+  fun `a glob is anchored and case-insensitive`() {
+    assertEquals(rows.indices.toList(), PreviewRowFilter.keptRows(rows, listOf("mber")))
+    assertEquals(listOf(1, 2, 3), PreviewRowFilter.keptRows(rows, listOf("amb*")))
+  }
+
+  @Test
+  fun `a pattern matching nothing keeps every row`() {
+    // Exclusion polarity: a stale label renders too much, never too little.
+    assertEquals(rows.indices.toList(), PreviewRowFilter.keptRows(rows, listOf("Chartreuse")))
+  }
+
+  @Test
+  fun `excluding every row keeps them all`() {
+    // A preview that rendered nothing would publish as a component with no pixels — a misconfigured
+    // exclusion, not a deferral. Same never-empty rule the catalog derivation applies upstream.
+    assertEquals(rows.indices.toList(), PreviewRowFilter.keptRows(rows, listOf("*")))
+  }
+
+  @Test
+  fun `a preview with no fan-out is never filtered`() {
+    // The single empty suffix means "not parameterized": it has no rows, so a row pattern must not
+    // be
+    // able to delete its only render.
+    assertEquals(listOf(0), PreviewRowFilter.keptRows(listOf(""), listOf("*")))
+    assertEquals(listOf(0), PreviewRowFilter.keptRows(listOf(""), listOf("Dark")))
+  }
+
+  @Test
+  fun `unlabelled rows are addressable by their PARAM index form`() {
+    val indexed = listOf("_PARAM_0", "_PARAM_1")
+    assertEquals(listOf(0), PreviewRowFilter.keptRows(indexed, listOf("PARAM_1")))
+  }
+
+  @Test
+  fun `patterns are split on commas with blanks dropped`() {
+    assertEquals(listOf("Dark", "Extra_Dark"), PreviewRowFilter.patterns(" Dark, Extra_Dark ,, "))
+    assertEquals(emptyList<String>(), PreviewRowFilter.patterns(null))
+    assertEquals(emptyList<String>(), PreviewRowFilter.patterns(""))
+  }
+}

--- a/scripts/design-artifacts/deferred-preview-ids.mjs
+++ b/scripts/design-artifacts/deferred-preview-ids.mjs
@@ -71,6 +71,10 @@ export function deferredPreviewIds(spec, previews) {
   const referenced = specPreviewFunctions(spec);
   const modes = spec?.modes ?? [];
   const byFunction = new Map();
+  // Per referenced function: the ids it produced, and whether any of them is a `@PreviewParameter`
+  // preview — the row axis is decided per function, so a module-wide view would answer the wrong
+  // question (see [deferredRowLabels]).
+  const parameterized = new Set();
   for (const preview of previews ?? []) {
     const id = preview?.id;
     if (typeof id !== "string" || id.length === 0) continue;
@@ -79,7 +83,12 @@ export function deferredPreviewIds(spec, previews) {
     const list = byFunction.get(fn) ?? [];
     list.push(id);
     byFunction.set(fn, list);
+    if (previewParameterProvider(preview)) parameterized.add(fn);
   }
+  // A payload that carries no `params` at all (an older/brief listing) can't answer "is this
+  // parameterized?", so fall back to treating every referenced function as a candidate — the same
+  // exclusion polarity as everywhere else: a label that matches no row costs nothing.
+  const providerFieldAvailable = (previews ?? []).some((p) => p?.params !== undefined);
 
   const ids = new Set();
   const keptByGuard = [];
@@ -96,7 +105,7 @@ export function deferredPreviewIds(spec, previews) {
   }
   return {
     ids: [...ids].sort(),
-    rows: deferredRowLabels(spec, byFunction),
+    rows: deferredRowLabels(spec, byFunction, parameterized, providerFieldAvailable),
     keptByGuard: keptByGuard.sort(),
   };
 }
@@ -109,28 +118,51 @@ export function deferredPreviewIds(spec, previews) {
  * preview per function and the rows only exist inside the render — so a deferred mode leaves no
  * trace in [previews] to exclude by id, and `deferredPreviewIds` above finds nothing to skip. What it
  * *can* do is say which modes are deferred and let the renderer match them against the labels it
- * mints. Hence the selection rule: a deferred mode is emitted as a row label exactly when **no
- * discovered id carries it** — if the mode is visible as an id, the id filter already handles it
- * precisely and a module-wide label pattern would only add risk.
+ * mints.
  *
- * Two things bound that risk, which is real (labels are module-wide, so an unrelated parameterized
- * preview whose row happens to be labelled `Dark` would lose that row):
+ * The selection rule is **per function**, not per module: a deferred mode is emitted when some
+ * spec-referenced *parameterized* function has no discovered id carrying it. A module-wide "is this
+ * mode visible as an id anywhere?" test looks equivalent and isn't — in a mixed catalog where `A`
+ * fans out as `A_Light`/`A_Dark` while `B` gets its palettes from a provider, `dark` is visible on
+ * `A`, and suppressing the label on that basis would leave `B`'s Dark row rendering, which is exactly
+ * the cost this exists to remove. Conversely a function that IS covered by ids needs no label, and a
+ * catalog with no parameterized function at all gets none — the id filter is exact, so the wider tool
+ * is only reached for when it's the only one that fits.
+ *
+ * The residual risk is real but bounded: labels are matched module-wide inside the render, so an
+ * unrelated parameterized preview whose row happens to be labelled `Dark` loses that row. Then —
  *  - the renderer never empties a preview's row set, so nothing can render to zero pixels;
- *  - a row that *was* needed goes missing from a component the spec didn't defer, and the
- *    completeness gate fails the publish — loudly, rather than thinning the sheet in silence.
+ *  - the missing row belongs to a component the spec did NOT defer, so the completeness gate fails
+ *    the publish — loudly, rather than thinning the sheet in silence.
+ *
+ * @param parameterized function names known to carry a `@PreviewParameter` provider.
+ * @param providerFieldAvailable false when the payload carries no `params` at all (an older or brief
+ *   listing), in which case every referenced function is treated as a candidate rather than none —
+ *   the same exclusion polarity as everywhere else, since a label matching no row costs nothing.
  */
-function deferredRowLabels(spec, byFunction) {
+function deferredRowLabels(spec, byFunction, parameterized, providerFieldAvailable) {
   const modes = (spec?.modes ?? []).filter((m) => typeof m === "string" && m.length > 0);
-  const seenAsId = new Set();
-  for (const fnIds of byFunction.values()) {
-    for (const id of fnIds) {
-      const mode = modeOfPreviewId(id, modes);
-      if (mode) seenAsId.add(mode);
-    }
-  }
-  return modes
-    .filter((mode) => modePriority(spec, mode) === DEFERRED && !seenAsId.has(mode))
+  const deferredModes = modes.filter((mode) => modePriority(spec, mode) === DEFERRED);
+  if (deferredModes.length === 0) return [];
+
+  const candidates = [...byFunction.entries()].filter(
+    ([fn]) => !providerFieldAvailable || parameterized.has(fn),
+  );
+  return deferredModes
+    .filter((mode) =>
+      candidates.some(([, fnIds]) => !fnIds.some((id) => modeOfPreviewId(id, modes) === mode)),
+    )
     .sort();
+}
+
+/**
+ * The `@PreviewParameter` provider class a discovered preview declares, or null. Lives on
+ * `params.previewParameterProviderClassName` in both payload shapes this module accepts
+ * (`compose-preview list --json` and a module's `previews.json`).
+ */
+function previewParameterProvider(preview) {
+  const fqn = preview?.params?.previewParameterProviderClassName;
+  return typeof fqn === "string" && fqn.length > 0 ? fqn : null;
 }
 
 /**

--- a/scripts/design-artifacts/deferred-preview-ids.mjs
+++ b/scripts/design-artifacts/deferred-preview-ids.mjs
@@ -61,9 +61,11 @@ export function specPreviewFunctions(spec) {
  * @param {object} spec parsed `catalog.spec.json`.
  * @param {Array<{id: string, functionName?: string}>} previews discovered previews (from
  *   `compose-preview list --json`, or a `previews.json` manifest — both carry `id` + `functionName`).
- * @returns {{ ids: string[], keptByGuard: string[] }} `ids` sorted and unique; `keptByGuard` names
- *   the functions whose every id was mode-deferred and which were therefore left alone, so the caller
- *   can log the (spec-level) misconfiguration instead of hiding it behind a smaller render.
+ * @returns {{ ids: string[], rows: string[], keptByGuard: string[] }} `ids` sorted and unique;
+ *   `rows` the deferred mode names to skip as `@PreviewParameter` row labels (see [deferredRowLabels]);
+ *   `keptByGuard` names the functions whose every id was mode-deferred and which were therefore left
+ *   alone, so the caller can log the (spec-level) misconfiguration instead of hiding it behind a
+ *   smaller render.
  */
 export function deferredPreviewIds(spec, previews) {
   const referenced = specPreviewFunctions(spec);
@@ -92,7 +94,43 @@ export function deferredPreviewIds(spec, previews) {
     }
     for (const id of deferredIds) ids.add(id);
   }
-  return { ids: [...ids].sort(), keptByGuard: keptByGuard.sort() };
+  return {
+    ids: [...ids].sort(),
+    rows: deferredRowLabels(spec, byFunction),
+    keptByGuard: keptByGuard.sort(),
+  };
+}
+
+/**
+ * The deferred modes to hand the render as `@PreviewParameter` **row labels**
+ * (`--exclude-preview-row`), for the axis no id can name.
+ *
+ * When a catalog's palettes come from a provider rather than a multipreview, discovery emits ONE
+ * preview per function and the rows only exist inside the render — so a deferred mode leaves no
+ * trace in [previews] to exclude by id, and `deferredPreviewIds` above finds nothing to skip. What it
+ * *can* do is say which modes are deferred and let the renderer match them against the labels it
+ * mints. Hence the selection rule: a deferred mode is emitted as a row label exactly when **no
+ * discovered id carries it** — if the mode is visible as an id, the id filter already handles it
+ * precisely and a module-wide label pattern would only add risk.
+ *
+ * Two things bound that risk, which is real (labels are module-wide, so an unrelated parameterized
+ * preview whose row happens to be labelled `Dark` would lose that row):
+ *  - the renderer never empties a preview's row set, so nothing can render to zero pixels;
+ *  - a row that *was* needed goes missing from a component the spec didn't defer, and the
+ *    completeness gate fails the publish — loudly, rather than thinning the sheet in silence.
+ */
+function deferredRowLabels(spec, byFunction) {
+  const modes = (spec?.modes ?? []).filter((m) => typeof m === "string" && m.length > 0);
+  const seenAsId = new Set();
+  for (const fnIds of byFunction.values()) {
+    for (const id of fnIds) {
+      const mode = modeOfPreviewId(id, modes);
+      if (mode) seenAsId.add(mode);
+    }
+  }
+  return modes
+    .filter((mode) => modePriority(spec, mode) === DEFERRED && !seenAsId.has(mode))
+    .sort();
 }
 
 /**
@@ -108,27 +146,32 @@ export function previewsFromJson(parsed) {
 }
 
 // --- CLI ----------------------------------------------------------------------
-// `node deferred-preview-ids.mjs --spec catalog.spec.json --previews previews.json [--out ids.txt]`
+// `node deferred-preview-ids.mjs --spec catalog.spec.json --previews previews.json
+//    [--out ids.txt] [--rows-out rows.txt]`
 // Prints (and optionally writes) the comma-separated exclusion list the render consumes as
-// `compose-preview bundle pack --exclude-preview-id` / `-PcomposePreview.idExclude`. Empty output
-// is the normal case for a spec that defers no mode, and means "render everything".
+// `compose-preview bundle pack --exclude-preview-id` / `-PcomposePreview.idExclude`, and — for a
+// mode axis that lives in a `@PreviewParameter` provider rather than in ids — the row labels for
+// `--exclude-preview-row` / `-PcomposePreview.rowExclude`. Empty output on either is the normal case
+// for a spec that defers no mode, and means "render everything".
 if (import.meta.url === `file://${process.argv[1]}`) {
   const { values } = parseArgs({
     options: {
       spec: { type: "string" },
       previews: { type: "string" },
       out: { type: "string" },
+      "rows-out": { type: "string" },
     },
   });
   if (!values.spec || !values.previews) {
     console.error(
-      "usage: deferred-preview-ids.mjs --spec <catalog.spec.json> --previews <list.json> [--out <file>]",
+      "usage: deferred-preview-ids.mjs --spec <catalog.spec.json> --previews <list.json> " +
+        "[--out <file>] [--rows-out <file>]",
     );
     process.exit(2);
   }
   const spec = JSON.parse(readFileSync(values.spec, "utf8"));
   const previews = previewsFromJson(JSON.parse(readFileSync(values.previews, "utf8")));
-  const { ids, keptByGuard } = deferredPreviewIds(spec, previews);
+  const { ids, rows, keptByGuard } = deferredPreviewIds(spec, previews);
   for (const fn of keptByGuard) {
     console.error(
       `[${spec.system}] ${fn}: every discovered preview renders a DEFERRED mode — keeping all of ` +
@@ -140,7 +183,14 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     `[${spec.system}] mode deferral: ${ids.length} preview id(s) excluded from the render` +
       (ids.length > 0 ? ` (${ids.slice(0, 5).join(", ")}${ids.length > 5 ? ", …" : ""})` : ""),
   );
+  if (rows.length > 0) {
+    console.error(
+      `[${spec.system}] mode deferral: ${rows.length} mode(s) carry no discovered id, so they are ` +
+        `passed as @PreviewParameter row label(s) instead: ${rows.join(", ")}`,
+    );
+  }
   const line = ids.join(",");
   if (values.out) writeFileSync(values.out, line);
+  if (values["rows-out"]) writeFileSync(values["rows-out"], rows.join(","));
   console.log(line);
 }

--- a/scripts/design-artifacts/deferred-preview-ids.test.mjs
+++ b/scripts/design-artifacts/deferred-preview-ids.test.mjs
@@ -30,7 +30,14 @@ const spec = {
   ],
 };
 
-const preview = (id, functionName) => ({ id, functionName });
+const preview = (id, functionName) => ({ id, functionName, params: {} });
+
+/** A discovered preview whose function takes a `@PreviewParameter` provider. */
+const parameterized = (id, functionName) => ({
+  id,
+  functionName,
+  params: { previewParameterProviderClassName: "com.example.ThemeProvider" },
+});
 
 test("modeOfPreviewId reads the trailing mode segment case-insensitively", () => {
   const modes = ["light", "dark"];
@@ -155,29 +162,60 @@ test("ids are unique and sorted", () => {
   ]);
 });
 
-test("a mode with no discovered id is emitted as a row label", () => {
-  // The `@PreviewParameter` shape: one discovered preview for the whole palette fan-out, so neither
-  // `dark` nor `highContrastDark` appears in an id and no id-level exclusion can name them.
-  const previews = [preview("FilledButtonPreview", "FilledButtonPreview")];
+test("a parameterized function's deferred modes become row labels", () => {
+  // One discovered preview for the whole palette fan-out, so neither `dark` nor `highContrastDark`
+  // appears in an id and no id-level exclusion can name them.
+  const previews = [parameterized("FilledButtonPreview", "FilledButtonPreview")];
   const { ids, rows } = deferredPreviewIds(spec, previews);
   assert.deepEqual(ids, []);
   assert.deepEqual(rows, ["dark", "highContrastDark"]);
 });
 
-test("a mode visible as an id is left to the id filter, not duplicated as a row", () => {
+test("a multipreview-only catalog emits no row labels", () => {
+  // Every mode is visible as an id and nothing is parameterized: the id filter is exact, so the
+  // wider label tool is never reached for.
   const previews = [
     preview("FilledButtonPreview_Light", "FilledButtonPreview"),
     preview("FilledButtonPreview_Dark", "FilledButtonPreview"),
   ];
   const { ids, rows } = deferredPreviewIds(spec, previews);
   assert.deepEqual(ids, ["FilledButtonPreview_Dark"]);
-  // `dark` resolved to an id; only `highContrastDark` (which didn't) becomes a row label.
-  assert.deepEqual(rows, ["highContrastDark"]);
+  assert.deepEqual(rows, []);
+});
+
+test("a mixed catalog keeps the label a parameterized function still needs", () => {
+  // The regression this rule exists for: `dark` IS visible on the multipreview function, but the
+  // parameterized one renders its Dark row regardless — a module-wide "seen as an id" test would
+  // suppress the label and leave that row rendering.
+  const previews = [
+    preview("FilledButtonPreview_Light", "FilledButtonPreview"),
+    preview("FilledButtonPreview_Dark", "FilledButtonPreview"),
+    parameterized("OutlinedButtonPreview", "OutlinedButtonPreview"),
+  ];
+  const { ids, rows } = deferredPreviewIds(spec, previews);
+  assert.deepEqual(ids, ["FilledButtonPreview_Dark"]);
+  assert.deepEqual(rows, ["dark", "highContrastDark"]);
+});
+
+test("a parameterized function already covered by ids needs no label", () => {
+  const previews = [
+    parameterized("FilledButtonPreview_Light", "FilledButtonPreview"),
+    parameterized("FilledButtonPreview_Dark", "FilledButtonPreview"),
+    parameterized("FilledButtonPreview_HighContrastDark", "FilledButtonPreview"),
+  ];
+  assert.deepEqual(deferredPreviewIds(spec, previews).rows, []);
+});
+
+test("a payload with no params at all treats every function as a candidate", () => {
+  // An older or brief listing can't answer "is this parameterized?" — fall back to the wider set
+  // rather than silently emitting nothing.
+  const previews = [{ id: "FilledButtonPreview", functionName: "FilledButtonPreview" }];
+  assert.deepEqual(deferredPreviewIds(spec, previews).rows, ["dark", "highContrastDark"]);
 });
 
 test("a spec that defers no mode emits no row labels", () => {
   const strict = { ...spec, modePriority: undefined };
-  const previews = [preview("FilledButtonPreview", "FilledButtonPreview")];
+  const previews = [parameterized("FilledButtonPreview", "FilledButtonPreview")];
   assert.deepEqual(deferredPreviewIds(strict, previews).rows, []);
 });
 

--- a/scripts/design-artifacts/deferred-preview-ids.test.mjs
+++ b/scripts/design-artifacts/deferred-preview-ids.test.mjs
@@ -155,6 +155,32 @@ test("ids are unique and sorted", () => {
   ]);
 });
 
+test("a mode with no discovered id is emitted as a row label", () => {
+  // The `@PreviewParameter` shape: one discovered preview for the whole palette fan-out, so neither
+  // `dark` nor `highContrastDark` appears in an id and no id-level exclusion can name them.
+  const previews = [preview("FilledButtonPreview", "FilledButtonPreview")];
+  const { ids, rows } = deferredPreviewIds(spec, previews);
+  assert.deepEqual(ids, []);
+  assert.deepEqual(rows, ["dark", "highContrastDark"]);
+});
+
+test("a mode visible as an id is left to the id filter, not duplicated as a row", () => {
+  const previews = [
+    preview("FilledButtonPreview_Light", "FilledButtonPreview"),
+    preview("FilledButtonPreview_Dark", "FilledButtonPreview"),
+  ];
+  const { ids, rows } = deferredPreviewIds(spec, previews);
+  assert.deepEqual(ids, ["FilledButtonPreview_Dark"]);
+  // `dark` resolved to an id; only `highContrastDark` (which didn't) becomes a row label.
+  assert.deepEqual(rows, ["highContrastDark"]);
+});
+
+test("a spec that defers no mode emits no row labels", () => {
+  const strict = { ...spec, modePriority: undefined };
+  const previews = [preview("FilledButtonPreview", "FilledButtonPreview")];
+  assert.deepEqual(deferredPreviewIds(strict, previews).rows, []);
+});
+
 test("previewsFromJson accepts every shape the pipeline produces", () => {
   const rows = [{ id: "A" }];
   assert.deepEqual(previewsFromJson(rows), rows);

--- a/site/index.md
+++ b/site/index.md
@@ -116,8 +116,22 @@ pattern then renders too much rather than dropping a preview you wanted. Either
 way a filtered run is never stored in the build cache, since its render directory
 is only part of the module's output.
 
-(Android modules render previews through a Robolectric test task; the `--preview`
-filter there is tracked as a follow-up.)
+One fan-out has no ids to name: a `@PreviewParameter` provider's rows exist only
+once the renderer enumerates the provider, so discovery lists the parameterized
+function as a single preview. Those are skipped by **label** — the token in
+`<stem>_<label>.png`, matched case-insensitively:
+
+```sh
+./gradlew :desktopApp:composePreviewRender --exclude-preview-row 'Dark,ExtraDark'
+# or, as a Gradle property: -PcomposePreview.rowExclude='Dark,ExtraDark'
+```
+
+A row exclusion never empties a preview's rows: if every row matches, they all
+render, so nothing can silently produce a preview with no pixels.
+
+(Android modules render previews through a Robolectric test task, which reads none
+of these filters — tracked in
+[#2977](https://github.com/yschimke/compose-ai-tools/issues/2977).)
 
 Requirements and CI recipes live on the [Install page](./install/).
 


### PR DESCRIPTION
Follow-up to #2966 / #2973 / #2980 — the half of the deferral saving that never landed.

## Why

The measurement behind #2966 (−59% of renders on a nine-theme catalog) comes from `pocket-casts-android`, whose themes are a `@PreviewParameter(ThemePreviewParameterProvider::class)` fan-out — see #2948. That is exactly the shape the id filters cannot address:

```
previews.json:  …PreviewParameterPreviewsKt.SwatchPreview_Color Swatch     ← one entry
renders/:       SwatchPreview_Color_Swatch_{Amber,Crimson,Teal,Violet}.png ← four rows
```

Discovery reads bytecode, so it can't instantiate the provider; the rows only come into existence inside the render JVM once `PreviewParameterLabels` names them. `--exclude-preview-id` therefore had nothing to match and every deferred palette still rendered.

## What

A row axis, addressed by the **label** that already names the file — what you exclude is what you read off disk.

- **`PreviewRowFilter`** (desktop renderer), applied immediately after the rows are labelled. Exclusion polarity like the id filter; `*`/`?` globs or an exact label; matched **case-insensitively**, deliberately unlike the id filters — a label is user data (`"Dark"`) while the pattern is usually a spec's own spelling of the same axis (`"dark"`), and only an exclusion can be widened safely. Two never-empty rules: a preview with no fan-out is never filtered, and if *every* row matches, none is skipped.
- **`composePreviewRender --exclude-preview-row` / `-PcomposePreview.rowExclude`**, forwarded to the subprocess as `composeai.preview.rowExclude`. Gated out of the build cache like the other filters. Stale-fan-out cleanup still keys on **all** of the run's rows, so a skipped row keeps its previous PNG (stale-badged in the panel) instead of being deleted — the same treatment a skipped preview gets.
- **`bundle pack --exclude-preview-row`** → the same property. Render-only on purpose: the semantics capture is per *preview*, so a parameterized preview costs one capture however wide its provider is; there's nothing to thin there.
- **`deferred-preview-ids.mjs --rows-out`**: a deferred mode is emitted as a row label exactly when **no discovered id carries it**. If the mode is visible as an id, the id filter handles it precisely and a module-wide label would only add risk. Both design-artifacts workflows pass it through to the pack.

## The residual risk, stated rather than hidden

Labels are matched module-wide, so an unrelated parameterized preview whose row happens to be labelled like a deferred mode loses that row. Two things bound it: the renderer never empties a preview's rows, and the missing row belongs to a component the spec didn't defer — so the completeness gate fails the publish rather than thinning the sheet in silence. Documented in `DESIGN_CATALOGS.md`, the task KDoc and the derivation header.

Android/Robolectric renders still honour none of these filters (#2977) — unchanged by this PR, and still the other half of the pocket-casts saving.

## Test plan

- New `PreviewRowFilterTest` (11 cases: exact/glob/case-insensitivity, the underscore boundary, never-empty, unparameterized previews, `_PARAM_<idx>` rows, pattern parsing) and new `deferred-preview-ids` cases for the id-vs-label split. `:cli:test`, `:gradle-plugin:test`, `:renderer-desktop:test`, `ktfmtCheck` green.
- End-to-end against `:samples:cmp`'s four-row `SwatchPreview`, both entry points:

```
--exclude-preview-row 'Amber,teal'
  → "@PreviewParameter on SwatchPreview: skipping 2 of 4 row(s) … Teal, Amber"
  → only Crimson + Violet outputs written   (note 'teal' matched 'Teal')

-PcomposePreview.rowExclude='*e*'
  → "skipping 3 of 4 row(s) … Teal, Amber, Violet"
  → only Crimson written                     (the -P → system-property path)
```

Non-visual (render scheduling + plumbing), so no before/after images. As on #2980, PNG rasterisation can't complete in this sandbox — the Skiko fork can't resolve `libGL.so.1` — so the per-row outputs above are the renderer's error sidecars; which rows the renderer *schedules* is what this change controls, and CI renders the pixels.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Luh8YAEJ8y7L8pw99gdEsQ)_