### PR TITLE
fix(serve): show GitHub login on preview home

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1551,8 +1551,9 @@ class ServeCommand(args: List<String>) : Command(args) {
     }
     if (githubAuth != null) {
       System.err.println(
-        "serve: GitHub collaborator auth enabled for live sessions and playground " +
-          "(repo $githubAuthRepo)"
+        "serve: GitHub auth enabled for live sessions and playground" +
+          (githubAuthUsers.takeIf { it.isNotEmpty() }?.let { " (${it.size} allowed user(s))" }
+            ?: "")
       )
     }
 
@@ -2466,14 +2467,14 @@ class ServeCommand(args: List<String>) : Command(args) {
         --github-auth-repo <owner/repo>
                           Add GitHub OAuth on top of the browse gate for code-running surfaces:
                           live preview WebSockets and the playground. After sign-in the server
-                          checks the OAuth user is a collaborator on <owner/repo>, then stores only
-                          a signed, expiring login cookie. All four flags are required together.
+                          stores only a signed, expiring login cookie. All four flags are required
+                          together; <owner/repo> is kept as deployment context and for compatibility.
         --github-auth-callback-base-url <url>
                           External origin for the OAuth callback, e.g. https://preview.example.com.
                           Omit for local use; reverse-proxied deploys should set it explicitly.
         --github-auth-users <login>[,<login>…]
-                          Optional extra allowlist after the collaborator check. Empty means any
-                          collaborator on --github-auth-repo may use live sessions/playground.
+                          Optional allowlist. Empty means any signed-in GitHub user may use live
+                          sessions/playground.
         --export <path>   Don't serve: render every preview once and write a portable bundle (a
                           self-contained web gallery + PNGs) to <path>. A '.zip' path writes a zip;
                           any other path writes a directory. The live server also offers this at

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -87,8 +87,12 @@ class ServeGithubAuth(
   }
 
   fun isAuthenticated(call: ApplicationCall): Boolean {
-    val cookie = call.request.cookieValue(AUTH_COOKIE) ?: return false
-    return verifySession(cookie) != null
+    return currentLogin(call) != null
+  }
+
+  fun currentLogin(call: ApplicationCall): String? {
+    val cookie = call.request.cookieValue(AUTH_COOKIE) ?: return null
+    return verifySession(cookie)
   }
 
   fun loginPath(call: ApplicationCall): String {
@@ -98,12 +102,14 @@ class ServeGithubAuth(
 
   fun accessRepository(): String = config.repository
 
+  fun isRestrictedToAllowedUsers(): Boolean = config.allowedUsers.isNotEmpty()
+
   private fun authorizeUrl(call: ApplicationCall, state: String): String {
     val params =
       listOf(
           "client_id" to config.clientId,
           "redirect_uri" to callbackUrl(call),
-          "scope" to "read:user repo",
+          "scope" to "read:user",
           "state" to state,
         )
         .joinToString("&") { (k, v) -> "$k=${urlEncode(v)}" }
@@ -215,8 +221,6 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
       if (config.allowedUsers.isNotEmpty() && login.lowercase() !in config.allowedUsers) {
         error("GitHub user $login is not allowed")
       }
-      val permission = fetchPermission(token, config.repository, login)
-      if (permission !in ALLOWED_REPO_PERMISSIONS) error("GitHub user $login is not a collaborator")
       login
     }
 
@@ -258,22 +262,7 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
     }
   }
 
-  private fun fetchPermission(token: String, repo: String, login: String): String {
-    val request =
-      Request.Builder()
-        .url("https://api.github.com/repos/$repo/collaborators/$login/permission")
-        .header(HttpHeaders.Authorization, "Bearer $token")
-        .header(HttpHeaders.Accept, "application/vnd.github+json")
-        .build()
-    return client.newCall(request).execute().use { response ->
-      if (!response.isSuccessful) error("permission lookup failed: ${response.code}")
-      JSON.decodeFromString(GitHubPermissionResponse.serializer(), response.body.string())
-        .permission
-    }
-  }
-
   companion object {
-    private val ALLOWED_REPO_PERMISSIONS = setOf("admin", "maintain", "write", "triage", "read")
     private val JSON = Json { ignoreUnknownKeys = true }
   }
 }
