### PR TITLE
feat(serve): show loading state while previews rerender

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -941,6 +941,8 @@ object ServeWeb {
               setTimeout(function () { runThemeQueue(queue, gen); }, 1500);
               return;
             }
+            job.card.classList.remove("cp-reloading");
+            job.card.removeAttribute("aria-busy");
             runThemeQueue(queue, gen);
           }
           img.onload = function () { next(true); };
@@ -968,13 +970,20 @@ object ServeWeb {
         themeGen++;
         var themeQueue = [];
         var themeQueueGen = themeGen;
+        cards.forEach(function (c) {
+          c.classList.remove("cp-reloading");
+          c.removeAttribute("aria-busy");
+        });
         if (provider) {
           cards.forEach(function (c, i) {
             if (c.getAttribute("data-swap") === "1") applyVariant(c, c.getAttribute("data-def") || "l", false);
             var img = c.querySelector("img");
             var base = themeBase[i];
             if (!img || !base) return;
+            c.classList.add("cp-reloading");
+            c.setAttribute("aria-busy", "true");
             themeQueue.push({
+              card: c,
               img: img,
               src: base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider),
             });

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -123,7 +123,7 @@ html.cp-js .cp-section-head { display: none; }
 .cp-card { border: 1px solid #e3e3e8; border-radius: 10px; overflow: hidden; background: #fff;
   display: block; color: inherit; }
 .cp-card[hidden] { display: none; }
-.cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
+.cp-imgwrap { position: relative; display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 /* `width`/`height` stay auto so the max-* pair alone decides the used size and the image can
    never be stretched. The front door's prebaked heroes DO carry width/height attributes — they
@@ -175,6 +175,25 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   background: #fff; padding: 12px;
   display: flex; align-items: center; justify-content: center; min-height: 220px; }
 .cp-stage img, .cp-stage canvas { max-width: 100%; height: auto; }
+/* Override/theme renders can take a moment. Preserve the previous pixels as context, fade them
+   just enough to signal that they are stale, and layer a compact spinner over the affected
+   preview until its replacement image has loaded. */
+.cp-card.cp-reloading .cp-imgwrap img,
+.cp-viewer[data-reloading="true"] .cp-stage > img {
+  opacity: 0.55; transition: opacity 0.15s ease;
+}
+.cp-card.cp-reloading .cp-imgwrap::after,
+.cp-viewer[data-reloading="true"] .cp-stage::after {
+  content: ""; position: absolute; left: 50%; top: 50%; z-index: 2;
+  width: 24px; height: 24px; margin: -15px 0 0 -15px; border-radius: 50%;
+  border: 3px solid rgba(91, 91, 207, 0.25); border-top-color: #5b5bcf;
+  animation: cp-reload-spin 0.75s linear infinite; pointer-events: none;
+}
+@keyframes cp-reload-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .cp-card.cp-reloading .cp-imgwrap::after,
+  .cp-viewer[data-reloading="true"] .cp-stage::after { animation-duration: 1.5s; }
+}
 .cp-backend { position: absolute; top: 8px; right: 8px; font-size: 0.62rem; font-weight: 600;
   letter-spacing: 0.02em; padding: 2px 8px; border-radius: 999px; background: rgba(20,20,22,0.72);
   color: #fff; pointer-events: none; }

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -2,6 +2,7 @@
   "use strict";
   var root = document.querySelector(".cp-viewer");
   var img = document.getElementById("cp-img");
+  var stage = document.querySelector(".cp-stage");
   var canvas = document.getElementById("cp-canvas");
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
@@ -123,6 +124,23 @@
   // The render-mode radio flips this (".png" default, ".svg" in SVG mode); refreshSnapshot and
   // the copyable links read it so a re-render / copied URL matches the on-screen format.
   var snapshotExt = ".png";
+  // Keep the current frame visible while an override-triggered render is in flight. A generation
+  // token prevents an older, slower request from clearing the busy treatment (or replacing the
+  // pixels) after a newer control edit has already started another render.
+  var snapshotGen = 0;
+  function setSnapshotLoading(loading) {
+    if (loading) {
+      root.setAttribute("data-reloading", "true");
+      if (stage) stage.setAttribute("aria-busy", "true");
+    } else {
+      root.removeAttribute("data-reloading");
+      if (stage) stage.removeAttribute("aria-busy");
+    }
+  }
+  function cancelSnapshotLoading() {
+    snapshotGen++;
+    setSnapshotLoading(false);
+  }
 
   // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
   // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
@@ -309,12 +327,22 @@
   }
   function refreshSnapshot() {
     status.textContent = "rendering…";
+    var gen = ++snapshotGen;
+    setSnapshotLoading(true);
     var qs = withScroll(snapshotExt, query());
     var url =
       base + "/render/" + encodeURIComponent(previewId) + snapshotExt + (qs ? "?" + qs : "");
     var next = new Image();
-    next.onload = function () { img.src = url; status.textContent = ""; clearModeError(); };
+    next.onload = function () {
+      if (gen !== snapshotGen) return;
+      img.src = url;
+      status.textContent = "";
+      setSnapshotLoading(false);
+      clearModeError();
+    };
     next.onerror = function () {
+      if (gen !== snapshotGen) return;
+      setSnapshotLoading(false);
       showModeError((snapshotExt === ".svg" ? "SVG" : "PNG") + " render failed for this preview.");
     };
     next.src = url;
@@ -995,18 +1023,21 @@
     // A mode switch always clears a prior lane's error; the new lane re-raises its own if it fails.
     clearModeError();
     if (m === "live") {
+      cancelSnapshotLoading();
       snapshotExt = ".png";
       if (svgToggle) svgToggle.setAttribute("aria-pressed", "false");
       closeWasm();
       closeRc();
       openStream();
     } else if (m === "wasm") {
+      cancelSnapshotLoading();
       snapshotExt = ".png";
       if (svgToggle) svgToggle.setAttribute("aria-pressed", "false");
       closeStream();
       closeRc();
       openWasm();
     } else if (m === "rc") {
+      cancelSnapshotLoading();
       snapshotExt = ".png";
       if (svgToggle) svgToggle.setAttribute("aria-pressed", "false");
       closeStream();

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1111,6 +1111,12 @@ class ServeWebFixtureTest {
         landingDeclaredThemes.contains("job.src = job.src + \"&_retry=1\""),
       "themed renders are fetched serially with a retry, not fired as one burst",
     )
+    assertTrue(
+      landingDeclaredThemes.contains("c.classList.add(\"cp-reloading\")") &&
+        landingDeclaredThemes.contains("job.card.classList.remove(\"cp-reloading\")") &&
+        landingDeclaredThemes.contains("c.setAttribute(\"aria-busy\", \"true\")"),
+      "themed cards expose a busy treatment until each replacement thumbnail settles",
+    )
     // Re-pointing runs only when the theme itself changed, so a search keystroke (which also calls
     // apply()) never restarts an in-flight themed-render queue.
     assertTrue(
@@ -2440,6 +2446,12 @@ class ServeWebFixtureTest {
     assertTrue(
       assetText("viewer.js").contains("function onKnobEdited()"),
       "knob edits have a dedicated, transport-aware handler",
+    )
+    assertTrue(
+      assetText("viewer.js").contains("setSnapshotLoading(true)") &&
+        assetText("viewer.js").contains("data-reloading") &&
+        assetText("serve.css").contains("cp-reload-spin"),
+      "snapshot overrides fade the current preview and show a spinner while re-rendering",
     )
     // During an active Live (stream), the override map sent over the WebSocket must carry the knob
     // values too (as knob.<key> entries), not just the display fields — otherwise the daemon resets

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>loading-spinner.json — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>watchface.rc — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Share a document — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Design systems — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -117,6 +117,8 @@ function runThemeQueue(queue, gen) {
       setTimeout(function () { runThemeQueue(queue, gen); }, 1500);
       return;
     }
+    job.card.classList.remove("cp-reloading");
+    job.card.removeAttribute("aria-busy");
     runThemeQueue(queue, gen);
   }
   img.onload = function () { next(true); };
@@ -151,13 +153,20 @@ function applyThemeChoice() {
   themeGen++;
   var themeQueue = [];
   var themeQueueGen = themeGen;
+  cards.forEach(function (c) {
+    c.classList.remove("cp-reloading");
+    c.removeAttribute("aria-busy");
+  });
   if (provider) {
     cards.forEach(function (c, i) {
       if (c.getAttribute("data-swap") === "1") applyVariant(c, c.getAttribute("data-def") || "l", false);
       var img = c.querySelector("img");
       var base = themeBase[i];
       if (!img || !base) return;
+      c.classList.add("cp-reloading");
+      c.setAttribute("aria-busy", "true");
       themeQueue.push({
+        card: c,
         img: img,
         src: base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider),
       });

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Not found — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Playground — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-status.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-status.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Server status — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -290,7 +290,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Focus ring — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -244,7 +244,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>One-handed — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -242,7 +242,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -238,7 +238,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Checkbox · Checked (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -237,7 +237,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -243,7 +243,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -231,7 +231,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -235,7 +235,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -226,7 +226,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8942-a7ec4a9fe9442e11/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -239,7 +239,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/125e0-f3af1cd8adaa119e/viewer.js"></script>
+      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>


### PR DESCRIPTION
## What changed

- fade the current preview and show a centered spinner while override-driven snapshot renders are loading
- apply the same temporary loading treatment to catalog thumbnails while declared themes rerender serially
- mark affected stages and cards with `aria-busy`
- guard snapshot completion with a generation token so rapid edits cannot let stale requests replace newer results
- regenerate serve-page fixtures for the updated asset fingerprints

## Why

Override and declared-theme renders can take noticeable time. Previously the existing pixels remained unchanged with little visible feedback, making controls appear unresponsive. The loading treatment preserves visual context while clearly indicating that replacement pixels are on the way.

## Validation

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'`
- `node --check cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js`
- `git diff --check`