### PR TITLE
fix(daemon): require an explicit onExit so a forgotten override can't kill the test JVM

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -721,6 +721,8 @@ fun main(args: Array<String>) {
       historyManager = historyManager,
       extensions = extensions,
       btaCompileService = btaCompileService,
+      // A real daemon process: end the JVM on `exit` / idle timeout / classpathDirty grace.
+      onExit = JsonRpcServer.EXIT_PROCESS,
     )
   server.run()
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -92,6 +92,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.system.exitProcess
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -254,7 +255,19 @@ class JsonRpcServer(
    */
   private val btaCompileService: ee.schimke.composeai.daemon.bta.BtaCompileService? = null,
   private val fileSystem: FileSystem = SystemFileSystem,
-  private val onExit: (Int) -> Unit = { code -> System.exit(code) },
+  /**
+   * What the server does when it reaches a terminal path (`exit`, idle timeout, `classpathDirty`
+   * grace expiry). **Deliberately has no default.**
+   *
+   * It used to default to `System.exit(code)`, which is right for a real daemon and catastrophic
+   * in-process: one construction site that forgot to override it turned an `exit` notification into
+   * the death of the *test JVM*, taking the Gradle test executor and every class scheduled after it
+   * down with no failing test to point at — `:daemon:core:test` silently ran 20 of its 35 classes
+   * (#3087). Requiring the parameter moves that from a silent runtime truncation to a compile error
+   * at the call site. Real daemons pass [EXIT_PROCESS]; in-process callers pass a lambda that keeps
+   * the JVM alive.
+   */
+  private val onExit: (Int) -> Unit,
   /**
    * Factory for the native XR render server (see the "XR render service" section in
    * `protocol/Messages.kt`). When non-null the daemon advertises `capabilities.xr` and serves
@@ -4085,6 +4098,13 @@ class JsonRpcServer(
      * on `protocolVersion` mismatch so they get a clean handshake failure instead.
      */
     const val PROTOCOL_VERSION: Int = 2
+
+    /**
+     * The `onExit` a **real daemon process** wants: end the JVM with the server's exit code. Named
+     * rather than inlined at each `DaemonMain` so the process-ending call sites are greppable, and
+     * so no in-process caller reaches it by accident (see the `onExit` parameter doc / #3087).
+     */
+    val EXIT_PROCESS: (Int) -> Unit = { code -> exitProcess(code) }
 
     const val IDLE_TIMEOUT_PROP: String = "composeai.daemon.idleTimeoutMs"
     const val DEFAULT_IDLE_TIMEOUT_MS: Long = 5_000L

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -238,12 +238,11 @@ class JsonRpcServerIntegrationTest {
         host = host,
         daemonVersion = "test",
         extensions = extensions,
-        // `onExit` MUST be overridden in every in-process server test: its default is
-        // `System.exit(code)`, so an `exit` notification here doesn't end the server, it ends the
-        // *test JVM* — taking the Gradle test executor and every not-yet-run class with it. This
-        // test doesn't assert on the exit code, but it still has to keep the JVM alive; leaving
-        // the default in place silently truncated `:daemon:core:test` after this class, skipping
-        // the remaining 15 (#3086).
+        // `onExit` is a required parameter precisely because of this call site: it used to default
+        // to `System.exit(code)`, so an `exit` notification here didn't end the server, it ended
+        // the *test JVM* — taking the Gradle test executor and every not-yet-run class with it,
+        // silently truncating `:daemon:core:test` after this class (#3087). This test doesn't
+        // assert on the exit code, but it still has to keep the JVM alive.
         onExit = { /* keep the test JVM alive; this test asserts on notifications, not exit */ },
       )
     val serverThread =

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -41,8 +41,9 @@ import java.nio.file.Path
  *    out of `read()` and calls `host.shutdown(timeoutMs)` so the in-flight render drains before the
  *    JVM exits. Mirrors the no-mid-render-cancellation enforcement listed in
  *    [DESIGN.md § 9](../../../../../../docs/daemon/DESIGN.md#no-mid-render-cancellation--invariant--enforcement).
- * 6. [JsonRpcServer.run] blocks until the client sends `shutdown` + `exit` or stdin closes; it
- *    calls `System.exit` itself.
+ * 6. [JsonRpcServer.run] blocks until the client sends `shutdown` + `exit` or stdin closes, then
+ *    invokes the `onExit` it was built with — [JsonRpcServer.EXIT_PROCESS] on this subprocess path,
+ *    a no-op on the embedded path, which shares its JVM with the caller.
  * 7. Defensive `host.shutdown(...)` in `finally` — `JsonRpcServer.run` already calls
  *    `host.shutdown()` on its `cleanShutdown` path, but if `run()` itself throws (e.g. an
  *    unrecoverable IO error) before reaching that, the host's render thread is still alive and a
@@ -67,7 +68,7 @@ fun main(args: Array<String>) {
     input = System.`in`,
     output = realOut,
     installSigtermHook = true,
-    onExit = { code -> System.exit(code) },
+    onExit = JsonRpcServer.EXIT_PROCESS,
   )
 }
 
@@ -96,7 +97,13 @@ fun runDaemon(
   input: InputStream,
   output: OutputStream,
   installSigtermHook: Boolean,
-  onExit: (Int) -> Unit = { code -> System.exit(code) },
+  /**
+   * Terminal action, forwarded to [JsonRpcServer]. **No default, for the same reason the server's
+   * own parameter has none** (#3087): subprocess mode wants [JsonRpcServer.EXIT_PROCESS], embedded
+   * mode shares the JVM with its caller and must swallow the code — and a default silently picks
+   * the wrong one for whichever caller forgets.
+   */
+  onExit: (Int) -> Unit,
 ) {
 
   // D-harness.v1.5a — when the harness drives real-mode runs it sets

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
@@ -127,6 +127,8 @@ fun main(args: Array<String>) {
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
+      // The harness runs as its own daemon process, so ending the JVM is the right terminal action.
+      onExit = JsonRpcServer.EXIT_PROCESS,
     )
   server.run()
 }

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
@@ -128,6 +128,21 @@ public object SubspaceSceneRecorder {
         "@XrSubspacePreview must carry a unique testTag (panel ids and texture paths derive from it)."
     }
     val views = tagged.mapNotNull { (tag, node) -> contentView(node)?.let { tag to it } }.toMap()
+    // Recovering *no* view when there are tagged panels can't be a per-panel content problem — it
+    // means the reflective bridge in [contentView] no longer resolves, the way the scenecore
+    // `getRtEntity$scenecore` → `getRtEntity` rename broke it (#3087). Per-panel failures stay
+    // silent on purpose (one unreadable panel should cost an overlay, not the render), but the
+    // all-or-nothing case has exactly one cause and is worth naming: without this the symptom
+    // downstream is an empty semantics tree and a missing texture, which reads as "the recorder
+    // produced nothing" rather than "the accessor moved again".
+    if (views.isEmpty() && panels.isNotEmpty()) {
+      System.err.println(
+        "compose-ai-tools xr: recovered no content View for any of ${panels.size} tagged panel(s). " +
+          "SubspaceSceneRecorder reaches a panel's view reflectively via one of " +
+          "$RT_ENTITY_ACCESSORS then getView(); if androidx.xr.scenecore renamed either, panel " +
+          "textures and 2D semantics will be missing from this scene."
+      )
+    }
     val scene = SpatialScene(previewId = previewId, camera = defaultCamera(panels), panels = panels)
     return RecordedSubspace(scene, views)
   }


