### PR TITLE
fix(figma-svg): clip lookahead scrolls to rendered viewport

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1286,15 +1286,17 @@ internal object ComposeLayoutInspector {
     ) {
       ModifierTokenResolver.graphicsLayerAlpha(this)?.let { properties["alpha"] = it.toString() }
     }
-    // The `clip` flag identifies which coordinator on the chain is the one that clips, and the
-    // figma-svg model uses that coordinator's box as the rect the frame was actually drawn in
-    // (issue #3056). Desktop/release Compose compiles the inspector element out for the same reason
-    // it does `BackgroundElement`'s above, so carry the reflected field too — otherwise the model
-    // finds no clipping modifier and a lookahead-inflated node keeps its oversized box.
-    if (
+    // Mark the coordinator that actually clipped the captured frame. This catches both a static
+    // `Modifier.clip(shape)` graphics layer and Foundation's runtime scroll clip, whose element has
+    // no `clip` field. The latter owns the final viewport under lookahead (#3056).
+    if ("clip" !in properties && ModifierTokenResolver.appliedClipsContent(coordinates)) {
+      properties["clip"] = "true"
+    } else if (
       "clip" !in properties &&
         (name == "graphicsLayer" || modifier.javaClass.simpleName.contains("GraphicsLayer"))
     ) {
+      // Compatibility fallback for Compose versions that do not expose `isClipping` on the
+      // coordinator: retain the element-field path used for a static graphics-layer clip.
       runCatching {
           modifier.javaClass
             .getDeclaredField("clip")

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -81,6 +81,12 @@ internal object ModifierTokenResolver {
       val elements = inspectable?.inspectableElements?.associate { it.name to it.value }.orEmpty()
       val simpleName = mod.javaClass.simpleName
 
+      // A scrolling modifier installs clipping at runtime on its coordinator rather than exposing
+      // a static graphics-layer `clip` field. Treat the applied frame state as authoritative so a
+      // scroll-only viewport masks its children too (and supplies the final lookahead viewport to
+      // figma-svg; issue #3056).
+      if (!clipsContent && appliedClipsContent(info.coordinates)) clipsContent = true
+
       // `Surface`/`Card`/`FAB` cast their Material drop shadow via
       // `graphicsLayer { shadowElevation = … }`. Capture the largest shadow elevation on the node
       // so
@@ -295,6 +301,19 @@ internal object ModifierTokenResolver {
     if (!invoked) return null
     return reflectedFloat(coordinates, "lastLayerAlpha")
   }
+
+  /**
+   * Whether this modifier coordinator clipped the captured frame.
+   *
+   * This is deliberately read from the placed coordinator rather than only from the modifier
+   * element. Foundation's scrolling modifiers install a runtime clip on their coordinator but do
+   * not expose a static `clip` field like `Modifier.clip(shape)`'s `GraphicsLayerElement` does.
+   * Under lookahead/shared-element measurement that runtime coordinator is also the one that keeps
+   * the final height-limited viewport, while the shape clip farther out in the chain can report the
+   * taller lookahead content box (issue #3056).
+   */
+  internal fun appliedClipsContent(coordinates: Any): Boolean =
+    reflectedField(coordinates, "isClipping") as? Boolean ?: false
 
   /**
    * Reads a **linear** gradient brush off [mod]'s `brush` field (or an inspector `brush` element)

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/AppliedCoordinatorClipTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/AppliedCoordinatorClipTest.kt
@@ -1,0 +1,29 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pins the runtime coordinator clip signal used for scroll viewports in figma-svg (#3056). */
+class AppliedCoordinatorClipTest {
+
+  private open class CoordinatorFields(@JvmField val isClipping: Boolean)
+
+  /** The real field is declared on `NodeCoordinator`, above the concrete coordinator subclass. */
+  private class ConcreteCoordinator(clipping: Boolean) : CoordinatorFields(clipping)
+
+  @Test
+  fun `reads an applied runtime clip from a coordinator superclass`() {
+    assertTrue(ModifierTokenResolver.appliedClipsContent(ConcreteCoordinator(true)))
+  }
+
+  @Test
+  fun `does not mark a coordinator that did not clip`() {
+    assertFalse(ModifierTokenResolver.appliedClipsContent(ConcreteCoordinator(false)))
+  }
+
+  @Test
+  fun `is safely false when an older coordinator has no clip field`() {
+    assertFalse(ModifierTokenResolver.appliedClipsContent(Any()))
+  }
+}

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -1398,20 +1398,26 @@ data class FigmaSvgModel(
      */
     private fun LayoutInspectorNode.clipModifierBounds(): LayoutInspectorBounds? {
       if (tokens?.clipsContent != true) return null
-      val clip =
-        modifiers.lastOrNull { it.properties["clip"] == "true" && it.bounds != null }?.bounds
-          ?: return null
       val own = bounds
       if (own.right <= own.left || own.bottom <= own.top) return null
-      val inside =
-        clip.left >= own.left &&
-          clip.top >= own.top &&
-          clip.right <= own.right &&
-          clip.bottom <= own.bottom
-      val smaller =
-        clip.right - clip.left < own.right - own.left ||
-          clip.bottom - clip.top < own.bottom - own.top
-      return clip.takeIf { inside && smaller && it.right > it.left && it.bottom > it.top }
+      return modifiers
+        .asSequence()
+        .filter { it.properties["clip"] == "true" }
+        .mapNotNull { it.bounds }
+        .filter { clip ->
+          clip.right > clip.left &&
+            clip.bottom > clip.top &&
+            clip.left >= own.left &&
+            clip.top >= own.top &&
+            clip.right <= own.right &&
+            clip.bottom <= own.bottom &&
+            (clip.right - clip.left < own.right - own.left ||
+              clip.bottom - clip.top < own.bottom - own.top)
+        }
+        // Multiple coordinators can clip the same node (a rounded surface around a scroll clip).
+        // Their intersection is the actual visible region; for the nested, axis-aligned boxes
+        // Compose emits here, the smallest area is the tightest final rendered viewport.
+        .minByOrNull { (it.right - it.left).toLong() * (it.bottom - it.top).toLong() }
     }
 
     /**

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgClippedNodeTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgClippedNodeTest.kt
@@ -144,12 +144,19 @@ class FigmaSvgClippedNodeTest {
               size = LayoutInspectorSize(200, 300),
               modifiers =
                 listOf(
-                  // …while the clipping `graphicsLayer` still reports the rendered 100px viewport.
+                  // The runtime scroll clip reports the rendered 100px viewport.
+                  LayoutInspectorModifier(
+                    name = "scrollingContainer",
+                    properties = mapOf("clip" to "true"),
+                    bounds = bounds(0, 0, 200, 100),
+                  ),
+                  // The outer rounded surface still carries the lookahead content height. Put it
+                  // last to prove selection does not depend on modifier enumeration order.
                   LayoutInspectorModifier(
                     name = "graphicsLayer",
                     properties = mapOf("clip" to "true"),
-                    bounds = bounds(0, 0, 200, 100),
-                  )
+                    bounds = bounds(0, 0, 200, 300),
+                  ),
                 ),
               tokens = ComposeSemanticsTokens(backgroundColor = "#FFFFFFFF", clipsContent = true),
             )


### PR DESCRIPTION
## Summary

- capture Compose's applied coordinator clipping state, including runtime scroll clips that do not expose a static `clip` modifier field
- select the tightest valid clipping coordinator bounds for SVG layers under lookahead/shared-element measurement
- add coordinator-level and model-level regression coverage for the competing lookahead and rendered viewport bounds

## Root cause

`figma-svg` only recognized the static `graphicsLayer(clip = true)` signal. Foundation scrolling installs its clip at runtime on the placed coordinator, so the exporter missed the coordinator that retained the final height-limited viewport. With `sharedBounds` / `skipToLookaheadSize`, the shape clip could therefore contribute the taller lookahead content bounds and expose below-fold children.

## Impact

Height-limited scroll containers inside shared-element/lookahead layouts now export the same visible viewport as the rendered PNG. Below-fold controls remain clipped from the viewport SVG.

Fixes #3056.

## Validation

- `:data-layoutinspector-core:test --tests ee.schimke.composeai.data.layoutinspector.FigmaSvgClippedNodeTest`
- `:data-layoutinspector-connector:test --tests ee.schimke.composeai.daemon.AppliedCoordinatorClipTest`
- `:renderer-android:testDebugUnitTest --tests ee.schimke.composeai.renderer.FigmaSvgSharedBoundsScrollClipTest`
- `:data-layoutinspector-core:ktfmtCheck`
- `:data-layoutinspector-connector:ktfmtCheck`
