### PR TITLE
ci: improve preview and design artifact output

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -255,7 +255,7 @@ runs:
         echo "resources=$resources" >> "$GITHUB_OUTPUT"
         echo "a11y=$a11y" >> "$GITHUB_OUTPUT"
         echo "notifications=$notifications" >> "$GITHUB_OUTPUT"
-        echo "::notice::compose-preview/apply mode=$mode compose=$compose resources=$resources a11y=$a11y notifications=$notifications"
+        echo "compose-preview: mode=$mode; pipelines: compose=$compose resources=$resources a11y=$a11y notifications=$notifications"
         if [ "$mode" = "skip" ]; then
           echo "::notice::No pipeline applicable for event=$EVENT_NAME ref=$REF_NAME — skipping."
         fi
@@ -509,8 +509,8 @@ runs:
         : "${prev_mono:=DejaVu Sans Mono}"
 
         # 2. Install the Noto fallbacks.
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends \
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq --no-install-recommends \
           fonts-noto-cjk fonts-noto-core fonts-noto-color-emoji
 
         # 3. Pin the generic families back to the recorded defaults so Noto stays
@@ -672,14 +672,40 @@ runs:
         fi
 
         worst=0
+        results="$GITHUB_WORKSPACE/_pipeline_results"
+        : > "$results"
+        {
+          echo "### Compose preview pipelines"
+          echo
+          echo "| Pipeline | Result | Time |"
+          echo "| --- | --- | ---: |"
+        } >> "$GITHUB_STEP_SUMMARY"
         run_one() {
           local name="$1"
+          local started=$SECONDS
+          echo "▶ ${name}: started"
           echo "::group::${name} pipeline"
           bash "$ACTION_PATH/pipelines/${name}.sh"
           local rc=$?
           echo "::endgroup::"
-          if [ "$rc" -ne 0 ] && [ "$worst" -eq 0 ]; then
-            worst="$rc"
+          local render_rc
+          render_rc=$(cat "$GITHUB_WORKSPACE/_${name}_render_rc" 2>/dev/null || echo 0)
+          local effective_rc="$rc"
+          if [ "$effective_rc" -eq 0 ] && [ "$render_rc" -ne 0 ]; then
+            effective_rc="$render_rc"
+          fi
+          local elapsed=$((SECONDS - started))
+          if [ "$effective_rc" -eq 0 ]; then
+            echo "✓ ${name}: completed in ${elapsed}s"
+            echo "| ${name} | ✓ passed | ${elapsed}s |" >> "$GITHUB_STEP_SUMMARY"
+            echo "${name}|passed|0|${elapsed}" >> "$results"
+          else
+            echo "✗ ${name}: failed with exit ${effective_rc} after ${elapsed}s" >&2
+            echo "| ${name} | ✗ failed (exit ${effective_rc}) | ${elapsed}s |" >> "$GITHUB_STEP_SUMMARY"
+            echo "${name}|failed|${effective_rc}|${elapsed}" >> "$results"
+          fi
+          if [ "$effective_rc" -ne 0 ] && [ "$worst" -eq 0 ]; then
+            worst="$effective_rc"
           fi
         }
 
@@ -689,6 +715,8 @@ runs:
         [ "$WANT_NOTIFICATIONS" = "1" ] && run_one notifications
 
         echo "worst=$worst" >> "$GITHUB_OUTPUT"
+        echo "compose_render_rc=$(cat "$GITHUB_WORKSPACE/_compose_render_rc" 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
+        echo "resources_render_rc=$(cat "$GITHUB_WORKSPACE/_resources_render_rc" 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
         # Don't fail here — the trailing "surface failures" step decides
         # after pushes + comments have run.
         exit 0
