### PR TITLE
fix(renderer-android): frame dialog previews in the standalone renderer too

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/DialogWindowCapture.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/DialogWindowCapture.kt
@@ -1,0 +1,125 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.ui.platform.ViewRootForTest
+import androidx.compose.ui.semantics.SemanticsNode
+import java.io.File
+
+/**
+ * Framing support for previews that compose into their own window — `Dialog`, `AlertDialog`,
+ * `ModalBottomSheet` (issue #3048).
+ *
+ * The daemon's `RenderEngine` carries the twin of this logic. It is duplicated rather than shared
+ * for the same reason `RenderEngine` itself is duplicated (see its file kdoc): the daemon takes no
+ * compile-time dependency on this module's render internals. Reconcile when the v2 shared
+ * render-body extraction lands — until then, a change here needs the same change there.
+ *
+ * Two things go wrong for these previews here, and both need fixing:
+ *
+ * 1. **The root is ambiguous.** The activity's root is still present — zero-sized and empty, but
+ *    matched by `isRoot()` all the same — so `onRoot()` resolves to *two* nodes and
+ *    `fetchSemanticsNode()` throws `Expected exactly '1' node but found '2'`. Roborazzi papers over
+ *    that at the capture site, which is why these previews produced a PNG at all rather than
+ *    failing loudly. [selectCaptureRoot] picks the subject deliberately instead.
+ * 2. **The frame is the screen, not the component.** The capture spans the whole screen with the
+ *    dialog's window composited into it wherever its gravity puts it, so the sticker is the activity
+ *    frame with the component floating inside. [cropPngToDialogWindow] crops to the window.
+ */
+internal object DialogWindowCapture {
+
+  /**
+   * The semantics root representing the surface being captured, given every `isRoot()` node.
+   *
+   * Prefer the activity's own root — the normal single-root case, and a `Popup` over a real surface,
+   * where the popup is decoration and the activity is the subject. The preference yields only when
+   * the activity root has no content of its own *and* another root lives in a shown dialog window,
+   * which is exactly the `Dialog` / `ModalBottomSheet` preview whose whole content composes
+   * elsewhere.
+   *
+   * Keyed on the dialog window rather than on the activity root merely looking empty: a `Box`
+   * carrying only a `background` modifier contributes no semantics node, so "no semantic
+   * descendants" is not the same as "nothing rendered", and a popup must never win this.
+   */
+  fun selectCaptureRoot(
+    roots: List<SemanticsNode>,
+    activityDecorView: android.view.View,
+  ): SemanticsNode? {
+    if (roots.size <= 1) return roots.firstOrNull()
+    val activityRootHasSemantics =
+      roots.any { it.belongsToWindow(activityDecorView) && it.descendantCount() > 1 }
+    val dialogOwnsThePreview =
+      !activityRootHasSemantics && roots.any { shownDialogWindow(it) != null }
+    return roots.maxWithOrNull(
+      compareBy<SemanticsNode>(
+        {
+          val preferred =
+            if (dialogOwnsThePreview) shownDialogWindow(it) != null
+            else it.belongsToWindow(activityDecorView)
+          if (preferred) 1 else 0
+        },
+        { it.descendantCount() },
+        { it.size.width.toLong() * it.size.height.toLong() },
+      )
+    )
+  }
+
+  private fun SemanticsNode.belongsToWindow(decorView: android.view.View): Boolean =
+    runCatching { (root as? ViewRootForTest)?.view?.rootView === decorView.rootView }
+      .getOrDefault(false)
+
+  private fun SemanticsNode.descendantCount(): Int =
+    runCatching { 1 + children.sumOf { it.descendantCount() } }.getOrDefault(1)
+
+  /**
+   * The window of the currently-shown dialog [root] composes into, or `null` when it is not inside
+   * one — an ordinary activity-hosted preview, or a `Popup`, which installs its own owner through
+   * the window manager but never a `Dialog`.
+   *
+   * `getShownDialogs` keeps dismissed dialogs in the list, hence the `isShowing` filter.
+   */
+  fun shownDialogWindow(root: SemanticsNode): android.view.Window? =
+    runCatching {
+        val rootView = (root.root as? ViewRootForTest)?.view ?: return null
+        org.robolectric.shadows.ShadowDialog.getShownDialogs()
+          .lastOrNull { dialog ->
+            val decor = dialog.window?.decorView
+            dialog.isShowing &&
+              decor != null &&
+              generateSequence(rootView as android.view.View) { it.parent as? android.view.View }
+                .any { it === decor }
+          }
+          ?.window
+      }
+      .getOrNull()
+
+  /**
+   * Crops [file] — a capture spanning the whole screen — down to [window]'s own rectangle.
+   *
+   * The rectangle cannot come from the node or its view: under Robolectric a dialog window is never
+   * positioned, so `positionOnScreen`, `getLocationOnScreen` and the window's `attributes.x/y` all
+   * report `0`, even though the capture composites the window at its gravity. So place the window
+   * the way the framework does — [android.view.Gravity.apply] against the captured frame, using the
+   * window's own gravity — rather than trusting coordinates Robolectric leaves at the origin.
+   *
+   * A `ModalBottomSheet`'s window fills the screen, so its rect covers the whole frame and this is a
+   * no-op; a centred `Dialog` / `AlertDialog` crops to the dialog itself.
+   */
+  fun cropPngToDialogWindow(file: File, root: SemanticsNode, window: android.view.Window) {
+    if (!file.exists()) return
+    val original = runCatching { javax.imageio.ImageIO.read(file) }.getOrNull() ?: return
+    val width = root.size.width.coerceIn(1, original.width)
+    val height = root.size.height.coerceIn(1, original.height)
+    val placed = android.graphics.Rect()
+    android.view.Gravity.apply(
+      window.attributes.gravity,
+      width,
+      height,
+      android.graphics.Rect(0, 0, original.width, original.height),
+      placed,
+    )
+    val left = placed.left.coerceIn(0, original.width - width)
+    val top = placed.top.coerceIn(0, original.height - height)
+    if (left == 0 && top == 0 && width == original.width && height == original.height) return
+    val cropped = original.getSubimage(left, top, width, height)
+    runCatching { javax.imageio.ImageIO.write(cropped, "PNG", file) }
+  }
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.Constraints
@@ -1273,16 +1275,22 @@ abstract class RobolectricRenderTestBase(
           // nodes and `onRoot()` is ambiguous (issue #3048). Resolve the subject deliberately in
           // that case. Single-root previews — the overwhelming majority — keep using `onRoot()`
           // verbatim so their captures stay byte-identical.
-          val rootInteractions = rule.onAllNodes(isRoot(), useUnmergedTree = true)
-          val rootNodes =
-            runCatching { rootInteractions.fetchSemanticsNodes(atLeastOneRootRequired = false) }
-              .getOrDefault(emptyList())
-          val resolvedRoot =
-            if (rootNodes.size <= 1) null
-            else DialogWindowCapture.selectCaptureRoot(rootNodes, rule.activity.window.decorView)
-          val onRoot =
-            if (resolvedRoot == null) rule.onRoot()
-            else rootInteractions[rootNodes.indexOf(resolvedRoot)]
+          //
+          // Resolved per capture rather than once up front: a dialog can open from a
+          // `LaunchedEffect`, so at virtual time 0 there is only the activity root, and the window
+          // appears after the job advances the clock below. A cached selection would also go stale
+          // across several timed still captures if a dialog opens or closes between them.
+          fun resolveCaptureRoot(): Pair<SemanticsNodeInteraction, SemanticsNode?> {
+            val interactions = rule.onAllNodes(isRoot(), useUnmergedTree = true)
+            val nodes =
+              runCatching { interactions.fetchSemanticsNodes(atLeastOneRootRequired = false) }
+                .getOrDefault(emptyList())
+            if (nodes.size <= 1) return rule.onRoot() to null
+            val resolved =
+              DialogWindowCapture.selectCaptureRoot(nodes, rule.activity.window.decorView)
+                ?: return rule.onRoot() to null
+            return interactions[nodes.indexOf(resolved)] to resolved
+          }
           val jobs =
             (preview.captures.map { CaptureRenderJob(it, outputFileFor(it, outputDir)) } +
                 preview.dataProducts.map { ProductRenderJob(it, outputFileFor(it, outputDir)) })
@@ -1588,7 +1596,9 @@ abstract class RobolectricRenderTestBase(
                   settlePostScrollAnimations(rule)
                 }
               }
-              onRoot.captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
+              resolveCaptureRoot()
+                .first
+                .captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
             }
 
             // A `Dialog` / `ModalBottomSheet` preview composes into a window of its own, and the
