### PR TITLE
fix(serve): explain disabled playground on preview hosts

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -421,13 +421,19 @@ class ServeHttpServer(
         // path segment (e.g. `/api/1/compiler/run`) which we capture and ignore. The constant
         // `/api`
         // first segment outscores the `/{system}` catch-all. Never registered under `--public`.
-        playgroundService?.let { svc ->
+        if (playgroundService != null) {
+          val svc = playgroundService
           post("/api/{version}/compiler/run") { handlePlaygroundRun(svc) }
           // The Stage-1 editor page (`GET /playground`): the browser surface that POSTs to the run
           // route above and surfaces the diagnostics + first-frame + `/pg/` (live) or `/d/` (RC)
           // handoff. Only mounted when the lane is enabled, and — like the lane — never under
           // `--public`.
           get("/playground") { handlePlaygroundPage(svc) }
+        } else {
+          // Reserve the well-known page path even when the compile lane is disabled. Otherwise
+          // public catalog hosts route `/playground` through the `/{system}` catch-all and report
+          // that a design system named "playground" does not exist.
+          get("/playground") { handlePlaygroundDisabledPage() }
         }
 
         // Stage-2 redemption (`GET /pg/<token>`): redeem a preview token into a live streamed
@@ -827,6 +833,19 @@ class ServeHttpServer(
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
       ),
       ContentType.Text.Html,
+    )
+  }
+
+  private suspend fun RoutingContext.handlePlaygroundDisabledPage() {
+    markGeneration("static-page", DYNAMIC_RESOURCE_CACHE_CONTROL)
+    call.respondText(
+      ServeWeb.playgroundDisabledPage(
+        token = token,
+        isPublic = isPublic,
+        unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
+      ),
+      ContentType.Text.Html,
+      HttpStatusCode.ServiceUnavailable,
     )
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1759,6 +1759,34 @@ object ServeWeb {
     """
       .trimIndent()
 
+  fun playgroundDisabledPage(
+    token: String,
+    isPublic: Boolean,
+    unfurl: UnfurlMetadata? = null,
+  ): String {
+    val suffix = querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
+    return document(
+      title = "Playground unavailable — compose-preview",
+      unfurlDescription = "The playground is not enabled on this server.",
+      unfurl = unfurl,
+      body =
+        """
+        <h1 class="cp-head">Playground unavailable</h1>
+        <p class="cp-sub">
+          This server was started without a playground bundle, so it can browse design systems and
+          run live previews but cannot compile playground snippets.
+        </p>
+        <p class="cp-sub">
+          Configure <code>--playground-bundle</code> or
+          <code>--playground-android-bundle</code>, and on public servers also configure
+          <code>--playground-sandbox</code>.
+        </p>
+        <a class="cp-back" href="/$suffix">← All design systems</a>
+        """
+          .trimIndent(),
+    )
+  }
+
   /** The `<option>` value + label for a playground mode in the editor's selector. */
   private fun playgroundModeChoice(mode: PlaygroundMode): Pair<String, String> =
     when (mode) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -177,8 +177,15 @@ class PlaygroundRoutingTest {
   }
 
   @Test
-  fun `the editor page is absent when the playground lane isn't enabled`() {
-    get("/playground", plainServer.port).use { resp -> assertEquals(404, resp.code) }
+  fun `the editor page explains when the playground lane isn't enabled`() {
+    get("/playground", plainServer.port).use { resp ->
+      assertEquals(503, resp.code)
+      assertEquals("no-store", resp.header("Cache-Control"))
+      assertTrue(
+        resp.body!!.string().contains("Playground unavailable"),
+        "the reserved playground path explains the missing server config",
+      )
+    }
   }
 
   @Test

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -87,6 +87,22 @@ The compose profile derives the callback base URL from `DOMAIN`; set
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL` to override. Empty `SERVE_GITHUB_AUTH_USERS` allows any
 signed-in GitHub user; set it to a comma-separated login list to narrow access.
 
+### Playground on `preview.coo.ee`
+
+`/playground` is disabled unless the preview service is started with a catalog live bundle that can
+seed the snippet classpath. Add one or both bundle paths to `.env`; on public hosts also set a
+sandbox profile that passes startup preflight:
+
+```bash
+SERVE_PLAYGROUND_BUNDLE=/config/playground-cmp.bundle
+SERVE_PLAYGROUND_ANDROID_BUNDLE=/config/playground-android.bundle
+SERVE_PLAYGROUND_SANDBOX=bwrap
+SERVE_PLAYGROUND_COMPILE_SLOTS=1
+```
+
+If these are missing, `/playground` returns a styled “Playground unavailable” page instead of
+falling through as a missing design system.
+
 ## Auto-updates (zero-downtime)
 
 Updates are **rolling** — existing traffic keeps being served on the old

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -99,6 +99,18 @@ services:
       SERVE_CATALOG_SOURCE_REPO: "${SERVE_CATALOG_SOURCE_REPO:-}"
       SERVE_CATALOG_SOURCE_REF: "${SERVE_CATALOG_SOURCE_REF:-}"
       SERVE_LIVE_SEATS: "${SERVE_LIVE_SEATS:-}"
+      # Playground compile lane. Off by default: it runs visitor-supplied Kotlin and needs both a
+      # catalog liveBundle classpath plus a sandbox profile on public hosts. Set the bundle path(s)
+      # to local files available inside the container, for example a bind mount under /config.
+      SERVE_PLAYGROUND_BUNDLE: "${SERVE_PLAYGROUND_BUNDLE:-}"
+      SERVE_PLAYGROUND_ANDROID_BUNDLE: "${SERVE_PLAYGROUND_ANDROID_BUNDLE:-}"
+      SERVE_PLAYGROUND_SANDBOX: "${SERVE_PLAYGROUND_SANDBOX:-}"
+      SERVE_PLAYGROUND_SANDBOX_MEMORY_MB: "${SERVE_PLAYGROUND_SANDBOX_MEMORY_MB:-}"
+      SERVE_PLAYGROUND_SANDBOX_CPUS: "${SERVE_PLAYGROUND_SANDBOX_CPUS:-}"
+      SERVE_PLAYGROUND_SANDBOX_PIDS: "${SERVE_PLAYGROUND_SANDBOX_PIDS:-}"
+      SERVE_PLAYGROUND_SANDBOX_TTL: "${SERVE_PLAYGROUND_SANDBOX_TTL:-}"
+      SERVE_PLAYGROUND_SANDBOX_RO: "${SERVE_PLAYGROUND_SANDBOX_RO:-}"
+      SERVE_PLAYGROUND_COMPILE_SLOTS: "${SERVE_PLAYGROUND_COMPILE_SLOTS:-}"
       # Re-check each catalog's design-artifacts branch every N seconds and re-fetch on change, so a
       # regenerated branch reaches this running server without a restart (Watchtower only rolls the
       # image). Empty ⇒ the CLI default (600s); set 0 to disable and serve the boot snapshot only.

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -196,6 +196,29 @@ if [[ "${SERVE_ALLOW_RENDER_TRUSTED}" == "1" || "${SERVE_ALLOW_RENDER_TRUSTED}" 
     args+=(--catalog-source-root "${src_root}")
   fi
 fi
+
+# Playground compile lane. Off by default because it compiles and runs visitor-supplied Kotlin.
+# A public server must set a sandbox profile that passes the CLI preflight, otherwise serve refuses
+# the lane and `/playground` shows an explanatory disabled page.
+[[ -n "${SERVE_PLAYGROUND_BUNDLE:-}" ]] &&
+  args+=(--playground-bundle "${SERVE_PLAYGROUND_BUNDLE}")
+[[ -n "${SERVE_PLAYGROUND_ANDROID_BUNDLE:-}" ]] &&
+  args+=(--playground-android-bundle "${SERVE_PLAYGROUND_ANDROID_BUNDLE}")
+[[ -n "${SERVE_PLAYGROUND_SANDBOX:-}" ]] &&
+  args+=(--playground-sandbox "${SERVE_PLAYGROUND_SANDBOX}")
+[[ -n "${SERVE_PLAYGROUND_SANDBOX_MEMORY_MB:-}" ]] &&
+  args+=(--playground-sandbox-memory-mb "${SERVE_PLAYGROUND_SANDBOX_MEMORY_MB}")
+[[ -n "${SERVE_PLAYGROUND_SANDBOX_CPUS:-}" ]] &&
+  args+=(--playground-sandbox-cpus "${SERVE_PLAYGROUND_SANDBOX_CPUS}")
+[[ -n "${SERVE_PLAYGROUND_SANDBOX_PIDS:-}" ]] &&
+  args+=(--playground-sandbox-pids "${SERVE_PLAYGROUND_SANDBOX_PIDS}")
+[[ -n "${SERVE_PLAYGROUND_SANDBOX_TTL:-}" ]] &&
+  args+=(--playground-sandbox-ttl "${SERVE_PLAYGROUND_SANDBOX_TTL}")
+[[ -n "${SERVE_PLAYGROUND_SANDBOX_RO:-}" ]] &&
+  args+=(--playground-sandbox-ro "${SERVE_PLAYGROUND_SANDBOX_RO}")
+[[ -n "${SERVE_PLAYGROUND_COMPILE_SLOTS:-}" ]] &&
+  args+=(--playground-compile-slots "${SERVE_PLAYGROUND_COMPILE_SLOTS}")
+
 # Bound concurrent live (daemon-backed) stream sessions by a PERMIT BUDGET — each live session
 # charges permits by backend weight (a desktop CMP daemon = 1, a heavier Robolectric Android one = 2,
 # see LiveSeatLimiter), so one heavy catalog can't hog a flat seat count and starve the cheap CMP


### PR DESCRIPTION
## Summary
- reserve /playground even when the playground compile lane is disabled, returning a styled 503 instead of falling through as a missing design system
- mark the disabled playground response no-store so later config changes are not masked by cached HTML
- wire deploy/image environment variables through to the serve playground flags and document preview.coo.ee configuration
- keep live preview available to any signed-in GitHub user, but require GitHub repo access for playground page/run/redeem

## Testing
- ./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.PlaygroundRoutingTest --tests ee.schimke.composeai.cli.serve.ServeAuthTest
- ./gradlew :cli:ktfmtCheck