### PR TITLE
feat(daemon-desktop): resolve @PreviewParameter previews on the desktop daemon

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -58,19 +58,15 @@ internal class DaemonSemanticsFetcher(
    * **`@PreviewParameter` fan-outs read from the bare id like any other preview.** The daemon does
    * *not* fan a parameterized preview out across its provider's values — it renders one frame of
    * the provider's first value under the bare `<id>` base name (Android:
-   * `daemon/android/.../RenderEngine.kt`, `resolvePreviewInvocation`; the fan-out-per-value path
-   * stays with the standalone renderer). So a fan-out's `compose-semantics.json` lands at
+   * `daemon/android/.../RenderEngine.kt`, `resolvePreviewInvocation`; desktop:
+   * `daemon/desktop/.../RenderEngine.kt` via `PreviewParameterSupport`; the fan-out-per-value path
+   * stays with the standalone renderer on both). So a fan-out's `compose-semantics.json` lands at
    * `build/compose-previews/data/<id>/` exactly where a plain preview's does, and the bare-id read
    * below carries it. This was broken before the daemon learned to resolve `@PreviewParameter`
    * (previously the `(Composer, int)`-only lookup threw `NoSuchMethodException`, so every such
    * preview lost its PNG *and* its semantics — the drop reported in issue #3049 against a build
    * that predates that fix); nothing per-value is written, so there is nothing extra to resolve
    * here.
-   *
-   * **Known gap:** the desktop daemon does not resolve `@PreviewParameter` at all
-   * (`daemon/desktop/.../RenderEngine.kt`), so a fan-out in a CMP/desktop module renders no frame
-   * and produces no sidecar — its semantics stay absent until the desktop backend gains first-value
-   * resolution the way Android has.
    *
    * [projectDir] is the module's project directory (`PreviewModule.projectDir`);
    * `daemon-launch.json` and the daemon's `build/compose-previews/data/<id>/` output both sit under

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -539,6 +539,16 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
     uiMode = uiMode,
     orientation = defaults.orientation,
     wrapperClassName = params.wrapperClassName ?: defaults.wrapperClassName,
