### PR TITLE
fix(renderer): stabilize View-backed animated previews

### DIFF
--- a/data/remotecompose/connector/build.gradle.kts
+++ b/data/remotecompose/connector/build.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
   // selecting `player = embedded` there falls back to the view player instead of dying.
   compileOnly(project(":third-party-rc-embedded-player"))
   testImplementation(libs.compose.remote.player.core)
+  testImplementation(libs.compose.remote.core)
 
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
@@ -9,6 +9,8 @@ import androidx.compose.remote.creation.compose.capture.captureSingleRemoteDocum
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.profile.Profile
 import androidx.compose.remote.creation.profile.RcPlatformProfiles
+import androidx.compose.remote.core.RemoteClock
+import androidx.compose.remote.core.SystemClock
 import androidx.compose.remote.player.compose.RemoteDocumentPlayer
 import androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayer
 import androidx.compose.remote.player.core.RemoteDocument
@@ -23,6 +25,8 @@ import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind
 import ee.schimke.composeai.data.render.IrSidecarChannel
 import kotlinx.coroutines.runBlocking
+import java.time.Clock
+import java.time.ZoneId
 
 /**
  * `PreviewWrapperProvider` that bridges `renderNow.overrides.remoteCompose.namedValues` into the
@@ -146,7 +150,7 @@ fun RemoteOverridablePreview(
           // current preview id). Best-effort — never fail the render over IR capture. See
           // IrSidecarChannel.
           runCatching { IrSidecarChannel.offer(IrSidecarChannel.FORMAT_REMOTECOMPOSE, stamped) }
-          RemoteDocument(bytes)
+          remoteDocumentForPreview(bytes)
         }
       }
     }
@@ -186,6 +190,47 @@ fun RemoteOverridablePreview(
         applyConnectorOverrides(remotePlayer.stateUpdater, seededOverrides)
       },
     )
+  }
+}
+
+/**
+ * Builds a player document whose time source is controllable by Robolectric's paused Android
+ * looper. Remote Compose's default [SystemClock] reads `java.time.Clock` / `System.nanoTime()`, so
+ * advancing Compose's test clock (or Robolectric's shadow looper) cannot move it and an animated
+ * View-backed preview is captured at whatever real-time phase the render happens to reach.
+ *
+ * Production keeps the upstream clock unchanged. Under Robolectric, elapsed time starts at zero
+ * when the document is created and advances only with `android.os.SystemClock.uptimeMillis()`. The
+ * animated renderer advances that shadow clock alongside Compose's `mainClock`, giving both the
+ * View-backed and Compose-backed players the same deterministic frame cadence.
+ */
+private fun remoteDocumentForPreview(bytes: ByteArray): RemoteDocument =
+  if (android.os.Build.FINGERPRINT == "robolectric") {
+    RemoteDocument(bytes.inputStream(), RobolectricRemoteClock())
+  } else {
+    RemoteDocument(bytes)
+  }
+
+internal class RobolectricRemoteClock(
+  private val startUptimeMillis: Long = android.os.SystemClock.uptimeMillis(),
+  private val uptimeMillis: () -> Long = android.os.SystemClock::uptimeMillis,
+  private val clockZoneId: ZoneId = ZoneId.of("UTC"),
+) : RemoteClock {
+  private val snapshotClock = SystemClock(Clock.fixed(java.time.Instant.EPOCH, clockZoneId))
+
+  private fun elapsedMillis(): Long = (uptimeMillis() - startUptimeMillis).coerceAtLeast(0L)
+
+  override fun millis(): Long = elapsedMillis()
+
+  override fun nanoTime(): Long = elapsedMillis() * NANOS_PER_MILLISECOND
+
+  override fun getZoneId(): String = clockZoneId.id
+
+  override fun snapshot(epochMillis: Long?): RemoteClock.TimeSnapshot =
+    snapshotClock.snapshot(epochMillis ?: millis())
+
+  private companion object {
+    const val NANOS_PER_MILLISECOND = 1_000_000L
   }
 }
 

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricRemoteClockTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricRemoteClockTest.kt
@@ -1,0 +1,42 @@
+package ee.schimke.composeai.daemon
+
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class RobolectricRemoteClockTest {
+  @Test
+  fun `elapsed time starts at zero and follows shadow uptime`() {
+    var uptimeMillis = 4_200L
+    val clock =
+      RobolectricRemoteClock(
+        startUptimeMillis = uptimeMillis,
+        uptimeMillis = { uptimeMillis },
+        clockZoneId = ZoneId.of("UTC"),
+      )
+
+    assertEquals(0L, clock.millis())
+    assertEquals(0L, clock.nanoTime())
+
+    uptimeMillis += 100L
+
+    assertEquals(100L, clock.millis())
+    assertEquals(100_000_000L, clock.nanoTime())
+    assertEquals("UTC", clock.zoneId)
+    assertNotNull(clock.snapshot(null))
+  }
+
+  @Test
+  fun `elapsed time never moves backwards`() {
+    var uptimeMillis = 99L
+    val clock =
+      RobolectricRemoteClock(
+        startUptimeMillis = 100L,
+        uptimeMillis = { uptimeMillis },
+      )
+
+    assertEquals(0L, clock.millis())
+    assertEquals(0L, clock.nanoTime())
+  }
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -2583,6 +2583,13 @@ private fun handleAnimatedCapture(
     repeat(totalFrames) {
       t += frameIntervalMs.toLong()
       rule.mainClock.advanceTimeBy(frameIntervalMs.toLong())
+      // Compose's test clock does not drive Android Views. Advance Robolectric's paused main
+      // looper by the same interval so View/Choreographer animations land on the same virtual
+      // timestamp as Compose animations. Remote Compose's preview wrapper also derives its
+      // injected player clock from shadowed uptime, avoiding the real System.nanoTime phase drift
+      // that made unchanged animated GIFs differ between renders (issue #3156).
+      org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
+        .idleFor(java.time.Duration.ofMillis(frameIntervalMs.toLong()))
       captureFrame(virtualTimeMs = t)
     }
 


### PR DESCRIPTION
## What changed

- advance Robolectric's paused Android main looper alongside Compose's `mainClock` for each `@AnimatedPreview` frame
- give the View-backed Remote Compose player a Robolectric-only clock derived from shadow uptime instead of real `System.nanoTime()`
- add focused clock regression tests while preserving the upstream system clock in production playback

## Root cause

The animated capture loop controlled Compose virtual time, but Android Views and the Remote Compose View player used separate time sources. The player ultimately read real `java.time.Clock` / `System.nanoTime()`, so unchanged renders sampled different spinner phases.

## Validation

- `:data-remotecompose-connector:testDebugUnitTest`
- `:renderer-android:compileDebugKotlin`
- `:data-remotecompose-connector:ktfmtFormat`
- `:renderer-android:ktfmtFormat`
- two forced renders of `RemoteIndeterminateCircularProgressIndicatorStandardPreview` produced byte-identical GIFs: `4d03e72cc787baa37a45cdd2a67e9d4cfbedb40703e59b0b4aa789a95652c912`; the second render reported unchanged

Closes #3156