### PR TITLE
fix(ci): shard VS Code extension e2e

### DIFF
--- a/.github/workflows/vscode-extension-e2e.yml
+++ b/.github/workflows/vscode-extension-e2e.yml
@@ -18,11 +18,35 @@ name: VS Code Extension E2E
 #                       and CMP went unverified for ~60 commits.
 #   workflow_dispatch — manual one-off runs (any branch), e.g. to
 #                       reproduce a regression on a feature branch.
+#   pull_request      — runs the full sharded set when the extension or
+#                       its real Gradle/rendering fixtures change.
 
 on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - 'vscode-extension/**'
+      - 'gradle-plugin/**'
+      - 'daemon/**'
+      - 'renderers/**'
+      - 'runtimes/**'
+      - 'data/**'
+      - 'api/preview-annotations/**'
+      - 'api/preview-data-api/**'
+      - 'samples/cmp/**'
+      - 'samples/android/**'
+      - 'samples/wear/**'
+      - 'build-logic/**'
+      - 'gradle/**'
+      - 'settings.gradle*'
+      - 'build.gradle*'
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - '.github/actions/setup/**'
+      - '.github/workflows/vscode-extension-e2e.yml'
 
 permissions:
   contents: read
@@ -35,11 +59,31 @@ concurrency:
 
 jobs:
   e2e:
