### PR TITLE
fix(catalog): avoid refolding same-function axes

### DIFF
--- a/scripts/design-artifacts/catalog-preview-axes.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-axes.test.mjs
@@ -135,3 +135,34 @@ test("equal display params do not collapse distinct synthetic states", () => {
   assert.equal(candidates[0].images.length, 1);
   assert.equal(candidates[1].images.length, 1);
 });
+
+test("an explicit same-function font-scale variant is not folded twice", () => {
+  const candidates = [
+    candidate("Feed_Default"),
+    candidate("Feed_LargeFont"),
+  ];
+  const previews = [
+    { id: "Feed_Default", params: { widthDp: 412, fontScale: 1 } },
+    { id: "Feed_LargeFont", params: { widthDp: 412, fontScale: 2 } },
+  ];
+
+  applyCatalogPreviewAxes(candidates, previews);
+  const images = candidates.flatMap((entry) => entry.images);
+  const byFunction = new Map([["FeedScreenPreview", { images }]]);
+
+  const { ideal, missing } = foldVariants(
+    images,
+    {
+      componentId: "Screens/Feed",
+      variants: [{ props: { fontScale: 2 }, preview: "FeedScreenPreview" }],
+    },
+    byFunction,
+  );
+
+  assert.deepEqual(missing, []);
+  assert.equal(ideal.length, 2);
+  assert.deepEqual(
+    ideal.map((image) => image.props?.fontScale),
+    [undefined, "2.0"],
+  );
+});

--- a/scripts/design-artifacts/catalog-variants.mjs
+++ b/scripts/design-artifacts/catalog-variants.mjs
@@ -60,6 +60,19 @@ export function foldVariants(defaultImages, component, byFunction) {
       else missing.push(label);
       continue;
     }
+    // A single @Preview function can fan out into multiple images whose axes are promoted from
+    // annotation parameters before this fold (fontScale is the first such axis). When the spec
+    // explicitly names that same function as a variant, the matching image is already present in
+    // `defaultImages`. Folding the whole merged candidate again would retag every image with the
+    // variant axes and create duplicate output keys. Treat an already-tagged image as satisfying
+    // the same-function variant; variants backed by a different function still retain the
+    // authoritative re-tagging behavior below.
+    if (
+      candidate.images === defaultImages &&
+      defaultImages.some((image) => imageHasVariantAxes(image, variant))
+    ) {
+      continue;
+    }
     for (const image of candidate.images) {
       const tagged = { ...image };
       if (variant.state !== undefined) tagged.state = variant.state;
@@ -70,6 +83,35 @@ export function foldVariants(defaultImages, component, byFunction) {
     }
   }
   return { ideal, missing, noSticker };
+}
+
+function imageHasVariantAxes(image, variant) {
+  let hasExplicitAxis = false;
+  if (variant.state !== undefined) {
+    hasExplicitAxis = true;
+    if ((image.state ?? "default") !== variant.state) return false;
+  }
+  if (variant.theme !== undefined) {
+    hasExplicitAxis = true;
+    if (image.theme !== variant.theme) return false;
+  }
+  for (const [key, expected] of Object.entries(variant.props ?? {})) {
+    hasExplicitAxis = true;
+    if (!axisValueEquals(key, image.props?.[key], expected)) return false;
+  }
+  return hasExplicitAxis;
+}
+
+function axisValueEquals(key, actual, expected) {
+  if (Object.is(actual, expected)) return true;
+  if (key !== "fontScale") return false;
+  const actualNumber = Number(actual);
+  const expectedNumber = Number(expected);
+  return (
+    Number.isFinite(actualNumber) &&
+    Number.isFinite(expectedNumber) &&
+    actualNumber === expectedNumber
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- treat a same-function catalog variant as satisfied when its axes are already present on a promoted image
- preserve authoritative retagging for variants backed by a different preview function
- add regression coverage for explicit `props.fontScale` variants sharing their base function

## Root cause

PR #3145 promotes non-default preview font scales before candidates are merged by function. An explicit variant that referenced the same function then folded that merged candidate again, retagging every image and producing duplicate output axes.

This follow-up consumes the already-promoted matching image once instead of re-folding the entire same-function candidate.

Addresses https://github.com/yschimke/compose-ai-tools/pull/3145#discussion_r3695646136

## Validation

- `node --test catalog-*.test.mjs bridge-live-preview-ids.test.mjs` — 145 passed
- focused preview-axis and variant-fold tests — 20 passed
- `git diff --check`
- broad `npm test` passed all tests reached; browser-render cases could not complete locally because Playwright Chromium is not installed