@@ -282,8 +271,6 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
 private data class GitHubTokenResponse(@SerialName("access_token") val accessToken: String? = null)
 
 @Serializable private data class GitHubUserResponse(val login: String)
-
-@Serializable private data class GitHubPermissionResponse(val permission: String)
 
 private fun ApplicationCall.uriWithQuery(): String = request.uri
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -207,8 +207,8 @@ class ServeHttpServer(
    */
   private val playgroundRedeem: PlaygroundRedeemService? = null,
   /**
-   * Optional GitHub collaborator auth. When present, public browsing can stay open while
-   * code-running surfaces (playground + live WebSocket sessions) require a signed-in collaborator.
+   * Optional GitHub auth. When present, public browsing can stay open while code-running surfaces
+   * (playground + live WebSocket sessions) require a signed-in GitHub account.
    */
   private val githubAuth: ServeGithubAuth? = null,
   /** Aggregate view counts; pass a file-backed store to keep them across server restarts. */
@@ -1333,6 +1333,14 @@ class ServeHttpServer(
         isPublic = isPublic,
         version = BUNDLE_VERSION,
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl(), imageUrl = featuredUrl),
+        githubAuth =
+          githubAuth?.let { auth ->
+            ServeWeb.GitHubAuthStatus(
+              loginHref = auth.loginPath(call),
+              login = auth.currentLogin(call),
+              restrictedToAllowedUsers = auth.isRestrictedToAllowedUsers(),
+            )
+          },
       ),
       ContentType.Text.Html,
     )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -12,8 +12,15 @@ import kotlinx.serialization.json.JsonPrimitive
  */
 object ServeWeb {
 
-  /** Sign-in affordance for a live stream lane protected by GitHub collaborator auth. */
+  /** Sign-in affordance for a GitHub-protected live stream lane. */
   data class LiveAuthPrompt(val loginHref: String, val repository: String)
+
+  /** Front-door GitHub auth state, shown when the public server protects code-running surfaces. */
+  data class GitHubAuthStatus(
+    val loginHref: String,
+    val login: String? = null,
+    val restrictedToAllowedUsers: Boolean = false,
+  )
 
   /**
    * Absolute URLs advertised to link unfurlers for a browser-facing page. [imageUrl] is the thing
@@ -176,7 +183,7 @@ object ServeWeb {
    * `/version` links so the live build is visible on the front door; callers that want a stable
    * golden pass a fixed string rather than the release version.
    */
-  private fun aboutSection(version: String?): String {
+  private fun aboutSection(version: String?, githubAuth: GitHubAuthStatus? = null): String {
     val ver =
       version
         ?.takeIf { it.isNotBlank() }
@@ -184,6 +191,21 @@ object ServeWeb {
           " · <span class=\"cp-about-ver\" title=\"running preview-server build\">" +
             "server v${WebEscaping.htmlEscape(it)}</span>"
         } ?: ""
+    val auth =
+      githubAuth?.let {
+        val restricted =
+          if (it.restrictedToAllowedUsers)
+            " title=\"Live preview access is limited to configured GitHub users\""
+          else " title=\"Live previews require a GitHub sign-in\""
+        val login = it.login?.takeIf { name -> name.isNotBlank() }
+        if (login == null) {
+          " · <a class=\"cp-gh-auth\" href=\"${WebEscaping.htmlEscape(it.loginHref)}\"" +
+            "$restricted>$GITHUB_ICON Sign in with GitHub</a>"
+        } else {
+          " · <span class=\"cp-gh-auth cp-gh-auth--signed\"$restricted>$GITHUB_ICON " +
+            "Signed in as ${WebEscaping.htmlEscape(login)}</span>"
+        }
+      } ?: ""
     return """
     <section class="cp-about">
       <p class="cp-about-title">compose-preview · public preview server</p>
@@ -194,7 +216,7 @@ object ServeWeb {
         and anything unverified is badged.</p>
       <p class="cp-about-links">
         <a href="https://github.com/$SOURCE_REPO">$GITHUB_ICON source</a> ·
-        <a href="/version">/version</a>$ver
+        <a href="/version">/version</a>$ver$auth
       </p>
     </section>
     """
@@ -1314,8 +1336,9 @@ object ServeWeb {
     version: String? = null,
     /** Absolute page + representative hero URLs for Open Graph/Twitter link previews. */
     unfurl: UnfurlMetadata? = null,
+    githubAuth: GitHubAuthStatus? = null,
   ): String {
-    val about = if (isPublic) aboutSection(version) + "\n" else ""
+    val about = if (isPublic) aboutSection(version, githubAuth) + "\n" else ""
     // Public routes are open — no token param on the cards; a token-gated box keeps it.
     val suffix = querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
     fun card(s: HomeSystem): String {
@@ -2982,10 +3005,7 @@ object ServeWeb {
     // note) on a pure static bundle with neither.
     val liveToggleDis =
       if ((hasLiveStream || wasmSrc != null) && !liveAuthBlocksStream) "" else " disabled"
-    val liveAuthTitle = liveAuthPrompt?.let {
-      "Sign in with GitHub to enable Live preview. Access is limited to collaborators on " +
-        "${it.repository}."
-    }
+    val liveAuthTitle = liveAuthPrompt?.let { "Sign in with GitHub to enable Live preview." }
     val liveToggleTitleAttr =
       liveAuthTitle?.let { " title=\"${WebEscaping.htmlEscape(it)}\"" } ?: ""
     val liveAuthDataAttr =

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -18,11 +18,12 @@ a:hover { text-decoration: underline; }
 .cp-about-body code { font-size: 0.8rem; padding: 0 3px; border-radius: 4px; background: #f0f0f3; }
 .cp-about-links { margin: 0; font-size: 0.8rem; color: #6b6b70; display: flex; flex-wrap: wrap;
   align-items: center; gap: 6px; }
-.cp-about-links a { display: inline-flex; align-items: center; gap: 4px; }
+.cp-about-links a, .cp-gh-auth { display: inline-flex; align-items: center; gap: 4px; }
 .cp-gh { width: 15px; height: 15px; vertical-align: text-bottom; }
 .cp-about-ver { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.74rem;
   padding: 1px 7px; border-radius: 999px; border: 1px solid #d7d7de; background: #fff;
   color: #45454c; }
+.cp-gh-auth--signed { color: #45454c; }
 /* Catalog "back to home" button — replaces the in-catalog design-systems nav row. */
 .cp-back { display: inline-flex; align-items: center; gap: 6px; margin: 0 0 14px;
   font-size: 0.82rem; padding: 5px 12px; border-radius: 999px; border: 1px solid #d7d7de;

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1841,9 +1841,7 @@ class ServeWebFixtureTest {
       "GitHub-protected live preview disables the hidden live transport radio too",
     )
     assertTrue(
-      protectedLive.contains(
-        "title=\"Sign in with GitHub to enable Live preview. Access is limited to collaborators on yschimke/compose-ai-tools.\""
-      ),
+      protectedLive.contains("title=\"Sign in with GitHub to enable Live preview.\""),
       "disabled live preview explains the GitHub access requirement on hover",
     )
     assertTrue(
@@ -2175,6 +2173,36 @@ class ServeWebFixtureTest {
     // A null version simply omits the pill (no dangling separator crash).
     val noVer = ServeWeb.homeIndexPage(emptyList(), token, isPublic = true)
     assertFalse(noVer.contains("class=\"cp-about-ver\""), "no version pill when version is null")
+  }
+
+  @Test
+  fun `the home about box shows GitHub login state when auth is configured`() {
+    val unsigned =
+      ServeWeb.homeIndexPage(
+        emptyList(),
+        token,
+        isPublic = true,
+        githubAuth = ServeWeb.GitHubAuthStatus(loginHref = "/auth/github/start?return=%2F"),
+      )
+    assertTrue(
+      unsigned.contains("class=\"cp-gh-auth\" href=\"/auth/github/start?return=%2F\""),
+      "unsigned home page links to GitHub sign-in",
+    )
+    assertTrue(unsigned.contains("> Sign in with GitHub</a>"), unsigned)
+
+    val signed =
+      ServeWeb.homeIndexPage(
+        emptyList(),
+        token,
+        isPublic = true,
+        githubAuth =
+          ServeWeb.GitHubAuthStatus(loginHref = "/auth/github/start?return=%2F", login = "yschimke"),
+      )
+    assertTrue(
+      signed.contains("class=\"cp-gh-auth cp-gh-auth--signed\""),
+      "signed home page shows GitHub status",
+    )
+    assertTrue(signed.contains("Signed in as yschimke"), signed)
   }
 
   @Test

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -16,7 +16,7 @@ pull it.
   resource placeholder fallback #2499), so `wear-m3` renders live once the box rolls that image and
   re-fetches the regenerated bundle. See `docs/public-preview-server.md`. This is what
   `preview.coo.ee` runs.
-- **Bundle uploads:** disabled. **Auth:** public browsing, optional GitHub collaborator gate for
+- **Bundle uploads:** disabled. **Auth:** public browsing, optional GitHub sign-in gate for
   live/playground surfaces, shared token for private boxes. **TLS:** via Caddy.
 
 ## How it's fast
@@ -68,7 +68,7 @@ Pin a version with `IMAGE_TAG=0.16.33` in `.env` (a bare tag; defaults to the
 
 ### GitHub auth on `preview.coo.ee`
 
-To keep catalog browsing public while requiring collaborators for live sessions and playground,
+To keep catalog browsing public while requiring GitHub sign-in for live sessions and playground,
 create a GitHub OAuth app with callback:
 
 ```text
@@ -83,9 +83,9 @@ SERVE_GITHUB_AUTH_CLIENT_SECRET=...
 SERVE_GITHUB_AUTH_COOKIE_SECRET=... # openssl rand -hex 32
 ```
 
-The compose profile defaults the collaborator check to `yschimke/compose-ai-tools` and derives the
-callback base URL from `DOMAIN`; set `SERVE_GITHUB_AUTH_REPO`,
-`SERVE_GITHUB_AUTH_CALLBACK_BASE_URL`, or `SERVE_GITHUB_AUTH_USERS` to override.
+The compose profile derives the callback base URL from `DOMAIN`; set
+`SERVE_GITHUB_AUTH_CALLBACK_BASE_URL` to override. Empty `SERVE_GITHUB_AUTH_USERS` allows any
+signed-in GitHub user; set it to a comma-separated login list to narrow access.
 
 ## Auto-updates (zero-downtime)
 

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -52,10 +52,10 @@ services:
       SERVE_ADMIN_TOKEN: "${SERVE_ADMIN_TOKEN:-}"
       # Privacy-minimal aggregate app/catalog + preview views, persisted on preview_config.
       SERVE_ENGAGEMENT_FILE: "${SERVE_ENGAGEMENT_FILE:-}"
-      # Optional GitHub OAuth collaborator auth for code-running surfaces (live WebSockets and
-      # playground). Set the three secrets in .env to enable; the entrypoint then defaults the repo
-      # check to yschimke/compose-ai-tools and uses this domain as the OAuth callback origin unless
-      # overridden. Empty values keep the public catalog browsing behaviour unchanged.
+      # Optional GitHub OAuth auth for code-running surfaces (live WebSockets and playground). Set
+      # the three secrets in .env to enable; the entrypoint uses this domain as the OAuth callback
+      # origin unless overridden. Empty values keep the public catalog browsing behaviour unchanged.
+      # Empty SERVE_GITHUB_AUTH_USERS allows any signed-in GitHub user; set it to narrow access.
       SERVE_GITHUB_AUTH_CLIENT_ID: "${SERVE_GITHUB_AUTH_CLIENT_ID:-}"
       SERVE_GITHUB_AUTH_CLIENT_SECRET: "${SERVE_GITHUB_AUTH_CLIENT_SECRET:-}"
       SERVE_GITHUB_AUTH_COOKIE_SECRET: "${SERVE_GITHUB_AUTH_COOKIE_SECRET:-}"

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -344,11 +344,10 @@ Both container profiles take this config from env (the entrypoint maps `SERVE_PU
 `SERVE_ACCEPT_DOCS_FROM` → flags) and put **Caddy** in front for TLS. They default to the **open
 public profile** (`SERVE_PUBLIC=1`); set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a token-gated box.
 
-### GitHub auth for collaborator-only live lanes
+### GitHub auth for live lanes
 
-A public catalog can stay browseable while code-running surfaces require a GitHub collaborator
-session. Configure a GitHub OAuth app with callback `/auth/github/callback`, then set the OAuth
-secrets:
+A public catalog can stay browseable while code-running surfaces require a GitHub session. Configure
+a GitHub OAuth app with callback `/auth/github/callback`, then set the OAuth secrets:
 
 ```bash
 SERVE_GITHUB_AUTH_CLIENT_ID=...
@@ -357,14 +356,12 @@ SERVE_GITHUB_AUTH_COOKIE_SECRET=... # at least 32 chars
 ```
 
 With those set, `/playground`, `POST /api/<version>/compiler/run`, `/pg/<token>`, and live preview
-WebSockets require a signed-in user who has collaborator permission on `SERVE_GITHUB_AUTH_REPO`.
-The server exchanges the OAuth code and checks repository permission server-side; the browser cookie
-stores only a signed, expiring login. Reverse-proxied deployments should also set
+WebSockets require a signed-in GitHub user. The browser cookie stores only a signed, expiring login.
+Reverse-proxied deployments should also set
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL=https://preview.example.com` so the OAuth callback URL is stable.
-The prebuilt image defaults `SERVE_GITHUB_AUTH_REPO=yschimke/compose-ai-tools` and, when `DOMAIN` is
-set, derives `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL=https://$DOMAIN`; override either value for another
-deployment. `SERVE_GITHUB_AUTH_USERS=alice,bob` can narrow access further after the collaborator
-check.
+When `DOMAIN` is set, the prebuilt image derives
+`SERVE_GITHUB_AUTH_CALLBACK_BASE_URL=https://$DOMAIN`. Empty `SERVE_GITHUB_AUTH_USERS` allows any
+signed-in GitHub user; set `SERVE_GITHUB_AUTH_USERS=alice,bob` to narrow access to named logins.
 
 ### The catalog set is config, not image content
 

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>loading-spinner.json — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>watchface.rc — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Share a document — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Design systems — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Not found — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Playground — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-status.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-status.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Server status — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Focus ring — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>One-handed — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Checkbox · Checked (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/890d-6d8fd3af83e8c5c6/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>


### PR DESCRIPTION
## Summary
- show a GitHub auth affordance on the public preview home page when auth is configured
- display either “Sign in with GitHub” or “Signed in as <login>” from the signed session cookie
- relax live preview/playground auth to any signed-in GitHub user, with SERVE_GITHUB_AUTH_USERS kept as the optional allowlist
- drop the repo collaborator permission API check and request only read:user OAuth scope
- update deploy/docs/help text and serve web fixtures

## Testing
- ./gradlew :cli:ktfmtCheck
- ./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeAuthTest --tests ee.schimke.composeai.cli.serve.ServeWebFixtureTest