### PR TITLE
fix(figma-svg): support Compose 1.9 applied alpha

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -285,14 +285,14 @@ internal object ModifierTokenResolver {
    *
    * `NodeCoordinator.lastLayerAlpha` is updated immediately after Compose invokes that
    * coordinator's layer block and before it hands the properties to `OwnedLayer`. The field starts
-   * at a non-identity sentinel, so it is usable only when the coordinator owns a layer and the
-   * block has actually run. All access is reflective to keep the connector compatible with Compose
-   * lines that predate this implementation detail; those fall back to [evaluateLayerBlockAlpha].
+   * at a non-identity sentinel, but Compose calls `updateLayerParameters()` synchronously when it
+   * creates the coordinator's layer, so a non-null layer means the value has been applied. Compose
+   * 1.9.5 does not expose newer versions' `wasLayerBlockInvoked` field, so that field cannot be
+   * used as a compatibility guard. All access remains reflective for Compose lines that predate
+   * `lastLayerAlpha`; those fall back to [evaluateLayerBlockAlpha].
    */
   internal fun appliedGraphicsLayerAlpha(coordinates: Any): Float? {
     if (reflectedField(coordinates, "layer") == null) return null
-    val invoked = reflectedField(coordinates, "wasLayerBlockInvoked") as? Boolean ?: return null
-    if (!invoked) return null
     return reflectedFloat(coordinates, "lastLayerAlpha")
   }
 

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/AppliedGraphicsLayerAlphaTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/AppliedGraphicsLayerAlphaTest.kt
@@ -9,38 +9,29 @@ class AppliedGraphicsLayerAlphaTest {
 
   private open class CoordinatorFields(
     @JvmField val layer: Any?,
-    @JvmField val wasLayerBlockInvoked: Boolean,
     @JvmField val lastLayerAlpha: Float,
   )
 
-  /** The real field is declared on `NodeCoordinator`, above the concrete coordinator subclass. */
-  private class ConcreteCoordinator(layer: Any?, invoked: Boolean, alpha: Float) :
-    CoordinatorFields(layer, invoked, alpha)
+  /** Mirrors Compose 1.9.5, where the coordinator has no `wasLayerBlockInvoked` field. */
+  private class ConcreteCoordinator(layer: Any?, alpha: Float) : CoordinatorFields(layer, alpha)
 
   @Test
-  fun `reads the alpha applied by this coordinator's real layer block`() {
-    val coordinates = ConcreteCoordinator(layer = Any(), invoked = true, alpha = 1f)
+  fun `reads applied alpha from a Compose 1_9 coordinator`() {
+    val coordinates = ConcreteCoordinator(layer = Any(), alpha = 1f)
 
     assertEquals(1f, ModifierTokenResolver.appliedGraphicsLayerAlpha(coordinates)!!, 0.001f)
   }
 
   @Test
   fun `preserves an intentional transparent applied layer`() {
-    val coordinates = ConcreteCoordinator(layer = Any(), invoked = true, alpha = 0f)
+    val coordinates = ConcreteCoordinator(layer = Any(), alpha = 0f)
 
     assertEquals(0f, ModifierTokenResolver.appliedGraphicsLayerAlpha(coordinates)!!, 0.001f)
   }
 
   @Test
   fun `does not expose the coordinator sentinel before a layer exists`() {
-    val coordinates = ConcreteCoordinator(layer = null, invoked = false, alpha = 0.8f)
-
-    assertNull(ModifierTokenResolver.appliedGraphicsLayerAlpha(coordinates))
-  }
-
-  @Test
-  fun `does not expose the coordinator sentinel before the block runs`() {
-    val coordinates = ConcreteCoordinator(layer = Any(), invoked = false, alpha = 0.8f)
+    val coordinates = ConcreteCoordinator(layer = null, alpha = 0.8f)
 
     assertNull(ModifierTokenResolver.appliedGraphicsLayerAlpha(coordinates))
   }


### PR DESCRIPTION
## Summary

- remove the `wasLayerBlockInvoked` reflection requirement from applied graphics-layer alpha capture
- retain the non-null coordinator layer guard before reading `lastLayerAlpha`
- reshape the regression fixture to match Compose UI 1.9.5, where no invocation field exists

## Root cause

PR #3130 used `wasLayerBlockInvoked` to guard `lastLayerAlpha`. Compose UI 1.9.5—the repository's explicit compatibility baseline—has `layer` and `lastLayerAlpha` fields but does not expose `wasLayerBlockInvoked`, so the frame-applied alpha path returned `null` and fell back to synthetic block evaluation.

Compose creates the coordinator layer and synchronously calls `updateLayerParameters()`, which writes `lastLayerAlpha`. A non-null layer is therefore the compatible initialization guard.

## Impact

Consumers on Compose UI 1.9.x now use the coordinator's frame-applied graphics-layer alpha, matching newer Compose runtimes and avoiding synthetic re-evaluation for Wear transformations.

## Validation

- `:data-layoutinspector-connector:test`
- `:data-layoutinspector-connector:ktfmtCheck`
- `FigmaSvgWearTlcAlphaTest`
- `:renderer-android:ktfmtCheck`

Follow-up to #3130 and its P1 review thread: https://github.com/yschimke/compose-ai-tools/pull/3130#discussion_r3695481026