### PR TITLE
fix(serve): prioritize visible theme renders

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -963,6 +963,13 @@ object ServeWeb {
     // Under a DECLARED theme a swap card keeps its server-side default variant's metadata (label /
     // id / viewer link / stage backing, from `data-def`) — only the pixels come from the themed
     // render — so picking a theme never silently flips the light/dark axis too.
+    val correctInitialThemeVisibility =
+      if (hasTabs)
+        "\n            var themeSection = c.closest(\".cp-section\");" +
+          "\n            if (themeVisible && themeSection && (!input || input.value.trim() === \"\")) {" +
+          "\n              themeVisible = themeSection.getAttribute(\"data-section\") === current;" +
+          "\n            }"
+      else ""
     val applyDeclaredTheme =
       if (hasDeclaredThemes)
         """
@@ -989,9 +996,11 @@ object ServeWeb {
               src: base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider),
             };
             // A tabbed catalog's hidden cards can take several daemon renders before the visitor
-            // sees any response to their click. Render the cards visible in the active tab/search
-            // first, then finish the rest of the catalog without changing the one-at-a-time gate.
-            (c.hidden ? themeDeferredQueue : themeQueue).push(job);
+            // sees any response to their click. On initial load c.hidden is not assigned yet, so
+            // also compare the card's section with the saved current tab. During a live search the
+            // existing hidden state already spans tabs and remains authoritative.
+            var themeVisible = !c.hidden;$correctInitialThemeVisibility
+            (themeVisible ? themeQueue : themeDeferredQueue).push(job);
           });
           themeQueue = themeQueue.concat(themeDeferredQueue);
           runThemeQueue(themeQueue, themeQueueGen);

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -969,6 +969,7 @@ object ServeWeb {
         var provider = theme.indexOf("theme:") === 0 ? theme.slice(6) : "";
         themeGen++;
         var themeQueue = [];
+        var themeDeferredQueue = [];
         var themeQueueGen = themeGen;
         cards.forEach(function (c) {
           c.classList.remove("cp-reloading");
@@ -982,12 +983,17 @@ object ServeWeb {
             if (!img || !base) return;
             c.classList.add("cp-reloading");
             c.setAttribute("aria-busy", "true");
-            themeQueue.push({
+            var job = {
               card: c,
               img: img,
               src: base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider),
-            });
+            };
+            // A tabbed catalog's hidden cards can take several daemon renders before the visitor
+            // sees any response to their click. Render the cards visible in the active tab/search
+            // first, then finish the rest of the catalog without changing the one-at-a-time gate.
+            (c.hidden ? themeDeferredQueue : themeQueue).push(job);
           });
+          themeQueue = themeQueue.concat(themeDeferredQueue);
           runThemeQueue(themeQueue, themeQueueGen);
           return;
         }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1106,7 +1106,7 @@ class ServeWebFixtureTest {
     // serially (each queued, the next started on the previous image's load) with one delayed retry
     // — otherwise a grid-sized burst would leave most cards on their pre-theme pixels.
     assertTrue(
-      landingDeclaredThemes.contains("themeQueue.push({") &&
+      landingDeclaredThemes.contains("var job = {") &&
         landingDeclaredThemes.contains("runThemeQueue(themeQueue, themeQueueGen)") &&
         landingDeclaredThemes.contains("job.src = job.src + \"&_retry=1\""),
       "themed renders are fetched serially with a retry, not fired as one burst",
@@ -1116,6 +1116,14 @@ class ServeWebFixtureTest {
         landingDeclaredThemes.contains("job.card.classList.remove(\"cp-reloading\")") &&
         landingDeclaredThemes.contains("c.setAttribute(\"aria-busy\", \"true\")"),
       "themed cards expose a busy treatment until each replacement thumbnail settles",
+    )
+    // Issue #3160: when the visitor is on a later tab, its visible cards must lead the serial
+    // daemon queue. Otherwise every hidden Theme/Component card renders before the selected tab's
+    // first image request, making the theme control appear to do nothing.
+    assertTrue(
+      landingDeclaredThemes.contains("(c.hidden ? themeDeferredQueue : themeQueue).push(job)") &&
+        landingDeclaredThemes.contains("themeQueue = themeQueue.concat(themeDeferredQueue)"),
+      "visible cards are rendered before hidden cards after a declared-theme change",
     )
     // Re-pointing runs only when the theme itself changed, so a search keystroke (which also calls
     // apply()) never restarts an in-flight themed-render queue.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -702,6 +702,17 @@ class ServeWebFixtureTest {
         basePath = "/meshcore-mobile",
         version = version,
       )
+    // A tabbed declared-theme catalog exercises initial queue priority before apply() has assigned
+    // each card's hidden state (for a returning visitor whose saved tab is not the first one).
+    val landingDeclaredTabbedThemes =
+      ServeWeb.landingPage(
+        "meshcore-mobile",
+        sectionedPreviews,
+        token,
+        sessionId = "meshcore-mobile",
+        declaredThemes = listOf(ServeTheme("Brand Dark", "com.example.BrandDarkThemeCatalog")),
+        canRenderThemeFor = { true },
+      )
     // The default-state viewer for that catalog: renders the `<nav class="cp-states">` switcher of
     // links to the component's other same-theme states, the current (Default) state marked active.
     val viewerStates =
@@ -1121,9 +1132,14 @@ class ServeWebFixtureTest {
     // daemon queue. Otherwise every hidden Theme/Component card renders before the selected tab's
     // first image request, making the theme control appear to do nothing.
     assertTrue(
-      landingDeclaredThemes.contains("(c.hidden ? themeDeferredQueue : themeQueue).push(job)") &&
-        landingDeclaredThemes.contains("themeQueue = themeQueue.concat(themeDeferredQueue)"),
-      "visible cards are rendered before hidden cards after a declared-theme change",
+      landingDeclaredTabbedThemes.contains(
+        "(themeVisible ? themeQueue : themeDeferredQueue).push(job)"
+      ) &&
+        landingDeclaredTabbedThemes.contains(
+          "themeVisible = themeSection.getAttribute(\"data-section\") === current"
+        ) &&
+        landingDeclaredTabbedThemes.contains("themeQueue = themeQueue.concat(themeDeferredQueue)"),
+      "current-tab cards are rendered first, including before hidden state is initialized",
     )
     // Re-pointing runs only when the theme itself changed, so a search keystroke (which also calls
     // apply()) never restarts an in-flight themed-render queue.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -152,6 +152,7 @@ function applyThemeChoice() {
   var provider = theme.indexOf("theme:") === 0 ? theme.slice(6) : "";
   themeGen++;
   var themeQueue = [];
+  var themeDeferredQueue = [];
   var themeQueueGen = themeGen;
   cards.forEach(function (c) {
     c.classList.remove("cp-reloading");
@@ -165,12 +166,17 @@ function applyThemeChoice() {
       if (!img || !base) return;
       c.classList.add("cp-reloading");
       c.setAttribute("aria-busy", "true");
-      themeQueue.push({
+      var job = {
         card: c,
         img: img,
         src: base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider),
-      });
+      };
+      // A tabbed catalog's hidden cards can take several daemon renders before the visitor
+      // sees any response to their click. Render the cards visible in the active tab/search
+      // first, then finish the rest of the catalog without changing the one-at-a-time gate.
+      (c.hidden ? themeDeferredQueue : themeQueue).push(job);
     });
+    themeQueue = themeQueue.concat(themeDeferredQueue);
     runThemeQueue(themeQueue, themeQueueGen);
     return;
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -172,9 +172,11 @@ function applyThemeChoice() {
         src: base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider),
       };
       // A tabbed catalog's hidden cards can take several daemon renders before the visitor
-      // sees any response to their click. Render the cards visible in the active tab/search
-      // first, then finish the rest of the catalog without changing the one-at-a-time gate.
-      (c.hidden ? themeDeferredQueue : themeQueue).push(job);
+      // sees any response to their click. On initial load c.hidden is not assigned yet, so
+      // also compare the card's section with the saved current tab. During a live search the
+      // existing hidden state already spans tabs and remains authoritative.
+      var themeVisible = !c.hidden;
+      (themeVisible ? themeQueue : themeDeferredQueue).push(job);
     });
     themeQueue = themeQueue.concat(themeDeferredQueue);
     runThemeQueue(themeQueue, themeQueueGen);


### PR DESCRIPTION
## Summary

- prioritize cards visible in the active tab/search when applying a declared theme
- preserve the daemon's serialized render queue, delayed retry, and completion of hidden cards
- update the generated landing-page fixture and add a regression assertion

## Root cause

Declared-theme renders are intentionally serialized because the preview daemon renders one image at a time. The queue followed document order, so on later tabs it rendered hidden Theme and Component cards before the cards the visitor could see. The selected theme changed immediately, but visible image requests could be delayed long enough to look like no refresh happened.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebFixtureTest`
- reproduced against the live Confetti catalog by selecting KotlinConf Dark and observing the document-order queue delay

There is no static layout/pixel change: this only changes request priority after an existing theme control is selected.

Closes #3160