### PR TITLE
feat(rc-embedded-jvm): add JvmRemoteContext with a skiko bitmap decode

### DIFF
--- a/third_party/rc-embedded-player-jvm/build.gradle.kts
+++ b/third_party/rc-embedded-player-jvm/build.gradle.kts
@@ -85,7 +85,12 @@ val sharedPlayerSources =
  * be told apart — including the jvm one by name would silently pull in the Android one as well.
  */
 val jvmPlayerSources =
-  listOf("androidx/compose/remote/player/compose/embedded/RcPlayerTextPlatformJvm.kt")
+  listOf(
+    "androidx/compose/remote/player/compose/embedded/RcPlayerTextPlatformJvm.kt",
+    // The jvm draw RemoteContext — StoreBackedRemoteContext + a skiko `loadBitmap` decode, the one
+    // platform-bound member of the contract. Written here, so it names skiko rather than the SDK.
+    "androidx/compose/remote/player/compose/embedded/JvmRemoteContext.kt",
+  )
 
 kotlin {
   sourceSets["main"].kotlin.apply {

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/JvmRemoteContext.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/JvmRemoteContext.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.remote.player.compose.embedded
+
+import androidx.compose.remote.core.RemoteClock
+import androidx.compose.remote.core.RemoteComposeState
+import androidx.compose.remote.core.SystemClock
+import androidx.compose.remote.core.operations.BitmapData
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+
+/**
+ * The desktop/JVM draw [androidx.compose.remote.core.RemoteContext] — the jvm counterpart of
+ * `remote-player-core`'s `AndroidRemoteContext` for the pixel path.
+ *
+ * `AndroidRemoteContext` "is barely an Android class" (`PROVENANCE.md`): of the 42 `RemoteContext`
+ * members, all but **one** are the platform-neutral variable/state store that
+ * [StoreBackedRemoteContext] already reimplements. The sole platform-bound member is [loadBitmap] —
+ * decoding a document's encoded bytes to a raster — so this class is exactly that one override over
+ * skiko, plus the store it inherits.
+ *
+ * Where [StoreBackedRemoteContext] leaves [loadBitmap] a no-op (its subclass [GraphContext]
+ * evaluates values and never paints), the *drawing* context must actually decode: `resolveBitmap`
+ * drives `BitmapData.apply(context)` → `context.loadBitmap(...)` and then reads the decoded image
+ * back out of the store under the same id. On Android that cached value is an
+ * `android.graphics.Bitmap`; here it is a Compose [ImageBitmap] decoded through
+ * `org.jetbrains.skia.Image`, which is the type the jvm half of the image seam
+ * (`RcPlayerImagePlatform`'s `resolveImage`) will read back — the store is untyped (`putObject` /
+ * `cacheData` take `Any`), so the two platforms cache different concrete types behind the same id
+ * and each reads its own.
+ *
+ * ## Coverage and limits
+ *
+ * - **Encoding.** Only [BitmapData.ENCODING_INLINE] carries bytes to decode; `ENCODING_URL` /
+ *   `ENCODING_FILE` are host-fetched (the pluggable image loader's job, deferred) and
+ *   `ENCODING_EMPTY` has nothing, so all three are a no-op here.
+ * - **PNG types** (`TYPE_PNG`, `TYPE_PNG_8888`, `TYPE_PNG_ALPHA_8`) decode through
+ *   `Image.makeFromEncoded`. `TYPE_PNG_ALPHA_8` is an alpha-only mask on Android; skiko decodes it
+ *   to RGBA like any other PNG, a parity nuance for documents that use it as a tint mask.
+ * - **Raw types** (`TYPE_RAW8888` straight RGBA, `TYPE_RAW8` single-channel alpha) build a raster
+ *   directly from the pixel bytes. Buffers too short for the declared `width × height × stride` are
+ *   rejected rather than read out of bounds.
+ * - A decode that throws (malformed/truncated bytes, an unsupported type) is swallowed to a null,
+ *   so a bad image leaves a blank rather than failing the whole render — mirroring the Android
+ *   loader's resilience and the text seam's never-throw contract.
+ */
+internal class JvmRemoteContext(
+    state: RemoteComposeState = SnapshotRemoteComposeState(),
+    clock: RemoteClock = SystemClock(),
+) : StoreBackedRemoteContext(clock) {
+
+    init {
+        mRemoteComposeState = state
+    }
+
+    override fun loadBitmap(
+        imageId: Int,
+        encoding: Short,
+        type: Short,
+        width: Int,
+        height: Int,
+        data: ByteArray,
+    ) {
+        // Only inline bytes are decodable here; URL/FILE are the (deferred) host image loader's job
+        // and EMPTY has nothing. Caching under the id is what a later `resolveImage` reads back.
+        if (encoding != BitmapData.ENCODING_INLINE) return
+        val image = decode(type, width, height, data) ?: return
+        mRemoteComposeState.cacheData(imageId, image)
+    }
+
+    private fun decode(type: Short, width: Int, height: Int, data: ByteArray): ImageBitmap? =
+        try {
+            when (type) {
+                BitmapData.TYPE_PNG,
+                BitmapData.TYPE_PNG_8888,
+                BitmapData.TYPE_PNG_ALPHA_8 -> Image.makeFromEncoded(data).toComposeImageBitmap()
+                BitmapData.TYPE_RAW8888 ->
+                    raster(data, width, height, rowBytes = width * 4, ColorType.RGBA_8888)
+                BitmapData.TYPE_RAW8 ->
+                    raster(data, width, height, rowBytes = width, ColorType.ALPHA_8)
+                else -> null
+            }
+        } catch (t: Throwable) {
+            // A malformed/undersized buffer or an unsupported skiko path must not crash the render.
+            null
+        }
+
+    /** A raster [ImageBitmap] over straight (unpremultiplied) pixel bytes; null if the buffer is short. */
+    private fun raster(
+        data: ByteArray,
+        width: Int,
+        height: Int,
+        rowBytes: Int,
+        colorType: ColorType,
+    ): ImageBitmap? {
+        if (width <= 0 || height <= 0 || data.size < rowBytes * height) return null
+        val info = ImageInfo(width, height, colorType, ColorAlphaType.UNPREMUL)
+        return Image.makeRaster(info, data, rowBytes).toComposeImageBitmap()
+    }
+}

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/JvmRemoteContext.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/JvmRemoteContext.kt
@@ -98,8 +98,11 @@ internal class JvmRemoteContext(
                     raster(data, width, height, rowBytes = width, ColorType.ALPHA_8)
                 else -> null
             }
-        } catch (t: Throwable) {
-            // A malformed/undersized buffer or an unsupported skiko path must not crash the render.
+        } catch (e: Exception) {
+            // A malformed/undersized buffer must not crash the render — skiko throws an ordinary
+            // exception on bytes it can't decode. Deliberately NOT Throwable: a LinkageError (skiko
+            // mispackaged) or OutOfMemoryError is a real deployment/runtime failure that must stay
+            // visible rather than be hidden behind a blank image.
             null
         }
 

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/JvmRemoteContextBitmapTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/JvmRemoteContextBitmapTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded.jvm
+
+import androidx.compose.remote.core.operations.BitmapData
+import androidx.compose.remote.player.compose.embedded.JvmRemoteContext
+import androidx.compose.remote.player.compose.embedded.SnapshotRemoteComposeState
+import androidx.compose.ui.graphics.ImageBitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Exercises [JvmRemoteContext.loadBitmap] — the one platform-bound member of the draw
+ * `RemoteContext` — on a plain desktop JVM, decoding through skiko with no Android and no
+ * Robolectric.
+ *
+ * The contract under test is the one `resolveBitmap` depends on: `loadBitmap(id, …)` decodes the
+ * bytes and caches the result under `id`, so a subsequent read of the store yields a Compose
+ * [ImageBitmap] of the document's declared size. The store is untyped, so the test reads the id
+ * back from its own [SnapshotRemoteComposeState] rather than through a (non-existent) typed getter
+ * — the same value the jvm image seam's `resolveImage` will later read.
+ *
+ * Like [DesktopTextPlatformTest] this needs skiko's natives (decode + raster both touch them), so
+ * it skips loudly where they cannot load rather than failing every method with a cryptic linkage
+ * error.
+ */
+class JvmRemoteContextBitmapTest {
+
+  @Before
+  fun requireSkikoNatives() {
+    if (!SKIKO_LOADED) {
+      System.err.println(
+        "JvmRemoteContextBitmapTest skipped entirely: skiko's native library did not load, so " +
+          "nothing here exercised the jvm bitmap decode. Cause: $skikoLoadFailure"
+      )
+    }
+    Assume.assumeTrue("skiko natives unavailable: $skikoLoadFailure", SKIKO_LOADED)
+  }
+
+  /** A solid-red W×H image encoded as PNG bytes. */
+  private fun redPng(width: Int, height: Int): ByteArray {
+    val rgba = ByteArray(width * height * 4)
+    for (i in 0 until width * height) {
+      rgba[i * 4] = 0xFF.toByte() // R
+      rgba[i * 4 + 3] = 0xFF.toByte() // A
+    }
+    val info = ImageInfo(width, height, ColorType.RGBA_8888, ColorAlphaType.UNPREMUL)
+    val image = Image.makeRaster(info, rgba, width * 4)
+    return image.encodeToData(EncodedImageFormat.PNG)!!.bytes
+  }
+
+  @Test
+  fun `an inline png decodes to an image bitmap of the declared size`() {
+    val state = SnapshotRemoteComposeState()
+    val context = JvmRemoteContext(state)
+    context.loadBitmap(ID, BitmapData.ENCODING_INLINE, BitmapData.TYPE_PNG_8888, 3, 2, redPng(3, 2))
+
+    val cached = state.getFromId(ID)
+    assertTrue("cached value is a Compose ImageBitmap, got $cached", cached is ImageBitmap)
+    cached as ImageBitmap
+    assertEquals(3, cached.width)
+    assertEquals(2, cached.height)
+  }
+
+  @Test
+  fun `raw rgba pixels build an image bitmap of the declared size`() {
+    val width = 2
+    val height = 2
+    val pixels = ByteArray(width * height * 4)
+    for (i in 0 until width * height) {
+      pixels[i * 4 + 2] = 0xFF.toByte() // B
+      pixels[i * 4 + 3] = 0xFF.toByte() // A
+    }
+    val state = SnapshotRemoteComposeState()
+    val context = JvmRemoteContext(state)
+    context.loadBitmap(
+      ID,
+      BitmapData.ENCODING_INLINE,
+      BitmapData.TYPE_RAW8888,
+      width,
+      height,
+      pixels,
+    )
+
+    val cached = state.getFromId(ID)
+    assertTrue("cached value is a Compose ImageBitmap, got $cached", cached is ImageBitmap)
+    cached as ImageBitmap
+    assertEquals(width, cached.width)
+    assertEquals(height, cached.height)
+  }
+
+  @Test
+  fun `a non-inline encoding caches nothing`() {
+    val state = SnapshotRemoteComposeState()
+    val context = JvmRemoteContext(state)
+    // ENCODING_URL carries no inline bytes — the (deferred) host loader's job, not this decode.
+    context.loadBitmap(ID, BitmapData.ENCODING_URL, BitmapData.TYPE_PNG_8888, 3, 2, redPng(3, 2))
+    assertNull("a URL-encoded bitmap must not be decoded from inline bytes", state.getFromId(ID))
+  }
+
+  @Test
+  fun `a raw buffer too short for the declared size caches nothing rather than crashing`() {
+    val state = SnapshotRemoteComposeState()
+    val context = JvmRemoteContext(state)
+    // 4×4 RGBA needs 64 bytes; hand it 8 and the decode must reject, not read out of bounds.
+    context.loadBitmap(ID, BitmapData.ENCODING_INLINE, BitmapData.TYPE_RAW8888, 4, 4, ByteArray(8))
+    assertNull(state.getFromId(ID))
+  }
+
+  @Test
+  fun `malformed png bytes cache nothing rather than crashing`() {
+    val state = SnapshotRemoteComposeState()
+    val context = JvmRemoteContext(state)
+    context.loadBitmap(
+      ID,
+      BitmapData.ENCODING_INLINE,
+      BitmapData.TYPE_PNG_8888,
+      3,
+      2,
+      byteArrayOf(1, 2, 3, 4, 5),
+    )
+    assertNull(state.getFromId(ID))
+  }
+
+  private companion object {
+    const val ID = 42
+
+    var skikoLoadFailure: String? = null
+
+    /**
+     * Whether Skia is callable at all — decided once by touching a class that loads the native lib.
+     */
+    val SKIKO_LOADED: Boolean =
+      try {
+        org.jetbrains.skia.FontMgr.default.familiesCount
+        true
+      } catch (t: Throwable) {
+        skikoLoadFailure = "${t::class.java.simpleName}: ${t.message}"
+        false
+      }
+  }
+}

--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -473,6 +473,32 @@ What this does **not** finish: the ops that call these four still live in `RcPla
 needs `Bitmap`/`BitmapDrawable`, so no draw op runs on the JVM yet. The seam is ready ahead of its
 callers — deliberately, since it was the piece with an unknown in it.
 
+#### Done: the jvm draw context decodes bitmaps
+
+`:third-party-rc-embedded-player-jvm` now carries **`JvmRemoteContext.kt`** — the desktop/JVM draw
+`RemoteContext`, the counterpart of `remote-player-core`'s `AndroidRemoteContext` for the pixel path.
+As the "What a `JvmRemoteContext` actually costs" section predicted, it is `StoreBackedRemoteContext`
+(the whole neutral variable/state store, already shared) plus the **one** genuinely platform-bound
+member, `loadBitmap` — decoding a document's encoded bytes to a raster — over skiko.
+
+It handles the inline PNG types through `Image.makeFromEncoded` and the raw types (`TYPE_RAW8888`,
+`TYPE_RAW8`) by building a raster straight from the pixel bytes, rejecting a buffer too short for the
+declared size and swallowing any decode failure to a blank rather than crashing the render — the same
+never-throw posture as the text seam. Where Android caches an `android.graphics.Bitmap` under the id,
+this caches a Compose `ImageBitmap`; the store is untyped, so the jvm image seam's `resolveImage`
+reads its own concrete type back. Two documented parity nuances: `TYPE_PNG_ALPHA_8` decodes to RGBA
+here rather than an alpha mask, and `ENCODING_URL`/`ENCODING_FILE` are the deferred host loader's job.
+
+`JvmRemoteContextBitmapTest` exercises it for real — PNG + raw round-trips to an `ImageBitmap` of the
+declared size, plus the reject-short-buffer / reject-malformed / skip-non-inline paths. Like
+`DesktopTextPlatformTest` it **needs skiko's natives** (`skiko-awt-runtime-*` + a loadable GL lib) and
+skips loudly where they are absent, so it is a CI check, not a bare-working-tree one.
+
+This is step 3's `RemoteContext` half. What it does **not** finish: the jvm `resolveImage`/
+`resolveCanvasImage` seam siblings (which read this cache back) and putting the draw files on the jvm
+source list — those wait on the `Drawable` image loader and googlefonts text layout being split, the
+remaining androidMain callees of the dispatch.
+
 #### Done: it runs on the desktop JVM
 
 `:third-party-rc-embedded-player-jvm` compiles the neutral subset of this module's sources against
@@ -628,7 +654,10 @@ single-target milestone it cannot be verified. It splits into 1a/1b.
    now, the module owns no resources, and `androidResources` is back at its default.
 3. Add the `jvm` target and the `expect`/`actual` seams, starting with `RemoteContext`
    (`GraphContext`'s `AndroidRemoteContext` base) and image decode. This is where the remaining
-   chains in the table are actually paid for, not step 1.
+   chains in the table are actually paid for, not step 1. **Partly done:** the draw `RemoteContext`
+   and its bitmap decode are in place (`JvmRemoteContext.kt` — see "Done: the jvm draw context decodes
+   bitmaps"). What remains here is the jvm `resolveImage`/`resolveCanvasImage` seam siblings that read
+   that decode back, and the `Drawable`-typed host loader.
 4. ~~Port text off framework `Paint`.~~ — **done ahead of order**, both halves. Pulled forward
    because it was the step with an actual unknown in it (does Skia answer the same four questions?),
    and the answer turned out to be yes; leaving it last would have deferred the only risk in the plan


### PR DESCRIPTION
## Summary

Step 3 of porting the embedded Remote Compose player's **draw path** to CMP Desktop / Skiko (toward the `cmp-jvm` render lane): the desktop/JVM draw `RemoteContext` — the counterpart of `remote-player-core`'s `AndroidRemoteContext` for the pixel path.

As `PROVENANCE.md`'s *"What a `JvmRemoteContext` actually costs"* predicted, it's `StoreBackedRemoteContext` (the whole neutral variable/state store, already shared to JVM) **plus the one genuinely platform-bound member** — `loadBitmap`, decoding a document's encoded bytes to a raster — over skiko:
- **PNG types** (`TYPE_PNG` / `TYPE_PNG_8888` / `TYPE_PNG_ALPHA_8`) → `org.jetbrains.skia.Image.makeFromEncoded`.
- **Raw types** (`TYPE_RAW8888` straight RGBA, `TYPE_RAW8` single-channel alpha) → a raster built straight from the pixel bytes.
- A buffer too short for the declared `width × height × stride` is rejected (no OOB read), and any decode failure is swallowed to a blank rather than crashing the render — the text seam's never-throw posture.
- Only `ENCODING_INLINE` decodes; `ENCODING_URL` / `ENCODING_FILE` are the (deferred) host image loader's job.

Where Android caches an `android.graphics.Bitmap` under the id, this caches a Compose `ImageBitmap`; the store is untyped, so the JVM image seam's `resolveImage` (a later increment) reads its own concrete type back.

Two documented parity nuances: `TYPE_PNG_ALPHA_8` decodes to RGBA here rather than an alpha mask, and URL/FILE encodings are host-fetched.

## Sequencing (per `third_party/rc-embedded-player/PROVENANCE.md`)

- ✅ text seam (both halves)
- ✅ image seam (Android half) — #3009
- ✅ draw dispatcher out of `RcPlayer.kt` — #3011
- ✅ **JVM draw `RemoteContext` + bitmap decode** — this PR (step 3's `RemoteContext` half)
- ⏭ next: the JVM `resolveImage`/`resolveCanvasImage` seam siblings (which read this decode back) + splitting the `Drawable`-typed host loader and googlefonts text layout, then the draw files onto the JVM source list → a JVM `ImageComposeScene` raster harness that finally renders an `.rc` to PNG

## Test plan

- [x] `:third-party-rc-embedded-player-jvm:check` — compiles the new context against skiko + shares the Android sources; green.
- [x] `JvmRemoteContextBitmapTest` — PNG + raw round-trip to an `ImageBitmap` of the declared size, plus reject-short-buffer / reject-malformed / skip-non-inline.
- ⚠️ **skiko-native-gated:** like the existing `DesktopTextPlatformTest`, the decode tests need `skiko-awt-runtime-*` + a loadable GL library. In this PR's build container the loader couldn't bring skiko up, so the 5 tests **skip loudly** there (compile-verified); they **execute on CI**, which has the natives. Not a silent skip — the class prints why and `Assume`-skips.
- [x] `ktfmtCheck` clean.

Text-only PR: a new JVM-only building block, not yet wired into any render, so no rendered-output change and no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXNXNpWA4JUpN3m4mVD8zT)_