### PR TITLE
fix(daemon): resolve @PreviewParameter previews instead of failing on the parameterless lookup

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -249,6 +249,10 @@ dependencies {
   "testFixturesImplementation"(libs.compose.foundation)
   "testFixturesImplementation"(libs.compose.material3)
   "testFixturesImplementation"(libs.compose.ui)
+  // `ThemedTintedSquare` carries a real `@PreviewParameter(SquareTintProvider::class)` so
+  // `previewParameterPreviewRendersFirstProviderValue` exercises the exact annotation shape a
+  // consumer writes (issue #3027) rather than a stand-in with a bare parameter.
+  "testFixturesImplementation"(libs.compose.ui.tooling.preview)
   // `BrandedDownloadableText` builds a `Font(GoogleFont("Orbitron"), …)` family so
   // `FigmaSvgDownloadableFontFamilyTest` can prove the export names the branded face rather than
   // collapsing to Roboto — the exact shape a consumer's production typography uses.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -840,6 +840,9 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
     orientation = defaults.orientation,
     kind = params.kind ?: defaults.kind,
     wrapperClassName = params.wrapperClassName ?: defaults.wrapperClassName,
+    previewParameterProviderClassName =
+      params.previewParameterProviderClassName ?: defaults.previewParameterProviderClassName,
+    previewParameterLimit = params.previewParameterLimit ?: defaults.previewParameterLimit,
     overrides = bakedOverrides,
   )
 }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -176,6 +176,18 @@ class PreviewManifestRouter(
       resolved.wrapperClassName
         ?.takeIf { it.isNotBlank() }
         ?.let { append("wrapperClassName=").append(it).append(';') }
+      // `@PreviewParameter(SomeProvider::class)` FQN, sourced from `previews.json` for the same
+      // reason as the wrapper above (BINARY retention, invisible to runtime reflection). The render
+      // body loads the provider and invokes the preview with its first value; without it the
+      // parameterless lookup throws `NoSuchMethodException` for every parameterized preview (#3027).
+      resolved.previewParameterProviderClassName
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          append("previewParameterProvider=").append(it).append(';')
+          if (resolved.previewParameterLimit != Int.MAX_VALUE) {
+            append("previewParameterLimit=").append(resolved.previewParameterLimit).append(';')
+          }
+        }
       append("outputBaseName=").append(resolved.outputBaseName)
     }
   }
@@ -224,6 +236,8 @@ private fun PreviewManifestEntry.renderSpec(): RenderSpec {
     kind = resolved.kind,
     previewName = resolved.name,
     wrapperClassName = resolved.wrapperClassName,
+    previewParameterProviderClassName = resolved.previewParameterProviderClassName,
+    previewParameterLimit = resolved.previewParameterLimit,
     wrapWidth = resolved.wrapWidth,
     wrapHeight = resolved.wrapHeight,
     // The manifest-declared night bit, so a held session composes the same theme the one-shot
@@ -345,6 +359,9 @@ data class PreviewManifestEntry(
       uiMode = uiMode,
       fontScale = fontScale,
       locale = locale,
+      previewParameterProviderClassName =
+        p?.previewParameterProviderClassName?.takeIf { it.isNotBlank() },
+      previewParameterLimit = p?.previewParameterLimit ?: Int.MAX_VALUE,
     )
   }
 
@@ -421,6 +438,16 @@ data class PreviewParamsEntry(
    * motivated `@PreviewWrapper` in the first place).
    */
   val wrapperClassName: String? = null,
+  /**
+   * FQN of the `PreviewParameterProvider` from `@PreviewParameter(SomeProvider::class)` when the
+   * preview declares one, with its `limit`. Same story as [wrapperClassName]: the upstream
+   * annotation has `AnnotationRetention.BINARY`, so discovery's class-file read is the only way the
+   * render body can learn about it. Without this plumbing the daemon resolved the parameterless
+   * overload of a parameterized preview and threw `NoSuchMethodException` out of
+   * `getDeclaredComposableMethod` before composing anything (issue #3027).
+   */
+  val previewParameterProviderClassName: String? = null,
+  val previewParameterLimit: Int = Int.MAX_VALUE,
 )
 
 /**
@@ -451,4 +478,11 @@ data class ResolvedRenderParams(
   val fontScale: Float? = null,
   /** `@Preview(locale = ...)` BCP-47 tag, null when unset. */
   val locale: String? = null,
+  /**
+   * `@PreviewParameter(SomeProvider::class, limit = N)` from discovery — see
+   * [PreviewParamsEntry.previewParameterProviderClassName]. The render body loads the provider and
+   * invokes the preview with its first value; null renders the parameterless overload.
+   */
+  val previewParameterProviderClassName: String? = null,
+  val previewParameterLimit: Int = Int.MAX_VALUE,
 )

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -307,6 +307,14 @@ data class PreviewManifestEntry(
    * router.
    */
   val uiMode: Int? = null,
+  /**
+   * Flat-schema mirrors of [PreviewParamsEntry.previewParameterProviderClassName] /
+   * [PreviewParamsEntry.previewParameterLimit] — see the kdoc there. The production gradle plugin
+   * writes them under `params`; `:daemon:harness` scenario manifests use the flat shape, which is
+   * what gives the `@PreviewParameter` render path (issue #3027) end-to-end cover in CI.
+   */
+  val previewParameterProviderClassName: String? = null,
+  val previewParameterLimit: Int? = null,
 ) {
   fun resolved(): ResolvedRenderParams {
     val p = params
@@ -360,8 +368,11 @@ data class PreviewManifestEntry(
       fontScale = fontScale,
       locale = locale,
       previewParameterProviderClassName =
-        p?.previewParameterProviderClassName?.takeIf { it.isNotBlank() },
-      previewParameterLimit = p?.previewParameterLimit ?: Int.MAX_VALUE,
+        (previewParameterProviderClassName ?: p?.previewParameterProviderClassName)?.takeIf {
+          it.isNotBlank()
+        },
+      previewParameterLimit =
+        previewParameterLimit ?: p?.previewParameterLimit ?: Int.MAX_VALUE,
     )
   }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -86,10 +86,16 @@ import okio.Path.Companion.toPath
  * versa); the `:samples:android-daemon-bench:composePreviewRender` task + CI pixel-diff catches
  * drift.
  *
- * **What's duplicated, what isn't.** This is the "small composable, no `@PreviewParameter`, no
- * `@AnimatedPreview`, no `@ScrollingPreview`" subset — the daemon's v1 surface only renders single
- * static previews. The fan-out / animation / GIF stitching paths from `RobolectricRenderTest` stay
- * behind the standalone renderer for now; B1.7+ revisits if the harness needs them.
+ * **What's duplicated, what isn't.** This is the "small composable, no `@AnimatedPreview`, no
+ * `@ScrollingPreview`" subset — the daemon's v1 surface renders a single static frame per preview
+ * id. The animation / GIF stitching paths from `RobolectricRenderTest` stay behind the standalone
+ * renderer for now; B1.7+ revisits if the harness needs them.
+ *
+ * `@PreviewParameter` is *resolved* here but not *fanned out*: a parameterized preview renders its
+ * provider's first value (see [resolvePreviewInvocation]), matching the one-frame-per-id contract.
+ * Emitting one file per value stays with the standalone renderer. Before issue #3027 the daemon
+ * didn't resolve these at all — the parameterless lookup threw `NoSuchMethodException`, so every
+ * parameterized preview lost its PNG and its composition-derived data products.
  *
  * **Threading contract.** Called from inside [RobolectricHost.SandboxRunner.holdSandboxOpen], i.e.
  * the test thread of the dummy `@Test` runner, with the Robolectric sandbox classloader as the
