### PR TITLE
fix(catalog): preserve Wear font-scale preview axes

### DIFF
--- a/scripts/design-artifacts/catalog-preview-axes.mjs
+++ b/scripts/design-artifacts/catalog-preview-axes.mjs
@@ -1,0 +1,89 @@
+/**
+ * Preserve preview parameters that the candidate reader does not currently expose as catalog
+ * image axes, then remove duplicate renders produced by overlapping multi-preview annotations.
+ *
+ * Wear commonly stacks `@WearPreviewDevices` and `@WearPreviewFontScales` on one function. Both
+ * annotations include the small-round/default-font render, while the remaining font-scale renders
+ * differ only by `PreviewParams.fontScale`. The candidate reader otherwise represents all of them
+ * as the same default/compact image, so the catalog either overwrites stickers or (correctly) trips
+ * its duplicate-axis guard.
+ *
+ * Non-default font scales become a `props.fontScale` catalog axis. Exact render duplicates are
+ * removed only when every effective preview/capture parameter matches after discarding `name` and
+ * `group`, which label an annotation but do not change its pixels. The image's already-derived
+ * catalog axes are part of the identity too, so synthetic states and other meaningful variants are
+ * never collapsed merely because they share display parameters.
+ *
+ * @param {Array<{previewId?: string, componentId: string, functionName?: string, images?: Array<object>}>} candidates
+ * @param {Array<{id: string, params?: object, captures?: Array<{params?: object}>}>} previews
+ * @returns {{fontScales: number, duplicates: number}} applied axis and duplicate counts
+ */
+export function applyCatalogPreviewAxes(candidates, previews) {
+  const previewById = new Map(previews.map((preview) => [preview.id, preview]));
+  const seenByFunction = new Map();
+  let fontScales = 0;
+  let duplicates = 0;
+
+  for (const candidate of candidates) {
+    const preview = previewById.get(candidate.previewId ?? candidate.componentId);
+    if (!preview) continue;
+    const captures =
+      Array.isArray(preview.captures) && preview.captures.length > 0
+        ? preview.captures
+        : [{}];
+    const fn = candidate.functionName ?? candidate.componentId;
+    const seen = seenByFunction.get(fn) ?? new Set();
+    seenByFunction.set(fn, seen);
+
+    candidate.images = (candidate.images ?? []).filter((image, index) => {
+      const params = {
+        ...(preview.params ?? {}),
+        ...(captures[index]?.params ?? {}),
+      };
+      const fontScale = params.fontScale;
+      if (typeof fontScale === "number" && Number.isFinite(fontScale) && fontScale !== 1) {
+        image.props = { ...(image.props ?? {}), fontScale: formatFontScale(fontScale) };
+        fontScales += 1;
+      }
+
+      const key = stableJson({
+        params: renderParams(params),
+        axes: {
+          variant: image.variant ?? "ideal",
+          state: image.state ?? "default",
+          theme: image.theme ?? null,
+          size: image.size ?? null,
+          props: image.props ?? {},
+        },
+      });
+      if (seen.has(key)) {
+        duplicates += 1;
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+  }
+
+  return { fontScales, duplicates };
+}
+
+function formatFontScale(value) {
+  return Number.isInteger(value) ? value.toFixed(1) : String(value);
+}
+
+function renderParams(params) {
+  const { name: _name, group: _group, ...rendering } = params;
+  return rendering;
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stableJson(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/scripts/design-artifacts/catalog-preview-axes.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-axes.test.mjs
@@ -1,0 +1,137 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applySpecBreakpoints } from "./catalog-breakpoints.mjs";
+import { applyCatalogPreviewAxes } from "./catalog-preview-axes.mjs";
+import { foldVariants } from "./catalog-variants.mjs";
+
+const candidate = (id, images = [{}]) => ({
+  componentId: "HomePreview",
+  previewId: id,
+  images,
+});
+
+test("Wear font-scale previews become distinct catalog props axes", () => {
+  const candidates = [candidate("Home_Fonts")];
+  const previews = [
+    {
+      id: "Home_Fonts",
+      params: { device: "id:wearos_small_round", widthDp: 192, fontScale: 1 },
+      captures: [
+        { params: { fontScale: 1.24 } },
+      ],
+    },
+  ];
+
+  const result = applyCatalogPreviewAxes(candidates, previews);
+
+  assert.deepEqual(result, { fontScales: 1, duplicates: 0 });
+  assert.deepEqual(candidates[0].images[0].props, { fontScale: "1.24" });
+});
+
+test("overlapping Wear multi-previews keep scaled/device renders and dedupe only small/default", () => {
+  const candidates = [
+    candidate("Home_Devices_Large"),
+    candidate("Home_Devices_Small"),
+    candidate("Home_Fonts_Small"),
+    candidate("Home_Fonts_Normal"),
+    candidate("Home_Fonts_Large"),
+  ];
+  const previews = [
+    {
+      id: "Home_Devices_Large",
+      params: {
+        group: "Devices - Large Round",
+        device: "id:wearos_large_round",
+        widthDp: 227,
+        fontScale: 1,
+      },
+    },
+    {
+      id: "Home_Devices_Small",
+      params: {
+        group: "Devices - Small Round",
+        device: "id:wearos_small_round",
+        widthDp: 192,
+        fontScale: 1,
+      },
+    },
+    {
+      id: "Home_Fonts_Small",
+      params: {
+        group: "Fonts - Small",
+        device: "id:wearos_small_round",
+        widthDp: 192,
+        fontScale: 0.94,
+      },
+    },
+    {
+      id: "Home_Fonts_Normal",
+      params: {
+        group: "Fonts - Normal",
+        device: "id:wearos_small_round",
+        widthDp: 192,
+        fontScale: 1,
+      },
+    },
+    {
+      id: "Home_Fonts_Large",
+      params: {
+        group: "Fonts - Large",
+        device: "id:wearos_small_round",
+        widthDp: 192,
+        fontScale: 1.12,
+      },
+    },
+  ];
+
+  const result = applyCatalogPreviewAxes(candidates, previews);
+
+  assert.deepEqual(result, { fontScales: 2, duplicates: 1 });
+  assert.deepEqual(
+    candidates.map(({ previewId, images }) => [previewId, images[0]?.props?.fontScale]),
+    [
+      ["Home_Devices_Large", undefined],
+      ["Home_Devices_Small", undefined],
+      ["Home_Fonts_Small", "0.94"],
+      ["Home_Fonts_Normal", undefined],
+      ["Home_Fonts_Large", "1.12"],
+    ],
+  );
+  assert.equal(candidates[3].images.length, 0);
+
+  applySpecBreakpoints(candidates, previews, [
+    { size: "smallRound", widthDp: 192 },
+    { size: "largeRound", widthDp: 227 },
+  ]);
+  const merged = candidates.flatMap(({ images }) => images);
+  assert.doesNotThrow(() =>
+    foldVariants(merged, { componentId: "Home" }, new Map()),
+  );
+  assert.deepEqual(
+    merged.map(({ size, props }) => [size, props?.fontScale]),
+    [
+      ["largeRound", undefined],
+      ["smallRound", undefined],
+      ["smallRound", "0.94"],
+      ["smallRound", "1.12"],
+    ],
+  );
+});
+
+test("equal display params do not collapse distinct synthetic states", () => {
+  const candidates = [
+    candidate("Home_Default", [{ state: "default" }]),
+    candidate("Home_Selected", [{ state: "selected" }]),
+  ];
+  const previews = [
+    { id: "Home_Default", params: { widthDp: 192, fontScale: 1 } },
+    { id: "Home_Selected", params: { widthDp: 192, fontScale: 1 } },
+  ];
+
+  const result = applyCatalogPreviewAxes(candidates, previews);
+
+  assert.equal(result.duplicates, 0);
+  assert.equal(candidates[0].images.length, 1);
+  assert.equal(candidates[1].images.length, 1);
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -98,6 +98,7 @@ import {
 import { applySpecSections } from "./apply-spec-sections.mjs";
 import { applySourceFiles } from "./apply-source-files.mjs";
 import { applySpecBreakpoints } from "./catalog-breakpoints.mjs";
+import { applyCatalogPreviewAxes } from "./catalog-preview-axes.mjs";
 
 /**
  * Best-effort fetch + parse of a JSON URL, with a short timeout. Returns null on
@@ -176,15 +177,6 @@ async function loadCandidates(path, breakpoints) {
     candidateBundle,
     (entry) => entry.functionName ?? entry.id,
   );
-  // The published candidate reader classifies every numeric width with Material
-  // window classes. Give this catalog's declared names precedence so domain
-  // breakpoints such as Wear's 192 dp `smallRound` and 227 dp `largeRound` remain
-  // distinct output axes instead of both collapsing to `compact`.
-  applySpecBreakpoints(
-    candidates,
-    candidateBundle.previews,
-    breakpoints,
-  );
   // `@OverrideVariant` synthetic previews share their base's `functionName`, so `mergeByFunction`
   // (below) folds their images into the parent candidate. Stamp each one's `_VARIANT_<name>` suffix
   // as `image.state` HERE — before the merge — so the fold surfaces it as a distinct secondary
@@ -197,6 +189,21 @@ async function loadCandidates(path, breakpoints) {
     const state = variantStateFromId(candidate.previewId ?? candidate.id);
     if (state) for (const image of candidate.images ?? []) image.state = state;
   }
+  // Candidate images retain width-derived size but not `PreviewParams.fontScale`. Promote a
+  // non-default scale to a props axis before candidates sharing one function are folded, and remove
+  // the exact small-round/default-font duplicate emitted when Wear stacks its device + font-scale
+  // multi-previews. Synthetic state tagging above intentionally runs first so equal display params
+  // never collapse distinct override states.
+  applyCatalogPreviewAxes(candidates, candidateBundle.previews);
+  // The published candidate reader classifies every numeric width with Material
+  // window classes. Give this catalog's declared names precedence so domain
+  // breakpoints such as Wear's 192 dp `smallRound` and 227 dp `largeRound` remain
+  // distinct output axes instead of both collapsing to `compact`.
+  applySpecBreakpoints(
+    candidates,
+    candidateBundle.previews,
+    breakpoints,
+  );
   // Return the ORIGINAL (unfiltered) bundle: its raw `entries` carry the per-preview
   // `previews/<id>.layout.json` (layout-inspector tree) the wireframe is built from, and its full
   // `previews` list carries the catalog-token sheets `catalogTokensFromBundle` needs.


### PR DESCRIPTION
## Summary

- promote non-default Compose preview `fontScale` values to the catalog's `props.fontScale` axis
- deduplicate only pixel-equivalent renders emitted by overlapping Wear device and font-scale multi-previews
- retain the existing duplicate-output guard for genuinely distinct catalog variants
- add regression coverage across font-scale promotion, Wear breakpoint naming, and variant folding

## Root cause

Wear screens can stack `@WearPreviewDevices` and `@WearPreviewFontScales`. The candidate reader retained device-derived size but dropped `fontScale`, so the exporter folded distinct scaled renders onto the same default/compact output key. The two annotations also both emit the small-round/default-font render, producing one legitimate duplicate.

This caused Confetti's design-artifacts workflow to fail while folding the Home component:
https://github.com/joreilly/Confetti/actions/runs/30636170187/job/91174217006

## Impact

Confetti and other Wear consumers can keep their normal device and font-scale multi-previews without adding catalog-only alias composables. Scaled renders receive stable, collision-free image paths such as `__fontscale-1.12.png`.

## Validation

- `node --test scripts/design-artifacts/catalog-preview-axes.test.mjs scripts/design-artifacts/catalog-breakpoints.test.mjs scripts/design-artifacts/catalog-variants.test.mjs`
- `npm test -- --test-reporter=dot` from `scripts/design-artifacts`
- `git diff --check`

Browser-only tests self-skipped locally because Chromium is not installed; GitHub Actions installs Chromium before running the same suite.