### PR TITLE
feat(plugin): honour @PreviewParameter row exclusions on the Robolectric render too

### DIFF
--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewFilter.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewFilter.kt
@@ -34,6 +34,9 @@ object PreviewFilter {
   /** System property carrying the comma-separated `--exclude-preview-id` id patterns. */
   const val ID_EXCLUDE_PROPERTY: String = "composeai.preview.idExclude"
 
+  /** System property carrying the comma-separated `--exclude-preview-row` label patterns. */
+  const val ROW_EXCLUDE_PROPERTY: String = "composeai.preview.rowExclude"
+
   /**
    * Reads one of the comma-separated pattern system properties into a cleaned list: split on `,`,
    * trimmed, blanks dropped. Absent / blank → an empty list ("no filter"). The same comma-separated
@@ -239,4 +242,46 @@ object PreviewFilter {
     flushLiteral()
     return Regex(out.toString())
   }
+
+  /**
+   * The indices of [suffixes] whose `@PreviewParameter` row should render, in order.
+   *
+   * The row axis is separate from the id filters above because the ids they match are the
+   * **discovered** ones: a parameterized function is one entry in `previews.json` (discovery reads
+   * bytecode and can't instantiate a provider), and its rows only exist once the render JVM has
+   * enumerated the values and labelled them. So a design system whose palettes come from a provider
+   * — the shape behind #2966's measurement — can only be thinned here, by label.
+   *
+   * [suffixes] are the per-row suffixes the renderer computed (`"_Dark"`, or `"_PARAM_3"` for a
+   * value that couldn't be labelled); the leading `_` is stripped before matching, so a caller
+   * writes `--exclude-preview-row Dark`, matching the filename they see. Matching is
+   * **case-insensitive** — deliberately unlike [matchesId], since a label comes from user data
+   * (`"Dark"`) while the pattern is usually a design spec's own spelling (`"dark"`), and widening
+   * an exclusion is safe where widening a positive filter would not be.
+   *
+   * Two rules keep it from ever costing coverage silently, mirroring the desktop renderer's
+   * `PreviewRowFilter`:
+   * - a preview with no fan-out (a single empty suffix) is never filtered — it has no rows, so a
+   *   row pattern must not be able to delete its only render;
+   * - if every row matches, none is skipped: a preview that rendered nothing would publish as a
+   *   component with no pixels, which is a misconfigured exclusion rather than a deferral.
+   */
+  fun keptRowIndices(suffixes: List<String>, patterns: List<String>): List<Int> {
+    val all = suffixes.indices.toList()
+    val cleaned = patterns.map(String::trim).filter(String::isNotEmpty)
+    if (cleaned.isEmpty()) return all
+    if (suffixes.size == 1 && suffixes[0].isEmpty()) return all
+    val kept = all.filterNot { matchesRowLabel(cleaned, suffixes[it].removePrefix("_")) }
+    return if (kept.isEmpty()) all else kept
+  }
+
+  /**
+   * True when a row [label] matches one of [patterns] — glob when it has `*`/`?`, else equality.
+   */
+  fun matchesRowLabel(patterns: Collection<String>, label: String): Boolean =
+    patterns.map(String::trim).filter(String::isNotEmpty).any { pattern ->
+      if (pattern.any { it == '*' || it == '?' })
+        Regex(globToRegex(pattern).pattern, RegexOption.IGNORE_CASE).matches(label)
+      else label.equals(pattern, ignoreCase = true)
+    }
 }

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/PreviewFilterTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/PreviewFilterTest.kt
@@ -184,4 +184,69 @@ class PreviewFilterTest {
   fun patternsFromAbsentPropertyIsEmpty() {
     assertEquals(emptyList(), PreviewFilter.patternsFrom("missing") { null })
   }
+
+  // --- @PreviewParameter row exclusions ---------------------------------------------------------
+
+  /** What `PreviewParameterLabels.suffixesFor` hands the Robolectric expansion for four values. */
+  private val rowSuffixes = listOf("_Amber", "_Crimson", "_Teal", "_Violet")
+
+  @Test
+  fun keptRowIndicesWithNoPatternsKeepsEveryRow() {
+    assertEquals(listOf(0, 1, 2, 3), PreviewFilter.keptRowIndices(rowSuffixes, emptyList()))
+    assertEquals(listOf(0, 1, 2, 3), PreviewFilter.keptRowIndices(rowSuffixes, listOf(" ", "")))
+  }
+
+  @Test
+  fun keptRowIndicesDropsAnExactLabel() {
+    assertEquals(listOf(0, 2, 3), PreviewFilter.keptRowIndices(rowSuffixes, listOf("Crimson")))
+  }
+
+  @Test
+  fun keptRowIndicesMatchesLabelsCaseInsensitively() {
+    // The motivating case: a spec says `modePriority: { dark: deferred }` while the provider value
+    // labels itself `Dark`. Unlike `matchesId`, the row axis folds case.
+    assertEquals(listOf(0, 1, 3), PreviewFilter.keptRowIndices(rowSuffixes, listOf("teal")))
+  }
+
+  @Test
+  fun keptRowIndicesMatchesGlobs() {
+    assertEquals(listOf(1, 3), PreviewFilter.keptRowIndices(rowSuffixes, listOf("?ea*", "Amber")))
+    // Anchored: a bare substring is not a glob and must not match.
+    assertEquals(listOf(0, 1, 2, 3), PreviewFilter.keptRowIndices(rowSuffixes, listOf("mber")))
+  }
+
+  @Test
+  fun keptRowIndicesIgnoresTheLeadingUnderscore() {
+    // A caller writes what they read off the filename (`Foo_Crimson.png` -> `Crimson`).
+    assertEquals(listOf(0, 1, 2, 3), PreviewFilter.keptRowIndices(rowSuffixes, listOf("_Crimson")))
+  }
+
+  @Test
+  fun keptRowIndicesNeverEmptiesTheRowSet() {
+    // A preview that rendered nothing would publish as a component with no pixels — a misconfigured
+    // exclusion, not a deferral. Same never-empty rule the desktop renderer applies.
+    assertEquals(listOf(0, 1, 2, 3), PreviewFilter.keptRowIndices(rowSuffixes, listOf("*")))
+  }
+
+  @Test
+  fun keptRowIndicesLeavesAnUnparameterizedPreviewAlone() {
+    // The single empty suffix means "no fan-out": no rows, so a row pattern must not delete its
+    // only
+    // render.
+    assertEquals(listOf(0), PreviewFilter.keptRowIndices(listOf(""), listOf("*")))
+    assertEquals(listOf(0), PreviewFilter.keptRowIndices(listOf(""), listOf("Dark")))
+  }
+
+  @Test
+  fun keptRowIndicesAddressesUnlabelledRowsByIndexForm() {
+    assertEquals(
+      listOf(0),
+      PreviewFilter.keptRowIndices(listOf("_PARAM_0", "_PARAM_1"), listOf("PARAM_1")),
+    )
+  }
+
+  @Test
+  fun rowExcludePropertyIsTheWireContractWithThePlugin() {
+    assertEquals("composeai.preview.rowExclude", PreviewFilter.ROW_EXCLUDE_PROPERTY)
+  }
 }

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -429,11 +429,14 @@ Caveats worth knowing before reaching for it:
   module-wide inside the render, an unrelated parameterized preview whose row is labelled like
   a deferred mode loses that row — the completeness gate then fails the publish for that
   component, which is the loud outcome, and the renderer never empties a preview's rows.
