### PR TITLE
fix(figma-svg): remove orphaned raster references

### DIFF
--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -671,8 +671,14 @@ data class FigmaSvgModel(
               it.bottom > extent.minY &&
               it.top < extent.maxY)
         }
+      // Filtering only the write targets strands the corresponding `<image href>` in the layer
+      // tree: the producer correctly skips the crop, but the published SVG still requests it. This
+      // happened for every below-fold Image in a clamped lazy screen (issue #3147). Remove only the
+      // raster paint whose target was dropped; keep the layer's vector shape/text/children intact.
+      val retainedRasterHrefs = targets.mapTo(mutableSetOf()) { it.href }
+      val retainedRoot = rootLayer.withRasterHrefs(retainedRasterHrefs)
       return FigmaSvgModel(
-        root = rootLayer,
+        root = retainedRoot,
         minX = extent.minX,
         minY = extent.minY,
         width = (extent.maxX - extent.minX) + padding * 2,
@@ -685,6 +691,13 @@ data class FigmaSvgModel(
         backgroundRect = backgroundRect,
       )
     }
+
+    private fun FigmaSvgLayer.withRasterHrefs(retained: Set<String>): FigmaSvgLayer =
+      copy(
+        raster = raster?.takeIf { it.href in retained },
+        background = background?.takeIf { it.href in retained },
+        children = children.map { it.withRasterHrefs(retained) },
+      )
 
     /** Build inputs + the accumulating raster-target list, threaded through the walk. */
     private class BuildContext(

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgOffscreenItemTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgOffscreenItemTest.kt
@@ -130,4 +130,48 @@ class FigmaSvgOffscreenItemTest {
       )
     }
   }
+
+  @Test
+  fun offscreenRasterLayersAreRemovedWithTheirDroppedTargets() {
+    val screen =
+      LayoutInspectorNode(
+        nodeId = "screen",
+        component = "Box",
+        bounds = bounds(0, 0, 400, 800),
+        size = LayoutInspectorSize(400, 800),
+        tokens = ComposeSemanticsTokens(backgroundColor = "#FFFFFFFF"),
+        children =
+          listOf(
+            LayoutInspectorNode(
+              nodeId = "visible-photo",
+              component = "Image",
+              bounds = bounds(24, 52, 144, 172),
+              size = LayoutInspectorSize(120, 120),
+            ),
+            LayoutInspectorNode(
+              nodeId = "below-fold-photo",
+              component = "Image",
+              bounds = bounds(24, 900, 144, 1020),
+              size = LayoutInspectorSize(120, 120),
+            ),
+          ),
+      )
+    val model =
+      FigmaSvgModel.from(
+        layout = LayoutInspectorPayload(screen),
+        density = 1f,
+        rasterComponents = FigmaSvgModel.DEFAULT_RASTER_COMPONENTS,
+        frameWidthPx = 400,
+        frameHeightPx = 800,
+      )
+
+    val svg = FigmaLayeredSvg.render(model)
+    val referenced = Regex("""href="([^"]+)"""").findAll(svg).map { it.groupValues[1] }.toList()
+    assertEquals(listOf("figma-raster/visible_photo.png"), referenced)
+    assertEquals(referenced, model.rasterTargets.map { it.href })
+    assertTrue(
+      "the offscreen crop must not remain as a dangling href:\n$svg",
+      "figma-raster/below_fold_photo.png" !in svg,
+    )
+  }
 }


### PR DESCRIPTION
## What changed

- remove raster paint from the SVG layer tree whenever its off-canvas crop target is filtered out
- preserve the layer's vector shape, text, and children
- add a regression test covering visible and below-fold images in a frame-clamped screen

## Root cause

The Figma SVG model filtered off-canvas raster write targets, but left the corresponding `<image href>` nodes in the rendered layer tree. Catalog packaging copied every retained crop correctly, while those orphaned SVG references requested PNGs that could never exist.

## Validation

- `./gradlew :data-layoutinspector-core:test --no-daemon`
- `./gradlew :data-layoutinspector-core:ktfmtCheck --no-daemon`

Closes #3147