### PR TITLE
feat(playground): remote-compose data path — capture → /d/&lt;id&gt; permalink

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
@@ -120,6 +120,11 @@ data class PlaygroundStockError(
  * ([previewToken] stays null). [exception] is reserved for a server-side failure that isn't a user
  * compile error (e.g. the render subprocess died).
  *
+ * [documentUrl] is the [PlaygroundMode.REMOTE_COMPOSE] terminal instead of a token: the snippet's
+ * captured `.rc` document is published as an expiring `/d/<id>` permalink the browser plays
+ * client-side (PLAYGROUND.md §3). A run yields **either** a [previewToken] (the live CMP/Android
+ * modes) **or** a [documentUrl] (RC) — never both — and [previewToken] stays null on the RC path.
+ *
  * [errors] is the **same** diagnostics projected into the stock `kotlin-compiler-server` wire shape
  * (a map keyed by file name → [PlaygroundStockError]s with nested `interval` positions), so an
  * unmodified `kotlin-playground` frontend can render inline squiggles. Our own frontend reads the
@@ -134,4 +139,5 @@ data class PlaygroundRunResponse(
   val image: String? = null,
   val previewToken: String? = null,
   val previewUrl: String? = null,
+  val documentUrl: String? = null,
 )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -11,6 +11,11 @@ import okio.Path
  * token that Stage 2 redeems into a live session. Compile errors return diagnostics and **no**
  * token.
  *
+ * [PlaygroundMode.REMOTE_COMPOSE] is the exception to the token model: instead of a live session it
+ * captures the snippet's `.rc` document and publishes it as an expiring `/d/<id>` permalink
+ * ([remoteComposeResult]), returning a [PlaygroundRunResponse.documentUrl] and no token — the
+ * document plays client-side, so the server keeps no daemon for it (PLAYGROUND.md §3).
+ *
  * Every collaborator that touches the daemon, the compiler, or the catalog is an **injected seam**,
  * so the orchestration (staging, gating, cleanup, token minting, response shaping) is unit-testable
  * without a real BTA classloader or a running daemon — the same split
@@ -40,6 +45,21 @@ class PlaygroundCompileService(
   private val fileSystem: FileSystem = FileSystem.SYSTEM,
   /** Optional first-frame render; returns PNG bytes or null. Defaults to no image (wired later). */
   private val renderFirstFrame: (PlaygroundTokenStore.PlaygroundSnippet) -> ByteArray? = { null },
+  /**
+   * [PlaygroundMode.REMOTE_COMPOSE] capture: run the compiled snippet's `@Preview` under the
+   * RC-capable render and return the serialized `.rc` document bytes, or null when the snippet
+   * emitted none (a non-RC `@Preview`) or no capture engine is wired here. Like [renderFirstFrame],
+   * defaults to no capture — the production Robolectric capture subprocess is wired later.
+   */
+  private val captureRemoteDocument: (PlaygroundTokenStore.PlaygroundSnippet) -> ByteArray? = {
+    null
+  },
+  /**
+   * Publishes captured `.rc` bytes to a document store and returns the `/d/<id>` permalink, or null
+   * when no store is available (or it refused the bytes). The `Boolean` is the [isSecurityChecked]
+   * audit marker forwarded from [run], matching [ServeDocStore.add]. Defaults to no publisher.
+   */
+  private val publishRemoteDocument: (String, ByteArray, Boolean) -> String? = { _, _, _ -> null },
 ) {
 
   /**
@@ -135,6 +155,11 @@ class PlaygroundCompileService(
         moduleName = classpath.moduleName,
         previewId = previews.first(),
       )
+
+    if (mode == PlaygroundMode.REMOTE_COMPOSE) {
+      return remoteComposeResult(snippet, diagnostics, workDir, isSecurityChecked)
+    }
+
     val image = renderFirstFrame(snippet)?.let(::toDataUri)
     // From here the token owns workDir; do NOT cleanup on this path.
     val token = tokenStore.add(snippet, isSecurityChecked = isSecurityChecked)
@@ -146,6 +171,50 @@ class PlaygroundCompileService(
       previewUrl = token.path,
     )
   }
+
+  /**
+   * The [PlaygroundMode.REMOTE_COMPOSE] terminal: capture the snippet's `.rc` document and hand it
+   * to the document store as an expiring `/d/<id>` permalink. Unlike the live CMP/Android modes, RC
+   * needs no daemon session — the document, not a session, is the deliverable (PLAYGROUND.md §3).
+   * So the work dir is released as soon as the one-shot capture is done and **no** token is minted;
+   * a snippet that emits no document, or a store that refuses the bytes, is a clean failure with
+   * neither a token nor a permalink.
+   */
+  private fun remoteComposeResult(
+    snippet: PlaygroundTokenStore.PlaygroundSnippet,
+    diagnostics: List<PlaygroundDiagnostic>,
+    workDir: Path,
+    isSecurityChecked: Boolean,
+  ): PlaygroundRunResponse {
+    val errors = PlaygroundErrorsWire.project(diagnostics)
+    val bytes = captureRemoteDocument(snippet)
+    // The capture reads the compiled classes, then RC is done with them — it never stands up a live
+    // session — so the work dir goes now regardless of what the capture produced.
+    cleanup(workDir)
+    if (bytes == null) {
+      return PlaygroundRunResponse(
+        diagnostics = diagnostics,
+        errors = errors,
+        exception =
+          "no Remote Compose document was captured — a remote-compose snippet must declare an " +
+            "@Preview that emits a RemoteDocument",
+      )
+    }
+    val url =
+      publishRemoteDocument(documentLabel(snippet), bytes, isSecurityChecked)
+        ?: return PlaygroundRunResponse(
+          diagnostics = diagnostics,
+          errors = errors,
+          exception = "remote-compose documents are not accepted on this host",
+        )
+    return PlaygroundRunResponse(diagnostics = diagnostics, errors = errors, documentUrl = url)
+  }
+
+  /**
+   * A short, human label for the published document — the preview's simple name, `.rc`-suffixed.
+   */
+  private fun documentLabel(snippet: PlaygroundTokenStore.PlaygroundSnippet): String =
+    snippet.previewId.substringAfterLast('.').ifBlank { "snippet" } + ".rc"
 
   /**
    * Write each file to [srcDir] under a safe, unique `.kt` name; return the staged source paths.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
@@ -31,6 +31,8 @@ class PlaygroundCompileServiceTest {
     },
     discover: (Path, List<Path>) -> List<String> = { _, _ -> listOf("com.example.SnippetPreview") },
     render: (PlaygroundTokenStore.PlaygroundSnippet) -> ByteArray? = { null },
+    capture: (PlaygroundTokenStore.PlaygroundSnippet) -> ByteArray? = { null },
+    publish: (String, ByteArray, Boolean) -> String? = { _, _, _ -> null },
   ) =
     PlaygroundCompileService(
       catalogClasspath = classpathFor,
@@ -40,6 +42,8 @@ class PlaygroundCompileServiceTest {
       newWorkDir = { "/work/run${++workDirs}".toPath() },
       fileSystem = fs,
       renderFirstFrame = render,
+      captureRemoteDocument = capture,
+      publishRemoteDocument = publish,
     )
 
   private fun request(
@@ -161,6 +165,87 @@ class PlaygroundCompileServiceTest {
     val svc = service(render = { byteArrayOf(1, 2, 3) })
     val resp = svc.run(request(), isSecurityChecked = true)
     assertEquals("data:image/png;base64,AQID", resp.image)
+  }
+
+  @Test
+  fun `a remote-compose snippet publishes a document permalink and mints no token`() {
+    var publishedName: String? = null
+    var publishedChecked: Boolean? = null
+    val svc =
+      service(
+        capture = { byteArrayOf(9, 8, 7) },
+        publish = { name, bytes, checked ->
+          publishedName = name
+          publishedChecked = checked
+          assertEquals(listOf<Byte>(9, 8, 7), bytes.toList(), "the captured bytes reach the store")
+          "/d/doc123"
+        },
+      )
+
+    val resp = svc.run(request(confType = "remote-compose"), isSecurityChecked = true)
+
+    assertEquals("/d/doc123", resp.documentUrl)
+    assertNull(resp.previewToken, "RC returns a document, not a live-session token")
+    assertNull(resp.exception)
+    assertTrue(tokenStore.snapshot().isEmpty(), "no token is minted on the RC path")
+    assertFalse(
+      fs.exists("/work/run1".toPath()),
+      "RC needs no live session, so the work dir is released",
+    )
+    // The label is the preview's simple name, `.rc`-suffixed; the audit marker is forwarded.
+    assertEquals("SnippetPreview.rc", publishedName)
+    assertEquals(true, publishedChecked)
+  }
+
+  @Test
+  fun `a remote-compose snippet that emits no document is a user error with no token and cleanup`() {
+    // publish would succeed if reached — proving the failure is the absent capture, not the store.
+    val svc = service(capture = { null }, publish = { _, _, _ -> "/d/never" })
+
+    val resp = svc.run(request(confType = "remote-compose"), isSecurityChecked = true)
+
+    assertNull(resp.documentUrl)
+    assertNull(resp.previewToken)
+    assertNotNull(resp.exception)
+    assertTrue(resp.exception!!.contains("RemoteDocument"))
+    assertTrue(tokenStore.snapshot().isEmpty())
+    assertFalse(fs.exists("/work/run1".toPath()), "a capture-less RC run deletes its own work dir")
+  }
+
+  @Test
+  fun `a captured document the store refuses returns an exception, no token, and cleanup`() {
+    val svc = service(capture = { byteArrayOf(1) }, publish = { _, _, _ -> null })
+
+    val resp = svc.run(request(confType = "remote-compose"), isSecurityChecked = true)
+
+    assertNull(resp.documentUrl)
+    assertNull(resp.previewToken)
+    assertNotNull(resp.exception)
+    assertTrue(resp.exception!!.contains("not accepted"))
+    assertTrue(tokenStore.snapshot().isEmpty())
+    assertFalse(fs.exists("/work/run1".toPath()))
+  }
+
+  @Test
+  fun `the live modes never invoke the RC capture or publish seams`() {
+    var touched = false
+    val svc =
+      service(
+        capture = {
+          touched = true
+          byteArrayOf(1)
+        },
+        publish = { _, _, _ ->
+          touched = true
+          "/d/x"
+        },
+      )
+
+    val resp = svc.run(request(confType = "compose-cmp"), isSecurityChecked = true)
+
+    assertNotNull(resp.previewToken, "CMP still takes the token path")
+    assertNull(resp.documentUrl)
+    assertFalse(touched, "the RC seams are inert for a live-session mode")
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds the **Remote Compose terminal** to the Stage-1 playground orchestrator (`PlaygroundCompileService`), per [`docs/design/PLAYGROUND.md` §3](docs/design/PLAYGROUND.md). The three playground modes differ only in what a clean compile hands back:

- **CMP / Android** → a `previewToken` that Stage 2 redeems into a live daemon session (unchanged).
- **Remote Compose** → the snippet's `.rc` document, published to the document store as an expiring `/d/<id>` permalink the browser plays **client-side**. No live seat, no daemon, no server round-trip — so the work dir is released as soon as the one-shot capture is done and **no token is minted**.

A run now yields **either** a `previewToken` **or** a `documentUrl`, never both.

### Why this shape

`PlaygroundCompileService` is designed so every daemon/compiler/catalog collaborator is an **injected seam**, and its orchestration is unit-tested without a live daemon (the same reason `renderFirstFrame` ships as an injected `{ null }` default). This PR follows that grain exactly: it adds two injected seams —

- `captureRemoteDocument(snippet) -> ByteArray?` — run the compiled `@Preview` under the RC-capable render and return the serialized `.rc` bytes (or null when the snippet emits none).
- `publishRemoteDocument(name, bytes, isSecurityChecked) -> String?` — hand the bytes to a document store and return the `/d/<id>` path.

— and the `REMOTE_COMPOSE` branch that wires them: capture → release work dir → publish → return `documentUrl`, with clean failures when a snippet emits no document or the store refuses the bytes.

### Scope — what this PR does *not* do

This is the **data path + contract**, deliberately kept self-contained and fully unit-tested. It does **not** flip on RC/Android in production. The remaining pieces land in a focused, Android-SDK-dependent follow-up, because they can't be verified end-to-end without building the installed distribution (the `lib-daemon-android` sidecar):

- the production **Robolectric capture subprocess** that drives `IrSidecarChannel.setCurrentPreviewId → render → consume(previewId).bytes` on freshly compiled snippet classes;
- the `ServeCommand` wiring — an Android-catalog compile classpath for `ANDROID`/`REMOTE_COMPOSE` (the existing `PlaygroundCatalogClasspath.resolve` is already mode-agnostic) and binding `publishRemoteDocument` to the shared `ServeDocStore`.

Keeping the engine out avoids advertising a mode that dead-ends and avoids landing subprocess code that can't be exercised in CI here.

## Test plan

- [x] `./gradlew :cli:test --tests "…PlaygroundCompileServiceTest"` — **BUILD SUCCESSFUL**. New cases: RC publishes a permalink with no token and releases the work dir; a snippet that emits no document is a clean user error; a store that refuses the bytes is a clean failure; the live modes never touch the RC seams.
- [x] `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest` — clean (format gate).

Non-visual change (orchestration + wire types only), so no rendered evidence applies.

## Follow-up

1. Robolectric capture subprocess → wire `captureRemoteDocument` (Android SDK-dependent; verified against an installed dist).
2. `ServeCommand`: Android/RC mode classpaths + `ServeDocStore` publisher; e2e route test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_