### PR TITLE
fix(playground): redeem /pg/ on token-gated hosts, with a browser e2e

### DIFF
--- a/.github/workflows/serve-lanes-e2e.yml
+++ b/.github/workflows/serve-lanes-e2e.yml
@@ -29,6 +29,9 @@ on:
       - "vscode-extension/preview-harness/serve-lanes.*"
       - "vscode-extension/preview-harness/serve-lanes-boot.sh"
       - "vscode-extension/preview-harness/serve-android-lane-boot.sh"
+      # The playground e2e (editor → compile → first-frame → /pg live redemption).
+      - "vscode-extension/preview-harness/playground.*"
+      - "vscode-extension/preview-harness/playground-boot.sh"
       # The Android lane's fixture and the detached-render Application pin it guards.
       - "samples/android-live-lane/**"
       - "cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt"
@@ -48,6 +51,9 @@ on:
       - "vscode-extension/preview-harness/serve-lanes.*"
       - "vscode-extension/preview-harness/serve-lanes-boot.sh"
       - "vscode-extension/preview-harness/serve-android-lane-boot.sh"
+      # The playground e2e (editor → compile → first-frame → /pg live redemption).
+      - "vscode-extension/preview-harness/playground.*"
+      - "vscode-extension/preview-harness/playground-boot.sh"
       # The Android lane's fixture and the detached-render Application pin it guards.
       - "samples/android-live-lane/**"
       - "cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt"
