### PR TITLE
feat(serve): project playground diagnostics into the stock kotlin-playground errors map

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
@@ -88,6 +88,29 @@ data class PlaygroundDiagnostic(
   val endCh: Int? = null,
 )
 
+/** A CodeMirror position in the stock `errors`-map shape (0-based line + char). */
+@Serializable data class PlaygroundPosition(val line: Int, val ch: Int)
+
+/** A `[start, end)` span in the stock `errors`-map shape. */
+@Serializable
+data class PlaygroundInterval(val start: PlaygroundPosition, val end: PlaygroundPosition)
+
+/**
+ * One diagnostic in the **stock `kotlin-compiler-server`** `errors`-map shape — the wire form a
+ * stock `kotlin-playground` frontend reads to draw inline squiggles. Distinct from
+ * [PlaygroundDiagnostic] (our flat internal shape): the stock frontend iterates the `errors` map
+ * per file and reads `error.interval.start`, so the position must be **nested** under `interval`,
+ * and `severity` is the upstream uppercase spelling (`ERROR`/`WARNING`). [PlaygroundErrorsWire]
+ * projects our diagnostics into this shape.
+ */
+@Serializable
+data class PlaygroundStockError(
+  val interval: PlaygroundInterval,
+  val message: String,
+  val severity: String,
+  val className: String,
+)
+
 /**
  * The Stage-1 result.
  *
@@ -96,10 +119,16 @@ data class PlaygroundDiagnostic(
  * Stage-2 session. On a compile error: [diagnostics] carries the errors and **no** token is minted
  * ([previewToken] stays null). [exception] is reserved for a server-side failure that isn't a user
  * compile error (e.g. the render subprocess died).
+ *
+ * [errors] is the **same** diagnostics projected into the stock `kotlin-compiler-server` wire shape
+ * (a map keyed by file name → [PlaygroundStockError]s with nested `interval` positions), so an
+ * unmodified `kotlin-playground` frontend can render inline squiggles. Our own frontend reads the
+ * richer [diagnostics] instead; both are populated, so neither client is second-class.
  */
 @Serializable
 data class PlaygroundRunResponse(
   val diagnostics: List<PlaygroundDiagnostic> = emptyList(),
+  val errors: Map<String, List<PlaygroundStockError>> = emptyMap(),
   val text: String = "",
   val exception: String? = null,
   val image: String? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundErrorsWire.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundErrorsWire.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.cli.serve
+
+/**
+ * Projects our internal [PlaygroundDiagnostic]s into the **stock `kotlin-compiler-server`**
+ * `errors`-map wire shape ([PlaygroundStockError]) that an unmodified `kotlin-playground` frontend
+ * reads. See [docs/design/PLAYGROUND.md](../../../../../../../../docs/design/PLAYGROUND.md) §4.
+ *
+ * Why this exists as a projection rather than a field rename: the stock frontend does **not** read
+ * `errors` as a flat list — it iterates a **map keyed by file name** and reads
+ * `error.interval.start.line`. So compatibility is a shape change (group by file, nest the position
+ * under `interval`, uppercase the severity), not a serialised-name swap. A straight `diagnostics` →
+ * `errors` rename would look compatible while still rendering nothing.
+ *
+ * Warnings are carried too, not just errors — upstream's `errors` map includes `WARNING`-severity
+ * descriptors, and the frontend styles them differently by `className`.
+ */
+object PlaygroundErrorsWire {
+
+  /** Fallback file key for a diagnostic with no file anchor (a module-level message). */
+  const val DEFAULT_FILE: String = "File.kt"
+
+  /** Group [diagnostics] by file and convert each to the stock [PlaygroundStockError] shape. */
+  fun project(diagnostics: List<PlaygroundDiagnostic>): Map<String, List<PlaygroundStockError>> =
+    diagnostics
+      .groupBy { it.file ?: DEFAULT_FILE }
+      .mapValues { (_, group) -> group.map { it.toStockError() } }
+
+  private fun PlaygroundDiagnostic.toStockError(): PlaygroundStockError {
+    // A file-level diagnostic (null position) collapses to the origin; a diagnostic with a start
+    // but
+    // no explicit end is a zero-width caret at the start.
+    val startLine = line ?: 0
+    val startCh = ch ?: 0
+    val start = PlaygroundPosition(startLine, startCh)
+    val end = PlaygroundPosition(endLine ?: startLine, endCh ?: startCh)
+    return PlaygroundStockError(
+      interval = PlaygroundInterval(start, end),
+      message = message,
+      severity = severity.wireName(),
+      className = severity.gutterClass(),
+    )
+  }
+
+  /** Upstream spells severities in uppercase (`ERROR` / `WARNING` / `INFO`). */
+  private fun PlaygroundSeverity.wireName(): String =
+    when (this) {
+      PlaygroundSeverity.ERROR -> "ERROR"
+      PlaygroundSeverity.WARNING -> "WARNING"
+      PlaygroundSeverity.INFO -> "INFO"
+    }
+
+  /** The CodeMirror gutter class `kotlin-playground` applies per severity. */
+  private fun PlaygroundSeverity.gutterClass(): String =
+    when (this) {
+      PlaygroundSeverity.ERROR -> "red_wavy_line"
+      PlaygroundSeverity.WARNING -> "yellow_wavy_line"
+      PlaygroundSeverity.INFO -> "info"
+    }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundErrorsWireTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundErrorsWireTest.kt
@@ -1,0 +1,102 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** The projection of our flat diagnostics into the stock kotlin-compiler-server `errors` map. */
+class PlaygroundErrorsWireTest {
+
+  @Test
+  fun `diagnostics are grouped by file into the stock map shape`() {
+    val errors =
+      PlaygroundErrorsWire.project(
+        listOf(
+          PlaygroundDiagnostic(
+            PlaygroundSeverity.ERROR,
+            "unresolved",
+            file = "A.kt",
+            line = 3,
+            ch = 5,
+          ),
+          PlaygroundDiagnostic(
+            PlaygroundSeverity.WARNING,
+            "unused",
+            file = "A.kt",
+            line = 7,
+            ch = 0,
+          ),
+          PlaygroundDiagnostic(
+            PlaygroundSeverity.ERROR,
+            "type mismatch",
+            file = "B.kt",
+            line = 1,
+            ch = 2,
+          ),
+        )
+      )
+
+    assertEquals(setOf("A.kt", "B.kt"), errors.keys)
+    assertEquals(2, errors.getValue("A.kt").size)
+    assertEquals(1, errors.getValue("B.kt").size)
+  }
+
+  @Test
+  fun `position nests under interval and severity uses the upstream spelling`() {
+    val error =
+      PlaygroundErrorsWire.project(
+          listOf(
+            PlaygroundDiagnostic(
+              PlaygroundSeverity.ERROR,
+              "unresolved reference",
+              file = "A.kt",
+              line = 3,
+              ch = 5,
+              endLine = 3,
+              endCh = 12,
+            )
+          )
+        )
+        .getValue("A.kt")
+        .single()
+
+    assertEquals(PlaygroundPosition(3, 5), error.interval.start)
+    assertEquals(PlaygroundPosition(3, 12), error.interval.end)
+    assertEquals("ERROR", error.severity)
+    assertEquals("red_wavy_line", error.className)
+    assertEquals("unresolved reference", error.message)
+  }
+
+  @Test
+  fun `a diagnostic with no end collapses to a zero-width caret at the start`() {
+    val error =
+      PlaygroundErrorsWire.project(
+          listOf(
+            PlaygroundDiagnostic(PlaygroundSeverity.WARNING, "w", file = "A.kt", line = 4, ch = 2)
+          )
+        )
+        .getValue("A.kt")
+        .single()
+
+    assertEquals(PlaygroundPosition(4, 2), error.interval.start)
+    assertEquals(PlaygroundPosition(4, 2), error.interval.end, "end defaults to the start")
+    assertEquals("yellow_wavy_line", error.className)
+  }
+
+  @Test
+  fun `a file-less diagnostic lands under the default file key at the origin`() {
+    val errors =
+      PlaygroundErrorsWire.project(
+        listOf(PlaygroundDiagnostic(PlaygroundSeverity.ERROR, "module-level failure"))
+      )
+
+    val error = errors.getValue(PlaygroundErrorsWire.DEFAULT_FILE).single()
+    assertEquals(PlaygroundPosition(0, 0), error.interval.start)
+    assertEquals(PlaygroundPosition(0, 0), error.interval.end)
+  }
+
+  @Test
+  fun `no diagnostics projects to an empty map`() {
+    assertTrue(PlaygroundErrorsWire.project(emptyList()).isEmpty())
+  }
+}

--- a/docs/design/PLAYGROUND.md
+++ b/docs/design/PLAYGROUND.md
@@ -193,9 +193,17 @@ we mount the shim at the versioned path the frontend emits.
 
 Request body is `{ args, files: [{ name, text, publicId }], confType }`; the
 `confType` selects the mode ([§3](#3-the-three-modes--three-permalink-targets)).
-Response reuses the upstream shape (`{ errors, text, exception, … }`) with two
-**additive** fields — `image` (first-frame `data:` PNG) and `previewToken` — that
-the upstream frontend ignores and ours surfaces.
+
+The response carries the diagnostics in **both** shapes so neither client is
+second-class. Our own frontend reads a flat `diagnostics` list (`PlaygroundDiagnostic`);
+a stock `kotlin-playground` frontend reads `errors` — and that field is **not** a
+renamed flat list, it's upstream's **map keyed by file name** whose entries nest
+their position under `interval: { start, end }`, with an uppercase `severity`. So
+`errors` is a genuine *projection* of the same diagnostics (`PlaygroundErrorsWire`),
+not an alias — a straight `diagnostics` → `errors` rename would look compatible
+while rendering nothing in the stock editor. On top of that the response adds two
+fields the upstream frontend ignores and ours surfaces: `image` (first-frame
+`data:` PNG) and `previewToken`.
 
 > **On reusing the frontend at all.** Implementing this contract is what keeps a
 > stock editor an option; it is not a commitment to ship theirs. `kotlin-playground`


### PR DESCRIPTION
## Summary

Delivers the follow-up I committed to on the #2989 review, plus the doc precision fix. A stock `kotlin-playground` frontend reads compile errors from an `errors` **map keyed by file name**, each entry nesting its position under `interval: { start, end }` with an uppercase `severity` — **not** a flat list. So `diagnostics` → `errors` couldn't be a rename (it would look compatible and render nothing); it has to be a real projection.

- **`PlaygroundStockError` / `PlaygroundInterval` / `PlaygroundPosition`** wire types, and an `errors` field on `PlaygroundRunResponse` alongside our own flat `diagnostics`. Both are populated, so neither a stock nor our own frontend is second-class.
- **`PlaygroundErrorsWire.project`** groups diagnostics by file, nests positions under `interval`, and maps severity to the upstream uppercase spelling + the CodeMirror gutter class. Warnings are carried too (upstream's `errors` includes `WARNING` descriptors). A file-less diagnostic lands under a `File.kt` default at the origin; a diagnostic with no end collapses to a zero-width caret.
- **`PLAYGROUND.md` §4** tightened — it previously said the response "reuses the upstream shape", which conflated our response with the stock wire format and was the source of the review mismatch.

Still pure data + a projection function — not wired to any route yet, so nothing is reachable from a running server until the compile-handler follow-up lands.

## Context on the classpath question (for reviewers)

Settled the design-doc open question on classpath source: the playground compile classpath will be the **liveBundle's resolved `userClassPath`** (`ServeBundleDaemon` already extracts `classes/app.jar` + resolves the Maven coordinates), so a snippet can `import` both the library and the catalog's own composables with no new resolver. First catalog is `compose-m3` (CMP), whose component surface is a complete, un-minimized Google-Maven jar. That work lands with the compile handler, not here.

## Test plan

- [x] `./gradlew :cli:test --tests "ee.schimke.composeai.cli.serve.PlaygroundErrorsWireTest"` — green (grouping by file, interval nesting + upstream severity/className, caret collapse, file-less default, empty→empty).
- [x] `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` — clean.
- Non-visual change (server-side wire types + a pure projection); no rendered surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_