### PR TITLE
feat(serve): light up the cmp-jvm Remote Compose chip via an isolated desktop subprocess

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -82,6 +82,20 @@ val composePreviewDaemonDesktop =
     isCanBeConsumed = false
   }
 
+// Sidecar configuration carrying the desktop/JVM embedded Remote Compose player
+// (`:third-party-rc-embedded-player-jvm`). `compose-preview serve` spawns its `RcJvmRenderMain` as
+// a one-shot subprocess to render a captured `ir/<id>.rc` to PNG for the viewer's cmp-jvm chip —
+// the same subprocess-only isolation as the desktop daemon. Deliberately does NOT bundle Compose
+// Multiplatform / Skiko: the subprocess classpath joins `lib-rcjvm/*` + `lib-daemon-desktop/*` at
+// launch, and the daemon sidecar already carries the per-OS Compose + Skiko stack. Resolved into
+// `cli/build/install/compose-preview/lib-rcjvm/`, located at runtime via `APP_HOME/lib-rcjvm/` (or
+// `-Dcomposeai.cli.libRcjvmDir`).
+val composePreviewRcJvm =
+  configurations.create("composePreviewRcJvm") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+  }
+
 // Sidecar configuration carrying the Android (Robolectric) daemon module (`:daemon:android`).
 // Same subprocess-only isolation as the desktop daemon above — never on the CLI's own classpath,
 // only loaded by the JVM that `compose-preview bundle daemon` spawns for an `backend="android"`