### PR DESCRIPTION
Closes #3087.

## Both red tasks in #3087 are already green on `main`

Before writing anything I re-ran both, forced (`--rerun-tasks --no-build-cache`, since the read-only BuildFetch cache was serving passing entries) against `main` @ `6992130`:

| task | result |
| --- | --- |
| `:renderer-xr:testDebugUnitTest` | **11 tests, 0 failures** — including all three the issue names (`SubspaceSceneRecorderTreeTest`, `SubspaceWorldIntegrationTest`, `XrSubspaceRendererTest`) |
| `:daemon:core:test` | **58 classes, 475 tests, 0 failures** — no truncation, JVM ran the whole suite |

Both were fixed by #3094, which landed *after* the issue was filed:

- **XR half** — the empty scene was the scenecore `getRtEntity$scenecore` → `getRtEntity` rename. #3094's `rtEntityOf` spans both accessor names, so panel views resolve again and the per-panel 2D content is recorded.
- **`:daemon:core` half** — #3094 added the missing `onExit` override to the `JsonRpcServerIntegrationTest` call site that was taking the test JVM down.

#3094's commit message cites **#3086** (an unrelated dialog-window issue), which is why #3087 never got closed by the merge. Nothing further was needed to make either task pass.

## What this PR actually changes

The issue asked for more than the specific call site, and that's what's here:

