### PR TITLE
feat(remotecompose): surface the captured .rc document as a fetchable data product

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
@@ -23,9 +23,12 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
 import ee.schimke.composeai.daemon.protocol.RemoteHostAction
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentPayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentProduct
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
 import ee.schimke.composeai.data.remotecompose.RemoteComposeProduct
+import ee.schimke.composeai.data.render.IrSidecarChannel
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtension
 import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
@@ -36,6 +39,7 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
 import ee.schimke.composeai.data.render.extensions.compose.ExtensionComposeContext
+import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -322,6 +326,7 @@ class RemoteComposePreviewOverrideExtension : DataExtension<PreviewOverrides> {
  */
 class RemoteComposeDataProductRegistry : DataProductRegistry {
   private val latestPayloads = ConcurrentHashMap<String, RemoteComposePayload>()
+  private val latestDocuments = ConcurrentHashMap<String, ByteArray>()
 
   override val capabilities: List<DataProductCapability> =
     listOf(
@@ -336,7 +341,17 @@ class RemoteComposeDataProductRegistry : DataProductRegistry {
         // (where the panel observes via `data/subscribe` rather than re-asking the dispatcher to
         // queue an extra render).
         requiresRerender = false,
-      )
+      ),
+      // The captured document (`.rc`). Fetching it needs no re-render — it's the byte stream the
+      // just-finished render already produced; a client fetches it once and takes the bytes.
+      DataProductCapability(
+        kind = DOC_KIND,
+        schemaVersion = DOC_SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      ),
     )
 
   fun capture(previewId: String?, payload: RemoteComposePayload) {
@@ -349,33 +364,81 @@ class RemoteComposeDataProductRegistry : DataProductRegistry {
     latestPayloads.remove(previewId)
   }
 
+  /**
+   * Drain this render's captured Remote Compose document (`.rc`) off [IrSidecarChannel] and hold it
+   * for a later `compose/remotecompose-doc` fetch. Runs on every render (from [onRender]), before
+   * the knob-state logic, so the document is captured even when the preview declared no editable
+   * knobs. [IrSidecarChannel.peek] first, then [IrSidecarChannel.consume] **only** when the format
+   * is Remote Compose — so a protolayout capture waiting for its own drainer is left untouched.
+   *
+   * Daemon-only: [onRender] is invoked exclusively by `JsonRpcServer` on the live render path, never
+   * by the batch renderer (which drains the channel itself via `RobolectricRenderTest.writeIrSidecar`
+   * to write the bundle's `ir/<id>.rc` sidecar), so this never competes with bundle capture.
+   */
+  private fun captureDocument(previewId: String) {
+    val capture = IrSidecarChannel.peek(previewId)
+    if (capture != null && capture.format == IrSidecarChannel.FORMAT_REMOTECOMPOSE) {
+      latestDocuments[previewId] = capture.bytes
+      IrSidecarChannel.consume(previewId)
+    } else {
+      latestDocuments.remove(previewId)
+    }
+  }
+
   override fun fetch(
     previewId: String,
     kind: String,
     params: JsonElement?,
     inline: Boolean,
   ): DataProductRegistry.Outcome {
-    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
-    val payload = latestPayloads[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
-    return DataProductRegistry.Outcome.Ok(
-      DataFetchResult(
-        kind = KIND,
-        schemaVersion = SCHEMA_VERSION,
-        payload = json.encodeToJsonElement(RemoteComposePayload.serializer(), payload),
-      )
-    )
+    return when (kind) {
+      KIND -> {
+        val payload = latestPayloads[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
+        DataProductRegistry.Outcome.Ok(
+          DataFetchResult(
+            kind = KIND,
+            schemaVersion = SCHEMA_VERSION,
+            payload = json.encodeToJsonElement(RemoteComposePayload.serializer(), payload),
+          )
+        )
+      }
+      DOC_KIND -> {
+        val bytes = latestDocuments[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
+        DataProductRegistry.Outcome.Ok(
+          DataFetchResult(
+            kind = DOC_KIND,
+            schemaVersion = DOC_SCHEMA_VERSION,
+            payload = json.encodeToJsonElement(documentPayloadSerializer, documentPayload(bytes)),
+          )
+        )
+      }
+      else -> DataProductRegistry.Outcome.Unknown
+    }
   }
 
   override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
-    if (KIND !in kinds) return emptyList()
-    val payload = latestPayloads[previewId] ?: return emptyList()
-    return listOf(
-      DataProductAttachment(
-        kind = KIND,
-        schemaVersion = SCHEMA_VERSION,
-        payload = json.encodeToJsonElement(RemoteComposePayload.serializer(), payload),
-      )
-    )
+    val out = mutableListOf<DataProductAttachment>()
+    if (KIND in kinds) {
+      latestPayloads[previewId]?.let { payload ->
+        out +=
+          DataProductAttachment(
+            kind = KIND,
+            schemaVersion = SCHEMA_VERSION,
+            payload = json.encodeToJsonElement(RemoteComposePayload.serializer(), payload),
+          )
+      }
+    }
+    if (DOC_KIND in kinds) {
+      latestDocuments[previewId]?.let { bytes ->
+        out +=
+          DataProductAttachment(
+            kind = DOC_KIND,
+            schemaVersion = DOC_SCHEMA_VERSION,
+            payload = json.encodeToJsonElement(documentPayloadSerializer, documentPayload(bytes)),
+          )
+      }
+    }
+    return out
   }
 
   override fun onRender(previewId: String, result: RenderResult) {
@@ -388,6 +451,9 @@ class RemoteComposeDataProductRegistry : DataProductRegistry {
     overrides: PreviewOverrides?,
     previewContext: PreviewContext?,
   ) {
+    // Independent of the knob state below — a preview can emit a document while declaring no knobs.
+    captureDocument(previewId)
+
     val namedValues = RemoteComposeController.namedValues.value
     val hostActions = RemoteComposeController.hostActions.value
     val profile = RemoteComposeController.profile.value
@@ -477,9 +543,18 @@ class RemoteComposeDataProductRegistry : DataProductRegistry {
     }
   }
 
+  private fun documentPayload(bytes: ByteArray): RemoteComposeDocumentPayload =
+    RemoteComposeDocumentPayload(documentBase64 = Base64.getEncoder().encodeToString(bytes))
+
   companion object {
     const val KIND: String = RemoteComposeProduct.KIND
     const val SCHEMA_VERSION: Int = RemoteComposeProduct.SCHEMA_VERSION
+
+    /** The captured-document facet — see [RemoteComposeDocumentProduct]. */
+    const val DOC_KIND: String = RemoteComposeDocumentProduct.KIND
+    const val DOC_SCHEMA_VERSION: Int = RemoteComposeDocumentProduct.SCHEMA_VERSION
+
+    private val documentPayloadSerializer = RemoteComposeDocumentPayload.serializer()
 
     private val json = Json {
       encodeDefaults = true

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
@@ -7,9 +7,12 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
 import ee.schimke.composeai.daemon.protocol.RemoteHostAction
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentPayload
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
+import ee.schimke.composeai.data.render.IrSidecarChannel
 import ee.schimke.composeai.data.render.PreviewContext
+import java.util.Base64
 import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
@@ -17,6 +20,7 @@ import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
 import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
 import kotlinx.serialization.json.Json
 import org.junit.After
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -28,6 +32,22 @@ class RemoteComposeDataProductTest {
   @After
   fun reset() {
     RemoteComposeController.resetForNewSession()
+    // The IR sidecar channel is process-static; drop anything a test left so it can't leak into
+    // the next one.
+    IrSidecarChannel.setCurrentPreviewId(null)
+    IrSidecarChannel.consume("preview-1")
+    IrSidecarChannel.consume("preview-2")
+  }
+
+  /** Stash [bytes] as [previewId]'s captured IR of [format], the way a render's producer would. */
+  private fun offerIr(
+    previewId: String,
+    bytes: ByteArray,
+    format: String = IrSidecarChannel.FORMAT_REMOTECOMPOSE,
+  ) {
+    IrSidecarChannel.setCurrentPreviewId(previewId)
+    IrSidecarChannel.offer(format, bytes)
+    IrSidecarChannel.setCurrentPreviewId(null)
   }
 
   @Test
@@ -64,9 +84,22 @@ class RemoteComposeDataProductTest {
 
   @Test
   fun capabilities_advertise_compose_remotecompose_as_inline_no_rerender_product() {
-    val cap = RemoteComposeDataProductRegistry().capabilities.single()
-    assertEquals("compose/remotecompose", cap.kind)
+    val cap =
+      RemoteComposeDataProductRegistry().capabilities.single { it.kind == "compose/remotecompose" }
     assertEquals(2, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertEquals(false, cap.requiresRerender)
+  }
+
+  @Test
+  fun capabilities_advertise_compose_remotecompose_doc_as_inline_no_rerender_product() {
+    val cap =
+      RemoteComposeDataProductRegistry().capabilities.single {
+        it.kind == "compose/remotecompose-doc"
+      }
+    assertEquals(1, cap.schemaVersion)
     assertEquals(DataProductTransport.INLINE, cap.transport)
     assertTrue(cap.attachable)
     assertTrue(cap.fetchable)
@@ -315,6 +348,86 @@ class RemoteComposeDataProductTest {
     assertEquals("label", payload.declarations[0].name)
     assertEquals(RemoteNamedValue.StringValue("Filled"), payload.declarations[0].default)
     assertEquals("stopColor", payload.declarations[1].name)
+  }
+
+  @Test
+  fun document_fetch_before_any_render_returns_not_available() {
+    val registry = RemoteComposeDataProductRegistry()
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/remotecompose-doc", params = null, inline = true),
+    )
+  }
+
+  @Test
+  fun on_render_captures_the_document_fetchable_as_base64() {
+    val registry = RemoteComposeDataProductRegistry()
+    val rc = byteArrayOf(1, 2, 3, 4, 5)
+    offerIr("preview-1", rc)
+
+    registry.onRender("preview-1", stubRenderResult(), overrides = null, previewContext = stubContext())
+
+    val outcome = registry.fetch("preview-1", "compose/remotecompose-doc", params = null, inline = true)
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val result = (outcome as DataProductRegistry.Outcome.Ok).result
+    assertEquals("compose/remotecompose-doc", result.kind)
+    val payload = Json.decodeFromJsonElement(RemoteComposeDocumentPayload.serializer(), result.payload!!)
+    assertArrayEquals(rc, Base64.getDecoder().decode(payload.documentBase64))
+    // The render drained the channel — a second render with nothing offered clears the document.
+    assertNull(IrSidecarChannel.peek("preview-1"))
+  }
+
+  @Test
+  fun the_document_is_captured_even_when_the_preview_declares_no_knobs() {
+    // The knob payload and the document are independent facets: a preview can emit a `.rc` while
+    // declaring zero editable knobs, and the empty-knob clear must not suppress the document.
+    val registry = RemoteComposeDataProductRegistry()
+    offerIr("preview-1", byteArrayOf(9, 9, 9))
+
+    registry.onRender("preview-1", stubRenderResult(), overrides = null, previewContext = stubContext())
+
+    assertEquals(
+      "no knobs → the knob facet is unavailable",
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/remotecompose", params = null, inline = true),
+    )
+    assertTrue(
+      "…but the captured document is still fetchable",
+      registry.fetch("preview-1", "compose/remotecompose-doc", params = null, inline = true)
+        is DataProductRegistry.Outcome.Ok,
+    )
+  }
+
+  @Test
+  fun a_render_with_no_capture_clears_a_stale_document() {
+    val registry = RemoteComposeDataProductRegistry()
+    offerIr("preview-1", byteArrayOf(7))
+    registry.onRender("preview-1", stubRenderResult(), overrides = null, previewContext = stubContext())
+    // Next render offers nothing — the previously captured document must not linger.
+    registry.onRender("preview-1", stubRenderResult(), overrides = null, previewContext = stubContext())
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/remotecompose-doc", params = null, inline = true),
+    )
+  }
+
+  @Test
+  fun a_protolayout_capture_is_left_for_its_own_drainer() {
+    // The RC drainer must not swallow another format's capture: it peeks, and only consumes a
+    // Remote Compose capture. A protolayout tile's IR stays put for its own consumer.
+    val registry = RemoteComposeDataProductRegistry()
+    offerIr("preview-1", byteArrayOf(4, 2), format = IrSidecarChannel.FORMAT_PROTOLAYOUT)
+
+    registry.onRender("preview-1", stubRenderResult(), overrides = null, previewContext = stubContext())
+
+    assertEquals(
+      "a non-RC capture yields no RC document",
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/remotecompose-doc", params = null, inline = true),
+    )
+    val left = IrSidecarChannel.peek("preview-1")
+    assertNotNull("the protolayout capture must survive the RC drainer", left)
+    assertEquals(IrSidecarChannel.FORMAT_PROTOLAYOUT, left!!.format)
   }
 
   private fun stubRenderResult(): RenderResult =

--- a/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
+++ b/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
@@ -22,6 +22,31 @@ object RemoteComposeProduct {
 }
 
 /**
+ * Stable identity of the `compose/remotecompose-doc` data product — the **document** a preview
+ * drew, distinct from the editable-knob state of [RemoteComposeProduct]. Where
+ * `compose/remotecompose` carries the named-value / host-action / knob surface, this carries the
+ * serialized Remote Compose document (`.rc`) the live render just captured (via
+ * `IrSidecarChannel`), so a client can take the bytes the composition produced instead of a
+ * pre-packed replay. The playground's remote-compose mode fetches this after a render to publish
+ * the document as a `/d/<id>` permalink.
+ *
+ * Kept in this alpha-free core module (beside [RemoteComposeProduct]) so a client can depend on the
+ * payload schema without the daemon-side registry or the `androidx.compose.remote.*` artifacts.
+ */
+object RemoteComposeDocumentProduct {
+  const val KIND: String = "compose/remotecompose-doc"
+  const val SCHEMA_VERSION: Int = 1
+}
+
+/**
+ * Wire-shape returned by `data/fetch?kind=compose/remotecompose-doc`: the serialized Remote Compose
+ * document (`.rc`) captured during the latest render, Base64-encoded (the `data/fetch` transport is
+ * JSON, so the raw bytes ride as text). [documentBase64] decodes to the exact `.rc` byte stream the
+ * vendored player consumes — the same bytes a bundle's `ir/<id>.rc` sidecar would carry.
+ */
+@Serializable data class RemoteComposeDocumentPayload(val documentBase64: String)
+
+/**
  * One editable Remote Compose named-value knob a preview declared during its render — the auto-
  * capture counterpart of a plain-Compose `compose/overrides`
  * [ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration]. A knob is declared whenever

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/IrSidecarChannel.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/IrSidecarChannel.kt
@@ -83,4 +83,13 @@ object IrSidecarChannel {
 
   /** Drain (read + remove) the IR captured for [previewId] during the just-finished render. */
   fun consume(previewId: String): IrCapture? = pending.remove(previewId)
+
+  /**
+   * Read the IR captured for [previewId] **without** removing it. Lets a consumer inspect a
+   * capture's [IrCapture.format] before deciding whether it owns it — a format-specific drainer
+   * (e.g. the daemon's Remote Compose data product) peeks first and only [consume]s when the format
+   * matches, so it never swallows another format's capture (a protolayout tile) that a different
+   * consumer is due to drain.
+   */
+  fun peek(previewId: String): IrCapture? = pending[previewId]
 }


### PR DESCRIPTION
## Summary

The daemon return path the playground's **remote-compose producer** needs. Today a live daemon render can only *replay* a bundle's pre-packed `ir/<id>.rc`; a freshly-rendered snippet's document — offered to `IrSidecarChannel` by `RemoteOverridablePreview` during composition — is **stranded**, because the only drainer is the batch renderer's `writeIrSidecar` (the bundle-build path, not the daemon). This adds a `compose/remotecompose-doc` data product so a client can fetch the exact `.rc` bytes the composition just produced.

### What changed

- **`IrSidecarChannel.peek`** — a non-removing read alongside `consume`, so a format-specific drainer can inspect a capture's format before claiming it.
- **`RemoteComposeDocumentProduct` / `RemoteComposeDocumentPayload`** (`compose/remotecompose-doc`, schema v1) in the alpha-free core module — the `.rc` bytes, Base64-encoded (the `data/fetch` transport is JSON).
- **`RemoteComposeDataProductRegistry`** now, in `onRender`, drains the Remote Compose capture and exposes it under the new kind (a second capability on the same registry; `fetch` + `attachmentsFor` handle both kinds).

### Why it's safe

- **Daemon-only.** `onRender` for data products is invoked *solely* by `JsonRpcServer` on the live render path — never by the batch `RobolectricRenderTest`, which drains the channel itself via `writeIrSidecar`. So this never competes with bundle `.rc` capture.
- **Doesn't steal other formats.** The drainer `peek`s first and only `consume`s a `FORMAT_REMOTECOMPOSE` capture — a protolayout tile's IR is left in place for its own consumer.
- **Independent of the knob facet.** The document is captured before the knob-state logic, so a preview that emits a `.rc` while declaring zero editable knobs still surfaces the document (guarded by a test).

## Test plan

- [x] `./gradlew :data-remotecompose-connector:test` — **BUILD SUCCESSFUL**. New cases: capture → fetch decodes to the exact bytes; not-available before a render; captured even with no knobs; a no-capture render clears a stale document; a protolayout capture survives the RC drainer; both `compose/remotecompose` and `compose/remotecompose-doc` capabilities advertised.
- [x] `./gradlew ktfmtFormat` — clean.

The new logic is unit-tested in plain JVM (`IrSidecarChannel`, the registry). The live Android/Robolectric render that *populates* the channel runs under the daemon runtime and is exercised by CI, not reproducible in this sandbox — so no rendered evidence applies (non-visual daemon plumbing).

## Follow-up

The cli half of the producer, landing next: `PlaygroundCompileService.captureRemoteDocument` wired to open an Android daemon session over the compiled snippet's `classesDir`, `renderNow(previewId)`, then `fetchData(previewId, "compose/remotecompose-doc")` → publish the `.rc` as a `/d/<id>` permalink (the seam added in #3028), plus the `ServeCommand` Android/RC classpath wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_