### PR TITLE
fix(serve): always register the /wasm/ route

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -333,52 +333,54 @@ class ServeHttpServer(
 
         // In-browser CMP tier: serve the static Wasm app for a registered system at
         // `/wasm/<system>/<file>`. Ungated (generic client code, no session data) so the viewer's
-        // sandboxed iframe and its relative asset fetches work without a token. Registered only
-        // when
-        // the operator mapped a system to its built dist (`--wasm-dir`).
-        // Registered when the server has any Wasm app OR can gain one at runtime: [wasmCatalogs] is
-        // a live view of the served catalogs' apps, so an admin-published catalog that carries one
-        // needs this route to already exist. Unknown systems 404 either way.
-        if (wasmCatalogs.isNotEmpty() || adminEnabled) {
-          get("/wasm/{system}/{path...}") {
-            val dir = call.parameters["system"]?.let { wasmCatalogs[it] }
-            if (dir == null) {
-              call.respondText("not found", status = HttpStatusCode.NotFound)
-              return@get
-            }
-            val segments = call.parameters.getAll("path").orEmpty().filter { it.isNotEmpty() }
-            val rel = if (segments.isEmpty()) "index.html" else segments.joinToString("/")
-            val base = dir.toPath().toAbsolutePath().normalize()
-            val resolved = base.resolve(rel).normalize()
-            // Zip-slip guard: a crafted `../` path must not escape the app directory.
-            if (!resolved.startsWith(base)) {
-              call.respondText("not found", status = HttpStatusCode.NotFound)
-              return@get
-            }
-            val file = resolved.toFile()
-            if (!file.isFile) {
-              call.respondText("not found", status = HttpStatusCode.NotFound)
-              return@get
-            }
-            // The viewer mounts this app in a `sandbox="allow-scripts"` iframe, which has an opaque
-            // (null) origin — so the app's own ES-module + wasm fetches count as cross-origin and
-            // need CORS. `*` is safe: these are public static client assets with no session data,
-            // and keeping the strong sandbox (no `allow-same-origin`) isolates even untrusted wasm.
-            call.response.headers.append(HttpHeaders.AccessControlAllowOrigin, "*")
-            // Cache the heavy payload (skiko + app wasm ≈ 8 MB gzipped). The filenames aren't
-            // content-hashed, so pair a moderate max-age with a size+mtime ETag: within the window
-            // the browser serves from cache (no request); after it, a conditional request gets a
-            // cheap 304 instead of re-downloading megabytes.
-            val etag = "\"${file.length().toString(16)}-${file.lastModified().toString(16)}\""
-            call.response.headers.append(HttpHeaders.CacheControl, "public, max-age=3600")
-            call.response.headers.append(HttpHeaders.ETag, etag)
-            if (call.request.headers[HttpHeaders.IfNoneMatch] == etag) {
-              call.respond(HttpStatusCode.NotModified)
-              return@get
-            }
-            val bytes = withContext(Dispatchers.IO) { file.readBytes() }
-            call.respondBytes(bytes, wasmContentType(file.name))
+        // sandboxed iframe and its relative asset fetches work without a token.
+        //
+        // Registered UNCONDITIONALLY. [wasmCatalogs] is a live view of the served catalogs' apps,
+        // but routes are installed once, at bind time — and since #3127 the listener binds BEFORE
+        // the catalogs load, so a `wasmCatalogs.isNotEmpty()` guard here always saw an empty map
+        // and dropped the route for the whole process lifetime. The viewer meanwhile reads the
+        // same live map later (it offers "Run in browser (Wasm)" for any system present in it), so
+        // the toggle appeared while every `/wasm/…` fetch 404'd — the serve-lanes E2E's "Wasm
+        // iframe re-renders on knob override" failure. An unknown system 404s inside the handler
+        // either way, so the route costs nothing when no app is ever registered.
+        get("/wasm/{system}/{path...}") {
+          val dir = call.parameters["system"]?.let { wasmCatalogs[it] }
+          if (dir == null) {
+            call.respondText("not found", status = HttpStatusCode.NotFound)
+            return@get
           }
+          val segments = call.parameters.getAll("path").orEmpty().filter { it.isNotEmpty() }
+          val rel = if (segments.isEmpty()) "index.html" else segments.joinToString("/")
+          val base = dir.toPath().toAbsolutePath().normalize()
+          val resolved = base.resolve(rel).normalize()
+          // Zip-slip guard: a crafted `../` path must not escape the app directory.
+          if (!resolved.startsWith(base)) {
+            call.respondText("not found", status = HttpStatusCode.NotFound)
+            return@get
+          }
+          val file = resolved.toFile()
+          if (!file.isFile) {
+            call.respondText("not found", status = HttpStatusCode.NotFound)
+            return@get
+          }
+          // The viewer mounts this app in a `sandbox="allow-scripts"` iframe, which has an opaque
+          // (null) origin — so the app's own ES-module + wasm fetches count as cross-origin and
+          // need CORS. `*` is safe: these are public static client assets with no session data,
+          // and keeping the strong sandbox (no `allow-same-origin`) isolates even untrusted wasm.
+          call.response.headers.append(HttpHeaders.AccessControlAllowOrigin, "*")
+          // Cache the heavy payload (skiko + app wasm ≈ 8 MB gzipped). The filenames aren't
+          // content-hashed, so pair a moderate max-age with a size+mtime ETag: within the window
+          // the browser serves from cache (no request); after it, a conditional request gets a
+          // cheap 304 instead of re-downloading megabytes.
+          val etag = "\"${file.length().toString(16)}-${file.lastModified().toString(16)}\""
+          call.response.headers.append(HttpHeaders.CacheControl, "public, max-age=3600")
+          call.response.headers.append(HttpHeaders.ETag, etag)
+          if (call.request.headers[HttpHeaders.IfNoneMatch] == etag) {
+            call.respond(HttpStatusCode.NotModified)
+            return@get
+          }
+          val bytes = withContext(Dispatchers.IO) { file.readBytes() }
+          call.respondBytes(bytes, wasmContentType(file.name))
         }
 
         // Prebaked front-door hero thumbnails ([ServeHeroImages]). Deliberately NOT the `/render`

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -333,6 +333,51 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `the wasm route serves an app registered after the listener bound`() {
+    // #3127 made the listener bind BEFORE the catalogs load, so `wasmCatalogs` is empty at route-
+    // installation time and only fills in later. Gating the route's registration on the map being
+    // non-empty therefore dropped `/wasm/…` for the whole process lifetime, while the viewer —
+    // which reads the same live map on each request — still offered "Run in browser (Wasm)". The
+    // route must be installed unconditionally and consult the map per request.
+    val appDir = Files.createTempDirectory("serve-wasm-late").toFile().also { it.deleteOnExit() }
+    val wasmCatalogs = mutableMapOf<String, File>()
+    val lateRegistry = ServeSessionRegistry(open = { null })
+    lateRegistry.register("default-mod", host = bundle("late-default"), pinned = true)
+    val lateServer =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused-in-public",
+          sessions = lateRegistry,
+          defaultSessionId = "default-mod",
+          isPublic = true,
+          wasmCatalogs = wasmCatalogs,
+        )
+        .also { it.start() }
+    fun fetch(path: String): Pair<Int, String> {
+      val req = Request.Builder().url("http://127.0.0.1:${lateServer.port}$path").build()
+      client.newCall(req).execute().use { r ->
+        return r.code to (r.body?.string() ?: "")
+      }
+    }
+    try {
+      // Nothing registered yet: 404 from inside the handler, not a missing route.
+      assertEquals(404, fetch("/wasm/compose-m3/").first)
+      // The catalog load finishes and publishes its app into the live map.
+      File(appDir, "index.html").writeText("<!doctype html><title>wasm app</title>")
+      wasmCatalogs["compose-m3"] = appDir
+      val (code, body) = fetch("/wasm/compose-m3/")
+      assertEquals(200, code, "the late-registered wasm app must be reachable")
+      assertTrue(body.contains("wasm app"), "served index.html: $body")
+      // An unknown system still 404s.
+      assertEquals(404, fetch("/wasm/nope/").first)
+    } finally {
+      lateServer.stop()
+      lateRegistry.close()
+    }
+  }
+
+  @Test
   fun `a catalog is reachable under its canonical path`() {
     val (landingCode, landing) = get("/compose-m3/")
     assertEquals(200, landingCode)


### PR DESCRIPTION
Fixes the `Wasm iframe re-renders on knob override` failure that has been red on **Serve Lanes E2E** on `main` and on every PR branch since #3127 merged (last green run: `ci: scope pull request workflows (#3128)`, 10:33 UTC).

## Root cause

`#3127` (bind before loading catalogs) made the listener bind — and therefore install its routes — **before** the catalogs load. `wasmCatalogs` is a live view of the served catalogs' apps, but the `/wasm/` route was gated on it:

```kotlin
if (wasmCatalogs.isNotEmpty() || adminEnabled) {
  get("/wasm/{system}/{path...}") { … }
}
```

That predicate is evaluated **once, at route-installation time**, when the map is necessarily empty. On a `--catalogs` serve (no admin token) the route was therefore never registered at all, for the whole process lifetime.

Meanwhile `ServeWeb` reads the *same live map* per request, so by the time a viewer page renders the map is populated and the page happily advertises "Run in browser (Wasm)" — pointing at a route that doesn't exist. Every `/wasm/<system>/…` fetch 404'd, the iframe mounted an error page, and no knob override could ever repaint it.

Reproduced locally against a daemon-backed `serve --catalogs compose-m3`, exactly as the CI job boots it:

```
$ curl -o /dev/null -w '%{http_code}' http://127.0.0.1:8725/wasm/compose-m3/
404
serve-lanes.log: serve: catalog compose-m3 carries an in-browser Wasm app (/wasm/compose-m3/)
```

— the app was fetched and registered, only the route was missing.

## Fix

Register the route unconditionally. An unknown system already 404s inside the handler (as the original comment itself noted), so the route costs nothing when no app is ever published, and it can't be dropped by load ordering again.

## Test plan

- New `ServeHttpRoutingTest.the wasm route serves an app registered after the listener bound` — builds a server with an **empty** `wasmCatalogs` at construction, asserts `/wasm/compose-m3/` 404s, then publishes an app into the live map and asserts it serves 200 with the right bytes; an unknown system still 404s. This is the exact ordering that regressed, and it fails on `main`.
- `./gradlew :cli:test --tests '*ServeHttpRoutingTest*'` → green.
- Full local lane against a real `serve --catalogs compose-m3 --allow-render-trusted` (same boot script CI uses), driven with the harness's own Chromium:

```
✓ 1 PNG lane re-renders on knob override (3.1s)
✓ 2 SVG lane bakes the override text into the vector (349ms)
✓ 3 Live WebSocket lane upgrades and pushes a frame (1.2s)
✓ 4 viewer wires the knob into every render lane (6.8s)
✓ 5 Live mode surfaces a visible error when the stream can't activate (480ms)
✓ 6 Wasm iframe re-renders on knob override (4.1s)
6 passed (17.8s)
```

  Before the fix, run 6 failed here identically to CI (`Wasm stage pixels should change after the knob override`), and `/wasm/compose-m3/` returned 404; after it, `/wasm/compose-m3/` returns 200.

## Visual evidence

The affected surface is the in-browser Wasm tier — a live Kotlin/Wasm + Skiko canvas inside the viewer's sandboxed iframe, which the `@Preview` PNG render pipeline doesn't reach. Its pixel check *is* the Serve Lanes E2E lane above (test 6 screenshots the iframe before/after a knob edit and asserts the bytes differ), which now passes locally against a real serve and had been failing on `main`. No static render output changes in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPgP8v6tA9nMoisxKqjU3V)_