### PR TITLE
feat(serve): add catalog refresh control

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.cli.serve.BundleVerifier
 import ee.schimke.composeai.cli.serve.CatalogLoadTracker
+import ee.schimke.composeai.cli.serve.CatalogRefreshResult
 import ee.schimke.composeai.cli.serve.DaemonStartupLog
 import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
@@ -797,6 +798,10 @@ class ServeCommand(args: List<String>) : Command(args) {
         ),
       catalogLoads = catalogReg?.loads,
       catalogStore = catalogReg?.store,
+      catalogRefresh =
+        catalogRefresher?.let {
+          { system -> activeRefresher?.refresh(system) ?: CatalogRefreshResult.UNAVAILABLE }
+        },
       onStarted = {
         catalogReg?.loader?.start { loaded ->
           catalogRefresher?.let {
@@ -890,6 +895,10 @@ class ServeCommand(args: List<String>) : Command(args) {
         listOfNotNull(catalogReg?.loader, catalogRefresher, catalogPerPreviewPoolsCloseable),
       catalogLoads = catalogReg?.loads,
       catalogStore = catalogReg?.store,
+      catalogRefresh =
+        catalogRefresher?.let {
+          { system -> activeRefresher?.refresh(system) ?: CatalogRefreshResult.UNAVAILABLE }
+        },
       onStarted = {
         catalogReg?.loader?.start { loaded ->
           catalogRefresher?.let {
@@ -1463,6 +1472,8 @@ class ServeCommand(args: List<String>) : Command(args) {
     catalogLoads: CatalogLoadTracker?,
     /** The catalog store an admin registration fetches through; null ⇒ no runtime admin. */
     catalogStore: ServeCatalogStore? = null,
+    /** Immediate branch-head check used by the Refresh control on catalog landing pages. */
+    catalogRefresh: ((String) -> CatalogRefreshResult)? = null,
     /** Called immediately after the HTTP listener binds, before the long blocking wait. */
     onStarted: () -> Unit = {},
   ) {
@@ -1520,6 +1531,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         catalogSessions = configuredCatalogs,
         appCatalogSessions = configuredApps,
         catalogLoads = catalogLoads,
+        catalogRefresh = catalogRefresh,
         maxLiveSeats = liveSeats,
         daemonLog = daemonLog,
         allowRenderTrusted = allowRenderTrusted,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -771,6 +771,9 @@ class ServeCommand(args: List<String>) : Command(args) {
       if (needsCatalogMachinery) registerCatalogs(registry, catalogWorktrees, openHost) else null
     // Keep the catalogs fresh against their (routinely-changing) branches without a restart.
     val catalogRefresher = catalogReg?.let { buildCatalogRefresher(it.store, it.loads) }
+    // Make manual refresh + trust-revocation invalidation available as soon as any catalog page
+    // can be served. The background cadence is still seeded and started after the loader finishes.
+    activeRefresher = catalogRefresher
     // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
     // registered as a pinned session. Unpacked under a temp dir for this server's lifetime.
     val bundleStore = if (acceptBundles) openUploadStore(registry) else null
@@ -798,16 +801,12 @@ class ServeCommand(args: List<String>) : Command(args) {
         ),
       catalogLoads = catalogReg?.loads,
       catalogStore = catalogReg?.store,
-      catalogRefresh =
-        catalogRefresher?.let {
-          { system -> activeRefresher?.refresh(system) ?: CatalogRefreshResult.UNAVAILABLE }
-        },
+      catalogRefresh = catalogRefresher?.let { refresher -> refresher::refresh },
       onStarted = {
         catalogReg?.loader?.start { loaded ->
           catalogRefresher?.let {
             it.seedInitialHeads(loaded)
             it.start()
-            activeRefresher = it
           }
         }
       },
@@ -840,6 +839,9 @@ class ServeCommand(args: List<String>) : Command(args) {
     // Keep the catalogs fresh against their (routinely-changing) branches without a restart — the
     // public preview server (preview.coo.ee) runs this module-less path.
     val catalogRefresher = catalogReg?.let { buildCatalogRefresher(it.store, it.loads) }
+    // A catalog registered early in the asynchronous startup load can already show Refresh; wire
+    // its immediate check now instead of waiting for every configured catalog to finish loading.
+    activeRefresher = catalogRefresher
     val bundleStore = if (acceptBundles) openUploadStore(registry) else null
 
     val wasmCatalogs = mergedWasmCatalogs(catalogReg)
@@ -895,16 +897,12 @@ class ServeCommand(args: List<String>) : Command(args) {
         listOfNotNull(catalogReg?.loader, catalogRefresher, catalogPerPreviewPoolsCloseable),
       catalogLoads = catalogReg?.loads,
       catalogStore = catalogReg?.store,
-      catalogRefresh =
-        catalogRefresher?.let {
-          { system -> activeRefresher?.refresh(system) ?: CatalogRefreshResult.UNAVAILABLE }
-        },
+      catalogRefresh = catalogRefresher?.let { refresher -> refresher::refresh },
       onStarted = {
         catalogReg?.loader?.start { loaded ->
           catalogRefresher?.let {
             it.seedInitialHeads(loaded)
             it.start()
-            activeRefresher = it
           }
         }
       },

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -5,6 +5,14 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
+enum class CatalogRefreshResult {
+  UPDATED,
+  CURRENT,
+  UNAVAILABLE,
+  FAILED,
+  NOT_FOUND,
+}
+
 /**
  * Keeps a running `serve` fresh against routinely-changing catalog branches.
  *
@@ -94,14 +102,23 @@ internal class ServeCatalogRefresher(
    * One poll pass over every watched branch. Package-visible so a test can drive it
    * deterministically.
    */
+  @Synchronized
   fun tick() {
     for (e in entries()) checkOne(e)
   }
 
-  private fun checkOne(e: Entry) {
+  /** Check one catalog immediately, using the same branch-head + reload path as the poller. */
+  @Synchronized
+  fun refresh(system: String): CatalogRefreshResult {
+    val entry =
+      entries().firstOrNull { it.system == system } ?: return CatalogRefreshResult.NOT_FOUND
+    return checkOne(entry)
+  }
+
+  private fun checkOne(e: Entry): CatalogRefreshResult {
     // Can't resolve the head (offline / git missing / private) → leave what we serve untouched.
-    val head = headResolver(e.repo, e.branch) ?: return
-    if (head == lastHead[e.system]) return
+    val head = headResolver(e.repo, e.branch) ?: return CatalogRefreshResult.UNAVAILABLE
+    if (head == lastHead[e.system]) return CatalogRefreshResult.CURRENT
     val prev = lastHead[e.system]
     onLog(
       "serve: catalog ${e.system} (${e.branch}) moved ${prev?.take(7) ?: "?"}→${head.take(7)} — re-fetching"
@@ -110,8 +127,10 @@ internal class ServeCatalogRefresher(
       // Only advance the recorded head on success, so a failed reload retries next tick.
       lastHead[e.system] = head
       onLog("serve: catalog ${e.system} refreshed to ${head.take(7)}")
+      return CatalogRefreshResult.UPDATED
     } else {
       onLog("serve: catalog ${e.system} refresh failed — keeping the current copy, will retry")
+      return CatalogRefreshResult.FAILED
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -227,6 +227,9 @@ class ServeHttpServer(
 
   private val renderSemaphore = Semaphore(renderSlots)
 
+  /** Catalog ids with a manual branch check in flight; public callers coalesce at this boundary. */
+  private val catalogRefreshesInFlight = ConcurrentHashMap.newKeySet<String>()
+
   /**
    * Readiness latch for `/readyz` (the rolling-update gate). Unlike `/healthz` — a static "ok" that
    * only proves the HTTP listener is up — readiness is `true` only once a representative preview
@@ -676,7 +679,22 @@ class ServeHttpServer(
       )
       return
     }
-    val result = withContext(Dispatchers.IO) { refresh(system) }
+    if (!catalogRefreshesInFlight.add(system)) {
+      call.response.headers.append(HttpHeaders.CacheControl, "no-store")
+      call.response.headers.append(HttpHeaders.RetryAfter, "2")
+      call.respondText(
+        "{\"status\":\"checking\"}",
+        ContentType.Application.Json,
+        HttpStatusCode.Accepted,
+      )
+      return
+    }
+    val result =
+      try {
+        withContext(Dispatchers.IO) { refresh(system) }
+      } finally {
+        catalogRefreshesInFlight.remove(system)
+      }
     val (status, code) =
       when (result) {
         CatalogRefreshResult.UPDATED -> "updated" to HttpStatusCode.OK

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -122,6 +122,8 @@ class ServeHttpServer(
    * explicit and recoverable. Null preserves the plain/test server behaviour.
    */
   private val catalogLoads: CatalogLoadTracker? = null,
+  /** Immediate catalog branch check exposed by `POST /{system}/refresh`. */
+  private val catalogRefresh: ((String) -> CatalogRefreshResult)? = null,
   portRange: Int = DEFAULT_PORT_RANGE,
   /**
    * Max renders in flight across the HTTP `/render` lane. Defaults to the host's CPU count so a
@@ -597,6 +599,9 @@ class ServeHttpServer(
         get("/{system}") { handleLanding(sessionInPath = true) }
         get("/{system}/") { handleLanding(sessionInPath = true) }
 
+        post("/refresh") { handleCatalogRefresh(sessionInPath = false) }
+        post("/{system}/refresh") { handleCatalogRefresh(sessionInPath = true) }
+
         get("/api/previews") { handleApiPreviews(sessionInPath = false) }
         get("/{system}/api/previews") { handleApiPreviews(sessionInPath = true) }
 
@@ -656,6 +661,32 @@ class ServeHttpServer(
     val system = if (sessionInPath) call.parameters["system"] else null
     return if (system != null) system to "/" + WebEscaping.urlEncodeSegment(system)
     else call.request.queryParameters["session"] to ""
+  }
+
+  /** `POST /{system}/refresh`: check the published catalog branch and reload it when newer. */
+  private suspend fun RoutingContext.handleCatalogRefresh(sessionInPath: Boolean) {
+    if (rejectBadToken()) return
+    val system = selectedSessionId(sessionInPath)
+    val refresh = catalogRefresh
+    if (system.isEmpty() || refresh == null) {
+      call.respondText(
+        "{\"status\":\"unavailable\"}",
+        ContentType.Application.Json,
+        HttpStatusCode.NotFound,
+      )
+      return
+    }
+    val result = withContext(Dispatchers.IO) { refresh(system) }
+    val (status, code) =
+      when (result) {
+        CatalogRefreshResult.UPDATED -> "updated" to HttpStatusCode.OK
+        CatalogRefreshResult.CURRENT -> "current" to HttpStatusCode.OK
+        CatalogRefreshResult.UNAVAILABLE -> "unavailable" to HttpStatusCode.ServiceUnavailable
+        CatalogRefreshResult.FAILED -> "failed" to HttpStatusCode.BadGateway
+        CatalogRefreshResult.NOT_FOUND -> "not-found" to HttpStatusCode.NotFound
+      }
+    call.response.headers.append(HttpHeaders.CacheControl, "no-store")
+    call.respondText("{\"status\":\"$status\"}", ContentType.Application.Json, code)
   }
 
   /**
@@ -1096,6 +1127,8 @@ class ServeHttpServer(
           // Catalog provenance (delivery branch, generation date, tool versions) for the strip
           // under the header; null for a plain (non-catalog) module session.
           provenance = catalogBundleHost(renderHost)?.provenance,
+          refreshUrl =
+            if (catalogRefresh != null) "$basePath/refresh${requestQuerySuffix()}" else null,
           // Crop each card's thumbnail to the component's figma-svg content box (cheap baked
           // reads),
           // so a Wear sticker shows the component, not the empty watch canvas around it.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -355,7 +355,8 @@ object ServeWeb {
             window.location.reload();
             return;
           }
-          status.textContent = result.status === 'current' ? 'up to date' : 'check failed';
+          status.textContent = result.status === 'current' ? 'up to date' :
+            result.status === 'checking' ? 'check in progress' : 'check failed';
         } catch (_) {
           status.textContent = 'check failed';
         }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -288,7 +288,7 @@ object ServeWeb {
    * design-parity versions it was rendered with, and a link to re-run the `design-artifacts`
    * workflow that regenerates it. Empty [prov] fields drop their item.
    */
-  private fun provenanceSection(prov: CatalogProvenance): String {
+  private fun provenanceSection(prov: CatalogProvenance, refreshUrl: String?): String {
     val repo = WebEscaping.htmlEscape(prov.repo)
     val branch = WebEscaping.htmlEscape(prov.branch)
     // Branch names carry a `/` (`design-artifacts/compose-m3`); it's a valid path in a tree URL.
@@ -320,14 +320,51 @@ object ServeWeb {
         )
       }
       add("<span class=\"cp-prov-item\"><a href=\"$actionUrl\">regenerate ↗</a></span>")
+      refreshUrl?.let {
+        add(
+          "<span class=\"cp-prov-item\"><button type=\"button\" class=\"cp-prov-refresh\" " +
+            "data-refresh-url=\"${WebEscaping.htmlEscape(it)}\">refresh</button>" +
+            "<span class=\"cp-prov-refresh-status\" role=\"status\" aria-live=\"polite\"></span></span>"
+        )
+      }
     }
     return """
       <section class="cp-prov" aria-label="Catalog provenance">
         ${items.joinToString("\n        ")}
       </section>
+      ${if (refreshUrl == null) "" else provenanceRefreshScript()}
       """
       .trimIndent()
   }
+
+  private fun provenanceRefreshScript(): String =
+    """
+    <script>
+    (() => {
+      const button = document.querySelector('.cp-prov-refresh');
+      if (!button) return;
+      const status = document.querySelector('.cp-prov-refresh-status');
+      button.addEventListener('click', async () => {
+        button.disabled = true;
+        status.textContent = 'checking…';
+        try {
+          const response = await fetch(button.dataset.refreshUrl, { method: 'POST' });
+          const result = await response.json();
+          if (result.status === 'updated') {
+            status.textContent = 'updated';
+            window.location.reload();
+            return;
+          }
+          status.textContent = result.status === 'current' ? 'up to date' : 'check failed';
+        } catch (_) {
+          status.textContent = 'check failed';
+        }
+        button.disabled = false;
+      });
+    })();
+    </script>
+    """
+      .trimIndent()
 
   /**
    * The theme axis (`light`/`dark`) baked into a flattened catalog id, or null if it carries none.
@@ -2490,6 +2527,8 @@ object ServeWeb {
      * uploaded bundle / non-catalog module (no such metadata).
      */
     provenance: CatalogProvenance? = null,
+    /** POST URL that checks this catalog's delivery branch immediately. Null omits Refresh. */
+    refreshUrl: String? = null,
     /**
      * The catalog's declared stage surface (`catalog.json`'s `display.surface`: `"light"`/`"dark"`)
      * — decides whether unthemed cards sit on the dark stage. Null ⇒ fall back to the system-name
@@ -2700,7 +2739,7 @@ object ServeWeb {
     val back = if (hasHomeIndex) backButton(token, isPublic) + "\n" else ""
     // The catalog-provenance strip (delivery branch, generation date, tool versions, regenerate
     // link), shown under the header for a served design-system catalog.
-    val prov = provenance?.let { provenanceSection(it) + "\n" } ?: ""
+    val prov = provenance?.let { provenanceSection(it, refreshUrl) + "\n" } ?: ""
     // The Theme control shows when there is more than one theme to choose between: a baked
     // light/dark pair to swap, and/or the app-declared themes this session can re-render under. A
     // catalog with neither (mostly theme-neutral app screens on a static bundle) never sprouts a

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -37,6 +37,11 @@ a:hover { text-decoration: underline; }
 .cp-prov-item { display: inline-flex; align-items: center; gap: 5px; }
 .cp-prov-item .cp-prov-key { color: #8a8a92; }
 .cp-prov-item code { font-size: 0.74rem; padding: 0 4px; border-radius: 4px; background: #f0f0f3; }
+.cp-prov-refresh { appearance: none; border: 0; padding: 0; background: none; color: #5b5bd6;
+  font: inherit; cursor: pointer; }
+.cp-prov-refresh:hover { text-decoration: underline; }
+.cp-prov-refresh:disabled { color: #8a8a92; cursor: wait; text-decoration: none; }
+.cp-prov-refresh-status { color: #8a8a92; }
 .cp-systems { margin: 0 0 20px; display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
   font-size: 0.85rem; }
 .cp-systems-label { font-weight: 600; color: #6b6b70; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
@@ -41,6 +41,31 @@ class ServeCatalogRefresherTest {
   }
 
   @Test
+  fun `manual refresh reports whether a later version was found`() {
+    var head = "aaaaaaa"
+    val reloads = mutableListOf<String>()
+    val r =
+      ServeCatalogRefresher(
+        entries = { listOf(entry()) },
+        reload = { system, _ ->
+          reloads += system
+          true
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> head },
+        onLog = {},
+      )
+    r.seedInitialHeads()
+
+    assertEquals(CatalogRefreshResult.CURRENT, r.refresh("compose-m3"))
+    head = "bbbbbbb"
+    assertEquals(CatalogRefreshResult.UPDATED, r.refresh("compose-m3"))
+    assertEquals(listOf("compose-m3"), reloads)
+    assertEquals(CatalogRefreshResult.NOT_FOUND, r.refresh("unknown"))
+    r.close()
+  }
+
+  @Test
   fun `a failed reload keeps the old head and retries next tick`() {
     var head = "aaaaaaa"
     var succeed = false

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -11,6 +11,9 @@ import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import javax.imageio.ImageIO
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -35,6 +38,9 @@ class ServeHttpRoutingTest {
 
   private val previewId = "com.example.Red"
   private val refreshes = mutableListOf<String>()
+  @Volatile private var blockRefresh = false
+  private val refreshStarted = CountDownLatch(1)
+  private val releaseRefresh = CountDownLatch(1)
 
   private fun png(): ByteArray =
     ByteArrayOutputStream()
@@ -116,6 +122,10 @@ class ServeHttpRoutingTest {
         catalogSessions = listOf("compose-m3"),
         catalogRefresh = { system ->
           refreshes += system
+          if (blockRefresh) {
+            refreshStarted.countDown()
+            releaseRefresh.await(5, TimeUnit.SECONDS)
+          }
           CatalogRefreshResult.CURRENT
         },
       )
@@ -170,6 +180,25 @@ class ServeHttpRoutingTest {
     assertEquals(200 to "{\"status\":\"current\"}", post("/compose-m3/refresh"))
     assertEquals(200 to "{\"status\":\"current\"}", post("/refresh?session=compose-m3"))
     assertEquals(listOf("compose-m3", "compose-m3"), refreshes)
+  }
+
+  @Test
+  fun `concurrent catalog refresh requests coalesce before remote work`() {
+    blockRefresh = true
+    val executor = Executors.newSingleThreadExecutor()
+    try {
+      val first = executor.submit<Pair<Int, String>> { post("/compose-m3/refresh") }
+      assertTrue(refreshStarted.await(5, TimeUnit.SECONDS), "the first refresh started")
+
+      assertEquals(202 to "{\"status\":\"checking\"}", post("/compose-m3/refresh"))
+      assertEquals(listOf("compose-m3"), refreshes, "the second request did no remote work")
+
+      releaseRefresh.countDown()
+      assertEquals(200 to "{\"status\":\"current\"}", first.get(5, TimeUnit.SECONDS))
+    } finally {
+      releaseRefresh.countDown()
+      executor.shutdownNow()
+    }
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * End-to-end routing check for [ServeHttpServer]: a real embedded server fronting two static
@@ -33,6 +34,7 @@ import okhttp3.Request
 class ServeHttpRoutingTest {
 
   private val previewId = "com.example.Red"
+  private val refreshes = mutableListOf<String>()
 
   private fun png(): ByteArray =
     ByteArrayOutputStream()
@@ -112,6 +114,10 @@ class ServeHttpRoutingTest {
         defaultSessionId = "default-mod",
         isPublic = true,
         catalogSessions = listOf("compose-m3"),
+        catalogRefresh = { system ->
+          refreshes += system
+          CatalogRefreshResult.CURRENT
+        },
       )
       .also { it.start() }
   }
@@ -120,6 +126,17 @@ class ServeHttpRoutingTest {
 
   private fun get(path: String): Pair<Int, String> {
     val req = Request.Builder().url("http://127.0.0.1:${server.port}$path").build()
+    client.newCall(req).execute().use { r ->
+      return r.code to (r.body?.string() ?: "")
+    }
+  }
+
+  private fun post(path: String): Pair<Int, String> {
+    val req =
+      Request.Builder()
+        .url("http://127.0.0.1:${server.port}$path")
+        .post(ByteArray(0).toRequestBody())
+        .build()
     client.newCall(req).execute().use { r ->
       return r.code to (r.body?.string() ?: "")
     }
@@ -146,6 +163,13 @@ class ServeHttpRoutingTest {
     val (code, body) = get("/version")
     assertEquals(200, code)
     assertTrue(body.contains("compose-preview-serve/version/v1"), "version json: $body")
+  }
+
+  @Test
+  fun `catalog refresh supports path and query session routes`() {
+    assertEquals(200 to "{\"status\":\"current\"}", post("/compose-m3/refresh"))
+    assertEquals(200 to "{\"status\":\"current\"}", post("/refresh?session=compose-m3"))
+    assertEquals(listOf("compose-m3", "compose-m3"), refreshes)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -384,6 +384,7 @@ class ServeWebFixtureTest {
         hasHomeIndex = true,
         version = version,
         provenance = provenance,
+        refreshUrl = "/compose-m3/refresh",
       )
     // The public preview server's FRONT DOOR: an index of the published design systems, each a card
     // with a meaningful hero preview, its title + library, trust badge, and a link to /<system>/.
@@ -2150,6 +2151,7 @@ class ServeWebFixtureTest {
             toolVersion = "0.16.54",
             designParityVersion = "0.1.25",
           ),
+        refreshUrl = "/compose-m3/refresh",
       )
     assertTrue(landing.contains("class=\"cp-prov\""), "the provenance strip renders")
     // Links to the delivery branch and the regenerating workflow.
@@ -2167,6 +2169,11 @@ class ServeWebFixtureTest {
     )
     // Friendly generation date + both tool versions.
     assertTrue(landing.contains("2026-07-17 09:30 UTC"), "the generation date is shown")
+    assertTrue(
+      landing.contains("class=\"cp-prov-refresh\"") &&
+        landing.contains("data-refresh-url=\"/compose-m3/refresh\""),
+      "the strip offers an immediate catalog refresh next to regenerate",
+    )
     assertTrue(
       landing.contains("compose-ai-tools <code>0.16.54</code>") &&
         landing.contains("design-parity <code>0.1.25</code>"),

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>loading-spinner.json — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>watchface.rc — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Share a document — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Design systems — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -12,12 +12,37 @@
         <main class="cp-main">
                 <a class="cp-back" href="/">← All design systems</a>
 <h1 class="cp-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-        <section class="cp-prov" aria-label="Catalog provenance">
-  <span class="cp-prov-item"><span class="cp-prov-key">catalog</span> <a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/compose-m3"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> yschimke/compose-ai-tools@design-artifacts/compose-m3</a></span>
-  <span class="cp-prov-item"><span class="cp-prov-key">generated</span> 2026-07-17 09:30 UTC</span>
-  <span class="cp-prov-item"><span class="cp-prov-key">rendered by</span> compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></span>
-  <span class="cp-prov-item"><a href="https://github.com/yschimke/compose-ai-tools/actions/workflows/design-artifacts.yml">regenerate ↗</a></span>
-</section>
+              <section class="cp-prov" aria-label="Catalog provenance">
+        <span class="cp-prov-item"><span class="cp-prov-key">catalog</span> <a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/compose-m3"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> yschimke/compose-ai-tools@design-artifacts/compose-m3</a></span>
+        <span class="cp-prov-item"><span class="cp-prov-key">generated</span> 2026-07-17 09:30 UTC</span>
+        <span class="cp-prov-item"><span class="cp-prov-key">rendered by</span> compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></span>
+        <span class="cp-prov-item"><a href="https://github.com/yschimke/compose-ai-tools/actions/workflows/design-artifacts.yml">regenerate ↗</a></span>
+        <span class="cp-prov-item"><button type="button" class="cp-prov-refresh" data-refresh-url="/compose-m3/refresh">refresh</button><span class="cp-prov-refresh-status" role="status" aria-live="polite"></span></span>
+      </section>
+      <script>
+(() => {
+  const button = document.querySelector('.cp-prov-refresh');
+  if (!button) return;
+  const status = document.querySelector('.cp-prov-refresh-status');
+  button.addEventListener('click', async () => {
+    button.disabled = true;
+    status.textContent = 'checking…';
+    try {
+      const response = await fetch(button.dataset.refreshUrl, { method: 'POST' });
+      const result = await response.json();
+      if (result.status === 'updated') {
+        status.textContent = 'updated';
+        window.location.reload();
+        return;
+      }
+      status.textContent = result.status === 'current' ? 'up to date' : 'check failed';
+    } catch (_) {
+      status.textContent = 'check failed';
+    }
+    button.disabled = false;
+  });
+})();
+</script>
 <p class="cp-sub">6 preview(s) · click one to view with overrides ·
           <a href="/bundle.zip">download all (.zip)</a></p>
         <div class="cp-searchbar">

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -35,7 +35,8 @@
         window.location.reload();
         return;
       }
-      status.textContent = result.status === 'current' ? 'up to date' : 'check failed';
+      status.textContent = result.status === 'current' ? 'up to date' :
+        result.status === 'checking' ? 'check in progress' : 'check failed';
     } catch (_) {
       status.textContent = 'check failed';
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Not found — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Playground — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-status.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-status.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Server status — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Focus ring — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>One-handed — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Checkbox · Checked (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/8d41-c25ce9e4a2287970/serve.css">
+        <link rel="stylesheet" href="/assets/serve/8e79-7d05d4be78060cff/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>


### PR DESCRIPTION
## Summary

- add a Refresh control beside Regenerate on catalog landing pages
- check the published catalog branch immediately and reload only when a newer head is available
- support canonical path and legacy query-session routes with user-visible status
- cover refresh results, HTTP routing, generated HTML, and refreshed visual fixtures

## Why

Catalogs already poll their delivery branches in the background, but app pages offered no way to request an immediate version check. This reuses the existing branch-head and catalog reload path so visitors can pick up a newly generated catalog without waiting for the polling interval.

## Validation

- `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.ServeCatalogRefresherTest' --tests 'ee.schimke.composeai.cli.serve.ServeHttpRoutingTest' --tests 'ee.schimke.composeai.cli.serve.ServeWebFixtureTest'`
- visually inspected the generated public catalog fixture in light mode