### PR TITLE
fix(cli): make preview render orchestration reliable

### DIFF
--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -12,7 +12,10 @@ import org.gradle.tooling.events.OperationDescriptor
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.StartEvent
+import org.gradle.tooling.events.task.TaskFailureResult
 import org.gradle.tooling.events.task.TaskOperationDescriptor
+import org.gradle.tooling.events.task.TaskSkippedResult
+import org.gradle.tooling.events.task.TaskSuccessResult
 import org.gradle.tooling.events.test.JvmTestOperationDescriptor
 import org.gradle.tooling.events.test.TestOperationDescriptor
 
@@ -33,6 +36,19 @@ data class GradleAccessFailure(
   val message: String,
   val detail: String? = null,
 )
+
+enum class GradleTaskDisposition {
+  SUCCESS,
+  UP_TO_DATE,
+  FROM_CACHE,
+  FAILED,
+  SKIPPED,
+}
+
+data class GradleTaskOutcome(val taskPath: String, val disposition: GradleTaskDisposition) {
+  val canReadOutputs: Boolean
+    get() = disposition != GradleTaskDisposition.SKIPPED
+}
 
 class GradleConnection(
   private val projectDir: File,
@@ -67,6 +83,8 @@ class GradleConnection(
 
   private val capturedTestFailures =
     Collections.synchronizedList(mutableListOf<CapturedTestFailure>())
+  private val capturedTaskOutcomes =
+    Collections.synchronizedMap(linkedMapOf<String, GradleTaskOutcome>())
 
   /**
    * Test failures captured during the most recent [runTasks] call. Populated live from the Tooling
@@ -75,6 +93,9 @@ class GradleConnection(
    */
   fun lastTestFailures(): List<CapturedTestFailure> =
     synchronized(capturedTestFailures) { capturedTestFailures.toList() }
+
+  fun lastTaskOutcomes(): Map<String, GradleTaskOutcome> =
+    synchronized(capturedTaskOutcomes) { capturedTaskOutcomes.toMap() }
 
   fun runTasks(
     vararg tasks: String,
@@ -85,6 +106,7 @@ class GradleConnection(
     val startTime = System.currentTimeMillis()
     val runningTasks = Collections.synchronizedSet(linkedSetOf<String>())
     capturedTestFailures.clear()
+    capturedTaskOutcomes.clear()
 
     // Ctrl+C otherwise kills the CLI without going through the cancellation
     // token — leaving the Gradle daemon still executing and any forked Test
@@ -176,6 +198,9 @@ class GradleConnection(
                 is FinishEvent -> {
                   runningTasks.remove(desc)
                   tasksFinished++
+                  val taskPath = descriptor.taskPath
+                  capturedTaskOutcomes[taskPath] =
+                    GradleTaskOutcome(taskPath, event.result.toTaskDisposition())
                   if (taskCount > 0) {
                     TerminalProgress.show((tasksFinished * 100) / taskCount)
                   }
@@ -226,6 +251,19 @@ class GradleConnection(
       } catch (_: IllegalStateException) {}
     }
   }
+
+  private fun org.gradle.tooling.events.OperationResult.toTaskDisposition(): GradleTaskDisposition =
+    when (this) {
+      is TaskSuccessResult ->
+        when {
+          isFromCache -> GradleTaskDisposition.FROM_CACHE
+          isUpToDate -> GradleTaskDisposition.UP_TO_DATE
+          else -> GradleTaskDisposition.SUCCESS
+        }
+      is TaskFailureResult -> GradleTaskDisposition.FAILED
+      is TaskSkippedResult -> GradleTaskDisposition.SKIPPED
+      else -> GradleTaskDisposition.SUCCESS
+    }
 
   private fun printBuildFailure(
     e: org.gradle.tooling.BuildException,

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
@@ -96,14 +96,19 @@ class GradlePreviewDriver(projectRoot: File, private val options: DriverOptions 
         val tasks = modules.map(request.taskFor).toTypedArray()
         connection.runTasks(*tasks, timeoutSeconds = options.timeoutSeconds, arguments = args)
       }
-    val manifests = PreviewResultBuilder.readAllManifests(modules)
+    val taskOutcomes = if (modules.isEmpty()) emptyMap() else connection.lastTaskOutcomes()
+    val readableModules = modules.filter { module ->
+      taskOutcomes[request.taskFor(module)]?.canReadOutputs == true
+    }
+    val manifests = PreviewResultBuilder.readAllManifests(readableModules)
     val previews = PreviewResultBuilder.build(manifests)
     return RenderOutcome(
       buildOk = buildOk,
-      modules = modules,
+      modules = readableModules,
       manifests = manifests,
       previews = previews,
       testFailures = connection.lastTestFailures(),
+      taskOutcomes = taskOutcomes,
     )
   }
 
@@ -173,4 +178,5 @@ data class RenderOutcome(
   val manifests: List<Pair<PreviewModule, PreviewManifest>>,
   val previews: List<PreviewResult>,
   val testFailures: List<CapturedTestFailure>,
+  val taskOutcomes: Map<String, GradleTaskOutcome> = emptyMap(),
 )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -470,13 +470,23 @@ abstract class Command(
           // render-configuration time (see [runDiscover]). Kept as a first-class step — not an
           // incidental side effect of XR provisioning — so shard sizing can't regress if the XR
           // path changes. provisionXr therefore skips its own (now-redundant) discover.
-          runDiscover(gradle, modules, silenceStdout)
-          val discoveryManifests = readAllManifests(modules)
+          val discoverySucceeded = runDiscover(gradle, modules, silenceStdout)
+          val discoveryManifests =
+            if (discoverySucceeded) readAllManifests(modules) else emptyList()
           val renderModules =
-            if (scopeToPreviewRequest) modulesMatchingPreviewRequest(modules, discoveryManifests)
-            else modules
+            if (scopeToPreviewRequest) {
+              modulesMatchingPreviewRequest(
+                modules,
+                discoveryManifests,
+                discoverySucceeded = discoverySucceeded,
+              )
+            } else modules
           if (scopeToPreviewRequest) {
-            warnIfPreviewFilterStillRendersExtraRows(renderModules, discoveryManifests)
+            warnIfPreviewFilterStillRendersExtraRows(
+              renderModules,
+              discoveryManifests,
+              discoverySucceeded = discoverySucceeded,
+            )
           }
           val xrArgs =
             provisionXrCompositeArgs(gradle, renderModules, silenceStdout, discoverFirst = false)
@@ -760,20 +770,31 @@ abstract class Command(
   private fun modulesMatchingPreviewRequest(
     modules: List<PreviewModule>,
     manifests: List<Pair<PreviewModule, PreviewManifest>>,
+    discoverySucceeded: Boolean,
   ): List<PreviewModule> =
     modulesMatchingPreviewRequest(
       modules = modules,
       manifests = manifests,
       exactId = exactId,
       filter = filter,
+      discoverySucceeded = discoverySucceeded,
     )
 
   private fun warnIfPreviewFilterStillRendersExtraRows(
     renderModules: List<PreviewModule>,
     manifests: List<Pair<PreviewModule, PreviewManifest>>,
+    discoverySucceeded: Boolean,
   ) {
     if (exactId == null && filter == null) return
     if (renderModules.isEmpty()) return
+    val flag = if (exactId != null) "--id" else "--filter"
+    if (!discoverySucceeded) {
+      System.err.println(
+        "compose-preview: preview discovery failed, so $flag could not narrow the render; " +
+          "rendering all resolved modules so Gradle can retry discovery."
+      )
+      return
+    }
     val byPath = renderModules.map { it.gradlePath }.toSet()
     val rendersExtraRows =
       manifests
@@ -784,7 +805,6 @@ abstract class Command(
           }
         }
     if (!rendersExtraRows) return
-    val flag = if (exactId != null) "--id" else "--filter"
     System.err.println(
       "compose-preview: $flag narrowed the render to matching module(s) " +
         renderModules.joinToString(", ") { it.gradlePath } +
@@ -952,7 +972,11 @@ internal fun modulesMatchingPreviewRequest(
   manifests: List<Pair<PreviewModule, PreviewManifest>>,
   exactId: String?,
   filter: String?,
+  discoverySucceeded: Boolean = true,
 ): List<PreviewModule> {
+  // The render task depends on discovery and is the authoritative retry. Do not let missing or
+  // stale discovery manifests suppress that retry after the separate optimization pass fails.
+  if (!discoverySucceeded) return modules
   if (exactId == null && filter == null) return modules
   val matchingPaths =
     manifests

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -421,6 +421,7 @@ abstract class Command(
     val modules: List<PreviewModule>,
     val manifests: List<Pair<PreviewModule, PreviewManifest>>,
     val results: List<PreviewResult>,
+    val discoveredPreviewCount: Int,
   )
 
   /**
@@ -429,7 +430,12 @@ abstract class Command(
    * whose manifests don't fit the `PreviewManifest` / `PreviewResult` shape (today:
    * `show-resources`, which has its own resource-manifest type).
    */
-  protected data class RawRenderOutcome(val buildOk: Boolean, val modules: List<PreviewModule>)
+  protected data class RawRenderOutcome(
+    val buildOk: Boolean,
+    val modules: List<PreviewModule>,
+    val discoveredPreviewCount: Int,
+    val taskOutcomes: Map<String, GradleTaskOutcome> = emptyMap(),
+  )
 
   /**
    * Shared gradle-drive pipeline — open the connector, resolve preview modules, optionally filter
@@ -452,32 +458,55 @@ abstract class Command(
     moduleFilter: (PreviewModule) -> Boolean = { true },
     taskFor: (PreviewModule) -> String = { ":${it.gradlePath}:composePreviewRenderAll" },
     gradleArguments: List<String> = emptyList(),
+    scopeToPreviewRequest: Boolean = false,
   ): RawRenderOutcome {
     var outcome: RawRenderOutcome? = null
     withGradle(silenceStdout = silenceStdout) { gradle ->
       val modules = withGradleStdout(silenceStdout) { resolveModules(gradle).filter(moduleFilter) }
-      val buildOk =
-        if (modules.isEmpty()) true
+      val (buildOk, modulesToRead, discoveredPreviewCount, taskOutcomes) =
+        if (modules.isEmpty()) Quad(true, emptyList(), 0, emptyMap<String, GradleTaskOutcome>())
         else {
           // Explicit discover pass before the render so `shards=auto` sees a fresh previews.json at
           // render-configuration time (see [runDiscover]). Kept as a first-class step — not an
           // incidental side effect of XR provisioning — so shard sizing can't regress if the XR
           // path changes. provisionXr therefore skips its own (now-redundant) discover.
           runDiscover(gradle, modules, silenceStdout)
+          val discoveryManifests = readAllManifests(modules)
+          val renderModules =
+            if (scopeToPreviewRequest) modulesMatchingPreviewRequest(modules, discoveryManifests)
+            else modules
+          if (scopeToPreviewRequest) {
+            warnIfPreviewFilterStillRendersExtraRows(renderModules, discoveryManifests)
+          }
           val xrArgs =
-            provisionXrCompositeArgs(gradle, modules, silenceStdout, discoverFirst = false)
-          val tasks = modules.map(taskFor).toTypedArray()
+            provisionXrCompositeArgs(gradle, renderModules, silenceStdout, discoverFirst = false)
+          val tasks = renderModules.map(taskFor).toTypedArray()
           val ok =
-            withGradleStdout(silenceStdout) {
-              runGradle(gradle, *tasks, arguments = gradleArguments + xrArgs)
+            if (renderModules.isEmpty()) true
+            else {
+              withGradleStdout(silenceStdout) {
+                runGradle(gradle, *tasks, arguments = gradleArguments + xrArgs)
+              }
             }
           if (!ok) reportRenderFailures(gradle)
-          ok
+          val outcomes = gradle.lastTaskOutcomes()
+          val readableModules = readableRenderModules(renderModules, taskFor, outcomes)
+          val discoveredPreviewCount =
+            if (scopeToPreviewRequest) discoveryManifests.sumOf { it.second.previews.size } else 0
+          Quad(ok, readableModules, discoveredPreviewCount, outcomes)
         }
-      outcome = RawRenderOutcome(buildOk = buildOk, modules = modules)
+      outcome =
+        RawRenderOutcome(
+          buildOk = buildOk,
+          modules = modulesToRead,
+          discoveredPreviewCount = discoveredPreviewCount,
+          taskOutcomes = taskOutcomes,
+        )
     }
     return outcome ?: error("renderModules: gradle block did not produce an outcome")
   }
+
+  private data class Quad<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
 
   /**
    * Standard "discover modules → run `:composePreviewRenderAll` → load manifests → build results"
@@ -492,7 +521,12 @@ abstract class Command(
     silenceStdout: Boolean,
     gradleArguments: List<String> = emptyList(),
   ): RenderModulesOutcome {
-    val raw = renderModules(silenceStdout = silenceStdout, gradleArguments = gradleArguments)
+    val raw =
+      renderModules(
+        silenceStdout = silenceStdout,
+        gradleArguments = gradleArguments,
+        scopeToPreviewRequest = true,
+      )
     val manifests = readAllManifests(raw.modules)
     val results = if (manifests.isEmpty()) emptyList() else buildResults(manifests)
     return RenderModulesOutcome(
@@ -500,6 +534,8 @@ abstract class Command(
       modules = raw.modules,
       manifests = manifests,
       results = results,
+      discoveredPreviewCount =
+        raw.discoveredPreviewCount.takeIf { it > 0 } ?: manifests.sumOf { it.second.previews.size },
     )
   }
 
@@ -718,9 +754,43 @@ abstract class Command(
     )
 
   protected fun matchesRequest(result: PreviewResult): Boolean {
-    if (exactId != null && result.id != exactId) return false
-    if (filter != null && !result.id.contains(filter, ignoreCase = true)) return false
-    return true
+    return previewIdMatchesRequest(result.id, exactId = exactId, filter = filter)
+  }
+
+  private fun modulesMatchingPreviewRequest(
+    modules: List<PreviewModule>,
+    manifests: List<Pair<PreviewModule, PreviewManifest>>,
+  ): List<PreviewModule> =
+    modulesMatchingPreviewRequest(
+      modules = modules,
+      manifests = manifests,
+      exactId = exactId,
+      filter = filter,
+    )
+
+  private fun warnIfPreviewFilterStillRendersExtraRows(
+    renderModules: List<PreviewModule>,
+    manifests: List<Pair<PreviewModule, PreviewManifest>>,
+  ) {
+    if (exactId == null && filter == null) return
+    if (renderModules.isEmpty()) return
+    val byPath = renderModules.map { it.gradlePath }.toSet()
+    val rendersExtraRows =
+      manifests
+        .filter { (module, _) -> module.gradlePath in byPath }
+        .any { (_, manifest) ->
+          manifest.previews.any {
+            !previewIdMatchesRequest(it.id, exactId = exactId, filter = filter)
+          }
+        }
+    if (!rendersExtraRows) return
+    val flag = if (exactId != null) "--id" else "--filter"
+    System.err.println(
+      "compose-preview: $flag narrowed the render to matching module(s) " +
+        renderModules.joinToString(", ") { it.gradlePath } +
+        "; Gradle still renders the full selected module task, so other previews in those " +
+        "module(s) may execute but will not be printed."
+    )
   }
 
   private fun stateFile(module: PreviewModule): File =
@@ -871,6 +941,38 @@ internal fun agpClassloaderGuidance(failures: List<ProjectDiscoveryFailure>): St
 
 internal val NON_PNG_PREVIEW_KINDS = setOf("XR_SUBSPACE")
 
+internal fun previewIdMatchesRequest(id: String, exactId: String?, filter: String?): Boolean {
+  if (exactId != null && id != exactId) return false
+  if (filter != null && !id.contains(filter, ignoreCase = true)) return false
+  return true
+}
+
+internal fun modulesMatchingPreviewRequest(
+  modules: List<PreviewModule>,
+  manifests: List<Pair<PreviewModule, PreviewManifest>>,
+  exactId: String?,
+  filter: String?,
+): List<PreviewModule> {
+  if (exactId == null && filter == null) return modules
+  val matchingPaths =
+    manifests
+      .filter { (_, manifest) ->
+        manifest.previews.any { previewIdMatchesRequest(it.id, exactId = exactId, filter = filter) }
+      }
+      .map { (module, _) -> module.gradlePath }
+      .toSet()
+  return modules.filter { it.gradlePath in matchingPaths }
+}
+
+internal fun readableRenderModules(
+  modules: List<PreviewModule>,
+  taskFor: (PreviewModule) -> String,
+  outcomes: Map<String, GradleTaskOutcome>,
+): List<PreviewModule> = modules.filter { module ->
+  val outcome = outcomes[taskFor(module)]
+  outcome?.canReadOutputs == true
+}
+
 /**
  * Previews that finished rendering but produced no PNG for at least one capture — the set
  * `--missing-renders` gates on and the diagnostic enumerates. Excludes [NON_PNG_PREVIEW_KINDS],
@@ -961,7 +1063,7 @@ class ShowCommand(args: List<String>) : Command(args) {
       )
     }
 
-    if (outcome.manifests.isEmpty() || outcome.manifests.all { it.second.previews.isEmpty() }) {
+    if (outcome.discoveredPreviewCount == 0) {
       if (jsonOutput) println(encodeResponse(emptyList(), countsScope = emptyList()))
       else println("No previews found.")
       // Mirror ShowResourcesCommand: a workspace with the plugin applied
@@ -1511,7 +1613,12 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
     // Hand-roll the renderModules→manifests→buildResults pipeline so the subclass hook can slot
     // between gradle finish and renderer load. `renderAllModules` is the same shape but
     // single-shot — no hook seam — so we expand it here.
-    val raw = renderModules(silenceStdout = jsonOutput, gradleArguments = gradleArgsWithForce())
+    val raw =
+      renderModules(
+        silenceStdout = jsonOutput,
+        gradleArguments = gradleArgsWithForce(),
+        scopeToPreviewRequest = true,
+      )
     val manifests = readAllManifests(raw.modules)
     produceAdditionalDataProducts(raw.modules, manifests)
     // After production runs, give the subclass a chance to abort the run when its data product
@@ -1528,6 +1635,9 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
         modules = raw.modules,
         manifests = manifests,
         results = results,
+        discoveredPreviewCount =
+          raw.discoveredPreviewCount.takeIf { it > 0 }
+            ?: manifests.sumOf { it.second.previews.size },
       )
 
     if (outcome.manifests.isEmpty()) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ShowPartialResultsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ShowPartialResultsTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,6 +19,27 @@ import kotlin.test.assertTrue
  * The exit code deliberately does **not** change: a failed build still exits 2.
  */
 class ShowPartialResultsTest {
+
+  private fun module(path: String): PreviewModule =
+    PreviewModule(path, File("/tmp/compose-preview-test/${path.replace(':', '/')}"))
+
+  private fun manifest(
+    module: PreviewModule,
+    vararg ids: String,
+  ): Pair<PreviewModule, PreviewManifest> =
+    module to
+      PreviewManifest(
+        module = module.gradlePath,
+        variant = "debug",
+        previews =
+          ids.map { id ->
+            PreviewInfo(
+              id = id,
+              functionName = id.substringAfterLast('.'),
+              className = id.substringBeforeLast('.'),
+            )
+          },
+      )
 
   private fun result(id: String, pngPath: String?): PreviewResult =
     PreviewResult(
@@ -39,6 +61,51 @@ class ShowPartialResultsTest {
       canReportAfterBuildFailure(results),
       "one broken preview must not suppress the ones that rendered",
     )
+  }
+
+  @Test
+  fun `preview filter scopes render to modules that can match`() {
+    val app = module("app")
+    val wear = module("wear")
+
+    val scoped =
+      modulesMatchingPreviewRequest(
+        modules = listOf(app, wear),
+        manifests =
+          listOf(
+            manifest(app, "com.example.HomePreview"),
+            manifest(wear, "com.example.LowBatteryPreview", "com.example.OtherWearPreview"),
+          ),
+        exactId = null,
+        filter = "LowBattery",
+      )
+
+    assertEquals(listOf(wear), scoped)
+  }
+
+  @Test
+  fun `task outcomes decide which module manifests may be read after render`() {
+    val ok = module("ok")
+    val cached = module("cached")
+    val failed = module("failed")
+    val skipped = module("skipped")
+    val neverStarted = module("neverStarted")
+    val taskFor: (PreviewModule) -> String = { ":${it.gradlePath}:composePreviewRenderAll" }
+
+    val readable =
+      readableRenderModules(
+        modules = listOf(ok, cached, failed, skipped, neverStarted),
+        taskFor = taskFor,
+        outcomes =
+          mapOf(
+            taskFor(ok) to GradleTaskOutcome(taskFor(ok), GradleTaskDisposition.SUCCESS),
+            taskFor(cached) to GradleTaskOutcome(taskFor(cached), GradleTaskDisposition.FROM_CACHE),
+            taskFor(failed) to GradleTaskOutcome(taskFor(failed), GradleTaskDisposition.FAILED),
+            taskFor(skipped) to GradleTaskOutcome(taskFor(skipped), GradleTaskDisposition.SKIPPED),
+          ),
+      )
+
+    assertEquals(listOf(ok, cached, failed), readable)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ShowPartialResultsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ShowPartialResultsTest.kt
@@ -84,6 +84,23 @@ class ShowPartialResultsTest {
   }
 
   @Test
+  fun `failed discovery keeps all modules for the render retry`() {
+    val app = module("app")
+    val wear = module("wear")
+
+    val scoped =
+      modulesMatchingPreviewRequest(
+        modules = listOf(app, wear),
+        manifests = emptyList(),
+        exactId = null,
+        filter = "LowBattery",
+        discoverySucceeded = false,
+      )
+
+    assertEquals(listOf(app, wear), scoped)
+  }
+
+  @Test
   fun `task outcomes decide which module manifests may be read after render`() {
     val ok = module("ok")
     val cached = module("cached")


### PR DESCRIPTION
## Summary

- capture Gradle task outcomes and only read render outputs for modules whose render task succeeded, was up to date, came from cache, or started and failed
- exclude skipped and never-started modules so stale manifests and PNGs cannot be reported as current
- discover previews before rendering and scope `--filter` / `--id` builds to modules that can match
- warn when a selected module still renders previews outside the requested filter

## Root cause

The CLI treated files left in `build/compose-previews` as authoritative even when the current Gradle invocation never reached a module's render task. It also applied preview filters only after rendering, causing unrelated modules to compile and render.

The build's task finish events now provide the primary currency signal. Successful, up-to-date, cached, and started-but-failed render tasks retain their rows; skipped and absent task outcomes drop the module's stale outputs.

## Impact

Agent iterate loops no longer receive previous-run images with `changed: false` after an upstream build failure. Filtered commands avoid compiling and rendering modules with no matching previews, while preserving partial failure rows from render tasks that actually ran.

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.ShowPartialResultsTest`
- `./gradlew :gradle-preview-driver:test`
- `git diff --check`

Fixes #3085
Fixes #3083
