### PR TITLE
fix(serve): lease and cache catalog theme renders

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -115,6 +115,18 @@ class ServeCatalogLiveHost(
   // per-variant.
   private val warmDaemonIds = ConcurrentHashMap.newKeySet<String>()
   private val warmingInFlight = ConcurrentHashMap.newKeySet<String>()
+
+  /**
+   * Completed catalog-grid theme renders, retained for this catalog host's lifetime. The
+   * per-preview daemon pool is deliberately LRU and may evict the daemon (and its local cache)
+   * between theme selections; keeping the pure `themeProvider` result here makes a repeat selection
+   * instant without pinning every preview daemon. A catalog refresh installs a new host that cannot
+   * observe this map, then closing the old host clears it. Only pure theme selections participate,
+   * so the key space is bounded by `previews × declaredThemes`; arbitrary knob combinations stay in
+   * the daemon's bounded cache.
+   */
+  private val themeRenderCache = ConcurrentHashMap<String, ByteArray>()
+  private val themeRendersInFlight = ConcurrentHashMap.newKeySet<String>()
   private val warmExecutor by lazy {
     Executors.newSingleThreadExecutor { r ->
       Thread(r, "serve-catalog-warm").apply { isDaemon = true }
@@ -208,8 +220,8 @@ class ServeCatalogLiveHost(
    */
   override fun canRenderOverridesFor(previewId: String): Boolean = previewId in alias
 
-  /** Parallel redraw is safe only when distinct previews have independent pooled daemons. */
-  override val themeRenderConcurrency: Int = if (perPreviewResolve != null) 2 else 1
+  /** A leased burst is safe only when distinct previews have independent pooled daemons. */
+  override val themeRenderBurstCapacity: Int = if (perPreviewResolve != null) 5 else 1
 
   /** The gesture override is honoured by the daemon lane, if that daemon is Android-backed. */
   override val gesturesRenderable: Boolean = live.gesturesRenderable
@@ -252,22 +264,60 @@ class ServeCatalogLiveHost(
    * re-render; an unmapped Android-only variant always replays baked.
    */
   override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
-    val daemonId =
-      daemonIdForOverrideRender(previewId, overrides) ?: return baked.render(previewId, overrides)
-    // A live-only (deferred) preview has NO baked PNG to fall back to — the daemon is its only
-    // lane, so it must be awaited even cold and its outcome returned as-is. Everything below is the
-    // baked-first routing, which such an id can't use.
-    if (previewId in liveOnlyPreviewIds) return liveHostFor(daemonId).render(daemonId, overrides)
-    // Only await the daemon when it's warm and free. A cold Android render can take minutes, and
-    // blocking the browse — and the HTTP render slot it holds — on it is what saturates the whole
-    // server. A not-yet-warm daemon serves baked now and warms in the background; a warm daemon
-    // that reports [RenderOutcome.Busy] (the bounded-lock back-off — another render in flight)
-    // likewise falls back to baked instead of pinning a slot. This mirrors [renderSvg]'s warm gate.
-    if (daemonWarmOrScheduling(daemonId)) {
-      val live = liveHostFor(daemonId).render(daemonId, overrides)
-      if (live !is RenderOutcome.Busy) return live
+    val themeCacheKey = themeCacheKey(previewId, overrides)
+    cachedRender(previewId, overrides)?.let {
+      return it
     }
-    return baked.render(previewId, overrides)
+    if (themeCacheKey != null && !themeRendersInFlight.add(themeCacheKey)) {
+      return RenderOutcome.Busy
+    }
+    try {
+      val daemonId =
+        daemonIdForOverrideRender(previewId, overrides) ?: return baked.render(previewId, overrides)
+      // A live-only (deferred) preview has NO baked PNG to fall back to — the daemon is its only
+      // lane, so it must be awaited even cold and its outcome returned as-is. Everything below is
+      // the baked-first routing, which such an id can't use.
+      if (previewId in liveOnlyPreviewIds) {
+        return cacheThemeRender(themeCacheKey, liveHostFor(daemonId).render(daemonId, overrides))
+      }
+      // Only await the daemon when it's warm and free. A cold Android render can take minutes, and
+      // blocking the browse — and the HTTP render slot it holds — on it is what saturates the whole
+      // server. Ordinary override requests may fall back to baked pixels while warming. A pure
+      // theme request must instead report Busy: returning baked pixels as a successful 200 would
+      // make the grid believe the requested theme had loaded and it would never retry.
+      if (daemonWarmOrScheduling(daemonId)) {
+        val live = liveHostFor(daemonId).render(daemonId, overrides)
+        if (live !is RenderOutcome.Busy) return cacheThemeRender(themeCacheKey, live)
+      }
+      if (themeCacheKey != null) return RenderOutcome.Busy
+      return baked.render(previewId, overrides)
+    } finally {
+      if (themeCacheKey != null) themeRendersInFlight.remove(themeCacheKey)
+    }
+  }
+
+  override fun cachedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? =
+    themeCacheKey(previewId, overrides)?.let(themeRenderCache::get)?.let { bytes ->
+      RenderOutcome.Ok(bytes, RenderOutcome.Generation.CATALOG_CACHE)
+    }
+
+  /** Cache only the catalog grid's pure theme selection, never a baked fallback or a failure. */
+  private fun cacheThemeRender(key: String?, outcome: RenderOutcome): RenderOutcome {
+    if (
+      key != null &&
+        outcome is RenderOutcome.Ok &&
+        outcome.generation != RenderOutcome.Generation.BAKED
+    ) {
+      themeRenderCache.putIfAbsent(key, outcome.png)
+    }
+    return outcome
+  }
+
+  private fun themeCacheKey(previewId: String, overrides: PreviewOverrides): String? {
+    val provider = overrides.themeProvider ?: return null
+    if (previewId !in alias || declaredThemes.none { it.providerFqn == provider }) return null
+    if (overrides != PreviewOverrides(themeProvider = provider)) return null
+    return ServeOverrides.cacheKey(previewId, overrides)
   }
 
   /**
@@ -446,6 +496,8 @@ class ServeCatalogLiveHost(
   }
 
   override fun close() {
+    themeRenderCache.clear()
+    themeRendersInFlight.clear()
     if (warmInBackground) {
       try {
         warmExecutor.shutdownNow()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -93,13 +93,20 @@ interface ServeHost : AutoCloseable {
   fun canRenderOverridesFor(previewId: String): Boolean = canRenderOverrides
 
   /**
-   * Safe browser-side concurrency for a catalog-wide themed thumbnail redraw. A plain daemon has
-   * one render lock, so the default remains serial. A composite backed by independent per-preview
-   * daemons may opt into a small worker pool without making monolithic fallback hosts return baked
-   * pixels for concurrent override requests.
+   * Maximum browser-side concurrency a short-lived themed-thumbnail burst may request. A plain
+   * daemon has one render lock, so the default remains serial. A composite backed by independent
+   * per-preview daemons may opt into a larger temporary burst; the HTTP server still clamps it to
+   * its render slots and grants at most one page a burst lease at a time.
    */
-  val themeRenderConcurrency: Int
+  val themeRenderBurstCapacity: Int
     get() = 1
+
+  /**
+   * Return an already-materialised PNG without entering the HTTP render admission queue. Hosts with
+   * no cache return null. [render] remains the authoritative path and must recheck its cache after
+   * admission to close the lookup/render race.
+   */
+  fun cachedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
 
   /**
    * Aggregate render-performance counters for this host's live render lane, surfaced on `/status`

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -226,6 +226,8 @@ class ServeHttpServer(
   private val startedAtMillis: Long = System.currentTimeMillis()
 
   private val renderSemaphore = Semaphore(renderSlots)
+  private val unleasedThemeSemaphore = Semaphore(1)
+  private val themeRenderLeases = ThemeRenderLeaseManager(renderSlots)
 
   /** Catalog ids with a manual branch check in flight; public callers coalesce at this boundary. */
   private val catalogRefreshesInFlight = ConcurrentHashMap.newKeySet<String>()
@@ -609,6 +611,10 @@ class ServeHttpServer(
 
         get("/api/previews") { handleApiPreviews(sessionInPath = false) }
         get("/{system}/api/previews") { handleApiPreviews(sessionInPath = true) }
+        post("/api/theme-render-lease") { handleThemeRenderLease(sessionInPath = false) }
+        post("/{system}/api/theme-render-lease") { handleThemeRenderLease(sessionInPath = true) }
+        post("/api/theme-render-lease/release") { handleThemeRenderLeaseRelease() }
+        post("/{system}/api/theme-render-lease/release") { handleThemeRenderLeaseRelease() }
 
         // Storybook-compatibility surface (see [StorybookCompat]). `/index.json` is the stories
         // index every downstream visual tool (Chromatic, Percy, storycap/reg-suit, BackstopJS, the
@@ -1168,7 +1174,7 @@ class ServeHttpServer(
           // a daemon-twinned card can actually re-render one, hence the per-preview predicate.
           declaredThemes = renderHost.declaredThemes,
           canRenderThemeFor = { id -> renderHost.canRenderOverridesFor(id) },
-          themeRenderConcurrency = renderHost.themeRenderConcurrency,
+          themeRenderBurstCapacity = renderHost.themeRenderBurstCapacity,
           engagement = previewEngagement(selectedSessionId, renderHost.previews),
           systemViews = systemViews,
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl(), imageUrl = heroUrl),
@@ -1176,6 +1182,41 @@ class ServeHttpServer(
         ContentType.Text.Html,
       )
     }
+  }
+
+  /** Grant one catalog page a short-lived themed-thumbnail burst; all other pages stay serial. */
+  private suspend fun RoutingContext.handleThemeRenderLease(sessionInPath: Boolean) {
+    if (rejectBadToken()) return
+    val sessionId = selectedSessionId(sessionInPath)
+    withLeasedSession(sessionId) { renderHost ->
+      val grant =
+        themeRenderLeases.acquire(
+          sessionId = sessionId,
+          hostIdentity = renderHost,
+          requestedCapacity = renderHost.themeRenderBurstCapacity,
+        )
+      if (grant == null) {
+        call.response.headers.append(HttpHeaders.RetryAfter, "2")
+        call.respondText("theme render burst unavailable", status = HttpStatusCode.Conflict)
+      } else {
+        call.respondText(
+          """{"lease":"${grant.token}","concurrency":${grant.concurrency},"expiresAt":${grant.expiresAtMillis}}""",
+          ContentType.Application.Json,
+        )
+      }
+    }
+  }
+
+  /** Best-effort page/queue release; fixed lease expiry remains authoritative. */
+  private suspend fun RoutingContext.handleThemeRenderLeaseRelease() {
+    if (rejectBadToken()) return
+    val lease = call.request.queryParameters["lease"]
+    if (lease.isNullOrBlank()) {
+      call.respondText("missing lease", status = HttpStatusCode.BadRequest)
+      return
+    }
+    themeRenderLeases.release(lease)
+    call.respond(HttpStatusCode.NoContent)
   }
 
   /** `GET /compare` and `GET /{system}/compare`: native format-fidelity comparison gallery. */
@@ -2474,17 +2515,59 @@ class ServeHttpServer(
           // concurrent renders (default = CPU count) so a small box sheds a storm instead of
           // thrashing: wait briefly for a slot, else 503 + Retry-After. A null outcome signals the
           // wait timed out.
+          // Catalog-host theme cache hits are memory reads and must not be rejected merely because
+          // unrelated live renders occupy every global slot. [render] rechecks after admission to
+          // close the race with a render that completes between these two calls.
+          val cached = renderHost.cachedRender(previewId, overrides)
+          val pureThemeProvider =
+            overrides.themeProvider?.takeIf {
+              overrides == PreviewOverrides(themeProvider = it) &&
+                renderHost.declaredThemes.any { theme -> theme.providerFqn == it }
+            }
+          val leaseToken = call.request.queryParameters["_themeLease"]
+          val leasePermit =
+            if (cached == null && pureThemeProvider != null && leaseToken != null) {
+              themeRenderLeases.admit(leaseToken, sessionId, renderHost)
+            } else {
+              null
+            }
+          if (
+            cached == null && pureThemeProvider != null && leaseToken != null && leasePermit == null
+          ) {
+            call.response.headers.append(HttpHeaders.RetryAfter, "2")
+            call.respondText(
+              "theme render lease expired or saturated",
+              status = HttpStatusCode.TooManyRequests,
+            )
+            return@withLeasedSession
+          }
+          val needsSerialThemePermit =
+            cached == null && pureThemeProvider != null && leaseToken == null
           val outcome =
-            withContext(Dispatchers.IO) {
-              if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
-                null
-              } else {
-                try {
-                  renderHost.render(previewId, overrides)
-                } finally {
-                  renderSemaphore.release()
+            try {
+              cached
+                ?: withContext(Dispatchers.IO) {
+                  val serialAcquired =
+                    !needsSerialThemePermit ||
+                      unleasedThemeSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)
+                  if (!serialAcquired) {
+                    null
+                  } else if (
+                    !renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)
+                  ) {
+                    if (needsSerialThemePermit) unleasedThemeSemaphore.release()
+                    null
+                  } else {
+                    try {
+                      renderHost.render(previewId, overrides)
+                    } finally {
+                      renderSemaphore.release()
+                      if (needsSerialThemePermit) unleasedThemeSemaphore.release()
+                    }
+                  }
                 }
-              }
+            } finally {
+              leasePermit?.close()
             }
           when (outcome) {
             null -> {
@@ -2496,7 +2579,8 @@ class ServeHttpServer(
             }
             RenderOutcome.Busy -> {
               // Daemon mid-render; backed off in ~DAEMON_BUSY_WAIT instead of pinning this slot.
-              // A catalog host serves baked instead of returning Busy; a bare bundle host 503s.
+              // Pure catalog-theme requests also use this retry signal: serving baked pixels with
+              // a successful status would leave that thumbnail on the wrong theme permanently.
               call.response.headers.append(HttpHeaders.RetryAfter, "2")
               call.respondText(
                 "render busy; retry shortly",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -201,6 +201,8 @@ sealed interface RenderOutcome {
   enum class Generation(val wire: String) {
     /** Read directly from a published bundle; no renderer was involved in this request. */
     BAKED("baked"),
+    /** Reused from the catalog host's theme cache, which survives per-preview daemon eviction. */
+    CATALOG_CACHE("catalog-cache"),
     /** Reused from the daemon host's in-memory override cache. */
     DAEMON_CACHE("daemon-cache"),
     /** Produced by a daemon render during this request. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -922,10 +922,10 @@ object ServeWeb {
      * emitted at all.
      */
     themeBaseJs: String = "",
-    themeRenderConcurrency: Int = 1,
+    themeLeaseUrl: String = "",
   ): String {
     val hasDeclaredThemes = themeBaseJs.isNotEmpty()
-    val safeThemeRenderConcurrency = themeRenderConcurrency.coerceIn(1, 2)
+    val themeLeaseUrlJs = WebEscaping.jsString(themeLeaseUrl)
     // The stored choice is one of `light` / `dark` (a baked swap), `default` (the catalog's own
     // renders), or `theme:<providerFqn>` (an app-declared @ThemeCatalog theme, applied by
     // re-pointing each daemon-twinned card's thumbnail at a `?themeProvider=` render).
@@ -950,21 +950,50 @@ object ServeWeb {
         """
           .trimIndent()
       else ""
-    // The declared-theme lane. A catalog host backed by a bounded pool of per-preview daemons may
-    // advertise a small amount of parallelism; a monolithic host advertises one and stays serial.
-    // Keep the browser cap deliberately below the server/pool caps: opening an Android daemon is
-    // expensive, and an unbounded grid burst would still shed requests (503 "render busy") or
-    // create a JVM storm. Each worker advances only after its image settles; failures get bounded
-    // delayed retries with cache-busting URLs. Baked light/dark swaps never queue: those bytes are
-    // already published. themeGen abandons all workers the moment a new theme is chosen.
+    // The declared-theme lane is serial unless the server grants this page a short-lived burst
+    // lease. The server clamps a grant to its render capacity and one page at a time, so opening
+    // another catalog tab cannot multiply a five-worker burst into a JVM storm. Each worker
+    // advances only after its image settles; failures get bounded delayed retries with
+    // cache-busting URLs. Baked light/dark swaps never queue. themeGen abandons all workers the
+    // moment a new theme is chosen and releases that generation's lease.
     val themeRenderInit =
       if (hasDeclaredThemes)
         """
         var themeBase = $themeBaseJs;
         var themeGen = 0;
-        var themeRenderConcurrency = $safeThemeRenderConcurrency;
+        var themeLeaseUrl = $themeLeaseUrlJs;
+        var themeLease = null;
         var themeRenderRetries = 3;
-        function runThemeWorker(queue, gen) {
+        function releaseThemeLease(lease, beacon) {
+          if (!lease || !themeLeaseUrl) return;
+          if (themeLease === lease) themeLease = null;
+          var queryAt = themeLeaseUrl.indexOf("?");
+          var url = queryAt === -1
+            ? themeLeaseUrl + "/release"
+            : themeLeaseUrl.slice(0, queryAt) + "/release" + themeLeaseUrl.slice(queryAt);
+          url += (url.indexOf("?") === -1 ? "?" : "&") + "lease=" + encodeURIComponent(lease);
+          if (beacon && navigator.sendBeacon) navigator.sendBeacon(url, "");
+          else fetch(url, { method: "POST", credentials: "same-origin", keepalive: true }).catch(function () {});
+        }
+        function acquireThemeLease(gen, callback) {
+          if (!themeLeaseUrl) { callback(null, 1); return; }
+          fetch(themeLeaseUrl, { method: "POST", credentials: "same-origin" })
+            .then(function (response) { return response.ok ? response.json() : null; })
+            .then(function (grant) {
+              var lease = grant && typeof grant.lease === "string" ? grant.lease : null;
+              var concurrency = grant && Number.isFinite(grant.concurrency)
+                ? Math.max(1, Math.min(5, grant.concurrency)) : 1;
+              if (gen !== themeGen) { releaseThemeLease(lease, false); return; }
+              themeLease = lease;
+              callback(lease, concurrency);
+            })
+            .catch(function () { if (gen === themeGen) callback(null, 1); });
+        }
+        function finishThemeJob(batch) {
+          batch.remaining--;
+          if (batch.remaining === 0) releaseThemeLease(batch.lease, false);
+        }
+        function runThemeWorker(queue, gen, batch) {
           if (gen !== themeGen) return;
           var job = queue.shift();
           if (!job) return;
@@ -983,22 +1012,26 @@ object ServeWeb {
               setTimeout(function () {
                 if (gen !== themeGen) return;
                 queue.push(job);
-                runThemeWorker(queue, gen);
+                runThemeWorker(queue, gen, batch);
               }, 1000 * Math.pow(2, job.retries));
               return;
             }
             job.card.classList.remove("cp-reloading");
             job.card.removeAttribute("aria-busy");
-            runThemeWorker(queue, gen);
+            finishThemeJob(batch);
+            runThemeWorker(queue, gen, batch);
           }
           img.onload = function () { next(true); };
           img.onerror = function () { next(false); };
           img.src = job.src;
         }
-        function runThemeQueue(queue, gen) {
-          var workers = Math.min(themeRenderConcurrency, queue.length);
-          for (var i = 0; i < workers; i++) runThemeWorker(queue, gen);
+        function runThemeQueue(queue, gen, lease, concurrency) {
+          var batch = { lease: lease, remaining: queue.length };
+          if (!batch.remaining) { releaseThemeLease(lease, false); return; }
+          var workers = Math.min(concurrency, queue.length);
+          for (var i = 0; i < workers; i++) runThemeWorker(queue, gen, batch);
         }
+        window.addEventListener("pagehide", function () { releaseThemeLease(themeLease, true); });
         """
           .trimIndent()
       else ""
@@ -1024,6 +1057,7 @@ object ServeWeb {
       if (hasDeclaredThemes)
         """
         var provider = theme.indexOf("theme:") === 0 ? theme.slice(6) : "";
+        releaseThemeLease(themeLease, false);
         themeGen++;
         var themeQueue = [];
         var themeDeferredQueue = [];
@@ -1056,7 +1090,15 @@ object ServeWeb {
             (themeVisible ? themeQueue : themeDeferredQueue).push(job);
           });
           themeQueue = themeQueue.concat(themeDeferredQueue);
-          runThemeQueue(themeQueue, themeQueueGen);
+          acquireThemeLease(themeQueueGen, function (lease, concurrency) {
+            if (lease) {
+              themeQueue.forEach(function (job) {
+                job.baseSrc += "&_themeLease=" + encodeURIComponent(lease);
+                job.src = job.baseSrc;
+              });
+            }
+            runThemeQueue(themeQueue, themeQueueGen, lease, concurrency);
+          });
           return;
         }
         """
@@ -2576,11 +2618,11 @@ object ServeWeb {
      */
     canRenderThemeFor: (String) -> Boolean = { false },
     /**
-     * Number of themed thumbnail workers this host can safely sustain. Monolithic daemons pass one;
-     * catalog composites with independent per-preview daemons pass a conservative two. Clamped so a
-     * future caller cannot accidentally turn a landing page into an unbounded render burst.
+     * Maximum themed-thumbnail burst supported by this host. Values above one enable the
+     * server-issued page lease endpoint; actual concurrency is granted dynamically and clamped by
+     * server render capacity. Monolithic daemons remain serial.
      */
-    themeRenderConcurrency: Int = 1,
+    themeRenderBurstCapacity: Int = 1,
     /**
      * Per-preview engagement counts for this running server. The map is additive UI/API metadata:
      * missing or zero entries render no badge.
@@ -2592,6 +2634,8 @@ object ServeWeb {
     unfurl: UnfurlMetadata? = null,
   ): String {
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
+    val themeLeaseUrl =
+      if (themeRenderBurstCapacity > 1) "$basePath/api/theme-render-lease$q" else ""
     // A dark-first system (Wear) puts every unthemed card on the dark stage; explicit light/dark
     // variants keep their own token. Only affects the background — the Light/Dark filter axis below
     // still keys off the explicit-only [cardTheme].
@@ -2801,7 +2845,7 @@ object ServeWeb {
           themeStorageKey(sessionId, basePath),
           tabStorageKey(sessionId, basePath),
           themeBaseJs,
-          themeRenderConcurrency,
+          themeLeaseUrl,
         )}</script>"
       else ""
     val formatLink =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManager.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManager.kt
@@ -1,0 +1,131 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Grants one short-lived, server-wide burst for a catalog page's themed thumbnail renders.
+ *
+ * This is deliberately separate from [ServeSessionRegistry.Lease]: a session lease keeps a host
+ * resident, whereas this lease limits how much parallel render work one browser page may admit. A
+ * grant is bound to both its session and the exact host instance, so replacing a catalog host
+ * invalidates its outstanding token without relying on a generation string.
+ *
+ * Releasing or expiring a lease stops new admissions immediately. Existing [Permit]s may finish;
+ * the lease remains in a draining state until the last one closes, preventing a replacement page
+ * from overlapping the old burst. The fixed TTL cannot be renewed, so a lost page cannot retain
+ * burst capacity indefinitely.
+ *
+ * Thread-safe. The caller must still use the server's ordinary global render semaphore: this
+ * manager narrows admission for the privileged page and never expands the server-wide limit.
+ */
+internal class ThemeRenderLeaseManager(
+  private val serverRenderSlots: Int,
+  private val clock: () -> Long = System::currentTimeMillis,
+  private val tokenSource: () -> String = { UUID.randomUUID().toString() },
+) {
+  data class Grant(val token: String, val concurrency: Int, val expiresAtMillis: Long)
+
+  private class Lease(
+    val token: String,
+    val sessionId: String,
+    val hostIdentity: Any,
+    val concurrency: Int,
+    val expiresAtMillis: Long,
+    var inFlight: Int = 0,
+    var released: Boolean = false,
+  )
+
+  private val lock = ReentrantLock()
+  private var active: Lease? = null
+
+  /**
+   * Try to grant a burst for [sessionId] and this exact [hostIdentity]. Only one grant can exist
+   * server-wide. Capacities that cannot exceed the serial baseline are denied.
+   */
+  fun acquire(sessionId: String, hostIdentity: Any, requestedCapacity: Int): Grant? =
+    lock.withLock {
+      reapTerminalLease()
+      if (active != null) return null
+
+      val concurrency = minOf(requestedCapacity, serverRenderSlots, MAX_CONCURRENCY)
+      if (concurrency <= BASELINE_CONCURRENCY) return null
+
+      val lease =
+        Lease(
+          token = tokenSource(),
+          sessionId = sessionId,
+          hostIdentity = hostIdentity,
+          concurrency = concurrency,
+          expiresAtMillis = clock() + TTL_MILLIS,
+        )
+      active = lease
+      Grant(lease.token, lease.concurrency, lease.expiresAtMillis)
+    }
+
+  /**
+   * Admit one render under [token]. A token is valid only for its original session and exact host
+   * object, before expiry/release, and while fewer than the granted number are already in flight.
+   * The returned permit must be closed after the render finishes.
+   */
+  fun admit(token: String, sessionId: String, hostIdentity: Any): Permit? = lock.withLock {
+    val lease = active ?: return null
+    if (
+      lease.token != token || lease.sessionId != sessionId || lease.hostIdentity !== hostIdentity
+    ) {
+      return null
+    }
+    if (lease.released || clock() >= lease.expiresAtMillis) {
+      lease.released = true
+      reapTerminalLease()
+      return null
+    }
+    if (lease.inFlight >= lease.concurrency) return null
+
+    lease.inFlight++
+    Permit {
+      lock.withLock {
+        check(lease.inFlight > 0) { "theme render lease permit underflow" }
+        lease.inFlight--
+        reapTerminalLease()
+      }
+    }
+  }
+
+  /**
+   * Stop new admissions for [token]. Returns false for an unknown token. The active slot becomes
+   * available immediately when there are no in-flight renders, otherwise after the final permit
+   * closes. Repeated releases are harmless.
+   */
+  fun release(token: String): Boolean = lock.withLock {
+    val lease = active ?: return false
+    if (lease.token != token) return false
+    lease.released = true
+    reapTerminalLease()
+    true
+  }
+
+  /** One admitted render. Closing it is idempotent. */
+  class Permit internal constructor(private val onClose: () -> Unit) : AutoCloseable {
+    private val closed = AtomicBoolean(false)
+
+    override fun close() {
+      if (closed.compareAndSet(false, true)) onClose()
+    }
+  }
+
+  /** Caller holds [lock]. Expiry drains just like an explicit release. */
+  private fun reapTerminalLease() {
+    val lease = active ?: return
+    if (clock() >= lease.expiresAtMillis) lease.released = true
+    if (lease.released && lease.inFlight == 0) active = null
+  }
+
+  companion object {
+    const val BASELINE_CONCURRENCY = 1
+    const val MAX_CONCURRENCY = 5
+    const val TTL_MILLIS = 60_000L
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -32,6 +32,7 @@ class ServeCatalogLiveHostTest {
     private val streaming: Boolean = false,
     /** When true, `renderSvg` reports `NotFound` (a baked catalog missing this slug's vector). */
     private val svgNotFound: Boolean = false,
+    private val forcedRenderOutcome: RenderOutcome? = null,
     override val declaredThemes: List<ServeTheme> = emptyList(),
     override val gesturesRenderable: Boolean = false,
     /**
@@ -53,6 +54,9 @@ class ServeCatalogLiveHostTest {
       renderCalls++
       lastRenderId = previewId
       lastRenderOverrides = overrides
+      forcedRenderOutcome?.let {
+        return it
+      }
       if (previewId in liveOnlyPreviewIds) return RenderOutcome.NotFound
       return RenderOutcome.Ok("$tag:$previewId".encodeToByteArray())
     }
@@ -563,6 +567,29 @@ class ServeCatalogLiveHostTest {
         perPreviewResolve = { null },
       )
     assertEquals(5, pooled.themeRenderBurstCapacity)
+  }
+
+  @Test
+  fun `pure theme render propagates busy from monolithic fallback`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val monolithic =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "mono",
+        forcedRenderOutcome = RenderOutcome.Busy,
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = monolithic,
+        baked = baked,
+        perPreviewResolve = { null },
+      )
+
+    assertEquals(RenderOutcome.Busy, composite.render(catalogId, themeOverride()))
+    assertEquals(1, monolithic.renderCalls)
+    assertEquals(0, baked.renderCalls, "baked pixels must not masquerade as the requested theme")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -46,9 +46,11 @@ class ServeCatalogLiveHostTest {
     var lastRenderOverrides: PreviewOverrides? = null
     var lastSvgId: String? = null
     var lastStreamId: String? = null
+    var renderCalls = 0
     var closed = false
 
     override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+      renderCalls++
       lastRenderId = previewId
       lastRenderOverrides = overrides
       if (previewId in liveOnlyPreviewIds) return RenderOutcome.NotFound
@@ -125,6 +127,11 @@ class ServeCatalogLiveHostTest {
   /** A knob-bearing override — the sole case the baked PNG can't satisfy. */
   private fun knobOverride() =
     PreviewOverrides(namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("Tap me")))
+
+  private fun themeOverride(provider: String = "com.example.BrandDark") =
+    PreviewOverrides(themeProvider = provider)
+
+  private val brandTheme = ServeTheme("Brand Dark", "com.example.BrandDark")
 
   @Test
   fun `canRenderOverridesFor is true only for aliased previews`() {
@@ -546,7 +553,7 @@ class ServeCatalogLiveHostTest {
   @Test
   fun `theme redraw is parallel only when the per-preview lane is available`() {
     val (monolithicOnly, live, baked) = host()
-    assertEquals(1, monolithicOnly.themeRenderConcurrency)
+    assertEquals(1, monolithicOnly.themeRenderBurstCapacity)
 
     val pooled =
       ServeCatalogLiveHost(
@@ -555,7 +562,79 @@ class ServeCatalogLiveHostTest {
         baked = baked,
         perPreviewResolve = { null },
       )
-    assertEquals(2, pooled.themeRenderConcurrency)
+    assertEquals(5, pooled.themeRenderBurstCapacity)
+  }
+
+  @Test
+  fun `pure theme renders stay cached across per-preview daemon reuse`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val monolithic =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "mono",
+        declaredThemes = listOf(brandTheme),
+      )
+    val perPreview = RecordingHost(previews = emptyList(), tag = "per")
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = monolithic,
+        baked = baked,
+        perPreviewResolve = { perPreview },
+      )
+
+    val first = composite.render(catalogId, themeOverride()) as RenderOutcome.Ok
+    val second = composite.render(catalogId, themeOverride()) as RenderOutcome.Ok
+
+    assertEquals("per:$daemonId", first.png.decodeToString())
+    assertEquals(RenderOutcome.Generation.CATALOG_CACHE, second.generation)
+    assertEquals(1, perPreview.renderCalls)
+    assertEquals(0, monolithic.renderCalls)
+    assertEquals(0, baked.renderCalls)
+  }
+
+  @Test
+  fun `catalog theme cache excludes mixed overrides`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val mixed =
+      themeOverride()
+        .copy(namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("First")))
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+
+    composite.render(catalogId, mixed)
+    composite.render(catalogId, mixed)
+    assertEquals(2, live.renderCalls)
+  }
+
+  @Test
+  fun `catalog refresh starts a fresh theme cache generation`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val oldLive =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "old",
+        declaredThemes = listOf(brandTheme),
+      )
+    val oldHost = ServeCatalogLiveHost(mapOf(catalogId to daemonId), oldLive, baked)
+    oldHost.render(catalogId, themeOverride())
+    oldHost.render(catalogId, themeOverride())
+    assertEquals(1, oldLive.renderCalls)
+
+    val refreshedLive =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "new",
+        declaredThemes = listOf(brandTheme),
+      )
+    val refreshedHost = ServeCatalogLiveHost(mapOf(catalogId to daemonId), refreshedLive, baked)
+    refreshedHost.render(catalogId, themeOverride())
+    assertEquals(1, refreshedLive.renderCalls)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -183,6 +183,13 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `theme burst lease routes deny hosts that only support serial rendering`() {
+    assertEquals(409, post("/compose-m3/api/theme-render-lease").first)
+    assertEquals(409, post("/api/theme-render-lease?session=compose-m3").first)
+    assertEquals(400, post("/compose-m3/api/theme-render-lease/release").first)
+  }
+
+  @Test
   fun `concurrent catalog refresh requests coalesce before remote work`() {
     blockRefresh = true
     val executor = Executors.newSingleThreadExecutor()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -690,7 +690,7 @@ class ServeWebFixtureTest {
             ServeTheme("High Contrast", "com.example.HighContrastThemeCatalog"),
           ),
         canRenderThemeFor = { true },
-        themeRenderConcurrency = 2,
+        themeRenderBurstCapacity = 5,
       )
     // A catalog whose components carry baked non-default states: the landing folds each to ONE card
     // (the default), the non-default states reachable via the viewer switcher.
@@ -1176,22 +1176,31 @@ class ServeWebFixtureTest {
       landingDeclaredThemes.contains("data-base-src"),
       "no render URL is round-tripped through a DOM attribute",
     )
-    // The catalog has a bounded per-preview daemon pool, so themed thumbnails use a conservative
-    // two-worker queue: enough parallelism to avoid multi-minute catalog redraws without firing a
-    // grid-sized burst. Each worker advances on image settlement and retries shed requests with
-    // bounded exponential backoff and a cache-busting URL.
+    // A declared-theme selection asks the server for one short-lived page lease. A grant may run
+    // five workers; denial/failure stays serial. Retries keep the same lease capability.
     assertTrue(
       landingDeclaredThemes.contains("var job = {") &&
-        landingDeclaredThemes.contains("var themeRenderConcurrency = 2") &&
+        landingDeclaredThemes.contains(
+          "var themeLeaseUrl = \"/api/theme-render-lease?session=compose-m3\""
+        ) &&
         landingDeclaredThemes.contains("var themeRenderRetries = 3") &&
-        landingDeclaredThemes.contains("function runThemeWorker(queue, gen)") &&
-        landingDeclaredThemes.contains("runThemeQueue(themeQueue, themeQueueGen)") &&
-        landingDeclaredThemes.contains("Math.min(themeRenderConcurrency, queue.length)") &&
+        landingDeclaredThemes.contains("function acquireThemeLease(gen, callback)") &&
+        landingDeclaredThemes.contains("Math.max(1, Math.min(5, grant.concurrency))") &&
+        landingDeclaredThemes.contains("function runThemeWorker(queue, gen, batch)") &&
+        landingDeclaredThemes.contains(
+          "runThemeQueue(themeQueue, themeQueueGen, lease, concurrency)"
+        ) &&
+        landingDeclaredThemes.contains("var workers = Math.min(concurrency, queue.length)") &&
+        landingDeclaredThemes.contains("&_themeLease=\" + encodeURIComponent(lease)") &&
         landingDeclaredThemes.contains("job.src = job.baseSrc + \"&_retry=\" + job.retries") &&
         landingDeclaredThemes.contains("if (gen !== themeGen) return;") &&
-        landingDeclaredThemes.contains("queue.push(job);\n        runThemeWorker(queue, gen)") &&
-        landingDeclaredThemes.contains("1000 * Math.pow(2, job.retries)"),
-      "themed renders use a bounded worker pool with bounded backoff retries",
+        landingDeclaredThemes.contains(
+          "queue.push(job);\n        runThemeWorker(queue, gen, batch)"
+        ) &&
+        landingDeclaredThemes.contains("1000 * Math.pow(2, job.retries)") &&
+        landingDeclaredThemes.contains("releaseThemeLease(batch.lease, false)") &&
+        landingDeclaredThemes.contains("navigator.sendBeacon(url, \"\")"),
+      "themed renders use a leased worker burst with bounded backoff retries",
     )
     assertTrue(
       landingDeclaredThemes.contains("c.classList.add(\"cp-reloading\")") &&

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManagerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManagerTest.kt
@@ -1,0 +1,103 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ThemeRenderLeaseManagerTest {
+  private var now = 1_000L
+  private var tokenNumber = 0
+
+  private fun manager(serverSlots: Int = 8) =
+    ThemeRenderLeaseManager(
+      serverRenderSlots = serverSlots,
+      clock = { now },
+      tokenSource = { "token-${++tokenNumber}" },
+    )
+
+  @Test
+  fun `one lease is active server-wide and is bound to session and host identity`() {
+    val manager = manager()
+    val host = Any()
+    val grant = assertNotNull(manager.acquire("wear", host, requestedCapacity = 5))
+
+    assertNull(manager.acquire("material", Any(), requestedCapacity = 5))
+    assertNull(manager.admit(grant.token, "material", host))
+    assertNull(manager.admit(grant.token, "wear", Any()))
+    assertNotNull(manager.admit(grant.token, "wear", host)).close()
+  }
+
+  @Test
+  fun `grant is capped by requested capacity server slots and the burst ceiling`() {
+    assertEquals(3, manager().acquire("app", Any(), requestedCapacity = 3)?.concurrency)
+    assertEquals(2, manager(serverSlots = 2).acquire("app", Any(), 5)?.concurrency)
+    assertEquals(5, manager(serverSlots = 20).acquire("app", Any(), 20)?.concurrency)
+  }
+
+  @Test
+  fun `capacity at the serial baseline is denied`() {
+    assertNull(manager().acquire("app", Any(), requestedCapacity = 1))
+    assertNull(manager(serverSlots = 1).acquire("app", Any(), requestedCapacity = 5))
+  }
+
+  @Test
+  fun `admission cannot exceed the granted concurrency and permits close idempotently`() {
+    val manager = manager()
+    val host = Any()
+    val grant = assertNotNull(manager.acquire("app", host, requestedCapacity = 3))
+    val permits = List(3) { assertNotNull(manager.admit(grant.token, "app", host)) }
+
+    assertNull(manager.admit(grant.token, "app", host))
+    permits.first().close()
+    permits.first().close()
+    assertNotNull(manager.admit(grant.token, "app", host)).close()
+    permits.drop(1).forEach { it.close() }
+  }
+
+  @Test
+  fun `release drains in-flight work before permitting a replacement`() {
+    val manager = manager()
+    val host = Any()
+    val grant = assertNotNull(manager.acquire("app", host, requestedCapacity = 5))
+    val permit = assertNotNull(manager.admit(grant.token, "app", host))
+
+    assertTrue(manager.release(grant.token))
+    assertTrue(manager.release(grant.token), "release is idempotent while draining")
+    assertNull(manager.admit(grant.token, "app", host))
+    assertNull(manager.acquire("other", Any(), requestedCapacity = 5))
+
+    permit.close()
+    assertNotNull(manager.acquire("other", Any(), requestedCapacity = 5))
+    assertFalse(manager.release("unknown"))
+  }
+
+  @Test
+  fun `expiry rejects new admits and allows replacement once no work is in flight`() {
+    val manager = manager()
+    val host = Any()
+    val grant = assertNotNull(manager.acquire("app", host, requestedCapacity = 5))
+    assertEquals(now + ThemeRenderLeaseManager.TTL_MILLIS, grant.expiresAtMillis)
+
+    now = grant.expiresAtMillis
+    assertNull(manager.admit(grant.token, "app", host))
+    assertNotNull(manager.acquire("other", Any(), requestedCapacity = 5))
+  }
+
+  @Test
+  fun `expired lease with in-flight work drains before replacement`() {
+    val manager = manager()
+    val host = Any()
+    val grant = assertNotNull(manager.acquire("app", host, requestedCapacity = 5))
+    val permit = assertNotNull(manager.admit(grant.token, "app", host))
+
+    now = grant.expiresAtMillis
+    assertNull(manager.admit(grant.token, "app", host))
+    assertNull(manager.acquire("other", Any(), requestedCapacity = 5))
+
+    permit.close()
+    assertNotNull(manager.acquire("other", Any(), requestedCapacity = 5))
+  }
+}

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -122,6 +122,20 @@ to an `<img src>` originates as DOM text. A theme-neutral module whose session
 declares themes gets a leading **Default** chip to return to. The choice persists per catalog
 (`cp-theme:<system>` in `localStorage`, shared with that catalog's viewer Theme select).
 
+Completed catalog-grid theme renders are cached on the catalog host, above the LRU pool of
+preview-scoped daemons. Re-selecting a theme therefore reuses its PNGs even if those daemons were
+evicted. Refreshing the catalog replaces the host, so the replacement starts with an empty cache;
+mixed theme-plus-knob renders remain in the daemon's bounded override cache rather than growing
+this catalog-lifetime cache. Dynamic theme URLs remain `no-store`, preventing a browser or shared
+proxy from replaying old-catalog pixels after refresh.
+
+The grid is serial by default. Selecting an app-declared theme asks the server for a fixed,
+60-second page lease; at most one page server-wide receives a burst, clamped to five workers and
+the server's render-slot count. Other pages remain serial, queue completion/page exit releases the
+lease early, and catalog replacement invalidates it because the grant is bound to that host
+instance. This burst changes admission only: the app/catalog still owns its bounded LRU pool of
+preview-scoped daemons.
+
 ![Catalog theme selector (light)](images/serve-catalog-themes-light.png)
 
 ![Catalog theme selector (dark)](images/serve-catalog-themes-dark.png)

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -98,9 +98,39 @@ if (!known && themeBtns.length) theme = themeBtns[0].getAttribute("data-theme-ch
 var appliedTheme = null;
 var themeBase = ["/render/button-filled__ideal__default__light.png?session=compose-m3", "/render/switch-on__ideal__default__light.png?session=compose-m3", "/render/badge.png?session=compose-m3"];
 var themeGen = 0;
-var themeRenderConcurrency = 2;
+var themeLeaseUrl = "/api/theme-render-lease?session=compose-m3";
+var themeLease = null;
 var themeRenderRetries = 3;
-function runThemeWorker(queue, gen) {
+function releaseThemeLease(lease, beacon) {
+  if (!lease || !themeLeaseUrl) return;
+  if (themeLease === lease) themeLease = null;
+  var queryAt = themeLeaseUrl.indexOf("?");
+  var url = queryAt === -1
+    ? themeLeaseUrl + "/release"
+    : themeLeaseUrl.slice(0, queryAt) + "/release" + themeLeaseUrl.slice(queryAt);
+  url += (url.indexOf("?") === -1 ? "?" : "&") + "lease=" + encodeURIComponent(lease);
+  if (beacon && navigator.sendBeacon) navigator.sendBeacon(url, "");
+  else fetch(url, { method: "POST", credentials: "same-origin", keepalive: true }).catch(function () {});
+}
+function acquireThemeLease(gen, callback) {
+  if (!themeLeaseUrl) { callback(null, 1); return; }
+  fetch(themeLeaseUrl, { method: "POST", credentials: "same-origin" })
+    .then(function (response) { return response.ok ? response.json() : null; })
+    .then(function (grant) {
+      var lease = grant && typeof grant.lease === "string" ? grant.lease : null;
+      var concurrency = grant && Number.isFinite(grant.concurrency)
+        ? Math.max(1, Math.min(5, grant.concurrency)) : 1;
+      if (gen !== themeGen) { releaseThemeLease(lease, false); return; }
+      themeLease = lease;
+      callback(lease, concurrency);
+    })
+    .catch(function () { if (gen === themeGen) callback(null, 1); });
+}
+function finishThemeJob(batch) {
+  batch.remaining--;
+  if (batch.remaining === 0) releaseThemeLease(batch.lease, false);
+}
+function runThemeWorker(queue, gen, batch) {
   if (gen !== themeGen) return;
   var job = queue.shift();
   if (!job) return;
@@ -119,22 +149,26 @@ function runThemeWorker(queue, gen) {
       setTimeout(function () {
         if (gen !== themeGen) return;
         queue.push(job);
-        runThemeWorker(queue, gen);
+        runThemeWorker(queue, gen, batch);
       }, 1000 * Math.pow(2, job.retries));
       return;
     }
     job.card.classList.remove("cp-reloading");
     job.card.removeAttribute("aria-busy");
-    runThemeWorker(queue, gen);
+    finishThemeJob(batch);
+    runThemeWorker(queue, gen, batch);
   }
   img.onload = function () { next(true); };
   img.onerror = function () { next(false); };
   img.src = job.src;
 }
-function runThemeQueue(queue, gen) {
-  var workers = Math.min(themeRenderConcurrency, queue.length);
-  for (var i = 0; i < workers; i++) runThemeWorker(queue, gen);
+function runThemeQueue(queue, gen, lease, concurrency) {
+  var batch = { lease: lease, remaining: queue.length };
+  if (!batch.remaining) { releaseThemeLease(lease, false); return; }
+  var workers = Math.min(concurrency, queue.length);
+  for (var i = 0; i < workers; i++) runThemeWorker(queue, gen, batch);
 }
+window.addEventListener("pagehide", function () { releaseThemeLease(themeLease, true); });
       function apply() {
         themeBtns.forEach(function (b) {
   b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
@@ -160,6 +194,7 @@ function applyThemeChoice() {
   if (theme === appliedTheme) return;
   appliedTheme = theme;
   var provider = theme.indexOf("theme:") === 0 ? theme.slice(6) : "";
+  releaseThemeLease(themeLease, false);
   themeGen++;
   var themeQueue = [];
   var themeDeferredQueue = [];
@@ -192,7 +227,15 @@ function applyThemeChoice() {
       (themeVisible ? themeQueue : themeDeferredQueue).push(job);
     });
     themeQueue = themeQueue.concat(themeDeferredQueue);
-    runThemeQueue(themeQueue, themeQueueGen);
+    acquireThemeLease(themeQueueGen, function (lease, concurrency) {
+      if (lease) {
+        themeQueue.forEach(function (job) {
+          job.baseSrc += "&_themeLease=" + encodeURIComponent(lease);
+          job.src = job.baseSrc;
+        });
+      }
+      runThemeQueue(themeQueue, themeQueueGen, lease, concurrency);
+    });
     return;
   }
   var k = theme === "dark" ? "d" : "l";

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -183,6 +183,19 @@ test("contract · declared theme renders use bounded parallelism", async ({ page
     let maxActive = 0;
     let completed = 0;
     const attempts = new Map();
+    let released = false;
+
+    await page.route("**/api/theme-render-lease?*", async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({ lease: "page-lease", concurrency: 5 }),
+        });
+    });
+    await page.route("**/api/theme-render-lease/release?*", async (route) => {
+        released = true;
+        await route.fulfill({ status: 204, body: "" });
+    });
 
     await page.route("**/render/**", async (route) => {
         const url = new URL(route.request().url());
@@ -193,6 +206,7 @@ test("contract · declared theme renders use bounded parallelism", async ({ page
             });
             return;
         }
+        expect(url.searchParams.get("_themeLease")).toBe("page-lease");
 
         active++;
         maxActive = Math.max(maxActive, active);
@@ -219,6 +233,7 @@ test("contract · declared theme renders use bounded parallelism", async ({ page
     await page.getByRole("button", { name: "Brand Light" }).click();
 
     await expect.poll(() => completed, { timeout: 10_000 }).toBe(3);
-    expect(maxActive).toBe(2);
+    expect(maxActive).toBe(3);
     expect(Array.from(attempts.values())).toEqual([2, 2, 2]);
+    await expect.poll(() => released).toBe(true);
 });


### PR DESCRIPTION
## What changed

- replace the fixed two-worker browser cap with a server-issued, 60-second page burst lease
- grant at most one burst server-wide, capped by five workers, host capacity, and global render slots
- keep unleased theme renders serial and validate leased requests against the session and current host instance
- cache successful pure-theme PNGs on the catalog host until that catalog is replaced
- serve catalog-cache hits before render admission while retaining no-store HTTP responses
- make cold, busy, or duplicate theme work retry instead of returning misleading baked pixels
- release leases when a batch settles or the page exits, with fixed expiry as the fallback

## Why

PR #3185 proved that catalog theme rendering can safely use independent preview daemons, but a permanent client-side cap of two was still arbitrary. This follow-up lets one active page temporarily use more of the app-owned daemon pool without allowing every open page to multiply the burst.

Keeping completed theme renders on the catalog host also avoids re-rendering after preview-daemon LRU eviction. Catalog replacement creates a new host and therefore a fresh cache and invalid lease.

## Validation

- focused Gradle tests for the lease manager, catalog host/cache, HTTP routing, and generated web fixture
- cli ktfmt check
- Playwright declared-theme contract: granted concurrency, retry token retention, and release
- git diff --check