### PR TITLE
test(daemon): cover override and keyboard helpers

### DIFF
--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/KeyboardBandLabelsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/KeyboardBandLabelsTest.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class KeyboardBandLabelsTest {
+
+  @Test
+  fun maps_every_letter_to_its_lowercase_band_label() {
+    val labels = ('a'..'z').map(Char::toString)
+
+    labels.forEachIndexed { offset, label ->
+      assertEquals(
+        label,
+        KeyboardBandLabels.fromAndroidKeycode((InteractiveKeyCodes.A + offset).toString()),
+      )
+    }
+  }
+
+  @Test
+  fun maps_punctuation_and_special_keys_to_band_tokens() {
+    val expected =
+      mapOf(
+        InteractiveKeyCodes.COMMA to ",",
+        InteractiveKeyCodes.PERIOD to ".",
+        InteractiveKeyCodes.SPACE to "space",
+        InteractiveKeyCodes.ENTER to "enter",
+        InteractiveKeyCodes.BACKSPACE to "backspace",
+        InteractiveKeyCodes.SHIFT_LEFT to "shift",
+        InteractiveKeyCodes.SHIFT_RIGHT to "shift",
+      )
+
+    expected.forEach { (keycode, label) ->
+      assertEquals(label, KeyboardBandLabels.fromAndroidKeycode(keycode.toString()))
+    }
+  }
+
+  @Test
+  fun accepts_whitespace_around_wire_keycode() {
+    assertEquals("a", KeyboardBandLabels.fromAndroidKeycode("  ${InteractiveKeyCodes.A}  "))
+  }
+
+  @Test
+  fun returns_null_for_absent_invalid_or_unmapped_keycodes() {
+    assertNull(KeyboardBandLabels.fromAndroidKeycode(null))
+    assertNull(KeyboardBandLabels.fromAndroidKeycode(""))
+    assertNull(KeyboardBandLabels.fromAndroidKeycode("KEYCODE_A"))
+    assertNull(KeyboardBandLabels.fromAndroidKeycode(InteractiveKeyCodes.DIGIT_0.toString()))
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideExtensionsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideExtensionsTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreviewOverrideExtensionsTest {
+
+  @Test
+  fun non_null_overrides_are_planned_by_active_extensions_in_registration_order() {
+    val overrides = PreviewOverrides(widthPx = 320)
+    val first = RecordingExtension("first")
+    val inactive = RecordingExtension("inactive")
+    val abstaining = RecordingExtension("abstaining", result = null)
+    val last = RecordingExtension("last")
+    val subject =
+      PreviewOverrideExtensions(
+        extensions = listOf(first, inactive, abstaining, last),
+        isActive = { it !== inactive },
+      )
+
+    val plans = subject.plan(overrides)
+
+    assertEquals(listOf("first", "last"), plans.map { it.id.value })
+    assertSame(overrides, first.requests.single())
+    assertTrue(inactive.requests.isEmpty())
+    assertSame(overrides, abstaining.requests.single())
+    assertSame(overrides, last.requests.single())
+  }
+
+  @Test
+  fun null_overrides_plan_only_active_always_on_extensions_with_an_empty_bag() {
+    val regular = RecordingExtension("regular")
+    val first = AlwaysOnRecordingExtension("first")
+    val inactive = AlwaysOnRecordingExtension("inactive")
+    val abstaining = AlwaysOnRecordingExtension("abstaining", result = null)
+    val last = AlwaysOnRecordingExtension("last")
+    val subject =
+      PreviewOverrideExtensions(
+        extensions = listOf(regular, first, inactive, abstaining, last),
+        isActive = { it !== inactive },
+      )
+
+    val plans = subject.plan(null)
+
+    assertEquals(listOf("first", "last"), plans.map { it.id.value })
+    assertTrue(regular.requests.isEmpty())
+    assertTrue(inactive.requests.isEmpty())
+    assertEquals(PreviewOverrides(), first.requests.single())
+    assertSame(first.requests.single(), abstaining.requests.single())
+    assertSame(first.requests.single(), last.requests.single())
+  }
+
+  @Test
+  fun empty_registry_returns_no_plans_without_consulting_activation() {
+    var activationChecked = false
+    val subject =
+      PreviewOverrideExtensions(emptyList()) {
+        activationChecked = true
+        true
+      }
+
+    assertTrue(subject.plan(PreviewOverrides()).isEmpty())
+    assertTrue(subject.plan(null).isEmpty())
+    assertFalse(activationChecked)
+    assertTrue(PreviewOverrideExtensions.Empty.plan(PreviewOverrides()).isEmpty())
+  }
+
+  private open class RecordingExtension(name: String, result: PlannedDataExtension? = Plan(name)) :
+    PreviewOverrideExtension {
+    override val id = DataExtensionId(name)
+    val requests = mutableListOf<PreviewOverrides>()
+    private val plannedResult = result
+
+    override fun plan(request: PreviewOverrides): PlannedDataExtension? {
+      requests += request
+      return plannedResult
+    }
+  }
+
+  private class AlwaysOnRecordingExtension(
+    name: String,
+    result: PlannedDataExtension? = Plan(name),
+  ) : RecordingExtension(name, result), AlwaysOnPreviewOverrideExtension
+
+  private data class Plan(private val name: String) : PlannedDataExtension {
+    override val id = DataExtensionId(name)
+    override val hooks = emptySet<DataExtensionHookKind>()
+    override val constraints = DataExtensionConstraints()
+  }
+}


### PR DESCRIPTION
## Summary

- cover every keyboard band letter mapping plus punctuation, special-key, whitespace, invalid, and unmapped inputs
- cover preview override extension ordering, activation filtering, abstention, always-on null-bag behavior, and the empty registry
- complete coverage of the remaining pure daemon helpers listed in #3078

## Why

Most of the high-return pure helpers from #3078 gained tests in earlier changes, but `KeyboardBandLabels` and `PreviewOverrideExtensions` remained unpinned. These tests protect their wire-format mapping and extension-planning invariants without requiring renderer or daemon fixtures.

## Validation

- `./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.KeyboardBandLabelsTest --tests ee.schimke.composeai.daemon.PreviewOverrideExtensionsTest`
- `./gradlew :daemon:core:ktfmtCheck`

The complete `:daemon:core:test` run passed 501 of 502 tests; the unrelated existing `RenderNowAppPreviewGateTest.activityAndTourPreviewsAreRejectedNotFailed` timed out waiting for a render-finished event.

Refs #3078