### PR TITLE
feat(design-artifacts): add a ref input to the reusable publish workflow

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -42,6 +42,11 @@ on:
         description: 'Gradle module path to render (e.g. ":app").'
         required: true
         type: string
+      ref:
+        description: 'Git ref of the CALLING repo to check out and render (branch, tag or SHA). Empty ⇒ the ref that triggered the caller — the normal push/PR case. Set this when the trigger cannot imply the right ref: a `schedule` run only fires for a workflow on the default branch and checks out that branch, so a catalog living on a side branch (e.g. `previews`) needs `ref: previews` here or the render finds no catalog.spec.json (issue #2963).'
+        required: false
+        type: string
+        default: ''
       extra-module:
         description: 'Optional second module folded in via --extra-renders (previews override same-named functions in the primary render).'
         required: false
@@ -203,6 +208,10 @@ jobs:
       - name: Check out the calling repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Empty ⇒ checkout's default (the triggering ref), unchanged for push/PR
+          # callers; a caller can pass `ref` to render a specific branch, which a
+          # scheduled run needs to reach a catalog that lives off the default branch.
+          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Set up JDK 21

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -443,13 +443,22 @@ jobs:
           key: composeai-fonts-${{ runner.os }}-${{ inputs.system }}-${{ github.run_id }}
 
       - name: Generate importable catalog
+        env:
+          # The ref actually rendered (see "Check out the calling repo"). Empty ⇒ the
+          # triggering ref. The live-rerender source metadata and Code Connect links must
+          # name the branch the catalog was rendered FROM, not the event ref — for a
+          # scheduled caller that passed `ref: previews` those differ, and recording the
+          # event ref (a default branch with no catalog) would point live re-render at a
+          # revision the catalog doesn't exist on (issue #2963).
+          RENDERED_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           extra=()
           if [ -n "${{ inputs.extra-module }}" ]; then extra=(--extra-renders "$GITHUB_WORKSPACE/extra-bundle.png"); fi
           source_args=()
           if [ "${{ inputs.live-rerender-source }}" = "true" ]; then
-            source_args=(--source-repo "${GITHUB_REPOSITORY}" --source-ref "${GITHUB_REF_NAME}" --source-module "${{ inputs.module }}")
+            source_ref="${RENDERED_REF:-$GITHUB_REF_NAME}"
+            source_args=(--source-repo "${GITHUB_REPOSITORY}" --source-ref "${source_ref}" --source-module "${{ inputs.module }}")
           fi
           incomplete=()
           if [ "${{ inputs.allow-incomplete }}" = "true" ]; then incomplete=(--allow-incomplete); fi


### PR DESCRIPTION
## Summary

The reusable `design-artifacts-reusable.yml` checked out the calling repo at whatever ref triggered it, with no override. That's fine for `push` / `pull_request` callers, but blocks a **scheduled** regeneration: GitHub only fires `schedule` for a workflow on the default branch and checks that branch out, so a catalog living on a side branch (Pocket Casts' `previews`) would render a default branch that carries no `catalog.spec.json`.

This adds an optional `ref` input, forwarded to the "Check out the calling repo" step:

- **Empty (default)** ⇒ checkout's current behaviour, unchanged — the triggering ref. Every existing caller is unaffected.
- A scheduled caller can pass `ref: previews` to render the branch its catalog actually lives on.

This is the upstream enabler called out in the "weekly regeneration is not currently automatic" note in #2963 ("A `ref` input would close this"). The caller-side wiring (relocating the caller workflow to the default branch and passing `ref` on the `schedule` path) is a per-consumer change and stays in the consuming repo.

## Test plan

- `design-artifacts-reusable.yml` parses as valid YAML.
- Change is additive and backward-compatible: the new input defaults to `''`, and `ref: ${{ inputs.ref }}` with an empty value is exactly how `actions/checkout` already resolves the triggering ref — so existing `push`/PR callers (compose-samples, this repo's own `design-artifacts.yml`, pocket-casts-android) render identically.

Text-only: workflow plumbing, no rendered surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX62hnwVtX6EnEQZ6FGbmH)_