### PR TITLE
fix(serve): bound concurrent playground compiles, and clamp them to the sandbox TTL

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -71,6 +71,7 @@ internal object CliFlags {
       "--playground-sandbox-pids",
       "--playground-sandbox-ttl",
       "--playground-sandbox-ro",
+      "--playground-compile-slots",
       "--extra-maven-repos",
       "--trust-store",
       "--catalogs",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -278,6 +278,15 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val playgroundSandboxPids: Int =
     args.flagValue("--playground-sandbox-pids")?.toIntOrNull() ?: PlaygroundSandbox.DEFAULT_PIDS
 
+  /**
+   * `--playground-compile-slots <n>`: how many snippet compiles may hold a jailed JVM at once. The
+   * compile-side counterpart to `--live-seats` — per-process caps bound one compile, this bounds
+   * the aggregate, so peak compile memory is `slots × --playground-sandbox-memory-mb`.
+   */
+  private val playgroundCompileSlots: Int =
+    args.flagValue("--playground-compile-slots")?.toIntOrNull()?.takeIf { it > 0 }
+      ?: PlaygroundJailedCompiler.DEFAULT_COMPILE_SLOTS
+
   /** Hard wall-clock lifetime of one snippet JVM; the spawner kills it at the deadline. */
   private val playgroundSandboxTtlSeconds: Long =
     args.flagValue("--playground-sandbox-ttl")?.toLongOrNull()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -997,6 +997,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         inProcess = it,
         btaImplJars = implJars,
         compilerPluginJars = pluginJars,
+        slots = playgroundCompileSlots,
       )
     }
     if (compiler == null) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
