### PR TITLE
feat(daemon): give each sandbox its own process so the pool can boot

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -434,8 +434,7 @@ internal constructor(
     lastUsedAtMs.set(System.currentTimeMillis())
     val replyLatch = CountDownLatch(1)
     val replyError = AtomicReference<Throwable?>(null)
-    val replyReason =
-      AtomicReference<ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason?>(null)
+    val replyReasonJson = AtomicReference<String?>(null)
     slot.interactiveCommands.put(
       InteractiveCommand.FindUiAutomatorEvidence(
         streamId = streamId,
@@ -445,7 +444,7 @@ internal constructor(
         inputText = inputText,
         replyLatch = replyLatch,
         replyError = replyError,
-        replyReason = replyReason,
+        replyReasonJson = replyReasonJson,
       )
     )
     if (!replyLatch.await(DISPATCH_TIMEOUT_SEC, TimeUnit.SECONDS)) {
@@ -456,7 +455,8 @@ internal constructor(
       )
     }
     replyError.get()?.let { throw it }
-    return replyReason.get()
+    // Re-parse into the host's own class — the sandbox only ever hands back a String.
+    return replyReasonJson.get()?.let { UiAutomatorEvidence.decode(it) }
   }
 
   /**

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -26,10 +26,13 @@ import kotlinx.serialization.json.Json
  * sandbox-side [RobolectricHost.SandboxRunner.runHeldInteractiveSession] loop.
  *
  * **Sandbox pinning** (INTERACTIVE-ANDROID.md § 2). Each session pins exactly one sandbox slot for
- * its lifetime. v3 ships with `INTERACTIVE_SLOT_INDEX = 1` so slot 0 stays the always-on
- * normal-render slot — that's enforced host-side in [RobolectricHost.acquireInteractiveSession]
- * (the constraint that `sandboxCount >= 2`). The session itself is slot-agnostic; it only carries a
- * reference to the slot it was constructed against.
+ * its lifetime. Since #3072 that is `INTERACTIVE_SLOT_INDEX = 0`, the sandbox in the daemon JVM:
+ * the held rule and its bridge queues are live object handles that can't be proxied to a worker
+ * process, so the session stays local and the *normal* renders move to slots 1..N-1 (worker JVMs)
+ * for its lifetime. Enforced host-side in [RobolectricHost.acquireInteractiveSession] (the
+ * constraint that `sandboxCount >= 2` — one sandbox to pin, at least one left to render). The
+ * session itself is slot-agnostic; it only carries a reference to the slot it was constructed
+ * against.
  *
  * **Threading.** Per the [InteractiveSession] contract, callers are serialised — `JsonRpcServer`
  * dispatches one input per session at a time. Each public method enqueues an [InteractiveCommand]
@@ -39,7 +42,7 @@ import kotlinx.serialization.json.Json
  * the composition.
  *
  * **Lifecycle** (INTERACTIVE-ANDROID.md § 7).
- * - **Allocate** at `interactive/start`. The host enqueues [InteractiveCommand.Start] onto slot 1's
+ * - **Allocate** at `interactive/start`. The host enqueues [InteractiveCommand.Start] onto slot 0's
  *   [SandboxSlot.interactiveCommands]; the sandbox's idle loop picks it up and enters
  *   `runHeldInteractiveSession`, which constructs the rule + ActivityScenario + paused-clock
  *   `setContent`, then counts down [InteractiveCommand.Start.replyLatch] before draining further
@@ -63,8 +66,8 @@ internal constructor(
    */
   internal val streamId: String,
   /**
-   * The sandbox slot this session was acquired against — almost always slot 1 in v3 (slot 0 is the
-   * always-on normal-render slot). Carried explicitly rather than re-derived because the host's
+   * The sandbox slot this session was acquired against — slot 0, the in-process sandbox, since
+   * #3072. Carried explicitly rather than re-derived because the host's
    * routing code (`acquireInteractiveSession`) already chose it; passing it in keeps the session
    * itself slot-policy-agnostic so v4 (multi-target Android) can reuse this class unchanged.
    */
@@ -82,7 +85,7 @@ internal constructor(
    * tests can drive a sub-second lease without sleeping CI for a minute.
    *
    * Without this lease, a panel that crashes or a websocket that drops mid-session would leak a
-   * pinned sandbox slot for the rest of the daemon's lifetime — slot 1 stays held with no
+   * pinned sandbox slot for the rest of the daemon's lifetime — slot 0 stays held with no
    * `interactive/stop` ever arriving. v3 supports one held session at a time per host, so a single
    * zombie burns the whole interactive capacity. Symmetry with the desktop story comes via the
    * panel's auto-stop on editor change/scroll (#427); the lease is the daemon-side belt-and-braces.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -78,9 +78,10 @@ fun main(args: Array<String>) {
   // The plugin has exposed `composeai.daemon.warmSpare=true` by default since the daemon launch
   // descriptor was introduced, but the Android daemon previously ignored it and came up with a
   // single sandbox unless the experimental sandbox-count property was set manually. Held
-  // interactive sessions need slot 1 pinned while slot 0 continues normal renders, and a typical
-  // preview grid wants extra slots for parallel renders, so default the pool to five sandboxes
-  // when warmSpare is on. Explicit `composeai.daemon.sandboxCount` still wins.
+  // interactive sessions pin the in-process sandbox (slot 0) and need at least one worker process
+  // left to serve normal renders, and a typical preview grid wants extra slots for parallel
+  // renders, so default the pool to five sandboxes when warmSpare is on — one here plus four
+  // worker JVMs (SANDBOX-POOL.md). Explicit `composeai.daemon.sandboxCount` still wins.
   val warmSpareEnabled = System.getProperty(WARM_SPARE_PROP)?.toBooleanStrictOrNull() ?: true
   val defaultSandboxCount = if (warmSpareEnabled) 5 else 1
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -923,8 +923,52 @@ open class RobolectricHost(
     // Throwable path still classifies it into a typed `renderFailed`.
     if (slotIdx > 0) {
       val pool = processPool ?: error("slot $slotIdx dispatched with no process pool configured")
-      return pool.submit(slotIdx - 1, typed, timeoutMs)
+      try {
+        return pool.submit(slotIdx - 1, typed, timeoutMs)
+      } catch (t: Throwable) {
+        // A render failure *inside* a live worker is the caller's to see — re-throw it. A worker
+        // that died taking the request with it is different: the pool has already dropped it, so
+        // re-dispatch once across the remaining slots rather than failing a render the pool can
+        // still serve. Only one retry: if the replacement slot dies too, something systemic is
+        // wrong and the caller should hear about it.
+        if (pool.isReady(slotIdx - 1)) throw t
+        val fallback = chooseSlotIndex(typed)
+        System.err.println(
+          "compose-ai-daemon: sandbox worker $slotIdx died holding render ${typed.id}; " +
+            "re-dispatching to slot $fallback (${t.javaClass.simpleName}: ${t.message})"
+        )
+        if (fallback > 0) return pool.submit(fallback - 1, typed, timeoutMs)
+        return submitInProcess(typed, timeoutMs)
+      }
     }
+    return submitInProcess(typed, timeoutMs)
+  }
+
+  /**
+   * Blocks until at least one sandbox worker is routable (so a held session on slot 0 leaves
+   * something to serve normal renders), or [timeoutMs] elapses.
+   *
+   * Throws the same clean `UnsupportedOperationException` the caller already handles with a v1
+   * fallback if the wait times out — that is the "the pool never produced a worker" case (every
+   * worker's boot failed permanently), not the ordinary warm-up window.
+   */
+  private fun awaitWorkerForInteractive(timeoutMs: Long) {
+    val deadline = System.nanoTime() + timeoutMs * 1_000_000
+    while (routableSlots().size < 2) {
+      if (System.nanoTime() >= deadline) {
+        throw UnsupportedOperationException(
+          "RobolectricHost: no sandbox worker process became routable within ${timeoutMs}ms " +
+            "(${readySlotCount.get()}/$sandboxCount sandboxes ready) — a held session would leave " +
+            "no sandbox for normal renders. Retry once the pool has finished booting."
+        )
+      }
+      Thread.sleep(INTERACTIVE_WORKER_POLL_MS)
+    }
+  }
+
+  /** The in-process (slot 0) half of [submit] — the pre-pool path, unchanged. */
+  private fun submitInProcess(typed: RenderRequest.Render, timeoutMs: Long): RenderResult {
+    val slotIdx = 0
     val slot = DaemonHostBridge.slot(slotIdx)
     // Publish the (possibly-just-swapped) child classloader to the slot the render is about to land
     // on. `currentChildLoader()` is lazily allocated on
@@ -964,31 +1008,50 @@ open class RobolectricHost(
     id: Long,
     interactiveSlotPinned: Boolean = false,
   ): Int =
-    // Tests probe the steady-state dispatch (all slots booted), independent of whether this host
-    // instance ever started — pass the full pool size rather than the live ready count.
+    // Tests probe the steady-state dispatch (all slots booted and healthy), independent of whether
+    // this host instance ever started — pass the full slot range rather than the live one.
     chooseSlotIndex(
       RenderRequest.Render(id = id, payload = payload),
       interactiveSlotPinned,
-      dispatchSlotCount = sandboxCount,
+      routable = (0 until sandboxCount).toList(),
     )
+
+  /**
+   * Slots a render may currently land on: the in-process sandbox, plus every worker that is both
+   * booted and still alive.
+   *
+   * Background boot (see [start]) brings workers up one at a time, so the ready count bounds the
+   * range. Liveness is checked per worker on top of that: [SandboxProcessPool] marks a worker dead
+   * when it dies mid-request, and a dead worker must drop out of *routing* too — otherwise every
+   * preview whose affinity hash pinned it keeps hashing to a slot that can only fail, for the rest
+   * of the daemon's life. Excluding it re-keys those previews onto live slots instead (a cache-
+   * warmth cost, not a correctness one) and the pool degrades slot by slot rather than stranding a
+   * share of the catalog.
+   */
+  private fun routableSlots(): List<Int> {
+    val readyPrefix = readySlotCount.get().coerceIn(1, sandboxCount)
+    if (readyPrefix == 1) return listOf(0)
+    val pool = processPool ?: return listOf(0)
+    return buildList {
+      add(0)
+      for (slot in 1 until readyPrefix) if (pool.isReady(slot - 1)) add(slot)
+    }
+  }
 
   private fun chooseSlotIndex(
     render: RenderRequest.Render,
     interactiveSlotPinned: Boolean = activeInteractiveStreamId.get() != null,
-    // Background boot (see [start]) brings slots up one at a time; dispatch across only the ready
-    // prefix so a render never queues on a still-bootstrapping sandbox. Affinity shifts as slots
-    // come up (mod 1 → mod 2 → …) which only costs cache warmth, not correctness — the same
-    // preview re-keys at most N-1 times and then stays stable for the daemon's lifetime.
-    dispatchSlotCount: Int = readySlotCount.get().coerceAtLeast(1),
+    routable: List<Int> = routableSlots(),
   ): Int {
-    val slots = dispatchSlotCount.coerceIn(1, sandboxCount)
-    if (slots == 1) return 0
+    // A held session pins the in-process slot, so normal renders route to the workers. If no worker
+    // is live, slot 0 is all there is — the render queues behind the session rather than failing.
+    val candidates =
+      if (interactiveSlotPinned) routable.filter { it != INTERACTIVE_SLOT_INDEX } else routable
+    if (candidates.isEmpty()) return INTERACTIVE_SLOT_INDEX
+    if (candidates.size == 1) return candidates.single()
     val previewId = parsePreviewIdFromPayload(render.payload)
     val key: Int = previewId?.hashCode() ?: render.id.hashCode()
-    if (!interactiveSlotPinned) return Math.floorMod(key, slots)
-    val normalSlotCount = slots - 1
-    val normalSlot = Math.floorMod(key, normalSlotCount)
-    return if (normalSlot < INTERACTIVE_SLOT_INDEX) normalSlot else normalSlot + 1
+    return candidates[Math.floorMod(key, candidates.size)]
   }
 
   /**
@@ -1352,17 +1415,16 @@ open class RobolectricHost(
           "(ready ${readySlotCount.get()}/$sandboxCount sandboxes). Retry shortly."
       )
     }
-    // Background boot (see [start]) brings the worker processes up after slot 0. Holding a session
-    // while no worker is ready would pin the only dispatchable sandbox and stall every normal
-    // render for the session's lifetime, so report the same clean `Unsupported` the caller already
-    // handles with a v1 fallback and let the panel retry once the pool has filled in.
-    if (readySlotCount.get() < 2) {
-      throw UnsupportedOperationException(
-        "RobolectricHost: no sandbox worker process is ready yet " +
-          "(${readySlotCount.get()}/$sandboxCount sandboxes) — a held session would leave no " +
-          "sandbox for normal renders. Retry shortly."
-      )
-    }
+    // Background boot (see [start]) brings the worker processes up after slot 0, so with the
+    // launch-descriptor default (`backgroundSandboxBoot=true`) an ordinary `interactive/start`
+    // right after `initialize` lands in the warm-up window with no worker ready yet. Holding a
+    // session then would pin the only dispatchable sandbox and stall every normal render for the
+    // session's lifetime — but failing is worse than waiting: the host advertises
+    // `supportsInteractive = true`, so `JsonRpcServer.handleInteractiveStart` turns the throw into
+    // an internal error and the VS Code panel just drops its live toggle without retrying. Wait out
+    // the same budget the held-rule handshake already gets, and only give up if the pool really
+    // hasn't produced a worker by then.
+    awaitWorkerForInteractive(INTERACTIVE_START_TIMEOUT_MS)
     val streamId = "android-stream-${nextStreamCounter.getAndIncrement()}"
     if (!activeInteractiveStreamId.compareAndSet(null, streamId)) {
       val held = activeInteractiveStreamId.get() ?: "<concurrent close>"
@@ -1845,6 +1907,13 @@ open class RobolectricHost(
      * preview composable's body is genuinely stuck.
      */
     internal const val INTERACTIVE_START_TIMEOUT_MS: Long = 30_000L
+
+    /**
+     * Poll interval while `acquireInteractiveSession` waits for a sandbox worker to become routable
+     * during a background pool boot. Short enough that a session acquired right after `initialize`
+     * doesn't feel gated, coarse enough not to spin.
+     */
+    private const val INTERACTIVE_WORKER_POLL_MS: Long = 100L
   }
 
   override fun shutdown(timeoutMs: Long) {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -18,6 +18,7 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
 import ee.schimke.composeai.daemon.bridge.InteractiveCommand
 import ee.schimke.composeai.daemon.bridge.SandboxSlot
+import ee.schimke.composeai.daemon.pool.SandboxProcessPool
 import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
 import ee.schimke.composeai.daemon.protocol.SemanticsTargetCandidate
 import ee.schimke.composeai.daemon.protocol.SemanticsTargetUnresolvedCode
@@ -416,10 +417,31 @@ open class RobolectricHost(
   // Mutable so [start] can replace a slot's worker with a fresh one when its first boot attempt
   // fails transiently (see the retry loop in [start] / [bootSlotWithRetries]). A dead worker's
   // Thread can't be re-`start()`ed, so a retry allocates a new one at the same index.
+  //
+  // Exactly one entry: slot 0, the in-process sandbox. Slots 1..N-1 are worker *processes*
+  // ([processPool]), not threads — see [SandboxProcessPool] for why a second sandbox can't share
+  // this JVM.
   private val workerThreads: Array<Thread> =
-    Array(sandboxCount) { i ->
+    Array(LOCAL_SANDBOX_COUNT) { i ->
       Thread({ runJUnit(workerIndex = i) }, threadName(i)).apply { isDaemon = false }
     }
+
+  /**
+   * Out-of-process slots 1..[sandboxCount]-1 (issue #3072). `null` for a single-sandbox host, which
+   * spawns nothing and behaves exactly as it always has.
+   */
+  private val processPool: SandboxProcessPool? =
+    if (sandboxCount > 1)
+      SandboxProcessPool(
+        workerCount = sandboxCount - 1,
+        bootTimeoutMs =
+          System.getProperty(SANDBOX_BOOT_TIMEOUT_PROP)?.toLongOrNull()
+            ?: DEFAULT_SANDBOX_BOOT_TIMEOUT_MS,
+      )
+    else null
+
+  /** Test seam: process ids of the worker JVMs, in slot order (slot 1 first). */
+  internal fun workerPidsForTest(): List<Long?> = processPool?.workerPids() ?: emptyList()
 
   /**
    * Bootstrap failures captured by [runJUnit] when its `SandboxRunner` JUnit run exits without
@@ -434,7 +456,7 @@ open class RobolectricHost(
    * in order, so `worker[i]` is the only thread that can ever claim `slot[i]`.
    */
   private val workerBootErrors: java.util.concurrent.atomic.AtomicReferenceArray<Throwable?> =
-    java.util.concurrent.atomic.AtomicReferenceArray<Throwable?>(sandboxCount)
+    java.util.concurrent.atomic.AtomicReferenceArray<Throwable?>(LOCAL_SANDBOX_COUNT)
 
   private fun threadName(i: Int): String =
     if (sandboxCount == 1) "compose-ai-daemon-host" else "compose-ai-daemon-host-$i"
@@ -498,7 +520,8 @@ open class RobolectricHost(
   override fun start() {
     StartupTimings.mark("RobolectricHost.start() entered")
     DaemonHostBridge.reset()
-    DaemonHostBridge.configureSlotCount(sandboxCount)
+    // One in-process slot, always. Slots 1..N-1 live in worker JVMs and hold no bridge state here.
+    DaemonHostBridge.configureSlotCount(LOCAL_SANDBOX_COUNT)
     readySlotCount.set(0)
     val timeoutMs =
       System.getProperty(SANDBOX_BOOT_TIMEOUT_PROP)?.toLongOrNull()
@@ -508,23 +531,26 @@ open class RobolectricHost(
       sandboxCount > 1 &&
         (System.getProperty(BACKGROUND_BOOT_PROP)?.toBooleanStrictOrNull() ?: false)
 
-    // SANDBOX-POOL.md — boot sandboxes sequentially, one worker at a time. We could in principle
-    // start them concurrently (each sandbox is independent now that the cache-key fix lands and
-    // `SandboxManager.getAndroidSandbox` is internally synchronized), but sequenced boots keep
-    // diagnosis simple if a future Robolectric upgrade reintroduces a global-state path. Total
-    // cold-start is proportional to N × per-sandbox-boot — on warm cache 5–15s × N — which is why
-    // background boot moves slots 1..N-1 off the [start] critical path.
-    val eagerCount = if (backgroundBoot) 1 else sandboxCount
-    var bootedThrough = -1
+    // SANDBOX-POOL.md — slot 0 is the in-process sandbox and always boots eagerly: [start]'s
+    // contract is that the host can serve a render when it returns. Slots 1..N-1 are worker JVMs,
+    // booted sequentially (either here or on the background thread below). Sequential because the
+    // cost is CPU- and memory-bound — N concurrent Robolectric bootstraps thrash a build machine
+    // far worse than they save wall-clock — and because a serial boot keeps failure diagnosis to
+    // one worker's stderr at a time.
     try {
-      for (i in 0 until eagerCount) {
-        bootSlotWithRetries(i, timeoutMs)
-        bootedThrough = i
-        readySlotCount.set(i + 1)
-      }
+      bootSlotWithRetries(0, timeoutMs)
+      readySlotCount.set(1)
     } catch (t: Throwable) {
-      runCatching { abortPartialStart(bootedThrough) }
+      runCatching { abortPartialStart(bootedThrough = -1) }
       throw t
+    }
+    if (!backgroundBoot) {
+      try {
+        bootRemainingSlots(timeoutMs, background = false)
+      } catch (t: Throwable) {
+        runCatching { abortPartialStart(bootedThrough = 0) }
+        throw t
+      }
     }
     StartupTimings.mark(
       when {
@@ -536,7 +562,11 @@ open class RobolectricHost(
     )
     if (backgroundBoot) {
       backgroundBootWorker =
-        Thread({ bootRemainingSlotsInBackground(timeoutMs) }, "compose-ai-daemon-pool-boot").apply {
+        Thread(
+            { runCatching { bootRemainingSlots(timeoutMs, background = true) } },
+            "compose-ai-daemon-pool-boot",
+          )
+          .apply {
           // Daemon thread: a JVM exiting mid-pool-boot shouldn't be held open by the booter (the
           // sandbox workers it spawns are non-daemon, but JsonRpcServer exits via System.exit).
           isDaemon = true
@@ -546,28 +576,32 @@ open class RobolectricHost(
   }
 
   /**
-   * Background-boot path for slots 1..N-1 (see [start]). Sequential like the eager path; stops at
-   * the first slot that fails permanently — [DaemonHostBridge.registerSandbox] claims the first
-   * *free* slot, so booting a later worker past a dead slot would register into the dead slot's
-   * index and strand its own ready latch. A permanent slot failure therefore caps the pool at
-   * [readySlotCount] instead of aborting the whole daemon (the eager path's behaviour): the live
-   * lane degrades to fewer sandboxes rather than collapsing to baked PNGs.
+   * Boots the worker-process slots 1..N-1 (see [start]), sequentially.
    *
-   * After each slot comes up it gets a best-effort [warmSlotRender] so its first affinity-routed
-   * real render doesn't pay the per-sandbox first-render init (Compose runtime, HardwareRenderer
-   * native pipeline, font + text stack, PNG encode). The warm render runs BEFORE the slot is
-   * published into [readySlotCount] — publishing first would let a live render hash onto the
-   * just-advertised slot and queue behind the cold warm-up, putting the very cost the warm-up
-   * absorbs back on the request path.
+   * [background] picks the failure policy, and the split is deliberate:
+   * * `false` (eager boot) — a failed worker throws, and [start] aborts the host. Callers that
+   *   pinned the strict all-sandboxes-ready contract (embedders, `:daemon:harness`, unit tests)
+   *   get told the pool is short rather than silently running degraded.
+   * * `true` (background boot) — a failed worker **caps** the pool at whatever booted, loudly, and
+   *   the daemon keeps serving on its live slots. On the public preview server a single flaky
+   *   worker taking the whole daemon down collapses the live lane to baked PNGs, which is far worse
+   *   than one fewer sandbox.
+   *
+   * Each worker gets a best-effort [warmSlotRender] before it is published into [readySlotCount], so
+   * its first affinity-routed real render doesn't pay the per-sandbox first-render init (Compose
+   * runtime, HardwareRenderer native pipeline, font + text stack, PNG encode). Publishing first
+   * would let a live render hash onto the just-advertised slot and queue behind the cold warm-up.
    */
-  private fun bootRemainingSlotsInBackground(timeoutMs: Long) {
+  private fun bootRemainingSlots(timeoutMs: Long, background: Boolean) {
+    val pool = processPool ?: return
     for (i in 1 until sandboxCount) {
       if (DaemonHostBridge.shutdown.get()) return
       try {
-        bootSlotWithRetries(i, timeoutMs)
+        pool.bootWorker(i - 1)
       } catch (t: Throwable) {
+        if (!background) throw t
         System.err.println(
-          "RobolectricHost: background boot of sandbox slot $i failed permanently " +
+          "RobolectricHost: background boot of sandbox worker $i failed permanently " +
             "(${t.javaClass.simpleName}: ${t.message}); continuing with ${readySlotCount.get()} " +
             "ready sandbox(es) — renders stay up on the booted slots."
         )
@@ -576,7 +610,9 @@ open class RobolectricHost(
       if (DaemonHostBridge.shutdown.get()) return
       warmSlotRender(i)
       readySlotCount.set(i + 1)
-      StartupTimings.mark("sandbox $i ready (background boot)")
+      StartupTimings.mark(
+        if (background) "sandbox $i ready (background boot)" else "sandbox $i ready"
+      )
     }
   }
 
@@ -594,11 +630,25 @@ open class RobolectricHost(
     val id = RenderHost.nextRequestId()
     val startedAt = System.nanoTime()
     try {
-      publishChildLoaderForSlot(slotIdx)
       val payload =
         "className=$WARMUP_PREVIEW_CLASS;functionName=$WARMUP_PREVIEW_FUNCTION;" +
           "widthPx=64;heightPx=64;density=1.0;showBackground=true;" +
           "outputBaseName=__warmup-slot-$slotIdx"
+      // Worker slots: the warm render is a plain remote submit — the worker owns its own child
+      // classloader, so there's nothing to publish across first.
+      if (slotIdx > 0) {
+        val pool = processPool ?: error("warm render on slot $slotIdx without a process pool")
+        pool.submit(
+          slotIdx - 1,
+          RenderRequest.Render(id = id, payload = payload),
+          WARM_RENDER_TIMEOUT_MS,
+        )
+        StartupTimings.mark(
+          "sandbox $slotIdx warm render done (${(System.nanoTime() - startedAt) / 1_000_000}ms)"
+        )
+        return
+      }
+      publishChildLoaderForSlot(slotIdx)
       DaemonHostBridge.slot(slotIdx).requests.put(RenderRequest.Render(id = id, payload = payload))
       val resultQueue = DaemonHostBridge.results.computeIfAbsent(id) { LinkedBlockingQueue() }
       val raw = resultQueue.poll(WARM_RENDER_TIMEOUT_MS, TimeUnit.MILLISECONDS)
@@ -714,6 +764,8 @@ open class RobolectricHost(
    */
   private fun abortPartialStart(bootedThrough: Int) {
     DaemonHostBridge.shutdown.set(true)
+    // Worker JVMs that did come up must not outlive the failed start.
+    processPool?.let { runCatching { it.shutdown(2_000) } }
     val slots = DaemonHostBridge.slots()
     for ((i, slot) in slots.withIndex()) {
       if (i <= bootedThrough) runCatching { slot.requests.put(RenderRequest.Shutdown) }
@@ -797,9 +849,12 @@ open class RobolectricHost(
     // serve stale paint until idle-lease expiry or crash on the next dispatch when the loader's
     // backing JAR is gone.
     forceCloseActiveInteractiveSession(reason = "user classloader swap (source recompile)")
-    for (i in 0 until sandboxCount) {
+    for (i in 0 until LOCAL_SANDBOX_COUNT) {
       perSlotHolders.get(i)?.swap()
     }
+    // #3072 — each worker JVM owns its own child URLClassLoader, so the broadcast has to cross the
+    // process boundary too; otherwise a worker-served preview keeps resolving pre-save bytecode.
+    processPool?.swapUserClassLoaders()
   }
 
   /**
@@ -861,6 +916,15 @@ open class RobolectricHost(
     // pre-pool path (slot 0's `requests` queue is the same instance as the legacy top-level
     // queue).
     val slotIdx = chooseSlotIndex(typed)
+    // #3072 — slots 1..N-1 are worker JVMs. The remote round-trip is a plain request/response over
+    // the worker socket; the result comes back as the same host-side [RenderResult] the in-process
+    // path produces, and a worker-side failure re-throws here as a `RemoteSandboxRenderException`
+    // whose message carries the worker's flattened cause chain, so `JsonRpcServer`'s existing
+    // Throwable path still classifies it into a typed `renderFailed`.
+    if (slotIdx > 0) {
+      val pool = processPool ?: error("slot $slotIdx dispatched with no process pool configured")
+      return pool.submit(slotIdx - 1, typed, timeoutMs)
+    }
     val slot = DaemonHostBridge.slot(slotIdx)
     // Publish the (possibly-just-swapped) child classloader to the slot the render is about to land
     // on. `currentChildLoader()` is lazily allocated on
@@ -1238,8 +1302,9 @@ open class RobolectricHost(
     if (sandboxCount < 2) {
       throw UnsupportedOperationException(
         "RobolectricHost: interactive sessions require sandboxCount >= 2 " +
-          "(have $sandboxCount); v3 pins one sandbox slot per held session and slot 0 must stay " +
-          "available for normal renders. See docs/daemon/INTERACTIVE-ANDROID.md § 2."
+          "(have $sandboxCount); a held session pins the in-process sandbox for its lifetime, so " +
+          "the pool needs at least one worker process left to serve normal renders. See " +
+          "docs/daemon/INTERACTIVE-ANDROID.md § 2 and docs/daemon/SANDBOX-POOL.md."
       )
     }
     val resolver =
@@ -1276,18 +1341,26 @@ open class RobolectricHost(
     inspectionMode: Boolean? = spec.inspectionMode,
     onSessionClosed: (() -> Unit)? = null,
   ): AndroidInteractiveSession {
-    // Background pool boot (see [start]): slot 1 may still be bootstrapping when the first
-    // `interactive/start` arrives. Wait briefly for it rather than failing outright — the slot's
-    // ready latch also counts down on a *failed* boot, so gate on the classloader actually being
-    // registered. A slot that never comes up (permanent background-boot failure) times out here
-    // and surfaces the same clean Unsupported the caller already handles with a v1 fallback.
+    // The interactive slot is the in-process sandbox (slot 0), which `start()` boots eagerly — so
+    // unlike the pre-#3072 shape this never waits on a background boot. The await stays as a cheap
+    // guard for callers that reach acquire before `start()` has returned.
     val interactiveSlot = DaemonHostBridge.slot(INTERACTIVE_SLOT_INDEX)
     interactiveSlot.awaitSandboxReady(INTERACTIVE_START_TIMEOUT_MS)
     if (interactiveSlot.sandboxClassLoaderRef.get() == null) {
       throw UnsupportedOperationException(
         "RobolectricHost: interactive slot $INTERACTIVE_SLOT_INDEX is not booted " +
-          "(ready ${readySlotCount.get()}/$sandboxCount sandboxes) — still warming in the " +
-          "background, or its boot failed permanently. Retry shortly."
+          "(ready ${readySlotCount.get()}/$sandboxCount sandboxes). Retry shortly."
+      )
+    }
+    // Background boot (see [start]) brings the worker processes up after slot 0. Holding a session
+    // while no worker is ready would pin the only dispatchable sandbox and stall every normal
+    // render for the session's lifetime, so report the same clean `Unsupported` the caller already
+    // handles with a v1 fallback and let the panel retry once the pool has filled in.
+    if (readySlotCount.get() < 2) {
+      throw UnsupportedOperationException(
+        "RobolectricHost: no sandbox worker process is ready yet " +
+          "(${readySlotCount.get()}/$sandboxCount sandboxes) — a held session would leave no " +
+          "sandbox for normal renders. Retry shortly."
       )
     }
     val streamId = "android-stream-${nextStreamCounter.getAndIncrement()}"
@@ -1730,6 +1803,17 @@ open class RobolectricHost(
     const val FORENSIC_SURVEY_KEY: String = "survey"
 
     /**
+     * Sandboxes hosted **in this JVM** — always exactly one (issue #3072).
+     *
+     * Robolectric's native-graphics runtime loads `libandroid_runtime.so` once per process and
+     * registers its JNI natives against the first sandbox's instrumented framework classes. A
+     * second sandbox in the same JVM comes up with a `Typeface` whose system font map never
+     * populated and takes the process down with a `SIGSEGV` on the first native text call. So the
+     * pool scales by processes ([SandboxProcessPool]), and this stays 1.
+     */
+    internal const val LOCAL_SANDBOX_COUNT: Int = 1
+
+    /**
      * Affinity-key prefix in the [RenderRequest.Render.payload] used by [chooseSlotIndex].
      * `JsonRpcServer.handleRenderNow` and `PreviewManifestRouter` both encode the previewId here;
      * the dispatch path reads it to pin renders of the same preview to the same sandbox slot.
@@ -1738,12 +1822,20 @@ open class RobolectricHost(
     private const val PREVIEW_ID_KEY: String = "previewId="
 
     /**
-     * INTERACTIVE-ANDROID.md § 7 — slot index pinned to interactive sessions in v3. Slot 0 stays
-     * the always-on normal-render slot; the held-rule loop runs exclusively on slot 1. Any future
-     * multi-target (v4) lift would expand this to a slot range and gate per-session slot allocation
-     * through a free-list.
+     * INTERACTIVE-ANDROID.md § 7 — slot index pinned to interactive sessions.
+     *
+     * **Slot 0, i.e. the in-process sandbox** (changed from slot 1 when the pool moved
+     * out-of-process for #3072). The held-rule loop needs the sandbox that lives in *this* JVM: the
+     * session hands callers an [AndroidInteractiveSession] backed by live bridge queues, frame
+     * latches and a `ComposeTestRule` — object handles, not a serializable request/response pair, so
+     * they cannot be proxied over the worker socket. Normal renders are the ones that serialize
+     * cleanly, so they are what moves to the worker processes: while a session holds slot 0,
+     * [chooseSlotIndex] routes every render to slots 1..N-1.
+     *
+     * Any future multi-target (v4) lift would expand this to a slot range and gate per-session slot
+     * allocation through a free-list.
      */
-    internal const val INTERACTIVE_SLOT_INDEX: Int = 1
+    internal const val INTERACTIVE_SLOT_INDEX: Int = 0
 
     /**
      * Upper bound on `interactive/start` round-trip — sandbox bootstraps the held rule, the
@@ -1772,6 +1864,9 @@ open class RobolectricHost(
     // Background pool boot: give the booter a moment to observe the shutdown flag so it stops
     // spawning/awaiting further workers before we start joining them.
     backgroundBootWorker?.let { runCatching { it.join(2_000) } }
+    // Worker JVMs first: each gets a polite Shutdown over its socket and is force-killed if it
+    // outlives the budget, so a wedged worker can never outlive the daemon that spawned it.
+    processPool?.let { runCatching { it.shutdown(timeoutMs) } }
     workerThreads.forEach { it.join(timeoutMs) }
     // A worker whose sandbox never registered (still inside Robolectric bootstrap when shutdown
     // raced a background pool boot) can't see the poison pill and legitimately outlives the join —
@@ -1787,42 +1882,38 @@ open class RobolectricHost(
     }
   }
 
+  /**
+   * #3072 — no per-worker cache-key discriminator any more. It existed to make Robolectric build N
+   * distinct sandboxes in one JVM, which is exactly the thing that can't work: this JVM hosts one
+   * sandbox and the rest of the pool lives in worker processes. With no discriminator every runner
+   * in this JVM shares one `InstrumentationConfiguration`, which is what lets sequential hosts (test
+   * suites, daemon restarts) reuse the cached sandbox instead of building a second one and tripping
+   * the native-runtime single-classloader constraint.
+   */
   private fun runJUnit(workerIndex: Int) {
-    // Pin the worker-index hint on this thread before invoking JUnit. SandboxHoldingRunner reads
-    // it in `createClassLoaderConfig` to add a synthetic `doNotAcquirePackage` discriminator,
-    // forcing Robolectric to allocate a distinct sandbox per worker. Skip for sandboxCount=1 so
-    // the legacy single-sandbox bootstrap path stays bit-identical with pre-pool code.
-    if (sandboxCount > 1) SandboxHoldingHints.workerIndex.set(workerIndex)
-    try {
-      val result = JUnitCore.runClasses(SandboxRunner::class.java)
-      if (!result.wasSuccessful()) {
-        for (failure in result.failures) {
-          System.err.println(
-            "RobolectricHost SandboxRunner[$workerIndex] failed: ${failure.message}"
-          )
-          failure.exception?.printStackTrace()
-        }
-        // If we exit JUnit before the slot's sandbox-ready latch was tripped, no other path will
-        // unblock `start()`. Stash the underlying exception and trip the latch ourselves so the
-        // awaiting `start()` loop reports the real cause instead of the 600s timeout.
-        // Failures that happen *after* the latch was already counted down (e.g. a render-loop
-        // crash during shutdown) are still logged above but not promoted to a boot error —
-        // `start()` has long since returned by then.
-        val slot = DaemonHostBridge.slot(workerIndex)
-        val latch = slot.sandboxReadyLatchRef.get()
-        if (latch.count > 0L) {
-          val first = result.failures.firstOrNull()
-          val cause = first?.exception
-          val message =
-            "RobolectricHost SandboxRunner[$workerIndex] aborted during sandbox bootstrap " +
-              "(${result.failures.size} JUnit failure(s)). First: " +
-              (first?.message ?: "<no message>")
-          workerBootErrors.set(workerIndex, IllegalStateException(message, cause))
-          latch.countDown()
-        }
-      }
-    } finally {
-      if (sandboxCount > 1) SandboxHoldingHints.workerIndex.remove()
+    val result = JUnitCore.runClasses(SandboxRunner::class.java)
+    if (result.wasSuccessful()) return
+    for (failure in result.failures) {
+      System.err.println("RobolectricHost SandboxRunner[$workerIndex] failed: ${failure.message}")
+      failure.exception?.printStackTrace()
+    }
+    // If we exit JUnit before the slot's sandbox-ready latch was tripped, no other path will
+    // unblock `start()`. Stash the underlying exception and trip the latch ourselves so the
+    // awaiting `start()` loop reports the real cause instead of the 600s timeout.
+    // Failures that happen *after* the latch was already counted down (e.g. a render-loop
+    // crash during shutdown) are still logged above but not promoted to a boot error —
+    // `start()` has long since returned by then.
+    val slot = DaemonHostBridge.slot(workerIndex)
+    val latch = slot.sandboxReadyLatchRef.get()
+    if (latch.count > 0L) {
+      val first = result.failures.firstOrNull()
+      val cause = first?.exception
+      val message =
+        "RobolectricHost SandboxRunner[$workerIndex] aborted during sandbox bootstrap " +
+          "(${result.failures.size} JUnit failure(s)). First: " +
+          (first?.message ?: "<no message>")
+      workerBootErrors.set(workerIndex, IllegalStateException(message, cause))
+      latch.countDown()
     }
   }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -2956,14 +2956,16 @@ open class RobolectricHost(
                 }
                 is InteractiveCommand.FindUiAutomatorEvidence -> {
                   try {
-                    val reason =
-                      UiAutomatorEvidence.compute(
+                    // Serialise inside the sandbox — only a String may cross to the host (the
+                    // reason object is loaded by the instrumenting classloader).
+                    cmd.replyReasonJson.set(
+                      UiAutomatorEvidence.computeJson(
                         rule = rule,
                         actionKind = cmd.actionKind,
                         selectorJson = cmd.selectorJson,
                         useUnmergedTree = cmd.useUnmergedTree,
                       )
-                    cmd.replyReason.set(reason)
+                    )
                   } catch (t: Throwable) {
                     cmd.replyError.set(t)
                   } finally {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -25,29 +25,16 @@ import org.robolectric.internal.bytecode.InstrumentationConfiguration
  * inside [UserClassLoaderHolder]'s `ChildFirstURLClassLoader` to win against the parent — see
  * CLASSLOADER.md for the trade-off discussion.
  *
- * **Sandbox pool (SANDBOX-POOL.md).** When [SandboxHoldingHints.workerIndex] is set on the worker
- * thread that constructs this runner, [createClassLoaderConfig] adds a synthetic per-runner
- * discriminator so each pool worker's [InstrumentationConfiguration] differs and Robolectric's
- * sandbox cache builds a fresh sandbox per worker. Without this, multi-worker hosts share a single
- * cached sandbox (the cache key would be identical) and concurrent renders queue on one
- * single-thread executor.
+ * **Sandbox pool (SANDBOX-POOL.md).** This runner carries no per-worker cache-key discriminator any
+ * more (issue #3072). It had one — a synthetic `doNotAcquireClass` that forced Robolectric to build
+ * a distinct sandbox per pool worker in one JVM — and that is exactly the arrangement Robolectric's
+ * native runtime cannot survive: the second sandbox's `Typeface` init fails against an already-
+ * loaded `libandroid_runtime.so` and the process dies. The pool now scales by processes, one
+ * sandbox each, so every runner in a JVM shares one [InstrumentationConfiguration] and hits
+ * Robolectric's sandbox cache — which is what lets sequential hosts in a test suite reuse one
+ * sandbox instead of building a second.
  */
 open class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(testClass) {
-
-  /**
-   * Snapshot of the worker-index hint at construction time. The ThreadLocal is set on the pool
-   * worker thread before `JUnitCore.runClasses` instantiates the runner; capture it now because
-   * Robolectric subsequently invokes [createClassLoaderConfig] from at least two different threads
-   * (the worker thread initially, then the sandbox's main thread later) and ThreadLocal would
-   * silently miss on the latter — collapsing the cache to a single shared sandbox. Verified
-   * empirically with a probe on Robolectric 4.16.1 (see SANDBOX-POOL.md "Layer 2 — empirical
-   * finding").
-   *
-   * Null when the runner is constructed on a thread without the hint set — i.e., the legacy
-   * single-sandbox path. In that case the discriminator is not applied, preserving cache hits
-   * across runs.
-   */
-  private val poolWorkerIndex: Int? = SandboxHoldingHints.workerIndex.get()
 
   /**
    * Mirrors the `application=android.app.Application` line that
@@ -96,24 +83,6 @@ open class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(tes
     val builder =
       InstrumentationConfiguration.Builder(super.createClassLoaderConfig(method))
         .doNotAcquirePackage("ee.schimke.composeai.daemon.bridge")
-    // SANDBOX-POOL.md (Layer 2) — pool discriminator. Two interlocking subtleties:
-    //
-    //   1. Use `doNotAcquireClass`, not `doNotAcquirePackage`. Robolectric's
-    //      [InstrumentationConfiguration.equals] checks `classesToNotAcquire` but NOT
-    //      `packagesToNotAcquire` — verified empirically via `javap -c` on Robolectric 4.16.1.
-    //      A package-level discriminator silently collides on the cache key.
-    //   2. Read the snapshot, NOT the ThreadLocal. Robolectric calls this method twice for one
-    //      runner — first on the worker thread, then on the sandbox's main thread — and
-    //      ThreadLocal.get on the second call returns null (different thread). Snapshotting in
-    //      the constructor (which runs on the worker thread under JUnitCore.runClasses) keeps the
-    //      discriminator stable across both calls. The runner instance's identity hash is the
-    //      discriminator value so per-runner configs stay distinct.
-    //
-    // The synthetic class name never matches a real class — it exists purely to break the cache
-    // key.
-    if (poolWorkerIndex != null) {
-      builder.doNotAcquireClass("composeai.sandbox.uniq.Runner${System.identityHashCode(this)}")
-    }
     // Coil 2's `AsyncImagePainter` lives in a plain library package, which Robolectric does NOT
     // instrument by default — and an uninstrumented class can't be shadowed. Instrument it so
     // [ee.schimke.composeai.renderer.ShadowAsyncImagePainter] (registered in `getExtraShadows`
@@ -293,27 +262,3 @@ internal fun isRemoteComposeAvailable(loader: ClassLoader?): Boolean {
   }
 }
 
-/**
- * Cross-thread hints consumed by [SandboxHoldingRunner] during sandbox bootstrap. Lives at file
- * scope (not on a companion) so set/get is cheap and readable without instantiating a runner.
- *
- * Used by SANDBOX-POOL.md (Layer 2) — the host's pool worker thread sets [workerIndex] before
- * calling `JUnitCore.runClasses` so each pool worker bootstraps a distinct Robolectric sandbox
- * (otherwise the sandbox cache key — which includes the [InstrumentationConfiguration] — matches
- * across workers and the pool collapses to a single cached sandbox).
- */
-internal object SandboxHoldingHints {
-  /**
-   * Worker index hint. Non-null on the pool worker thread between
-   * [ee.schimke.composeai.daemon.RobolectricHost.runJUnit]'s `set` and `remove` calls; null
-   * otherwise so the pre-pool single-sandbox bootstrap path keeps its historical
-   * [InstrumentationConfiguration] (and therefore Robolectric's sandbox cache hits across runs).
-   *
-   * Read **only** at runner construction (snapshotted into [SandboxHoldingRunner.poolWorkerIndex]).
-   * Reading it elsewhere — particularly inside [SandboxHoldingRunner.createClassLoaderConfig] —
-   * silently misses on the second invocation (which Robolectric makes on the sandbox's main thread,
-   * where the ThreadLocal isn't set), so the discriminator vanishes and the cache key collapses
-   * across workers.
-   */
-  val workerIndex: ThreadLocal<Int?> = ThreadLocal()
-}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/UiAutomatorEvidence.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/UiAutomatorEvidence.kt
@@ -47,6 +47,30 @@ internal object UiAutomatorEvidence {
     prettyPrint = false
   }
 
+  /**
+   * [compute], serialised for the sandbox→host hop.
+   *
+   * [compute] runs under Robolectric's instrumenting classloader, so the [UiAutomatorUnsupportedReason]
+   * it returns is loaded by the sandbox — handing that reference to the host fails the host-side cast
+   * with a same-name `ClassCastException`. Only a String may cross, exactly as
+   * `ComposeSemanticsDataProducer.probeNodesJson` does for probe nodes and `CaptureA11yFindings` does
+   * for ATF findings; [decode] re-parses it into the host's own class.
+   */
+  fun computeJson(
+    rule: AndroidComposeTestRule<*, androidx.activity.ComponentActivity>,
+    actionKind: String,
+    selectorJson: String,
+    useUnmergedTree: Boolean,
+  ): String =
+    WireJson.encodeToString(
+      UiAutomatorUnsupportedReason.serializer(),
+      compute(rule, actionKind, selectorJson, useUnmergedTree),
+    )
+
+  /** Host-side inverse of [computeJson]. */
+  fun decode(json: String): UiAutomatorUnsupportedReason =
+    WireJson.decodeFromString(UiAutomatorUnsupportedReason.serializer(), json)
+
   fun compute(
     rule: AndroidComposeTestRule<*, androidx.activity.ComponentActivity>,
     actionKind: String,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -610,8 +610,14 @@ sealed interface InteractiveCommand {
     val inputText: String?,
     val replyLatch: CountDownLatch,
     val replyError: AtomicReference<Throwable?>,
-    val replyReason:
-      AtomicReference<ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason?>,
+    /**
+     * The evidence as a JSON string (do-not-acquire), not a typed
+     * `UiAutomatorUnsupportedReason` — same boundary rule as [CaptureProbeSemantics.replyNodesJson]
+     * and [CaptureA11yFindings.replyFindingsJson]. The reason object is built under Robolectric's
+     * instrumenting classloader, so a typed reference arrives host-side as a sandbox-loaded object
+     * and fails the host cast with a same-name `ClassCastException`.
+     */
+    val replyReasonJson: AtomicReference<String?>,
   ) : InteractiveCommand
 
   /**

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPool.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPool.kt
@@ -1,0 +1,353 @@
+package ee.schimke.composeai.daemon.pool
+
+import ee.schimke.composeai.daemon.RenderRequest
+import ee.schimke.composeai.daemon.RenderResult
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.lang.management.ManagementFactory
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Out-of-process sandbox pool (issue #3072) — the parent half.
+ *
+ * Robolectric's native-graphics runtime binds to a **single classloader per process**: it loads
+ * `libandroid_runtime.so` once and registers its JNI natives against whichever sandbox's
+ * instrumented framework classes reach it first. A second sandbox in the same JVM boots with a
+ * `Typeface` whose system font map never populated, and the first native call that touches it takes
+ * the whole process down with a `SIGSEGV`. That is a hard, load-once-per-JVM constraint, not a
+ * version bug — so extra sandboxes get extra **processes**.
+ *
+ * Each worker is a plain JVM (`java -cp <this JVM's classpath> …SandboxWorkerMain`) hosting exactly
+ * one Robolectric sandbox, talking newline-delimited JSON ([WorkerRequest] / [WorkerResponse]) over
+ * a loopback socket that the *parent* listens on and the worker dials back. Listening in the parent
+ * means no port has to be agreed in advance and a worker that dies before connecting fails the
+ * accept with a clear diagnostic rather than hanging on a connect retry loop.
+ *
+ * Threading: one outstanding request per worker, guarded by that worker's [Worker.lock]. That is
+ * the same contract an in-JVM slot had — a sandbox renders one preview at a time — so the pool adds
+ * no new concurrency semantics, only a process boundary.
+ */
+class SandboxProcessPool(
+  /** Number of worker processes; equals `sandboxCount - 1` (slot 0 stays in the daemon JVM). */
+  val workerCount: Int,
+  /** Wall-clock budget for a worker's `java` launch + Robolectric boot + ready handshake. */
+  private val bootTimeoutMs: Long,
+  /**
+   * Test seam: extra system properties handed to every worker. Production passes nothing — workers
+   * inherit the daemon's own `composeai.*` / `robolectric.*` properties (see [workerSysprops]).
+   */
+  private val extraSysprops: Map<String, String> = emptyMap(),
+) : AutoCloseable {
+
+  private class Worker(
+    val index: Int,
+    val process: Process,
+    val socket: Socket,
+    val reader: BufferedReader,
+    val writer: BufferedWriter,
+    val pid: Long,
+  ) {
+    val lock = ReentrantLock()
+    @Volatile var dead: Boolean = false
+  }
+
+  private val workers = arrayOfNulls<Worker>(workerCount)
+
+  /**
+   * Bound lazily on the first [bootWorker] so a host that never starts its pool (`sandboxCount = 1`,
+   * or a host constructed but never started) opens no socket at all. Loopback-bound: workers are
+   * always local children.
+   */
+  private var serverSocket: ServerSocket? = null
+
+  private val serverLock = ReentrantLock()
+
+  @Volatile private var closed = false
+
+  private fun ensureServerSocket(): ServerSocket =
+    serverLock.withLock {
+      serverSocket
+        ?: ServerSocket(0, workerCount + 4, InetAddress.getLoopbackAddress()).also {
+          serverSocket = it
+        }
+    }
+
+  /**
+   * Spawns worker [index] and blocks until it reports [WorkerResponse.Ready] (its Robolectric
+   * sandbox is booted and it is polling for renders). Throws on launch failure, accept timeout, or
+   * a worker-side boot failure — the caller decides whether that caps the pool (background boot) or
+   * aborts the host (eager boot), exactly as the in-JVM path did.
+   */
+  fun bootWorker(index: Int) {
+    require(index in 0 until workerCount) { "worker index $index out of range 0..${workerCount - 1}" }
+    check(!closed) { "SandboxProcessPool is closed" }
+    val server = ensureServerSocket()
+    val process = launchWorkerProcess(index, server.localPort)
+    val socket =
+      try {
+        server.soTimeout = bootTimeoutMs.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+        server.accept()
+      } catch (t: Throwable) {
+        process.destroyForcibly()
+        throw IllegalStateException(
+          "sandbox worker $index never connected back within ${bootTimeoutMs}ms " +
+            "(exited=${!process.isAlive}); see the [sandbox-worker-$index] stderr above.",
+          t,
+        )
+      }
+    socket.tcpNoDelay = true
+    val reader = BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.UTF_8))
+    val writer = BufferedWriter(OutputStreamWriter(socket.getOutputStream(), Charsets.UTF_8))
+    // The worker boots its sandbox *after* connecting, so the ready line can take as long as a
+    // Robolectric bootstrap. Reuse the boot budget for it rather than a socket-level default.
+    socket.soTimeout = bootTimeoutMs.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+    val hello =
+      try {
+        readResponse(reader)
+      } catch (t: Throwable) {
+        process.destroyForcibly()
+        throw IllegalStateException("sandbox worker $index died before reporting ready", t)
+      }
+    when (hello) {
+      is WorkerResponse.Ready -> {
+        socket.soTimeout = 0
+        workers[index] = Worker(index, process, socket, reader, writer, hello.pid)
+        System.err.println(
+          "compose-ai-daemon: sandbox worker $index ready (pid=${hello.pid}, port=${server.localPort})"
+        )
+      }
+      is WorkerResponse.BootFailed -> {
+        process.destroyForcibly()
+        error("sandbox worker $index failed to boot its Robolectric sandbox: ${hello.diagnostic}")
+      }
+      else -> {
+        process.destroyForcibly()
+        error("sandbox worker $index sent $hello before reporting ready")
+      }
+    }
+  }
+
+  /** True once [bootWorker] has completed for [index] and the worker is still alive. */
+  fun isReady(index: Int): Boolean = workers.getOrNull(index)?.let { !it.dead } == true
+
+  /** Worker process ids, in slot order; `null` for slots that never booted. Diagnostics + tests. */
+  fun workerPids(): List<Long?> = workers.map { if (it?.dead == false) it.pid else null }
+
+  /**
+   * Dispatches [request] to worker [index] and blocks for its result. Re-throws a worker-side render
+   * failure as a [RemoteSandboxRenderException] carrying the worker's flattened cause chain, so
+   * `JsonRpcServer`'s existing Throwable path turns it into the same typed `renderFailed` an
+   * in-process failure produces.
+   */
+  fun submit(index: Int, request: RenderRequest.Render, timeoutMs: Long): RenderResult {
+    val worker =
+      workers.getOrNull(index)?.takeIf { !it.dead }
+        ?: error("sandbox worker $index is not ready (pool of $workerCount)")
+    return worker.lock.withLock {
+      val response =
+        exchange(
+          worker,
+          WorkerRequest.Render(id = request.id, payload = request.payload, timeoutMs = timeoutMs),
+          // Give the socket read a margin over the render budget so a worker that answers just
+          // inside its own deadline still beats ours.
+          readTimeoutMs = timeoutMs + SOCKET_READ_MARGIN_MS,
+        )
+      when (response) {
+        is WorkerResponse.Result -> response.result.toRenderResult()
+        is WorkerResponse.Failed -> throw RemoteSandboxRenderException(response.diagnostic)
+        else -> error("sandbox worker $index answered a render with $response")
+      }
+    }
+  }
+
+  /**
+   * Broadcasts `swapUserClassLoaders` to every live worker. Best-effort per worker: a worker that
+   * fails to answer is marked dead and logged rather than failing the whole hot-reload — the host
+   * keeps serving on its remaining slots.
+   */
+  fun swapUserClassLoaders() {
+    for (worker in workers) {
+      if (worker == null || worker.dead) continue
+      try {
+        worker.lock.withLock { exchange(worker, WorkerRequest.Swap, readTimeoutMs = SWAP_TIMEOUT_MS) }
+      } catch (t: Throwable) {
+        markDead(worker, "classloader swap failed", t)
+      }
+    }
+  }
+
+  /** Politely stops every worker, then force-kills anything still alive after [timeoutMs]. */
+  fun shutdown(timeoutMs: Long) {
+    closed = true
+    for (worker in workers) {
+      if (worker == null) continue
+      runCatching {
+        worker.lock.withLock {
+          if (!worker.dead) exchange(worker, WorkerRequest.Shutdown, readTimeoutMs = timeoutMs)
+        }
+      }
+      runCatching { worker.socket.close() }
+      if (!worker.process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)) {
+        System.err.println(
+          "compose-ai-daemon: sandbox worker ${worker.index} (pid=${worker.pid}) did not exit " +
+            "within ${timeoutMs}ms; killing"
+        )
+        worker.process.destroyForcibly()
+      }
+      worker.dead = true
+    }
+    runCatching { serverLock.withLock { serverSocket?.close() } }
+  }
+
+  override fun close() = shutdown(SHUTDOWN_TIMEOUT_MS)
+
+  private fun markDead(worker: Worker, what: String, cause: Throwable) {
+    worker.dead = true
+    System.err.println(
+      "compose-ai-daemon: sandbox worker ${worker.index} (pid=${worker.pid}) $what " +
+        "(${cause.javaClass.simpleName}: ${cause.message}); dropping it from the pool"
+    )
+    runCatching { worker.socket.close() }
+    runCatching { worker.process.destroyForcibly() }
+  }
+
+  private fun exchange(
+    worker: Worker,
+    request: WorkerRequest,
+    readTimeoutMs: Long,
+  ): WorkerResponse {
+    try {
+      worker.socket.soTimeout = readTimeoutMs.coerceIn(1L, Int.MAX_VALUE.toLong()).toInt()
+      worker.writer.write(workerJson.encodeToString(WorkerRequest.serializer(), request))
+      worker.writer.write("\n")
+      worker.writer.flush()
+      return readResponse(worker.reader)
+    } catch (t: Throwable) {
+      markDead(worker, "died mid-request", t)
+      throw IllegalStateException(
+        "sandbox worker ${worker.index} (pid=${worker.pid}) failed while handling $request",
+        t,
+      )
+    }
+  }
+
+  private fun readResponse(reader: BufferedReader): WorkerResponse {
+    val line = reader.readLine() ?: error("sandbox worker closed its socket (EOF)")
+    return workerJson.decodeFromString(WorkerResponse.serializer(), line)
+  }
+
+  private fun launchWorkerProcess(index: Int, port: Int): Process {
+    val java = File(File(System.getProperty("java.home"), "bin"), "java").absolutePath
+    val command = buildList {
+      add(java)
+      addAll(inheritedJvmArgs())
+      addAll(workerSysprops(index, port).map { (k, v) -> "-D$k=$v" })
+      add("-cp")
+      add(System.getProperty("java.class.path") ?: "")
+      add(SandboxWorkerMain::class.java.name)
+    }
+    val process =
+      ProcessBuilder(command)
+        .redirectErrorStream(false)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+    // The worker speaks its protocol over the socket, so both of its stdio streams are pure
+    // diagnostics — pump them onto the daemon's stderr with a slot tag. Unpumped pipes fill and
+    // deadlock a chatty Robolectric bootstrap, so this is load-bearing, not just nice logging.
+    pumpToStderr(process.errorStream, "sandbox-worker-$index")
+    pumpToStderr(process.inputStream, "sandbox-worker-$index")
+    return process
+  }
+
+  private fun pumpToStderr(stream: java.io.InputStream, tag: String) {
+    Thread({
+        stream.bufferedReader().useLines { lines ->
+          for (line in lines) System.err.println("[$tag] $line")
+        }
+      }, "compose-ai-$tag-log")
+      .apply {
+        isDaemon = true
+        start()
+      }
+  }
+
+  /**
+   * JVM flags the worker inherits from the daemon JVM: heap sizing, GC, `--add-opens`, and the
+   * module flags Robolectric needs. Deliberately dropped: anything that must not be duplicated in a
+   * second process — a debugger/JDWP port (would fail to bind), JaCoCo/agent attachments (would
+   * write to the same exec file), and the pool's own properties, which [workerSysprops] re-derives.
+   */
+  private fun inheritedJvmArgs(): List<String> =
+    ManagementFactory.getRuntimeMXBean().inputArguments.filter { arg ->
+      when {
+        arg.startsWith("-agentlib:") -> false
+        arg.startsWith("-agentpath:") -> false
+        arg.startsWith("-javaagent:") -> false
+        arg.startsWith("-Xrunjdwp") -> false
+        arg.startsWith("-D") -> false // re-derived below, minus the pool-control properties
+        else -> true
+      }
+    }
+
+  /**
+   * System properties the worker needs. The `composeai.*` / `robolectric.*` / `android.*` families
+   * carry everything that shapes a render — user-class dirs, the SDK pin, Robolectric's offline /
+   * dependency-dir settings, feature flags — so forwarding them wholesale keeps a worker's render
+   * configured identically to the daemon's own sandbox.
+   *
+   * Overridden per worker: `sandboxCount` is forced to 1 (a worker JVM hosts exactly one sandbox —
+   * the whole point), background boot is off (the worker's own `start()` must block until its
+   * sandbox is up, because that is what the ready handshake means), and the boot-time warm render is
+   * left to the parent, which already warms each slot as it comes up.
+   */
+  private fun workerSysprops(index: Int, port: Int): Map<String, String> {
+    val forwarded = linkedMapOf<String, String>()
+    for ((rawKey, rawValue) in System.getProperties()) {
+      val key = rawKey as? String ?: continue
+      val value = rawValue as? String ?: continue
+      if (FORWARDED_PREFIXES.any { key.startsWith(it) }) forwarded[key] = value
+    }
+    forwarded.keys.removeAll(WORKER_OVERRIDDEN_PROPS)
+    forwarded[SANDBOX_COUNT_PROP] = "1"
+    forwarded[WORKER_PORT_PROP] = port.toString()
+    forwarded[WORKER_SLOT_PROP] = index.toString()
+    forwarded.putAll(extraSysprops)
+    return forwarded
+  }
+
+  companion object {
+    const val WORKER_PORT_PROP: String = "composeai.daemon.sandboxWorker.port"
+    const val WORKER_SLOT_PROP: String = "composeai.daemon.sandboxWorker.slot"
+
+    private const val SANDBOX_COUNT_PROP = "composeai.daemon.sandboxCount"
+
+    private val FORWARDED_PREFIXES = listOf("composeai.", "robolectric.", "android.", "roborazzi.")
+
+    /**
+     * Pool-control properties a worker must never inherit verbatim: the pool size (a worker hosts
+     * one sandbox), background boot (the ready handshake requires an eager boot), and the parent's
+     * own worker coordinates when a worker somehow spawns from a worker.
+     */
+    private val WORKER_OVERRIDDEN_PROPS =
+      setOf(
+        SANDBOX_COUNT_PROP,
+        "composeai.daemon.backgroundSandboxBoot",
+        "composeai.daemon.warmRenderOnBoot",
+        WORKER_PORT_PROP,
+        WORKER_SLOT_PROP,
+      )
+
+    private const val SOCKET_READ_MARGIN_MS = 15_000L
+    private const val SWAP_TIMEOUT_MS = 30_000L
+    private const val SHUTDOWN_TIMEOUT_MS = 30_000L
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxWorkerMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxWorkerMain.kt
@@ -38,6 +38,19 @@ object SandboxWorkerMain {
     val slot = System.getProperty(SandboxProcessPool.WORKER_SLOT_PROP)?.toIntOrNull() ?: 0
     Thread.currentThread().name = "compose-ai-sandbox-worker-$slot"
 
+    // A worker must never outlive the daemon that spawned it. Socket EOF covers the normal case,
+    // but only once the serve loop is reading — a parent that dies while this worker is still
+    // inside its (minutes-long) Robolectric bootstrap would leave a whole JVM stranded, holding a
+    // sandbox's worth of heap until something reaps it. Watch the parent process directly so the
+    // boot window is covered too. The daemon's own test JVM aborting mid-suite (SIGABRT out of
+    // `libandroid_runtime.so`) is exactly that case.
+    ProcessHandle.current().parent().ifPresent { parent ->
+      parent.onExit().thenRun {
+        System.err.println("sandbox worker: parent process ${parent.pid()} exited; halting")
+        Runtime.getRuntime().halt(0)
+      }
+    }
+
     Socket(InetAddress.getLoopbackAddress(), port).use { socket ->
       socket.tcpNoDelay = true
       val reader = BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.UTF_8))

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxWorkerMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxWorkerMain.kt
@@ -1,0 +1,118 @@
+package ee.schimke.composeai.daemon.pool
+
+import ee.schimke.composeai.daemon.RenderRequest
+import ee.schimke.composeai.daemon.RobolectricHost
+import ee.schimke.composeai.daemon.UserClassLoaderHolder
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.InetAddress
+import java.net.Socket
+
+/**
+ * Out-of-process sandbox pool (issue #3072) — the child half. One worker JVM hosts exactly **one**
+ * Robolectric sandbox, which is the constraint the whole pool exists to respect: Robolectric's
+ * native runtime binds to a single classloader per process.
+ *
+ * The worker is deliberately *not* a daemon. It has no preview index, no extension registry, no
+ * watch state and no JSON-RPC surface: the parent daemon resolves a `previewId` into a full spec
+ * payload before it dispatches, and re-runs the host-side data products on the result it gets back.
+ * All the worker owns is a `RobolectricHost(sandboxCount = 1)` — the exact same single-sandbox host
+ * the daemon has always run — plus a socket loop.
+ *
+ * Lifecycle: dial the parent's loopback port, boot the sandbox, send [WorkerResponse.Ready] (or
+ * [WorkerResponse.BootFailed]), then serve requests until [WorkerRequest.Shutdown] or EOF. EOF is a
+ * shutdown too — if the parent daemon dies, its workers must not survive it and leak a JVM each.
+ */
+object SandboxWorkerMain {
+
+  @JvmStatic
+  fun main(args: Array<String>) {
+    val port =
+      System.getProperty(SandboxProcessPool.WORKER_PORT_PROP)?.toIntOrNull()
+        ?: error(
+          "${SandboxProcessPool.WORKER_PORT_PROP} is unset — SandboxWorkerMain is spawned by " +
+            "SandboxProcessPool, not run directly"
+        )
+    val slot = System.getProperty(SandboxProcessPool.WORKER_SLOT_PROP)?.toIntOrNull() ?: 0
+    Thread.currentThread().name = "compose-ai-sandbox-worker-$slot"
+
+    Socket(InetAddress.getLoopbackAddress(), port).use { socket ->
+      socket.tcpNoDelay = true
+      val reader = BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.UTF_8))
+      val writer = BufferedWriter(OutputStreamWriter(socket.getOutputStream(), Charsets.UTF_8))
+
+      val host =
+        RobolectricHost(
+          sandboxCount = 1,
+          // Same derivation DaemonMain uses, from the `composeai.daemon.userClassDirs` sysprop the
+          // pool forwards. Unset (in-process tests, no hot-reload wiring) → null → the worker
+          // resolves preview classes off its own sandbox classpath, like a single-sandbox daemon.
+          userClassloaderHolderFactory =
+            UserClassLoaderHolder.urlsFromSysprop().takeIf { it.isNotEmpty() }?.let { urls ->
+              { sandboxClassLoader: ClassLoader ->
+                UserClassLoaderHolder(urls = urls, parentSupplier = { sandboxClassLoader })
+              }
+            },
+        )
+      try {
+        host.start()
+      } catch (t: Throwable) {
+        send(writer, WorkerResponse.BootFailed(slot = slot, diagnostic = flattenDiagnostic(t)))
+        return
+      }
+      send(writer, WorkerResponse.Ready(slot = slot, pid = ProcessHandle.current().pid()))
+
+      serve(host, reader, writer)
+      runCatching { host.shutdown() }
+    }
+    // Robolectric leaves non-daemon threads (the sandbox's `SDK Main Thread`) behind, so a plain
+    // return from main would not end the JVM. The parent has its result; leave deliberately.
+    Runtime.getRuntime().halt(0)
+  }
+
+  private fun serve(host: RobolectricHost, reader: BufferedReader, writer: BufferedWriter) {
+    while (true) {
+      val line = reader.readLine() ?: return // parent closed the socket / died — exit with it
+      val request =
+        try {
+          workerJson.decodeFromString(WorkerRequest.serializer(), line)
+        } catch (t: Throwable) {
+          System.err.println("sandbox worker: undecodable request '$line': $t")
+          continue
+        }
+      when (request) {
+        is WorkerRequest.Render -> {
+          val response =
+            try {
+              val result =
+                host.submit(
+                  RenderRequest.Render(id = request.id, payload = request.payload),
+                  timeoutMs = request.timeoutMs,
+                )
+              WorkerResponse.Result(RenderResultDto.of(result))
+            } catch (t: Throwable) {
+              WorkerResponse.Failed(id = request.id, diagnostic = flattenDiagnostic(t))
+            }
+          send(writer, response)
+        }
+        WorkerRequest.Swap -> {
+          runCatching { host.swapUserClassLoaders() }
+            .onFailure { System.err.println("sandbox worker: classloader swap failed: $it") }
+          send(writer, WorkerResponse.Ok)
+        }
+        WorkerRequest.Shutdown -> {
+          send(writer, WorkerResponse.Ok)
+          return
+        }
+      }
+    }
+  }
+
+  private fun send(writer: BufferedWriter, response: WorkerResponse) {
+    writer.write(workerJson.encodeToString(WorkerResponse.serializer(), response))
+    writer.write("\n")
+    writer.flush()
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxWorkerProtocol.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxWorkerProtocol.kt
@@ -1,0 +1,241 @@
+package ee.schimke.composeai.daemon.pool
+
+import ee.schimke.composeai.daemon.MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY
+import ee.schimke.composeai.daemon.RenderResult
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.PreviewDeviceContext
+import ee.schimke.composeai.data.render.PreviewDeviceSpec
+import ee.schimke.composeai.data.theme.ThemePayload
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Wire types for the out-of-process sandbox pool (issue #3072) — one newline-delimited JSON message
+ * per line over a loopback socket between [SandboxProcessPool] (parent, in the daemon JVM) and
+ * [SandboxWorkerMain] (child, one Robolectric sandbox per JVM).
+ *
+ * **Why a bespoke protocol and not the daemon's own JSON-RPC?** The worker is not a daemon: it
+ * owns no preview index, no extension registry, no watch state. The parent resolves `previewId` to
+ * a full spec payload *before* dispatch (`RobolectricHost.submit`'s `reshapeRenderPayload`), so the
+ * only things that need to cross the process boundary are a spec payload in and a [RenderResult]
+ * out. Three message kinds each way is the whole surface.
+ *
+ * **Why the result survives the trip intact.** `RobolectricHost` already reduces a sandbox-side
+ * `RenderResult` to plain data before handing it to callers — `copyPreviewContextAcrossClassloaders`
+ * copies the device context and the Material3 theme payload and deliberately drops the live
+ * `slotTables` / `rootForTest` handles, which are Compose objects the host classloader can't use
+ * anyway. Everything that survives that copy is a `String`/number/`Map`, so [RenderResultDto] is a
+ * faithful carrier: a render served by a worker process yields the same host-side `RenderResult` as
+ * one served in-process, and the host-side data products (`ExtensionRegistry.onRender`) see the
+ * same input either way.
+ */
+@Serializable
+sealed interface WorkerRequest {
+
+  /** Render [payload] (an already-resolved `key=value;…` spec payload) and reply with the result. */
+  @Serializable
+  @SerialName("render")
+  data class Render(val id: Long, val payload: String, val timeoutMs: Long) : WorkerRequest
+
+  /**
+   * Broadcast of `RenderHost.swapUserClassLoaders` — the worker drops its child `URLClassLoader` so
+   * the next render resolves recompiled user bytecode. Replies [WorkerResponse.Ok].
+   */
+  @Serializable @SerialName("swap") data object Swap : WorkerRequest
+
+  /** Drain and exit. The worker replies [WorkerResponse.Ok] and then closes the socket. */
+  @Serializable @SerialName("shutdown") data object Shutdown : WorkerRequest
+}
+
+@Serializable
+sealed interface WorkerResponse {
+
+  /**
+   * Sent once, unsolicited, after the worker's Robolectric sandbox has booted. [pid] is the
+   * worker's own process id — the pool surfaces it in diagnostics and the pool test asserts on it
+   * to prove slots really are distinct processes.
+   */
+  @Serializable
+  @SerialName("ready")
+  data class Ready(val slot: Int, val pid: Long) : WorkerResponse
+
+  /** Sent instead of [Ready] when the worker's sandbox never came up. */
+  @Serializable
+  @SerialName("bootFailed")
+  data class BootFailed(val slot: Int, val diagnostic: String) : WorkerResponse
+
+  /** Successful render. */
+  @Serializable
+  @SerialName("result")
+  data class Result(val result: RenderResultDto) : WorkerResponse
+
+  /**
+   * Failed render. [diagnostic] is the flattened `class: message` cause chain of the worker-side
+   * throwable — `RenderErrorClassifier` matches on exactly that text, so a remote failure classifies
+   * into the same `renderFailed.kind` an in-process one would.
+   */
+  @Serializable
+  @SerialName("failed")
+  data class Failed(val id: Long, val diagnostic: String) : WorkerResponse
+
+  /** Acknowledgement for the non-render requests. */
+  @Serializable @SerialName("ok") data object Ok : WorkerResponse
+}
+
+@Serializable
+data class RenderResultDto(
+  val id: Long,
+  val classLoaderHashCode: Int,
+  val classLoaderName: String,
+  val pngPath: String? = null,
+  val metrics: Map<String, Long>? = null,
+  val previewContext: PreviewContextDto? = null,
+) {
+  fun toRenderResult(): RenderResult =
+    RenderResult(
+      id = id,
+      classLoaderHashCode = classLoaderHashCode,
+      classLoaderName = classLoaderName,
+      pngPath = pngPath,
+      metrics = metrics?.let { LinkedHashMap(it) },
+      previewContext = previewContext?.toPreviewContext(),
+    )
+
+  companion object {
+    fun of(result: RenderResult): RenderResultDto =
+      RenderResultDto(
+        id = result.id,
+        classLoaderHashCode = result.classLoaderHashCode,
+        classLoaderName = result.classLoaderName,
+        pngPath = result.pngPath,
+        metrics = result.metrics,
+        previewContext = result.previewContext?.let(PreviewContextDto::of),
+      )
+  }
+}
+
+/**
+ * The serializable projection of [PreviewContext] — exactly the fields
+ * `RobolectricHost.copyPreviewContextAcrossClassloaders` already carries across the sandbox
+ * classloader boundary. Keep the two in sync: a field that starts surviving the classloader copy
+ * has to be added here too, or worker-served renders would silently lose it.
+ */
+@Serializable
+data class PreviewContextDto(
+  val previewId: String? = null,
+  val backend: String? = null,
+  val renderMode: String? = null,
+  val outputBaseName: String? = null,
+  val device: PreviewDeviceContextDto? = null,
+  val parameterInformationCollected: Boolean = false,
+  val themePayload: ThemePayload? = null,
+) {
+  fun toPreviewContext(): PreviewContext {
+    val builder =
+      PreviewContext.Builder(
+        previewId = previewId,
+        backend = backend,
+        renderMode = renderMode,
+        outputBaseName = outputBaseName,
+      )
+    device?.let { builder.device(it.toDeviceContext()) }
+    if (parameterInformationCollected) builder.parameterInformationCollected()
+    themePayload?.let { builder.putInspectionValue(MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY, it) }
+    return builder.build()
+  }
+
+  companion object {
+    fun of(context: PreviewContext): PreviewContextDto =
+      PreviewContextDto(
+        previewId = context.previewId,
+        backend = context.backend,
+        renderMode = context.renderMode,
+        outputBaseName = context.outputBaseName,
+        device = PreviewDeviceContextDto.of(context.device),
+        parameterInformationCollected = context.inspection.parameterInformationCollected,
+        themePayload = context.inspection.values[MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY] as? ThemePayload,
+      )
+  }
+}
+
+@Serializable
+data class PreviewDeviceContextDto(
+  val device: String? = null,
+  val widthDp: Double? = null,
+  val heightDp: Double? = null,
+  val density: Float? = null,
+  val resolvedDevice: PreviewDeviceSpecDto? = null,
+) {
+  fun toDeviceContext(): PreviewDeviceContext =
+    PreviewDeviceContext(
+      device = device,
+      widthDp = widthDp,
+      heightDp = heightDp,
+      density = density,
+      resolvedDevice = resolvedDevice?.toSpec(),
+    )
+
+  companion object {
+    fun of(device: PreviewDeviceContext): PreviewDeviceContextDto =
+      PreviewDeviceContextDto(
+        device = device.device,
+        widthDp = device.widthDp,
+        heightDp = device.heightDp,
+        density = device.density,
+        resolvedDevice = device.resolvedDevice?.let(PreviewDeviceSpecDto::of),
+      )
+  }
+}
+
+@Serializable
+data class PreviewDeviceSpecDto(
+  val widthDp: Int,
+  val heightDp: Int,
+  val density: Float,
+  val isRound: Boolean = false,
+) {
+  fun toSpec(): PreviewDeviceSpec =
+    PreviewDeviceSpec(
+      widthDp = widthDp,
+      heightDp = heightDp,
+      density = density,
+      isRound = isRound,
+    )
+
+  companion object {
+    fun of(spec: PreviewDeviceSpec): PreviewDeviceSpecDto =
+      PreviewDeviceSpecDto(
+        widthDp = spec.widthDp,
+        heightDp = spec.heightDp,
+        density = spec.density,
+        isRound = spec.isRound,
+      )
+  }
+}
+
+/** Shared codec. `encodeDefaults = false` keeps the per-render line small. */
+internal val workerJson: Json = Json {
+  ignoreUnknownKeys = true
+  encodeDefaults = false
+  classDiscriminator = "type"
+}
+
+/** Flattens a cause chain into the `class: message` text `RenderErrorClassifier` matches on. */
+internal fun flattenDiagnostic(t: Throwable, maxDepth: Int = 10): String = buildString {
+  var cause: Throwable? = t
+  var depth = 0
+  while (cause != null && depth < maxDepth) {
+    append(cause.javaClass.name).append(": ").append(cause.message ?: "").append('\n')
+    cause = cause.cause
+    depth++
+  }
+  append(t.stackTraceToString().lineSequence().take(40).joinToString("\n"))
+}
+
+/**
+ * Host-side stand-in for a throwable raised inside a worker process. Carries the worker's flattened
+ * cause chain as its message so `RenderErrorClassifier.classify` produces the same `renderFailed`
+ * kind + suggestion an in-process failure would.
+ */
+class RemoteSandboxRenderException(diagnostic: String) : RuntimeException(diagnostic)

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
@@ -9,34 +9,27 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * SANDBOX-POOL.md Layer 2 — boots [RobolectricHost] with `sandboxCount = 2`, submits a spread of
- * stub renders, and asserts that:
+ * SANDBOX-POOL.md — boots [RobolectricHost] with `sandboxCount = 2` and asserts the pool's
+ * load-bearing properties in its **out-of-process** shape (issue #3072): slot 0 is the sandbox in
+ * this JVM, slot 1 is a worker JVM, and renders dispatch across both.
  *
- * 1. Both slots accept renders (each handles at least one).
- * 2. The two slots have **distinct** sandbox classloaders — proving Robolectric's sandbox cache
- *    didn't collapse the pool to a single shared sandbox via the
- *    [SandboxHoldingRunner]/[SandboxHoldingHints] discriminator + constructor-snapshot path.
- * 3. Renders dispatched to the same slot consistently see that slot's classloader (i.e. the slot
- *    dispatch in [RobolectricHost.submit] is stable — `Math.floorMod(id, sandboxCount)` is keyed on
- *    the request id which is monotonic per process).
+ * **Why processes and not classloaders.** Robolectric's native-graphics runtime loads
+ * `libandroid_runtime.so` once per process and registers its JNI natives against the first
+ * sandbox's instrumented framework classes. A second sandbox in the same JVM comes up with a
+ * `Typeface` whose system font map never populated (`NullPointerException` at `Typeface.java:928`)
+ * and the next native text call takes the process down with a `SIGSEGV`. Every assertion here that
+ * used to read "the two slots have distinct classloaders" now reads "the two slots are distinct
+ * processes" — `RobolectricHost.workerPidsForTest()` is the seam.
  *
  * **Why ids are bucketed by `id and 1`**: when the payload doesn't carry a `previewId=` key (legacy
  * stub payloads like `render-N`), [RobolectricHost.submit] hashes the request id instead. For small
  * positive Long ids `Long.hashCode()` is the low 32 bits as a signed int, so its parity matches `id
  * and 1L`; bucketing by that aligns with the actual dispatch path.
- *
- * Affinity-aware dispatch (`previewId=<id>` in the payload) is covered by
- * [samePreviewIdAlwaysLandsOnSameSlot] below.
- *
- * **Why `legacyStubPayload` and not real RenderSpecs**: [RobolectricHostTest] already submits the
- * `payload="render-N"` shape that the B1.3-era stub path was built for. Reusing that path keeps the
- * assertion focused on slot dispatch and sandbox identity rather than the heavier render- engine
- * work (Roborazzi capture, bitmap save, etc.).
  */
 class RobolectricHostPoolTest {
 
   @Test
-  fun twoSandboxesServeDistinctClassloaders() {
+  fun twoSlotsServeRendersFromDistinctProcesses() {
     val host = RobolectricHost(sandboxCount = 2)
     try {
       host.start()
@@ -50,45 +43,27 @@ class RobolectricHostPoolTest {
         byBucket.keys,
       )
 
-      // Both buckets must consistently see *one* sandbox classloader each — slot dispatch is
-      // stable (id-keyed, `Math.floorMod`).
-      val bucket0Hashes = byBucket.getValue(0).map { it.classLoaderHashCode }.toSet()
-      val bucket1Hashes = byBucket.getValue(1).map { it.classLoaderHashCode }.toSet()
-      assertEquals(
-        "bucket 0 should see exactly one classloader, saw $bucket0Hashes",
-        1,
-        bucket0Hashes.size,
-      )
-      assertEquals(
-        "bucket 1 should see exactly one classloader, saw $bucket1Hashes",
-        1,
-        bucket1Hashes.size,
-      )
-
-      // The load-bearing assertion: the two buckets see *different* classloaders. If the
-      // discriminator failed to break Robolectric's sandbox cache, both buckets would land on the
-      // same cached sandbox and these would match — proving the pool collapsed to a single
-      // sandbox.
+      // The load-bearing assertion: slot 1 is a *separate JVM*. If the pool ever regresses to
+      // allocating its second sandbox in-process, this list is empty (and the JVM most likely dies
+      // in `libandroid_runtime.so` long before the assertion runs).
+      val workerPids = host.workerPidsForTest()
+      assertEquals("sandboxCount=2 should own exactly one worker process", 1, workerPids.size)
+      val workerPid = workerPids.single()
+      assertNotNull("worker 0 should be booted and alive", workerPid)
       assertNotEquals(
-        "expected distinct sandbox classloaders across slots — see SANDBOX-POOL.md if this " +
-          "regresses (discriminator may be back to colliding on the cache key)",
-        bucket0Hashes.single(),
-        bucket1Hashes.single(),
+        "the worker must be a different process from the daemon JVM",
+        ProcessHandle.current().pid(),
+        workerPid,
       )
 
-      // Sanity probe: classloader names look like Robolectric's instrumenting loader on both
-      // sides, so we know we're inside two real sandboxes (not on the test JVM's app classloader).
-      val sampleNames =
-        setOf(
-          byBucket.getValue(0).first().classLoaderName,
-          byBucket.getValue(1).first().classLoaderName,
-        )
-      for (cl in sampleNames) {
-        assertTrue(
-          "expected an instrumenting/sandbox classloader, got '$cl'",
-          cl.contains("Instrument") || cl.contains("Sandbox") || cl.contains("Robolectric"),
-        )
-      }
+      // Sanity probe: the in-process slot still renders inside a real Robolectric sandbox.
+      val localName = byBucket.getValue(0).first().classLoaderName
+      assertTrue(
+        "expected an instrumenting/sandbox classloader on slot 0, got '$localName'",
+        localName.contains("Instrument") ||
+          localName.contains("Sandbox") ||
+          localName.contains("Robolectric"),
+      )
     } finally {
       host.shutdown()
     }
@@ -96,55 +71,42 @@ class RobolectricHostPoolTest {
 
   @Test
   fun samePreviewIdAlwaysLandsOnSameSlot() {
-    // Same previewId across many submits must hit the same sandbox slot every time so per-sandbox
-    // Compose snapshot caches +
-    // Robolectric shadow caches accumulate as intended; without this, repeat renders of the same
-    // preview never warm a single sandbox.
-    val host = RobolectricHost(sandboxCount = 2)
-    try {
-      host.start()
+    // Affinity dispatch: the same previewId must resolve to the same slot every time so per-sandbox
+    // Compose snapshot caches and Robolectric shadow caches accumulate as intended. Asserted
+    // against the dispatch function directly rather than by rendering — with slots in different
+    // processes there is no shared classloader identity to read back off a result, and dispatch is
+    // the thing under test either way.
+    val host = RobolectricHost(sandboxCount = 3)
+    val previewIds = (0 until 32).map { i -> "com.example.preview.Foo$i.method" }
 
-      // Use many previewIds so at least one lands on each slot regardless of how the hash
-      // distributes — the per-previewId stability assertion below is the load-bearing one,
-      // independent of which slot any individual id lands on.
-      val previewIds = (0 until 16).map { i -> "com.example.preview.Foo$i.method" }
-      val rendersPerPreview = 4
-      val byPreview = previewIds.associateWith { previewId ->
-        (1..rendersPerPreview).map { _ ->
-          host.submit(RenderRequest.Render(payload = "previewId=$previewId"))
-        }
-      }
-
-      // Load-bearing: each previewId's renders all land on a single classloader (= same slot).
-      for ((previewId, results) in byPreview) {
-        val classloaderHashes = results.map { it.classLoaderHashCode }.toSet()
+    val slotByPreview =
+      previewIds.associateWith { previewId ->
+        val slots =
+          (1L..8L)
+            .map { id -> host.chooseSlotIndexForTest(payload = "previewId=$previewId", id = id) }
+            .toSet()
         assertEquals(
-          "previewId='$previewId' should always land on one slot, saw $classloaderHashes",
+          "previewId='$previewId' should always resolve to one slot, saw $slots",
           1,
-          classloaderHashes.size,
+          slots.size,
         )
+        slots.single()
       }
 
-      // Sanity: across 16 previewIds, at least both slots got something. If everything pinned to
-      // slot 0 the test would silently pass the per-id stability assertion on a degenerate hash.
-      val allClassloaderHashes =
-        previewIds
-          .flatMap { previewId -> byPreview.getValue(previewId).map { it.classLoaderHashCode } }
-          .toSet()
-      assertEquals(
-        "16 previewIds should spread across both slots, saw $allClassloaderHashes",
-        2,
-        allClassloaderHashes.size,
-      )
-    } finally {
-      host.shutdown()
-    }
+    assertEquals(
+      "32 previewIds should spread across all three slots, saw ${slotByPreview.values.toSet()}",
+      setOf(0, 1, 2),
+      slotByPreview.values.toSet(),
+    )
   }
 
   @Test
   fun normalRendersAvoidInteractiveSlotWhenHeldSessionIsPinned() {
+    // A held session pins slot 0 — the in-process sandbox, the only one that can back a live
+    // `ComposeTestRule` — so every normal render has to route to a worker process for the
+    // session's lifetime.
     val host = RobolectricHost(sandboxCount = 2)
-    val slotOnePayload =
+    val slotZeroPayload =
       (0 until 64)
         .map { i -> "previewId=com.example.preview.HashesToInteractiveSlot$i" }
         .first { payload ->
@@ -159,27 +121,31 @@ class RobolectricHostPoolTest {
       "test setup should pick a payload that normally hashes to the interactive slot",
       RobolectricHost.INTERACTIVE_SLOT_INDEX,
       host.chooseSlotIndexForTest(
-        payload = slotOnePayload,
+        payload = slotZeroPayload,
         id = 100L,
         interactiveSlotPinned = false,
       ),
     )
-    assertEquals(
-      "when slot 1 is held by live interactive mode, normal renderNow dispatch must stay on slot 0",
-      0,
-      host.chooseSlotIndexForTest(payload = slotOnePayload, id = 100L, interactiveSlotPinned = true),
+    assertNotEquals(
+      "while the in-process slot is held by a live session, normal dispatch must move to a worker",
+      RobolectricHost.INTERACTIVE_SLOT_INDEX,
+      host.chooseSlotIndexForTest(
+        payload = slotZeroPayload,
+        id = 100L,
+        interactiveSlotPinned = true,
+      ),
     )
   }
 
   @Test
   fun backgroundBootServesRendersBeforePoolCompletesAndWarmsTheLateSlot() {
     // Cold-start fast path (`composeai.daemon.backgroundSandboxBoot=true`): start() blocks only
-    // until slot 0 is up, slots 1..N-1 boot on a background thread, and dispatch routes across
-    // the ready prefix meanwhile. Asserts the three load-bearing pieces:
+    // until slot 0 (in-process) is up, the worker JVMs boot on a background thread, and dispatch
+    // routes across the ready prefix meanwhile. Asserts the three load-bearing pieces:
     //   1. a render succeeds immediately after start() (before the pool completes),
-    //   2. the background boot eventually completes the pool and steady-state dispatch spreads
-    //      across both sandboxes again,
-    //   3. the background-booted slot got its boot-time warm render (the __warmup-slot-1 PNG).
+    //   2. the background boot eventually completes the pool,
+    //   3. the background-booted worker got its boot-time warm render (the __warmup-slot-1 PNG,
+    //      written by the worker process into the shared output dir).
     val outputDir = Files.createTempDirectory("pool-background-boot").toFile()
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
     System.setProperty("roborazzi.test.record", "true")
@@ -187,12 +153,14 @@ class RobolectricHostPoolTest {
     val host = RobolectricHost(sandboxCount = 2)
     try {
       host.start()
-      // Must not block on slot 1: a stub render right after start() succeeds on the ready prefix.
+      // Must not block on the worker: a stub render right after start() succeeds on the ready
+      // prefix (slot 0 alone).
       val first = host.submit(RenderRequest.Render(payload = "render-1"))
       assertNotNull("render immediately after start() should succeed", first)
 
-      // Background boot completes the pool (generous bound — a sandbox boot is ~10s warm-cache).
-      val poolDeadline = System.currentTimeMillis() + 180_000
+      // Background boot completes the pool (generous bound — a worker pays a JVM launch plus a
+      // full Robolectric boot).
+      val poolDeadline = System.currentTimeMillis() + 300_000
       while (host.readySlotCountForTest() < 2 && System.currentTimeMillis() < poolDeadline) {
         Thread.sleep(200)
       }
@@ -200,24 +168,14 @@ class RobolectricHostPoolTest {
 
       // The late slot's boot-time warm render lands (it runs right after the slot turns ready).
       val warmPng = File(outputDir, "__warmup-slot-1.png")
-      val warmDeadline =
-        System.currentTimeMillis() + RobolectricHost.WARM_RENDER_TIMEOUT_MS + 10_000
-      while (!warmPng.exists() && System.currentTimeMillis() < warmDeadline) {
-        Thread.sleep(200)
-      }
       assertTrue("expected boot-time warm render PNG at $warmPng", warmPng.exists())
 
-      // Steady state: affinity dispatch spreads across both sandboxes, exactly like the
-      // non-background pool.
+      // Steady state: renders dispatched to the worker come back with a real PNG.
       val results =
-        (0 until 16).map { i ->
+        (0 until 8).map { i ->
           host.submit(RenderRequest.Render(payload = "previewId=com.example.preview.Bg$i"))
         }
-      assertEquals(
-        "steady-state dispatch should reach both sandboxes",
-        2,
-        results.map { it.classLoaderHashCode }.toSet().size,
-      )
+      assertEquals("every steady-state render should return a result", 8, results.size)
     } finally {
       System.clearProperty(RobolectricHost.BACKGROUND_BOOT_PROP)
       host.shutdown()
@@ -265,95 +223,22 @@ class RobolectricHostPoolTest {
   }
 
   @Test
-  fun perSlotHoldersHaveDistinctChildLoadersParentedToTheirSandbox() {
-    // The load-bearing per-slot guarantee: each slot's holder is parented to that slot's sandbox
-    // classloader, so a render that lands on slot N resolves user
-    // classes against sandbox N's framework classes (no classloader-identity skew across slots).
-    //
-    // Implementation note: we record the sandbox classloader the factory was invoked with for
-    // each slot, then assert the recorded set matches the sandbox classloaders the renders
-    // actually saw. This proves the factory was invoked with the right parent — without trying to
-    // build a real child URLClassLoader (which would require URL resources we don't have here).
-    val recordedParents = java.util.concurrent.ConcurrentHashMap<Int, ClassLoader>()
-    val factory: (ClassLoader) -> UserClassLoaderHolder = { sandboxClassLoader ->
-      val slotIndex =
-        // Each slot has a unique sandbox classloader; use its identity as the key. We don't know
-        // the slot index from inside the factory but identityHash is unique-per-instance.
-        System.identityHashCode(sandboxClassLoader)
-      recordedParents[slotIndex] = sandboxClassLoader
-      UserClassLoaderHolder(urls = emptyList(), parentSupplier = { sandboxClassLoader })
-    }
-    val host = RobolectricHost(sandboxCount = 2, userClassloaderHolderFactory = factory)
-    try {
-      host.start()
-      // Drive enough renders that each slot is exercised at least once.
-      val results =
-        (1..8).map { i ->
-          host.submit(RenderRequest.Render(payload = "previewId=com.example.Preview$i"))
-        }
-      val sandboxCls = results.map { it.classLoaderHashCode }.toSet()
-      assertEquals(
-        "two slots must produce two distinct sandbox classloaders, saw $sandboxCls",
-        2,
-        sandboxCls.size,
-      )
-      // The factory must have been invoked exactly once per slot (idempotent CAS in the host).
-      assertEquals(
-        "factory should be invoked once per slot, saw ${recordedParents.size}: ${recordedParents.keys}",
-        2,
-        recordedParents.size,
-      )
-      // Recorded parent classloaders match the classloaders the renders actually observed.
-      assertEquals(
-        "recorded parents must equal the rendered-against classloaders",
-        sandboxCls,
-        recordedParents.keys.toSet(),
-      )
-    } finally {
-      host.shutdown()
-    }
-  }
-
-  @Test
-  fun realRenderUsesTheCurrentSlotsChildLoader() {
-    // Regression for the slot-1 NoSuchMethodException loop seen in VS Code after #536. Stub
-    // renders only report the sandbox classloader and never enter RenderEngine, so they cannot
-    // catch classloader-identity skew. This test drives real Compose reflection through a
-    // UserClassLoaderHolder-backed child loader:
-    //
-    // 1. Render a real fixture on slot 0 so the legacy slot-0 currentChildLoader alias is
-    // populated.
-    // 2. Render the same fixture on slot 1.
-    //
-    // The bug was that slot 1 read DaemonHostBridge.currentChildLoader() (slot 0's alias) instead
-    // of slot.childLoaderRef. That loaded RedFixturePreviewsKt with slot 0's sandbox as parent
-    // while
-    // executing inside slot 1's sandbox, so Compose's Composer parameter type did not match and
-    // getDeclaredComposableMethod reported the valid @Composable function as missing.
+  fun realRendersOnBothSlotsResolveUserClassesThroughTheirOwnChildLoader() {
+    // Both halves of the pool have to resolve preview classes out of the disposable user-class
+    // loader — the in-process slot through the holder the host allocates, the worker through the
+    // one it builds for itself from `composeai.daemon.userClassDirs` (the pool forwards every
+    // `composeai.*` property to the worker JVM, which is the same seam `DaemonMain` reads in
+    // production). A worker that ignored the sysprop would fail to find the fixture class rather
+    // than silently render something else, so a PNG from slot 1 is the assertion.
     val userClassesDir = stageFixtureClassesDir()
     val outputDir = Files.createTempDirectory("pool-real-renders").toFile()
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
     System.setProperty("roborazzi.test.record", "true")
+    System.setProperty(UserClassLoaderHolder.USER_CLASS_DIRS_PROP, userClassesDir.absolutePath)
 
     val probe = RobolectricHost(sandboxCount = 2)
-    val slot0PreviewId =
-      (0 until 128)
-        .map { i -> "ee.schimke.composeai.daemon.RedFixturePreviewsKt.RedSquare.slot0.$i" }
-        .first { previewId ->
-          probe.chooseSlotIndexForTest(
-            payload = renderPayload(previewId, outputBaseName = "probe"),
-            id = 1L,
-          ) == 0
-        }
-    val slot1PreviewId =
-      (0 until 128)
-        .map { i -> "ee.schimke.composeai.daemon.RedFixturePreviewsKt.RedSquare.slot1.$i" }
-        .first { previewId ->
-          probe.chooseSlotIndexForTest(
-            payload = renderPayload(previewId, outputBaseName = "probe"),
-            id = 2L,
-          ) == 1
-        }
+    val slot0PreviewId = previewIdHashingTo(probe, slot = 0, tag = "slot0")
+    val slot1PreviewId = previewIdHashingTo(probe, slot = 1, tag = "slot1")
 
     val urls = listOf(userClassesDir.toURI().toURL())
     val host =
@@ -379,34 +264,26 @@ class RobolectricHostPoolTest {
           RenderRequest.Render(payload = renderPayload(slot1PreviewId, outputBaseName = "slot-1")),
           timeoutMs = 120_000,
         )
-      assertNotNull("slot 1 real render should produce a PNG", slot1.pngPath)
+      assertNotNull("slot 1 (worker process) real render should produce a PNG", slot1.pngPath)
       assertTrue("slot 1 PNG should exist", File(slot1.pngPath!!).exists())
     } finally {
       host.shutdown()
+      System.clearProperty(UserClassLoaderHolder.USER_CLASS_DIRS_PROP)
       outputDir.deleteRecursively()
       userClassesDir.deleteRecursively()
     }
   }
 
   @Test
-  fun interactiveStartUsesTheCurrentSlotsChildLoader() {
+  fun interactiveSessionRunsOnTheInProcessSandbox() {
+    // #3072 — the held session's `ComposeTestRule`, bridge queues and frame latches are live object
+    // handles, so the session runs on the sandbox in *this* JVM (slot 0) while the worker
+    // process(es) take the normal renders. This is the test the cap had disabled: with a
+    // single-JVM pool it could never boot two sandboxes to get here.
     val userClassesDir = stageFixtureClassesDir()
     val outputDir = Files.createTempDirectory("pool-interactive-renders").toFile()
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
     System.setProperty("roborazzi.test.record", "true")
-
-    val probe = RobolectricHost(sandboxCount = 2)
-    val slot0PreviewId =
-      (0 until 128)
-        .map { i ->
-          "ee.schimke.composeai.daemon.RedFixturePreviewsKt.RedSquare.interactive.slot0.$i"
-        }
-        .first { previewId ->
-          probe.chooseSlotIndexForTest(
-            payload = renderPayload(previewId, outputBaseName = "probe"),
-            id = 1L,
-          ) == 0
-        }
 
     val urls = listOf(userClassesDir.toURI().toURL())
     val host =
@@ -429,11 +306,7 @@ class RobolectricHostPoolTest {
       )
     try {
       host.start()
-
-      host.submit(
-        RenderRequest.Render(payload = renderPayload(slot0PreviewId, outputBaseName = "slot-0")),
-        timeoutMs = 120_000,
-      )
+      assertTrue("host with a worker process should advertise interactive", host.supportsInteractive)
 
       val session =
         host.acquireInteractiveSession(
@@ -444,6 +317,14 @@ class RobolectricHostPoolTest {
         val result = session.render(RenderHost.nextRequestId())
         assertNotNull("interactive render should produce a PNG", result.pngPath)
         assertTrue("interactive PNG should exist", File(result.pngPath!!).exists())
+
+        // While the session holds slot 0, a normal render still succeeds — on the worker.
+        val normal =
+          host.submit(
+            RenderRequest.Render(payload = renderPayload("during-session", "during-session")),
+            timeoutMs = 120_000,
+          )
+        assertNotNull("normal renders must keep flowing during a held session", normal.pngPath)
       } finally {
         session.close()
       }
@@ -455,44 +336,54 @@ class RobolectricHostPoolTest {
   }
 
   @Test
-  fun swapUserClassLoadersBroadcastsToEverySlot() {
-    // `fileChanged({ kind: "source" })` calls `host.swapUserClassLoaders()`, which must invalidate
-    // every slot's holder so the next render to any slot allocates a fresh child loader.
-    val swapCallsPerSlot =
-      java.util.concurrent.ConcurrentHashMap<Int, java.util.concurrent.atomic.AtomicInteger>()
+  fun swapUserClassLoadersBroadcastsToTheInProcessHolderAndTheWorkers() {
+    // `fileChanged({ kind: "source" })` calls `host.swapUserClassLoaders()`. The in-process holder
+    // must observe the swap, and the worker processes must survive their half of the broadcast —
+    // a worker that died on the swap would drop out of the pool and later renders would fail.
+    val swaps = java.util.concurrent.atomic.AtomicInteger()
     val factory: (ClassLoader) -> UserClassLoaderHolder = { sandboxClassLoader ->
-      val key = System.identityHashCode(sandboxClassLoader)
-      val counter =
-        swapCallsPerSlot.computeIfAbsent(key) { java.util.concurrent.atomic.AtomicInteger() }
       UserClassLoaderHolder(
         urls = emptyList(),
         parentSupplier = { sandboxClassLoader },
-        onSwap = { counter.incrementAndGet() },
+        onSwap = { swaps.incrementAndGet() },
       )
     }
     val host = RobolectricHost(sandboxCount = 2, userClassloaderHolderFactory = factory)
     try {
       host.start()
-      // Warm both slots so both holders are allocated. Without this the swap is a no-op for slots
-      // whose factory has never been invoked.
-      (1..8).forEach { i ->
-        host.submit(RenderRequest.Render(payload = "previewId=com.example.P$i"))
-      }
-      assertEquals("expected both slots warmed", 2, swapCallsPerSlot.size)
-      // Trigger the broadcast.
+      // Warm slot 0 so its holder is allocated; without this the swap is a no-op locally. The
+      // payload has to be one that actually dispatches to slot 0 — affinity hashing sends most
+      // previewIds to a worker, which owns its own holder in its own JVM.
+      val slotZeroPayload =
+        (0 until 64)
+          .map { i -> "previewId=com.example.P$i" }
+          .first { payload -> host.chooseSlotIndexForTest(payload = payload, id = 1L) == 0 }
+      host.submit(RenderRequest.Render(payload = slotZeroPayload))
+
       host.swapUserClassLoaders()
-      // Each slot's holder must have observed exactly one swap.
-      for ((key, counter) in swapCallsPerSlot) {
-        assertEquals(
-          "slot identityHash=$key should observe exactly one swap broadcast",
-          1,
-          counter.get(),
-        )
-      }
+
+      assertEquals("the in-process holder should observe exactly one swap", 1, swaps.get())
+      assertNotNull(
+        "the worker must survive the swap broadcast and stay in the pool",
+        host.workerPidsForTest().single(),
+      )
+      // And it must still serve renders afterwards.
+      val after = (1..6).map { i -> host.submit(RenderRequest.Render(payload = "render-$i")) }
+      assertEquals(6, after.size)
     } finally {
       host.shutdown()
     }
   }
+
+  private fun previewIdHashingTo(probe: RobolectricHost, slot: Int, tag: String): String =
+    (0 until 128)
+      .map { i -> "ee.schimke.composeai.daemon.RedFixturePreviewsKt.RedSquare.$tag.$i" }
+      .first { previewId ->
+        probe.chooseSlotIndexForTest(
+          payload = renderPayload(previewId, outputBaseName = "probe"),
+          id = 1L,
+        ) == slot
+      }
 
   private fun <T : Throwable> assertThrows(expected: Class<T>, block: () -> Unit): T {
     try {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/SandboxPoolMemoryBench.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/SandboxPoolMemoryBench.kt
@@ -1,23 +1,30 @@
 package ee.schimke.composeai.daemon
 
 import com.sun.management.OperatingSystemMXBean
+import java.io.File
 import java.lang.management.ManagementFactory
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * SANDBOX-POOL.md bench — boots `RobolectricHost(sandboxCount = 4)` and prints heap and native
- * footprint before vs after, plus the per-sandbox marginal cost. The numbers are the empirical
- * basis for the "~750 MB per replica saved by Layer 3" claim in SANDBOX-POOL.md and the CHANGELOG.
+ * SANDBOX-POOL.md bench — boots `RobolectricHost(sandboxCount = 4)` and prints the footprint of the
+ * daemon JVM plus each of its sandbox worker processes.
  *
- * **Not a correctness test.** Asserts only loose sanity bounds (e.g. "the 4-sandbox pool spends
- * less heap than 4× a single sandbox would"); real measurement variation across hardware /
- * Robolectric versions makes tighter bounds flaky. The actual numbers are the artifact — they print
- * to the test's stdout/stderr and the JUnit XML's `<system-out>`.
+ * **Rewritten for the out-of-process pool (issue #3072).** The pre-#3072 bench measured this JVM's
+ * heap and committed-virtual size on the premise that all N sandboxes lived here; they don't any
+ * more (Robolectric's native runtime binds one classloader per process, so extra sandboxes get
+ * extra JVMs). Reading only this JVM would now under-report the pool by a factor of N and quietly
+ * turn into a meaningless number, so the bench reads each worker's resident set from
+ * `/proc/<pid>/status` instead and reports the pool total.
  *
- * Pair with [RobolectricHostTest] (which boots a single sandbox in the same JVM via the same
- * Robolectric stack) to compare absolute footprints. Run both, eyeball the deltas, write the
- * numbers up in SANDBOX-POOL.md when the picture changes.
+ * **Not a correctness test.** It asserts only that the workers actually booted and that the total
+ * is in a sane range; real measurement variation across hardware / Robolectric versions makes
+ * tighter bounds flaky. The numbers are the artifact — they print to stdout/stderr and land in the
+ * JUnit XML's `<system-out>`.
+ *
+ * Pair with [RobolectricHostTest] (a single sandbox, one JVM, same Robolectric stack) to compare
+ * against the one-sandbox baseline. Run both, eyeball the deltas, write the numbers up in
+ * SANDBOX-POOL.md when the picture changes.
  */
 class SandboxPoolMemoryBench {
 
@@ -25,7 +32,7 @@ class SandboxPoolMemoryBench {
   fun `report sandboxCount=4 memory footprint`() {
     val sandboxCount = 4
 
-    val baseline = sample("baseline (before host.start)")
+    val baseline = sample()
 
     val host = RobolectricHost(sandboxCount = sandboxCount)
     try {
@@ -36,35 +43,36 @@ class SandboxPoolMemoryBench {
         host.submit(RenderRequest.Render(payload = "bench-warmup-$i"))
       }
 
-      val warm = sample("warm pool (sandboxCount=$sandboxCount)")
-
-      val heapDeltaMb = warm.heapMb - baseline.heapMb
-      val nativeDeltaMb = warm.nativeHeapMb - baseline.nativeHeapMb
-      val perSandboxHeapMb = heapDeltaMb / sandboxCount
-      val perSandboxNativeMb = nativeDeltaMb / sandboxCount
+      val warm = sample()
+      val workerPids = host.workerPidsForTest().filterNotNull()
+      val workerRssMb = workerPids.associateWith(::residentSetMb)
+      val poolTotalMb = warm.nativeHeapMb + workerRssMb.values.sum()
 
       val report = buildString {
-        appendLine("---- sandbox-pool memory bench ----")
-        appendLine(
-          "baseline:    heap=${baseline.heapMb} MiB  nativeHeap=${baseline.nativeHeapMb} MiB"
-        )
-        appendLine(
-          "warm (×$sandboxCount): heap=${warm.heapMb} MiB  nativeHeap=${warm.nativeHeapMb} MiB"
-        )
-        appendLine("delta:       heap=$heapDeltaMb MiB    nativeHeap=$nativeDeltaMb MiB")
-        appendLine(
-          "per-sandbox amortized: heap≈$perSandboxHeapMb MiB  nativeHeap≈$perSandboxNativeMb MiB"
-        )
-        appendLine("-----------------------------------")
+        appendLine("---- sandbox-pool memory bench (out-of-process, #3072) ----")
+        appendLine("daemon JVM (slot 0, 1 sandbox):")
+        appendLine("  baseline: heap=${baseline.heapMb} MiB  committedVirtual=${baseline
+          .nativeHeapMb} MiB")
+        appendLine("  warm:     heap=${warm.heapMb} MiB  committedVirtual=${warm.nativeHeapMb} MiB")
+        appendLine("workers (${workerPids.size} × 1 sandbox):")
+        for ((pid, rss) in workerRssMb) appendLine("  pid=$pid rss=$rss MiB")
+        appendLine("pool total (daemon committedVirtual + worker RSS): $poolTotalMb MiB")
+        appendLine("-----------------------------------------------------------")
       }
       println(report)
       System.err.println(report)
 
-      // Loose sanity: a 4-sandbox pool's heap delta should be measurable (i.e. above noise floor)
-      // but not blow past a generous ceiling. 4 GB ceiling protects against an accidental leak
-      // turning the bench into a regression alarm.
-      assertTrue("heap delta should be positive (got $heapDeltaMb MiB)", heapDeltaMb > 0)
-      assertTrue("heap delta should be < 4 GiB (got $heapDeltaMb MiB)", heapDeltaMb < 4096)
+      assertTrue(
+        "sandboxCount=$sandboxCount should own ${sandboxCount - 1} worker processes, " +
+          "saw ${workerPids.size}",
+        workerPids.size == sandboxCount - 1,
+      )
+      // Loose sanity: every worker is a real JVM hosting a Robolectric sandbox, so its RSS is well
+      // above nothing and well under a runaway. `0` also covers a platform without /proc, where
+      // [residentSetMb] can't read a value — treat that as "not measurable", not as a failure.
+      for ((pid, rss) in workerRssMb) {
+        assertTrue("worker pid=$pid RSS looks implausible ($rss MiB)", rss == 0L || rss in 32..8192)
+      }
     } finally {
       host.shutdown()
     }
@@ -72,7 +80,7 @@ class SandboxPoolMemoryBench {
 
   private data class Sample(val heapMb: Long, val nativeHeapMb: Long)
 
-  private fun sample(@Suppress("UNUSED_PARAMETER") label: String): Sample {
+  private fun sample(): Sample {
     // Force a GC before reading heap so transient allocations don't pollute the snapshot. This is
     // a hint, not a guarantee — HotSpot mostly honours System.gc() for instrumentation paths.
     System.gc()
@@ -86,4 +94,17 @@ class SandboxPoolMemoryBench {
         .getOrDefault(0L)
     return Sample(heapMb = heapMb, nativeHeapMb = nativeHeapMb)
   }
+
+  /** Resident set of [pid] in MiB from `/proc`; `0` where that isn't readable (non-Linux, gone). */
+  private fun residentSetMb(pid: Long): Long =
+    runCatching {
+        File("/proc/$pid/status")
+          .takeIf { it.isFile }
+          ?.readLines()
+          ?.firstOrNull { it.startsWith("VmRSS:") }
+          ?.filter(Char::isDigit)
+          ?.toLongOrNull()
+          ?.div(1024L) ?: 0L
+      }
+      .getOrDefault(0L)
 }

--- a/docs/daemon/SANDBOX-POOL.md
+++ b/docs/daemon/SANDBOX-POOL.md
@@ -1,269 +1,173 @@
-# Preview daemon — in-JVM sandbox pool
+# Preview daemon — sandbox pool
 
 ## Status
 
-All three layers landed.
+The pool is **out-of-process** (issue #3072): the daemon JVM hosts exactly
+one Robolectric sandbox and every additional sandbox is a worker JVM.
 
-- **Layer 1** — bridge multi-slot foundation.
-- **Layer 2** — `RobolectricHost(sandboxCount = N)` boots N distinct
-  Robolectric sandboxes in one JVM, each with its own
-  `InstrumentingClassLoader` and `SDK Main Thread`; renders dispatch to
-  slots via `Math.floorMod(id, N)`. Two-sandbox boot completes in ~7s on
-  warm cache.
-- **Layer 3** — `DaemonSupervisor` passes
-  `composeai.daemon.sandboxCount = 1 + replicasPerDaemon` on the launch
-  descriptor instead of spawning N+1 JVM subprocesses. Public surface
-  (`SupervisedDaemon.client`, `allClients`, `clientForRender`) is
-  unchanged. **Default `replicasPerDaemon = 4`** — every daemon comes up
-  with 5 in-JVM sandboxes. Set `0` to opt out.
+- **Slot 0** — the sandbox in the daemon JVM. Serves renders and backs held
+  interactive / recording sessions.
+- **Slots 1..N-1** — one worker JVM each
+  ([`SandboxProcessPool`](../../daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPool.kt)
+  spawns them,
+  [`SandboxWorkerMain`](../../daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxWorkerMain.kt)
+  is what runs inside one), talking newline-delimited JSON over a loopback
+  socket.
+- `RobolectricHost(sandboxCount = N)` is unchanged as the public surface;
+  `sandboxCount = 1` spawns nothing and behaves exactly as it always has.
 
-## Memory math
+## Why processes — the constraint that killed the in-JVM pool
 
-For `replicasPerDaemon = 4` on one module:
-
-| Cost                    | Per-JVM | Per-sandbox-classloader |
-|-------------------------|--------:|------------------------:|
-| JVM baseline            | ~200 MB | —                       |
-| Native heap (Skia / lib)| ~540 MB | —                       |
-| `android-all` framework | ~250 MB | (re-instrumented per loader) |
-| User heap + bytecode    | ~1 GB   | ~1 GB                   |
-
-Native libs and JVM baseline are once-per-JVM. Pre-Layer-3 ~8 GB across
-5 JVMs; post-Layer-3 ~5 GB in one JVM with 5 sandbox classloaders.
+Robolectric's native-graphics runtime binds to a **single classloader per
+process**. `DefaultNativeRuntimeLoader` loads `libandroid_runtime.so` once
+and registers its JNI natives against whichever sandbox's instrumented
+framework classes got there first; its `loaded` flag lives in a static owned
+by *that sandbox's* classloader. A second sandbox in the same JVM therefore
+sees `loaded == false`, re-runs `Typeface.loadPreinstalledSystemFontMap()`
+against an already-loaded library, and gets back a font map with no default
+family:
 
 ```
-                    today                                pool
-   ┌──────────────────────────┐         ┌──────────────────────────────────┐
-   │ supervisor (mcp)         │         │ supervisor (mcp)                 │
-   │   replicasPerDaemon = 4  │         │   replicasPerDaemon = 4          │
-   │     ├─ JVM-A 2 GB        │         │     └─ JVM 2 GB + 3×sandbox 1 GB │
-   │     ├─ JVM-B 2 GB        │   →     │        ├─ sandbox 0  ─┐          │
-   │     ├─ JVM-C 2 GB        │         │        ├─ sandbox 1   │ shared   │
-   │     └─ JVM-D 2 GB        │         │        ├─ sandbox 2   │ JVM      │
-   │   total ≈ 8 GB           │         │        └─ sandbox 3  ─┘          │
-   └──────────────────────────┘         │   total ≈ 5 GB                   │
-                                        └──────────────────────────────────┘
+NullPointerException: Cannot read field "mStyle" because "family" is null
+  at android.graphics.Typeface.create(Typeface.java:928)
+  at android.graphics.Typeface.setSystemFontMap(Typeface.java:1410)
+  at android.graphics.Typeface.loadPreinstalledSystemFontMap(Typeface.java:1550)
+  at org.robolectric.nativeruntime.DefaultNativeRuntimeLoader.ensureLoaded(…)
 ```
 
-Replicas across **different modules** keep separate JVMs — different
-classpath / Compose version / native-lib graph. The win is
-intra-module.
+The next native text call then takes the whole process down with a `SIGSEGV`
+in `libandroid_runtime.so` (exit 134). This is a hard constraint, not a
+version bug — Robolectric 4.16.1 and 4.17-beta-2 behave identically.
 
-## Layer 1 — bridge multi-slot foundation
+Workarounds that were tried and **do not work** (don't re-try them):
 
-`DaemonHostBridge` is the cross-classloader handoff between host thread
-and sandbox thread. Refactored to be **slot-keyed**: each sandbox claims
-a slot at boot, gets its own queue + ref + ready latch. `slot 0` =
-single-sandbox path.
+| attempt | result |
+|---|---|
+| Drop the per-worker sandbox-cache discriminator so workers share one sandbox | Font crash gone, but slot 1 never registers — `start()` hangs to the full boot timeout |
+| Parent-load `org.robolectric.nativeruntime` so `loaded` is process-global | Font crash gone, replaced by `UnsatisfiedLinkError` from `RenderNode` — the runtime registers its JNI natives against one sandbox's instrumented framework classes |
+| Robolectric 4.16.1 instead of the pinned 4.17-beta-2 | Identical NPE |
 
-## Layer 2 — `RobolectricHost` as a sandbox pool
+Two *sequential* single-sandbox hosts in one JVM are fine — they share one
+`InstrumentationConfiguration`, so Robolectric hands back the same cached
+sandbox and the native runtime initialises exactly once. That is why the
+pre-#3072 per-worker cache-key discriminator (a synthetic
+`doNotAcquireClass("composeai.sandbox.uniq.RunnerN")` in
+`SandboxHoldingRunner`) is **gone**: it existed purely to defeat that cache,
+which is the one thing that must not happen.
 
-`RobolectricHost(sandboxCount: Int = 1)` spins up N worker threads, each
-running `JUnitCore.runClasses(SandboxRunner::class.java)`. Each worker
-bootstraps its own Robolectric sandbox (distinct
-`InstrumentingClassLoader`, distinct `SDK Main Thread`), registers
-itself with `DaemonHostBridge.registerSandbox` to claim a slot, then
-polls `slot.requests`. `submit` dispatches via
-`Math.floorMod(id, sandboxCount)`. `shutdown` poisons every slot.
-
-Default `sandboxCount = 1` preserves the pre-pool single-sandbox path
-bit-for-bit.
-
-`RobolectricHostPoolTest` asserts:
-- both slots accept renders (id-bucketed by `id and 1`);
-- each bucket consistently sees one sandbox classloader (stable
-  dispatch / slot affinity);
-- the two buckets see **different** classloaders.
-
-### Cache-key fixes
-
-Getting Robolectric to actually build N sandboxes required defeating
-its `SandboxManager.SandboxKey` cache:
-
-**`doNotAcquirePackage` is silently ignored by `equals`/`hashCode`.**
-Confirmed via `javap -c` on Robolectric 4.16.1:
+## Anatomy
 
 ```
-InstrumentationConfiguration.equals   → classNameTranslations, classesToNotAcquire,
-                                         instrumentedPackages, instrumentedClasses,
-                                         interceptedMethods
-                                      → packagesToNotAcquire is NOT compared
+ ┌──────────────────────────────────────────────┐
+ │ daemon JVM                                   │
+ │   JsonRpcServer                              │
+ │   RobolectricHost(sandboxCount = N)          │
+ │     ├── slot 0: in-process Robolectric sandbox
+ │     │            └── held interactive session lives here
+ │     └── SandboxProcessPool                   │
+ │           ├── worker JVM ── slot 1 sandbox   │
+ │           ├── worker JVM ── slot 2 sandbox   │
+ │           └── …                              │
+ └──────────────────────────────────────────────┘
+        loopback socket, newline-delimited JSON
 ```
 
-**Fix:** use `doNotAcquireClass("composeai.sandbox.uniq.RunnerN")` —
-`classesToNotAcquire` **is** in `equals`. Synthetic class name; never
-resolved.
+A worker is **not** a daemon: no preview index, no extension registry, no
+watch state, no JSON-RPC. `RobolectricHost.submit` resolves a `previewId`
+into a full spec payload *before* dispatch, so the only things crossing the
+process boundary are a payload in and a `RenderResult` out
+([`SandboxWorkerProtocol.kt`](../../daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxWorkerProtocol.kt)):
 
-**`createClassLoaderConfig` is invoked twice per runner — on different
-threads.** First on the worker thread (where the worker-index
-ThreadLocal hint is set), again later on the sandbox's main thread
-(where it isn't). The second invocation produced a config without the
-discriminator.
+| message | direction | meaning |
+|---|---|---|
+| `ready` / `bootFailed` | worker → pool | sent once, after the worker's sandbox boots |
+| `render` → `result` / `failed` | pool ↔ worker | one render, one reply |
+| `swap` → `ok` | pool → worker | `fileChanged{kind:"source"}` — drop the child classloader |
+| `shutdown` → `ok` | pool → worker | drain and exit |
 
-**Fix:** snapshot the worker-index hint in the runner's constructor
-into `private val poolWorkerIndex`. Both subsequent
-`createClassLoaderConfig` calls read the same snapshot. Lives in
-[`SandboxHoldingRunner.kt`](../../daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt).
+**The result survives the trip intact.** `RobolectricHost` already reduced a
+sandbox-side `RenderResult` to plain data before handing it to callers:
+`copyPreviewContextAcrossClassloaders` copies the device context and the
+Material3 theme payload and deliberately drops the live `slotTables` /
+`rootForTest` handles (Compose objects the host classloader can't use). Every
+field that survives that copy is a `String`, number or `Map`, so the wire DTO
+is faithful — a worker-served render produces the same host-side
+`RenderResult`, and the host-side data products (`ExtensionRegistry.onRender`)
+see the same input either way. **If a field ever starts surviving the
+classloader copy, add it to `PreviewContextDto` too.**
 
-## Layer 2 — empirical bench
+Workers inherit the daemon's JVM flags (heap, GC, `--add-opens`) minus
+anything that must not be duplicated (agents, JDWP), plus every `composeai.*`
+/ `robolectric.*` / `android.*` / `roborazzi.*` system property — which is
+what makes a worker's render configured identically to the daemon's own,
+including `composeai.daemon.userClassDirs` for hot reload.
 
-Referenced by `SandboxPoolMemoryBench.kt`. Boots
-`RobolectricHost(sandboxCount = 4)` in a fresh JVM, runs a warm-up
-render per sandbox, reports heap + native-virtual delta. Sample run on
-Robolectric 4.16.1 / SDK 35 / OpenJDK 17 / Linux x86_64:
+## Interactive sessions run on slot 0
 
-```
-baseline:  heap=10 MiB    nativeHeap=3758 MiB
-warm (×4): heap=101 MiB   nativeHeap=4596 MiB
-delta:     heap=91 MiB    nativeHeap=838 MiB
-per-sandbox amortized: heap≈22 MiB  nativeHeap≈209 MiB
-```
+`INTERACTIVE_SLOT_INDEX` moved from 1 to **0**. A held session hands callers
+an `AndroidInteractiveSession` backed by live bridge queues, frame latches and
+a `ComposeTestRule` — object handles, not a serializable request/response
+pair, so they can't be proxied over the worker socket. Normal renders are the
+ones that serialize cleanly, so they are what moves out of process: while a
+session holds slot 0, `chooseSlotIndex` routes every render to slots 1..N-1.
 
-`nativeHeap` is `committedVirtualMemorySize` — a portable proxy for "JVM
-resident set" that folds JVM heap + native libs + instrumented framework
-JARs + mmap'd resources. The 838 MiB delta for 4 sandboxes conflates
-once-per-JVM cost (Skia / sqlite / Robolectric native libs ~540 MiB;
-framework loading ~250 MiB) with per-sandbox cost (per-loader
-instrumented bytecode + classloader internals — ~75 MiB each).
+`supportsInteractive` therefore still reads `sandboxCount >= 2` — one sandbox
+to pin, at least one left to render. `acquireInteractiveSession` additionally
+refuses (cleanly, with the `Unsupported` the caller already handles via its v1
+fallback) while fewer than two slots are ready, so a session can never pin the
+only dispatchable sandbox during a background boot.
 
-Attribution against the subprocess model:
+## Slot dispatch / affinity
 
-| replicasPerDaemon | Subprocess model | Pool model | Saved |
-|------------------:|----------------:|----------:|----:|
-| 0 (1 sandbox)     | ~1 GB           | ~1 GB     | 0   |
-| 2 (3 sandboxes)   | ~3 GB           | ~1.15 GB  | ~1.85 GB |
-| 3 (4 sandboxes)   | ~4 GB           | ~1.23 GB  | ~2.77 GB |
-| 4 (5 sandboxes, default) | ~5 GB    | ~1.30 GB  | ~3.70 GB |
-
-Bench prints to JUnit's `<system-out>` so CI logs preserve the numbers;
-rerun and update the table on Robolectric / JDK / framework upgrades.
-
-## Slot dispatch / affinity-aware dispatch
-
-Constraint: `sandboxCount > 1` requires `userClassloaderHolder == null`.
-Stable dispatch via `Math.floorMod(id, sandboxCount)` — same preview ID
-goes to the same slot, so per-slot warm caches survive across renders.
-The `previewId` argument on `clientForRender` is preserved for a future
-affinity-aware wire change.
-
-## Layer 3 supervisor surface
-
-`DaemonSupervisor` keeps `replicasPerDaemon` as the public surface.
-Implementation:
-
-- `spawn(project, modulePath)` reads the descriptor, calls
-  `descriptor.withSandboxCount(1 + replicasPerDaemon)` to inject
-  `composeai.daemon.sandboxCount` into `systemProperties`, and forks a
-  **single** JVM via `clientFactory.spawn`. The previous N+1-JVM-fork
-  loop and `replicaSpawnExecutor` are gone.
-- `SupervisedDaemon` is now backed by a single `DaemonSpawn`; the public
-  surface — `client`, `allClients()`, `clientForRender(previewId)`,
-  `replicaCount()` — is unchanged. `clientForRender` is a degenerate
-  no-op (always returns the single client) but `previewId` is preserved
-  for future affinity routing.
-- `DaemonMain` reads `composeai.daemon.sandboxCount` (default 1) and
-  constructs `RobolectricHost(sandboxCount = N)`. When the user-class
-  loader holder is wired (gradle plugin's hot-reload path), sandboxCount
-  falls back to 1 with a stderr warning.
-- Wire-protocol-visible behaviour (`initialize`, `renderNow`,
-  `fileChanged` fan-out, `classpathDirty` respawn) is unchanged.
-
-`replicasPerDaemon == 0` keeps a single sandbox in a single JVM —
-bit-identical with pre-pool behaviour (the sysprop is omitted from the
-descriptor entirely at count=1).
-
-## Per-slot child loaders for hot reload
-
-The disposable child URLClassLoader is single-instance today; per-slot
-child loaders are layered work for the `fileChanged` hot-reload path.
-The supervisor's production daemon path stays at `sandboxCount = 1`
-until that lands. Per-slot recycle
-is the other main remaining item — heap-driven recycle could restart
-one sandbox instead of the whole daemon JVM.
+Unchanged: `Math.floorMod(hash(previewId ?: requestId), readySlots)`, so the
+same preview lands on the same sandbox and its per-sandbox caches pay off.
+With `sandboxCount = 1` dispatch collapses to slot 0, bit-identical with the
+pre-pool path.
 
 ## Background pool boot (cold-start fast path)
 
-`composeai.daemon.backgroundSandboxBoot` changes
-`RobolectricHost.start()`'s contract for a pool: it blocks only until
-**slot 0** is registered, then boots slots 1..N-1 sequentially on a
-background daemon thread. Sandbox boot is the dominant cold-start cost
-(~11.6 s measured per sandbox on a warm `android-all` cache), so a
-3-sandbox pool otherwise holds `initialize` — and therefore serve's first
-live render — for ~35 s of capacity nothing needs yet.
+`composeai.daemon.backgroundSandboxBoot` (launch descriptors default it **on**,
+the raw sysprop defaults **off** — see [CONFIG.md](CONFIG.md)) makes `start()`
+block only until slot 0 is up; the workers boot sequentially on a background
+daemon thread. Dispatch routes across the ready prefix meanwhile, so a render
+never queues on a still-booting worker.
 
-**Two different defaults, and the distinction matters when diagnosing:**
+- **A permanent worker boot failure caps the pool** at the slots already
+  booted (loudly logged) instead of aborting the daemon. The eager path keeps
+  the strict contract: a failed worker throws out of `start()`.
+- **Boot-time warm render.** Each worker renders the daemon-shipped
+  `DaemonWarmupPreview` once before it is published for dispatch (disable with
+  `-Dcomposeai.daemon.warmRenderOnBoot=false`), so a live render never queues
+  behind a cold warm-up. Slot 0 is left to serve's own `prewarm()`.
+- **A worker that dies mid-request is dropped from the pool**, logged with its
+  pid; the remaining slots keep serving.
 
-- **Launch descriptors default it ON.** `composePreview.daemon
-  .backgroundSandboxBoot` defaults to `true`
-  ([CONFIG.md](CONFIG.md)), so every daemon the Gradle plugin describes —
-  VS Code, MCP, the integration leg — answers `initialize` once slot 0 is
-  hot. `ServeBundleDaemon` and the deploy image do the same. Set it
-  `false` in the `daemon { … }` block to get the eager
-  all-sandboxes-ready contract back.
-- **The sysprop itself defaults OFF.** `RobolectricHost` reads
-  `-Dcomposeai.daemon.backgroundSandboxBoot` with a `false` fallback, so a
-  host constructed **in-process** (embedders, `:daemon:harness`, unit
-  tests) still boots the whole pool eagerly unless its caller opts in.
-  That code sets the property directly and its tests pin the eager
-  contract, so the fallback stays conservative.
+## Memory
 
-In practice a descriptor always carries an explicit value, so the sysprop
-fallback only applies where nothing set one.
+The honest trade: this is a **process** pool, so per-slot cost is a whole JVM
+again — roughly the pre-Layer-3 profile (~1–2 GB per sandbox), not the ~75 MB
+per extra classloader the in-JVM pool claimed. That claim was never realisable:
+the second in-JVM sandbox cannot boot at all. `SandboxPoolMemoryBench` now
+reports the daemon JVM plus each worker's RSS from `/proc/<pid>/status`; rerun
+it and update this section on Robolectric / JDK / framework upgrades.
 
-Semantics under background boot:
-
-- **Dispatch routes across the ready prefix.** `chooseSlotIndex` mods by
-  the ready-slot count, not `sandboxCount`, so a render never queues on a
-  still-bootstrapping sandbox. Affinity re-keys as slots come up (mod 1 →
-  mod 2 → …) — a cache-warmth cost only; once the pool completes,
-  dispatch is bit-identical with the eager path.
-- **Interactive waits for slot 1.** `acquireInteractiveSession` awaits
-  the interactive slot's readiness (bounded by the existing 30 s start
-  timeout) and throws the usual clean `Unsupported` if it isn't up yet —
-  callers already handle that with the v1 fallback.
-- **A permanent background slot failure caps the pool** at the slots
-  already booted (loudly logged) instead of aborting the daemon — the
-  eager path's whole-host abort only applies to slot 0. Boot-retry
-  behaviour per slot is unchanged.
-- **Boot-time warm render.** Each background-booted slot renders the
-  daemon-shipped `DaemonWarmupPreview` once (disable with
-  `-Dcomposeai.daemon.warmRenderOnBoot=false`), paying first-composition
-  + `HardwareRenderer` + font-stack + PNG-encode init off the request
-  path. The slot is published for dispatch only **after** its warm render
-  completes, so a live render can never queue behind the cold warm-up.
-  Slot 0 is left to serve's own `prewarm()` throwaway render.
-
-`ServeBundleDaemon` opts serve-spawned Android daemons in by default
-(serve fronts the daemon with baked PNGs while it warms, so nothing
-needs the strict all-ready `initialize`); the Gradle-plugin / VS Code
-launch keeps the eager contract. The deploy image also carries the flag
-in `JAVA_TOOL_OPTIONS` for the source-build catalog path.
-
-## atrace sections (`androidx.tracing`)
-
-`-Dcomposeai.daemon.atrace=true` (default **off**) installs
-`AndroidxTraceSections` inside each sandbox: every render-phase span the
-daemon's chrome-trace recorder already times (`compose:setContent`,
-`render:captureRoboImage`, `dataArtifact:*`, …) plus a whole-render
-`composeai:render:<previewId>` parent span is mirrored onto
-`android.os.Trace` via `androidx.tracing`, lining the daemon's phases up
-with the framework's and Compose's own sections in an atrace-level
-capture. Opt-in because Robolectric's `ShadowTrace` accumulates section
-history in static state with no test-lifecycle resets in a long-lived
-daemon.
+Sizing knobs are unchanged — `replicasPerDaemon` on the supervisor,
+`composeai.daemon.sandboxCount` on the daemon — so a memory-constrained host
+turns the pool down the same way it always did (`replicasPerDaemon = 0`).
 
 ## What this does NOT solve
 
-- **Cross-module sharing.** Different Compose / Kotlin / AGP versions
-  still need separate JVMs.
-- **OOM blast radius.** A leak in one pooled sandbox takes down its
-  peers. v1 keeps the whole-JVM recycle.
-- **Desktop replicas.** AWT EDT and Skiko's GPU context are
-  process-global; out of scope.
+- **Cross-module sharing.** Different Compose / Kotlin / AGP versions still
+  need separate daemons.
+- **Concurrent held sessions.** Still one at a time per host — the pinned slot
+  is the in-process one.
+- **Desktop replicas.** AWT EDT and Skiko's GPU context are process-global;
+  out of scope.
 
 ## Cross-references
 
 - DESIGN.md § 9 — sandbox bootstrap and recycle policy.
 - CLASSLOADER.md — parent/child classloader split per slot.
-- ROBOLECTRIC-PRIMER.md § "Native library loading" — load-once-per-JVM
-  constraint.
+- ROBOLECTRIC-PRIMER.md § "Native library loading" — the load-once-per-JVM
+  constraint this design is built around.
+- INTERACTIVE-ANDROID.md § 2 — held-session capacity.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -33,22 +33,23 @@ class DaemonSupervisor(
   private val clientFactory: DaemonClientFactory,
   private val router: NotificationRouter = NotificationRouter(),
   /**
-   * Concurrent render slots per (workspace, module) beyond the first. SANDBOX-POOL.md Layer 3 — the
+   * Concurrent render slots per (workspace, module) beyond the first. SANDBOX-POOL.md — the
    * supervisor passes `composeai.daemon.sandboxCount = 1 + replicasPerDaemon` as a sysprop on the
    * launch descriptor; the daemon's
-   * [`RobolectricHost`][ee.schimke.composeai.daemon.RobolectricHost] boots that many in-JVM
-   * Robolectric sandboxes and dispatches concurrent `renderNow` requests across them.
+   * [`RobolectricHost`][ee.schimke.composeai.daemon.RobolectricHost] then hosts one sandbox itself
+   * and spawns a worker JVM for each remaining slot (Robolectric's native runtime allows exactly
+   * one sandbox per process — issue #3072), dispatching concurrent `renderNow` requests across
+   * them.
    *
-   * **Default 3** — the daemon comes up with **4** in-JVM sandboxes (1 + 3) so a typical preview
-   * grid can render in parallel without the user opting in. This is cheap thanks to Layer 3: extra
-   * sandboxes share the JVM baseline + native heap, so the marginal cost per slot is the sandbox
-   * classloader's instrumented bytecode (~ a few hundred MB each at peak). `0` opts out and keeps a
-   * single sandbox — bit-identical with the pre-pool path on disk.
+   * **Default 4** — the daemon comes up with 5 sandboxes (1 + 4) so a typical preview grid can
+   * render in parallel without the user opting in. Each slot beyond the first is a worker JVM the
+   * daemon spawns and owns, so the marginal cost is a whole JVM: turn the knob down (or to `0`,
+   * which keeps a single sandbox, bit-identical with the pre-pool path) on memory-constrained
+   * hosts.
    *
-   * Pre-Layer-3 this knob spawned N additional **JVM subprocesses**; that wasted ~2 GB per replica
-   * on shared per-JVM cost (native heap, JVM baseline, instrumented framework). Layer 3 collapses
-   * those into a single daemon JVM with N sandbox classloaders. Wire-protocol-visible behaviour
-   * (initialize, renderNow, fileChanged fan-out) is unchanged from the consumer's perspective.
+   * Wire-protocol-visible behaviour (initialize, renderNow, fileChanged fan-out) is unchanged from
+   * the consumer's perspective — the supervisor still talks to exactly one daemon process per
+   * (workspace, module), and that daemon fans renders out to its workers internally.
    */
   private val replicasPerDaemon: Int = DEFAULT_REPLICAS_PER_DAEMON,
   /**
@@ -191,9 +192,9 @@ class DaemonSupervisor(
 
   private fun spawn(project: RegisteredProject, modulePath: String): SupervisedDaemon {
     val baseDescriptor = descriptorProvider.descriptorFor(project, modulePath)
-    // SANDBOX-POOL.md Layer 3 — inject `composeai.daemon.sandboxCount = 1 + replicasPerDaemon`
-    // into the descriptor's systemProperties so the spawned daemon JVM boots that many in-JVM
-    // sandboxes. The daemon's DaemonMain reads this sysprop and passes it to RobolectricHost. We
+    // SANDBOX-POOL.md — inject `composeai.daemon.sandboxCount = 1 + replicasPerDaemon` into the
+    // descriptor's systemProperties so the spawned daemon owns that many sandboxes (one in its own
+    // JVM, the rest in worker JVMs it spawns). DaemonMain reads the sysprop and passes it on. We
     // merge into a copy rather than mutating the original — the descriptor object is cached by
     // `DescriptorProvider.readingFromDisk` and shared across `daemonFor` calls.
     val descriptor = baseDescriptor.withSandboxCount(1 + replicasPerDaemon)
@@ -322,8 +323,8 @@ class DaemonSupervisor(
     /**
      * Out-of-the-box value for [replicasPerDaemon]. Picked so a typical preview grid renders
      * concurrently without the user opting in: 5 sandboxes per daemon (1 primary + 4 replicas). The
-     * marginal cost is per-sandbox instrumented bytecode in one shared JVM, not a whole extra JVM
-     * each — see SANDBOX-POOL.md Layer 3 for the memory math. Override via the MCP CLI's
+     * cost is one JVM per sandbox beyond the first (#3072 moved the pool out of process — a second
+     * Robolectric sandbox cannot share a JVM); see SANDBOX-POOL.md. Override via the MCP CLI's
      * `--replicas-per-daemon N` flag or the `composeai.mcp.replicasPerDaemon` system property.
      */
     const val DEFAULT_REPLICAS_PER_DAEMON: Int = 4
@@ -343,10 +344,10 @@ data class RegisteredProject(
 )
 
 /**
- * A live daemon — owned by [DaemonSupervisor]. SANDBOX-POOL.md Layer 3: one daemon JVM per
- * (workspaceId, modulePath); concurrent render capacity comes from in-JVM sandbox pooling
+ * A live daemon — owned by [DaemonSupervisor]. SANDBOX-POOL.md: one *supervised* daemon process per
+ * (workspaceId, modulePath); concurrent render capacity comes from that daemon's own sandbox pool,
  * configured via `composeai.daemon.sandboxCount` on the launch descriptor (the supervisor passes
- * `1 + replicasPerDaemon`).
+ * `1 + replicasPerDaemon`) and realised as one in-daemon sandbox plus N worker JVMs.
  *
  * Pre-Layer-3 this class fronted N+1 separate JVM subprocesses; the public surface ([client],
  * [allClients], [clientForRender]) survives that change because the daemon-side slot dispatch
@@ -523,24 +524,24 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
 
   /**
    * Snapshot of every active client — for fan-out APIs (e.g. `fileChanged`, `setVisible`). Always a
-   * singleton list under Layer 3; kept as a list for source-compatibility with callers that iterate
-   * it (they keep working unchanged).
+   * singleton list — one supervised daemon per module; kept as a list for source-compatibility with
+   * callers that iterate it (they keep working unchanged).
    */
   fun allClients(): List<DaemonClient> = spawn?.let { listOf(it.client) } ?: emptyList()
 
   /**
-   * Returns the client for a render keyed on [previewId]. Layer 3: always the single client; the
-   * daemon-side `RobolectricHost.submit` dispatches across in-JVM sandbox slots internally. The
+   * Returns the client for a render keyed on [previewId]. Always the single client; the daemon-side
+   * `RobolectricHost.submit` dispatches across its sandbox slots (in-process plus workers). The
    * [previewId] argument is informational — kept on the API so a future affinity-aware wire change
    * can use it without breaking callers.
    */
   fun clientForRender(@Suppress("UNUSED_PARAMETER") previewId: String): DaemonClient = client
 
   /**
-   * Always 1 under Layer 3 (one JVM subprocess per supervised daemon). Concurrent render capacity
-   * is `1 + replicasPerDaemon` and is realised inside the daemon JVM's sandbox pool, not at the
-   * subprocess level. Kept for source-compatibility with callers that previously asserted "primary
-   * plus N replicas" — those assertions are now wrong, but the method itself doesn't lie.
+   * Always 1 — one *supervised* subprocess per daemon. Concurrent render capacity is `1 +
+   * replicasPerDaemon` and is realised by the daemon's own sandbox pool (whose worker JVMs the
+   * supervisor neither spawns nor counts). Kept for source-compatibility with callers that asserted
+   * "primary plus N replicas" — those assertions are now wrong, but the method itself doesn't lie.
    */
   fun replicaCount(): Int = if (spawn != null) 1 else 0
 
@@ -702,7 +703,7 @@ data class DaemonLaunchDescriptor(
 ) {
 
   /**
-   * SANDBOX-POOL.md Layer 3 — returns a copy with `composeai.daemon.sandboxCount` merged into
+   * SANDBOX-POOL.md — returns a copy with `composeai.daemon.sandboxCount` merged into
    * [systemProperties]. The supervisor calls this on the descriptor read from disk before passing
    * it to [DaemonClientFactory.spawn] so the daemon JVM picks up the right pool size at boot.
    *


### PR DESCRIPTION
Closes #3072.

## Why

Robolectric's native-graphics runtime binds to a **single classloader per process**. `libandroid_runtime.so` loads once and registers its JNI natives against the first sandbox's instrumented framework classes; its `loaded` flag lives in a static owned by *that sandbox's* classloader. A second sandbox in the same JVM sees `loaded == false`, re-runs `Typeface.loadPreinstalledSystemFontMap()` against an already-loaded library, and gets a font map with no default family:

```
NullPointerException: Cannot read field "mStyle" because "family" is null
  at android.graphics.Typeface.create(Typeface.java:928)
  at android.graphics.Typeface.setSystemFontMap(Typeface.java:1410)
```

…then the next native text call kills the process with `SIGSEGV` (exit 134). So `RobolectricHost(sandboxCount > 1)` could never boot — which blocked interactive sessions, scripted recording, and concurrent multi-slot renders. Reproduced on `main` in this session: **all 7** `RobolectricHostPoolTest` cases fail with that NPE.

## What

Scale the pool by **processes**, one sandbox each.

- **`SandboxProcessPool`** (parent side) spawns one worker JVM per slot beyond the first — same classpath, the daemon's JVM flags minus what must not be duplicated (agents, JDWP), and every `composeai.*` / `robolectric.*` / `android.*` / `roborazzi.*` system property, so a worker's render is configured identically to the daemon's own (including `composeai.daemon.userClassDirs` for hot reload). The parent listens; the worker dials back.
- **`SandboxWorkerMain`** (child side) is a plain `RobolectricHost(sandboxCount = 1)` plus a socket loop — deliberately *not* a daemon. `RobolectricHost.submit` resolves `previewId` → full spec payload before dispatch, so only a payload in and a `RenderResult` out cross the boundary.
- **The result survives intact.** The host already reduced sandbox-side results to plain data before handing them to callers (`copyPreviewContextAcrossClassloaders` copies device context + theme payload and drops the live `slotTables` / `rootForTest` handles). Every surviving field is a String/number/Map, so the wire DTO is faithful and host-side data products see the same input either way.
- **Interactive sessions move to slot 0**, the in-process sandbox: the held rule, bridge queues and frame latches are live object handles that can't be proxied. The *renders* are what serialize cleanly, so they move out of process while a session holds the slot. `supportsInteractive` still reads `sandboxCount >= 2` — one to pin, one left to render — plus a new clean `Unsupported` while no worker is ready yet.
- **The per-worker sandbox-cache discriminator is gone** from `SandboxHoldingRunner`. It existed to force N sandboxes into one JVM, i.e. the exact arrangement that breaks; without it, sequential hosts in a JVM share one cached sandbox.
- Hot-reload swaps, background boot, boot-time warm renders, affinity dispatch and shutdown all cross the process boundary; a worker that dies mid-request is dropped from the pool and logged with its pid.
- `SandboxPoolMemoryBench` rewritten: it now reports the daemon JVM plus each worker's RSS from `/proc/<pid>/status`, since reading only this JVM would under-report the pool by a factor of N.
- `docs/daemon/SANDBOX-POOL.md` rewritten around the process model, including the rejected in-JVM workarounds so they don't get re-tried.

## Trade-off, stated plainly

A slot beyond the first is now a whole JVM again (~1–2 GB), not the ~75 MB per extra classloader the in-JVM pool claimed. That claim was never realisable — the second in-JVM sandbox cannot boot at all. Sizing knobs are unchanged (`replicasPerDaemon`, `composeai.daemon.sandboxCount`), so a constrained host turns the pool down the same way it always did.

## Test plan

Run in this session on `:daemon:android` (JDK 17 / Robolectric SDK 35):

- [x] `RobolectricHostPoolTest.twoSlotsServeRendersFromDistinctProcesses` — 20 renders spread across both slots; the worker's pid is present and differs from the daemon JVM's. **This is the case that could not boot before.**
- [x] `swapUserClassLoadersBroadcastsToTheInProcessHolderAndTheWorkers` — in-process holder observes the swap, the worker survives it and keeps serving.
- [x] `samePreviewIdAlwaysLandsOnSameSlot`, `normalRendersAvoidInteractiveSlotWhenHeldSessionIsPinned`, `rejectsLegacyHolderPlusFactory`, `rejectsLegacyHolderWithSandboxCountAboveOne`
- [x] `RobolectricHostTest` (single sandbox) and `ThemeConsumerCaptureRenderTest` (real render, plain runner) still pass — the `sandboxCount = 1` path is untouched.
- [x] `./gradlew :daemon:android:ktfmtFormat :mcp:ktfmtFormat`, `:mcp:compileKotlin`, `:daemon:android:compileDebugKotlin` / `compileDebugUnitTestKotlin`

**Not verifiable in this container — needs CI:** the three pool cases that require real Compose *text* rendering through the daemon host path (`realRendersOnBothSlots…`, `interactiveSessionRunsOnTheInProcessSandbox`, `backgroundBootServesRendersBeforePoolCompletesAndWarmsTheLateSlot`). This sandbox's daemon-host sandbox comes up with a broken font map and any real render aborts the JVM — and that is **pre-existing, not from this change**: `RenderEngineTest` on unmodified `main` dies the same way here (exit 134). Please watch those three on CI; I'll follow the run and fix what it reports.

Text-only PR (no rendered-surface changes), so no visual evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpgFQcgv5s3P25GGJxNGv6)_