### PR TITLE
docs(bundle): correct the @PreviewParameter contract in DaemonSemanticsFetcher

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -52,9 +52,25 @@ internal class DaemonSemanticsFetcher(
   /**
    * Render [previewIds] through a temporary daemon and return each preview's
    * `compose-semantics.json` bytes, keyed by preview id. Previews whose sidecar never materialised
-   * (a `@PreviewParameter` fan-out whose data dir is keyed by a per-value base name, a render that
-   * failed, an unsupported backend) are simply absent from the returned map — the caller carries
-   * what it got and reports the rest.
+   * (a render that failed, an unsupported backend) are simply absent from the returned map — the
+   * caller carries what it got and reports the rest.
+   *
+   * **`@PreviewParameter` fan-outs read from the bare id like any other preview.** The daemon does
+   * *not* fan a parameterized preview out across its provider's values — it renders one frame of
+   * the provider's first value under the bare `<id>` base name (Android:
+   * `daemon/android/.../RenderEngine.kt`, `resolvePreviewInvocation`; the fan-out-per-value path
+   * stays with the standalone renderer). So a fan-out's `compose-semantics.json` lands at
+   * `build/compose-previews/data/<id>/` exactly where a plain preview's does, and the bare-id read
+   * below carries it. This was broken before the daemon learned to resolve `@PreviewParameter`
+   * (previously the `(Composer, int)`-only lookup threw `NoSuchMethodException`, so every such
+   * preview lost its PNG *and* its semantics — the drop reported in issue #3049 against a build
+   * that predates that fix); nothing per-value is written, so there is nothing extra to resolve
+   * here.
+   *
+   * **Known gap:** the desktop daemon does not resolve `@PreviewParameter` at all
+   * (`daemon/desktop/.../RenderEngine.kt`), so a fan-out in a CMP/desktop module renders no frame
+   * and produces no sidecar — its semantics stay absent until the desktop backend gains first-value
+   * resolution the way Android has.
    *
    * [projectDir] is the module's project directory (`PreviewModule.projectDir`);
    * `daemon-launch.json` and the daemon's `build/compose-previews/data/<id>/` output both sit under

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -86,6 +86,49 @@ class DaemonSemanticsFetcherTest {
   }
 
   @Test
+  fun `carries a PreviewParameter fan-out's semantics from the bare id`() {
+    // Issue #3049: `bundle pack --with-semantics` dropped every `@PreviewParameter` preview's a11y
+    // tree on a build predating the daemon's `@PreviewParameter` support — the parameterless
+    // `(Composer, int)` lookup threw `NoSuchMethodException`, so no sidecar was written at all.
+    // Once the daemon resolves the annotation it renders one frame of the provider's *first* value
+    // under the **bare** function id (it does not fan out per value — that stays with the
+    // standalone
+    // renderer), so the sidecar lands at `build/compose-previews/data/<id>/` exactly like a plain
+    // preview's. This guards that contract from the fetcher's side: a fan-out id is carried with no
+    // per-value directory resolution, because none is written.
+    val projectDir = newTempFolder("semantics-fanout")
+    writeDescriptor(projectDir)
+
+    val logs = mutableListOf<String>()
+    val fanoutTree = """{"root":{"nodeId":"searchbar","boundsInRoot":"0,0,48,12"}}"""
+    val fetcher =
+      DaemonSemanticsFetcher(
+        // The daemon writes the first value's sidecar under the bare id, keyed just like any other
+        // preview — no `SearchBarPreview_Light` / `_PARAM_0` leaf is ever produced.
+        factory = FakeFactory(mapOf("SearchBarPreview" to fanoutTree)),
+        onLog = { logs += it },
+      )
+
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        moduleName = "sample",
+        previewIds = listOf("SearchBarPreview"),
+      )
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertEquals(setOf("SearchBarPreview"), outcome.semanticsById.keys)
+    assertEquals(
+      fanoutTree,
+      outcome.semanticsById.getValue("SearchBarPreview").toString(Charsets.UTF_8),
+    )
+    assertTrue(
+      logs.none { "no compose-semantics.json for 'SearchBarPreview'" in it },
+      "a fan-out's bare-id sidecar must be carried, not reported missing, got: $logs",
+    )
+  }
+
+  @Test
   fun `carries the fonts-used sidecar for previews whose backend records it`() {
     val projectDir = newTempFolder("semantics-fonts")
     writeDescriptor(projectDir)


### PR DESCRIPTION
Closes #3049.

## What changed after review

The original approach (scan `build/compose-previews/data/` for per-value `<id>_<value>` leaves) was **wrong** — Codex's P1 review was correct, and verifying it against the source disproved the issue's stated premise. This PR is now a **documentation correction + regression guard**, not a behavior change.

## Ground truth (verified in source)

- The **Android daemon does not fan a `@PreviewParameter` preview out** across its provider's values. It renders **one frame of the provider's first value under the bare `<id>` base name** (`daemon/android/.../RenderEngine.kt:94-98`, `resolvePreviewInvocation`; `PreviewManifestRouter.kt:361` `outputBaseName ?: id`). The per-value fan-out stays with the standalone renderer.
- **Discovery does not expand fan-outs** (`preview-discovery/PreviewData.kt:571-574`) — one manifest entry per function, no per-value `outputBaseName`.
- The **bundle passes the bare id** (`BundlePreviewTask.kt:499-500,723-728` — "one representative per preview id").
- So a fan-out's `compose-semantics.json` lands at `build/compose-previews/data/<id>/`, exactly where a plain preview's does, and `DaemonSemanticsFetcher`'s **existing bare-id read already carries it**. No per-value directory is ever written — the earlier scan targeted directories no backend produces.

## Why the issue saw drops

The #3049 repro was on **0.19.10**, which predates the daemon's `@PreviewParameter` support (**#3041**, shipped in 0.19.12 — this branch sits directly on it). Before #3041 the parameterless `(Composer, int)` lookup threw `NoSuchMethodException`, so every parameterized preview lost its PNG **and** its semantics. #3041 already fixes the Android symptom.

## Fix

- **Revert** the dead directory-scan in `DaemonSemanticsFetcher` back to the bare-id read (unchanged behavior from `main`).
- **Correct the KDoc**, which falsely claimed fan-outs write "a per-value base name" — that stale comment is what mislead the original approach. It now describes the real contract.
- **Regression test** (`carries a PreviewParameter fan-out's semantics from the bare id`) guarding the #3041 contract from the fetcher's side.

## Known gap (follow-up, not fixed here)

The **desktop daemon does not resolve `@PreviewParameter` at all** (`daemon/desktop/.../RenderEngine.kt:77-81`), so a fan-out in a CMP/desktop module renders no frame and produces no sidecar — its semantics stay absent until the desktop backend gains first-value resolution the way Android has. Documented in the KDoc; happy to open a follow-up to implement it if wanted.

## Tests

`:cli:test --tests DaemonSemanticsFetcherTest` → 11 passing (0 failures); `ktfmt` clean.

Data-product plumbing with no visual surface, so no render evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_015CZUZDZrumh5LKpX3ENuNu)_