### PR TITLE
fix: stabilize format comparison scoring

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2823,6 +2823,11 @@ object ServeWeb {
     val hasRc = defaults.any { hasRemoteComposeFor(it.id) }
     val defaultFormat = if (hasSvg) "svg" else "rc"
     val darkFirst = isDarkFirstSystem(basePath, sessionId, declaredSurface)
+    // A viewer deep-link may name a non-default state/props variant that is intentionally folded
+    // out of this gallery. Keep every sibling id as an alias on the included component row so the
+    // client can still select that row instead of presenting an empty comparison page.
+    val previewIdsByComponent =
+      previews.groupBy(::componentKey).mapValues { (_, values) -> values.map { it.id } }
 
     fun path(preview: ServePreview, extension: String): String =
       "$basePath/render/${WebEscaping.urlEncodeSegment(preview.id)}.$extension$q"
@@ -2849,7 +2854,7 @@ object ServeWeb {
           val current = if (darkFirst) card.dark ?: card.default else card.default
           val label = componentKey(current)
           val viewer = "$basePath/p/${WebEscaping.urlEncodeSegment(current.id)}$q"
-          val ids = variants.joinToString(" ") { it.id }
+          val ids = previewIdsByComponent[label].orEmpty().joinToString(" ")
           val hay = (label + " " + ids).lowercase()
           val pngAttrs =
             attrs("png", "light", card.light) { true } +

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js
@@ -286,9 +286,17 @@
       return response.arrayBuffer();
     }).then(function (buffer) {
       var player = new window.RC.RcdPlayer(canvas);
+      // Artifact theme is an explicit comparison input; it must not inherit the site's / OS's
+      // prefers-color-scheme or a light PNG can be scored against a dark RC canvas.
+      player.setTheme(theme);
       return player.loadFromArrayBuffer(buffer).then(function () {
         if (player.repaint) player.repaint();
-        return nextFrame().then(nextFrame).then(function () { return scoreCanvas(pngUrl, canvas); });
+        // The first paint discovers named font families. Wait for those faces, repaint with the
+        // resolved glyphs, and only then take the single-shot fidelity measurement.
+        return player.fontsReady().then(function () {
+          if (player.repaint) player.repaint();
+          return nextFrame().then(nextFrame).then(function () { return scoreCanvas(pngUrl, canvas); });
+        });
       });
     });
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebAssetsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebAssetsTest.kt
@@ -74,4 +74,22 @@ class ServeWebAssetsTest {
       assertEquals(0, result.waitFor(), "$name failed node --check:\n$output")
     }
   }
+
+  @Test
+  fun `remote compose comparison fixes theme and fonts before scoring`() {
+    val script = ServeWebAssets.load("format-compare.js")!!.bytes.decodeToString()
+    val theme = script.indexOf("player.setTheme(theme)")
+    val firstPaint = script.indexOf("player.repaint", startIndex = theme)
+    val fonts = script.indexOf("player.fontsReady()", startIndex = firstPaint)
+    val finalPaint = script.indexOf("player.repaint", startIndex = fonts)
+    val score = script.indexOf("scoreCanvas(pngUrl, canvas)", startIndex = finalPaint)
+    assertTrue(
+      theme >= 0 &&
+        theme < firstPaint &&
+        firstPaint < fonts &&
+        fonts < finalPaint &&
+        finalPaint < score,
+      "the RC player must apply artifact theme, discover and await fonts, then repaint before SSIM",
+    )
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1134,6 +1134,20 @@ class ServeWebFixtureTest {
         ),
       "each comparison row pairs PNG and SVG from the exact same baked theme variant",
     )
+    val variantComparison =
+      ServeWeb.comparisonPage(
+        "compose-m3",
+        variantPreviews,
+        token,
+        sessionId = "compose-m3",
+        hasSvgFor = { true },
+      )
+    val variantComparisonIds =
+      variantComparison.substringAfter("data-preview-ids=\"").substringBefore('"')
+    assertTrue(
+      variantComparisonIds.contains("button-filled__ideal__default__light__direction-rtl"),
+      "a folded non-default variant deep-link aliases to its included component comparison row",
+    )
     assertGolden(File(pagesDir, "serve-landing-declared-themes.html"), landingDeclaredThemes)
     // Issue #2881: the header control lists every CONFIGURED theme, not just Light/Dark — the baked
     // pair plus one chip per declared `@ThemeCatalog` theme, each carrying its provider FQN.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-format-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-format-compare.html
@@ -46,7 +46,7 @@
         </div>
         <p id="cp-compare-empty" class="cp-empty" hidden>No comparisons match this filter.</p>
         </div>
-        <script src="/assets/serve/38c2-63624ebdf518c1a2/format-compare.js"></script>
+        <script src="/assets/serve/3abe-e1cc687a7a6b9594/format-compare.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -291,7 +291,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/38c2-63624ebdf518c1a2/format-compare.js"></script>
+      <script src="/assets/serve/3abe-e1cc687a7a6b9594/format-compare.js"></script>
       <script src="/assets/serve/1307f-2ecf5daf922b0713/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>


### PR DESCRIPTION
Follow-up to #3183, addressing all three post-merge review findings:

- fixes the Remote Compose player to the explicitly selected artifact theme before loading/scoring
- waits for discovered web fonts, then repaints before measuring SSIM
- aliases folded state/props variants to their included component comparison row so “view diff” deep links do not produce an empty gallery

Review threads addressed:
- https://github.com/yschimke/compose-ai-tools/pull/3183#discussion_r3699841898
- https://github.com/yschimke/compose-ai-tools/pull/3183#discussion_r3699841901
- https://github.com/yschimke/compose-ai-tools/pull/3183#discussion_r3699841905

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests '*ServeWebFixtureTest*' --tests '*ServeWebAssetsTest*'`
- `HARNESS_FIXTURE=serve-format-compare npx playwright test -c preview-harness/playwright.config.mjs preview-harness/pages-snapshot.spec.mjs`
- browser captures are byte-identical before/after: this changes scoring lifecycle and deep-link behavior, not layout

## Visual evidence

| Before | After |
|---|---|
| ![Before](https://raw.githubusercontent.com/yschimke/compose-ai-tools/6ba5bd68b7d0ab815a717f249f13d22b461b7c9d/renders/serve-format-compare-after-light.png) | ![After](https://raw.githubusercontent.com/yschimke/compose-ai-tools/6ba5bd68b7d0ab815a717f249f13d22b461b7c9d/renders/serve-format-compare-after-light.png) |

The captured PNG is identical on both sides (SHA-1 `144c3f467185c72e43ce3c6cdca4a1fabc16e519`), confirming no unintended visual drift.
