### PR TITLE
feat(playground): render remote-compose snippets on the Android daemon → /d/&lt;id&gt;

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -64,6 +64,7 @@ internal object CliFlags {
       "--accept-docs-from",
       "--doc-ttl",
       "--playground-bundle",
+      "--playground-android-bundle",
       "--extra-maven-repos",
       "--trust-store",
       "--catalogs",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -11,6 +11,7 @@ import ee.schimke.composeai.cli.serve.PlaygroundCatalogClasspath
 import ee.schimke.composeai.cli.serve.PlaygroundCompileService
 import ee.schimke.composeai.cli.serve.PlaygroundMode
 import ee.schimke.composeai.cli.serve.PlaygroundPreviewDiscoverer
+import ee.schimke.composeai.cli.serve.PlaygroundRcCaptureService
 import ee.schimke.composeai.cli.serve.PlaygroundTokenStore
 import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundle
@@ -46,6 +47,7 @@ import ee.schimke.composeai.cli.serve.declaredThemesFromPreviews
 import ee.schimke.composeai.cli.serve.detectedFeaturesOf
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.render.session.RenderSessionException
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
 import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -239,6 +241,15 @@ class ServeCommand(args: List<String>) : Command(args) {
    * compile runs **user-supplied code** in-process). See docs/design/PLAYGROUND.md.
    */
   private val playgroundBundlePath: String? = args.flagValue("--playground-bundle")
+
+  /**
+   * `--playground-android-bundle <path>`: enable the playground's **Android / Remote Compose**
+   * compile lane, resolving its classpath from this Android catalog liveBundle. Snippets sent with
+   * `confType=remote-compose` compile against it, render on the Robolectric daemon, and their
+   * captured `.rc` is published as a `/d/<id>` permalink (needs the `lib-daemon-android` sidecar +
+   * `android.jar` + the `/d/` document store). Refused under `--public` like `--playground-bundle`.
+   */
+  private val playgroundAndroidBundlePath: String? = args.flagValue("--playground-android-bundle")
 
   /**
    * Extra remote Maven repository base URLs the live-daemon classpath resolver may fetch from, on
@@ -842,29 +853,28 @@ class ServeCommand(args: List<String>) : Command(args) {
    * server" model forbids (docs/design/PLAYGROUND.md § isolation). Fail-soft: any missing piece
    * (bundle unresolvable, no `lib-bta/`) logs why and disables the lane rather than aborting serve.
    */
-  private fun openPlaygroundService(): PlaygroundCompileService? {
-    val bundlePath = playgroundBundlePath ?: return null
+  private fun openPlaygroundService(docStore: ServeDocStore?): PlaygroundCompileService? {
+    val cmpBundle = playgroundBundlePath
+    val androidBundle = playgroundAndroidBundlePath
+    if (cmpBundle == null && androidBundle == null) return null
     if (public) {
       System.err.println(
-        "serve: --playground-bundle is refused under --public — it compiles and runs user-supplied " +
-          "code in-process. Omit --public to enable the playground."
+        "serve: --playground-bundle / --playground-android-bundle are refused under --public — they " +
+          "compile and run user-supplied code in-process. Omit --public to enable the playground."
       )
       return null
     }
     val workRoot = java.nio.file.Files.createTempDirectory("compose-playground").toFile()
-    val classpath =
-      PlaygroundCatalogClasspath.resolve(
-        bundleFile = java.io.File(bundlePath),
-        destDir = java.io.File(workRoot, "catalog"),
-        system = "playground",
-        onLog = { System.err.println("serve playground: $it") },
-      )
-    if (classpath == null) {
-      System.err.println(
-        "serve: --playground-bundle could not resolve a classpath from $bundlePath; playground disabled."
-      )
+
+    val cmpClasspath = cmpBundle?.let { resolvePlaygroundClasspath(it, workRoot, "cmp") }
+    val androidClasspath = androidBundle?.let {
+      resolvePlaygroundClasspath(it, workRoot, "android")
+    }
+    if (cmpClasspath == null && androidClasspath == null) {
+      System.err.println("serve: playground resolved no compile classpath; playground disabled.")
       return null
     }
+
     val compiler = PlaygroundBtaCompiler.fromInstall(java.io.File(workRoot, "bta-ic").toPath())
     if (compiler == null) {
       System.err.println(
@@ -873,18 +883,127 @@ class ServeCommand(args: List<String>) : Command(args) {
       )
       return null
     }
+
+    // Remote-compose mode needs the Android compile classpath, the Robolectric daemon sidecar, and
+    // a
+    // `/d/` document store to publish into. Absent any of the three it stays unavailable while CMP
+    // is
+    // unaffected.
+    val rcCapture =
+      if (androidClasspath != null) buildPlaygroundRcCaptureService(workRoot, docStore) else null
+
     System.err.println(
-      "serve: playground enabled (POST /api/1/compiler/run) — CMP snippets compile against $bundlePath"
+      "serve: playground enabled (POST /api/1/compiler/run) — " +
+        listOfNotNull(
+            cmpClasspath?.let { "cmp✓" },
+            androidClasspath?.let { "android✓" },
+            rcCapture?.let { "remote-compose✓" },
+          )
+          .joinToString(" ")
     )
+
     val snippetCounter = java.util.concurrent.atomic.AtomicLong()
     return PlaygroundCompileService(
-      catalogClasspath = { mode -> if (mode == PlaygroundMode.CMP) classpath else null },
+      catalogClasspath = { mode ->
+        when (mode) {
+          PlaygroundMode.CMP -> cmpClasspath
+          PlaygroundMode.ANDROID,
+          PlaygroundMode.REMOTE_COMPOSE -> androidClasspath
+        }
+      },
       compiler = compiler,
       discoverer = PlaygroundPreviewDiscoverer(),
       tokenStore = PlaygroundTokenStore(),
       newWorkDir = {
         java.io.File(workRoot, "snippet-${snippetCounter.incrementAndGet()}").absolutePath.toPath()
       },
+      captureRemoteDocument = { snippet -> rcCapture?.capture(snippet) },
+      publishRemoteDocument = { name, bytes, checked ->
+        (docStore?.add(name, bytes, isSecurityChecked = checked) as? ServeDocStore.Result.Ok)
+          ?.doc
+          ?.path
+      },
+    )
+  }
+
+  /** Resolve a playground compile classpath from a catalog liveBundle; null (logged) on failure. */
+  private fun resolvePlaygroundClasspath(
+    bundlePath: String,
+    workRoot: java.io.File,
+    system: String,
+  ): PlaygroundCompileService.Classpath? {
+    val classpath =
+      PlaygroundCatalogClasspath.resolve(
+        bundleFile = java.io.File(bundlePath),
+        destDir = java.io.File(workRoot, "catalog-$system"),
+        system = "playground-$system",
+        onLog = { System.err.println("serve playground: $it") },
+      )
+    if (classpath == null) {
+      System.err.println(
+        "serve: playground could not resolve a $system classpath from $bundlePath; that mode disabled."
+      )
+    }
+    return classpath
+  }
+
+  /**
+   * Assemble the Android/Robolectric capture backend for the playground's remote-compose mode — the
+   * `lib-daemon-android` sidecar + `android.jar` on the daemon classpath, the Robolectric
+   * jvmArgs/sysprops, and a subprocess `openBundleDaemon` opener. Mirrors [ServeBundleDaemon]'s
+   * `androidBundleDaemonLaunch`. Returns null (logging why) when the sidecar, `android.jar`, or the
+   * `/d/` document store is missing — remote-compose then reports unavailable rather than compiling
+   * to a dead end.
+   */
+  private fun buildPlaygroundRcCaptureService(
+    workRoot: java.io.File,
+    docStore: ServeDocStore?,
+  ): PlaygroundRcCaptureService? {
+    if (docStore == null) {
+      System.err.println(
+        "serve: playground remote-compose mode needs the /d/ document store — enable it with " +
+          "--docs. Remote-compose mode disabled."
+      )
+      return null
+    }
+    val daemonJars = locateBundleSidecarJars("lib-daemon-android")
+    if (daemonJars.isEmpty()) {
+      System.err.println(
+        "serve: playground remote-compose mode needs the Android daemon sidecar " +
+          "(lib-daemon-android/), which ships separately as " +
+          "compose-preview-android-daemon-<version>.zip; unpack it and set " +
+          "-Dcomposeai.cli.libDaemonAndroidDir=<dir>/lib-daemon-android. Remote-compose disabled."
+      )
+      return null
+    }
+    val androidJar =
+      AndroidBundleLaunch.resolveAndroidJar(localPropertiesFile = null)
+        ?: run {
+          System.err.println(
+            "serve: playground remote-compose mode needs android.jar — set ANDROID_HOME / " +
+              "ANDROID_SDK_ROOT. Remote-compose mode disabled."
+          )
+          return null
+        }
+    val launch = AndroidBundleLaunch()
+    val daemonClasspath = (daemonJars + listOf(androidJar)).map { it.absolutePath }
+    val jvmArgs = launch.jvmArgs()
+    val sysprops = launch.robolectricSystemProperties()
+    val captureCounter = java.util.concurrent.atomic.AtomicLong()
+    return PlaygroundRcCaptureService(
+      openSession = { classesDir, previewsJson, workspaceRoot, userClasspath ->
+        SubprocessRenderSessions.openBundleDaemon(
+          daemonClasspath = daemonClasspath,
+          classesDir = classesDir,
+          previewsJson = previewsJson,
+          workspaceRoot = workspaceRoot,
+          modulePath = ":playground",
+          jvmArgs = jvmArgs,
+          extraSystemProperties = sysprops,
+          userClasspath = userClasspath,
+        )
+      },
+      newWorkDir = { java.io.File(workRoot, "rc-capture-${captureCounter.incrementAndGet()}") },
     )
   }
 
@@ -999,6 +1118,9 @@ class ServeCommand(args: List<String>) : Command(args) {
       } else {
         null
       }
+    // Resolved once so the playground's remote-compose lane publishes into the SAME store the `/d/`
+    // route serves from — otherwise a minted `/d/<id>` link wouldn't resolve.
+    val docStore = openDocStore()
     val server =
       ServeHttpServer(
         host = host,
@@ -1023,8 +1145,8 @@ class ServeCommand(args: List<String>) : Command(args) {
         catalogAdmin = catalogAdmin,
         trustAdmin = trustAdmin,
         adminToken = adminToken,
-        docStore = openDocStore(),
-        playgroundService = openPlaygroundService(),
+        docStore = docStore,
+        playgroundService = openPlaygroundService(docStore),
       )
     if (trustAdmin != null) {
       System.err.println(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -907,8 +907,11 @@ class ServeCommand(args: List<String>) : Command(args) {
       catalogClasspath = { mode ->
         when (mode) {
           PlaygroundMode.CMP -> cmpClasspath
-          PlaygroundMode.ANDROID,
-          PlaygroundMode.REMOTE_COMPOSE -> androidClasspath
+          PlaygroundMode.ANDROID -> androidClasspath
+          // Only advertise REMOTE_COMPOSE when its capture backend actually came up — otherwise the
+          // host would accept the mode, run a full Android compile, then report the preview drew no
+          // document. A null classpath routes to the existing "mode … is not available" response.
+          PlaygroundMode.REMOTE_COMPOSE -> androidClasspath?.takeIf { rcCapture != null }
         }
       },
       compiler = compiler,
@@ -962,7 +965,7 @@ class ServeCommand(args: List<String>) : Command(args) {
     if (docStore == null) {
       System.err.println(
         "serve: playground remote-compose mode needs the /d/ document store — enable it with " +
-          "--docs. Remote-compose mode disabled."
+          "--accept-docs. Remote-compose mode disabled."
       )
       return null
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureService.kt
@@ -90,6 +90,19 @@ class PlaygroundRcCaptureService(
   }
 
   private fun renderAndFetch(session: RenderSession, previewId: String): ByteArray? {
+    // The daemon registers `data/remotecompose` **inactive** (like every extension): its `onRender`
+    // hook — the one that drains the `.rc` off `IrSidecarChannel` into `compose/remotecompose-doc`
+    // —
+    // runs only while the extension is active (`JsonRpcServer.handleRenderFinished` feeds
+    // `activeDataProducts().onRender(...)`), and `fetchData` rejects the kind as "not advertised"
+    // until it's enabled. So enable it before rendering, or the capture silently draws nothing.
+    // An unknown/rejected id (or an enable RPC failure) means the backend carries no Remote Compose
+    // runtime — a clean "no document", handled like every other miss below.
+    val enabled =
+      runCatching { session.enableExtensions(listOf(REMOTE_COMPOSE_EXTENSION_ID)) }.getOrNull()
+        ?: return null
+    if (REMOTE_COMPOSE_EXTENSION_ID in enabled.unknown) return null
+
     val latch = CountDownLatch(1)
     val failure = AtomicReference<String?>()
     val handle = session.onNotification { method, params ->
@@ -145,6 +158,13 @@ class PlaygroundRcCaptureService(
   }
 
   companion object {
+    /**
+     * The daemon's Remote Compose extension **id** (`DaemonMain`'s `tryAdd("data/remotecompose")`)
+     * — distinct from the data-product **kind** `compose/remotecompose(-doc)`. `extensions/enable`
+     * resolves by extension id, so this is what activates the document-capture `onRender` hook.
+     */
+    const val REMOTE_COMPOSE_EXTENSION_ID: String = "data/remotecompose"
+
     /** Cold Android/Robolectric renders take tens of seconds; budget generously. */
     val DEFAULT_RENDER_BUDGET: Duration = 180.seconds
     val DEFAULT_ACK_TIMEOUT: Duration = 30.seconds

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureService.kt
@@ -1,0 +1,157 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.PreviewInfo
+import ee.schimke.composeai.cli.PreviewManifest
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentPayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentProduct
+import ee.schimke.composeai.render.session.RenderSession
+import java.io.File
+import java.util.Base64
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * The production [PlaygroundCompileService] `captureRemoteDocument`: render a freshly-compiled
+ * **remote-compose** snippet on an Android/Robolectric daemon and return the serialized Remote
+ * Compose document (`.rc`) it drew — the bytes the playground then publishes as a `/d/<id>`
+ * permalink (`docs/design/PLAYGROUND.md` §3, epic #3014).
+ *
+ * The flow mirrors `ServeRenderHost.render`'s open → render → await → fetch shape, over a
+ * bundle-less daemon standing on the snippet's own compiled classes:
+ *
+ * 1. synthesize a one-preview `previews.json` from the snippet's discovered `@Preview` id;
+ * 2. [openSession] over the snippet's `classesDir` + full compile classpath (the production opener
+ *    is [SubprocessRenderSessions.openBundleDaemon] with the Android backend — `lib-daemon-android`
+ *     + `android.jar` on the daemon classpath, the Robolectric jvmArgs/sysprops, and the snippet
+ *       classpath as `userClassDirs`);
+ * 3. `renderNow` the preview and await its terminal `renderFinished` / `renderFailed` notification
+ *    — the render is what drives `RemoteOverridablePreview` to capture the `.rc` into the daemon's
+ *    `compose/remotecompose-doc` product;
+ * 4. `fetchData(compose/remotecompose-doc)` and Base64-decode the document bytes.
+ *
+ * [openSession] is injected so the orchestration is unit-testable against a fake `RenderSession`
+ * without a real daemon subprocess (the same seam split `PlaygroundCompileService` uses for its
+ * other collaborators). Returns null — a clean "no document" — on any miss: the mode couldn't
+ * queue, the render failed or timed out, or the preview drew no Remote Compose document.
+ */
+class PlaygroundRcCaptureService(
+  private val openSession: SessionOpener,
+  /** Mints a fresh scratch dir per capture (holds the synthesized manifest + render outputs). */
+  private val newWorkDir: () -> File,
+  private val renderBudget: Duration = DEFAULT_RENDER_BUDGET,
+  private val ackTimeout: Duration = DEFAULT_ACK_TIMEOUT,
+) {
+
+  /**
+   * Opens a render session over a compiled snippet. Production binds this to the Android
+   * `openBundleDaemon`; tests supply a fake session.
+   */
+  fun interface SessionOpener {
+    fun open(
+      classesDir: File,
+      previewsJson: File,
+      workspaceRoot: File,
+      userClasspath: List<String>,
+    ): RenderSession
+  }
+
+  /**
+   * The [PlaygroundCompileService] `captureRemoteDocument` seam: snippet → `.rc` bytes, or null.
+   */
+  fun capture(snippet: PlaygroundTokenStore.PlaygroundSnippet): ByteArray? {
+    val workDir = newWorkDir().apply { mkdirs() }
+    return try {
+      val previewsJson =
+        File(workDir, "previews.json").apply { writeText(previewsManifestJson(snippet)) }
+      // The playground's classpath entries are already absolute okio paths; File(toString()) is the
+      // safe bridge to the java.io.File the render-session API takes.
+      val classesDir = File(snippet.classesDir.toString())
+      val userClasspath = snippet.classpath.map { File(it.toString()).absolutePath }
+      val session = openSession.open(classesDir, previewsJson, workDir, userClasspath)
+      try {
+        renderAndFetch(session, snippet.previewId)
+      } finally {
+        runCatching { session.close() }
+      }
+    } catch (_: Exception) {
+      // A capture failure is a clean "no document" to the caller (which reports the RC failure);
+      // it must never escape as a throwable out of the render seam.
+      null
+    } finally {
+      runCatching { workDir.deleteRecursively() }
+    }
+  }
+
+  private fun renderAndFetch(session: RenderSession, previewId: String): ByteArray? {
+    val latch = CountDownLatch(1)
+    val failure = AtomicReference<String?>()
+    val handle = session.onNotification { method, params ->
+      if (params == null) return@onNotification
+      val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
+      if (id != previewId) return@onNotification
+      when (method) {
+        "renderFinished" -> latch.countDown()
+        "renderFailed" -> {
+          failure.set(
+            params["error"]?.jsonObject?.get("message")?.jsonPrimitive?.contentOrNull
+              ?: "daemon reported renderFailed"
+          )
+          latch.countDown()
+        }
+      }
+    }
+    return handle.use {
+      val ack =
+        session.renderNow(listOf(previewId), reason = "playground-rc-capture", timeout = ackTimeout)
+      if (ack.rejected.isNotEmpty()) return@use null
+      if (!latch.await(renderBudget.inWholeMilliseconds, TimeUnit.MILLISECONDS)) return@use null
+      if (failure.get() != null) return@use null
+      val result = session.fetchData(previewId, RemoteComposeDocumentProduct.KIND)
+      val payloadJson = result.payload ?: return@use null
+      val payload =
+        json.decodeFromJsonElement(RemoteComposeDocumentPayload.serializer(), payloadJson)
+      runCatching { Base64.getDecoder().decode(payload.documentBase64) }.getOrNull()
+    }
+  }
+
+  /**
+   * A one-preview `previews.json` the daemon can render: the snippet's discovered id split back
+   * into its `className` + `functionName` (the id is `"$className.$methodName"`, per
+   * [PlaygroundPreviewDiscoverer]).
+   */
+  private fun previewsManifestJson(snippet: PlaygroundTokenStore.PlaygroundSnippet): String {
+    val id = snippet.previewId
+    val manifest =
+      PreviewManifest(
+        module = snippet.moduleName,
+        variant = "",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = id,
+              functionName = id.substringAfterLast('.'),
+              className = id.substringBeforeLast('.'),
+            )
+          ),
+      )
+    return json.encodeToString(PreviewManifest.serializer(), manifest)
+  }
+
+  companion object {
+    /** Cold Android/Robolectric renders take tens of seconds; budget generously. */
+    val DEFAULT_RENDER_BUDGET: Duration = 180.seconds
+    val DEFAULT_ACK_TIMEOUT: Duration = 30.seconds
+
+    private val json = Json {
+      encodeDefaults = true
+      ignoreUnknownKeys = true
+    }
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -97,6 +97,12 @@ internal class FakeRenderSession(
    */
   private val figmaSvgAvailable: Boolean = true,
   /**
+   * Extension ids the modelled daemon does not carry — [enableExtensions] returns them in
+   * [ExtensionsEnableResult.unknown] (e.g. a backend with no Remote Compose runtime rejects
+   * `data/remotecompose`). Empty by default.
+   */
+  private val unknownExtensionIds: Set<String> = emptySet(),
+  /**
    * Stubs [fetchData] for kinds this fake doesn't model natively (e.g.
    * `compose/remotecompose-doc`). Consulted first; a non-null return short-circuits the built-in
    * figma-svg / semantics handling.
@@ -364,10 +370,12 @@ internal class FakeRenderSession(
   ): ExtensionsEnableResult {
     enabledExtensionIds.addAll(ids)
     val figmaKinds = setOf(ComposeFigmaSvgProduct.KIND, ComposeFigmaSvgProduct.KIND_LONG)
-    val (figma, other) = ids.partition { it in figmaKinds }
-    // A backend without figma-svg reports those ids as unknown; everything else enables.
-    val unknown = if (figmaSvgAvailable) emptyList() else figma
-    val enabled = if (figmaSvgAvailable) ids else other
+    // A backend without figma-svg reports those ids as unknown, as does any id in
+    // [unknownExtensionIds]; everything else enables.
+    val unknown = ids.filter {
+      it in unknownExtensionIds || (!figmaSvgAvailable && it in figmaKinds)
+    }
+    val enabled = ids - unknown.toSet()
     return ExtensionsEnableResult(newlyEnabled = enabled, unknown = unknown)
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -96,6 +96,12 @@ internal class FakeRenderSession(
    * without it (the ids come back in [ExtensionsEnableResult.unknown]).
    */
   private val figmaSvgAvailable: Boolean = true,
+  /**
+   * Stubs [fetchData] for kinds this fake doesn't model natively (e.g.
+   * `compose/remotecompose-doc`). Consulted first; a non-null return short-circuits the built-in
+   * figma-svg / semantics handling.
+   */
+  private val fetchDataHook: ((previewId: String, kind: String) -> DataFetchResult?)? = null,
 ) : RenderSession {
   val renderCount = AtomicInteger(0)
 
@@ -296,6 +302,9 @@ internal class FakeRenderSession(
     params: JsonElement?,
     timeout: kotlin.time.Duration,
   ): DataFetchResult {
+    fetchDataHook?.invoke(previewId, kind)?.let {
+      return it
+    }
     if (kind == ComposeFigmaSvgProduct.KIND) {
       val file = File(renderRoot, "$previewId/${ComposeFigmaSvgProduct.FILE_SVG}")
       return DataFetchResult(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureServiceTest.kt
@@ -83,10 +83,36 @@ class PlaygroundRcCaptureServiceTest {
     val bytes = svc.capture(snippet())
 
     assertEquals(rc.toList(), bytes?.toList())
+    // The `data/remotecompose` extension must be enabled (it registers inactive) or the daemon's
+    // document-capture `onRender` hook never runs and the fetch comes back empty.
+    assertTrue(
+      "data/remotecompose" in fake.enabledExtensionIds,
+      "the RC extension must be enabled before the render captures the document",
+    )
     val preview = seenManifest!!.previews.single()
     assertEquals("com.example.SnippetKt.RemotePreview", preview.id)
     assertEquals("com.example.SnippetKt", preview.className)
     assertEquals("RemotePreview", preview.functionName)
+  }
+
+  @Test
+  fun `a backend without the remote-compose extension yields null`() {
+    // The daemon reports `data/remotecompose` unknown (no Remote Compose runtime). Even though the
+    // fetch hook would hand back a document, capture must fail soft — the extension never
+    // activated.
+    val rc = byteArrayOf(9, 8, 7)
+    val fake =
+      FakeRenderSession(
+        renderRoot = tmp(),
+        unknownExtensionIds = setOf("data/remotecompose"),
+        fetchDataHook = { _, kind ->
+          if (kind == "compose/remotecompose-doc") docResult(rc) else null
+        },
+      )
+    val svc =
+      PlaygroundRcCaptureService(openSession = { _, _, _, _ -> fake }, newWorkDir = { tmp() })
+
+    assertNull(svc.capture(snippet()))
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureServiceTest.kt
@@ -1,0 +1,133 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.PreviewManifest
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentPayload
+import java.io.File
+import java.util.Base64
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+
+/**
+ * The Android/Remote-Compose capture orchestrator: previews.json synthesis, render→await→fetch, and
+ * document decode — driven against a fake render session (no real daemon subprocess).
+ */
+class PlaygroundRcCaptureServiceTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+  private val tmpDirs = mutableListOf<File>()
+
+  private fun tmp(): File =
+    java.nio.file.Files.createTempDirectory("rc-capture-test").toFile().also { tmpDirs += it }
+
+  @AfterTest
+  fun cleanup() {
+    tmpDirs.forEach { it.deleteRecursively() }
+  }
+
+  private fun snippet(previewId: String = "com.example.SnippetKt.RemotePreview") =
+    PlaygroundTokenStore.PlaygroundSnippet(
+      mode = PlaygroundMode.REMOTE_COMPOSE,
+      workDir = "/work".toPath(),
+      classesDir = "/work/classes".toPath(),
+      classpath = listOf("/catalog/app.jar".toPath(), "/work/classes".toPath()),
+      moduleName = "playground-android",
+      previewId = previewId,
+    )
+
+  private fun docResult(bytes: ByteArray) =
+    DataFetchResult(
+      kind = "compose/remotecompose-doc",
+      schemaVersion = 1,
+      payload =
+        json.encodeToJsonElement(
+          RemoteComposeDocumentPayload.serializer(),
+          RemoteComposeDocumentPayload(Base64.getEncoder().encodeToString(bytes)),
+        ),
+    )
+
+  @Test
+  fun `a rendered snippet's document is captured, and previews_json is synthesized from its id`() {
+    val rc = byteArrayOf(1, 2, 3, 4, 5)
+    val fake =
+      FakeRenderSession(
+        renderRoot = tmp(),
+        fetchDataHook = { _, kind ->
+          if (kind == "compose/remotecompose-doc") docResult(rc) else null
+        },
+      )
+    var seenManifest: PreviewManifest? = null
+    val svc =
+      PlaygroundRcCaptureService(
+        openSession = { classesDir, previewsJson, _, userClasspath ->
+          assertTrue(previewsJson.exists(), "the manifest is written before the session opens")
+          seenManifest =
+            json.decodeFromString(PreviewManifest.serializer(), previewsJson.readText())
+          assertEquals("/work/classes", classesDir.path)
+          assertTrue(
+            userClasspath.any { it.endsWith("app.jar") },
+            "catalog jars ride userClasspath",
+          )
+          fake
+        },
+        newWorkDir = { tmp() },
+      )
+
+    val bytes = svc.capture(snippet())
+
+    assertEquals(rc.toList(), bytes?.toList())
+    val preview = seenManifest!!.previews.single()
+    assertEquals("com.example.SnippetKt.RemotePreview", preview.id)
+    assertEquals("com.example.SnippetKt", preview.className)
+    assertEquals("RemotePreview", preview.functionName)
+  }
+
+  @Test
+  fun `a render that produces no document yields null`() {
+    val fake =
+      FakeRenderSession(
+        renderRoot = tmp(),
+        // The product reports nothing captured (null payload) — a non-RC @Preview.
+        fetchDataHook = { _, kind ->
+          if (kind == "compose/remotecompose-doc")
+            DataFetchResult(kind = kind, schemaVersion = 1, payload = null)
+          else null
+        },
+      )
+    val svc =
+      PlaygroundRcCaptureService(openSession = { _, _, _, _ -> fake }, newWorkDir = { tmp() })
+
+    assertNull(svc.capture(snippet()))
+  }
+
+  @Test
+  fun `a render that never finishes times out to null`() {
+    // renderHook that emits nothing models a render whose terminal event never arrives.
+    val fake = FakeRenderSession(renderRoot = tmp(), renderHook = { _, _ -> })
+    val svc =
+      PlaygroundRcCaptureService(
+        openSession = { _, _, _, _ -> fake },
+        newWorkDir = { tmp() },
+        renderBudget = 200.milliseconds,
+        ackTimeout = 1.seconds,
+      )
+
+    assertNull(svc.capture(snippet()))
+  }
+
+  @Test
+  fun `a rejected render yields null`() {
+    val fake = FakeRenderSession(renderRoot = tmp(), rejectAll = true)
+    val svc =
+      PlaygroundRcCaptureService(openSession = { _, _, _, _ -> fake }, newWorkDir = { tmp() })
+
+    assertNull(svc.capture(snippet()))
+  }
+}

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -88,10 +88,22 @@ object SubprocessRenderSessions : RenderSessionFactory {
    * schema version and field names stay owned by the module that owns [DaemonLaunchDescriptor].
    *
    * @param daemonClasspath absolute paths of every jar on the daemon subprocess classpath.
-   * @param classesDir directory holding the bundle's extracted `classes/app.jar` contents.
+   * @param classesDir directory holding the bundle's extracted `classes/app.jar` contents; also the
+   *   default single entry of [userClasspath] when the caller doesn't pass a fuller one.
    * @param previewsJson the bundle's extracted `previews.json` discovery manifest.
    * @param workspaceRoot a scratch directory used as the daemon's working directory + workspace id.
    * @param modulePath informational module label surfaced in diagnostics (defaults to the bundle).
+   * @param jvmArgs JVM args for the daemon subprocess. Defaults to the desktop set
+   *   (`--enable-native-access=ALL-UNNAMED`); an Android/Robolectric caller passes
+   *   `AndroidBundleLaunch().jvmArgs()` (which adds the `--add-opens` set JDK 17+ Robolectric
+   *   needs).
+   * @param extraSystemProperties merged over the base daemon sysprops (last-wins). An
+   *   Android/Robolectric caller passes `AndroidBundleLaunch().robolectricSystemProperties()`.
+   * @param userClasspath the child-loaded user classpath (`composeai.daemon.userClassDirs`, a
+   *   `File.pathSeparator`-joined list of dirs **and** jars — the same shape the Gradle plugin's
+   *   launch emits). Defaults to just [classesDir] (a bundle already carries its deps on
+   *   [daemonClasspath]); a playground snippet passes its full compile classpath so the catalog's
+   *   library jars reach the render.
    */
   fun openBundleDaemon(
     daemonClasspath: List<String>,
@@ -100,6 +112,9 @@ object SubprocessRenderSessions : RenderSessionFactory {
     workspaceRoot: File,
     modulePath: String = ":bundle",
     initializeTimeout: Duration = 60.seconds,
+    jvmArgs: List<String> = listOf("--enable-native-access=ALL-UNNAMED"),
+    extraSystemProperties: Map<String, String> = emptyMap(),
+    userClasspath: List<String> = listOf(classesDir.absolutePath),
     factory: DaemonClientFactory = SubprocessDaemonClientFactory(),
   ): RenderSession {
     require(daemonClasspath.isNotEmpty()) { "daemonClasspath must not be empty" }
@@ -114,10 +129,10 @@ object SubprocessRenderSessions : RenderSessionFactory {
         mainClass = DESKTOP_DAEMON_MAIN_CLASS,
         javaLauncher = null,
         classpath = daemonClasspath,
-        jvmArgs = listOf("--enable-native-access=ALL-UNNAMED"),
+        jvmArgs = jvmArgs,
         systemProperties =
           mapOf(
-            "composeai.daemon.userClassDirs" to classesDir.absolutePath,
+            "composeai.daemon.userClassDirs" to userClasspath.joinToString(File.pathSeparator),
             "composeai.daemon.previewsJsonPath" to previewsJson.absolutePath,
             // Set the render-output dir so DaemonMain.dataRoot is non-null and the file-based data
             // products (compose/figma-svg + -long, semantics, wireframe, …) register — otherwise a
@@ -125,7 +140,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
             // `<root>/data` (where the registry + the RenderEngine producer both resolve) then sits
             // inside this session's tree. Mirrors ServeBundleDaemon.materialize.
             "composeai.render.outputDir" to File(canonicalRoot, "renders").absolutePath,
-          ),
+          ) + extraSystemProperties,
         workingDirectory = canonicalRoot.absolutePath,
         manifestPath = previewsJson.absolutePath,
       )


### PR DESCRIPTION
## Summary

Completes the **Phase 3 producer** (epic #3014): a `remote-compose` playground snippet now compiles, renders on the Robolectric daemon, and its captured `.rc` document is published as a `/d/<id>` permalink — the end-to-end *compile → .rc → /d/&lt;id&gt;* loop. Builds on the `compose/remotecompose-doc` daemon return-path from #3034 (merged).

### What changed

- **`PlaygroundRcCaptureService`** — the production `captureRemoteDocument`. It synthesizes a one-preview `previews.json` from the snippet's discovered `@Preview` id, opens a **bundle-less Android daemon** over the snippet's own `classesDir` + full compile classpath, `renderNow`s and awaits the terminal `renderFinished`/`renderFailed`, then `fetchData(compose/remotecompose-doc)` and Base64-decodes the document. The session opener is an injected seam, so the whole open→render→await→fetch orchestration is unit-tested against a fake session.
- **`SubprocessRenderSessions.openBundleDaemon`** gains optional `jvmArgs` / `extraSystemProperties` / `userClasspath`, so an Android/Robolectric caller can pass the `--add-opens` set, the `robolectric.*` sysprops, and the snippet's full user classpath. **Defaults preserve the existing desktop behavior** (verified byte-identical on the `.open()` path).
- **`ServeCommand`** — a new `--playground-android-bundle` resolves the Android/RC compile classpath; the Robolectric launch is assembled from `lib-daemon-android` + `android.jar` + `AndroidBundleLaunch` jvmArgs/sysprops (mirroring `ServeBundleDaemon.androidBundleDaemonLaunch`); and `captureRemoteDocument` / `publishRemoteDocument` bind to the shared `/d/` `ServeDocStore`. **Fail-soft**: absent the sidecar, `android.jar`, or `--docs`, remote-compose reports unavailable while CMP is unaffected.

## Test plan

- [x] `./gradlew :cli:test` — **passing** (1052 tests). New `PlaygroundRcCaptureServiceTest`: capture + `previews.json` synthesis, no-document → null, timeout → null, rejected → null. The `CliFlags` registry gate is satisfied for the new flag.
- [x] `./gradlew ktfmtFormat` — clean.
- [x] Verified `openBundleDaemon` is behavior-preserving for the desktop `.open()` path (its test path is untouched by the change).

**Verification scope:** the orchestration, manifest synthesis, and `openBundleDaemon` defaults are unit-tested in-process. The **live Robolectric render** that populates the document needs the Android daemon sidecar + Robolectric runtime, which the dev sandbox can't run — it's exercised by CI's Android daemon harness. One pre-existing, unrelated sandbox failure (`NonGradleContractTest`, a real desktop render that times out at 60s) reproduces *without* this change and lives on the untouched `.open()` path.

Non-visual (daemon/CLI plumbing), so no rendered evidence applies.

## Epic #3014 checklist

- [x] Compile mode captures the snippet's `RemoteDocument` → `.rc` bytes
- [x] Store the `.rc` via `ServeDocStore` and return `/d/<id>` (by `confType`/mode)
- [x] Wire RC into `confType` resolution + the run route
- [x] Gating: refused under `--public` (inherited)
- [x] Round-trip + orchestration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_