### PR TITLE
fix(design-artifacts): preserve lazy SVG blobs

### DIFF
--- a/scripts/design-artifacts/render-compare-html.mjs
+++ b/scripts/design-artifacts/render-compare-html.mjs
@@ -246,16 +246,23 @@ const SCORER = String.raw`
   }
 
   // Point a display <img> at the overridden SVG so the column shows what was scored
-  // (glyphs overflowing at >1x, the substituted face with fonts off). Revoked after
-  // the browser has had a chance to decode it. Marks the row so a later return to
-  // identity knows to restore the original source.
+  // (glyphs overflowing at >1x, the substituted face with fonts off). Keep the blob
+  // alive until this display image actually settles: loading="lazy" can defer its
+  // request indefinitely while the row is below the fold. Marks the row so a later
+  // return to identity knows to restore the original source.
   function showSvg(tr, svgText) {
     const img = tr.querySelector(".col-svg .shot img");
     if (!img) return;
     const url = svgBlobUrl(svgText);
+    const release = () => {
+      img.removeEventListener("load", release);
+      img.removeEventListener("error", release);
+      URL.revokeObjectURL(url);
+    };
+    img.addEventListener("load", release);
+    img.addEventListener("error", release);
     img.src = url;
     tr.dataset.svgShown = "override";
-    setTimeout(() => URL.revokeObjectURL(url), 4000);
   }
 
   // Put the display <img> back to the authored figma-svg once the overrides return to

--- a/scripts/design-artifacts/render-compare-html.test.mjs
+++ b/scripts/design-artifacts/render-compare-html.test.mjs
@@ -285,6 +285,16 @@ test("returning overrides to identity restores the displayed SVG (not the last b
   assert.match(html, /img\.getAttribute\("src"\) !== svgPath/);
 });
 
+test("a lazy display SVG keeps its blob URL until the image settles", () => {
+  const html = renderCompareHtml(catalog, { figmaSvgSlugs: new Set(["button-filled"]) });
+  // Below-fold images may not request their blob URL for an arbitrary amount of time. Revoke it
+  // only after this display image has loaded (or failed), rather than on a wall-clock timeout.
+  assert.match(html, /img\.addEventListener\("load", release\)/);
+  assert.match(html, /img\.addEventListener\("error", release\)/);
+  assert.match(html, /URL\.revokeObjectURL\(url\)/);
+  assert.doesNotMatch(html, /setTimeout\(\(\) => URL\.revokeObjectURL\(url\), 4000\)/);
+});
+
 test("the theme override repoints the displayed PNG, not just the scored one", () => {
   const html = renderCompareHtml(catalog, { figmaSvgSlugs: new Set(["button-filled"]) });
   // The PNG column's <img> src follows the theme-selected path (guarded to avoid reloads).


### PR DESCRIPTION
## Summary

- keep generated hybrid SVG blob URLs alive until the display image settles
- revoke each URL on the display image's `load` or `error` event
- add regression coverage for lazy below-fold images

## Root cause

`compare.html` assigns generated blob URLs to display images that use native lazy loading, but previously revoked those URLs after a fixed four-second timeout. A below-fold image could therefore request an already-revoked URL and remain blank even though scoring had completed with a separate eager image.

The cleanup is now tied to the display image lifecycle, so lazy loading can defer the request for as long as needed while each blob is still released once the image settles.

## Validation

- `node --test scripts/design-artifacts/render-compare-html.test.mjs` (23 passed)
- `npm test -- --test-reporter=dot` in `scripts/design-artifacts`
- `git diff --check`

Closes #3143