### PR TITLE
fix(playground): gate the editor's mode selector and fence stale runs

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -912,39 +912,56 @@ class ServeCommand(args: List<String>) : Command(args) {
     )
 
     val snippetCounter = java.util.concurrent.atomic.AtomicLong()
-    return PlaygroundCompileService(
-      catalogClasspath = { mode ->
-        when (mode) {
-          PlaygroundMode.CMP -> cmpClasspath
-          // Only advertise the Android modes when their daemon backend actually came up — absent
-          // the
-          // sidecar/android.jar the host would otherwise accept the mode, run a full Android
-          // compile,
-          // then mint a dead token with no image (ANDROID) / report the preview drew no document
-          // (REMOTE_COMPOSE), contradicting the "Android modes disabled" startup log. A null
-          // classpath routes to the existing "mode … is not available" response.
-          PlaygroundMode.ANDROID -> androidClasspath?.takeIf { androidRender != null }
-          PlaygroundMode.REMOTE_COMPOSE -> androidClasspath?.takeIf { rcCapture != null }
-        }
-      },
-      compiler = compiler,
-      discoverer = PlaygroundPreviewDiscoverer(),
-      tokenStore = PlaygroundTokenStore(),
-      newWorkDir = {
-        java.io.File(workRoot, "snippet-${snippetCounter.incrementAndGet()}").absolutePath.toPath()
-      },
-      // The still first frame is the Android live render (ANDROID mode); CMP's desktop first frame
-      // is a separate lane, and REMOTE_COMPOSE never reaches this seam (it returns a documentUrl).
-      renderFirstFrame = { snippet ->
-        if (snippet.mode == PlaygroundMode.ANDROID) androidRender?.render(snippet) else null
-      },
-      captureRemoteDocument = { snippet -> rcCapture?.capture(snippet) },
-      publishRemoteDocument = { name, bytes, checked ->
-        (docStore?.add(name, bytes, isSecurityChecked = checked) as? ServeDocStore.Result.Ok)
-          ?.doc
-          ?.path
-      },
-    )
+    val service =
+      PlaygroundCompileService(
+        catalogClasspath = { mode ->
+          when (mode) {
+            PlaygroundMode.CMP -> cmpClasspath
+            // Only advertise the Android modes when their daemon backend actually came up — absent
+            // the
+            // sidecar/android.jar the host would otherwise accept the mode, run a full Android
+            // compile,
+            // then mint a dead token with no image (ANDROID) / report the preview drew no document
+            // (REMOTE_COMPOSE), contradicting the "Android modes disabled" startup log. A null
+            // classpath routes to the existing "mode … is not available" response.
+            PlaygroundMode.ANDROID -> androidClasspath?.takeIf { androidRender != null }
+            PlaygroundMode.REMOTE_COMPOSE -> androidClasspath?.takeIf { rcCapture != null }
+          }
+        },
+        compiler = compiler,
+        discoverer = PlaygroundPreviewDiscoverer(),
+        tokenStore = PlaygroundTokenStore(),
+        newWorkDir = {
+          java.io
+            .File(workRoot, "snippet-${snippetCounter.incrementAndGet()}")
+            .absolutePath
+            .toPath()
+        },
+        // The still first frame is the Android live render (ANDROID mode); CMP's desktop first
+        // frame
+        // is a separate lane, and REMOTE_COMPOSE never reaches this seam (it returns a
+        // documentUrl).
+        renderFirstFrame = { snippet ->
+          if (snippet.mode == PlaygroundMode.ANDROID) androidRender?.render(snippet) else null
+        },
+        captureRemoteDocument = { snippet -> rcCapture?.capture(snippet) },
+        publishRemoteDocument = { name, bytes, checked ->
+          (docStore?.add(name, bytes, isSecurityChecked = checked) as? ServeDocStore.Result.Ok)
+            ?.doc
+            ?.path
+        },
+      )
+    // No mode survived gating (e.g. an Android-only host whose daemon sidecar / android.jar is
+    // absent, so every classpath gated to null): don't enable a lane that would render an empty
+    // mode selector and mint dead tokens on Run. Disable it, like the no-classpath case above.
+    if (service.availableModes.isEmpty()) {
+      System.err.println(
+        "serve: playground resolved no runnable mode (a classpath resolved but its render backend " +
+          "is unavailable); playground disabled."
+      )
+      return null
+    }
+    return service
   }
 
   /** Resolve a playground compile classpath from a catalog liveBundle; null (logged) on failure. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -63,6 +63,14 @@ class PlaygroundCompileService(
 ) {
 
   /**
+   * The modes this host can actually serve — the ones whose [catalogClasspath] resolved to a real
+   * classpath. Drives the editor's mode selector so it never offers a mode that would immediately
+   * answer "mode … is not available" (e.g. an Android-only host must not default to CMP).
+   */
+  val availableModes: List<PlaygroundMode> =
+    PlaygroundMode.entries.filter { catalogClasspath(it) != null }
+
+  /**
    * The resolved classpath a snippet compiles and renders against. Backed in production by a
    * catalog's liveBundle `userClassPath` (see the class KDoc); [moduleName] matches the catalog's
    * Kotlin module so the snippet's classes carry a consistent `kotlin.Metadata`.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -400,7 +400,7 @@ class ServeHttpServer(
           // route above and surfaces the diagnostics + first-frame + `/pg/` (live) or `/d/` (RC)
           // handoff. Only mounted when the lane is enabled, and — like the lane — never under
           // `--public`.
-          get("/playground") { handlePlaygroundPage() }
+          get("/playground") { handlePlaygroundPage(svc) }
         }
 
         // Shared/public mode ingestion: a client contributes a pre-rendered bundle (upload the zip
@@ -781,13 +781,14 @@ class ServeHttpServer(
    * never public); a static HTML page whose script POSTs to `/api/{v}/compiler/run` and follows the
    * returned `/pg/` or `/d/` handoff.
    */