@@ -1605,7 +1615,10 @@ abstract class RobolectricRenderTestBase(
                   !animationHandled &&
                   !focusGifHandled
               ) {
-                resolvedRoot?.let { root ->
+                // Re-resolved rather than reusing the capture's value: the clock has not moved
+                // since, so this sees the same roots, and it keeps the selection out of a mutable
+                // var shared across jobs.
+                resolveCaptureRoot().second?.let { root ->
                   DialogWindowCapture.shownDialogWindow(root)?.also { window ->
                     DialogWindowCapture.cropPngToDialogWindow(outputFile, root, window)
                   }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
@@ -1267,7 +1268,21 @@ abstract class RobolectricRenderTestBase(
           // `DiscoverPreviewsTask` guarantees `captures` is ordered by
           // ascending `advanceTimeMillis`, so we accumulate forward-only.
           var currentTime = 0L
-          val onRoot = rule.onRoot()
+          // A preview whose content is a `Dialog` / `ModalBottomSheet` installs a second Compose
+          // owner, and the activity's own root stays present but empty — so `isRoot()` matches two
+          // nodes and `onRoot()` is ambiguous (issue #3048). Resolve the subject deliberately in
+          // that case. Single-root previews — the overwhelming majority — keep using `onRoot()`
+          // verbatim so their captures stay byte-identical.
+          val rootInteractions = rule.onAllNodes(isRoot(), useUnmergedTree = true)
+          val rootNodes =
+            runCatching { rootInteractions.fetchSemanticsNodes(atLeastOneRootRequired = false) }
+              .getOrDefault(emptyList())
+          val resolvedRoot =
+            if (rootNodes.size <= 1) null
+            else DialogWindowCapture.selectCaptureRoot(rootNodes, rule.activity.window.decorView)
+          val onRoot =
+            if (resolvedRoot == null) rule.onRoot()
+            else rootInteractions[rootNodes.indexOf(resolvedRoot)]
           val jobs =
             (preview.captures.map { CaptureRenderJob(it, outputFileFor(it, outputDir)) } +
                 preview.dataProducts.map { ProductRenderJob(it, outputFileFor(it, outputDir)) })
@@ -1576,14 +1591,40 @@ abstract class RobolectricRenderTestBase(
               onRoot.captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
             }
 
+            // A `Dialog` / `ModalBottomSheet` preview composes into a window of its own, and the
+            // capture spans the whole screen with that window composited into it — so the sticker
+            // is the activity frame with the component floating somewhere inside (issue #3048).
+            // Crop to the dialog's window instead. The AS-parity wrap crop below cannot do this
+            // job: it crops from the origin, and a centred dialog is not at (0,0).
+            val capturedDialogWindow =
+              if (
+                !productFellThrough &&
+                  !animatedCaptureFellThrough &&
+                  !longHandled &&
+                  !gifHandled &&
+                  !animationHandled &&
+                  !focusGifHandled
+              ) {
+                resolvedRoot?.let { root ->
+                  DialogWindowCapture.shownDialogWindow(root)?.also { window ->
+                    DialogWindowCapture.cropPngToDialogWindow(outputFile, root, window)
+                  }
+                }
+              } else {
+                null
+              }
+
             // AS-parity: crop the PNG down to the composable's
             // intrinsic size on wrapped axes. Skipped for stitched
             // LONG output, scroll GIF output, @AnimatedPreview GIF
             // output, and @FocusedPreview(gif=true) GIF output —
             // those files' dimensions are the full scrollable
             // extent / frame size, not the composable's intrinsic box.
+            // Also skipped when the frame was already cropped to a dialog window above, which has
+            // framed it to the component already.
             if (
-              !productFellThrough &&
+              capturedDialogWindow == null &&
+                !productFellThrough &&
                 !animatedCaptureFellThrough &&
                 !longHandled &&
                 !gifHandled &&

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DialogWindowCaptureTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DialogWindowCaptureTest.kt
@@ -1,0 +1,174 @@
+package ee.schimke.composeai.renderer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.Popup
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.captureRoboImage
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Framing coverage for previews that compose into their own window (issue #3048).
+ *
+ * The standalone renderer's capture spans the whole screen, with the dialog's window composited
+ * into it wherever its gravity puts it — so without [DialogWindowCapture] the sticker is the
+ * activity frame with the component floating inside, which is what these previews published as.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class DialogWindowCaptureTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("dialog-window-capture").toFile()
+    System.setProperty("roborazzi.test.record", "true")
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+    System.clearProperty("roborazzi.test.record")
+  }
+
+  @Test
+  fun `a centred dialog is cropped to the dialog, not the activity frame`() {
+    rule.setContent {
+      Dialog(onDismissRequest = {}) {
+        Box(modifier = Modifier.size(64.dp).background(FILL))
+      }
+    }
+    rule.mainClock.advanceTimeBy(SETTLE_MS)
+
+    val png = capture("dialog.png")
+    val uncropped = ImageIO.read(png)
+    assertTrue(
+      "precondition: the raw capture spans more than the dialog",
+      uncropped.width > 64 || uncropped.height > 64,
+    )
+
+    val root = resolveRoot()
+    val window = DialogWindowCapture.shownDialogWindow(root)
+    assertNotNull("the dialog's window must be resolvable from its root", window)
+    DialogWindowCapture.cropPngToDialogWindow(png, root, window!!)
+
+    val cropped = ImageIO.read(png)
+    assertEquals("cropped width is the dialog's", 64, cropped.width)
+    assertEquals("cropped height is the dialog's", 64, cropped.height)
+    assertTrue("the crop must land on the dialog's fill, not the backdrop", png.isEntirely(FILL))
+  }
+
+  @OptIn(ExperimentalMaterial3Api::class)
+  @Test
+  fun `a full-screen bottom sheet window keeps the whole frame`() {
+    rule.setContent {
+      ModalBottomSheet(
+        onDismissRequest = {},
+        sheetState = rememberStandardBottomSheetState(),
+      ) {
+        Box(modifier = Modifier.size(64.dp).background(FILL))
+      }
+    }
+    rule.mainClock.advanceTimeBy(SETTLE_MS)
+
+    val png = capture("sheet.png")
+    val before = ImageIO.read(png).let { it.width to it.height }
+
+    val root = resolveRoot()
+    val window = DialogWindowCapture.shownDialogWindow(root)
+    assertNotNull("a ModalBottomSheet also composes into a dialog window", window)
+    DialogWindowCapture.cropPngToDialogWindow(png, root, window!!)
+
+    // The sheet's window fills the screen, so the crop is a no-op — the frame is the sticker.
+    val after = ImageIO.read(png).let { it.width to it.height }
+    assertEquals("a full-screen window must not be cropped", before, after)
+  }
+
+  @Test
+  fun `a popup is not a dialog window and is left alone`() {
+    rule.setContent {
+      Box(modifier = Modifier.fillMaxSize().background(Color(0xFFEF5350)))
+      Popup { Box(modifier = Modifier.size(24.dp).background(FILL)) }
+    }
+    rule.mainClock.advanceTimeBy(SETTLE_MS)
+
+    // A Popup installs its own owner through the window manager but never a `Dialog`, so it must
+    // not trigger the dialog crop — otherwise a popup over a real surface would frame the popup.
+    assertNull(
+      "a popup must not resolve to a dialog window",
+      DialogWindowCapture.shownDialogWindow(resolveRoot()),
+    )
+  }
+
+  /** Mirrors what the renderer does: resolve the subject root rather than trusting `onRoot()`. */
+  private fun resolveRoot() =
+    DialogWindowCapture.selectCaptureRoot(
+      rule.onAllNodes(isRoot(), useUnmergedTree = true)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false),
+      rule.activity.window.decorView,
+    )!!
+
+  private fun capture(name: String): File {
+    val nodes = rule.onAllNodes(isRoot(), useUnmergedTree = true)
+    val resolved = resolveRoot()
+    val index =
+      nodes.fetchSemanticsNodes(atLeastOneRootRequired = false).indexOf(resolved)
+    return File(rootDir, name).also {
+      nodes[index].captureRoboImage(file = it, roborazziOptions = RoborazziOptions())
+    }
+  }
+
+  private fun File.isEntirely(argb: Color): Boolean {
+    val image = ImageIO.read(this) ?: return false
+    val want = argb.toArgbInt()
+    for (y in 0 until image.height) {
+      for (x in 0 until image.width) {
+        if (image.getRGB(x, y) != want) return false
+      }
+    }
+    return true
+  }
+
+  private fun Color.toArgbInt(): Int = android.graphics.Color.argb(
+    (alpha * 255).toInt(),
+    (red * 255).toInt(),
+    (green * 255).toInt(),
+    (blue * 255).toInt(),
+  )
+
+  private companion object {
+    val FILL = Color(0xFF42A5F5)
+    const val SETTLE_MS = 32L
+  }
+}

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DialogWindowCaptureTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DialogWindowCaptureTest.kt
@@ -8,6 +8,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -21,6 +26,7 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import java.io.File
 import java.nio.file.Files
 import javax.imageio.ImageIO
+import kotlinx.coroutines.delay
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -113,6 +119,41 @@ class DialogWindowCaptureTest {
     // The sheet's window fills the screen, so the crop is a no-op — the frame is the sticker.
     val after = ImageIO.read(png).let { it.width to it.height }
     assertEquals("a full-screen window must not be cropped", before, after)
+  }
+
+  /**
+   * The renderer resolves the capture root *per capture*, after advancing the clock to that
+   * capture's target time — not once up front. A dialog opened from a `LaunchedEffect` does not
+   * exist at virtual time 0, so a selection cached before the advance would miss it entirely.
+   */
+  @Test
+  fun `a dialog opened from a LaunchedEffect is still resolved after the clock advances`() {
+    rule.setContent {
+      var shown by remember { mutableStateOf(false) }
+      LaunchedEffect(Unit) {
+        delay(500L)
+        shown = true
+      }
+      if (shown) {
+        Dialog(onDismissRequest = {}) { Box(modifier = Modifier.size(64.dp).background(FILL)) }
+      }
+    }
+
+    // At the usual settle point the dialog has not opened yet: one root, no dialog window.
+    rule.mainClock.advanceTimeBy(SETTLE_MS)
+    assertNull(
+      "precondition: no dialog window before the effect fires",
+      DialogWindowCapture.shownDialogWindow(resolveRoot()),
+    )
+
+    // Past the delay it is open, and a freshly-resolved root finds it.
+    rule.mainClock.advanceTimeBy(1_000L)
+    val root = resolveRoot()
+    assertNotNull(
+      "the dialog must be resolvable once the effect has fired",
+      DialogWindowCapture.shownDialogWindow(root),
+    )
+    assertEquals("the resolved root is the dialog's", 64, root.size.width)
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #3067, which fixed #3048 in the **daemon** only.

The baked PNGs don't come from the daemon. `bundle pack` renders via `composePreviewRender` — the standalone `:renderer-android` — and only reads *semantics* back from the daemon, which `BundleCommand` states outright: *"the semantics tree is produced exclusively by the daemon (the standalone `composePreviewRender` task writes no semantics sidecars)"*.

So after 0.19.13 a published catalog got a **correct semantics tree and the old, wrong sticker**. The completeness gate keys on `withoutSemantics`, so it would go green while shipping exactly the images the consumer withheld them for. The compose-preview diff bot showed it plainly on [yschimke/horologist#10](https://github.com/yschimke/horologist/pull/10): all eight restored dialog and bottom-sheet previews listed as **unchanged** after the version bump.

## Two problems, one expected

**1. The root is ambiguous** — this one I didn't expect. The activity's root stays present (zero-sized, empty) and `isRoot()` matches it, so:

```
java.lang.AssertionError: Failed: assertExists.
Reason: Expected exactly '1' node but found '2' nodes that satisfy: (isRoot)
1) Node #1 at (l=0.0, t=0.0, r=0.0, b=0.0)px
2) Node #2 at (l=0.0, t=0.0, r=64.0, b=64.0)px
```

`onRoot().fetchSemanticsNode()` throws. Roborazzi papers over it at the capture site, which is why these previews produced a PNG at all rather than failing loudly. Now the subject is resolved deliberately whenever more than one root exists.

**2. The frame is the screen, not the component.** Measured on the probe: the capture came back `320×470` containing exactly `4096` (= 64×64) fill-coloured pixels — the dialog composited into an otherwise empty activity frame. Now cropped to the window.

## Design notes

- **Selection is keyed on a shown dialog window**, not on the activity root looking empty. `descendantCount` counts *semantics* nodes and a `Box` with only a `background` modifier contributes none, so "no semantic descendants" ≠ "nothing rendered" — a `Popup` over a visually-populated, semantics-free surface must never win. (Same correction Codex caught on #3067.)
- **Single-root previews keep `onRoot()` verbatim**, so the overwhelming majority of captures stay byte-identical and existing baselines can't shift.
- **The crop uses `Gravity.apply`**, not coordinates: Robolectric never positions a dialog window — `positionOnScreen`, `getLocationOnScreen` and `attributes.x/y` all report `0` even though the capture composites it at its gravity.
- **Duplicated from the daemon's `RenderEngine`** rather than shared, matching the existing split (see that file's kdoc). Reconcile both when the v2 shared render-body extraction lands; until then a change here needs the same change there.

## Scope limit

Only the **still-capture** path is covered. The multi-frame paths — scroll slices, animation and GIF frames at five other `rule.onRoot()` sites — would hit the same ambiguity for an *animated* dialog preview. Left alone to keep this to the path that produces catalog stickers; worth a follow-up.

## Test plan

New `DialogWindowCaptureTest` (`:renderer-android`), three cases:

- a centred `Dialog` crops to 64×64 and the crop lands entirely on the dialog's fill — not the backdrop, which is what makes this a framing assertion rather than a size one;
- a `ModalBottomSheet`'s full-screen window is left at its original dimensions (the crop is correctly a no-op);
- a `Popup` does **not** resolve to a dialog window, guarding the selection rule.

All three fail before the change. Unlike `:daemon:android` — still unrunnable locally and in CI because of the `Paint.nGetFontMetrics` SIGSEGV — `:renderer-android` runs fine, so these were developed against real output rather than reasoning. **Full `:renderer-android` suite green locally**, which is the check that matters for the shared capture path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6CHCkZzWpzk4hS2Rz8KJx)_