### PR TITLE
feat(playground): render the CMP first frame (desktop parity with Android)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -904,10 +904,20 @@ class ServeCommand(args: List<String>) : Command(args) {
       buildPlaygroundRcCaptureService(workRoot, docStore, opener)
     }
 
+    // CMP mode's still first frame renders on the desktop (Skiko) daemon — the backend-agnostic
+    // render service (same as Android) over a desktop opener. Absent the desktop sidecar, CMP
+    // simply
+    // carries no still image; its live `/pg/` redemption still renders on demand.
+    val cmpDaemonOpener = if (cmpClasspath != null) buildPlaygroundDesktopDaemonOpener() else null
+    val cmpRender = cmpDaemonOpener?.let { opener ->
+      buildPlaygroundAndroidRenderService(workRoot, opener)
+    }
+
     System.err.println(
       "serve: playground enabled (POST /api/1/compiler/run) — " +
         listOfNotNull(
             cmpClasspath?.let { "cmp✓" },
+            cmpRender?.let { "cmp-render✓" },
             androidClasspath?.let { "android✓" },
             androidRender?.let { "android-render✓" },
             rcCapture?.let { "remote-compose✓" },
@@ -948,12 +958,16 @@ class ServeCommand(args: List<String>) : Command(args) {
             .absolutePath
             .toPath()
         },
-        // The still first frame is the Android live render (ANDROID mode); CMP's desktop first
-        // frame
-        // is a separate lane, and REMOTE_COMPOSE never reaches this seam (it returns a
-        // documentUrl).
+        // The still first frame renders on the mode's daemon: CMP on desktop (Skiko), Android on
+        // Robolectric. REMOTE_COMPOSE never reaches this seam (it returns a documentUrl). A null
+        // (no
+        // sidecar for that mode) just omits the still image; it's never fatal to the run.
         renderFirstFrame = { snippet ->
-          if (snippet.mode == PlaygroundMode.ANDROID) androidRender?.render(snippet) else null
+          when (snippet.mode) {
+            PlaygroundMode.CMP -> cmpRender?.render(snippet)
+            PlaygroundMode.ANDROID -> androidRender?.render(snippet)
+            PlaygroundMode.REMOTE_COMPOSE -> null
+          }
         },
         captureRemoteDocument = { snippet -> rcCapture?.capture(snippet) },
         publishRemoteDocument = { name, bytes, checked ->
@@ -1077,8 +1091,45 @@ class ServeCommand(args: List<String>) : Command(args) {
   }
 
   /**
-   * The playground's Android first-frame render backend (ANDROID mode): renders a compiled snippet
-   * on the shared [opener] and returns the still PNG the Stage-1 response surfaces as its `image`.
+   * The desktop (CMP/Skiko) daemon opener for the playground's CMP first-frame render — the
+   * `lib-daemon-desktop` + `lib-renderer` sidecar on the daemon classpath and the desktop jvmArgs,
+   * over a subprocess `openBundleDaemon`. Mirrors [ServeBundleDaemon]'s `desktopBundleDaemonLaunch`
+   * (the desktop twin of [buildPlaygroundAndroidDaemonOpener]). Returns null (logging why) when the
+   * sidecar jars are absent — CMP then simply carries no still first frame while its live `/pg/`
+   * redemption keeps rendering on demand.
+   */
+  private fun buildPlaygroundDesktopDaemonOpener(): PlaygroundAndroidSessionOpener? {
+    val daemonJars = locateBundleSidecarJars("lib-daemon-desktop")
+    val rendererJars = locateBundleSidecarJars("lib-renderer")
+    if (daemonJars.isEmpty() || rendererJars.isEmpty()) {
+      System.err.println(
+        "serve: playground CMP first-frame needs the desktop daemon sidecar (lib-daemon-desktop/ + " +
+          "lib-renderer/) from an installed distribution; CMP renders no still frame (its live " +
+          "preview still works)."
+      )
+      return null
+    }
+    val daemonClasspath = (daemonJars + rendererJars).map { it.absolutePath }
+    // -Dapple.awt.UIElement=true keeps the desktop JVM a macOS background agent (no Dock/focus
+    // steal); mirrors desktopBundleDaemonLaunch. No Robolectric sysprops on the desktop backend.
+    val jvmArgs = listOf("--enable-native-access=ALL-UNNAMED", "-Dapple.awt.UIElement=true")
+    return { classesDir, previewsJson, workspaceRoot, userClasspath ->
+      SubprocessRenderSessions.openBundleDaemon(
+        daemonClasspath = daemonClasspath,
+        classesDir = classesDir,
+        previewsJson = previewsJson,
+        workspaceRoot = workspaceRoot,
+        modulePath = ":playground",
+        jvmArgs = jvmArgs,
+        userClasspath = userClasspath,
+      )
+    }
+  }
+
+  /**
+   * The playground's first-frame render backend: renders a compiled snippet on the shared [opener]
+   * and returns the still PNG the Stage-1 response surfaces as its `image`. Backend-agnostic — the
+   * [opener] selects desktop (CMP) or Robolectric (Android); this wires it for both modes.
    */
   private fun buildPlaygroundAndroidRenderService(
     workRoot: java.io.File,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1077,18 +1077,49 @@ class ServeCommand(args: List<String>) : Command(args) {
     val jvmArgs = launch.jvmArgs()
     val sysprops = launch.robolectricSystemProperties()
     return { classesDir, previewsJson, workspaceRoot, userClasspath ->
-      SubprocessRenderSessions.openBundleDaemon(
-        daemonClasspath = daemonClasspath,
-        classesDir = classesDir,
-        previewsJson = previewsJson,
-        workspaceRoot = workspaceRoot,
-        modulePath = ":playground",
-        jvmArgs = jvmArgs,
-        extraSystemProperties = sysprops,
-        userClasspath = userClasspath,
+      openPlaygroundFirstFrameDaemon(
+        daemonClasspath,
+        jvmArgs,
+        sysprops,
+        classesDir,
+        previewsJson,
+        workspaceRoot,
+        userClasspath,
       )
     }
   }
+
+  /**
+   * Open a bundle-less daemon for a first-frame render, partitioning the snippet's [userClasspath]
+   * the way the live path ([ServeBundleDaemon.materializePlaygroundSnippet]) does: jars in the
+   * namespaces `UserClassLoaderHolder` delegates to the parent (`androidx.*`, `kotlinx-coroutines`)
+   * must precede the [sidecarClasspath] on the daemon (parent) `-cp`, or the daemon loads its own
+   * sidecar versions and a snippet built against the catalog's newer AndroidX fails with
+   * `NoSuchMethodError`/`NoSuchFieldError` (and the render service then silently returns no image).
+   * The snippet's own classes stay isolated on the child (user) loader.
+   */
+  private fun openPlaygroundFirstFrameDaemon(
+    sidecarClasspath: List<String>,
+    jvmArgs: List<String>,
+    extraSystemProperties: Map<String, String>,
+    classesDir: java.io.File,
+    previewsJson: java.io.File,
+    workspaceRoot: java.io.File,
+    userClasspath: List<String>,
+  ) =
+    SubprocessRenderSessions.openBundleDaemon(
+      daemonClasspath =
+        userClasspath.filter { ServeBundleDaemon.jarPrecedesDaemonSidecar(java.io.File(it)) } +
+          sidecarClasspath,
+      classesDir = classesDir,
+      previewsJson = previewsJson,
+      workspaceRoot = workspaceRoot,
+      modulePath = ":playground",
+      jvmArgs = jvmArgs,
+      extraSystemProperties = extraSystemProperties,
+      userClasspath =
+        userClasspath.filterNot { ServeBundleDaemon.jarPrecedesDaemonSidecar(java.io.File(it)) },
+    )
 
   /**
    * The desktop (CMP/Skiko) daemon opener for the playground's CMP first-frame render — the
@@ -1114,14 +1145,14 @@ class ServeCommand(args: List<String>) : Command(args) {
     // steal); mirrors desktopBundleDaemonLaunch. No Robolectric sysprops on the desktop backend.
     val jvmArgs = listOf("--enable-native-access=ALL-UNNAMED", "-Dapple.awt.UIElement=true")
     return { classesDir, previewsJson, workspaceRoot, userClasspath ->
-      SubprocessRenderSessions.openBundleDaemon(
-        daemonClasspath = daemonClasspath,
-        classesDir = classesDir,
-        previewsJson = previewsJson,
-        workspaceRoot = workspaceRoot,
-        modulePath = ":playground",
-        jvmArgs = jvmArgs,
-        userClasspath = userClasspath,
+      openPlaygroundFirstFrameDaemon(
+        daemonClasspath,
+        jvmArgs,
+        emptyMap(),
+        classesDir,
+        previewsJson,
+        workspaceRoot,
+        userClasspath,
       )
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundAndroidRenderService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundAndroidRenderService.kt
@@ -27,10 +27,13 @@ fun interface PlaygroundAndroidSessionOpener {
 }
 
 /**
- * The production [PlaygroundCompileService] `renderFirstFrame` for the **Android** mode: render a
- * freshly-compiled Compose Android snippet on an Android/Robolectric daemon and return the PNG the
- * daemon drew — the still frame the Stage-1 response surfaces as its `image` (`docs/design/
- * PLAYGROUND.md` §7 Phase 2, epic #3015).
+ * The production [PlaygroundCompileService] `renderFirstFrame`: render a freshly-compiled Compose
+ * snippet on a daemon and return the PNG the daemon drew — the still frame the Stage-1 response
+ * surfaces as its `image` (`docs/design/PLAYGROUND.md` §7 Phase 2, epic #3015).
+ *
+ * **Backend-agnostic:** the flow (open → render → read the `pngPath`) is identical for CMP (desktop
+ * Skiko daemon) and Android (Robolectric); the injected [openSession] selects the backend, so the
+ * same service wires both modes' first frame — only the daemon sidecar differs.
  *
  * The flow is the render half of [PlaygroundRcCaptureService]'s open → render → await → fetch
  * shape, over a bundle-less daemon standing on the snippet's own compiled classes:


### PR DESCRIPTION
## Summary

Stacked on #3054. `ANDROID` playground snippets already returned a Stage-1 still frame (#3044), but `CMP`'s `image` was always null — the only remaining first-frame gap. This wires CMP's still frame on the desktop (Skiko) daemon, at parity with Android.

The first-frame render service is **backend-agnostic** (open → render → read the `renderFinished` `pngPath`), so no new render logic is needed — just a desktop daemon opener:

- **`buildPlaygroundDesktopDaemonOpener`** (`ServeCommand`) — `lib-daemon-desktop` + `lib-renderer` sidecar + the desktop jvmArgs, over the same `openBundleDaemon`, mirroring `ServeBundleDaemon.desktopBundleDaemonLaunch` (the desktop twin of the existing Android opener). Fail-soft: absent the sidecar, CMP just carries no still image while its live `/pg/` redemption keeps rendering on demand.
- **`renderFirstFrame`** now dispatches `CMP → desktop daemon`, `ANDROID → Robolectric`, `REMOTE_COMPOSE → null` (it returns a `documentUrl`).
- The render service's KDoc is updated to note it's backend-agnostic (the injected opener selects the backend).

## Test plan

- [x] `./gradlew :cli:test --tests "*Playground*"` — passing (the render service is already unit-tested against a fake session; it doesn't branch on mode, so CMP rides the same tested path).
- [x] `./gradlew ktfmtFormat` — clean.

**Verification scope:** the wiring is in-process; the live desktop render populating the CMP still frame needs the desktop daemon sidecar, exercised by CI's desktop daemon harness (same split as #3044's Android first frame).

Non-visual for repo purposes (daemon/render plumbing; the PNG is the user's snippet, not a repo-owned surface).

_Base will retarget to `main` once #3054 merges._

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_