### PR TITLE
feat(ci): rerun preview diff from comment

### DIFF
--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -345,6 +345,22 @@ Two caveats worth knowing:
   cached. Pinning faces by content hash — so a substitution is a hard failure
   rather than a silent metric change — needs a lockfile and is not part of this.
 
+## Re-run checkbox
+
+Set `rerun-checkbox: true` to put an unchecked **Re-run preview diff** item
+near the top of the compose sticky comment. The action only renders the
+control; the repository must handle the resulting `issue_comment: edited`
+event and authorize the actor before calling GitHub's workflow-run rerun API.
+Keeping this opt-in prevents consumers without that handler from receiving an
+inert checkbox.
+
+This repository's [pr-commands.yml](../../workflows/pr-commands.yml) is the
+reference handler. It accepts the checkbox only on the bot-authored
+`<!-- preview-diff -->` comment, checks the clicking actor has write-level
+repository access, updates the same comment with an in-progress status, and
+fully reruns the latest `compose-preview` workflow on the PR's current head
+SHA. The new render then replaces the sticky comment as usual.
+
 ## Related actions
 
 - [`install`](../install/) — just put the CLI on `$PATH`, no pipelines.

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -136,6 +136,12 @@ inputs:
       Passthrough to the comment pipeline: post / update an empty-diff
       sticky comment instead of staying silent on no-change runs.
     default: 'false'
+  rerun-checkbox:
+    description: >
+      Add a "Re-run preview diff" task-list control to the compose sticky
+      comment. This is presentation only: enable it when the repository has
+      an issue_comment workflow that handles edits to the checked item.
+    default: 'false'
   mode:
     description: >
       Override the event-based mode selector: `auto` (default), `baseline`,
@@ -831,6 +837,7 @@ runs:
         RESOURCE_HEAD_BRANCH: 'compose-preview/resources/pr'
         AB_CONFIG: ${{ inputs.ab-config }}
         SCOPE_MODULES: ${{ steps.scope.outputs.modules }}
+        RERUN_CHECKBOX: ${{ inputs.rerun-checkbox }}
       run: |
         set -euo pipefail
         # Compose comment is only meaningful when the compose pipeline
@@ -863,6 +870,11 @@ runs:
           SCOPE_ARGS=(--scope-modules "$SCOPE_MODULES")
         fi
 
+        RERUN_ARGS=()
+        if [ "$RERUN_CHECKBOX" = "true" ]; then
+          RERUN_ARGS=(--rerun-checkbox)
+        fi
+
         python3 "$ACTION_PATH/../lib/compare-previews.py" compare _previews.json \
           --baselines _baselines/baselines.json \
           --baseline-renders _baselines/renders \
@@ -871,6 +883,7 @@ runs:
           --head-ref "$HEAD_REF" \
           "${AB_ARGS[@]}" \
           "${SCOPE_ARGS[@]}" \
+          "${RERUN_ARGS[@]}" \
           > _comment_body.md
 
     # Sibling step for the resources comment — separately gated on

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -1134,6 +1134,8 @@ def cmd_compare(args: argparse.Namespace) -> int:
     # --- generate markdown ---
     marker = "<!-- preview-diff -->"
     lines = [marker, "## Preview Changes", ""]
+    if getattr(args, "rerun_checkbox", False):
+        lines.extend(["- [ ] Re-run preview diff", ""])
 
     if not new and not changed and not removed and not failures and not ab_groups \
             and not partial_render:
@@ -1920,6 +1922,9 @@ def main() -> int:
                           "for modules outside this set are treated as "
                           "unchanged instead of removed — they were never "
                           "rendered this run. Omit for full runs.")
+    cmp.add_argument("--rerun-checkbox", action="store_true",
+                     help="Add the task-list control consumed by a repository's "
+                          "issue_comment rerun workflow.")
 
     cp = sub.add_parser("copy-changed", help="Copy new/changed PNGs to output dir")
     cp.add_argument("cli_json", help="Path to compose-preview show --json output")

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -821,7 +821,7 @@ class CompareMarkdownTest(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.tmp)
 
-    def _run(self, current_payload, baselines_payload) -> str:
+    def _run(self, current_payload, baselines_payload, *, rerun_checkbox=False) -> str:
         cli_path = self.tmp / "cli.json"
         cli_path.write_text(json.dumps(current_payload))
         bl_path = self.tmp / "baselines.json"