-  private suspend fun RoutingContext.handlePlaygroundPage() {
+  private suspend fun RoutingContext.handlePlaygroundPage(service: PlaygroundCompileService) {
     if (rejectBadToken()) return
     markGeneration("static-page", pageCacheControl())
     call.respondText(
       ServeWeb.playgroundPage(
         token = token,
         isPublic = isPublic,
+        modes = service.availableModes,
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
       ),
       ContentType.Text.Html,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2051,9 +2051,25 @@ object ServeWeb {
    * the links it builds. A plain `<textarea>` is the v1 editor — a stock `kotlin-playground` /
    * bespoke CodeMirror surface is a deferred, non-blocking decision (design §7 item 5).
    */
-  fun playgroundPage(token: String, isPublic: Boolean, unfurl: UnfurlMetadata? = null): String {
+  fun playgroundPage(
+    token: String,
+    isPublic: Boolean,
+    /**
+     * The modes this host serves — the selector offers only these, and the first is preselected.
+     */
+    modes: List<PlaygroundMode>,
+    unfurl: UnfurlMetadata? = null,
+  ): String {
     val suffix = querySuffix(queryString(token, sessionId = null, isPublic = isPublic))
     val sample = WebEscaping.htmlEscape(PLAYGROUND_SAMPLE)
+    val options =
+      modes
+        .mapIndexed { i, mode ->
+          val (value, label) = playgroundModeChoice(mode)
+          val selected = if (i == 0) " selected" else ""
+          """<option value="$value"$selected>$label</option>"""
+        }
+        .joinToString("\n              ")
     return document(
       title = "Playground — compose-preview",
       unfurlDescription = "Compile a Compose snippet against the live catalog and open a preview.",
@@ -2068,9 +2084,7 @@ object ServeWeb {
           <div class="cp-pg-bar">
             <label class="cp-pg-modelabel" for="pg-mode">Mode</label>
             <select id="pg-mode" class="cp-pg-mode">
-              <option value="compose-cmp">Compose (Desktop)</option>
-              <option value="compose-android">Compose (Android)</option>
-              <option value="remote-compose">Remote Compose</option>
+              $options
             </select>
             <button id="pg-run" class="cp-doc-btn cp-pg-run" type="button">Run</button>
           </div>
@@ -2129,7 +2143,12 @@ object ServeWeb {
           diags.appendChild(li);
         });
       }
+      // A monotonic id fences stale runs: only the newest click updates the DOM, and Run is disabled
+      // while a compile is in flight so a burst can't double-submit (each submit mints a token).
+      var reqId = 0;
       run.addEventListener("click", function () {
+        var myId = ++reqId;
+        run.disabled = true;
         clearOut();
         setStatus("Compiling…", false);
         var body = JSON.stringify({
@@ -2148,6 +2167,8 @@ object ServeWeb {
             });
           })
           .then(function (res) {
+            if (myId !== reqId) return;
+            run.disabled = false;
             renderDiags(res.diagnostics);
             var hasError = (res.diagnostics || []).some(function (d) { return d.severity === "error"; });
             if (res.exception) { setStatus(res.exception, true); return; }
@@ -2162,11 +2183,23 @@ object ServeWeb {
             }
             setStatus("Done.", false);
           })
-          .catch(function (e) { setStatus(e.message || "run failed", true); });
+          .catch(function (e) {
+            if (myId !== reqId) return;
+            run.disabled = false;
+            setStatus(e.message || "run failed", true);
+          });
       });
     })();
     """
       .trimIndent()
+
+  /** The `<option>` value + label for a playground mode in the editor's selector. */
+  private fun playgroundModeChoice(mode: PlaygroundMode): Pair<String, String> =
+    when (mode) {
+      PlaygroundMode.CMP -> "compose-cmp" to "Compose (Desktop)"
+      PlaygroundMode.ANDROID -> "compose-android" to "Compose (Android)"
+      PlaygroundMode.REMOTE_COMPOSE -> "remote-compose" to "Remote Compose"
+    }
 
   /**
    * One ingested document as the permalink page shows it — the display facts only, so this page

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -769,7 +769,8 @@ class ServeWebFixtureTest {
     // The playground Stage-1 editor (`GET /playground`): the code box, mode selector, and result
     // pane. Always token-gated (the lane runs user code, refused under `--public`), so the fixture
     // renders the non-public form the server actually serves.
-    val playground = ServeWeb.playgroundPage(token, isPublic = false)
+    val playground =
+      ServeWeb.playgroundPage(token, isPublic = false, modes = PlaygroundMode.entries.toList())
     val docLottie =
       ServeWeb.docPage(
         ServeWeb.DocView(

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -525,7 +525,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
           <div class="cp-pg-bar">
             <label class="cp-pg-modelabel" for="pg-mode">Mode</label>
             <select id="pg-mode" class="cp-pg-mode">
-              <option value="compose-cmp">Compose (Desktop)</option>
+              <option value="compose-cmp" selected>Compose (Desktop)</option>
               <option value="compose-android">Compose (Android)</option>
               <option value="remote-compose">Remote Compose</option>
             </select>
@@ -584,7 +584,12 @@ fun Greeting() {
       diags.appendChild(li);
     });
   }
+  // A monotonic id fences stale runs: only the newest click updates the DOM, and Run is disabled
+  // while a compile is in flight so a burst can't double-submit (each submit mints a token).
+  var reqId = 0;
   run.addEventListener("click", function () {
+    var myId = ++reqId;
+    run.disabled = true;
     clearOut();
     setStatus("Compiling…", false);
     var body = JSON.stringify({
@@ -603,6 +608,8 @@ fun Greeting() {
         });
       })
       .then(function (res) {
+        if (myId !== reqId) return;
+        run.disabled = false;
         renderDiags(res.diagnostics);
         var hasError = (res.diagnostics || []).some(function (d) { return d.severity === "error"; });
         if (res.exception) { setStatus(res.exception, true); return; }
@@ -617,7 +624,11 @@ fun Greeting() {
         }
         setStatus("Done.", false);
       })
-      .catch(function (e) { setStatus(e.message || "run failed", true); });
+      .catch(function (e) {
+        if (myId !== reqId) return;
+        run.disabled = false;
+        setStatus(e.message || "run failed", true);
+      });
   });
 })();</script>
         </main>


### PR DESCRIPTION
## Summary

Follow-up to #3050 (merged), addressing the two Codex P2 findings on the Stage-1 editor page — the review landed after #3050 had already auto-merged, so the fixes ride here.

- **Gate the mode selector to modes the host actually serves.** The editor offered all three modes regardless of which the host enabled, so an Android-only host (`--playground-android-bundle` alone) defaulted to CMP and the starter snippet immediately returned "mode CMP is not available" — and a CMP-only host advertised two Android modes that always fail. `PlaygroundCompileService` now exposes `availableModes` (the modes whose classpath resolved), and `ServeWeb.playgroundPage` renders and preselects only those.
- **Fence stale compile responses.** Re-clicking Run before the previous compile returned raced two live fetch chains over the same DOM (and minted two tokens); if the older finished last, the page showed a preview for superseded source. The script now stamps each run with a monotonic id (only the newest updates the DOM) and disables Run while a compile is in flight.

## Test plan

- [x] `./gradlew :cli:test --tests "*ServeWebFixtureTest*" --tests "*PlaygroundRoutingTest*"` — passing (regenerated `serve-playground.html` fixture golden; route served/gated).
- [x] `./gradlew ktfmtFormat` — clean.

Non-visual behavior change to the same editor page #3050 added (the `pages-snapshot` bot re-renders the fixture on this PR); the selector still shows all three modes on a host that serves all three.

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_