### PR TITLE
feat(discovery): warn when a preview installs a theme under declared theme catalogs

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -406,6 +406,10 @@ object PreviewDiscovery {
     val rawShapeCatalogTokens = mutableListOf<RawCatalogToken>()
     // `@ThemeCatalog`-annotated `PreviewWrapperProvider` classes → one theme catalog sheet each.
     val rawThemeCatalogs = mutableListOf<RawThemeCatalog>()
+    // (declaring class, method) for every method that produced at least one preview. Fed to
+    // [PreviewThemeShadowing] after the class walk, which needs both the theme providers (collected
+    // in the same pass) and the previews before it can say anything.
+    val previewMethods = mutableListOf<Pair<ClassInfo, MethodInfo>>()
 
     if (classpath.isNotEmpty()) {
       ClassGraph()
@@ -478,6 +482,7 @@ object PreviewDiscovery {
               for (ann in annotations) {
                 annotationFqnCounts.merge(ann.name, 1, Int::plus)
               }
+              val previewCountBefore = previews.size
               discoverFromMethod(
                 classInfo,
                 method,
@@ -489,6 +494,12 @@ object PreviewDiscovery {
                 warnings,
                 catalogGroupsByFile,
               )
+              // Remember the methods that actually yielded previews, so the theme-shadowing check
+              // below walks exactly those rather than re-deriving "is this a preview?" (which
+              // multi-preview meta-annotations make non-trivial).
+              if (previews.size > previewCountBefore) {
+                previewMethods += classInfo to method
+              }
             }
             // `@ColorCatalog` / `@TypographyCatalog` / `@ShapeCatalog` design tokens: an annotated
             // `Color` / `TextStyle` / `Shape` (single token) or `ColorScheme` / `Typography` /
@@ -542,6 +553,19 @@ object PreviewDiscovery {
                   )
               }
             }
+          }
+
+          // A module that declares theme providers has an interactive theme axis, and a preview
+          // that installs its own theme silently opts out of it — the provider wraps the preview,
+          // the body's theme composes inside that wrapper and shadows it. Only worth saying when
+          // the module actually declares themes; otherwise every app preview would be "guilty".
+          if (rawThemeCatalogs.isNotEmpty()) {
+            PreviewThemeShadowing.warningOrNull(
+                findings =
+                  PreviewThemeShadowing.detect(previewMethods, scanResult, projectClassFqns),
+                themeCount = rawThemeCatalogs.size,
+              )
+              ?.let { warnings.add(it) }
           }
         }
     }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewThemeShadowing.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewThemeShadowing.kt
