### PR TITLE
fix(plugin): stop the XR render's cacheIf capturing Project

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2296,6 +2296,19 @@ internal object AndroidPreviewSupport {
     // `XR_SUBSPACE` itself, and writes `scene.json` per preview under `renders/`. Opt-in via
     // `composePreview.enableXrPreviews` (see the renderer-config gate above) — registered only when
     // the consumer asked for XR, so non-XR consumers don't get the task (or its deps) at all.
+    // Read at configuration time so the `outputs.cacheIf` spec below closes over these
+    // **Providers**
+    // and not over `project`. A `cacheIf` spec is serialised into the configuration-cache entry, so
+    // calling `ComposePreviewTasks.previewFilterProperty(project)` inside it captures
+    // `DefaultProject` and fails the whole build with `cannot serialize object of type
+    // 'org.gradle.api.internal.project.DefaultProject' … not supported with the configuration
+    // cache` — which sank every render, not just XR ones, because storing the entry fails the build
+    // (issue #2994's gate, fixed here). The sibling `composePreviewRender` gate reads its own task
+    // properties and was never affected.
+    val xrFilterPatterns = ComposePreviewTasks.previewFilterProperty(project)
+    val xrIdFilterPatterns = ComposePreviewTasks.previewIdFilterProperty(project)
+    val xrIdExcludePatterns = ComposePreviewTasks.previewIdExcludeProperty(project)
+    val xrRowExcludePatterns = ComposePreviewTasks.previewRowExcludeProperty(project)
     if (xrPreviewsEnabled)
       project.tasks.register("composePreviewRenderXr", Test::class.java) {
         group = "compose preview"
@@ -2385,10 +2398,10 @@ internal object AndroidPreviewSupport {
         // sibling that shares its directory has to refuse too, or the gate leaks through the back
         // door.
         outputs.cacheIf("composePreviewRenderXr caches unfiltered runs only") {
-          ComposePreviewTasks.previewFilterProperty(project).get().none { it.isNotBlank() } &&
-            ComposePreviewTasks.previewIdFilterProperty(project).get().none { it.isNotBlank() } &&
-            ComposePreviewTasks.previewIdExcludeProperty(project).get().none { it.isNotBlank() } &&
-            ComposePreviewTasks.previewRowExcludeProperty(project).get().none { it.isNotBlank() }
+          xrFilterPatterns.get().none { it.isNotBlank() } &&
+            xrIdFilterPatterns.get().none { it.isNotBlank() } &&
+            xrIdExcludePatterns.get().none { it.isNotBlank() } &&
+            xrRowExcludePatterns.get().none { it.isNotBlank() }
         }
 
         outputs.dir(rendersDirectory).withPropertyName("xrRendersDir")


### PR DESCRIPTION
This is the second failure that has been keeping `Apply compose-preview` red on `main` — the one whose cause was invisible until #3003 stopped the CLI dropping it.

## What was wrong

`composePreviewRenderXr`'s cache gate called the filter-property helpers *inside* the spec:

```kotlin
outputs.cacheIf("composePreviewRenderXr caches unfiltered runs only") {
  ComposePreviewTasks.previewFilterProperty(project).get().none { it.isNotBlank() } && …
}
```

A `cacheIf` spec is serialised into the configuration-cache entry, so the lambda captured `DefaultProject` and **storing the entry failed the build**:

```
* What went wrong:
Configuration cache problems found in this build.
1 problem was found storing the configuration cache.
- Task `:samples:xr-spatial:composePreviewRenderXr` of type `org.gradle.api.tasks.testing.Test`:
  cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of
  'org.gradle.api.Project', as these are not supported with the configuration cache.
```

Storing failure fails the whole invocation, so this sank *every* `compose-preview show` render — not just XR ones — leaving `Render failed` → `no _previews.json` → empty diff comments. Introduced by `e77598d` (#2994) and inherited by the row-exclusion line #3001 added to the same lambda.

## The change

The four providers are read once at configuration time; the spec closes over those, which serialise fine. Gate behaviour is unchanged — a filtered run still refuses to be cached, for the reason the existing comment gives (the shared render dir would snapshot excluded rows' stale PNGs). The sibling `composePreviewRender` gate reads its own task properties and was never affected; only this one reached for `project`.

## Test plan

Run against the exact task that failed, with the configuration cache on:

```
./gradlew :samples:xr-spatial:composePreviewRenderXr --configuration-cache
```

| | result |
|---|---|
| before (`git stash` of this diff) | `BUILD FAILED in 34s` — `cannot serialize object of type … DefaultProject` on `:samples:xr-spatial:composePreviewRenderXr` |
| after | `BUILD SUCCESSFUL in 1m 59s` — `Configuration cache entry stored.` |

No visual surfaces touched — this is build-graph plumbing, so text-only evidence is the right kind here. `Apply compose-preview` on this PR is the end-to-end check: with #3002 (the `createFullJarDebug` provider fix) already merged and this one, the compose pipeline should produce a `_previews.json` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Luh8YAEJ8y7L8pw99gdEsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Luh8YAEJ8y7L8pw99gdEsQ)_