### PR TITLE
fix: survive a non-UTF-8 locale, and report show results from a failed render

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -885,6 +885,30 @@ internal fun previewsMissingPng(results: List<PreviewResult>): List<PreviewResul
   }
 
 /**
+ * Whether `show` can still emit a useful report after gradle reported failure.
+ *
+ * `composePreviewRenderAll` fails the **whole task** when any single preview fails to render, so
+ * one persistently broken preview in a module of sixty used to make `show` discard the fifty-nine
+ * good ones and print nothing but "Render failed" — no `pngPath`, no `sha256`, no `changed`. That
+ * makes the documented iterate loop ("re-render, read the entries marked changed") unusable in any
+ * real repo. `renderAllModules` reads every manifest regardless of the build result, so whenever it
+ * produced results there is something worth reporting; only a build that died before writing any
+ * manifest leaves genuinely nothing to say. The exit code is unaffected either way — see
+ * [showExitCode].
+ *
+ * Pure function so the policy is unit-testable without standing up a Gradle render.
+ */
+internal fun canReportAfterBuildFailure(results: List<PreviewResult>): Boolean =
+  results.isNotEmpty()
+
+/**
+ * `show`'s exit code: a gradle failure (2) outranks whatever the output itself would have reported,
+ * so emitting partial results never downgrades a failed build to a success — and never reports "no
+ * previews matched" (3) for a build that never got far enough to know.
+ */
+internal fun showExitCode(buildOk: Boolean, naturalCode: Int): Int = if (buildOk) naturalCode else 2
+
+/**
  * Human-readable coordinate for a capture: `default`, `500ms`, `scroll long`, `500ms · scroll end`.
  */
 internal fun captureCoordLabel(c: CaptureResult): String =
