### PR TITLE
fix(theme): resolve bundle compose resources

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -639,6 +639,8 @@ internal object ServeBundleDaemon {
    */
   internal fun shouldPrecedeDaemonSidecar(coordinate: BundleReader.ClasspathEntry.Maven): Boolean =
     coordinate.group.startsWith("androidx.") ||
+      (coordinate.group == "org.jetbrains.compose.components" &&
+        coordinate.artifact.startsWith("components-resources")) ||
       (coordinate.group == "org.jetbrains.kotlinx" &&
         coordinate.artifact.startsWith("kotlinx-coroutines"))
 
@@ -648,12 +650,15 @@ internal object ServeBundleDaemon {
    * only the resolved files (the coordinates were dropped during catalog resolution). Both the
    * Maven-local (`…/androidx/compose/…`) and Gradle-cache (`…/androidx.compose.material3/…`)
    * layouts put the dotted/slashed group right after a path separator, so a `/androidx` segment
-   * identifies the AndroidX graph and `kotlinx-coroutines` the coroutines artifacts — the two
-   * namespaces `UserClassLoaderHolder` delegates to the daemon parent.
+   * identifies the AndroidX graph, `components-resources` the Compose resources runtime, and
+   * `kotlinx-coroutines` the coroutines artifacts — the namespaces `UserClassLoaderHolder`
+   * delegates to the daemon parent.
    */
   internal fun jarPrecedesDaemonSidecar(jar: File): Boolean {
     val path = jar.path.replace('\\', '/')
-    return path.contains("/androidx") || path.contains("kotlinx-coroutines")
+    return path.contains("/androidx") ||
+      path.contains("components-resources") ||
+      path.contains("kotlinx-coroutines")
   }
 
   private data class ResolvedBundleDependency(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -100,6 +100,12 @@ class ServeBundleDaemonTest {
       )
     )
     assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("org.jetbrains.compose.components", "components-resources")
+      ),
+      "bundle resource APIs must share the parent-loaded LocalResourceReader with the daemon",
+    )
+    assertTrue(
       !ServeBundleDaemon.shouldPrecedeDaemonSidecar(
         coordinate("org.jetbrains.kotlinx", "kotlinx-serialization-json-jvm")
       ),
@@ -107,6 +113,15 @@ class ServeBundleDaemonTest {
     )
     assertTrue(
       !ServeBundleDaemon.shouldPrecedeDaemonSidecar(coordinate("com.squareup.okhttp3", "okhttp"))
+    )
+  }
+
+  @Test
+  fun `playground resource runtime overlays daemon sidecar`() {
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/cache/org.jetbrains.compose.components/components-resources-desktop/library.jar")
+      )
     )
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
@@ -165,11 +165,10 @@ class UserClassLoaderHolder(
    *
    * **Shared process-static bridges are forced to the parent even when the child's URLs carry
    * them.** [mustDelegateToParent] lists the framework packages *plus*
-   * `ee.schimke.composeai.daemon.*` and `ee.schimke.composeai.overrides.*` — the latter is the
-   * `previewOverride*` named-override runtime, whose `PreviewOverrideController` static the daemon
-   * seeds and the preview reads. On the bundle-backed live daemon the runtime jar is on the child's
-   * URLs, so a bare child-first lookup would load a *second* copy and split the shared static; the
-   * explicit delegation keeps it a singleton. See [mustDelegateToParent] for the full rationale.
+   * `org.jetbrains.compose.resources.*`, `ee.schimke.composeai.daemon.*`, and
+   * `ee.schimke.composeai.overrides.*`. These packages expose composition locals or process-static
+   * bridges shared between the daemon and preview, so a child-loaded copy would split that shared
+   * state. See [mustDelegateToParent] for the full rationale.
    *
    * **Loaded-class cache discipline.** The JVM's `findLoadedClass` is checked first so a user class
    * loaded via the child stays the same `Class<?>` instance for repeated lookups within the
@@ -216,12 +215,14 @@ class UserClassLoaderHolder(
      *    Skiko, etc. Punching holes in the JDK packages would break the JVM's bootstrap invariants,
      *    and the Compose/AndroidX runtime must be the *one* copy the parent bootstrapped
      *    (child-loading it would fail on classloader-identity skew).
-     * 2. **Process-static bridges shared with the daemon** — `ee.schimke.composeai.daemon.*` (the
-     *    cross-classloader handoff queues) and `ee.schimke.composeai.overrides.*` (the
-     *    `previewOverride*` named-override runtime: `PreviewOverrideController` is a process-static
-     *    the daemon's connector seeds *before* the preview composes, and the preview reads it back
-     *    during composition). These only work when the daemon and the user preview see the **same**
-     *    `Class<?>` — one shared static, not two per-classloader copies.
+     * 2. **Composition locals / process-static bridges shared with the daemon** —
+     *    `org.jetbrains.compose.resources.*` (the `LocalResourceReader` provided by the renderer),
+     *    `ee.schimke.composeai.daemon.*` (the cross-classloader handoff queues), and
+     *    `ee.schimke.composeai.overrides.*` (the `previewOverride*` named-override runtime:
+     *    `PreviewOverrideController` is a process-static the daemon's connector seeds *before* the
+     *    preview composes, and the preview reads it back during composition). These only work when
+     *    the daemon and the user preview see the **same** `Class<?>` — one shared static, not two
+     *    per-classloader copies.
      *
      * The overrides runtime is the load-bearing case for the **bundle-backed live daemon**
      * (`ServeBundleDaemon`, the engine behind `--catalogs` `liveBundle` / `preview.coo.ee`): there
@@ -246,6 +247,7 @@ class UserClassLoaderHolder(
         name.startsWith("org.robolectric.") ||
         name.startsWith("com.github.takahirom.roborazzi.") ||
         name.startsWith("org.jetbrains.skia.") ||
+        name.startsWith("org.jetbrains.compose.resources.") ||
         name.startsWith("ee.schimke.composeai.daemon.") ||
         name.startsWith("ee.schimke.composeai.overrides.")
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolderTest.kt
@@ -138,6 +138,13 @@ class UserClassLoaderHolderTest {
     assertTrue(UserClassLoaderHolder.mustDelegateToParent("kotlin.Unit"))
     assertTrue(UserClassLoaderHolder.mustDelegateToParent("androidx.compose.runtime.Composer"))
     assertTrue(UserClassLoaderHolder.mustDelegateToParent("org.jetbrains.skia.Image"))
+    // LocalResourceReader is provided by the parent-loaded renderer and consumed by bundle code.
+    // Both sides must see the same composition-local key rather than one copy per classloader.
+    assertTrue(
+      UserClassLoaderHolder.mustDelegateToParent(
+        "org.jetbrains.compose.resources.LocalResourceReaderKt"
+      )
+    )
     // Cross-classloader process-static bridges shared with the daemon.
     assertTrue(
       UserClassLoaderHolder.mustDelegateToParent(

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -138,6 +138,11 @@ dependencies {
   // rendered content, so a `PreviewSlot` marker draws a placeholder when `slotMode` is set.
   implementation(project(":slot-preview-runtime"))
 
+  // Bundle previews keep generated composeResources on the disposable user classloader. The
+  // daemon provides a JvmResourceReader for that loader around every composition so CMP resource
+  // lookups do not fall back to components-resources' parent-classloader-bound default reader.
+  implementation(libs.jetbrains.compose.components.resources)
+
   // Compose runtime / foundation / ui — the B-desktop.1.4 RenderEngine body
   // imports `ImageComposeScene`, `@Composable`, `currentComposer`,
   // `getDeclaredComposableMethod`, and a few Modifier / layout helpers.

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -58,6 +58,10 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okio.FileSystem
 import okio.Path.Companion.toPath
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.JvmResourceReader
+import org.jetbrains.compose.resources.LocalResourceReader
+import org.jetbrains.compose.resources.ResourceReader
 import org.jetbrains.skia.EncodedImageFormat
 
 /**
@@ -220,7 +224,7 @@ class RenderEngine(
    * inspection branch. Interactive sessions pass `false` so `pointerInput` modifiers fire and the
    * preview shows its real, click-aware behaviour.
    */
-  @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+  @OptIn(androidx.compose.ui.InternalComposeUiApi::class, ExperimentalResourceApi::class)
   fun setUp(
     spec: RenderSpec,
     classLoader: ClassLoader =
@@ -386,8 +390,17 @@ class RenderEngine(
               RenderSpec.SpecUiMode.LIGHT -> SystemTheme.Light
               null -> SystemTheme.Unknown
             }
+          val previewResources = remember(classLoader) { previewResourceReader(classLoader) }
           CompositionLocalProvider(
             LocalInspectionMode provides inspectionMode,
+            // Compose Resources' desktop default reader is permanently bound to the classloader
+            // that loaded components-resources (the daemon parent). Bundle classes and their
+            // composeResources payload live only on this render's disposable child loader, so an
+            // unqualified stringResource() lookup can otherwise miss a resource that is visibly
+            // present beside the preview classes. Point the public reader local at the same child
+            // loader used to invoke the preview; unlike the thread context-loader install above,
+            // Compose Resources actually consults this value.
+            LocalResourceReader provides previewResources,
             // Slot mode: a `PreviewSlot` marker renders a labelled placeholder instead of its
             // content, so a structured-screen builder gets a visible slot map. Defaults false.
             ee.schimke.composeai.preview.slots.LocalSlotMode provides (spec.slotMode ?: false),
@@ -1453,6 +1466,11 @@ class RenderEngine(
     }
   }
 }
+
+/** A Compose Resources reader whose lookup scope matches the preview's disposable classloader. */
+@OptIn(ExperimentalResourceApi::class)
+internal fun previewResourceReader(classLoader: ClassLoader): ResourceReader =
+  JvmResourceReader(classLoader)
 
 /**
  * The flat colour a render paints behind the composable: the per-render "crisp outline" override

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewResourceReaderTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewResourceReaderTest.kt
@@ -1,0 +1,30 @@
+package ee.schimke.composeai.daemon
+
+import java.net.URLClassLoader
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.junit.Assert.assertArrayEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class PreviewResourceReaderTest {
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  @OptIn(ExperimentalResourceApi::class)
+  fun `reader resolves compose resources carried only by preview classloader`() {
+    val resourcePath =
+      "composeResources/com.example.generated.resources/values/strings.commonMain.cvr"
+    val expected = "string|catalog title".encodeToByteArray()
+    val resourceFile = tempFolder.root.toPath().resolve(resourcePath)
+    Files.createDirectories(resourceFile.parent)
+    Files.write(resourceFile, expected)
+
+    URLClassLoader(arrayOf(tempFolder.root.toURI().toURL()), null).use { previewClassLoader ->
+      val actual = runBlocking { previewResourceReader(previewClassLoader).read(resourcePath) }
+      assertArrayEquals(expected, actual)
+    }
+  }
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewResourceReaderTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewResourceReaderTest.kt
@@ -4,7 +4,9 @@ import java.net.URLClassLoader
 import java.nio.file.Files
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.JvmResourceReader
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertSame
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -25,6 +27,26 @@ class PreviewResourceReaderTest {
     URLClassLoader(arrayOf(tempFolder.root.toURI().toURL()), null).use { previewClassLoader ->
       val actual = runBlocking { previewResourceReader(previewClassLoader).read(resourcePath) }
       assertArrayEquals(expected, actual)
+    }
+  }
+
+  @Test
+  @OptIn(ExperimentalResourceApi::class)
+  fun `preview and daemon share the same compose resource API classes`() {
+    val parentClass = JvmResourceReader::class.java
+    val resourceRuntime = parentClass.protectionDomain.codeSource.location
+    val holder =
+      UserClassLoaderHolder(
+        urls = listOf(resourceRuntime),
+        parentSupplier = { parentClass.classLoader },
+      )
+
+    holder.currentChildLoader().use { previewClassLoader ->
+      assertSame(
+        "LocalResourceReader and its implementation must retain one class identity",
+        parentClass,
+        previewClassLoader.loadClass(parentClass.name),
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary

- bind Compose Resources' desktop `LocalResourceReader` to the same disposable child classloader that loads each bundle preview
- keep the reader stable across recompositions
- add regression coverage for a `.cvr` resource available only through the preview classloader

## Root cause

The bundle daemon extracts `classes/app.jar`, including generated `composeResources/**`, onto its disposable user classloader. Compose Resources' desktop default `JvmResourceReader` is instead permanently bound to the daemon parent classloader. Setting the render thread's context classloader does not change that reader, so `stringResource(...)` could throw `MissingResourceException` even though the resource was present in the bundle.

## Impact

Bundle re-theme renders now resolve generated Compose Multiplatform resources from the bundle's own classloader instead of depending on parent-classloader visibility or process cache state.

## Validation

- `./gradlew :daemon:desktop:test`
- `./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.PreviewResourceReaderTest`
- `./gradlew :daemon:desktop:ktfmtFormat`

Closes #3157