-    name: VS Code Extension E2E (real Gradle)
+    name: VS Code Extension E2E (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    # 60 minutes ceiling — local cold runs land closer to 5-10 min, but a
-    # CI runner with no Gradle/Compose caches warm and a fresh
-    # @vscode/test-electron download can stretch.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: cmp-smoke
+            files: e2e.test.js
+            grep: ''
+          - shard: cached-preload
+            files: e2eCachedPreloadOnSwitch.test.js
+            grep: ''
+          - shard: interactive-a-d
+            files: e2eInteractive.test.js
+            grep: ' [A-D]\. '
+          - shard: interactive-e-g
+            files: e2eInteractive.test.js
+            grep: ' [E-G]\. '
+          # These suites intentionally share one host: e2eA11y warms the
+          # Wear daemon and e2eBundleChain reuses that state.
+          - shard: wear
+            files: e2eA11y.test.js,e2eBundleChain.test.js
+            grep: ''
+    # Per-shard ceiling. The complete suite is deliberately split because
+    # its serial worst case exceeds an hour; each shard remains bounded.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -73,15 +117,19 @@ jobs:
 
       - name: Run e2e tests under xvfb
         working-directory: vscode-extension
+        env:
+          COMPOSE_PREVIEW_E2E_FILES: ${{ matrix.files }}
+          COMPOSE_PREVIEW_E2E_GREP: ${{ matrix.grep }}
         run: xvfb-run -a npm run test:e2e
 
       - name: Upload renders on failure
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-renders
+          name: e2e-renders-${{ matrix.shard }}
           path: |
             samples/cmp/build/compose-previews/
+            samples/android/build/compose-previews/
             samples/wear/build/compose-previews/
             vscode-extension/.vscode-test/user-data/logs/
           if-no-files-found: ignore

--- a/.github/workflows/vscode-extension-e2e.yml
+++ b/.github/workflows/vscode-extension-e2e.yml
@@ -29,10 +29,12 @@ on:
     paths:
       - 'vscode-extension/**'
       - 'gradle-plugin/**'
+      - 'common/**'
       - 'daemon/**'
       - 'renderers/**'
       - 'runtimes/**'
       - 'data/**'
+      - 'third_party/**'
       - 'api/preview-annotations/**'
       - 'api/preview-data-api/**'
       - 'samples/cmp/**'

--- a/vscode-extension/src/test/electron/runTest.ts
+++ b/vscode-extension/src/test/electron/runTest.ts
@@ -132,6 +132,18 @@ async function main(): Promise<void> {
             ELECTRON_RUN_AS_NODE: undefined,
             COMPOSE_PREVIEW_TEST_MODE: "1",
             ...(e2eMode ? { COMPOSE_PREVIEW_E2E: "1" } : {}),
+            ...(process.env.COMPOSE_PREVIEW_E2E_FILES
+                ? {
+                      COMPOSE_PREVIEW_E2E_FILES:
+                          process.env.COMPOSE_PREVIEW_E2E_FILES,
+                  }
+                : {}),
+            ...(process.env.COMPOSE_PREVIEW_E2E_GREP
+                ? {
+                      COMPOSE_PREVIEW_E2E_GREP:
+                          process.env.COMPOSE_PREVIEW_E2E_GREP,
+                  }
+                : {}),
             // Forward the external-consumer flag (and the workspace
             // path, for diagnostic logs) into the extension host so the
             // gated `describeExternal(...)` actually runs. The

--- a/vscode-extension/src/test/electron/suite/index.ts
+++ b/vscode-extension/src/test/electron/suite/index.ts
@@ -62,11 +62,37 @@ export async function run(): Promise<void> {
     // suite paying the wear composePreviewRenderAll's tax in its own 10-minute
     // budget. Plain lexical order runs the lighter cmp suite first.
     const files = (await glob(pattern, { cwd: testsRoot, ignore })).sort();
+    const selectedFiles = process.env.COMPOSE_PREVIEW_E2E_FILES;
+    const selected = selectedFiles
+        ? new Set(
+              selectedFiles
+                  .split(",")
+                  .map((file) => file.trim())
+                  .filter(Boolean),
+          )
+        : undefined;
+    const filteredFiles = selected
+        ? files.filter((file) => selected.has(path.basename(file)))
+        : files;
+    if (selected && filteredFiles.length !== selected.size) {
+        const found = new Set(filteredFiles.map((file) => path.basename(file)));
+        const missing = [...selected].filter((file) => !found.has(file));
+        throw new Error(
+            `COMPOSE_PREVIEW_E2E_FILES selected unknown test file(s): ${missing.join(", ")}`,
+        );
+    }
+
+    const grep = process.env.COMPOSE_PREVIEW_E2E_GREP;
+    if (grep) {
+        mocha.grep(new RegExp(grep));
+    }
     console.log(
-        `[suite] discovered ${files.length} test file(s) in ${testsRoot} ` +
-            `(e2e=${e2eMode} external=${e2eExternalMode})`,
+        `[suite] discovered ${filteredFiles.length}/${files.length} test file(s) in ${testsRoot} ` +
+            `(e2e=${e2eMode} external=${e2eExternalMode}` +
+            `${selectedFiles ? ` files=${selectedFiles}` : ""}` +
+            `${grep ? ` grep=${grep}` : ""})`,
     );
-    for (const f of files) {
+    for (const f of filteredFiles) {
         const abs = path.resolve(testsRoot, f);
         console.log(`[suite] add ${abs}`);
         mocha.addFile(abs);


### PR DESCRIPTION
## Summary

- shard the real-Gradle VS Code extension E2E suite into five bounded parallel jobs
- split the long interactive scenarios into A–D and E–G while keeping the Wear suites together to reuse warmed state
- run the complete set on every `main` push and on pull requests only when VS Code/Gradle/rendering-related paths change
- upload shard-specific CMP, Android, Wear, and VS Code log artifacts on failure or cancellation

## Root cause

The workflow ran all real-Gradle E2E files serially under one 60-minute job timeout. Run 30737151055 spent roughly 20 minutes in cached preload and then continued through interactive scenarios A–D before GitHub cancelled the job while scenario E was starting. The individual suites were bounded, but their combined serial runtime was not.

## Validation

- `npm test` — 1,622 passing
- `npm run compile`
- `npm run format:check`
- workflow YAML parse
- matrix grep filter sanity check
- `git diff --check`

The Linux/Xvfb real-Gradle shards are left for GitHub Actions because they take tens of minutes and depend on the hosted runner environment.