### PR TITLE
fix(figma-svg): fill showBackground across the full crop, not the thinnest child

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -80,6 +80,10 @@ object ComposeFigmaSvgDataProducer {
   ) {
     val previewDir = rootDir.resolve(previewId).also { it.mkdirs() }
     val frame = frameImage?.takeIf { it.exists() }
+    // The frame PNG's pixel size is the exact area a maskless `showBackground` preview fills, so
+    // hand it to the model — a thin/short child no longer shrink-wraps the background to itself
+    // (issue #2974). Read via ImageIO's header (no full decode) through the injected FileSystem.
+    val frameSize = frame?.let { readImageSize(it, fileSystem) }
     val model =
       FigmaSvgModel.from(
         layout = layout,
@@ -87,6 +91,8 @@ object ComposeFigmaSvgDataProducer {
         colorNames = colorNames,
         density = density,
         fontScale = fontScale,
+        frameWidthPx = frameSize?.first,
+        frameHeightPx = frameSize?.second,
         rasterComponents =
           if (frame != null) FigmaSvgModel.DEFAULT_RASTER_COMPONENTS else emptySet(),
         // Hybrid mode also crops Canvas-drawn chrome (progress track, slider groove) the token
@@ -470,6 +476,29 @@ object ComposeFigmaSvgDataProducer {
   }
 
   private fun transparentPixel(): BufferedImage = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+
+  /**
+   * The `(width, height)` in pixels of the image at [file], read via `ImageIO`'s reader header
+   * without decoding the pixels; null on any read/parse failure so a missing size degrades to the
+   * extent-based background sizing rather than stranding the SVG. Bytes come through the injected
+   * [fileSystem] so a fake/in-memory filesystem is honoured (docs/AGENTS.md).
+   */
+  private fun readImageSize(file: File, fileSystem: FileSystem): Pair<Int, Int>? =
+    runCatching {
+        val bytes = fileSystem.read(file.path.toPath()) { readByteArray() }
+        ImageIO.createImageInputStream(ByteArrayInputStream(bytes)).use { stream ->
+          val readers = ImageIO.getImageReaders(stream)
+          if (!readers.hasNext()) return@runCatching null
+          val reader = readers.next()
+          try {
+            reader.input = stream
+            reader.getWidth(reader.minIndex) to reader.getHeight(reader.minIndex)
+          } finally {
+            reader.dispose()
+          }
+        }
+      }
+      .getOrNull()
 }
 
 /**

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -485,6 +485,13 @@ data class FigmaSvgModel(
      *   token-driven vector export can't see — e.g. a `LinearProgressIndicator`/`Slider` track
      *   drawn into a bare `Spacer`) is emitted as an `<image>` crop of that drawn region instead of
      *   vanishing. Off in vector-only mode (no frame to crop from).
+     * @param frameWidthPx the captured frame PNG's pixel width, in the same root-pixel space the
+     *   bounds live in. Supplied alongside a [deviceBackground] so a maskless `showBackground`
+     *   preview fills its whole crop — the render paints the background across the entire window
+     *   and crops top-left, so the PNG size is exactly the background area, even when the only
+     *   drawn child is thinner/shorter than the root (issue #2974). Null (the vector-only /
+     *   no-frame path) falls back to sizing the background from the drawn-content extent.
+     * @param frameHeightPx the captured frame PNG's pixel height; see [frameWidthPx].
      */
     fun from(
       layout: LayoutInspectorPayload,
@@ -499,6 +506,8 @@ data class FigmaSvgModel(
       roundClip: Boolean = false,
       capsuleClip: Boolean = false,
       deviceBackground: String? = null,
+      frameWidthPx: Int? = null,
+      frameHeightPx: Int? = null,
     ): FigmaSvgModel {
       val textByNodeId =
         semantics?.let { assignTextToLayers(layout.root, it, density, fontScale) } ?: emptyMap()
@@ -533,10 +542,44 @@ data class FigmaSvgModel(
       // canvas extent to the frame — otherwise the square/tall full-frame background paints the
       // corners the render leaves transparent. No drawing layer (a tree of pure grouping nodes) → a
       // minimal padding-square canvas, matching the wireframe's empty-tree convention.
-      val extent =
+      val contentExtent =
         if (clip != null || capsule != null)
           Extent(frame.left, frame.top, frame.right, frame.bottom)
         else rootLayer.extent() ?: Extent(0, 0, 0, 0)
+      val deviceBgResolved = deviceBackground?.let { argbToColor(it, names) }
+      // The captured frame PNG's pixel size is the exact area a maskless `showBackground` preview
+      // fills: the render paints the background across the whole window and crops top-left, so
+      // every
+      // pixel of the crop is that colour. The drawn-content extent alone can be smaller — a 1dp
+      // divider centred in a taller fixed-size Box (issue #2974) leaves the extent thin, stranding
+      // most of the background as transparency. Anchor a frame-sized rect at the root origin (the
+      // crop is top-left from the window, whose origin is the root node) so the background — and
+      // the
+      // canvas that must contain it — cover the full crop. Skipped for masked device frames (they
+      // paint the mask shape) and when no frame size is known (the vector-only path keeps the
+      // extent-based sizing, e.g. #2884's synthetic model).
+      val backgroundFrame =
+        if (
+          deviceBgResolved != null &&
+            clip == null &&
+            capsule == null &&
+            frameWidthPx != null &&
+            frameHeightPx != null &&
+            frameWidthPx > 0 &&
+            frameHeightPx > 0
+        )
+          Extent(frame.left, frame.top, frame.left + frameWidthPx, frame.top + frameHeightPx)
+        else null
+      // The canvas has to contain both the drawn content and the background crop.
+      val extent =
+        backgroundFrame?.let {
+          Extent(
+            minOf(contentExtent.minX, it.minX),
+            minOf(contentExtent.minY, it.minY),
+            maxOf(contentExtent.maxX, it.maxX),
+            maxOf(contentExtent.maxY, it.maxY),
+          )
+        } ?: contentExtent
       // A preview that opted into a background paints it behind the whole tree as the bottom
       // layer. A device frame (round or capsule mask) paints it in the mask shape, so a Wear
       // device export reads as a solid face with light chrome legible while the corners outside
@@ -545,20 +588,18 @@ data class FigmaSvgModel(
       // rect instead; before this it painted nothing, so the SVG was transparent where the PNG was
       // opaque. Previews that pass no `deviceBackground` (the default, and every preview that
       // didn't declare `showBackground`) still export background-free.
-      val deviceBg = deviceBackground?.let { argbToColor(it, names) }
-      // Sized from the canvas extent rather than the root node's bounds: a wrap-content preview
-      // measures inside a generous sandbox frame (400×800 dp) and the PNG is cropped back to the
-      // composable's intrinsic size, so the background the viewer sees covers the *cropped* area.
-      // Using the raw frame here would paint the sandbox.
+      val deviceBg = deviceBgResolved
+      // Prefer the frame crop when its size is known (issue #2974) — that is exactly the area the
+      // PNG fills, so a thin/short child no longer shrink-wraps the fill to itself. Without a frame
+      // size, fall back to the drawn-content extent: a wrap-content preview measures inside a
+      // generous sandbox frame (400×800 dp) and the PNG is cropped back to the composable's
+      // intrinsic size, so the background the viewer sees covers the *cropped* area — using the raw
+      // root-node frame there would paint the sandbox.
       val backgroundRect =
-        if (deviceBg != null && clip == null && capsule == null)
-          FigmaSvgRect(
-            x = extent.minX,
-            y = extent.minY,
-            width = extent.maxX - extent.minX,
-            height = extent.maxY - extent.minY,
-          )
-        else null
+        if (deviceBg != null && clip == null && capsule == null) {
+          val r = backgroundFrame ?: contentExtent
+          FigmaSvgRect(x = r.minX, y = r.minY, width = r.maxX - r.minX, height = r.maxY - r.minY)
+        } else null
       return FigmaSvgModel(
         root = rootLayer,
         minX = extent.minX,

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -589,17 +589,28 @@ data class FigmaSvgModel(
       // opaque. Previews that pass no `deviceBackground` (the default, and every preview that
       // didn't declare `showBackground`) still export background-free.
       val deviceBg = deviceBgResolved
-      // Prefer the frame crop when its size is known (issue #2974) — that is exactly the area the
-      // PNG fills, so a thin/short child no longer shrink-wraps the fill to itself. Without a frame
-      // size, fall back to the drawn-content extent: a wrap-content preview measures inside a
-      // generous sandbox frame (400×800 dp) and the PNG is cropped back to the composable's
-      // intrinsic size, so the background the viewer sees covers the *cropped* area — using the raw
-      // root-node frame there would paint the sandbox.
+      // Paint the background across the full exported canvas [extent], which already unions the
+      // drawn-content extent with the frame crop:
+      //  - the frame crop grows it to the whole cropped area a thin/short child would otherwise
+      //    shrink-wrap the fill away from (issue #2974), and
+      //  - any drawing the SVG deliberately retains beyond the captured viewport (a card's chrome
+      //    wider than its box, #2937; a scroll item past its parent edge) sat on the window
+      //    background in the live render, so it must sit on the background here too rather than
+      // over
+      //    transparency.
+      // With no frame size [extent] is just the drawn-content extent, so a wrap-content preview
+      // (measured inside a generous 400×800 dp sandbox, PNG cropped back to intrinsic size) still
+      // fills only the cropped area rather than the sandbox, and the #2884 maskless path is
+      // unchanged.
       val backgroundRect =
-        if (deviceBg != null && clip == null && capsule == null) {
-          val r = backgroundFrame ?: contentExtent
-          FigmaSvgRect(x = r.minX, y = r.minY, width = r.maxX - r.minX, height = r.maxY - r.minY)
-        } else null
+        if (deviceBg != null && clip == null && capsule == null)
+          FigmaSvgRect(
+            x = extent.minX,
+            y = extent.minY,
+            width = extent.maxX - extent.minX,
+            height = extent.maxY - extent.minY,
+          )
+        else null
       return FigmaSvgModel(
         root = rootLayer,
         minX = extent.minX,

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -2345,6 +2345,54 @@ class FigmaLayeredSvgTest {
     assertEquals(40, rect.height)
   }
 
+  /**
+   * Follow-up to #2974: when the SVG retains drawing beyond the captured frame (a card's chrome
+   * wider than its box, a scroll item past its parent edge), the exported canvas grows to include
+   * it — so the background must grow with it, not stop at the frame crop. Otherwise the retained
+   * content renders over transparency, whereas in the live render it sat on the window background.
+   */
+  @Test
+  fun aShowBackgroundFillCoversContentRetainedBeyondTheFrame() {
+    val layout =
+      layoutNode(
+        "Box",
+        0,
+        0,
+        100,
+        26,
+        children =
+          listOf(
+            // A drawing layer that extends past the 100×26 captured frame (to 120×40).
+            layoutNode(
+              "Chrome",
+              0,
+              0,
+              120,
+              40,
+              tokens = ComposeSemanticsTokens(backgroundColor = "#FF6750A4"),
+            )
+          ),
+      )
+    val model =
+      FigmaSvgModel.from(
+        layout = LayoutInspectorPayload(layout),
+        deviceBackground = "#FF1C1B1F",
+        frameWidthPx = 100,
+        frameHeightPx = 26,
+      )
+    val rect = model.backgroundRect
+    assertNotNull(rect)
+    // Background spans the full retained extent (120×40), not just the 100×26 frame, so the
+    // retained chrome sits on the backing colour rather than over transparency.
+    assertEquals(0, rect!!.x)
+    assertEquals(0, rect.y)
+    assertEquals(120, rect.width)
+    assertEquals(40, rect.height)
+    // And the canvas contains it (extent + padding on each side).
+    assertEquals(120 + FigmaSvgModel.DEFAULT_PADDING * 2, model.width)
+    assertEquals(40 + FigmaSvgModel.DEFAULT_PADDING * 2, model.height)
+  }
+
   @Test
   fun aRoundDeviceStillPaintsItsBackgroundAsTheMaskShapeNotARect() {
     val layout = layoutNode("Screen", 0, 0, 384, 384)

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -2258,6 +2258,93 @@ class FigmaLayeredSvgTest {
     )
   }
 
+  /**
+   * Issue #2974: a dark `@Preview(showBackground = true)` whose only drawn child is a thin divider
+   * centred in a taller fixed-size `Box` sized the background rect to the *divider* bounds, so most
+   * of the SVG stayed transparent while the PNG filled the whole crop. When the render's frame size
+   * is known, the background must cover that whole crop, not the shrink-wrapped drawn content.
+   */
+  @Test
+  fun aThinChildDoesNotShrinkWrapTheShowBackgroundFillWhenTheFrameSizeIsKnown() {
+    // Root Box is 263×26; the only painting child is a 1dp divider centred vertically.
+    val layout =
+      layoutNode(
+        "Box",
+        0,
+        0,
+        263,
+        26,
+        children =
+          listOf(
+            layoutNode(
+              "JetsnackDivider",
+              0,
+              12,
+              263,
+              14,
+              tokens = ComposeSemanticsTokens(backgroundColor = "#1FFFFFFF"),
+            )
+          ),
+      )
+    val model =
+      FigmaSvgModel.from(
+        layout = LayoutInspectorPayload(layout),
+        deviceBackground = "#FF1C1B1F",
+        frameWidthPx = 263,
+        frameHeightPx = 26,
+      )
+    val rect = model.backgroundRect
+    assertNotNull("a maskless preview gets a frame rect to fill", rect)
+    assertEquals("background fills the full crop width", 0, rect!!.x)
+    assertEquals("background fills the full crop height", 0, rect.y)
+    assertEquals(263, rect.width)
+    assertEquals(26, rect.height)
+    // The canvas must contain the full background crop, not shrink-wrap to the thin divider.
+    assertEquals(263 + FigmaSvgModel.DEFAULT_PADDING * 2, model.width)
+    assertEquals(26 + FigmaSvgModel.DEFAULT_PADDING * 2, model.height)
+    val svg = FigmaLayeredSvg.render(model)
+    assertWellFormedXml(svg)
+    assertTrue(
+      "the full-crop dark background rect is emitted",
+      svg.contains("""<rect x="0" y="0" width="263" height="26" fill="#1C1B1F""""),
+    )
+  }
+
+  /**
+   * Without a known frame size (the vector-only path — e.g. #2884's synthetic model) the background
+   * still sizes from the drawn-content extent, so that regression guard keeps holding.
+   */
+  @Test
+  fun withNoFrameSizeTheShowBackgroundFillStillSizesFromTheDrawnExtent() {
+    val layout =
+      layoutNode(
+        "Screen",
+        0,
+        0,
+        100,
+        60,
+        children =
+          listOf(
+            layoutNode(
+              "Box",
+              10,
+              10,
+              90,
+              50,
+              tokens = ComposeSemanticsTokens(backgroundColor = "#FF6750A4"),
+            )
+          ),
+      )
+    val model =
+      FigmaSvgModel.from(layout = LayoutInspectorPayload(layout), deviceBackground = "#FF000000")
+    val rect = model.backgroundRect
+    assertNotNull(rect)
+    assertEquals(10, rect!!.x)
+    assertEquals(10, rect.y)
+    assertEquals(80, rect.width)
+    assertEquals(40, rect.height)
+  }
+
   @Test
   fun aRoundDeviceStillPaintsItsBackgroundAsTheMaskShapeNotARect() {
     val layout = layoutNode("Screen", 0, 0, 384, 384)

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgShowBackgroundBoundsRenderTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgShowBackgroundBoundsRenderTest.kt
@@ -1,0 +1,198 @@
+package ee.schimke.composeai.renderer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.LocalInspectionTables
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.captureRoboImage
+import ee.schimke.composeai.daemon.ComposeFigmaSvgDataProducer
+import ee.schimke.composeai.daemon.ComposeSemanticsDataProducer
+import ee.schimke.composeai.daemon.LayoutInspectorDataProducer
+import ee.schimke.composeai.data.render.PreviewBackground
+import ee.schimke.composeai.data.render.PreviewContext
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Issue #2974 — end-to-end PNG↔SVG parity for a dark `@Preview(showBackground = true)` whose only
+ * drawn child is a hairline divider centred in a taller fixed-size `Box`.
+ *
+ * The render paints the backing colour across the whole window (exactly as production's
+ * `RobolectricRenderTest` does — on the activity's `decorView`, not a wrapper composable) and crops
+ * top-left, so the PNG fills the whole 100×26 crop with the dark surface. The layered-SVG export
+ * must agree: its `showBackground` rect has to cover that same full crop, not shrink-wrap to the
+ * ~1px divider extent. Before the fix the background rect was sized from the drawn-content extent,
+ * so the SVG was transparent almost everywhere while the PNG was opaque — the two disagreed.
+ *
+ * Both artifacts are produced here from one capture, so this asserts the two halves against each
+ * other: the PNG corners are the dark surface, and the SVG's background rect spans the full frame
+ * with the same colour, even though the only child that paints is a single-pixel-tall line.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class FigmaSvgShowBackgroundBoundsRenderTest {
+
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("figma-svg-show-background").toFile()
+    System.setProperty("roborazzi.test.record", "true")
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+    System.clearProperty("roborazzi.test.record")
+  }
+
+  @Test
+  fun `a thin divider does not shrink-wrap the dark showBackground fill`() {
+    val nightArgb = PreviewBackground.NIGHT_ARGB // 0xFF1C1B1F
+    val result =
+      export(
+        previewId = "divider-dark",
+        widthPx = 100,
+        heightPx = 26,
+        backgroundArgb = nightArgb,
+      ) {
+        Box(Modifier.size(width = 100.dp, height = 26.dp)) {
+          // The only child that paints: a hairline, translucent-white like a Material divider.
+          Box(
+            Modifier.align(Alignment.Center)
+              .fillMaxWidth()
+              .height(1.dp)
+              .background(Color(0x1FFFFFFF))
+          )
+        }
+      }
+
+    // PNG half: every corner is the opaque dark surface — the full crop is background-filled.
+    val png = ImageIO.read(result.frame)
+    assertEquals("capture is the full fixed-size crop", 100, png.width)
+    assertEquals(26, png.height)
+    listOf(0 to 0, png.width - 1 to 0, 0 to png.height - 1, png.width - 1 to png.height - 1).forEach {
+      (x, y) ->
+      val argb = png.getRGB(x, y)
+      assertEquals("corner ($x,$y) alpha", 0xff, (argb ushr 24) and 0xff)
+      assertEquals("corner ($x,$y) rgb", nightArgb and 0xffffff, argb and 0xffffff)
+    }
+
+    // SVG half: the background rect spans the full 100×26 crop with the same dark fill…
+    val svg = result.svg
+    assertTrue(
+      "the dark background must cover the whole crop, not the divider bounds:\n$svg",
+      svg.contains("""<rect x="0" y="0" width="100" height="26" fill="#1C1B1F""""),
+    )
+    // …even though the only child that paints is a single-pixel-tall line (the regression scenario).
+    assertTrue(
+      "the divider is a hairline, so the background is not shrink-wrapped to it:\n$svg",
+      Regex("""<rect[^>]*\bheight="1"[^>]*fill="#FFFFFF"""").containsMatchIn(svg),
+    )
+    // The canvas is sized to the full crop (+ the 16px export padding on each side), not the ~1px
+    // divider extent.
+    val canvasHeight = Regex("""<svg[^>]*\bheight="(\d+)"""").find(svg)?.groupValues?.get(1)?.toInt()
+    assertEquals("canvas height covers the full crop", 26 + 16 * 2, canvasHeight)
+  }
+
+  private class ExportResult(val svg: String, val frame: File)
+
+  /**
+   * Renders [content] in a [widthPx]×[heightPx] window painted with [backgroundArgb] (the production
+   * `decorView` background paint), captures the frame, then runs the real capture → figma-svg
+   * export in hybrid mode with the frame supplied — the same path `RenderEngine` drives.
+   */
+  private fun export(
+    previewId: String,
+    widthPx: Int,
+    heightPx: Int,
+    backgroundArgb: Int,
+    content: @Composable () -> Unit,
+  ): ExportResult {
+    RuntimeEnvironment.setQualifiers("w${widthPx}dp-h${heightPx}dp-mdpi")
+    @Suppress("DEPRECATION") val rule = createAndroidComposeRule<ComponentActivity>()
+    var svg = ""
+    val frameFile = File(rootDir, "$previewId-frame.png")
+    val statement =
+      object : Statement() {
+        override fun evaluate() {
+          val slotTables = mutableSetOf<CompositionData>()
+          rule.setContent { InspectableShowBackgroundContent(slotTables, content) }
+          // Paint the backing colour on the window, exactly as production's RobolectricRenderTest
+          // does for `showBackground` — the wrapper-free path that #2884 established.
+          rule.runOnUiThread { rule.activity.window.decorView.setBackgroundColor(backgroundArgb) }
+          rule.waitForIdle()
+          frameFile.parentFile?.mkdirs()
+          rule.onRoot().captureRoboImage(file = frameFile)
+          val semanticsRoot = rule.onRoot(useUnmergedTree = true).fetchSemanticsNode()
+          val previewContext =
+            PreviewContext.Builder(
+                previewId = previewId,
+                backend = null,
+                renderMode = null,
+                outputBaseName = previewId,
+              )
+              .rootForTest(semanticsRoot.root as RootForTest)
+              .addSlotTables(slotTables.toList())
+              .parameterInformationCollected()
+              .build()
+          val layout = LayoutInspectorDataProducer.buildPayload(previewContext, density = 1f)!!
+          val semantics = ComposeSemanticsDataProducer.buildPayload(semanticsRoot, density = 1f)
+          ComposeFigmaSvgDataProducer.writeSvg(
+            rootDir = rootDir,
+            previewId = previewId,
+            layout = layout,
+            semantics = semantics,
+            density = 1f,
+            frameImage = frameFile,
+            deviceBackground = argbToHex(backgroundArgb),
+          )
+          svg = File(rootDir, "$previewId/compose-figma.svg").readText()
+        }
+      }
+    rule.apply(statement, Description.createTestDescription(javaClass, previewId)).evaluate()
+    return ExportResult(svg, frameFile)
+  }
+
+  private fun argbToHex(argb: Int): String = "#%08X".format(argb)
+}
+
+@OptIn(InternalComposeApi::class)
+@Composable
+private fun InspectableShowBackgroundContent(
+  capture: MutableSet<CompositionData>,
+  content: @Composable () -> Unit,
+) {
+  currentComposer.collectParameterInformation()
+  capture.add(currentComposer.compositionData)
+  CompositionLocalProvider(LocalInspectionTables provides capture, content = content)
+}

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/DividerShowBackgroundPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/DividerShowBackgroundPreviews.kt
@@ -1,0 +1,51 @@
+package com.example.sampleandroid
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * Regression fixture for issue #2974: a dark `@Preview(showBackground = true)` whose only drawn
+ * child is a thin divider centred in a taller fixed-size `Box`.
+ *
+ * The `showBackground` fill must cover the **whole** 100×26dp root, not shrink-wrap to the 1dp
+ * divider. The bug sized the layered-SVG background rect to the divider's bounds, so the SVG was
+ * transparent almost everywhere while the PNG correctly filled the whole preview — the two disagreed
+ * only on the dark variant, which is why it slipped past when the night annotation used to render as
+ * light. Kept deliberately `Surface`-free so the backing colour (not a surface fill) is what covers
+ * the frame. Pair-asserted end-to-end by [DividerShowBackgroundPreviewPixelTest].
+ */
+@Preview(
+  name = "Divider Dark",
+  showBackground = true,
+  widthDp = 100,
+  heightDp = 26,
+  uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun DividerShowBackgroundDarkPreview() {
+  MaterialTheme(colorScheme = darkColorScheme()) {
+    Box(modifier = Modifier.size(width = 100.dp, height = 26.dp)) {
+      // A hairline divider — the only thing that paints. Translucent white, like a Material
+      // `HorizontalDivider`, so the dark backing shows through and the two must agree pixel-for-pixel.
+      Box(
+        modifier =
+          Modifier.align(Alignment.Center)
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(Color(0x1FFFFFFF))
+      )
+    }
+  }
+}

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/DividerShowBackgroundPreviewPixelTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/DividerShowBackgroundPreviewPixelTest.kt
@@ -1,0 +1,52 @@
+package com.example.sampleandroid
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Test
+
+/**
+ * End-to-end verification for issue #2974: a dark `@Preview(showBackground = true)` whose only drawn
+ * child is a thin divider centred in a taller fixed-size `Box` fills the **whole** preview with the
+ * dark backing colour, not just the divider's bounds.
+ *
+ * Reads the PNG produced by `:samples:android:composePreviewRenderAll` (wired into this module's
+ * `test` task in `build.gradle.kts`) and asserts every corner — well outside the centred divider —
+ * is the opaque Material dark surface (`#1C1B1F`, `PreviewBackground.NIGHT_ARGB`). This is the PNG
+ * half of the PNG/SVG parity the layered-SVG export must match: the SVG background rect has to cover
+ * the same full crop these pixels do (asserted against the SVG in
+ * `FigmaSvgShowBackgroundBoundsRenderTest`).
+ */
+class DividerShowBackgroundPreviewPixelTest {
+
+  private val rendersDir = File("build/compose-previews/renders")
+  private val pngName = "DividerShowBackgroundDarkPreview_Divider_Dark.png"
+
+  /** `PreviewBackground.NIGHT_ARGB` (`#1C1B1F`) — Material 3's dark surface. */
+  private val nightRgb = 0x1C1B1F
+
+  @Test
+  fun `dark showBackground divider preview fills the whole crop with the dark surface`() {
+    val file = File(rendersDir, pngName)
+    assertThat(file.exists()).isTrue()
+    val img = ImageIO.read(file)
+
+    val w = img.width
+    val h = img.height
+    // 100×26dp fixed Box: guard against a zero-/thin-sized capture silently passing the reads
+    // below (the bug shrank the SVG canvas to the ~1px divider — the PNG never had that problem,
+    // but a broken render should still fail loudly here rather than read an empty image).
+    assertThat(w).isAtLeast(40)
+    assertThat(h).isAtLeast(10)
+
+    // Every corner sits above/below the centred hairline divider, so each must be the opaque dark
+    // backing — this is the "full background coverage" the divider used to strand as transparency
+    // in the SVG.
+    listOf(0 to 0, w - 1 to 0, 0 to h - 1, w - 1 to h - 1).forEach { (x, y) ->
+      val argb = img.getRGB(x, y)
+      val alpha = (argb ushr 24) and 0xff
+      assertThat(alpha).isEqualTo(0xff)
+      assertThat(argb and 0xffffff).isEqualTo(nightRgb)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2974.

In released 0.19.7 a dark `@Preview(showBackground = true)` whose only drawn child is a **thin divider centred in a taller fixed-size `Box`** (Jetsnack `DividerPreview`) applied the preview background only to the bounds of that ~1px divider. Most of the layered SVG stayed transparent while the Android PNG correctly filled the whole 263×26 crop.

## Root cause

`FigmaSvgModel.from` sized both the `showBackground` fill rect **and** the SVG canvas from `rootLayer.extent()` — the union of every *drawing* layer's bounds. A grouping-only root `Box` with no fill of its own contributes nothing, so the extent collapses to the single hairline that actually paints. The background then shrink-wrapped to the divider (`<rect ... width="263" height="1" .../>`) instead of the root preview bounds.

## Fix

The captured frame PNG's pixel size is exactly the area a maskless `showBackground` preview fills — the render paints the backing colour across the whole window (`RobolectricRenderTest`, on the activity `decorView`) and crops top-left. So:

- Thread the frame PNG size (`frameWidthPx`/`frameHeightPx`) into `FigmaSvgModel.from`; the connector reads it from the already-captured frame via `ImageIO`'s header (through the injected Okio `FileSystem`).
- When a maskless `showBackground` preview has a known frame size, anchor the background rect to the **full crop** and grow the canvas extent to contain it.
- With no frame size, keep the drawn-content extent sizing — so the wrap-content sandbox case, the #2884 maskless synthetic path, and the masked-device (round/capsule) path are all unchanged.

## Visual evidence

The `compose/figma-svg` export is a daemon-only surface and isn't reached by the PNG `@Preview` diff-bot pipeline, so it can't be captured as a committed render PNG here. Below is the actual emitted SVG, rendered in Chromium (checkerboard = SVG transparency), for the `100×26` divider case:

| Before (#2974) | After (fixed) |
| --- | --- |
| dark fill sized to the 1px divider — canvas `132×33`, transparent almost everywhere | dark fill covers the full `100×26` crop — canvas `132×58` |

The emitted background rect changes from `<rect x="0" y="12" width="100" height="1" fill="#1C1B1F"/>` (divider bounds) to `<rect x="0" y="0" width="100" height="26" fill="#1C1B1F"/>` (full crop). The rendered before/after comparison is attached in the PR thread.

A new Android `@Preview` fixture (`DividerShowBackgroundDarkPreview`) wires this surface into the render pipeline so the diff bot renders it on every PR; its produced PNG is a fully-dark `100×26` frame with the centred divider.

## Test plan

- [x] `:data-layoutinspector-core:test --tests FigmaLayeredSvgTest` — new regression tests: a thin child with a known frame size fills the full crop; and the no-frame-size path still sizes from the drawn extent (#2884 guard). **Green.**
- [x] `:renderer-android:testDebugUnitTest --tests FigmaSvgShowBackgroundBoundsRenderTest` — new end-to-end Robolectric PNG↔SVG parity: paints the window background like production, captures, exports, and asserts the PNG corners are the dark surface **and** the SVG background rect covers the full crop even though the only painting child is a 1px line. **Green.**
- [x] `DividerShowBackgroundDarkPreview` renders end-to-end via `composePreviewRenderAll` (PNG verified fully dark + centred divider).
- [x] Connector + core compile clean; `ktfmtCheckAll` clean (pre-commit hook).

Note: in this sandbox `composePreviewRenderAll` fails for two unrelated pre-existing previews (`lottie_spin`, `svg_badge`) that need the Skiko `libGL.so.1` system library the container lacks — not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTPpiN5fvggmsycH9sDoVw)_