@@ -287,12 +293,13 @@ class RenderEngine(
     // matching renderer helper in the setContent body below.
     val nonComposableInvocation =
       isTile || isNotification || isGlanceAppWidget || isSyntheticThemeCatalog || isIrReplay
-    val composableMethod: ComposableMethod? =
+    // `@PreviewParameter` previews compile to `foo(<T>, Composer, int)`, so the parameterless
+    // lookup misses them entirely — see [resolvePreviewInvocation] and issue #3027.
+    val resolvedInvocation =
       if (nonComposableInvocation) null
-      else
-        trace.section("compose:resolveComposable") {
-          clazz!!.getDeclaredComposableMethod(spec.functionName)
-        }
+      else trace.section("compose:resolveComposable") { resolvePreviewInvocation(clazz!!, spec) }
+    val composableMethod: ComposableMethod? = resolvedInvocation?.method
+    val previewArgs: List<Any?> = resolvedInvocation?.args ?: emptyList()
     // Kotlin `private fun` previews compile to JVM-private methods. `getDeclaredComposableMethod`
     // still resolves them (it scans `declaredMethods`), but the reflective `invoke` in
     // [InvokeComposable] would throw IllegalAccessException, so open the method up first — mirrors
@@ -660,6 +667,7 @@ class RenderEngine(
                             // `@PreviewWrapper` — "render this preview under theme X" — but only when
                             // it resolves; a stale/misspelled FQN falls back to the declared wrapper.
                             themeProviderFqn = spec.overrides?.themeProvider,
+                            previewArgs = previewArgs,
                           )
                         }
                       }
@@ -1196,7 +1204,7 @@ class RenderEngine(
         override fun evaluate() {
           rule.mainClock.autoAdvance = false
           val clazz = Class.forName(spec.className, true, classLoader)
-          val composableMethod = clazz.getDeclaredComposableMethod(spec.functionName)
+          val (composableMethod, previewArgs) = resolvePreviewInvocation(clazz, spec)
           val bgArgb = resolveBackgroundColor(spec).toArgb()
           // Coil-backed images: same install as `render`'s main body, repeated here because
           // `render` returns INTO this scenario before reaching that call — a direct scroll /
@@ -1246,6 +1254,7 @@ class RenderEngine(
                   composableMethod = composableMethod,
                   wrapperFqnFromSpec = spec.wrapperClassName,
                   themeProviderFqn = spec.overrides?.themeProvider,
+                  previewArgs = previewArgs,
                 )
               }
             }
