### PR TITLE
fix(cli): make bundle pack --with-semantics deadline an inactivity window

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -12,7 +12,7 @@ import ee.schimke.composeai.render.session.RenderSessionFactory
 import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -37,6 +37,11 @@ import okio.Path.Companion.toPath
  *
  * @param factory pluggable render-session factory; defaults to the subprocess backend. Test
  *   scaffolding can inject a fake by constructing a custom [RenderSessionFactory].
+ * @param renderTimeout the *inactivity* budget for the semantics render (issue #2948): how long to
+ *   keep waiting after the **last** render completed before concluding the daemon has stalled. It
+ *   is deliberately not a batch-wide deadline — a wide catalog's full render can legitimately
+ *   outlast any single value here, and it still finishes as long as renders keep landing within the
+ *   window.
  */
 internal class DaemonSemanticsFetcher(
   private val factory: RenderSessionFactory = SubprocessRenderSessions,
@@ -101,13 +106,16 @@ internal class DaemonSemanticsFetcher(
       }
 
       val pending = ConcurrentHashMap.newKeySet<String>().apply { addAll(previewIds) }
-      val latch = CountDownLatch(previewIds.size)
+      // Each terminal event offers one token here, so the wait below wakes on *every* completed
+      // render rather than only when the whole batch is done — that's what lets the deadline be an
+      // inactivity budget instead of a batch-wide one (issue #2948).
+      val progress = LinkedBlockingQueue<Unit>()
       live
         .onNotification { method, params ->
           val failed = method == "renderFailed"
           if ((method != "renderFinished" && !failed) || params == null) return@onNotification
           val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
-          // Count down on either terminal event for a pending id — the daemon owes exactly one
+          // Signal progress on either terminal event for a pending id — the daemon owes exactly one
           // (`renderFinished` OR `renderFailed`) per queued render, and a render whose composition
           // throws emits only the latter. Waiting on `renderFinished` alone meant one broken
           // preview burned the ENTIRE batch budget: a Glance composable reached through the plain
@@ -122,7 +130,7 @@ internal class DaemonSemanticsFetcher(
                 ?: "daemon reported renderFailed"
             onLog("render failed for '$id': $reason")
           }
-          if (pending.remove(id)) latch.countDown()
+          if (pending.remove(id)) progress.offer(Unit)
         }
         .use {
           val ack =
@@ -139,13 +147,27 @@ internal class DaemonSemanticsFetcher(
           // Rejected ids will never emit renderFinished — stop waiting on them.
           ack?.rejected?.forEach { rejected ->
             onLog("render rejected for '${rejected.id}': ${rejected.reason}")
-            if (pending.remove(rejected.id)) latch.countDown()
+            if (pending.remove(rejected.id)) progress.offer(Unit)
           }
-          val finished = latch.await(renderTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-          if (!finished) {
-            onLog(
-              "timed out after $renderTimeout waiting for renders: " + pending.joinToString(",")
-            )
+          // Wait for every queued render to reach a terminal event. `renderTimeout` is an
+          // *inactivity* deadline, not a batch-wide one (issue #2948, #2857): it resets each time a
+          // render completes, so a wide catalog — a component library fanning out across many
+          // themes — whose full render legitimately outlasts any single `--timeout` still finishes
+          // as long as the daemon keeps making progress. Each individual render still lands
+          // quickly;
+          // only a genuine stall (no render completing at all for the whole window) trips the
+          // timeout. The old batch-wide `--timeout`-length budget silently dropped a third of a
+          // large catalog's semantics once the total render time crossed it.
+          val timeoutMs = renderTimeout.inWholeMilliseconds
+          while (pending.isNotEmpty()) {
+            val signalled = progress.poll(timeoutMs, TimeUnit.MILLISECONDS)
+            if (signalled == null) {
+              onLog(
+                "timed out after $renderTimeout with no render progress; still waiting on: " +
+                  pending.joinToString(",")
+              )
+              break
+            }
           }
         }
 
@@ -253,7 +275,10 @@ internal class DaemonSemanticsFetcher(
     /** RPC ack budget for the (fast, queue-only) `renderNow` call itself. */
     val RENDER_ACK_TIMEOUT = 60.seconds
 
-    /** Default used by callers that do not expose a command timeout. */
+    /**
+     * Default inactivity window used by callers that do not expose a command timeout — the gap a
+     * single render may take before the daemon is presumed stalled, not a whole-batch budget.
+     */
     val DEFAULT_RENDER_TIMEOUT = 300.seconds
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -249,6 +249,41 @@ class DaemonSemanticsFetcherTest {
   }
 
   @Test
+  fun `render timeout is an inactivity window, not a batch-wide budget`() {
+    // Issue #2948: a wide catalog (a component library fanning out across many themes) renders far
+    // more previews than fit inside a single `--timeout`, yet each individual render still lands
+    // quickly. The daemon here completes one render every 20ms across 15 previews (~300ms total),
+    // well past the 150ms window — but never idle for that long. Every semantics sidecar must still
+    // be collected: the old batch-wide budget cut the batch off mid-flight and silently dropped
+    // roughly a third of the catalog's semantics.
+    val projectDir = newTempFolder("semantics-inactivity")
+    writeDescriptor(projectDir)
+
+    val ids = (1..15).map { "Preview$it" }
+    val produced = ids.associateWith { """{"root":{"nodeId":"$it","boundsInRoot":"0,0,4,8"}}""" }
+    val logs = mutableListOf<String>()
+    val fetcher =
+      DaemonSemanticsFetcher(
+        factory = FakeFactory(produced = produced, staggerMs = 20),
+        onLog = { logs += it },
+        renderTimeout = 150.milliseconds,
+      )
+
+    val outcome = fetcher.fetch(projectDir = projectDir, moduleName = "sample", previewIds = ids)
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertEquals(
+      ids.toSet(),
+      outcome.semanticsById.keys,
+      "every render lands within the inactivity window, so no semantics may be dropped; logs: $logs",
+    )
+    assertTrue(
+      logs.none { "timed out" in it },
+      "steady progress must not trip the inactivity timeout, got: $logs",
+    )
+  }
+
+  @Test
   fun `missing descriptor returns DescriptorMissing`() {
     val projectDir = newTempFolder("semantics-no-descriptor")
     val fetcher = DaemonSemanticsFetcher(factory = FakeFactory(emptyMap()))
@@ -291,6 +326,7 @@ class DaemonSemanticsFetcherTest {
     private val fontsProduced: Map<String, String> = emptyMap(),
     private val failedIds: Map<String, String> = emptyMap(),
     private val silentIds: Set<String> = emptySet(),
+    private val staggerMs: Long = 0,
   ) : RenderSessionFactory {
     override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
 
@@ -301,6 +337,7 @@ class DaemonSemanticsFetcherTest {
         fontsProduced = fontsProduced,
         failedIds = failedIds,
         silentIds = silentIds,
+        staggerMs = staggerMs,
         dataRoot = File(config.workspaceRoot, "build/compose-previews/data"),
       )
   }
@@ -326,6 +363,7 @@ class DaemonSemanticsFetcherTest {
     private val fontsProduced: Map<String, String> = emptyMap(),
     private val failedIds: Map<String, String> = emptyMap(),
     private val silentIds: Set<String> = emptySet(),
+    private val staggerMs: Long = 0,
   ) : RenderSession {
     private val listeners = java.util.concurrent.CopyOnWriteArrayList<NotificationListener>()
 
@@ -359,38 +397,55 @@ class DaemonSemanticsFetcherTest {
       overrides: PreviewOverrides?,
       timeout: kotlin.time.Duration,
     ): RenderNowResult {
-      for (id in previewIds) {
-        val failure = failedIds[id]
-        if (failure != null) {
-          // A render whose composition throws emits `renderFailed` and *no* `renderFinished` — the
-          // daemon owes exactly one terminal event per queued render.
-          val params =
-            kotlinx.serialization.json.buildJsonObject {
-              put("id", id)
-              putJsonObject("error") { put("message", failure) }
+      // With a stagger, model the real daemon: `renderNow` only queues and acks, then the terminal
+      // notifications land one at a time on a background thread as each render actually completes.
+      // This lets a test drive the total render past the fetcher's inactivity window while keeping
+      // each individual gap inside it (issue #2948).
+      if (staggerMs > 0) {
+        Thread {
+            for (id in previewIds) {
+              Thread.sleep(staggerMs)
+              emitTerminal(id)
             }
-          listeners.forEach { it.onNotification("renderFailed", params) }
-          continue
-        }
-        if (id in silentIds) continue
-        produced[id]?.let { content ->
-          val dir = File(dataRoot, id).also { it.mkdirs() }
-          File(dir, "compose-semantics.json").writeText(content)
-        }
-        fontsProduced[id]?.let { content ->
-          val dir = File(dataRoot, id).also { it.mkdirs() }
-          File(dir, "fonts-used.json").writeText(content)
-        }
-        // Emit renderFinished for every remaining id — including ones that wrote no sidecar — so
-        // the fetcher's wait completes rather than timing out.
+          }
+          .apply { isDaemon = true }
+          .start()
+        return RenderNowResult(queued = previewIds, rejected = emptyList())
+      }
+      for (id in previewIds) emitTerminal(id)
+      return RenderNowResult(queued = previewIds, rejected = emptyList())
+    }
+
+    private fun emitTerminal(id: String) {
+      val failure = failedIds[id]
+      if (failure != null) {
+        // A render whose composition throws emits `renderFailed` and *no* `renderFinished` — the
+        // daemon owes exactly one terminal event per queued render.
         val params =
           kotlinx.serialization.json.buildJsonObject {
             put("id", id)
-            put("pngPath", "$id.png")
+            putJsonObject("error") { put("message", failure) }
           }
-        listeners.forEach { it.onNotification("renderFinished", params) }
+        listeners.forEach { it.onNotification("renderFailed", params) }
+        return
       }
-      return RenderNowResult(queued = previewIds, rejected = emptyList())
+      if (id in silentIds) return
+      produced[id]?.let { content ->
+        val dir = File(dataRoot, id).also { it.mkdirs() }
+        File(dir, "compose-semantics.json").writeText(content)
+      }
+      fontsProduced[id]?.let { content ->
+        val dir = File(dataRoot, id).also { it.mkdirs() }
+        File(dir, "fonts-used.json").writeText(content)
+      }
+      // Emit renderFinished for every remaining id — including ones that wrote no sidecar — so
+      // the fetcher's wait completes rather than timing out.
+      val params =
+        kotlinx.serialization.json.buildJsonObject {
+          put("id", id)
+          put("pngPath", "$id.png")
+        }
+      listeners.forEach { it.onNotification("renderFinished", params) }
     }
 
     override fun fetchData(


### PR DESCRIPTION
## Summary

Fixes #2948 — `compose-preview bundle pack --with-semantics` dropping semantics for roughly a third of a wide catalog even when `--timeout` was raised.

The semantics collector (`DaemonSemanticsFetcher`) already received `--timeout`, but it spent that budget the wrong way: it waited on a **single batch-wide deadline** (`latch.await(renderTimeout)`) in which *every* queued render had to reach a terminal event. A component library that fans out across many themes (Pocket Casts ships nine user-selectable palettes) legitimately renders for far longer than any single `--timeout`, so the batch was cut off mid-flight and the previews that hadn't finished yet came back with no `compose-semantics.json` sidecar — which is exactly the "no semantics for: …" list in the issue. Raising `--timeout 600` didn't help because the whole batch, not each render, had to finish inside it.

### The fix

Turn the wait into an **inactivity** deadline instead of a batch-wide one, which is what #2948 (and the original #2857) asked for — "stay attached until rendering finishes, or derive its deadline from render progress":

- Each terminal event (`renderFinished` / `renderFailed` / rejected) now offers a token on a `LinkedBlockingQueue` and the wait loop wakes on **every** completed render.
- `renderTimeout` is reinterpreted as the maximum gap between two renders completing. As long as the daemon keeps making progress the fetcher stays attached, however long the full catalog takes.
- It only gives up once `renderTimeout` elapses with **no** render completing at all — a genuine stall (or a hung preview), not a slow-but-large catalog.

Net effect: `--timeout` now governs the collector, so a strict run no longer needs `allow-incomplete: true` to tolerate a large theme fan-out. This unblocks the #2948 checklist item in the tracking issue #2963 (dropping `allowIncomplete: true` from the `pocketcasts` matrix entry); the remaining #2963 items are blocked on #2946 / #2950 and on regenerating the catalogs in `pocket-casts-android`, so that tracking issue stays open.

The existing fast-fail behaviour for a broken preview (the `renderFailed` early-release, issue #1885) is preserved — a failure still counts as progress and releases the wait immediately rather than idling out the window.

## Test plan

- New regression test `render timeout is an inactivity window, not a batch-wide budget`: 15 previews complete one every 20 ms (~300 ms total) against a 150 ms window — well past a batch-wide budget but never idle that long. Asserts every semantics sidecar is still collected and no timeout is logged. Fails against the old batch-wide `latch.await`.
- The fake render session gained a `staggerMs` mode that emits terminal notifications asynchronously, one per render, to model the real daemon's queue-then-notify flow.
- Existing `DaemonSemanticsFetcherTest` cases still pass (10/10), including the `renderFailed` fast-return and the configured-timeout-on-stall cases.
- `./gradlew :cli:test --tests DaemonSemanticsFetcherTest` green; `./gradlew :cli:ktfmtCheck` green.

Text-only PR: this is CLI/data-plumbing, no rendered surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX62hnwVtX6EnEQZ6FGbmH)_