@@ -839,6 +839,7 @@ class CompareMarkdownTest(unittest.TestCase):
                 repo="owner/repo",
                 base_ref="deadbeef",
                 head_ref="cafef00d",
+                rerun_checkbox=rerun_checkbox,
             ))
         return buf.getvalue()
 
@@ -849,6 +850,25 @@ class CompareMarkdownTest(unittest.TestCase):
         )
         self.assertIn("No visual changes detected.", out)
         self.assertIn("1 preview(s) unchanged", out)
+
+    def test_optional_rerun_checkbox_is_near_comment_heading(self):
+        out = self._run(
+            {"previews": [_entry(id="X", sha="s1", png="/p.png")]},
+            {"app/X": {"sha256": "s1", "functionName": "Fn"}},
+            rerun_checkbox=True,
+        )
+        self.assertIn(
+            "<!-- preview-diff -->\n## Preview Changes\n\n"
+            "- [ ] Re-run preview diff\n",
+            out,
+        )
+
+    def test_rerun_checkbox_is_absent_by_default(self):
+        out = self._run(
+            {"previews": [_entry(id="X", sha="s1", png="/p.png")]},
+            {"app/X": {"sha256": "s1", "functionName": "Fn"}},
+        )
+        self.assertNotIn("Re-run preview diff", out)
 
     def test_marks_added_changed_and_removed(self):
         out = self._run(

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -102,6 +102,10 @@ jobs:
           # frozen. This is a safety ceiling against a hung build, not a
           # budget, so keep it comfortably above the slowest observed run.
           timeout: '1800'
+          # pr-commands.yml consumes edits that check this task-list item,
+          # acknowledges them in place, and reruns this workflow for the
+          # current PR head.
+          rerun-checkbox: 'true'
           # No `missing-renders` override: the action's default `fail` gates
           # every push + PR on all required renders producing a PNG. The one
           # legitimately unrenderable capture (the desktop `@ColorCatalog`

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,8 +1,8 @@
 name: PR Commands
 
-# Slash commands in PR comments, for maintainers. GitHub Actions has no
-# trigger for comment *reactions*, so commands are the available shape —
-# the workflow ACKs with a 🚀 reaction so the comment thread stays clean.
+# Lightweight controls in PR comments, for maintainers. Slash commands are
+# ACKed with a 🚀 reaction; the preview-diff checkbox is ACKed by updating the
+# same sticky comment, then reset by the fresh preview result.
 #
 #   /rerun               re-run the failed jobs of every failed / cancelled
 #                        run on the PR's current head SHA (flaky render,
@@ -14,6 +14,9 @@ name: PR Commands
 #                        vscode-preview-comment
 #   /rerun all           full re-run of every completed run on the head SHA
 #
+# Checking "Re-run preview diff" in the sticky <!-- preview-diff --> comment
+# is the UI equivalent of `/rerun previews`.
+#
 # Re-runs execute against the same commit the original run used, which is
 # exactly right for the common cases: a flaked render, or re-diffing after
 # the baseline branches moved (baselines are fetched at run time, not baked
@@ -22,11 +25,12 @@ name: PR Commands
 #
 # issue_comment workflows always run the workflow file from the default
 # branch, so a PR cannot smuggle changes into this logic; the author gate
-# below additionally restricts commands to owners / members / collaborators.
+# below restricts slash commands to owners / members / collaborators and
+# resolves the actual checkbox-clicking actor's repository permission.
 
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
 
 permissions: {}
 
@@ -40,8 +44,20 @@ jobs:
     if: >-
       ${{
         github.event.issue.pull_request != null &&
-        startsWith(github.event.comment.body, '/rerun') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        (
+          (
+            github.event.action == 'created' &&
+            startsWith(github.event.comment.body, '/rerun') &&
+            contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+          ) ||
+          (
+            github.event.action == 'edited' &&
+            github.event.comment.user.type == 'Bot' &&
+            startsWith(github.event.comment.body, '<!-- preview-diff -->') &&
+            contains(github.event.changes.body.from, '- [ ] Re-run preview diff') &&
+            contains(github.event.comment.body, '- [x] Re-run preview diff')
+          )
+        )
       }}
     runs-on: ubuntu-latest
     permissions:
@@ -50,6 +66,7 @@ jobs:
       pull-requests: read   # resolve the PR head SHA
     steps:
       - name: Acknowledge command
+        if: ${{ github.event.action == 'created' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -65,13 +82,49 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          EVENT_ACTION: ${{ github.event.action }}
+          ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
 
-          # First line only; everything after `/rerun` is the target.
-          cmd=$(printf '%s\n' "$COMMENT_BODY" | head -1 | tr -d '\r')
-          target=$(printf '%s' "$cmd" | sed -E 's|^/rerun[[:space:]]*||' \
-                   | tr '[:upper:]' '[:lower:]' | awk '{print $1}')
+          checkbox=false
+          status_file=$(mktemp)
+          trap 'rm -f "$status_file"' EXIT
+
+          set_checkbox_status() {
+            local status="$1"
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" --jq .body > "$status_file"
+            STATUS="$status" perl -0pi -e \
+              's/^- \[[ xX]\] Re-run preview diff.*$/- [ ] Re-run preview diff — $ENV{STATUS}/m' \
+              "$status_file"
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -F "body=@${status_file}" >/dev/null
+          }
+
+          if [ "$EVENT_ACTION" = "edited" ]; then
+            checkbox=true
+            target="compose-preview"
+
+            # The edited comment is bot-authored, so author_association names
+            # the bot rather than the person who clicked. Authorize the event
+            # actor directly, matching GitHub's own write-access rerun rule.
+            permission=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
+              --jq '.user.permission' 2>/dev/null || true)
+            case "$permission" in
+              admin|maintain|write) ;;
+              *)
+                set_checkbox_status "not started: @${ACTOR} needs write access"
+                exit 0
+                ;;
+            esac
+            set_checkbox_status "⏳ requested by @${ACTOR}; starting…"
+          else
+            # First line only; everything after `/rerun` is the target.
+            cmd=$(printf '%s\n' "$COMMENT_BODY" | head -1 | tr -d '\r')
+            target=$(printf '%s' "$cmd" | sed -E 's|^/rerun[[:space:]]*||' \
+                     | tr '[:upper:]' '[:lower:]' | awk '{print $1}')
+          fi
 
           case "$target" in
             previews) target="compose-preview" ;;
