### PR TITLE
feat(serve): the playground — compile a snippet against a catalog's components

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -193,6 +193,10 @@ dependencies {
   // Renderer-agnostic daemon core helpers that are safe to use as a local library from CLI
   // commands. Keep renderer backends (`:daemon:android`, `:daemon:desktop`) out of this module.
   implementation(project(":daemon:core"))
+  // ClassGraph for the `serve --playground` preview scan: a scoped `@Preview` enumeration of a
+  // just-compiled snippet's classes dir (mirrors `:daemon:core`'s IncrementalDiscovery, which keeps
+  // classgraph as its own `implementation` and so doesn't leak it here).
+  implementation(libs.classgraph)
   // Wire-shape of the `compose/overrides` data product (`PreviewOverrideDeclaration`) — the
   // editable
   // knobs `compose-preview serve` reads from a bundle's `previews/<id>.overrides.json` sidecar to

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -110,7 +110,39 @@ val composePreviewDaemonAndroid =
     }
   }
 
+// BTA (Kotlin Build Tools API) *implementation* classpath for the `serve --playground` in-process
+// compile: `kotlin-build-tools-impl` (transitively `kotlin-compiler-embeddable` + runtime) plus the
+// Compose compiler plugin. These are the jars the gradle plugin's `DaemonBootstrapTask` supplies to
+// the editor daemon via sysprops — the serve host has no gradle plugin, so it stages them into the
+// CLI install (`lib-bta/`) and loads them into BTA's isolated classloader at compile time. Never on
+// the CLI's own classpath (a whole compiler frontend); resolved into
+// `cli/build/install/compose-preview/lib-bta/`, located at runtime via `APP_HOME/lib-bta/` (or
+// `-Dcomposeai.cli.libBtaDir`).
+val composePreviewBta =
+  configurations.create("composePreviewBta") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+  }
+
 dependencies {
+  // The BTA implementation + Compose compiler plugin jars, staged into `lib-bta/` (see the
+  // `composePreviewBta` configuration above). `kotlin-build-tools-impl` pulls
+  // `kotlin-compiler-embeddable` and the rest of the frontend transitively.
+  add(
+    "composePreviewBta",
+    "org.jetbrains.kotlin:kotlin-build-tools-impl:${libs.versions.kotlin.get()}",
+  )
+  add(
+    "composePreviewBta",
+    "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable:${libs.versions.kotlin.get()}",
+  )
+  // BTA *interfaces only* — the CLI references `BtaCompileSession`'s build-tools-api parameter
+  // types
+  // (`CompilerPlugin`, `KotlinLogger`, `SourcesChanges`) to drive an in-process playground compile.
+  // `:daemon:core` declares this as `implementation`, so it isn't transitive; the impl JARs ride in
+  // `lib-bta/`, not here.
+  implementation("org.jetbrains.kotlin:kotlin-build-tools-api:${libs.versions.kotlin.get()}")
+
   // Published wire-format DTOs (`PreviewResult`, `PreviewManifest`, the v1 a11y mirror types,
   // `ExtensionPayload`). `api` so the existing in-package imports across this module (and the
   // CLI tests) keep resolving without an explicit `import` change — same source-compat pattern
@@ -294,11 +326,40 @@ val stageDaemonAndroidLibs =
     destinationDir.set(layout.buildDirectory.dir("staged-daemon-android-libs"))
   }
 
