### PR TITLE
fix(daemon): stop encodeRenderPayload dropping 8 PreviewOverrides fields

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1082,67 +1082,51 @@ class JsonRpcServer(
       }
       // Extension-driven overrides ride along as a single base64-encoded `PreviewOverrides`
       // bag — the renderer's [PreviewOverrideExtensions] hands the bag to every registered
-      // planner. New override-driven fields don't need a new wire token; they ride this bag.
-      // `permissions` is included so the panel's permissions tab body (Inspection bundle)
-      // can push `renderNow.overrides.permissions` and reach
-      // `PermissionsPreviewOverrideExtension.plan(request)` end-to-end — without this the
-      // planner sees `request.permissions == null` and the around-composable's controller
-      // seed never lands.
+      // planner, and the renderer itself reads a few fields off it directly (`themeProvider`,
+      // the min/max content bounds). New override-driven fields don't need a new wire token;
+      // they ride this bag.
+      //
+      // The bag is a **denylist**: take the caller's whole `overrides` and null out only what
+      // already travelled as a typed token above. It used to be a hand-maintained allowlist
+      // shadowed by a parallel emptiness check, so every field nobody remembered to add to
+      // *both* lists was accepted by the protocol, merged by `PreviewOverrideMerge`, then
+      // dropped here with no error and default pixels returned. #3073 counted eight live ones
+      // (`clockEpochMillis`, `placeholderActive`, `ambient`, `focus`, `keyboard`,
+      // `touchOverlay`, `remoteCompose`, `launcherWidget`), and `permissions`, `gestures`,
+      // `lottie`, `namedOverrides` and `themeProvider` had each been fixed the same way one at
+      // a time before that. Inverted, a new `PreviewOverrides` field reaches the renderer by
+      // default and the only edit it can ever need here is a *removal* — when it grows a typed
+      // token of its own. [PreviewOverridesEncodingCompletenessTest] walks the serializer
+      // descriptor and fails if any field reaches the renderer on neither path.
+      //
+      // `talkBack` rides the bag deliberately even though `DesktopRecordingSession` is its only
+      // reader today: a one-shot render ignores an unread field harmlessly, whereas scoping it
+      // out here would rebuild exactly the silent-drop trap for whoever wires it into
+      // single-frame capture later.
       val extensionBag =
