### PR TITLE
test: cover remaining command and lifecycle helpers

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSignCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSignCommandTest.kt
@@ -1,0 +1,82 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.cli.serve.TrustStore
+import ee.schimke.composeai.cli.serve.TrustedBranch
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class BundleSignCommandTest {
+  @Test
+  fun `keygen sign and verify command layer completes a local workflow`() {
+    val root = Files.createTempDirectory("bundle-command").toFile()
+    val key = root.resolve("producer.pem")
+    val bundle = sampleBundle(root.resolve("sample.png"))
+    val trust = root.resolve("trust.json")
+    trust.writeText(
+      TrustStore.encode(TrustStore(branches = listOf(TrustedBranch("owner/repo", "main"))))
+    )
+
+    val output = captureStdout {
+      KeygenSubcommand(listOf("--output", key.path, "--key-id", "ci-key")).run()
+      SignSubcommand(
+          listOf(bundle.path, "--key", key.path, "--key-id", "ci-key", "--producer", "CI")
+        )
+        .run()
+      VerifySubcommand(listOf(bundle.path, "--trust", trust.path, "--origin", "owner/repo@main"))
+        .run()
+    }
+
+    assertTrue(key.isFile)
+    assertEquals(1, BundleSigning.readSignatures(bundle)?.signatures?.size)
+    assertNotNull(BundleSigning.parsePrivateKey(key.readText()))
+    assertTrue(output.contains("signed ${bundle.path}"))
+    assertTrue(output.contains("verdict: TRUSTED"))
+    assertTrue(output.contains("trusted branch (owner/repo@main)"))
+  }
+
+  private fun sampleBundle(file: File): File {
+    val image = BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB)
+    val png = ByteArrayOutputStream().also { ImageIO.write(image, "png", it) }.toByteArray()
+    val zip = ByteArrayOutputStream()
+    ZipOutputStream(zip).use { out ->
+      mapOf(
+          "bundle.json" to
+            """{"schemaVersion":7,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a","classpath":[],"modulePath":":app","producedBy":"test"}"""
+              .toByteArray(),
+          "previews/a.png" to png,
+        )
+        .forEach { (name, bytes) ->
+          out.putNextEntry(ZipEntry(name))
+          out.write(bytes)
+          out.closeEntry()
+        }
+    }
+    file.outputStream().use {
+      it.write(png)
+      it.write(zip.toByteArray())
+    }
+    return file
+  }
+
+  private fun captureStdout(block: () -> Unit): String {
+    val original = System.out
+    val bytes = ByteArrayOutputStream()
+    try {
+      System.setOut(PrintStream(bytes, true, Charsets.UTF_8))
+      block()
+    } finally {
+      System.setOut(original)
+    }
+    return bytes.toString(Charsets.UTF_8)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtensionReportRendererTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtensionReportRendererTest.kt
@@ -1,0 +1,18 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+
+class ExtensionReportRendererTest {
+  @Test
+  fun `built in registry exposes fresh stateful renderers`() {
+    val reporters = builtInExtensionReporters()
+
+    assertEquals(setOf("a11y"), reporters.keys)
+    val first: ExtensionReportRenderer = reporters.getValue("a11y")()
+    val second = reporters.getValue("a11y")()
+    assertEquals("a11y", first.id)
+    assertNotSame(first, second)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/RecordPreviewCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/RecordPreviewCommandTest.kt
@@ -1,0 +1,79 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RecordPreviewCommandTest {
+  @Test
+  fun `record format inference covers every supported artifact extension`() {
+    val command = RecordPreviewCommand(emptyList())
+
+    assertEquals(RecordingFormat.GIF, command.call("resolveFormat", null, "demo.GIF"))
+    assertEquals(RecordingFormat.APNG, command.call("resolveFormat", null, "demo.apng"))
+    assertEquals(RecordingFormat.MP4, command.call("resolveFormat", null, "demo.mp4"))
+    assertEquals(RecordingFormat.WEBM, command.call("resolveFormat", null, "demo.webm"))
+    assertEquals(RecordingFormat.GIF, command.call("resolveFormat", "gif", "demo.apng"))
+  }
+
+  @Test
+  fun `record overrides parse typed values into the protocol model`() {
+    val command = RecordPreviewCommand(emptyList())
+    val overrides =
+      command.call<PreviewOverrides>(
+        "parseOverrides",
+        listOf(
+          "touchOverlay=yes",
+          "talkBack=off",
+          "fontScale=1.25",
+          "density=2",
+          "widthPx=320",
+          "heightPx=480",
+          "clockEpochMillis=1234",
+          "localeTag=fr-FR",
+        ),
+      )
+
+    assertEquals(true, overrides.touchOverlay)
+    assertEquals(false, overrides.talkBack)
+    assertEquals(1.25f, overrides.fontScale)
+    assertEquals(2f, overrides.density)
+    assertEquals(320, overrides.widthPx)
+    assertEquals(480, overrides.heightPx)
+    assertEquals(1234, overrides.clockEpochMillis)
+    assertEquals("fr-FR", overrides.localeTag)
+    assertNull(
+      RecordPreviewCommand(emptyList())
+        .call<PreviewOverrides?>("parseOverrides", emptyList<String>())
+    )
+  }
+
+  @Test
+  fun `pixel baselines are made absolute without rewriting other events`() {
+    val baselineDir = Files.createTempDirectory("record-baselines").toFile()
+    val command = RecordPreviewCommand(listOf("--baseline-dir", baselineDir.path))
+    val pixel = RecordingScriptEvent(10, "assert.pixels", inputText = "cards/home.png")
+    val click = RecordingScriptEvent(20, "input.click", inputText = "unchanged")
+
+    val resolved =
+      command.call<List<RecordingScriptEvent>>("resolveBaselines", listOf(pixel, click))
+
+    assertEquals(File(baselineDir, "cards/home.png").absolutePath, resolved[0].inputText)
+    assertEquals(click, resolved[1])
+    assertTrue(File(resolved[0].inputText!!).isAbsolute)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun <T> Any.call(name: String, vararg args: Any?): T {
+    val method =
+      javaClass.declaredMethods.single { it.name == name && it.parameterCount == args.size }
+    method.isAccessible = true
+    return method.invoke(this, *args) as T
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ResourceCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ResourceCommandsTest.kt
@@ -1,0 +1,29 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ResourceCommandsTest {
+  @Test
+  fun `resource result is changed when any capture changed`() {
+    val unchanged = ResourceCaptureResult(changed = false)
+    val changed = ResourceCaptureResult(changed = true)
+
+    assertFalse(ResourcePreviewResult("id", ":app", "drawable").anyChanged())
+    assertFalse(
+      ResourcePreviewResult("id", ":app", "drawable", captures = listOf(unchanged)).anyChanged()
+    )
+    assertTrue(
+      ResourcePreviewResult("id", ":app", "drawable", captures = listOf(unchanged, changed))
+        .anyChanged()
+    )
+  }
+
+  @Test
+  fun `show resources command accepts the resource-specific filter surface`() {
+    ShowResourcesCommand(
+      listOf("--json", "--changed-only", "--module", ":app", "--id", "drawable/icon")
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeCommandTest.kt
@@ -1,0 +1,56 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.cli.serve.ServeUrls
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ServeCommandTest {
+  @Test
+  fun `serve constructor normalises its network and capacity arguments`() {
+    val command =
+      ServeCommand(
+        listOf(
+          "--lan",
+          "--host",
+          "ignored.example",
+          "--port=9090",
+          "--live-seats",
+          "-4",
+          "--revisions-allow",
+          " main, release/*, ,",
+          "--accept-bundles-from",
+          "artifacts.example, cdn.example",
+          "--exit-when-idle=45",
+        )
+      )
+
+    assertTrue(command.field("lan"))
+    assertEquals(ServeUrls.ALL_INTERFACES, command.field<String>("host"))
+    assertEquals(9090, command.field<Int>("requestedPort"))
+    assertEquals(0, command.field<Int>("liveSeats"))
+    assertEquals(listOf("main", "release/*"), command.field<List<String>>("revisionAllowRefs"))
+    assertEquals(
+      listOf("artifacts.example", "cdn.example"),
+      command.field<List<String>>("acceptBundlesFrom"),
+    )
+    assertTrue(command.field("exitWhenIdle"))
+    assertEquals(45L, command.field<Long>("idleExitSeconds"))
+  }
+
+  @Test
+  fun `serve defaults remain loopback token gated and non discovering`() {
+    val command = ServeCommand(emptyList())
+
+    assertEquals(ServeUrls.LOOPBACK, command.field<String>("host"))
+    assertFalse(command.field("lan"))
+    assertFalse(command.field("public"))
+    assertFalse(command.field("discover"))
+    assertFalse(command.field("allowRenderTrusted"))
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun <T> Any.field(name: String): T =
+    javaClass.getDeclaredField(name).apply { isAccessible = true }.get(this) as T
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilderTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilderTest.kt
@@ -1,0 +1,39 @@
+package ee.schimke.composeai.cli.serve
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GradleRevisionBuilderTest {
+  @Test
+  fun `missing wrapper fails closed with an actionable log`() {
+    val root = Files.createTempDirectory("revision").toFile()
+    val logs = mutableListOf<String>()
+
+    val result =
+      GradleRevisionBuilder(onLog = logs::add)
+        .build(root, ServeModuleRef(gradlePath = "app", relativePath = "app"), true)
+
+    assertNull(result)
+    assertTrue(logs.single().contains("no executable gradlew"))
+  }
+
+  @Test
+  fun `gradle failure is logged and produces no revision`() {
+    val root = Files.createTempDirectory("revision").toFile()
+    root.resolve("app").mkdirs()
+    root.resolve("gradlew").apply {
+      writeText("#!/bin/sh\necho revision-build\nexit 7\n")
+      setExecutable(true)
+    }
+    val logs = mutableListOf<String>()
+
+    val result =
+      GradleRevisionBuilder(timeoutSeconds = 5, onLog = logs::add)
+        .build(root, ServeModuleRef(gradlePath = "app", relativePath = "app"), true)
+
+    assertNull(result)
+    assertTrue(logs.any { it == "[gradle] revision-build" })
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/SandboxLifecycleTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/SandboxLifecycleTest.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RenderMetrics
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SandboxLifecycleTest {
+  @Test
+  fun `stats count renders and reset both counters`() {
+    val stats = SandboxLifecycleStats(System.nanoTime() - 25_000_000L)
+
+    assertTrue(stats.ageMs() >= 20)
+    assertEquals(0, stats.renders())
+    assertEquals(1, stats.bumpRenderCount())
+    assertEquals(2, stats.bumpRenderCount())
+
+    stats.reset()
+
+    assertEquals(0, stats.renders())
+    assertTrue(stats.ageMs() < 1_000)
+  }
+
+  @Test
+  fun `measurement reports the complete wire contract and advances sandbox age`() {
+    val stats = SandboxLifecycleStats()
+
+    val first = SandboxMeasurement.collect(stats, tookMs = 17)
+    val second = SandboxMeasurement.collect(stats, tookMs = 23)
+
+    assertEquals(
+      setOf(
+        "tookMs",
+        RenderMetrics.KEY_HEAP_AFTER_GC_MB,
+        RenderMetrics.KEY_NATIVE_HEAP_MB,
+        RenderMetrics.KEY_SANDBOX_AGE_RENDERS,
+        RenderMetrics.KEY_SANDBOX_AGE_MS,
+      ),
+      first.keys,
+    )
+    assertEquals(17L, first["tookMs"])
+    assertEquals(1L, first[RenderMetrics.KEY_SANDBOX_AGE_RENDERS])
+    assertEquals(2L, second[RenderMetrics.KEY_SANDBOX_AGE_RENDERS])
+    assertTrue(first.getValue(RenderMetrics.KEY_HEAP_AFTER_GC_MB) >= 0)
+    assertTrue(first.getValue(RenderMetrics.KEY_NATIVE_HEAP_MB) >= 0)
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StartupTimingsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StartupTimingsTest.kt
@@ -1,0 +1,42 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StartupTimingsTest {
+  @After
+  fun cleanUp() {
+    System.clearProperty(StartupTimings.QUIET_PROP)
+    StartupTimings.reset()
+  }
+
+  @Test
+  fun `marks retain their label thread and monotonic JVM-relative time`() {
+    System.setProperty(StartupTimings.QUIET_PROP, "true")
+    StartupTimings.reset()
+
+    StartupTimings.mark("configuration loaded")
+    StartupTimings.mark("sandbox ready")
+
+    val marks = StartupTimings.marks()
+    assertEquals(listOf("configuration loaded", "sandbox ready"), marks.map { it.label })
+    assertEquals(List(2) { Thread.currentThread().name }, marks.map { it.thread })
+    assertTrue(marks.all { it.elapsedMs >= 0 })
+    assertTrue(marks.zipWithNext().all { (a, b) -> a.elapsedMs <= b.elapsedMs })
+    assertTrue(StartupTimings.jvmStartMs <= System.currentTimeMillis())
+  }
+
+  @Test
+  fun `quiet summary is idempotent and reset clears the timeline`() {
+    System.setProperty(StartupTimings.QUIET_PROP, "true")
+    StartupTimings.mark("one")
+
+    StartupTimings.summary()
+    StartupTimings.summary()
+    StartupTimings.reset()
+
+    assertEquals(emptyList<StartupTimings.Mark>(), StartupTimings.marks())
+  }
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityDataProductRegistryTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DesktopAccessibilityDataProductRegistryTest {
+  @Test
+  fun `producer writes parseable empty desktop payloads and removes stale overlays`() {
+    val root = Files.createTempDirectory("a11y").toFile()
+    val previewDir = root.resolve("preview").apply { mkdirs() }
+    val staleOverlay =
+      previewDir.resolve(DesktopAccessibilityDataProducer.FILE_OVERLAY).apply {
+        writeBytes(byteArrayOf(1, 2, 3))
+      }
+
+    DesktopAccessibilityDataProducer.writeArtifacts(root, "preview", emptyList(), pngFile = null)
+
+    assertEquals(
+      "{\"findings\":[]}",
+      previewDir.resolve(DesktopAccessibilityDataProducer.FILE_ATF).readText(),
+    )
+    assertEquals(
+      "{\"nodes\":[]}",
+      previewDir.resolve(DesktopAccessibilityDataProducer.FILE_HIERARCHY).readText(),
+    )
+    assertFalse(staleOverlay.exists())
+  }
+
+  @Test
+  fun `registry advertises only desktop a11y products with their required transports`() {
+    val registry =
+      DesktopAccessibilityDataProductRegistry(Files.createTempDirectory("a11y").toFile())
+
+    assertEquals(
+      listOf(
+        DesktopAccessibilityDataProducer.KIND_ATF,
+        DesktopAccessibilityDataProducer.KIND_HIERARCHY,
+        DesktopAccessibilityDataProducer.KIND_OVERLAY,
+      ),
+      registry.capabilities.map { it.kind },
+    )
+    assertTrue(registry.capabilities.all { it.requiresRerender })
+    assertEquals("a11y", registry.renderModeFor(DesktopAccessibilityDataProducer.KIND_ATF))
+    assertNull(registry.renderModeFor("a11y/touchTargets"))
+    assertTrue(
+      registry.call<DataProductRegistry.Outcome>(
+        "missingOutcome",
+        "preview",
+        DesktopAccessibilityDataProducer.KIND_ATF,
+      ) is DataProductRegistry.Outcome.RequiresRerender
+    )
+  }
+
+  @Test
+  fun `files extras and inline policy preserve the overlay as a PNG path`() {
+    val root = Files.createTempDirectory("a11y").toFile()
+    val previewDir = root.resolve("preview").apply { mkdirs() }
+    val overlay =
+      previewDir.resolve(DesktopAccessibilityDataProducer.FILE_OVERLAY).apply {
+        writeBytes(byteArrayOf(1, 2, 3))
+      }
+    val registry = DesktopAccessibilityDataProductRegistry(root)
+
+    assertEquals(
+      previewDir.resolve(DesktopAccessibilityDataProducer.FILE_HIERARCHY),
+      registry.call("fileFor", "preview", DesktopAccessibilityDataProducer.KIND_HIERARCHY),
+    )
+    assertNull(registry.call<File?>("fileFor", "preview", "unknown"))
+    assertFalse(registry.call("allowInlineUpgrade", DesktopAccessibilityDataProducer.KIND_OVERLAY))
+    assertTrue(registry.call("allowInlineUpgrade", DesktopAccessibilityDataProducer.KIND_ATF))
+    val extra =
+      registry
+        .call<List<ee.schimke.composeai.daemon.protocol.DataProductExtra>?>(
+          "extras",
+          "preview",
+          DesktopAccessibilityDataProducer.KIND_ATF,
+          null,
+        )
+        .orEmpty()
+        .single()
+    assertEquals(overlay.absolutePath, extra.path)
+    assertEquals("image/png", extra.mediaType)
+    assertEquals(3L, extra.sizeBytes)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun <T> Any.call(name: String, vararg args: Any?): T {
+    val method =
+      javaClass.declaredMethods.single { it.name == name && it.parameterCount == args.size }
+    method.isAccessible = true
+    return method.invoke(this, *args) as T
+  }
+}


### PR DESCRIPTION
## Summary

- cover the remaining CLI command-layer surfaces from #3078, including serve argument policy, record parsing, resource change detection, extension reporter registration, revision build failures, and the bundle keygen/sign/verify workflow
- pin daemon sandbox lifecycle metrics and startup timing behavior
- cover desktop accessibility artifact production and registry contracts

The pure helper files in the issue's top table were already covered on `main` by #3112, #3114, and #3135. This PR adds the remaining command/lifecycle coverage in one change set.

## Impact

These tests pin security-sensitive defaults, command parsing and signing workflows, lifecycle metric keys, and accessibility artifact behavior without changing production behavior.

## Validation

- `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.ExtensionReportRendererTest' --tests 'ee.schimke.composeai.cli.ResourceCommandsTest' --tests 'ee.schimke.composeai.cli.serve.GradleRevisionBuilderTest' --tests 'ee.schimke.composeai.cli.ServeCommandTest' --tests 'ee.schimke.composeai.cli.RecordPreviewCommandTest' --tests 'ee.schimke.composeai.cli.BundleSignCommandTest'`
- `./gradlew :daemon:core:test --tests 'ee.schimke.composeai.daemon.SandboxLifecycleTest' --tests 'ee.schimke.composeai.daemon.StartupTimingsTest'`
- `./gradlew :daemon:desktop:test --tests 'ee.schimke.composeai.daemon.DesktopAccessibilityDataProductRegistryTest'`
- `./gradlew :cli:ktfmtCheck :daemon:core:ktfmtCheck :daemon:desktop:ktfmtCheck`

A broader `:daemon:core:test` run also surfaced an unrelated existing failure in `RenderNowAppPreviewGateTest.activityAndTourPreviewsAreRejectedNotFailed`; the new isolated daemon-core tests pass.

Closes #3078