### PR TITLE
fix(serve): parallelize catalog theme renders

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -208,6 +208,9 @@ class ServeCatalogLiveHost(
    */
   override fun canRenderOverridesFor(previewId: String): Boolean = previewId in alias
 
+  /** Parallel redraw is safe only when distinct previews have independent pooled daemons. */
+  override val themeRenderConcurrency: Int = if (perPreviewResolve != null) 2 else 1
+
   /** The gesture override is honoured by the daemon lane, if that daemon is Android-backed. */
   override val gesturesRenderable: Boolean = live.gesturesRenderable
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -93,6 +93,15 @@ interface ServeHost : AutoCloseable {
   fun canRenderOverridesFor(previewId: String): Boolean = canRenderOverrides
 
   /**
+   * Safe browser-side concurrency for a catalog-wide themed thumbnail redraw. A plain daemon has
+   * one render lock, so the default remains serial. A composite backed by independent per-preview
+   * daemons may opt into a small worker pool without making monolithic fallback hosts return baked
+   * pixels for concurrent override requests.
+   */
+  val themeRenderConcurrency: Int
+    get() = 1
+
+  /**
    * Aggregate render-performance counters for this host's live render lane, surfaced on `/status`
    * + `/status.json` (`runningServers[].renderStats`). Null when the host has no live render lane
    *   to measure — a static baked bundle never renders. Daemon-backed hosts ([ServeRenderHost])

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1168,6 +1168,7 @@ class ServeHttpServer(
           // a daemon-twinned card can actually re-render one, hence the per-preview predicate.
           declaredThemes = renderHost.declaredThemes,
           canRenderThemeFor = { id -> renderHost.canRenderOverridesFor(id) },
+          themeRenderConcurrency = renderHost.themeRenderConcurrency,
           engagement = previewEngagement(selectedSessionId, renderHost.previews),
           systemViews = systemViews,
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl(), imageUrl = heroUrl),

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -922,8 +922,10 @@ object ServeWeb {
      * emitted at all.
      */
     themeBaseJs: String = "",
+    themeRenderConcurrency: Int = 1,
   ): String {
     val hasDeclaredThemes = themeBaseJs.isNotEmpty()
+    val safeThemeRenderConcurrency = themeRenderConcurrency.coerceIn(1, 2)
     // The stored choice is one of `light` / `dark` (a baked swap), `default` (the catalog's own
     // renders), or `theme:<providerFqn>` (an app-declared @ThemeCatalog theme, applied by
     // re-pointing each daemon-twinned card's thumbnail at a `?themeProvider=` render).
@@ -948,19 +950,21 @@ object ServeWeb {
         """
           .trimIndent()
       else ""
-    // The declared-theme lane. A declared theme re-renders on the daemon, which renders ONE AT A
-    // TIME and sheds the overflow (503 "render busy" on a bare daemon session; the baked PNG on a
-    // catalog-live one). Firing a whole grid's worth of themed thumbnails at once would therefore
-    // leave most cards on their pre-theme pixels, so they are fetched serially — each waits for the
-    // previous to load — with one delayed retry for a shed request. Baked light/dark swaps never
-    // queue: those bytes are already published. themeGen abandons an in-flight queue the moment a
-    // new theme is chosen.
+    // The declared-theme lane. A catalog host backed by a bounded pool of per-preview daemons may
+    // advertise a small amount of parallelism; a monolithic host advertises one and stays serial.
+    // Keep the browser cap deliberately below the server/pool caps: opening an Android daemon is
+    // expensive, and an unbounded grid burst would still shed requests (503 "render busy") or
+    // create a JVM storm. Each worker advances only after its image settles; failures get bounded
+    // delayed retries with cache-busting URLs. Baked light/dark swaps never queue: those bytes are
+    // already published. themeGen abandons all workers the moment a new theme is chosen.
     val themeRenderInit =
       if (hasDeclaredThemes)
         """
         var themeBase = $themeBaseJs;
         var themeGen = 0;
-        function runThemeQueue(queue, gen) {
+        var themeRenderConcurrency = $safeThemeRenderConcurrency;
+        var themeRenderRetries = 3;
+        function runThemeWorker(queue, gen) {
           if (gen !== themeGen) return;
           var job = queue.shift();
           if (!job) return;
@@ -971,21 +975,29 @@ object ServeWeb {
             settled = true;
             img.onload = null;
             img.onerror = null;
-            if (!ok && !job.retried) {
-              // Re-request rather than re-assign the identical (failed, uncached) URL.
-              job.retried = true;
-              job.src = job.src + "&_retry=1";
-              queue.unshift(job);
-              setTimeout(function () { runThemeQueue(queue, gen); }, 1500);
+            if (!ok && job.retries < themeRenderRetries) {
+              // Re-request rather than re-assign the identical (failed, uncached) URL. Exponential
+              // backoff gives a busy daemon time to finish without stalling the other worker.
+              job.retries++;
+              job.src = job.baseSrc + "&_retry=" + job.retries;
+              setTimeout(function () {
+                if (gen !== themeGen) return;
+                queue.push(job);
+                runThemeWorker(queue, gen);
+              }, 1000 * Math.pow(2, job.retries));
               return;
             }
             job.card.classList.remove("cp-reloading");
             job.card.removeAttribute("aria-busy");
-            runThemeQueue(queue, gen);
+            runThemeWorker(queue, gen);
           }
           img.onload = function () { next(true); };
           img.onerror = function () { next(false); };
           img.src = job.src;
+        }
+        function runThemeQueue(queue, gen) {
+          var workers = Math.min(themeRenderConcurrency, queue.length);
+          for (var i = 0; i < workers; i++) runThemeWorker(queue, gen);
         }
         """
           .trimIndent()
@@ -1028,10 +1040,13 @@ object ServeWeb {
             if (!img || !base) return;
             c.classList.add("cp-reloading");
             c.setAttribute("aria-busy", "true");
+            var themedSrc = base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider);
             var job = {
               card: c,
               img: img,
-              src: base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider),
+              baseSrc: themedSrc,
+              src: themedSrc,
+              retries: 0,
             };
             // A tabbed catalog's hidden cards can take several daemon renders before the visitor
             // sees any response to their click. On initial load c.hidden is not assigned yet, so
@@ -2561,6 +2576,12 @@ object ServeWeb {
      */
     canRenderThemeFor: (String) -> Boolean = { false },
     /**
+     * Number of themed thumbnail workers this host can safely sustain. Monolithic daemons pass one;
+     * catalog composites with independent per-preview daemons pass a conservative two. Clamped so a
+     * future caller cannot accidentally turn a landing page into an unbounded render burst.
+     */
+    themeRenderConcurrency: Int = 1,
+    /**
      * Per-preview engagement counts for this running server. The map is additive UI/API metadata:
      * missing or zero entries render no badge.
      */
@@ -2780,6 +2801,7 @@ object ServeWeb {
           themeStorageKey(sessionId, basePath),
           tabStorageKey(sessionId, basePath),
           themeBaseJs,
+          themeRenderConcurrency,
         )}</script>"
       else ""
     val formatLink =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -544,6 +544,21 @@ class ServeCatalogLiveHostTest {
   // --- Per-preview lane (default, with monolithic fallback) -----------------------------------
 
   @Test
+  fun `theme redraw is parallel only when the per-preview lane is available`() {
+    val (monolithicOnly, live, baked) = host()
+    assertEquals(1, monolithicOnly.themeRenderConcurrency)
+
+    val pooled =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = baked,
+        perPreviewResolve = { null },
+      )
+    assertEquals(2, pooled.themeRenderConcurrency)
+  }
+
+  @Test
   fun `an override render prefers the per-preview daemon over the monolithic one`() {
     val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
     val monolithic =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -690,6 +690,7 @@ class ServeWebFixtureTest {
             ServeTheme("High Contrast", "com.example.HighContrastThemeCatalog"),
           ),
         canRenderThemeFor = { true },
+        themeRenderConcurrency = 2,
       )
     // A catalog whose components carry baked non-default states: the landing folds each to ONE card
     // (the default), the non-default states reachable via the viewer switcher.
@@ -1161,14 +1162,22 @@ class ServeWebFixtureTest {
       landingDeclaredThemes.contains("data-base-src"),
       "no render URL is round-tripped through a DOM attribute",
     )
-    // The daemon renders one at a time and sheds the overflow, so themed thumbnails are fetched
-    // serially (each queued, the next started on the previous image's load) with one delayed retry
-    // — otherwise a grid-sized burst would leave most cards on their pre-theme pixels.
+    // The catalog has a bounded per-preview daemon pool, so themed thumbnails use a conservative
+    // two-worker queue: enough parallelism to avoid multi-minute catalog redraws without firing a
+    // grid-sized burst. Each worker advances on image settlement and retries shed requests with
+    // bounded exponential backoff and a cache-busting URL.
     assertTrue(
       landingDeclaredThemes.contains("var job = {") &&
+        landingDeclaredThemes.contains("var themeRenderConcurrency = 2") &&
+        landingDeclaredThemes.contains("var themeRenderRetries = 3") &&
+        landingDeclaredThemes.contains("function runThemeWorker(queue, gen)") &&
         landingDeclaredThemes.contains("runThemeQueue(themeQueue, themeQueueGen)") &&
-        landingDeclaredThemes.contains("job.src = job.src + \"&_retry=1\""),
-      "themed renders are fetched serially with a retry, not fired as one burst",
+        landingDeclaredThemes.contains("Math.min(themeRenderConcurrency, queue.length)") &&
+        landingDeclaredThemes.contains("job.src = job.baseSrc + \"&_retry=\" + job.retries") &&
+        landingDeclaredThemes.contains("if (gen !== themeGen) return;") &&
+        landingDeclaredThemes.contains("queue.push(job);\n        runThemeWorker(queue, gen)") &&
+        landingDeclaredThemes.contains("1000 * Math.pow(2, job.retries)"),
+      "themed renders use a bounded worker pool with bounded backoff retries",
     )
     assertTrue(
       landingDeclaredThemes.contains("c.classList.add(\"cp-reloading\")") &&

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -113,12 +113,12 @@ not just Light/Dark (issue #2881):
 
 Declared themes are offered only when the session can actually render them (a trusted catalog served
 live, or a daemon-backed module); a static bundle keeps the baked light/dark chips alone, and an
-individual card with no daemon twin keeps its baked pixels. Because the daemon renders one preview
-at a time and sheds the overflow (`503 render busy`), the themed thumbnails are fetched **serially**
-— each starts when the previous image loads, with one delayed retry — rather than as a grid-sized
-burst that would leave most cards on their pre-theme pixels. Their URLs are emitted by the server
-into the page script (never read back out of a `data-` attribute), so nothing the page assigns to an
-`<img src>` originates as DOM text. A theme-neutral module whose session
+individual card with no daemon twin keeps its baked pixels. A catalog with independent per-preview
+daemons uses a conservative **two-worker queue**, while a monolithic daemon stays serial. The small
+cap avoids a grid-sized JVM/request burst. Each worker starts its next card only when the previous
+image settles; shed requests get bounded exponential-backoff retries. Their URLs are emitted by the
+server into the page script (never read back out of a `data-` attribute), so nothing the page assigns
+to an `<img src>` originates as DOM text. A theme-neutral module whose session
 declares themes gets a leading **Default** chip to return to. The choice persists per catalog
 (`cp-theme:<system>` in `localStorage`, shared with that catalog's viewer Theme select).
 

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -98,7 +98,9 @@ if (!known && themeBtns.length) theme = themeBtns[0].getAttribute("data-theme-ch
 var appliedTheme = null;
 var themeBase = ["/render/button-filled__ideal__default__light.png?session=compose-m3", "/render/switch-on__ideal__default__light.png?session=compose-m3", "/render/badge.png?session=compose-m3"];
 var themeGen = 0;
-function runThemeQueue(queue, gen) {
+var themeRenderConcurrency = 2;
+var themeRenderRetries = 3;
+function runThemeWorker(queue, gen) {
   if (gen !== themeGen) return;
   var job = queue.shift();
   if (!job) return;
@@ -109,21 +111,29 @@ function runThemeQueue(queue, gen) {
     settled = true;
     img.onload = null;
     img.onerror = null;
-    if (!ok && !job.retried) {
-      // Re-request rather than re-assign the identical (failed, uncached) URL.
-      job.retried = true;
-      job.src = job.src + "&_retry=1";
-      queue.unshift(job);
-      setTimeout(function () { runThemeQueue(queue, gen); }, 1500);
+    if (!ok && job.retries < themeRenderRetries) {
+      // Re-request rather than re-assign the identical (failed, uncached) URL. Exponential
+      // backoff gives a busy daemon time to finish without stalling the other worker.
+      job.retries++;
+      job.src = job.baseSrc + "&_retry=" + job.retries;
+      setTimeout(function () {
+        if (gen !== themeGen) return;
+        queue.push(job);
+        runThemeWorker(queue, gen);
+      }, 1000 * Math.pow(2, job.retries));
       return;
     }
     job.card.classList.remove("cp-reloading");
     job.card.removeAttribute("aria-busy");
-    runThemeQueue(queue, gen);
+    runThemeWorker(queue, gen);
   }
   img.onload = function () { next(true); };
   img.onerror = function () { next(false); };
   img.src = job.src;
+}
+function runThemeQueue(queue, gen) {
+  var workers = Math.min(themeRenderConcurrency, queue.length);
+  for (var i = 0; i < workers; i++) runThemeWorker(queue, gen);
 }
       function apply() {
         themeBtns.forEach(function (b) {
@@ -166,10 +176,13 @@ function applyThemeChoice() {
       if (!img || !base) return;
       c.classList.add("cp-reloading");
       c.setAttribute("aria-busy", "true");
+      var themedSrc = base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider);
       var job = {
         card: c,
         img: img,
-        src: base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider),
+        baseSrc: themedSrc,
+        src: themedSrc,
+        retries: 0,
       };
       // A tabbed catalog's hidden cards can take several daemon renders before the visitor
       // sees any response to their click. On initial load c.hidden is not assigned yet, so

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -15,7 +15,7 @@
 // `harness:snapshot` invocation (the `snapshot` path filter matches this
 // file too) and the existing baseline/PR-comment actions — no CI change.
 
-import { test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { readdirSync } from "node:fs";
@@ -177,3 +177,48 @@ for (const fixture of listPageFixtures()) {
         });
     }
 }
+
+test("contract · declared theme renders use bounded parallelism", async ({ page }) => {
+    let active = 0;
+    let maxActive = 0;
+    let completed = 0;
+    const attempts = new Map();
+
+    await page.route("**/render/**", async (route) => {
+        const url = new URL(route.request().url());
+        if (!url.searchParams.has("themeProvider")) {
+            await route.fulfill({
+                path: renderPlaceholder,
+                contentType: "image/png",
+            });
+            return;
+        }
+
+        active++;
+        maxActive = Math.max(maxActive, active);
+        const attempt = (attempts.get(url.pathname) ?? 0) + 1;
+        attempts.set(url.pathname, attempt);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        active--;
+
+        // Shed every card's first request. The page must retry it without exceeding the worker cap.
+        if (attempt === 1) {
+            await route.fulfill({ status: 503, body: "render busy" });
+        } else {
+            completed++;
+            await route.fulfill({
+                path: renderPlaceholder,
+                contentType: "image/png",
+            });
+        }
+    });
+
+    await page.goto(
+        "/preview-harness/fixtures/pages/serve-landing-declared-themes.html",
+    );
+    await page.getByRole("button", { name: "Brand Light" }).click();
+
+    await expect.poll(() => completed, { timeout: 10_000 }).toBe(3);
+    expect(maxActive).toBe(2);
+    expect(Array.from(attempts.values())).toEqual([2, 2, 2]);
+});


### PR DESCRIPTION
## What changed

- advertise a safe catalog-theme render concurrency from each serve host
- use two browser workers only for app/catalog hosts backed by independent per-preview daemons
- keep monolithic daemon hosts serial
- add bounded exponential-backoff retries without allowing delayed jobs to leak extra workers
- retain visible-first ordering and generation cancellation
- update serve documentation and generated fixtures
- add host/fixture coverage plus a Playwright contract that simulates initial 503 responses and asserts the two-request cap

## Why

The Wear M3 catalog theme selector appeared broken because all 38 themed thumbnails were rendered serially. At observed production latency, a full redraw took several minutes.

The server already supports an app-owned LRU pool whose entries are preview-scoped daemons. The landing page was not using that safe per-preview capacity. Unbounded parallelism would be risky, while parallel requests against a monolithic daemon can fall back to baked pixels, so concurrency is now explicitly host-aware and conservatively capped at two.

## User impact

Theme changes begin updating multiple catalog cards promptly instead of waiting on one long serial queue, while apps without independent preview daemons preserve the previous correctness-first serial behavior.

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebFixtureTest --tests ee.schimke.composeai.cli.serve.ServeCatalogLiveHostTest :cli:ktfmtCheck`
- `node --check preview-harness/pages-snapshot.spec.mjs`
- generated serve-page fixtures refreshed and verified
