### PR TITLE
fix(plugin): scope the render duplicate-guard coordinate map to each task's own classpath

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1740,16 +1740,35 @@ internal object AndroidPreviewSupport {
         } ?: RenderClasspathDuplicates.MODE_WARN
     // Exact file → `group:name:version` map for the duplicate guard, covering every configuration
     // that can put a module artifact on a render classpath. Lazy: nothing resolves here.
+    //
+    // **One map per consumer classpath, and only configurations that classpath actually resolves.**
+    // The map is read with `.get()` from a `doFirst`, which resolves the artifacts of every
+    // configuration folded into it. A configuration that is NOT on the reading task's own
+    // `classpath` contributes no task dependency, so when its artifacts come from a project in the
+    // same build — `project(":daemon:android")`, whose consumable jar is produced by
+    // `:daemon:android:createFullJarDebug` — Gradle refuses the read with `Querying the mapped
+    // value of provider(java.util.Set) before task ':daemon:android:createFullJarDebug' has
+    // completed is not supported`, and only when the producer happens not to have run yet for some
+    // other reason (so it presents as an intermittent whole-render failure, not a reliable one).
+    // Hence the split: the render `Test` tasks read [renderArtifactCoordinates] (built from the
+    // configurations `buildTestClasspath` resolves for them), and the daemon-descriptor task reads
+    // [daemonArtifactCoordinates], which swaps in the daemon config it — and only it — puts on its
+    // classpath. Adding a configuration here that the reading task's classpath doesn't carry
+    // reintroduces the failure.
     val renderArtifactCoordinates =
       AndroidPreviewClasspath.buildArtifactCoordinates(
         project = project,
+        configurations = listOfNotNull(rendererConfig, testConfig, screenshotTestRuntimeConfig),
+      )
+    // The daemon descriptor task's classpath resolves `daemonRendererConfig` in place of
+    // `rendererConfig` (it extends it, so one resolution covers both — see the `classpath.from`
+    // below), which is what makes `:daemon:android`'s jar a dependency of that task and this read
+    // legal there.
+    val daemonArtifactCoordinates =
+      AndroidPreviewClasspath.buildArtifactCoordinates(
+        project = project,
         configurations =
-          listOfNotNull(
-            rendererConfig,
-            daemonRendererConfig,
-            testConfig,
-            screenshotTestRuntimeConfig,
-          ),
+          listOfNotNull(daemonRendererConfig, testConfig, screenshotTestRuntimeConfig),
       )
     val resolvedClasspath =
       AndroidPreviewClasspath.buildTestClasspath(
@@ -2829,13 +2848,15 @@ internal object AndroidPreviewSupport {
       // a duplicate surviving in the AGP extras — or introduced by a future daemon-only addition —
       // invisible to both the warning and `composePreview.classpathDuplicates=fail`. Runs before
       // the descriptor is written, so a `fail` build never emits a descriptor the daemon would
-      // then launch from.
+      // then launch from. Reads the DAEMON-scoped coordinate map — this is the one task whose
+      // classpath resolves `daemonRendererConfig`, so it's the one task allowed to resolve that
+      // config's artifacts (see [renderArtifactCoordinates]).
       doFirst {
         RenderClasspathDuplicates.check(
           this,
           classpath.files,
           classpathDuplicatesMode,
-          renderArtifactCoordinates.get(),
+          daemonArtifactCoordinates.get(),
         )
       }
       // Static JVM open flags from the shared helper, plus the


### PR DESCRIPTION
Fixes the `Apply compose-preview` failure currently red on `main`.

## What was wrong

`composePreviewRender` (and its resources / XR siblings) read the file → `group:name:version` map for the duplicate-jar guard from a `doFirst`, with `.get()`. The map was built from four configurations, one of which — `daemonRendererConfig` — those tasks' classpath never resolves: `buildTestClasspath` is given `rendererConfig`, `testConfig` and `screenshotTestRuntimeConfig` for them.

Reading the map therefore resolved `project(":daemon:android")`'s consumable jar with no task dependency on its producer, and Gradle rejects that:

```
* What went wrong:
Execution failed for task ':samples:android-library:composePreviewRender'.
> Querying the mapped value of provider(java.util.Set) before task
  ':daemon:android:createFullJarDebug' has completed is not supported

Caused by: org.gradle.api.InvalidUserCodeException: …
	at org.gradle.api.internal.provider.TransformBackedProvider.beforeRead(TransformBackedProvider.java:95)
	at ee.schimke.composeai.plugin.AndroidPreviewSupport$registerAndroidTasks$renderTask$1$9
	    .execute(AndroidPreviewSupport.kt:2133)
```

It only fires when the producer happens not to have run yet, so it presents as an intermittent whole-render failure rather than a reliable one — which is how `Apply compose-preview` went red on `main` with no commit in the area:

| Run | Head | Result |
|---|---|---|
| [30532713621](https://github.com/yschimke/compose-ai-tools/actions/runs/30532713621) | `main` @ `6d9d700` | ❌ 4 × this error |
| [30532572883](https://github.com/yschimke/compose-ai-tools/actions/runs/30532572883) | `main` @ `32167d4` | ❌ |
| [30526623810](https://github.com/yschimke/compose-ai-tools/actions/runs/30526623810) | `main` @ `87ee1d2` | ❌ first completed red run |
| [30526258891](https://github.com/yschimke/compose-ai-tools/actions/runs/30526258891) | `main` @ `c59bfad8` | ✅ last green |

The pipeline then reports `Render failed` → `no _previews.json` → the render/notification comparison comments come out empty (`0 added · 0 changed · 22 removed`), which is the same failure wearing a different hat.

## The change

One coordinate map per consumer classpath, containing only configurations that classpath actually resolves:

* `renderArtifactCoordinates` — `rendererConfig` + `testConfig` + `screenshotTestRuntimeConfig`, read by the three render `Test` tasks.
* `daemonArtifactCoordinates` (new) — swaps in `daemonRendererConfig`, read only by the daemon-descriptor task, which is the one task that puts that config on its classpath (`classpath.from(buildTestClasspath(rendererConfig = daemonRendererConfig, …))`) and therefore does depend on `:daemon:android:createFullJarDebug`.

Coverage of the guard is unchanged: each classpath is still checked against a map spanning every configuration that can put a module artifact in front of *that* classloader. The comment on `renderArtifactCoordinates` records the invariant so a future addition doesn't quietly reintroduce it.

## Test plan

Full workspace render, before and after, on this machine (`./gradlew composePreviewRenderAll --continue --stacktrace`):

| | before | after |
|---|---|---|
| `Querying the mapped value …createFullJarDebug…` occurrences | 28 | **0** |
| failing tasks | 18 | 9 |

The 9 remaining failures are unrelated to this change and are artefacts of this sandbox, not of the build: 5 Android tasks fail in Gradle's HTML *report writer* (`Could not generate test report` → `Malformed input or input contains unmappable characters` on preview names containing non-ASCII, i.e. a non-UTF-8 default charset here), and 4 desktop `composePreviewRenderAll` tasks fail because Skiko can't rasterise without `libGL.so.1` in this container. Every Android module that previously failed *only* on the provider error now renders: `android-library`, `android-screenshot-test`, `sdk-matrix`, `remotecompose`, `wear-widget`, `design-catalog-m3-android`, `design-catalog-remote-m3`, `design-catalog-wear-m3`, `xr-spatial:composePreviewRenderXr`.

No visual surface changes — this is build-graph plumbing, so text-only evidence is the right kind here. The real verification is `Apply compose-preview` going green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Luh8YAEJ8y7L8pw99gdEsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Luh8YAEJ8y7L8pw99gdEsQ)_