### PR TITLE
fix(daemon-tests): assert the gradient export contract the exporter actually implements

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -373,8 +373,22 @@ class RenderEngineTest {
     }
   }
 
+  /**
+   * A **linear** brush background exports as a real `<linearGradient>` fill with its label left
+   * editable — no raster at all.
+   *
+   * This test used to assert the opposite ("brush-backed layer must use the hybrid raster path"),
+   * which was correct when any brush defeated flat-colour resolution and forced the whole subtree
+   * to be baked. #2852 superseded that for linear gradients: the brush is now captured and emitted
+   * as an SVG gradient def, so the export stays vector and the text stays editable in Figma. The
+   * assertion was simply never updated, and the failure sat masked inside a larger Robolectric
+   * breakage on `main` until that was fixed (#3099).
+   *
+   * [figmaSvgExportRastersARadialBrushBackground] holds the other half of the contract, so
+   * "gradients no longer raster" can't quietly become "nothing rasters".
+   */
   @Test
-  fun figmaSvgExportRastersBrushBackgroundWithItsCompleteSubtree() {
+  fun figmaSvgExportEmitsALinearBrushBackgroundAsAGradientWithEditableText() {
     val outputDir = tempFolder.newFolder("renders-figma-gradient")
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
     System.setProperty("roborazzi.test.record", "true")
@@ -395,10 +409,61 @@ class RenderEngineTest {
 
       val previewDir = outputDir.parentFile!!.resolve("data").resolve("figma-gradient")
       val svg = previewDir.resolve("compose-figma.svg").readText()
-      assertTrue("brush-backed layer must use the hybrid raster path", svg.contains("<image "))
+
+      assertTrue("a linear brush must be emitted as a gradient def, got:\n$svg", svg.contains("<linearGradient"))
+      assertTrue("the background rect must reference that def, got:\n$svg", svg.contains("fill=\"url(#"))
+      // The whole point of the gradient path over a raster: the label survives as editable text.
+      assertTrue("the label must stay editable, got:\n$svg", svg.contains(">Gradient<"))
+      assertFalse("a linear brush must not fall back to a raster, got:\n$svg", svg.contains("<image "))
       assertFalse(
-        "the complete raster already contains the label, so no editable duplicate should survive",
-        svg.contains(">Gradient<"),
+        "no raster crop should be written for a linear brush",
+        previewDir.resolve("figma-raster").exists(),
+      )
+
+      // Same end-to-end colour claim the raster crop used to make — red on the left, blue on the
+      // right — now read off the gradient's stops rather than sampled pixels.
+      val stops = Regex("""<stop offset="([\d.]+)" stop-color="(#[0-9A-Fa-f]{6})"/>""").findAll(svg)
+      val byOffset = stops.map { it.groupValues[1].toDouble() to it.groupValues[2].uppercase() }.toList()
+      assertEquals("expected exactly two stops, got $byOffset", 2, byOffset.size)
+      assertEquals("gradient must start red", "#FF0000", byOffset.first().second)
+      assertEquals("gradient must end blue", "#0000FF", byOffset.last().second)
+      assertTrue("stops must run left to right", byOffset.first().first < byOffset.last().first)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * The raster half of the brush contract: `ModifierTokenResolver.linearGradient` returns null for
+   * anything that isn't a `LinearGradient`, so a radial brush resolves neither a flat colour nor a
+   * gradient def and the layer bakes to a raster instead of being drawn as a gradient it isn't.
+   */
+  @Test
+  fun figmaSvgExportRastersARadialBrushBackground() {
+    val outputDir = tempFolder.newFolder("renders-figma-radial")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=RadialGradientBackgroundCard;" +
+              "widthPx=128;heightPx=48;density=1.0;" +
+              "showBackground=true;" +
+              "outputBaseName=figma-radial"
+        ),
+        timeoutMs = 120_000,
+      )
+
+      val previewDir = outputDir.parentFile!!.resolve("data").resolve("figma-radial")
+      val svg = previewDir.resolve("compose-figma.svg").readText()
+      assertTrue("a radial brush must keep the hybrid raster path, got:\n$svg", svg.contains("<image "))
+      assertFalse(
+        "a radial brush must not be emitted as a linear gradient it isn't, got:\n$svg",
+        svg.contains("<linearGradient"),
       )
 
       val crop =
@@ -406,16 +471,14 @@ class RenderEngineTest {
           .resolve("figma-raster")
           .listFiles { file -> file.extension == "png" }
           ?.singleOrNull()
-      assertNotNull("gradient layer must produce one raster crop", crop)
+      assertNotNull("radial layer must produce one raster crop", crop)
       val image = ByteArrayInputStream(crop!!.readBytes()).use { ImageIO.read(it) }
-      assertNotNull("gradient raster crop must decode", image)
-      val left = image!!.getRGB(image.width / 8, image.height / 2)
-      val right = image.getRGB(image.width * 7 / 8, image.height / 2)
-      assertTrue("left side should remain red-dominant", ((left shr 16) and 0xFF) > (left and 0xFF))
-      assertTrue(
-        "right side should remain blue-dominant",
-        (right and 0xFF) > ((right shr 16) and 0xFF),
-      )
+      assertNotNull("radial raster crop must decode", image)
+      // Radial: red at the centre, shading to blue at the edges.
+      val centre = image!!.getRGB(image.width / 2, image.height / 2)
+      val edge = image.getRGB(image.width - 1, image.height / 2)
+      assertTrue("centre should be red-dominant", ((centre shr 16) and 0xFF) > (centre and 0xFF))
+      assertTrue("edge should be blue-dominant", (edge and 0xFF) > ((edge shr 16) and 0xFF))
     } finally {
       host.shutdown()
     }

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -243,7 +243,11 @@ fun OpaqueImageSquare() {
   }
 }
 
-/** Brush-background hybrid SVG fixture: gradient pixels plus editable-looking child content. */
+/**
+ * **Linear**-brush background fixture. Since #2852 a linear gradient is captured and emitted as a
+ * real SVG `<linearGradient>` fill, so this exports fully vector: gradient def + editable `<text>`,
+ * no raster. [RadialGradientBackgroundCard] is the other half of that contract.
+ */
 @Composable
 fun GradientBackgroundCard() {
   Box(
@@ -256,6 +260,29 @@ fun GradientBackgroundCard() {
     contentAlignment = Alignment.Center,
   ) {
     Text("Gradient", color = Color.White)
+  }
+}
+
+/**
+ * **Radial**-brush background fixture — the raster half of the brush contract.
+ *
+ * `ModifierTokenResolver.linearGradient` deliberately returns null for anything that isn't a
+ * `LinearGradient`, so a radial brush resolves no flat colour and no gradient def: the layer falls
+ * back to the hybrid raster path rather than being emitted as a gradient it isn't. Same shape and
+ * label as [GradientBackgroundCard] so the two differ only in the brush.
+ */
+@Composable
+fun RadialGradientBackgroundCard() {
+  Box(
+    modifier =
+      Modifier.fillMaxSize()
+        .background(
+          Brush.radialGradient(listOf(Color(0xFFFF0000), Color(0xFF0000FF))),
+          RoundedCornerShape(8.dp),
+        ),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text("Radial", color = Color.White)
   }
 }
 


### PR DESCRIPTION
Fixes #3099 — `main` is red on `RenderEngineTest.figmaSvgExportRastersBrushBackgroundWithItsCompleteSubtree`.

## It wasn't the font fix

I originally suspected #3094, which landed alongside it. That was wrong, and I've corrected the issue: **the test fails identically on `a30b0f9`, the commit before the font fix**. #3094 only made the failure *visible*, by clearing the 43-failure Robolectric/Typeface collapse this one was buried inside.

## What's actually happening

The fixture uses `Brush.horizontalGradient`. Here is what the exporter produces today:

```svg
<defs>
  <linearGradient id="gf-0" x1="0" y1="0" x2="1" y2="0">
    <stop offset="0" stop-color="#FF0000"/>
    <stop offset="1" stop-color="#0000FF"/>
  </linearGradient>
</defs>
...
<rect x="0" y="0" width="128" height="48" rx="8" ry="8" fill="url(#gf-0)"/>
<text x="37" y="29.02" font-size="14" fill="#FFFFFF">Gradient</text>
```

No `<image>`, no `figma-raster/` crop — fully vector, gradient preserved exactly, label still editable in Figma. The test demands the opposite ("brush-backed layer must use the hybrid raster path").

That output is **correct and better**, and it's the documented contract. #2852 added `ModifierTokenResolver.linearGradient` to capture a linear brush as a real gradient def, and its KDoc is explicit that it returns null for radial/sweep/shader brushes *"so those keep the raster fallback rather than being emitted as a gradient they aren't"*. `FigmaLayeredSvgTest.aGradientBackgroundIsEmittedAsALinearGradientFill` already pins the same rule at unit level and passes. The end-to-end test just never got updated when the feature landed, and has been failing since — masked.

## The fix

Rather than relax the assertion and lose what it was guarding, the contract is split across two tests, so "gradients no longer raster" can't quietly become "nothing rasters":

| test | asserts |
|---|---|
| `figmaSvgExportEmitsALinearBrushBackgroundAsAGradientWithEditableText` | `<linearGradient>` def emitted, rect references it via `fill="url(#…)"`, `>Gradient<` **stays** editable, and **no** `<image >` or `figma-raster/` directory is produced |
| `figmaSvgExportRastersARadialBrushBackground` *(new)* | a radial brush still bakes to exactly one raster crop, is **not** emitted as a linear gradient, and the crop is red at the centre → blue at the edge |

The new `RadialGradientBackgroundCard` fixture is deliberately identical to `GradientBackgroundCard` apart from the brush, so the pair isolates the one variable that decides the path.

The old test's end-to-end colour claim is kept rather than dropped — red on the left, blue on the right — now read off the gradient's stops instead of sampled crop pixels, since there are no longer any crop pixels to sample.

## Test plan

- `:daemon:android:testDebugUnitTest --tests "*figmaSvgExportEmitsALinearBrushBackgroundAsAGradientWithEditableText*" --tests "*figmaSvgExportRastersARadialBrushBackground*"` — **BUILD SUCCESSFUL**, both pass
- Verified the failure predates #3094 by running the original test on `a30b0f9` — fails there too
- Captured the exported SVG directly to confirm the emitted shape quoted above, rather than inferring it
- `ktfmtFormat` applied
- Full `:daemon:android:testDebugUnitTest` was still running locally when this was pushed; CI's Module Unit Tests leg is the authority and should now go green. I'm tracking it and will follow up here if anything else in that module surfaces.

No visual surface changes — this is test/fixture only, so there is nothing to render for before/after evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fuba6kiB52jrnnuaxc8JtR)_