### PR TITLE
feat(serve): resolve a catalog liveBundle into a playground compile classpath

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspath.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspath.kt
@@ -83,7 +83,7 @@ object PlaygroundCatalogClasspath {
 
     val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir, fileSystem)
     val mavenCoords = manifest.classpath.filterIsInstance<BundleReader.ClasspathEntry.Maven>()
-    val resolvedJars =
+    val resolutions =
       CoordinateResolver(
           warn = { onLog("playground $system: $it") },
           networkEnabled = if (offline) false else CoordinateResolver.defaultNetworkEnabled(),
@@ -92,9 +92,33 @@ object PlaygroundCatalogClasspath {
               extraMavenRepos.filter { it.isNotBlank() },
         )
         .resolveAll(mavenCoords)
-        .mapNotNull { it.file }
+    val resolvedJars = requireAllResolved(system, resolutions, onLog) ?: return null
 
     return assemble(system, classesDir, libJars, resolvedJars)
+  }
+
+  /**
+   * Every declared coordinate must resolve, or the compile classpath is **incomplete** and the mode
+   * is reported unavailable (return null). Unlike the live-daemon path — which tolerates a partial
+   * classpath and falls back to baked PNGs — a playground compile against a missing catalog library
+   * would surface a misleading `unresolved reference` to the user instead of the honest
+   * mode-unavailable response. So fail closed: log the misses and refuse the whole classpath rather
+   * than assembling a partial one. Returns the resolved jars when every coordinate resolved.
+   */
+  internal fun requireAllResolved(
+    system: String,
+    resolutions: List<CoordinateResolver.Resolution>,
+    onLog: (String) -> Unit,
+  ): List<File>? {
+    val unresolved = resolutions.filter { it.file == null }
+    if (unresolved.isNotEmpty()) {
+      onLog(
+        "playground $system: ${unresolved.size} unresolved dependency coordinate(s), mode " +
+          "unavailable: ${unresolved.joinToString { it.coordinate.toString() }}"
+      )
+      return null
+    }
+    return resolutions.mapNotNull { it.file }
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspath.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspath.kt
@@ -1,0 +1,118 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.cli.CoordinateResolver
+import ee.schimke.composeai.cli.extractBundleClassesAndManifest
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Resolves a catalog's packed **liveBundle** into the classpath a playground snippet compiles
+ * against — the production backing for [PlaygroundCompileService]'s `catalogClasspath` seam
+ * (`docs/design/PLAYGROUND.md` §8).
+ *
+ * This is the compile-time twin of [ServeBundleDaemon.materialize]'s classpath resolution, minus
+ * the daemon launch: extract the bundle's `classes/app.jar` (the catalog's own composables) and
+ * resolve its `manifest.classpath` Maven coordinates to jars via [CoordinateResolver] (Central +
+ * Google Maven + any [extraMavenRepos]). A snippet compiled against the result can `import` both
+ * the resolved library (e.g. `androidx.compose.material3.*`, complete because it comes from the
+ * unminimized library jar) and whatever of the catalog's own composables survived bundle
+ * minimization.
+ *
+ * **One flat classpath, no parent/child split.** [ServeBundleDaemon.bundleDaemonClasspaths]
+ * partitions jars into a daemon-parent overlay and a user-child loader — but that split is a
+ * *render-time* classloader-delegation concern. For *compiling* the snippet, every jar belongs on
+ * one classpath, so this resolver keeps it flat (catalog classes first, then embedded libs, then
+ * resolved deps).
+ */
+object PlaygroundCatalogClasspath {
+
+  /**
+   * Resolve [bundleFile] into a compile classpath, extracting into [destDir]. Returns null (logging
+   * why) when the bundle can't be read or extracted — the caller then reports the mode as
+   * unavailable rather than compiling against an incomplete classpath.
+   */
+  fun resolve(
+    bundleFile: File,
+    destDir: File,
+    system: String,
+    extraMavenRepos: List<String> = emptyList(),
+    offline: Boolean = false,
+    fileSystem: FileSystem = SystemFileSystem,
+    onLog: (String) -> Unit = {},
+  ): PlaygroundCompileService.Classpath? {
+    val manifest =
+      try {
+        BundleReader.readMetadata(bundleFile).manifest
+      } catch (e: Exception) {
+        onLog("playground $system: could not read bundle metadata (${e.message})")
+        return null
+      }
+
+    val zipBytes =
+      try {
+        BundleReader.extractZipBytes(bundleFile, fileSystem)
+      } catch (e: Exception) {
+        onLog("playground $system: could not read bundle zip (${e.message})")
+        return null
+      }
+
+    destDir.mkdirs()
+    val classesDir = File(destDir, "classes").apply { mkdirs() }
+    val libsDir = File(destDir, "libs").apply { mkdirs() }
+    val previewsJson = File(destDir, "previews.json")
+    // A fully IR-backed bundle carries no classes/app.jar; a mixed/class-backed one must — mirrors
+    // ServeBundleDaemon.materialize's gate.
+    val irPreviewIds = manifest.intermediateRepresentations.mapTo(mutableSetOf()) { it.previewId }
+    val requireAppJar = manifest.previewIds.any { it !in irPreviewIds }
+    try {
+      extractBundleClassesAndManifest(
+        zipBytes,
+        classesDir,
+        previewsJson,
+        bundleFile,
+        requireAppJar,
+        fileSystem,
+      )
+    } catch (e: Exception) {
+      onLog("playground $system: bundle extraction failed (${e.message})")
+      return null
+    }
+
+    val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir, fileSystem)
+    val mavenCoords = manifest.classpath.filterIsInstance<BundleReader.ClasspathEntry.Maven>()
+    val resolvedJars =
+      CoordinateResolver(
+          warn = { onLog("playground $system: $it") },
+          networkEnabled = if (offline) false else CoordinateResolver.defaultNetworkEnabled(),
+          remoteRepositories =
+            CoordinateResolver.DEFAULT_REMOTE_REPOSITORIES +
+              extraMavenRepos.filter { it.isNotBlank() },
+        )
+        .resolveAll(mavenCoords)
+        .mapNotNull { it.file }
+
+    return assemble(system, classesDir, libJars, resolvedJars)
+  }
+
+  /**
+   * Pure classpath assembly: catalog classes first, then embedded libs, then every resolved Maven
+   * jar, deduplicated and order-preserving. Separated from [resolve]'s IO so the ordering/dedup can
+   * be unit-tested without a real bundle.
+   */
+  internal fun assemble(
+    system: String,
+    classesDir: File,
+    libJars: List<File>,
+    resolvedJars: List<File>,
+  ): PlaygroundCompileService.Classpath {
+    val entries =
+      (listOf(classesDir) + libJars + resolvedJars)
+        .map { it.absolutePath }
+        .distinct()
+        .map { it.toPath() }
+    return PlaygroundCompileService.Classpath(moduleName = "playground-$system", entries = entries)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspathTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspathTest.kt
@@ -1,0 +1,65 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The pure classpath-assembly half of the catalog liveBundle → playground compile classpath
+ * resolver.
+ */
+class PlaygroundCatalogClasspathTest {
+
+  private val root: File = Files.createTempDirectory("pg-catalog-cp").toFile()
+
+  @Test
+  fun `catalog classes come first, then libs, then resolved jars`() {
+    val classes = File(root, "classes")
+    val embeddedLib = File(root, "app-project.jar")
+    val material3 = File(root, "material3.jar")
+    val foundation = File(root, "foundation.jar")
+
+    val cp =
+      PlaygroundCatalogClasspath.assemble(
+        system = "compose-m3",
+        classesDir = classes,
+        libJars = listOf(embeddedLib),
+        resolvedJars = listOf(material3, foundation),
+      )
+
+    assertEquals("playground-compose-m3", cp.moduleName)
+    assertEquals(
+      listOf(classes, embeddedLib, material3, foundation).map { it.absolutePath },
+      cp.entries.map { it.toString() },
+      "the snippet compiles against the catalog classes first, then its resolved dependencies",
+    )
+  }
+
+  @Test
+  fun `duplicate jars are collapsed while preserving first-seen order`() {
+    val classes = File(root, "classes")
+    val material3 = File(root, "material3.jar")
+
+    val cp =
+      PlaygroundCatalogClasspath.assemble(
+        system = "compose-m3",
+        classesDir = classes,
+        libJars = listOf(material3),
+        resolvedJars = listOf(material3, File(root, "runtime.jar")),
+      )
+
+    assertEquals(
+      listOf(classes, material3, File(root, "runtime.jar")).map { it.absolutePath },
+      cp.entries.map { it.toString() },
+      "a jar that appears as both an embedded lib and a resolved dep is listed once",
+    )
+  }
+
+  @Test
+  fun `an empty dependency set still yields the catalog classes`() {
+    val classes = File(root, "classes")
+    val cp = PlaygroundCatalogClasspath.assemble("bespoke", classes, emptyList(), emptyList())
+    assertEquals(listOf(classes.absolutePath), cp.entries.map { it.toString() })
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspathTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspathTest.kt
@@ -1,9 +1,13 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.cli.CoordinateResolver
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * The pure classpath-assembly half of the catalog liveBundle → playground compile classpath
@@ -61,5 +65,48 @@ class PlaygroundCatalogClasspathTest {
     val classes = File(root, "classes")
     val cp = PlaygroundCatalogClasspath.assemble("bespoke", classes, emptyList(), emptyList())
     assertEquals(listOf(classes.absolutePath), cp.entries.map { it.toString() })
+  }
+
+  private fun maven(group: String, artifact: String) =
+    BundleReader.ClasspathEntry.Maven(group, artifact, "1.0", "jar")
+
+  private fun resolution(group: String, artifact: String, file: File?) =
+    CoordinateResolver.Resolution(maven(group, artifact), file, verified = true, mismatch = false)
+
+  @Test
+  fun `every coordinate resolving yields the jar list in order`() {
+    val m3 = File(root, "material3.jar")
+    val runtime = File(root, "runtime.jar")
+    val resolved =
+      PlaygroundCatalogClasspath.requireAllResolved(
+        system = "compose-m3",
+        resolutions =
+          listOf(
+            resolution("androidx.compose.material3", "material3", m3),
+            resolution("androidx.compose.runtime", "runtime", runtime),
+          ),
+        onLog = {},
+      )
+    assertEquals(listOf(m3, runtime), resolved)
+  }
+
+  @Test
+  fun `an unresolved coordinate makes the mode unavailable rather than a partial classpath`() {
+    val logs = mutableListOf<String>()
+    val resolved =
+      PlaygroundCatalogClasspath.requireAllResolved(
+        system = "compose-m3",
+        resolutions =
+          listOf(
+            resolution("androidx.compose.material3", "material3", File(root, "material3.jar")),
+            resolution("androidx.compose.runtime", "runtime", null), // couldn't be resolved
+          ),
+        onLog = { logs.add(it) },
+      )
+    assertNull(resolved, "a missing dependency fails the whole classpath closed")
+    assertTrue(
+      logs.any { it.contains("unavailable") && it.contains("runtime") },
+      "the miss is logged with the offending coordinate: $logs",
+    )
   }
 }


### PR DESCRIPTION
## Summary

The keystone toward "build a snippet against a catalog's components": `PlaygroundCatalogClasspath` is the production backing for `PlaygroundCompileService`'s `catalogClasspath` seam (#3004). It turns a catalog's packed **liveBundle** into the classpath a playground snippet compiles against, so `import`s resolve to the real catalog components.

It's the compile-time twin of `ServeBundleDaemon.materialize`'s classpath resolution, **minus the daemon launch**, reusing the exact same helpers (`BundleReader.readMetadata` / `extractZipBytes` / `extractEmbeddedLibs`, `extractBundleClassesAndManifest`, `CoordinateResolver`):

1. Extract the bundle's `classes/app.jar` — the catalog's own composables.
2. Resolve `manifest.classpath` Maven coordinates to jars (Central + Google Maven + `extraMavenRepos`).
3. Assemble a **flat** compile classpath: catalog classes first, then embedded libs, then all resolved dependency jars.

The flatness is deliberate and documented: `ServeBundleDaemon.bundleDaemonClasspaths` splits jars into a daemon-parent overlay and a user-child loader, but that partition is a *render-time* classloader-delegation concern. For *compiling* the snippet, every jar belongs on one classpath. A snippet compiled against this can `import androidx.compose.material3.*` (complete, from the unminimized library jar) plus whatever catalog composables survived bundle minimization — which is why `compose-m3` is the clean first catalog.

Structured so the pure assembly (ordering, dedup) is unit-tested, while the IO orchestration is thin reuse of already-tested bundle helpers — the same split the existing `ServeBundleDaemonTest` uses (it unit-tests `bundleDaemonClasspaths` with fake paths, not `materialize`'s IO).

## Test plan

- [x] `./gradlew :cli:test --tests "…PlaygroundCatalogClasspathTest"` — green (3 cases: catalog-classes-first ordering, dedup with first-seen order preserved, empty-deps still yields catalog classes).
- [x] `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` — clean.
- Non-visual change (classpath resolution plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_