### PR TITLE
feat(serve): persist preview engagement

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -79,6 +79,7 @@ internal object CliFlags {
       "--catalogs-unlisted",
       "--catalogs-file",
       "--admin-token",
+      "--engagement-file",
       "--github-auth-client-id",
       "--github-auth-client-secret",
       "--github-auth-cookie-secret",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -33,6 +33,7 @@ import ee.schimke.composeai.cli.serve.ServeCatalogsConfig
 import ee.schimke.composeai.cli.serve.ServeCatalogsConfigFile
 import ee.schimke.composeai.cli.serve.ServeDocFormats
 import ee.schimke.composeai.cli.serve.ServeDocStore
+import ee.schimke.composeai.cli.serve.ServeEngagementStore
 import ee.schimke.composeai.cli.serve.ServeGithubAuth
 import ee.schimke.composeai.cli.serve.ServeGithubAuthConfig
 import ee.schimke.composeai.cli.serve.ServeHost
@@ -418,6 +419,10 @@ class ServeCommand(args: List<String>) : Command(args) {
    * `/admin/trust` can make a producer's Compose eligible for server-side re-render here.
    */
   private val adminToken: String? = args.flagValue("--admin-token")?.takeIf { it.isNotBlank() }
+
+  /** Optional durable aggregate counters. Null keeps local serve sessions in-memory only. */
+  private val engagementFile: File? =
+    args.flagValue("--engagement-file")?.takeIf { it.isNotBlank() }?.let(::File)
 
   private val githubAuthClientId: String? =
     args.flagValue("--github-auth-client-id")?.takeIf { it.isNotBlank() }
@@ -1528,6 +1533,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         playgroundService = playgroundLane?.compile,
         playgroundRedeem = playgroundLane?.redeem,
         githubAuth = githubAuth,
+        engagementStore = ServeEngagementStore(engagementFile),
       )
     if (trustAdmin != null) {
       System.err.println(
@@ -2573,6 +2579,10 @@ class ServeCommand(args: List<String>) : Command(args) {
                           routes don't exist at all. NB with --allow-render-trusted this token can
                           grant server-side execution, since trusting a branch makes that
                           producer's Compose eligible for re-render here.
+        --engagement-file <path>
+                          Persist privacy-minimal aggregate catalog/app and per-preview view counts
+                          as JSON. No IPs, cookies, user agents, or referrers are stored. Omitted =
+                          counters last only for this server process.
         --catalog-repo <owner/repo>
                           Default repo the catalogs are fetched from (default
                           yschimke/compose-ai-tools); per-entry @<owner>/<repo> overrides it.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeEngagementStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeEngagementStore.kt
@@ -1,0 +1,169 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.channels.FileChannel
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Durable, privacy-minimal engagement counters for the preview server.
+ *
+ * Only aggregate page-view counts are retained: no IP address, cookie, user agent, or referrer is
+ * recorded. A null [file] keeps the in-memory behaviour useful for local `serve` sessions; deployed
+ * servers point it at their persistent config volume.
+ */
+class ServeEngagementStore(
+  private val file: File? = null,
+  private val maxPreviewEntries: Int = DEFAULT_MAX_PREVIEW_ENTRIES,
+) {
+  @Serializable
+  private data class Counter(val views: Long = 0, val lastViewedAtEpochMillis: Long = 0)
+
+  @Serializable
+  private data class State(
+    val schema: String = SCHEMA,
+    val systems: Map<String, Counter> = emptyMap(),
+    val previews: Map<String, Map<String, Counter>> = emptyMap(),
+  )
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = true
+  }
+  private var state: State = load()
+
+  @Synchronized
+  fun incrementSystem(system: String): Long = update {
+    val current = state.systems[system] ?: Counter()
+    val updated =
+      current.copy(views = current.views + 1, lastViewedAtEpochMillis = System.currentTimeMillis())
+    state = state.copy(systems = state.systems + (system to updated))
+    updated.views
+  }
+
+  @Synchronized fun systemViews(system: String): Long = read { it.systems[system]?.views ?: 0 }
+
+  @Synchronized
+  fun systemViews(systems: Collection<String>): Map<String, Long> = read { snapshot ->
+    systems.associateWith { snapshot.systems[it]?.views ?: 0 }
+  }
+
+  @Synchronized
+  fun incrementPreview(system: String, preview: String): Long = update {
+    val systemPreviews = state.previews[system].orEmpty()
+    val current = systemPreviews[preview] ?: Counter()
+    val updated =
+      current.copy(views = current.views + 1, lastViewedAtEpochMillis = System.currentTimeMillis())
+    state =
+      state.copy(previews = state.previews + (system to (systemPreviews + (preview to updated))))
+    updated.views
+  }
+
+  @Synchronized
+  fun previewViews(system: String, preview: String): Long = read {
+    it.previews[system]?.get(preview)?.views ?: 0
+  }
+
+  @Synchronized
+  fun previewViews(system: String, previews: Collection<String>): Map<String, Long> =
+    read { snapshot ->
+      previews.associateWith { preview -> snapshot.previews[system]?.get(preview)?.views ?: 0 }
+    }
+
+  /**
+   * Re-read while holding a cross-process lock before every mutation. During a rolling deployment
+   * the retiring and replacement containers share `/config`; merging under this lock prevents
+   * either process from replacing the other's newer counts.
+   */
+  private fun <T> update(block: () -> T): T = withFileLock {
+    if (file != null) state = load()
+    val result = block()
+    prunePreviews()
+    persist()
+    result
+  }
+
+  private fun <T> read(block: (State) -> T): T = withFileLock {
+    if (file != null) state = load()
+    block(state)
+  }
+
+  private fun <T> withFileLock(block: () -> T): T {
+    val target = file ?: return block()
+    return runCatching {
+        target.parentFile?.mkdirs()
+        val lock = File(target.parentFile ?: File("."), ".${target.name}.lock")
+        FileChannel.open(lock.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE).use {
+          channel ->
+          channel.lock().use { block() }
+        }
+      }
+      .onFailure {
+        System.err.println("serve: engagement file lock unavailable: ${target.path}: ${it.message}")
+      }
+      .getOrElse { block() }
+  }
+
+  private fun load(): State {
+    val source = file ?: return State()
+    if (!source.isFile) return State()
+    return runCatching { json.decodeFromString<State>(source.readText()) }
+      .onFailure {
+        System.err.println("serve: engagement file unreadable: ${source.path}: ${it.message}")
+      }
+      .getOrDefault(State())
+  }
+
+  private fun prunePreviews() {
+    val overflow = state.previews.values.sumOf { it.size } - maxPreviewEntries
+    if (overflow <= 0) return
+    val victims =
+      state.previews
+        .flatMap { (system, previews) ->
+          previews.map { (preview, counter) ->
+            Triple(system, preview, counter.lastViewedAtEpochMillis)
+          }
+        }
+        .sortedBy { it.third }
+        .take(overflow)
+        .groupBy({ it.first }, { it.second })
+    val retained = state.previews.toMutableMap()
+    victims.forEach { (system, previewIds) ->
+      val systemPreviews = retained[system].orEmpty() - previewIds.toSet()
+      if (systemPreviews.isEmpty()) retained.remove(system) else retained[system] = systemPreviews
+    }
+    state = state.copy(previews = retained)
+  }
+
+  private fun persist() {
+    val target = file ?: return
+    runCatching {
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile ?: File("."), ".${target.name}.tmp")
+        temporary.writeText(json.encodeToString(state) + "\n")
+        try {
+          Files.move(
+            temporary.toPath(),
+            target.toPath(),
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING,
+          )
+        } catch (_: AtomicMoveNotSupportedException) {
+          Files.move(temporary.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+      }
+      .onFailure {
+        System.err.println("serve: engagement file not persisted: ${target.path}: ${it.message}")
+      }
+  }
+
+  companion object {
+    const val SCHEMA = "compose-preview-serve/engagement/v1"
+    const val DEFAULT_MAX_PREVIEW_ENTRIES = 10_000
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeEngagementStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeEngagementStore.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.json.Json
  */
 class ServeEngagementStore(
   private val file: File? = null,
+  private val maxSystemEntries: Int = DEFAULT_MAX_SYSTEM_ENTRIES,
   private val maxPreviewEntries: Int = DEFAULT_MAX_PREVIEW_ENTRIES,
 ) {
   @Serializable
@@ -83,6 +84,7 @@ class ServeEngagementStore(
   private fun <T> update(block: () -> T): T = withFileLock {
     if (file != null) state = load()
     val result = block()
+    pruneSystems()
     prunePreviews()
     persist()
     result
@@ -117,6 +119,21 @@ class ServeEngagementStore(
         System.err.println("serve: engagement file unreadable: ${source.path}: ${it.message}")
       }
       .getOrDefault(State())
+  }
+
+  private fun pruneSystems() {
+    val overflow = state.systems.size - maxSystemEntries
+    if (overflow <= 0) return
+    val victims =
+      state.systems.entries
+        .sortedBy { it.value.lastViewedAtEpochMillis }
+        .take(overflow)
+        .map { it.key }
+    state =
+      state.copy(
+        systems = state.systems - victims.toSet(),
+        previews = state.previews - victims.toSet(),
+      )
   }
 
   private fun prunePreviews() {
@@ -164,6 +181,7 @@ class ServeEngagementStore(
 
   companion object {
     const val SCHEMA = "compose-preview-serve/engagement/v1"
+    const val DEFAULT_MAX_SYSTEM_ENTRIES = 1_000
     const val DEFAULT_MAX_PREVIEW_ENTRIES = 10_000
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -42,7 +42,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -212,6 +211,8 @@ class ServeHttpServer(
    * code-running surfaces (playground + live WebSocket sessions) require a signed-in collaborator.
    */
   private val githubAuth: ServeGithubAuth? = null,
+  /** Aggregate view counts; pass a file-backed store to keep them across server restarts. */
+  private val engagementStore: ServeEngagementStore = ServeEngagementStore(),
 ) {
   /** The actual bound port — may differ from the requested one if it was taken (auto-picked). */
   val port: Int = pickPort(host, requestedPort, portRange)
@@ -223,9 +224,6 @@ class ServeHttpServer(
   private val startedAtMillis: Long = System.currentTimeMillis()
 
   private val renderSemaphore = Semaphore(renderSlots)
-
-  /** Best-effort bounded in-memory engagement counts, keyed by session id + preview id. */
-  private val previewViews = ConcurrentHashMap<String, PreviewViewCounter>()
 
   /**
    * Readiness latch for `/readyz` (the rolling-update gate). Unlike `/healthz` — a static "ok" that
@@ -1013,43 +1011,19 @@ class ServeHttpServer(
     cacheControl?.let { call.response.headers.append(HttpHeaders.CacheControl, it) }
   }
 
-  private fun previewViewKey(sessionId: String, previewId: String): String =
-    "$sessionId\u0000$previewId"
-
-  private data class PreviewViewCounter(
-    val views: AtomicLong = AtomicLong(0),
-    val lastAccessMillis: AtomicLong = AtomicLong(0),
-  )
-
   private fun incrementPreviewViews(
     sessionId: String,
     previewId: String,
-  ): ServeWeb.PreviewEngagement {
-    prunePreviewViewsIfNeeded()
-    val counter =
-      previewViews.computeIfAbsent(previewViewKey(sessionId, previewId)) { PreviewViewCounter() }
-    counter.lastAccessMillis.set(System.currentTimeMillis())
-    return ServeWeb.PreviewEngagement(counter.views.incrementAndGet())
-  }
+  ): ServeWeb.PreviewEngagement =
+    ServeWeb.PreviewEngagement(engagementStore.incrementPreview(sessionId, previewId))
 
   private fun previewEngagement(sessionId: String, previewId: String): ServeWeb.PreviewEngagement =
-    ServeWeb.PreviewEngagement(
-      previewViews[previewViewKey(sessionId, previewId)]?.views?.get() ?: 0L
-    )
+    ServeWeb.PreviewEngagement(engagementStore.previewViews(sessionId, previewId))
 
   private fun previewEngagement(sessionId: String, previews: List<ServePreview>) =
-    previews.associate {
-      it.id to previewEngagement(sessionId, it.id)
+    engagementStore.previewViews(sessionId, previews.map { it.id }).mapValues {
+      ServeWeb.PreviewEngagement(it.value)
     }
-
-  private fun prunePreviewViewsIfNeeded() {
-    val overflow = previewViews.size - MAX_PREVIEW_VIEW_ENTRIES
-    if (overflow <= 0) return
-    previewViews.entries
-      .sortedBy { it.value.lastAccessMillis.get() }
-      .take(overflow + MAX_PREVIEW_VIEW_PRUNE_BATCH)
-      .forEach { previewViews.remove(it.key, it.value) }
-  }
 
   /** `GET /` (query) and `GET /{system}[/]` (path): the session's preview-list landing page. */
   private suspend fun RoutingContext.handleLanding(sessionInPath: Boolean) {
@@ -1068,10 +1042,12 @@ class ServeHttpServer(
       return
     }
     val (webSessionId, basePath) = webSessionAndBase(sessionInPath)
+    val selectedSessionId = selectedSessionId(sessionInPath)
     withLeasedSession(
-      selectedSessionId(sessionInPath),
+      selectedSessionId,
       onMissing = { respondNotFoundHtml("That design system was not found on this server.") },
     ) { renderHost ->
+      val systemViews = engagementStore.incrementSystem(selectedSessionId)
       val heroId =
         catalogBundleHost(renderHost)?.declaredHeroPreviewId
           ?: ServeWeb.representativePreviewId(renderHost.previews)
@@ -1114,7 +1090,8 @@ class ServeHttpServer(
           // a daemon-twinned card can actually re-render one, hence the per-preview predicate.
           declaredThemes = renderHost.declaredThemes,
           canRenderThemeFor = { id -> renderHost.canRenderOverridesFor(id) },
-          engagement = previewEngagement(selectedSessionId(sessionInPath), renderHost.previews),
+          engagement = previewEngagement(selectedSessionId, renderHost.previews),
+          systemViews = systemViews,
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl(), imageUrl = heroUrl),
         ),
         ContentType.Text.Html,
@@ -1904,8 +1881,9 @@ class ServeHttpServer(
    * count. A catalog with neither a resident host nor a last-known snapshot is skipped rather than
    * sinking the whole page.
    */
-  private fun homeSystemsFor(ids: List<String>): List<ServeWeb.HomeSystem> =
-    ids.mapNotNull { system ->
+  private fun homeSystemsFor(ids: List<String>): List<ServeWeb.HomeSystem> {
+    val views = engagementStore.systemViews(ids)
+    return ids.mapNotNull { system ->
       sessions.peekHost(system)?.let { rememberCatalogMeta(system, it) }
       val meta = catalogMetaSeen[system] ?: return@mapNotNull null
       ServeWeb.HomeSystem(
@@ -1916,6 +1894,7 @@ class ServeHttpServer(
         title = meta.title ?: system,
         subtitle = meta.subtitle,
         previewCount = meta.previews ?: 0,
+        views = views.getValue(system),
         trust = meta.trust,
         sourceRepo = meta.provenance?.repo,
         heroPreviewId = meta.heroPreviewId,
@@ -1933,6 +1912,7 @@ class ServeHttpServer(
         darkStage = meta.darkStage,
       )
     }
+  }
 
   /**
    * `GET /api/previews` (query) and `GET /{system}/api/previews` (path): the session's preview
@@ -1940,7 +1920,8 @@ class ServeHttpServer(
    */
   private suspend fun RoutingContext.handleApiPreviews(sessionInPath: Boolean) {
     if (rejectBadToken()) return
-    withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
+    val sessionId = selectedSessionId(sessionInPath)
+    withLeasedSession(sessionId) { renderHost ->
       val dto =
         PreviewsResponse(
           module = renderHost.label,
@@ -1950,6 +1931,7 @@ class ServeHttpServer(
           // Why the session is snapshot-only (no live lane), when it is — read off the host so a
           // programmatic client sees the same reason the viewer banner shows.
           degradations = renderHost.degradations.map { DegradationDto(it.code, it.detail) },
+          views = engagementStore.systemViews(sessionId),
           previews =
             renderHost.previews.map { p ->
               PreviewDto(
@@ -1959,7 +1941,7 @@ class ServeHttpServer(
                 overrides = p.overrides,
                 remoteComposeKnobs = p.remoteComposeKnobs,
                 liveOnly = p.id in renderHost.liveOnlyPreviewIds,
-                views = previewEngagement(selectedSessionId(sessionInPath), p.id).views,
+                views = previewEngagement(sessionId, p.id).views,
               )
             },
         )
@@ -2744,12 +2726,6 @@ class ServeHttpServer(
     /** Variant renders and all token-gated responses stay out of shared and browser caches. */
     private const val DYNAMIC_RESOURCE_CACHE_CONTROL = "no-store"
 
-    /** Bound best-effort engagement counters so short-lived playground sessions cannot leak. */
-    private const val MAX_PREVIEW_VIEW_ENTRIES = 10_000
-
-    /** Remove a little extra when pruning so a burst does not sort the map on every new entry. */
-    private const val MAX_PREVIEW_VIEW_PRUNE_BATCH = 256
-
     internal fun viewerCacheControl(
       githubAuthConfigured: Boolean,
       hasLiveStream: Boolean,
@@ -3095,6 +3071,8 @@ private data class PreviewsResponse(
    * plus a human [detail]. Additive since `compose-preview-serve/v2`. See [ServeDegradation].
    */
   val degradations: List<DegradationDto> = emptyList(),
+  /** Aggregate landing-page visits for this catalog/app. */
+  val views: Long = 0,
   val previews: List<PreviewDto>,
 )
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1017,9 +1017,6 @@ class ServeHttpServer(
   ): ServeWeb.PreviewEngagement =
     ServeWeb.PreviewEngagement(engagementStore.incrementPreview(sessionId, previewId))
 
-  private fun previewEngagement(sessionId: String, previewId: String): ServeWeb.PreviewEngagement =
-    ServeWeb.PreviewEngagement(engagementStore.previewViews(sessionId, previewId))
-
   private fun previewEngagement(sessionId: String, previews: List<ServePreview>) =
     engagementStore.previewViews(sessionId, previews.map { it.id }).mapValues {
       ServeWeb.PreviewEngagement(it.value)
@@ -1922,6 +1919,7 @@ class ServeHttpServer(
     if (rejectBadToken()) return
     val sessionId = selectedSessionId(sessionInPath)
     withLeasedSession(sessionId) { renderHost ->
+      val previewEngagement = previewEngagement(sessionId, renderHost.previews)
       val dto =
         PreviewsResponse(
           module = renderHost.label,
@@ -1941,7 +1939,7 @@ class ServeHttpServer(
                 overrides = p.overrides,
                 remoteComposeKnobs = p.remoteComposeKnobs,
                 liveOnly = p.id in renderHost.liveOnlyPreviewIds,
-                views = previewEngagement(sessionId, p.id).views,
+                views = previewEngagement.getValue(p.id).views,
               )
             },
         )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -24,7 +24,7 @@ object ServeWeb {
    */
   data class UnfurlMetadata(val pageUrl: String, val imageUrl: String? = null)
 
-  /** In-memory engagement metrics surfaced by the live server UI/API. */
+  /** Aggregate engagement metrics surfaced by the live server UI/API. */
   data class PreviewEngagement(val views: Long = 0)
 
   private fun assetHref(name: String): String = ServeWebAssets.href(name)
@@ -32,10 +32,13 @@ object ServeWeb {
   private fun scriptTag(name: String): String = "<script src=\"${assetHref(name)}\"></script>"
 
   private fun viewCountHtml(views: Long): String =
-    if (views <= 0) "" else "<div class=\"cp-engage\">${formatCount(views)} views</div>"
+    if (views <= 0) "" else "<div class=\"cp-engage\">${formatViews(views)}</div>"
 
   private fun viewerViewCountHtml(views: Long): String =
-    if (views <= 0) "" else "<p class=\"cp-viewer-engage\">${formatCount(views)} views</p>"
+    if (views <= 0) "" else "<p class=\"cp-viewer-engage\">${formatViews(views)}</p>"
+
+  private fun formatViews(views: Long): String =
+    "${formatCount(views)} ${if (views == 1L) "view" else "views"}"
 
   private fun formatCount(n: Long): String =
     if (n < 1000) n.toString()
@@ -1213,6 +1216,8 @@ object ServeWeb {
      * takes effect when [sourceRepo] is one of [HomeGroup.repos] — see [homeSections].
      */
     val group: HomeGroup? = null,
+    /** Aggregate visits to this catalog/app landing page. */
+    val views: Long = 0,
   )
 
   /**
@@ -1354,7 +1359,7 @@ object ServeWeb {
         <div class="cp-meta">
           <div class="cp-sys-title">$title${compactTrustBadge(s.trust)}</div>
           <div class="cp-id">$sysId</div>$desc
-          <div class="cp-sys-foot">${s.previewCount} preview(s)</div>
+          <div class="cp-sys-foot">${s.previewCount} preview(s)${if (s.views > 0) " · ${formatViews(s.views)}" else ""}</div>
         </div>
       </a>
       """
@@ -2443,6 +2448,8 @@ object ServeWeb {
      * missing or zero entries render no badge.
      */
     engagement: Map<String, PreviewEngagement> = emptyMap(),
+    /** Aggregate visits to this app/design-system landing page. */
+    systemViews: Long = 0,
     /** Absolute page + representative preview URLs for Open Graph/Twitter link previews. */
     unfurl: UnfurlMetadata? = null,
   ): String {
@@ -2666,7 +2673,7 @@ object ServeWeb {
       body =
         """
         $back<h1 class="cp-head">${WebEscaping.htmlEscape(moduleLabel)}${trustBadge(trust)}</h1>
-        ${degradeBanner(degradations)}$prov$themeToggle<p class="cp-sub">${previews.size} preview(s) · click one to view with overrides ·
+        ${degradeBanner(degradations)}$prov$themeToggle<p class="cp-sub">${previews.size} preview(s)${if (systemViews > 0) " · ${formatViews(systemViews)}" else ""} · click one to view with overrides ·
           <a href="$basePath/bundle.zip$q">download all (.zip)</a></p>
         $searchBox$tabBar$gridBlock$emptyState$filterScript$about
         """

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeEngagementStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeEngagementStoreTest.kt
@@ -1,0 +1,54 @@
+package ee.schimke.composeai.cli.serve
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ServeEngagementStoreTest {
+  @Test
+  fun `counts survive reopening the store`() {
+    val file = Files.createTempDirectory("engagement").resolve("counts.json").toFile()
+    val first = ServeEngagementStore(file)
+
+    assertEquals(1, first.incrementSystem("compose-m3"))
+    assertEquals(2, first.incrementSystem("compose-m3"))
+    assertEquals(1, first.incrementPreview("compose-m3", "button"))
+    assertEquals(2, first.incrementPreview("compose-m3", "button"))
+
+    val reopened = ServeEngagementStore(file)
+    assertEquals(2, reopened.systemViews("compose-m3"))
+    assertEquals(2, reopened.previewViews("compose-m3", "button"))
+    assertFalse(file.readText().contains("127.0.0.1"), "store contains aggregate counts only")
+  }
+
+  @Test
+  fun `rolling server instances merge instead of overwriting counts`() {
+    val file = Files.createTempDirectory("engagement-roll").resolve("counts.json").toFile()
+    val retiring = ServeEngagementStore(file)
+    val replacement = ServeEngagementStore(file)
+
+    assertEquals(1, retiring.incrementSystem("compose-m3"))
+    assertEquals(2, replacement.incrementSystem("compose-m3"))
+    assertEquals(3, retiring.incrementSystem("compose-m3"))
+    assertEquals(1, replacement.incrementPreview("compose-m3", "button"))
+    assertEquals(2, retiring.incrementPreview("compose-m3", "button"))
+
+    assertEquals(3, replacement.systemViews("compose-m3"))
+    assertEquals(2, replacement.previewViews("compose-m3", "button"))
+  }
+
+  @Test
+  fun `old preview counters are bounded without dropping system totals`() {
+    val store = ServeEngagementStore(maxPreviewEntries = 2)
+    store.incrementSystem("app")
+    store.incrementPreview("app", "oldest")
+    store.incrementPreview("app", "middle")
+    store.incrementPreview("app", "newest")
+
+    assertEquals(1, store.systemViews("app"))
+    assertEquals(0, store.previewViews("app", "oldest"))
+    assertEquals(1, store.previewViews("app", "middle"))
+    assertEquals(1, store.previewViews("app", "newest"))
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeEngagementStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeEngagementStoreTest.kt
@@ -51,4 +51,18 @@ class ServeEngagementStoreTest {
     assertEquals(1, store.previewViews("app", "middle"))
     assertEquals(1, store.previewViews("app", "newest"))
   }
+
+  @Test
+  fun `old system counters and their previews are bounded`() {
+    val store = ServeEngagementStore(maxSystemEntries = 2)
+    store.incrementSystem("oldest")
+    store.incrementPreview("oldest", "button")
+    store.incrementSystem("middle")
+    store.incrementSystem("newest")
+
+    assertEquals(0, store.systemViews("oldest"))
+    assertEquals(0, store.previewViews("oldest", "button"))
+    assertEquals(1, store.systemViews("middle"))
+    assertEquals(1, store.systemViews("newest"))
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -340,6 +340,7 @@ class ServeHttpRoutingTest {
     // also carries no ?token — the route needs none.
     assertTrue(landing.contains("href=\"/compose-m3/p/$previewId\""), "path card link: $landing")
     assertTrue(!landing.contains("token="), "public path landing links are token-free: $landing")
+    assertTrue(landing.contains("1 preview(s) · 1 view"), "catalog visit counted: $landing")
 
     val (viewerCode, viewer) = get("/compose-m3/p/$previewId")
     assertEquals(200, viewerCode)
@@ -358,6 +359,7 @@ class ServeHttpRoutingTest {
     val (apiCode, api) = get("/compose-m3/api/previews")
     assertEquals(200, apiCode)
     assertTrue(api.contains("\"module\":\"compose-m3\""), "api for the path session: $api")
+    assertTrue(api.contains("\"views\":1"), "catalog and preview engagement in api: $api")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -389,8 +389,10 @@ class ServeWebTest {
         previews,
         token = "t",
         engagement = mapOf("plain.Button" to ServeWeb.PreviewEngagement(12)),
+        systemViews = 1234,
       )
     assertTrue(landing.contains("""<div class="cp-engage">12 views</div>"""), landing)
+    assertTrue(landing.contains("2 preview(s) · 1.2k views"), landing)
 
     val viewer =
       ServeWeb.viewerPage(
@@ -400,6 +402,27 @@ class ServeWebTest {
         engagement = ServeWeb.PreviewEngagement(13),
       )
     assertTrue(viewer.contains("""<p class="cp-viewer-engage">13 views</p>"""), viewer)
+  }
+
+  @Test
+  fun `home cards subtly surface catalog engagement`() {
+    val html =
+      ServeWeb.homeIndexPage(
+        systems =
+          listOf(
+            ServeWeb.HomeSystem(
+              system = "compose-m3",
+              title = "Material 3",
+              subtitle = null,
+              previewCount = 42,
+              trust = null,
+              heroPreviewId = null,
+              views = 12_345,
+            )
+          ),
+        token = "t",
+      )
+    assertTrue(html.contains("42 preview(s) · 12.3k views"), html)
   }
 
   @Test

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       # code-execution credential: trusting a branch makes that producer's Compose eligible for
       # server-side re-render here. Treat it like a deploy key, not a read token.
       SERVE_ADMIN_TOKEN: "${SERVE_ADMIN_TOKEN:-}"
+      # Privacy-minimal aggregate app/catalog + preview views, persisted on preview_config.
+      SERVE_ENGAGEMENT_FILE: "${SERVE_ENGAGEMENT_FILE:-}"
       # Optional GitHub OAuth collaborator auth for code-running surfaces (live WebSockets and
       # playground). Set the three secrets in .env to enable; the entrypoint then defaults the repo
       # check to yschimke/compose-ai-tools and uses this domain as the OAuth callback origin unless

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -107,6 +107,10 @@ fi
 # gated by its own secret — never the browse token, which a public box hands to every visitor.
 # Unset (the default) means the admin routes don't exist at all.
 [[ -n "${SERVE_ADMIN_TOKEN:-}" ]] && args+=(--admin-token "${SERVE_ADMIN_TOKEN}")
+# Aggregate view counts live beside catalog/trust config so container restarts and image updates do
+# not erase engagement. Set to `none` to keep counters process-local.
+: "${SERVE_ENGAGEMENT_FILE:=/config/engagement.json}"
+[[ "${SERVE_ENGAGEMENT_FILE}" != "none" ]] && args+=(--engagement-file "${SERVE_ENGAGEMENT_FILE}")
 if [[ -n "${SERVE_GITHUB_AUTH_CLIENT_ID:-}" ||
   -n "${SERVE_GITHUB_AUTH_CLIENT_SECRET:-}" ||
   -n "${SERVE_GITHUB_AUTH_COOKIE_SECRET:-}" ]]; then

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -22,6 +22,13 @@
    served module's own preview grid at `/`.) This replaces showing an arbitrary default module at the
    root — the point of the public server is the catalogs, so the landing leads with them.
 
+   The server keeps privacy-minimal **engagement counts** for catalog/app landing visits and each
+   preview viewer. Small view totals appear in the front-door card footer, catalog summary, preview
+   cards, and viewer; `/api/previews` exposes the same aggregate `views` fields. No IP address,
+   cookie, user agent, or referrer is retained. `--engagement-file <path>` makes the JSON counters
+   survive restarts; the prebuilt image defaults this to `/config/engagement.json` on its existing
+   `preview_config` volume (`SERVE_ENGAGEMENT_FILE=none` opts out of persistence).
+
    Two per-system display choices are **systematised** in one place (`ServeWeb.SystemDisplay`), so
    the front door and each catalog grid agree:
    - **Hero** — the card fronts the *most representative* preview: a real `Screens`-section preview


### PR DESCRIPTION
Closes #3062.

## What changed

- replace process-local preview counters with a bounded, file-backed engagement store
- count app/design-system landing visits as well as individual preview viewer visits
- surface compact view totals on the home index, catalog pages, preview cards, viewers, and `/api/previews`
- persist production counts at `/config/engagement.json` on the existing `preview_config` volume
- merge updates under a cross-process file lock so rolling replicas cannot overwrite each other
- add `--engagement-file` / `SERVE_ENGAGEMENT_FILE`, with `none` opting out of persistence

## Why

The server already rendered subtle per-preview view badges, but those counts lived only in memory and disappeared on every deployment. It also had no app/design-system-level engagement signal. This keeps aggregate engagement useful across restarts while retaining no IP address, cookie, user agent, or referrer.

## Validation

- `./gradlew :cli:ktfmtCheck`
- targeted CLI tests covering store persistence, bounded pruning, rolling-replica merging, HTTP routing/API counts, web rendering, and CLI flag registration
- `bash -n deploy/image/entrypoint.sh`