### PR TITLE
fix(serve): clear cancelled render status

### DIFF
--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -139,6 +139,7 @@
   }
   function cancelSnapshotLoading() {
     snapshotGen++;
+    status.textContent = "";
     setSnapshotLoading(false);
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -2453,6 +2453,13 @@ class ServeWebFixtureTest {
         assetText("serve.css").contains("cp-reload-spin"),
       "snapshot overrides fade the current preview and show a spinner while re-rendering",
     )
+    assertTrue(
+      assetText("viewer.js")
+        .contains(
+          "function cancelSnapshotLoading() {\n    snapshotGen++;\n    status.textContent = \"\";"
+        ),
+      "cancelling a snapshot render clears its stale rendering status",
+    )
     // During an active Live (stream), the override map sent over the WebSocket must carry the knob
     // values too (as knob.<key> entries), not just the display fields — otherwise the daemon resets
     // an edited knob to its default. The setOverrides sends use liveOverrides(), which folds them

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -290,7 +290,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -244,7 +244,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -242,7 +242,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -238,7 +238,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -237,7 +237,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -243,7 +243,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -231,7 +231,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -235,7 +235,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -226,7 +226,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -239,7 +239,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/129f4-ce59c3eba723c762/viewer.js"></script>
+      <script src="/assets/serve/12a11-b751f1af3b40dd48/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>


### PR DESCRIPTION
## What changed

- clear the snapshot footer status when an in-flight render is cancelled
- add a regression assertion for cancellation cleanup
- regenerate viewer fixtures for the updated asset fingerprint

## Why

PR #3161 invalidates pending snapshot callbacks when users switch render modes. Because the cancelled callbacks no longer run, the prior `rendering…` status could remain visible throughout a Live session even though the spinner and `aria-busy` state were cleared.

Addresses https://github.com/yschimke/compose-ai-tools/pull/3161#discussion_r3698845689

## Validation

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'`
- `node --check cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js`
- `git diff --check`