@@ -708,10 +736,12 @@ runs:
         key: composeai-fonts-${{ runner.os }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     # Upload artifacts as top-level GHA steps (can't run from subshells).
-    # Fires whenever the relevant pipeline flagged a non-zero render rc,
-    # regardless of whether the orchestrator step itself succeeded.
+    # Fires only when the relevant pipeline flagged a non-zero render rc,
+    # regardless of whether the orchestrator step itself succeeded. Checking
+    # the output value (not merely whether the rc file exists) avoids noisy,
+    # empty artifact steps on every successful run.
     - name: Upload composePreviewRender reports
-      if: always() && hashFiles('_compose_render_rc') != ''
+      if: always() && steps.pipelines.outputs.compose_render_rc != '' && steps.pipelines.outputs.compose_render_rc != '0'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: composePreviewRender-reports
@@ -723,7 +753,7 @@ runs:
         retention-days: 14
 
     - name: Upload composePreviewRenderAndroidResources reports
-      if: always() && hashFiles('_resources_render_rc') != ''
+      if: always() && steps.pipelines.outputs.resources_render_rc != '' && steps.pipelines.outputs.resources_render_rc != '0'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: composePreviewRenderAndroidResources-reports
@@ -735,7 +765,7 @@ runs:
         retention-days: 14
 
     - name: Upload CLI JSON output on failure
-      if: failure()
+      if: always() && ((steps.pipelines.outputs.worst != '' && steps.pipelines.outputs.worst != '0') || (steps.pipelines.outputs.compose_render_rc != '' && steps.pipelines.outputs.compose_render_rc != '0') || (steps.pipelines.outputs.resources_render_rc != '' && steps.pipelines.outputs.resources_render_rc != '0'))
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: preview-cli-output
@@ -1140,6 +1170,14 @@ runs:
         WORST_RC: ${{ steps.pipelines.outputs.worst }}
       run: |
         rc="${WORST_RC:-0}"
+        failed=()
+        if [ -f "$GITHUB_WORKSPACE/_pipeline_results" ]; then
+          while IFS='|' read -r name status pipeline_rc elapsed; do
+            if [ "$status" = "failed" ]; then
+              failed+=("${name} (exit ${pipeline_rc})")
+            fi
+          done < "$GITHUB_WORKSPACE/_pipeline_results"
+        fi
         for p in compose resources a11y notifications; do
           extra=$(cat "$GITHUB_WORKSPACE/_${p}_render_rc" 2>/dev/null || echo 0)
           if [ "$extra" -ne 0 ] && [ "$rc" -eq 0 ]; then
@@ -1147,6 +1185,11 @@ runs:
           fi
         done
         if [ "$rc" -ne 0 ]; then
-          echo "::error::One or more compose-preview pipelines exited non-zero (rc=$rc). Pushes + comments have been published; see uploaded reports for per-task stack traces." >&2
+          if [ "${#failed[@]}" -gt 0 ]; then
+            cause=$(IFS=,; echo "${failed[*]}")
+          else
+            cause="render process (exit ${rc})"
+          fi
+          echo "::error title=Compose preview failed::Failed: ${cause}. PR comments and successful renders were still published. Open the failed pipeline group for the concise cause; download the matching composePreviewRender report artifact for full test output." >&2
           exit "$rc"
         fi

--- a/.github/actions/apply/lib/post-comment.sh
+++ b/.github/actions/apply/lib/post-comment.sh
@@ -51,7 +51,7 @@ if [ "$BODY_BYTES" -gt "$MAX_BYTES" ]; then
   # multi-byte character.
   head -c "$BUDGET" "$BODY_FILE" | sed '$d' > "$TRUNCATED"
   printf '%s\n' "$NOTICE" >> "$TRUNCATED"
-  echo "post-comment: body was ${BODY_BYTES} bytes; truncated to fit GitHub's 65,536-char comment limit." >&2
+  echo "::warning title=Preview comment truncated::The generated comment was ${BODY_BYTES} bytes and was truncated to fit GitHub's 65,536-character limit. Open the published render branch for the complete result." >&2
   BODY_FILE="$TRUNCATED"
 fi
 

--- a/.github/actions/apply/pipelines/a11y.sh
+++ b/.github/actions/apply/pipelines/a11y.sh
@@ -53,7 +53,7 @@ split_csv() {
 mapfile -t ALLOW_MODULES < <(split_csv "${A11Y_MODULES:-}")
 mapfile -t SKIP_MODULES < <(split_csv "${A11Y_SKIP_MODULES:-}")
 
-cli_args=(a11y)
+cli_args=(a11y --progress)
 if [ "${#ALLOW_MODULES[@]}" -gt 0 ]; then
   for m in "${ALLOW_MODULES[@]}"; do
     cli_args+=(--module ":${m}")

--- a/.github/actions/apply/pipelines/compose.sh
+++ b/.github/actions/apply/pipelines/compose.sh
@@ -59,7 +59,7 @@ elif [ -n "${SCOPE_MODULES:-}" ] && [ "${SCOPE_MODULES}" != "full" ]; then
     [ -z "$m" ] && continue
     out="_previews_scope_${i}.json"
     i=$((i + 1))
-    show_args=(show --json --timeout "$RENDER_TIMEOUT" --module ":${m#:}")
+    show_args=(show --json --progress --timeout "$RENDER_TIMEOUT" --module ":${m#:}")
     if [ -n "${MISSING_RENDERS:-}" ]; then
       show_args+=(--missing-renders "${MISSING_RENDERS}")
     fi
@@ -78,7 +78,7 @@ elif [ -n "${SCOPE_MODULES:-}" ] && [ "${SCOPE_MODULES}" != "full" ]; then
   echo "$WORST_RC" > "$GITHUB_WORKSPACE/_compose_render_rc"
 else
   # Render. Don't fail on non-zero — partial envelope still drives the rest.
-  show_args=(show --json --timeout "$RENDER_TIMEOUT")
+  show_args=(show --json --progress --timeout "$RENDER_TIMEOUT")
   # Forwards as `-PcomposePreview.missingRenders=<value>` to the Gradle
   # `composePreviewRenderAll` task the CLI spawns; default `fail` is a
   # no-op vs the plugin's own default so always-pass is safe.

--- a/.github/actions/apply/pipelines/notifications.sh
+++ b/.github/actions/apply/pipelines/notifications.sh
@@ -77,13 +77,13 @@ fi
 # allowlist the missing task IS a misconfiguration and we let Gradle fail
 # the run as before.
 if [ "${#ALLOW_MODULES[@]}" -eq 0 ]; then
-  if ! ./gradlew "${gradle_args[@]}" --no-daemon; then
+  if ! ./gradlew "${gradle_args[@]}" --no-daemon --quiet; then
     echo "notifications pipeline: ./gradlew ${gradle_args[*]} failed (likely no module registers the task); skipping."
     echo "0" > "$GITHUB_WORKSPACE/_notifications_rc"
     exit 0
   fi
 else
-  ./gradlew "${gradle_args[@]}" --no-daemon
+  ./gradlew "${gradle_args[@]}" --no-daemon --quiet
 fi
 
 # Discover every module with notification PNG output under

--- a/.github/actions/apply/pipelines/resources.sh
+++ b/.github/actions/apply/pipelines/resources.sh
@@ -30,7 +30,7 @@ if [ "${SKIP_RENDER:-false}" = "true" ]; then
   echo "resources pipeline: skip-render=true; reusing pre-staged _resources.json."
   echo "0" > "$GITHUB_WORKSPACE/_resources_render_rc"
 else
-  res_args=(show-resources --json --timeout "$RENDER_TIMEOUT")
+  res_args=(show-resources --json --progress --timeout "$RENDER_TIMEOUT")
   if [ -n "${MISSING_RENDERS:-}" ]; then
     res_args+=(--missing-renders "${MISSING_RENDERS}")
   fi

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -255,7 +255,7 @@ jobs:
         working-directory: compose-ai-tools
         run: |
           set -euo pipefail
-          ./gradlew :cli:installDist --no-daemon
+          ./gradlew :cli:installDist --no-daemon --quiet
           echo "$GITHUB_WORKSPACE/compose-ai-tools/cli/build/install/compose-preview/bin" >> "$GITHUB_PATH"
 
       - name: Set up Node
@@ -264,7 +264,7 @@ jobs:
           node-version: 24
       - name: Install export engine (pinned npm packages)
         working-directory: compose-ai-tools/scripts/design-artifacts
-        run: npm ci
+        run: npm ci --no-audit --no-fund --loglevel=warn
 
       # Fast, build-free pre-flight: resolve every spec `preview` against the
       # module's @Preview functions BEFORE the (long) render, so a mistyped or
@@ -353,7 +353,7 @@ jobs:
           FONT_GLOBS: ${{ inputs.stage-font-globs }}
         run: |
           set -euo pipefail
-          command -v fc-cache >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y --no-install-recommends fontconfig; }
+          command -v fc-cache >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends fontconfig; }
           mkdir -p "$HOME/.local/share/fonts"
           shopt -s nullglob
           for g in $FONT_GLOBS; do cp $g "$HOME/.local/share/fonts/"; done