-- **An Android/Robolectric catalog gets the publish saving but not the render saving**
-  (`design-catalog-wear-m3`, `design-catalog-remote-m3`): that `composePreviewRender` is a
-  `Test` task reading the manifest directly and honours none of these filters — the same
-  backend gap #2066 left open for the name filter, tracked in #2977. The `--with-semantics`
-  saving *does* land there, since the CLI drives that pass.
+- **Both backends now honour every axis.** An Android/Robolectric catalog
+  (`design-catalog-wear-m3`, `design-catalog-remote-m3`, and the `pocket-casts` catalogs whose
+  nine palettes come from a provider) renders through a `RobolectricRenderTask` that reads the
+  same `composePreview.*` properties and forwards them into the render JVM as
+  `composeai.preview.*`, where the shared `PreviewFilter` applies them — the entry filter and
+  the id filters per #2977, and the row labels alongside them, since that renderer expands its
+  own `@PreviewParameter` rows. So the measured axis saving lands on the backend it was measured
+  on.
 - **A skipped render is still declared.** Deferred previews stay listed in the bundle's
   `previews.json` — the bundle task carries every selected preview and simply omits the
   PNG for one that didn't render — which is what keeps them addressable on the serve

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1906,15 +1906,19 @@ internal object AndroidPreviewSupport {
         // Preview filters (issues #2066 / #2966 / #2977). Conventions from the same Gradle
         // properties the desktop task uses; the `--preview` / `--preview-id` /
         // `--exclude-preview-id` options on this task override them. Forwarded to the render JVM as
-        // `composeai.preview.*` system properties below, where `PreviewFilter` applies them.
+        // `composeai.preview.*` system properties below, where `PreviewFilter` applies them. The
+        // `--exclude-preview-row` axis rides along: this backend expands `@PreviewParameter` rows
+        // itself, so it needs the same label filter the desktop renderer got.
         previewFilters.convention(ComposePreviewTasks.previewFilterProperty(project))
         previewIdFilters.convention(ComposePreviewTasks.previewIdFilterProperty(project))
         previewIdExcludes.convention(ComposePreviewTasks.previewIdExcludeProperty(project))
+        previewRowExcludes.convention(ComposePreviewTasks.previewRowExcludeProperty(project))
         jvmArgumentProviders.add(
           PreviewFilterSystemPropsProvider(
             nameFilters = previewFilters,
             idFilters = previewIdFilters,
             idExcludes = previewIdExcludes,
+            rowExcludes = previewRowExcludes,
           )
         )
         // Bail fast (with remediation) when the gate passed via project-deps tier but the
@@ -2093,7 +2097,8 @@ internal object AndroidPreviewSupport {
           tierProvider.get().equals("full", ignoreCase = true) &&
             previewFilters.getOrElse(emptyList()).none { it.isNotBlank() } &&
             previewIdFilters.getOrElse(emptyList()).none { it.isNotBlank() } &&
-            previewIdExcludes.getOrElse(emptyList()).none { it.isNotBlank() }
+            previewIdExcludes.getOrElse(emptyList()).none { it.isNotBlank() } &&
+            previewRowExcludes.getOrElse(emptyList()).none { it.isNotBlank() }
         }
         // The PNG files are written to `rendersDirectory` via the
         // `composeai.render.outputDir` system property, not through any
@@ -2344,6 +2349,9 @@ internal object AndroidPreviewSupport {
             nameFilters = ComposePreviewTasks.previewFilterProperty(project),
             idFilters = ComposePreviewTasks.previewIdFilterProperty(project),
             idExcludes = ComposePreviewTasks.previewIdExcludeProperty(project),
+            // Forwarded for uniformity; the XR subspace render has no `@PreviewParameter` fan-out
+            // to thin, so it is inert there rather than meaningful.
+            rowExcludes = ComposePreviewTasks.previewRowExcludeProperty(project),
           )
         )
         outputs.cacheIf("composePreviewRenderXr caches unfiltered runs only") {
@@ -3127,11 +3135,11 @@ internal object AndroidPreviewSupport {
   }
 
   /**
-   * Forwards the `--preview` / `--preview-id` / `--exclude-preview-id` selection to the Robolectric
-   * render JVM as the `composeai.preview.*` system properties `PreviewFilter` reads (issue #2977).
-   * Lazy `@Input` providers so a filter change re-runs the render without invalidating the
-   * configuration cache more than the underlying `composePreview.*` property already does; an empty
-   * list emits no argument ("render everything").
+   * Forwards the `--preview` / `--preview-id` / `--exclude-preview-id` / `--exclude-preview-row`
+   * selection to the Robolectric render JVM as the `composeai.preview.*` system properties
+   * `PreviewFilter` reads (issue #2977). Lazy `@Input` providers so a filter change re-runs the
+   * render without invalidating the configuration cache more than the underlying `composePreview.*`
+   * property already does; an empty list emits no argument ("render everything").
    *
    * The property names are the wire contract with the renderer-side
    * `ee.schimke.composeai.data.render.PreviewFilter` constants (`NAME_FILTER_PROPERTY` etc.) — the
@@ -3141,11 +3149,16 @@ internal object AndroidPreviewSupport {
     @get:org.gradle.api.tasks.Input val nameFilters: org.gradle.api.provider.Provider<List<String>>,
     @get:org.gradle.api.tasks.Input val idFilters: org.gradle.api.provider.Provider<List<String>>,
     @get:org.gradle.api.tasks.Input val idExcludes: org.gradle.api.provider.Provider<List<String>>,
+    @get:org.gradle.api.tasks.Input val rowExcludes: org.gradle.api.provider.Provider<List<String>>,
   ) : org.gradle.process.CommandLineArgumentProvider {
     override fun asArguments(): Iterable<String> = buildList {
       arg("composeai.preview.filter", nameFilters.getOrElse(emptyList()))
       arg("composeai.preview.idFilter", idFilters.getOrElse(emptyList()))
       arg("composeai.preview.idExclude", idExcludes.getOrElse(emptyList()))
+      // The `@PreviewParameter` row axis. It has to travel separately from the id patterns because
+      // this backend, like the desktop one, applies the id filters to DISCOVERED entries — before
+      // `expandParameterProvider` mints the per-row ids — so an id pattern can never name a row.
+      arg("composeai.preview.rowExclude", rowExcludes.getOrElse(emptyList()))
     }
 
     private fun MutableList<String>.arg(property: String, values: List<String>) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2354,10 +2354,22 @@ internal object AndroidPreviewSupport {
             rowExcludes = ComposePreviewTasks.previewRowExcludeProperty(project),
           )
         )
+        // The row filter joins the gate even though it can't change what this task renders: XR has
+        // no
+        // `@PreviewParameter` fan-out. What matters is the OUTPUT — this task declares the whole
+        // shared `rendersDirectory` below, so under a row-filtered run it would happily store a
+        // snapshot containing the excluded rows' stale PNGs (left there by whatever ran last,
+        // exactly
+        // as the image render intends) and a clean machine would later restore them for the same
+        // filtered key. `composePreviewRender` refuses to cache such a run for that very reason;
+        // the
+        // sibling that shares its directory has to refuse too, or the gate leaks through the back
+        // door.
         outputs.cacheIf("composePreviewRenderXr caches unfiltered runs only") {
           ComposePreviewTasks.previewFilterProperty(project).get().none { it.isNotBlank() } &&
             ComposePreviewTasks.previewIdFilterProperty(project).get().none { it.isNotBlank() } &&
-            ComposePreviewTasks.previewIdExcludeProperty(project).get().none { it.isNotBlank() }
+            ComposePreviewTasks.previewIdExcludeProperty(project).get().none { it.isNotBlank() } &&
+            ComposePreviewTasks.previewRowExcludeProperty(project).get().none { it.isNotBlank() }
         }
 
         outputs.dir(rendersDirectory).withPropertyName("xrRendersDir")

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RobolectricRenderTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RobolectricRenderTask.kt
@@ -8,11 +8,11 @@ import org.gradle.api.tasks.testing.Test
 /**
  * The Android `composePreviewRender` task — a Robolectric [Test] that renders `@Preview`s inside
  * the test JVM — subtyped only so it can carry the same `--preview` / `--preview-id` /
- * `--exclude-preview-id` command-line options the desktop [RenderPreviewsTask] exposes
- * (issues #2066 / #2966 / #2977). A plain `Test` can't declare `@Option`s, and before #2977 those
- * options (and their `composePreview.filter` / `.idFilter` / `.idExclude` property conventions)
- * reached only the desktop backend, so `:app:composePreviewRender --preview Foo` was inert on an
- * Android module.
+ * `--exclude-preview-id` / `--exclude-preview-row` command-line options the desktop
+ * [RenderPreviewsTask] exposes (issues #2066 / #2966 / #2977). A plain `Test` can't declare
+ * `@Option`s, and before #2977 those options (and their `composePreview.filter` / `.idFilter` /
+ * `.idExclude` property conventions) reached only the desktop backend, so
+ * `:app:composePreviewRender --preview Foo` was inert on an Android module.
  *
  * The three list properties are the single source of truth: [AndroidPreviewSupport] sets their
  * conventions from the matching Gradle properties, forwards them to the Robolectric render JVM as
@@ -70,5 +70,28 @@ abstract class RobolectricRenderTask : Test() {
   )
   fun setPreviewIdExcludeOption(values: List<String>) {
     previewIdExcludes.set(values)
+  }
+
+  /**
+   * `--exclude-preview-row` label patterns (repeatable). Convention: `composePreview.rowExclude`.
+   *
+   * The one axis the id patterns above can't express on either backend: the id filters run over
+   * DISCOVERED entries, and a `@PreviewParameter` provider's rows don't exist until
+   * `expandParameterProvider` enumerates them inside this render JVM. Matched against the row's
+   * label — the token in `<stem>_<label>.png` — case-insensitively, and never allowed to empty a
+   * preview's row set. Mirrors the desktop task's `previewRowExcludes`.
+   */
+  @get:Input abstract val previewRowExcludes: ListProperty<String>
+
+  @Option(
+    option = "exclude-preview-row",
+    description =
+      "Skip @PreviewParameter rows whose label matches this pattern (repeatable; '*'/'?' globs or " +
+        "an exact label, case-insensitive), rendering the rest. Addresses one row of a " +
+        "parameterized preview, which --exclude-preview-id cannot. Never empties a preview's rows. " +
+        "Overrides -PcomposePreview.rowExclude.",
+  )
+  fun setPreviewRowExcludeOption(values: List<String>) {
+    previewRowExcludes.set(values)
   }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewFilterSystemPropsProviderTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewFilterSystemPropsProviderTest.kt
@@ -24,6 +24,7 @@ class PreviewFilterSystemPropsProviderTest {
           nameFilters = list("Foo", "Bar"),
           idFilters = list("*_Light"),
           idExcludes = list("*_Dark"),
+          rowExcludes = list("Dark", "ExtraDark"),
         )
         .asArguments()
         .toList()
@@ -33,6 +34,7 @@ class PreviewFilterSystemPropsProviderTest {
         "-Dcomposeai.preview.filter=Foo,Bar",
         "-Dcomposeai.preview.idFilter=*_Light",
         "-Dcomposeai.preview.idExclude=*_Dark",
+        "-Dcomposeai.preview.rowExclude=Dark,ExtraDark",
       )
   }
 