@@ -1,0 +1,169 @@
+package ee.schimke.composeai.discovery
+
+import io.github.classgraph.ClassInfo
+import io.github.classgraph.MethodInfo
+import io.github.classgraph.ScanResult
+
+/**
+ * Detects `@Preview` functions that install a `MaterialTheme` in their **own body** in a module
+ * that also declares `@ThemeCatalog` / `@WearThemeCatalog` providers — the combination that
+ * silently kills the preview server's theme switcher.
+ *
+ * The two features disagree about composition order. A theme catalog is applied by *wrapping* the
+ * preview function: the renderer resolves the provider and composes `Wrap(content)` around the
+ * preview body ([`InvokeWithOptionalWrapper`] in the daemon). A theme installed *inside* the
+ * preview body therefore composes within that wrapper and shadows it, so every entry in the
+ * viewer's **Theme** select renders byte-identical pixels. The catalog looks like it has a live
+ * theme axis and doesn't.
+ *
+ * This is not hypothetical: it is exactly what shipped in `confetti-wear` and `confetti-mobile`,
+ * where all five conference themes rendered the same PNG because every catalog preview opened with
+ * `ConfettiThemeFixed { … }`. Nothing in the pipeline noticed, because the synthetic per-theme
+ * specimen sheets ([PreviewKind.THEME_CATALOG]) wrap a *canned* grid rather than an app preview and
+ * so kept differing correctly.
+ *
+ * **Warning, never an error.** Pinning a preview to one theme is legitimate — a per-identity "theme
+ * foundation" sticker documents exactly one theme on purpose, and should stay pinned. The check
+ * can't tell that apart from the bug, so it reports and lets the author decide.
+ *
+ * Detection is a bounded walk of the preview's bytecode: direct calls first, then into the module's
+ * own methods (a preview almost never calls `MaterialTheme` directly — it calls the app's theme
+ * wrapper, which calls it). Library code other than the theme entry points themselves is not
+ * followed, so the walk stays cheap and can't wander into Compose internals.
+ */
+internal object PreviewThemeShadowing {
+
+  /**
+   * Owners of the `MaterialTheme(…)` *composable* — the call that installs a theme. Kotlin compiles
+   * a top-level composable into a `…Kt` facade, so `MaterialTheme { }` in `material3` becomes
+   * `androidx.compose.material3.MaterialThemeKt.MaterialTheme(…)`.
+   *
+   * Deliberately NOT matched: `MaterialTheme.colorScheme` and friends, which *read* the ambient
+   * theme and compile to `androidx.compose.material3.MaterialTheme.getColorScheme(…)` — owner
+   * without the `Kt` facade suffix, and a different method name. Reading the theme is what a
+   * well-behaved preview body does; only installing one shadows the wrapper.
+   */
+  private val THEME_INSTALL_OWNERS =
+    setOf(
+      "androidx.compose.material3.MaterialThemeKt",
+      "androidx.compose.material.MaterialThemeKt",
+      "androidx.wear.compose.material3.MaterialThemeKt",
+      "androidx.wear.compose.material.MaterialThemeKt",
+    )
+
+  private const val THEME_INSTALL_METHOD = "MaterialTheme"
+
+  /**
+   * How many module-local hops to follow from the preview body. Real chains are short —
+   * `SessionCardPopulatedPreview → ConfettiThemeFixed → MaterialTheme` is two, and the deepest in
+   * Confetti (`…Preview → ConfettiPreviewScaffold → ConfettiThemeFixed → MaterialTheme`) is three.
+   * The cap keeps a pathological call graph from turning discovery into a whole-program analysis.
+   */
+  private const val MAX_DEPTH = 6
+
+  /** One preview whose body installs a theme, with the call chain that gets there. */
+  internal data class Finding(
+    val classFqn: String,
+    val methodName: String,
+    /** Human-readable hops from the preview to the `MaterialTheme` call, nearest first. */
+    val chain: List<String>,
+  ) {
+    /** `com.example.FooKt.BarPreview (via AppTheme → MaterialTheme)` */
+    fun describe(): String = "$classFqn.$methodName (via ${chain.joinToString(" → ")})"
+  }
+
+  /**
+   * @param previewMethods the `@Preview` methods discovery actually produced previews from, as
+   *   (declaring class, method) pairs.
+   * @param projectClassFqns FQNs compiled from the module's own sources; the walk only recurses
+   *   into these, never into dependency JARs.
+   */
+  internal fun detect(
+    previewMethods: List<Pair<ClassInfo, MethodInfo>>,
+    scanResult: ScanResult,
+    projectClassFqns: Set<String>,
+  ): List<Finding> = previewMethods.mapNotNull { (classInfo, method) ->
+    val chain =
+      try {
+        walk(classInfo, method, scanResult, projectClassFqns, depth = 0, visited = mutableSetOf())
+      } catch (_: Throwable) {
+        // Bytecode we can't read is not worth failing discovery over — the whole check is
+        // advisory. Same posture as PreviewTargetInference's own extractCalls guard.
+        null
+      }
+    chain?.let { Finding(classInfo.name, method.name, it) }
+  }
+
+  /**
+   * Returns the chain of call names from [method] down to a theme install, or `null` if this method
+   * doesn't reach one within [MAX_DEPTH] module-local hops.
+   */
+  private fun walk(
+    classInfo: ClassInfo,
+    method: MethodInfo,
+    scanResult: ScanResult,
+    projectClassFqns: Set<String>,
+    depth: Int,
+    visited: MutableSet<String>,
+  ): List<String>? {
+    if (!visited.add("${classInfo.name}#${method.name}${method.typeDescriptorStr}")) return null
+    // Reuses the inference walker: it already follows the method's own lambda bodies, so a theme
+    // installed as `AppTheme { … }` inside the preview is seen from the preview's own root method.
+    val calls = PreviewTargetInference.extractCalls(classInfo, method)
+
+    if (calls.any(::isThemeInstall)) return listOf(THEME_INSTALL_METHOD)
+    if (depth >= MAX_DEPTH) return null
+
+    for (call in calls) {
+      if (call.ownerFqn !in projectClassFqns) continue
+      val targetClass = scanResult.getClassInfo(call.ownerFqn) ?: continue
+      val targetMethod =
+        targetClass.methodInfo.firstOrNull {
+          it.name == call.methodName && it.typeDescriptorStr == call.descriptor
+        } ?: continue
+      val deeper = walk(targetClass, targetMethod, scanResult, projectClassFqns, depth + 1, visited)
+      if (deeper != null) return listOf(call.methodName) + deeper
+    }
+    return null
+  }
+
+  /**
+   * `MaterialTheme` takes defaulted parameters (`colorScheme`, `typography`, `shapes`), so all but
+   * the fully-specified call site compiles to the synthetic `MaterialTheme$default` bridge rather
+   * than `MaterialTheme` itself — and `AppTheme { … }` passing only `content` is by far the common
+   * shape. Matching the bare name alone would miss nearly every real occurrence.
+   */
+  internal fun isThemeInstall(call: PreviewTargetInference.Invocation): Boolean =
+    call.ownerFqn in THEME_INSTALL_OWNERS &&
+      (call.methodName == THEME_INSTALL_METHOD ||
+        call.methodName == "$THEME_INSTALL_METHOD\$default")
+
+  /**
+   * The discovery warning for [findings], or `null` when there is nothing to say. [themeCount] is
+   * how many theme providers the module declares — quoted back so the message explains *why* this
+   * matters for this module specifically.
+   */
+  internal fun warningOrNull(findings: List<Finding>, themeCount: Int): String? {
+    if (findings.isEmpty() || themeCount == 0) return null
+    return buildString {
+      append("composePreviewDiscover: ")
+      append(findings.size)
+      append(" @Preview function(s) install a theme in their own body, while this module declares ")
+      append(themeCount)
+      append(" @ThemeCatalog/@WearThemeCatalog provider(s).\n")
+      append(
+        "  A theme catalog is applied by WRAPPING the preview, so a theme installed inside the " +
+          "preview body composes within that wrapper and shadows it — the viewer's Theme select " +
+          "will render identical pixels for these previews:\n"
+      )
+      findings.take(10).forEach { append("    - ").append(it.describe()).append('\n') }
+      if (findings.size > 10) append("    (+").append(findings.size - 10).append(" more)\n")
+      append(
+        "  Fix: declare the theme with `@PreviewWrapper(SomeThemeCatalog::class)` on the preview " +
+          "instead of calling it in the body, or have the app's theme stand down when an override " +
+          "is already installed. Pinning a preview to one theme on purpose (a per-theme specimen " +
+          "sheet) is fine — this is a warning, not an error."
+      )
+    }
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewThemeShadowingTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewThemeShadowingTest.kt
@@ -1,0 +1,118 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PreviewThemeShadowingTest {
+
+  private fun invocation(owner: String, method: String) =
+    PreviewTargetInference.Invocation(owner, method, "(Landroidx/compose/runtime/Composer;I)V")
+
+  @Test
+  fun `installing MaterialTheme is a theme install`() {
+    assertThat(
+        PreviewThemeShadowing.isThemeInstall(
+          invocation("androidx.compose.material3.MaterialThemeKt", "MaterialTheme")
+        )
+      )
+      .isTrue()
+    assertThat(
+        PreviewThemeShadowing.isThemeInstall(
+          invocation("androidx.wear.compose.material3.MaterialThemeKt", "MaterialTheme")
+        )
+      )
+      .isTrue()
+  }
+
+  @Test
+  fun `the defaulted-args bridge is a theme install`() {
+    // `MaterialTheme { content }` leaves colorScheme/typography/shapes defaulted, so the compiler
+    // emits the synthetic `MaterialTheme$default` bridge. This is the shape almost every real app
+    // theme wrapper produces — missing it would make the check fire on nearly nothing.
+    assertThat(
+        PreviewThemeShadowing.isThemeInstall(
+          invocation("androidx.compose.material3.MaterialThemeKt", "MaterialTheme\$default")
+        )
+      )
+      .isTrue()
+  }
+
+  @Test
+  fun `reading the ambient theme is not a theme install`() {
+    // `MaterialTheme.colorScheme` — the object accessor, not the `…Kt` facade composable. A preview
+    // body reading the theme it was handed is exactly the well-behaved case; flagging it would make
+    // the check useless.
+    assertThat(
+        PreviewThemeShadowing.isThemeInstall(
+          invocation("androidx.compose.material3.MaterialTheme", "getColorScheme")
+        )
+      )
+      .isFalse()
+    assertThat(
+        PreviewThemeShadowing.isThemeInstall(
+          invocation("androidx.compose.material3.MaterialTheme", "getTypography")
+        )
+      )
+      .isFalse()
+  }
+
+  @Test
+  fun `unrelated composables are not theme installs`() {
+    assertThat(PreviewThemeShadowing.isThemeInstall(invocation("com.example.AppKt", "Surface")))
+      .isFalse()
+    assertThat(
+        PreviewThemeShadowing.isThemeInstall(
+          invocation("androidx.compose.foundation.layout.BoxKt", "Box")
+        )
+      )
+      .isFalse()
+  }
+
+  @Test
+  fun `no findings produces no warning`() {
+    assertThat(PreviewThemeShadowing.warningOrNull(findings = emptyList(), themeCount = 3)).isNull()
+  }
+
+  @Test
+  fun `findings without declared themes produce no warning`() {
+    // A module with no theme providers has no theme axis to shadow — an app preview installing its
+    // own theme there is just an app preview.
+    val finding = PreviewThemeShadowing.Finding("com.example.FooKt", "BarPreview", listOf("Theme"))
+    assertThat(PreviewThemeShadowing.warningOrNull(listOf(finding), themeCount = 0)).isNull()
+  }
+
+  @Test
+  fun `warning names the previews and the call chain`() {
+    val warning =
+      PreviewThemeShadowing.warningOrNull(
+        findings =
+          listOf(
+            PreviewThemeShadowing.Finding(
+              "dev.example.ComponentCatalogKt",
+              "CardPreview",
+              listOf("AppThemeFixed", "MaterialTheme"),
+            )
+          ),
+        themeCount = 5,
+      )
+    assertThat(warning).isNotNull()
+    assertThat(warning)
+      .contains("dev.example.ComponentCatalogKt.CardPreview (via AppThemeFixed → MaterialTheme)")
+    assertThat(warning).contains("5 @ThemeCatalog/@WearThemeCatalog provider(s)")
+    // Actionable, and explicit that a deliberately pinned preview is allowed to stay.
+    assertThat(warning).contains("@PreviewWrapper")
+    assertThat(warning).contains("warning, not an error")
+  }
+
+  @Test
+  fun `warning truncates a long finding list`() {
+    val findings =
+      (1..14).map {
+        PreviewThemeShadowing.Finding("com.example.FooKt", "Preview$it", listOf("MaterialTheme"))
+      }
+    val warning = PreviewThemeShadowing.warningOrNull(findings, themeCount = 2)
+    assertThat(warning).contains("14 @Preview function(s)")
+    assertThat(warning).contains("(+4 more)")
+    assertThat(warning).doesNotContain("Preview11")
+  }
+}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -667,6 +667,135 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `composePreviewDiscover warns when a preview installs a theme under declared theme catalogs`() {
+    val projectDir = createCmpTestProject()
+
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    annDir.mkdirs()
+    File(annDir, "ThemeCatalog.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.CLASS)
+        annotation class ThemeCatalog(val name: String = "", val group: String = "")
+        """
+          .trimIndent()
+      )
+    // Two declared themes → this module has a theme axis the viewer can drive. `AppTheme` is the
+    // app's own wrapper, exactly like Confetti's `ConfettiThemeFixed`: the preview calls it, and it
+    // installs the real `MaterialTheme`. Leaving colorScheme/typography/shapes defaulted is what
+    // makes the compiler emit the `MaterialTheme$default` bridge, so this also pins that the
+    // detector matches the shape real code produces.
+    File(projectDir, "src/main/kotlin/test/Themes.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.MaterialTheme
+        import androidx.compose.runtime.Composable
+        import ee.schimke.composeai.preview.ThemeCatalog
+
+        @ThemeCatalog(name = "Brand Light") class BrandLightTheme
+        @ThemeCatalog(name = "Brand Dark") class BrandDarkTheme
+
+        @Composable
+        fun AppTheme(content: @Composable () -> Unit) {
+            MaterialTheme(content = content)
+        }
+        """
+          .trimIndent()
+      )
+    File(projectDir, "src/main/kotlin/test/ShadowingPreviews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Preview
+        @Composable
+        fun ShadowedPreview() {
+            AppTheme { Text("shadowed") }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    // Names the preview and the hop through the app wrapper, so the fix is obvious from the log.
+    assertThat(result.output).contains("install a theme in their own body")
+    assertThat(result.output).contains("test.ShadowingPreviewsKt.ShadowedPreview")
+    assertThat(result.output).contains("AppTheme")
+    // Advisory only — discovery still succeeds and the preview is still published.
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    assertThat(manifest.previews.map { it.functionName }).contains("ShadowedPreview")
+  }
+
+  @Test
+  fun `composePreviewDiscover stays quiet about body themes when no theme catalog is declared`() {
+    val projectDir = createCmpTestProject()
+
+    // Same body-installed theme, but nothing declares a theme catalog — there is no theme axis to
+    // shadow, so this is just an ordinary app preview and must not be warned about.
+    File(projectDir, "src/main/kotlin/test/Themes.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.MaterialTheme
+        import androidx.compose.runtime.Composable
+
+        @Composable
+        fun AppTheme(content: @Composable () -> Unit) {
+            MaterialTheme(content = content)
+        }
+        """
+          .trimIndent()
+      )
+    File(projectDir, "src/main/kotlin/test/ShadowingPreviews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Preview
+        @Composable
+        fun ThemedPreview() {
+            AppTheme { Text("fine") }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.output).doesNotContain("install a theme in their own body")
+  }
+
+  @Test
   fun `composePreviewDiscover routes @WearThemeCatalog to its own kind and id namespace`() {
     val projectDir = createCmpTestProject()
 


### PR DESCRIPTION
## The gap

A `@ThemeCatalog` / `@WearThemeCatalog` provider is applied by **wrapping** the preview function. A theme installed *inside* the preview body composes within that wrapper and shadows it, so every entry in the viewer's **Theme** select renders byte-identical pixels — the catalog looks like it has a live theme axis and doesn't.

That is exactly what shipped in `confetti-wear` and `confetti-mobile` (fixed in joreilly/Confetti#1753). All five conference themes returned the same PNG, including the *Typography* specimen that is meant to show a different type family per conference, because every catalog preview opened with `ConfettiThemeFixed { … }`.

Nothing in this pipeline noticed. The one surface that would have shown it is the one surface the existing checks don't cover: the synthetic per-theme specimen sheets wrap a **canned grid** rather than an app preview, so they kept differing correctly while every real preview was pinned.

## The check

Discovery already walks a preview's bytecode for `PreviewTargetInference`, so this reuses that walker rather than adding a render pass or a manifest field:

- Follow the preview body (the existing walker already descends into its own lambdas, so `AppTheme { … }` is seen from the preview's root method), then into module-local methods, bounded to 6 hops. Dependency JARs are never followed.
- Look for a `MaterialTheme` install — `material`, `material3`, and both Wear variants.
- Report only when the module declares theme providers. Without them there is no theme axis, and an app preview installing its own theme is just an app preview.

Reported through the existing `Outcome.warnings` channel, so no schema change and no new task: it surfaces on `composePreviewDiscover` like `CheckDebugPreviewsTask`'s warning.

**Warning, never an error.** Pinning a preview to one theme is legitimate — a per-identity theme-foundation sticker documents exactly one theme on purpose. The check can't distinguish that from the bug, so it reports and lets the author decide.

Two precision details, both pinned by tests:

- `MaterialTheme.colorScheme` **reads** compile to `…material3.MaterialTheme.getColorScheme` — different owner (no `Kt` facade) and method. Reading the ambient theme is what a well-behaved preview does; only installing one shadows the wrapper.
- `MaterialTheme` has defaulted parameters, so all but the fully-specified call site compiles to the synthetic **`MaterialTheme$default`** bridge — and `AppTheme { content }` is by far the common shape. Matching the bare name fired on almost nothing; the functional test caught this before it shipped.

## Test plan

- `:gradle-plugin:preview-discovery:test` — 8 new unit tests, all pass. Cover the install-vs-read distinction, the `$default` bridge, the "no themes declared → silent" gate, and the warning's content/truncation.
- `:gradle-plugin:functionalTest --tests "*DiscoveryFunctionalTest*"` — 37/37 pass, including two new end-to-end cases that compile a real Compose project against real `compose.material3`:
  - **positive** — two `@ThemeCatalog` providers plus `ShadowedPreview → AppTheme → MaterialTheme`; asserts the warning names `test.ShadowingPreviewsKt.ShadowedPreview` and the `AppTheme` hop, and that discovery still succeeds and still publishes the preview.
  - **negative control** — the identical body-installed theme with *no* theme catalog declared; asserts the warning does not appear.
- ktfmt clean.

Text-only PR: this changes a discovery warning, not rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhWssk26QYPNjkx7vcbKC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhWssk26QYPNjkx7vcbKC6)_