-        PreviewOverrides(
-          material3Theme = overrides.material3Theme,
-          wallpaper = overrides.wallpaper,
-          permissions = overrides.permissions,
-          // `gestures` rides the bag so `renderNow.overrides.gestures` reaches the Wear
-          // `GesturePreviewOverrideExtension` planner — force-showing hints (`showHints`) or
-          // invoking a handler (`invoke`) on the immediate render path, and letting the
-          // `compose/gestures` data product capture the applied state instead of stale defaults.
-          gestures = overrides.gestures,
-          // `lottie` rides the same bag so `renderNow.overrides.lottie.progress` reaches the
-          // desktop `RenderEngine`, which provides it as `LocalLottieProgress` — the interactive
-          // Lottie timeline scrub path. No new wire token needed.
-          lottie = overrides.lottie,
-          // `namedOverrides` rides the bag so `renderNow.overrides.namedOverrides` reaches the
-          // `PreviewOverridesPreviewOverrideExtension` planner, which seeds
-          // `PreviewOverrideController`
-          // so a preview's `previewOverride*("title", …)` returns the requested value, not its
-          // default.
-          namedOverrides = overrides.namedOverrides,
-          // Min/max content-size bounds ride the bag so
-          // `renderNow.overrides.{min,max}{Width,Height}Px`
-          // reach the desktop `RenderEngine`, which clamps the wrap-layout measure to them (the
-          // Fixed / Max / Min / Within size modes). Fixed size stays on the `widthPx`/`heightPx`
-          // tokens above; these are the wrapped-axis bounds only, so no new fixed-frame token.
-          minWidthPx = overrides.minWidthPx,
-          minHeightPx = overrides.minHeightPx,
-          maxWidthPx = overrides.maxWidthPx,
-          maxHeightPx = overrides.maxHeightPx,
-          // `themeProvider` rides the bag so `renderNow.overrides.themeProvider` reaches the
-          // renderer, which reads `spec.overrides.themeProvider` in `InvokeWithOptionalWrapper` to
-          // wrap the preview in an app-declared `@ThemeCatalog` / `@WearThemeCatalog`
-          // `PreviewWrapperProvider`. It is renderer-read rather than planner-read, but it has no
-          // typed wire token of its own, so without a slot here the one-shot `renderNow` path
-          // dropped it silently: every `?themeProvider=` render on the preview server came back
-          // with
-          // the preview's declared wrapper (the theme chips redrew identical pixels). The live
-          // `stream/start` path carries it separately as
-          // `InteractiveCommand.Start.themeProviderFqn`
-          // and was unaffected.
-          themeProvider = overrides.themeProvider,
-        )
-      if (
-        extensionBag.material3Theme != null ||
-          extensionBag.wallpaper != null ||
-          extensionBag.permissions != null ||
-          extensionBag.gestures != null ||
-          extensionBag.lottie != null ||
-          !extensionBag.namedOverrides.isNullOrEmpty() ||
-          extensionBag.minWidthPx != null ||
-          extensionBag.minHeightPx != null ||
-          extensionBag.maxWidthPx != null ||
-          extensionBag.maxHeightPx != null ||
-          !extensionBag.themeProvider.isNullOrBlank()
-      ) {
+        overrides
+          .copy(
+            // The 12 typed wire tokens emitted above. Nulled so the bag never restates them —
+            // the tokens are what each backend's `parseFromPayload` reads, and `device` in
+            // particular has already been resolved into widthPx/heightPx/density up there.
+            widthPx = null,
+            heightPx = null,
+            density = null,
+            localeTag = null,
+            fontScale = null,
+            uiMode = null,
+            orientation = null,
+            device = null,
+            captureAdvanceMs = null,
+            inspectionMode = null,
+            slotMode = null,
+            clearBackground = null,
+          )
+          // Blank/empty means "not set" for these two, so normalize before the emptiness check
+          // below — a `themeProvider: ""` must not conjure a bag out of nothing.
+          .let { if (it.themeProvider.isNullOrBlank()) it.copy(themeProvider = null) else it }
+          .let { if (it.namedOverrides.isNullOrEmpty()) it.copy(namedOverrides = null) else it }
+      if (extensionBag != PreviewOverrides()) {
         if (isNotEmpty()) append(';')
         append("overrides=")
         append(

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverridesEncodingCompletenessTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverridesEncodingCompletenessTest.kt
@@ -1,0 +1,406 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import ee.schimke.composeai.daemon.protocol.FocusDirection
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.daemon.protocol.GestureKindOverride
+import ee.schimke.composeai.daemon.protocol.GestureOverride
+import ee.schimke.composeai.daemon.protocol.KeyboardOverride
+import ee.schimke.composeai.daemon.protocol.LauncherWidgetOverride
+import ee.schimke.composeai.daemon.protocol.LauncherWidgetSize
+import ee.schimke.composeai.daemon.protocol.LottieOverride
+import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
+import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
+import ee.schimke.composeai.daemon.protocol.PermissionsOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.daemon.protocol.WallpaperOverride
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.Base64
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Completeness gate for [JsonRpcServer]'s `renderNow` encoder (issue #3073).
+ *
+ * `encodeRenderPayload` can carry a [PreviewOverrides] field to the renderer in exactly two ways: a
+ * **typed wire token** (`widthPx=…;uiMode=dark;…`) or the base64 `overrides=<bag>` **extension
+ * bag**. A field on neither path is accepted by the protocol, merged by `PreviewOverrideMerge`,
+ * documented in `Messages.kt` as honoured — and then silently dropped on the wire, so the render
+ * comes back with default pixels and no error. That happened five separate times (`permissions`,
+ * `gestures`, `lottie`, `namedOverrides`, `themeProvider`, each fixed one at a time) and had eight
+ * more live instances when #3073 was filed (`clockEpochMillis`, `placeholderActive`, `ambient`,
+ * `focus`, `keyboard`, `touchOverlay`, `remoteCompose`, `launcherWidget`).
+ *
+ * Rather than fix it a ninth time, this test walks `PreviewOverrides.serializer().descriptor` and
+ * asserts every declared field survives a real `initialize` → `renderNow` round-trip on one of the
+ * two paths. Adding a field to [PreviewOverrides] without either giving it a token or letting it
+ * ride the bag now fails here instead of in a user's render.
+ *
+ * Sibling to [PermissionsOverrideEncodingTest] / [ThemeProviderOverrideEncodingTest], which pin the
+ * per-field semantics; this one only asks "does it reach the renderer at all".
+ */
+class PreviewOverridesEncodingCompletenessTest {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+
+  /**
+   * The fields [JsonRpcServer.encodeRenderPayload] emits as typed `key=value` tokens. Kept as the
+   * *only* hand-maintained list in the test: everything else is expected to ride the bag, which is
+   * exactly the invariant the encoder's denylist `copy(...)` establishes.
+   */
+  private val wireTokens =
+    setOf(
+      "widthPx",
+      "heightPx",
+      "density",
+      "localeTag",
+      "fontScale",
+      "uiMode",
+      "orientation",
+      "device",
+      "captureAdvanceMs",
+      "inspectionMode",
+      "slotMode",
+      "clearBackground",
+    )
+
+  /**
+   * Every [PreviewOverrides] field set to a non-default value, so serializing it (with
+   * `encodeDefaults = false`) yields a JSON object whose keys are the full field set. The
+   * descriptor check below fails loudly if a newly added field is missing from here.
+   */
+  private val fullyPopulated =
+    PreviewOverrides(
+      widthPx = 411,
+      heightPx = 891,
+      minWidthPx = 100,
+      minHeightPx = 120,
+      maxWidthPx = 800,
+      maxHeightPx = 900,
+      density = 2.75f,
+      localeTag = "fr-FR",
+      fontScale = 1.3f,
+      uiMode = UiMode.DARK,
+      orientation = Orientation.LANDSCAPE,
+      device = "id:pixel_5",
+      captureAdvanceMs = 64L,
+      clockEpochMillis = 1_700_000_000_000L,
+      inspectionMode = false,
+      slotMode = true,
+      placeholderActive = true,
+      clearBackground = true,
+      material3Theme = Material3ThemeOverrides(colorScheme = mapOf("primary" to "#FF3366FF")),
+      themeProvider = "com.example.BrandDarkThemeCatalog",
+      wallpaper = WallpaperOverride(seedColor = "#FF8800"),
+      ambient = AmbientOverride(state = AmbientStateOverride.AMBIENT),
+      gestures = GestureOverride(showHints = true, invoke = GestureKindOverride.PRIMARY),
+      focus = FocusOverride(tabIndex = 2, direction = FocusDirection.Next),
+      touchOverlay = true,
+      talkBack = true,
+      keyboard = KeyboardOverride(visible = true, pressedKey = "a"),
+      permissions =
+        PermissionsOverride(
+          grants = mapOf("android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED)
+        ),
+      remoteCompose = RemoteComposeOverride(profile = RemoteComposeProfile.ANDROIDX),
+      launcherWidget = LauncherWidgetOverride(cells = LauncherWidgetSize(width = 4, height = 2)),
+      lottie = LottieOverride(progress = 0.42f),
+      namedOverrides = mapOf("title" to PreviewOverrideValue.StringValue("Hello")),
+    )
+
+  /**
+   * Guards the fixture itself: a field added to [PreviewOverrides] but not to [fullyPopulated]
+   * would otherwise sail through the encoding assertion below (nothing to drop → nothing to
+   * notice).
+   */
+  @Test
+  fun fixtureCoversEveryDeclaredField() {
+    val declared = declaredFieldNames()
+    val populated =
+      json.encodeToString(PreviewOverrides.serializer(), fullyPopulated).let {
+        json.parseToJsonElement(it).jsonObject.keys
+      }
+    val missing = declared - populated
+    assertTrue(
+      "PreviewOverrides gained field(s) $missing — add non-default value(s) for them to " +
+        "PreviewOverridesEncodingCompletenessTest.fullyPopulated so the encoding assertion " +
+        "actually exercises them.",
+      missing.isEmpty(),
+    )
+  }
+
+  /** The list of typed tokens must stay a subset of the real field set. */
+  @Test
+  fun wireTokensNameRealFields() {
+    val unknown = wireTokens - declaredFieldNames()
+    assertTrue(
+      "wireTokens names non-existent PreviewOverrides field(s): $unknown",
+      unknown.isEmpty(),
+    )
+  }
+
+  @Test(timeout = 60_000)
+  fun everyOverrideFieldReachesTheRendererOnSomePath() {
+    val payload =
+      renderAndCapturePayload(json.encodeToString(PreviewOverrides.serializer(), fullyPopulated))
+    val tokens =
+      payload
+        .split(';')
+        .mapNotNull { it.trim().takeIf { t -> '=' in t } }
+        .associate { it.substringBefore('=') to it.substringAfter('=') }
+    val bagKeys = decodeExtensionBagKeys(payload)
+
+    val dropped =
+      declaredFieldNames().filterNot { field ->
+        if (field in wireTokens) field in tokens else field in bagKeys
+      }
+    assertTrue(
+      "renderNow.overrides field(s) $dropped reach the renderer on no path — they are neither a " +
+        "typed wire token nor present in the base64 `overrides=` bag, so a caller setting them " +
+        "gets default pixels and no error (issue #3073). Payload: $payload",
+      dropped.isEmpty(),
+    )
+  }
+
+  @Test(timeout = 60_000)
+  fun tokenisedFieldsAreNotRestatedInTheBag() {
+    // The bag is built by nulling the tokenised fields, so nothing travels twice — the tokens are
+    // the single source of truth for size/locale/uiMode/device, and `device` in particular has
+    // already been resolved into widthPx/heightPx/density by the encoder.
+    val payload =
+      renderAndCapturePayload(json.encodeToString(PreviewOverrides.serializer(), fullyPopulated))
+    val duplicated = decodeExtensionBagKeys(payload).intersect(wireTokens)
+    assertTrue(
+      "tokenised field(s) restated in the extension bag: $duplicated",
+      duplicated.isEmpty(),
+    )
+  }
+
+  @Test(timeout = 60_000)
+  fun bagIsOmittedWhenOnlyTokenisedFieldsAreSet() {
+    // Byte-identical-payload guard: an overrides object that is fully covered by typed tokens must
+    // not start emitting an (empty) bag now that the emptiness check is structural.
+    val payload = renderAndCapturePayload("""{"uiMode":"dark","widthPx":320}""")
+    assertTrue("overrides= bag must be omitted: '$payload'", "overrides=" !in payload)
+  }
+
+  @Test(timeout = 60_000)
+  fun previouslyDroppedFieldRidesTheBag() {
+    // Spot-check the headline regression from #3073 rather than trusting the descriptor walk
+    // alone: the deterministic wall clock (#1968) and the loading-state pin (#2646).
+    val payload =
+      renderAndCapturePayload("""{"clockEpochMillis":1700000000000,"placeholderActive":true}""")
+    val bag = decodeExtensionBag(payload)
+    assertEquals(1_700_000_000_000L, bag.clockEpochMillis)
+    assertEquals(true, bag.placeholderActive)
+  }
+
+  private fun declaredFieldNames(): Set<String> {
+    val descriptor = PreviewOverrides.serializer().descriptor
+    return (0 until descriptor.elementsCount).map { descriptor.getElementName(it) }.toSet()
+  }
+
+  private fun decodeExtensionBag(payload: String): PreviewOverrides =
+    json.decodeFromString(PreviewOverrides.serializer(), decodeExtensionBagJson(payload))
+
+  private fun decodeExtensionBagKeys(payload: String): Set<String> =
+    json.parseToJsonElement(decodeExtensionBagJson(payload)).jsonObject.keys
+
+  private fun decodeExtensionBagJson(payload: String): String {
+    val token =
+      payload.split(';').firstOrNull { it.trim().startsWith("overrides=") }
+        ?: error("payload must carry an overrides= token: '$payload'")
+    val b64 = token.substringAfter('=').trim()
+    return String(Base64.getUrlDecoder().decode(b64), Charsets.UTF_8)
+  }
+
+  /**
+   * Spins up a [JsonRpcServer] backed by a payload-capturing host with a single-preview index, runs
+   * `initialize` → `renderNow` with the supplied overrides JSON, and returns the
+   * `RenderRequest.payload` string the host received. Mirrors [ThemeProviderOverrideEncodingTest]'s
+   * helper — kept file-local for the same reason.
+   */
+  private fun renderAndCapturePayload(overrides: String): String {
+    val sourceKt = java.nio.file.Files.createTempFile("overrides-completeness-test", ".kt")
+    java.nio.file.Files.writeString(sourceKt, "@Preview fun A() {}\n")
+    val previewDto =
+      PreviewInfoDto(
+        id = "preview-A",
+        className = "com.example.AKt",
+        methodName = "A",
+        sourceFile = sourceKt.toAbsolutePath().toString(),
+      )
+    val index = PreviewIndex.fromMap(path = sourceKt, byId = mapOf("preview-A" to previewDto))
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val host = PayloadCapturingCompletenessHost()
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        previewIndex = index,
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val serverThread =
+      Thread({ server.run() }, "overrides-completeness-test").apply { isDaemon = true }
+    serverThread.start()
+
+    val reader = ContentLengthFramer(serverToClientIn)
+    val received = LinkedBlockingQueue<JsonObject>()
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "overrides-completeness-test-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    try {
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":t","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false}}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":2,"method":"renderNow","params":{
+              "previews":["preview-A"],"tier":"fast","overrides":$overrides}}""",
+      )
+      val finished =
+        pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+      assertNotNull("renderFinished must arrive within timeout", finished)
+
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"exit"}""")
+      assertTrue(exitLatch.await(5, TimeUnit.SECONDS))
+      return host.lastPayload.get() ?: error("host never received a render request")
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      try {
+        java.nio.file.Files.deleteIfExists(sourceKt)
+      } catch (_: Throwable) {}
+      serverThread.join(5_000)
+    }
+  }
+
+  private fun writeFrame(out: PipedOutputStream, jsonStr: String) {
+    val payload = jsonStr.toByteArray(Charsets.UTF_8)
+    out.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+    out.write(payload)
+    out.flush()
+  }
+
+  private fun pollUntil(
+    queue: LinkedBlockingQueue<JsonObject>,
+    timeoutMs: Long = 10_000,
+    matcher: (JsonObject) -> Boolean,
+  ): JsonObject? {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+      if (matcher(msg)) return msg
+    }
+    return null
+  }
+}
+
+/**
+ * Captures the [RenderRequest.Render.payload] string the daemon submits, then completes the render
+ * synchronously with a stub success result. File-local copy of the shape
+ * [ThemeProviderOverrideEncodingTest] uses, so the two tests take no cross-file dependency.
+ */
+private class PayloadCapturingCompletenessHost : RenderHost {
+  val lastPayload: AtomicReference<String?> = AtomicReference(null)
+  private val queue = LinkedBlockingQueue<RenderRequest>()
+  private val results = LinkedBlockingQueue<RenderResult>()
+
+  @Volatile private var stopped = false
+
+  private val worker: Thread =
+    Thread(
+        {
+          while (!stopped) {
+            when (val req = queue.poll(50, TimeUnit.MILLISECONDS)) {
+              null -> continue
+              is RenderRequest.Render -> {
+                lastPayload.set(req.payload)
+                results.put(
+                  RenderResult(
+                    id = req.id,
+                    classLoaderHashCode = 0,
+                    classLoaderName = "overrides-completeness-test",
+                  )
+                )
+              }
+              RenderRequest.Shutdown -> return@Thread
+            }
+          }
+        },
+        "payload-capturing-completeness-host",
+      )
+      .apply { isDaemon = true }
+
+  override fun start() {
+    worker.start()
+  }
+
+  override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+    require(request is RenderRequest.Render)
+    queue.put(request)
+    return results.poll(timeoutMs, TimeUnit.MILLISECONDS)
+      ?: error("PayloadCapturingCompletenessHost.submit timed out")
+  }
+
+  override fun shutdown(timeoutMs: Long) {
+    stopped = true
+    queue.put(RenderRequest.Shutdown)
+    worker.join(timeoutMs)
+  }
+}


