### PR TITLE
fix(daemon): restore the capture overload the forensic dump looks up reflectively

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
@@ -65,7 +65,24 @@ object ClassloaderForensics {
    * @param contextHint short string identifying the configuration ("standalone-control" /
    *   "daemon-subject" / etc.). Recorded verbatim in the dump.
    * @param out target file. Parent directories are created if absent. Existing file is overwritten.
+   *
+   * **`@JvmOverloads` is load-bearing — do not remove it.** `RobolectricHost.runForensicDump` calls
+   * this method *reflectively* (`getMethod("capture", List, RobolectricConfigSnapshot, String,
+   * File)`), because the forensics library is on the sandbox runtime classpath rather than the
+   * host's compile classpath. Kotlin does not emit an overload for a defaulted parameter: without
+   * this annotation the only JVM entry points are the full 5-arg `capture` and the synthetic
+   * `capture$default`, so that lookup throws `NoSuchMethodException` at runtime and nothing at
+   * compile time catches it. `@JvmOverloads` materialises the trailing-`fileSystem`-omitted
+   * overload the reflective caller names, and keeps doing so if further defaulted parameters are
+   * appended.
+   *
+   * The same trap applies to the `fileSystem` parameter itself: adding it to satisfy the injected-
+   * `FileSystem` convention in `docs/AGENTS.md` is source-compatible for ordinary Kotlin callers
+   * but silently binary-incompatible for a reflective one. Any future signature change here needs
+   * `ClassloaderForensicsDaemonTest` re-run, since that is the only thing that exercises the
+   * reflective path.
    */
+  @JvmOverloads
   fun capture(
     surveySet: List<String>,
     robolectricConfig: RobolectricConfigSnapshot? = null,


### PR DESCRIPTION
`ClassloaderForensicsDaemonTest > captureDaemonClassloaderForensics` has never passed. It's one of the failures in the `Module Unit Tests` job that is currently red on `main`.

## Root cause

`RobolectricHost.runForensicDump` resolves the forensics library reflectively — it lives on the sandbox runtime classpath, not the host's compile classpath — and asks for a 4-arg method:

```kotlin
forensicsClass.getMethod(
  "capture",
  List::class.java,
  Class.forName("…RobolectricConfigSnapshot", true, effectiveLoader),
  String::class.java,
  java.io.File::class.java,
)
```

But `capture` carries a defaulted trailing parameter, and **Kotlin does not emit an overload for a defaulted parameter**. Before this change the compiled class had exactly two entry points:

```
public final void capture(List, RobolectricConfigSnapshot, String, File, okio.FileSystem);
public static void capture$default(ClassloaderForensics, List, …, FileSystem, int, Object);
```

No 4-arg `capture` — so the lookup threw at runtime, with nothing at compile time to catch it:

```
java.lang.NoSuchMethodException: …ClassloaderForensics.capture(
  java.util.List, …RobolectricConfigSnapshot, java.lang.String, java.io.File)
	at java.base/java.lang.Class.getMethod(Class.java:2229)
	at …RobolectricHost$SandboxRunner.runForensicDump(RobolectricHost.kt:2212)
```

The library, the reflective caller and the test all landed together in #2985 (`git log -S` shows no later edit to either side), so this shipped broken rather than regressing later — which also means #2985 merged with this test red.

## Fix

`@JvmOverloads` on `capture`. It materialises exactly the trailing-`fileSystem`-omitted overload the reflective caller names, and keeps doing so if further defaulted parameters are appended later:

```
public final void capture(List, RobolectricConfigSnapshot, String, File, okio.FileSystem);
public final void capture(List, RobolectricConfigSnapshot, String, File);   ← restored
public final void capture(List, String, File);
public static void capture$default(…);
```

Chosen over patching the reflective call to name the 5-arg method, because it pins the ABI the reflective consumer depends on instead of leaving it implicit — the next signature change would otherwise re-break it silently.

The KDoc now records why the annotation is load-bearing. The underlying trap is worth naming: `fileSystem` was added to satisfy the injected-`FileSystem` convention in `docs/AGENTS.md`, which is source-compatible for ordinary Kotlin callers but **silently binary-incompatible for a reflective one**. Any future convention sweep over this class needs `ClassloaderForensicsDaemonTest` re-run, since it is the only thing exercising the reflective path.

## Test plan

- [x] Reproduced the failure locally on `main` before the change
- [x] `javap` before/after confirms the 4-arg overload is absent, then present
- [x] `./gradlew :daemon:android:testDebugUnitTest --tests "*ClassloaderForensicsDaemonTest*"` — **BUILD SUCCESSFUL** (failed before)
- [x] `./gradlew :daemon:core:compileKotlin` — green
- [x] ktfmt applied

## Scope

This fixes **one** of the failures in `Module Unit Tests`. The larger group in that job — ~23 of 70 in `:daemon:android`, plus `:daemon:desktop`, `:daemon:core` and `:renderer-xr` — is a separate crash: `NullPointerException at Typeface.java:928` during Robolectric native-runtime font loading. Notes on that in the comment below; it is not addressed here.

Visual evidence: N/A — diagnostic library, no rendered output.

---
_Generated by [Claude Code](https://claude.ai/code/session_014NDRHMxYyfVYUF3pih7LjL)_