### PR TITLE
fix(ci): unbreak the release-please workflow and the desktop resolver test

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,9 @@ concurrency:
   # Ordinary main pushes share one pending slot so release-please PR updates coalesce during a
   # merge burst. A merged release PR must not share that slot: if it is still pending, the next
   # main push can replace it before any publish job starts.
-  group: release-please-${{ github.ref }}-${{ github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release ') && github.sha || 'updates' }}
+  # Quoted: the `chore(main): release ` literal contains `: `, which YAML would otherwise read as a
+  # nested mapping and reject the whole workflow at startup.
+  group: "release-please-${{ github.ref }}-${{ github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release ') && github.sha || 'updates' }}"
   cancel-in-progress: false
 
 jobs:

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestEntryResolveTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestEntryResolveTest.kt
@@ -80,8 +80,10 @@ class PreviewManifestEntryResolveTest {
   fun `nested schema - plugin shape - reads params block`() {
     // Mirrors what `DiscoverPreviewsTask` writes for a Wear preview annotated with
     // `@Preview(device = "id:wearos_small_round")` — production manifest the daemon was silently
-    // dropping pre-fix. `widthDp` × `density` is the per-render sandbox size; the resolver does
-    // the dp→px conversion the plugin's schema requires.
+    // dropping pre-fix. Since #3113 (Studio geometry parity) a device frame owns its own size: the
+    // resolver deliberately ignores the manifest's `widthDp`/`heightDp` and `PreviewManifestRouter`
+    // derives the frame from `DeviceDimensions.resolve(device)`. The resolver still pins both axes
+    // (no wrap) and passes the device id through.
     val raw =
       """{"id":"wear-1","className":"X","functionName":"R","sourceFile":"P.kt",""" +
         """"params":{"device":"id:wearos_small_round","widthDp":192,"heightDp":192,""" +
@@ -89,8 +91,8 @@ class PreviewManifestEntryResolveTest {
         """"captures":[{"renderOutput":"renders/wear-1.png","cost":1.0}]}"""
     val entry = json.decodeFromString(PreviewManifestEntry.serializer(), raw)
     val resolved = entry.resolved()
-    assertEquals(504, resolved.widthPx) // 192 * 2.625
-    assertEquals(504, resolved.heightPx)
+    assertEquals(false, resolved.wrapWidth) // device frame pins both axes
+    assertEquals(false, resolved.wrapHeight)
     assertEquals(2.625f, resolved.density, 0.0001f)
     assertEquals(true, resolved.showBackground)
     assertEquals("id:wearos_small_round", resolved.device)
@@ -143,7 +145,8 @@ class PreviewManifestEntryResolveTest {
     val entry = json.decodeFromString(PreviewManifestEntry.serializer(), raw)
     val resolved = entry.resolved()
     assertEquals("id:wearos_small_round", resolved.device)
-    assertEquals(384, resolved.widthPx) // 192 * 2.0 default density
+    // Device frame pins the axes; the size itself comes from the router.
+    assertEquals(false, resolved.wrapWidth)
   }
 
   @Test


### PR DESCRIPTION
Two independent red-on-`main` fixes, one commit each.

## 1. `fix(ci): quote the release-please concurrency group`

`.github/workflows/release-please.yml` has failed at **startup** on every push to `main` since #3139 — the run completes with `conclusion: failure` and **zero jobs**, and GitHub shows the run under the workflow *path* rather than its `name:`, the tell-tale sign it couldn't parse the file. Cause: the concurrency group added in #3139 embeds the literal `'chore(main): release '`, and the `: ` inside it makes YAML read the unquoted `group:` scalar as a nested mapping:

```
yaml.scanner.ScannerError: mapping values are not allowed here
  in ".github/workflows/release-please.yml", line 25, column 135
```

Quoting the scalar fixes it. Consequence while broken: no release PR was being opened or updated at all.

## 2. `test(daemon-desktop): align resolver test with device-frame geometry`

`Module Unit Tests` (CI) is red on `main` — `:daemon:desktop:test`:

```
PreviewManifestEntryResolveTest > nested schema - plugin shape - reads params block FAILED
    java.lang.AssertionError at PreviewManifestEntryResolveTest.kt:92
PreviewManifestEntryResolveTest > unknown plugin-side fields don't break decoding FAILED
    java.lang.AssertionError at PreviewManifestEntryResolveTest.kt:146
```

#3113 (Studio geometry parity) changed `PreviewManifestEntry.resolved()` so a device frame owns its own size — `params.widthDp`/`heightDp` are deliberately ignored when `device` is set, and `PreviewManifestRouter` derives the frame from `DeviceDimensions.resolve(device)` instead. The desktop test still asserted the old `dp × density` product (504 / 384); the Android mirror had already been updated. This asserts the contract the resolver actually owns now (device pins both axes, device id passes through) and leaves the frame size to the router.

Semantic conflict, not a behaviour change: no production code is touched.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-please.yml'))"` → parses; every other workflow under `.github/workflows/` also re-checked and parses.
- `./gradlew :daemon:desktop:test --tests '*PreviewManifestEntryResolveTest*'` → green locally (was failing on `main`).
- `ktfmt` clean (pre-commit hook).

Non-visual change (CI wiring + a unit test), so no render evidence.

## Still red on `main`, not fixed here

- **Serve Lanes E2E** — `Wasm iframe re-renders on knob override` has failed on every run since ~10:35 UTC today, across unrelated branches (including a docs-only PR), so it's a `main`/environment regression rather than any one PR. Under investigation; the artifact with the failure context isn't reachable from this environment (blob storage is blocked by the proxy), so I'm reproducing the lane locally.
- **Integration → `adaptive-apps-samples (AdaptiveJetStream — XR spatial Compose)`** — `XrSubspaceRenderTest.renderScene` throws `IllegalStateException` (wrapped in `InvocationTargetException`) for both spatial previews; Gradle's console output carries no message, so this needs a local repro of the patched upstream sample.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPgP8v6tA9nMoisxKqjU3V)_