### PR TITLE
feat(vscode): navigate previews to their component source on title click

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5778,9 +5778,28 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             );
             break;
         }
-        case "openFile":
-            openPreviewSource(msg.className, msg.functionName, msg.sourceFile);
+        case "openFile": {
+            // Resolve the destination under the preview's owning module first,
+            // so a module-relative source path that also exists in a sibling
+            // module can't open the wrong module's file.
+            let moduleDirAbs: string | undefined;
+            if (msg.previewId && gradleService) {
+                const mod = previewModuleIndex.get(msg.previewId);
+                if (mod) {
+                    moduleDirAbs = path.join(
+                        gradleService.workspaceRoot,
+                        mod.projectDir,
+                    );
+                }
+            }
+            openPreviewSource(
+                msg.className,
+                msg.functionName,
+                msg.sourceFile,
+                moduleDirAbs,
+            );
             break;
+        }
         case "selectModule":
             selectedModule = msg.value || null;
             logInfo(`[panel] module selected: ${selectedModule ?? "<none>"}`);
@@ -8275,18 +8294,42 @@ function emptyStateMessage(activeFile: string | undefined): string {
  * Resolve the source file for a preview/component the user clicked. Prefers the
  * manifest's [sourceFile] — a module-relative path (`src/main/kotlin/…/Foo.kt`)
  * that unambiguously identifies the file even when its name differs from the
- * compiled class (multiple classes per file, `@JvmName`, etc.). Falls back to
- * the class-derived path (`com.example.FooKt` → `com/example/Foo.kt`) for older
- * manifests that don't carry a `sourceFile`, or when the recorded path no longer
- * exists on disk. The `build` output tree is excluded from both globs so a stale
- * generated copy never wins over the real source.
+ * compiled class (multiple classes per file, `@JvmName`, etc.).
+ *
+ * Resolution order:
+ *  1. [sourceFile] under [moduleDirAbs] (the preview's owning module) — exact,
+ *     so a module-relative path that also exists in a sibling module resolves to
+ *     the right module's file rather than whichever the workspace glob hits
+ *     first.
+ *  2. [sourceFile] workspace-wide — covers a target composable that genuinely
+ *     lives in another module (its `sourceFile` is relative to *its* module).
+ *  3. Class-derived path (`com.example.FooKt` → `com/example/Foo.kt`) for older
+ *     manifests that don't carry a `sourceFile`, or when the recorded path no
+ *     longer exists on disk.
+ *
+ * The `build` output tree is excluded from every glob so a stale generated copy
+ * never wins over the real source.
  */
 async function resolvePreviewSourceUri(
     className: string,
     sourceFile?: string,
+    moduleDirAbs?: string,
 ): Promise<vscode.Uri | null> {
     if (sourceFile) {
         const normalized = sourceFile.replace(/\\/g, "/").replace(/^\.\/+/, "");
+        if (moduleDirAbs) {
+            const scoped = await vscode.workspace.findFiles(
+                new vscode.RelativePattern(
+                    vscode.Uri.file(moduleDirAbs),
+                    normalized,
+                ),
+                "**/build/**",
+                1,
+            );
+            if (scoped.length > 0) {
+                return scoped[0];
+            }
+        }
         const hits = await vscode.workspace.findFiles(
             `**/${normalized}`,
             "**/build/**",
@@ -8309,8 +8352,13 @@ async function openPreviewSource(
     className: string,
     functionName: string,
     sourceFile?: string,
+    moduleDirAbs?: string,
 ) {
-    const uri = await resolvePreviewSourceUri(className, sourceFile);
+    const uri = await resolvePreviewSourceUri(
+        className,
+        sourceFile,
+        moduleDirAbs,
+    );
     if (!uri) {
         vscode.window.showWarningMessage(
             `Could not find source for ${className}.${functionName}`,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5779,7 +5779,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             break;
         }
         case "openFile":
-            openPreviewSource(msg.className, msg.functionName);
+            openPreviewSource(msg.className, msg.functionName, msg.sourceFile);
             break;
         case "selectModule":
             selectedModule = msg.value || null;
@@ -8271,21 +8271,54 @@ function emptyStateMessage(activeFile: string | undefined): string {
     return "No @Preview functions in this file.";
 }
 
-async function openPreviewSource(className: string, functionName: string) {
+/**
+ * Resolve the source file for a preview/component the user clicked. Prefers the
+ * manifest's [sourceFile] — a module-relative path (`src/main/kotlin/…/Foo.kt`)
+ * that unambiguously identifies the file even when its name differs from the
+ * compiled class (multiple classes per file, `@JvmName`, etc.). Falls back to
+ * the class-derived path (`com.example.FooKt` → `com/example/Foo.kt`) for older
+ * manifests that don't carry a `sourceFile`, or when the recorded path no longer
+ * exists on disk. The `build` output tree is excluded from both globs so a stale
+ * generated copy never wins over the real source.
+ */
+async function resolvePreviewSourceUri(
+    className: string,
+    sourceFile?: string,
+): Promise<vscode.Uri | null> {
+    if (sourceFile) {
+        const normalized = sourceFile.replace(/\\/g, "/").replace(/^\.\/+/, "");
+        const hits = await vscode.workspace.findFiles(
+            `**/${normalized}`,
+            "**/build/**",
+            1,
+        );
+        if (hits.length > 0) {
+            return hits[0];
+        }
+    }
     const classFile = className.replace(/Kt$/, "").replace(/\./g, "/") + ".kt";
-    const files = await vscode.workspace.findFiles(
+    const hits = await vscode.workspace.findFiles(
         `**/${classFile}`,
         "**/build/**",
         1,
     );
-    if (files.length === 0) {
+    return hits.length > 0 ? hits[0] : null;
+}
+
+async function openPreviewSource(
+    className: string,
+    functionName: string,
+    sourceFile?: string,
+) {
+    const uri = await resolvePreviewSourceUri(className, sourceFile);
+    if (!uri) {
         vscode.window.showWarningMessage(
             `Could not find source for ${className}.${functionName}`,
         );
         return;
     }
 
-    const doc = await vscode.workspace.openTextDocument(files[0]);
+    const doc = await vscode.workspace.openTextDocument(uri);
     const editor = await vscode.window.showTextDocument(doc);
 
     const text = doc.getText();

--- a/vscode-extension/src/test/cardData.test.ts
+++ b/vscode-extension/src/test/cardData.test.ts
@@ -7,10 +7,18 @@ import {
     kindSupportsLiveMode,
     mimeFor,
     parseBounds,
+    previewSourceTarget,
     sanitizeId,
     shortDevice,
 } from "../webview/preview/cardData";
-import type { Capture, PreviewInfo } from "../types";
+import type { Capture, PreviewInfo, PreviewTarget } from "../types";
+
+const componentTarget: PreviewTarget = {
+    className: "com.example.HomeScreenKt",
+    functionName: "HomeScreen",
+    sourceFile: "src/main/kotlin/com/example/HomeScreen.kt",
+    confidence: "HIGH",
+};
 
 const baseCapture: Capture = {
     advanceTimeMillis: null,
@@ -212,11 +220,62 @@ describe("buildVariantLabel", () => {
     });
 });
 
+describe("previewSourceTarget", () => {
+    it("falls back to the preview function when no target is inferred", () => {
+        assert.deepStrictEqual(
+            previewSourceTarget(
+                preview({
+                    sourceFile: "src/main/kotlin/com/example/Previews.kt",
+                }),
+            ),
+            {
+                className: "com.example.PreviewsKt",
+                functionName: "MyPreview",
+                sourceFile: "src/main/kotlin/com/example/Previews.kt",
+                isComponent: false,
+            },
+        );
+    });
+
+    it("points at the inferred component when a target exists", () => {
+        assert.deepStrictEqual(
+            previewSourceTarget(preview({ targets: [componentTarget] })),
+            {
+                className: "com.example.HomeScreenKt",
+                functionName: "HomeScreen",
+                sourceFile: "src/main/kotlin/com/example/HomeScreen.kt",
+                isComponent: true,
+            },
+        );
+    });
+
+    it("uses the most-confident target (first entry)", () => {
+        const second: PreviewTarget = {
+            className: "com.example.OtherKt",
+            functionName: "Other",
+            sourceFile: "src/main/kotlin/com/example/Other.kt",
+            confidence: "LOW",
+        };
+        assert.strictEqual(
+            previewSourceTarget(preview({ targets: [componentTarget, second] }))
+                .functionName,
+            "HomeScreen",
+        );
+    });
+});
+
 describe("buildTooltip", () => {
     it("starts with `Open source: <FQN>`", () => {
         assert.match(
             buildTooltip(preview()),
             /^Open source: com\.example\.PreviewsKt\.MyPreview/,
+        );
+    });
+
+    it("says `Open component: <target FQN>` when a target is inferred", () => {
+        assert.match(
+            buildTooltip(preview({ targets: [componentTarget] })),
+            /^Open component: com\.example\.HomeScreenKt\.HomeScreen/,
         );
     });
 

--- a/vscode-extension/src/test/cardData.test.ts
+++ b/vscode-extension/src/test/cardData.test.ts
@@ -10,6 +10,7 @@ import {
     previewSourceTarget,
     sanitizeId,
     shortDevice,
+    writeNavDataset,
 } from "../webview/preview/cardData";
 import type { Capture, PreviewInfo, PreviewTarget } from "../types";
 
@@ -261,6 +262,33 @@ describe("previewSourceTarget", () => {
                 .functionName,
             "HomeScreen",
         );
+    });
+});
+
+describe("writeNavDataset", () => {
+    it("stamps the inferred component target and its sourceFile", () => {
+        const card = { dataset: {} } as unknown as HTMLElement;
+        writeNavDataset(card, preview({ targets: [componentTarget] }));
+        assert.deepStrictEqual(
+            { ...card.dataset },
+            {
+                navClassName: "com.example.HomeScreenKt",
+                navFunction: "HomeScreen",
+                navSourceFile: "src/main/kotlin/com/example/HomeScreen.kt",
+            },
+        );
+    });
+
+    it("clears a stale navSourceFile when the new destination has none", () => {
+        // Simulates a reseed of the same card onto a preview that lost its
+        // sourceFile — the old value must not linger.
+        const card = {
+            dataset: { navSourceFile: "src/old/Stale.kt" },
+        } as unknown as HTMLElement;
+        writeNavDataset(card, preview());
+        assert.strictEqual(card.dataset.navSourceFile, undefined);
+        assert.strictEqual(card.dataset.navClassName, "com.example.PreviewsKt");
+        assert.strictEqual(card.dataset.navFunction, "MyPreview");
     });
 });
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -889,7 +889,18 @@ export type WebviewToExtension =
           tabHandleCount: number;
           overlayCountByBundle: Record<string, number>;
       }
-    | { command: "openFile"; className: string; functionName: string }
+    | {
+          command: "openFile";
+          className: string;
+          functionName: string;
+          /**
+           * Manifest-provided, module-relative source path of the destination
+           * (the inferred component's file, or the preview's own). The host
+           * resolves the file from this first and only falls back to the
+           * class-derived path when it is absent or doesn't match.
+           */
+          sourceFile?: string;
+      }
     | { command: "selectModule"; value: string }
     /**
      * User clicked a faded heavy card. The extension opts that preview into

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -900,6 +900,13 @@ export type WebviewToExtension =
            * class-derived path when it is absent or doesn't match.
            */
           sourceFile?: string;
+          /**
+           * Id of the clicked preview. Lets the host resolve `sourceFile` under
+           * the preview's owning module first, so a module-relative path that
+           * also exists in a sibling module (`feature-a` vs `feature-b`) can't
+           * open the wrong module's file.
+           */
+          previewId?: string;
       }
     | { command: "selectModule"; value: string }
     /**

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -27,8 +27,8 @@ import {
     buildVariantLabel,
     isAnimatedPreview,
     isWearPreview,
-    previewSourceTarget,
     sanitizeId,
+    writeNavDataset,
 } from "./cardData";
 import type { DiffOverlayConfig } from "./diffOverlay";
 import type { InspectorRenderer } from "./applyA11yUpdate";
@@ -229,16 +229,22 @@ export function populatePreviewCard(
         p.functionName + (p.params.name ? " — " + p.params.name : "");
     title.title = buildTooltip(p);
     // Navigate to the component the preview renders when discovery inferred one
-    // (targets[0]), else the preview function itself. `sourceFile` is the
-    // manifest's authoritative module-relative path — the host resolves the
-    // file from it and only falls back to the class-derived path when absent.
-    const nav = previewSourceTarget(p);
+    // (targets[0]), else the preview function itself. The destination is stamped
+    // onto the card's dataset (see writeNavDataset) and read back at click time
+    // — a manifest reseed that changes the inferred target for the same preview
+    // id restamps it via refreshCardMetadata, so the tooltip and the click can't
+    // drift out of sync. `sourceFile` is the manifest's authoritative
+    // module-relative path; the host resolves the file from it (scoped to the
+    // preview's owning module) and only falls back to the class-derived path
+    // when it is absent.
+    writeNavDataset(card, p);
     title.addEventListener("click", () => {
         config.vscode.postMessage({
             command: "openFile",
-            className: nav.className,
-            functionName: nav.functionName,
-            sourceFile: nav.sourceFile ?? undefined,
+            className: card.dataset.navClassName || p.className,
+            functionName: card.dataset.navFunction || p.functionName,
+            sourceFile: card.dataset.navSourceFile || undefined,
+            previewId: card.dataset.previewId || undefined,
         });
     });
     titleRow.appendChild(title);

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -27,6 +27,7 @@ import {
     buildVariantLabel,
     isAnimatedPreview,
     isWearPreview,
+    previewSourceTarget,
     sanitizeId,
 } from "./cardData";
 import type { DiffOverlayConfig } from "./diffOverlay";
@@ -227,11 +228,17 @@ export function populatePreviewCard(
     title.textContent =
         p.functionName + (p.params.name ? " — " + p.params.name : "");
     title.title = buildTooltip(p);
+    // Navigate to the component the preview renders when discovery inferred one
+    // (targets[0]), else the preview function itself. `sourceFile` is the
+    // manifest's authoritative module-relative path — the host resolves the
+    // file from it and only falls back to the class-derived path when absent.
+    const nav = previewSourceTarget(p);
     title.addEventListener("click", () => {
         config.vscode.postMessage({
             command: "openFile",
-            className: p.className,
-            functionName: p.functionName,
+            className: nav.className,
+            functionName: nav.functionName,
+            sourceFile: nav.sourceFile ?? undefined,
         });
     });
     titleRow.appendChild(title);

--- a/vscode-extension/src/webview/preview/cardData.ts
+++ b/vscode-extension/src/webview/preview/cardData.ts
@@ -156,6 +156,24 @@ export function previewSourceTarget(p: PreviewInfo): PreviewSourceTarget {
 }
 
 /**
+ * Stamp the title's navigation destination onto the card's dataset so the
+ * click handler reads it fresh at click time. Called on initial build and on
+ * every manifest reseed (`refreshCardMetadata`), so a reused card whose inferred
+ * target changed navigates to the new component — matching the reseeded tooltip
+ * — rather than the one captured when the handler was first attached.
+ */
+export function writeNavDataset(card: HTMLElement, p: PreviewInfo): void {
+    const nav = previewSourceTarget(p);
+    card.dataset.navClassName = nav.className;
+    card.dataset.navFunction = nav.functionName;
+    if (nav.sourceFile) {
+        card.dataset.navSourceFile = nav.sourceFile;
+    } else {
+        delete card.dataset.navSourceFile;
+    }
+}
+
+/**
  * Hover tooltip for the card title button — `Open source: <FQN>` (or
  * `Open component: <FQN>` when the title navigates to an inferred target
  * composable), followed by a `·`-separated digest of the preview's parameters.

--- a/vscode-extension/src/webview/preview/cardData.ts
+++ b/vscode-extension/src/webview/preview/cardData.ts
@@ -116,11 +116,54 @@ export function isWearPreview(p: PreviewInfo): boolean {
 }
 
 /**
- * Hover tooltip for the card title button — `Open source: <FQN>`,
- * followed by a `·`-separated digest of the preview's parameters.
+ * Where the card title should navigate to. A `@Preview` is usually a thin
+ * wrapper around a real component, and discovery infers that component into
+ * [PreviewInfo.targets] (most-confident first — see `PreviewTargetInference`).
+ * When a target is known we point navigation at the *component's* source rather
+ * than the preview stub, which is what a developer clicking a preview expects
+ * ("take me to the thing I'm looking at"). Falls back to the preview function's
+ * own coordinates when no target cleared discovery's confidence threshold.
+ *
+ * [sourceFile] is the manifest-provided, module-relative path — authoritative
+ * for resolving the file, and carried alongside so the host doesn't have to
+ * reconstruct it from the class name (which breaks for files whose name differs
+ * from the class). [isComponent] is `true` when the destination is an inferred
+ * target rather than the preview itself; the tooltip uses it for wording.
+ */
+export interface PreviewSourceTarget {
+    className: string;
+    functionName: string;
+    sourceFile: string | null;
+    isComponent: boolean;
+}
+
+export function previewSourceTarget(p: PreviewInfo): PreviewSourceTarget {
+    const target = p.targets && p.targets.length > 0 ? p.targets[0] : null;
+    if (target) {
+        return {
+            className: target.className,
+            functionName: target.functionName,
+            sourceFile: target.sourceFile,
+            isComponent: true,
+        };
+    }
+    return {
+        className: p.className,
+        functionName: p.functionName,
+        sourceFile: p.sourceFile,
+        isComponent: false,
+    };
+}
+
+/**
+ * Hover tooltip for the card title button — `Open source: <FQN>` (or
+ * `Open component: <FQN>` when the title navigates to an inferred target
+ * composable), followed by a `·`-separated digest of the preview's parameters.
  */
 export function buildTooltip(p: PreviewInfo): string {
-    const base = "Open source: " + p.className + "." + p.functionName;
+    const nav = previewSourceTarget(p);
+    const verb = nav.isComponent ? "Open component: " : "Open source: ";
+    const base = verb + nav.className + "." + nav.functionName;
     const parts: string[] = [];
     if (p.params.name) parts.push(p.params.name);
     if (p.params.device) parts.push(p.params.device);

--- a/vscode-extension/src/webview/preview/cardMetadata.ts
+++ b/vscode-extension/src/webview/preview/cardMetadata.ts
@@ -24,6 +24,7 @@ import {
     buildVariantLabel,
     isAnimatedPreview,
     isWearPreview,
+    writeNavDataset,
 } from "./cardData";
 import type {
     CapturePresentation,
@@ -64,6 +65,10 @@ export function refreshCardMetadata(
     card.dataset.function = p.functionName;
     card.dataset.group = p.params.group || "";
     card.dataset.wearPreview = isWearPreview(p) ? "1" : "0";
+    // Keep the title's navigation destination in step with the reseeded
+    // tooltip below — otherwise a reused card whose inferred target changed
+    // would advertise the new component but still open the old one.
+    writeNavDataset(card, p);
     const title = card.querySelector<HTMLButtonElement>(".card-title");
     if (title) {
         title.textContent =


### PR DESCRIPTION
Closes #2940.

## Summary

Clicking a preview card's title in the VS Code panel already opened source, but it (a) reconstructed the file path from the compiled class name and (b) always landed on the `@Preview` **function stub**. Discovery already records each preview's authoritative, module-relative `sourceFile` **and** infers the composable a preview renders (`PreviewInfo.targets[]`, via `PreviewTargetInference`) — neither was being used for navigation.

This wires both into the existing title-click affordance so a click takes you to the **component** the preview shows, which is what the issue asks for:

- **`previewSourceTarget(p)`** (pure, in `cardData.ts`) picks the navigation destination: the inferred component (`targets[0]`, most-confident first) when discovery found one, else the preview function itself. It carries the destination's `sourceFile` along.
- The `openFile` webview→host message gains an optional **`sourceFile`**; the card sends the resolved destination's coordinates.
- **`resolvePreviewSourceUri`** resolves the file from the manifest's `sourceFile` first (a `src/…/Foo.kt` glob, robust when the file name differs from the class), falling back to the old class-derived path (`com.example.FooKt` → `com/example/Foo.kt`) for older manifests or stale paths. The `build` output tree is excluded from both globs.
- The title tooltip now reads **`Open component: <FQN>`** when the destination is an inferred component, and keeps `Open source: <FQN>` for the preview-function fallback.

Behaviour is backward compatible: previews with no inferred target and no recorded `sourceFile` (older manifests) resolve exactly as before.

## Test plan

- [x] `npm run compile` — clean (host + webview)
- [x] `npm test` — **1610 passing**, including new `previewSourceTarget` cases and the `Open component:` tooltip assertion in `cardData.test.ts`
- [x] `npm run format` check (`prettier --tab-width 4`) — all touched files clean

## Visual evidence

Not applicable — this is a navigation/behaviour change. The card renders identically; the only user-visible surface is the click destination and the hover-tooltip string (`Open component: …`), neither of which the `@Preview` PNG / preview-harness pipeline captures. Covered by the unit tests above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR2akUjBgsAj6cZrsRpmnU)_