@@ -225,4 +231,90 @@ jobs:
           path: |
             serve-android-lane.log
             vscode-extension/preview-harness/test-results-serve-lanes/**
+          if-no-files-found: warn
+
+  # The Kotlin playground, end to end (#3015). The two lanes above prove the *render* backends honor
+  # knob overrides; this proves the *playground* itself: the browser editor compiles a user snippet on
+  # the server (BTA), gets a first-frame still back, and the returned `/pg/<token>` capability redeems
+  # into the ordinary live viewer. That whole chain — editor → `POST /api/1/compiler/run` → compile →
+  # Android/Robolectric first frame → `/pg/` redemption → viewer — has only ever been unit-tested
+  # against fakes; nothing exercised the real wiring in a browser until here.
+  #
+  # It reuses the Android/Robolectric backend (the default editor snippet declares an Android
+  # `@Preview`), booting serve with `--playground-android-bundle` over a locally packed
+  # `:samples:android-live-lane` — the same bundle the android lane packs. The playground lane compiles
+  # and runs user-supplied code in-process, so it is refused under `--public`; the boot is token-gated
+  # and the spec carries `?token=`.
+  playground-e2e:
+    name: Playground compiles + redeems a snippet end to end
+    runs-on: ubuntu-latest
+    # Same cost profile as the android lane: Robolectric sandbox bootstrap + the android-all fetch
+    # dominate the cold render, and the compile POST blocks on that first-frame render before it
+    # answers. Plus a bundle pack that renders the sample first.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      # `lib-daemon-android` ships as a standalone archive rather than inside the CLI dist (#1685), so
+      # stage it and point the CLI at it via `-Dcomposeai.cli.libDaemonAndroidDir` (the boot script
+      # sets that through JAVA_OPTS). `android.jar` comes from the runner's Android SDK.
+      - name: Build the CLI (installDist) + Android daemon sidecar
+        shell: bash
+        run: ./gradlew --no-daemon :cli:installDist :cli:stageDaemonAndroidLibs --stacktrace
+
+      # The playground compiles user snippets against this bundle's classpath (not as a served
+      # catalog). It's the same sample the android lane serves.
+      - name: Pack the Android playground bundle
+        shell: bash
+        run: |
+          cli/build/install/compose-preview/bin/compose-preview bundle pack \
+            --module samples:android-live-lane \
+            -o "$GITHUB_WORKSPACE/playground-lane.png" --timeout 900
+
+      - name: Install harness deps + Chromium
+        working-directory: vscode-extension
+        shell: bash
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      # Boots serve with the playground lane enabled (token-gated) and fails the step unless the lane
+      # actually came up ("playground enabled" in the log) — see the boot script header.
+      - name: Boot playground serve
+        shell: bash
+        env:
+          SERVE_BUNDLE: playground-lane.png
+          LIB_DAEMON_ANDROID_DIR: cli/build/staged-daemon-android-libs
+          SERVE_TOKEN: playground-e2e
+        run: |
+          url="$(bash vscode-extension/preview-harness/playground-boot.sh)"
+          echo "playground: SERVE_URL=$url"
+          echo "SERVE_URL=$url" >> "$GITHUB_ENV"
+
+      - name: Drive the playground (Chromium)
+        working-directory: vscode-extension
+        shell: bash
+        env:
+          CI: "true"
+          SERVE_TOKEN: playground-e2e
+        run: npm run harness:playground
+
+      - name: Tear down serve
+        if: always()
+        shell: bash
+        run: |
+          [ -f playground-lane.pid ] && kill "$(cat playground-lane.pid)" 2>/dev/null || true
+          pkill -f 'MainKt serve' 2>/dev/null || true
+
+      - name: Upload serve log + trace on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playground-e2e-artifacts
+          path: |
+            playground-lane.log
+            vscode-extension/preview-harness/test-results-playground/**
           if-no-files-found: warn

--- a/.github/workflows/serve-lanes-e2e.yml
+++ b/.github/workflows/serve-lanes-e2e.yml
@@ -23,6 +23,9 @@ on:
     branches: [main]
     paths:
       - "cli/src/main/kotlin/ee/schimke/composeai/cli/serve/**"
+      # ServeCommand owns openPlaygroundService, the daemon-opener wiring, and the ServeHttpServer
+      # hookup — it lives one directory up from serve/**, so trigger on it explicitly.
+      - "cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt"
       - "daemon/**"
       - "render-session/**"
       - "render-session-subprocess/**"
@@ -45,6 +48,9 @@ on:
   pull_request:
     paths:
       - "cli/src/main/kotlin/ee/schimke/composeai/cli/serve/**"
+      # ServeCommand owns openPlaygroundService, the daemon-opener wiring, and the ServeHttpServer
+      # hookup — it lives one directory up from serve/**, so trigger on it explicitly.
+      - "cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt"
       - "daemon/**"
       - "render-session/**"
       - "render-session-subprocess/**"
@@ -301,6 +307,17 @@ jobs:
           CI: "true"
           SERVE_TOKEN: playground-e2e
         run: npm run harness:playground
+
+      # Surface the serve log INLINE in the job log on failure. The `onLog` reason a redemption
+      # failure carries (`[playground live] …` — sidecar/android.jar missing, no previews, …) is
+      # written to the serve stderr, which only reaches the uploaded artifact; echoing it here makes
+      # a first-frame / redemption failure diagnosable straight from the job log.
+      - name: Dump serve log on failure
+        if: failure()
+        shell: bash
+        run: |
+          echo "===== playground-lane.log ====="
+          tail -200 playground-lane.log || echo "(no serve log)"
 
       - name: Tear down serve
         if: always()

--- a/.github/workflows/serve-lanes-e2e.yml
+++ b/.github/workflows/serve-lanes-e2e.yml
@@ -316,8 +316,13 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          echo "===== playground-lane.log ====="
-          tail -200 playground-lane.log || echo "(no serve log)"
+          echo "===== playground live/redeem reasons ====="
+          # The per-render daemon output is extremely verbose, so a plain tail buries the one line
+          # that matters (a redemption `[playground live] …` reason). Surface those first.
+          grep -nE 'playground live|redeem|Unavailable|Live preview|no previews|backend=android|android\.jar|sidecar' \
+            playground-lane.log || echo "(no redemption-reason lines matched)"
+          echo "===== playground-lane.log (tail) ====="
+          tail -120 playground-lane.log || echo "(no serve log)"
 
       - name: Tear down serve
         if: always()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -412,7 +412,10 @@ class ServeHttpServer(
 
         // Stage-2 redemption (`GET /pg/<token>`): redeem a preview token into a live streamed
         // session and redirect to its viewer. Mounted with the playground lane; token-gated.
-        playgroundRedeem?.let { redeem -> get("/pg/{token}") { handlePlaygroundRedeem(redeem) } }
+        // The path segment is named `{pgToken}`, NOT `{token}`: on a token-gated host the access
+        // token rides as `?token=…`, and `call.parameters` merges path + query, so a `{token}` path
+        // segment would collide with the access token and redeem the wrong id (a NotFound 404).
+        playgroundRedeem?.let { redeem -> get("/pg/{pgToken}") { handlePlaygroundRedeem(redeem) } }
 
         // Shared/public mode ingestion: a client contributes a pre-rendered bundle (upload the zip
         // as the body, or pass `?url=` to a build-results artifact) and gets back a ?session= link.
@@ -813,7 +816,9 @@ class ServeHttpServer(
    */
   private suspend fun RoutingContext.handlePlaygroundRedeem(redeem: PlaygroundRedeemService) {
     if (rejectBadToken()) return
-    val id = call.parameters["token"].orEmpty()
+    // Read the PATH segment explicitly (see the route mount): it's named `{pgToken}` so it can't be
+    // shadowed by the `?token=` access token that `call.parameters` also carries on a gated host.
+    val id = call.parameters["pgToken"].orEmpty()
     val gone = "That preview link has expired, or never existed."
     if (!PlaygroundTokenStore.isWellFormedId(id)) {
       respondNotFoundHtml(gone)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -25,6 +25,11 @@ class PlaygroundRoutingTest {
   private val fs = FakeFileSystem()
   private var workN = 0
 
+  // Shared between the compile service (mints tokens) and the redeem service (looks them up), like
+  // production — so the token-gated redemption test below exercises a real mint → redeem
+  // round-trip.
+  private val tokenStore = PlaygroundTokenStore(fileSystem = fs)
+
   private val playground =
     PlaygroundCompileService(
       catalogClasspath = { mode ->
@@ -37,12 +42,29 @@ class PlaygroundRoutingTest {
       compiler = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() },
       discoverer =
         PlaygroundCompileService.PreviewDiscoverer { _, _ -> listOf("com.example.PScreen") },
-      tokenStore = PlaygroundTokenStore(fileSystem = fs),
+      tokenStore = tokenStore,
       newWorkDir = { "/work/run${++workN}".toPath() },
       fileSystem = fs,
     )
 
   private val registry = ServeSessionRegistry(open = { null })
+
+  // Materialize always succeeds (a real daemon isn't in scope here) so redemption reaches its Live
+  // redirect — the path we assert isn't shadowed by the access token on a gated host.
+  private val redeem =
+    PlaygroundRedeemService(
+      tokenStore = tokenStore,
+      registry = registry,
+      materialize = { snippet ->
+        ServeSessionState(
+          descriptor = java.io.File("/tmp/pg-none.json"),
+          workspaceRoot = java.io.File("/tmp"),
+          workspaceName = "pg",
+          previews = listOf(ServePreview(id = snippet.previewId, label = snippet.previewId)),
+          label = "pg",
+        )
+      },
+    )
 
   private val server: ServeHttpServer by lazy {
     ServeHttpServer(
@@ -70,12 +92,32 @@ class PlaygroundRoutingTest {
       .also { it.start() }
   }
 
+  /**
+   * A **token-gated** host (`isPublic = false`) with the redemption lane wired — the shape a real
+   * playground runs as (the lane is refused under `--public`). Here the access token rides as
+   * `?token=…`, which is what made the `/pg/{token}` path-param collision surface.
+   */
+  private val gatedServer: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "sekret",
+        sessions = registry,
+        defaultSessionId = "none",
+        isPublic = false,
+        playgroundService = playground,
+        playgroundRedeem = redeem,
+      )
+      .also { it.start() }
+  }
+
   private val client = OkHttpClient()
 
   @AfterTest
   fun stop() {
     runCatching { server.stop() }
     runCatching { plainServer.stop() }
+    runCatching { gatedServer.stop() }
     runCatching { registry.close() }
   }
 
@@ -137,5 +179,49 @@ class PlaygroundRoutingTest {
   @Test
   fun `the editor page is absent when the playground lane isn't enabled`() {
     get("/playground", plainServer.port).use { resp -> assertEquals(404, resp.code) }
+  }
+
+  @Test
+  fun `a gated pg redemption redirects to the viewer instead of 404ing on the access token`() {
+    // Mint a token on the gated host; the access token rides as ?token=sekret.
+    val body =
+      """{"files":[{"name":"Snippet.kt","text":"@Preview @Composable fun P(){}"}],"confType":"compose-cmp"}"""
+    val previewUrl =
+      client
+        .newCall(
+          Request.Builder()
+            .url("http://127.0.0.1:${gatedServer.port}/api/1/compiler/run?token=sekret")
+            .post(body.toRequestBody("application/json".toMediaType()))
+            .build()
+        )
+        .execute()
+        .use { resp ->
+          assertEquals(200, resp.code)
+          Json.parseToJsonElement(resp.body!!.string())
+            .jsonObject["previewUrl"]!!
+            .jsonPrimitive
+            .content
+        }
+
+    // Redeem it WITH the access token in the query. The `/pg/{pgToken}` path segment must resolve
+    // to
+    // the minted id — NOT be shadowed by the same-named `?token=` access token (which would fail
+    // the
+    // pg_ shape check and 404 as NotFound). Assert the 302 to the viewer, don't follow it.
+    val noRedirect = client.newBuilder().followRedirects(false).build()
+    noRedirect
+      .newCall(
+        Request.Builder()
+          .url("http://127.0.0.1:${gatedServer.port}$previewUrl?token=sekret")
+          .build()
+      )
+      .execute()
+      .use { resp ->
+        assertEquals(302, resp.code, "redemption redirects to the viewer, not a 404")
+        assertTrue(
+          resp.header("Location")?.contains("/p/") == true,
+          "redirect targets the viewer /p/ route: ${resp.header("Location")}",
+        )
+      }
   }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -284,7 +284,8 @@
         "package": "npm run compile && vsce package --no-dependencies",
         "harness:snapshot": "node esbuild.webview.mjs && playwright test -c preview-harness/playwright.config.mjs snapshot",
         "harness:contract": "node esbuild.webview.mjs && playwright test -c preview-harness/playwright.config.mjs contract",
-        "harness:serve-lanes": "playwright test -c preview-harness/serve-lanes.config.mjs"
+        "harness:serve-lanes": "playwright test -c preview-harness/serve-lanes.config.mjs",
+        "harness:playground": "playwright test -c preview-harness/playground.config.mjs"
     },
     "devDependencies": {
         "@happy-dom/global-registrator": "^20.9.0",

--- a/vscode-extension/preview-harness/README.md
+++ b/vscode-extension/preview-harness/README.md
@@ -173,6 +173,29 @@ being free of `ClassNotFoundException`. The fixture's manifest names an
 `Application` the render classpath doesn't carry precisely to keep that gate
 honest.
 
+## Playground, end to end (compile → first frame → live redemption)
+
+[`playground.spec.mjs`](playground.spec.mjs) drives the Kotlin **playground**
+(`docs/design/PLAYGROUND.md`) the whole way through in a browser: the editor
+compiles a Compose snippet on the server (`POST /api/1/compiler/run`, BTA), gets a
+first-frame still back, and the returned `/pg/<token>` capability redeems into the
+ordinary live viewer. The playground's seams are unit-tested against fakes; this is
+the only thing that exercises the real wiring with a daemon behind it.
+
+```sh
+SERVE_URL=http://127.0.0.1:8727 SERVE_TOKEN=playground-e2e npm run harness:playground
+```
+
+[`playground-boot.sh`](playground-boot.sh) stands one up (also run by
+[`serve-lanes-e2e.yml`](../../.github/workflows/serve-lanes-e2e.yml)). It reuses the
+Android/Robolectric backend — the default editor snippet declares an Android
+`@Preview` — booting serve with `--playground-android-bundle` over a locally packed
+`:samples:android-live-lane`. The lane compiles and runs user code in-process, so it
+is refused under `--public`: the boot is **token-gated** (`SERVE_TOKEN`, which the
+spec carries as `?token=`), and the script fails loud unless the log shows
+`playground enabled`. Same `LIB_DAEMON_ANDROID_DIR` + Android-SDK prerequisites as
+the Android render lane above.
+
 ## Wire-side contract
 
 ```sh

--- a/vscode-extension/preview-harness/playground-boot.sh
+++ b/vscode-extension/preview-harness/playground-boot.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Boot a daemon-backed `compose-preview serve` with the **playground** lane enabled over a locally
+# packed Android bundle, and print its base URL — the target for playground.spec.mjs (the browser
+# e2e of the Kotlin playground: editor → compile → first-frame → /pg live redemption).
+#
+# Unlike the serve-lanes boots, this enables `--playground-android-bundle` (the compile classpath a
+# snippet builds against) rather than serving the bundle as a catalog. The playground lane compiles
+# and runs user-supplied code in-process, so it is **refused under --public** — this boots
+# token-gated instead (SERVE_TOKEN). `--accept-docs` enables the `/d/` store the Remote Compose mode
+# publishes into. The Android/Robolectric daemon sidecar (lib-daemon-android, shipped outside the CLI
+# tarball, #1685) is wired via JAVA_OPTS, and `android.jar` comes from the runner's Android SDK.
+#
+# Runs MODULE-LESS from a scratch dir outside the Gradle project (same reason as serve-lanes-boot.sh)
+# so serve hosts only the playground lane, not the repo's ~20 preview modules.
+#
+# Env:
+#   SERVE_CLI                 compose-preview launcher (default: :cli:installDist output)
+#   SERVE_BUNDLE              packed Android bundle used as the compile classpath
+#                             (default: playground-lane.png at the repo root)
+#   LIB_DAEMON_ANDROID_DIR    staged :daemon:android runtime jars (:cli:stageDaemonAndroidLibs output)
+#   SERVE_PORT                bind port (default 8727 — above the two serve-lanes ports)
+#   SERVE_TOKEN               the access token (default playground-e2e); the spec passes ?token=…
+#   SERVE_LOG                 serve log file, relative to the repo root (default playground-lane.log)
+#
+# Writes the pid to playground-lane.pid (repo root) for teardown.
+set -euo pipefail
+
+REPO_ROOT="$(pwd)"
+CLI="$(readlink -f "${SERVE_CLI:-cli/build/install/compose-preview/bin/compose-preview}")"
+BUNDLE="$(readlink -f "${SERVE_BUNDLE:-playground-lane.png}")"
+LIB_DAEMON_ANDROID="$(readlink -f "${LIB_DAEMON_ANDROID_DIR:-cli/build/staged-daemon-android-libs}")"
+PORT="${SERVE_PORT:-8727}"
+TOKEN="${SERVE_TOKEN:-playground-e2e}"
+LOG="${REPO_ROOT}/${SERVE_LOG:-playground-lane.log}"
+PID_FILE="${REPO_ROOT}/playground-lane.pid"
+BASE="http://127.0.0.1:${PORT}"
+
+if [ ! -x "$CLI" ]; then
+  echo "::error::serve CLI not found or not executable at $CLI — run :cli:installDist first" >&2
+  exit 1
+fi
+if [ ! -f "$BUNDLE" ]; then
+  echo "::error::playground bundle not found at $BUNDLE — run \`compose-preview bundle pack --module samples:android-live-lane -o $BUNDLE\` first" >&2
+  exit 1
+fi
+if [ ! -d "$LIB_DAEMON_ANDROID" ]; then
+  echo "::error::lib-daemon-android jars dir not found at $LIB_DAEMON_ANDROID — run :cli:stageDaemonAndroidLibs first" >&2
+  exit 1
+fi
+
+# The Robolectric daemon resolves android.jar from a local SDK; without one the render lanes report
+# unavailable. CI runners export ANDROID_HOME; a dev box may only have sdk.dir in local.properties.
+if [ -z "${ANDROID_HOME:-}" ] && [ -z "${ANDROID_SDK_ROOT:-}" ] && [ -f "${REPO_ROOT}/local.properties" ]; then
+  sdk_dir="$(sed -n 's/^sdk\.dir=//p' "${REPO_ROOT}/local.properties" | head -1)"
+  [ -n "$sdk_dir" ] && export ANDROID_HOME="$sdk_dir"
+fi
+if [ -z "${ANDROID_HOME:-}" ] && [ -z "${ANDROID_SDK_ROOT:-}" ]; then
+  echo "::error::no Android SDK — set ANDROID_HOME (or ANDROID_SDK_ROOT), or add sdk.dir to local.properties. The Robolectric daemon needs android.jar to render." >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d "${RUNNER_TEMP:-/tmp}/playground-lane.XXXXXX")"
+echo "playground: booting playground-lane serve on $BASE (module-less, cwd=$WORK)" >&2
+cd "$WORK"
+# --live-seats 2: an Android/Robolectric daemon costs ANDROID_LIVE_SEAT_WEIGHT (2) permits, so a
+# redeemed /pg session needs at least that budget. NOT --public (the lane is refused there).
+JAVA_OPTS="-Dcomposeai.cli.libDaemonAndroidDir=${LIB_DAEMON_ANDROID}" nohup "$CLI" serve \
+  --playground-android-bundle "$BUNDLE" --accept-docs \
+  --host 127.0.0.1 --port "$PORT" --token "$TOKEN" --live-seats 2 \
+  > "$LOG" 2>&1 &
+echo $! > "$PID_FILE"
+
+# Wait for the HTTP server to answer, and confirm the playground lane actually came up (the CLI logs
+# "playground enabled …" once the compile classpath + compiler resolved; absent it, the /playground
+# page and /api routes 404 and every spec assertion would fail cryptically).
+up=""
+for _ in $(seq 1 120); do
+  if curl -sf -o /dev/null --max-time 4 "$BASE/version"; then up=1; break; fi
+  sleep 2
+done
+if [ -z "$up" ]; then
+  echo "::error::serve did not answer /version in time" >&2
+  tail -80 "$LOG" >&2 || true
+  exit 1
+fi
+if ! grep -q "playground enabled" "$LOG"; then
+  echo "::error::the playground lane did not enable — the compile classpath or the BTA compiler didn't resolve. See the log." >&2
+  tail -80 "$LOG" >&2 || true
+  exit 1
+fi
+
+echo "$BASE"

--- a/vscode-extension/preview-harness/playground.config.mjs
+++ b/vscode-extension/preview-harness/playground.config.mjs
@@ -1,0 +1,52 @@
+// Playwright config for the playground e2e spec (`playground.spec.mjs`).
+//
+// Like serve-lanes.config.mjs, this drives a REAL, daemon-backed
+// `compose-preview serve` that the CI job (or a developer) boots separately and
+// points at via SERVE_URL — here with the **playground lane** enabled
+// (`--playground-android-bundle`), not a live catalog. Booting that serve needs a
+// JVM, the BTA compiler, the Android/Robolectric daemon sidecar and an Android SDK,
+// so it's orchestrated by the workflow / playground-boot.sh, not Playwright's
+// `webServer` lifecycle. The spec self-skips with a clear message when SERVE_URL is
+// unset (a local run without a playground target).
+//
+// The playground page is token-gated (the lane is refused under --public), so the
+// spec appends `?token=<SERVE_TOKEN>` to every navigation; SERVE_TOKEN must match the
+// token the boot script passed to `serve --token`.
+
+import { defineConfig } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// `||` (not `??`) so an empty SERVE_URL — e.g. an env var set to "" — falls back to
+// the default instead of becoming a broken empty baseURL.
+const serveUrl = process.env.SERVE_URL || "http://127.0.0.1:8727";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "playground.spec.mjs",
+  outputDir: resolve(here, "test-results-playground"),
+  // A cold Android/Robolectric first-frame render blocks the compile POST: the
+  // service renders the still frame synchronously before answering (up to its 180s
+  // render budget), on top of the BTA compile. Budget the whole test well past that.
+  timeout: 300_000,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    browserName: "chromium",
+    baseURL: serveUrl,
+    viewport: { width: 1100, height: 820 },
+    trace: "retain-on-failure",
+    launchOptions: {
+      // Software WebGL so any in-browser tier the /pg/ viewer opens renders
+      // headlessly. HARNESS_CHROMIUM points at a Chromium binary when the bundled
+      // Playwright download isn't present.
+      args: ["--enable-unsafe-swiftshader", "--use-gl=angle"],
+      ...(process.env.HARNESS_CHROMIUM
+        ? { executablePath: process.env.HARNESS_CHROMIUM }
+        : {}),
+    },
+  },
+});

--- a/vscode-extension/preview-harness/playground.spec.mjs
+++ b/vscode-extension/preview-harness/playground.spec.mjs
@@ -138,19 +138,21 @@ test("the /pg/ token redeems into the live viewer", async ({ page }) => {
   const href = await page.locator("#pg-open").getAttribute("href");
 
   // Hit the /pg/ capability RAW (no redirect-follow) first. Redemption must 302 to the
-  // viewer at /<sessionId>/p/<previewId>; a NotFound/Unavailable serves inline HTML with
-  // NO redirect, so checking the raw status + Location surfaces exactly which outcome it
-  // was (and any body) instead of a cryptic "URL never became /p/".
+  // viewer at /<sessionId>/p/<previewId>; a NotFound/Unavailable serves inline HTML with NO
+  // redirect. One assertion on the Location header, whose failure message carries the status
+  // AND the body — the body text ("expired, or never existed" vs "Live preview isn't
+  // available") says whether it was NotFound or Unavailable.
   const raw = await page.request.get(href, { maxRedirects: 0 });
   const location = raw.headers()["location"] ?? "";
-  const bodyHint = raw.status() >= 400 ? (await raw.text()).slice(0, 200) : "";
+  const body =
+    raw.status() >= 300 && raw.status() < 400
+      ? ""
+      : (await raw.text()).slice(0, 300);
   expect(
-    raw.status(),
-    `/pg/ redemption should 3xx-redirect to the viewer; got ${raw.status()} ` +
-      `location="${location}" body="${bodyHint}"`,
-  ).toBeGreaterThanOrEqual(300);
-  expect(raw.status(), "redemption redirect is a 3xx").toBeLessThan(400);
-  expect(location, "redirect target is the viewer /p/ route").toMatch(/\/p\//);
+    location,
+    `/pg/ must 302 to the viewer /p/ route; got status ${raw.status()} ` +
+      `location="${location}" body="${body}"`,
+  ).toMatch(/\/p\//);
 
   // And the viewer actually loads (follow the redirect in a real page). The live frame
   // itself is the /ws/ lane's job (proven by the serve-lanes suite); here we only assert

--- a/vscode-extension/preview-harness/playground.spec.mjs
+++ b/vscode-extension/preview-harness/playground.spec.mjs
@@ -1,0 +1,144 @@
+// End-to-end proof that the Kotlin **playground** of a live, daemon-backed
+// `compose-preview serve` works the whole way through: the browser editor compiles a
+// Compose snippet on the server, gets back a first-frame still, and the returned
+// `/pg/<token>` capability redeems into the ordinary live viewer.
+//
+// This is the browser counterpart to the playground's unit tests (compile service,
+// token store, redeem service): those prove each seam in isolation against fakes;
+// this proves the real wiring — editor page → `POST /api/1/compiler/run` → BTA
+// compile → Android/Robolectric first frame → `/pg/` live redemption → viewer — with
+// a real daemon behind it, the one thing a fake can't cover.
+//
+// Requires a running playground serve; point SERVE_URL at it. The CI job boots one
+// with `--playground-android-bundle` (a locally packed `:samples:android-live-lane`),
+// token-gated (the lane is refused under --public), so the spec appends
+// `?token=<SERVE_TOKEN>` to every navigation. Self-skips with a clear message when no
+// SERVE_URL / playground page is reachable (a local run without a target).
+
+import { test, expect } from "@playwright/test";
+
+// Must match the `--token` the boot script passed to serve.
+const TOKEN = process.env.SERVE_TOKEN || "playground-e2e";
+// The editor's Android mode option (ServeWeb.playgroundModeChoice): compiles the
+// snippet against the Android bundle and mints a live `/pg/` token.
+const ANDROID_MODE = "compose-android";
+
+// The token gates every route; carry it on each navigation.
+const q = `?token=${encodeURIComponent(TOKEN)}`;
+
+// Resolved in beforeAll: is a playground editor page actually reachable? Left false
+// when SERVE_URL is unset/unreachable so the suite self-skips locally (and hard-fails
+// in CI, where the boot step guarantees the page).
+let playgroundUp = false;
+
+test.beforeAll(async ({ request }) => {
+  const res = await request.get(`/playground${q}`);
+  playgroundUp = res.ok() && (await res.text()).includes('id="pg-source"');
+});
+
+function requirePlayground() {
+  if (!playgroundUp && process.env.CI) {
+    throw new Error(
+      `no playground editor at /playground — the daemon-backed serve isn't exposing the lane; ` +
+        `refusing to green-skip the Playground suite`,
+    );
+  }
+  test.skip(
+    !playgroundUp,
+    `no playground editor reachable at /playground — is a --playground-android-bundle serve ` +
+      `running at ${process.env.SERVE_URL} with token "${TOKEN}"?`,
+  );
+}
+
+// After a run the status ends on one of two terminal strings ("Done." on success, or
+// an error message on a compile/exception failure) — "Compiling…" is the only
+// non-terminal one. Wait for a terminal status, then let the test assert which.
+async function runAndAwaitTerminal(page) {
+  await page.click("#pg-run");
+  const status = page.locator("#pg-status");
+  await expect(status).toBeVisible();
+  await expect
+    .poll(async () => (await status.textContent())?.trim(), {
+      // The compile POST blocks on the cold Android first-frame render (synchronous,
+      // up to the service's 180s budget) before it answers.
+      timeout: 280_000,
+    })
+    .not.toBe("Compiling…");
+  return (await status.textContent())?.trim();
+}
+
+test("editor page serves its controls and the Android mode", async ({
+  page,
+}) => {
+  requirePlayground();
+  await page.goto(`/playground${q}`, { waitUntil: "domcontentloaded" });
+
+  await expect(page.locator("#pg-source"), "source editor").toBeVisible();
+  await expect(page.locator("#pg-mode"), "mode selector").toBeVisible();
+  await expect(page.locator("#pg-run"), "run button").toBeVisible();
+
+  // The Android compile mode must be offered — it's the one this lane serves.
+  const values = await page
+    .locator("#pg-mode option")
+    .evaluateAll((opts) => opts.map((o) => o.value));
+  expect(values, "mode options").toContain(ANDROID_MODE);
+});
+
+test("compiles the default Android snippet to a first frame + live /pg/ handoff", async ({
+  page,
+}) => {
+  requirePlayground();
+  await page.goto(`/playground${q}`, { waitUntil: "domcontentloaded" });
+
+  // The default sample already declares an Android @Preview; just select the mode
+  // and run it — a clean compile is the happy path this test pins.
+  await page.selectOption("#pg-mode", ANDROID_MODE);
+  const terminal = await runAndAwaitTerminal(page);
+  expect(
+    terminal,
+    `run should succeed on the default snippet, got status "${terminal}" ` +
+      `(diagnostics: ${await page.locator("#pg-diagnostics").textContent()})`,
+  ).toBe("Done.");
+
+  // A successful CMP/Android run always mints a live preview token and surfaces its
+  // "Open live preview →" handoff pointing at /pg/<token> (the still image is
+  // best-effort — the token is the contract).
+  const open = page.locator("#pg-open");
+  await expect(open, "live-preview handoff link").toBeVisible();
+  const href = await open.getAttribute("href");
+  expect(href, "handoff href targets the /pg/ capability").toMatch(
+    /\/pg\/pg_[A-Za-z0-9_-]+/,
+  );
+});
+
+test("the /pg/ token redeems into the live viewer", async ({ page }) => {
+  requirePlayground();
+  await page.goto(`/playground${q}`, { waitUntil: "domcontentloaded" });
+  await page.selectOption("#pg-mode", ANDROID_MODE);
+  const terminal = await runAndAwaitTerminal(page);
+  test.skip(
+    terminal !== "Done.",
+    `compile did not succeed (status "${terminal}") — nothing to redeem`,
+  );
+
+  // Follow the handoff. Redemption registers the compiled snippet as a live session
+  // and 302-redirects to the ordinary viewer at /<sessionId>/p/<previewId>; the
+  // browser lands there, NOT on the styled /pg/ 404 (which would mean Unavailable —
+  // no live backend). So the post-navigation URL must have left /pg/ for a /p/ route.
+  const open = page.locator("#pg-open");
+  const href = await open.getAttribute("href");
+  await page.goto(href, { waitUntil: "domcontentloaded" });
+
+  await expect
+    .poll(() => new URL(page.url()).pathname, { timeout: 30_000 })
+    .toMatch(/\/p\//);
+  expect(
+    new URL(page.url()).pathname,
+    "left the /pg/ capability route",
+  ).not.toMatch(/^\/pg\//);
+
+  // The viewer stage is present — the redeemed session resolved to the real viewer,
+  // not an error page. (The live frame itself is the /ws/ lane's job, proven by the
+  // serve-lanes suite; here we only assert redemption reached the viewer.)
+  await expect(page.locator("#cp-img"), "viewer stage").toBeAttached();
+});

--- a/vscode-extension/preview-harness/playground.spec.mjs
+++ b/vscode-extension/preview-harness/playground.spec.mjs
@@ -100,15 +100,26 @@ test("compiles the default Android snippet to a first frame + live /pg/ handoff"
       `(diagnostics: ${await page.locator("#pg-diagnostics").textContent()})`,
   ).toBe("Done.");
 
-  // A successful CMP/Android run always mints a live preview token and surfaces its
-  // "Open live preview →" handoff pointing at /pg/<token> (the still image is
-  // best-effort — the token is the contract).
+  // A successful CMP/Android run mints a live preview token and surfaces its
+  // "Open live preview →" handoff pointing at /pg/<token>.
   const open = page.locator("#pg-open");
   await expect(open, "live-preview handoff link").toBeVisible();
   const href = await open.getAttribute("href");
   expect(href, "handoff href targets the /pg/ capability").toMatch(
     /\/pg\/pg_[A-Za-z0-9_-]+/,
   );
+
+  // The advertised first frame must actually render — the daemon drew a still and the
+  // response carried it as a data:image/png URI. Asserting it (rather than treating the
+  // image as best-effort) is what proves the compile→daemon→PNG path really ran, not
+  // just that a token was minted; a silent render failure is otherwise invisible here.
+  const image = page.locator("#pg-image");
+  await expect(image, "first-frame image is shown").toBeVisible();
+  const src = await image.getAttribute("src");
+  expect(
+    src ?? "",
+    "first-frame src is an inline PNG (empty ⇒ the daemon render produced no frame; see serve log)",
+  ).toMatch(/^data:image\/png/);
 });
 
 test("the /pg/ token redeems into the live viewer", async ({ page }) => {
@@ -116,29 +127,37 @@ test("the /pg/ token redeems into the live viewer", async ({ page }) => {
   await page.goto(`/playground${q}`, { waitUntil: "domcontentloaded" });
   await page.selectOption("#pg-mode", ANDROID_MODE);
   const terminal = await runAndAwaitTerminal(page);
-  test.skip(
-    terminal !== "Done.",
+  // A non-Done terminal in CI is a real regression, not a reason to skip: the boot
+  // guarantees a compilable lane, so failing here (rather than green-skipping) keeps the
+  // redemption chain actually covered.
+  expect(
+    terminal,
     `compile did not succeed (status "${terminal}") — nothing to redeem`,
-  );
+  ).toBe("Done.");
 
-  // Follow the handoff. Redemption registers the compiled snippet as a live session
-  // and 302-redirects to the ordinary viewer at /<sessionId>/p/<previewId>; the
-  // browser lands there, NOT on the styled /pg/ 404 (which would mean Unavailable —
-  // no live backend). So the post-navigation URL must have left /pg/ for a /p/ route.
-  const open = page.locator("#pg-open");
-  const href = await open.getAttribute("href");
+  const href = await page.locator("#pg-open").getAttribute("href");
+
+  // Hit the /pg/ capability RAW (no redirect-follow) first. Redemption must 302 to the
+  // viewer at /<sessionId>/p/<previewId>; a NotFound/Unavailable serves inline HTML with
+  // NO redirect, so checking the raw status + Location surfaces exactly which outcome it
+  // was (and any body) instead of a cryptic "URL never became /p/".
+  const raw = await page.request.get(href, { maxRedirects: 0 });
+  const location = raw.headers()["location"] ?? "";
+  const bodyHint = raw.status() >= 400 ? (await raw.text()).slice(0, 200) : "";
+  expect(
+    raw.status(),
+    `/pg/ redemption should 3xx-redirect to the viewer; got ${raw.status()} ` +
+      `location="${location}" body="${bodyHint}"`,
+  ).toBeGreaterThanOrEqual(300);
+  expect(raw.status(), "redemption redirect is a 3xx").toBeLessThan(400);
+  expect(location, "redirect target is the viewer /p/ route").toMatch(/\/p\//);
+
+  // And the viewer actually loads (follow the redirect in a real page). The live frame
+  // itself is the /ws/ lane's job (proven by the serve-lanes suite); here we only assert
+  // redemption reached the real viewer shell, not an error page.
   await page.goto(href, { waitUntil: "domcontentloaded" });
-
   await expect
     .poll(() => new URL(page.url()).pathname, { timeout: 30_000 })
     .toMatch(/\/p\//);
-  expect(
-    new URL(page.url()).pathname,
-    "left the /pg/ capability route",
-  ).not.toMatch(/^\/pg\//);
-
-  // The viewer stage is present — the redeemed session resolved to the real viewer,
-  // not an error page. (The live frame itself is the /ws/ lane's job, proven by the
-  // serve-lanes suite; here we only assert redemption reached the viewer.)
   await expect(page.locator("#cp-img"), "viewer stage").toBeAttached();
 });


### PR DESCRIPTION
## Summary

Adds the first **browser end-to-end** coverage of the Kotlin playground (`docs/design/PLAYGROUND.md`, epic #3015) — and that e2e immediately caught a real bug, now fixed here.

### The bug it caught

Stage-2 redemption was mounted at `GET /pg/{token}`, but on a token-gated host the access token also rides as `?token=…`. Ktor's `call.parameters` merges path + query, so `call.parameters["token"]` resolved to the **access token** instead of the `pg_…` path segment, failed the shape check, and 404'd **every** redemption as NotFound. Because the playground lane is refused under `--public`, a token-gated host is the *only* way it runs — so live redemption was broken for all real deployments. The existing `serve-lanes` suites never caught it: they run `--public`, so there's no `?token=` to collide.

Fix: rename the path segment to `{pgToken}` (can't be shadowed) and read it explicitly. Plus a token-gated `PlaygroundRoutingTest` case (mint → redeem with `?token=`) that asserts the 302 to the viewer — it 404'd before the fix.

### The e2e (`playground.spec.mjs`)

Drives the whole chain in Chromium against a live, daemon-backed serve:

1. **Editor page** serves its controls and offers the Android compile mode.
2. **Compile → first frame** — running the default `@Preview` snippet reaches `Done.` via `POST /api/1/compiler/run` (BTA compile → Android/Robolectric first frame) and the response carries an inline `data:image/png` still (asserted, not treated as best-effort).
3. **Live redemption** — the returned `/pg/<token>` capability 302-redirects into the ordinary viewer (`/<sessionId>/p/<previewId>`), not the styled 404.

Reuses the Android/Robolectric backend (the default snippet declares an Android `@Preview`): `playground-boot.sh` packs `:samples:android-live-lane` and boots `serve --playground-android-bundle` **token-gated** (so the spec carries `?token=` — which is exactly what surfaced the bug). A `playground-e2e` CI job mirrors the Android render lane; on failure it dumps the serve log into the job log so a redemption reason is diagnosable without the artifact.

### Review follow-ups (Codex)

- Assert the first-frame `#pg-image` is a real PNG data URI (not just that a token minted).
- The redemption test **fails** rather than green-skips on a non-`Done.` compile.
- Trigger the workflow on `ServeCommand.kt` (owns `openPlaygroundService` + the daemon-opener wiring, outside `serve/**`).

## Test plan

- [x] `./gradlew :cli:test --tests "*PlaygroundRoutingTest*"` — passes, incl. the new gated-redemption case (which 404'd before the route-param fix).
- [x] `node --check` / `prettier --check` clean on the harness files; YAML + `package.json` parse.
- [ ] The `playground-e2e` CI job drives the full chain green (compile + first-frame already pass; redemption fixed by this PR).

Visual note: no repo-owned surface changes — the rendered PNG is the user's snippet. Non-visual for repo purposes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012zgaKUxKwJreq17xDK5WGn)_