### PR TITLE
build(rc-embedded-player): publish the vendored embedded RC player for testing

### DIFF
--- a/third_party/rc-embedded-player/build.gradle.kts
+++ b/third_party/rc-embedded-player/build.gradle.kts
@@ -38,7 +38,10 @@
 
 plugins {
   id("composeai.base-conventions")
-  id("composeai.android-conventions")
+  // Published for TESTING only — see `composeAiMavenPublishing` below. This is a vendored AOSP
+  // snapshot, not a supported API; the coordinates exist so the embedded render lane can be pulled
+  // as an artifact. `composeai.maven-publishing` also applies `composeai.android-conventions`.
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
@@ -74,6 +77,26 @@ android {
   // The player reaches `androidx.compose.remote.core.*` members marked `@RestrictTo(LIBRARY_GROUP)`
   // — unavoidable for an out-of-tree copy of in-tree code. Upstream's module disables it too.
   lint { disable += "RestrictedApi" }
+}
+
+// Published under the compose-ai-tools group (`ee.schimke.composeai`, set by the convention plugin)
+// deliberately, NOT under `androidx.*` — that package name is only the vendored code's namespace,
+// kept verbatim so a snapshot refresh stays a plain `diff -r` (see PROVENANCE.md). This is a
+// testing
+// artifact for the embedded render lane, not a library intended for external consumption; the POM's
+// Apache-2.0 license and the retained AOSP source headers keep the vendored snapshot compliant.
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "third-party-rc-embedded-player",
+    displayName = "Compose Preview — Embedded Remote Compose Player (vendored, testing)",
+    description =
+      "Vendored snapshot of AndroidX's experimental Compose embedded Remote Compose player " +
+        "(RcPlayer), lifted from an androidx integration-test app that publishes no artifact of its " +
+        "own. Backs the embedded render/compare lane in compose-ai-tools. Published under " +
+        "ee.schimke.composeai for testing only — not a supported API and not intended for external " +
+        "use.",
+  )
+  inceptionYear.set("2026")
 }
 
 // Hand the render harness its input/output directories. Gradle properties rather than ambient env,


### PR DESCRIPTION
## Summary

Applies the `composeai.maven-publishing` convention plugin to `:third-party-rc-embedded-player` so it produces a Maven artifact and is picked up by the release publish chain, exactly like every other opted-in module. Until now this module applied no publishing plugin, so no artifact was produced for it.

**Coordinates:** `ee.schimke.composeai:third-party-rc-embedded-player` — under the compose-ai-tools group, **not** `androidx.*`. The `androidx.compose.remote.player.compose.embedded` string is only the vendored code's package/namespace, kept verbatim so a snapshot refresh stays a plain `diff -r` (see `PROVENANCE.md`); the Maven group is set to `ee.schimke.composeai` by the convention plugin.

## This is a testing artifact, not a library

The module is a **verbatim vendored snapshot** of AndroidX's experimental Compose embedded Remote Compose player (`RcPlayer`), which upstream ships only as integration-test-app sources with no artifact of its own. It backs the embedded render/compare lane here. It is **not a supported API and not intended for external consumption** — the POM description says so. Publishing it just makes the embedded render lane pullable as an artifact for testing.

- Apache-2.0 license is set in the generated POM (matches the retained AOSP source headers), so redistributing the vendored snapshot stays compliant.
- The Android library publishes a single `maven` publication (the release variant, via the vanniktech plugin's Android single-variant default).
- Only the Android player module is wired here; the JVM sibling (`:third-party-rc-embedded-player-jvm`) is left unpublished — say the word if you want it too.

## Test plan

- `./gradlew :third-party-rc-embedded-player:tasks --group publishing` — the full publish task set registers (`publishToMavenLocal`, `publishToMavenCentral`, `publishMavenPublicationToMavenLocal`, …), configuration succeeds.
- `./gradlew :third-party-rc-embedded-player:ktfmtCheck` — green.
- Text-only change: build wiring, no rendered surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX62hnwVtX6EnEQZ6FGbmH)_