### PR TITLE
test: add code-quality sweep coverage

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -603,13 +603,6 @@ class BundleRenderer(
 
   companion object {
     /**
-     * Leaf filename the Android renderer ([ee.schimke.composeai.renderer.RobolectricRenderTest]'s
-     * `outputFileFor`) writes a preview's primary capture to: the first capture's `renderOutput`
-     * basename, or `"<id>.png"` when unset. Reconciling against this — rather than a name derived
-     * from the preview id — is what keeps a successful Android render from being mis-reported as a
-     * failure. Fan-out captures write additional files; the primary capture is the render signal.
-     */
-    /**
      * Return [raw] (a `previews.json` body) with every preview whose `id` is in [drop] removed from
      * the top-level `previews` array, preserving all other fields verbatim (operates on the JSON
      * tree, not the lossy `ignoreUnknownKeys` model). Used to hide IR-backed previews from the
@@ -627,6 +620,13 @@ class BundleRenderer(
       )
     }
 
+    /**
+     * Leaf filename the Android renderer writes for a preview's primary capture: the first
+     * capture's `renderOutput` basename, or `"<id>.png"` when unset. Reconciling against this,
+     * rather than a name derived from the preview id, keeps successful Android renders from being
+     * mis-reported as failures. Fan-out captures write additional files; the primary capture is the
+     * render signal.
+     */
     internal fun androidOutputLeaf(preview: PreviewInfo): String {
       val leaf = preview.captures.firstOrNull()?.renderOutput?.substringAfterLast('/')
       return if (leaf.isNullOrEmpty()) "${preview.id}.png" else leaf

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/WebEmbed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/WebEmbed.kt
@@ -295,7 +295,7 @@ object WebEmbed {
    * attribute.
    */
   internal fun embedKey(title: String, modulePath: String, previewIds: List<String>): String {
-    val material = (listOf(title, modulePath) + previewIds).joinToString(" ")
+    val material = (listOf(title, modulePath) + previewIds).joinToString("\u0000")
     val digest = java.security.MessageDigest.getInstance("SHA-256").digest(material.toByteArray())
     return digest.take(6).joinToString("") { "%02x".format(it) }
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -974,7 +974,7 @@ class JsonRpcServer(
           try {
             // 5-minute ceiling: covers cold sandbox bootstrap (~5–15s on
             // first render) plus B1.4's eventual real Compose render
-            // (single-digit seconds). DaemonHost still uses its own 60s
+            // (single-digit seconds). The Android host still uses its own 60s
             // default for direct callers; we override here because the
             // first render in a daemon's life sits behind the sandbox cold
             // boot.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryFilters.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryFilters.kt
@@ -5,10 +5,10 @@ import java.util.Base64
 /**
  * Shared `HistoryFilter` matchers and pagination cursor helpers.
  *
- * Extracted from [LocalFsHistorySource] (H1+H2) so [GitRefHistorySource] (H10-read) and any future
- * read-only source ([HttpMirrorHistorySource], H13) apply identical filter / pagination logic
- * without duplicating it across implementations. See HISTORY.md § "HistorySource interface" — every
- * source returns the same shape; only the storage backend differs.
+ * Extracted from [LocalFsHistorySource] so every read source can apply identical filter /
+ * pagination logic without duplicating it across implementations. See HISTORY.md § "HistorySource
+ * interface" — every source returns the same [HistoryEntry] shape; only the storage backend
+ * differs.
  */
 internal object HistoryFilters {
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -15,8 +15,8 @@ import kotlinx.serialization.json.JsonElement
 /**
  * Daemon-side history orchestrator — see HISTORY.md § "What this PR lands § H1" / § "H2".
  *
- * Holds the configured [HistorySource]s in priority order. H1+H2 ships only [LocalFsHistorySource];
- * future phases (H10+) add `GitRefHistorySource` / `HttpMirrorHistorySource` here without changing
+ * Holds the configured [HistorySource]s in priority order. [LocalFsHistorySource] handles local
+ * writes and reads; reporting-branch read sources can plug in here without changing
  * [JsonRpcServer]'s call site.
  *
  * **Read** ([list], [read]) merges across all configured sources. For H1+H2 with one source this is

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
@@ -106,11 +106,11 @@ enum class WriteResult {
 /**
  * Pluggable history backend — see HISTORY.md § "HistorySource interface".
  *
- * H1+H2 ships only [LocalFsHistorySource]. Future phases (H10 onward) will add
- * `GitRefHistorySource` and `HttpMirrorHistorySource`; the consumer side merges across configured
- * sources by `pngHash + previewId + git.commit`. The interface is intentionally narrow: write is a
- * side-effect of [HistoryManager.recordRender]; read is paginated; watch is reserved for future
- * phases (a UI doesn't poll, it subscribes to `historyAdded`).
+ * [LocalFsHistorySource] handles local writes and reads; [GitRefHistorySource] exposes reporting
+ * refs as read sources. The consumer side merges across configured sources by `pngHash +
+ * previewId + git.commit`. The interface is intentionally narrow: write is a side-effect of
+ * [HistoryManager.recordRender]; read is paginated; watch is reserved for future phases (a UI
+ * doesn't poll, it subscribes to `historyAdded`).
  */
 interface HistorySource {
   /** Stable identifier — e.g. `"fs:/abs/historyDir"`, `"git:preview/main"`, `"http:https://…"`. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ApngEncoderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ApngEncoderTest.kt
@@ -1,0 +1,120 @@
+package ee.schimke.composeai.daemon
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.ByteBuffer
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ApngEncoderTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun encodes_png_frames_as_apng_with_expected_control_chunks() {
+    val frames =
+      listOf(
+        writeFrame("frame-0.png", Color.RED),
+        writeFrame("frame-1.png", Color.GREEN),
+        writeFrame("frame-2.png", Color.BLUE),
+      )
+    val out = File(tmp.newFolder("out"), "demo.apng")
+
+    ApngEncoder.encodeFromPngFrames(
+      frames = frames,
+      delayNumerator = 1,
+      delayDenominator = 30,
+      loopCount = 0,
+      out = out,
+    )
+
+    val chunks = chunks(out)
+    assertEquals("IHDR", chunks.first().type)
+    assertEquals(1, chunks.count { it.type == "acTL" })
+    assertEquals(frames.size, chunks.count { it.type == "fcTL" })
+    assertEquals(1, chunks.count { it.type == "IDAT" })
+    assertEquals(frames.size - 1, chunks.count { it.type == "fdAT" })
+    assertEquals("IEND", chunks.last().type)
+
+    val acTl = ByteBuffer.wrap(chunks.single { it.type == "acTL" }.data)
+    assertEquals(frames.size, acTl.int)
+    assertEquals(0, acTl.int)
+    assertTrue("APNG should be non-empty", out.length() > 0)
+  }
+
+  @Test
+  fun rejects_empty_frame_list() {
+    assertThrows(IllegalArgumentException::class.java) {
+      ApngEncoder.encodeFromPngFrames(
+        frames = emptyList(),
+        delayNumerator = 1,
+        delayDenominator = 30,
+        loopCount = 0,
+        out = File(tmp.root, "empty.apng"),
+      )
+    }
+  }
+
+  @Test
+  fun rejects_mismatched_frame_dimensions() {
+    val frames = listOf(writeFrame("a.png", Color.RED, 8, 8), writeFrame("b.png", Color.BLUE, 9, 8))
+
+    assertThrows(IllegalArgumentException::class.java) {
+      ApngEncoder.encodeFromPngFrames(
+        frames = frames,
+        delayNumerator = 1,
+        delayDenominator = 30,
+        loopCount = 0,
+        out = File(tmp.root, "mismatch.apng"),
+      )
+    }
+  }
+
+  @Test
+  fun rejects_non_png_frame() {
+    val bad = File(tmp.root, "bad.png").apply { writeText("not a png") }
+
+    assertThrows(IllegalArgumentException::class.java) {
+      ApngEncoder.encodeFromPngFrames(
+        frames = listOf(bad),
+        delayNumerator = 1,
+        delayDenominator = 30,
+        loopCount = 0,
+        out = File(tmp.root, "bad.apng"),
+      )
+    }
+  }
+
+  private fun writeFrame(name: String, color: Color, width: Int = 8, height: Int = 8): File {
+    val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    val g = img.createGraphics()
+    g.color = color
+    g.fillRect(0, 0, width, height)
+    g.dispose()
+    return File(tmp.root, name).also { ImageIO.write(img, "png", it) }
+  }
+
+  private fun chunks(file: File): List<Chunk> {
+    val bytes = file.readBytes()
+    val buf = ByteBuffer.wrap(bytes)
+    val signature = ByteArray(8)
+    buf.get(signature)
+    val chunks = mutableListOf<Chunk>()
+    while (buf.remaining() >= 12) {
+      val length = buf.int
+      val typeBytes = ByteArray(4).also { buf.get(it) }
+      val data = ByteArray(length).also { buf.get(it) }
+      buf.int
+      chunks += Chunk(String(typeBytes, Charsets.US_ASCII), data)
+    }
+    return chunks
+  }
+
+  private data class Chunk(val type: String, val data: ByteArray)
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveKeyCodesTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveKeyCodesTest.kt
@@ -1,0 +1,35 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class InteractiveKeyCodesTest {
+
+  @Test
+  fun parse_accepts_decimal_wire_spelling_with_whitespace() {
+    assertEquals(InteractiveKeyCodes.A, InteractiveKeyCodes.parse(" 29 "))
+    assertEquals(InteractiveKeyCodes.F12, InteractiveKeyCodes.parse("142"))
+  }
+
+  @Test
+  fun parse_returns_null_for_missing_blank_or_non_numeric_wire_values() {
+    assertNull(InteractiveKeyCodes.parse(null))
+    assertNull(InteractiveKeyCodes.parse(" "))
+    assertNull(InteractiveKeyCodes.parse("KEYCODE_A"))
+  }
+
+  @Test
+  fun constants_pin_android_keycode_ranges_used_by_clients() {
+    assertEquals(29, InteractiveKeyCodes.A)
+    assertEquals(54, InteractiveKeyCodes.Z)
+    assertEquals(7, InteractiveKeyCodes.DIGIT_0)
+    assertEquals(16, InteractiveKeyCodes.DIGIT_9)
+    assertEquals(131, InteractiveKeyCodes.F1)
+    assertEquals(142, InteractiveKeyCodes.F12)
+    assertEquals(144, InteractiveKeyCodes.NUMPAD_0)
+    assertEquals(161, InteractiveKeyCodes.NUMPAD_EQUALS)
+    assertEquals(62, InteractiveKeyCodes.SPACE)
+    assertEquals(67, InteractiveKeyCodes.BACKSPACE)
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryFiltersTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryFiltersTest.kt
@@ -1,0 +1,97 @@
+package ee.schimke.composeai.daemon.history
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HistoryFiltersTest {
+
+  @Test
+  fun matches_uses_only_entry_fields_shared_by_all_sources() {
+    val local = entry(id = "local", sourceKind = "fs", sourceId = "fs:/history")
+    val git =
+      local.copy(id = "git", source = HistorySourceInfo(kind = "git", id = "git:preview/main"))
+    val shared =
+      HistoryFilter(
+        previewId = "com.example.Card",
+        since = "2026-04-30T10:00:00Z",
+        until = "2026-04-30T11:00:00Z",
+        branch = "codex/history",
+        commit = "abcdef0",
+        worktreePath = "/repo",
+        agentId = "agent-1",
+      )
+
+    assertTrue(
+      HistoryFilters.matches(local, shared.copy(sourceKind = "fs", sourceId = "fs:/history"))
+    )
+    assertTrue(
+      HistoryFilters.matches(git, shared.copy(sourceKind = "git", sourceId = "git:preview/main"))
+    )
+    assertFalse(HistoryFilters.matches(local, shared.copy(sourceKind = "git")))
+  }
+
+  @Test
+  fun matches_supports_short_commit_and_branch_regex() {
+    val matching =
+      entry(branch = "codex/history-filters", commit = "abcdef012345", short = "abcdef0")
+
+    assertTrue(HistoryFilters.matches(matching, HistoryFilter(commit = "abcdef0")))
+    assertTrue(HistoryFilters.matches(matching, HistoryFilter(branchPattern = "codex/.*")))
+    assertFalse(HistoryFilters.matches(matching, HistoryFilter(branchPattern = "main")))
+  }
+
+  @Test
+  fun ref_is_routing_only_not_a_match_clause() {
+    assertTrue(HistoryFilters.matches(entry(), HistoryFilter(ref = "refs/heads/preview/main")))
+  }
+
+  @Test
+  fun paginate_returns_limit_bounded_slice_and_cursor_after_last_entry() {
+    val entries = (1..4).map { i -> entry(id = "id-$i", timestamp = "2026-04-30T10:0$i:00Z") }
+
+    val first = HistoryFilters.paginate(entries, HistoryFilter(limit = 2))
+    assertEquals(listOf("id-1", "id-2"), first.entries.map { it.id })
+    assertEquals(HistoryFilters.encodeCursor("2026-04-30T10:02:00Z", "id-2"), first.nextCursor)
+
+    val second =
+      HistoryFilters.paginate(entries, HistoryFilter(limit = 2, cursor = first.nextCursor))
+    assertEquals(listOf("id-3", "id-4"), second.entries.map { it.id })
+    assertNull(second.nextCursor)
+  }
+
+  @Test
+  fun invalid_cursor_returns_empty_tail() {
+    val page = HistoryFilters.paginate(listOf(entry()), HistoryFilter(cursor = "not base64"))
+
+    assertEquals(emptyList<HistoryEntry>(), page.entries)
+    assertNull(page.nextCursor)
+  }
+
+  private fun entry(
+    id: String = "id-1",
+    timestamp: String = "2026-04-30T10:12:34Z",
+    branch: String = "codex/history",
+    commit: String = "abcdef012345",
+    short: String = "abcdef0",
+    sourceKind: String = "fs",
+    sourceId: String = "fs:/history",
+  ): HistoryEntry =
+    HistoryEntry(
+      id = id,
+      previewId = "com.example.Card",
+      module = ":app",
+      timestamp = timestamp,
+      pngHash = "hash-$id",
+      pngSize = 12L,
+      pngPath = "$id.png",
+      producer = "daemon",
+      trigger = "renderNow",
+      source = HistorySourceInfo(kind = sourceKind, id = sourceId),
+      worktree = WorktreeInfo(path = "/repo", id = "repo", agentId = "agent-1"),
+      git = GitInfo(branch = branch, commit = commit, shortCommit = short, dirty = false),
+      renderTookMs = 7L,
+    )
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryImageDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryImageDiffTest.kt
@@ -1,0 +1,81 @@
+package ee.schimke.composeai.daemon.history
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HistoryImageDiffTest {
+
+  @Test
+  fun identical_images_have_zero_pixel_diff_and_perfect_ssim() {
+    val png = png(2, 2) { _, _ -> Color.BLUE.rgb }
+
+    val diff = HistoryImageDiff.diff(png, png)
+
+    assertEquals(0L, diff.diffPx)
+    assertEquals(1.0, diff.ssim, 0.0)
+    assertNotNull(diff.markedPng)
+  }
+
+  @Test
+  fun alpha_only_changes_count_as_different_pixels() {
+    val from = png(1, 1) { _, _ -> 0x00FF0000 }
+    val to = png(1, 1) { _, _ -> 0xFFFF0000.toInt() }
+
+    val diff = HistoryImageDiff.diff(from, to)
+
+    assertEquals(1L, diff.diffPx)
+    assertTrue("SSIM should move when alpha changes", diff.ssim < 1.0)
+  }
+
+  @Test
+  fun mismatched_dimensions_return_everything_changed_without_overlay() {
+    val diff = HistoryImageDiff.diff(png(2, 2), png(3, 1))
+
+    assertEquals(4L, diff.diffPx)
+    assertEquals(0.0, diff.ssim, 0.0)
+    assertNull(diff.markedPng)
+  }
+
+  @Test
+  fun result_uses_structural_byte_array_equality() {
+    val a = HistoryImageDiff.Result(1, 0.5, byteArrayOf(1, 2, 3))
+    val b = HistoryImageDiff.Result(1, 0.5, byteArrayOf(1, 2, 3))
+
+    assertEquals(a, b)
+    assertEquals(a.hashCode(), b.hashCode())
+    assertArrayEquals(a.markedPng, b.markedPng)
+  }
+
+  @Test
+  fun undecodable_bytes_throw_typed_exception() {
+    assertThrows(HistoryImageDiff.UndecodableImageException::class.java) {
+      HistoryImageDiff.diff("nope".toByteArray(), png(1, 1))
+    }
+  }
+
+  private fun png(
+    width: Int,
+    height: Int,
+    argb: (Int, Int) -> Int = { _, _ -> Color.RED.rgb },
+  ): ByteArray {
+    val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        img.setRGB(x, y, argb(x, y))
+      }
+    }
+    return ByteArrayOutputStream().use { out ->
+      ImageIO.write(img, "png", out)
+      out.toByteArray()
+    }
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/PreviewIdSanitiserTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/PreviewIdSanitiserTest.kt
@@ -1,0 +1,27 @@
+package ee.schimke.composeai.daemon.history
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class PreviewIdSanitiserTest {
+
+  @Test
+  fun keeps_letters_digits_dot_underscore_and_dash() {
+    assertEquals("com.example_Preview-1", PreviewIdSanitiser.sanitise("com.example_Preview-1"))
+    assertEquals("Ångström.预览-1", PreviewIdSanitiser.sanitise("Ångström.预览-1"))
+  }
+
+  @Test
+  fun replaces_path_separators_whitespace_and_shell_punctuation() {
+    val sanitised = PreviewIdSanitiser.sanitise("../com example/Card:primary?state=on")
+
+    assertEquals(".._com_example_Card_primary_state_on", sanitised)
+    assertFalse("sanitised ids must not contain path separators", sanitised.contains('/'))
+  }
+
+  @Test
+  fun empty_preview_id_has_stable_directory_name() {
+    assertEquals("_", PreviewIdSanitiser.sanitise(""))
+  }
+}

--- a/docs/daemon/DESIGN.md
+++ b/docs/daemon/DESIGN.md
@@ -271,7 +271,7 @@ Enforced in code:
 
 - Render thread does **not** poll `Thread.interrupted()`; the daemon's
   own code never calls `interrupt()` on it.
-- Shutdown is a poison-pill on `DaemonHost`'s queue, not a thread
+- Shutdown is a poison-pill on `DaemonHostBridge`'s request queue, not a thread
   abort. The in-flight render finishes before the sandbox tears down.
 - `JsonRpcServer.shutdown` (PROTOCOL.md § 3) drains the in-flight queue
   before resolving the response.

--- a/docs/daemon/PREDICTIVE.md
+++ b/docs/daemon/PREDICTIVE.md
@@ -31,7 +31,7 @@ on a file the user is currently scoped to.
   **Enforcement (so accidental cancellation can't sneak in):**
   - Render thread does not poll `Thread.interrupted()` and the daemon's
     own code never calls `interrupt()` on it.
-  - Shutdown is a poison-pill on `DaemonHost`'s queue, not a thread
+  - Shutdown is a poison-pill on `DaemonHostBridge`'s request queue, not a thread
     abort; the in-flight render finishes before the sandbox tears down.
   - `JsonRpcServer.shutdown` drains the in-flight queue and blocks the
     response until drain completes — per PROTOCOL.md § 3.

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/CoilPreviewSupport.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/CoilPreviewSupport.kt
@@ -270,7 +270,7 @@ object CoilLoadDiagnostics {
     inFlight.clear()
     synchronized(failures) { failures.clear() }
     val all = failed + pending
-    all.forEach { if (warnedThisProcess.add(it.model + ' ' + it.outcome)) warn(it) }
+    all.forEach { if (warnedThisProcess.add(it.model + '\u0000' + it.outcome)) warn(it) }
     return all
   }
 


### PR DESCRIPTION
## Summary

- Adds focused unit tests for the pure helpers called out in #3078: `ApngEncoder`, `HistoryImageDiff`, `InteractiveKeyCodes`, `HistoryFilters`, and `PreviewIdSanitiser`.
- Cleans stale KDoc references from #3075 around `HttpMirrorHistorySource` and `DaemonHost`, including the overlapping `HistoryFilters` invariant.
- Removes literal NUL bytes from `WebEmbed.kt` and `CoilPreviewSupport.kt` by replacing them with escaped `\u0000` source literals, preserving runtime separator behavior while keeping the files visible to grep/ripgrep.
- Moves the Android output-name KDoc in `BundleRenderer` onto the function it actually documents.

## Validation

- `./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.ApngEncoderTest --tests ee.schimke.composeai.daemon.InteractiveKeyCodesTest --tests ee.schimke.composeai.daemon.history.HistoryFiltersTest --tests ee.schimke.composeai.daemon.history.HistoryImageDiffTest --tests ee.schimke.composeai.daemon.history.PreviewIdSanitiserTest`
- `./gradlew :cli:compileKotlin`
- `./gradlew :cli:ktfmtFormat :renderer-android:ktfmtFormat`
- `git diff --check`
- `LC_ALL=C rg -a -n "\\x00" cli/src/main/kotlin/ee/schimke/composeai/cli/WebEmbed.kt renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/CoilPreviewSupport.kt`

## Note

`./gradlew :renderer-android:compileDebugKotlin` could not run in this worktree because no Android SDK is configured via `ANDROID_HOME` or `local.properties`.