### PR TITLE
fix(serve): require repo access for playground

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -2466,15 +2466,17 @@ class ServeCommand(args: List<String>) : Command(args) {
         --github-auth-cookie-secret <secret>
         --github-auth-repo <owner/repo>
                           Add GitHub OAuth on top of the browse gate for code-running surfaces:
-                          live preview WebSockets and the playground. After sign-in the server
-                          stores only a signed, expiring login cookie. All four flags are required
-                          together; <owner/repo> is kept as deployment context and for compatibility.
+                          live preview WebSockets and the playground. Live preview accepts any
+                          signed-in GitHub user (unless --github-auth-users narrows sign-in);
+                          playground additionally requires access to <owner/repo>. After sign-in
+                          the server stores only a signed, expiring login cookie plus the repo
+                          access verdict. All four flags are required together.
         --github-auth-callback-base-url <url>
                           External origin for the OAuth callback, e.g. https://preview.example.com.
                           Omit for local use; reverse-proxied deploys should set it explicitly.
         --github-auth-users <login>[,<login>…]
-                          Optional allowlist. Empty means any signed-in GitHub user may use live
-                          sessions/playground.
+                          Optional sign-in allowlist. Empty means any signed-in GitHub user may use
+                          live sessions; playground still requires access to --github-auth-repo.
         --export <path>   Don't serve: render every preview once and write a portable bundle (a
                           self-contained web gallery + PNGs) to <path>. A '.zip' path writes a zip;
                           any other path writes a directory. The live server also offers this at

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -2470,7 +2470,8 @@ class ServeCommand(args: List<String>) : Command(args) {
                           signed-in GitHub user (unless --github-auth-users narrows sign-in);
                           playground additionally requires access to <owner/repo>. After sign-in
                           the server stores only a signed, expiring login cookie plus the repo
-                          access verdict. All four flags are required together.
+                          access verdict. The OAuth request includes GitHub's repo scope so private
+                          repositories can be checked. All four flags are required together.
         --github-auth-callback-base-url <url>
                           External origin for the OAuth callback, e.g. https://preview.example.com.
                           Omit for local use; reverse-proxied deploys should set it explicitly.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -80,7 +80,7 @@ class ServeGithubAuth(
           call.respondText("GitHub sign-in failed.", status = HttpStatusCode.Forbidden)
           return
         }
-    val session = signedSession(user)
+    val session = signedSession(user.login, user.repositoryAccess)
     call.response.cookies.append(authCookie(session, maxAge = SESSION_TTL_SECONDS))
     call.response.cookies.append(stateCookie("", maxAge = 0))
     call.respondRedirect(statePayload.returnTo)
@@ -92,7 +92,12 @@ class ServeGithubAuth(
 
   fun currentLogin(call: ApplicationCall): String? {
     val cookie = call.request.cookieValue(AUTH_COOKIE) ?: return null
-    return verifySession(cookie)
+    return verifySession(cookie)?.login
+  }
+
+  fun hasRepositoryAccess(call: ApplicationCall): Boolean {
+    val cookie = call.request.cookieValue(AUTH_COOKIE) ?: return false
+    return verifySession(cookie)?.repositoryAccess == true
   }
 
   fun loginPath(call: ApplicationCall): String {
@@ -131,17 +136,25 @@ class ServeGithubAuth(
     return StatePayload(returnTo)
   }
 
-  private fun signedSession(login: String): String {
+  private fun signedSession(login: String, repositoryAccess: Boolean): String {
     val expiresAt = clock.millis() + SESSION_TTL_SECONDS * 1000
-    return sign("${login.lowercase()}|$expiresAt")
+    val repoFlag = if (repositoryAccess) "repo" else "no-repo"
+    return sign("${login.lowercase()}|$repoFlag|$expiresAt")
   }
 
-  private fun verifySession(value: String): String? {
+  private fun verifySession(value: String): SessionPayload? {
     val payload = verifySigned(value) ?: return null
-    val parts = payload.split("|", limit = 2)
-    if (parts.size != 2) return null
-    val expiresAt = parts[1].toLongOrNull() ?: return null
-    return parts[0].takeIf { expiresAt > clock.millis() && it.isNotBlank() }
+    val parts = payload.split("|")
+    val (login, repositoryAccess, expiresAt) =
+      when (parts.size) {
+        // Backwards compatible with cookies minted before playground repo-rights gating. They stay
+        // authenticated for live preview, but do not satisfy the stricter playground gate.
+        2 -> Triple(parts[0], false, parts[1].toLongOrNull())
+        3 -> Triple(parts[0], parts[1] == "repo", parts[2].toLongOrNull())
+        else -> return null
+      }
+    if (expiresAt == null || expiresAt <= clock.millis() || login.isBlank()) return null
+    return SessionPayload(login, repositoryAccess)
   }
 
   private fun sign(payload: String): String {
@@ -194,6 +207,8 @@ class ServeGithubAuth(
 
   private data class StatePayload(val returnTo: String)
 
+  private data class SessionPayload(val login: String, val repositoryAccess: Boolean)
+
   companion object {
     const val START_PATH = "/auth/github/start"
     const val CALLBACK_PATH = "/auth/github/callback"
@@ -213,16 +228,24 @@ class ServeGithubAuth(
   }
 }
 
+data class GitHubOAuthUser(val login: String, val repositoryAccess: Boolean)
+
 class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
-  fun verify(code: String, redirectUri: String, config: ServeGithubAuthConfig): Result<String> =
-    runCatching {
-      val token = exchangeCode(code, redirectUri, config)
-      val login = fetchLogin(token)
-      if (config.allowedUsers.isNotEmpty() && login.lowercase() !in config.allowedUsers) {
-        error("GitHub user $login is not allowed")
-      }
-      login
+  fun verify(
+    code: String,
+    redirectUri: String,
+    config: ServeGithubAuthConfig,
+  ): Result<GitHubOAuthUser> = runCatching {
+    val token = exchangeCode(code, redirectUri, config)
+    val login = fetchLogin(token)
+    if (config.allowedUsers.isNotEmpty() && login.lowercase() !in config.allowedUsers) {
+      error("GitHub user $login is not allowed")
     }
+    GitHubOAuthUser(
+      login,
+      repositoryAccess = fetchRepositoryAccess(token, config.repository, login),
+    )
+  }
 
   private fun exchangeCode(
     code: String,
@@ -262,6 +285,24 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
     }
   }
 
+  private fun fetchRepositoryAccess(token: String, repository: String, login: String): Boolean {
+    val request =
+      Request.Builder()
+        .url("https://api.github.com/repos/$repository/collaborators/$login/permission")
+        .header(HttpHeaders.Authorization, "Bearer $token")
+        .header(HttpHeaders.Accept, "application/vnd.github+json")
+        .build()
+    return client.newCall(request).execute().use { response ->
+      if (response.code == 404) return@use false
+      if (!response.isSuccessful) return@use false
+      val permission =
+        JSON.decodeFromString(GitHubPermissionResponse.serializer(), response.body.string())
+          .permission
+          .lowercase()
+      permission != "none"
+    }
+  }
+
   companion object {
     private val JSON = Json { ignoreUnknownKeys = true }
   }
@@ -271,6 +312,8 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
 private data class GitHubTokenResponse(@SerialName("access_token") val accessToken: String? = null)
 
 @Serializable private data class GitHubUserResponse(val login: String)
+
+@Serializable private data class GitHubPermissionResponse(val permission: String = "none")
 
 private fun ApplicationCall.uriWithQuery(): String = request.uri
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -114,7 +114,7 @@ class ServeGithubAuth(
       listOf(
           "client_id" to config.clientId,
           "redirect_uri" to callbackUrl(call),
-          "scope" to "read:user",
+          "scope" to "read:user repo",
           "state" to state,
         )
         .joinToString("&") { (k, v) -> "$k=${urlEncode(v)}" }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -824,6 +824,7 @@ class ServeHttpServer(
   private suspend fun RoutingContext.handlePlaygroundPage(service: PlaygroundCompileService) {
     if (rejectBadToken()) return
     if (rejectMissingGithubAuth()) return
+    if (rejectMissingGithubRepoAccess()) return
     markGeneration("static-page", pageCacheControl())
     call.respondText(
       ServeWeb.playgroundPage(
@@ -857,6 +858,7 @@ class ServeHttpServer(
   private suspend fun RoutingContext.handlePlaygroundRedeem(redeem: PlaygroundRedeemService) {
     if (rejectBadToken()) return
     if (rejectMissingGithubAuth()) return
+    if (rejectMissingGithubRepoAccess()) return
     // Read the PATH segment explicitly (see the route mount): it's named `{pgToken}` so it can't be
     // shadowed by the `?token=` access token that `call.parameters` also carries on a gated host.
     val id = call.parameters["pgToken"].orEmpty()
@@ -883,6 +885,7 @@ class ServeHttpServer(
   private suspend fun RoutingContext.handlePlaygroundRun(service: PlaygroundCompileService) {
     if (rejectBadToken()) return
     if (rejectMissingGithubAuth(api = true)) return
+    if (rejectMissingGithubRepoAccess(api = true)) return
     val body =
       withContext(Dispatchers.IO) {
         call.receiveStream().use { readCapped(it, MAX_PLAYGROUND_BYTES) }
@@ -2727,6 +2730,29 @@ class ServeHttpServer(
       call.respondText("GitHub sign-in required.", status = HttpStatusCode.Unauthorized)
     } else {
       call.respondRedirect(auth.loginPath(call))
+    }
+    return true
+  }
+
+  private suspend fun RoutingContext.rejectMissingGithubRepoAccess(api: Boolean = false): Boolean {
+    val auth = githubAuth ?: return false
+    if (auth.hasRepositoryAccess(call)) return false
+    val message =
+      "Playground requires access to ${auth.accessRepository()}. Live preview is available to any " +
+        "signed-in GitHub user."
+    if (api) {
+      call.respondText(message, status = HttpStatusCode.Forbidden)
+    } else {
+      call.respondText(
+        ServeWeb.notFoundPage(
+          message,
+          token,
+          isPublic,
+          unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
+        ),
+        ContentType.Text.Html,
+        HttpStatusCode.Forbidden,
+      )
     }
     return true
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -9,8 +9,11 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 
@@ -111,6 +114,34 @@ class PlaygroundRoutingTest {
       .also { it.start() }
   }
 
+  private val githubNoRepoServer: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "unused-in-public",
+        sessions = registry,
+        defaultSessionId = "none",
+        isPublic = true,
+        playgroundService = playground,
+        githubAuth = githubAuth(repositoryAccess = false),
+      )
+      .also { it.start() }
+  }
+
+  private val githubRepoServer: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "unused-in-public",
+        sessions = registry,
+        defaultSessionId = "none",
+        isPublic = true,
+        playgroundService = playground,
+        githubAuth = githubAuth(repositoryAccess = true),
+      )
+      .also { it.start() }
+  }
+
   private val client = OkHttpClient()
 
   @AfterTest
@@ -118,6 +149,8 @@ class PlaygroundRoutingTest {
     runCatching { server.stop() }
     runCatching { plainServer.stop() }
     runCatching { gatedServer.stop() }
+    runCatching { githubNoRepoServer.stop() }
+    runCatching { githubRepoServer.stop() }
     runCatching { registry.close() }
   }
 
@@ -158,6 +191,13 @@ class PlaygroundRoutingTest {
   private fun get(path: String, port: Int) =
     client.newCall(Request.Builder().url("http://127.0.0.1:$port$path").build()).execute()
 
+  private fun get(path: String, port: Int, cookie: String) =
+    client
+      .newCall(
+        Request.Builder().url("http://127.0.0.1:$port$path").header("Cookie", cookie).build()
+      )
+      .execute()
+
   @Test
   fun `the editor page is served when the playground lane is enabled`() {
     get("/playground", server.port).use { resp ->
@@ -173,6 +213,27 @@ class PlaygroundRoutingTest {
           html.contains("/api/1/compiler/run"),
         "the editor page exposes the source box, Run button, and the compile route",
       )
+    }
+  }
+
+  @Test
+  fun `github login without repo rights cannot open playground`() {
+    val cookie = githubSessionCookie(githubNoRepoServer.port)
+    get("/playground", githubNoRepoServer.port, cookie).use { resp ->
+      assertEquals(403, resp.code)
+      assertTrue(
+        resp.body!!.string().contains("Playground requires access to yschimke/compose-ai-tools"),
+        "playground explains the repo-rights gate",
+      )
+    }
+  }
+
+  @Test
+  fun `github login with repo rights can open playground`() {
+    val cookie = githubSessionCookie(githubRepoServer.port)
+    get("/playground", githubRepoServer.port, cookie).use { resp ->
+      assertEquals(200, resp.code)
+      assertTrue(resp.body!!.string().contains("id=\"pg-source\""))
     }
   }
 
@@ -229,6 +290,70 @@ class PlaygroundRoutingTest {
           resp.header("Location")?.contains("/p/") == true,
           "redirect targets the viewer /p/ route: ${resp.header("Location")}",
         )
+      }
+  }
+
+  private fun githubAuth(repositoryAccess: Boolean): ServeGithubAuth {
+    val fakeGitHub =
+      OkHttpClient.Builder()
+        .addInterceptor { chain ->
+          val request = chain.request()
+          val path = request.url.encodedPath
+          val body =
+            when {
+              path == "/login/oauth/access_token" -> """{"access_token":"token"}"""
+              path == "/user" -> """{"login":"octo"}"""
+              path.endsWith("/permission") ->
+                if (repositoryAccess) """{"permission":"write"}""" else """{"permission":"none"}"""
+              else -> "{}"
+            }
+          Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(body.toResponseBody("application/json".toMediaType()))
+            .build()
+        }
+        .build()
+    return ServeGithubAuth(
+      ServeGithubAuthConfig(
+        clientId = "client",
+        clientSecret = "secret",
+        cookieSecret = "x".repeat(32),
+        repository = "yschimke/compose-ai-tools",
+      ),
+      verifier = GitHubOAuthVerifier(fakeGitHub),
+    )
+  }
+
+  private fun githubSessionCookie(port: Int): String {
+    val noRedirect = client.newBuilder().followRedirects(false).build()
+    val start =
+      noRedirect
+        .newCall(
+          Request.Builder()
+            .url("http://127.0.0.1:$port/auth/github/start?return=/playground")
+            .build()
+        )
+        .execute()
+        .use { resp ->
+          assertEquals(302, resp.code)
+          resp.header("Location").orEmpty() to
+            resp.header("Set-Cookie").orEmpty().substringBefore(";")
+        }
+    val state = start.first.substringAfter("state=").substringBefore("&")
+    return noRedirect
+      .newCall(
+        Request.Builder()
+          .url("http://127.0.0.1:$port/auth/github/callback?code=ok&state=$state")
+          .header("Cookie", start.second)
+          .build()
+      )
+      .execute()
+      .use { resp ->
+        assertEquals(302, resp.code)
+        resp.headers("Set-Cookie").first { it.startsWith("cp_gh_auth=") }.substringBefore(";")
       }
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -342,6 +342,10 @@ class PlaygroundRoutingTest {
           resp.header("Location").orEmpty() to
             resp.header("Set-Cookie").orEmpty().substringBefore(";")
         }
+    assertTrue(
+      start.first.contains("scope=read%3Auser+repo"),
+      "GitHub OAuth requests repo scope so private-repo playground access can be checked: ${start.first}",
+    )
     val state = start.first.substringAfter("state=").substringBefore("&")
     return noRedirect
       .newCall(

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -87,7 +87,9 @@ The compose profile derives the callback base URL from `DOMAIN`; set
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL` to override. Empty `SERVE_GITHUB_AUTH_USERS` allows any
 signed-in GitHub user to use live previews; playground additionally requires access to
 `SERVE_GITHUB_AUTH_REPO` (default `yschimke/compose-ai-tools`). Set `SERVE_GITHUB_AUTH_USERS` to a
-comma-separated login list only if you want to narrow sign-in for both surfaces.
+comma-separated login list only if you want to narrow sign-in for both surfaces. The OAuth app
+requests GitHub's `repo` scope so private repository access can be checked during sign-in; the
+server stores only the signed login and the access verdict, not the OAuth token.
 
 ### Playground on `preview.coo.ee`
 

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -85,7 +85,9 @@ SERVE_GITHUB_AUTH_COOKIE_SECRET=... # openssl rand -hex 32
 
 The compose profile derives the callback base URL from `DOMAIN`; set
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL` to override. Empty `SERVE_GITHUB_AUTH_USERS` allows any
-signed-in GitHub user; set it to a comma-separated login list to narrow access.
+signed-in GitHub user to use live previews; playground additionally requires access to
+`SERVE_GITHUB_AUTH_REPO` (default `yschimke/compose-ai-tools`). Set `SERVE_GITHUB_AUTH_USERS` to a
+comma-separated login list only if you want to narrow sign-in for both surfaces.
 
 ### Playground on `preview.coo.ee`
 

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -52,10 +52,9 @@ services:
       SERVE_ADMIN_TOKEN: "${SERVE_ADMIN_TOKEN:-}"
       # Privacy-minimal aggregate app/catalog + preview views, persisted on preview_config.
       SERVE_ENGAGEMENT_FILE: "${SERVE_ENGAGEMENT_FILE:-}"
-      # Optional GitHub OAuth auth for code-running surfaces (live WebSockets and playground). Set
-      # the three secrets in .env to enable; the entrypoint uses this domain as the OAuth callback
-      # origin unless overridden. Empty values keep the public catalog browsing behaviour unchanged.
-      # Empty SERVE_GITHUB_AUTH_USERS allows any signed-in GitHub user; set it to narrow access.
+      # Optional GitHub OAuth auth for code-running surfaces. Empty values keep public catalog
+      # browsing unchanged. Empty SERVE_GITHUB_AUTH_USERS lets any signed-in GitHub user use live
+      # preview; playground also requires access to SERVE_GITHUB_AUTH_REPO.
       SERVE_GITHUB_AUTH_CLIENT_ID: "${SERVE_GITHUB_AUTH_CLIENT_ID:-}"
       SERVE_GITHUB_AUTH_CLIENT_SECRET: "${SERVE_GITHUB_AUTH_CLIENT_SECRET:-}"
       SERVE_GITHUB_AUTH_COOKIE_SECRET: "${SERVE_GITHUB_AUTH_COOKIE_SECRET:-}"

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -358,7 +358,8 @@ SERVE_GITHUB_AUTH_COOKIE_SECRET=... # at least 32 chars
 With those set, live preview WebSockets require a signed-in GitHub user. `/playground`,
 `POST /api/<version>/compiler/run`, and `/pg/<token>` require a signed-in GitHub user that also has
 access to `SERVE_GITHUB_AUTH_REPO` / `--github-auth-repo`. The browser cookie stores only a signed,
-expiring login plus the repo access verdict.
+expiring login plus the repo access verdict. The OAuth request includes GitHub's `repo` scope so
+private repository access can be checked during sign-in; the OAuth token is not stored.
 Reverse-proxied deployments should also set
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL=https://preview.example.com` so the OAuth callback URL is stable.
 When `DOMAIN` is set, the prebuilt image derives

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -355,13 +355,17 @@ SERVE_GITHUB_AUTH_CLIENT_SECRET=...
 SERVE_GITHUB_AUTH_COOKIE_SECRET=... # at least 32 chars
 ```
 
-With those set, `/playground`, `POST /api/<version>/compiler/run`, `/pg/<token>`, and live preview
-WebSockets require a signed-in GitHub user. The browser cookie stores only a signed, expiring login.
+With those set, live preview WebSockets require a signed-in GitHub user. `/playground`,
+`POST /api/<version>/compiler/run`, and `/pg/<token>` require a signed-in GitHub user that also has
+access to `SERVE_GITHUB_AUTH_REPO` / `--github-auth-repo`. The browser cookie stores only a signed,
+expiring login plus the repo access verdict.
 Reverse-proxied deployments should also set
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL=https://preview.example.com` so the OAuth callback URL is stable.
 When `DOMAIN` is set, the prebuilt image derives
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL=https://$DOMAIN`. Empty `SERVE_GITHUB_AUTH_USERS` allows any
-signed-in GitHub user; set `SERVE_GITHUB_AUTH_USERS=alice,bob` to narrow access to named logins.
+signed-in GitHub user to use live previews; playground still requires access to
+`SERVE_GITHUB_AUTH_REPO`. Set `SERVE_GITHUB_AUTH_USERS=alice,bob` to narrow sign-in to named logins
+for both surfaces.
 
 ### The catalog set is config, not image content
 


### PR DESCRIPTION
## Summary
- keep live preview available to any signed-in GitHub user
- require GitHub repo access for playground page/run/redeem using --github-auth-repo / SERVE_GITHUB_AUTH_REPO
- store the repo access verdict in the signed auth session and treat lookup failures as no playground access, while preserving live-preview sign-in
- update CLI/deploy docs for the split access model

## Testing
- ./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.PlaygroundRoutingTest --tests ee.schimke.composeai.cli.serve.ServeAuthTest
- ./gradlew :cli:ktfmtCheck