+    // `@PreviewParameter` provider FQN + limit — without these the parameterless
+    // `getDeclaredComposableMethod` lookup throws `NoSuchMethodException` on a parameterized
+    // preview
+    // and it renders nothing. This is the *production* live/interactive path (the preview-index
+    // resolver), distinct from the harness-only `PreviewManifestRouter`; both must thread the
+    // field.
+    // Mirrors `:daemon:android`'s `renderSpecFromInfo`.
+    previewParameterProviderClassName =
+      params.previewParameterProviderClassName ?: defaults.previewParameterProviderClassName,
+    previewParameterLimit = params.previewParameterLimit ?: defaults.previewParameterLimit,
     kind = params.kind ?: defaults.kind,
     assetPath = params.assetPath ?: defaults.assetPath,
     overrides = bakedOverrides,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -169,6 +169,16 @@ class PreviewManifestRouter(
             resolved.wrapperClassName
               ?.takeIf { it.isNotBlank() }
               ?.let { append("wrapperClassName=").append(it).append(';') }
+            // `@PreviewParameter` provider FQN sourced from `previews.json` (same BINARY-retention
+            // provenance as the wrapper — discovery reads it off the class-file annotation tables).
+            // When set the render body renders the provider's first value under the bare id. The
+            // limit rides along so the resolver's `limit <= 0` guard matches the annotation.
+            resolved.previewParameterProviderClassName
+              ?.takeIf { it.isNotBlank() }
+              ?.let {
+                append("previewParameterProvider=").append(it).append(';')
+                append("previewParameterLimit=").append(resolved.previewParameterLimit).append(';')
+              }
             // kind=LOTTIE + the asset path so `DesktopHost` builds a `RenderSpec` that inflates the
             // asset instead of reflecting a (non-existent) class. Plain Compose previews omit both.
             resolved.kind
@@ -238,6 +248,8 @@ class PreviewManifestRouter(
           // follow-up).
           uiMode = if ((resolved.uiMode and 0x30) == 0x20) RenderSpec.SpecUiMode.DARK else null,
           wrapperClassName = resolved.wrapperClassName,
+          previewParameterProviderClassName = resolved.previewParameterProviderClassName,
+          previewParameterLimit = resolved.previewParameterLimit,
           kind = resolved.kind,
           assetPath = resolved.assetPath,
         )
@@ -297,6 +309,15 @@ data class PreviewManifestEntry(
    * chrome for night `showSystemUi` previews (issue #1930 follow-up).
    */
   val uiMode: Int? = null,
+  /**
+   * Flat-schema mirror of `@PreviewParameter`'s provider FQN (used by `:daemon:harness` tests).
+   * Optional; when null the resolver consults the nested
+   * `params.previewParameterProviderClassName`. When set the render body renders the provider's
+   * first value under the bare id.
+   */
+  val previewParameterProviderClassName: String? = null,
+  /** Flat-schema mirror of `@PreviewParameter.limit`; null falls back to the nested params. */
+  val previewParameterLimit: Int? = null,
   val outputBaseName: String? = null,
 ) {
   fun resolved(): ResolvedRenderParams {
@@ -321,6 +342,9 @@ data class PreviewManifestEntry(
     val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
     val uiMode = uiMode ?: p?.uiMode ?: 0
     val wrapperClassName = p?.wrapperClassName
+    val previewParameterProviderClassName =
+      previewParameterProviderClassName ?: p?.previewParameterProviderClassName
+    val previewParameterLimit = previewParameterLimit ?: p?.previewParameterLimit ?: Int.MAX_VALUE
     return ResolvedRenderParams(
       widthPx = widthPx,
       heightPx = heightPx,
@@ -336,6 +360,8 @@ data class PreviewManifestEntry(
       assetPath = p?.assetPath,
       wrapWidth = wrapWidth,
       wrapHeight = wrapHeight,
+      previewParameterProviderClassName = previewParameterProviderClassName,
+      previewParameterLimit = previewParameterLimit,
     )
   }
 
@@ -388,6 +414,15 @@ data class PreviewParamsEntry(
    * [RenderSpec.wrapperClassName] for the render body.
    */
   val wrapperClassName: String? = null,
+  /**
+   * FQN of the `@PreviewParameter` provider harvested by discovery (BINARY-retention annotation,
+   * invisible to runtime reflection — same provenance as [wrapperClassName]). Threaded into
+   * [RenderSpec.previewParameterProviderClassName] so the render body renders the provider's first
+   * value under the bare id.
+   */
+  val previewParameterProviderClassName: String? = null,
+  /** Mirrors `@PreviewParameter.limit`. `Int.MAX_VALUE` is the annotation default. */
+  val previewParameterLimit: Int = Int.MAX_VALUE,
 )
 
 /**
@@ -415,4 +450,6 @@ data class ResolvedRenderParams(
    */
   val wrapWidth: Boolean = false,
   val wrapHeight: Boolean = false,
+  val previewParameterProviderClassName: String? = null,
+  val previewParameterLimit: Int = Int.MAX_VALUE,
 )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -74,11 +74,14 @@ import org.jetbrains.skia.EncodedImageFormat
  * landed here also has to land in `:renderer-desktop`'s `renderPreview` (and vice versa); the bench
  * + CI pixel-diff (D2.2 / harness S1) will catch divergence.
  *
- * **What's duplicated, what isn't.** This is the "small composable, no PreviewParameter, no
- * wrapper" subset — the daemon's v1 surface only renders single previews from existing
- * `previews.json` discovery. The fan-out / `@PreviewParameter` / `@PreviewWrapper` paths from
- * `DesktopRendererMain` stay behind the standalone renderer for now; B-desktop.1.7+ revisits if the
- * harness needs them.
+ * **What's duplicated, what isn't.** This is the small-composable, single-frame subset — the
+ * daemon's v1 surface renders one frame per preview id from existing `previews.json` discovery.
+ * `@PreviewParameter` is *resolved* here (via
+ * [ee.schimke.composeai.renderer.PreviewParameterSupport]) but not *fanned out*: a parameterized
+ * preview renders its provider's first value under the bare id, matching the one-frame-per-id
+ * contract and mirroring `:daemon:android`. Emitting one file per value stays with the standalone
+ * `DesktopRendererMain`. The scroll / animation / GIF paths from `DesktopRendererMain` likewise
+ * stay behind the standalone renderer for now; B-desktop.1.7+ revisits if the harness needs them.
  *
  * **Threading contract.** Called from [DesktopHost]'s single render thread. [ImageComposeScene] is
  * instantiated *per render* (not held warm across renders) — see
@@ -231,23 +234,28 @@ class RenderEngine(
 
     // kind=LOTTIE has no class to reflect — the asset is rendered directly via Compottie below.
     val isLottie = spec.kind == "LOTTIE"
-    val composableMethod: ComposableMethod? =
+    // Resolve the composable entrypoint plus any `@PreviewParameter` argument list. A parameterized
+    // preview compiles to `foo(<T>, Composer, int)`, so the bare `getDeclaredComposableMethod`
+    // lookup used to throw `NoSuchMethodException` here — no PNG, no semantics. The daemon now
+    // renders the provider's *first* value under the bare id (the per-value fan-out stays with the
+    // standalone renderer), mirroring `:daemon:android`'s single-frame contract.
+    // [PreviewParameterSupport.resolve] opens the method for reflective invocation (Kotlin `private
+    // fun` previews are idiomatic and would otherwise throw `IllegalAccessException`).
+    val resolvedInvocation: ee.schimke.composeai.renderer.PreviewParameterSupport.Resolved? =
       if (isLottie) {
         null
       } else {
         val clazz = Class.forName(spec.className, true, classLoader)
-        clazz.getDeclaredComposableMethod(spec.functionName).also {
-          // Kotlin `private fun` previews compile to JVM-private methods.
-          // `getDeclaredComposableMethod` still resolves them (it scans `declaredMethods`), but the
-          // reflective `invoke` in [InvokeComposable] would throw IllegalAccessException, so open
-          // the method up first — mirrors `:renderer-android`'s ComposePreviewStrategy. Guarded
-          // with
-          // `runCatching`: a SecurityManager or strong module encapsulation can refuse, in which
-          // case we still attempt the invoke (which succeeds for public/internal previews) rather
-          // than failing resolution outright.
-          runCatching { it.asMethod().isAccessible = true }
-        }
+        ee.schimke.composeai.renderer.PreviewParameterSupport.resolve(
+          clazz = clazz,
+          functionName = spec.functionName,
+          providerClassName = spec.previewParameterProviderClassName,
+          limit = spec.previewParameterLimit,
+          classLoader = classLoader,
+        )
       }
+    val composableMethod: ComposableMethod? = resolvedInvocation?.method
+    val previewArgs: List<Any?> = resolvedInvocation?.args ?: emptyList()
 
     // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
     // Pairs with `[classloader] swap requested` / `allocate child loader` lines from
@@ -461,6 +469,9 @@ class RenderEngine(
                       // "render this preview under theme X" — but only when it resolves; a
                       // stale/misspelled FQN falls back to the declared wrapper.
                       themeProviderFqn = spec.overrides?.themeProvider,
+                      // The provider's first value for a `@PreviewParameter` preview; empty for a
+                      // plain parameterless one.
+                      previewArgs = previewArgs,
                     )
                   }
                 }
@@ -1557,6 +1568,17 @@ data class RenderSpec(
    * bypass the manifest.
    */
   val wrapperClassName: String? = null,
+  /**
+   * FQN of the `PreviewParameterProvider` from `@PreviewParameter` on the preview function's
+   * parameter, when discovery recorded one. Sourced from `previews.json` (the upstream annotation
+   * has `AnnotationRetention.BINARY` and is invisible to `Method.annotations` at runtime — same
+   * provenance as [wrapperClassName]). When set the render body resolves and renders the provider's
+   * *first* value under the bare id, matching `:daemon:android`'s single-frame contract; the
+   * per-value fan-out stays with the standalone renderer. Null is the plain parameterless preview.
+   */
+  val previewParameterProviderClassName: String? = null,
+  /** Mirrors `@PreviewParameter.limit`. `Int.MAX_VALUE` is the annotation default. */
+  val previewParameterLimit: Int = Int.MAX_VALUE,
 ) {
 
   enum class SpecUiMode {
@@ -1633,6 +1655,10 @@ data class RenderSpec(
         clearBackground = map["clearBackground"]?.toBoolean() ?: defaults.clearBackground,
         overrides = map["overrides"]?.decodePreviewOverrides(),
         wrapperClassName = map["wrapperClassName"]?.takeIf { it.isNotBlank() },
+        previewParameterProviderClassName =
+          map["previewParameterProvider"]?.takeIf { it.isNotBlank() },
+        previewParameterLimit =
+          map["previewParameterLimit"]?.toIntOrNull() ?: defaults.previewParameterLimit,
       )
     }
 
@@ -1667,8 +1693,8 @@ data class RenderSpec(
  * compose-compiler plugin recognises it as a composable function.
  */
 @androidx.compose.runtime.Composable
-private fun InvokeComposable(composableMethod: ComposableMethod) {
-  composableMethod.invoke(currentComposer, null)
+private fun InvokeComposable(composableMethod: ComposableMethod, previewArgs: List<Any?>) {
+  composableMethod.invoke(currentComposer, null, *previewArgs.toTypedArray())
 }
 
 /**
@@ -1697,6 +1723,7 @@ private fun InvokeWithOptionalWrapper(
   composableMethod: ComposableMethod,
   wrapperFqnFromSpec: String?,
   themeProviderFqn: String? = null,
+  previewArgs: List<Any?> = emptyList(),
 ) {
   val wrapper =
     remember(composableMethod, wrapperFqnFromSpec, themeProviderFqn) {
@@ -1708,10 +1735,10 @@ private fun InvokeWithOptionalWrapper(
         ?: resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
     }
   if (wrapper == null) {
-    InvokeComposable(composableMethod)
+    InvokeComposable(composableMethod, previewArgs)
   } else {
     val (wrapMethod, wrapperInstance) = wrapper
-    val body: @Composable () -> Unit = { InvokeComposable(composableMethod) }
+    val body: @Composable () -> Unit = { InvokeComposable(composableMethod, previewArgs) }
     wrapMethod.invoke(currentComposer, wrapperInstance, body)
   }
 }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -174,4 +174,30 @@ class RenderSpecFromInfoTest {
     assertEquals(true, spec.showBackground)
     assertEquals(0xFFEEEEEE, spec.backgroundColor)
   }
+
+  @Test
+  fun `previewParameter provider and limit pass through the index resolver`() {
+    // The production live/interactive path (this preview-index resolver, not the harness-only
+    // PreviewManifestRouter): a `@PreviewParameter` preview's provider FQN + limit must reach the
+    // RenderSpec, else the render body's parameterless lookup throws NoSuchMethodException and the
+    // preview produces no render / no semantics. Mirrors :daemon:android's renderSpecFromInfo.
+    val spec =
+      renderSpecFromInfo(
+        info(
+          params =
+            PreviewParamsDto(
+              previewParameterProviderClassName = "com.example.SquareTintProvider",
+              previewParameterLimit = 3,
+            )
+        )
+      )
+    assertEquals("com.example.SquareTintProvider", spec.previewParameterProviderClassName)
+    assertEquals(3, spec.previewParameterLimit)
+  }
+
+  @Test
+  fun `previewParameter provider defaults to null when the params omit it`() {
+    val spec = renderSpecFromInfo(info(params = PreviewParamsDto()))
+    assertNull(spec.previewParameterProviderClassName)
+  }
 }

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -917,3 +917,34 @@ fun KeyPressColorSquare() {
         }
   )
 }
+
+/**
+ * `@PreviewParameter` regression fixture — the desktop counterpart of `:daemon:android`'s
+ * `SquareTintProvider` / `ThemedTintedSquare` (issue #3027 on Android; the desktop follow-up that
+ * taught the desktop daemon to resolve `@PreviewParameter` at all).
+ *
+ * The desktop daemon used to resolve every preview with the parameterless
+ * `getDeclaredComposableMethod(functionName)` lookup, which matches only `foo(Composer, int)`. A
+ * preview with a `@PreviewParameter` argument compiles to `ThemedTintedSquare(long, Composer,
+ * int)`, so resolution threw `NoSuchMethodException` before composition started — no PNG, none of
+ * the composition-derived data products, and `bundle pack --with-semantics` dropped the whole
+ * fan-out's a11y tree on CMP/desktop modules.
+ *
+ * The provider is resolved reflectively via `getValues()` — the harness manifest carries its FQN in
+ * `previewParameterProviderClassName`, so it needs no `@PreviewParameter` annotation or
+ * `PreviewParameterProvider` supertype here, just a `values: Sequence` property and a `Long`
+ * parameter, matching the shapes [ee.schimke.composeai.renderer.PreviewParameterSupport] probes.
+ *
+ * Two values on purpose: the daemon renders one frame per preview id, so it must invoke the FIRST
+ * one (green `0xFF43A047`), never the second (blue `0xFF1E88E5`). A regression that silently picks
+ * the wrong value fails the pixel assertion instead of passing on "something rendered".
+ */
+@Suppress("unused")
+class SquareTintProvider {
+  val values: Sequence<Long> = sequenceOf(0xFF43A047L, 0xFF1E88E5L)
+}
+
+@Composable
+fun ThemedTintedSquare(tint: Long) {
+  Box(modifier = Modifier.fillMaxSize().background(Color(tint)))
+}

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/PreviewParameterDesktopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/PreviewParameterDesktopRealModeTest.kt
@@ -1,0 +1,137 @@
+package ee.schimke.composeai.daemon.harness
+
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+
+/**
+ * Regression scenario for the desktop follow-up to issue #3027 — a `@PreviewParameter` preview must
+ * render through the real **desktop** daemon.
+ *
+ * Before the fix the desktop daemon resolved every preview with the parameterless
+ * `getDeclaredComposableMethod(functionName)` lookup, which matches only `foo(Composer, int)`. A
+ * preview declaring `@PreviewParameter` compiles to `foo(<T>, Composer, int)`, so resolution threw
+ * `NoSuchMethodException` *before composition started*: no PNG, none of the composition-derived
+ * data products, just an `.error.json`. On a CMP/desktop consumer module that dropped every
+ * fan-out's a11y tree, which took down `bundle pack --with-semantics`. The Android daemon already
+ * resolved these (issue #3027); this is the desktop counterpart.
+ *
+ * The fixture provider yields **two** values (green then blue) on purpose: the daemon renders one
+ * frame per preview id, so the contract is the *first* value, not "any value". A regression that
+ * binds the wrong one fails the pixel assertion instead of passing on "something rendered". Mirrors
+ * [PreviewParameterAndroidRealModeTest] one-to-one, swapping `realAndroidModeScenario` →
+ * [realModeScenario] and the Android target gate → desktop.
+ */
+class PreviewParameterDesktopRealModeTest {
+
+  @Test
+  fun preview_parameter_preview_renders_first_provider_value() {
+    Assume.assumeTrue(
+      "Skipping PreviewParameterDesktopRealModeTest — set -Pharness.host=real to enable.",
+      HarnessTestSupport.harnessHost() == "real",
+    )
+    Assume.assumeTrue(
+      "Skipping PreviewParameterDesktopRealModeTest — desktop variant; set -Ptarget=desktop " +
+        "(default).",
+      HarnessTestSupport.harnessTarget() == "desktop",
+    )
+
+    val previewId = "tinted-square"
+    val paths =
+      realModeScenario(
+        name = "preview-parameter-desktop",
+        previews =
+          listOf(
+            RealModePreview(
+              id = previewId,
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "ThemedTintedSquare",
+              previewParameterProvider = "ee.schimke.composeai.daemon.SquareTintProvider",
+            )
+          ),
+      )
+
+    val client = HarnessClient.start(paths.launcher)
+    try {
+      assertEquals(2, client.initialize().protocolVersion)
+      client.sendInitialized()
+
+      val renderNowResult = client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
+      assertEquals(listOf(previewId), renderNowResult.queued)
+      assertTrue(
+        "renderNow.rejected must be empty: ${renderNowResult.rejected}",
+        renderNowResult.rejected.isEmpty(),
+      )
+
+      // Desktop cold start (Compose + Skiko bootstrap) is faster than Robolectric's, but keep a
+      // generous window so a cold CI runner doesn't flake.
+      val finished = client.pollRenderFinishedFor(previewId, timeout = 120.seconds)
+      val finishedParams = finished["params"]?.jsonObject
+      assertNotNull("renderFinished must carry params", finishedParams)
+      // Pre-fix this is where the scenario died: resolution threw, so no pngPath was ever reported.
+      val reportedPath = finishedParams!!["pngPath"]?.jsonPrimitive?.contentOrNull
+      assertNotNull(
+        "renderFinished.pngPath must be present — a @PreviewParameter preview must render",
+        reportedPath,
+      )
+      val reportedPng = File(reportedPath!!)
+      assertTrue("rendered PNG must exist: $reportedPath", reportedPng.exists())
+      assertTrue("rendered PNG must be non-empty: $reportedPath", reportedPng.length() > 0)
+
+      val img = ImageIO.read(reportedPng)
+      assertNotNull("rendered PNG must decode", img)
+      // SquareTintProvider's FIRST value is 0xFF43A047 (green); its second is 0xFF1E88E5 (blue).
+      val green = dominantGreenFraction(img!!)
+      assertTrue(
+        "render must carry the provider's first value (green #43A047), not its second (blue) — " +
+          "dominantGreen=$green",
+        green > 0.9,
+      )
+
+      assertEquals(
+        "Daemon must exit cleanly. Stderr=\n${client.dumpStderr()}",
+        0,
+        client.shutdownAndExit(timeout = 60.seconds),
+      )
+    } catch (t: Throwable) {
+      System.err.println(
+        "PreviewParameterDesktopRealModeTest failed; stderr from daemon:\n" + client.dumpStderr()
+      )
+      throw t
+    } finally {
+      try {
+        client.close()
+      } catch (_: Throwable) {}
+    }
+  }
+
+  /**
+   * Fraction of pixels whose green channel is dominant — keyed on green so it separates the
+   * provider's first value (`0xFF43A047`) from its second (`0xFF1E88E5`, blue-dominant). Mirrors
+   * [PreviewParameterAndroidRealModeTest.dominantGreenFraction].
+   */
+  private fun dominantGreenFraction(img: BufferedImage): Double {
+    var matching = 0
+    val total = img.width * img.height
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val argb = img.getRGB(x, y)
+        val r = (argb shr 16) and 0xFF
+        val g = (argb shr 8) and 0xFF
+        val b = argb and 0xFF
+        if (g > 100 && (g - r) > 30 && (g - b) > 30) matching++
+      }
+    }
+    return matching.toDouble() / total.toDouble()
+  }
+}

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
@@ -1,0 +1,198 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.runtime.reflect.ComposableMethod
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+
+/**
+ * Reflective `@PreviewParameter` support for the **desktop daemon** render body
+ * (`:daemon:desktop`'s `RenderEngine`), which renders a single frame and therefore takes the
+ * provider's first value only. The desktop equivalent of `:renderer-android`'s
+ * [ee.schimke.composeai.renderer.PreviewParameterSupport]; the two artefacts keep independent
+ * copies on purpose so neither renderer takes a shared-module dependency (see
+ * [DesktopRendererMain]'s own `loadProviderValues` / `findComposableMethodWithArgs`, which the
+ * standalone renderer's fan-out still uses — those soft-fail per row so one bad value can't sink a
+ * batch, whereas the daemon's single-frame [resolve] hard-fails so the caller can surface one
+ * preview's `.error.json`).
+ *
+ * **Why the provider FQN is passed in rather than read off the method.** The upstream
+ * `androidx.compose.ui.tooling.preview.PreviewParameter` annotation has
+ * `AnnotationRetention.BINARY` — it is written into the class file but is not visible through
+ * `Method.parameterAnnotations` at runtime. The gradle plugin's discovery reads it off the
+ * class-file annotation tables into `previews.json` (`params.previewParameterProviderClassName` /
+ * `params.previewParameterLimit`), and both render bodies get it from there. Nothing here can
+ * recover it by reflecting on the composable.
+ *
+ * **What went wrong without this.** The desktop daemon resolved every preview with the
+ * parameterless `getDeclaredComposableMethod(functionName)` lookup, which matches only
+ * `foo(Composer, int)`. A preview declaring `@PreviewParameter` compiles to `foo(<T>, Composer,
+ * int)`, so the lookup threw `NoSuchMethodException` before composition ever started — no PNG, no
+ * semantics, just a `.error.json`. This is the desktop counterpart of the Android fix in
+ * issue #3027, and it is what let `bundle pack --with-semantics` drop a CMP/desktop fan-out's a11y
+ * tree entirely.
+ */
+object PreviewParameterSupport {
+
+  /** A resolved preview entrypoint: the composable method plus the arguments to invoke it with. */
+  data class Resolved(val method: ComposableMethod, val args: List<Any?>)
+
+  /**
+   * Resolves the composable entrypoint for a preview, supplying `@PreviewParameter` arguments when
+   * the discovery manifest recorded a provider.
+   *
+   * [providerClassName] `null` (the common case) is the plain parameterless lookup. When a provider
+   * is named, its first value is used: a single-frame renderer has one output file per preview id,
+   * and the daemon's manifest ids are the un-suffixed base ids the fan-out renderer would render as
+   * `<id>_<label>`. Value 0 is the one Android Studio shows first as well.
+   *
+   * The returned method is always opened for reflective invocation ([openForInvoke]) — Kotlin
+   * `private fun` previews are idiomatic and resolve fine, but invoking one without that throws
+   * `IllegalAccessException`.
+   */
+  fun resolve(
+    clazz: Class<*>,
+    functionName: String,
+    providerClassName: String?,
+    limit: Int = Int.MAX_VALUE,
+    classLoader: ClassLoader? = null,
+  ): Resolved {
+    if (providerClassName.isNullOrBlank()) {
+      return Resolved(clazz.getDeclaredComposableMethod(functionName).openForInvoke(), emptyList())
+    }
+    if (limit <= 0) {
+      throw PreviewParameterLoadException(
+        "@PreviewParameter(provider = $providerClassName, limit = $limit) on $functionName " +
+          "leaves no value to render",
+        null,
+      )
+    }
+    // Only the first value is needed; `take(1)` also keeps an infinite `generateSequence` provider
+    // from being driven to exhaustion.
+    val values = loadValues(providerClassName, limit = 1, classLoader = classLoader)
+    if (values.isEmpty()) {
+      throw PreviewParameterLoadException(
+        "@PreviewParameter(provider = $providerClassName) on $functionName produced no values",
+        null,
+      )
+    }
+    val args = listOf(values.first())
+    return Resolved(findComposableMethodWithArgs(clazz, functionName, args).openForInvoke(), args)
+  }
+
+  /**
+   * Opens [this] method for reflective invocation. Guarded with `runCatching`: a SecurityManager or
+   * strong module encapsulation can refuse, in which case we still attempt the invoke (which
+   * succeeds for public/internal previews) rather than failing resolution outright.
+   */
+  private fun ComposableMethod.openForInvoke(): ComposableMethod = also {
+    runCatching { it.asMethod().isAccessible = true }
+  }
+
+  /**
+   * Enumerate a `PreviewParameterProvider`'s values reflectively, up to [limit].
+   *
+   * Throws [PreviewParameterLoadException] on any hard failure (class missing, no no-arg
+   * constructor, missing/throwing `getValues()`) so the caller can isolate the failing preview and
+   * surface it as a per-preview error card. Returns an empty list only when the provider
+   * legitimately yields no values.
+   *
+   * [classLoader] is the loader the consumer's classes live on — the daemon hands in its per-swap
+   * child loader; leave it null to use `Class.forName`'s default (the caller's / context loader).
+   */
+  fun loadValues(providerFqn: String, limit: Int, classLoader: ClassLoader? = null): List<Any?> {
+    val clazz =
+      try {
+        if (classLoader == null) Class.forName(providerFqn)
+        else Class.forName(providerFqn, true, classLoader)
+      } catch (e: ClassNotFoundException) {
+        throw PreviewParameterLoadException(
+          "provider class $providerFqn not found on the render classpath",
+          e,
+        )
+      }
+    val instance =
+      try {
+        val ctor = clazz.getDeclaredConstructor()
+        // `private` providers (idiomatic Kotlin, and rendered fine by Android Studio) compile to
+        // package-private JVM classes, so their no-arg constructor isn't reflectively callable from
+        // this package without opening it up first.
+        ctor.isAccessible = true
+        ctor.newInstance()
+      } catch (e: Throwable) {
+        throw PreviewParameterLoadException(
+          "couldn't instantiate $providerFqn via its no-arg constructor",
+          e,
+        )
+      }
+    // `PreviewParameterProvider<T>` exposes `values: Sequence<T>` — its JVM signature is
+    // `getValues(): Sequence`. Look it up by name to avoid a compile-time dependency on the
+    // provider
+    // interface (which lives in the consumer's Compose artifact).
+    val getValues =
+      try {
+        clazz.getMethod("getValues")
+      } catch (e: Throwable) {
+        throw PreviewParameterLoadException(
+          "$providerFqn has no getValues() — not a PreviewParameterProvider?",
+          e,
+        )
+      }
+    // Same package-private-class problem as the constructor: a public `getValues()` on a
+    // package-private class throws `IllegalAccessException` from `Method.invoke` unless opened up.
+    getValues.isAccessible = true
+    return try {
+      @Suppress("UNCHECKED_CAST")
+      val sequence = getValues.invoke(instance) as? Sequence<Any?> ?: return emptyList()
+      // `Sequence.take(Int).toList()` drives the sequence lazily up to `limit` without reflective
+      // access into package-private iterator implementations (which `Method.invoke` rejects).
+      sequence.take(limit).toList()
+    } catch (e: Throwable) {
+      throw PreviewParameterLoadException("$providerFqn.getValues() failed", e)
+    }
+  }
+
+  /**
+   * Resolve the `foo(<T>, Composer, int)` overload of a `@PreviewParameter` preview given the
+   * argument list to bind. Mirrors [DesktopRendererMain]'s local `findComposableMethodWithArgs`
+   * (kept in sync by hand) — scans `declaredMethods` for the name whose leading parameters match
+   * the provided args, then resolves the `ComposableMethod` for that concrete signature.
+   */
+  fun findComposableMethodWithArgs(
+    clazz: Class<*>,
+    name: String,
+    previewArgs: List<Any?>,
+  ): ComposableMethod {
+    val argCount = previewArgs.size
+    val candidate =
+      clazz.declaredMethods.firstOrNull { m ->
+        m.name == name && m.parameterCount >= argCount + 2 && argsMatch(m, previewArgs)
+      }
+        ?: throw NoSuchMethodException(
+          "Couldn't find composable method $name on ${clazz.name} taking $argCount parameter(s); " +
+            "check that the @PreviewParameter provider's value type matches the preview's parameter type."
+        )
+    val declaredTypes = candidate.parameterTypes.take(argCount).toTypedArray()
+    return clazz.getDeclaredComposableMethod(name, *declaredTypes)
+  }
+
+  private fun argsMatch(method: java.lang.reflect.Method, previewArgs: List<Any?>): Boolean {
+    for ((i, arg) in previewArgs.withIndex()) {
+      val expected = method.parameterTypes[i]
+      if (arg == null) {
+        if (expected.isPrimitive) return false
+        continue
+      }
+      val actual = arg.javaClass
+      if (expected.isAssignableFrom(actual)) continue
+      if (expected.kotlin.javaObjectType.isAssignableFrom(actual)) continue
+      return false
+    }
+    return true
+  }
+}
+
+/**
+ * Thrown by [PreviewParameterSupport] on a hard provider-load failure so the caller can isolate the
+ * failing preview instead of failing every preview that shares its shard / sandbox.
+ */
+class PreviewParameterLoadException(message: String, cause: Throwable?) :
+  RuntimeException(message, cause)


### PR DESCRIPTION
Follow-up to #3061 — closes the desktop half of the `@PreviewParameter` gap that PR documented.

## Problem

The desktop daemon resolved every preview with the parameterless `getDeclaredComposableMethod(functionName)` lookup, which matches only `foo(Composer, int)`. A preview declaring `@PreviewParameter` compiles to `foo(<T>, Composer, int)`, so resolution threw `NoSuchMethodException` **before composition started** — no PNG, none of the composition-derived data products, just an `.error.json`. On a CMP/desktop consumer module that dropped **every** fan-out's a11y tree, which took down `bundle pack --with-semantics`. Android was already fixed (#3041); this is the desktop counterpart.

## Fix

Resolve the provider's **first value** under the bare id, mirroring `:daemon:android`'s single-frame contract (the per-value fan-out stays with the standalone `DesktopRendererMain`):

- **`:renderer-desktop` / `PreviewParameterSupport`** (new) — a first-value resolver parallel to `:renderer-android`'s. Hard-fails on a bad provider so one preview surfaces its own `.error.json` rather than sinking the batch (the standalone renderer keeps its per-row soft-fail).
- **`daemon/desktop/RenderEngine`** — `setUp` resolves the composable + `@PreviewParameter` args through it and threads `previewArgs` into the compose invoke (`setContent` → `InvokeWithOptionalWrapper` → `InvokeComposable`). Class doc corrected.
- **`RenderSpec`** — gains `previewParameterProviderClassName` / `previewParameterLimit` + payload parsing.
- **`PreviewManifestRouter`** — carries the provider FQN through `PreviewManifestEntry` (flat mirror) + nested `PreviewParamsEntry` + `ResolvedRenderParams`, emitted in the `submit` payload and the interactive `manifestPreviewSpecResolver` — the same shape as `:daemon:android`.
- **`DaemonSemanticsFetcher`** KDoc — the "known gap: desktop doesn't resolve `@PreviewParameter`" note (added in #3061) is updated: desktop now resolves the first value too.

## Tests

`PreviewParameterDesktopRealModeTest` renders a two-value provider through the **real desktop daemon** and asserts the first (green `#43A047`) value, never the second (blue) — backed by a `SquareTintProvider` / `ThemedTintedSquare` fixture mirroring the Android one.

Verified locally:
- `:renderer-desktop` + `:daemon:desktop` + `:daemon:harness` + `:cli` compile; `ktfmt` clean.
- `:daemon:harness:test --tests PreviewParameterDesktopRealModeTest -Pharness.host=real -Ptarget=desktop` → **1 test, 0 failures** (the green-first pixel assertion actually ran against a spawned desktop daemon, ~9s).

**On visual evidence:** this is daemon render-path plumbing — it does not change the pixels of any existing product `@Preview`; it makes previously-erroring `@PreviewParameter` previews render at all. The pixel verification is the real-mode test's green-first assertion above (the daemon's desktop `@Preview` PNG pipeline doesn't reach a committed product surface here).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CZUZDZrumh5LKpX3ENuNu

---
_Generated by [Claude Code](https://claude.ai/code/session_015CZUZDZrumh5LKpX3ENuNu)_