### PR TITLE
fix(catalog): default Wear device breakpoints

### DIFF
--- a/scripts/design-artifacts/catalog-breakpoints.mjs
+++ b/scripts/design-artifacts/catalog-breakpoints.mjs
@@ -48,3 +48,28 @@ export function applySpecBreakpoints(candidates, previews, breakpoints) {
   }
   return applied;
 }
+
+export const DEFAULT_WEAR_BREAKPOINTS = Object.freeze([
+  Object.freeze({ size: "smallRound", widthDp: 192 }),
+  Object.freeze({ size: "largeRound", widthDp: 227 }),
+]);
+
+/**
+ * Resolve the breakpoint vocabulary for one catalog.
+ *
+ * Wear's standard device previews use 192 dp and 227 dp round displays. Without domain names the
+ * generic candidate reader classifies both widths as Material `compact`, collapsing distinct
+ * renders onto one output axis. Apply the standard Wear names when a catalog declares a Wear
+ * Compose library and omits `breakpoints`; any explicit array (including `[]`) remains
+ * authoritative.
+ *
+ * @param {{library?: string[], breakpoints?: Array<{size: string, widthDp: number}>}} spec
+ * @returns {Array<{size: string, widthDp: number}> | undefined}
+ */
+export function catalogBreakpoints(spec) {
+  if (Array.isArray(spec?.breakpoints)) return spec.breakpoints;
+  const isWear = (spec?.library ?? []).some((dependency) =>
+    dependency.startsWith("androidx.wear.compose:"),
+  );
+  return isWear ? DEFAULT_WEAR_BREAKPOINTS : undefined;
+}

--- a/scripts/design-artifacts/catalog-breakpoints.test.mjs
+++ b/scripts/design-artifacts/catalog-breakpoints.test.mjs
@@ -1,7 +1,47 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { applySpecBreakpoints } from "./catalog-breakpoints.mjs";
+import {
+  applySpecBreakpoints,
+  catalogBreakpoints,
+  DEFAULT_WEAR_BREAKPOINTS,
+} from "./catalog-breakpoints.mjs";
+
+test("Wear catalogs default to standard round device breakpoints", () => {
+  assert.equal(
+    catalogBreakpoints({ library: ["androidx.wear.compose:compose-material3"] }),
+    DEFAULT_WEAR_BREAKPOINTS,
+  );
+  assert.deepEqual(DEFAULT_WEAR_BREAKPOINTS, [
+    { size: "smallRound", widthDp: 192 },
+    { size: "largeRound", widthDp: 227 },
+  ]);
+});
+
+test("explicit breakpoints override Wear defaults, including an empty opt-out", () => {
+  const declared = [{ size: "xlRound", widthDp: 240 }];
+  assert.equal(
+    catalogBreakpoints({
+      library: ["androidx.wear.compose:compose-material3"],
+      breakpoints: declared,
+    }),
+    declared,
+  );
+  assert.deepEqual(
+    catalogBreakpoints({
+      library: ["androidx.wear.compose:compose-material3"],
+      breakpoints: [],
+    }),
+    [],
+  );
+});
+
+test("non-Wear catalogs do not acquire round device breakpoints", () => {
+  assert.equal(
+    catalogBreakpoints({ library: ["androidx.compose.material3:material3"] }),
+    undefined,
+  );
+});
 
 test("declared Wear breakpoints replace canonical compact sizes", () => {
   const candidates = [

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -41,7 +41,7 @@
     },
     "breakpoints": {
       "type": "array",
-      "description": "Informational: the width breakpoints the sticker sheet documents.",
+      "description": "The named width breakpoints the sticker sheet documents and uses as image size axes. When omitted, a catalog whose library includes androidx.wear.compose defaults to smallRound at 192 dp and largeRound at 227 dp. An explicit array, including an empty array, overrides that Wear default.",
       "items": {
         "type": "object",
         "additionalProperties": false,

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -101,7 +101,10 @@ import {
 } from "./catalog-image-path.mjs";
 import { applySpecSections } from "./apply-spec-sections.mjs";
 import { applySourceFiles } from "./apply-source-files.mjs";
-import { applySpecBreakpoints } from "./catalog-breakpoints.mjs";
+import {
+  applySpecBreakpoints,
+  catalogBreakpoints,
+} from "./catalog-breakpoints.mjs";
 import { applyCatalogPreviewAxes } from "./catalog-preview-axes.mjs";
 
 /**
@@ -649,6 +652,8 @@ const rendersPath = resolve(values.renders);
 const outPath = resolve(values.out);
 
 const spec = JSON.parse(await readFile(specPath, "utf8"));
+const effectiveBreakpoints = catalogBreakpoints(spec);
+if (effectiveBreakpoints !== undefined) spec.breakpoints = effectiveBreakpoints;
 // Read candidates with componentId resolved to the `@Preview` function name so
 // the join folds a function's theme/size multipreview variants (whose ids differ
 // only by an appended `_<mode>`) onto one component. See `loadCandidates` (which


### PR DESCRIPTION
## Summary

- default Wear Compose catalogs to `smallRound` at 192 dp and `largeRound` at 227 dp
- detect Wear catalogs from an `androidx.wear.compose:*` library coordinate
- keep any explicit `breakpoints` array authoritative, including `[]` as an opt-out
- resolve the effective spec once so baked image axes and live-preview routing share the same map
- document the default in the catalog spec schema

## Root cause

The generic candidate reader maps both standard Wear device widths into Material's `compact` window class. A Wear catalog that omits explicit breakpoint names can therefore produce two distinct device renders with identical output axes and abort export.

This was observed in the Confetti Wear catalog:
https://github.com/joreilly/Confetti/actions/runs/30737837868/job/91469766825

Confetti also declares the breakpoints explicitly in:
https://github.com/joreilly/Confetti/pull/1767

## Validation

- focused breakpoint, preview-axis, and live-routing tests — 39 passed
- all catalog-related tests — 148 passed
- sample catalog validation — 3 passed
- schema JSON validation and `git diff --check`