### PR DESCRIPTION
Fixes #3073.

## Summary

`JsonRpcServer.encodeRenderPayload` built its base64 `overrides=` extension bag from a hand-maintained **allowlist**, shadowed by a parallel 11-clause emptiness check that had to be kept in sync with it. Any `PreviewOverrides` field missing from either list was accepted by the protocol, merged by `PreviewOverrideMerge`, documented in `Messages.kt` as honoured — and then silently dropped on the wire, so the render came back with default pixels and **no error**.

Eight fields were live in that state on the one-shot `renderNow` path: `clockEpochMillis`, `placeholderActive`, `ambient`, `focus`, `keyboard`, `touchOverlay`, `remoteCompose`, `launcherWidget` — each with a connector-side planner reading it straight off the request, including the deterministic wall clock (#1968) and the loading-state pin (#2646).

Changes:

- **Allowlist → denylist.** The bag is now `overrides.copy(...)` with only the 12 already-tokenised fields (`widthPx`, `heightPx`, `density`, `localeTag`, `fontScale`, `uiMode`, `orientation`, `device`, `captureAdvanceMs`, `inspectionMode`, `slotMode`, `clearBackground`) nulled out. A new `PreviewOverrides` field reaches the renderer by default; the only edit it can ever need here is a *removal*, when it gains a typed token of its own.
- **Structural emptiness check.** The 11-clause `if` becomes `extensionBag != PreviewOverrides()`, with blank `themeProvider` / empty `namedOverrides` normalized to null first so an unset-but-present value still can't conjure a bag.
- **`talkBack` decided explicitly** (per the issue): it rides the bag rather than being absent by accident. Only `DesktopRecordingSession` reads it today, a one-shot render ignores it harmlessly, and scoping it out would rebuild the same trap for whoever wires it into single-frame capture later.
- **New completeness gate.** `PreviewOverridesEncodingCompletenessTest` walks `PreviewOverrides.serializer().descriptor` and asserts every declared field survives a real `initialize` → `renderNow` round-trip as either a typed token or a bag entry, so this class of bug fails in CI instead of in a user's render. It also guards its own fixture (a new field with no non-default value in the fixture fails loudly) and asserts tokenised fields are never restated in the bag.

Net effect on the encoder: 44 insertions, 60 deletions — the archaeology-log comments are replaced by one explanation of the invariant.

## Test plan

- `./gradlew :daemon:core:test --tests "*PreviewOverridesEncodingCompletenessTest*" --tests "*ThemeProviderOverrideEncodingTest*" --tests "*PermissionsOverrideEncodingTest*" --tests "*DeviceOverrideEncodingTest*"` — **BUILD SUCCESSFUL** (6 new tests, 0 failures).
- **Verified the new test is a real gate**: stashing only the `JsonRpcServer.kt` change and re-running fails `everyOverrideFieldReachesTheRendererOnSomePath` and `previouslyDroppedFieldRidesTheBag`.
- `./gradlew :daemon:desktop:test --tests "*Override*" :cli:test --tests "*ServeWeb*"` — **BUILD SUCCESSFUL** (payload decoders and the serve-web fixture are unaffected).
- `./gradlew :daemon:core:ktfmtFormat` applied.
- Note: the full `:daemon:core:test` suite aborts the test JVM in this container — reproduced identically on an unmodified tree at `72facbd`, so it is pre-existing and unrelated. Every test that runs targeted passes.

No visual surface is touched (wire-encoding + tests only), so there is nothing to render for before/after evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fuba6kiB52jrnnuaxc8JtR)_