@@ -43,10 +43,32 @@ class PlaygroundJailedCompiler(
   /** `kotlin-compose-compiler-plugin-embeddable`, split out of the same dir. */
   private val compilerPluginJars: List<String>,
   private val moduleName: String = "playground",
+  /**
+   * How many snippet compiles may hold a JVM at once. **Load-bearing:** the in-process compiler it
+   * replaces serialized compiles behind one `BtaCompileSession`, so concurrency was implicitly 1; a
+   * subprocess per request removes that, and per-process caps bound one compile without bounding
+   * the *aggregate* — N concurrent compiles is N × [PlaygroundSandbox.memoryMb]. This is the
+   * playground's compile-side counterpart to `--live-seats`: peak compile memory an operator has to
+   * budget for is `slots × memoryMb`.
+   */
+  private val slots: Int = DEFAULT_COMPILE_SLOTS,
+  /** How long a request waits for a slot before answering "busy" rather than queueing forever. */
+  private val slotWaitSeconds: Long = DEFAULT_SLOT_WAIT_SECONDS,
   private val timeoutSeconds: Long = DEFAULT_COMPILE_TIMEOUT_SECONDS,
   /** Injected in tests; null (the default) forks a real JVM via [spawn]. */
   private val launcher: ((List<String>, File) -> PlaygroundSandboxProbe.Launch)? = null,
 ) : PlaygroundCompileService.Compiler {
+
+  private val compileSlots = java.util.concurrent.Semaphore(slots.coerceAtLeast(1), true)
+
+  /**
+   * A compile never outlives the sandbox's own wall-clock deadline: an operator who shortens
+   * `--playground-sandbox-ttl` is asking for *everything* snippet-related to be reclaimed by then,
+   * and the render path already honours it via the descriptor's `hardTtlSeconds`. Whichever of the
+   * two budgets is tighter wins.
+   */
+  internal val effectiveTimeoutSeconds: Long =
+    if (sandbox.isActive) minOf(timeoutSeconds, sandbox.ttlSeconds) else timeoutSeconds
 
   override fun compile(
     sources: List<Path>,
@@ -68,6 +90,15 @@ class PlaygroundJailedCompiler(
         icWorkingDir = File(workDir, "bta-ic").absolutePath,
         moduleName = moduleName,
       )
+    // Admission control BEFORE the fork: without it, every concurrent POST is another whole JVM
+    // holding another whole memory budget, and the per-process caps say nothing about the total.
+    if (!compileSlots.tryAcquire(slotWaitSeconds, TimeUnit.SECONDS)) {
+      return listOf(
+        internalError(
+          "the playground is busy compiling (all $slots compile slots in use) — try again shortly"
+        )
+      )
+    }
     return try {
       requestFile.writeText(JSON.encodeToString(PlaygroundCompileRequest.serializer(), request))
       val argv = command(workDir, classpath, requestFile)
@@ -86,6 +117,7 @@ class PlaygroundJailedCompiler(
     } catch (e: Exception) {
       listOf(internalError("compile sandbox failed: ${e.message ?: e.javaClass.simpleName}"))
     } finally {
+      compileSlots.release()
       runCatching { requestFile.delete() }
     }
   }
@@ -146,7 +178,7 @@ class PlaygroundJailedCompiler(
     val err = StringBuilder()
     val outThread = drain(process.inputStream, out)
     val errThread = drain(process.errorStream, err)
-    val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+    val finished = process.waitFor(effectiveTimeoutSeconds, TimeUnit.SECONDS)
     if (!finished) {
       process.destroyForcibly()
       process.waitFor(5, TimeUnit.SECONDS)
@@ -157,7 +189,8 @@ class PlaygroundJailedCompiler(
       exitCode = if (finished) process.exitValue() else -1,
       stdout = out.toString(),
       stderr =
-        if (finished) err.toString() else "the compile exceeded its ${timeoutSeconds}s budget",
+        if (finished) err.toString()
+        else "the compile exceeded its ${effectiveTimeoutSeconds}s budget",
     )
   }
 
@@ -180,9 +213,21 @@ class PlaygroundJailedCompiler(
 
     /**
      * A cold BTA bootstrap plus a snippet compile; generous, because the cost of being wrong is a
-     * spurious "no result" on a slow box. The sandbox's own wall-clock TTL still applies on top.
+     * spurious "no result" on a slow box. Clamped to the sandbox's own wall-clock TTL when that is
+     * tighter (see `effectiveTimeoutSeconds`).
      */
     const val DEFAULT_COMPILE_TIMEOUT_SECONDS = 180L
+
+    /**
+     * Concurrent compile JVMs. Two, not one: one in flight while another is being typed is the
+     * common case, and a sandbox's memory cap is per process — so the host budget an operator
+     * reasons about is `slots × --playground-sandbox-memory-mb` (3 GB at the defaults). Raise it
+     * only with that arithmetic in hand.
+     */
+    const val DEFAULT_COMPILE_SLOTS = 2
+
+    /** Long enough to ride out one in-flight compile, short enough that a client isn't stranded. */
+    const val DEFAULT_SLOT_WAIT_SECONDS = 30L
 
     private val JSON = Json { ignoreUnknownKeys = true }
 
@@ -197,6 +242,7 @@ class PlaygroundJailedCompiler(
       inProcess: PlaygroundCompileService.Compiler,
       btaImplJars: List<File>,
       compilerPluginJars: List<File>,
+      slots: Int = DEFAULT_COMPILE_SLOTS,
       onLog: (String) -> Unit = { System.err.println("serve: $it") },
     ): PlaygroundCompileService.Compiler {
       if (!sandbox.isActive) return inProcess
@@ -215,13 +261,17 @@ class PlaygroundJailedCompiler(
         )
         return inProcess
       }
-      onLog("playground: compiles run inside the ${sandbox.profile.id} sandbox")
+      onLog(
+        "playground: compiles run inside the ${sandbox.profile.id} sandbox, " +
+          "$slots at a time (peak ${slots * sandbox.memoryMb}MB)"
+      )
       return PlaygroundJailedCompiler(
         sandbox = sandbox,
         javaHome = File(System.getProperty("java.home")),
         cliClasspath = cliClasspath,
         btaImplJars = btaImplJars.map { it.absolutePath },
         compilerPluginJars = compilerPluginJars.map { it.absolutePath },
+        slots = slots,
       )
     }
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompilerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompilerTest.kt
@@ -190,6 +190,69 @@ class PlaygroundJailedCompilerTest {
   }
 
   @Test
+  fun `concurrent compiles are bounded, and the overflow is told so`() {
+    // The in-process compiler this replaces serialized compiles behind one BtaCompileSession, so
+    // concurrency was implicitly 1. A subprocess per request removes that: without a bound, N
+    // parallel POSTs are N whole JVMs each holding the full per-process memory budget.
+    val inFlight = java.util.concurrent.CountDownLatch(1)
+    val release = java.util.concurrent.CountDownLatch(1)
+    val compiler =
+      PlaygroundJailedCompiler(
+        sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP),
+        javaHome = File("/opt/jdk17"),
+        cliClasspath = listOf("/install/lib/cli.jar"),
+        btaImplJars = listOf("/install/lib-bta/impl.jar"),
+        compilerPluginJars = emptyList(),
+        slots = 1,
+        slotWaitSeconds = 1,
+      ) { _, _ ->
+        inFlight.countDown()
+        release.await(10, java.util.concurrent.TimeUnit.SECONDS)
+        report()
+      }
+
+    val first = Thread { compile(compiler) }.apply { start() }
+    assertTrue(inFlight.await(10, java.util.concurrent.TimeUnit.SECONDS), "first compile started")
+
+    // The second request finds the only slot taken and is refused *quickly*, with a diagnostic
+    // rather than an unbounded queue.
+    val second = compile(compiler)
+    assertTrue("busy compiling" in second.single().message, second.single().message)
+    assertEquals(PlaygroundSeverity.ERROR, second.single().severity)
+
+    release.countDown()
+    first.join(10_000)
+
+    // …and the slot is handed back, so the next request compiles normally.
+    assertEquals(emptyList(), compile(compiler))
+  }
+
+  @Test
+  fun `a compile never outlives a shortened sandbox TTL`() {
+    fun budget(ttl: Long, compileTimeout: Long) =
+      PlaygroundJailedCompiler(
+          sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP, ttlSeconds = ttl),
+          javaHome = File("/opt/jdk17"),
+          cliClasspath = listOf("/install/lib/cli.jar"),
+          btaImplJars = listOf("/install/lib-bta/impl.jar"),
+          compilerPluginJars = emptyList(),
+          timeoutSeconds = compileTimeout,
+        ) { _, _ ->
+          report()
+        }
+        .effectiveTimeoutSeconds
+
+    // An operator who shortens --playground-sandbox-ttl means everything snippet-related is
+    // reclaimed by then — not just the render, which honours it via the descriptor's hardTtl.
+    assertEquals(45L, budget(ttl = 45, compileTimeout = 180), "the tighter budget wins")
+    assertEquals(
+      180L,
+      budget(ttl = 900, compileTimeout = 180),
+      "…and a generous TTL leaves the compile budget in charge",
+    )
+  }
+
+  @Test
   fun `wrap leaves an unsandboxed host on the in-process compiler`() {
     val inProcess = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompilerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompilerTest.kt
@@ -294,6 +294,27 @@ class PlaygroundJailedCompilerTest {
   }
 
   @Test
+  fun `wrap honours the operator's slot count, and says so`() {
+    val logs = mutableListOf<String>()
+
+    PlaygroundJailedCompiler.wrap(
+      sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.STRICT, memoryMb = 1024),
+      inProcess = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() },
+      btaImplJars = listOf(File("/install/lib-bta/impl.jar")),
+      compilerPluginJars = emptyList(),
+      slots = 1,
+    ) {
+      logs += it
+    }
+
+    // The host budget an operator reasons about is slots × memoryMb, so a `--playground-compile-
+    // slots 1` host must see 1024MB — not the default-2 arithmetic it would print if the flag
+    // were parsed but never forwarded (which is exactly how it shipped in #3105).
+    assertTrue(logs.single().contains("1 at a time"), logs.toString())
+    assertTrue(logs.single().contains("peak 1024MB"), logs.toString())
+  }
+
+  @Test
   fun `wrap jails the compiler when the sandbox and toolchain are both there`() {
     val logs = mutableListOf<String>()
 

--- a/docs/design/PLAYGROUND.md
+++ b/docs/design/PLAYGROUND.md
@@ -377,6 +377,17 @@ predictable seconds over an unbounded compiler in its own process), and it is
 why `--playground-sandbox none` — the dev posture — keeps warm compiles and the
 sub-second edit→pixel loop [§7.1](#71-latency-note) describes.
 
+**Bounded, like the live lanes.** The in-process compiler serialized compiles
+behind one `BtaCompileSession`, so concurrency was implicitly 1; a subprocess per
+request removes that, and a per-process memory cap bounds one compile without
+bounding the total. `--playground-compile-slots` (default 2) is the compile-side
+counterpart to `--live-seats`: peak compile memory an operator budgets for is
+`slots × --playground-sandbox-memory-mb`, and a request that finds every slot
+taken is told the playground is busy rather than queueing behind an unbounded
+fork. The compile budget is also clamped to `--playground-sandbox-ttl` whenever
+that is tighter — shortening the sandbox deadline shortens *everything*
+snippet-related, not just the render.
+
 The obvious follow-up is a **warm jailed compile JVM per catalog classpath**,
 recycled periodically. Worth noting *why* that's admissible where a warm render
 JVM isn't: compiling doesn't execute the snippet, so a reused compile process


### PR DESCRIPTION
Follow-up to #3105 (jailed playground compile), which auto-merged while I was addressing its review. Both findings are from Codex's review of that PR and both are real — each one is behaviour the in-process compiler provided implicitly and the subprocess dropped.

## Concurrency (P1)

The in-process path serialized compiles behind one shared `BtaCompileSession`, so concurrency was implicitly **1**. A subprocess per request removes that, and the sandbox's caps are *per process* — so N concurrent POSTs are N whole JVMs each holding the full memory budget. Per-process caps bound one compile and say nothing about the aggregate, which under `--public` is exactly the exhaustion vector the sandbox exists to close.

A semaphore now bounds compiles in flight:

- `--playground-compile-slots` (default **2**) — the compile-side counterpart to `--live-seats`, so the number an operator budgets for is `slots × --playground-sandbox-memory-mb` (3 GB at the defaults), and the startup log prints that peak.
- A request that finds every slot taken waits briefly, then answers **"the playground is busy compiling"** as an ordinary diagnostic rather than queueing behind an unbounded fork.

## Deadline (P2)

The compile waited its own 180 s budget regardless of `--playground-sandbox-ttl`, whose valid minimum is 30 s — so a pathological compile could outlive the deadline the operator configured. The wait is now the **tighter of the two**: shortening the sandbox TTL shortens everything snippet-related, not just the render (which already honoured it through the descriptor's `hardTtlSeconds`).

## Test plan

`./gradlew :cli:test` — green, 1,131 tests, 0 failures. Two new cases in `PlaygroundJailedCompilerTest`:

- **`concurrent compiles are bounded, and the overflow is told so`** — with one slot, a second request arriving while the first holds it gets the busy diagnostic quickly (not a hang), and the slot is returned so the next request compiles normally.
- **`a compile never outlives a shortened sandbox TTL`** — a 45 s TTL against a 180 s compile budget yields 45 s; a 900 s TTL leaves the 180 s compile budget in charge.

Doc updated with the slots knob, the `slots × memoryMb` arithmetic, and the TTL clamp.

Not visual — server plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGs7dbxsCdrFeHoysh8wka

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGs7dbxsCdrFeHoysh8wka)_