### PR TITLE
refactor(rc-embedded): split the draw dispatcher out of RcPlayer.kt

### DIFF
--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -591,11 +591,20 @@ single-target milestone it cannot be verified. It splits into 1a/1b.
      draw context (whose `loadBitmap` decodes via `org.jetbrains.skia.Image`), which is step 3's
      `JvmRemoteContext` — so unlike the text seam, the image seam's jvm half is paced by the context,
      not ready ahead of it.
-   - **Next: the draw dispatcher.** `RcPlayerChildren`/`RcPlayerComponent` out of `RcPlayer.kt` (to
-     shed its `AndroidRemoteContext`/`PendingIntent` coupling), then add the now-import-clean
-     `RcPlayerDrawing.kt` / `RcPlayerPaint.kt` / `RcPlayerCanvas.kt` / `RcPlayerModifiers.kt` /
-     `RcPlayerDensity.kt` and the neutral `layout/**` + `modifier/**` to the jvm source list once
-     their callees resolve. This is the large remaining piece and where the deferrals below matter.
+   - The draw dispatcher out of `RcPlayer.kt` — **done** (`RcPlayerDispatch.kt`). The four
+     component-tree composables (`RcPlayerRawDocument`, `RcPlayerRootLayoutComponent`,
+     `RcPlayerComponent`, `RcPlayerChildren`) touch only neutral types — the composition locals, the
+     seamed `executeOperations`, and the per-layout composables — so moving them out keeps
+     `RcPlayer.kt`'s `SuppressLint`/`PendingIntent`/`AndroidRemoteContext` coupling (document setup +
+     interactive dispatch, neither on the pixel path) off the draw/layout path. A move, not a change:
+     the bodies are verbatim. `RcPlayerDispatch.kt` is import-clean but not yet movable — its `when`
+     still reaches `RcPlayerText` (googlefonts) and `RcPlayerImageLayout` (the `Drawable` loader).
+   - **Next: add the import-clean set to the jvm source list.** `RcPlayerDrawing.kt` /
+     `RcPlayerPaint.kt` / `RcPlayerDispatch.kt` / `RcPlayerCanvas.kt` / `RcPlayerModifiers.kt` /
+     `RcPlayerDensity.kt` and the neutral `layout/**` + `modifier/**`, once their remaining
+     androidMain callees (the `Drawable` image loader, the googlefonts text layout, and a jvm draw
+     `RemoteContext` whose `loadBitmap` decodes) are split or seamed. This is where the deferrals
+     below start to matter.
 
    **Import-clean and movable are different things**, and 1a keeps tripping over the difference —
    `GraphContext` imports nothing Android yet still cannot move, because of an ordinary in-package

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -32,8 +32,6 @@ import androidx.collection.ObjectIntMap
 import androidx.collection.emptyIntObjectMap
 import androidx.collection.emptyObjectIntMap
 import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.remote.core.CoreDocument
 import androidx.compose.remote.core.Limits
 import androidx.compose.remote.core.Operation
@@ -56,31 +54,10 @@ import androidx.compose.remote.core.operations.layout.Component
 import androidx.compose.remote.core.operations.layout.Container
 import androidx.compose.remote.core.operations.layout.LayoutComponent
 import androidx.compose.remote.core.operations.layout.LayoutComponentContent
-import androidx.compose.remote.core.operations.layout.RootLayoutComponent
-import androidx.compose.remote.core.operations.layout.managers.BoxLayout
-import androidx.compose.remote.core.operations.layout.managers.CanvasLayout
-import androidx.compose.remote.core.operations.layout.managers.ColumnLayout
-import androidx.compose.remote.core.operations.layout.managers.CoreText
-import androidx.compose.remote.core.operations.layout.managers.Custom
-import androidx.compose.remote.core.operations.layout.managers.FitBoxLayout
-import androidx.compose.remote.core.operations.layout.managers.FlowLayout
-import androidx.compose.remote.core.operations.layout.managers.ImageLayout
-import androidx.compose.remote.core.operations.layout.managers.RowLayout
-import androidx.compose.remote.core.operations.layout.managers.StateLayout
-import androidx.compose.remote.core.operations.layout.managers.TextLayout
-import androidx.compose.remote.core.operations.layout.modifiers.ComponentVisibilityOperation
 import androidx.compose.remote.core.operations.utilities.AnimatedFloatExpression
 import androidx.compose.remote.core.operations.utilities.NanMap
 import androidx.compose.remote.creation.compose.capture.CapturedDocument
 import androidx.compose.remote.player.compose.ExperimentalRemotePlayerApi