+// Stage the BTA impl + Compose-plugin jars into `lib-bta/`, disambiguating any colliding filenames
+// by Maven `module-version.jar` (same reason as the desktop daemon: multiple artifacts can share a
+// basename). The playground compile loads this whole directory into BTA's isolated classloader.
+val stageBtaLibs =
+  tasks.register<Sync>("stageBtaLibs") {
+    description = "Stages the BTA impl + Compose compiler plugin jars for serve --playground."
+    destinationDir = layout.buildDirectory.dir("staged-bta-libs").get().asFile
+    val artifactsProvider = composePreviewBta.incoming.artifacts.resolvedArtifacts
+    from(artifactsProvider.map { it.map(ResolvedArtifactResult::getFile) })
+    val nameByPath = artifactsProvider.map { resolved ->
+      val counts = resolved.groupingBy { it.file.name }.eachCount()
+      resolved.associate { artifact ->
+        val original = artifact.file.name
+        val mapped =
+          if (counts.getValue(original) > 1) {
+            val id = artifact.id.componentIdentifier
+            if (id is ModuleComponentIdentifier) "${id.module}-${id.version}.jar" else original
+          } else original
+        artifact.file.absolutePath to mapped
+      }
+    }
+    inputs.property("nameByPath", nameByPath)
+    eachFile {
+      val mapped = nameByPath.get()[file.absolutePath]
+      if (mapped != null) name = mapped
+    }
+  }
+
 distributions {
   named("main") {
     contents {
       into("lib-renderer") { from(composePreviewRenderer) }
       into("lib-daemon-desktop") { from(stageDaemonDesktopLibs) }
+      into("lib-bta") { from(stageBtaLibs) }
     }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
@@ -132,6 +132,7 @@ private fun bundleSidecarSysprop(sidecarName: String): String =
     "lib-daemon-desktop" -> "composeai.cli.libDaemonDesktopDir"
     "lib-daemon-android" -> "composeai.cli.libDaemonAndroidDir"
     "lib-renderer" -> "composeai.cli.libRendererDir"
+    "lib-bta" -> "composeai.cli.libBtaDir"
     else -> "composeai.cli.${sidecarName.replace('-', '.')}Dir"
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -63,6 +63,7 @@ internal object CliFlags {
       "--accept-bundles-from",
       "--accept-docs-from",
       "--doc-ttl",
+      "--playground-bundle",
       "--extra-maven-repos",
       "--trust-store",
       "--catalogs",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -6,6 +6,12 @@ import ee.schimke.composeai.cli.serve.DaemonStartupLog
 import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
 import ee.schimke.composeai.cli.serve.MutableTrustStore
+import ee.schimke.composeai.cli.serve.PlaygroundBtaCompiler
+import ee.schimke.composeai.cli.serve.PlaygroundCatalogClasspath
+import ee.schimke.composeai.cli.serve.PlaygroundCompileService
+import ee.schimke.composeai.cli.serve.PlaygroundMode
+import ee.schimke.composeai.cli.serve.PlaygroundPreviewDiscoverer
+import ee.schimke.composeai.cli.serve.PlaygroundTokenStore
 import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundle
 import ee.schimke.composeai.cli.serve.ServeBundleDaemon
@@ -226,6 +232,13 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val acceptDocsFrom: List<String> =
     args.flagValue("--accept-docs-from")?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
       ?: emptyList()
+
+  /**
+   * `--playground-bundle <path>`: enable the playground lane (`POST /api/{v}/compiler/run`),
+   * resolving the CMP compile classpath from this catalog liveBundle. Refused under `--public` (the
+   * compile runs **user-supplied code** in-process). See docs/design/PLAYGROUND.md.
+   */
+  private val playgroundBundlePath: String? = args.flagValue("--playground-bundle")
 
   /**
    * Extra remote Maven repository base URLs the live-daemon classpath resolver may fetch from, on
@@ -821,6 +834,60 @@ class ServeCommand(args: List<String>) : Command(args) {
     return ServeDocStore(ttlSeconds = docTtlSeconds, allowedHosts = acceptDocsFrom)
   }
 
+  /**
+   * Build the `--playground-bundle` compile service, or null when not opted in. Resolves the CMP
+   * compile classpath from the catalog liveBundle once at startup and wires the in-process BTA
+   * compiler from the CLI install's `lib-bta/`. **Refused under `--public`**: the compile runs
+   * user-supplied code in-process, which the public server's "never run untrusted code on the
+   * server" model forbids (docs/design/PLAYGROUND.md § isolation). Fail-soft: any missing piece
+   * (bundle unresolvable, no `lib-bta/`) logs why and disables the lane rather than aborting serve.
+   */
+  private fun openPlaygroundService(): PlaygroundCompileService? {
+    val bundlePath = playgroundBundlePath ?: return null
+    if (public) {
+      System.err.println(
+        "serve: --playground-bundle is refused under --public — it compiles and runs user-supplied " +
+          "code in-process. Omit --public to enable the playground."
+      )
+      return null
+    }
+    val workRoot = java.nio.file.Files.createTempDirectory("compose-playground").toFile()
+    val classpath =
+      PlaygroundCatalogClasspath.resolve(
+        bundleFile = java.io.File(bundlePath),
+        destDir = java.io.File(workRoot, "catalog"),
+        system = "playground",
+        onLog = { System.err.println("serve playground: $it") },
+      )
+    if (classpath == null) {
+      System.err.println(
+        "serve: --playground-bundle could not resolve a classpath from $bundlePath; playground disabled."
+      )
+      return null
+    }
+    val compiler = PlaygroundBtaCompiler.fromInstall(java.io.File(workRoot, "bta-ic").toPath())
+    if (compiler == null) {
+      System.err.println(
+        "serve: playground compiler unavailable — no lib-bta/ in the CLI install (run from an " +
+          "installed distribution). Playground disabled."
+      )
+      return null
+    }
+    System.err.println(
+      "serve: playground enabled (POST /api/1/compiler/run) — CMP snippets compile against $bundlePath"
+    )
+    val snippetCounter = java.util.concurrent.atomic.AtomicLong()
+    return PlaygroundCompileService(
+      catalogClasspath = { mode -> if (mode == PlaygroundMode.CMP) classpath else null },
+      compiler = compiler,
+      discoverer = PlaygroundPreviewDiscoverer(),
+      tokenStore = PlaygroundTokenStore(),
+      newWorkDir = {
+        java.io.File(workRoot, "snippet-${snippetCounter.incrementAndGet()}").absolutePath.toPath()
+      },
+    )
+  }
+
   /** Build the `--accept-bundles` upload store (temp-dir backed), wired to [registry]. */
   private fun openUploadStore(registry: ServeSessionRegistry): ServeBundleStore {
     val uploads =
@@ -957,6 +1024,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         trustAdmin = trustAdmin,
         adminToken = adminToken,
         docStore = openDocStore(),
+        playgroundService = openPlaygroundService(),
       )
     if (trustAdmin != null) {
       System.err.println(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
@@ -10,7 +10,6 @@ import java.io.File
 import java.nio.file.Path as NioPath
 import okio.Path
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
-import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPlugin
 import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPluginOption
 
@@ -37,25 +36,36 @@ class PlaygroundBtaCompiler(
   private val moduleName: String = "playground",
 ) : PlaygroundCompileService.Compiler {
 
+  // One session per compiler instance, retained across requests: its lazily-loaded toolchain pays
+  // the BTA-impl bootstrap once (not per request), and BtaCompileSession serializes concurrent
+  // compiles internally, so there's no per-request lock/cache race. Built lazily so constructing
+  // the
+  // compiler (e.g. probing availability) doesn't force the ~5 s toolchain load.
+  private val session by lazy {
+    BtaCompileSession(
+      implClasspath = btaImplJars,
+      icWorkingDir = icWorkingDir,
+      moduleName = moduleName,
+    )
+  }
+  private val compilerPlugins by lazy { composeCompilerPlugins(compilerPluginJars) }
+
   override fun compile(
     sources: List<Path>,
     classpath: List<Path>,
     outputDir: Path,
   ): List<PlaygroundDiagnostic> {
-    val session =
-      BtaCompileSession(
-        implClasspath = btaImplJars,
-        icWorkingDir = icWorkingDir,
-        moduleName = moduleName,
-      )
     val collector = DiagnosticCollector()
     return try {
-      session.compileIncremental(
+      // Non-incremental on purpose: a playground compiles a *fresh* snippet against a stable
+      // catalog classpath, so IC's per-entry classpath snapshotting is pure overhead — and it would
+      // throw on the catalog's leading `classes/` **directory** entry (it treats every entry as a
+      // JAR). The non-incremental path accepts directory entries and needs no icWorkingDir writes.
+      session.compile(
         sources = sources.map { it.toNioPath() },
         compileClasspath = classpath.map { it.toNioPath() },
         outputDir = outputDir.toNioPath(),
-        compilerPlugins = composeCompilerPlugins(compilerPluginJars),
-        sourcesChanges = SourcesChanges.ToBeCalculated,
+        compilerPlugins = compilerPlugins,
         diagnosticListener = collector,
       )
       // A clean compile: DiagnosticCollector only captures errors, so success yields no

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
@@ -1,0 +1,140 @@
+@file:OptIn(org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi::class)
+
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.locateBundleSidecarJars
+import ee.schimke.composeai.daemon.bta.BtaCompileSession
+import ee.schimke.composeai.daemon.bta.DiagnosticCollector
+import ee.schimke.composeai.daemon.protocol.CompileErrorDetail
+import java.io.File
+import java.nio.file.Path as NioPath
+import okio.Path
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.SourcesChanges
+import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPlugin
+import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPluginOption
+
+/**
+ * In-process [PlaygroundCompileService.Compiler] backed by the Kotlin Build Tools API — compiles a
+ * playground snippet against a catalog classpath without a daemon or a Gradle build
+ * (`docs/design/PLAYGROUND.md` §2.1). Wraps the shipped [BtaCompileSession] (from `:daemon:core`,
+ * which `:cli` already depends on) and maps BTA's diagnostics to [PlaygroundDiagnostic].
+ *
+ * The BTA *implementation* jars (`kotlin-build-tools-impl` + `kotlin-compiler-embeddable`) and the
+ * Compose compiler plugin are staged into the CLI install's `lib-bta/` dir (see
+ * `cli/build.gradle.kts`) and located at runtime by [fromInstall] — the serve host has no Gradle
+ * plugin to supply them the way the editor daemon gets them. The impl jars load into BTA's isolated
+ * classloader; the Compose plugin rides the per-compile [CompilerPlugin] classpath, exactly as the
+ * daemon's `DefaultBtaCompileService` wires it.
+ */
+class PlaygroundBtaCompiler(
+  /** `kotlin-build-tools-impl` + its transitive frontend — BTA's isolated-classloader classpath. */
+  private val btaImplJars: List<NioPath>,
+  /** `kotlin-compose-compiler-plugin-embeddable` — the Compose plugin's per-compile classpath. */
+  private val compilerPluginJars: List<NioPath>,
+  /** Per-process IC cache dir; reused across compiles in this host. */
+  private val icWorkingDir: NioPath,
+  private val moduleName: String = "playground",
+) : PlaygroundCompileService.Compiler {
+
+  override fun compile(
+    sources: List<Path>,
+    classpath: List<Path>,
+    outputDir: Path,
+  ): List<PlaygroundDiagnostic> {
+    val session =
+      BtaCompileSession(
+        implClasspath = btaImplJars,
+        icWorkingDir = icWorkingDir,
+        moduleName = moduleName,
+      )
+    val collector = DiagnosticCollector()
+    return try {
+      session.compileIncremental(
+        sources = sources.map { it.toNioPath() },
+        compileClasspath = classpath.map { it.toNioPath() },
+        outputDir = outputDir.toNioPath(),
+        compilerPlugins = composeCompilerPlugins(compilerPluginJars),
+        sourcesChanges = SourcesChanges.ToBeCalculated,
+        diagnosticListener = collector,
+      )
+      // A clean compile: DiagnosticCollector only captures errors, so success yields no
+      // diagnostics.
+      emptyList()
+    } catch (t: Throwable) {
+      // BtaCompileSession throws on COMPILATION_ERROR. If the collector caught structured
+      // diagnostics, surface them; otherwise it's an internal fault (missing jar, BTA bootstrap) —
+      // report it as a single file-level error so the caller still returns the JSON contract.
+      if (collector.errors.isNotEmpty()) {
+        mapDiagnostics(collector.errors)
+      } else {
+        listOf(
+          PlaygroundDiagnostic(
+            severity = PlaygroundSeverity.ERROR,
+            message = "compilation failed: ${t.message ?: t.javaClass.simpleName}",
+          )
+        )
+      }
+    }
+  }
+
+  companion object {
+    /** The Compose plugin jar's stable coordinate prefix, used to split it out of `lib-bta/`. */
+    private const val COMPOSE_PLUGIN_PREFIX = "kotlin-compose-compiler-plugin-embeddable"
+
+    /**
+     * Build a compiler from the CLI install's staged `lib-bta/` dir, or null when it isn't present
+     * (a non-installed run, or a build that didn't stage it) — the route then reports the mode
+     * unavailable. Splits the Compose plugin jar(s) out of the impl classpath.
+     */
+    fun fromInstall(icWorkingDir: NioPath): PlaygroundBtaCompiler? {
+      val jars = locateBundleSidecarJars("lib-bta")
+      if (jars.isEmpty()) return null
+      val (pluginJars, implJars) = jars.partition { it.name.startsWith(COMPOSE_PLUGIN_PREFIX) }
+      if (implJars.isEmpty()) return null
+      return PlaygroundBtaCompiler(
+        btaImplJars = implJars.map(File::toPath),
+        compilerPluginJars = pluginJars.map(File::toPath),
+        icWorkingDir = icWorkingDir,
+      )
+    }
+
+    /**
+     * Compose compiler plugin config, mirroring `DefaultBtaCompileService.composeCompilerPlugins`
+     * (which is `internal` to `:daemon:core`): the plugin id, its embeddable jars, and the
+     * load-bearing `sourceInformation=true` option KGP enables by default. Empty when no plugin jar
+     * was staged (a plain Kotlin/JVM catalog with no Compose).
+     */
+    internal fun composeCompilerPlugins(pluginJars: List<NioPath>): List<CompilerPlugin> =
+      if (pluginJars.isEmpty()) {
+        emptyList()
+      } else {
+        listOf(
+          CompilerPlugin(
+            "androidx.compose.compiler.plugins.kotlin",
+            pluginJars,
+            listOf(CompilerPluginOption("sourceInformation", "true")),
+            emptySet(),
+          )
+        )
+      }
+
+    /**
+     * Map BTA's [CompileErrorDetail]s (kotlinc-style **1-based** line/column) to
+     * [PlaygroundDiagnostic] (CodeMirror **0-based**). The file is reduced to its basename — the
+     * staged snippet filename the editor knows — not the temp path it compiled from. BTA's
+     * [DiagnosticCollector] only captures errors, so every mapped diagnostic is
+     * [PlaygroundSeverity.ERROR].
+     */
+    internal fun mapDiagnostics(details: List<CompileErrorDetail>): List<PlaygroundDiagnostic> =
+      details.map { detail ->
+        PlaygroundDiagnostic(
+          severity = PlaygroundSeverity.ERROR,
+          message = detail.message,
+          file = File(detail.file).name,
+          line = (detail.line - 1).coerceAtLeast(0),
+          ch = (detail.column - 1).coerceAtLeast(0),
+        )
+      }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviewDiscoverer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviewDiscoverer.kt
@@ -1,0 +1,66 @@
+package ee.schimke.composeai.cli.serve
+
+import io.github.classgraph.ClassGraph
+import okio.Path
+
+/**
+ * Finds the `@Preview` id(s) in a just-compiled playground snippet — the production backing for
+ * [PlaygroundCompileService.PreviewDiscoverer].
+ *
+ * A scoped ClassGraph scan of **only** the snippet's `classesDir`: since that directory holds just
+ * the snippet's compiled output, every `@Preview`-annotated method in it is the snippet's own (no
+ * source-file filtering needed, unlike `:daemon:core`'s incremental `IncrementalDiscovery`, which
+ * scans a shared classpath and must filter by source file). The id shape —
+ * `<className>.<methodName>` — matches what the gradle plugin emits and what the render pipeline
+ * expects, so the token's `previewId` renders directly.
+ *
+ * Only **direct** `@Preview` annotations are recognised in v1; multi-preview meta-annotations
+ * (`@LightDarkPreviews` → many) are a follow-up. Fail-safe: returns an empty list (logging) on any
+ * scan failure, which the orchestrator reports as "no @Preview found".
+ */
+class PlaygroundPreviewDiscoverer(
+  private val previewAnnotationFqns: Set<String> = DEFAULT_PREVIEW_ANNOTATION_FQNS
+) : PlaygroundCompileService.PreviewDiscoverer {
+
+  override fun discover(classesDir: Path, classpath: List<Path>): List<String> =
+    try {
+      ClassGraph()
+        .enableMethodInfo()
+        .enableAnnotationInfo()
+        .ignoreMethodVisibility()
+        .overrideClasspath(classesDir.toNioPath().toAbsolutePath().toString())
+        .ignoreParentClassLoaders()
+        .scan()
+        .use { scan ->
+          val ids = LinkedHashSet<String>()
+          for (classInfo in scan.allClasses) {
+            for (method in classInfo.methodInfo) {
+              val isPreview =
+                method.annotationInfo?.any { it.name in previewAnnotationFqns } == true
+              if (isPreview) ids.add(previewId(classInfo.name, method.name))
+            }
+          }
+          ids.toList()
+        }
+    } catch (t: Throwable) {
+      System.err.println(
+        "playground: preview discovery failed (${t.javaClass.simpleName}: ${t.message}); none found"
+      )
+      emptyList()
+    }
+
+  companion object {
+    /**
+     * The `@Preview` annotation FQNs a playground snippet can use: Android Compose and Compose
+     * Multiplatform (`org.jetbrains.compose.*`). Mirrors `:daemon:core`'s default set.
+     */
+    val DEFAULT_PREVIEW_ANNOTATION_FQNS =
+      setOf(
+        "androidx.compose.ui.tooling.preview.Preview",
+        "org.jetbrains.compose.ui.tooling.preview.Preview",
+      )
+
+    /** The `<className>.<methodName>` id the render pipeline keys a preview by. */
+    internal fun previewId(className: String, methodName: String): String = "$className.$methodName"
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -189,6 +189,15 @@ class ServeHttpServer(
    * short-lived link, not a preview session.
    */
   private val docStore: ServeDocStore? = null,
+  /**
+   * When non-null, enables the **playground** lane: `POST /api/{version}/compiler/run` compiles a
+   * snippet against a catalog classpath and returns diagnostics + an expiring preview token.
+   * Supplied by `--playground-bundle`. Because the compile runs **user-supplied code** in-process,
+   * this lane is never enabled under `--public` — the CLI refuses the combination (see
+   * `ServeCommand`). See
+   * [docs/design/PLAYGROUND.md](../../../../../../../../docs/design/PLAYGROUND.md).
+   */
+  private val playgroundService: PlaygroundCompileService? = null,
 ) {
   /** The actual bound port — may differ from the requested one if it was taken (auto-picked). */
   val port: Int = pickPort(host, requestedPort, portRange)
@@ -377,6 +386,16 @@ class ServeHttpServer(
           // per-format. Ungated + CORS-open like `/rc-player/bundle.js` (generic client code, no
           // session data).
           get("/doc-player/{format}/bundle.js") { handleDocPlayer() }
+        }
+
+        // The playground lane (`--playground-bundle`): compile a snippet against a catalog
+        // classpath
+        // and return diagnostics + an expiring preview token. The frontend inserts a `{version}`
+        // path segment (e.g. `/api/1/compiler/run`) which we capture and ignore. The constant
+        // `/api`
+        // first segment outscores the `/{system}` catch-all. Never registered under `--public`.
+        playgroundService?.let { svc ->
+          post("/api/{version}/compiler/run") { handlePlaygroundRun(svc) }
         }
 
         // Shared/public mode ingestion: a client contributes a pre-rendered bundle (upload the zip
@@ -742,6 +761,44 @@ class ServeHttpServer(
       is ServeDocStore.Result.Failed ->
         call.respondText(result.reason, status = HttpStatusCode.BadRequest)
     }
+  }
+
+  /**
+   * `POST /api/{version}/compiler/run`: compile a playground snippet and return the Stage-1 result
+   * — diagnostics (both our shape and the stock `errors` map) plus, on a clean compile, an expiring
+   * preview token. Token-gated; the compile runs **user-supplied code** in-process, which is why
+   * the CLI refuses to enable this lane under `--public`. `isSecurityChecked = true`: the route
+   * cleared its token gate (`rejectBadToken`); the service still bounds the work (size cap, token
+   * TTL/caps).
+   */
+  private suspend fun RoutingContext.handlePlaygroundRun(service: PlaygroundCompileService) {
+    if (rejectBadToken()) return
+    val body =
+      withContext(Dispatchers.IO) {
+        call.receiveStream().use { readCapped(it, MAX_PLAYGROUND_BYTES) }
+      }
+        ?: run {
+          call.respondText(
+            "playground request exceeds ${MAX_PLAYGROUND_BYTES / 1024}KB",
+            status = HttpStatusCode.PayloadTooLarge,
+          )
+          return
+        }
+    val request =
+      try {
+        JSON.decodeFromString(PlaygroundRunRequest.serializer(), body.decodeToString())
+      } catch (e: Exception) {
+        call.respondText(
+          "invalid playground request: ${e.message}",
+          status = HttpStatusCode.BadRequest,
+        )
+        return
+      }
+    val response = withContext(Dispatchers.IO) { service.run(request, isSecurityChecked = true) }
+    call.respondText(
+      JSON.encodeToString(PlaygroundRunResponse.serializer(), response),
+      ContentType.Application.Json,
+    )
   }
 
   /** `GET /d/{id}`: the permalink page. An expired (or unknown) id is a styled 404, not a hint. */
@@ -2450,6 +2507,9 @@ class ServeHttpServer(
 
     /** Max accepted upload-body size for `POST /docs` (matches the document store's own cap). */
     private val MAX_DOC_BYTES: Long = ServeDocStore.DEFAULT_MAX_DOC_BYTES.toLong()
+
+    /** Max accepted body size for `POST /api/{v}/compiler/run` — a snippet is small. */
+    private val MAX_PLAYGROUND_BYTES: Long = 256L * 1024
 
     /** `1234567` → `1.2 MB`; the size line on a document page. */
     internal fun humanBytes(bytes: Int): String =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompilerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompilerTest.kt
@@ -1,0 +1,53 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.CompileErrorDetail
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** The pure BTA-diagnostic → PlaygroundDiagnostic mapping (positions, basename, severity). */
+class PlaygroundBtaCompilerTest {
+
+  @Test
+  fun `kotlinc 1-based positions map to codemirror 0-based, keyed by basename`() {
+    val details =
+      listOf(
+        CompileErrorDetail(
+          file = "/tmp/pg/abc/src/Snippet.kt",
+          line = 3,
+          column = 5,
+          message = "unresolved reference: Bttn",
+        ),
+        CompileErrorDetail(
+          file = "/tmp/pg/abc/src/Snippet.kt",
+          line = 1,
+          column = 1,
+          message = "expecting a top level declaration",
+        ),
+      )
+
+    val diags = PlaygroundBtaCompiler.mapDiagnostics(details)
+
+    assertEquals(2, diags.size)
+    assertEquals(PlaygroundSeverity.ERROR, diags[0].severity)
+    assertEquals(
+      "Snippet.kt",
+      diags[0].file,
+      "the editor sees the snippet basename, not the temp path",
+    )
+    assertEquals(2, diags[0].line, "line 3 (1-based) → 2 (0-based)")
+    assertEquals(4, diags[0].ch, "column 5 (1-based) → 4 (0-based)")
+    assertEquals("unresolved reference: Bttn", diags[0].message)
+    assertEquals(0, diags[1].line)
+    assertEquals(0, diags[1].ch)
+  }
+
+  @Test
+  fun `positions never go negative`() {
+    val diags =
+      PlaygroundBtaCompiler.mapDiagnostics(
+        listOf(CompileErrorDetail(file = "X.kt", line = 0, column = 0, message = "m"))
+      )
+    assertEquals(0, diags.single().line)
+    assertEquals(0, diags.single().ch)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviewDiscovererTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviewDiscovererTest.kt
@@ -1,0 +1,57 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import okio.Path.Companion.toPath
+
+/** A stand-in preview annotation so the scan can run against real compiled bytecode in the test. */
+annotation class FakePreviewMarker
+
+/** Compiled into the test output dir; the scan below finds `Shown` and ignores `Hidden`. */
+@Suppress("unused")
+class DiscoveryFixture {
+  @FakePreviewMarker fun Shown() {}
+
+  fun Hidden() {}
+}
+
+class PlaygroundPreviewDiscovererTest {
+
+  /** The test's own compiled-classes root — where [DiscoveryFixture] landed. */
+  private fun testClassesDir(): File =
+    File(DiscoveryFixture::class.java.protectionDomain.codeSource.location.toURI())
+
+  @Test
+  fun `scans a classes dir for @Preview-annotated methods, ignoring the rest`() {
+    val discoverer =
+      PlaygroundPreviewDiscoverer(
+        previewAnnotationFqns = setOf("ee.schimke.composeai.cli.serve.FakePreviewMarker")
+      )
+
+    val ids = discoverer.discover(testClassesDir().absolutePath.toPath(), classpath = emptyList())
+
+    assertTrue(
+      ids.any { it == "ee.schimke.composeai.cli.serve.DiscoveryFixture.Shown" },
+      "the annotated method is discovered with a <class>.<method> id: $ids",
+    )
+    assertFalse(ids.any { it.contains("Hidden") }, "unannotated methods are not previews")
+  }
+
+  @Test
+  fun `no matching annotation yields no previews`() {
+    val discoverer =
+      PlaygroundPreviewDiscoverer(previewAnnotationFqns = setOf("com.example.NotHere"))
+    assertTrue(discoverer.discover(testClassesDir().absolutePath.toPath(), emptyList()).isEmpty())
+  }
+
+  @Test
+  fun `id is class dot method`() {
+    assertEquals(
+      "com.example.Foo.Bar",
+      PlaygroundPreviewDiscoverer.previewId("com.example.Foo", "Bar"),
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -1,0 +1,115 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+/**
+ * The **playground lane** over real HTTP: `POST /api/{v}/compiler/run` returns the Stage-1 result
+ * (diagnostics + preview token) when the lane is enabled, and 404s when it isn't. The compile
+ * service is driven by fakes (a real compile is `PlaygroundBtaCompiler`'s job, covered elsewhere)
+ * so this is purely about the route wiring + JSON contract.
+ */
+class PlaygroundRoutingTest {
+
+  private val fs = FakeFileSystem()
+  private var workN = 0
+
+  private val playground =
+    PlaygroundCompileService(
+      catalogClasspath = { mode ->
+        if (mode == PlaygroundMode.CMP) {
+          PlaygroundCompileService.Classpath("compose-m3", listOf("/cat/app.jar".toPath()))
+        } else {
+          null
+        }
+      },
+      compiler = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() },
+      discoverer =
+        PlaygroundCompileService.PreviewDiscoverer { _, _ -> listOf("com.example.PScreen") },
+      tokenStore = PlaygroundTokenStore(fileSystem = fs),
+      newWorkDir = { "/work/run${++workN}".toPath() },
+      fileSystem = fs,
+    )
+
+  private val registry = ServeSessionRegistry(open = { null })
+
+  private val server: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "unused-in-public",
+        sessions = registry,
+        defaultSessionId = "none",
+        isPublic = true,
+        playgroundService = playground,
+      )
+      .also { it.start() }
+  }
+
+  /** A host with no playground service — the lane must not exist there. */
+  private val plainServer: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "unused-in-public",
+        sessions = ServeSessionRegistry(open = { null }),
+        defaultSessionId = "none",
+        isPublic = true,
+      )
+      .also { it.start() }
+  }
+
+  private val client = OkHttpClient()
+
+  @AfterTest
+  fun stop() {
+    runCatching { server.stop() }
+    runCatching { plainServer.stop() }
+    runCatching { registry.close() }
+  }
+
+  private fun postRun(body: String, port: Int) =
+    client
+      .newCall(
+        Request.Builder()
+          .url("http://127.0.0.1:$port/api/1/compiler/run")
+          .post(body.toRequestBody("application/json".toMediaType()))
+          .build()
+      )
+      .execute()
+
+  @Test
+  fun `a clean compile returns a preview token over the run route`() {
+    val body =
+      """{"files":[{"name":"Snippet.kt","text":"@Preview @Composable fun P(){}"}],"confType":"compose-cmp"}"""
+    postRun(body, server.port).use { resp ->
+      assertEquals(200, resp.code)
+      val json = Json.parseToJsonElement(resp.body!!.string()).jsonObject
+      assertTrue(
+        json["previewToken"]?.jsonPrimitive?.content?.startsWith("pg_") == true,
+        "a clean compile mints a pg_ token: $json",
+      )
+      assertEquals(
+        "/pg/${json["previewToken"]!!.jsonPrimitive.content}",
+        json["previewUrl"]!!.jsonPrimitive.content,
+      )
+    }
+  }
+
+  @Test
+  fun `the run route is absent when the playground lane isn't enabled`() {
+    val body = """{"files":[{"name":"S.kt","text":"x"}],"confType":"compose-cmp"}"""
+    postRun(body, plainServer.port).use { resp -> assertEquals(404, resp.code) }
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileSession.kt
@@ -79,13 +79,20 @@ class BtaCompileSession(
     compileClasspath: List<Path>,
     outputDir: Path,
     compilerPlugins: List<CompilerPlugin> = emptyList(),
+    /**
+     * When non-null, BTA's diagnostic stream is routed through this collector for the call (same
+     * role as [compileIncremental]'s listener). A non-incremental compile does **not** snapshot the
+     * classpath, so — unlike [compileIncremental] — it accepts **directory** classpath entries (an
+     * extracted `classes/` dir), which is what the playground's catalog classpath leads with.
+     */
+    diagnosticListener: KotlinLogger? = null,
   ): List<Path> {
     outputDir.toFile().mkdirs()
     val jvm = toolchains.getToolchain<JvmPlatformToolchain>()
     toolchains.createBuildSession().use { session ->
       val builder = jvm.jvmCompilationOperationBuilder(sources, outputDir)
       configureCompilerArgs(builder.compilerArguments, compileClasspath, compilerPlugins)
-      executeOrThrow(session, builder.build())
+      executeOrThrow(session, builder.build(), diagnosticListener ?: logger)
     }
     return collectClassFiles(outputDir)
   }


### PR DESCRIPTION
## Summary

Completes Phase 1 of the Compose playground (`docs/design/PLAYGROUND.md`): a `compose-preview serve` host can now **compile a snippet against a catalog's real components** and hand back diagnostics + an expiring preview token. Builds on the merged pieces (design doc, token store + DTOs, stock-`errors` wire, Stage-1 orchestrator, catalog classpath resolver).

**End to end:** `serve --playground-bundle <compose-m3 liveBundle>` → `POST /api/1/compiler/run` with `{files:[{name,text}], confType:"compose-cmp"}` → the snippet compiles against compose-m3's resolved classpath (so `import androidx.compose.material3.*` resolves), returning diagnostics and, on a clean compile, a `pg_…` preview token.

### The pieces

- **`lib-bta/` staging** — stage the BTA impl jars + Compose compiler plugin into the CLI install, mirroring `lib-daemon-desktop`. Verified: `installDist` stages 13 jars.
- **`PlaygroundBtaCompiler`** — in-process BTA compile over the shipped `BtaCompileSession`. Uses the **non-incremental** path (directory-safe classpath — the catalog classpath leads with an extracted `classes/` dir) on a **retained** session (bootstrap paid once). Diagnostics mapped 1-based kotlinc → 0-based CodeMirror.
- **`PlaygroundPreviewDiscoverer`** — scoped ClassGraph scan of the snippet's `classesDir` for `@Preview` methods → `<class>.<method>` ids.
- **`PlaygroundCatalogClasspath`** (merged #3008) resolves the catalog liveBundle → compile classpath.
- **The run route + `--playground-bundle` gate** — `POST /api/{version}/compiler/run` wired into `ServeHttpServer` (mirrors the `docStore` lane); `ServeCommand` resolves the classpath at startup and constructs the service. **Refused under `--public`** — the compile runs user-supplied code in-process, which the public server's "never run untrusted code" model forbids; fail-soft otherwise.

### Scope / follow-ups

Phase-1 minimum to reach "build against catalog components." Not yet here (design doc phases 2–4): the `/pg/<token>` Stage-2 **redemption** into the live interactive session, the Android + Remote-Compose modes, and the per-session **sandbox** that gates any `--public` exposure. The lane stays token-gated and off under `--public` until that sandbox lands.

## Test plan

- [x] `./gradlew :cli:test --tests "…Playground*"` — green: routing test over real HTTP (clean compile → `pg_` token; route 404s when the lane is off), compiler diagnostic mapping, discoverer real-bytecode scan, catalog classpath assembly + fail-closed, token store, orchestrator.
- [x] `./gradlew :cli:installDist` → `lib-bta/` staged (13 jars); `./gradlew --no-daemon :cli:installDist --stacktrace` (the serve-lanes CI command) builds clean.
- [x] `./gradlew :cli:compileKotlin :cli:ktfmtFormat` — clean.
- Non-visual (server-side compile plumbing + HTTP route); no rendered surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)