### PR TITLE
fix(cli): explain GitHub auth on live preview toggle

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -96,6 +96,8 @@ class ServeGithubAuth(
     return "$START_PATH?return=${urlEncode(current)}"
   }
 
+  fun accessRepository(): String = config.repository
+
   private fun authorizeUrl(call: ApplicationCall, state: String): String {
     val params =
       listOf(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2190,6 +2190,15 @@ class ServeHttpServer(
       val imageUrl =
         "$origin$basePath/render/${WebEscaping.urlEncodeSegment(preview.id)}.png${requestQuerySuffix()}"
       val engagement = incrementPreviewViews(sessionId, preview.id)
+      val liveAuthPrompt =
+        githubAuth
+          ?.takeUnless { it.isAuthenticated(call) }
+          ?.let {
+            ServeWeb.LiveAuthPrompt(
+              loginHref = it.loginPath(call),
+              repository = it.accessRepository(),
+            )
+          }
       markGeneration("static-page", pageCacheControl())
       call.respondText(
         ServeWeb.viewerPage(
@@ -2246,6 +2255,7 @@ class ServeHttpServer(
             catalogBundleHost(renderHost)?.catalogSource?.let { src ->
               ServeUrls.githubBlobUrl(src.repo, src.ref, src.module, preview.sourceFile)
             },
+          liveAuthPrompt = liveAuthPrompt,
         ),
         ContentType.Text.Html,
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2192,6 +2192,7 @@ class ServeHttpServer(
       val engagement = incrementPreviewViews(sessionId, preview.id)
       val liveAuthPrompt =
         githubAuth
+          ?.takeIf { renderHost.hasLiveStream }
           ?.takeUnless { it.isAuthenticated(call) }
           ?.let {
             ServeWeb.LiveAuthPrompt(
@@ -2199,7 +2200,14 @@ class ServeHttpServer(
               repository = it.accessRepository(),
             )
           }
-      markGeneration("static-page", pageCacheControl())
+      markGeneration(
+        "static-page",
+        viewerCacheControl(
+          githubAuthConfigured = githubAuth != null,
+          hasLiveStream = renderHost.hasLiveStream,
+          isPublic = isPublic,
+        ),
+      )
       call.respondText(
         ServeWeb.viewerPage(
           preview,
@@ -2741,6 +2749,14 @@ class ServeHttpServer(
 
     /** Remove a little extra when pruning so a burst does not sort the map on every new entry. */
     private const val MAX_PREVIEW_VIEW_PRUNE_BATCH = 256
+
+    internal fun viewerCacheControl(
+      githubAuthConfigured: Boolean,
+      hasLiveStream: Boolean,
+      isPublic: Boolean,
+    ): String =
+      if (githubAuthConfigured && hasLiveStream) DYNAMIC_RESOURCE_CACHE_CONTROL
+      else if (isPublic) STATIC_PAGE_CACHE_CONTROL else DYNAMIC_RESOURCE_CACHE_CONTROL
 
     /** Classpath location of the vendored Remote Compose player IIFE bundle (global `RC`). */
     private const val RC_PLAYER_RESOURCE = "/rc-player/bundle.js"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -12,6 +12,9 @@ import kotlinx.serialization.json.JsonPrimitive
  */
 object ServeWeb {
 
+  /** Sign-in affordance for a live stream lane protected by GitHub collaborator auth. */
+  data class LiveAuthPrompt(val loginHref: String, val repository: String)
+
   /**
    * Absolute URLs advertised to link unfurlers for a browser-facing page. [imageUrl] is the thing
    * that page represents (a featured catalog hero, catalog component, or exact viewer render);
@@ -2813,6 +2816,8 @@ object ServeWeb {
      * renders no link, matching how the footer/landing source links depend on a known repo.
      */
     sourceHref: String? = null,
+    /** GitHub sign-in prompt shown when the daemon live stream is present but requires auth. */
+    liveAuthPrompt: LiveAuthPrompt? = null,
   ): String {
     val idSeg = WebEscaping.urlEncodeSegment(preview.id)
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
@@ -2963,11 +2968,33 @@ object ServeWeb {
     // stream on demand. For plain daemon / static sessions hasLiveStream tracks canApplyOverrides,
     // so
     // this is unchanged there.
-    val liveDis = if (hasLiveStream) "" else " disabled"
+    val liveAuthBlocksStream = hasLiveStream && liveAuthPrompt != null
+    val liveDis = if (hasLiveStream && !liveAuthBlocksStream) "" else " disabled"
     // Whether the single Static⇄Live preview toggle has any interactive lane to switch to — the
     // daemon stream ([hasLiveStream]) or the in-browser Wasm app ([wasmSrc]). Disabled (with the
     // note) on a pure static bundle with neither.
-    val liveToggleDis = if (hasLiveStream || wasmSrc != null) "" else " disabled"
+    val liveToggleDis =
+      if ((hasLiveStream || wasmSrc != null) && !liveAuthBlocksStream) "" else " disabled"
+    val liveAuthTitle = liveAuthPrompt?.let {
+      "Sign in with GitHub to enable Live preview. Access is limited to collaborators on " +
+        "${it.repository}."
+    }
+    val liveToggleTitleAttr =
+      liveAuthTitle?.let { " title=\"${WebEscaping.htmlEscape(it)}\"" } ?: ""
+    val liveAuthDataAttr =
+      liveAuthPrompt?.let {
+        " data-github-login=\"${WebEscaping.htmlEscape(it.loginHref)}\" " +
+          "data-github-repo=\"${WebEscaping.htmlEscape(it.repository)}\""
+      } ?: ""
+    val liveToggleButton =
+      "<button type=\"button\" id=\"cp-live-toggle\" class=\"cp-live-toggle\" " +
+        "aria-pressed=\"false\"$liveToggleDis$liveToggleTitleAttr>\n" +
+        "            <span class=\"cp-live-dot\" aria-hidden=\"true\"></span>\n" +
+        "            <span id=\"cp-live-toggle-label\">Live preview</span>\n" +
+        "          </button>"
+    val liveToggleHtml =
+      if (liveAuthPrompt == null) liveToggleButton
+      else "<span$liveToggleTitleAttr$liveAuthDataAttr>$liveToggleButton</span>"
     // Controls the in-browser Wasm app also honours — day/night (uiMode), font scale (density),
     // locale (layout direction): live whenever the server can render an override OR a Wasm app
     // backs
@@ -3263,10 +3290,7 @@ object ServeWeb {
            (appearance, size, scroll, locale, device, knobs). -->
       <div class="cp-below">
         <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false"$liveToggleDis>
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
+          $liveToggleHtml
           $wasmToggleBtn
           $rcBackendSelector
           $svgFmtToggle

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -1161,7 +1161,7 @@
       // it's the generic interactive toggle that lights for either lane.
       var livePressed = wasmBtn ? liveOn : (liveOn || wasmOn);
       liveToggle.setAttribute("aria-pressed", livePressed ? "true" : "false");
-      liveToggle.disabled = !liveTransportAvailable();
+      liveToggle.disabled = wasmBtn ? !(live && !live.disabled) : !liveTransportAvailable();
     }
     if (wasmBtn) { wasmBtn.setAttribute("aria-pressed", wasmOn ? "true" : "false"); }
     if (modeHint) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAuthTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAuthTest.kt
@@ -70,6 +70,34 @@ class ServeAuthTest {
   }
 
   @Test
+  fun `github protected live viewer pages are not cached`() {
+    assertEquals(
+      "no-store",
+      ServeHttpServer.viewerCacheControl(
+        githubAuthConfigured = true,
+        hasLiveStream = true,
+        isPublic = true,
+      ),
+    )
+    assertEquals(
+      "public, max-age=60, stale-while-revalidate=300",
+      ServeHttpServer.viewerCacheControl(
+        githubAuthConfigured = true,
+        hasLiveStream = false,
+        isPublic = true,
+      ),
+    )
+    assertEquals(
+      "no-store",
+      ServeHttpServer.viewerCacheControl(
+        githubAuthConfigured = false,
+        hasLiveStream = true,
+        isPublic = false,
+      ),
+    )
+  }
+
+  @Test
   fun `wasm assets get the content types a streaming wasm load requires`() {
     // application/wasm is mandatory: WebAssembly.instantiateStreaming rejects octet-stream. The
     // ES-module loader (.mjs) and its glue (.js) must be a JS type to execute.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1813,6 +1813,54 @@ class ServeWebFixtureTest {
   }
 
   @Test
+  fun `viewer disables live preview with GitHub auth prompt when sign-in is required`() {
+    val card = previews.first { it.id.endsWith("CardPreview") }
+    val protectedLive =
+      ServeWeb.viewerPage(
+        card,
+        token,
+        canApplyOverrides = true,
+        liveAuthPrompt =
+          ServeWeb.LiveAuthPrompt(
+            loginHref = "/auth/github/start?return=%2Fp%2FCardPreview%3Ftoken%3Dabc",
+            repository = "yschimke/compose-ai-tools",
+          ),
+      )
+
+    assertTrue(
+      protectedLive.contains("id=\"cp-live-toggle\"") &&
+        protectedLive.contains(
+          "id=\"cp-live-toggle\" class=\"cp-live-toggle\" aria-pressed=\"false\" disabled"
+        ),
+      "GitHub-protected live preview renders the visible toggle disabled until sign-in",
+    )
+    assertTrue(
+      protectedLive.contains(
+        "name=\"cp-mode\" value=\"live\" id=\"cp-live\" tabindex=\"-1\" disabled"
+      ),
+      "GitHub-protected live preview disables the hidden live transport radio too",
+    )
+    assertTrue(
+      protectedLive.contains(
+        "title=\"Sign in with GitHub to enable Live preview. Access is limited to collaborators on yschimke/compose-ai-tools.\""
+      ),
+      "disabled live preview explains the GitHub access requirement on hover",
+    )
+    assertTrue(
+      protectedLive.contains(
+        "data-github-login=\"/auth/github/start?return=%2Fp%2FCardPreview%3Ftoken%3Dabc\""
+      ),
+      "disabled live preview keeps the GitHub sign-in URL available to the page",
+    )
+
+    val openLive = ServeWeb.viewerPage(card, token, canApplyOverrides = true)
+    assertTrue(
+      openLive.contains("id=\"cp-live-toggle\" class=\"cp-live-toggle\" aria-pressed=\"false\">"),
+      "live preview remains enabled when no GitHub sign-in prompt is required",
+    )
+  }
+
+  @Test
   fun `a dedicated In-browser Wasm toggle shows only when a wasm app and a daemon lane are both present`() {
     val card = previews.first { it.id.endsWith("CardPreview") }
     // Case C — daemon live lane + wasm app: "Live preview" would prefer the daemon (bestLiveMode)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1852,6 +1852,13 @@ class ServeWebFixtureTest {
       ),
       "disabled live preview keeps the GitHub sign-in URL available to the page",
     )
+    assertTrue(
+      assetText("viewer.js")
+        .contains(
+          "liveToggle.disabled = wasmBtn ? !(live && !live.disabled) : !liveTransportAvailable();"
+        ),
+      "hydration keeps the daemon Live preview button disabled when GitHub auth blocks live",
+    )
 
     val openLive = ServeWeb.viewerPage(card, token, canApplyOverrides = true)
     assertTrue(

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -290,7 +290,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -244,7 +244,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -242,7 +242,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -238,7 +238,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -237,7 +237,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -243,7 +243,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -231,7 +231,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -235,7 +235,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -226,7 +226,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -239,7 +239,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125ba-1d68b411d6440004/viewer.js"></script>
+      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>


### PR DESCRIPTION
## Summary
- Pass GitHub auth state into the preview viewer when live streams require collaborator sign-in.
- Render the Live preview toggle disabled for unauthenticated visitors and explain on hover that GitHub sign-in/collaborator access is required.
- Keep the GitHub login URL and protected repo on the control wrapper for follow-up UI hooks.

Follow-up to #3121.

## Validation
- `./gradlew :cli:ktfmtCheck`
- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebFixtureTest`
- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeAuthTest`