### PR TITLE
test(daemon-desktop): ignore two capture regressions against #3080

### DIFF
--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
@@ -137,18 +137,18 @@ class DesktopLayoutInspectorTest {
     assertEquals(LayoutInspectorBounds(left = 27, top = 14, right = 67, bottom = 44), layer.bounds)
   }
 
-  @Test
-  @Ignore(
-    "#3080 — the path's fillArgb resolves to #FF000000 instead of the declared #FF112233. " +
-      "Geometry is fine (viewport, single path, 'M12 0'…'Z' all assert clean), so this is colour " +
-      "resolution on the captured vector path only. Ignored, not deleted: it guards a real " +
-      "regression and comes back with the fix."
-  )
-  fun captures_an_imagevector_icon_as_editable_vector_paths() {
-    // Tier 1 capture: an `Icon` backed by an `ImageVector` paints through a `VectorPainter`; the
-    // inspector must reflect its path tree into `vectorGraphic` (in the vector's 24×24 viewport) so
-    // the figma-svg export can emit `<path>`s instead of a raster crop. Exercises the reflection
-    // against the real androidx VectorPainter/VectorComponent/PathComponent/PathNode classes.
+  /**
+   * Tier 1 capture: an `Icon` backed by an `ImageVector` paints through a `VectorPainter`; the
+   * inspector must reflect its path tree into `vectorGraphic` (in the vector's 24×24 viewport) so
+   * the figma-svg export can emit `<path>`s instead of a raster crop. Exercises the reflection
+   * against the real androidx VectorPainter/VectorComponent/PathComponent/PathNode classes.
+   *
+   * Shared by the geometry test below and the `@Ignore`d fill-colour one, so that #3080 costs us
+   * only the colour assertion — this `ImageComposeScene` → `LayoutInspectorDataProducer` path has
+   * no other end-to-end coverage (the sibling vector tests drive synthetic models or lower-level
+   * extraction), and losing it entirely would let a vector-capture regression through CI.
+   */
+  private fun captureStarIconNode(): LayoutInspectorNode {
     val star =
       ImageVector.Builder(
           defaultWidth = 24.dp,
@@ -177,13 +177,29 @@ class DesktopLayoutInspectorTest {
 
     val node = root.firstWhere { it.vectorGraphic != null }
     assertNotNull("an ImageVector-backed Icon must carry a captured vectorGraphic", node)
-    val graphic = node!!.vectorGraphic!!
+    return node!!
+  }
+
+  @Test
+  fun captures_an_imagevector_icon_as_editable_vector_paths() {
+    val graphic = captureStarIconNode().vectorGraphic!!
     assertEquals(24f, graphic.viewportWidth, 0.01f)
     assertEquals(24f, graphic.viewportHeight, 0.01f)
     assertEquals("one path captured", 1, graphic.paths.size)
     val path = graphic.paths.first()
     assertTrue("path starts at the star tip", path.pathData.startsWith("M12 0"))
     assertTrue("path is closed", path.pathData.trimEnd().endsWith("Z"))
+  }
+
+  @Test
+  @Ignore(
+    "#3080 — fillArgb resolves to #FF000000 instead of the declared #FF112233. Split out of " +
+      "captures_an_imagevector_icon_as_editable_vector_paths so the viewport/path-count/geometry " +
+      "assertions stay active: only colour resolution is broken, and the rest of that capture is " +
+      "worth guarding meanwhile."
+  )
+  fun resolves_the_solid_fill_on_a_captured_vector_path() {
+    val path = captureStarIconNode().vectorGraphic!!.paths.first()
     assertEquals("solid fill resolved", "#FF112233", path.fillArgb)
   }
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
@@ -38,6 +38,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -137,6 +138,12 @@ class DesktopLayoutInspectorTest {
   }
 
   @Test
+  @Ignore(
+    "#3080 — the path's fillArgb resolves to #FF000000 instead of the declared #FF112233. " +
+      "Geometry is fine (viewport, single path, 'M12 0'…'Z' all assert clean), so this is colour " +
+      "resolution on the captured vector path only. Ignored, not deleted: it guards a real " +
+      "regression and comes back with the fix."
+  )
   fun captures_an_imagevector_icon_as_editable_vector_paths() {
     // Tier 1 capture: an `Icon` backed by an `ImageVector` paints through a `VectorPainter`; the
     // inspector must reflect its path tree into `vectorGraphic` (in the vector's 24×24 viewport) so

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/TcpPanelFigmaSvgTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/TcpPanelFigmaSvgTest.kt
@@ -40,6 +40,7 @@ import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -94,6 +95,11 @@ class TcpPanelFigmaSvgTest {
   }
 
   @Test
+  @Ignore(
+    "#3080 — only 2 raster targets are emitted where the icon plus two text fields should give 3. " +
+      "The zero-area assertion just above still passes, so the target is absent rather than " +
+      "collapsed. Ignored, not deleted: it guards a real regression and comes back with the fix."
+  )
   fun `the tcp connect panel exports no zero-area layers or raster targets`() {
     val density = 2f
     val root =

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/TcpPanelFigmaSvgTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/TcpPanelFigmaSvgTest.kt
@@ -94,28 +94,35 @@ class TcpPanelFigmaSvgTest {
     return Json.decodeFromString(LayoutInspectorPayload.serializer(), file.readText()).root
   }
 
-  @Test
-  @Ignore(
-    "#3080 — only 2 raster targets are emitted where the icon plus two text fields should give 3. " +
-      "The zero-area assertion just above still passes, so the target is absent rather than " +
-      "collapsed. Ignored, not deleted: it guards a real regression and comes back with the fix."
-  )
-  fun `the tcp connect panel exports no zero-area layers or raster targets`() {
+  /**
+   * Renders the panel through the real capture and builds the production figma-svg model.
+   *
+   * Shared so the `@Ignore`d raster-count expectation doesn't take the zero-area guards down with
+   * it: this is the only end-to-end exercise of a live Compose panel through
+   * `LayoutInspectorDataProducer` → `FigmaSvgModel.from` (the sibling `FigmaSvgZeroBoundsTest` is
+   * synthetic), so a new collapsed-bounds regression would otherwise sail through CI while #3080 is
+   * open.
+   */
+  private fun tcpPanelModel(): FigmaSvgModel {
     val density = 2f
     val root =
       capture(width = 680, height = 640, density = density) { MaterialTheme { TcpPanel() } }
-    val model =
-      FigmaSvgModel.from(
-        layout = LayoutInspectorPayload(root),
-        density = density,
-        rasterComponents = FigmaSvgModel.DEFAULT_RASTER_COMPONENTS,
-        captureCanvasDraws = true,
-      )
+    return FigmaSvgModel.from(
+      layout = LayoutInspectorPayload(root),
+      density = density,
+      rasterComponents = FigmaSvgModel.DEFAULT_RASTER_COMPONENTS,
+      captureCanvasDraws = true,
+    )
+  }
 
-    fun flatten(layer: FigmaSvgLayer): List<FigmaSvgLayer> = buildList {
-      add(layer)
-      layer.children.forEach { addAll(flatten(it)) }
-    }
+  private fun flatten(layer: FigmaSvgLayer): List<FigmaSvgLayer> = buildList {
+    add(layer)
+    layer.children.forEach { addAll(flatten(it)) }
+  }
+
+  @Test
+  fun `the tcp connect panel exports no zero-area layers or raster targets`() {
+    val model = tcpPanelModel()
 
     val degenerateDrawn =
       flatten(model.root).filter {
@@ -135,15 +142,23 @@ class TcpPanelFigmaSvgTest {
       degenerateRasters.isEmpty(),
     )
 
-    // The panel's chrome must actually be present: two text-field rasters + the icon raster, and
-    // the button's filled pill as a vector layer.
-    assertTrue(
-      "expected at least the icon + two text-field raster targets (got ${model.rasterTargets.size})",
-      model.rasterTargets.size >= 3,
-    )
     assertTrue(
       "the button fill must survive as a positive-area vector layer",
       flatten(model.root).any { it.fill != null && it.right > it.left && it.bottom > it.top },
+    )
+  }
+
+  @Test
+  @Ignore(
+    "#3080 — 2 raster targets are emitted where the icon plus two text fields should give 3, so " +
+      "one is absent rather than collapsed (the zero-area checks still pass). Split out of the " +
+      "zero-area test so those end-to-end guards stay active meanwhile."
+  )
+  fun `the tcp connect panel exports a raster target for the icon and both text fields`() {
+    val model = tcpPanelModel()
+    assertTrue(
+      "expected at least the icon + two text-field raster targets (got ${model.rasterTargets.size})",
+      model.rasterTargets.size >= 3,
     )
   }
 }


### PR DESCRIPTION
Disables the two failing `:daemon:desktop:test` tests against the tracking bug #3080, so that task stops being a standing red.

These are **not** the sandbox-pool / native-font problem in #3072. Both are ordinary assertion failures against captured data — the render completes and the captured model is simply wrong.

## What's ignored

**`DesktopLayoutInspectorTest.captures_an_imagevector_icon_as_editable_vector_paths`**

```
ComparisonFailure: solid fill resolved expected:<#FF[112233]> but was:<#FF[000000]>
```

Every assertion before it passes — `vectorGraphic` present, 24×24 viewport, one path, `pathData` starting `M12 0` and ending `Z`. Only `fillArgb` is wrong, so this is colour resolution on the captured vector path, not vector capture in general.

**`TcpPanelFigmaSvgTest.the tcp connect panel exports no zero-area layers or raster targets`**

```
AssertionError: expected at least the icon + two text-field raster targets (got 2)
```

The zero-area assertion immediately above still passes, so the missing raster is **absent**, not collapsed to an empty rect.

## Note on scope

I originally described these as the `FigmaSvgDownloadableFont*` failures, from a CI log for an earlier `main`. That was stale — those tests pass now. Re-ran `:daemon:desktop:test` against `d82d03a` and these two are the actual current failures. Same count (2), different tests.

`@Ignore` rather than delete, so they come back with the fix. Worth being blunt: **this is masking two real capture regressions**, and while they're ignored nothing guards that path. #3080 carries the detail plus a suspect list from the recent figma-svg churn (#3006 in particular explicitly drops rasters under live text, which is the shape of the second symptom).

## Test plan

- [x] Reproduced both failures locally off `main` (`d82d03a`) before the change
- [x] `./gradlew :daemon:desktop:test` — **BUILD SUCCESSFUL** after (was 2 failed / 204 completed)
- [x] Method-level `@Ignore`, so the other 203 tests in those two classes keep running
- [x] ktfmt applied

Visual evidence: N/A — test-only change, no rendered output affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_014NDRHMxYyfVYUF3pih7LjL)_