@@ -86,7 +139,11 @@ jobs:
             --jq '[.workflow_runs[] | {id, path, status, conclusion, name}]')
 
           reply() {
-            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$1" >/dev/null
+            if [ "$checkbox" = "true" ]; then
+              set_checkbox_status "$1"
+            else
+              gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$1" >/dev/null
+            fi
           }
 
           count=$(printf '%s' "$runs" | jq 'length')
@@ -141,5 +198,8 @@ jobs:
             fi
             rerun_one "$id" rerun "$name" && triggered=$((triggered+1)) \
               || reply "\`/rerun ${target}\`: GitHub refused to re-run **${name}** (run ${id}); see the Actions tab."
+          fi
+          if [ "$checkbox" = "true" ] && [ "$triggered" -gt 0 ]; then
+            set_checkbox_status "⏳ re-run started by @${ACTOR}; [view run](https://github.com/${REPO}/actions/runs/${id}) — this report will update when it finishes"
           fi
           echo "triggered: $triggered"

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -110,7 +110,7 @@ jobs:
             # the bot rather than the person who clicked. Authorize the event
             # actor directly, matching GitHub's own write-access rerun rule.
             permission=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
-              --jq '.user.permission' 2>/dev/null || true)
+              --jq '.permission' 2>/dev/null || true)
             case "$permission" in
               admin|maintain|write) ;;
               *)


### PR DESCRIPTION
## Summary

- add an opt-in **Re-run preview diff** checkbox to the primary sticky preview comment
- handle checkbox edits through the existing maintainer-only PR command workflow
- keep the current report visible while showing in-place rerun status and a workflow link
- verify the clicking actor has write-level repository access before rerunning

## Why

Reviewers currently need to know and type `/rerun previews`. The checkbox makes the action discoverable without adding extra comments or hiding the visual evidence while a replacement run is pending.

The action input defaults to disabled so downstream repositories do not receive an inert checkbox unless they install a compatible `issue_comment: edited` handler.

## Validation

- `python3 .github/actions/lib/test_compare_previews.py -v` — 100 tests passed, 3 skipped
- `python3 .github/actions/apply/test_post_comment.py -v` — 8 tests passed
- YAML parsed successfully for the modified workflows and composite action
- `git diff --check`

`actionlint` was not installed locally.