### PR TITLE
fix(figma-svg): fit a scaled vector to its drawn bounds and drop a raster under live text

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -508,6 +508,88 @@ class RenderEngineTest {
   }
 
   @Test
+  fun figmaSvgFadesAnAlphaZeroRecordButtonEmbeddedInAnInputBar() {
+    // Issue #2853, the embedded alpha-zero clipped background: the recording circle is faded to
+    // `alpha = 0` through a `graphicsLayer` lambda block over a visible mic. The export must carry
+    // that evaluated layer alpha onto the group (opacity 0) and keep the mic as an editable path,
+    // rather than leaking an opaque blue circle the PNG never shows.
+    val outputDir = tempFolder.newFolder("renders-record-button")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=AlphaZeroRecordButton;" +
+              "widthPx=200;heightPx=56;density=1.0;" +
+              "showBackground=true;outputBaseName=record-button"
+        ),
+        timeoutMs = 120_000,
+      )
+
+      val svg =
+        outputDir.parentFile!!
+          .resolve("data")
+          .resolve("record-button")
+          .resolve("compose-figma.svg")
+          .readText()
+      assertTrue("the alpha-zero recording circle must be faded out", svg.contains("""opacity="0""""))
+      assertTrue("the microphone must remain an editable path", svg.contains("<path "))
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun figmaSvgKeepsAScaledVectorSquareInAnAnimatedLayout() {
+    // Issue #2853, the embedded distorted vector: a square create icon scaled through a graphics
+    // layer (Jetchat's `Profile/Animating FAB content`). Its captured scale is already baked into
+    // the drawn bounds, so the export must fit the vector to those bounds once — a uniform scale for
+    // a square icon — never multiplying a layout-slot fit by the captured scale again.
+    val outputDir = tempFolder.newFolder("renders-animated-fab")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=VectorIconInAnimatedLayout;" +
+              "widthPx=96;heightPx=96;density=1.0;" +
+              "showBackground=true;outputBaseName=animated-fab"
+        ),
+        timeoutMs = 120_000,
+      )
+
+      val svg =
+        outputDir.parentFile!!
+          .resolve("data")
+          .resolve("animated-fab")
+          .resolve("compose-figma.svg")
+          .readText()
+      assertTrue("the create icon must remain an editable path", svg.contains("<path "))
+
+      val scales =
+        Regex("""scale\(([-0-9.]+) ([-0-9.]+)\)""")
+          .findAll(svg)
+          .map { it.groupValues[1].toDouble() to it.groupValues[2].toDouble() }
+          .toList()
+      assertTrue("the scaled vector must emit a scale transform", scales.isNotEmpty())
+      assertTrue(
+        "a square icon must stay square (uniform scale), never squashed or double-counted: $scales",
+        scales.all { (x, y) -> abs(x - y) < 0.01 },
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun figmaSvgLongRenderModeProducesFullPageSvg() {
     // Parity with the desktop backend: the `figma-svg-long` render mode grows the viewport until a
     // virtualised LazyColumn composes every row, sizes to content, and writes the full-page SVG to

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -272,6 +272,130 @@ fun GraphicsLayerAndWideVector() {
   }
 }
 
+/**
+ * Android end-to-end fidelity fixture for #2853, the alpha-zero clipped background: Jetchat's
+ * `Composer/Record button` authors its recording circle with
+ * `graphicsLayer { alpha = containerAlpha.value; scaleX = scale; scaleY = scale }`, and idle it
+ * evaluates to `alpha = 0`, so the PNG shows only the microphone. The circle here is faded exactly
+ * that way — through the lambda block, over a visible vector mic — so the export must carry the
+ * evaluated layer alpha onto the group and drop the opaque circle, rather than leaking it as an
+ * opaque fill. Embedding it in an input-bar `Row` matches the container the regression appeared in.
+ */
+@Composable
+fun AlphaZeroRecordButton() {
+  val mic =
+    ImageVector.Builder(
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+      )
+      .apply {
+        path(fill = SolidColor(Color.White)) {
+          moveTo(12f, 3f)
+          lineTo(15f, 3f)
+          lineTo(15f, 13f)
+          lineTo(12f, 13f)
+          close()
+        }
+      }
+      .build()
+
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFF1F1F1F))) {
+    Row(
+      modifier = Modifier.fillMaxSize().padding(8.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      // A stand-in for the input field the record button sits beside (kept text-free so the fixture
+      // renders without a downloadable font under Robolectric).
+      Box(
+        modifier =
+          Modifier.testTag("input-field")
+            .width(120.dp)
+            .height(24.dp)
+            .background(Color(0xFF3A3A3A), RoundedCornerShape(12.dp))
+      )
+      Box(modifier = Modifier.width(8.dp).height(1.dp))
+      Box(contentAlignment = Alignment.Center) {
+        Box(
+          modifier =
+            Modifier.testTag("record-circle")
+              .size(40.dp)
+              .graphicsLayer {
+                alpha = 0f
+                scaleX = 0.8f
+                scaleY = 0.8f
+              }
+              .background(Color(0xFF2962FF), RoundedCornerShape(20.dp))
+        )
+        Icon(
+          imageVector = mic,
+          contentDescription = "record",
+          tint = Color.White,
+          modifier = Modifier.testTag("record-mic").size(24.dp),
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Android end-to-end fidelity fixture for #2853, a vector icon inside a custom animated layout:
+ * Jetchat's `Profile/Animating FAB content` scales its create icon through a graphics layer as the
+ * FAB expands. The captured draw-time scale is already baked into the icon's drawn bounds, so the
+ * export must fit the vector to those bounds *once* (keeping the square icon square) rather than
+ * multiplying a layout-slot fit by the captured scale again — the double-count that blew an embedded
+ * mic group up from `scale(2.62)` to `scale(6.54)`.
+ */
+@Composable
+fun VectorIconInAnimatedLayout() {
+  val create =
+    ImageVector.Builder(
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+      )
+      .apply {
+        path(fill = SolidColor(Color.White)) {
+          moveTo(11f, 5f)
+          lineTo(13f, 5f)
+          lineTo(13f, 11f)
+          lineTo(19f, 11f)
+          lineTo(19f, 13f)
+          lineTo(13f, 13f)
+          lineTo(13f, 19f)
+          lineTo(11f, 19f)
+          lineTo(11f, 13f)
+          lineTo(5f, 13f)
+          lineTo(5f, 11f)
+          lineTo(11f, 11f)
+          close()
+        }
+      }
+      .build()
+
+  Box(
+    modifier = Modifier.fillMaxSize().background(Color(0xFF6200EE)),
+    contentAlignment = Alignment.Center,
+  ) {
+    Box(
+      modifier =
+        Modifier.testTag("fab-content").graphicsLayer {
+          scaleX = 1.5f
+          scaleY = 1.5f
+        }
+    ) {
+      Icon(
+        imageVector = create,
+        contentDescription = "create",
+        tint = Color.White,
+        modifier = Modifier.testTag("create-icon").size(24.dp),
+      )
+    }
+  }
+}
+
 @Composable
 fun ThemedPrimarySquare() {
   MaterialTheme(colorScheme = lightColorScheme(primary = Color(0xFF123456))) {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -332,6 +332,83 @@ class RenderEngineTest {
   }
 
   @Test
+  fun figmaSvgFidelityScoresAlphaZeroRecordButton() {
+    // Issue #2853 end-to-end: a real render of the alpha-zero record button (a recording circle
+    // faded to alpha 0 over a mic, in an input-bar row) must produce a fidelity composite + score.
+    // The score guards the whole render→SVG→raster path for the alpha-zero clipped background — a
+    // leaked opaque circle would drag it down.
+    assertFidelityScored(
+      functionName = "AlphaZeroRecordButton",
+      widthPx = 200,
+      heightPx = 56,
+      baseName = "fidelity-record-button",
+    )
+  }
+
+  @Test
+  fun figmaSvgFidelityScoresAnimatedLayoutVector() {
+    // Issue #2853 end-to-end: a square create icon scaled through a graphics layer (Jetchat's
+    // animating FAB). The score guards the render→SVG→raster path for a scaled vector — the
+    // double-counted `scale(6.54)` blow-up would misplace the icon and drag it down.
+    assertFidelityScored(
+      functionName = "VectorIconInAnimatedLayout",
+      widthPx = 96,
+      heightPx = 96,
+      baseName = "fidelity-animated-fab",
+    )
+  }
+
+  private fun assertFidelityScored(
+    functionName: String,
+    widthPx: Int,
+    heightPx: Int,
+    baseName: String,
+  ) {
+    System.setProperty("composeai.figma.fidelity", "true")
+    val outputDir = tempFolder.newFolder("renders-$baseName")
+    val dataDir = tempFolder.newFolder("data-$baseName")
+    val engine = RenderEngine(outputDir = outputDir, dataDir = dataDir)
+    val host = DesktopHost(engine = engine)
+    host.start()
+    try {
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=$functionName;" +
+              "widthPx=$widthPx;heightPx=$heightPx;density=1.0;" +
+              "showBackground=true;" +
+              "outputBaseName=$baseName"
+        ),
+        timeoutMs = 60_000,
+      )
+
+      val previewDir = File(dataDir, baseName)
+      val composite = File(previewDir, FigmaSvgFidelity.FILE_COMPOSITE)
+      val scoreFile = File(previewDir, FigmaSvgFidelity.FILE_SCORE)
+      assertTrue(
+        "fidelity composite must be produced: ${composite.absolutePath}",
+        composite.exists(),
+      )
+      assertTrue(
+        "fidelity score sidecar must be produced: ${scoreFile.absolutePath}",
+        scoreFile.exists(),
+      )
+
+      val scoreJson = scoreFile.readText()
+      val score = Regex("\"score\":([0-9.]+)").find(scoreJson)?.groupValues?.get(1)?.toDouble()
+      assertNotNull("score must parse: $scoreJson", score)
+      assertTrue(
+        "score must be a real fraction in (0,1], was $score",
+        score!! > 0.0 && score <= 1.0,
+      )
+    } finally {
+      host.shutdown()
+      System.clearProperty("composeai.figma.fidelity")
+    }
+  }
+
+  @Test
   fun privateComposableRendersToValidPng() {
     // Regression: Kotlin `private fun` previews compile to JVM-private static methods. The daemon
     // resolves them via `getDeclaredComposableMethod` but the reflective `invoke` threw

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -6,14 +6,18 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -25,11 +29,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -119,6 +128,125 @@ fun FidelityCardPreview() {
         Text(text = "harness card", style = MaterialTheme.typography.bodyMedium)
         Box(modifier = Modifier.size(48.dp).background(MaterialTheme.colorScheme.primary))
       }
+    }
+  }
+}
+
+/**
+ * Desktop mirror of the Android `AlphaZeroRecordButton` fidelity fixture (issue #2853): a recording
+ * circle faded to `alpha = 0` through a `graphicsLayer` lambda block, over a visible vector mic in
+ * an input-bar row. Same FQN + function name as the Android copy so one harness scenario resolves
+ * on either backend; the desktop backend is the one that rasterises the SVG and scores fidelity.
+ */
+@Composable
+fun AlphaZeroRecordButton() {
+  val mic =
+    ImageVector.Builder(
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+      )
+      .apply {
+        path(fill = SolidColor(Color.White)) {
+          moveTo(12f, 3f)
+          lineTo(15f, 3f)
+          lineTo(15f, 13f)
+          lineTo(12f, 13f)
+          close()
+        }
+      }
+      .build()
+
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFF1F1F1F))) {
+    Row(
+      modifier = Modifier.fillMaxSize().padding(8.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      // A stand-in for the input field the record button sits beside (kept text-free so the fixture
+      // renders without a downloadable font under Robolectric on the Android backend).
+      Box(
+        modifier =
+          Modifier.testTag("input-field")
+            .width(120.dp)
+            .height(24.dp)
+            .background(Color(0xFF3A3A3A), RoundedCornerShape(12.dp))
+      )
+      Box(modifier = Modifier.width(8.dp).height(1.dp))
+      Box(contentAlignment = Alignment.Center) {
+        Box(
+          modifier =
+            Modifier.testTag("record-circle")
+              .size(40.dp)
+              .graphicsLayer {
+                alpha = 0f
+                scaleX = 0.8f
+                scaleY = 0.8f
+              }
+              .background(Color(0xFF2962FF), RoundedCornerShape(20.dp))
+        )
+        Icon(
+          imageVector = mic,
+          contentDescription = "record",
+          tint = Color.White,
+          modifier = Modifier.testTag("record-mic").size(24.dp),
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Desktop mirror of the Android `VectorIconInAnimatedLayout` fidelity fixture (issue #2853): a
+ * square create icon scaled through a graphics layer, as in Jetchat's `Profile/Animating FAB
+ * content`. The export must fit the vector to its drawn bounds once and keep it square, not
+ * double-count the captured scale.
+ */
+@Composable
+fun VectorIconInAnimatedLayout() {
+  val create =
+    ImageVector.Builder(
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+      )
+      .apply {
+        path(fill = SolidColor(Color.White)) {
+          moveTo(11f, 5f)
+          lineTo(13f, 5f)
+          lineTo(13f, 11f)
+          lineTo(19f, 11f)
+          lineTo(19f, 13f)
+          lineTo(13f, 13f)
+          lineTo(13f, 19f)
+          lineTo(11f, 19f)
+          lineTo(11f, 13f)
+          lineTo(5f, 13f)
+          lineTo(5f, 11f)
+          lineTo(11f, 11f)
+          close()
+        }
+      }
+      .build()
+
+  Box(
+    modifier = Modifier.fillMaxSize().background(Color(0xFF6200EE)),
+    contentAlignment = Alignment.Center,
+  ) {
+    Box(
+      modifier =
+        Modifier.testTag("fab-content").graphicsLayer {
+          scaleX = 1.5f
+          scaleY = 1.5f
+        }
+    ) {
+      Icon(
+        imageVector = create,
+        contentDescription = "create",
+        tint = Color.White,
+        modifier = Modifier.testTag("create-icon").size(24.dp),
+      )
     }
   }
 }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.data.layoutinspector
 
 import java.util.IdentityHashMap
 import kotlin.math.PI
+import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.roundToInt
 import kotlin.math.sin
@@ -525,17 +526,28 @@ object FigmaLayeredSvg {
         val placedScaleY = if (layoutHeight > 0.0) layer.height / layoutHeight else 1.0
         scaleX = layoutScale * placedScaleX
         scaleY = layoutScale * placedScaleY
+      } else if (
+        abs(vec.scaleX - 1.0) > VECTOR_SCALE_EPSILON || abs(vec.scaleY - 1.0) > VECTOR_SCALE_EPSILON
+      ) {
+        // The node carries a captured draw-time graphics-layer scale (issue #2853). The connector
+        // measures that scale through the root coordinates, so it is *already baked into the drawn*
+        // `bounds` — re-deriving the fit as `layoutScale * vec.scaleX` (a layout-slot fit times the
+        // scale) double-counts it whenever the measured slot is itself scaled. That double-count
+        // blew an embedded Jetchat mic group up from `scale(2.62)` to `scale(6.54)`. A *present*
+        // transform means the node was genuinely scaled (not clipped — a clip leaves no captured
+        // scale and falls through below), so the drawn bounds carry the real per-axis scale
+        // directly: fit the vector into its drawn bounds and read the scale straight off them,
+        // which also preserves a legitimately non-uniform layer scale.
+        scaleX = if (vec.viewportWidth > 0f) layer.width / vec.viewportWidth.toDouble() else 1.0
+        scaleY = if (vec.viewportHeight > 0f) layer.height / vec.viewportHeight.toDouble() else 1.0
       } else {
-        // An `ImageVector`'s viewport is the icon's own space, so after fitting it to the layout
-        // slot the only thing left to apply is the node's *captured* draw-time scale — not the
-        // ratio of its drawn box to that slot. Those two disagree whenever a node is clipped
-        // rather than scaled, and the ratio reading squashed a square icon in an animating
-        // container to `scale(0.49 0.13)` (issue #2853): Jetsnack's FAB shrinks the box it draws
-        // its icon into, but the icon is never distorted — it's cropped, and stays square right up
-        // to the point it vanishes. A real non-uniform layer scale still reads correctly, because
-        // the capture reports it.
-        scaleX = layoutScale * vec.scaleX
-        scaleY = layoutScale * vec.scaleY
+        // Identity transform: nothing scaled the node, so any gap between its drawn box and its
+        // layout slot is a *clip*, not a scale. Fit the layout slot — never the ratio of the drawn
+        // box, which squashed a square icon in an animating container to `scale(0.49 0.13)` (issue
+        // #2853): Jetsnack's FAB shrinks the box it draws its icon into, but the icon is never
+        // distorted — it's cropped, and stays square right up to the point it vanishes.
+        scaleX = layoutScale
+        scaleY = layoutScale
       }
     }
     val fittedWidth = vec.viewportWidth.toDouble() * scaleX
@@ -859,6 +871,9 @@ object FigmaLayeredSvg {
   // it; the baseline then sits [ASCENT]·em below the top of that font box. Approximations, not the
   // exact resolved face metrics — but close enough that the SVG text lands within a pixel of the
   // render (the fidelity harness confirms it), and a designer nudges it in Figma regardless.
+  /** A captured graphics-layer scale within this of 1.0 counts as the identity (no scale). */
+  private const val VECTOR_SCALE_EPSILON = 0.001
+
   private const val ASCENT_EM = 0.93
   private const val FONT_BOX_EM = 1.17
 

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -535,11 +535,26 @@ object FigmaLayeredSvg {
         // scale) double-counts it whenever the measured slot is itself scaled. That double-count
         // blew an embedded Jetchat mic group up from `scale(2.62)` to `scale(6.54)`. A *present*
         // transform means the node was genuinely scaled (not clipped — a clip leaves no captured
-        // scale and falls through below), so the drawn bounds carry the real per-axis scale
-        // directly: fit the vector into its drawn bounds and read the scale straight off them,
-        // which also preserves a legitimately non-uniform layer scale.
-        scaleX = if (vec.viewportWidth > 0f) layer.width / vec.viewportWidth.toDouble() else 1.0
-        scaleY = if (vec.viewportHeight > 0f) layer.height / vec.viewportHeight.toDouble() else 1.0
+        // scale and falls through below), so the fit comes off the drawn bounds instead of the
+        // slot, avoiding the double-count.
+        val boundsScaleX =
+          if (vec.viewportWidth > 0f) layer.width / vec.viewportWidth.toDouble() else 1.0
+        val boundsScaleY =
+          if (vec.viewportHeight > 0f) layer.height / vec.viewportHeight.toDouble() else 1.0
+        if (abs(vec.scaleX - vec.scaleY) > VECTOR_SCALE_EPSILON) {
+          // A genuinely *non-uniform* layer scale: the two drawn axes really do differ, so read
+          // each straight off its bounds.
+          scaleX = boundsScaleX
+          scaleY = boundsScaleY
+        } else {
+          // A *uniform* layer scale: keep the viewport's aspect ratio by fitting it uniformly into
+          // the drawn bounds. Reading each axis independently would squash a square icon sitting in
+          // a non-square layout slot — a 24×24 icon in a 48×24 slot at 0.5× has 24×12 drawn bounds,
+          // which must stay `scale(0.5 0.5)`, not become `scale(1 0.5)`.
+          val uniform = minOf(boundsScaleX, boundsScaleY)
+          scaleX = uniform
+          scaleY = uniform
+        }
       } else {
         // Identity transform: nothing scaled the node, so any gap between its drawn box and its
         // layout slot is a *clip*, not a scale. Fit the layout slot — never the ratio of the drawn

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -884,13 +884,19 @@ data class FigmaSvgModel(
         // is no frame to crop from. Its pixels carry nothing but this node's own paint, so
         // children stay editable on top of it.
         //
-        // …except where that paint is *already* exported as vector. A Wear `CurvedLayout` /
+        // …except where that paint is *already* exported as live text. A Wear `CurvedLayout` /
         // `TimeText` paints its runs through a draw modifier, and the export re-emits exactly
         // those runs as `<textPath>` from [curvedTexts] — so laying the capture underneath would
-        // draw the clock twice, once as pixels and once as live text. The vector wins; the same
-        // rule the `vectorGraphic` tiers follow.
+        // draw the clock twice, once as pixels and once as live text. The same hazard applies to a
+        // node whose own draw includes its straight text (a Jetchat `Conversation/Input` field):
+        // the isolated re-draw bakes the text into its pixels while the export still emits the live
+        // `<text>` from [textByNodeId], visibly doubling "Message #composers" (issue #2853). In
+        // both cases the live text wins and the raster is dropped — the same rule the
+        // `vectorGraphic` tiers follow. A drawn *container* whose text lives on child nodes keeps
+        // its background: its own `textByNodeId` entry is null, so the capture rides underneath the
+        // still-editable children.
         drawRaster
-            ?.takeIf { curvedTexts.isEmpty() }
+            ?.takeIf { curvedTexts.isEmpty() && ctx.textByNodeId[nodeId] == null }
             ?.let { captured ->
               val href = ctx.rasterHref(nodeId)
               ctx.rasterTargets.add(

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -506,6 +506,43 @@ class FigmaLayeredSvgTest {
     assertFalse("must not double-count the captured scale\n$svg", svg.contains("scale(6.25"))
   }
 
+  /**
+   * Issue #2853: a *uniform* graphics-layer scale on a square icon in a **non-square** layout slot
+   * must keep its aspect ratio. A 24×24 icon in a 48×24 slot at 0.5× has 24×12 drawn bounds;
+   * reading each axis straight off those bounds would emit `scale(1 0.5)` and squash the icon. The
+   * uniform transform is the signal that the two axes should stay equal — fit the viewport
+   * uniformly into the drawn bounds instead, `scale(0.5 0.5)`.
+   */
+  @Test
+  fun aUniformlyScaledVectorInANonSquareSlotKeepsItsAspectRatio() {
+    val node =
+      LayoutInspectorNode(
+        nodeId = "icon",
+        component = "Icon",
+        // 48×24 slot drawn at 0.5× → 24×12 bounds. The transform is uniform (0.5, 0.5).
+        bounds = bounds(0, 0, 24, 12),
+        size = LayoutInspectorSize(48, 24),
+        transform = LayoutInspectorTransform(scaleX = 0.5f, scaleY = 0.5f),
+        vectorGraphic =
+          LayoutInspectorVectorGraphic(
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            paths =
+              listOf(
+                LayoutInspectorVectorPath(
+                  pathData = "M0,0 L24,0 L24,24 L0,24 Z",
+                  fillArgb = "#FF000000",
+                )
+              ),
+          ),
+      )
+
+    val svg = render(node)
+
+    assertTrue("the icon must keep its aspect ratio\n$svg", svg.contains("""scale(0.5 0.5)"""))
+    assertFalse("a square icon must not be squashed\n$svg", svg.contains("scale(1 0.5)"))
+  }
+
   @Test
   fun vectorHonorsExplicitFillBoundsContentScale() {
     val node =

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -467,6 +467,45 @@ class FigmaLayeredSvgTest {
     assertTrue(render(node).contains("""scale(0.5 0.5)"""))
   }
 
+  /**
+   * Issue #2853, the embedded-container regression: a captured graphics-layer scale is measured
+   * through the root coordinates, so it is already baked into the node's drawn `bounds` — and, when
+   * the container also scales the node's *measured* slot, into its `size`. Fitting the layout slot
+   * (`size / viewport`) and then multiplying by the captured `transform` again double-counts the
+   * scale: an embedded Jetchat mic group blew up from `scale(2.62)` to `scale(6.54)` that way. The
+   * fit must come from the drawn bounds alone, uniformly.
+   */
+  @Test
+  fun aScaledVectorFitsItsDrawnBoundsInsteadOfDoubleCountingTheTransform() {
+    val node =
+      LayoutInspectorNode(
+        nodeId = "icon",
+        component = "Icon",
+        // A 24-unit icon drawn at 2.5×: the container scaled both the drawn bounds and the measured
+        // slot to 60, and `transform` reports the same 2.5 the coordinate mapping measured.
+        bounds = bounds(0, 0, 60, 60),
+        size = LayoutInspectorSize(60, 60),
+        transform = LayoutInspectorTransform(scaleX = 2.5f, scaleY = 2.5f),
+        vectorGraphic =
+          LayoutInspectorVectorGraphic(
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            paths =
+              listOf(
+                LayoutInspectorVectorPath(
+                  pathData = "M0,0 L24,0 L24,24 L0,24 Z",
+                  fillArgb = "#FF000000",
+                )
+              ),
+          ),
+      )
+
+    val svg = render(node)
+
+    assertTrue("fits the drawn bounds once\n$svg", svg.contains("""scale(2.5 2.5)"""))
+    assertFalse("must not double-count the captured scale\n$svg", svg.contains("scale(6.25"))
+  }
+
   @Test
   fun vectorHonorsExplicitFillBoundsContentScale() {
     val node =

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgDrawRasterTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgDrawRasterTest.kt
@@ -252,4 +252,47 @@ class FigmaSvgDrawRasterTest {
     assertTrue("cropped from the frame, not from the payload", m.root.background!!.fromFrame)
     assertNull(m.rasterTargets.single().pngBase64)
   }
+
+  /**
+   * Issue #2853, the embedded-container regression: a node whose own draw includes its straight
+   * text (a Jetchat `Conversation/Input` field) carries a `drawRaster` whose pixels already bake in
+   * that text — while the export still emits the live `<text>`, visibly doubling
+   * "Message #composers". The live text wins: the isolated raster is dropped, exactly as a
+   * curved-text node already drops it.
+   */
+  @Test
+  fun aDrawRasterIsDroppedUnderANodesOwnLiveTextInsteadOfDoublingIt() {
+    val input =
+      LayoutInspectorNode(
+        nodeId = "input-1",
+        component = "BasicTextField",
+        bounds = bounds(0, 0, 240, 48),
+        size = LayoutInspectorSize(240, 48),
+        modifiers =
+          listOf(LayoutInspectorModifier(name = "drawWithContent", bounds = bounds(0, 0, 240, 48))),
+        drawRaster =
+          LayoutInspectorDrawRaster(left = 0, top = 0, right = 240, bottom = 48, pngBase64 = png),
+      )
+    val m =
+      FigmaSvgModel.from(
+        layout = LayoutInspectorPayload(input),
+        semantics =
+          ComposeSemanticsPayload(
+            ComposeSemanticsNode(
+              nodeId = "sem",
+              boundsInRoot = "0,0,240,48",
+              text = "Message #composers",
+            )
+          ),
+        captureCanvasDraws = true,
+      )
+
+    assertNull("no isolated raster laid under the node's own live text", m.root.background)
+    assertTrue("nothing was rastered for it", m.rasterTargets.isEmpty())
+    assertNotNull("the text stays editable", m.root.text)
+    assertEquals("Message #composers", m.root.text!!.content)
+    val svg = FigmaLayeredSvg.render(m)
+    assertTrue("no <image> to double the text", !svg.contains("<image"))
+    assertEquals("the string appears exactly once", 1, svg.split(">Message #composers<").size - 1)
+  }
 }


### PR DESCRIPTION
Fixes #2853 (the embedded-container regression the second reopen describes).

## Root cause

**Distorted vectors.** An icon's captured draw-time graphics-layer scale (`LayoutInspectorTransform`) is measured through the root coordinates on the connector side, so it is **already baked into the node's drawn `bounds`**. The emitter fitted the vector as `layoutScale * vec.scaleX` — a layout-slot fit *times* the captured scale — which double-counts the scale whenever the measured slot is itself scaled. That is what blew the embedded Jetchat mic group up from `translate(947 70.42) scale(2.62 2.88)` to `translate(900 26.5) scale(6.54 6.54)`, and dragged Conversation/Input (86.4%→77.1%) and Channel bar (90.8%→77.7%) down after 0.19.7.

**Doubled text.** A node whose own draw bakes in its text (a `Conversation/Input` field) carried an isolated draw-raster **under** the live `<text>` — the raster branch guarded only `curvedTexts`, not the node's own text — visibly doubling "Message #composers".

## Fix

- **`FigmaLayeredSvg.vectorGroup`** — a *present* transform means the node was genuinely scaled (a clip leaves no captured scale), so read the per-axis fit straight off the drawn bounds instead of multiplying the slot fit by the captured scale. This restores the known-good ~`scale(2.62)` geometry, keeps a legitimately non-uniform layer scale, keeps a uniformly-scaled square icon square, and still routes a *clipped* icon (no transform) through the layout-slot fit that stops the `scale(0.49 0.13)` squash.
- **`FigmaSvgModel.toLayer`** — drop the isolated draw-raster when the node emits its own live text (`textByNodeId[nodeId] != null`), the same rule curved text already followed. A drawn *container* whose text lives on child nodes keeps its background (its own entry is null).

The alpha-zero record circle was already fixed on the connector side by PR #2944's lambda-`graphicsLayer` alpha capture; the leaked opaque circle in embedded containers was this same double-count/raster path, not a missed alpha.

## Tests

- **Core (`:data-layoutinspector-core`) — deterministic, all 143 pass locally:**
  - `aScaledVectorFitsItsDrawnBoundsInsteadOfDoubleCountingTheTransform` — a 24-unit icon in a scaled 60×60 slot must emit `scale(2.5 2.5)`, never `scale(6.25)`.
  - `aDrawRasterIsDroppedUnderANodesOwnLiveTextInsteadOfDoublingIt` — no `<image>` under the node's own `<text>`; "Message #composers" appears once.
  - Existing scaled/clipped/non-uniform/FillBounds vector tests still pass unchanged.
- **End-to-end fidelity fixtures** (issue's explicit ask), mirrored on both backends:
  - `AlphaZeroRecordButton` — an alpha-0 clipped record circle over a mic, embedded in an input-bar row.
  - `VectorIconInAnimatedLayout` — a square create icon scaled through a graphics layer (Jetchat's `Profile/Animating FAB content`).
  - Android structural tests (`figmaSvgFadesAnAlphaZeroRecordButtonEmbeddedInAnInputBar`, `figmaSvgKeepsAScaledVectorSquareInAnAnimatedLayout`) assert `opacity="0"`, an editable `<path>`, and a uniform (non-squashed, non-double-counted) vector scale. Desktop fidelity-scoring tests (`figmaSvgFidelityScores…`) run the full render→SVG→raster→score path.

## Visual evidence — not capturable in this session

This is a visual change, and I could not render it in the agent container: **both** render backends are currently broken here independent of this diff — Robolectric's native capture path SIGSEGVs in `libandroid_runtime.so` (the pre-existing `figmaSvgExportPreservesGraphicsLayerAlphaAndVectorAspectRatio` test crashes identically), and the desktop Skiko path fails to load its native library (`UnsatisfiedLinkError`, the pre-existing `figmaSvgFidelityScoresARender` fails identically). All new fixtures and tests **compile clean** and mirror existing passing patterns, so CI — where the native render stack works — will render the two new fixtures through the visual-diff bot and produce before/after pixels for the mic-scale and alpha-zero cases. The deterministic core unit tests above pin the exact fixed geometry (`scale(2.5)` not `scale(6.25)`; single `<text>`) without needing a renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYL42bhH9aGgBdKory7koE)_