### PR TITLE
feat(serve): run the playground compile inside the sandbox too

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -11,6 +11,7 @@ import ee.schimke.composeai.cli.serve.PlaygroundAndroidSessionOpener
 import ee.schimke.composeai.cli.serve.PlaygroundBtaCompiler
 import ee.schimke.composeai.cli.serve.PlaygroundCatalogClasspath
 import ee.schimke.composeai.cli.serve.PlaygroundCompileService
+import ee.schimke.composeai.cli.serve.PlaygroundJailedCompiler
 import ee.schimke.composeai.cli.serve.PlaygroundMode
 import ee.schimke.composeai.cli.serve.PlaygroundPreviewDiscoverer
 import ee.schimke.composeai.cli.serve.PlaygroundPublicGate
@@ -973,7 +974,22 @@ class ServeCommand(args: List<String>) : Command(args) {
       return null
     }
 
-    val compiler = PlaygroundBtaCompiler.fromInstall(java.io.File(workRoot, "bta-ic").toPath())
+    val inProcessCompiler =
+      PlaygroundBtaCompiler.fromInstall(java.io.File(workRoot, "bta-ic").toPath())
+    // Phase 4's residual (issue #3090): with a sandbox configured, the *compile* runs in the jail
+    // too, so a pathological snippet burns a disposable child's CPU/heap budget instead of the
+    // serve JVM's. Falls back to the in-process compiler (loudly) when it can't be jailed.
+    val compiler = inProcessCompiler?.let {
+      val (implJars, pluginJars) =
+        PlaygroundBtaCompiler.installJars()
+          ?: (emptyList<java.io.File>() to emptyList<java.io.File>())
+      PlaygroundJailedCompiler.wrap(
+        sandbox = sandbox,
+        inProcess = it,
+        btaImplJars = implJars,
+        compilerPluginJars = pluginJars,
+      )
+    }
     if (compiler == null) {
       System.err.println(
         "serve: playground compiler unavailable — no lib-bta/ in the CLI install (run from an " +

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
@@ -98,15 +98,26 @@ class PlaygroundBtaCompiler(
      * unavailable. Splits the Compose plugin jar(s) out of the impl classpath.
      */
     fun fromInstall(icWorkingDir: NioPath): PlaygroundBtaCompiler? {
-      val jars = locateBundleSidecarJars("lib-bta")
-      if (jars.isEmpty()) return null
-      val (pluginJars, implJars) = jars.partition { it.name.startsWith(COMPOSE_PLUGIN_PREFIX) }
-      if (implJars.isEmpty()) return null
+      val (implJars, pluginJars) = installJars() ?: return null
       return PlaygroundBtaCompiler(
         btaImplJars = implJars.map(File::toPath),
         compilerPluginJars = pluginJars.map(File::toPath),
         icWorkingDir = icWorkingDir,
       )
+    }
+
+    /**
+     * The staged `lib-bta/` split into (impl, Compose-plugin) jars, or null when the dir is absent
+     * or carries no impl jar. Shared with [PlaygroundJailedCompiler], which binds the same jars
+     * read-only into the compile sandbox and passes them to the child — so the jailed and
+     * in-process compilers can never be looking at different toolchains.
+     */
+    fun installJars(): Pair<List<File>, List<File>>? {
+      val jars = locateBundleSidecarJars("lib-bta")
+      if (jars.isEmpty()) return null
+      val (pluginJars, implJars) = jars.partition { it.name.startsWith(COMPOSE_PLUGIN_PREFIX) }
+      if (implJars.isEmpty()) return null
+      return implJars to pluginJars
     }
 
     /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
@@ -1,0 +1,297 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.Path
+import okio.Path.Companion.toPath
+
+/**
+ * The compile half of the playground's per-session sandbox (`docs/design/PLAYGROUND.md` §6.3,
+ * issue #3090): run `kotlinc` **outside** the serve JVM, inside the same jail the render lanes use.
+ *
+ * Phase 4 ([PlaygroundSandbox]) contained everything that *executes* a snippet — the first frame,
+ * the RC capture, the live session — but [PlaygroundBtaCompiler] still compiled in-process. That
+ * compile does not run snippet code, so it was never an arbitrary-execution hole; it is a
+ * **resource** one. The Kotlin compiler is the least predictable thing on the request path: a
+ * pathological snippet (deep generic inference, a huge literal, an exponential type) can burn CPU
+ * and heap inside the serve JVM itself, where `-Xmx` is the operator's, not the snippet's, and no
+ * wall clock applies. Moving it into the jail puts the compiler under the same memory ceiling, CPU
+ * quota and hard TTL as everything else a stranger touches — and a compiler that OOMs now kills a
+ * disposable child instead of the host.
+ *
+ * The subprocess speaks the same one-JSON-line protocol as [PlaygroundSandboxProbe]: the parent
+ * writes a [PlaygroundCompileRequest] into the snippet's own (jail-writable) work dir, the child
+ * prints one [PlaygroundCompileReport], and anything else — a jail that wouldn't launch, a killed
+ * JVM, unparseable output — becomes a single file-level error so the route still answers the JSON
+ * contract instead of throwing.
+ *
+ * **Cost.** Each compile pays a cold BTA toolchain bootstrap (the in-process compiler amortised it
+ * across requests by holding one `BtaCompileSession`). That is the deliberate v1 trade: a warm
+ * compile JVM per catalog classpath would claw the seconds back, but it re-introduces exactly the
+ * long-lived, shared, snippet-touched process Phase 4 exists to avoid — so it stays a follow-up
+ * with a measurement behind it rather than a guess.
+ */
+class PlaygroundJailedCompiler(
+  private val sandbox: PlaygroundSandbox,
+  private val javaHome: File,
+  /** The serve process's own classpath — the child runs [PLAYGROUND_COMPILE_MAIN] off it. */
+  private val cliClasspath: List<String>,
+  /** `kotlin-build-tools-impl` + friends, staged in the install's `lib-bta/`. */
+  private val btaImplJars: List<String>,
+  /** `kotlin-compose-compiler-plugin-embeddable`, split out of the same dir. */
+  private val compilerPluginJars: List<String>,
+  private val moduleName: String = "playground",
+  private val timeoutSeconds: Long = DEFAULT_COMPILE_TIMEOUT_SECONDS,
+  /** Injected in tests; null (the default) forks a real JVM via [spawn]. */
+  private val launcher: ((List<String>, File) -> PlaygroundSandboxProbe.Launch)? = null,
+) : PlaygroundCompileService.Compiler {
+
+  override fun compile(
+    sources: List<Path>,
+    classpath: List<Path>,
+    outputDir: Path,
+  ): List<PlaygroundDiagnostic> {
+    // The snippet's work dir — the one path the jail leaves writable, and the parent of both the
+    // staged sources and the class output. Everything the compile writes (classes, the IC dir, this
+    // request file) therefore lands inside the directory the token store deletes.
+    val workDir = File(outputDir.toString()).parentFile ?: File(outputDir.toString())
+    val requestFile = File(workDir, "compile-request.json")
+    val request =
+      PlaygroundCompileRequest(
+        sources = sources.map { it.toString() },
+        classpath = classpath.map { it.toString() },
+        outputDir = outputDir.toString(),
+        btaImplJars = btaImplJars,
+        compilerPluginJars = compilerPluginJars,
+        icWorkingDir = File(workDir, "bta-ic").absolutePath,
+        moduleName = moduleName,
+      )
+    return try {
+      requestFile.writeText(JSON.encodeToString(PlaygroundCompileRequest.serializer(), request))
+      val argv = command(workDir, classpath, requestFile)
+      val launch =
+        try {
+          (launcher ?: ::spawn)(argv, workDir)
+        } catch (e: Exception) {
+          return listOf(
+            internalError(
+              "could not launch the compile sandbox '${argv.firstOrNull()}': " +
+                (e.message ?: e.javaClass.simpleName)
+            )
+          )
+        }
+      parse(launch)
+    } catch (e: Exception) {
+      listOf(internalError("compile sandbox failed: ${e.message ?: e.javaClass.simpleName}"))
+    } finally {
+      runCatching { requestFile.delete() }
+    }
+  }
+
+  /** The jail argv + the child JVM's command line. Split out so a test can assert its shape. */
+  internal fun command(workDir: File, classpath: List<Path>, requestFile: File): List<String> {
+    // Read-only: everything the compiler reads — the catalog classpath it compiles against, the BTA
+    // impl + Compose plugin jars, and the CLI's own classpath (the child's main class lives there).
+    val readOnly =
+      (classpath.map { File(it.toString()) } +
+          btaImplJars.map(::File) +
+          compilerPluginJars.map(::File) +
+          cliClasspath.map(::File))
+        .distinct()
+    return sandbox.command(
+      PlaygroundSandbox.Paths(workDir = workDir, readOnly = readOnly, javaHome = javaHome)
+    ) +
+      listOf(File(javaHome, "bin/java").absolutePath) +
+      sandbox.jvmArgs(workDir) +
+      listOf(
+        "-cp",
+        cliClasspath.joinToString(File.pathSeparator),
+        PLAYGROUND_COMPILE_MAIN,
+        requestFile.absolutePath,
+      )
+  }
+
+  /** Read the child's one report line, or explain — as a diagnostic — why there wasn't one. */
+  internal fun parse(launch: PlaygroundSandboxProbe.Launch): List<PlaygroundDiagnostic> {
+    val line = launch.stdout.lineSequence().firstOrNull { it.startsWith(REPORT_PREFIX) }
+    if (line == null) {
+      val why =
+        launch.stderr.lineSequence().filter { it.isNotBlank() }.lastOrNull()
+          ?: "exit code ${launch.exitCode}, no output"
+      // A compiler killed by its own cgroup/TTL lands here: the snippet gets a real error rather
+      // than a mystery "no @Preview found" two steps later.
+      return listOf(internalError("the compile sandbox produced no result — ${why.take(400)}"))
+    }
+    return try {
+      JSON.decodeFromString(PlaygroundCompileReport.serializer(), line.removePrefix(REPORT_PREFIX))
+        .diagnostics
+    } catch (e: Exception) {
+      listOf(internalError("unreadable compile report: ${e.message ?: e.javaClass.simpleName}"))
+    }
+  }
+
+  private fun internalError(message: String) =
+    PlaygroundDiagnostic(severity = PlaygroundSeverity.ERROR, message = message)
+
+  private fun spawn(argv: List<String>, workDir: File): PlaygroundSandboxProbe.Launch {
+    val process =
+      ProcessBuilder(argv)
+        .directory(workDir)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+    val out = StringBuilder()
+    val err = StringBuilder()
+    val outThread = drain(process.inputStream, out)
+    val errThread = drain(process.errorStream, err)
+    val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+    if (!finished) {
+      process.destroyForcibly()
+      process.waitFor(5, TimeUnit.SECONDS)
+    }
+    outThread.join(2_000)
+    errThread.join(2_000)
+    return PlaygroundSandboxProbe.Launch(
+      exitCode = if (finished) process.exitValue() else -1,
+      stdout = out.toString(),
+      stderr =
+        if (finished) err.toString() else "the compile exceeded its ${timeoutSeconds}s budget",
+    )
+  }
+
+  private fun drain(stream: java.io.InputStream, into: StringBuilder): Thread =
+    Thread {
+        runCatching {
+          stream.bufferedReader().forEachLine { synchronized(into) { into.appendLine(it) } }
+        }
+      }
+      .apply {
+        isDaemon = true
+        start()
+      }
+
+  companion object {
+    /** Prefix of the child's single report line, so JVM noise on stdout can't be mistaken. */
+    const val REPORT_PREFIX = "PLAYGROUND_COMPILE "
+
+    const val PLAYGROUND_COMPILE_MAIN = "ee.schimke.composeai.cli.serve.PlaygroundCompileMain"
+
+    /**
+     * A cold BTA bootstrap plus a snippet compile; generous, because the cost of being wrong is a
+     * spurious "no result" on a slow box. The sandbox's own wall-clock TTL still applies on top.
+     */
+    const val DEFAULT_COMPILE_TIMEOUT_SECONDS = 180L
+
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Wrap [inProcess] in a jailed subprocess when [sandbox] is active; otherwise hand back the
+     * in-process compiler unchanged. A dev host with no sandbox keeps today's warm, fast compile
+     * (and today's exposure, which is bounded by the token gate); a `--public` host cannot reach
+     * here without a verified sandbox, so its compiles are always jailed.
+     */
+    fun wrap(
+      sandbox: PlaygroundSandbox,
+      inProcess: PlaygroundCompileService.Compiler,
+      btaImplJars: List<File>,
+      compilerPluginJars: List<File>,
+      onLog: (String) -> Unit = { System.err.println("serve: $it") },
+    ): PlaygroundCompileService.Compiler {
+      if (!sandbox.isActive) return inProcess
+      val cliClasspath =
+        System.getProperty("java.class.path").orEmpty().split(File.pathSeparator).filter {
+          it.isNotBlank()
+        }
+      if (cliClasspath.isEmpty() || btaImplJars.isEmpty()) {
+        // Fail *loud but soft*: the lane still works, just with the pre-#3090 exposure, and the
+        // operator is told which half is missing rather than quietly getting an unjailed compiler.
+        onLog(
+          "playground: cannot jail the compiler (" +
+            (if (cliClasspath.isEmpty()) "the serve process reports no classpath"
+            else "no lib-bta/ jars") +
+            ") — compiles run in-process; snippet execution is still sandboxed."
+        )
+        return inProcess
+      }
+      onLog("playground: compiles run inside the ${sandbox.profile.id} sandbox")
+      return PlaygroundJailedCompiler(
+        sandbox = sandbox,
+        javaHome = File(System.getProperty("java.home")),
+        cliClasspath = cliClasspath,
+        btaImplJars = btaImplJars.map { it.absolutePath },
+        compilerPluginJars = compilerPluginJars.map { it.absolutePath },
+      )
+    }
+  }
+}
+
+/**
+ * What the parent asks the in-jail compiler to do. Paths are absolute; the child opens nothing
+ * else.
+ */
+@Serializable
+data class PlaygroundCompileRequest(
+  val sources: List<String>,
+  val classpath: List<String>,
+  val outputDir: String,
+  val btaImplJars: List<String>,
+  val compilerPluginJars: List<String>,
+  val icWorkingDir: String,
+  val moduleName: String,
+)
+
+/** What it answers: the same diagnostics an in-process compile would have returned. */
+@Serializable
+data class PlaygroundCompileReport(val diagnostics: List<PlaygroundDiagnostic> = emptyList())
+
+/**
+ * The in-jail compiler entrypoint: read one [PlaygroundCompileRequest], run the *same*
+ * [PlaygroundBtaCompiler] the in-process path uses, print one [PlaygroundCompileReport].
+ *
+ * Deliberately thin — the compile behaviour (BTA session, Compose plugin wiring, diagnostic
+ * mapping) stays in one place, so jailing the compiler can't silently drift from not jailing it.
+ */
+object PlaygroundCompileMain {
+
+  @JvmStatic
+  fun main(args: Array<String>) {
+    val requestPath = args.firstOrNull()
+    if (requestPath == null) {
+      System.err.println("usage: PlaygroundCompileMain <request.json>")
+      return
+    }
+    val json = Json { ignoreUnknownKeys = true }
+    val diagnostics =
+      try {
+        val request =
+          json.decodeFromString(PlaygroundCompileRequest.serializer(), File(requestPath).readText())
+        PlaygroundBtaCompiler(
+            btaImplJars = request.btaImplJars.map { File(it).toPath() },
+            compilerPluginJars = request.compilerPluginJars.map { File(it).toPath() },
+            icWorkingDir = File(request.icWorkingDir).toPath(),
+            moduleName = request.moduleName,
+          )
+          .compile(
+            sources = request.sources.map { it.toPath() },
+            classpath = request.classpath.map { it.toPath() },
+            outputDir = request.outputDir.toPath(),
+          )
+      } catch (t: Throwable) {
+        listOf(
+          PlaygroundDiagnostic(
+            severity = PlaygroundSeverity.ERROR,
+            message = "compile sandbox error: ${t.message ?: t.javaClass.simpleName}",
+          )
+        )
+      }
+    println(
+      PlaygroundJailedCompiler.REPORT_PREFIX +
+        Json.encodeToString(
+          PlaygroundCompileReport.serializer(),
+          PlaygroundCompileReport(diagnostics),
+        )
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompilerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompilerTest.kt
@@ -1,0 +1,250 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+
+/**
+ * The compile half of the sandbox (issue #3090): the snippet's `kotlinc` runs in the same jail its
+ * render does, and every way that subprocess can go wrong still answers the route's JSON contract.
+ */
+class PlaygroundJailedCompilerTest {
+
+  private val tempDir: File =
+    java.nio.file.Files.createTempDirectory("playground-jailed-compile-test").toFile()
+
+  @AfterTest
+  fun cleanUp() {
+    tempDir.deleteRecursively()
+  }
+
+  private val workDir = File(tempDir, "snippet-1").apply { mkdirs() }
+  private val outputDir = File(workDir, "classes").apply { mkdirs() }
+
+  private fun compiler(
+    sandbox: PlaygroundSandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP),
+    launcher: (List<String>, File) -> PlaygroundSandboxProbe.Launch,
+  ) =
+    PlaygroundJailedCompiler(
+      sandbox = sandbox,
+      javaHome = File("/opt/jdk17"),
+      cliClasspath = listOf("/install/lib/cli.jar"),
+      btaImplJars = listOf("/install/lib-bta/kotlin-build-tools-impl.jar"),
+      compilerPluginJars = listOf("/install/lib-bta/kotlin-compose-compiler-plugin.jar"),
+      launcher = launcher,
+    )
+
+  private fun report(vararg diagnostics: PlaygroundDiagnostic) =
+    PlaygroundSandboxProbe.Launch(
+      exitCode = 0,
+      stdout =
+        "Picked up JAVA_TOOL_OPTIONS: -Dx\n" +
+          PlaygroundJailedCompiler.REPORT_PREFIX +
+          Json.encodeToString(
+            PlaygroundCompileReport.serializer(),
+            PlaygroundCompileReport(diagnostics.toList()),
+          ),
+      stderr = "",
+    )
+
+  private fun compile(compiler: PlaygroundJailedCompiler) =
+    compiler.compile(
+      sources = listOf(File(workDir, "src/Snippet.kt").absolutePath.toPath()),
+      classpath = listOf("/catalog/app.jar".toPath()),
+      outputDir = outputDir.absolutePath.toPath(),
+    )
+
+  @Test
+  fun `a clean compile reports no diagnostics`() {
+    val diags = compile(compiler { _, _ -> report() })
+
+    assertEquals(emptyList(), diags)
+  }
+
+  @Test
+  fun `the child's diagnostics come back verbatim`() {
+    val diags =
+      compile(
+        compiler { _, _ ->
+          report(
+            PlaygroundDiagnostic(
+              severity = PlaygroundSeverity.ERROR,
+              message = "unresolved reference: Bttn",
+              file = "Snippet.kt",
+              line = 4,
+              ch = 8,
+            )
+          )
+        }
+      )
+
+    assertEquals(1, diags.size)
+    assertEquals("unresolved reference: Bttn", diags.single().message)
+    assertEquals("Snippet.kt", diags.single().file)
+    assertEquals(4, diags.single().line)
+  }
+
+  @Test
+  fun `the request rides a file in the snippet's own work dir, and is cleaned up`() {
+    var seen: PlaygroundCompileRequest? = null
+    val diags =
+      compile(
+        compiler { argv, _ ->
+          val requestFile = File(argv.last())
+          // The jail leaves exactly one path writable — the snippet work dir — so the request has
+          // to live there, not in the parent's temp dir the child can't see.
+          assertEquals(workDir.absolutePath, requestFile.parentFile.absolutePath)
+          seen =
+            Json.decodeFromString(PlaygroundCompileRequest.serializer(), requestFile.readText())
+          report()
+        }
+      )
+
+    assertEquals(emptyList(), diags)
+    val request = requireNotNull(seen)
+    assertEquals(listOf("/catalog/app.jar"), request.classpath)
+    assertEquals(outputDir.absolutePath, request.outputDir)
+    assertTrue(request.icWorkingDir.startsWith(workDir.absolutePath))
+    assertFalse(
+      File(workDir, "compile-request.json").exists(),
+      "the request file is removed once the compile returns",
+    )
+  }
+
+  @Test
+  fun `the child launches behind the jail, on the same toolchain the in-process path uses`() {
+    var argv: List<String> = emptyList()
+    compile(
+      compiler { command, _ ->
+        argv = command
+        report()
+      }
+    )
+
+    assertEquals("bwrap", argv.first(), "the compile runs inside the jail, not beside it")
+    assertTrue("/opt/jdk17/bin/java" in argv)
+    assertTrue(PlaygroundJailedCompiler.PLAYGROUND_COMPILE_MAIN in argv)
+    // The catalog classpath and the BTA toolchain are bound read-only; the work dir is the only
+    // writable bind (asserted in PlaygroundSandboxTest) and carries the request + class output.
+    listOf(
+        "/catalog/app.jar",
+        "/install/lib-bta/kotlin-build-tools-impl.jar",
+        "/install/lib/cli.jar",
+      )
+      .forEach { path ->
+        assertTrue(
+          argv.windowed(3).any { it == listOf("--ro-bind-try", path, path) },
+          "$path should be bound read-only: $argv",
+        )
+      }
+    // The sandbox's JVM caps apply to the compiler too — that is the point of the issue.
+    assertTrue(argv.any { it.startsWith("-Xmx") })
+  }
+
+  @Test
+  fun `a jail that produces no report is a diagnostic, not a throw`() {
+    val diags =
+      compile(
+        compiler { _, _ ->
+          PlaygroundSandboxProbe.Launch(
+            exitCode = 137,
+            stdout = "",
+            stderr = "the compile exceeded its 180s budget",
+          )
+        }
+      )
+
+    val only = diags.single()
+    assertEquals(PlaygroundSeverity.ERROR, only.severity)
+    assertTrue("compile sandbox produced no result" in only.message, only.message)
+    assertTrue("180s budget" in only.message, only.message)
+  }
+
+  @Test
+  fun `garbled child output is a diagnostic too`() {
+    val diags =
+      compile(
+        compiler { _, _ ->
+          PlaygroundSandboxProbe.Launch(
+            exitCode = 0,
+            stdout = PlaygroundJailedCompiler.REPORT_PREFIX + "{not json",
+            stderr = "",
+          )
+        }
+      )
+
+    assertTrue("unreadable compile report" in diags.single().message, diags.single().message)
+  }
+
+  @Test
+  fun `a launcher that throws is reported against the jail, not swallowed`() {
+    val diags = compile(compiler { _, _ -> throw java.io.IOException("bwrap: not found") })
+
+    assertTrue("could not launch the compile sandbox" in diags.single().message)
+    assertTrue("bwrap: not found" in diags.single().message)
+  }
+
+  @Test
+  fun `wrap leaves an unsandboxed host on the in-process compiler`() {
+    val inProcess = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() }
+
+    val wrapped =
+      PlaygroundJailedCompiler.wrap(
+        sandbox = PlaygroundSandbox.NONE,
+        inProcess = inProcess,
+        btaImplJars = listOf(File("/install/lib-bta/impl.jar")),
+        compilerPluginJars = emptyList(),
+      ) {}
+
+    assertTrue(wrapped === inProcess, "no sandbox ⇒ nothing to jail the compiler with")
+  }
+
+  @Test
+  fun `wrap falls back loudly when the toolchain to jail is missing`() {
+    val inProcess = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() }
+    val logs = mutableListOf<String>()
+
+    val wrapped =
+      PlaygroundJailedCompiler.wrap(
+        sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP),
+        inProcess = inProcess,
+        btaImplJars = emptyList(),
+        compilerPluginJars = emptyList(),
+      ) {
+        logs += it
+      }
+
+    assertTrue(wrapped === inProcess)
+    assertTrue(
+      logs.single().contains("cannot jail the compiler"),
+      "an operator who asked for a sandbox must be told the compiler isn't in it: $logs",
+    )
+    assertTrue(
+      logs.single().contains("snippet execution is still sandboxed"),
+      "…and told what IS still contained, so the message isn't alarming beyond its scope",
+    )
+  }
+
+  @Test
+  fun `wrap jails the compiler when the sandbox and toolchain are both there`() {
+    val logs = mutableListOf<String>()
+
+    val wrapped =
+      PlaygroundJailedCompiler.wrap(
+        sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.STRICT),
+        inProcess = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() },
+        btaImplJars = listOf(File("/install/lib-bta/impl.jar")),
+        compilerPluginJars = listOf(File("/install/lib-bta/compose.jar")),
+      ) {
+        logs += it
+      }
+
+    assertTrue(wrapped is PlaygroundJailedCompiler)
+    assertTrue(logs.single().contains("strict"), logs.toString())
+  }
+}

--- a/docs/design/PLAYGROUND.md
+++ b/docs/design/PLAYGROUND.md
@@ -286,6 +286,7 @@ is a pure policy type that produces three things for each snippet JVM:
 | Read-only / ephemeral FS | `bwrap` binds the host read-only with a tmpfs `/tmp`, and the snippet's work dir is the **only** writable path — and that dir is deleted when its preview token drops. |
 | Memory + CPU caps | cgroup (`MemoryMax` / `CPUQuota` / `TasksMax`) on the `systemd`/`strict` profiles, **plus** JVM-level caps on every active profile (`-Xmx`, `-XX:ActiveProcessorCount`, `-XX:+ExitOnOutOfMemoryError`). |
 | One snippet per JVM | Structural: each lane opens its own subprocess daemon over one snippet's classes. |
+| The compile, too | With a sandbox configured, `kotlinc` runs in the same jail — see [§6.3](#63-the-compile-is-jailed-too). |
 
 Profiles, chosen with `--playground-sandbox`:
 
@@ -343,15 +344,44 @@ refused under `--public` and pointed at `strict`; a `custom:` jail is taken at
 its word on caps (they're the operator's to supply, and the startup log says so)
 but must still pass the probe.
 
-### 6.3 Residual: the compiler still runs in-process
+### 6.3 The compile is jailed too
 
-`BtaCompileSession` compiles the snippet **in the serve JVM**. That compile does
-not *execute* snippet code (no annotation processors, no `init` blocks — only
-the Kotlin + Compose compiler plugins we ship), and the request body is capped
-(`MAX_PLAYGROUND_BYTES`), so it is a resource-exhaustion surface rather than an
-execution one. Jailing the compiler too — a compile subprocess per request,
-sharing this same `PlaygroundSandbox` — is the natural follow-up, tracked in
-[#3090](https://github.com/yschimke/compose-ai-tools/issues/3090).
+`kotlinc` used to run **in the serve JVM**, which was never an
+arbitrary-execution hole — compiling a snippet does not run it (no annotation
+processors, no `init` blocks; only the Kotlin + Compose plugins we ship) — but it
+was a **resource** one. The Kotlin compiler is the least predictable thing on the
+request path: a pathological snippet can burn CPU and heap inside the host
+process, where `-Xmx` is the operator's and no wall clock applies.
+
+So with a sandbox configured, [`PlaygroundJailedCompiler`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt)
+runs the compile in the **same jail** the render lanes use: the catalog classpath
+and the `lib-bta/` toolchain bound read-only, the snippet's work dir the one
+writable path, the sandbox's `-Xmx`/CPU caps applied, and a compile budget on
+top. Parent and child speak the same one-JSON-line protocol as the preflight
+probe — the child runs the *same* `PlaygroundBtaCompiler`, so a jailed compile
+can't drift from an unjailed one — and every failure mode (jail won't launch,
+compiler killed, unparseable output) comes back as an ordinary compile
+diagnostic instead of an exception.
+
+**What it costs, measured** (trivial snippet, this container, `bwrap`):
+
+| | first compile | subsequent |
+|---|---|---|
+| in-process (`--playground-sandbox none`) | 3.8 s | **0.3–0.5 s** (warm `BtaCompileSession`) |
+| jailed subprocess | 3.4 s | **3.3–3.5 s** (cold every time) |
+
+The jail itself is free — a jailed cold compile is no slower than an unjailed
+one. What costs ~3 s is losing the *warm* toolchain: a fresh JVM re-bootstraps
+BTA per request. That is the deliberate v1 trade (a `--public` host takes
+predictable seconds over an unbounded compiler in its own process), and it is
+why `--playground-sandbox none` — the dev posture — keeps warm compiles and the
+sub-second edit→pixel loop [§7.1](#71-latency-note) describes.
+
+The obvious follow-up is a **warm jailed compile JVM per catalog classpath**,
+recycled periodically. Worth noting *why* that's admissible where a warm render
+JVM isn't: compiling doesn't execute the snippet, so a reused compile process
+never runs a stranger's code — the "one snippet per JVM" rule exists for the
+lanes that do.
 
 ---
 


### PR DESCRIPTION
Closes #3090 — the residual Phase 4 (#3016) left behind, documented in `docs/design/PLAYGROUND.md` §6.3.

## Why

Phase 4 jailed everything that *executes* a snippet — the Stage-1 first frame, the RC capture, the Stage-2 live session — but `kotlinc` still ran in the serve JVM. That was never an arbitrary-execution hole (compiling doesn't run the snippet: no annotation processors, no `init` blocks, only the Kotlin + Compose plugins we ship), but it was a **resource** one. The Kotlin compiler is the least predictable thing on the request path — a pathological snippet can burn CPU and heap inside the host process, where `-Xmx` is the operator's and no wall clock applies.

## What

With a sandbox configured, `PlaygroundJailedCompiler` runs the compile in the **same jail** the render lanes use:

- catalog classpath + the `lib-bta/` toolchain bound **read-only**, the snippet's work dir the one writable path (so the request file, class output and IC dir all land in the directory the token store already deletes);
- the sandbox's `-Xmx` / `ActiveProcessorCount` caps applied to the compiler, plus a compile budget on top of the session TTL;
- parent and child speak the same one-JSON-line protocol as the preflight probe, and the child runs the **same `PlaygroundBtaCompiler`** — so a jailed compile can't silently drift from an unjailed one;
- every failure mode (jail won't launch, compiler killed by its cgroup, unparseable output) returns an ordinary compile *diagnostic*, never an exception out of the route.

`--playground-sandbox none` keeps the in-process compiler untouched. A host that asked for a sandbox but can't jail the compiler (no `lib-bta/`) logs *which* half is missing and says plainly that snippet execution is still contained, rather than quietly degrading.

## What it costs — measured, not guessed

Trivial snippet, this container, `bwrap`:

| | first compile | subsequent |
|---|---|---|
| in-process (`--playground-sandbox none`) | 3.8 s | **0.3–0.5 s** (warm `BtaCompileSession`) |
| jailed subprocess | 3.4 s | **3.3–3.5 s** (cold every time) |

**The jail itself is free** — a jailed cold compile is no slower than an unjailed cold one. What costs ~3 s is losing the *warm* toolchain, since a fresh JVM re-bootstraps BTA per request. That's the deliberate trade for a `--public` host (predictable seconds over an unbounded compiler in its own process), and it's why the dev posture keeps warm compiles. Both numbers are now in the doc, along with the follow-up shape: a warm jailed compile JVM **per catalog classpath** — admissible precisely because compiling doesn't execute the snippet, so a reused compile process never runs a stranger's code. The "one snippet per JVM" rule exists for the lanes that do.

## Test plan

`./gradlew :cli:test` — green, 1,129 tests, 0 failures. `PlaygroundJailedCompilerTest` covers the request landing in the jail-writable work dir (and being cleaned up), diagnostics coming back verbatim, the argv shape (jail first, read-only binds for classpath + toolchain + CLI, the sandbox's `-Xmx` applied), and each failure mode mapping to a diagnostic rather than a throw — plus `wrap`'s three outcomes.

**A real Kotlin compile, actually run inside the jail** — the unit tests stub the subprocess, so this is the part they can't prove. Against the `:cli:installDist` toolchain, with the exact bind set `PlaygroundJailedCompiler.command()` computes:

```
== compiling inside the bwrap jail ==
PLAYGROUND_COMPILE {}          # no diagnostics = clean compile

real    0m3.9s

== class files the jailed compile produced ==
classes/SnippetKt.class

== the same jail could not read the host canary ==
cat: …/jailcanary/canary.txt: No such file or directory
```

So the compiler runs, produces real class output into the snippet's work dir, and cannot see a file the parent placed outside the bind set.

One finding worth recording from that run: loading the Compose compiler plugin against a classpath with **no Compose runtime** fails as `COMPILER_INTERNAL_ERROR` with no diagnostics. That's a property of the toolchain, not of this change (it reproduces identically unjailed — which is how I ruled the jail out), and it doesn't arise in production because a playground mode always compiles against a Compose catalog. It's the reason the demo above compiles a plain Kotlin snippet with no plugin.

Not visual — server plumbing only, no rendered surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGs7dbxsCdrFeHoysh8wka

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGs7dbxsCdrFeHoysh8wka)_