### PR TITLE
style(vscode): reformat extension sources

### DIFF
--- a/vscode-extension/src/androidSdk.ts
+++ b/vscode-extension/src/androidSdk.ts
@@ -22,10 +22,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 export type AndroidSdkSource =
-    | "setting"
-    | "ANDROID_HOME"
-    | "ANDROID_SDK_ROOT"
-    | "local.properties";
+    "setting" | "ANDROID_HOME" | "ANDROID_SDK_ROOT" | "local.properties";
 
 export interface AndroidSdkResolution {
     /** Absolute path to the Android SDK root (an existing directory). */

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -144,12 +144,7 @@ export type DataProductFacet =
     | "interactive";
 
 export type SamplingPolicy =
-    | "Start"
-    | "End"
-    | "EachFrame"
-    | "OnDemand"
-    | "Aggregate"
-    | "Failure";
+    "Start" | "End" | "EachFrame" | "OnDemand" | "Aggregate" | "Failure";
 
 export interface PreviewExtensionDescriptor {
     id: string;
@@ -205,8 +200,7 @@ export interface PreviewPipelineStep {
 }
 
 export type PreviewExtensionUsageMode =
-    | "ExplicitEffect"
-    | "SuggestedExtraPreview";
+    "ExplicitEffect" | "SuggestedExtraPreview";
 
 export type PipelineStepTrait =
     | "ScenarioDriver"

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -270,8 +270,7 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
             if (against === "current") {
                 const synthList = currentRendersFor(scope).list(previewId);
                 const synth = synthList.entries[0] as
-                    | { id?: string; timestamp?: string }
-                    | undefined;
+                    { id?: string; timestamp?: string } | undefined;
                 if (!synth?.id) {
                     this.view.webview.postMessage({
                         command: "diffPairError",
@@ -298,8 +297,7 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                 const prev =
                     idx >= 0
                         ? (sorted[idx + 1] as
-                              | { id?: string; timestamp?: string }
-                              | undefined)
+                              { id?: string; timestamp?: string } | undefined)
                         : undefined;
                 if (!prev?.id) {
                     this.view.webview.postMessage({

--- a/vscode-extension/src/refreshOrchestrator.ts
+++ b/vscode-extension/src/refreshOrchestrator.ts
@@ -24,12 +24,7 @@
  * public phase flips to B's preload. Tests assert this behaviour directly.
  */
 export type RefreshPhase =
-    | "idle"
-    | "preload"
-    | "discover"
-    | "reconcile"
-    | "render"
-    | "warm";
+    "idle" | "preload" | "discover" | "reconcile" | "render" | "warm";
 
 /**
  * Sub-phase callback the orchestrator threads into `refresh()` so the monolithic

--- a/vscode-extension/src/test/daemonIntegration.test.ts
+++ b/vscode-extension/src/test/daemonIntegration.test.ts
@@ -30,14 +30,13 @@ class FakeDaemon {
     private readonly decoder: FrameDecoder;
     private onInitialize: ((req: JsonRpcRequest) => void) | null = null;
     private onRenderNow:
-        | ((req: JsonRpcRequest, params: RenderNowParams) => void)
-        | null = null;
+        ((req: JsonRpcRequest, params: RenderNowParams) => void) | null = null;
     private onSubscribeReq:
-        | ((req: JsonRpcRequest, params: DataSubscribeParams) => void)
-        | null = null;
+        ((req: JsonRpcRequest, params: DataSubscribeParams) => void) | null =
+        null;
     private onUnsubscribeReq:
-        | ((req: JsonRpcRequest, params: DataSubscribeParams) => void)
-        | null = null;
+        ((req: JsonRpcRequest, params: DataSubscribeParams) => void) | null =
+        null;
 
     constructor() {
         this.toClient = new PassThrough();

--- a/vscode-extension/src/test/electron/suite/e2e.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2e.test.ts
@@ -39,8 +39,7 @@ function findMessage(
     command: string,
 ): PostedMessage | undefined {
     return messages.find((m) => (m as PostedMessage).command === command) as
-        | PostedMessage
-        | undefined;
+        PostedMessage | undefined;
 }
 
 async function waitFor<T>(

--- a/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
@@ -409,8 +409,7 @@ describeE2E("Compose Preview cached preload on module switch", function () {
                     const m = raw as PostedMessage;
                     if (m.command !== "setPreviews") continue;
                     const previews = m.previews as
-                        | Array<{ id?: string }>
-                        | undefined;
+                        Array<{ id?: string }> | undefined;
                     if (!previews || previews.length === 0) continue;
                     // Bind to wear by checking the previews' fully-qualified
                     // names — `preloadCachedPreviews` filters by file path,

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -357,8 +357,7 @@ describeExternal(
                         const m = msgs[i] as PostedMessage;
                         if (m.command !== "setPreviews") continue;
                         const previews = m.previews as
-                            | Array<unknown>
-                            | undefined;
+                            Array<unknown> | undefined;
                         if (previews && previews.length > 0) return m;
                     }
                     return undefined;
@@ -555,8 +554,7 @@ describeExternal(
                             const msg = m as PostedMessage;
                             if (msg.command !== "setPreviews") return false;
                             const previews = msg.previews as
-                                | Array<{ id?: string }>
-                                | undefined;
+                                Array<{ id?: string }> | undefined;
                             return previews?.some((p) =>
                                 /ComposeAiEditLoopProbe/.test(
                                     String(p.id ?? ""),

--- a/vscode-extension/src/test/electron/suite/lifecycle.test.ts
+++ b/vscode-extension/src/test/electron/suite/lifecycle.test.ts
@@ -82,8 +82,7 @@ function findMessage(
     command: string,
 ): PostedMessage | undefined {
     return messages.find((m) => (m as PostedMessage).command === command) as
-        | PostedMessage
-        | undefined;
+        PostedMessage | undefined;
 }
 
 describe("Compose Preview lifecycle", () => {

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -272,9 +272,7 @@ describe("renderInitScript", () => {
             "expected resolution via a detached configuration (not a buildscript.repositories add)",
         );
         assert.ok(
-            script.includes(
-                'add("classpath", composeAiPreviewClasspathFiles)',
-            ),
+            script.includes('add("classpath", composeAiPreviewClasspathFiles)'),
             "expected the resolved files to be injected onto the buildscript classpath",
         );
         // The resolved set is memoised so a large multi-module build resolves once.

--- a/vscode-extension/src/webview/fonts/main.ts
+++ b/vscode-extension/src/webview/fonts/main.ts
@@ -321,16 +321,20 @@ export class FontBrowserApp extends LitElement {
                     </div>
                     <div class="gfb-row-meta">
                         <span class="gfb-tag">${meta.category}</span>
-                        ${meta.isVariable
-                            ? html`<span class="gfb-tag gfb-variable"
-                                  >variable · ${meta.axes.length} axes</span
-                              >`
-                            : html`<span class="gfb-tag"
-                                  >${meta.weights.length} weights</span
-                              >`}
-                        ${meta.hasItalic
-                            ? html`<span class="gfb-tag">italic</span>`
-                            : nothing}
+                        ${
+                            meta.isVariable
+                                ? html`<span class="gfb-tag gfb-variable"
+                                      >variable · ${meta.axes.length} axes</span
+                                  >`
+                                : html`<span class="gfb-tag"
+                                      >${meta.weights.length} weights</span
+                                  >`
+                        }
+                        ${
+                            meta.hasItalic
+                                ? html`<span class="gfb-tag">italic</span>`
+                                : nothing
+                        }
                     </div>
                 </div>
                 <div class="gfb-row-actions">
@@ -347,17 +351,19 @@ export class FontBrowserApp extends LitElement {
                     >
                         Specimen ↗
                     </button>
-                    ${downloaded
-                        ? html`<span class="gfb-downloaded-pill"
-                              >Downloaded</span
-                          >`
-                        : html`<button
-                              class="gfb-btn gfb-primary"
-                              ?disabled=${busy}
-                              @click=${() => this.onDownload(meta)}
-                          >
-                              ${busy ? "Downloading…" : "Download"}
-                          </button>`}
+                    ${
+                        downloaded
+                            ? html`<span class="gfb-downloaded-pill"
+                                  >Downloaded</span
+                              >`
+                            : html`<button
+                                  class="gfb-btn gfb-primary"
+                                  ?disabled=${busy}
+                                  @click=${() => this.onDownload(meta)}
+                              >
+                                  ${busy ? "Downloading…" : "Download"}
+                              </button>`
+                    }
                 </div>
             </div>
         `;
@@ -416,11 +422,13 @@ export class FontBrowserApp extends LitElement {
                 <div class="gfb-customiser-head">
                     <h2 class="gfb-section-title">${font.family}</h2>
                     <div class="gfb-customiser-head-actions">
-                        ${face
-                            ? nothing
-                            : html`<span class="gfb-warn"
-                                  >no matching face</span
-                              >`}
+                        ${
+                            face
+                                ? nothing
+                                : html`<span class="gfb-warn"
+                                      >no matching face</span
+                                  >`
+                        }
                         <button
                             class="gfb-btn"
                             @click=${() => this.onRemove(font)}

--- a/vscode-extension/src/webview/history/components/HistoryRow.ts
+++ b/vscode-extension/src/webview/history/components/HistoryRow.ts
@@ -273,12 +273,14 @@ export class HistoryRow extends LitElement {
 
         return html`
             <div class="thumb" data-id=${entryId}>
-                ${cached !== undefined
-                    ? html`<img
-                          src=${"data:image/png;base64," + cached}
-                          alt=""
-                      />`
-                    : ""}
+                ${
+                    cached !== undefined
+                        ? html`<img
+                              src=${"data:image/png;base64," + cached}
+                              alt=""
+                          />`
+                        : ""
+                }
             </div>
             <div class="meta">
                 <div class="ts" title=${entry.timestamp || ""}>
@@ -308,20 +310,24 @@ export class HistoryRow extends LitElement {
                     ></i>
                 </button>
             </div>
-            ${this._expandedKind === "image"
-                ? html`<div class="expanded" data-id=${entryId}>
-                      ${this._renderImageExpansion(entry, entryId)}
-                  </div>`
-                : ""}
-            ${this._expandedKind === "diff" && this._diffAgainst
-                ? html`<div
-                      class="expanded diff-expanded"
-                      data-id=${entryId}
-                      data-against=${this._diffAgainst}
-                  >
-                      ${this._renderDiffExpansion()}
-                  </div>`
-                : ""}
+            ${
+                this._expandedKind === "image"
+                    ? html`<div class="expanded" data-id=${entryId}>
+                          ${this._renderImageExpansion(entry, entryId)}
+                      </div>`
+                    : ""
+            }
+            ${
+                this._expandedKind === "diff" && this._diffAgainst
+                    ? html`<div
+                          class="expanded diff-expanded"
+                          data-id=${entryId}
+                          data-against=${this._diffAgainst}
+                      >
+                          ${this._renderDiffExpansion()}
+                      </div>`
+                    : ""
+            }
         `;
     }
 
@@ -346,13 +352,15 @@ export class HistoryRow extends LitElement {
                     alt=${alt}
                 />
                 <div class="actions">
-                    ${sourceFile
-                        ? html`<button
-                              @click=${() => this._openSource(sourceFile)}
-                          >
-                              Open in Editor
-                          </button>`
-                        : ""}
+                    ${
+                        sourceFile
+                            ? html`<button
+                                  @click=${() => this._openSource(sourceFile)}
+                              >
+                                  Open in Editor
+                              </button>`
+                            : ""
+                    }
                 </div>
             `;
         }
@@ -378,8 +386,7 @@ export class HistoryRow extends LitElement {
 
     private _openSource(sourceFile: string): void {
         const vscode = this.diffViewConfig?.vscode as
-            | VsCodeApi<unknown>
-            | undefined;
+            VsCodeApi<unknown> | undefined;
         if (vscode) vscode.postMessage({ command: "openSource", sourceFile });
     }
 

--- a/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
@@ -357,29 +357,36 @@ export function a11yTableColumns(): readonly DataTableColumn<A11yRow>[] {
                         data-depth=${row.depth}
                         data-merged=${row.merged ? "true" : "false"}
                     >
-                        ${row.depth > 0
-                            ? html`<span
-                                  class="a11y-tree-arm"
-                                  aria-hidden="true"
-                                  >↳</span
-                              >`
-                            : html`<span
-                                  class="a11y-tree-pip"
-                                  aria-hidden="true"
-                                  title="Merged (focusable / screen-reader stop)"
-                                  >●</span
-                              >`}
-                        <div class="a11y-label-text">
-                            ${row.merged
-                                ? html`<strong>${row.label}</strong>`
-                                : html`<span class="a11y-label-unmerged-text"
-                                      >${row.label}</span
-                                  >`}
-                            ${row.role
-                                ? html`<span class="a11y-row-role"
-                                      >${row.role}</span
+                        ${
+                            row.depth > 0
+                                ? html`<span
+                                      class="a11y-tree-arm"
+                                      aria-hidden="true"
+                                      >↳</span
                                   >`
-                                : ""}
+                                : html`<span
+                                      class="a11y-tree-pip"
+                                      aria-hidden="true"
+                                      title="Merged (focusable / screen-reader stop)"
+                                      >●</span
+                                  >`
+                        }
+                        <div class="a11y-label-text">
+                            ${
+                                row.merged
+                                    ? html`<strong>${row.label}</strong>`
+                                    : html`<span
+                                          class="a11y-label-unmerged-text"
+                                          >${row.label}</span
+                                      >`
+                            }
+                            ${
+                                row.role
+                                    ? html`<span class="a11y-row-role"
+                                          >${row.role}</span
+                                      >`
+                                    : ""
+                            }
                         </div>
                     </div>
                 `;

--- a/vscode-extension/src/webview/preview/components/BoxOverlay.ts
+++ b/vscode-extension/src/webview/preview/components/BoxOverlay.ts
@@ -111,9 +111,9 @@ export class BoxOverlay extends LitElement {
         return html`
             <div
                 ${ref(applyStyle)}
-                class=${active
-                    ? "overlay-box overlay-box-active"
-                    : "overlay-box"}
+                class=${
+                    active ? "overlay-box overlay-box-active" : "overlay-box"
+                }
                 data-overlay-id=${b.id}
                 data-level=${b.level ?? "info"}
                 title=${b.tooltip ?? ""}

--- a/vscode-extension/src/webview/preview/components/BundleExpander.ts
+++ b/vscode-extension/src/webview/preview/components/BundleExpander.ts
@@ -93,13 +93,15 @@ export class BundleExpander extends LitElement {
                     @change=${(e: Event) => this.onCheckboxChanged(e, k.kind)}
                 />
                 <span class="bundle-expander-label">${k.label}</span>
-                ${k.defaultOn
-                    ? html`<span
-                          class="bundle-expander-default"
-                          title="On by default"
-                          >default</span
-                      >`
-                    : html``}
+                ${
+                    k.defaultOn
+                        ? html`<span
+                              class="bundle-expander-default"
+                              title="On by default"
+                              >default</span
+                          >`
+                        : html``
+                }
                 <code class="bundle-expander-kind">${k.kind}</code>
             </label>
         `;

--- a/vscode-extension/src/webview/preview/components/BundleLegend.ts
+++ b/vscode-extension/src/webview/preview/components/BundleLegend.ts
@@ -187,9 +187,11 @@ export class BundleLegend extends LitElement {
         };
         return html`
             <li
-                class=${active
-                    ? "bundle-legend-entry bundle-legend-entry-active"
-                    : "bundle-legend-entry"}
+                class=${
+                    active
+                        ? "bundle-legend-entry bundle-legend-entry-active"
+                        : "bundle-legend-entry"
+                }
                 data-legend-id=${e.id}
                 tabindex="0"
                 role="button"
@@ -208,11 +210,13 @@ export class BundleLegend extends LitElement {
                 ></span>
                 <div class="bundle-legend-text">
                     <strong class="bundle-legend-label">${e.label}</strong>
-                    ${e.detail
-                        ? html`<span class="bundle-legend-detail"
-                              >${e.detail}</span
-                          >`
-                        : ""}
+                    ${
+                        e.detail
+                            ? html`<span class="bundle-legend-detail"
+                                  >${e.detail}</span
+                              >`
+                            : ""
+                    }
                 </div>
             </li>
         `;

--- a/vscode-extension/src/webview/preview/components/CompileErrorsBanner.ts
+++ b/vscode-extension/src/webview/preview/components/CompileErrorsBanner.ts
@@ -28,9 +28,7 @@ interface ClearCompileErrorsMessage {
 }
 
 type IncomingMessage =
-    | SetCompileErrorsMessage
-    | ClearCompileErrorsMessage
-    | { command: string };
+    SetCompileErrorsMessage | ClearCompileErrorsMessage | { command: string };
 
 @customElement("compile-errors-banner")
 export class CompileErrorsBanner extends LitElement {

--- a/vscode-extension/src/webview/preview/components/DataTable.ts
+++ b/vscode-extension/src/webview/preview/components/DataTable.ts
@@ -107,11 +107,13 @@ export class DataTable<TRow = unknown> extends LitElement {
                 <div class="data-table-header">
                     <div class="data-table-title">
                         <span class="data-table-heading">${this.heading}</span>
-                        ${this.summary
-                            ? html`<span class="data-table-summary"
-                                  >· ${this.summary}</span
-                              >`
-                            : nothing}
+                        ${
+                            this.summary
+                                ? html`<span class="data-table-summary"
+                                      >· ${this.summary}</span
+                                  >`
+                                : nothing
+                        }
                     </div>
                     <div class="data-table-actions">
                         <slot name="actions"></slot>
@@ -130,9 +132,11 @@ export class DataTable<TRow = unknown> extends LitElement {
                         </button>
                     </div>
                 </div>
-                ${this.rows.length === 0
-                    ? html`<div class="data-table-empty">No rows.</div>`
-                    : this.renderTable()}
+                ${
+                    this.rows.length === 0
+                        ? html`<div class="data-table-empty">No rows.</div>`
+                        : this.renderTable()
+                }
             </div>
         `;
     }

--- a/vscode-extension/src/webview/preview/components/DataTabs.ts
+++ b/vscode-extension/src/webview/preview/components/DataTabs.ts
@@ -98,9 +98,11 @@ export class DataTabs extends LitElement {
         const selected = b.id === this.activeTab;
         return html`
             <div
-                class=${selected
-                    ? "data-tab-handle data-tab-handle-active"
-                    : "data-tab-handle"}
+                class=${
+                    selected
+                        ? "data-tab-handle data-tab-handle-active"
+                        : "data-tab-handle"
+                }
                 role="tab"
                 aria-selected=${selected ? "true" : "false"}
                 data-bundle=${b.id}

--- a/vscode-extension/src/webview/preview/components/FocusInspector.ts
+++ b/vscode-extension/src/webview/preview/components/FocusInspector.ts
@@ -57,11 +57,13 @@ export class FocusInspector extends LitElement {
                         <div class="focus-error-message">
                             ${this.renderError}
                         </div>
-                        ${this.renderErrorDetail
-                            ? html`<div class="focus-error-detail">
-                                  ${this.renderErrorDetail}
-                              </div>`
-                            : nothing}
+                        ${
+                            this.renderErrorDetail
+                                ? html`<div class="focus-error-detail">
+                                      ${this.renderErrorDetail}
+                                  </div>`
+                                : nothing
+                        }
                     </div>
                 </div>
             </section>

--- a/vscode-extension/src/webview/preview/components/ProgressBar.ts
+++ b/vscode-extension/src/webview/preview/components/ProgressBar.ts
@@ -24,9 +24,7 @@ interface ClearProgressMessage {
 }
 
 type IncomingMessage =
-    | SetProgressMessage
-    | ClearProgressMessage
-    | { command: string };
+    SetProgressMessage | ClearProgressMessage | { command: string };
 
 interface ProgressVisual {
     pct: number;

--- a/vscode-extension/src/webview/preview/inspectionPresenters.ts
+++ b/vscode-extension/src/webview/preview/inspectionPresenters.ts
@@ -270,29 +270,25 @@ export function computeInspectionBundleData(
     const nodeById = new Map<string, InspectionNodeRecord>();
     if (enabledKinds.has("compose/semantics")) {
         const payload = getPayload("compose/semantics") as
-            | ComposeSemanticsPayload
-            | undefined;
+            ComposeSemanticsPayload | undefined;
         const data = computeComposeSemanticsBundleData(payload, nodeById);
         if (data) sections.push({ kind: "compose/semantics", data });
     }
     if (enabledKinds.has("layout/inspector")) {
         const payload = getPayload("layout/inspector") as
-            | LayoutInspectorPayload
-            | undefined;
+            LayoutInspectorPayload | undefined;
         const data = computeLayoutInspectorBundleData(payload, nodeById);
         if (data) sections.push({ kind: "layout/inspector", data });
     }
     if (enabledKinds.has("uia/hierarchy")) {
         const payload = getPayload("uia/hierarchy") as
-            | UiaHierarchyPayload
-            | undefined;
+            UiaHierarchyPayload | undefined;
         const data = computeUiaHierarchyBundleData(payload, nodeById);
         if (data) sections.push({ kind: "uia/hierarchy", data });
     }
     if (enabledKinds.has("compose/permissions")) {
         const payload = getPayload("compose/permissions") as
-            | PermissionsPayload
-            | undefined;
+            PermissionsPayload | undefined;
         const data = computePermissionsInspectionData(payload);
         if (data) sections.push({ kind: "compose/permissions", data });
     }

--- a/vscode-extension/src/webview/preview/interactiveInput.ts
+++ b/vscode-extension/src/webview/preview/interactiveInput.ts
@@ -584,11 +584,7 @@ const DOM_CODE_TO_ANDROID_KEYCODE: ReadonlyMap<string, number> = new Map([
 ]);
 
 type InteractiveInputKind =
-    | "click"
-    | "pointerDown"
-    | "pointerMove"
-    | "pointerUp"
-    | "rotaryScroll";
+    "click" | "pointerDown" | "pointerMove" | "pointerUp" | "rotaryScroll";
 
 function postInteractiveInput(
     vscode: VsCodeApi<unknown>,

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -281,48 +281,50 @@ export class PreviewApp extends LitElement {
             <progress-bar></progress-bar>
             <compile-errors-banner></compile-errors-banner>
             <filter-toolbar></filter-toolbar>
-            ${minimal
-                ? html`
-                      <div
-                          class="minimal-refresh-bar"
-                          id="minimal-refresh-bar"
-                          role="region"
-                          aria-label="Minimal mode"
-                      >
-                          <div class="minimal-refresh-text">
-                              <strong>Minimal mode</strong>
-                              <span class="minimal-refresh-hint"
-                                  >Renders don't auto-update on save. Click
-                                  Refresh to apply changes, or apply the Compose
-                                  Preview Gradle plugin to enable
-                                  auto-render.</span
-                              >
-                              <span
-                                  class="minimal-save-pending"
-                                  id="minimal-save-pending"
-                                  hidden
-                                  >Saved changes pending — click Refresh
-                                  previews.</span
-                              >
+            ${
+                minimal
+                    ? html`
+                          <div
+                              class="minimal-refresh-bar"
+                              id="minimal-refresh-bar"
+                              role="region"
+                              aria-label="Minimal mode"
+                          >
+                              <div class="minimal-refresh-text">
+                                  <strong>Minimal mode</strong>
+                                  <span class="minimal-refresh-hint"
+                                      >Renders don't auto-update on save. Click
+                                      Refresh to apply changes, or apply the
+                                      Compose Preview Gradle plugin to enable
+                                      auto-render.</span
+                                  >
+                                  <span
+                                      class="minimal-save-pending"
+                                      id="minimal-save-pending"
+                                      hidden
+                                      >Saved changes pending — click Refresh
+                                      previews.</span
+                                  >
+                              </div>
+                              <div class="minimal-refresh-actions">
+                                  <button
+                                      type="button"
+                                      id="btn-minimal-refresh"
+                                      class="minimal-refresh-button"
+                                      title="Re-run composePreviewRenderAll"
+                                      aria-label="Refresh previews"
+                                  >
+                                      <i
+                                          class="codicon codicon-refresh"
+                                          aria-hidden="true"
+                                      ></i>
+                                      <span>Refresh previews</span>
+                                  </button>
+                              </div>
                           </div>
-                          <div class="minimal-refresh-actions">
-                              <button
-                                  type="button"
-                                  id="btn-minimal-refresh"
-                                  class="minimal-refresh-button"
-                                  title="Re-run composePreviewRenderAll"
-                                  aria-label="Refresh previews"
-                              >
-                                  <i
-                                      class="codicon codicon-refresh"
-                                      aria-hidden="true"
-                                  ></i>
-                                  <span>Refresh previews</span>
-                              </button>
-                          </div>
-                      </div>
-                  `
-                : ""}
+                      `
+                    : ""
+            }
 
             <message-banner></message-banner>
             <div id="focus-controls" class="focus-controls" hidden>
@@ -1419,8 +1421,7 @@ export class PreviewApp extends LitElement {
                     ? dataProductsByPreview.get(focusedId)
                     : undefined;
                 const semantics = byKind?.get("compose/semantics") as
-                    | SemanticsLookupPayload
-                    | undefined;
+                    SemanticsLookupPayload | undefined;
                 const boundsMap = buildSemanticsBoundsMap(
                     semantics,
                     "theming-consumer",
@@ -1459,11 +1460,9 @@ export class PreviewApp extends LitElement {
             // bundle whose data is already in memory.
             const byKind = dataProductsByPreview.get(previewId);
             const hierarchyPayload = byKind?.get("a11y/hierarchy") as
-                | { nodes?: readonly AccessibilityNode[] }
-                | undefined;
+                { nodes?: readonly AccessibilityNode[] } | undefined;
             const atfPayload = byKind?.get("a11y/atf") as
-                | { findings?: readonly AccessibilityFinding[] }
-                | undefined;
+                { findings?: readonly AccessibilityFinding[] } | undefined;
             const nodes =
                 store.cardA11yNodes.get(previewId) ??
                 hierarchyPayload?.nodes ??
@@ -1481,8 +1480,7 @@ export class PreviewApp extends LitElement {
         ): readonly import("./a11yBundlePresenter").AccessibilityTouchTarget[] => {
             const byKind = dataProductsByPreview.get(previewId);
             const raw = byKind?.get("a11y/touchTargets") as
-                | { targets?: unknown }
-                | undefined;
+                { targets?: unknown } | undefined;
             const targets = raw?.targets;
             if (!Array.isArray(targets)) return [];
             return targets as readonly import("./a11yBundlePresenter").AccessibilityTouchTarget[];
@@ -1688,8 +1686,7 @@ export class PreviewApp extends LitElement {
                 : null;
             const wallpaper = enabled.includes("compose/wallpaper")
                 ? ((byKind?.get("compose/wallpaper") as
-                      | WallpaperPayload
-                      | undefined) ?? null)
+                      WallpaperPayload | undefined) ?? null)
                 : null;
             const data = computeThemingBundleData(theme, wallpaper, target);
             const body = themingBody();
@@ -1824,8 +1821,7 @@ export class PreviewApp extends LitElement {
                     ? dataProductsByPreview.get(focusedId)
                     : undefined;
                 const semantics = byKind?.get("compose/semantics") as
-                    | SemanticsLookupPayload
-                    | undefined;
+                    SemanticsLookupPayload | undefined;
                 const boundsMap = buildSemanticsBoundsMap(
                     semantics,
                     "resources-consumer",
@@ -1880,8 +1876,7 @@ export class PreviewApp extends LitElement {
             const byKind = dataProductsByPreview.get(target);
             const payload =
                 (byKind?.get("compose/ambient") as
-                    | AmbientPayload
-                    | undefined) ?? null;
+                    AmbientPayload | undefined) ?? null;
             const data = computeAmbientBundleData(payload);
             const body = ambientBodyBuilt();
             const table = body.table;
@@ -1948,8 +1943,7 @@ export class PreviewApp extends LitElement {
             const byKind = dataProductsByPreview.get(target);
             const payload =
                 (byKind?.get("compose/remotecompose") as
-                    | RemoteComposePayload
-                    | undefined) ?? null;
+                    RemoteComposePayload | undefined) ?? null;
             const data = computeRemoteComposeBundleData(payload);
             const body = remoteComposeBodyBuilt();
             const table = body.table;
@@ -2011,8 +2005,7 @@ export class PreviewApp extends LitElement {
             const byKind = dataProductsByPreview.get(target);
             const metadata =
                 (byKind?.get("animation/lottie") as
-                    | LottieTimelineMetadata
-                    | undefined) ?? null;
+                    LottieTimelineMetadata | undefined) ?? null;
             const progress = lottieProgressByPreview.get(target) ?? 0;
             const data = computeLottieScrubberData(metadata, progress);
             const body = lottieScrubberBodyBuilt();
@@ -2121,8 +2114,7 @@ export class PreviewApp extends LitElement {
             const byKind = dataProductsByPreview.get(target);
             const payload =
                 (byKind?.get("history/diff/regions") as
-                    | HistoryDiffPayload
-                    | undefined) ?? null;
+                    HistoryDiffPayload | undefined) ?? null;
             const data = computeHistoryDiffBundleData(payload);
             const body = historyDiffBodyBuilt();
             const host = body.wrapper;
@@ -2172,8 +2164,7 @@ export class PreviewApp extends LitElement {
                     (dataProductsByPreview
                         .get(previewId)
                         ?.get("history/diff/regions") as
-                        | HistoryDiffPayload
-                        | undefined) ?? null;
+                        HistoryDiffPayload | undefined) ?? null;
                 return computeHistoryDiffBundleData(cardPayload).overlay;
             });
         };
@@ -2198,8 +2189,7 @@ export class PreviewApp extends LitElement {
             const byKind = dataProductsByPreview.get(target);
             const payload =
                 (byKind?.get("test/failure") as
-                    | TestFailurePayload
-                    | undefined) ?? null;
+                    TestFailurePayload | undefined) ?? null;
             const data = computeErrorsBundleData(payload);
             const body = errorsBodyBuilt();
             const host = body.wrapper;
@@ -2747,8 +2737,7 @@ export class PreviewApp extends LitElement {
         // it via the focusController and call `setActiveOverlayId`
         // on the layer that matches the active tab.
         const overlayLayerForActiveTab = ():
-            | import("./components/BoxOverlay").BoxOverlay
-            | null => {
+            import("./components/BoxOverlay").BoxOverlay | null => {
             const tab = bundleController.state().activeTab;
             if (!tab) return null;
             const card = focusController.focusedCard();

--- a/vscode-extension/src/webview/preview/remoteComposeBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/remoteComposeBundlePresenter.ts
@@ -260,10 +260,11 @@ function renderValueCell(row: RemoteComposeRow): TemplateResult | string {
             return html`<div class="rc-action-cell">
                 <code class="rc-action-payload">${row.payload}</code>
                 <span class="rc-action-meta"
-                    >handler=${row.handlerId.toFixed(0)}${row.firedAtMillis !==
-                    null
-                        ? html` · @${formatMillis(row.firedAtMillis)}`
-                        : ""}</span
+                    >handler=${row.handlerId.toFixed(0)}${
+                        row.firedAtMillis !== null
+                            ? html` · @${formatMillis(row.firedAtMillis)}`
+                            : ""
+                    }</span
                 >
             </div>`;
     }
@@ -339,9 +340,9 @@ function renderNamedValueInput(row: NamedValueRow): TemplateResult {
                             value: { kind: v.kind, value: n },
                         });
                     }}
-                />${suffix
-                    ? html`<span class="rc-unit">${suffix}</span>`
-                    : ""}</span
+                />${
+                    suffix ? html`<span class="rc-unit">${suffix}</span>` : ""
+                }</span
             >`;
         }
         case "string":

--- a/vscode-extension/src/webview/preview/textBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/textBundlePresenter.ts
@@ -248,15 +248,17 @@ export function textBundleStringColumns(): readonly DataTableColumn<DrawnTextRow
                     <strong class="text-bundle-text-rendered"
                         >${row.text || "(empty)"}</strong
                     >
-                    ${row.truncated ||
-                    row.didOverflowWidth ||
-                    row.didOverflowHeight
-                        ? html`<span
-                              class="text-bundle-flag"
-                              data-level="warning"
-                              >${overflowBadge(row)}</span
-                          >`
-                        : ""}
+                    ${
+                        row.truncated ||
+                        row.didOverflowWidth ||
+                        row.didOverflowHeight
+                            ? html`<span
+                                  class="text-bundle-flag"
+                                  data-level="warning"
+                                  >${overflowBadge(row)}</span
+                              >`
+                            : ""
+                    }
                 </div>`,
         },
         {
@@ -545,9 +547,11 @@ export function textBundleTranslationColumns(
                 html`<span
                     class="text-bundle-locale-chip"
                     data-tone="supported"
-                    title=${row.translatedLocales.length === 0
-                        ? "No translations recorded"
-                        : "Translated: " + row.translatedLocales.join(", ")}
+                    title=${
+                        row.translatedLocales.length === 0
+                            ? "No translations recorded"
+                            : "Translated: " + row.translatedLocales.join(", ")
+                    }
                     >${row.supportedLocaleCount}</span
                 >`,
         },
@@ -565,8 +569,9 @@ export function textBundleTranslationColumns(
                     : html`<span
                           class="text-bundle-locale-chip"
                           data-tone="warning"
-                          title=${"Missing: " +
-                          row.untranslatedLocales.join(", ")}
+                          title=${
+                              "Missing: " + row.untranslatedLocales.join(", ")
+                          }
                           >${row.untranslatedLocaleCount}</span
                       >`,
         },

--- a/vscode-extension/src/webview/preview/themingBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/themingBundlePresenter.ts
@@ -79,10 +79,7 @@ export type ThemingColorSource = "theme" | "wallpaper" | "seed";
  *  so the column factory can render mixed sections without juggling
  *  three tables. Each variant tags itself with `kind` for the renderers. */
 export type ThemingRow =
-    | ThemingColorRow
-    | ThemingTypographyRow
-    | ThemingShapeRow
-    | ThemingSeedRow;
+    ThemingColorRow | ThemingTypographyRow | ThemingShapeRow | ThemingSeedRow;
 
 export interface ThemingColorRow {
     id: string;
@@ -425,9 +422,9 @@ function renderSwatch(row: ThemingRow): TemplateResult | string {
         };
         return html`<span
             class="theming-swatch"
-            data-source=${row.kind === "seed"
-                ? "seed"
-                : (row as ThemingColorRow).source}
+            data-source=${
+                row.kind === "seed" ? "seed" : (row as ThemingColorRow).source
+            }
             ${ref(apply)}
             title=${row.hex}
         ></span>`;
@@ -474,9 +471,11 @@ function renderName(row: ThemingRow): TemplateResult {
     if (row.kind === "color") {
         return html`<div class="theming-name-stack">
             <strong>${row.name}</strong>
-            ${row.source === "wallpaper"
-                ? html`<span class="theming-name-sub">from wallpaper</span>`
-                : ""}
+            ${
+                row.source === "wallpaper"
+                    ? html`<span class="theming-name-sub">from wallpaper</span>`
+                    : ""
+            }
         </div>`;
     }
     if (row.kind === "typography") {

--- a/vscode-extension/src/webview/shared/spatialSemanticsTree.ts
+++ b/vscode-extension/src/webview/shared/spatialSemanticsTree.ts
@@ -26,12 +26,7 @@ export interface Size3dDp {
 
 /** The kind of a {@link SpatialSemanticsNode} — a 3D container type, or a content-hosting panel. */
 export type SpatialSemanticsKind =
-    | "subspaceRoot"
-    | "row"
-    | "column"
-    | "box"
-    | "panel"
-    | "orbiter";
+    "subspaceRoot" | "row" | "column" | "box" | "panel" | "orbiter";
 
 /**
  * The 2D semantics node a panel hosts. A structural mirror of the Kotlin `ComposeSemanticsNode`

--- a/vscode-extension/src/webview/spatial/main.ts
+++ b/vscode-extension/src/webview/spatial/main.ts
@@ -76,11 +76,13 @@ export class SpatialView extends LitElement {
     protected render(): TemplateResult {
         return html`
             <div class="spatial-stage"></div>
-            ${this.scene
-                ? ""
-                : html`<div class="spatial-empty">
-                      No spatial scene loaded
-                  </div>`}
+            ${
+                this.scene
+                    ? ""
+                    : html`<div class="spatial-empty">
+                          No spatial scene loaded
+                      </div>`
+            }
         `;
     }
 


### PR DESCRIPTION
## Summary

- Reformat existing VS Code extension TypeScript sources with the configured Prettier script.
- Leave Kotlin/Gradle sources unchanged after running the repo-wide ktfmt formatter.

## Why

The commit hook had previously been bypassed because of pre-existing Prettier drift in VS Code extension files. This brings those files back in line with the repository formatter.

## Validation

- `./gradlew ktfmtFormatAll`
- `./gradlew ktfmtCheckAll`
- `npm ci` in `vscode-extension`
- `npm run format` in `vscode-extension`
- `npm run format:check` in `vscode-extension`