@@ -365,8 +365,8 @@ jobs:
       - name: Install desktop (Skiko) render deps
         if: ${{ inputs.desktop-render || inputs.rc-embedded-jvm-lane }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
             xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig
 
       # Restore the downloadable-font cache (the matching save runs after the render,
@@ -421,7 +421,7 @@ jobs:
           embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
           exclude=(); if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS"); fi
           if [ -n "${EXCLUDE_PREVIEW_ROWS:-}" ]; then exclude+=(--exclude-preview-row "$EXCLUDE_PREVIEW_ROWS"); fi
-          run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics \
+          run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics --progress \
             "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" --timeout 600
 
       - name: Render extra module
@@ -431,7 +431,7 @@ jobs:
           set -euo pipefail
           run() { if [ "${{ inputs.desktop-render }}" = "true" ]; then xvfb-run -a -s "-screen 0 2000x1400x24" "$@"; else "$@"; fi; }
           embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
-          run compose-preview bundle pack --module "${{ inputs.extra-module }}" --with-semantics \
+          run compose-preview bundle pack --module "${{ inputs.extra-module }}" --with-semantics --progress \
             "${embed[@]}" -o "$GITHUB_WORKSPACE/extra-bundle.png" --timeout 600
 
       # Save the font cache even when a render step FAILED. A cold-cache run that downloaded
@@ -558,7 +558,14 @@ jobs:
             echo "No ir/*.rc documents in the bundle — skipping the Remote Compose parity page."
             exit 0
           fi
-          npx playwright install --with-deps chromium
+          install_log="$RUNNER_TEMP/playwright-install.log"
+          echo "Installing Chromium and system dependencies…"
+          if ! npx playwright install --with-deps chromium >"$install_log" 2>&1; then
+            echo "::error title=Chromium install failed::Playwright could not install Chromium. The final 80 log lines follow." >&2
+            tail -n 80 "$install_log" >&2
+            exit 1
+          fi
+          echo "✓ Chromium ready."
 
           PLAYER="$GITHUB_WORKSPACE/compose-ai-tools/cli/src/main/resources/rc-player/bundle.js"
           EMBEDDED_ARGS=()
@@ -594,7 +601,7 @@ jobs:
             # `testDebugUnitTest UP-TO-DATE` and leaves RC_OUT empty. Ephemeral GitHub runners never
             # hit it, but `runs-on` is an input, so self-hosted callers would.
             if (cd "$GITHUB_WORKSPACE/compose-ai-tools" && \
-                ./gradlew :third-party-rc-embedded-player:testDebugUnitTest --no-daemon --rerun \
+                ./gradlew :third-party-rc-embedded-player:testDebugUnitTest --no-daemon --rerun --quiet \
                   -Prc.embedded.input="$RC_IN" -Prc.embedded.output="$RC_OUT") \
                && [ -n "$(find "$RC_OUT" -maxdepth 1 -name '*.png' -print -quit 2>/dev/null)" ]; then
               EMBEDDED_ARGS+=(--embedded "$RC_OUT")
@@ -614,7 +621,7 @@ jobs:
             rm -rf "$RC_JVM_OUT"
             if (cd "$GITHUB_WORKSPACE/compose-ai-tools" && \
                 xvfb-run -a -s "-screen 0 2000x1400x24" \
-                  ./gradlew :third-party-rc-embedded-player-jvm:test --no-daemon --rerun \
+                  ./gradlew :third-party-rc-embedded-player-jvm:test --no-daemon --rerun --quiet \
                     -Prc.jvm.input="$RC_IN" -Prc.jvm.output="$RC_JVM_OUT") \
                && [ -n "$(find "$RC_JVM_OUT" -maxdepth 1 -name '*.png' -print -quit 2>/dev/null)" ]; then
               EMBEDDED_ARGS+=(--embedded-jvm "$RC_JVM_OUT")

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -151,7 +151,20 @@ jobs:
           esac
 
           if [ -n "$files" ]; then
-            printf 'Changed files:\n```\n%s\n```\n' "$files" >> "$GITHUB_STEP_SUMMARY"
+            file_count=$(printf '%s\n' "$files" | sed '/^$/d' | wc -l | xargs)
+            {
+              echo "Resolved ${file_count} changed file(s)."
+              echo
+              echo '<details><summary>Changed files (first 30)</summary>'
+              echo
+              echo '```'
+              printf '%s\n' "$files" | sed -n '1,30p'
+              if [ "$file_count" -gt 30 ]; then
+                echo "… $((file_count - 30)) more"
+              fi
+              echo '```'
+              echo '</details>'
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo 'Could not resolve the changed files — regenerating every system.' >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -217,7 +230,7 @@ jobs:
       # Remote Android rows don't need them, but the packages are harmless there).
       - name: Install desktop (Skiko) render deps
         run: |
-          sudo apt-get update
+          sudo apt-get update -qq
           # `fonts-noto-*` are FALLBACK faces so a `@Preview(locale = "ja"/"ar"/…)`
           # catalog variant renders real glyphs instead of tofu on runners whose
           # base image lacks CJK/Arabic/emoji. A catalog's own declared FontFamily
@@ -236,7 +249,7 @@ jobs:
           : "${prev_sans:=DejaVu Sans}"
           : "${prev_serif:=DejaVu Serif}"
           : "${prev_mono:=DejaVu Sans Mono}"
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get install -y -qq --no-install-recommends \
             xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig \
             fonts-noto-cjk fonts-noto-core fonts-noto-color-emoji
           # Pin the generics back to the recorded defaults so Noto stays
@@ -269,7 +282,7 @@ jobs:
           node-version: 22
       - name: Install export engine (pinned npm packages)
         working-directory: scripts/design-artifacts
-        run: npm ci
+        run: npm ci --no-audit --no-fund --loglevel=warn
 
       # Fast, build-free pre-flight: resolve every spec `preview` against the
       # @Preview functions the module actually declares BEFORE the ~90-minute
@@ -330,23 +343,32 @@ jobs:
           set -euo pipefail
           version="$(grep -oP '(?<=^composeaiReleasedRuntimeVersion=).*' gradle.properties || true)"
           if [ -z "$version" ]; then
-            echo "no composeaiReleasedRuntimeVersion in gradle.properties" >&2
+            echo "::error title=Released runtime version missing::gradle.properties has no composeaiReleasedRuntimeVersion, so the catalog cannot resolve its published preview runtimes." >&2
             exit 1
           fi
           base="https://repo1.maven.org/maven2/ee/schimke/composeai"
-          echo "waiting for preview-runtimes $version on Maven Central…"
+          echo "Waiting for preview-runtimes $version on Maven Central (up to 60 minutes)…"
+          last_status=""
           for i in $(seq 1 60); do
             ok=1
+            statuses=()
             for a in data-preview-overrides-runtime slot-preview-runtime; do
               code="$(curl -s -o /dev/null -w '%{http_code}' \
                 "$base/$a/$version/$a-$version.pom" || true)"
-              [ "$code" = "200" ] || { ok=0; echo "  $a:$version -> HTTP ${code:-000}"; }
+              statuses+=("$a=HTTP ${code:-000}")
+              [ "$code" = "200" ] || ok=0
             done
-            if [ "$ok" = 1 ]; then echo "all preview-runtimes $version on Central (attempt $i)"; exit 0; fi
-            echo "attempt $i/60 — not fully propagated; retrying in 60s"
+            last_status=$(IFS=,; echo "${statuses[*]}")
+            if [ "$ok" = 1 ]; then
+              echo "✓ preview-runtimes $version available (attempt $i)."
+              exit 0
+            fi
+            if [ "$i" -eq 1 ] || [ $((i % 5)) -eq 0 ]; then
+              echo "Still waiting (attempt $i/60): $last_status"
+            fi
             sleep 60
           done
-          echo "preview-runtimes $version never fully appeared on Maven Central after ~60m" >&2
+          echo "::error title=Preview runtimes unavailable::Version $version did not fully appear on Maven Central after 60 minutes. Last response: $last_status" >&2
           exit 1
 
       - name: Render catalog bundle
@@ -395,7 +417,7 @@ jobs:
           exclude=(); if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS"); fi
           if [ -n "${EXCLUDE_PREVIEW_ROWS:-}" ]; then exclude+=(--exclude-preview-row "$EXCLUDE_PREVIEW_ROWS"); fi
           xvfb-run -a -s "-screen 0 2000x1400x24" \
-            compose-preview bundle pack --module "$MODULE" --with-semantics \
+            compose-preview bundle pack --module "$MODULE" --with-semantics --progress \
               "${exclude[@]}" -o "$GITHUB_WORKSPACE/$SYSTEM-bundle.png"
 
       # Android-only supplement (Robolectric): render the previews that need androidx
@@ -410,7 +432,7 @@ jobs:
           JAVA_TOOL_OPTIONS: -Dcomposeai.svg.embedFonts=true
         run: |
           set -euo pipefail
-          compose-preview bundle pack --module "$EXTRA_MODULE" --with-semantics \
+          compose-preview bundle pack --module "$EXTRA_MODULE" --with-semantics --progress \
             -o "$GITHUB_WORKSPACE/$SYSTEM-extra-bundle.png"
 
       # In-browser CMP tier: assemble the Kotlin/Wasm catalog app (webpack-free —
@@ -422,7 +444,7 @@ jobs:
         if: ${{ matrix.wasmModule != '' }}
         env:
           WASM_MODULE: ${{ matrix.wasmModule }}
-        run: ./gradlew ":${WASM_MODULE}:wasmCatalogDist"
+        run: ./gradlew ":${WASM_MODULE}:wasmCatalogDist" --quiet
 
       # The exporter gates on a complete render: `bundle pack --with-semantics`
       # is best-effort (exits 0 even if the daemon failed or captured zero

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -135,9 +135,11 @@ class GradleConnection(
 
         // Heartbeat so the user can see what is still running (Robolectric
         // can take minutes on a cold start with no output). Opt-in via
-        // --progress / --verbose so default CLI output stays quiet.
+        // --progress / --verbose so default CLI output stays quiet. CI gets
+        // a slower cadence: one useful heartbeat per minute without flooding
+        // a long design-catalog render with hundreds of near-identical lines.
         if (progress) {
-          val heartbeatMs = 15_000L
+          val heartbeatMs = if (System.getenv("CI") == "true") 60_000L else 15_000L
           schedule(
             object : java.util.TimerTask() {
               override fun run() {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -225,6 +225,7 @@ private class PackSubcommand(private val args: List<String>) {
   private val withSemantics: Boolean = "--with-semantics" in args
   private val perPreview: Boolean = "--per-preview" in args
   private val verbose: Boolean = "--verbose" in args || "-v" in args
+  private val progress: Boolean = verbose || "--progress" in args
   private val timeout: String? = args.flagValue("--timeout")
   private val ids: List<String> =
     args
@@ -260,6 +261,7 @@ private class PackSubcommand(private val args: List<String>) {
         add(it)
       }
       if (verbose) add("--verbose")
+      if (progress && !verbose) add("--progress")
       timeout?.let {
         add("--timeout")
         add(it)
@@ -416,6 +418,7 @@ private class PackSubcommand(private val args: List<String>) {
         add(it)
       }
       if (verbose) add("--verbose")
+      if (progress && !verbose) add("--progress")
     }
     object : Command(cmdArgs) {
         override fun run() {

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -90,6 +90,18 @@ import {
   candidatePreviewBundle,
   daemonPreviewIdsByFunction,
 } from "./bundle-previews.mjs";
+
+// CI warnings and fatal diagnostics should be visible as workflow annotations,
+// not buried among catalog-generation milestones. Keep local output unchanged.
+if (process.env.GITHUB_ACTIONS === "true") {
+  const annotate = (level, title, sink) => (...parts) => {
+    const escape = (value) =>
+      String(value).replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+    sink(`::${level} title=${escape(title)}::${escape(parts.join(" "))}`);
+  };
+  console.warn = annotate("warning", "Design artifact warning", console.warn.bind(console));
+  console.error = annotate("error", "Design artifact failure", console.error.bind(console));
+}
 import { exportsNoSticker } from "./capture-mode.mjs";
 import {
   bridgeLivePreviewIds,

--- a/scripts/design-artifacts/validate-catalog-spec.mjs
+++ b/scripts/design-artifacts/validate-catalog-spec.mjs
@@ -165,8 +165,8 @@ if (values.json) {
           : " No @Preview function is wholly deferred, so the render set is unchanged."),
     );
   }
-  for (const w of warnings) console.log(`  warning: ${w}`);
-  for (const e of errors) console.log(`  error:   ${e}`);
+  for (const w of warnings) reportFinding("warning", "Catalog spec warning", w);
+  for (const e of errors) reportFinding("error", "Catalog spec error", e);
   console.log(
     errors.length === 0
       ? `OK — ${warnings.length} warning(s), 0 errors.`
@@ -177,6 +177,17 @@ if (values.json) {
 process.exit(errors.length === 0 ? 0 : 1);
 
 function fail(msg) {
-  console.error(`validate-catalog-spec: ${msg}`);
+  reportFinding("error", "Catalog spec validation failed", msg);
   process.exit(1);
+}
+
+function reportFinding(level, title, message) {
+  const sink = level === "error" ? console.error : console.log;
+  if (process.env.GITHUB_ACTIONS === "true") {
+    const escape = (value) =>
+      String(value).replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+    sink(`::${level} title=${escape(title)}::${escape(message)}`);
+  } else {
+    sink(`  ${level}: ${message}`);
+  }
 }


### PR DESCRIPTION
## What changed

- add concise start/finish/timing output and a job-summary table for preview pipelines
- enable task milestones and one-minute CI heartbeats without exposing full Gradle logs
- name failing pipelines and preserve concise causes in the final error annotation
- upload preview reports and CLI envelopes only for genuine failures
- turn design-catalog warnings and errors into GitHub annotations
- reduce apt, npm, Gradle, Maven polling, changed-file, and Playwright installation noise
- retain the final 80 Playwright installation lines when setup fails
- propagate `bundle pack --progress`, which was previously dropped internally

## Why

The preview-diff action grouped all pipelines under a single generic step and ended failures with only a combined non-zero status. Developers had little indication of current progress or which pipeline failed.

The report upload gates checked whether RC files existed rather than whether their values were non-zero, causing noisy artifact steps on successful runs. Conversely, the generic failure upload ran before the action was marked failed and could miss real render failures.

The long-running design-artifact jobs also streamed setup/build noise while actionable catalog warnings were easy to miss.

## Developer impact

Successful runs are quieter and provide rough progress plus compact results. Warnings surface as annotations. Failed runs identify the failing pipeline and reliably retain the relevant reports and JSON envelopes.

## Validation

- `:gradle-preview-driver:compileKotlin :cli:compileKotlin`
- `:gradle-preview-driver:ktfmtCheck :cli:ktfmtCheck`
- 223 preview-action Python tests
- 56 focused design-artifact tests
- design-artifact scope workflow tests
- YAML parsing, shell/Node syntax, and `git diff --check`

Browser-backed design tests require a local Chromium installation; the affected CI path installs Chromium explicitly and now retains a concise failure tail.