### PR TITLE
feat(playground): render the Android first frame for ANDROID-mode snippets

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -6,6 +6,8 @@ import ee.schimke.composeai.cli.serve.DaemonStartupLog
 import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
 import ee.schimke.composeai.cli.serve.MutableTrustStore
+import ee.schimke.composeai.cli.serve.PlaygroundAndroidRenderService
+import ee.schimke.composeai.cli.serve.PlaygroundAndroidSessionOpener
 import ee.schimke.composeai.cli.serve.PlaygroundBtaCompiler
 import ee.schimke.composeai.cli.serve.PlaygroundCatalogClasspath
 import ee.schimke.composeai.cli.serve.PlaygroundCompileService
@@ -884,19 +886,26 @@ class ServeCommand(args: List<String>) : Command(args) {
       return null
     }
 
-    // Remote-compose mode needs the Android compile classpath, the Robolectric daemon sidecar, and
-    // a
-    // `/d/` document store to publish into. Absent any of the three it stays unavailable while CMP
-    // is
-    // unaffected.
-    val rcCapture =
-      if (androidClasspath != null) buildPlaygroundRcCaptureService(workRoot, docStore) else null
+    // The Android compile classpath plus the Robolectric daemon sidecar back both the live
+    // first-frame render (ANDROID mode) and the remote-compose capture (REMOTE_COMPOSE mode). Build
+    // the shared daemon opener once; absent the sidecar, both Android lanes stay unavailable while
+    // CMP is unaffected. Remote-compose additionally needs the `/d/` document store to publish
+    // into.
+    val androidDaemonOpener =
+      if (androidClasspath != null) buildPlaygroundAndroidDaemonOpener() else null
+    val androidRender = androidDaemonOpener?.let { opener ->
+      buildPlaygroundAndroidRenderService(workRoot, opener)
+    }
+    val rcCapture = androidDaemonOpener?.let { opener ->
+      buildPlaygroundRcCaptureService(workRoot, docStore, opener)
+    }
 
     System.err.println(
       "serve: playground enabled (POST /api/1/compiler/run) — " +
         listOfNotNull(
             cmpClasspath?.let { "cmp✓" },
             androidClasspath?.let { "android✓" },
+            androidRender?.let { "android-render✓" },
             rcCapture?.let { "remote-compose✓" },
           )
           .joinToString(" ")
@@ -919,6 +928,11 @@ class ServeCommand(args: List<String>) : Command(args) {
       tokenStore = PlaygroundTokenStore(),
       newWorkDir = {
         java.io.File(workRoot, "snippet-${snippetCounter.incrementAndGet()}").absolutePath.toPath()
+      },
+      // The still first frame is the Android live render (ANDROID mode); CMP's desktop first frame
+      // is a separate lane, and REMOTE_COMPOSE never reaches this seam (it returns a documentUrl).
+      renderFirstFrame = { snippet ->
+        if (snippet.mode == PlaygroundMode.ANDROID) androidRender?.render(snippet) else null
       },
       captureRemoteDocument = { snippet -> rcCapture?.capture(snippet) },
       publishRemoteDocument = { name, bytes, checked ->
@@ -951,16 +965,75 @@ class ServeCommand(args: List<String>) : Command(args) {
   }
 
   /**
-   * Assemble the Android/Robolectric capture backend for the playground's remote-compose mode — the
-   * `lib-daemon-android` sidecar + `android.jar` on the daemon classpath, the Robolectric
-   * jvmArgs/sysprops, and a subprocess `openBundleDaemon` opener. Mirrors [ServeBundleDaemon]'s
-   * `androidBundleDaemonLaunch`. Returns null (logging why) when the sidecar, `android.jar`, or the
-   * `/d/` document store is missing — remote-compose then reports unavailable rather than compiling
-   * to a dead end.
+   * Resolve the Android/Robolectric daemon opener shared by the playground's Android render lanes —
+   * the `lib-daemon-android` sidecar + `android.jar` on the daemon classpath, the Robolectric
+   * jvmArgs/sysprops, and a subprocess `openBundleDaemon`. Mirrors [ServeBundleDaemon]'s
+   * `androidBundleDaemonLaunch`. Returns null (logging why) when the sidecar or `android.jar` is
+   * missing — both Android lanes then report unavailable rather than compiling to a dead end.
+   */
+  private fun buildPlaygroundAndroidDaemonOpener(): PlaygroundAndroidSessionOpener? {
+    val daemonJars = locateBundleSidecarJars("lib-daemon-android")
+    if (daemonJars.isEmpty()) {
+      System.err.println(
+        "serve: playground Android modes need the Android daemon sidecar " +
+          "(lib-daemon-android/), which ships separately as " +
+          "compose-preview-android-daemon-<version>.zip; unpack it and set " +
+          "-Dcomposeai.cli.libDaemonAndroidDir=<dir>/lib-daemon-android. Android modes disabled."
+      )
+      return null
+    }
+    val androidJar =
+      AndroidBundleLaunch.resolveAndroidJar(localPropertiesFile = null)
+        ?: run {
+          System.err.println(
+            "serve: playground Android modes need android.jar — set ANDROID_HOME / " +
+              "ANDROID_SDK_ROOT. Android modes disabled."
+          )
+          return null
+        }
+    val launch = AndroidBundleLaunch()
+    val daemonClasspath = (daemonJars + listOf(androidJar)).map { it.absolutePath }
+    val jvmArgs = launch.jvmArgs()
+    val sysprops = launch.robolectricSystemProperties()
+    return { classesDir, previewsJson, workspaceRoot, userClasspath ->
+      SubprocessRenderSessions.openBundleDaemon(
+        daemonClasspath = daemonClasspath,
+        classesDir = classesDir,
+        previewsJson = previewsJson,
+        workspaceRoot = workspaceRoot,
+        modulePath = ":playground",
+        jvmArgs = jvmArgs,
+        extraSystemProperties = sysprops,
+        userClasspath = userClasspath,
+      )
+    }
+  }
+
+  /**
+   * The playground's Android first-frame render backend (ANDROID mode): renders a compiled snippet
+   * on the shared [opener] and returns the still PNG the Stage-1 response surfaces as its `image`.
+   */
+  private fun buildPlaygroundAndroidRenderService(
+    workRoot: java.io.File,
+    opener: PlaygroundAndroidSessionOpener,
+  ): PlaygroundAndroidRenderService {
+    val renderCounter = java.util.concurrent.atomic.AtomicLong()
+    return PlaygroundAndroidRenderService(
+      openSession = opener,
+      newWorkDir = { java.io.File(workRoot, "android-render-${renderCounter.incrementAndGet()}") },
+    )
+  }
+
+  /**
+   * The playground's remote-compose capture backend (REMOTE_COMPOSE mode): renders a compiled
+   * snippet on the shared [opener] and captures its `.rc` document. Returns null (logging why) when
+   * the `/d/` document store is missing — remote-compose then reports unavailable rather than
+   * compiling to a dead end.
    */
   private fun buildPlaygroundRcCaptureService(
     workRoot: java.io.File,
     docStore: ServeDocStore?,
+    opener: PlaygroundAndroidSessionOpener,
   ): PlaygroundRcCaptureService? {
     if (docStore == null) {
       System.err.println(
@@ -969,43 +1042,9 @@ class ServeCommand(args: List<String>) : Command(args) {
       )
       return null
     }
-    val daemonJars = locateBundleSidecarJars("lib-daemon-android")
-    if (daemonJars.isEmpty()) {
-      System.err.println(
-        "serve: playground remote-compose mode needs the Android daemon sidecar " +
-          "(lib-daemon-android/), which ships separately as " +
-          "compose-preview-android-daemon-<version>.zip; unpack it and set " +
-          "-Dcomposeai.cli.libDaemonAndroidDir=<dir>/lib-daemon-android. Remote-compose disabled."
-      )
-      return null
-    }
-    val androidJar =
-      AndroidBundleLaunch.resolveAndroidJar(localPropertiesFile = null)
-        ?: run {
-          System.err.println(
-            "serve: playground remote-compose mode needs android.jar — set ANDROID_HOME / " +
-              "ANDROID_SDK_ROOT. Remote-compose mode disabled."
-          )
-          return null
-        }
-    val launch = AndroidBundleLaunch()
-    val daemonClasspath = (daemonJars + listOf(androidJar)).map { it.absolutePath }
-    val jvmArgs = launch.jvmArgs()
-    val sysprops = launch.robolectricSystemProperties()
     val captureCounter = java.util.concurrent.atomic.AtomicLong()
     return PlaygroundRcCaptureService(
-      openSession = { classesDir, previewsJson, workspaceRoot, userClasspath ->
-        SubprocessRenderSessions.openBundleDaemon(
-          daemonClasspath = daemonClasspath,
-          classesDir = classesDir,
-          previewsJson = previewsJson,
-          workspaceRoot = workspaceRoot,
-          modulePath = ":playground",
-          jvmArgs = jvmArgs,
-          extraSystemProperties = sysprops,
-          userClasspath = userClasspath,
-        )
-      },
+      openSession = opener,
       newWorkDir = { java.io.File(workRoot, "rc-capture-${captureCounter.incrementAndGet()}") },
     )
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -916,10 +916,14 @@ class ServeCommand(args: List<String>) : Command(args) {
       catalogClasspath = { mode ->
         when (mode) {
           PlaygroundMode.CMP -> cmpClasspath
-          PlaygroundMode.ANDROID -> androidClasspath
-          // Only advertise REMOTE_COMPOSE when its capture backend actually came up — otherwise the
-          // host would accept the mode, run a full Android compile, then report the preview drew no
-          // document. A null classpath routes to the existing "mode … is not available" response.
+          // Only advertise the Android modes when their daemon backend actually came up — absent
+          // the
+          // sidecar/android.jar the host would otherwise accept the mode, run a full Android
+          // compile,
+          // then mint a dead token with no image (ANDROID) / report the preview drew no document
+          // (REMOTE_COMPOSE), contradicting the "Android modes disabled" startup log. A null
+          // classpath routes to the existing "mode … is not available" response.
+          PlaygroundMode.ANDROID -> androidClasspath?.takeIf { androidRender != null }
           PlaygroundMode.REMOTE_COMPOSE -> androidClasspath?.takeIf { rcCapture != null }
         }
       },

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundAndroidRenderService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundAndroidRenderService.kt
@@ -1,0 +1,132 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.render.session.RenderSession
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Opens a bundle-less render session over a compiled playground snippet — the injected daemon seam
+ * shared by [PlaygroundAndroidRenderService] and [PlaygroundRcCaptureService], both of which stand
+ * one Android/Robolectric daemon over a snippet's own classes. Production binds this to
+ * [SubprocessRenderSessions.openBundleDaemon] with the Android backend; tests supply a fake
+ * session.
+ */
+fun interface PlaygroundAndroidSessionOpener {
+  fun open(
+    classesDir: File,
+    previewsJson: File,
+    workspaceRoot: File,
+    userClasspath: List<String>,
+  ): RenderSession
+}
+
+/**
+ * The production [PlaygroundCompileService] `renderFirstFrame` for the **Android** mode: render a
+ * freshly-compiled Compose Android snippet on an Android/Robolectric daemon and return the PNG the
+ * daemon drew — the still frame the Stage-1 response surfaces as its `image` (`docs/design/
+ * PLAYGROUND.md` §7 Phase 2, epic #3015).
+ *
+ * The flow is the render half of [PlaygroundRcCaptureService]'s open → render → await → fetch
+ * shape, over a bundle-less daemon standing on the snippet's own compiled classes:
+ * 1. synthesize a one-preview `previews.json` from the snippet's discovered `@Preview` id
+ *    ([PlaygroundPreviews]);
+ * 2. [openSession] over the snippet's `classesDir` + full compile classpath (the production opener
+ *    is [SubprocessRenderSessions.openBundleDaemon] with the Android backend —
+ *    `lib-daemon-android` + `android.jar` on the daemon classpath, the Robolectric
+ *    jvmArgs/sysprops, and the snippet classpath as `userClassDirs`);
+ * 3. `renderNow` the preview and await its terminal `renderFinished` / `renderFailed` notification;
+ * 4. read the PNG the daemon wrote to the `renderFinished` `pngPath` — no data-product fetch and no
+ *    extension enable, unlike the RC capture: a plain first frame is the base render product.
+ *
+ * [openSession] is injected so the orchestration is unit-testable against a fake `RenderSession`
+ * without a real daemon subprocess (the same seam split [PlaygroundRcCaptureService] uses). Returns
+ * null — a clean "no frame" — on any miss: the render couldn't queue, it failed or timed out, or it
+ * produced no PNG. A null first frame is never fatal to the run: the Stage-1 response simply
+ * carries no still image while the preview token is still minted.
+ */
+class PlaygroundAndroidRenderService(
+  private val openSession: PlaygroundAndroidSessionOpener,
+  /** Mints a fresh scratch dir per render (holds the synthesized manifest + render outputs). */
+  private val newWorkDir: () -> File,
+  private val renderBudget: Duration = DEFAULT_RENDER_BUDGET,
+  private val ackTimeout: Duration = DEFAULT_ACK_TIMEOUT,
+) {
+
+  /**
+   * The [PlaygroundCompileService] `renderFirstFrame` seam: snippet → first-frame PNG bytes, or
+   * null.
+   */
+  fun render(snippet: PlaygroundTokenStore.PlaygroundSnippet): ByteArray? {
+    val workDir = newWorkDir().apply { mkdirs() }
+    return try {
+      val previewsJson =
+        File(workDir, "previews.json").apply {
+          writeText(PlaygroundPreviews.singlePreviewManifestJson(snippet))
+        }
+      // The playground's classpath entries are already absolute okio paths; File(toString()) is the
+      // safe bridge to the java.io.File the render-session API takes.
+      val classesDir = File(snippet.classesDir.toString())
+      val userClasspath = snippet.classpath.map { File(it.toString()).absolutePath }
+      val session = openSession.open(classesDir, previewsJson, workDir, userClasspath)
+      try {
+        renderFirstFrame(session, snippet.previewId)
+      } finally {
+        runCatching { session.close() }
+      }
+    } catch (_: Exception) {
+      // A render failure is a clean "no frame" to the caller; it must never escape as a throwable
+      // out of the render seam.
+      null
+    } finally {
+      runCatching { workDir.deleteRecursively() }
+    }
+  }
+
+  private fun renderFirstFrame(session: RenderSession, previewId: String): ByteArray? {
+    val latch = CountDownLatch(1)
+    val pngPath = AtomicReference<String?>()
+    val failure = AtomicReference<String?>()
+    val handle = session.onNotification { method, params ->
+      if (params == null) return@onNotification
+      val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
+      if (id != previewId) return@onNotification
+      when (method) {
+        "renderFinished" -> {
+          params["pngPath"]?.jsonPrimitive?.contentOrNull?.let { pngPath.set(it) }
+          latch.countDown()
+        }
+        "renderFailed" -> {
+          failure.set("daemon reported renderFailed")
+          latch.countDown()
+        }
+      }
+    }
+    return handle.use {
+      val ack =
+        session.renderNow(
+          listOf(previewId),
+          reason = "playground-first-frame",
+          timeout = ackTimeout,
+        )
+      if (ack.rejected.isNotEmpty()) return@use null
+      if (!latch.await(renderBudget.inWholeMilliseconds, TimeUnit.MILLISECONDS)) return@use null
+      if (failure.get() != null) return@use null
+      val path = pngPath.get() ?: return@use null
+      val file = File(path)
+      if (!file.isFile) return@use null
+      runCatching { file.readBytes() }.getOrNull()
+    }
+  }
+
+  companion object {
+    /** Cold Android/Robolectric renders take tens of seconds; budget generously. */
+    val DEFAULT_RENDER_BUDGET: Duration = 180.seconds
+    val DEFAULT_ACK_TIMEOUT: Duration = 30.seconds
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviews.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviews.kt
@@ -1,0 +1,43 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.PreviewInfo
+import ee.schimke.composeai.cli.PreviewManifest
+import kotlinx.serialization.json.Json
+
+/**
+ * Shared synthesis of a one-preview `previews.json` for a compiled playground snippet — the
+ * manifest a bundle-less daemon renders against. Both the Remote Compose capture
+ * ([PlaygroundRcCaptureService]) and the Android first-frame render
+ * ([PlaygroundAndroidRenderService]) stand a daemon over the snippet's own classes and need the
+ * identical single-entry manifest, so the synthesis lives here rather than in either service.
+ */
+internal object PlaygroundPreviews {
+
+  private val json = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+  }
+
+  /**
+   * A one-preview `previews.json` the daemon can render: the snippet's discovered id split back
+   * into its `className` + `functionName` (the id is `"$className.$functionName"`, per
+   * [PlaygroundPreviewDiscoverer]).
+   */
+  fun singlePreviewManifestJson(snippet: PlaygroundTokenStore.PlaygroundSnippet): String {
+    val id = snippet.previewId
+    val manifest =
+      PreviewManifest(
+        module = snippet.moduleName,
+        variant = "",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = id,
+              functionName = id.substringAfterLast('.'),
+              className = id.substringBeforeLast('.'),
+            )
+          ),
+      )
+    return json.encodeToString(PreviewManifest.serializer(), manifest)
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureService.kt
@@ -1,7 +1,5 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.PreviewInfo
-import ee.schimke.composeai.cli.PreviewManifest
 import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentPayload
 import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentProduct
 import ee.schimke.composeai.render.session.RenderSession
@@ -42,25 +40,12 @@ import kotlinx.serialization.json.jsonPrimitive
  * queue, the render failed or timed out, or the preview drew no Remote Compose document.
  */
 class PlaygroundRcCaptureService(
-  private val openSession: SessionOpener,
+  private val openSession: PlaygroundAndroidSessionOpener,
   /** Mints a fresh scratch dir per capture (holds the synthesized manifest + render outputs). */
   private val newWorkDir: () -> File,
   private val renderBudget: Duration = DEFAULT_RENDER_BUDGET,
   private val ackTimeout: Duration = DEFAULT_ACK_TIMEOUT,
 ) {
-
-  /**
-   * Opens a render session over a compiled snippet. Production binds this to the Android
-   * `openBundleDaemon`; tests supply a fake session.
-   */
-  fun interface SessionOpener {
-    fun open(
-      classesDir: File,
-      previewsJson: File,
-      workspaceRoot: File,
-      userClasspath: List<String>,
-    ): RenderSession
-  }
 
   /**
    * The [PlaygroundCompileService] `captureRemoteDocument` seam: snippet → `.rc` bytes, or null.
@@ -69,7 +54,9 @@ class PlaygroundRcCaptureService(
     val workDir = newWorkDir().apply { mkdirs() }
     return try {
       val previewsJson =
-        File(workDir, "previews.json").apply { writeText(previewsManifestJson(snippet)) }
+        File(workDir, "previews.json").apply {
+          writeText(PlaygroundPreviews.singlePreviewManifestJson(snippet))
+        }
       // The playground's classpath entries are already absolute okio paths; File(toString()) is the
       // safe bridge to the java.io.File the render-session API takes.
       val classesDir = File(snippet.classesDir.toString())
@@ -132,29 +119,6 @@ class PlaygroundRcCaptureService(
         json.decodeFromJsonElement(RemoteComposeDocumentPayload.serializer(), payloadJson)
       runCatching { Base64.getDecoder().decode(payload.documentBase64) }.getOrNull()
     }
-  }
-
-  /**
-   * A one-preview `previews.json` the daemon can render: the snippet's discovered id split back
-   * into its `className` + `functionName` (the id is `"$className.$methodName"`, per
-   * [PlaygroundPreviewDiscoverer]).
-   */
-  private fun previewsManifestJson(snippet: PlaygroundTokenStore.PlaygroundSnippet): String {
-    val id = snippet.previewId
-    val manifest =
-      PreviewManifest(
-        module = snippet.moduleName,
-        variant = "",
-        previews =
-          listOf(
-            PreviewInfo(
-              id = id,
-              functionName = id.substringAfterLast('.'),
-              className = id.substringBeforeLast('.'),
-            )
-          ),
-      )
-    return json.encodeToString(PreviewManifest.serializer(), manifest)
   }
 
   companion object {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundAndroidRenderServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundAndroidRenderServiceTest.kt
@@ -1,0 +1,117 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.PreviewManifest
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+
+/**
+ * The Android first-frame render orchestrator: previews.json synthesis, render→await, and reading
+ * the daemon's `renderFinished` PNG — driven against a fake render session (no real daemon
+ * subprocess).
+ */
+class PlaygroundAndroidRenderServiceTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+  private val tmpDirs = mutableListOf<File>()
+
+  private fun tmp(): File =
+    java.nio.file.Files.createTempDirectory("android-render-test").toFile().also { tmpDirs += it }
+
+  @AfterTest
+  fun cleanup() {
+    tmpDirs.forEach { it.deleteRecursively() }
+  }
+
+  private fun snippet(previewId: String = "com.example.SnippetKt.AndroidPreview") =
+    PlaygroundTokenStore.PlaygroundSnippet(
+      mode = PlaygroundMode.ANDROID,
+      workDir = "/work".toPath(),
+      classesDir = "/work/classes".toPath(),
+      classpath = listOf("/catalog/app.jar".toPath(), "/work/classes".toPath()),
+      moduleName = "playground-android",
+      previewId = previewId,
+    )
+
+  @Test
+  fun `a rendered snippet's first frame is returned, and previews_json is synthesized from its id`() {
+    val fake = FakeRenderSession(renderRoot = tmp())
+    var seenManifest: PreviewManifest? = null
+    val svc =
+      PlaygroundAndroidRenderService(
+        openSession = { classesDir, previewsJson, _, userClasspath ->
+          assertTrue(previewsJson.exists(), "the manifest is written before the session opens")
+          seenManifest =
+            json.decodeFromString(PreviewManifest.serializer(), previewsJson.readText())
+          assertEquals("/work/classes", classesDir.path)
+          assertTrue(
+            userClasspath.any { it.endsWith("app.jar") },
+            "catalog jars ride userClasspath",
+          )
+          fake
+        },
+        newWorkDir = { tmp() },
+      )
+
+    val png = svc.render(snippet())
+
+    // The fake writes "png:<uiMode>:<locale>:<device>" as the frame; a no-overrides first frame is
+    // all-null. That the bytes come back at all proves we read the `renderFinished` pngPath file.
+    assertEquals("png:null:null:null", png?.decodeToString())
+    val preview = seenManifest!!.previews.single()
+    assertEquals("com.example.SnippetKt.AndroidPreview", preview.id)
+    assertEquals("com.example.SnippetKt", preview.className)
+    assertEquals("AndroidPreview", preview.functionName)
+  }
+
+  @Test
+  fun `a render that never finishes times out to null`() {
+    // A renderHook that emits nothing models a render whose terminal event never arrives.
+    val fake = FakeRenderSession(renderRoot = tmp(), renderHook = { _, _ -> })
+    val svc =
+      PlaygroundAndroidRenderService(
+        openSession = { _, _, _, _ -> fake },
+        newWorkDir = { tmp() },
+        renderBudget = 200.milliseconds,
+        ackTimeout = 1.seconds,
+      )
+
+    assertNull(svc.render(snippet()))
+  }
+
+  @Test
+  fun `a rejected render yields null`() {
+    val fake = FakeRenderSession(renderRoot = tmp(), rejectAll = true)
+    val svc =
+      PlaygroundAndroidRenderService(openSession = { _, _, _, _ -> fake }, newWorkDir = { tmp() })
+
+    assertNull(svc.render(snippet()))
+  }
+
+  @Test
+  fun `a render the daemon reports failed yields null`() {
+    val previewId = "com.example.SnippetKt.AndroidPreview"
+    lateinit var fake: FakeRenderSession
+    fake =
+      FakeRenderSession(
+        renderRoot = tmp(),
+        // The daemon reports the render body threw instead of emitting a frame.
+        renderHook = { _, _ -> fake.emitFailed(previewId, "boom") },
+      )
+    val svc =
+      PlaygroundAndroidRenderService(
+        openSession = { _, _, _, _ -> fake },
+        newWorkDir = { tmp() },
+        renderBudget = 2.seconds,
+      )
+
+    assertNull(svc.render(snippet(previewId)))
+  }
+}


### PR DESCRIPTION
## Summary

**Phase 2 render half** (epic #3015): an `ANDROID` playground snippet now renders its **first frame** on the Android/Robolectric daemon, so the Stage-1 `POST /api/{v}/compiler/run` response carries the still `image` — which was always `null` for the live modes until now. Builds directly on the Android daemon plumbing #3040 (merged) landed for the Remote Compose producer.

This is the render half of epic item _"compile the snippet for the Android target and render via the Robolectric daemon path"_. The Stage-2 live-redemption (`/pg/<token>` → streaming session) remains a follow-up stacked PR; the token is still minted as before.

### What changed

- **`PlaygroundAndroidRenderService`** — the production `renderFirstFrame` for `ANDROID` mode. It synthesizes a one-preview `previews.json`, opens a **bundle-less Android daemon** over the snippet's own `classesDir` + full compile classpath, `renderNow`s, awaits the terminal `renderFinished`/`renderFailed`, and reads the PNG the daemon wrote to the notification's `pngPath`. Mirrors `PlaygroundRcCaptureService`'s open→render→await shape — **minus** the data-product fetch and extension enable, since a plain first frame is the daemon's base render product. The session opener is an injected seam, so the whole orchestration is unit-tested against a fake session.
- **`PlaygroundPreviews`** — extracts the one-preview `previews.json` synthesis shared by the first-frame render and the RC capture (both stand a daemon over the snippet's own classes and need the identical manifest), replacing the private copy in `PlaygroundRcCaptureService`.
- **`ServeCommand`** — factors the Android/Robolectric daemon opener (`lib-daemon-android` + `android.jar` + Robolectric jvmArgs/sysprops) out of the RC builder into a shared `PlaygroundAndroidSessionOpener`, so the first-frame render and the RC capture launch **one** daemon assembly. `renderFirstFrame` is wired for `ANDROID` mode only — CMP's desktop first frame is a separate lane, and `REMOTE_COMPOSE` never reaches this seam (it returns a `documentUrl`). **Fail-soft**: absent the sidecar/`android.jar`, both Android lanes report unavailable while CMP is unaffected; a null first frame is never fatal (the token is still minted, the response just carries no still image).

## Test plan

- [x] `./gradlew :cli:test --tests "*Playground*"` — **passing**. New `PlaygroundAndroidRenderServiceTest`: first-frame capture + `previews.json` synthesis, render-timeout → null, rejected → null, daemon-`renderFailed` → null. Existing `PlaygroundRcCaptureServiceTest` / `PlaygroundCompileServiceTest` still green after the shared-manifest + shared-opener refactor.
- [x] `./gradlew ktfmtFormat` — clean.

**Verification scope:** the orchestration, manifest synthesis, and the shared opener are unit-tested in-process against a fake `RenderSession`. The **live Robolectric render** that populates the PNG needs the Android daemon sidecar + Robolectric runtime, which the dev sandbox can't run — it's exercised by CI's Android daemon harness.

Non-visual for repo purposes (daemon/CLI render plumbing; the rendered PNG is the user's snippet, not a repo-owned surface), so no rendered evidence applies.

## Epic #3015 checklist

- [x] Resolve an Android catalog liveBundle → compile classpath _(landed with #3040's `--playground-android-bundle`)_
- [x] Render via the Robolectric daemon path rather than the desktop `ImageComposeScene` path _(this PR: the first-frame render)_
- [ ] Admission control: 2 permits via `LiveSeatLimiter` _(follow-up, with Stage-2 live redemption)_
- [x] Wire the Android mode into `PlaygroundApi` `confType` resolution (`compose-android`) _(landed with #3040)_
- [ ] Live compile→token→**redeem** streaming session _(follow-up stacked PR)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_