### PR TITLE
fix(figma-svg): size the canvas from the rendered frame, not off-screen items (#2853)

### DIFF
--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -652,13 +652,19 @@ data class FigmaSvgModel(
       // shows. Drop those targets so an off-viewport lazy item costs neither a PNG nor a dangling
       // reference (issue #2853). Targets carrying their own captured bytes are unaffected: their
       // pixels come with the payload, not out of the frame.
+      // Filtered against the **final canvas**, not the frame: the two must agree, or the SVG
+      // references a PNG nobody writes. The clamp above falls back to the drawn extent when content
+      // lies entirely outside the frame, and in that case those layers — `<image>` included — are
+      // still on the canvas and still need their crops. With no frame the canvas *is* the drawn
+      // extent, so every target is inside it and nothing is dropped.
       val targets =
-        frameExtent?.let { f ->
-          ctx.rasterTargets.filter {
-            it.pngBase64 != null ||
-              (it.right > f.minX && it.left < f.maxX && it.bottom > f.minY && it.top < f.maxY)
-          }
-        } ?: ctx.rasterTargets
+        ctx.rasterTargets.filter {
+          it.pngBase64 != null ||
+            (it.right > extent.minX &&
+              it.left < extent.maxX &&
+              it.bottom > extent.minY &&
+              it.top < extent.maxY)
+        }
       return FigmaSvgModel(
         root = rootLayer,
         minX = extent.minX,

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -550,10 +550,38 @@ data class FigmaSvgModel(
       // canvas extent to the frame — otherwise the square/tall full-frame background paints the
       // corners the render leaves transparent. No drawing layer (a tree of pure grouping nodes) → a
       // minimal padding-square canvas, matching the wireframe's empty-tree convention.
+      // The captured frame PNG's rect, anchored at the root origin (the render crops top-left from
+      // the window, whose origin is the root node). This is *everything that was rendered* — no
+      // pixel outside it exists in the frame.
+      val frameExtent =
+        if (frameWidthPx != null && frameHeightPx != null && frameWidthPx > 0 && frameHeightPx > 0)
+          Extent(frame.left, frame.top, frame.left + frameWidthPx, frame.top + frameHeightPx)
+        else null
       val contentExtent =
         if (clip != null || capsule != null)
           Extent(frame.left, frame.top, frame.right, frame.bottom)
-        else rootLayer.extent() ?: Extent(0, 0, 0, 0)
+        else
+        // Clamped to the rendered frame (issue #2853). A lazy list reports every *composed* item,
+        // including the ones scrolled past the viewport — Jetsnack's `Screens/App shell` carries a
+        // third snack column at x 397…565 and two more rows below y 800, none of which the 400×800
+        // render paints. Letting them size the canvas grew it to 598×1003 and stranded their white
+        // card backgrounds outside the phone UI as detached tiles. With no frame size (the
+        // vector-only path, a synthetic model) there is nothing to clamp to and the drawn-content
+        // extent still decides, so an overflowing child of an unclipped container keeps growing
+        // the canvas exactly as `FigmaSvgChildClipTest` pins.
+        (rootLayer.extent() ?: Extent(0, 0, 0, 0)).let { drawn ->
+            frameExtent?.let { f ->
+              Extent(
+                  maxOf(drawn.minX, f.minX),
+                  maxOf(drawn.minY, f.minY),
+                  minOf(drawn.maxX, f.maxX),
+                  minOf(drawn.maxY, f.maxY),
+                )
+                // A tree drawn entirely outside its own frame is pathological; keep what it drew
+                // rather than emitting an inverted extent.
+                .takeIf { it.maxX > it.minX && it.maxY > it.minY }
+            } ?: drawn
+          }
       val deviceBgResolved = deviceBackground?.let { argbToColor(it, names) }
       // The captured frame PNG's pixel size is the exact area a maskless `showBackground` preview
       // fills: the render paints the background across the whole window and crops top-left, so
@@ -619,6 +647,18 @@ data class FigmaSvgModel(
             height = extent.maxY - extent.minY,
           )
         else null
+      // A crop whose rect lies entirely outside the rendered frame has no pixels to take — the
+      // connector would write a 1×1 transparent placeholder for an `<image>` the canvas no longer
+      // shows. Drop those targets so an off-viewport lazy item costs neither a PNG nor a dangling
+      // reference (issue #2853). Targets carrying their own captured bytes are unaffected: their
+      // pixels come with the payload, not out of the frame.
+      val targets =
+        frameExtent?.let { f ->
+          ctx.rasterTargets.filter {
+            it.pngBase64 != null ||
+              (it.right > f.minX && it.left < f.maxX && it.bottom > f.minY && it.top < f.maxY)
+          }
+        } ?: ctx.rasterTargets
       return FigmaSvgModel(
         root = rootLayer,
         minX = extent.minX,
@@ -626,7 +666,7 @@ data class FigmaSvgModel(
         width = (extent.maxX - extent.minX) + padding * 2,
         height = (extent.maxY - extent.minY) + padding * 2,
         padding = padding,
-        rasterTargets = ctx.rasterTargets,
+        rasterTargets = targets,
         roundClip = clip,
         capsuleClip = capsule,
         deviceBackground = deviceBg,

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -2422,13 +2422,20 @@ class FigmaLayeredSvgTest {
   }
 
   /**
-   * Follow-up to #2974: when the SVG retains drawing beyond the captured frame (a card's chrome
-   * wider than its box, a scroll item past its parent edge), the exported canvas grows to include
-   * it — so the background must grow with it, not stop at the frame crop. Otherwise the retained
-   * content renders over transparency, whereas in the live render it sat on the window background.
+   * Follow-up to #2974, revised by #2853: the background fills whatever the canvas ends up being,
+   * and with a captured frame the canvas **is** the frame.
+   *
+   * The earlier rule grew the canvas to any drawing retained past the frame (a card's chrome wider
+   * than its box, a scroll item past its parent edge) so that content wouldn't sit over
+   * transparency. But a lazy list composes items far outside the viewport — Jetsnack's `Screens/App
+   * shell` renders 400×800 and carries cards out to 566×970 — and growing the canvas to hold them
+   * stranded their white backgrounds outside the phone UI as detached tiles the render never
+   * painted. The frame PNG is the authority on what was rendered, so it now bounds the canvas;
+   * retained drawing that overhangs is cropped at the frame edge exactly as the render cropped it,
+   * and the background still covers every pixel of the result.
    */
   @Test
-  fun aShowBackgroundFillCoversContentRetainedBeyondTheFrame() {
+  fun aShowBackgroundFillCoversTheFrameTheRenderCaptured() {
     val layout =
       layoutNode(
         "Box",
@@ -2458,15 +2465,15 @@ class FigmaLayeredSvgTest {
       )
     val rect = model.backgroundRect
     assertNotNull(rect)
-    // Background spans the full retained extent (120×40), not just the 100×26 frame, so the
-    // retained chrome sits on the backing colour rather than over transparency.
+    // Background spans the captured 100×26 frame — every pixel the render produced — rather than
+    // the 120×40 bbox of a chrome layer that overhangs it.
     assertEquals(0, rect!!.x)
     assertEquals(0, rect.y)
-    assertEquals(120, rect.width)
-    assertEquals(40, rect.height)
-    // And the canvas contains it (extent + padding on each side).
-    assertEquals(120 + FigmaSvgModel.DEFAULT_PADDING * 2, model.width)
-    assertEquals(40 + FigmaSvgModel.DEFAULT_PADDING * 2, model.height)
+    assertEquals(100, rect.width)
+    assertEquals(26, rect.height)
+    // And the canvas is that frame (extent + padding on each side).
+    assertEquals(100 + FigmaSvgModel.DEFAULT_PADDING * 2, model.width)
+    assertEquals(26 + FigmaSvgModel.DEFAULT_PADDING * 2, model.height)
   }
 
   @Test

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgOffscreenItemTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgOffscreenItemTest.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A lazy list reports every *composed* item, including the ones scrolled past the viewport — so the
+ * captured tree extends well beyond what the render actually painted (issue #2853).
+ *
+ * Jetsnack's `Search/Categories` renders 1081×577 and its capture carries grid rows down to y 737,
+ * which grew the exported canvas to 1082×769 — a quarter of the sticker being space the render
+ * never painted, with the below-fold rows' backgrounds stranded in it. (`Screens/App shell` showed
+ * the same shape more severely, 400×800 rendered against a 598×1003 canvas, until the
+ * `Modifier.clip` child-clipping of #2852 cut its off-screen cards; a list inside a container that
+ * does *not* clip still reaches here.)
+ *
+ * The captured frame's pixel size is the authority on what was rendered, so the canvas is clamped
+ * to it. With no frame size (the vector-only path) nothing is known to clamp against and the drawn
+ * extent still decides — the behaviour `FigmaSvgChildClipTest` pins for an unclipped overflow.
+ */
+class FigmaSvgOffscreenItemTest {
+
+  private fun bounds(l: Int, t: Int, r: Int, b: Int) = LayoutInspectorBounds(l, t, r, b)
+
+  /**
+   * A 400×800 screen whose lazy row composed one on-screen card and one that sits entirely past the
+   * right edge, plus a row below the fold — the shape of the App shell capture.
+   */
+  private fun screenWithOffscreenItems() =
+    LayoutInspectorNode(
+      nodeId = "screen",
+      component = "Box",
+      bounds = bounds(0, 0, 400, 800),
+      size = LayoutInspectorSize(400, 800),
+      tokens = ComposeSemanticsTokens(backgroundColor = "#FFFFFFFF"),
+      children =
+        listOf(
+          LayoutInspectorNode(
+            nodeId = "card-visible",
+            component = "Box",
+            bounds = bounds(24, 168, 194, 416),
+            size = LayoutInspectorSize(170, 248),
+            tokens = ComposeSemanticsTokens(backgroundColor = "#FFFFFFFF"),
+          ),
+          LayoutInspectorNode(
+            nodeId = "card-offscreen-right",
+            component = "Box",
+            bounds = bounds(397, 168, 565, 416),
+            size = LayoutInspectorSize(168, 248),
+            tokens = ComposeSemanticsTokens(backgroundColor = "#FFFFFFFF"),
+          ),
+          LayoutInspectorNode(
+            nodeId = "card-below-fold",
+            component = "Box",
+            bounds = bounds(24, 722, 194, 970),
+            size = LayoutInspectorSize(170, 248),
+            tokens = ComposeSemanticsTokens(backgroundColor = "#FFFFFFFF"),
+          ),
+        ),
+    )
+
+  private fun model(frameWidthPx: Int?, frameHeightPx: Int?) =
+    FigmaSvgModel.from(
+      layout = LayoutInspectorPayload(screenWithOffscreenItems()),
+      density = 1f,
+      frameWidthPx = frameWidthPx,
+      frameHeightPx = frameHeightPx,
+    )
+
+  @Test
+  fun theCanvasIsTheRenderedFrameNotTheOffscreenBbox() {
+    val m = model(400, 800)
+    assertEquals("canvas width must be the 400px render", 400 + m.padding * 2, m.width)
+    assertEquals("canvas height must be the 800px render", 800 + m.padding * 2, m.height)
+  }
+
+  @Test
+  fun withoutAFrameSizeTheDrawnExtentStillDecides() {
+    // The vector-only path knows nothing about what was rendered, so it must not start guessing —
+    // this is the same rule that keeps an unclipped overflowing child on the canvas.
+    val m = model(null, null)
+    assertTrue("no frame size → the overflow still grows the canvas (${m.width})", m.width > 400)
+  }
+
+  @Test
+  fun anOnScreenSliverOfAPartlyOffscreenItemSurvives() {
+    // Clamping is on the canvas, not on the layers: a card straddling the right edge keeps its
+    // visible sliver, exactly as the render paints it.
+    val m = model(400, 800)
+    val svg = FigmaLayeredSvg.render(m)
+    assertTrue("the straddling card must still be emitted:\n$svg", svg.contains("""x="397""""))
+  }
+}

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgOffscreenItemTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgOffscreenItemTest.kt
@@ -91,4 +91,43 @@ class FigmaSvgOffscreenItemTest {
     val svg = FigmaLayeredSvg.render(m)
     assertTrue("the straddling card must still be emitted:\n$svg", svg.contains("""x="397""""))
   }
+
+  @Test
+  fun aTreeDrawnEntirelyOffFrameKeepsItsLayersAndTheirCrops() {
+    // Pathological capture: everything composed sits past the frame, so the clamp has nothing to
+    // intersect and falls back to the drawn extent — those layers stay on the canvas. The raster
+    // targets must stay with them, or the `<image>` they emit would reference a PNG nobody writes.
+    val offFrame =
+      LayoutInspectorNode(
+        nodeId = "screen",
+        component = "Box",
+        bounds = bounds(0, 0, 400, 800),
+        size = LayoutInspectorSize(400, 800),
+        children =
+          listOf(
+            LayoutInspectorNode(
+              nodeId = "photo",
+              component = "Image",
+              bounds = bounds(600, 900, 720, 1020),
+              size = LayoutInspectorSize(120, 120),
+            )
+          ),
+      )
+    val m =
+      FigmaSvgModel.from(
+        layout = LayoutInspectorPayload(offFrame),
+        density = 1f,
+        rasterComponents = FigmaSvgModel.DEFAULT_RASTER_COMPONENTS,
+        frameWidthPx = 400,
+        frameHeightPx = 800,
+      )
+    val svg = FigmaLayeredSvg.render(m)
+    val referenced = Regex("""href="([^"]+)"""").findAll(svg).map { it.groupValues[1] }.toList()
+    for (href in referenced) {
+      assertTrue(
+        "every <image href> must have a raster target to write it: $href in ${m.rasterTargets}",
+        m.rasterTargets.any { it.href == href },
+      )
+    }
+  }
 }


### PR DESCRIPTION
Follow-up to #3042, closing out the last thread of #2853.

## The bug

A lazy list reports every *composed* item, not just the visible ones, so the captured tree runs past what the render painted. Jetsnack's `Search/Categories` renders **1081×577** while its capture carries grid rows down to **y 737** — the export sized its canvas from that bbox and came out **1082×769**. A quarter of the sticker is space the PNG never painted, with the below-fold rows' backgrounds stranded in it.

## The fix

The captured frame's pixel size is the authority on what was rendered, so the canvas is clamped to it. Raster targets falling entirely outside the frame are dropped rather than writing a 1×1 transparent placeholder for an `<image>` the canvas no longer shows.

Layers themselves are untouched — a card straddling the frame edge keeps the sliver the render paints, cropped at the edge exactly as the render cropped it.

## What this revises

#2974's follow-up deliberately grew the canvas to hold drawing retained past the frame, so it wouldn't sit over transparency. That rule can't distinguish a card's overhanging chrome from a list item a full screen away. With a frame present the frame now wins, and the background still covers every pixel of the result. `aShowBackgroundFillCoversContentRetainedBeyondTheFrame` is updated to `aShowBackgroundFillCoversTheFrameTheRenderCaptured` with that rationale.

The vector-only path (no frame size) is unchanged, so an unclipped overflowing child still grows the canvas exactly as `FigmaSvgChildClipTest` pins.

## Scope — measured, and smaller than it first looked

I surveyed all **171** published previews (94 jetsnack + 77 jetchat), comparing each SVG canvas against its PNG:

| | |
|---|---|
| Oversized today | **1 of 171** — `search-categories`, 1.28× taller (769 vs 609 incl. padding) |
| Oversized horizontally | none |

`Screens/App shell` and `Snack/Detail` showed this same shape far more severely — 598×1003 against a 400×800 render, with white cards stranded outside the phone UI, which is what #2853's last comment reported. **Those are already fixed on main**: their published SVGs are now 432×832 against a 400×800 render, an exact match, after the `Modifier.clip` child-clipping of #2852 (#3023) cut their off-screen cards. This change covers the remaining case, where the list's container does *not* clip and nothing else bounds it.

Evidence (before / after / render for `search-categories`): [`docs/evidence/figma-svg-offscreen-items/offscreen-items-before-after.png`](``https://github.com/yschimke/compose-ai-tools/blob/agent/issue-2853-appshell-unscaled-bounds/docs/evidence/figma-svg-offscreen-items/offscreen-items-before-after.png).`` The two SVG panels are rasterised offline by cairosvg, which can't fetch the remote `figma-raster` hrefs or webfonts — the photo boxes and smeared text are its artifacts, not the export's. (Embedding it inline isn't possible from here: this repo's own raw URLs get rewritten in the PR body.)

## Test plan

- `:data-layoutinspector-core:test` — green (227 + 3 new). New `FigmaSvgOffscreenItemTest` pins the clamp, that a straddling item keeps its visible sliver, and that the vector-only path still grows the canvas.
- No end-to-end run: as with #3042, neither daemon backend runs in this container and no CI job invokes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GpzckZtKxBbgy3SSE6LSn

---
_Generated by [Claude Code](https://claude.ai/code/session_015GpzckZtKxBbgy3SSE6LSn)_