### PR TITLE
feat(playground): Stage-2 live redemption at /pg/&lt;token&gt;

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -14,6 +14,7 @@ import ee.schimke.composeai.cli.serve.PlaygroundCompileService
 import ee.schimke.composeai.cli.serve.PlaygroundMode
 import ee.schimke.composeai.cli.serve.PlaygroundPreviewDiscoverer
 import ee.schimke.composeai.cli.serve.PlaygroundRcCaptureService
+import ee.schimke.composeai.cli.serve.PlaygroundRedeemService
 import ee.schimke.composeai.cli.serve.PlaygroundTokenStore
 import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundle
@@ -855,7 +856,10 @@ class ServeCommand(args: List<String>) : Command(args) {
    * server" model forbids (docs/design/PLAYGROUND.md § isolation). Fail-soft: any missing piece
    * (bundle unresolvable, no `lib-bta/`) logs why and disables the lane rather than aborting serve.
    */
-  private fun openPlaygroundService(docStore: ServeDocStore?): PlaygroundCompileService? {
+  private fun openPlaygroundService(
+    docStore: ServeDocStore?,
+    registry: ServeSessionRegistry,
+  ): PlaygroundLane? {
     val cmpBundle = playgroundBundlePath
     val androidBundle = playgroundAndroidBundlePath
     if (cmpBundle == null && androidBundle == null) return null
@@ -912,6 +916,12 @@ class ServeCommand(args: List<String>) : Command(args) {
     )
 
     val snippetCounter = java.util.concurrent.atomic.AtomicLong()
+    // Stage 1 (mint) and Stage 2 (redeem) share ONE token store, so a dropped token both deletes its
+    // work dir and releases any live session it stood up. onRemove closes over the redeem service —
+    // which needs the store — so it's wired through a holder set once both exist below.
+    val redeemRef = java.util.concurrent.atomic.AtomicReference<PlaygroundRedeemService?>()
+    val tokenStore =
+      PlaygroundTokenStore(onRemove = { token -> redeemRef.get()?.release(token.id) })
     val service =
       PlaygroundCompileService(
         catalogClasspath = { mode ->
@@ -930,7 +940,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         },
         compiler = compiler,
         discoverer = PlaygroundPreviewDiscoverer(),
-        tokenStore = PlaygroundTokenStore(),
+        tokenStore = tokenStore,
         newWorkDir = {
           java.io
             .File(workRoot, "snippet-${snippetCounter.incrementAndGet()}")
@@ -961,8 +971,25 @@ class ServeCommand(args: List<String>) : Command(args) {
       )
       return null
     }
-    return service
+    // Stage-2 redemption: stand the snippet's compiled classes up as a live daemon session via the
+    // registry, reusing the whole live/stream/input lane. materializePlaygroundSnippet self-gates —
+    // it returns null (→ "live preview unavailable") when the mode's daemon backend is absent — so
+    // this is always safe to enable alongside the compile lane.
+    val redeem =
+      PlaygroundRedeemService(
+        tokenStore = tokenStore,
+        registry = registry,
+        materialize = { ServeBundleDaemon.materializePlaygroundSnippet(it) },
+      )
+    redeemRef.set(redeem)
+    return PlaygroundLane(compile = service, redeem = redeem)
   }
+
+  /** The playground's Stage-1 compile lane + Stage-2 redeem lane, sharing one token store. */
+  private class PlaygroundLane(
+    val compile: PlaygroundCompileService,
+    val redeem: PlaygroundRedeemService,
+  )
 
   /** Resolve a playground compile classpath from a catalog liveBundle; null (logged) on failure. */
   private fun resolvePlaygroundClasspath(
@@ -1184,6 +1211,7 @@ class ServeCommand(args: List<String>) : Command(args) {
     // Resolved once so the playground's remote-compose lane publishes into the SAME store the `/d/`
     // route serves from — otherwise a minted `/d/<id>` link wouldn't resolve.
     val docStore = openDocStore()
+    val playgroundLane = openPlaygroundService(docStore, registry)
     val server =
       ServeHttpServer(
         host = host,
@@ -1209,7 +1237,8 @@ class ServeCommand(args: List<String>) : Command(args) {
         trustAdmin = trustAdmin,
         adminToken = adminToken,
         docStore = docStore,
-        playgroundService = openPlaygroundService(docStore),
+        playgroundService = playgroundLane?.compile,
+        playgroundRedeem = playgroundLane?.redeem,
       )
     if (trustAdmin != null) {
       System.err.println(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -916,7 +916,8 @@ class ServeCommand(args: List<String>) : Command(args) {
     )
 
     val snippetCounter = java.util.concurrent.atomic.AtomicLong()
-    // Stage 1 (mint) and Stage 2 (redeem) share ONE token store, so a dropped token both deletes its
+    // Stage 1 (mint) and Stage 2 (redeem) share ONE token store, so a dropped token both deletes
+    // its
     // work dir and releases any live session it stood up. onRemove closes over the redeem service —
     // which needs the store — so it's wired through a holder set once both exist below.
     val redeemRef = java.util.concurrent.atomic.AtomicReference<PlaygroundRedeemService?>()
@@ -982,6 +983,24 @@ class ServeCommand(args: List<String>) : Command(args) {
         materialize = { ServeBundleDaemon.materializePlaygroundSnippet(it) },
       )
     redeemRef.set(redeem)
+
+    // A redeemed /pg session lives in ServeSessionRegistry and is reached only via the viewer + WS
+    // lanes, which never touch the token store — so the store's lazy purge (driven from mint / get
+    // /
+    // snapshot) would never fire onRemove for it, and the session (plus its work dir) would outlive
+    // the token's TTL indefinitely. Sweep expired tokens on a timer so a redeemed session is torn
+    // down at (roughly) its deadline even with no further playground requests.
+    val purgePeriod = tokenStore.ttlSeconds.coerceIn(15L, 60L)
+    java.util.concurrent.Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "playground-token-purge").apply { isDaemon = true }
+      }
+      .scheduleWithFixedDelay(
+        { runCatching { tokenStore.purgeExpired() } },
+        purgePeriod,
+        purgePeriod,
+        java.util.concurrent.TimeUnit.SECONDS,
+      )
+
     return PlaygroundLane(compile = service, redeem = redeem)
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemService.kt
@@ -1,7 +1,5 @@
 package ee.schimke.composeai.cli.serve
 
-import java.util.concurrent.ConcurrentHashMap
-
 /**
  * Stage-2 of the playground (`docs/design/PLAYGROUND.md` §2 + §5): redeem a `/pg/<token>`
  * capability into a **live, streamed, interactive** preview session, reusing the serve host's
@@ -55,32 +53,49 @@ class PlaygroundRedeemService(
     data class Live(val sessionId: String, val previewId: String) : Outcome
   }
 
-  /** Session ids this service registered, so a re-redeem within the TTL reuses the live session. */
-  private val registered = ConcurrentHashMap.newKeySet<String>()
+  /**
+   * Ids whose session is **fully registered** — added only *after* [ServeSessionRegistry.register]
+   * returns, so a second redeem never reports `Live` before the viewer's session actually exists.
+   * Mutated only under [lock].
+   */
+  private val registered = HashSet<String>()
+
+  /**
+   * Serialises redeem/release **per service** so token expiry can't race a registration: a redeem
+   * that materializes while an expiry fires either wins the lock and registers, or the release wins
+   * and there's nothing to tear down. Redemption is a deliberate, rate-limited act (and the daemon
+   * boot happens later, in the registry lease — not here), so one coarse lock is ample.
+   */
+  private val lock = Any()
 
   /** Redeem [id] into (or back onto) its live session. Idempotent within the token's TTL. */
   fun redeem(id: String): Outcome {
-    val token = tokenStore.get(id) ?: return Outcome.NotFound
-    val previewId = token.snippet.previewId
-    // `add` is the register-once gate: the winner materializes + registers; a concurrent (or later)
-    // redeem of the same live token rides the session already standing.
-    if (!registered.add(id)) return Outcome.Live(id, previewId)
-    val state =
-      materialize(token.snippet)
-        ?: run {
-          registered.remove(id)
-          return Outcome.Unavailable
-        }
-    registry.register(id, state = state)
-    return Outcome.Live(id, previewId)
+    val previewId = (tokenStore.get(id) ?: return Outcome.NotFound).snippet.previewId
+    synchronized(lock) {
+      if (id in registered) return Outcome.Live(id, previewId)
+      // Re-check under the lock: the token may have expired/been evicted between the get above and
+      // here. If so, release() has already run (a no-op — we hadn't registered yet), and
+      // registering
+      // now would strand a session whose work dir is gone and which the token hook can never
+      // release.
+      val token = tokenStore.get(id) ?: return Outcome.NotFound
+      val state = materialize(token.snippet) ?: return Outcome.Unavailable
+      registry.register(id, state = state)
+      // Mark registered ONLY now: a concurrent redeem that got here first is still holding the
+      // lock,
+      // so no one observes `Live` until the registry entry the viewer resolves actually exists.
+      registered.add(id)
+      return Outcome.Live(id, previewId)
+    }
   }
 
   /**
    * Release the live session a token owned — unregister it (closing its daemon). Wired to
    * [PlaygroundTokenStore]'s removal hook, so a token's expiry/eviction tears down its session. A
-   * no-op for a token that was never redeemed into a session.
+   * no-op for a token that was never redeemed into a session. Takes [lock] so it can't interleave
+   * with a redeem mid-registration.
    */
   fun release(id: String) {
-    if (registered.remove(id)) registry.unregister(id)
+    synchronized(lock) { if (registered.remove(id)) registry.unregister(id) }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemService.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Stage-2 of the playground (`docs/design/PLAYGROUND.md` §2 + §5): redeem a `/pg/<token>`
+ * capability into a **live, streamed, interactive** preview session, reusing the serve host's
+ * existing live lane wholesale.
+ *
+ * Redemption is deliberately thin. A token already names a *compiled* snippet
+ * ([PlaygroundTokenStore.PlaygroundSnippet] — classes on disk, resolved classpath, discovered
+ * `@Preview`), so standing up its session is just:
+ * 1. [materialize] the snippet into a resumable [ServeSessionState] — a `daemon-launch.json`
+ *    descriptor over the snippet's own classes, with the backend (desktop CMP / Android
+ *    Robolectric) and [ServeSessionState.liveSeatWeight] chosen by the token's mode;
+ * 2. [ServeSessionRegistry.register] that state under `sessionId = token.id`;
+ * 3. hand the browser the existing viewer at `/{token.id}/p/{previewId}` — its WebSocket
+ *    (`/{token.id}/ws/{previewId}`), frame fan-out, `input` protocol, and **live-seat admission**
+ *    (the registered state's `liveSeatWeight`) all work unchanged (see `ServeHttpServer`'s
+ *    `serveStreamLane`).
+ *
+ * So there is **no new streaming/input protocol and no new WebSocket handler** — redemption is a
+ * registry `register` + a redirect. [materialize] is injected so this orchestration (lookup, the
+ * register-once gate, the fail-soft when no live backend exists, and releasing on token expiry) is
+ * unit-testable without a real daemon; the production seam is
+ * [ServeBundleDaemon.materializePlaygroundSnippet].
+ *
+ * Because a token is single-tenant and short-lived, the session it registers is released when the
+ * token drops: wire [release] to [PlaygroundTokenStore]'s removal hook so an expired/evicted token
+ * both deletes its work dir (the store) and unregisters + closes its live daemon (here).
+ */
+class PlaygroundRedeemService(
+  private val tokenStore: PlaygroundTokenStore,
+  private val registry: ServeSessionRegistry,
+  /**
+   * Materialize a compiled snippet into a resumable live-session state, or null when this host has
+   * no live backend for the snippet's mode (e.g. the daemon sidecar / `android.jar` is absent) — in
+   * which case redemption is a clean [Outcome.Unavailable] rather than a dead session.
+   */
+  private val materialize: (PlaygroundTokenStore.PlaygroundSnippet) -> ServeSessionState?,
+) {
+
+  /** The result of redeeming a `/pg/<token>` request. */
+  sealed interface Outcome {
+    /** The token is unknown or expired — answer a styled 404 that discloses neither. */
+    data object NotFound : Outcome
+
+    /** The token is live but this host can't stand up a live session (no daemon backend for it). */
+    data object Unavailable : Outcome
+
+    /**
+     * Redeemed: a live session is registered under [sessionId]; send the browser to the viewer for
+     * [previewId], whose WebSocket lane streams it.
+     */
+    data class Live(val sessionId: String, val previewId: String) : Outcome
+  }
+
+  /** Session ids this service registered, so a re-redeem within the TTL reuses the live session. */
+  private val registered = ConcurrentHashMap.newKeySet<String>()
+
+  /** Redeem [id] into (or back onto) its live session. Idempotent within the token's TTL. */
+  fun redeem(id: String): Outcome {
+    val token = tokenStore.get(id) ?: return Outcome.NotFound
+    val previewId = token.snippet.previewId
+    // `add` is the register-once gate: the winner materializes + registers; a concurrent (or later)
+    // redeem of the same live token rides the session already standing.
+    if (!registered.add(id)) return Outcome.Live(id, previewId)
+    val state =
+      materialize(token.snippet)
+        ?: run {
+          registered.remove(id)
+          return Outcome.Unavailable
+        }
+    registry.register(id, state = state)
+    return Outcome.Live(id, previewId)
+  }
+
+  /**
+   * Release the live session a token owned — unregister it (closing its daemon). Wired to
+   * [PlaygroundTokenStore]'s removal hook, so a token's expiry/eviction tears down its session. A
+   * no-op for a token that was never redeemed into a session.
+   */
+  fun release(id: String) {
+    if (registered.remove(id)) registry.unregister(id)
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundTokenStore.kt
@@ -38,6 +38,13 @@ class PlaygroundTokenStore(
   /** Injected so tests can drive expiry without sleeping. */
   private val clock: () -> Long = System::currentTimeMillis,
   private val mintId: () -> String = ::randomId,
+  /**
+   * Invoked as a token is dropped (expiry, overflow eviction, [remove], [clear]), after its work
+   * dir is deleted. Stage 2 wires this to [PlaygroundRedeemService.release] so a dropped token also
+   * unregisters + closes any live session it stood up. Best-effort — a throw here must not wedge
+   * purging — so it runs under `runCatching`. Defaults to a no-op (mint-only hosts).
+   */
+  private val onRemove: (Token) -> Unit = {},
 ) {
 
   /**
@@ -117,7 +124,7 @@ class PlaygroundTokenStore(
   /** Explicitly drop [id] (and delete its work dir); returns true if it was present. */
   fun remove(id: String): Boolean {
     val removed = tokens.remove(id) ?: return false
-    disposeSnippet(removed.snippet)
+    drop(removed)
     return true
   }
 
@@ -129,7 +136,7 @@ class PlaygroundTokenStore(
       val entry = it.next()
       if (entry.value.expiresAtMillis <= nowMillis) {
         it.remove()
-        disposeSnippet(entry.value.snippet)
+        drop(entry.value)
         dropped++
       }
     }
@@ -147,7 +154,7 @@ class PlaygroundTokenStore(
   fun clear() {
     val all = tokens.values.toList()
     tokens.clear()
-    all.forEach { disposeSnippet(it.snippet) }
+    all.forEach { drop(it) }
   }
 
   /**
@@ -158,8 +165,14 @@ class PlaygroundTokenStore(
   private fun evictOverflow() {
     while (tokens.size > maxTokens) {
       val oldest = tokens.values.minByOrNull { it.expiresAtMillis } ?: return
-      tokens.remove(oldest.id)?.let { disposeSnippet(it.snippet) }
+      tokens.remove(oldest.id)?.let { drop(it) }
     }
+  }
+
+  /** The single drop path for every removal: delete the work dir, then fire [onRemove]. */
+  private fun drop(token: Token) {
+    disposeSnippet(token.snippet)
+    runCatching { onRemove(token) }
   }
 
   /** Best-effort delete of a dropped snippet's work dir; a failure must not wedge purging. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -307,6 +307,98 @@ internal object ServeBundleDaemon {
   }
 
   /**
+   * Materialize a compiled **playground snippet** into a resumable live-session state — the Stage-2
+   * ([PlaygroundRedeemService]) counterpart of [materialize], but over a just-compiled snippet's
+   * own classes instead of a fetched bundle. Writes a one-preview `previews.json` and a
+   * `daemon-launch.json` for the snippet's mode (desktop CMP / Android Robolectric) into the
+   * snippet's work dir, so the registry opens, resumes, seat-counts, and streams it through the
+   * exact same path a catalog uses — no new live-session machinery. Returns null (logged) when the
+   * mode's daemon backend (sidecar / `android.jar`) is unavailable, so redemption reports
+   * "unavailable" rather than standing up a dead session.
+   */
+  fun materializePlaygroundSnippet(
+    snippet: PlaygroundTokenStore.PlaygroundSnippet,
+    fileSystem: FileSystem = SystemFileSystem,
+    onLog: (String) -> Unit = { System.err.println("[playground live] $it") },
+  ): ServeSessionState? {
+    val label = "playground:${snippet.previewId.substringAfterLast('.').ifBlank { "snippet" }}"
+    val android = snippet.mode == PlaygroundMode.ANDROID
+    val backendLaunch =
+      (if (android) androidBundleDaemonLaunch(label, onLog)
+      else desktopBundleDaemonLaunch(label, onLog)) ?: return null
+
+    val workDir = File(snippet.workDir.toString())
+    val classesDir = File(snippet.classesDir.toString())
+    val previewsJson = File(workDir, "previews.json")
+    try {
+      fileSystem.write(previewsJson.path.toPath()) {
+        writeUtf8(PlaygroundPreviews.singlePreviewManifestJson(snippet))
+      }
+    } catch (e: Exception) {
+      onLog("$label: could not write previews.json (${e.message})")
+      return null
+    }
+
+    // The snippet's classpath already includes classesDir; bundleDaemonClasspaths dedupes, and puts
+    // the snippet classes on the user (child) classloader — never the daemon's own -cp.
+    val classpaths =
+      bundleDaemonClasspaths(
+        classesDir = classesDir,
+        extraClasspathDirs = emptyList(),
+        embeddedLibJars = emptyList(),
+        parentOverlayJars = emptyList(),
+        childDependencyJars = snippet.classpath.map { File(it.toString()) },
+        daemonSidecarClasspath = backendLaunch.daemonClasspath,
+        androidResourceClasspath = emptyList(),
+      )
+    val descriptor =
+      DaemonLaunchDescriptor(
+        schemaVersion = DAEMON_LAUNCH_SCHEMA_VERSION,
+        modulePath = ":playground",
+        variant = backendLaunch.variant,
+        enabled = true,
+        mainClass = DAEMON_MAIN_CLASS,
+        javaLauncher = null,
+        classpath = classpaths.daemonClasspath,
+        jvmArgs = backendLaunch.jvmArgs,
+        systemProperties =
+          buildMap {
+            put("composeai.daemon.userClassDirs", classpaths.userClassPath)
+            put("composeai.daemon.previewsJsonPath", previewsJson.absolutePath)
+            put("composeai.render.outputDir", File(workDir, "renders").absolutePath)
+            put("composeai.render.placeholderMissingResources", "true")
+            putAll(backendLaunch.extraSystemProperties)
+          },
+        workingDirectory = workDir.absolutePath,
+        manifestPath = previewsJson.absolutePath,
+      )
+    val descriptorFile = File(workDir, "daemon-launch.json")
+    try {
+      fileSystem.write(descriptorFile.path.toPath()) {
+        writeUtf8(json.encodeToString(DaemonLaunchDescriptor.serializer(), descriptor))
+      }
+    } catch (e: Exception) {
+      onLog("$label: could not write daemon-launch.json (${e.message})")
+      return null
+    }
+
+    val previews =
+      readPreviews(previewsJson, File(workDir, "previews").apply { mkdirs() }, fileSystem)
+    if (previews.isEmpty()) {
+      onLog("$label: synthesized previews.json carried no previews")
+      return null
+    }
+    return ServeSessionState(
+      descriptor = descriptorFile,
+      workspaceRoot = workDir,
+      workspaceName = workDir.name.ifBlank { "playground" },
+      previews = previews,
+      label = label,
+      liveSeatWeight = if (android) ANDROID_LIVE_SEAT_WEIGHT else 1,
+    )
+  }
+
+  /**
    * Read the catalog's declared `@ThemeCatalog` themes from the carried `previews.json` (the
    * synthetic `THEME_CATALOG` entries discovery emits). Module-global, so the whole catalog shares
    * one theme set. Absent / unreadable previews.json → no themes.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -339,15 +339,27 @@ internal object ServeBundleDaemon {
       return null
     }
 
-    // The snippet's classpath already includes classesDir; bundleDaemonClasspaths dedupes, and puts
-    // the snippet classes on the user (child) classloader — never the daemon's own -cp.
+    // Partition the resolved catalog jars exactly as the bundle path does: the namespaces
+    // UserClassLoaderHolder delegates to the daemon parent (androidx.*, kotlinx-coroutines) must
+    // *precede* the sidecar on the parent -cp, or the daemon loads its own (possibly older) sidecar
+    // versions and a snippet/catalog composable built against the catalog's newer AndroidX fails
+    // with NoSuchMethodError/NoSuchFieldError. Everything else — including the snippet's own
+    // classes
+    // (classesDir) — stays isolated on the user (child) classloader. We only have file paths here
+    // (not coordinates), so match the same groups by their Maven/Gradle cache path segment.
+    // classesDir
+    // lands in `child` (its temp path matches neither), and bundleDaemonClasspaths dedupes it
+    // against
+    // the explicit classesDir arg.
+    val (parentOverlayJars, childJars) =
+      snippet.classpath.map { File(it.toString()) }.partition { jarPrecedesDaemonSidecar(it) }
     val classpaths =
       bundleDaemonClasspaths(
         classesDir = classesDir,
         extraClasspathDirs = emptyList(),
         embeddedLibJars = emptyList(),
-        parentOverlayJars = emptyList(),
-        childDependencyJars = snippet.classpath.map { File(it.toString()) },
+        parentOverlayJars = parentOverlayJars,
+        childDependencyJars = childJars,
         daemonSidecarClasspath = backendLaunch.daemonClasspath,
         androidResourceClasspath = emptyList(),
       )
@@ -606,6 +618,20 @@ internal object ServeBundleDaemon {
     coordinate.group.startsWith("androidx.") ||
       (coordinate.group == "org.jetbrains.kotlinx" &&
         coordinate.artifact.startsWith("kotlinx-coroutines"))
+
+  /**
+   * The [shouldPrecedeDaemonSidecar] rule applied to a resolved **jar path** rather than a
+   * coordinate — used by the playground live path ([materializePlaygroundSnippet]), which carries
+   * only the resolved files (the coordinates were dropped during catalog resolution). Both the
+   * Maven-local (`…/androidx/compose/…`) and Gradle-cache (`…/androidx.compose.material3/…`)
+   * layouts put the dotted/slashed group right after a path separator, so a `/androidx` segment
+   * identifies the AndroidX graph and `kotlinx-coroutines` the coroutines artifacts — the two
+   * namespaces `UserClassLoaderHolder` delegates to the daemon parent.
+   */
+  internal fun jarPrecedesDaemonSidecar(jar: File): Boolean {
+    val path = jar.path.replace('\\', '/')
+    return path.contains("/androidx") || path.contains("kotlinx-coroutines")
+  }
 
   private data class ResolvedBundleDependency(
     val coordinate: BundleReader.ClasspathEntry.Maven,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -18,6 +18,7 @@ import io.ktor.server.request.queryString
 import io.ktor.server.request.receiveStream
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondBytes
+import io.ktor.server.response.respondRedirect
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.delete
@@ -198,6 +199,12 @@ class ServeHttpServer(
    * [docs/design/PLAYGROUND.md](../../../../../../../../docs/design/PLAYGROUND.md).
    */
   private val playgroundService: PlaygroundCompileService? = null,
+  /**
+   * When non-null, enables Stage-2 redemption: `GET /pg/<token>` redeems a preview token into a
+   * live streamed session (registered under the token id) and redirects to its viewer. Supplied by
+   * `ServeCommand` alongside [playgroundService]; the two share one [PlaygroundTokenStore].
+   */
+  private val playgroundRedeem: PlaygroundRedeemService? = null,
 ) {
   /** The actual bound port — may differ from the requested one if it was taken (auto-picked). */
   val port: Int = pickPort(host, requestedPort, portRange)
@@ -402,6 +409,10 @@ class ServeHttpServer(
           // `--public`.
           get("/playground") { handlePlaygroundPage(svc) }
         }
+
+        // Stage-2 redemption (`GET /pg/<token>`): redeem a preview token into a live streamed
+        // session and redirect to its viewer. Mounted with the playground lane; token-gated.
+        playgroundRedeem?.let { redeem -> get("/pg/{token}") { handlePlaygroundRedeem(redeem) } }
 
         // Shared/public mode ingestion: a client contributes a pre-rendered bundle (upload the zip
         // as the body, or pass `?url=` to a build-results artifact) and gets back a ?session= link.
@@ -793,6 +804,34 @@ class ServeHttpServer(
       ),
       ContentType.Text.Html,
     )
+  }
+
+  /**
+   * `GET /pg/<token>`: redeem a preview token into a live session and redirect to its viewer. An
+   * unknown/expired token — or a well-formed one this host has no live backend for — is a styled
+   * 404 that discloses neither. Token-gated (the redeemed session runs user code).
+   */
+  private suspend fun RoutingContext.handlePlaygroundRedeem(redeem: PlaygroundRedeemService) {
+    if (rejectBadToken()) return
+    val id = call.parameters["token"].orEmpty()
+    val gone = "That preview link has expired, or never existed."
+    if (!PlaygroundTokenStore.isWellFormedId(id)) {
+      respondNotFoundHtml(gone)
+      return
+    }
+    when (val outcome = redeem.redeem(id)) {
+      PlaygroundRedeemService.Outcome.NotFound -> respondNotFoundHtml(gone)
+      PlaygroundRedeemService.Outcome.Unavailable ->
+        respondNotFoundHtml("Live preview isn't available on this host.")
+      is PlaygroundRedeemService.Outcome.Live -> {
+        // Hand off to the existing path-form viewer for the just-registered session; its
+        // `/{session}/ws/{preview}` lane streams it and enforces the live-seat budget. Carry the
+        // token so the token-gated viewer + WS accept the follow-on requests.
+        val suffix =
+          if (isPublic) "" else "?token=" + java.net.URLEncoder.encode(token, Charsets.UTF_8)
+        call.respondRedirect("/${outcome.sessionId}/p/${outcome.previewId}$suffix")
+      }
+    }
   }
 
   private suspend fun RoutingContext.handlePlaygroundRun(service: PlaygroundCompileService) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemServiceTest.kt
@@ -1,0 +1,120 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+/**
+ * The Stage-2 redemption orchestration: token lookup → materialize → register (once) → live, and
+ * release-on-expiry — driven against a real [ServeSessionRegistry] (its `open` callback is the
+ * observation point) and a fake `materialize`, so no real daemon is stood up.
+ */
+class PlaygroundRedeemServiceTest {
+
+  private val fs = FakeFileSystem()
+  private var now = 1_000L
+
+  // The registry's resume callback records the state it's asked to open — a live entry that this
+  // test never leases invokes `open` on `acquire`, so it doubles as a "was this id registered?"
+  // probe.
+  private val opened = mutableListOf<ServeSessionState>()
+  private val registry =
+    ServeSessionRegistry(
+      open = {
+        opened.add(it)
+        null
+      },
+      clock = { now },
+    )
+
+  private lateinit var service: PlaygroundRedeemService
+  private var materializeCount = 0
+
+  private val store =
+    PlaygroundTokenStore(fileSystem = fs, clock = { now }, onRemove = { service.release(it.id) })
+
+  init {
+    service =
+      PlaygroundRedeemService(
+        tokenStore = store,
+        registry = registry,
+        materialize = {
+          materializeCount++
+          ServeSessionState(
+            descriptor = File("/w/daemon-launch.json"),
+            workspaceRoot = File("/w"),
+            workspaceName = "w",
+            previews = emptyList(),
+            label = "playground",
+          )
+        },
+      )
+  }
+
+  @AfterTest fun close() = runCatching { registry.close() }.let {}
+
+  private fun mint(previewId: String = "com.example.SnippetKt.Preview") =
+    store.add(
+      PlaygroundTokenStore.PlaygroundSnippet(
+        mode = PlaygroundMode.CMP,
+        workDir = "/w/snippet".toPath(),
+        classesDir = "/w/snippet/classes".toPath(),
+        classpath = listOf("/w/snippet/classes".toPath()),
+        moduleName = "playground-cmp",
+        previewId = previewId,
+      ),
+      isSecurityChecked = true,
+    )
+
+  @Test
+  fun `an unknown token is not found`() {
+    assertEquals(PlaygroundRedeemService.Outcome.NotFound, service.redeem("pg_missing"))
+    assertEquals(0, materializeCount)
+  }
+
+  @Test
+  fun `a live token redeems to a registered session and re-redeem reuses it`() {
+    val token = mint()
+    val first = service.redeem(token.id)
+    assertEquals(
+      PlaygroundRedeemService.Outcome.Live(token.id, "com.example.SnippetKt.Preview"),
+      first,
+    )
+    // Registered: acquiring the id resumes it through the registry's `open` callback.
+    registry.acquire(token.id)
+    assertEquals(1, opened.size, "the redeemed snippet's state was registered under the token id")
+
+    // A second redeem within the TTL rides the standing session — no re-materialize.
+    assertEquals(first, service.redeem(token.id))
+    assertEquals(1, materializeCount, "re-redeem reuses the session rather than re-materializing")
+  }
+
+  @Test
+  fun `a host with no live backend reports unavailable`() {
+    service =
+      PlaygroundRedeemService(tokenStore = store, registry = registry, materialize = { null })
+    val token = mint()
+    assertEquals(PlaygroundRedeemService.Outcome.Unavailable, service.redeem(token.id))
+    registry.acquire(token.id)
+    assertTrue(opened.isEmpty(), "an unavailable redemption registers nothing")
+  }
+
+  @Test
+  fun `an expiring token releases its live session`() {
+    val token = mint()
+    service.redeem(token.id)
+    registry.acquire(token.id)
+    assertEquals(1, opened.size)
+    opened.clear()
+
+    // Advance past the TTL and purge: the store's removal hook must unregister the session.
+    now += store.ttlSeconds * 1000 + 1
+    assertEquals(1, store.purgeExpired(), "the expired token is dropped")
+    registry.acquire(token.id)
+    assertTrue(opened.isEmpty(), "the released session is no longer registered (open not invoked)")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemServiceTest.kt
@@ -104,6 +104,16 @@ class PlaygroundRedeemServiceTest {
   }
 
   @Test
+  fun `a token that expired before redemption registers nothing`() {
+    val token = mint()
+    now += store.ttlSeconds * 1000 + 1 // expire (without an explicit purge)
+    assertEquals(PlaygroundRedeemService.Outcome.NotFound, service.redeem(token.id))
+    registry.acquire(token.id)
+    assertTrue(opened.isEmpty(), "an expired token stands up no session")
+    assertEquals(0, materializeCount)
+  }
+
+  @Test
   fun `an expiring token releases its live session`() {
     val token = mint()
     service.redeem(token.id)


### PR DESCRIPTION
## Summary

The playground could compile a snippet, render its first frame, and mint a `pg_` preview token (#3040/#3044/#3050) — but nothing redeemed the token. This adds **Stage-2**: `GET /pg/<token>` redeems a preview token into a **live, streamed, interactive** session — the second half of the playground loop the design doc describes (`docs/design/PLAYGROUND.md` §2, §5).

The key property (from the architecture): redemption **reuses the serve host's existing live lane wholesale** — the same `/{session}/ws/{preview}` WebSocket, frame fan-out, `input` protocol, and live-seat admission a catalog uses. **No new streaming/input protocol, no new WebSocket handler.** Redemption is a registry `register` + a redirect.

### What changed

- **`PlaygroundRedeemService`** — the orchestration: token lookup → `materialize` the snippet → `ServeSessionRegistry.register(token.id, state)` → redirect to the existing viewer at `/{token.id}/p/{previewId}`. Idempotent within the TTL (register-once gate); fail-soft to *unavailable* when the mode has no live backend. The `materialize` seam is injected, so the whole orchestration is unit-tested against a **real registry** + a fake materialize (no daemon).
- **`ServeBundleDaemon.materializePlaygroundSnippet`** — the production seam: writes a one-preview `previews.json` + a `daemon-launch.json` over the snippet's **own compiled classes** (desktop CMP / Android Robolectric by mode), reusing the exact descriptor recipe `materialize` uses for a bundle. So the registry opens, resumes, seat-counts, and streams it identically to a catalog. **Live-seat admission falls out for free** via the state's `liveSeatWeight` (CMP 1, Android 2) — no route changes (closes the `LiveSeatLimiter` item of epic #3015).
- **`PlaygroundTokenStore`** — an `onRemove` hook, so a dropped token (expiry / eviction) also **unregisters + closes** any live session it stood up. Stage 1 (mint) and Stage 2 (redeem) share one store.
- **`ServeHttpServer`** — `GET /pg/<token>`, token-gated (the redeemed session runs user code); a styled 404 for an unknown/expired token or a mode with no live backend.
- **`ServeCommand`** — hoists the shared token store and wires the redeem lane alongside the compile lane (merged with the #3052 empty-modes guard on rebase).

## Test plan

- [x] `./gradlew :cli:test --tests "*Playground*"` — passing. New `PlaygroundRedeemServiceTest`: unknown→NotFound, live→registered + idempotent re-redeem, no-backend→Unavailable, **expiry→release** (the store's `onRemove` unregisters). Existing token-store / routing / fixture suites still green.
- [x] `./gradlew ktfmtFormat` — clean.

**Verification scope:** the redemption orchestration, `previews.json` + `daemon-launch.json` synthesis, and expiry-release are unit-tested in-process against a real `ServeSessionRegistry` + a fake session. The **live daemon boot + stream** the redeemed session drives needs a real desktop/Robolectric daemon, which the dev sandbox can't run — it's exercised by CI's daemon harness (same split as #3040/#3044).

Non-visual (daemon/registry/routing plumbing); the viewer + WS lanes it hands off to are unchanged and already covered.

## Epic #3015 (Phase 2 — Android backend)

- [x] Live compile→token→**redeem** streaming session — this PR (both CMP and Android modes)
- [x] Admission control: permits via `LiveSeatLimiter` — automatic via the registered state's `liveSeatWeight`

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_