### PR TITLE
fix(cli): keep a build failure's reason when it isn't a decorated Gradle cause

### DIFF
--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -242,17 +242,7 @@ class GradleConnection(
     // Show the captured stderr (Gradle's error output)
     val captured = errorCapture.toString().trim()
     if (captured.isNotEmpty()) {
-      // Extract actionable lines from Gradle output
-      val lines = captured.lines()
-      val actionable = lines.filter { line ->
-        line.contains("error:", ignoreCase = true) ||
-          line.contains("FAILURE:") ||
-          line.contains("What went wrong") ||
-          line.contains("not found") ||
-          line.startsWith("e: ") ||
-          line.startsWith("> ") ||
-          line.startsWith("* ")
-      }
+      val actionable = actionableFailureLines(captured)
       if (actionable.isNotEmpty()) {
         for (line in actionable) {
           System.err.println(line)
@@ -452,4 +442,35 @@ private fun Throwable.causeMessages(): List<String> {
     cause = cause.cause
   }
   return messages
+}
+
+/**
+ * The lines worth showing from Gradle's captured stderr when a build fails, without `--verbose`.
+ *
+ * Everything between `* What went wrong:` and the next `* <section>:` header is kept **verbatim**,
+ * whatever it looks like. The per-line patterns only recognise Gradle's decorated cause lines (`>
+ * …`) and compiler diagnostics, so a reason written as plain prose — `Execution failed for task
+ * ':a:b'.`, or a task's own multi-line `GradleException` text — used to match nothing and be
+ * dropped, printing `* What went wrong:` followed immediately by `* Try:` and no reason at all.
+ * That empty block is worse than noise: `printBuildFailure`'s `captured.contains("What went
+ * wrong")` check then suppresses the exception-chain fallback too, so the run reports a failure
+ * with no cause anywhere in its output and the only way to learn what broke is to re-run the whole
+ * render with `--verbose` — which, in CI, means nobody can.
+ *
+ * Blank lines inside the block are dropped so the section stays tight (Gradle puts one before the
+ * next header).
+ */
+internal fun actionableFailureLines(captured: String): List<String> {
+  var inWhatWentWrong = false
+  return captured.lines().filter { line ->
+    val header = line.startsWith("* ")
+    if (header) inWhatWentWrong = line.contains("What went wrong")
+    header ||
+      (inWhatWentWrong && line.isNotBlank()) ||
+      line.contains("error:", ignoreCase = true) ||
+      line.contains("FAILURE:") ||
+      line.contains("not found") ||
+      line.startsWith("e: ") ||
+      line.startsWith("> ")
+  }
 }

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -459,18 +459,33 @@ private fun Throwable.causeMessages(): List<String> {
  *
  * Blank lines inside the block are dropped so the section stays tight (Gradle puts one before the
  * next header).
+ *
+ * The block ends at the next entry of [GRADLE_FAILURE_SECTIONS], not at the next line that merely
+ * starts with `* `: a task's `GradleException` message is free to contain its own unindented `* `
+ * bullets, and treating one of those as a section header would drop the rest of the reason —
+ * exactly the truncation this function exists to prevent (Codex review on #3003). Such a bullet is
+ * still printed, it just doesn't close the block.
  */
 internal fun actionableFailureLines(captured: String): List<String> {
   var inWhatWentWrong = false
   return captured.lines().filter { line ->
-    val header = line.startsWith("* ")
-    if (header) inWhatWentWrong = line.contains("What went wrong")
+    val header = GRADLE_FAILURE_SECTIONS.any { line.startsWith(it) }
+    if (header) inWhatWentWrong = line.startsWith("* What went wrong:")
     header ||
       (inWhatWentWrong && line.isNotBlank()) ||
       line.contains("error:", ignoreCase = true) ||
       line.contains("FAILURE:") ||
       line.contains("not found") ||
       line.startsWith("e: ") ||
-      line.startsWith("> ")
+      line.startsWith("> ") ||
+      line.startsWith("* ")
   }
 }
+
+/**
+ * The section headers Gradle's console failure report emits, each at column zero. Used to decide
+ * where a `* What went wrong:` block ends — see [actionableFailureLines]. `* Get more help at …` is
+ * the one that doesn't end in a colon, so these are matched as prefixes rather than by shape.
+ */
+private val GRADLE_FAILURE_SECTIONS =
+  listOf("* Where:", "* What went wrong:", "* Try:", "* Exception is:", "* Get more help at")

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/ActionableFailureLinesTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/ActionableFailureLinesTest.kt
@@ -1,0 +1,126 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins what a non-`--verbose` build failure shows from Gradle's stderr.
+ *
+ * The motivating bug: a render failure whose reason is plain prose (no `> ` decoration) printed `*
+ * What went wrong:` followed immediately by `* Try:` — a failure with no cause anywhere in the
+ * output, in CI, where re-running with `--verbose` isn't an option.
+ */
+class ActionableFailureLinesTest {
+
+  @Test
+  fun `keeps a plain-prose reason that matches none of the line patterns`() {
+    val captured =
+      """
+      FAILURE: Build failed with an exception.
+
+      * What went wrong:
+      Execution failed for task ':samples:android:composePreviewRender'.
+
+      * Try:
+      > Run with --stacktrace option to get the stack trace.
+      """
+        .trimIndent()
+
+    assertEquals(
+      listOf(
+        "FAILURE: Build failed with an exception.",
+        "* What went wrong:",
+        "Execution failed for task ':samples:android:composePreviewRender'.",
+        "* Try:",
+        "> Run with --stacktrace option to get the stack trace.",
+      ),
+      actionableFailureLines(captured),
+    )
+  }
+
+  @Test
+  fun `keeps every line of a multi-line task message`() {
+    val captured =
+      """
+      * What went wrong:
+      Execution failed for task ':app:composePreviewRenderAll'.
+      2 previews produced no PNG:
+        com.example.FooKt.Bar
+        com.example.FooKt.Baz
+      * Try:
+      """
+        .trimIndent()
+
+    val lines = actionableFailureLines(captured)
+    assertTrue(lines.contains("  com.example.FooKt.Bar"), lines.toString())
+    assertTrue(lines.contains("  com.example.FooKt.Baz"), lines.toString())
+  }
+
+  @Test
+  fun `stops keeping prose at the next section header`() {
+    val captured =
+      """
+      * What went wrong:
+      Something broke.
+      * Try:
+      Some untagged advice we don't need.
+      * Get more help at https://help.gradle.org
+      Another untagged line.
+      """
+        .trimIndent()
+
+    assertEquals(
+      listOf(
+        "* What went wrong:",
+        "Something broke.",
+        "* Try:",
+        "* Get more help at https://help.gradle.org",
+      ),
+      actionableFailureLines(captured),
+    )
+  }
+
+  @Test
+  fun `still keeps decorated causes and compiler diagnostics outside the block`() {
+    val captured =
+      """
+      e: file:///src/Foo.kt:3:1 Unresolved reference: bar
+      Something noisy we don't want.
+      > Task :app:compileKotlin FAILED
+      """
+        .trimIndent()
+
+    assertEquals(
+      listOf(
+        "e: file:///src/Foo.kt:3:1 Unresolved reference: bar",
+        "> Task :app:compileKotlin FAILED",
+      ),
+      actionableFailureLines(captured),
+    )
+  }
+
+  @Test
+  fun `each failure of a multi-failure build keeps its own reason`() {
+    val captured =
+      """
+      FAILURE: Build completed with 2 failures.
+      * What went wrong:
+      > Querying the mapped value of provider(java.util.Set) before task ':a:b' has completed
+      * Try:
+      * What went wrong:
+      Execution failed for task ':c:d'.
+      * Try:
+      """
+        .trimIndent()
+
+    val lines = actionableFailureLines(captured)
+    assertTrue(lines.contains("Execution failed for task ':c:d'."), lines.toString())
+    assertEquals(2, lines.count { it == "* What went wrong:" })
+  }
+
+  @Test
+  fun `empty input yields nothing`() {
+    assertEquals(emptyList<String>(), actionableFailureLines(""))
+  }
+}

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/ActionableFailureLinesTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/ActionableFailureLinesTest.kt
@@ -120,6 +120,57 @@ class ActionableFailureLinesTest {
   }
 
   @Test
+  fun `a starred bullet inside the message does not end the block`() {
+    // A task's own `GradleException` text may contain unindented `* ` bullets, which Gradle prints
+    // at column zero inside the block. Treating one as a section header would drop everything after
+    // it and reproduce the truncation this filter exists to prevent (Codex review on #3003).
+    val captured =
+      """
+      * What went wrong:
+      Execution failed for task ':app:composePreviewRenderAll'.
+      Previews declared in the manifest with no PNG:
+      * com.example.FooKt.Bar
+      * com.example.FooKt.Baz
+      Re-run with --preview to render one of them on its own.
+      * Try:
+      > Run with --stacktrace option to get the stack trace.
+      """
+        .trimIndent()
+
+    assertEquals(
+      listOf(
+        "* What went wrong:",
+        "Execution failed for task ':app:composePreviewRenderAll'.",
+        "Previews declared in the manifest with no PNG:",
+        "* com.example.FooKt.Bar",
+        "* com.example.FooKt.Baz",
+        "Re-run with --preview to render one of them on its own.",
+        "* Try:",
+        "> Run with --stacktrace option to get the stack trace.",
+      ),
+      actionableFailureLines(captured),
+    )
+  }
+
+  @Test
+  fun `every Gradle section header closes the block`() {
+    val captured =
+      """
+      * What went wrong:
+      The reason.
+      * Exception is:
+      org.gradle.api.GradleException: The reason.
+      """
+        .trimIndent()
+
+    // `* Exception is:` is a real header, so the stack-trace prose under it stays out.
+    assertEquals(
+      listOf("* What went wrong:", "The reason.", "* Exception is:"),
+      actionableFailureLines(captured),
+    )
+  }
+
+  @Test
   fun `empty input yields nothing`() {
     assertEquals(emptyList<String>(), actionableFailureLines(""))
   }


### PR DESCRIPTION
## What was wrong

Without `--verbose`, `GradleConnection.printBuildFailure` prints only the lines it recognises from Gradle's captured stderr: compiler diagnostics and `> `-decorated cause lines. A failure whose reason is plain prose matches none of those patterns and was dropped, so the whole render reported this and nothing else:

```
FAILURE: Build failed with an exception.
* What went wrong:
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
```

An empty `What went wrong` block is worse than noise, because the `captured.contains("What went wrong")` check immediately below then suppresses the exception-chain fallback as well — so a failed run can report a failure with no cause *anywhere* in its output, and the only way to find out what broke is to re-run the whole render with `--verbose`. In CI, nobody can.

That's not hypothetical: it's what made a render failure on `main` undiagnosable from its `Apply compose-preview` log ([one example](https://github.com/yschimke/compose-ai-tools/actions/runs/30537672932/job/90854769992) — the compose pipeline runs for 12 minutes, fails, and the log shows `* What went wrong:` followed straight by `* Try:`). The classes of message this silently ate:

* `Execution failed for task ':samples:android:composePreviewRender'.` — Gradle's own description line, no `> ` prefix.
* Any task's multi-line `GradleException` text, e.g. the missing-render list from `composePreviewRenderAll` — only the first line is decorated, the rest are bare.

## The change

Everything between `* What went wrong:` and the next `* <section>:` header is kept **verbatim** (blank lines dropped, since Gradle puts one before the next header). Lines outside the block keep matching exactly the patterns they did before, so ordinary compile-error output is unchanged. A multi-failure build gets each block's reason, not just the decorated ones.

The filter moves out of the private `printBuildFailure` into a top-level `internal fun actionableFailureLines(captured: String)` so it can be tested against real Gradle output shapes.

## Test plan

New `ActionableFailureLinesTest` (`:gradle-preview-driver:test`) — 6 cases, all passing locally:

* plain-prose reason (`Execution failed for task …`) is kept — the regression case;
* every line of a multi-line task message is kept;
* prose stops being kept at the next `* ` header (advice sections don't leak);
* decorated causes and `e: ` compiler diagnostics outside the block still pass;
* a two-failure build keeps both reasons;
* empty input yields nothing.

```
./gradlew :gradle-preview-driver:test --tests '*ActionableFailureLinesTest*'
BUILD SUCCESSFUL
```

No visual surfaces touched — this is CLI diagnostic output, so text-only evidence is the right kind here.

Found while diagnosing the `createFullJarDebug` provider failure fixed in #3002; the residual failure in that same log still has no visible cause, which this makes readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Luh8YAEJ8y7L8pw99gdEsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Luh8YAEJ8y7L8pw99gdEsQ)_