@@ -43,6 +45,7 @@ class PreviewFilterSystemPropsProviderTest {
           nameFilters = list(),
           idFilters = list(),
           idExcludes = list(),
+          rowExcludes = list(),
         )
         .asArguments()
         .toList()
@@ -57,10 +60,29 @@ class PreviewFilterSystemPropsProviderTest {
           nameFilters = list(" Foo ", "", "  "),
           idFilters = list(),
           idExcludes = list(),
+          rowExcludes = list(),
         )
         .asArguments()
         .toList()
 
     assertThat(args).containsExactly("-Dcomposeai.preview.filter=Foo")
+  }
+
+  @Test
+  fun `the row axis travels on its own property`() {
+    // It must not be folded into the id patterns: the id filters run over discovered entries, where
+    // a
+    // parameterized preview has no per-row id, so only a label can name one of its rows (#2966).
+    val args =
+      AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
+          nameFilters = list(),
+          idFilters = list(),
+          idExcludes = list(),
+          rowExcludes = list("Dark", " ExtraDark "),
+        )
+        .asArguments()
+        .toList()
+
+    assertThat(args).containsExactly("-Dcomposeai.preview.rowExclude=Dark,ExtraDark")
   }
 }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -170,7 +170,9 @@ object PreviewManifestLoader {
                 emptyList()
               }
         }