@@ -1383,9 +1392,9 @@ class RenderEngine(
         override fun evaluate() {
           rule.mainClock.autoAdvance = false
           val clazz = Class.forName(spec.className, true, classLoader)
-          val composableMethod =
-            clazz.getDeclaredComposableMethod(spec.functionName).also {
-              runCatching { it.asMethod().isAccessible = true }
+          val (composableMethod, previewArgs) =
+            resolvePreviewInvocation(clazz, spec).also {
+              runCatching { it.method.asMethod().isAccessible = true }
             }
           val bgArgb = resolveBackgroundColor(spec).toArgb()
           // Coil-backed images: same install as `render`'s main body, repeated here because
@@ -1425,6 +1434,7 @@ class RenderEngine(
                     composableMethod = composableMethod,
                     wrapperFqnFromSpec = spec.wrapperClassName,
                     themeProviderFqn = spec.overrides?.themeProvider,
+                    previewArgs = previewArgs,
                   )
                 }
               }
@@ -1711,11 +1721,11 @@ class RenderEngine(
         override fun evaluate() {
           rule.mainClock.autoAdvance = false
           val clazz = Class.forName(spec.className, true, classLoader)
-          val composableMethod =
-            clazz.getDeclaredComposableMethod(spec.functionName).also {
+          val (composableMethod, previewArgs) =
+            resolvePreviewInvocation(clazz, spec).also {
               // Kotlin `private fun` scrolling previews compile to JVM-private methods; open them
               // so the reflective invoke doesn't throw IllegalAccessException — same as `render`.
-              runCatching { it.asMethod().isAccessible = true }
+              runCatching { it.method.asMethod().isAccessible = true }
             }
           val bgArgb = resolveBackgroundColor(spec).toArgb()
           // Coil-backed images: same install as `render`'s main body, repeated here because
@@ -1765,6 +1775,7 @@ class RenderEngine(
                   composableMethod,
                   wrapperFqnFromSpec = spec.wrapperClassName,
                   themeProviderFqn = spec.overrides?.themeProvider,
+                  previewArgs = previewArgs,
                 )
               }
             }
@@ -2119,9 +2130,33 @@ private fun SemanticsNode.descendantCount(): Int =
  * private+top-level so the compose-compiler plugin recognises it as a composable function.
  */
 @Composable
-private fun InvokeComposable(composableMethod: ComposableMethod) {
-  composableMethod.invoke(currentComposer, null)
+private fun InvokeComposable(composableMethod: ComposableMethod, previewArgs: List<Any?>) {
+  composableMethod.invoke(currentComposer, null, *previewArgs.toTypedArray())
 }
+
+/**
+ * Resolves the composable entrypoint for [spec] — plus the `@PreviewParameter` argument list to
+ * invoke it with, empty for the ordinary parameterless preview.
+ *
+ * Delegates to `:renderer-android`'s [ee.schimke.composeai.renderer.PreviewParameterSupport] so the
+ * daemon and the standalone renderer resolve providers identically. Before issue #3027 the daemon
+ * only ever asked for the parameterless `(Composer, int)` overload, so every preview declaring a
+ * `@PreviewParameter` argument failed resolution with `NoSuchMethodException` — no PNG and none of
+ * the composition-derived data products (semantics, layout, figma-svg), just an `.error.json`. The
+ * daemon renders one frame per preview id, so it takes the provider's first value; the per-value
+ * fan-out stays with the standalone renderer (see this file's class doc).
+ */
+private fun resolvePreviewInvocation(
+  clazz: Class<*>,
+  spec: RenderSpec,
+): ee.schimke.composeai.renderer.PreviewParameterSupport.Resolved =
+  ee.schimke.composeai.renderer.PreviewParameterSupport.resolve(
+    clazz = clazz,
+    functionName = spec.functionName,
+    providerClassName = spec.previewParameterProviderClassName,
+    limit = spec.previewParameterLimit,
+    classLoader = clazz.classLoader,
+  )
 
 /**
  * Wraps [InvokeComposable] in the preview's `@PreviewWrapper(SomeProvider::class)` `Wrap { … }` if
@@ -2153,6 +2188,7 @@ internal fun InvokeWithOptionalWrapper(
   composableMethod: ComposableMethod,
   wrapperFqnFromSpec: String?,
   themeProviderFqn: String? = null,
+  previewArgs: List<Any?> = emptyList(),
 ) {
   val wrapper =
     remember(composableMethod, wrapperFqnFromSpec, themeProviderFqn) {
@@ -2165,10 +2201,10 @@ internal fun InvokeWithOptionalWrapper(
         ?: resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
     }
   if (wrapper == null) {
-    InvokeComposable(composableMethod)
+    InvokeComposable(composableMethod, previewArgs)
   } else {
     val (wrapMethod, wrapperInstance) = wrapper
-    val body: @Composable () -> Unit = { InvokeComposable(composableMethod) }
+    val body: @Composable () -> Unit = { InvokeComposable(composableMethod, previewArgs) }
     wrapMethod.invoke(currentComposer, wrapperInstance, body)
   }
 }
@@ -2426,6 +2462,21 @@ data class RenderSpec(
    * (best-effort) runtime-reflection lookup for direct-payload callers that bypass the manifest.
    */
   val wrapperClassName: String? = null,
+  /**
+   * FQN of the `PreviewParameterProvider` from `@PreviewParameter(SomeProvider::class)` when the
+   * source preview declares one, plus its `limit`. Sourced from the gradle plugin's discovery JSON
+   * for the same reason as [wrapperClassName] — the upstream annotation has
+   * `AnnotationRetention.BINARY` and is invisible to `Method.parameterAnnotations` at runtime.
+   *
+   * The render body resolves the preview's `(<T>, Composer, int)` overload and invokes it with the
+   * provider's **first** value: the daemon renders one frame per preview id, and these ids are the
+   * un-suffixed base ids the fan-out (standalone) renderer would emit as `<id>_<label>`. Null
+   * resolves the parameterless overload as before. Without this the daemon threw
+   * `NoSuchMethodException` from `getDeclaredComposableMethod` for every parameterized preview,
+   * costing them their PNG and every data product derived from the composition (issue #3027).
+   */
+  val previewParameterProviderClassName: String? = null,
+  val previewParameterLimit: Int = Int.MAX_VALUE,
 ) {
 
   enum class SpecUiMode {
@@ -2498,6 +2549,10 @@ data class RenderSpec(
         kind = map["kind"]?.takeIf { it.isNotBlank() },
         previewName = map["previewName"]?.takeIf { it.isNotBlank() },
         wrapperClassName = map["wrapperClassName"]?.takeIf { it.isNotBlank() },
+        previewParameterProviderClassName =
+          map["previewParameterProvider"]?.takeIf { it.isNotBlank() },
+        previewParameterLimit =
+          map["previewParameterLimit"]?.toIntOrNull() ?: defaults.previewParameterLimit,
       )
     }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -302,11 +302,9 @@ class RenderEngine(
     val previewArgs: List<Any?> = resolvedInvocation?.args ?: emptyList()
     // Kotlin `private fun` previews compile to JVM-private methods. `getDeclaredComposableMethod`
     // still resolves them (it scans `declaredMethods`), but the reflective `invoke` in
-    // [InvokeComposable] would throw IllegalAccessException, so open the method up first — mirrors
-    // `:renderer-android`'s ComposePreviewStrategy. Guarded with `runCatching`: a SecurityManager
-    // or strong module encapsulation can refuse, in which case we still attempt the invoke
-    // (which succeeds for public/internal previews) rather than failing resolution outright.
-    composableMethod?.let { runCatching { it.asMethod().isAccessible = true } }
+    // [InvokeComposable] would throw IllegalAccessException — [PreviewParameterSupport.resolve]
+    // opens the resolved method for every caller (this path, the scroll scenarios, and the
+    // held-session lane) so no single site has to remember.
 
     // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
     // Pairs with `[classloader] swap requested` / `allocate child loader` lines from
@@ -1392,10 +1390,7 @@ class RenderEngine(
         override fun evaluate() {
           rule.mainClock.autoAdvance = false
           val clazz = Class.forName(spec.className, true, classLoader)
-          val (composableMethod, previewArgs) =
-            resolvePreviewInvocation(clazz, spec).also {
-              runCatching { it.method.asMethod().isAccessible = true }
-            }
+          val (composableMethod, previewArgs) = resolvePreviewInvocation(clazz, spec)
           val bgArgb = resolveBackgroundColor(spec).toArgb()
           // Coil-backed images: same install as `render`'s main body, repeated here because
           // `render` returns INTO this scenario before reaching that call — a direct scroll /
@@ -1721,12 +1716,10 @@ class RenderEngine(
         override fun evaluate() {
           rule.mainClock.autoAdvance = false
           val clazz = Class.forName(spec.className, true, classLoader)
-          val (composableMethod, previewArgs) =
-            resolvePreviewInvocation(clazz, spec).also {
-              // Kotlin `private fun` scrolling previews compile to JVM-private methods; open them
-              // so the reflective invoke doesn't throw IllegalAccessException — same as `render`.
-              runCatching { it.method.asMethod().isAccessible = true }
-            }
+          // Kotlin `private fun` scrolling previews compile to JVM-private methods;
+          // `resolvePreviewInvocation` opens them so the reflective invoke below doesn't throw
+          // IllegalAccessException — same as `render`.
+          val (composableMethod, previewArgs) = resolvePreviewInvocation(clazz, spec)
           val bgArgb = resolveBackgroundColor(spec).toArgb()
           // Coil-backed images: same install as `render`'s main body, repeated here because
           // `render` returns INTO this scenario before reaching that call — a direct scroll /

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1,7 +1,6 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.runtime.tooling.observe
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.toArgb
@@ -1346,6 +1345,10 @@ open class RobolectricHost(
         // Preserve the preview's declared wrapper in held/live mode. This is part of the preview's
         // composition contract, not decoration: wrappers may provide required app locals.
         wrapperClassName = spec.wrapperClassName,
+        // …and its `@PreviewParameter` provider, so a held session resolves the same overload the
+        // one-shot render did instead of failing on the parameterless lookup (issue #3027).
+        previewParameterProviderClassName = spec.previewParameterProviderClassName,
+        previewParameterLimit = spec.previewParameterLimit,
         // Theme providers use the same PreviewWrapperProvider machinery and replace the declared
         // wrapper when they resolve, matching the one-shot render path.
         themeProviderFqn = spec.overrides?.themeProvider,
@@ -2359,13 +2362,21 @@ open class RobolectricHost(
       val isGlanceAppWidget =
         start.kind.equals(RenderEngine.GLANCE_APPWIDGET_KIND, ignoreCase = true)
       val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget
-      val composableMethod =
+      // `@PreviewParameter` previews resolve to the `(<T>, Composer, int)` overload and are invoked
+      // with the provider's first value — same contract as the one-shot render (issue #3027).
+      val resolvedInvocation =
         if (nonComposableInvocation) {
           null
         } else {
           try {
             val clazz = Class.forName(start.previewClassName, true, classLoader)
-            clazz.getDeclaredComposableMethod(start.previewFunctionName)
+            ee.schimke.composeai.renderer.PreviewParameterSupport.resolve(
+              clazz = clazz,
+              functionName = start.previewFunctionName,
+              providerClassName = start.previewParameterProviderClassName,
+              limit = start.previewParameterLimit,
+              classLoader = classLoader,
+            )
           } catch (t: Throwable) {
             // Resolution failure (class missing / method missing / signature mismatch) — surface
             // immediately on the start reply so the host doesn't wait out the 30s timeout.
@@ -2374,6 +2385,8 @@ open class RobolectricHost(
             return
           }
         }
+      val composableMethod = resolvedInvocation?.method
+      val previewArgs: List<Any?> = resolvedInvocation?.args ?: emptyList()
 
       // Activity registration — same idempotent shape RenderEngine.render uses. Robolectric
       // 4.13+ requires `ComponentActivity` to be reachable through `ShadowPackageManager` before
@@ -2643,6 +2656,7 @@ open class RobolectricHost(
                               composableMethod = composableMethod!!,
                               wrapperFqnFromSpec = start.wrapperClassName,
                               themeProviderFqn = start.themeProviderFqn,
+                              previewArgs = previewArgs,
                             )
                           }
                         }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -2364,6 +2364,8 @@ open class RobolectricHost(
       val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget
       // `@PreviewParameter` previews resolve to the `(<T>, Composer, int)` overload and are invoked
       // with the provider's first value — same contract as the one-shot render (issue #3027).
+      // `resolve` also opens the method for reflective invocation, so a `private fun` preview
+      // composes in the held session instead of blanking the panel with IllegalAccessException.
       val resolvedInvocation =
         if (nonComposableInvocation) {
           null

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -413,6 +413,14 @@ sealed interface InteractiveCommand {
      */
     val wrapperClassName: String? = null,
     /**
+     * FQN of the preview's `@PreviewParameter` provider (and its `limit`), threaded for the same
+     * reason as [wrapperClassName]: the held session must resolve the same overload the one-shot
+     * render did. Without it, live mode on a parameterized preview fails resolution with
+     * `NoSuchMethodException` and blanks the panel (issue #3027).
+     */
+    val previewParameterProviderClassName: String? = null,
+    val previewParameterLimit: Int = Int.MAX_VALUE,
+    /**
      * Optional app-declared theme `PreviewWrapperProvider` selected by a live override. Like the
      * one-shot path, a provider that resolves successfully replaces [wrapperClassName].
      */

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterRoutingTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterRoutingTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -52,6 +53,67 @@ class PreviewManifestRouterRoutingTest {
         "payload=$routed",
       routed.contains("wrapperClassName=com.example.RemotePreviewWrapper"),
     )
+  }
+
+  @Test
+  fun `routePayload forwards the PreviewParameter provider from nested params`() {
+    // Issue #3027: the provider FQN is the only thing that lets the render body resolve a
+    // parameterized preview's `(<T>, Composer, int)` overload — `@PreviewParameter` has BINARY
+    // retention, so the sandbox can't recover it by reflecting on the composable. Without this
+    // token every such preview died on `getDeclaredComposableMethod` with NoSuchMethodException.
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "themed",
+              className = "com.example.PreviewsKt",
+              functionName = "ThemedPreview",
+              params =
+                PreviewParamsEntry(
+                  widthDp = 100,
+                  heightDp = 100,
+                  previewParameterProviderClassName = "com.example.ThemeProvider",
+                  previewParameterLimit = 3,
+                ),
+            )
+          )
+      )
+
+    val routed = PreviewManifestRouter(manifest = manifest).routePayload("previewId=themed")
+
+    assertTrue(
+      "routed payload must carry the provider FQN. payload=$routed",
+      routed.contains("previewParameterProvider=com.example.ThemeProvider"),
+    )
+    assertTrue(
+      "a non-default limit rides along too. payload=$routed",
+      routed.contains("previewParameterLimit=3"),
+    )
+    val spec = RenderSpec.parseFromPayloadOrNull(routed)
+    assertEquals("com.example.ThemeProvider", spec!!.previewParameterProviderClassName)
+    assertEquals(3, spec.previewParameterLimit)
+  }
+
+  @Test
+  fun `routePayload omits the provider token for an ordinary preview`() {
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "plain",
+              className = "com.example.PreviewsKt",
+              functionName = "Plain",
+              params = PreviewParamsEntry(widthDp = 100, heightDp = 100),
+            )
+          )
+      )
+
+    val routed = PreviewManifestRouter(manifest = manifest).routePayload("previewId=plain")
+
+    assertFalse(routed.contains("previewParameterProvider="))
+    assertEquals(null, RenderSpec.parseFromPayloadOrNull(routed)!!.previewParameterProviderClassName)
   }
 
   @Test

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -687,6 +687,54 @@ class RenderEngineTest {
   }
 
   @Test
+  fun previewParameterPreviewRendersFirstProviderValue() {
+    // Regression (issue #3027): a preview declaring `@PreviewParameter` compiles to
+    // `foo(<T>, Composer, int)`, which the daemon's parameterless
+    // `getDeclaredComposableMethod(functionName)` lookup never matches — it threw
+    // `NoSuchMethodException: <class>.<function>` before composition started, so the preview
+    // produced no PNG and none of the composition-derived data products, only an `.error.json`.
+    // The provider FQN now rides the `RenderSpec` payload (the manifest router sources it from
+    // `previews.json`, since the annotation's BINARY retention hides it from runtime reflection)
+    // and the render invokes the preview with the provider's FIRST value.
+    val outputDir = tempFolder.newFolder("renders-preview-parameter")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      val result =
+        host.submit(
+          RenderRequest.Render(
+            payload =
+              "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+                "functionName=ThemedTintedSquare;" +
+                "previewParameterProvider=ee.schimke.composeai.daemon.SquareTintProvider;" +
+                "widthPx=64;heightPx=64;density=1.0;" +
+                "showBackground=true;" +
+                "outputBaseName=preview-parameter-square"
+          ),
+          timeoutMs = 120_000,
+        )
+
+      assertNotNull("@PreviewParameter preview must render a PNG, not error out", result.pngPath)
+      val pngFile = File(result.pngPath!!)
+      assertTrue("rendered PNG must exist on disk: ${pngFile.absolutePath}", pngFile.exists())
+      val img = ByteArrayInputStream(pngFile.readBytes()).use { ImageIO.read(it) }
+      assertNotNull("PNG must decode via javax.imageio", img)
+      // The provider's first value (green), not its second (blue) — a single-frame render has one
+      // output file per preview id, so "first value" is the contract, not "any value".
+      val matchPct = pixelMatchPct(img!!, 0x43A047, perChannelTolerance = 8)
+      assertTrue(
+        "expected >= 95% of pixels close to the provider's FIRST value #43A047; got " +
+          "${"%.2f".format(matchPct * 100)}%",
+        matchPct >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun serifTextWritesFontsUsedDataProduct() {
     val outputDir = tempFolder.newFolder("renders-fonts")
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -54,6 +54,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -731,4 +734,28 @@ fun LazyColumnListPreview() {
       }
     }
   }
+}
+
+/**
+ * `@PreviewParameter` regression fixture (issue #3027).
+ *
+ * The daemon used to resolve every preview with the parameterless
+ * `getDeclaredComposableMethod(functionName)` lookup, which matches only `foo(Composer, int)`. This
+ * preview compiles to `ThemedTintedSquare(long, Composer, int)`, so resolution threw
+ * `NoSuchMethodException` before composition started — no PNG, no semantics, just an `.error.json`.
+ * That took out 27 previews in one real consumer module, including the two `Summary*` previews the
+ * issue was filed against.
+ *
+ * Two values on purpose: the daemon renders one frame per preview id, so it must invoke the
+ * **first** one ([SquareTintProvider] green), never the second. A regression that silently picks the
+ * wrong value fails the pixel assertion rather than passing on "something rendered".
+ */
+class SquareTintProvider : PreviewParameterProvider<Long> {
+  override val values = sequenceOf(0xFF43A047L, 0xFF1E88E5L)
+}
+
+@Preview
+@Composable
+fun ThemedTintedSquare(@PreviewParameter(SquareTintProvider::class) tint: Long) {
+  Box(modifier = Modifier.fillMaxSize().background(Color(tint)))
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -222,6 +222,16 @@ data class PreviewParamsDto(
    * `RenderSpec.wrapperClassName` for the render body.
    */
   val wrapperClassName: String? = null,
+  /**
+   * FQN of the `PreviewParameterProvider` from `@PreviewParameter(SomeProvider::class)`, plus its
+   * `limit`, when the source preview declares one. Same discovery-time class-file read as
+   * [wrapperClassName] (this annotation is `AnnotationRetention.BINARY` too, so runtime reflection
+   * can't see it). The render body resolves the preview's parameterized overload from it and
+   * invokes it with the provider's first value; without it a parameterized preview fails resolution
+   * with `NoSuchMethodException` and produces no render (issue #3027).
+   */
+  val previewParameterProviderClassName: String? = null,
+  val previewParameterLimit: Int? = null,
 )
 
 /**

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessTestSupport.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessTestSupport.kt
@@ -194,6 +194,13 @@ data class RealModePreview(
   val heightPx: Int = 64,
   val density: Double = 1.0,
   val showBackground: Boolean = true,
+  /**
+   * FQN of the preview's `@PreviewParameter` provider, when it declares one. Emitted into the
+   * scenario manifest so the spawned daemon resolves the preview's `(<T>, Composer, int)` overload
+   * and renders the provider's first value — the path issue #3027 fixed. Null for the ordinary
+   * parameterless previews every other scenario uses.
+   */
+  val previewParameterProvider: String? = null,
 )
 
 data class RealModeScenarioPaths(
@@ -312,7 +319,11 @@ private fun prepareRealModeScenarioPaths(
         "widthPx": ${p.widthPx},
         "heightPx": ${p.heightPx},
         "density": ${p.density},
-        "showBackground": ${p.showBackground},
+        "showBackground": ${p.showBackground},${
+        p.previewParameterProvider?.let {
+          "\n        \"previewParameterProviderClassName\": \"$it\","
+        } ?: ""
+      }
         "outputBaseName": "${p.id}"
       }
       """

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/PreviewParameterAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/PreviewParameterAndroidRealModeTest.kt
@@ -1,0 +1,140 @@
+package ee.schimke.composeai.daemon.harness
+
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+
+/**
+ * Regression scenario for issue #3027 — a `@PreviewParameter` preview must render through the real
+ * Android daemon.
+ *
+ * Before the fix the daemon resolved every preview with the parameterless
+ * `getDeclaredComposableMethod(functionName)` lookup, which matches only `foo(Composer, int)`. A
+ * preview declaring `@PreviewParameter` compiles to `foo(<T>, Composer, int)`, so resolution threw
+ * `NoSuchMethodException` *before composition started*: no PNG, none of the composition-derived
+ * data products, just an `.error.json`. 27 previews in one real consumer module were lost that way.
+ *
+ * This lives in `:daemon:harness` rather than `:daemon:android`'s own unit tests because the
+ * harness is the Android-daemon surface CI actually runs (`daemon-harness.yml`,
+ * `-Pharness.host=real -Ptarget=android`); `:daemon:android:testDebugUnitTest` is not wired into
+ * any workflow, so an assertion left there would never execute on a PR.
+ *
+ * The fixture provider yields **two** values (green then blue) on purpose: the daemon renders one
+ * frame per preview id, so the contract is the *first* value, not "any value". A regression that
+ * binds the wrong one fails the pixel assertion instead of passing on "something rendered".
+ *
+ * **Skipped under fake mode and under `-Ptarget=desktop`** — same gating as the other
+ * `*AndroidRealModeTest` scenarios. Timeouts mirror [S1LifecycleAndroidRealModeTest]'s, which
+ * absorb Robolectric's sandbox bootstrap.
+ */
+class PreviewParameterAndroidRealModeTest {
+
+  @Test
+  fun preview_parameter_preview_renders_first_provider_value() {
+    Assume.assumeTrue(
+      "Skipping PreviewParameterAndroidRealModeTest — set -Pharness.host=real to enable.",
+      HarnessTestSupport.harnessHost() == "real",
+    )
+    Assume.assumeTrue(
+      "Skipping PreviewParameterAndroidRealModeTest — android variant; set -Ptarget=android.",
+      HarnessTestSupport.harnessTarget() == "android",
+    )
+
+    val previewId = "tinted-square"
+    val paths =
+      realAndroidModeScenario(
+        name = "preview-parameter-android",
+        previews =
+          listOf(
+            RealModePreview(
+              id = previewId,
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "ThemedTintedSquare",
+              previewParameterProvider = "ee.schimke.composeai.daemon.SquareTintProvider",
+            )
+          ),
+      )
+
+    val client = HarnessClient.start(paths.launcher)
+    try {
+      assertEquals(2, client.initialize().protocolVersion)
+      client.sendInitialized()
+
+      val renderNowResult = client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
+      assertEquals(listOf(previewId), renderNowResult.queued)
+      assertTrue(
+        "renderNow.rejected must be empty: ${renderNowResult.rejected}",
+        renderNowResult.rejected.isEmpty(),
+      )
+
+      client.pollNotification("renderStarted", 180.seconds)
+      val finished = client.pollNotification("renderFinished", 30.seconds)
+      val finishedParams = finished["params"]?.jsonObject
+      assertNotNull("renderFinished must carry params", finishedParams)
+      // Pre-fix this is where the scenario died: resolution threw, so no pngPath was ever reported.
+      val reportedPath = finishedParams!!["pngPath"]?.jsonPrimitive?.contentOrNull
+      assertNotNull(
+        "renderFinished.pngPath must be present — a @PreviewParameter preview must render",
+        reportedPath,
+      )
+      val reportedPng = File(reportedPath!!)
+      assertTrue("rendered PNG must exist: $reportedPath", reportedPng.exists())
+      assertTrue("rendered PNG must be non-empty: $reportedPath", reportedPng.length() > 0)
+
+      val img = ImageIO.read(reportedPng)
+      assertNotNull("rendered PNG must decode", img)
+      // SquareTintProvider's FIRST value is 0xFF43A047 (green); its second is 0xFF1E88E5 (blue).
+      val green = dominantGreenFraction(img!!)
+      assertTrue(
+        "render must carry the provider's first value (green #43A047), not its second (blue) — " +
+          "dominantGreen=$green",
+        green > 0.9,
+      )
+
+      assertEquals(
+        "Daemon must exit cleanly. Stderr=\n${client.dumpStderr()}",
+        0,
+        client.shutdownAndExit(timeout = 60.seconds),
+      )
+    } catch (t: Throwable) {
+      System.err.println(
+        "PreviewParameterAndroidRealModeTest failed; stderr from daemon:\n" + client.dumpStderr()
+      )
+      throw t
+    } finally {
+      try {
+        client.close()
+      } catch (_: Throwable) {}
+    }
+  }
+
+  /**
+   * Fraction of pixels whose green channel is dominant — the shape of
+   * [S1LifecycleAndroidRealModeTest.dominantRedFraction], keyed on green so it separates the
+   * provider's first value (`0xFF43A047`) from its second (`0xFF1E88E5`, blue-dominant).
+   */
+  private fun dominantGreenFraction(img: BufferedImage): Double {
+    var matching = 0
+    val total = img.width * img.height
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val argb = img.getRGB(x, y)
+        val r = (argb shr 16) and 0xFF
+        val g = (argb shr 8) and 0xFF
+        val b = argb and 0xFF
+        if (g > 100 && (g - r) > 30 && (g - b) > 30) matching++
+      }
+    }
+    return matching.toDouble() / total.toDouble()
+  }
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
@@ -37,6 +37,11 @@ object PreviewParameterSupport {
    * is named, its first value is used: a single-frame renderer has one output file per preview id,
    * and the daemon's manifest ids are the un-suffixed base ids the fan-out renderer would render as
    * `<id>_<label>`. Value 0 is the one Android Studio shows first as well.
+   *
+   * The returned method is always opened for reflective invocation ([openForInvoke]) — Kotlin
+   * `private fun` previews are idiomatic and resolve fine, but invoking one without that throws
+   * `IllegalAccessException`. Doing it here rather than at each call site is what keeps the daemon's
+   * scroll / `figma-svg-long` / held-session paths from each having to remember.
    */
   fun resolve(
     clazz: Class<*>,
@@ -46,7 +51,7 @@ object PreviewParameterSupport {
     classLoader: ClassLoader? = null,
   ): Resolved {
     if (providerClassName.isNullOrBlank()) {
-      return Resolved(clazz.getDeclaredComposableMethod(functionName), emptyList())
+      return Resolved(clazz.getDeclaredComposableMethod(functionName).openForInvoke(), emptyList())
     }
     if (limit <= 0) {
       throw PreviewParameterLoadException(
@@ -65,7 +70,17 @@ object PreviewParameterSupport {
       )
     }
     val args = listOf(values.first())
-    return Resolved(findComposableMethodWithArgs(clazz, functionName, args), args)
+    return Resolved(findComposableMethodWithArgs(clazz, functionName, args).openForInvoke(), args)
+  }
+
+  /**
+   * Opens [this] method for reflective invocation. Guarded with `runCatching`: a SecurityManager or
+   * strong module encapsulation can refuse, in which case we still attempt the invoke (which
+   * succeeds for public/internal previews) rather than failing resolution outright — same contract
+   * as `PreviewRenderStrategy`'s ComposePreviewStrategy.
+   */
+  private fun ComposableMethod.openForInvoke(): ComposableMethod = also {
+    runCatching { it.asMethod().isAccessible = true }
   }
 
   /**

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
@@ -1,0 +1,148 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.runtime.reflect.ComposableMethod
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+
+/**
+ * Reflective `@PreviewParameter` support shared by the two Android render bodies — `:renderer
+ * -android`'s [RobolectricRenderTest] (which fans a provider out into one render per value) and
+ * `:daemon:android`'s `RenderEngine` (which renders a single frame and therefore takes the first
+ * value only).
+ *
+ * **Why the provider FQN is passed in rather than read off the method.** The upstream
+ * `androidx.compose.ui.tooling.preview.PreviewParameter` annotation has `AnnotationRetention.BINARY`
+ * — it is written into the class file but is *not* visible through `Method.parameterAnnotations` at
+ * runtime, exactly like `@PreviewWrapper` (issue #1440). The gradle plugin's discovery reads it off
+ * the class-file annotation tables into `previews.json`
+ * (`params.previewParameterProviderClassName` / `params.previewParameterLimit`), and both render
+ * bodies get it from there. Nothing here can recover it by reflecting on the composable.
+ *
+ * **What went wrong without this (issue #3027).** The daemon resolved every preview with the
+ * parameterless `getDeclaredComposableMethod(functionName)` lookup, which matches only
+ * `foo(Composer, int)`. A preview declaring `@PreviewParameter` compiles to
+ * `foo(<T>, Composer, int)`, so the lookup threw
+ * `NoSuchMethodException: <class>.<function>` before composition ever started — no PNG, no
+ * semantics, just a `.error.json`. Observed across 27 previews in one consumer module.
+ */
+object PreviewParameterSupport {
+
+  /** A resolved preview entrypoint: the composable method plus the arguments to invoke it with. */
+  data class Resolved(val method: ComposableMethod, val args: List<Any?>)
+
+  /**
+   * Resolves the composable entrypoint for a preview, supplying `@PreviewParameter` arguments when
+   * the discovery manifest recorded a provider.
+   *
+   * [providerClassName] `null` (the common case) is the plain parameterless lookup. When a provider
+   * is named, its first value is used: a single-frame renderer has one output file per preview id,
+   * and the daemon's manifest ids are the un-suffixed base ids the fan-out renderer would render as
+   * `<id>_<label>`. Value 0 is the one Android Studio shows first as well.
+   */
+  fun resolve(
+    clazz: Class<*>,
+    functionName: String,
+    providerClassName: String?,
+    limit: Int = Int.MAX_VALUE,
+    classLoader: ClassLoader? = null,
+  ): Resolved {
+    if (providerClassName.isNullOrBlank()) {
+      return Resolved(clazz.getDeclaredComposableMethod(functionName), emptyList())
+    }
+    if (limit <= 0) {
+      throw PreviewParameterLoadException(
+        "@PreviewParameter(provider = $providerClassName, limit = $limit) on $functionName " +
+          "leaves no value to render",
+        null,
+      )
+    }
+    // Only the first value is needed; `take(1)` also keeps an infinite `generateSequence` provider
+    // from being driven to exhaustion.
+    val values = loadValues(providerClassName, limit = 1, classLoader = classLoader)
+    if (values.isEmpty()) {
+      throw PreviewParameterLoadException(
+        "@PreviewParameter(provider = $providerClassName) on $functionName produced no values",
+        null,
+      )
+    }
+    val args = listOf(values.first())
+    return Resolved(findComposableMethodWithArgs(clazz, functionName, args), args)
+  }
+
+  /**
+   * Enumerate a `PreviewParameterProvider`'s values reflectively, up to [limit].
+   *
+   * Throws [PreviewParameterLoadException] on any hard failure (class missing, no no-arg
+   * constructor, missing/throwing `getValues()`) so the caller can isolate the failing preview and
+   * surface it as a per-preview error card rather than letting the throw sink a whole shard.
+   * Returns an empty list only when the provider legitimately yields no values.
+   *
+   * [classLoader] is the loader the consumer's classes live on — the daemon hands in its per-swap
+   * child loader; the standalone renderer leaves it null and uses the caller's (which under
+   * Robolectric is the sandbox loader).
+   */
+  fun loadValues(
+    providerFqn: String,
+    limit: Int,
+    classLoader: ClassLoader? = null,
+  ): List<Any?> {
+    val clazz =
+      try {
+        if (classLoader == null) Class.forName(providerFqn)
+        else Class.forName(providerFqn, true, classLoader)
+      } catch (e: ClassNotFoundException) {
+        throw PreviewParameterLoadException(
+          "provider class $providerFqn not found on the render classpath",
+          e,
+        )
+      }
+    val instance =
+      try {
+        val ctor = clazz.getDeclaredConstructor()
+        // `private` providers (idiomatic Kotlin, and rendered fine by Android Studio) compile to
+        // package-private JVM classes, so their no-arg constructor isn't reflectively callable from
+        // this package without opening it up first — see issue #2493.
+        ctor.isAccessible = true
+        ctor.newInstance()
+      } catch (e: Throwable) {
+        throw PreviewParameterLoadException(
+          "couldn't instantiate $providerFqn via its no-arg constructor",
+          e,
+        )
+      }
+    // `PreviewParameterProvider<T>` exposes `values: Sequence<T>` as a Kotlin property — its JVM
+    // signature is `getValues(): Sequence`. Look up the method by name to avoid taking a
+    // compile-time dependency on the provider interface (which lives in the consumer's Compose
+    // artifact).
+    val getValues =
+      try {
+        clazz.getMethod("getValues")
+      } catch (e: Throwable) {
+        throw PreviewParameterLoadException(
+          "$providerFqn has no getValues() — not a PreviewParameterProvider?",
+          e,
+        )
+      }
+    // Same package-private-class problem as the constructor above: a public `getValues()` declared
+    // on a package-private class throws `IllegalAccessException` from `Method.invoke` unless the
+    // member is opened up first. This is the crash in issue #2493.
+    getValues.isAccessible = true
+    return try {
+      @Suppress("UNCHECKED_CAST")
+      val sequence = getValues.invoke(instance) as? Sequence<Any?> ?: return emptyList()
+      // `Sequence.take(Int).toList()` is the Kotlin stdlib contract — drives the sequence lazily up
+      // to `limit` without requiring reflective access into package-private iterator
+      // implementations (`kotlin.jvm.internal.ArrayIterator`, which `Method.invoke` rejects with
+      // IllegalAccessException from outside the stdlib module).
+      sequence.take(limit).toList()
+    } catch (e: Throwable) {
+      throw PreviewParameterLoadException("$providerFqn.getValues() failed", e)
+    }
+  }
+}
+
+/**
+ * Thrown by [PreviewParameterSupport] on a hard provider-load failure so the caller can isolate the
+ * failing preview instead of failing every preview that shares its shard / sandbox.
+ */
+class PreviewParameterLoadException(message: String, cause: Throwable?) :
+  RuntimeException(message, cause)

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -420,63 +420,16 @@ object PreviewManifestLoader {
   /**
    * Enumerate a `PreviewParameterProvider`'s values reflectively.
    *
-   * Throws [ProviderLoadException] on any hard failure (class missing, no no-arg constructor,
-   * missing/throwing `getValues()`) so the caller can isolate the failing preview and surface it as
-   * a per-preview error card rather than letting the throw sink the whole shard. Returns an empty
-   * list only when the provider legitimately yields no values.
+   * Throws [PreviewParameterLoadException] on any hard failure (class missing, no no-arg
+   * constructor, missing/throwing `getValues()`) so the caller can isolate the failing preview and
+   * surface it as a per-preview error card rather than letting the throw sink the whole shard.
+   * Returns an empty list only when the provider legitimately yields no values.
+   *
+   * The reflection itself lives in [PreviewParameterSupport] so the daemon's render body resolves
+   * providers exactly the same way (issue #3027) rather than growing a second copy that drifts.
    */
-  private fun loadProviderValues(providerFqn: String, limit: Int): List<Any?> {
-    val clazz =
-      try {
-        Class.forName(providerFqn)
-      } catch (e: ClassNotFoundException) {
-        throw ProviderLoadException("provider class $providerFqn not found on the test classpath", e)
-      }
-    val instance =
-      try {
-        val ctor = clazz.getDeclaredConstructor()
-        // `private` providers (idiomatic Kotlin, and rendered fine by Android Studio) compile to
-        // package-private JVM classes, so their no-arg constructor isn't reflectively callable from
-        // this package without opening it up first — see issue #2493.
-        ctor.isAccessible = true
-        ctor.newInstance()
-      } catch (e: Throwable) {
-        throw ProviderLoadException(
-          "couldn't instantiate $providerFqn via its no-arg constructor",
-          e,
-        )
-      }
-    // `PreviewParameterProvider<T>` exposes `values: Sequence<T>` as a Kotlin
-    // property — its JVM signature is `getValues(): Sequence`. Look up the
-    // method by name to avoid taking a compile-time dependency on the
-    // provider interface (which lives in the consumer's Compose artifact).
-    val getValues =
-      try {
-        clazz.getMethod("getValues")
-      } catch (e: Throwable) {
-        throw ProviderLoadException(
-          "$providerFqn has no getValues() — not a PreviewParameterProvider?",
-          e,
-        )
-      }
-    // Same package-private-class problem as the constructor above: a public `getValues()` declared
-    // on a package-private class throws `IllegalAccessException` from `Method.invoke` unless the
-    // member is opened up first. This is the crash in issue #2493.
-    getValues.isAccessible = true
-    return try {
-      @Suppress("UNCHECKED_CAST")
-      val sequence = getValues.invoke(instance) as? Sequence<Any?> ?: return emptyList()
-      // `Sequence.take(Int).toList()` is the Kotlin stdlib contract —
-      // drives the sequence lazily up to `limit` without requiring
-      // reflective access into package-private iterator implementations
-      // (`kotlin.jvm.internal.ArrayIterator`, which `Method.invoke`
-      // rejects with IllegalAccessException from outside the stdlib
-      // module).
-      sequence.take(limit).toList()
-    } catch (e: Throwable) {
-      throw ProviderLoadException("$providerFqn.getValues() failed", e)
-    }
-  }
+  private fun loadProviderValues(providerFqn: String, limit: Int): List<Any?> =
+    PreviewParameterSupport.loadValues(providerFqn, limit)
 
   /**
    * Resolve the base output PNG for [entry] the same way [RobolectricRenderTestBase.outputFileFor]
@@ -496,9 +449,6 @@ object PreviewManifestLoader {
     return null
   }
 
-  /** Thrown by [loadProviderValues] on a hard provider-load failure so the caller can isolate it. */
-  private class ProviderLoadException(message: String, cause: Throwable?) :
-    RuntimeException(message, cause)
 }
 
 /**

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupportTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupportTest.kt
@@ -28,6 +28,12 @@ fun PlainSquareFixture() {
   Box(modifier = Modifier.fillMaxSize().background(Color(0xFFEF5350)))
 }
 
+/** Idiomatic `private fun` preview — compiles to a JVM-private static method. */
+@Composable
+private fun PrivateTintedSquareFixture(@PreviewParameter(TintProviderFixture::class) tint: Long) {
+  Box(modifier = Modifier.fillMaxSize().background(Color(tint)))
+}
+
 /**
  * Resolution-level cover for [PreviewParameterSupport], the shared seam behind issue #3027.
  *
@@ -65,6 +71,24 @@ class PreviewParameterSupportTest {
     assertEquals("TintedSquareFixture", jvmMethod.name)
     // `(long, Composer, int)` — the parameterized overload, not the parameterless one.
     assertEquals(Long::class.javaPrimitiveType, jvmMethod.parameterTypes.first())
+  }
+
+  @Test
+  fun resolvedMethodIsOpenedForReflectiveInvocation() {
+    // A `private fun` preview resolves fine but `ComposableMethod.invoke` throws
+    // IllegalAccessException unless the method is opened. `resolve` does it for every caller, so
+    // the daemon's scroll / figma-svg-long / held-session paths can't each forget to.
+    val resolved =
+      PreviewParameterSupport.resolve(
+        fixtureClass,
+        "PrivateTintedSquareFixture",
+        providerClassName = TintProviderFixture::class.java.name,
+      )
+    assertTrue("private preview method must be accessible", resolved.method.asMethod().isAccessible)
+
+    val plain =
+      PreviewParameterSupport.resolve(fixtureClass, "PlainSquareFixture", providerClassName = null)
+    assertTrue("parameterless path opens its method too", plain.method.asMethod().isAccessible)
   }
 
   @Test

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupportTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupportTest.kt
@@ -1,0 +1,93 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/** Provider whose first value is deliberately distinct from the second — see the test kdoc. */
+class TintProviderFixture : PreviewParameterProvider<Long> {
+  override val values = sequenceOf(0xFF43A047L, 0xFF1E88E5L)
+}
+
+@Composable
+fun TintedSquareFixture(@PreviewParameter(TintProviderFixture::class) tint: Long) {
+  Box(modifier = Modifier.fillMaxSize().background(Color(tint)))
+}
+
+@Composable
+fun PlainSquareFixture() {
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFFEF5350)))
+}
+
+/**
+ * Resolution-level cover for [PreviewParameterSupport], the shared seam behind issue #3027.
+ *
+ * These assertions are the part of the fix that doesn't need a Robolectric sandbox: whether the
+ * right JVM overload is found and which provider value is bound. The end-to-end "does it produce
+ * pixels" half lives in `:daemon:android`'s `RenderEngineTest`.
+ */
+class PreviewParameterSupportTest {
+
+  private val fixtureClass: Class<*> =
+    Class.forName("ee.schimke.composeai.renderer.PreviewParameterSupportTestKt")
+
+  @Test
+  fun resolvesParameterlessPreviewWithNoArgs() {
+    val resolved =
+      PreviewParameterSupport.resolve(fixtureClass, "PlainSquareFixture", providerClassName = null)
+    assertEquals(emptyList<Any?>(), resolved.args)
+    // `(Composer, int)` — no leading value parameter.
+    assertEquals(2, resolved.method.asMethod().parameterCount)
+  }
+
+  @Test
+  fun resolvesParameterizedPreviewToItsFirstProviderValue() {
+    // Before the fix this shape was resolved with the parameterless lookup, which matches only
+    // `foo(Composer, int)` and therefore threw `NoSuchMethodException` — the failure reported in
+    // issue #3027. The daemon renders one frame per preview id, so the FIRST value is the contract.
+    val resolved =
+      PreviewParameterSupport.resolve(
+        fixtureClass,
+        "TintedSquareFixture",
+        providerClassName = TintProviderFixture::class.java.name,
+      )
+    assertEquals(listOf<Any?>(0xFF43A047L), resolved.args)
+    val jvmMethod = resolved.method.asMethod()
+    assertEquals("TintedSquareFixture", jvmMethod.name)
+    // `(long, Composer, int)` — the parameterized overload, not the parameterless one.
+    assertEquals(Long::class.javaPrimitiveType, jvmMethod.parameterTypes.first())
+  }
+
+  @Test
+  fun limitedToOneValueEvenForAnUnboundedProvider() {
+    // `take(1)` on the sequence, so an infinite `generateSequence` provider terminates.
+    val values = PreviewParameterSupport.loadValues(TintProviderFixture::class.java.name, limit = 1)
+    assertEquals(listOf<Any?>(0xFF43A047L), values)
+  }
+
+  @Test
+  fun missingProviderClassFailsWithAnActionableMessage() {
+    try {
+      PreviewParameterSupport.resolve(
+        fixtureClass,
+        "TintedSquareFixture",
+        providerClassName = "com.example.NotOnTheClasspath",
+      )
+      fail("expected a PreviewParameterLoadException")
+    } catch (e: PreviewParameterLoadException) {
+      assertTrue(
+        "message should name the missing provider: ${e.message}",
+        e.message!!.contains("com.example.NotOnTheClasspath"),
+      )
+    }
+  }
+}


### PR DESCRIPTION
Fixes #3027.

## Diagnosis

The `NoSuchMethodException` is not specific to the two `Summary*` previews — it is **every preview that declares a `@PreviewParameter` argument**, and it comes from the **daemon**, not the Gradle render path.

From the repro run's own log (`yschimke/pocket-casts-android`, run 30471225420, job 90641670656):

```
compose-ai-daemon: host.submit(25) failed: …buttons.IconButtonSmallKt.IconButtonSmallThemePreview
java.lang.NoSuchMethodException: …buttons.IconButtonSmallKt.IconButtonSmallThemePreview
    at androidx.compose.runtime.reflect.ComposableMethodKt.getDeclaredComposableMethod(ComposableMethod.jvmAndAndroid.kt:202)
    at ee.schimke.composeai.daemon.RenderEngine.render$lambda$2(RenderEngine.kt:291)
```

27 distinct previews in that one module throw it, including
`SummaryContentKt.SummaryContentPreview` and `SummaryPaywallKt.SummaryPaywallPreview`. Every one takes a `@PreviewParameter` argument; their parameterless siblings (e.g. `CalendarHeatMapPreviewFont150Percent`, `SummaryPaywallFreeTrialPreview`) do not throw. It also lines up with the run's "125 / 166 previews carried semantics (41 without a captured tree)" — the daemon is the sole producer of those.

**Mechanism.** `getDeclaredComposableMethod(functionName)` asks for the `(Composer, int)` overload. A preview declaring `@PreviewParameter` compiles to `(<T>, Composer, int)`, so nothing matches and resolution throws *before composition starts* — no PNG, no semantics/layout/figma-svg, just an `.error.json`. `RenderEngine`'s class doc had recorded "no `@PreviewParameter`" as a v1 limitation; in practice it is a hard failure on a very common shape (34 `@PreviewParameter` usages in that module alone).

Note this is a **different** cause from the missing PNGs in #2946/#2957 for the same two previews (both files render `HtmlText`, an `AndroidView` — fixed by #2995). The daemon-side data products were failing for this separate reason.

## Fix

`@PreviewParameter` has `AnnotationRetention.BINARY`, so the sandbox cannot recover the provider by reflecting on the composable — exactly the `@PreviewWrapper` problem from #1440. So the provider FQN + limit travel the same path `wrapperClassName` already uses:

`DiscoverPreviewsTask` → `previews.json` (`params.previewParameterProviderClassName`) → `PreviewManifestRouter` → `previewParameterProvider=` payload token → `RenderSpec` → render body.

- New `PreviewParameterSupport` in `:renderer-android` owns provider loading + overload resolution; `RobolectricRenderTest.loadProviderValues` now delegates to it, so the daemon and the standalone renderer resolve providers with one implementation rather than two. It also opens the resolved method for reflective invocation, so `private fun` previews compose on every path (Codex review, `8ded724` — the scroll and held-session lanes were missing that already).
- The daemon invokes the preview with the provider's **first** value. It renders one frame per preview id (and manifest ids are the un-suffixed base ids the fan-out renderer would emit as `<id>_<label>`), so per-value fan-out stays with the standalone renderer. Studio shows value 0 first too.
- All four Android daemon resolution sites are covered: the main render, the scroll/GIF scenario, the `figma-svg-long` slice + probe scenarios, and the held/interactive lane in `RobolectricHost` (without that last one, live mode on a parameterized preview would still blank the panel).

Scope note: `:daemon:desktop` has the same parameterless lookup and is **not** changed here — the reported failure and its repro are the Android/Robolectric backend, and the desktop engine threads its method through `SceneState` differently. Happy to follow up if you want desktop parity.

## Test plan

- ✅ **New** `renderers/android/.../PreviewParameterSupportTest` (plain JVM, 5 cases): parameterless preview resolves with no args; parameterized preview resolves to the `(long, Composer, int)` overload bound to the provider's first value; the resolved method is opened for invocation (`private fun` fixture); `take(1)` bounds an unbounded provider; a missing provider class fails with a message naming it. Run green here.
- ✅ **New** `PreviewManifestRouterRoutingTest` cases: the provider FQN + non-default limit reach the routed payload and parse back out of `RenderSpec`; an ordinary preview emits no token. Run green here.
- ✅ **New** `PreviewParameterAndroidRealModeTest` in `:daemon:harness` — spawns the **real** Android daemon, renders `ThemedTintedSquare` through it, and requires the provider's **first** value (green `#43A047`), not its second (blue). This is the end-to-end proof, and it runs on every PR in the `Daemon Harness (android, real renderer)` job.
  - Why there and not in `:daemon:android`'s own tests: **`:daemon:android:testDebugUnitTest` is not wired into any workflow**, so the equivalent `RenderEngineTest.previewParameterPreviewRendersFirstProviderValue` (also added, same assertion) would never have executed on a PR. An earlier revision of this description claimed "CI runs both" — that was wrong, and moving the assertion into the harness lane is the fix rather than the correction.
- ✅ `./gradlew ktfmtFormatAll`, plus `compileDebugKotlin` / `compileDebugUnitTestKotlin` for `:renderer-android`, `:daemon:android` (main, test, testFixtures), `:daemon:harness` and `:daemon:desktop`.
- ⚠️ Neither Robolectric-backed test could be **executed locally** in this container: the native runtime aborts the JVM (`Typeface.loadPreinstalledSystemFontMap` NPE → `SIGSEGV in libandroid_runtime.so`, exit 134). Environmental, not this change — the pre-existing `RenderEngineTest.redSquareRendersToValidPng` and `:daemon:core:test` fail identically on a clean checkout here. Both run on CI runners, which is why the harness placement matters.

## Visual evidence

No pixels change for anything that renders today — the change turns previews that produced *no* image into ones that produce their normal image. The honest before/after is "`.error.json`" → "the preview's own render", and I could not capture the "after" locally for the reason above.

Per the repo's "wire new visual surfaces into the preview workflow" rule, the evidence is wired in rather than one-off: `ThemedTintedSquare` + `SquareTintProvider` live in `:daemon:android`'s testFixtures and are driven by the harness scenario above, so every future change to this path is checked against real pixels on every PR — and the two-value provider means binding the *wrong* value fails just as loudly as rendering nothing.