### PR TITLE
test(daemon): stabilize interactive touch overlay

### DIFF
--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveTouchOverlayTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveTouchOverlayTest.kt
@@ -68,6 +68,12 @@ class InteractiveTouchOverlayTest {
           overrides = PreviewOverrides(touchOverlay = true),
         )
       try {
+        // Render once before dispatching input. RenderEngine.setUp() only seeds the composition;
+        // the first render installs pointerInput observers such as TouchOverlayExtension's. The
+        // real interactive flow also publishes an initial frame before accepting input. Sending
+        // the press before that bootstrap frame races observer installation on slower CI runners.
+        session.render(requestId = RenderHost.nextRequestId())
+
         // Push a single pointer down at the centre. The TouchOverlayExtension paints a cyan ring at
         // every currently-pressed pointer; rendering immediately after the press samples that ring.
         session.dispatch(


### PR DESCRIPTION
## Summary

- bootstrap the interactive session with an initial render before dispatching the touch event
- ensure `TouchOverlayExtension`'s pointer observer is installed before the assertion path runs

## Root cause

`RenderEngine.setUp()` seeds the composition but does not render it. The test dispatched `POINTER_DOWN` immediately after acquiring the session, which raced installation of the overlay's `pointerInput` observer on slower CI runners. This produced a frame without the expected cyan touch ring.

The updated test matches the real interactive flow, which publishes an initial frame before accepting input.

## Validation

- targeted test passed 12 consecutive executions
- `./gradlew :daemon:desktop:test`
- `git diff --check`