-    val expanded = expandedByEntry.flatMap { it.second }
+    // Excluded rows stay in `expandedByEntry` (the stale-fan-out sweep needs them in its expected
+    // set, see PreviewRow.excludedRow) but never reach sharding or the renderer.
+    val expanded = expandedByEntry.flatMap { it.second }.filterNot { it.excludedRow }
     // Tier filter (set by the plugin via TierSystemPropProvider). When
     // `fast`, drop heavyweight captures and annotation-sourced data
     // products. Heavy outputs keep their previous files on disk and stay
@@ -210,7 +212,18 @@ object PreviewManifestLoader {
     return ours.map { arrayOf<Any>(it.entry, it.previewArgs) }
   }
 
-  internal data class PreviewRow(val entry: RenderPreviewEntry, val previewArgs: List<Any?>)
+  /**
+   * One (preview, `@PreviewParameter` value) row. [excludedRow] marks a row the row filter dropped
+   * (`--exclude-preview-row`): it is NOT rendered, but it stays in the expanded list so
+   * [deleteStaleFanoutFiles]' expected-name set still covers its output — otherwise the sweep would
+   * delete the very PNG the filter exists to avoid re-rendering, which is the opposite of how a
+   * filtered-out preview behaves.
+   */
+  internal data class PreviewRow(
+    val entry: RenderPreviewEntry,
+    val previewArgs: List<Any?>,
+    val excludedRow: Boolean = false,
+  )
 
   /**
    * LPT (Longest-Processing-Time-first) bin-packing of preview rows onto `shardCount` shards by
@@ -296,9 +309,25 @@ object PreviewManifestLoader {
     // Provider loaded cleanly this run — drop any stale base error card a prior failed run left at
     // the unsuffixed output path, so a now-fixed provider doesn't keep haunting the panel.
     providerErrorOutputFile(entry)?.let { RenderErrorSidecar.deleteStale(it) }
-    val suffixes = PreviewParameterLabels.suffixesFor(values)
+    val allSuffixes = PreviewParameterLabels.suffixesFor(values)
+    // Row filter (`--exclude-preview-row` → `composeai.preview.rowExclude`). Applied here, after
+    // labelling: the id filters above ran over the DISCOVERED entries, where this parameterized
+    // preview is a single row with no per-value id, so a label is the only handle on one value. The
+    // stale fan-out cleanup below still keys on the FULL row set, so a skipped row keeps its previous
+    // PNG on disk exactly as a filtered-out preview does.
+    val keptRows =
+      PreviewFilter.keptRowIndices(
+        allSuffixes,
+        PreviewFilter.patternsFrom(PreviewFilter.ROW_EXCLUDE_PROPERTY),
+      )
+    if (keptRows.size < allSuffixes.size) {
+      System.err.println(
+        "@PreviewParameter on '${entry.id}': skipping ${allSuffixes.size - keptRows.size} of " +
+          "${allSuffixes.size} row(s) excluded by ${PreviewFilter.ROW_EXCLUDE_PROPERTY}"
+      )
+    }
     val rows = values.mapIndexed { idx, value ->
-      val paramSuffix = suffixes[idx]
+      val paramSuffix = allSuffixes[idx]
       val newCaptures =
         entry.captures.map { c ->
           c.copy(renderOutput = insertBeforeExtension(c.renderOutput, paramSuffix))
@@ -311,6 +340,7 @@ object PreviewManifestLoader {
       PreviewRow(
         entry.copy(id = newId, captures = newCaptures, dataProducts = newProducts),
         listOf(value),
+        excludedRow = idx !in keptRows,
       )
     }
     return rows

--- a/site/index.md
+++ b/site/index.md
@@ -129,9 +129,10 @@ function as a single preview. Those are skipped by **label** — the token in
 A row exclusion never empties a preview's rows: if every row matches, they all
 render, so nothing can silently produce a preview with no pixels.
 
-(Android modules render previews through a Robolectric test task, which reads none
-of these filters — tracked in
-[#2977](https://github.com/yschimke/compose-ai-tools/issues/2977).)
+All four filters work on both backends. An Android module renders through a
+Robolectric test task rather than this desktop one, and it reads the same options
+and the same `composePreview.*` properties — `#2977` closed the gap where they were
+desktop-only.
 
 Requirements and CI recipes live on the [Install page](./install/).
 


### PR DESCRIPTION
Closes the last gap between the deferral work and the number that motivated it.

## Why

#2977 brought the entry + id filters to the Android backend, and #2992 added the row axis — on desktop only. Robolectric expands its own `@PreviewParameter` rows, so the one combination the −59% measurement actually needs was still unthinned: `pocket-casts-android` is an **Android** module whose nine palettes come from `@PreviewParameter(ThemePreviewParameterProvider::class)` (see #2948), and neither existing filter reaches those rows.

The id filters can't, on either backend: they run over **discovered** entries, where a parameterized function is a single row with no per-value id — `expandParameterProvider` mints the row ids later, inside the render JVM.

## What

- **`PreviewFilter`** (the shared renderer-side filter, `:data-render-core`) gains `ROW_EXCLUDE_PROPERTY` + `keptRowIndices`, mirroring the desktop `PreviewRowFilter` rule for rule: label matched **case-insensitively** (a label is user data, `"Dark"`; the pattern is usually a spec's own spelling, `"dark"`), `*`/`?` globs, and two never-empty guards — an unparameterized preview is untouched, and if *every* row matches none is skipped.
- **`RobolectricRenderTest.expandParameterProvider`** applies it immediately after labelling, the only point where the rows exist.
- **`PreviewRow.excludedRow`** marks a dropped row rather than removing it from the expanded list. That's load-bearing: `deleteStaleFanoutFiles` builds its expected-name set *from* the expanded rows, so dropping them there would delete exactly the PNGs the filter exists to avoid re-rendering — the opposite of how a filtered-out preview behaves. Excluded rows are filtered out of what reaches sharding and the renderer.
- **`RobolectricRenderTask --exclude-preview-row`** + the `composePreview.rowExclude` convention, forwarded as `composeai.preview.rowExclude` through the existing `PreviewFilterSystemPropsProvider`, and folded into the Android task's `cacheIf` gate (a row-filtered run writes a partial `renders/` set, same as any other filtered one).

Every axis — `--preview`, `--preview-id`, `--exclude-preview-id`, `--exclude-preview-row` — now behaves the same on both backends.

## Docs corrected, not just extended

Two passages became false with this change and were wrong to leave: the site page's "(Android modules … reads none of these filters)" note and `DESIGN_CATALOGS.md`'s "an Android/Robolectric catalog gets the publish saving but not the render saving" bullet. Both were written on #2992, before #2977 landed. Replaced with what's now true.

## Test plan

- Nine `keptRowIndices` cases added to the shared `PreviewFilterTest` (exact label, glob, case-insensitivity, the underscore boundary, never-empty, unparameterized preview, `_PARAM_<idx>` rows, and the wire-contract property name), plus the row property pinned in `PreviewFilterSystemPropsProviderTest`.
- `:gradle-plugin:test`, `:data-render-core:test`, `ktfmtCheck` green; `:renderer-android:compileDebugKotlin` clean.
- No sample end-to-end run here: the Robolectric path needs the Android SDK render stack, and this sandbox can't complete a rasterising render at all (the desktop Skiko fork can't resolve `libGL.so.1`). The desktop half of this exact filter was verified end-to-end on `:samples:cmp` in #2992 — same rule, same never-empty guards, and CI's `Renderer Android Unit Tests` + `Build Samples` exercise this path.

Non-visual: render scheduling and plumbing only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Luh8YAEJ8y7L8pw99gdEsQ)_