@@ -225,6 +239,12 @@ dependencies {
   // at launch time, and the renderer sidecar already carries the per-OS Compose stack.
   add("composePreviewDaemonDesktop", project(":daemon:desktop"))
 
+  // `compose-preview serve` ships the desktop/JVM embedded Remote Compose player in `lib-rcjvm/`
+  // for the cmp-jvm chip's one-shot render subprocess. Subprocess-only isolation; the Compose +
+  // Skiko runtime is not bundled here (the subprocess joins `lib-rcjvm/*` +
+  // `lib-daemon-desktop/*`).
+  add("composePreviewRcJvm", project(":third-party-rc-embedded-player-jvm"))
+
   // `compose-preview bundle daemon` ships the Android (Robolectric) daemon in
   // `lib-daemon-android/`. This resolves `:daemon:android`'s `daemonHarnessClasspathFile`
   // descriptor (a text file of runtime jar paths) — see the configuration KDoc above — never the
@@ -269,6 +289,34 @@ val stageDaemonDesktopLibs =
     description = "Stages :daemon:desktop runtime artifacts, renaming filename collisions."
     destinationDir = layout.buildDirectory.dir("staged-daemon-desktop-libs").get().asFile
     val artifactsProvider = composePreviewDaemonDesktop.incoming.artifacts.resolvedArtifacts
+    from(artifactsProvider.map { it.map(ResolvedArtifactResult::getFile) })
+    val nameByPath = artifactsProvider.map { resolved ->
+      val counts = resolved.groupingBy { it.file.name }.eachCount()
+      resolved.associate { artifact ->
+        val original = artifact.file.name
+        val mapped =
+          if (counts.getValue(original) > 1) {
+            val id = artifact.id.componentIdentifier
+            if (id is ModuleComponentIdentifier) "${id.module}-${id.version}.jar" else original
+          } else original
+        artifact.file.absolutePath to mapped
+      }
+    }
+    inputs.property("nameByPath", nameByPath)
+    eachFile {
+      val mapped = nameByPath.get()[file.absolutePath]
+      if (mapped != null) name = mapped
+    }
+  }
+
+// Stage the JVM embedded player's runtime artifacts for `lib-rcjvm/`, disambiguating any colliding
+// `library-desktop-<version>.jar` filenames by Maven `module-version.jar` — same reasoning as
+// [stageDaemonDesktopLibs].
+val stageRcJvmLibs =
+  tasks.register<Sync>("stageRcJvmLibs") {
+    description = "Stages :third-party-rc-embedded-player-jvm runtime artifacts for lib-rcjvm/."
+    destinationDir = layout.buildDirectory.dir("staged-rcjvm-libs").get().asFile
+    val artifactsProvider = composePreviewRcJvm.incoming.artifacts.resolvedArtifacts
     from(artifactsProvider.map { it.map(ResolvedArtifactResult::getFile) })
     val nameByPath = artifactsProvider.map { resolved ->
       val counts = resolved.groupingBy { it.file.name }.eachCount()
@@ -363,6 +411,7 @@ distributions {
     contents {
       into("lib-renderer") { from(composePreviewRenderer) }
       into("lib-daemon-desktop") { from(stageDaemonDesktopLibs) }
+      into("lib-rcjvm") { from(stageRcJvmLibs) }
       into("lib-bta") { from(stageBtaLibs) }
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
@@ -132,6 +132,7 @@ private fun bundleSidecarSysprop(sidecarName: String): String =
     "lib-daemon-desktop" -> "composeai.cli.libDaemonDesktopDir"
     "lib-daemon-android" -> "composeai.cli.libDaemonAndroidDir"
     "lib-renderer" -> "composeai.cli.libRendererDir"
+    "lib-rcjvm" -> "composeai.cli.libRcjvmDir"
     "lib-bta" -> "composeai.cli.libBtaDir"
     else -> "composeai.cli.${sidecarName.replace('-', '.')}Dir"
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.bundleSidecarSearchDescription
+import ee.schimke.composeai.cli.locateBundleSidecarJars
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Renders a captured Remote Compose document to PNG for the serve viewer's **cmp-jvm** chip, by
+ * spawning the embedded desktop player ([ee.schimke.composeai.rcembedded.jvm] `RcJvmRenderMain`) as
+ * a one-shot subprocess off an isolated classpath — the same subprocess isolation `BundleRenderer`
+ * uses for the desktop `@Preview` renderer, and for the same reason: Compose Desktop + Skiko's
+ * per-OS natives are kept off the CLI's own classpath so a cross-platform release doesn't bake in
+ * one host's natives.
+ *
+ * The classpath joins the CLI install's `lib-rcjvm/` (the embedded jvm player + its Compose API
+ * deps, staged by the CLI build) with `lib-daemon-desktop/` (the Compose Desktop runtime + Skiko
+ * natives the desktop daemon already carries), so the natives are shared rather than bundled twice.
+ * When either sidecar is absent (a build that didn't stage them, or a headless host that dropped
+ * the desktop lane) [isAvailable] is false and the viewer never lights the chip.
+ */
+internal object RcJvmServerRenderer {
+
+  private const val MAIN_CLASS = "ee.schimke.composeai.rcembedded.jvm.RcJvmRenderMainKt"
+  private const val RENDER_TIMEOUT_SECONDS = 120L
+
+  /**
+   * The subprocess classpath: the embedded jvm player (`lib-rcjvm`) plus the desktop Compose +
+   * Skiko runtime (`lib-daemon-desktop`). Empty when either sidecar dir is missing.
+   */
+  private fun classpath(): List<File> {
+    val rcjvm = locateBundleSidecarJars("lib-rcjvm")
+    val desktop = locateBundleSidecarJars("lib-daemon-desktop")
+    if (rcjvm.isEmpty() || desktop.isEmpty()) return emptyList()
+    return rcjvm + desktop
+  }
+
+  /** True when both sidecar classpaths are present, so a cmp-jvm render can actually be spawned. */
+  fun isAvailable(): Boolean = classpath().isNotEmpty()
+
+  /** Human-readable description of where the sidecars were looked for, for error messages. */
+  fun unavailableReason(): String =
+    "cmp-jvm render needs lib-rcjvm and lib-daemon-desktop on the CLI install " +
+      "(${bundleSidecarSearchDescription("lib-rcjvm")}; " +
+      "${bundleSidecarSearchDescription("lib-daemon-desktop")})"
+
+  /**
+   * Render [docBytes] to a PNG at [spec]'s pixel size and density, or null when the subprocess is
+   * unavailable, times out, or the player could not draw the document (it prints the reason to
+   * stderr, surfaced in [RenderResult.Failed]).
+   */
+  fun render(docBytes: ByteArray, spec: RcJvmRenderSpec): RenderResult {
+    val cp = classpath()
+    if (cp.isEmpty()) return RenderResult.Unavailable(unavailableReason())
+
+    val input = File.createTempFile("rcjvm-in-", ".rc")
+    val output = File.createTempFile("rcjvm-out-", ".png")
+    try {
+      input.writeBytes(docBytes)
+      output.delete() // the subprocess creates it; absence after the run signals failure
+
+      val command = buildList {
+        add(javaBin())
+        add("--enable-native-access=ALL-UNNAMED")
+        // Skiko draws offscreen; keep the JVM out of the macOS Dock / app-switcher when spawned
+        // on a developer's Mac, matching BundleRenderer's desktop renderer launch.
+        add("-Dapple.awt.UIElement=true")
+        add("-cp")
+        add(cp.joinToString(File.pathSeparator) { it.absolutePath })
+        add(MAIN_CLASS)
+        add("--input")
+        add(input.absolutePath)
+        add("--output")
+        add(output.absolutePath)
+        add("--width")
+        add(spec.widthPx.toString())
+        add("--height")
+        add(spec.heightPx.toString())
+        add("--density")
+        add(spec.density.toString())
+      }
+
+      val process =
+        ProcessBuilder(command).redirectErrorStream(true).start().also { it.outputStream.close() }
+      val log = process.inputStream.bufferedReader().use { it.readText() }
+      val finished = process.waitFor(RENDER_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+      if (!finished) {
+        process.destroyForcibly()
+        return RenderResult.Failed("cmp-jvm render timed out after ${RENDER_TIMEOUT_SECONDS}s")
+      }
+      if (process.exitValue() != 0 || !output.isFile || output.length() == 0L) {
+        return RenderResult.Failed(
+          "cmp-jvm render failed (exit ${process.exitValue()})" +
+            log
+              .trim()
+              .takeIf { it.isNotEmpty() }
+              ?.let { ": ${it.lines().last().take(300)}" }
+              .orEmpty()
+        )
+      }
+      return RenderResult.Ok(output.readBytes())
+    } finally {
+      input.delete()
+      output.delete()
+    }
+  }
+
+  private fun javaBin(): String {
+    val home = System.getProperty("java.home")
+    val candidate = File(home, "bin/java")
+    return if (candidate.canExecute()) candidate.absolutePath else "java"
+  }
+
+  sealed interface RenderResult {
+    data class Ok(val png: ByteArray) : RenderResult
+
+    data class Failed(val reason: String) : RenderResult
+
+    data class Unavailable(val reason: String) : RenderResult
+  }
+}
+
+/**
+ * The pixel size and density a cmp-jvm render should use — matched to the baked/View-player lane.
+ */
+data class RcJvmRenderSpec(val widthPx: Int, val heightPx: Int, val density: Float)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
@@ -39,6 +39,7 @@ internal object RcJvmServerRenderer {
 
   private const val MAIN_CLASS = "ee.schimke.composeai.rcembedded.jvm.RcJvmRenderMainKt"
   private const val RENDER_TIMEOUT_SECONDS = 120L
+  private const val DRAIN_FLUSH_MILLIS = 1000L
 
   /**
    * The subprocess classpath: the embedded jvm player (`lib-rcjvm`) plus the desktop Compose +
@@ -98,16 +99,32 @@ internal object RcJvmServerRenderer {
 
       val process =
         ProcessBuilder(command).redirectErrorStream(true).start().also { it.outputStream.close() }
-      val log = process.inputStream.bufferedReader().use { it.readText() }
+      // Drain the merged stdout/stderr on a daemon thread *concurrently* with the timed wait — a
+      // blocking readText() here would wait for EOF, which a hung Skiko/native render never
+      // reaches,
+      // so the timeout below (and the render-semaphore permit the caller holds) would never
+      // release.
+      // Mirrors BundleRenderer.runRenderProcess.
+      val log = StringBuilder()
+      val drain =
+        Thread { process.inputStream.bufferedReader().forEachLine { log.appendLine(it) } }
+          .apply {
+            isDaemon = true
+            start()
+          }
       val finished = process.waitFor(RENDER_TIMEOUT_SECONDS, TimeUnit.SECONDS)
       if (!finished) {
         process.destroyForcibly()
+        drain.join(DRAIN_FLUSH_MILLIS)
         return RenderResult.Failed("cmp-jvm render timed out after ${RENDER_TIMEOUT_SECONDS}s")
       }
+      // The process exited, so the reader has hit EOF; this join just flushes the last lines.
+      drain.join(DRAIN_FLUSH_MILLIS)
       if (process.exitValue() != 0 || !output.isFile || output.length() == 0L) {
         return RenderResult.Failed(
           "cmp-jvm render failed (exit ${process.exitValue()})" +
             log
+              .toString()
               .trim()
               .takeIf { it.isNotEmpty() }
               ?.let { ": ${it.lines().last().take(300)}" }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcPlayerBackend.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcPlayerBackend.kt
@@ -19,13 +19,16 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind
  *   which interprets the document's operation tree into Compose layout/draw nodes directly, driven
  *   server-side via [RemoteComposePlayerKind.EMBEDDED].
  * * [CMP_JVM] — the same embedded player over Skiko/Desktop
- *   (`:third-party-rc-embedded-player-jvm`). The draw path now exists: the module renders a
- *   captured `.rc` to PNG on a plain JVM (`renderRemoteDocumentToPng`, verified by
- *   `RcJvmRendererTest` and the `rc-compare` cmp-jvm lane). What is not yet wired is a **serve
- *   render path** for it — the daemon protocol carries no JVM player kind, and the cli's render
- *   runtimes are subprocess-isolated, so lighting this chip needs either an in-process render in
- *   the cli or a desktop-daemon render lane (see the module's `PROVENANCE.md`). Until that lands
- *   [playerKind] stays null and no host enables it, so the viewer shows it as a disabled option.
+ *   (`:third-party-rc-embedded-player-jvm`), rendered **server-side** by [RcJvmServerRenderer]: it
+ *   spawns the module's `RcJvmRenderMain` as a one-shot subprocess off the CLI install's
+ *   `lib-rcjvm`
+ *     + `lib-daemon-desktop` sidecars (Compose Desktop + Skiko kept out of the CLI's own
+ *       classpath). Unlike [JAVA] / [CMP_ANDROID] it does **not** ride the daemon
+ *       `remoteCompose.player` override — [playerKind] stays null and [ServeHttpServer] renders it
+ *       directly from the captured `.rc` — so a host enables it (via [ServeHost.supportsCmpJvm])
+ *       whenever it carries the document, can size a render for it, and the sidecar is installed.
+ *       Where the sidecar is absent (a headless host, or a build that didn't stage it) the chip
+ *       stays disabled, exactly as before this lane existed.
  *
  * The viewer always renders every entry as a chip and enables the subset a host reports through
  * [ServeHost.enabledRcPlayersFor]; the rest are shown disabled. [wire] is the stable id used both

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcPlayerBackend.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcPlayerBackend.kt
@@ -40,9 +40,11 @@ enum class RcPlayerBackend(
   /** Short human label for the selector chip. */
   val label: String,
   /**
-   * The daemon player kind a **server-side** backend renders through, or null for the client-side
-   * [JS] lane and the not-yet-renderable [CMP_JVM] lane. Drives [ServeOverrides]'s mapping of the
-   * `rcPlayer=` param onto [ee.schimke.composeai.daemon.protocol.RemoteComposeOverride.player].
+   * The daemon player kind a **server-side** backend renders through, or null for the lanes that
+   * don't ride the daemon `remoteCompose.player` override: the client-side [JS] lane and the
+   * [CMP_JVM] lane (which renders in its own isolated subprocess, see [RcJvmServerRenderer]).
+   * Drives [ServeOverrides]'s mapping of the `rcPlayer=` param onto
+   * [ee.schimke.composeai.daemon.protocol.RemoteComposeOverride.player].
    */
   val playerKind: RemoteComposePlayerKind?,
   /**
@@ -69,11 +71,12 @@ enum class RcPlayerBackend(
       wire?.lowercase()?.let { v -> entries.firstOrNull { it.wire == v } }
 
     /**
-     * The server-side backend a `rcPlayer=` render param selects, or null when [raw] names no
-     * *server-side* backend. Accepts the backend [wire] ids (`java`, `cmp-android`) and the
-     * daemon-native player-kind spellings (`view`, `embedded`) as aliases, so a link can be written
-     * either way. A client-side / unavailable value (`js`, `cmp-jvm`) yields null — those never
-     * ride the PNG lane — which the parser turns into a hard error rather than a silent default.
+     * The server-side backend a `rcPlayer=` render param selects **through the daemon**, or null
+     * otherwise. Accepts the backend [wire] ids (`java`, `cmp-android`) and the daemon-native
+     * player-kind spellings (`view`, `embedded`) as aliases, so a link can be written either way.
+     * `js` (client-side) and `cmp-jvm` yield null: `js` replays in-browser, and `cmp-jvm` renders
+     * in its own subprocess lane ([ServeHttpServer] handles `rcPlayer=cmp-jvm` directly), so
+     * neither rides the daemon override this maps.
      */
     fun serverSideFromParam(raw: String): RcPlayerBackend? =
       when (raw.lowercase()) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -285,6 +285,53 @@ class ServeBundleHost(
     return fileSystem.exists(File(irDir, "$previewId$RC_SUFFIX").toOkioPath())
   }
 
+  // Per-preview render params (dp size + density) from the bundle's `previews.json`, used to size a
+  // cmp-jvm render to match the baked capture. Empty when the bundle carries no manifest.
+  private val rcRenderParams: Map<String, ee.schimke.composeai.cli.PreviewParams> by lazy {
+    val previewsJson = File(bundleDir, PREVIEWS_JSON).toOkioPath()
+    if (!fileSystem.exists(previewsJson)) return@lazy emptyMap()
+    try {
+      val text = fileSystem.read(previewsJson) { readUtf8() }
+      OVERRIDES_JSON.decodeFromString(ee.schimke.composeai.cli.PreviewManifest.serializer(), text)
+        .previews
+        .associate { it.id to it.params }
+    } catch (e: Exception) {
+      emptyMap()
+    }
+  }
+
+  // The cmp-jvm render is sized to the baked PNG's exact pixel dimensions — so the desktop-player
+  // PNG lands at the same size the viewer shows the baked / View-player lane at — with the density
+  // the capture used (from `previews.json`, else the renderer default). Null when the preview has
+  // no
+  // captured doc or no baked PNG to size against.
+  override fun remoteComposeRenderSpec(previewId: String): RcJvmRenderSpec? {
+    if (!hasRemoteComposeDoc(previewId)) return null
+    val (widthPx, heightPx) = readPngSize(File(previewsDir, "$previewId$PNG_SUFFIX")) ?: return null
+    val density = rcRenderParams[previewId]?.density ?: DEFAULT_RENDER_DENSITY
+    return RcJvmRenderSpec(widthPx, heightPx, density)
+  }
+
+  /** Read a PNG's pixel dimensions from its IHDR without decoding the image; null if unreadable. */
+  private fun readPngSize(pngFile: File): Pair<Int, Int>? {
+    val path = pngFile.toOkioPath()
+    if (!fileSystem.exists(path)) return null
+    return try {
+      val header = fileSystem.read(path) { readByteArray(24) }
+      // 8-byte PNG signature, 4-byte IHDR length, 4-byte "IHDR", then width + height, big-endian.
+      fun be(off: Int): Int =
+        ((header[off].toInt() and 0xff) shl 24) or
+          ((header[off + 1].toInt() and 0xff) shl 16) or
+          ((header[off + 2].toInt() and 0xff) shl 8) or
+          (header[off + 3].toInt() and 0xff)
+      val w = be(16)
+      val h = be(20)
+      if (w > 0 && h > 0) w to h else null
+    } catch (e: Exception) {
+      null
+    }
+  }
+
   /**
    * Serve the baked `compose/figma-svg` export for [previewId] from the catalog's [figmaDir], with
    * its hybrid raster crops inlined so the SVG is self-contained. The SVG is per component **slug**
@@ -414,6 +461,11 @@ class ServeBundleHost(
   companion object {
     private const val PREVIEWS_SUBDIR = "previews"
     private const val PNG_SUFFIX = ".png"
+
+    // Fallback render density for a cmp-jvm render when `previews.json` declares none — the desktop
+    // renderer's own default (a 200dp preview bakes to 525px), so an unspecified preview still
+    // renders at the density its baked PNG was captured with.
+    private const val DEFAULT_RENDER_DENSITY = 2.625f
     /** Bytes of a PNG needed to read its IHDR width/height (8 sig + 4 len + 4 tag + 4 + 4). */
     private const val PNG_HEADER_BYTES = 24L
     private const val SVG_SUFFIX = ".svg"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -254,6 +254,10 @@ class ServeCatalogLiveHost(
    */
   override fun remoteComposeDoc(previewId: String): ByteArray? = baked.remoteComposeDoc(previewId)
 
+  /** The cmp-jvm render spec (baked size + density) comes from the baked bundle, like the doc. */
+  override fun remoteComposeRenderSpec(previewId: String): RcJvmRenderSpec? =
+    baked.remoteComposeRenderSpec(previewId)
+
   /** The daemon lane honours the RC player override when the carried daemon is Android-backed. */
   override val remoteComposePlayerSelectable: Boolean = live.remoteComposePlayerSelectable
 
@@ -263,7 +267,8 @@ class ServeCatalogLiveHost(
    * [RcPlayerBackend.JAVA] / [RcPlayerBackend.CMP_ANDROID] lanes when this Remote Compose preview
    * has a daemon twin ([canRenderOverridesFor]) on a backend that honours the player override
    * ([remoteComposePlayerSelectable]). A preview with no `.rc` doc is not Remote Compose, so it
-   * gets no selector at all. [RcPlayerBackend.CMP_JVM] is never enabled (no Skiko draw path yet).
+   * gets no selector at all. [RcPlayerBackend.CMP_JVM] joins when the isolated desktop player is
+   * installed and the baked bundle can size a render for it ([supportsCmpJvm]).
    */
   override fun enabledRcPlayersFor(previewId: String): List<RcPlayerBackend> {
     if (!hasRemoteComposeDoc(previewId)) return emptyList()
@@ -273,6 +278,7 @@ class ServeCatalogLiveHost(
         add(RcPlayerBackend.JAVA)
         add(RcPlayerBackend.CMP_ANDROID)
       }
+      if (supportsCmpJvm(previewId)) add(RcPlayerBackend.CMP_JVM)
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -165,6 +165,25 @@ interface ServeHost : AutoCloseable {
   fun hasRemoteComposeDoc(previewId: String): Boolean = remoteComposeDoc(previewId) != null
 
   /**
+   * The pixel size and density a **cmp-jvm** render of [previewId] should use — matched to the
+   * baked View-player capture so the desktop-player PNG lands at the same size the viewer shows the
+   * other lanes at. Null when this host cannot supply one (no captured doc, or size metadata
+   * missing), in which case the cmp-jvm chip stays disabled. Only a bundle/catalog host that
+   * carries both the `ir/<id>.rc` sidecar and the baked `previews/<id>.png` returns a spec.
+   */
+  fun remoteComposeRenderSpec(previewId: String): RcJvmRenderSpec? = null
+
+  /**
+   * Whether the server-side **cmp-jvm** lane can render [previewId]: the host carries the captured
+   * document and a render spec, and the isolated desktop-player subprocess is installed
+   * ([RcJvmServerRenderer.isAvailable]). Hosts fold this into [enabledRcPlayersFor].
+   */
+  fun supportsCmpJvm(previewId: String): Boolean =
+    hasRemoteComposeDoc(previewId) &&
+      remoteComposeRenderSpec(previewId) != null &&
+      RcJvmServerRenderer.isAvailable()
+
+  /**
    * The Remote Compose render backends the viewer may offer for [previewId] as **enabled** options
    * — the subset of the fixed [RcPlayerBackend.UNIVERSE] this host can actually produce pixels
    * through. The viewer renders every backend as a chip and enables the ones returned here; the
@@ -179,7 +198,16 @@ interface ServeHost : AutoCloseable {
    * `remoteCompose.player`).
    */
   fun enabledRcPlayersFor(previewId: String): List<RcPlayerBackend> =
-    if (hasRemoteComposeDoc(previewId)) listOf(RcPlayerBackend.JS) else emptyList()
+    if (hasRemoteComposeDoc(previewId)) {
+      buildList {
+        add(RcPlayerBackend.JS)
+        // The desktop embedded player renders the same `.rc` server-side via an isolated
+        // subprocess; enable it wherever the sidecar player is installed and a render spec exists.
+        if (supportsCmpJvm(previewId)) add(RcPlayerBackend.CMP_JVM)
+      }
+    } else {
+      emptyList()
+    }
 
   /**
    * Whether this host's live render lane honours the Remote Compose **player** override

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2115,6 +2115,15 @@ class ServeHttpServer(
         }
         return@withLeasedSession
       }
+      // The cmp-jvm lane renders the captured document server-side with the embedded desktop player
+      // (an isolated subprocess), not through the daemon — so, like the `.rc` lane above, it
+      // short-circuits ahead of the daemon override parse and renders the base document (the
+      // browser
+      // JS lane is the one that layers live knob edits; cmp-jvm shows the captured doc).
+      if (call.request.queryParameters["rcPlayer"]?.lowercase() == RcPlayerBackend.CMP_JVM.wire) {
+        renderCmpJvmResponse(renderHost, previewId)
+        return@withLeasedSession
+      }
       // Forward the fixed render axes plus any dynamic override params (`knob.<key>=…` knobs and
       // `rc.<name>=…` Remote Compose seeds, neither in SUPPORTED_KEYS) so a live knob / Remote
       // Compose edit reaches ServeOverrides.parse instead of being silently dropped.
@@ -2219,6 +2228,58 @@ class ServeHttpServer(
           }
         }
       }
+    }
+  }
+
+  /**
+   * cmp-jvm lane of [handleRender]: render the captured document with the embedded desktop player
+   * in an isolated subprocess and respond the PNG. Load-shed through the same [renderSemaphore] as
+   * the daemon PNG lane. 404 when the preview carries no captured doc / render spec; 503 when the
+   * desktop player sidecar isn't installed or the queue is saturated; 500 when the player could not
+   * draw it.
+   */
+  private suspend fun RoutingContext.renderCmpJvmResponse(
+    renderHost: ServeHost,
+    previewId: String,
+  ) {
+    val doc = renderHost.remoteComposeDoc(previewId)
+    val spec = renderHost.remoteComposeRenderSpec(previewId)
+    if (doc == null || spec == null) {
+      call.respondText("no cmp-jvm render for this preview", status = HttpStatusCode.NotFound)
+      return
+    }
+    val result =
+      withContext(Dispatchers.IO) {
+        if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
+          null
+        } else {
+          try {
+            RcJvmServerRenderer.render(doc, spec)
+          } finally {
+            renderSemaphore.release()
+          }
+        }
+      }
+    when (result) {
+      null -> {
+        call.response.headers.append(HttpHeaders.RetryAfter, "2")
+        call.respondText(
+          "render queue saturated; retry shortly",
+          status = HttpStatusCode.ServiceUnavailable,
+        )
+      }
+      is RcJvmServerRenderer.RenderResult.Ok -> {
+        call.response.headers.append(HttpHeaders.CacheControl, DYNAMIC_RESOURCE_CACHE_CONTROL)
+        call.respondBytes(result.png, ContentType.Image.PNG)
+      }
+      is RcJvmServerRenderer.RenderResult.Unavailable -> {
+        // The chip is only offered when the sidecar is present, so this is a torn-down install
+        // rather than a user error; a retryable 503 with the search paths beats a hard 500.
+        call.response.headers.append(HttpHeaders.RetryAfter, "5")
+        call.respondText(result.reason, status = HttpStatusCode.ServiceUnavailable)
+      }
+      is RcJvmServerRenderer.RenderResult.Failed ->
+        call.respondText(result.reason, status = HttpStatusCode.InternalServerError)
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3793,12 +3793,18 @@ object ServeWeb {
         // knob; omitted when unchecked so the URL stays on the baked snapshot.
         var gc = document.getElementById("cp-gestures");
         if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-        // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-        // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-        // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-        // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-        // stays on the instant baked snapshot.
-        if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+        // Remote Compose render backend: a server-side player pick rides the render as
+        // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+        // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+        // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+        // (no server render), so it never sends the param, and an unpicked default stays on the
+        // instant baked snapshot.
+        if (
+          rcPlayerPicked &&
+          (rcPlayerBackend === "java" ||
+            rcPlayerBackend === "cmp-android" ||
+            rcPlayerBackend === "cmp-jvm")
+        ) {
           parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
         }
         return parts.join("&");

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmServeIntegrationTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmServeIntegrationTest.kt
@@ -1,0 +1,101 @@
+package ee.schimke.composeai.cli.serve
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The serve-side wiring of the cmp-jvm lane, exercised without Skiko: the render **spec** sourcing
+ * (baked PNG size + capture density) and the chip **enablement** gate ([ServeHost.supportsCmpJvm]).
+ * The actual pixel render runs in the isolated subprocess ([RcJvmServerRenderer]) and is covered by
+ * the jvm module's skiko-gated tests; here the sidecar is faked with an empty jar dir, so nothing
+ * native is touched.
+ */
+class RcJvmServeIntegrationTest {
+
+  private fun pngBytes(width: Int, height: Int): ByteArray {
+    val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    val out = ByteArrayOutputStream()
+    ImageIO.write(image, "png", out)
+    return out.toByteArray()
+  }
+
+  /**
+   * A bundle with a baked `previews/Foo.png` of the given size, optionally an `ir/Foo.rc` doc and a
+   * `previews.json` declaring [density].
+   */
+  private fun bundle(width: Int, height: Int, density: Float?, withDoc: Boolean = true): File {
+    val dir =
+      java.nio.file.Files.createTempDirectory("rcjvm-bundle").toFile().also { it.deleteOnExit() }
+    File(dir, "previews").mkdirs()
+    File(dir, "previews/Foo.png").writeBytes(pngBytes(width, height))
+    if (withDoc) {
+      File(dir, "ir").mkdirs()
+      File(dir, "ir/Foo.rc").writeBytes(byteArrayOf(1, 2, 3))
+    }
+    if (density != null) {
+      File(dir, "previews.json")
+        .writeText(
+          """
+          {"module":":m","variant":"debug","previews":[
+            {"id":"Foo","functionName":"Foo","className":"FooKt","params":{"density":$density}}]}
+          """
+            .trimIndent()
+        )
+    }
+    return dir
+  }
+
+  private fun jarDir(): File {
+    val dir = java.nio.file.Files.createTempDirectory("sidecar").toFile().also { it.deleteOnExit() }
+    File(dir, "x.jar").writeText("")
+    return dir
+  }
+
+  @Test
+  fun `render spec uses the baked png size and the manifest density`() {
+    val host = ServeBundleHost(bundle(width = 120, height = 80, density = 3.0f), label = "b")
+    assertEquals(RcJvmRenderSpec(120, 80, 3.0f), host.remoteComposeRenderSpec("Foo"))
+  }
+
+  @Test
+  fun `render spec falls back to the default density when the manifest declares none`() {
+    val host = ServeBundleHost(bundle(width = 120, height = 80, density = null), label = "b")
+    val spec = host.remoteComposeRenderSpec("Foo")
+    assertEquals(120, spec?.widthPx)
+    assertEquals(80, spec?.heightPx)
+    // ServeBundleHost.DEFAULT_RENDER_DENSITY — the desktop renderer's own default.
+    assertEquals(2.625f, spec?.density)
+  }
+
+  @Test
+  fun `render spec is null for a preview with no captured document`() {
+    val host = ServeBundleHost(bundle(120, 80, 3.0f, withDoc = false), label = "b")
+    assertNull(host.remoteComposeRenderSpec("Foo"))
+  }
+
+  @Test
+  fun `cmp-jvm chip is enabled only when the desktop-player sidecar is installed`() {
+    val host = ServeBundleHost(bundle(120, 80, 3.0f), label = "b")
+    // The JS lane always rides on a carried doc; cmp-jvm needs the sidecar, absent here.
+    assertTrue(RcPlayerBackend.JS in host.enabledRcPlayersFor("Foo"))
+    assertFalse(RcPlayerBackend.CMP_JVM in host.enabledRcPlayersFor("Foo"))
+
+    // Point both sidecar dirs at (empty-jar) temp dirs so RcJvmServerRenderer.isAvailable() is
+    // true.
+    System.setProperty("composeai.cli.libRcjvmDir", jarDir().absolutePath)
+    System.setProperty("composeai.cli.libDaemonDesktopDir", jarDir().absolutePath)
+    try {
+      assertTrue(RcPlayerBackend.CMP_JVM in host.enabledRcPlayersFor("Foo"))
+    } finally {
+      System.clearProperty("composeai.cli.libRcjvmDir")
+      System.clearProperty("composeai.cli.libDaemonDesktopDir")
+    }
+  }
+}

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -1132,12 +1132,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -1086,12 +1086,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -1084,12 +1084,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -1082,12 +1082,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -1080,12 +1080,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -1079,12 +1079,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -1085,12 +1085,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -1073,12 +1073,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -1077,12 +1077,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -1068,12 +1068,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -1080,12 +1080,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // knob; omitted when unchecked so the URL stays on the baked snapshot.
     var gc = document.getElementById("cp-gestures");
     if (gc && !gc.disabled && gc.checked) parts.push("gestures=true");
-    // Remote Compose render backend: a server-side player pick (java / cmp-android) rides the
-    // render as rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked)
-    // and only for a server-side lane — the js canvas replays the doc in-browser (no server
-    // render) and cmp-jvm can't render, so neither sends the param, and an unpicked default
-    // stays on the instant baked snapshot.
-    if (rcPlayerPicked && (rcPlayerBackend === "java" || rcPlayerBackend === "cmp-android")) {
+    // Remote Compose render backend: a server-side player pick rides the render as
+    // rcPlayer=<wire>. Emitted only once the visitor picks a backend (rcPlayerPicked) and only
+    // for a server-side lane — java / cmp-android render through the daemon, cmp-jvm through its
+    // isolated desktop subprocess (all three PNG lanes). The js canvas replays the doc in-browser
+    // (no server render), so it never sends the param, and an unpicked default stays on the
+    // instant baked snapshot.
+    if (
+      rcPlayerPicked &&
+      (rcPlayerBackend === "java" ||
+        rcPlayerBackend === "cmp-android" ||
+        rcPlayerBackend === "cmp-jvm")
+    ) {
       parts.push("rcPlayer=" + encodeURIComponent(rcPlayerBackend));
     }
     return parts.join("&");


### PR DESCRIPTION
## Summary

Follow-up to #3025 (the desktop/JVM embedded player + renderer). That PR proved the player produces previews; this one **wires it into the `compose-preview serve` viewer** so the `cmp-jvm` chip actually renders, instead of being shown-disabled.

The desktop embedded player needs Compose Desktop + Skiko's per-OS natives, which the cli deliberately keeps off its own classpath (so a cross-platform release doesn't bake in one host's natives). So `RcJvmServerRenderer` spawns the module's `RcJvmRenderMain` as a **one-shot subprocess** off an isolated classpath — the same isolation `BundleRenderer` uses for the desktop `@Preview` renderer.

## What the chip renders

The pixels the `cmp-jvm` chip serves for a preview — the captured document drawn by the desktop player (this is the render from #3025's `RcJvmRendererTest`):

![CMP JVM render](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/bacd0f5ef4f3cb6f30d1963819808873421fd2c5/third_party/rc-embedded-player-jvm/docs/renders/TitleCardRemote-jvm.png)``

## How it works

- **Build** (`cli/build.gradle.kts`): a `composePreviewRcJvm` sidecar configuration + `Sync` stage + `lib-rcjvm/` in the install image — carrying just the embedded jvm player (+ its Compose API deps), **no new native bundling**. The subprocess classpath joins `lib-rcjvm/*` with the desktop daemon's existing `lib-daemon-desktop/*` for the Compose Desktop runtime + Skiko natives. The boundary guard still passes (the jvm player never reaches the cli's own runtime classpath).
- **`RcJvmServerRenderer`**: writes the `.rc` to a temp file, spawns `java -cp lib-rcjvm:lib-daemon-desktop RcJvmRenderMain --input … --output … --width … --height … --density …`, reads the PNG back. Load-shed through the existing render semaphore; a timeout / non-zero exit surfaces the player's stderr reason.
- **Enablement** (`ServeHost.supportsCmpJvm` / `remoteComposeRenderSpec`): the chip lights only where a host carries the `.rc` doc, can size a render (baked PNG dimensions + the capture density from `previews.json`, else the renderer default), **and** the sidecar is installed. `ServeBundleHost` + `ServeCatalogLiveHost` implement it; a host without the sidecar shows the chip disabled exactly as before.
- **`ServeHttpServer`**: a `rcPlayer=cmp-jvm` branch that renders the captured document server-side, short-circuiting ahead of the daemon override parse (like the `.rc` lane). It renders the base document — the browser JS lane is the one that layers live knob edits.

## Test plan

- `./gradlew :cli:test --tests "*RcJvmServeIntegrationTest*"` — 4 tests, no Skiko: render-spec sizing (baked PNG size + `previews.json` density, default fallback, null without a doc) and the chip-enablement gate (off without the sidecar, on when `composeai.cli.libRcjvmDir` + `libDaemonDesktopDir` point at installed jars).
- `./gradlew :cli:checkCliDaemonLibraryBoundary` — the desktop player stays off the cli's own runtime classpath.
- `./gradlew :cli:installDist` populates `lib-rcjvm/` (45 jars). **Verified end-to-end locally**: running `RcJvmRenderMain` off the installed `lib-rcjvm` + `lib-daemon-desktop` (with Skiko natives) renders an `.rc` to a PNG at the requested size and density (500×300 @ 2.625 and 640×480 @ 2.0 both produced valid PNGs) — the exact subprocess `RcJvmServerRenderer` spawns.
- Serve golden fixtures (`*ServeWebFixture*`) and host tests (`*ServeBundleHostTest*`, `*ServeCatalogLiveHostTest*`) unchanged — the chip only appears when the sidecar sysprops are set, which the fixtures don't.

## Follow-ups (not in this PR)

- Applying live `rc.*` knob seeds to the cmp-jvm render (it currently renders the captured base document, matching the JS lane's replay).
- Per-preview density is sourced from `previews.json`; catalogs that don't declare one fall back to the renderer default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXNXNpWA4JUpN3m4mVD8zT)_