### PR TITLE
docs: fix stale KDoc symbol references

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -198,10 +198,10 @@ class BundleRenderer(
 
   /**
    * Re-render an `backend="android"` bundle by spawning the Android (Robolectric) renderer
-   * ([ee.schimke.composeai.renderer.AndroidRendererMain], which reads `composeai.render.manifest`
-   * and renders the whole `previews.json` into `composeai.render.outputDir` — one subprocess for
-   * the batch, vs the desktop per-preview spawn). Classpath/JVM-arg/property assembly lives in the
-   * unit-tested [AndroidBundleLaunch].
+   * (`AndroidRendererMainKt`, which reads `composeai.render.manifest` and renders the whole
+   * `previews.json` into `composeai.render.outputDir` — one subprocess for the batch, vs the
+   * desktop per-preview spawn). Classpath/JVM-arg/property assembly lives in the unit-tested
+   * [AndroidBundleLaunch].
    *
    * Phase 1: the Android renderer sidecar (`lib-renderer-android/`) isn't packaged into the CLI
    * distribution yet, so absent an override this surfaces an actionable diagnostic rather than the
@@ -634,7 +634,7 @@ class BundleRenderer(
 
     /**
      * Reconcile the Android batch renderer's exit code + produced PNGs into per-preview
-     * succeeded/failed lists. [AndroidRendererMain] renders the whole manifest into [outputDir];
+     * succeeded/failed lists. `AndroidRendererMainKt` renders the whole manifest into [outputDir];
      * each preview is matched by its capture's `renderOutput` leaf (the exact name
      * `RobolectricRenderTest.outputFileFor` writes — NOT an id-derived name, which the renderer
      * normalizes, e.g. `com.example.FooKt.CardPreview` → `CardPreview.png`).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSigning.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSigning.kt
@@ -15,9 +15,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 /**
- * Ed25519 bundle signing + verification — the reference implementation shared by `compose-preview
- * bundle sign|verify|keygen` ([BundleSignCommand]) and the public-server trust gate
- * ([BundleVerifier]).
+ * Ed25519 bundle signing + verification — the reference implementation shared by
+ * [KeygenSubcommand], [SignSubcommand], and [VerifySubcommand], exposed as `compose-preview bundle
+ * keygen|sign|verify`, and the public-server trust gate ([BundleVerifier]).
  *
  * The signed bytes are the bundle's **canonical digest**, not the raw `.png` file: zip ordering /
  * compression aren't byte-stable and `signatures.json` itself must be excluded so a second producer

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -10,13 +10,14 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Cross-classloader handoff for the Robolectric-sandboxed [DaemonHost].
+ * Cross-classloader handoff for the Robolectric-sandboxed
+ * [ee.schimke.composeai.daemon.RobolectricHost].
  *
  * **Why a separate package?** Robolectric's `InstrumentingClassLoader` re-loads classes in the
  * project's namespace by default — confirmed empirically: a static `companion object` on
- * `DaemonHost` resolves to different instances when accessed from the test thread vs. from inside
- * the sandbox (`@Test fun holdSandboxOpen`). That breaks the single-shared-queue assumption the
- * daemon depends on.
+ * `RobolectricHost` resolves to different instances when accessed from the test thread vs. from
+ * inside the sandbox (`@Test fun holdSandboxOpen`). That breaks the single-shared-queue assumption
+ * the daemon depends on.
  *
  * The fix is a custom Robolectric runner ([SandboxHoldingRunner]) that registers
  * `ee.schimke.composeai.daemon.bridge` as a do-not-acquire package. Classes here are then loaded


### PR DESCRIPTION
## Summary

- link bundle-signing documentation to the actual keygen, sign, and verify subcommands
- name the generated `AndroidRendererMainKt` entry point instead of linking a nonexistent class
- replace the stale `DaemonHost` reference with `RobolectricHost`

## Why

Several KDocs referenced symbols that do not exist, leaving readers with misleading text and broken navigation. The stale names came from file names or earlier host naming rather than the declarations currently present in the codebase.

This is documentation-only and does not change runtime behavior.

Addresses the KDoc findings in #3075.

## Validation

- `./gradlew :cli:ktfmtCheck :daemon:android:ktfmtCheck :cli:compileKotlin`
- `ANDROID_HOME=/Users/yschimke/Library/Android/sdk ./gradlew :daemon:android:compileDebugKotlin`
- `git diff --check`