### PR TITLE
feat(remotecompose): add animated Material 3 previews

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeIrReplay.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeIrReplay.kt
@@ -85,7 +85,7 @@ class RemoteComposeIrReplay {
  *
  * Invalid hex is skipped rather than thrown, matching [applyConnectorOverrides].
  */
-private fun Map<String, RemoteNamedValue>.toNamedColorOverrides(): ObjectIntMap<String> {
+internal fun Map<String, RemoteNamedValue>.toNamedColorOverrides(): ObjectIntMap<String> {
   val colors = entries.mapNotNull { (name, value) ->
     val color = value as? RemoteNamedValue.ColorValue ?: return@mapNotNull null
     val argb = color.argb.removePrefix("#").toLongOrNull(16)?.toInt() ?: return@mapNotNull null
@@ -95,7 +95,7 @@ private fun Map<String, RemoteNamedValue>.toNamedColorOverrides(): ObjectIntMap<
   return MutableObjectIntMap<String>(colors.size).apply { colors.forEach { (n, v) -> put(n, v) } }
 }
 
-private val isEmbeddedPlayerAvailable: Boolean by lazy {
+internal val isEmbeddedPlayerAvailable: Boolean by lazy {
   runCatching {
       Class.forName(
         "androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayerKt",

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
@@ -10,6 +10,7 @@ import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.profile.Profile
 import androidx.compose.remote.creation.profile.RcPlatformProfiles
 import androidx.compose.remote.player.compose.RemoteDocumentPlayer
+import androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayer
 import androidx.compose.remote.player.core.RemoteDocument
 import androidx.compose.remote.player.core.state.StateUpdater
 import androidx.compose.runtime.Composable
@@ -19,6 +20,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 import androidx.compose.ui.unit.LayoutDirection
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind
 import ee.schimke.composeai.data.render.IrSidecarChannel
 import kotlinx.coroutines.runBlocking
 
@@ -43,9 +45,28 @@ open class RemoteOverridablePreviewWrapper : PreviewWrapperProvider {
   /** Remote-compose platform profile to capture the document against. Defaults to ANDROIDX. */
   protected open val profile: Profile = RcPlatformProfiles.ANDROIDX
 
+  /** Player used to replay the captured document. */
+  protected open val player: RemoteComposePlayerKind = RemoteComposePlayerKind.VIEW
+
   @Composable
   override fun Wrap(content: @Composable () -> Unit) {
-    RemoteOverridablePreview(profile = profile, content = content)
+    RemoteOverridablePreview(profile = profile, player = player, content = content)
+  }
+}
+
+/**
+ * Preview wrapper that replays the captured document with the embedded Compose Remote player.
+ * Consumers must supply `:third-party-rc-embedded-player` (or its upstream equivalent) at runtime;
+ * when it is absent this falls back to the standard View-backed player.
+ */
+class RemoteEmbeddedPreviewWrapper : RemoteOverridablePreviewWrapper() {
+  override val player: RemoteComposePlayerKind = RemoteComposePlayerKind.EMBEDDED
+
+  // The renderer resolves wrapper methods with getDeclaredMethod, so this must be declared on the
+  // concrete wrapper rather than inherited from RemoteOverridablePreviewWrapper.
+  @Composable
+  override fun Wrap(content: @Composable () -> Unit) {
+    RemoteOverridablePreview(profile = profile, player = player, content = content)
   }
 }
 
@@ -74,6 +95,7 @@ open class RemoteOverridablePreviewWrapper : PreviewWrapperProvider {
 fun RemoteOverridablePreview(
   profile: Profile,
   modifier: Modifier = Modifier,
+  player: RemoteComposePlayerKind = RemoteComposePlayerKind.VIEW,
   content: @Composable @RemoteComposable () -> Unit,
 ) {
   val context = LocalContext.current
@@ -148,13 +170,23 @@ fun RemoteOverridablePreview(
   // controller's `MutableState`, so a follow-up render with a new override re-runs the bridge.
   val seededOverrides = RemoteComposeController.namedValues.value
 
-  RemoteDocumentPlayer(
-    document = remoteDocument.document,
-    documentWidth = displayMetrics.widthPixels,
-    documentHeight = displayMetrics.heightPixels,
-    modifier = modifier,
-    init = { player -> applyConnectorOverrides(player.stateUpdater, seededOverrides) },
-  )
+  if (player == RemoteComposePlayerKind.EMBEDDED && isEmbeddedPlayerAvailable) {
+    ExperimentalRemoteDocumentPlayer(
+      document = remoteDocument,
+      modifier = modifier,
+      namedColorOverrides = seededOverrides.toNamedColorOverrides(),
+    )
+  } else {
+    RemoteDocumentPlayer(
+      document = remoteDocument.document,
+      documentWidth = displayMetrics.widthPixels,
+      documentHeight = displayMetrics.heightPixels,
+      modifier = modifier,
+      init = { remotePlayer ->
+        applyConnectorOverrides(remotePlayer.stateUpdater, seededOverrides)
+      },
+    )
+  }
 }
 
 // Remote Compose modern-header wire constants (big-endian). The header op is:

--- a/samples/remotecompose/build.gradle.kts
+++ b/samples/remotecompose/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
   implementation(libs.compose.remote.creation)
   implementation(libs.compose.remote.creation.compose)
   implementation(libs.wear.compose.remote.material3)
+  implementation(project(":preview-annotations"))
   implementation(libs.activity.compose)
   // `RemoteOverridablePreview` bridges connector-side named-value overrides into the running
   // Remote Compose player. Sample uses it in place of upstream `RemotePreview` so the panel

--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/Previews.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/Previews.kt
@@ -8,6 +8,8 @@ import androidx.compose.remote.tooling.preview.RemotePreviewWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewWrapper
+import ee.schimke.composeai.daemon.RemoteEmbeddedPreviewWrapper
+import ee.schimke.composeai.preview.AnimatedPreview
 
 /**
  * Two ways to preview a Remote Compose component — same output, different code shape. The
@@ -68,6 +70,52 @@ fun RemoteButtonWithShapePreview() {
 @Composable
 fun RemoteButtonWithBorderPreview() {
   Container { RemoteButtonWithBorder() }
+}
+
+/**
+ * Captures the Remote Material 3 indeterminate progress indicator across one second of its
+ * document-driven animation. A fixed duration is required because the animation is intentionally
+ * infinite, and [AnimatedPreview.showCurves] is disabled because the moving values live in the
+ * Remote Compose document rather than Compose UI's animation inspector.
+ *
+ * The wrapper path also emits the captured `.rc` document. This variant uses the standard
+ * View-backed Remote Compose player; [RemoteIndeterminateCircularProgressIndicatorEmbeddedPreview]
+ * renders the identical remote content through the embedded Compose player.
+ */
+@Preview(showBackground = true, widthDp = 200, heightDp = 200)
+@PreviewWrapper(RemotePreviewWrapper::class)
+@AnimatedPreview(durationMs = 1000, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun RemoteIndeterminateCircularProgressIndicatorStandardPreview() {
+  Container { RemoteIndeterminateCircularProgressIndicator() }
+}
+
+/** Embedded-player companion to [RemoteIndeterminateCircularProgressIndicatorStandardPreview]. */
+@Preview(showBackground = true, widthDp = 200, heightDp = 200)
+@PreviewWrapper(RemoteEmbeddedPreviewWrapper::class)
+@AnimatedPreview(durationMs = 1000, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun RemoteIndeterminateCircularProgressIndicatorEmbeddedPreview() {
+  Container { RemoteIndeterminateCircularProgressIndicator() }
+}
+
+/**
+ * Standard-player preview for the interaction-driven `animateRemoteFloat` technique. Click the
+ * indicator (or use `compose-preview record`) to animate progress to the next quarter.
+ */
+@Preview(showBackground = true, widthDp = 200, heightDp = 200)
+@PreviewWrapper(RemotePreviewWrapper::class)
+@Composable
+fun RemoteAnimatedCircularProgressIndicatorStandardPreview() {
+  Container { RemoteAnimatedCircularProgressIndicator() }
+}
+
+/** Embedded-player companion to [RemoteAnimatedCircularProgressIndicatorStandardPreview]. */
+@Preview(showBackground = true, widthDp = 200, heightDp = 200)
+@PreviewWrapper(RemoteEmbeddedPreviewWrapper::class)
+@Composable
+fun RemoteAnimatedCircularProgressIndicatorEmbeddedPreview() {
+  Container { RemoteAnimatedCircularProgressIndicator() }
 }
 
 /**

--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/RemoteComponents.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/RemoteComponents.kt
@@ -3,25 +3,32 @@
 package com.example.sampleremotecompose
 
 import androidx.compose.remote.creation.compose.action.hostAction
+import androidx.compose.remote.creation.compose.action.valueChange
 import androidx.compose.remote.creation.compose.layout.RemoteAlignment
 import androidx.compose.remote.creation.compose.layout.RemoteBox
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.clickable
 import androidx.compose.remote.creation.compose.modifier.fillMaxSize
+import androidx.compose.remote.creation.compose.modifier.size
 import androidx.compose.remote.creation.compose.shaders.RemoteBrush
 import androidx.compose.remote.creation.compose.shaders.linearGradient
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.RemoteColor
+import androidx.compose.remote.creation.compose.state.animateRemoteFloat
 import androidx.compose.remote.creation.compose.state.rb
 import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rememberNamedRemoteColor
 import androidx.compose.remote.creation.compose.state.rememberNamedRemoteString
+import androidx.compose.remote.creation.compose.state.rememberMutableRemoteFloat
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.wear.compose.remote.material3.RemoteButton
+import androidx.wear.compose.remote.material3.RemoteCircularProgressIndicator
 import androidx.wear.compose.remote.material3.RemoteText
 import androidx.wear.compose.remote.material3.buttonSizeModifier
 
@@ -94,6 +101,41 @@ fun RemoteButtonWithShape() {
     modifier = RemoteModifier.buttonSizeModifier(),
     shape = RemoteRoundedCornerShape(4.rdp),
     content = { RemoteText("Custom shape".rs) },
+  )
+}
+
+/**
+ * The indeterminate Remote Material 3 progress indicator. Unlike a normal Compose animation, its
+ * motion is encoded into the [androidx.compose.remote.player.core.RemoteDocument]: the indicator
+ * reads Remote Compose's continuous-time variable and each player evaluates the arc expressions
+ * while replaying the document.
+ *
+ * Keeping this as a pure [RemoteComposable] lets the animated preview exercise both replay
+ * implementations — the standard View-backed Remote Compose player and the embedded Compose
+ * player — without an app-side animation masking a stalled document clock.
+ */
+@Composable
+@RemoteComposable
+fun RemoteIndeterminateCircularProgressIndicator() {
+  RemoteCircularProgressIndicator(modifier = RemoteModifier.size(72.rdp))
+}
+
+/**
+ * The interaction-driven animation technique from AndroidX's
+ * `RemoteCircularProgressIndicatorAnimatedSample`: clicking changes a mutable value in the remote
+ * document, and [animateRemoteFloat] interpolates the determinate indicator to its next quarter.
+ */
+@Composable
+@RemoteComposable
+fun RemoteAnimatedCircularProgressIndicator() {
+  val progress = rememberMutableRemoteFloat { 0.25f.rf }
+  val animatedProgress = animateRemoteFloat(progress, 0.25f)
+  val advanceProgress = valueChange(progress, ((progress + 0.25f) % 1f).createReference())
+
+  RemoteCircularProgressIndicator(
+    progress = animatedProgress,
+    modifier =
+      RemoteModifier.size(72.rdp).clickable(action = advanceProgress, role = Role.Button),
   )
 }
 

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/GraphContext.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/GraphContext.kt
@@ -132,9 +132,11 @@ internal class GraphContext(
         when {
             // Time variables come from the Compose frame-clock state (matching the resolver's time
             // special-case), not the raw store — so a time-driven op reads seconds/minutes/hours.
-            id == RemoteContext.ID_TIME_IN_SEC -> timeMillis.value / 1000f
+            id == RemoteContext.ID_CONTINUOUS_SEC || id == RemoteContext.ID_TIME_IN_SEC ->
+                timeMillis.value / 1000f
             id == RemoteContext.ID_TIME_IN_MIN -> timeMillis.value / 60000f
             id == RemoteContext.ID_TIME_IN_HR -> timeMillis.value / 3600000f
+            realState.isFloatOverridden(id) -> super.getFloat(id)
             isComputed(id) -> (computedValue(id) as? Number)?.toFloat() ?: 0f
             else -> super.getFloat(id)
         }

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/SnapshotRemoteComposeState.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/SnapshotRemoteComposeState.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateMap
  */
 internal class SnapshotRemoteComposeState : RemoteComposeState() {
     private val floats: SnapshotStateMap<Int, Float> = mutableStateMapOf()
+    private val overriddenFloats: SnapshotStateMap<Int, Boolean> = mutableStateMapOf()
     private val integers: SnapshotStateMap<Int, Int> = mutableStateMapOf()
     private val colors: SnapshotStateMap<Int, Int> = mutableStateMapOf()
     private val data: SnapshotStateMap<Int, Any> = mutableStateMapOf()
@@ -68,12 +69,16 @@ internal class SnapshotRemoteComposeState : RemoteComposeState() {
         val old = floats[id]
         super.overrideFloat(id, value)
         val new = super.getFloat(id)
+        overriddenFloats[id] = true
         if (new != old) {
             floats[id] = new
             integers[id] = super.getInteger(id)
             colors[id] = super.getColor(id)
         }
     }
+
+    /** Whether a host/action override should take precedence over the id's authored expression. */
+    fun isFloatOverridden(id: Int): Boolean = overriddenFloats[id] == true
 
     // --- Integer ---
     override fun getInteger(id: Int): Int {

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/state/RcPlayerState.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/state/RcPlayerState.kt
@@ -21,6 +21,8 @@ package androidx.compose.remote.player.compose.embedded.state
 import androidx.compose.remote.core.RemoteContext
 import androidx.compose.remote.core.VariableSupport
 import androidx.compose.remote.core.operations.Utils
+import androidx.compose.remote.core.operations.utilities.AnimatedFloatExpression
+import androidx.compose.remote.core.operations.utilities.NanMap
 import androidx.compose.remote.player.compose.embedded.LocalComponentValueStateMap
 import androidx.compose.remote.player.compose.embedded.LocalCoreDocument
 import androidx.compose.remote.player.compose.embedded.LocalCurrentTimeMillis
@@ -118,7 +120,8 @@ internal fun rememberRemoteFloatAsState(id: Int): State<Float> {
     val context = document.remoteComposeState
 
     if (
-        id == RemoteContext.ID_TIME_IN_SEC ||
+        id == RemoteContext.ID_CONTINUOUS_SEC ||
+            id == RemoteContext.ID_TIME_IN_SEC ||
             id == RemoteContext.ID_TIME_IN_MIN ||
             id == RemoteContext.ID_TIME_IN_HR
     ) {
@@ -127,6 +130,7 @@ internal fun rememberRemoteFloatAsState(id: Int): State<Float> {
             derivedStateOf {
                 val timeMillis = timeMillisState.value
                 when (id) {
+                    RemoteContext.ID_CONTINUOUS_SEC,
                     RemoteContext.ID_TIME_IN_SEC -> timeMillis / 1000f
                     RemoteContext.ID_TIME_IN_MIN -> timeMillis / 60000f
                     RemoteContext.ID_TIME_IN_HR -> timeMillis / 3600000f
@@ -145,8 +149,17 @@ internal fun rememberRemoteFloatAsState(id: Int): State<Float> {
     // Animation-bearing expressions resolve as a Compose-native animated State (Animatable). Plain
     // (non-animated) FloatExpressions fall through to the graph below — one evaluation path.
     val expression = document.getFloatExpressionsReflection()[id]
-    if (expression != null && expression.mFloatAnimation != null) {
-        return rememberAnimatedRemoteFloat(id)
+    if (expression != null) {
+        if (expression.mFloatAnimation != null) {
+            return rememberAnimatedRemoteFloat(id)
+        }
+        // Keep an expression chain in the Compose-native evaluator when any nested input is
+        // animated. GraphContext deliberately evaluates core FloatExpressions as pure target
+        // values, so routing an outer expression through it would flatten its animated child and
+        // make interaction-driven Material 3 progress indicators appear frozen.
+        if (expressionDependsOnAnimation(document.getFloatExpressionsReflection(), id)) {
+            return rememberRemoteExpression(id)
+        }
     }
 
     // Computed float (FloatExpression or e.g. ImageAttribute): resolve via the pure-Compose graph.
@@ -156,6 +169,30 @@ internal fun rememberRemoteFloatAsState(id: Int): State<Float> {
     }
     // Plain variable: reactive read of the snapshot-backed scalar store (no listener bridge).
     return remember(document, id) { derivedStateOf { context.getFloat(id) } }
+}
+
+private fun expressionDependsOnAnimation(
+    expressions: Map<Int, androidx.compose.remote.core.operations.FloatExpression>,
+    id: Int,
+    visiting: MutableSet<Int> = mutableSetOf(),
+): Boolean {
+    if (!visiting.add(id)) return false
+    val expression = expressions[id] ?: return false
+    return expression.mSrcValue.any { value ->
+        if (
+            !value.isNaN() ||
+                AnimatedFloatExpression.isMathOperator(value) ||
+                NanMap.isDataVariable(value)
+        ) {
+            false
+        } else {
+            val dependencyId = Utils.idFromNan(value)
+            val dependency = expressions[dependencyId]
+            dependency?.mFloatAnimation != null ||
+                (dependency != null &&
+                    expressionDependsOnAnimation(expressions, dependencyId, visiting))
+        }
+    }
 }
 
 @Composable

--- a/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/GraphContextTimeTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/GraphContextTimeTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("RestrictedApiAndroidX")
+
+package androidx.compose.remote.player.compose.embedded
+
+import androidx.compose.remote.core.RemoteClock
+import androidx.compose.remote.core.RemoteContext
+import androidx.compose.runtime.mutableFloatStateOf
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GraphContextTimeTest {
+  @Test
+  fun continuousSecondsTracksTheComposeFrameClock() {
+    val frameTimeMillis = mutableFloatStateOf(1_750f)
+    val context =
+      GraphContext(
+        realState = SnapshotRemoteComposeState(),
+        computedOps = emptyMap(),
+        timeMillis = frameTimeMillis,
+        clock = RemoteClock.SYSTEM,
+      )
+
+    assertEquals(1.75f, context.getFloat(RemoteContext.ID_CONTINUOUS_SEC), 0.0001f)
+
+    frameTimeMillis.floatValue = 2_500f
+
+    assertEquals(2.5f, context.getFloat(RemoteContext.ID_CONTINUOUS_SEC), 0.0001f)
+  }
+}

--- a/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/RcAnimatedInteractionTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/RcAnimatedInteractionTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("RestrictedApiAndroidX")
+
+package androidx.compose.remote.player.compose.embedded
+
+import android.content.Context
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.remote.core.CoreDocument
+import androidx.compose.remote.core.RemoteClock
+import androidx.compose.remote.core.RemoteComposeBuffer
+import androidx.compose.remote.creation.compose.action.valueChange
+import androidx.compose.remote.creation.compose.capture.captureSingleRemoteDocument
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.contentDescription
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.modifier.semantics
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.modifier.width
+import androidx.compose.remote.creation.compose.state.animateRemoteFloat
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rememberMutableRemoteFloat
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import java.io.ByteArrayInputStream
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class RcAnimatedInteractionTest {
+  @get:Rule val rule = createComposeRule()
+
+  @Test
+  fun valueChangeAnimatesRemoteFloatToItsNewTarget() = runBlocking {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val documentBytes =
+      captureSingleRemoteDocument(
+          context = context,
+          content = {
+            val progress = rememberMutableRemoteFloat { 0.25f.rf }
+            val animatedProgress = animateRemoteFloat(progress, 0.25f)
+            val advanceProgress =
+              valueChange(progress, ((progress + 0.25f) % 1f).createReference())
+
+            RemoteColumn(modifier = RemoteModifier.size(160.rdp)) {
+              RemoteBox(
+                modifier = RemoteModifier.size(160.rdp, 40.rdp).clickable(advanceProgress)
+              )
+              RemoteBox(
+                modifier =
+                  RemoteModifier.semantics { contentDescription = "animated-progress".rs }
+                    .width(animatedProgress * 200f)
+                    .height(20.rdp)
+              )
+            }
+          },
+        )
+        .bytes
+    val document =
+      CoreDocument(RemoteClock.SYSTEM).apply {
+        ByteArrayInputStream(documentBytes).use {
+          initFromBuffer(RemoteComposeBuffer.fromInputStream(it))
+        }
+      }
+
+    rule.mainClock.autoAdvance = false
+    rule.setContent {
+      Box(modifier = Modifier.size(200.dp)) {
+        RcPlayer(document = document)
+      }
+    }
+
+    rule.mainClock.advanceTimeBy(300)
+    val progressNode = rule.onNodeWithContentDescription("animated-progress")
+    fun progressWidth() =
+      progressNode.getUnclippedBoundsInRoot().let { it.right.value - it.left.value }
+
+    val initialWidth = progressWidth()
+    rule.onNode(hasClickAction()).performClick()
+    rule.waitForIdle()
+    rule.mainClock.advanceTimeBy(100)
+    val animatingWidth = progressWidth()
+    rule.mainClock.advanceTimeBy(200)
+    val settledWidth = progressWidth()
+
+    assert(animatingWidth > initialWidth) {
+      "Expected the click animation to grow past $initialWidth, but was $animatingWidth"
+    }
+    assert(settledWidth > animatingWidth) {
+      "Expected the animation to settle past $animatingWidth, but was $settledWidth"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add standard and embedded-player previews for Remote Material 3 indeterminate and click-driven circular progress animations
- add an embedded preview wrapper so the same captured Remote Compose document can be exercised through both replay implementations
- make continuous time, float overrides, and nested animated expressions reactive in the embedded player
- add focused regression coverage for continuous-time and interaction-driven animations

## Why

The Remote Material 3 samples previously had no animated preview coverage, and the embedded replay lane could freeze document-driven time or flatten nested `animateRemoteFloat` expressions to their target values. That made comparisons with the standard View-backed RC player incomplete.

## Validation

- rendered all four circular-progress previews with `compose-preview`; 11 total module previews, 0 missing
- recorded the standard and embedded click-driven previews
- `:third-party-rc-embedded-player:testDebugUnitTest` focused animation tests
- scoped `ktfmtCheck` for `:samples:remotecompose`, `:data-remotecompose-connector`, and `:third-party-rc-embedded-player`
- `git diff --check`