### PR TITLE
fix: scope comparison deep-link aliases

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -490,15 +490,17 @@ object ServeWeb {
    * the whole id when there's no state (a plain preview) or the state token isn't found, so such a
    * preview only ever groups with itself.
    */
-  private fun stateInvariantKey(p: ServePreview): String {
-    val state = p.state ?: return p.id
-    val parts = p.id.split("__")
+  private fun stateInvariantKey(id: String, state: String?): String {
+    state ?: return id
+    val parts = id.split("__")
     val idealIdx = parts.indexOf("ideal")
     val stateIdx =
       if (idealIdx in 0 until parts.lastIndex && parts[idealIdx + 1] == state) idealIdx + 1
-      else parts.indexOfFirst { it == state }.takeIf { it >= 1 } ?: return p.id
+      else parts.indexOfFirst { it == state }.takeIf { it >= 1 } ?: return id
     return parts.filterIndexed { i, _ -> i != stateIdx }.joinToString("__")
   }
+
+  private fun stateInvariantKey(p: ServePreview): String = stateInvariantKey(p.id, p.state)
 
   /**
    * The viewer's **state switcher**: a `<nav>` of plain links from [current] to each of its
@@ -610,6 +612,14 @@ object ServeWeb {
     val parts = p.id.split("__")
     return if (parts.size > n) parts.dropLast(n).joinToString("__") else p.id
   }
+
+  /**
+   * The comparison-table card family for [p]: fold state, props, and the baked light/dark pair,
+   * while preserving independent axes such as size. This mirrors the default-card grouping used by
+   * [groupPreviews] without broadening aliases to every render of the same [componentKey].
+   */
+  private fun comparisonCardKey(p: ServePreview): String =
+    baseKey(stateInvariantKey(propsFamilyKey(p), p.state))
 
   /**
    * The viewer's **variant switcher**: a `<nav>` of plain links from [current] to its component's
@@ -2848,8 +2858,8 @@ object ServeWeb {
     // A viewer deep-link may name a non-default state/props variant that is intentionally folded
     // out of this gallery. Keep every sibling id as an alias on the included component row so the
     // client can still select that row instead of presenting an empty comparison page.
-    val previewIdsByComponent =
-      previews.groupBy(::componentKey).mapValues { (_, values) -> values.map { it.id } }
+    val previewIdsByCard =
+      previews.groupBy(::comparisonCardKey).mapValues { (_, values) -> values.map { it.id } }
 
     fun path(preview: ServePreview, extension: String): String =
       "$basePath/render/${WebEscaping.urlEncodeSegment(preview.id)}.$extension$q"
@@ -2876,7 +2886,7 @@ object ServeWeb {
           val current = if (darkFirst) card.dark ?: card.default else card.default
           val label = componentKey(current)
           val viewer = "$basePath/p/${WebEscaping.urlEncodeSegment(current.id)}$q"
-          val ids = previewIdsByComponent[label].orEmpty().joinToString(" ")
+          val ids = previewIdsByCard[comparisonCardKey(current)].orEmpty().joinToString(" ")
           val hay = (label + " " + ids).lowercase()
           val pngAttrs =
             attrs("png", "light", card.light) { true } +

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1149,6 +1149,58 @@ class ServeWebFixtureTest {
       variantComparisonIds.contains("button-filled__ideal__default__light__direction-rtl"),
       "a folded non-default variant deep-link aliases to its included component comparison row",
     )
+    val sizedVariantPreviews =
+      listOf("compact", "expanded").flatMap { size ->
+        listOf(
+          ServePreview(
+            "button-filled__ideal__default__light__$size",
+            "Button · Filled · $size",
+            state = "default",
+            theme = "light",
+          ),
+          ServePreview(
+            "button-filled__ideal__pressed__light__$size",
+            "Button · Filled · pressed · $size",
+            state = "pressed",
+            theme = "light",
+          ),
+          ServePreview(
+            "button-filled__ideal__default__light__${size}__direction-rtl",
+            "Button · Filled · RTL · $size",
+            state = "default",
+            theme = "light",
+            props = jsonProps("direction" to "rtl"),
+          ),
+        )
+      }
+    val sizedVariantComparison =
+      ServeWeb.comparisonPage(
+        "compose-m3",
+        sizedVariantPreviews,
+        token,
+        sessionId = "compose-m3",
+        hasSvgFor = { true },
+      )
+    val sizedComparisonIds =
+      Regex("data-preview-ids=\"([^\"]+)\"")
+        .findAll(sizedVariantComparison)
+        .map { it.groupValues[1] }
+        .toList()
+    assertEquals(2, sizedComparisonIds.size)
+    assertTrue(
+      sizedComparisonIds[0].contains("__compact") &&
+        sizedComparisonIds[0].contains("__pressed__light__compact") &&
+        sizedComparisonIds[0].contains("__compact__direction-rtl") &&
+        !sizedComparisonIds[0].contains("__expanded"),
+      "compact aliases fold state and props without selecting the expanded comparison row",
+    )
+    assertTrue(
+      sizedComparisonIds[1].contains("__expanded") &&
+        sizedComparisonIds[1].contains("__pressed__light__expanded") &&
+        sizedComparisonIds[1].contains("__expanded__direction-rtl") &&
+        !sizedComparisonIds[1].contains("__compact"),
+      "expanded aliases fold state and props without selecting the compact comparison row",
+    )
     assertGolden(File(pagesDir, "serve-landing-declared-themes.html"), landingDeclaredThemes)
     // Issue #2881: the header control lists every CONFIGURED theme, not just Light/Dark — the baked
     // pair plus one chip per declared `@ThemeCatalog` theme, each carrying its provider FQN.


### PR DESCRIPTION
## Goal

Keep deep-link aliases scoped to the comparison card: fold state and props variants into their matching card without conflating independent size variants such as compact and expanded. Follow-up to [the review on #3184](https://github.com/yschimke/compose-ai-tools/pull/3184#discussion_r3699867438).

## Summary

- `ServeWeb.kt`: derive comparison aliases from a card-family key that folds state, props, and the baked light/dark pair while preserving size.
- `ServeWebFixtureTest.kt`: cover compact and expanded cards with pressed-state and RTL aliases, asserting the alias sets remain disjoint.
- No abandoned approaches or known gaps.

## Verification

- `./gradlew --no-daemon :cli:ktfmtCheck :cli:test --tests '*ServeWebFixtureTest*'`
- Standalone Playwright snapshots for `serve-format-compare` in light and dark: 2 passed.
- Visual output is unchanged byte-for-byte: light `6f92b15d`, dark `ad9c19d3`.