> a `System.exit` default on a server class that tests construct is a standing hazard, and one stray call costs 15 test classes of coverage with no failing test to point at. Requiring `onExit` explicitly, or defaulting it to a throw, would make this fail loudly at the call site instead.

**`JsonRpcServer.onExit` is now required.** It no longer defaults to `System.exit(code)`. A construction site that forgets it is a compile error, not a silent runtime truncation that reports zero failures while skipping 15 classes. Real daemons pass the new `JsonRpcServer.EXIT_PROCESS`, which also makes the process-ending call sites greppable. The two production sites that relied on the default (`:daemon:android`'s `DaemonMain`, `:daemon:harness`'s `FakeDaemonMain`) now pass it explicitly; every test call site already did after #3094, so no test needed touching.

**`daemon/desktop`'s `runDaemon(...)` had the identical hazard one layer up** — its own `onExit` defaulted to `System.exit(code)`, and embedded mode (`:render-session-embedded-desktop`) shares its JVM with the caller and must swallow the code. Same treatment; both existing callers already passed it explicitly.

**`SubspaceSceneRecorder` names the all-panels-failed case.** Per-panel view-recovery failures still degrade silently to a null `panelContent` on purpose — one unreadable panel should cost an overlay, not the render. But recovering *zero* views when there are tagged panels has exactly one cause: the reflective bridge stopped resolving, which is what the scenecore rename did. That surfaced as an empty semantics tree and missing textures — "the recorder produced nothing" rather than "the accessor moved again". It now says so on stderr, listing the accessors it tried.

## Test plan

- `:daemon:core:test` — 475 tests, 0 failures, with `onExit` required.
- `:renderer-xr:testDebugUnitTest` — 11 tests, 0 failures, with the new diagnostic compiled in.
- Compiles verified across every module that constructs a server or calls `runDaemon`: `:daemon:android:compileDebugKotlin`, `:daemon:desktop`, `:daemon:harness:compileKotlin`, `:render-session-embedded-desktop:compileKotlin`.
- `:daemon:desktop:test` cannot run in this container — 117 of 206 fail on `libskiko-linux-x64.so: libGL.so.1: cannot open shared object file` from `ImageComposeScene.<init>`, and the handful of non-native failures are downstream assertions of the same cause (`pngPath must be populated`, `renderStarted notification should arrive`). Confirmed pre-existing: `TouchOverlayShowcaseRecordingTest` fails identically with `UnsatisfiedLinkError` on unmodified `origin/main` in the same container. CI runs this suite fine, and #3087 does not list it as red.

No visual surfaces changed — this is daemon lifecycle plumbing plus one stderr diagnostic, so there is nothing to render before/after.

## Compatibility note

`:daemon:core` is published to Maven Central, so removing a default parameter is a source- and binary-breaking change for external embedders of `JsonRpcServer`. The module documents itself as pre-1.0 with API that may break across minor versions, and the build has no binary-compatibility validator, so nothing in CI gates it — flagging it so the choice is deliberate rather than discovered later.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRzdqBdWr9rmVc5wyR77Ei)_