-import androidx.compose.remote.player.compose.embedded.layout.RcPlayerBox
-import androidx.compose.remote.player.compose.embedded.layout.RcPlayerColumn
-import androidx.compose.remote.player.compose.embedded.layout.RcPlayerFitBoxLayout
-import androidx.compose.remote.player.compose.embedded.layout.RcPlayerFlowRow
-import androidx.compose.remote.player.compose.embedded.layout.RcPlayerImageLayout
-import androidx.compose.remote.player.compose.embedded.layout.RcPlayerRow
-import androidx.compose.remote.player.compose.embedded.layout.RcPlayerStateLayout
-import androidx.compose.remote.player.compose.embedded.state.rememberRemoteIntAsState
 import androidx.compose.remote.player.core.platform.AndroidRemoteContext
 import androidx.compose.remote.player.core.state.StateUpdater
 import androidx.compose.runtime.Composable
@@ -93,19 +70,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.layout.onPlaced
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionOnScreen
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.preferredFrameRate
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.util.fastForEach
 import java.io.ByteArrayInputStream
-import kotlin.math.abs
 
 /**
  * A player of a [CoreDocument].
@@ -513,160 +485,6 @@ public fun RcPlayer(
         // `CapturedDocument` in remote-creation-compose 1.0.0-alpha15. Same reasoning as the
         // named-action handler above: interactive dispatch, unused by the render lane.
     )
-}
-
-/**
- * Renders a document that has no root layout component — a raw draw-list document whose draw
- * operations live at the top level of `mOperations` rather than inside a component tree (e.g.
- * shader / canvas demos built without the layout DSL). The View player renders these via
- * `CoreDocument.paint`; here the document's operations are executed directly in a Canvas. Without
- * this fallback the layout-tree renderer dereferenced a null `rootLayoutComponent` and crashed
- * (NPE) for such documents.
- */
-@Composable
-internal fun RcPlayerRawDocument(size: IntSize) {
-    val document = LocalCoreDocument.current
-    val remoteContext = LocalRemoteContext.current
-    val graph = LocalGraphContext.current
-    val textMeasurer = rememberTextMeasurer()
-    Canvas(modifier = Modifier.fillMaxSize()) {
-        // Publish the on-screen size as the document dimensions before painting, mirroring
-        // CoreDocument.paint, so draws positioned by the document size resolve.
-        document.setWidth(size.width)
-        document.setHeight(size.height)
-        executeOperations(
-            document.getOperationsReflection(),
-            remoteContext,
-            graph = graph,
-            textMeasurer = textMeasurer,
-        )
-    }
-}
-
-@Composable
-internal fun RcPlayerRootLayoutComponent(size: IntSize) {
-    val document = LocalCoreDocument.current
-    val root: RootLayoutComponent = document.rootLayoutComponent!!
-    val remoteContext = LocalRemoteContext.current
-
-    root.setWidth(size.width.toFloat())
-    root.setHeight(size.height.toFloat())
-    root.updateVariables(remoteContext)
-
-    RcPlayerChildren(root)
-}
-
-@Composable
-internal fun RcPlayerComponent(component: Component, modifier: Modifier = Modifier) {
-    if (component is LayoutComponent) {
-        val remoteContext = LocalRemoteContext.current
-        val componentValueMap = LocalComponentValueMap.current
-        val componentValueStateMap = LocalComponentValueStateMap.current
-
-        val visibilityOp =
-            component.componentModifiers.list.find { it is ComponentVisibilityOperation }
-                as? ComponentVisibilityOperation
-        if (visibilityOp != null) {
-            val visible by rememberRemoteIntAsState(visibilityOp.getVisibilityIdReflection())
-            if (visible == Component.Visibility.GONE) {
-                return
-            }
-        }
-
-        var modifier =
-            component.componentModifiers
-                .toModifier(component.getDrawContentOperationsListReflection())
-                .then(modifier)
-
-        // Publish the component's measured WIDTH/HEIGHT (read by ComponentValue expressions) from
-        // an onSizeChanged callback rather than a custom Modifier.layout that wrote snapshot state
-        // during the measure pass (a relayout hazard) and sat ahead of the real modifiers (which
-        // disturbed constraint propagation, e.g. FILL children collapsing to wrap size). As the
-        // outermost modifier, onSizeChanged reports the full component size and fires after layout.
-        val sizeFeedbackOps = componentValueMap[component.getId()]
-        if (!sizeFeedbackOps.isNullOrEmpty()) {
-            modifier =
-                Modifier.onSizeChanged { sz ->
-                        sizeFeedbackOps.forEach { op ->
-                            val state = componentValueStateMap[op.valueId] ?: return@forEach
-                            val w = sz.width.toFloat()
-                            val h = sz.height.toFloat()
-                            if (op.type == ComponentValue.WIDTH && abs(w - state.value) > 2.0f) {
-                                state.value = w
-                            } else if (
-                                op.type == ComponentValue.HEIGHT && abs(h - state.value) > 2.0f
-                            ) {
-                                state.value = h
-                            }
-                        }
-                    }
-                    .then(modifier)
-        }
-
-        val drawOpsList = component.getDrawContentOperationsListReflection()
-        if (drawOpsList != null) {
-            val remoteContext = LocalRemoteContext.current
-            val graph = LocalGraphContext.current
-            val document = LocalCoreDocument.current
-            val textMeasurer = rememberTextMeasurer()
-            modifier =
-                modifier.drawWithContent {
-                    // Size feedback is published by onSizeChanged above; the draw pass only draws.
-                    // graph makes time/variable-driven reads reactive, so the draw self-invalidates
-                    // when they change — no per-frame applyOperations refreshing the store.
-                    executeOperations(
-                        drawOpsList,
-                        remoteContext,
-                        onDrawContent = { drawContent() },
-                        graph = graph,
-                        textMeasurer = textMeasurer,
-                    )
-                }
-        }
-        when (component) {
-            is CanvasLayout -> RcPlayerCanvas(component, modifier)
-            is ColumnLayout -> RcPlayerColumn(component, modifier)
-            is FlowLayout -> RcPlayerFlowRow(component, modifier)
-            is RowLayout -> RcPlayerRow(component, modifier)
-            is CoreText -> RcPlayerText(component, modifier)
-            is TextLayout -> RcPlayerText(component, modifier)
-            is FitBoxLayout -> RcPlayerFitBoxLayout(component, modifier)
-            is StateLayout -> RcPlayerStateLayout(component, modifier)
-            is ImageLayout -> RcPlayerImageLayout(component, modifier)
-            is Custom -> RcPlayerCustom(component, modifier)
-            // Last as others are often BoxLayout subclasses
-            is BoxLayout -> RcPlayerBox(component, modifier)
-            else -> {
-                // Unsupported layout type. Render nothing rather than crash; see
-                // operation_coverage.md. The modifier (incl. any drawContent) was still applied
-                // above.
-                println(
-                    "Warning: unsupported layout component ${component::class.java.simpleName}; rendering nothing"
-                )
-            }
-        }
-    } else {
-        // Non-LayoutComponent component reached dispatch — skip gracefully instead of crashing.
-        println(
-            "Warning: unsupported component ${component?.let { it::class.java.simpleName }}; rendering nothing"
-        )
-    }
-}
-
-@Composable
-internal fun RcPlayerChildren(
-    layout: Component,
-    modifierProvider: @Composable (Component) -> Modifier = { Modifier },
-) {
-    if (layout is LayoutComponent) {
-        layout.childrenComponents.fastForEach { child ->
-            val scopeModifier = modifierProvider(child)
-            RcPlayerComponent(child, scopeModifier)
-        }
-    } else {
-        val children = remember { ArrayList<Component>().apply { layout.getComponents(this) } }
-        children.fastForEach { op -> RcPlayerComponent(op) }
-    }
 }
 
 /** True if the op tree contains a particle loop (drives the frame-loop keepalive). */

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerDispatch.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerDispatch.kt
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.remote.player.compose.embedded
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.remote.core.operations.ComponentValue
+import androidx.compose.remote.core.operations.layout.Component
+import androidx.compose.remote.core.operations.layout.LayoutComponent
+import androidx.compose.remote.core.operations.layout.RootLayoutComponent
+import androidx.compose.remote.core.operations.layout.managers.BoxLayout
+import androidx.compose.remote.core.operations.layout.managers.CanvasLayout
+import androidx.compose.remote.core.operations.layout.managers.ColumnLayout
+import androidx.compose.remote.core.operations.layout.managers.CoreText
+import androidx.compose.remote.core.operations.layout.managers.Custom
+import androidx.compose.remote.core.operations.layout.managers.FitBoxLayout
+import androidx.compose.remote.core.operations.layout.managers.FlowLayout
+import androidx.compose.remote.core.operations.layout.managers.ImageLayout
+import androidx.compose.remote.core.operations.layout.managers.RowLayout
+import androidx.compose.remote.core.operations.layout.managers.StateLayout
+import androidx.compose.remote.core.operations.layout.managers.TextLayout
+import androidx.compose.remote.core.operations.layout.modifiers.ComponentVisibilityOperation
+import androidx.compose.remote.player.compose.embedded.layout.RcPlayerBox
+import androidx.compose.remote.player.compose.embedded.layout.RcPlayerColumn
+import androidx.compose.remote.player.compose.embedded.layout.RcPlayerFitBoxLayout
+import androidx.compose.remote.player.compose.embedded.layout.RcPlayerFlowRow
+import androidx.compose.remote.player.compose.embedded.layout.RcPlayerImageLayout
+import androidx.compose.remote.player.compose.embedded.layout.RcPlayerRow
+import androidx.compose.remote.player.compose.embedded.layout.RcPlayerStateLayout
+import androidx.compose.remote.player.compose.embedded.state.rememberRemoteIntAsState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.util.fastForEach
+import kotlin.math.abs
+
+/*
+ * The component-tree dispatch half of the embedded player, split out of `RcPlayer.kt`.
+ *
+ * `RcPlayer.kt` is the player's Android entry point — it names `android.annotation.SuppressLint`,
+ * `android.app.PendingIntent` and `androidx.compose.remote.player.core.platform.AndroidRemoteContext`
+ * for the document-setup / interactive-dispatch surface (none of which the pixel path touches). The
+ * four composables here — the raw-document and root-layout entry points plus the recursive
+ * `RcPlayerComponent` / `RcPlayerChildren` walk — reference only neutral types (the composition
+ * locals from `RcPlayerCompositionLocals.kt`, `executeOperations` from the image/text-seamed
+ * `RcPlayerDrawing.kt`, and the per-layout composables), so moving them here keeps `RcPlayer.kt`'s
+ * Android coupling off the draw/layout dispatch path. This is a **move, not a change**: the bodies
+ * are verbatim from `RcPlayer.kt`.
+ *
+ * It stays in `androidMain` for now — `RcPlayerComponent`'s `when` reaches `RcPlayerText` (google
+ * fonts) and `RcPlayerImageLayout` (the `Drawable`-typed loader), both still Android-only — but it no
+ * longer drags `RcPlayer.kt` behind it. See `PROVENANCE.md` ("Next: the draw dispatcher").
+ */
+
+/**
+ * Renders a document that has no root layout component — a raw draw-list document whose draw
+ * operations live at the top level of `mOperations` rather than inside a component tree (e.g.
+ * shader / canvas demos built without the layout DSL). The View player renders these via
+ * `CoreDocument.paint`; here the document's operations are executed directly in a Canvas. Without
+ * this fallback the layout-tree renderer dereferenced a null `rootLayoutComponent` and crashed
+ * (NPE) for such documents.
+ */
+@Composable
+internal fun RcPlayerRawDocument(size: IntSize) {
+    val document = LocalCoreDocument.current
+    val remoteContext = LocalRemoteContext.current
+    val graph = LocalGraphContext.current
+    val textMeasurer = rememberTextMeasurer()
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        // Publish the on-screen size as the document dimensions before painting, mirroring
+        // CoreDocument.paint, so draws positioned by the document size resolve.
+        document.setWidth(size.width)
+        document.setHeight(size.height)
+        executeOperations(
+            document.getOperationsReflection(),
+            remoteContext,
+            graph = graph,
+            textMeasurer = textMeasurer,
+        )
+    }
+}
+
+@Composable
+internal fun RcPlayerRootLayoutComponent(size: IntSize) {
+    val document = LocalCoreDocument.current
+    val root: RootLayoutComponent = document.rootLayoutComponent!!
+    val remoteContext = LocalRemoteContext.current
+
+    root.setWidth(size.width.toFloat())
+    root.setHeight(size.height.toFloat())
+    root.updateVariables(remoteContext)
+
+    RcPlayerChildren(root)
+}
+
+@Composable
+internal fun RcPlayerComponent(component: Component, modifier: Modifier = Modifier) {
+    if (component is LayoutComponent) {
+        val remoteContext = LocalRemoteContext.current
+        val componentValueMap = LocalComponentValueMap.current
+        val componentValueStateMap = LocalComponentValueStateMap.current
+
+        val visibilityOp =
+            component.componentModifiers.list.find { it is ComponentVisibilityOperation }
+                as? ComponentVisibilityOperation
+        if (visibilityOp != null) {
+            val visible by rememberRemoteIntAsState(visibilityOp.getVisibilityIdReflection())
+            if (visible == Component.Visibility.GONE) {
+                return
+            }
+        }
+
+        var modifier =
+            component.componentModifiers
+                .toModifier(component.getDrawContentOperationsListReflection())
+                .then(modifier)
+
+        // Publish the component's measured WIDTH/HEIGHT (read by ComponentValue expressions) from
+        // an onSizeChanged callback rather than a custom Modifier.layout that wrote snapshot state
+        // during the measure pass (a relayout hazard) and sat ahead of the real modifiers (which
+        // disturbed constraint propagation, e.g. FILL children collapsing to wrap size). As the
+        // outermost modifier, onSizeChanged reports the full component size and fires after layout.
+        val sizeFeedbackOps = componentValueMap[component.getId()]
+        if (!sizeFeedbackOps.isNullOrEmpty()) {
+            modifier =
+                Modifier.onSizeChanged { sz ->
+                        sizeFeedbackOps.forEach { op ->
+                            val state = componentValueStateMap[op.valueId] ?: return@forEach
+                            val w = sz.width.toFloat()
+                            val h = sz.height.toFloat()
+                            if (op.type == ComponentValue.WIDTH && abs(w - state.value) > 2.0f) {
+                                state.value = w
+                            } else if (
+                                op.type == ComponentValue.HEIGHT && abs(h - state.value) > 2.0f
+                            ) {
+                                state.value = h
+                            }
+                        }
+                    }
+                    .then(modifier)
+        }
+
+        val drawOpsList = component.getDrawContentOperationsListReflection()
+        if (drawOpsList != null) {
+            val remoteContext = LocalRemoteContext.current
+            val graph = LocalGraphContext.current
+            val document = LocalCoreDocument.current
+            val textMeasurer = rememberTextMeasurer()
+            modifier =
+                modifier.drawWithContent {
+                    // Size feedback is published by onSizeChanged above; the draw pass only draws.
+                    // graph makes time/variable-driven reads reactive, so the draw self-invalidates
+                    // when they change — no per-frame applyOperations refreshing the store.
+                    executeOperations(
+                        drawOpsList,
+                        remoteContext,
+                        onDrawContent = { drawContent() },
+                        graph = graph,
+                        textMeasurer = textMeasurer,
+                    )
+                }
+        }
+        when (component) {
+            is CanvasLayout -> RcPlayerCanvas(component, modifier)
+            is ColumnLayout -> RcPlayerColumn(component, modifier)
+            is FlowLayout -> RcPlayerFlowRow(component, modifier)
+            is RowLayout -> RcPlayerRow(component, modifier)
+            is CoreText -> RcPlayerText(component, modifier)
+            is TextLayout -> RcPlayerText(component, modifier)
+            is FitBoxLayout -> RcPlayerFitBoxLayout(component, modifier)
+            is StateLayout -> RcPlayerStateLayout(component, modifier)
+            is ImageLayout -> RcPlayerImageLayout(component, modifier)
+            is Custom -> RcPlayerCustom(component, modifier)
+            // Last as others are often BoxLayout subclasses
+            is BoxLayout -> RcPlayerBox(component, modifier)
+            else -> {
+                // Unsupported layout type. Render nothing rather than crash; see
+                // operation_coverage.md. The modifier (incl. any drawContent) was still applied
+                // above.
+                println(
+                    "Warning: unsupported layout component ${component::class.java.simpleName}; rendering nothing"
+                )
+            }
+        }
+    } else {
+        // Non-LayoutComponent component reached dispatch — skip gracefully instead of crashing.
+        println(
+            "Warning: unsupported component ${component?.let { it::class.java.simpleName }}; rendering nothing"
+        )
+    }
+}
+
+@Composable
+internal fun RcPlayerChildren(
+    layout: Component,
+    modifierProvider: @Composable (Component) -> Modifier = { Modifier },
+) {
+    if (layout is LayoutComponent) {
+        layout.childrenComponents.fastForEach { child ->
+            val scopeModifier = modifierProvider(child)
+            RcPlayerComponent(child, scopeModifier)
+        }
+    } else {
+        val children = remember { ArrayList<Component>().apply { layout.getComponents(this) } }
+        children.fastForEach { op -> RcPlayerComponent(op) }
+    }
+}

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/PlatformNeutralSourcesTest.kt
@@ -227,8 +227,10 @@ class PlatformNeutralSourcesTest {
         "EmbeddedRcImageLoader",
         "LocalRcImageLoader",
         "DrawablePainter",
-        // SuppressLint / PendingIntent / AndroidRemoteContext
+        // SuppressLint / PendingIntent / AndroidRemoteContext (the player's Android entry point)
         "RcPlayer",
+        // The dispatch composables are import-clean (RcPlayerDispatch.kt) but still reach the
+        // googlefonts text layout / Drawable-typed image layout below, so they stay androidMain.
         "RcPlayerChildren",
         "RcPlayerComponent",
         // googlefonts Font/GoogleFont, Typeface, FontRequest
@@ -252,6 +254,11 @@ class PlatformNeutralSourcesTest {
         // silently creeping back before the jvm draw context lands.
         "RcPlayerDrawing.kt",
         "RcPlayerPaint.kt",
+        // The component-tree dispatch (RcPlayerRawDocument / RcPlayerRootLayoutComponent /
+        // RcPlayerComponent / RcPlayerChildren), split out of the Android-coupled RcPlayer.kt. Import-
+        // clean, but not movable yet: its `when` reaches the still-androidMain RcPlayerText
+        // (googlefonts) and RcPlayerImageLayout (Drawable loader).
+        "RcPlayerDispatch.kt",
       )
 
     /**


### PR DESCRIPTION
## Summary

Second increment of porting the embedded Remote Compose player's **draw path** to CMP Desktop / Skiko (toward the `cmp-jvm` render lane). This sheds the last Android coupling from the component-tree dispatch.

`RcPlayer.kt` is the player's Android entry point — it names `android.annotation.SuppressLint`, `android.app.PendingIntent`, and `androidx.compose.remote.player.core.platform.AndroidRemoteContext` for document setup + interactive dispatch, none of which the pixel path touches. But it also held the four component-tree composables the draw/layout path walks:
- `RcPlayerRawDocument` (raw draw-list documents)
- `RcPlayerRootLayoutComponent` (layout-tree root)
- `RcPlayerComponent` / `RcPlayerChildren` (the recursive component dispatch)

Those reference only neutral types — the composition locals from `RcPlayerCompositionLocals.kt`, the seamed `executeOperations` from `RcPlayerDrawing.kt`, and the per-layout composables — so they now live in a new import-clean file, **`RcPlayerDispatch.kt`**. **A move, not a change**: the bodies are verbatim, and `RcPlayer.kt`'s now-unused imports are dropped. The draw/layout dispatch no longer drags `RcPlayer.kt`'s Android coupling behind it.

`RcPlayerDispatch.kt` is import-clean but **not yet movable** — its `when` still reaches `RcPlayerText` (googlefonts) and `RcPlayerImageLayout` (the `Drawable`-typed loader) — so it's registered in `PlatformNeutralSourcesTest.IMPORT_CLEAN` alongside `RcPlayerDrawing`/`RcPlayerPaint`, guarding against an `android.*` import creeping back before the JVM draw context lands.

## Sequencing (per `third_party/rc-embedded-player/PROVENANCE.md`)

- ✅ text seam (both halves)
- ✅ image seam (Android half) — #3009
- ✅ **draw dispatcher out of `RcPlayer.kt`** — this PR
- ⏭ next: add the import-clean set (`RcPlayerDrawing`/`RcPlayerPaint`/`RcPlayerDispatch`/`RcPlayerCanvas`/`RcPlayerModifiers`/`RcPlayerDensity` + `layout/**` + `modifier/**`) to the JVM source list once the remaining androidMain callees (the `Drawable` image loader, the googlefonts text layout, and a JVM draw `RemoteContext` whose `loadBitmap` decodes) are split/seamed
- ⏭ then: `JvmRemoteContext` + image-seam skiko half + a JVM `ImageComposeScene` raster harness; particles + AGSL shaders deferred

## Test plan

- [x] `:third-party-rc-embedded-player:check` — compiles + unit tests (incl. `PlatformNeutralSourcesTest`, and the Robolectric render harness) green.
- [x] `:third-party-rc-embedded-player-jvm:check` — the JVM module still compiles/tests (untouched; draw path not on its source list yet).
- [x] `ktfmtCheck` clean.
- Behaviour-preserving **by construction** (a verbatim move of composables + dead-import removal). Render parity is a staged-catalog / CI `rc-compare` step per `PROVENANCE.md`.

Text-only PR: no rendered output changes, so no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXNXNpWA4JUpN3m4mVD8zT)_