@@ -915,8 +939,26 @@ class ShowCommand(args: List<String>) : Command(args) {
       renderAllModules(silenceStdout = jsonOutput, gradleArguments = gradleArgsWithForce())
     if (!outcome.buildOk) {
       System.err.println("Render failed")
-      System.out.flush()
-      exitProcess(2)
+      // A failed build does not imply there is nothing to report. `renderAllModules` reads every
+      // module's manifest and builds results whether or not gradle succeeded (see
+      // [RenderModulesOutcome.buildOk]), and `composePreviewRenderAll` fails the *whole task* when
+      // any single preview fails to render — so one broken preview in a module of sixty used to
+      // discard the fifty-nine good ones, emitting no JSON at all: no `pngPath`, no `sha256`, no
+      // `changed`. That makes the documented iterate loop ("re-render, read the changed entries")
+      // unusable in any repo with one persistently broken preview, and pushes agents into
+      // hand-globbing the renders directory. Surface what did render, mark the rest via the
+      // existing per-preview `[no PNG]` / null-`pngPath` channel, and keep the exit code at 2 so
+      // scripts gating on success are unaffected. Only bail early when there is genuinely nothing
+      // to show (gradle died before any manifest was written).
+      if (!canReportAfterBuildFailure(outcome.results)) {
+        System.out.flush()
+        exitProcess(2)
+      }
+      System.err.println(
+        "Reporting the ${outcome.results.size} preview(s) that were discovered anyway — previews " +
+          "that failed to render carry a null pngPath (`[no PNG]` in text output). Exit code " +
+          "stays 2."
+      )
     }
 
     if (outcome.manifests.isEmpty() || outcome.manifests.all { it.second.previews.isEmpty() }) {
@@ -944,7 +986,9 @@ class ShowCommand(args: List<String>) : Command(args) {
       if (jsonOutput) println(encodeResponse(emptyList(), countsScope = all))
       else println("No previews matched.")
       System.out.flush()
-      exitProcess(3)
+      // A build failure outranks "no match": exit 3 advertises a healthy build that simply had
+      // nothing matching the filter, which would be a lie here.
+      exitProcess(showExitCode(outcome.buildOk, naturalCode = 3))
     }
 
     if (jsonOutput) {
@@ -1016,6 +1060,10 @@ class ShowCommand(args: List<String>) : Command(args) {
       if (shouldFailOnMissingRenders()) exitProcess(2)
     }
     System.out.flush()
+    // Output has been emitted; now honour the build failure we deferred above. Left as a guarded
+    // exit rather than an unconditional `exitProcess(showExitCode(...))` so the success path still
+    // returns normally to the caller instead of taking the process down from inside a subcommand.
+    if (!outcome.buildOk) exitProcess(showExitCode(false, naturalCode = 0))
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ShowPartialResultsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ShowPartialResultsTest.kt
@@ -1,0 +1,71 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers `show`'s behaviour when gradle reports failure but results were still produced.
+ *
+ * `composePreviewRenderAll` fails the whole task if any single preview fails to render, so a repo
+ * with one persistently broken preview (a `@Preview` on an Activity whose ViewModel can't be
+ * constructed, say) used to get nothing at all out of `compose-preview show --json` — the command
+ * printed "Render failed" and exited before emitting the envelope, discarding every preview that
+ * rendered perfectly well. That breaks the documented iterate loop, which tells agents to re-render
+ * and read the entries marked `changed`.
+ *
+ * The exit code deliberately does **not** change: a failed build still exits 2.
+ */
+class ShowPartialResultsTest {
+
+  private fun result(id: String, pngPath: String?): PreviewResult =
+    PreviewResult(
+      id = id,
+      module = "samples:demo",
+      functionName = id.substringAfterLast('.'),
+      className = id.substringBeforeLast('.'),
+      params = PreviewParams(kind = "COMPOSE"),
+      captures = listOf(CaptureResult(pngPath = pngPath)),
+      pngPath = pngPath,
+    )
+
+  @Test
+  fun `results present after a failed build are still worth reporting`() {
+    // The shape this actually fixes: one preview blew up, the other rendered fine, and the task
+    // failure applies to both.
+    val results = listOf(result("p.Ok", "/r/ok.png"), result("p.Broken", null))
+    assertTrue(
+      canReportAfterBuildFailure(results),
+      "one broken preview must not suppress the ones that rendered",
+    )
+  }
+
+  @Test
+  fun `a build that produced no results has nothing to report`() {
+    assertFalse(
+      canReportAfterBuildFailure(emptyList()),
+      "gradle died before any manifest was written — there is genuinely nothing to show",
+    )
+  }
+
+  @Test
+  fun `a failed build exits 2 even though output was emitted`() {
+    assertEquals(2, showExitCode(buildOk = false, naturalCode = 0))
+  }
+
+  @Test
+  fun `a failed build outranks the no-previews-matched exit code`() {
+    assertEquals(
+      2,
+      showExitCode(buildOk = false, naturalCode = 3),
+      "exit 3 would advertise a healthy build that simply had no match",
+    )
+  }
+
+  @Test
+  fun `a healthy build keeps its natural exit code`() {
+    assertEquals(0, showExitCode(buildOk = true, naturalCode = 0))
+    assertEquals(3, showExitCode(buildOk = true, naturalCode = 3))
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2002,6 +2002,10 @@ internal object AndroidPreviewSupport {
         }
         useJUnit()
 
+        // Locale-proof this task's reporting — see [configureRenderTaskReporting] for why a
+        // non-UTF-8 sandbox locale otherwise fails the render outright on em-dashed preview names.
+        configureRenderTaskReporting(this)
+
         // Copy JVM args from AGP's test task. Deferred to the configuration
         // lambda (rather than called at registration time) so AGP has had
         // a chance to register `test${capVariant}UnitTest` by the time this
@@ -2236,6 +2240,8 @@ internal object AndroidPreviewSupport {
           resolvedClasspath + (agpTestTask?.testClassesDirs ?: project.files()) + agpTestClasspath
         include("**/ResourcePreviewRenderTest.class")
         useJUnit()
+        // Same locale exposure as the main render task — resource names reach the report path too.
+        configureRenderTaskReporting(this)
 
         jvmArgs(agpTestTask?.jvmArgs ?: emptyList<String>())
         jvmArgs(AndroidPreviewClasspath.buildJvmArgs())
@@ -2353,6 +2359,8 @@ internal object AndroidPreviewSupport {
             }
         include("**/XrSubspaceRenderTest.class")
         useJUnit()
+        // Same locale exposure as the main render task — preview names reach the report path too.
+        configureRenderTaskReporting(this)
 
         jvmArgs(agpTestTask?.jvmArgs ?: emptyList<String>())
         jvmArgs(AndroidPreviewClasspath.buildJvmArgs())

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RobolectricRenderTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RobolectricRenderTask.kt
@@ -95,3 +95,40 @@ abstract class RobolectricRenderTask : Test() {
     previewRowExcludes.set(values)
   }
 }
+
+/**
+ * Make a render [Test] task's own output locale-independent.
+ *
+ * Agent sandboxes and minimal CI images routinely run under `LC_CTYPE=POSIX`, which leaves the JVM
+ * with `sun.jnu.encoding=ANSI_X3.4-1968` (US-ASCII). That breaks a render task in a way that looks
+ * nothing like an encoding problem:
+ * - `Test`'s **HTML** reporter creates one output directory *per test method*, and for these tasks
+ *   a test method is a preview, whose display name comes from consumer source — `@Preview(name =
+ *   "Play Store — 10 inch tablet")`. Gradle writes those directory names using the *daemon's*
+ *   platform encoding, so any preview name containing a non-ASCII character (an em dash, an accent,
+ *   CJK) fails report generation with "Malformed input or input contains unmappable characters".
+ *   Gradle then prints one line per failing file **twice** — once in the failure summary and once
+ *   in the cause list — so a handful of em-dashed preview names buries the actual render result
+ *   under hundreds of lines. Disabling the HTML report removes the failure class outright, and
+ *   costs nothing: this task's product is PNGs, and per-preview failures are already reported
+ *   through the `.error.json` sidecars that `formatMissingPreviewsMessage` reads.
+ * - [Test.setDefaultCharacterEncoding] fixes the forked render JVM's own streams. It cannot fix the
+ *   report-writing above (that happens in the daemon), and since JDK 18 `sun.jnu.encoding` cannot
+ *   be overridden with `-D` at all — hence disabling the report rather than trying to re-encode it.
+ *
+ * The **JUnit XML** report is deliberately left enabled: its files are named after the test *class*
+ * (`RobolectricRenderTest_Shard0`), which is always ASCII, so it is unaffected and CI test-result
+ * collection keeps working.
+ *
+ * Cost of turning HTML off, stated plainly: the `composePreviewRender-reports` CI artifact
+ * (`.github/actions/apply/action.yml`) uploads `build/reports/tests/composePreviewRender/`
+ * alongside `build/test-results/composePreviewRender/`, so that artifact loses its browsable HTML.
+ * No diagnostic content is lost — the HTML report is *generated from* the JUnit XML, which still
+ * ships with the full per-test stack traces — but triage from the artifact means reading XML
+ * instead of opening `index.html`. That is the deliberate trade: a browsable report on the runs
+ * that succeed, versus renders that fail outright on every machine with a non-UTF-8 locale.
+ */
+internal fun configureRenderTaskReporting(task: org.gradle.api.tasks.testing.Test) {
+  task.defaultCharacterEncoding = "UTF-8"
+  task.reports.html.required.set(false)
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderTaskReportingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderTaskReportingTest.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.tasks.testing.Test as TestTask
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+/**
+ * Pins [configureRenderTaskReporting], the guard against a render failing for reasons that have
+ * nothing to do with the preview.
+ *
+ * Under a non-UTF-8 platform locale (`LC_CTYPE=POSIX` — the default in agent sandboxes and minimal
+ * CI images) Gradle's HTML test reporter cannot write its per-test-method output directories when a
+ * preview's display name contains a non-ASCII character, e.g. `@Preview(name = "Play Store — 10
+ * inch tablet")`. The build then fails with "Malformed input or input contains unmappable
+ * characters" once per affected file, printed twice, drowning the real result. Turning the HTML
+ * report off removes the failure class; the sidecar `.error.json` files remain the diagnostic
+ * channel.
+ *
+ * The JUnit XML report must stay ON — its filenames come from the test *class*
+ * (`RobolectricRenderTest_Shard0`), which is always ASCII, so it is unaffected and CI test-result
+ * collection depends on it.
+ */
+class RenderTaskReportingTest {
+
+  private fun renderTask(): TestTask {
+    val project = ProjectBuilder.builder().build()
+    return project.tasks.create("render", TestTask::class.java).also {
+      configureRenderTaskReporting(it)
+    }
+  }
+
+  @Test
+  fun `html report is disabled so non-ascii preview names cannot fail report generation`() {
+    assertThat(renderTask().reports.html.required.get()).isFalse()
+  }
+
+  @Test
+  fun `junit xml report stays enabled for CI test-result collection`() {
+    assertThat(renderTask().reports.junitXml.required.get()).isTrue()
+  }
+
+  @Test
+  fun `render jvm encoding is pinned to UTF-8 regardless of ambient locale`() {
+    assertThat(renderTask().defaultCharacterEncoding).isEqualTo("UTF-8")
+  }
+}


### PR DESCRIPTION
Two independent bugs found while driving the `compose-preview` pipeline against `meshcore-mobile` in a Claude Code cloud sandbox. Both are cloud/CI-shaped: neither shows up on a developer laptop with a UTF-8 locale.

## 1. `fix(plugin)`: a non-UTF-8 locale fails the render

Rendering `:app` in the sandbox failed with ~30 copies of:

```
Malformed input or input contains unmappable characters:
  …/build/reports/tests/composePreviewRender/…/[…PlayStoreTabletTenHome_Play-Store-…-10-inch-tablet-home]/index.html
```

Root cause is not the renderer. The sandbox runs `LC_CTYPE=POSIX`, so the JVM reports:

```
file.encoding   = UTF-8      # set by gradle.properties, looks handled
sun.jnu.encoding = ANSI_X3.4-1968   # US-ASCII — this is the one that governs filenames
```

Gradle's HTML test reporter creates **one output directory per test method**, and for these tasks a test method is a preview, whose display name comes from consumer source — `@Preview(name = "Play Store — 10 inch tablet")`. Those directory names are written with the *daemon's* platform encoding, so every preview whose name contains an em dash, accent, or CJK character fails report generation. The PNGs render fine; the build fails anyway. Gradle then prints one line per failing file **twice** (failure summary + cause list), burying the actual result under hundreds of lines.

Confirmed by re-running with `LANG=C.UTF-8 LC_ALL=C.UTF-8`, which makes the failure disappear entirely.

**Fix:** disable the HTML report on the three render tasks (`composePreviewRender`, `composePreviewRenderAndroidResources`, `composePreviewRenderXr`) and pin `defaultCharacterEncoding` to UTF-8.

- `defaultCharacterEncoding` alone cannot fix this — it configures the forked test JVM, while the failure is in the daemon, and since JDK 18 `sun.jnu.encoding` can't be set with `-D` at all.
- The HTML report is dead weight for tasks whose product is PNGs: per-preview failures already surface through the `.error.json` sidecars that `formatMissingPreviewsMessage` reads.
- **JUnit XML stays enabled** — its filenames come from the test *class* (`RobolectricRenderTest_Shard0`), always ASCII.

Trade-off stated explicitly in the KDoc: the `composePreviewRender-reports` CI artifact loses its browsable HTML, but keeps the XML the HTML is generated from, so no diagnostic content is lost.

## 2. `fix(cli)`: `show` discarded everything when one preview failed

`composePreviewRenderAll` fails the **whole task** if any single preview fails. In `meshcore-mobile:wear`, 26 of 27 previews rendered perfectly, but one `@Preview` on an Activity whose ViewModel can't be constructed failed — and `show` printed `Render failed`, exited 2, and emitted **nothing**: no `pngPath`, no `sha256`, no `changed`, and with `--json` no envelope at all.

That makes the documented iterate loop ("re-render, read the entries marked `changed`") unusable in any repo with one persistently broken preview, and pushes agents into globbing the renders directory by hand — which is what I had to do.

`renderAllModules` already reads every module's manifest regardless of the build result; `RenderModulesOutcome.buildOk` is documented as data on the outcome *precisely* so callers can surface partial findings, which `a11y` already does. `show` was the outlier.

**Fix:** report what was discovered, let the existing per-preview channel mark the failures (null `pngPath`, `[no PNG]` in text output), and bail early only when gradle died before writing any manifest.

**Exit codes are unchanged** — a failed build still exits 2, and now also outranks the "no previews matched" 3, which would otherwise advertise a healthy build that simply had no match.

## Test plan

- [x] `./gradlew :cli:test :gradle-plugin:test` — green
- [x] `./gradlew :cli:compileKotlin :gradle-plugin:compileKotlin` — green
- [x] `./gradlew :cli:ktfmtFormat* :gradle-plugin:ktfmtFormat*` — applied
- [x] New `RenderTaskReportingTest` — pins HTML off, JUnit XML on, encoding UTF-8
- [x] New `ShowPartialResultsTest` — pins partial-report policy and the exit-code precedence
- [x] Locale root cause reproduced and confirmed fixed by `LANG=C.UTF-8` in the sandbox
- [ ] **Not** verified end-to-end against a consumer build with the plugin published to mavenLocal — the publish needs a full multi-module build that ran past the session budget. The unit tests pin the task config; the causal chain from "HTML report dirs are what fail to write" to "disabling the HTML report removes the failure" is direct, but a reviewer may want the in-situ run before merging.

Visual evidence: N/A — neither change alters rendered output. The plugin change only affects report generation; the CLI change only affects stdout/exit codes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014NDRHMxYyfVYUF3pih7LjL)_