### PR TITLE
feat(serve): Stage-1 playground compile orchestrator

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -1,0 +1,200 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.Base64
+import okio.FileSystem
+import okio.Path
+
+/**
+ * Stage-1 orchestrator for the playground (`docs/design/PLAYGROUND.md` §2). Turns a
+ * [PlaygroundRunRequest] into a [PlaygroundRunResponse]: stage the snippet to a temp dir, compile
+ * it against the mode's catalog classpath, and — on a clean compile — mint an expiring preview
+ * token that Stage 2 redeems into a live session. Compile errors return diagnostics and **no**
+ * token.
+ *
+ * Every collaborator that touches the daemon, the compiler, or the catalog is an **injected seam**,
+ * so the orchestration (staging, gating, cleanup, token minting, response shaping) is unit-testable
+ * without a real BTA classloader or a running daemon — the same split
+ * `DefaultBtaCompileService.forSession` uses. The route handler (a follow-up) constructs this with
+ * the real backends.
+ *
+ * The single knob with real design weight is [catalogClasspath]. Its production implementation is a
+ * thin adapter over the **liveBundle** resolution the serve host already runs
+ * ([ServeBundleDaemon.materialize]): the catalog's packed `.png`/zip bundle is extracted to its
+ * `classes/app.jar` and its `manifest.classpath` Maven coordinates resolved to jars, yielding the
+ * `userClassPath` the live daemon runs on. A snippet compiled against that classpath can `import`
+ * both the resolved library (e.g. `androidx.compose.material3.*`, complete because it comes from
+ * the unminimized library jar) and whatever of the catalog's own composables survived bundle
+ * minimization. `compose-m3` is the clean first catalog precisely because its component surface
+ * *is* the resolved library jar. See `docs/design/PLAYGROUND.md` §8.
+ */
+class PlaygroundCompileService(
+  /** Resolves the compile+render classpath for a mode; null ⇒ that mode isn't available here. */
+  private val catalogClasspath: (PlaygroundMode) -> Classpath?,
+  private val compiler: Compiler,
+  private val discoverer: PreviewDiscoverer,
+  private val tokenStore: PlaygroundTokenStore,
+  /**
+   * Mints a fresh, empty temp work dir per run — the token store deletes it when the token drops.
+   */
+  private val newWorkDir: () -> Path,
+  private val fileSystem: FileSystem = FileSystem.SYSTEM,
+  /** Optional first-frame render; returns PNG bytes or null. Defaults to no image (wired later). */
+  private val renderFirstFrame: (PlaygroundTokenStore.PlaygroundSnippet) -> ByteArray? = { null },
+) {
+
+  /**
+   * The resolved classpath a snippet compiles and renders against. Backed in production by a
+   * catalog's liveBundle `userClassPath` (see the class KDoc); [moduleName] matches the catalog's
+   * Kotlin module so the snippet's classes carry a consistent `kotlin.Metadata`.
+   */
+  data class Classpath(val moduleName: String, val entries: List<Path>)
+
+  /** Compiles [sources] against [classpath], emitting `.class` files into [outputDir]. */
+  fun interface Compiler {
+    fun compile(
+      sources: List<Path>,
+      classpath: List<Path>,
+      outputDir: Path,
+    ): List<PlaygroundDiagnostic>
+  }
+
+  /**
+   * Finds the `@Preview` id(s) in freshly compiled [classesDir]; empty ⇒ the snippet declared none.
+   */
+  fun interface PreviewDiscoverer {
+    fun discover(classesDir: Path, classpath: List<Path>): List<String>
+  }
+
+  /**
+   * Compile [request] and, on success, mint a preview token. [isSecurityChecked] is the greppable
+   * audit marker forwarded to [PlaygroundTokenStore.add]: the route passes `true` only once the
+   * request has cleared the playground gate.
+   */
+  fun run(request: PlaygroundRunRequest, isSecurityChecked: Boolean): PlaygroundRunResponse {
+    val files = request.files.filter { it.text.isNotBlank() }
+    if (files.isEmpty()) return failure("no source files supplied")
+
+    val mode = PlaygroundMode.fromConfType(request.confType)
+    val classpath =
+      catalogClasspath(mode) ?: return failure("mode ${mode.name} is not available on this host")
+
+    val workDir = newWorkDir()
+    return try {
+      compileAndMint(request, files, mode, classpath, workDir, isSecurityChecked)
+    } catch (t: Throwable) {
+      // Any unexpected failure past workDir creation must not strand the temp dir — the token store
+      // only owns dirs it accepted, so an aborted run cleans up its own.
+      cleanup(workDir)
+      failure("playground compile failed: ${t.message ?: t.javaClass.simpleName}")
+    }
+  }
+
+  private fun compileAndMint(
+    request: PlaygroundRunRequest,
+    files: List<PlaygroundFile>,
+    mode: PlaygroundMode,
+    classpath: Classpath,
+    workDir: Path,
+    isSecurityChecked: Boolean,
+  ): PlaygroundRunResponse {
+    val srcDir = workDir / "src"
+    val classesDir = workDir / "classes"
+    fileSystem.createDirectories(srcDir)
+    fileSystem.createDirectories(classesDir)
+    val sources = stageSources(files, srcDir)
+
+    val diagnostics = compiler.compile(sources, classpath.entries, classesDir)
+    if (diagnostics.any { it.severity == PlaygroundSeverity.ERROR }) {
+      cleanup(workDir)
+      return PlaygroundRunResponse(
+        diagnostics = diagnostics,
+        errors = PlaygroundErrorsWire.project(diagnostics),
+      )
+    }
+
+    val renderClasspath = classpath.entries + classesDir
+    val previews = discoverer.discover(classesDir, renderClasspath)
+    if (previews.isEmpty()) {
+      cleanup(workDir)
+      return PlaygroundRunResponse(
+        diagnostics = diagnostics,
+        errors = PlaygroundErrorsWire.project(diagnostics),
+        exception = "no @Preview found — a playground snippet must declare one @Preview composable",
+      )
+    }
+
+    val snippet =
+      PlaygroundTokenStore.PlaygroundSnippet(
+        mode = mode,
+        workDir = workDir,
+        classesDir = classesDir,
+        classpath = renderClasspath,
+        moduleName = classpath.moduleName,
+        previewId = previews.first(),
+      )
+    val image = renderFirstFrame(snippet)?.let(::toDataUri)
+    // From here the token owns workDir; do NOT cleanup on this path.
+    val token = tokenStore.add(snippet, isSecurityChecked = isSecurityChecked)
+    return PlaygroundRunResponse(
+      diagnostics = diagnostics,
+      errors = PlaygroundErrorsWire.project(diagnostics),
+      image = image,
+      previewToken = token.id,
+      previewUrl = token.path,
+    )
+  }
+
+  /**
+   * Write each file to [srcDir] under a safe, unique `.kt` name; return the staged source paths.
+   */
+  private fun stageSources(files: List<PlaygroundFile>, srcDir: Path): List<Path> {
+    val used = mutableSetOf<String>()
+    return files.map { file ->
+      val name = uniqueName(safeKtName(file.name), used)
+      val path = srcDir / name
+      fileSystem.write(path) { writeUtf8(file.text) }
+      path
+    }
+  }
+
+  private fun cleanup(workDir: Path) {
+    try {
+      fileSystem.deleteRecursively(workDir, mustExist = false)
+    } catch (_: Exception) {
+      // Best-effort — leaking one temp dir beats throwing out of an error path.
+    }
+  }
+
+  private fun failure(message: String) = PlaygroundRunResponse(exception = message)
+
+  companion object {
+    /**
+     * Reduce a client-supplied name to a safe `.kt` filename (last segment, printable, non-empty).
+     */
+    internal fun safeKtName(raw: String): String {
+      val base =
+        raw
+          .substringAfterLast('/')
+          .substringAfterLast('\\')
+          .filter { it.isLetterOrDigit() || it in "._-" }
+          .removeSuffix(".kt")
+          .takeIf { it.isNotBlank() } ?: "Snippet"
+      return "$base.kt"
+    }
+
+    /** Ensure the name is unique within a run, appending `_<n>` before `.kt` on collision. */
+    private fun uniqueName(name: String, used: MutableSet<String>): String {
+      if (used.add(name)) return name
+      val stem = name.removeSuffix(".kt")
+      var i = 1
+      while (true) {
+        val candidate = "${stem}_$i.kt"
+        if (used.add(candidate)) return candidate
+        i++
+      }
+    }
+
+    internal fun toDataUri(png: ByteArray): String =
+      "data:image/png;base64," + Base64.getEncoder().encodeToString(png)
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -78,13 +78,16 @@ class PlaygroundCompileService(
     val classpath =
       catalogClasspath(mode) ?: return failure("mode ${mode.name} is not available on this host")
 
-    val workDir = newWorkDir()
+    var workDir: Path? = null
     return try {
+      workDir = newWorkDir()
       compileAndMint(request, files, mode, classpath, workDir, isSecurityChecked)
     } catch (t: Throwable) {
-      // Any unexpected failure past workDir creation must not strand the temp dir — the token store
-      // only owns dirs it accepted, so an aborted run cleans up its own.
-      cleanup(workDir)
+      // Any failure — including newWorkDir() itself throwing on a full/unwritable temp volume —
+      // returns the JSON exception contract rather than escaping as a throwable. cleanup runs only
+      // once a path exists; the token store owns a dir only after it accepts one, so an aborted run
+      // clears its own.
+      workDir?.let { cleanup(it) }
       failure("playground compile failed: ${t.message ?: t.javaClass.simpleName}")
     }
   }
@@ -182,14 +185,21 @@ class PlaygroundCompileService(
       return "$base.kt"
     }
 
-    /** Ensure the name is unique within a run, appending `_<n>` before `.kt` on collision. */
-    private fun uniqueName(name: String, used: MutableSet<String>): String {
-      if (used.add(name)) return name
+    /**
+     * Ensure the name is unique within a run, appending `_<n>` before `.kt` on collision. Collision
+     * keys are **case-folded**: a case-insensitive target FS (Windows, default macOS) maps `A.kt`
+     * and `a.kt` to the same file, so two case-only-distinct names must be disambiguated or the
+     * second write silently overwrites the first while both paths still reach the compiler. Folding
+     * is universally safe — on a case-sensitive FS it only ever renames a name that would otherwise
+     * have been kept, never causing an overwrite.
+     */
+    private fun uniqueName(name: String, usedLowercase: MutableSet<String>): String {
+      if (usedLowercase.add(name.lowercase())) return name
       val stem = name.removeSuffix(".kt")
       var i = 1
       while (true) {
         val candidate = "${stem}_$i.kt"
-        if (used.add(candidate)) return candidate
+        if (usedLowercase.add(candidate.lowercase())) return candidate
         i++
       }
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
@@ -193,4 +193,46 @@ class PlaygroundCompileServiceTest {
       "colliding names are disambiguated",
     )
   }
+
+  @Test
+  fun `case-only-distinct names are disambiguated so a case-insensitive FS can't overwrite`() {
+    var staged: List<Path>? = null
+    val svc =
+      service(
+        compile = { s, _, _ ->
+          staged = s
+          emptyList()
+        }
+      )
+    svc.run(
+      PlaygroundRunRequest(
+        files = listOf(PlaygroundFile("A.kt", "fun a(){}"), PlaygroundFile("a.kt", "fun b(){}")),
+        confType = "compose-cmp",
+      ),
+      isSecurityChecked = true,
+    )
+    assertEquals(listOf("A.kt", "a_1.kt"), staged!!.map { it.name })
+  }
+
+  @Test
+  fun `a work-dir allocation failure returns the JSON contract, not a throw`() {
+    val svc =
+      PlaygroundCompileService(
+        catalogClasspath = { cmpClasspath },
+        compiler = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() },
+        discoverer = PlaygroundCompileService.PreviewDiscoverer { _, _ -> listOf("x") },
+        tokenStore = tokenStore,
+        newWorkDir = { throw java.io.IOException("no space left on device") },
+        fileSystem = fs,
+      )
+
+    val resp = svc.run(request(), isSecurityChecked = true)
+
+    assertNotNull(
+      resp.exception,
+      "a temp-volume failure is the JSON contract, not an escaped throw",
+    )
+    assertNull(resp.previewToken)
+    assertTrue(tokenStore.snapshot().isEmpty())
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
@@ -1,0 +1,196 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+/**
+ * The Stage-1 compile orchestrator: staging, compile gating, preview discovery, token minting,
+ * cleanup.
+ */
+class PlaygroundCompileServiceTest {
+
+  private val fs = FakeFileSystem()
+  private var workDirs = 0
+  private val tokenStore =
+    PlaygroundTokenStore(fileSystem = fs, clock = { 1_000L }, mintId = { "pg_token${workDirs}" })
+
+  private val cmpClasspath =
+    PlaygroundCompileService.Classpath("compose-m3", listOf("/catalog/app.jar".toPath()))
+
+  private fun service(
+    classpathFor: (PlaygroundMode) -> PlaygroundCompileService.Classpath? = { cmpClasspath },
+    compile: (List<Path>, List<Path>, Path) -> List<PlaygroundDiagnostic> = { _, _, _ ->
+      emptyList()
+    },
+    discover: (Path, List<Path>) -> List<String> = { _, _ -> listOf("com.example.SnippetPreview") },
+    render: (PlaygroundTokenStore.PlaygroundSnippet) -> ByteArray? = { null },
+  ) =
+    PlaygroundCompileService(
+      catalogClasspath = classpathFor,
+      compiler = PlaygroundCompileService.Compiler(compile),
+      discoverer = PlaygroundCompileService.PreviewDiscoverer(discover),
+      tokenStore = tokenStore,
+      newWorkDir = { "/work/run${++workDirs}".toPath() },
+      fileSystem = fs,
+      renderFirstFrame = render,
+    )
+
+  private fun request(
+    text: String = "@Preview @Composable fun P() {}",
+    confType: String = "compose-cmp",
+  ) = PlaygroundRunRequest(files = listOf(PlaygroundFile("Snippet.kt", text)), confType = confType)
+
+  @Test
+  fun `a clean compile mints a token pointing at the discovered preview`() {
+    var compiledClasspath: List<Path>? = null
+    val svc =
+      service(
+        compile = { sources, cp, out ->
+          compiledClasspath = cp
+          assertTrue(fs.exists(sources.single()), "the snippet is staged before compile")
+          assertTrue(out.toString().endsWith("classes"))
+          emptyList()
+        }
+      )
+
+    val resp = svc.run(request(), isSecurityChecked = true)
+
+    assertNotNull(resp.previewToken)
+    assertEquals("/pg/${resp.previewToken}", resp.previewUrl)
+    assertNull(resp.exception)
+    assertEquals(
+      listOf("/catalog/app.jar".toPath()),
+      compiledClasspath,
+      "compiled against the catalog classpath",
+    )
+
+    val token = tokenStore.get(resp.previewToken!!)!!
+    assertEquals("com.example.SnippetPreview", token.snippet.previewId)
+    assertEquals(PlaygroundMode.CMP, token.snippet.mode)
+    // The render classpath carries the catalog jars plus the snippet's own compiled classes.
+    assertTrue(token.snippet.classesDir in token.snippet.classpath)
+    assertTrue("/catalog/app.jar".toPath() in token.snippet.classpath)
+    assertTrue(fs.exists(token.snippet.workDir), "the work dir is retained for the live session")
+  }
+
+  @Test
+  fun `a compile error returns diagnostics under both shapes and no token, and cleans up`() {
+    val error =
+      PlaygroundDiagnostic(
+        PlaygroundSeverity.ERROR,
+        "unresolved reference: Bttun",
+        "Snippet.kt",
+        3,
+        4,
+      )
+    val svc = service(compile = { _, _, _ -> listOf(error) })
+
+    val resp = svc.run(request(), isSecurityChecked = true)
+
+    assertNull(resp.previewToken, "no token on a compile error")
+    assertEquals(listOf(error), resp.diagnostics)
+    assertEquals(listOf("Snippet.kt"), resp.errors.keys.toList(), "stock errors map keyed by file")
+    assertEquals(3, resp.errors.getValue("Snippet.kt").single().interval.start.line)
+    assertTrue(tokenStore.snapshot().isEmpty())
+    assertFalse(fs.exists("/work/run1".toPath()), "the aborted run deletes its own work dir")
+  }
+
+  @Test
+  fun `warnings survive a clean compile in both diagnostics and the errors map`() {
+    val warn =
+      PlaygroundDiagnostic(
+        PlaygroundSeverity.WARNING,
+        "parameter is never used",
+        "Snippet.kt",
+        1,
+        0,
+      )
+    val svc = service(compile = { _, _, _ -> listOf(warn) })
+
+    val resp = svc.run(request(), isSecurityChecked = true)
+
+    assertNotNull(resp.previewToken, "a warning is not an error — the token is still minted")
+    assertEquals(listOf(warn), resp.diagnostics)
+    assertEquals("WARNING", resp.errors.getValue("Snippet.kt").single().severity)
+  }
+
+  @Test
+  fun `no @Preview is a user error with no token and cleanup`() {
+    val svc = service(discover = { _, _ -> emptyList() })
+
+    val resp = svc.run(request(), isSecurityChecked = true)
+
+    assertNull(resp.previewToken)
+    assertNotNull(resp.exception)
+    assertTrue(resp.exception!!.contains("@Preview"))
+    assertFalse(fs.exists("/work/run1".toPath()))
+  }
+
+  @Test
+  fun `an unavailable mode is refused before any work dir is created`() {
+    val svc = service(classpathFor = { null })
+
+    val resp = svc.run(request(confType = "compose-android"), isSecurityChecked = true)
+
+    assertNull(resp.previewToken)
+    assertTrue(resp.exception!!.contains("ANDROID"))
+    assertEquals(0, workDirs, "no work dir minted when the mode is unavailable")
+  }
+
+  @Test
+  fun `blank requests are rejected`() {
+    val svc = service()
+    val resp =
+      svc.run(
+        PlaygroundRunRequest(files = listOf(PlaygroundFile("x.kt", "   "))),
+        isSecurityChecked = true,
+      )
+    assertNotNull(resp.exception)
+    assertNull(resp.previewToken)
+  }
+
+  @Test
+  fun `a first-frame render is surfaced as a data URI`() {
+    val svc = service(render = { byteArrayOf(1, 2, 3) })
+    val resp = svc.run(request(), isSecurityChecked = true)
+    assertEquals("data:image/png;base64,AQID", resp.image)
+  }
+
+  @Test
+  fun `file names are sanitised and de-duplicated`() {
+    // Path components are stripped (no traversal); only the safe basename survives.
+    assertEquals("passwd.kt", PlaygroundCompileService.safeKtName("../../etc/passwd"))
+    assertEquals("Main.kt", PlaygroundCompileService.safeKtName("Main.kt"))
+    // A name that reduces to nothing safe falls back to the default.
+    assertEquals("Snippet.kt", PlaygroundCompileService.safeKtName("   "))
+    assertEquals("Snippet.kt", PlaygroundCompileService.safeKtName("/////"))
+
+    var staged: List<Path>? = null
+    val svc =
+      service(
+        compile = { s, _, _ ->
+          staged = s
+          emptyList()
+        }
+      )
+    svc.run(
+      PlaygroundRunRequest(
+        files = listOf(PlaygroundFile("A.kt", "fun a(){}"), PlaygroundFile("A.kt", "fun b(){}")),
+        confType = "compose-cmp",
+      ),
+      isSecurityChecked = true,
+    )
+    assertEquals(
+      listOf("A.kt", "A_1.kt"),
+      staged!!.map { it.name },
+      "colliding names are disambiguated",
+    )
+  }
+}


### PR DESCRIPTION
## Summary

The Stage-1 brain for the Compose playground (`docs/design/PLAYGROUND.md` §2), building on the merged foundation (#2989) and stock-`errors` wire (#3000). `PlaygroundCompileService` turns a `PlaygroundRunRequest` into a `PlaygroundRunResponse`:

1. Stage the snippet files to a temp work dir (path-traversal-safe, deduplicated `.kt` names).
2. Resolve the mode's catalog classpath (unavailable mode → refused before any work dir is created).
3. Compile against it.
4. **Compile error** → diagnostics under both our `diagnostics` shape and the stock `errors` map, **no token**, work dir cleaned up.
5. **Clean compile** → discover the `@Preview`, mint an expiring preview token (the token store now owns the work dir), optionally attach a first-frame `data:` PNG, and return `previewToken` + `previewUrl` for the Stage-2 handoff.

Every daemon/compiler/catalog collaborator is an **injected seam** (the same split `DefaultBtaCompileService.forSession` uses), so the orchestration is unit-tested with fakes + a `FakeFileSystem` — no BTA classloader or running daemon.

### The classpath seam is bundle-backed (per discussion)

`catalogClasspath` is the one knob with design weight. Its production implementation is documented as a thin adapter over the **liveBundle** resolution the serve host already runs (`ServeBundleDaemon.materialize`): extract the catalog's packed `.png`/zip bundle to `classes/app.jar` and resolve its `manifest.classpath` Maven coordinates to jars — the same `userClassPath` the live daemon runs on. So a snippet can `import` the resolved library (complete, since it comes from the unminimized library jar) plus whatever catalog composables survived bundle minimization. `compose-m3` is the clean first catalog because its component surface *is* that resolved jar. Written up in PLAYGROUND.md §8; the real resolver + route wiring + Stage-2 redemption are the next slices.

## Test plan

- [x] `./gradlew :cli:test --tests "…PlaygroundCompileServiceTest" --tests "…PlaygroundErrorsWireTest" --tests "…PlaygroundTokenStoreTest"` — green (19 tests). Covers: clean compile → token + render classpath (catalog jars + snippet classes), compile error → both diagnostic shapes + cleanup + no token, warnings pass through, missing `@Preview`, unavailable mode refused pre-workdir, blank request, first-frame `data:` URI, filename sanitisation/dedup.
- [x] `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` — clean.
- Non-visual change (server-side orchestration + capability plumbing); no rendered surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_