### PR TITLE
fix(svg): preserve text fidelity

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
@@ -158,16 +158,21 @@ internal fun googleFontsImportUrl(faces: List<WebFontFace>): String? {
     if (fs.any { it.italic }) {
       val tuples =
         fs
-          .map { (if (it.italic) 1 else 0) to it.weight }
+          .map { (if (it.italic) 1 else 0) to googleFontsWeight(it.weight) }
           .distinct()
           .sortedWith(compareBy({ it.first }, { it.second }))
       "family=$enc:ital,wght@" + tuples.joinToString(";") { "${it.first},${it.second}" }
     } else {
-      "family=$enc:wght@" + fs.map { it.weight }.distinct().sorted().joinToString(";")
+      "family=$enc:wght@" +
+        fs.map { googleFontsWeight(it.weight) }.distinct().sorted().joinToString(";")
     }
   }
   return "https://fonts.googleapis.com/css2?" + families.joinToString("&") + "&display=swap"
 }
+
+/** CSS2 static-family instances use conventional 100-step weights, unlike Compose's 1..1000. */
+private fun googleFontsWeight(weight: Int): Int =
+  (((weight.coerceIn(1, 1000) + 50) / 100) * 100).coerceIn(100, 900)
 
 /**
  * True when this path is [root] or a descendant of it (both normalized) — traversal containment.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
@@ -81,6 +81,21 @@ class ServeFigmaSvgWebModeTest {
   }
 
   @Test
+  fun `googleFontsImportUrl rounds Compose intermediate weights`() {
+    val url =
+      googleFontsImportUrl(
+        listOf(
+          WebFontFace("Roboto", 599, italic = false),
+          WebFontFace("Roboto", 550, italic = true),
+        )
+      )
+    assertEquals(
+      "https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,600;1,600&display=swap",
+      url,
+    )
+  }
+
+  @Test
   fun `generic families are not sent to Google Fonts`() {
     assertNull(googleFontsImportUrl(listOf(WebFontFace("sans-serif", 400, false))))
     // A mix keeps only the real family.

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -415,15 +415,15 @@ object ComposeSemanticsDataProducer {
         .distinct()
         .singleOrNull()
         ?.takeIf { it.isNotBlank() }
-    // Per-line geometry for wrapped text — only for a single [TextLayoutResult] (so line offsets
-    // share one origin, the node's top-left) that actually wrapped (2+ lines). Each line's visible
-    // substring + left edge + baseline, in px relative to the layout origin, lets the export place
-    // one run per line instead of collapsing the string onto a single baseline. An ellipsised line
-    // gets the "…" the render draws re-appended (the visible end excludes it).
+    // Per-line geometry for wrapped or ellipsised text — only for a single [TextLayoutResult] (so
+    // line offsets share one origin, the node's top-left). Wrapped text needs its exact break
+    // points; a single ellipsised line needs the visible substring rather than the full source
+    // string. An ellipsised line gets the "…" the render draws re-appended (the visible end
+    // excludes it).
     val lines =
       results
         .singleOrNull()
-        ?.takeIf { it.lineCount >= 2 }
+        ?.takeIf { r -> r.lineCount >= 2 || (r.lineCount == 1 && r.isLineEllipsized(0)) }
         ?.let { r ->
           val str = r.layoutInput.text.text
           (0 until r.lineCount).map { i ->

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaFontResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaFontResolver.kt
@@ -39,14 +39,19 @@ class GoogleFontsWoff2Resolver(
 ) : FigmaFontResolver {
 
   override fun woff2(family: String, weight: Int, italic: Boolean): ByteArray? {
-    val cacheFile = cacheDir?.let { File(it, cacheName(family, weight, italic)) }
+    // Compose exposes the full 1..1000 FontWeight range (Wear TimeText currently resolves to 599),
+    // while Google Fonts' CSS2 endpoint accepts the conventional 100-step instances for static
+    // families such as Roboto. Fetch the nearest supported instance; the SVG still declares the
+    // original weight, so CSS selects this closest face for the run.
+    val googleWeight = googleFontsWeight(weight)
+    val cacheFile = cacheDir?.let { File(it, cacheName(family, googleWeight, italic)) }
     cacheFile
       ?.takeIf { it.exists() && it.length() > 0 }
       ?.let {
         return runCatching { fileSystem.read(it.path.toPath()) { readByteArray() } }.getOrNull()
       }
     if (offline) return null
-    val bytes = downloadWithRetry(family, weight, italic) ?: return null
+    val bytes = downloadWithRetry(family, googleWeight, italic) ?: return null
     cacheFile?.let { f ->
       runCatching {
         f.parentFile?.mkdirs()
@@ -103,9 +108,14 @@ class GoogleFontsWoff2Resolver(
     /** CSS2 request for a single face; a modern UA gets WOFF2 `src` URLs back. */
     fun cssUrl(family: String, weight: Int, italic: Boolean): String {
       @Suppress("DEPRECATION") val fam = URLEncoder.encode(family, "UTF-8").replace("+", "%20")
-      val axis = if (italic) "ital,wght@1,$weight" else "wght@$weight"
+      val supportedWeight = googleFontsWeight(weight)
+      val axis = if (italic) "ital,wght@1,$supportedWeight" else "wght@$supportedWeight"
       return "https://fonts.googleapis.com/css2?family=$fam:$axis&display=swap"
     }
+
+    /** Nearest conventional Google Fonts weight, with ties biased upward (550 -> 600). */
+    internal fun googleFontsWeight(weight: Int): Int =
+      (((weight.coerceIn(1, 1000) + 50) / 100) * 100).coerceIn(100, 900)
 
     /**
      * Pick the WOFF2 `src` URL from a CSS2 response — preferring the `latin` subset block (the

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaFontEmbedTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaFontEmbedTest.kt
@@ -46,6 +46,16 @@ class FigmaFontEmbedTest {
   }
 
   @Test
+  fun cssUrlRoundsComposeIntermediateWeightsToAFontInstance() {
+    assertTrue(
+      GoogleFontsWoff2Resolver.cssUrl("Roboto", 599, false).contains("family=Roboto:wght@600")
+    )
+    assertTrue(
+      GoogleFontsWoff2Resolver.cssUrl("Roboto", 550, true).contains("family=Roboto:ital,wght@1,600")
+    )
+  }
+
+  @Test
   fun firstWoff2UrlPrefersLatinSubset() {
     val css =
       """

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -938,11 +938,11 @@ object FigmaLayeredSvg {
         ?.takeIf { kotlin.math.abs(it) >= 0.01 }
         ?.let { """ letter-spacing="${fmt(it)}"""" } ?: ""
     val lines = t.lines
-    if (lines != null && lines.size > 1) {
-      // Wrapped text: one positioned <tspan> per line at the exact place the render wrapped it,
-      // instead of collapsing the whole string onto one baseline. x/y are absolute (layer origin +
-      // the captured per-line offset), so line alignment (centre/right) and the real break points
-      // are preserved on Figma import.
+    if (!lines.isNullOrEmpty()) {
+      // Wrapped or ellipsised text: one positioned <tspan> per captured line at the exact place the
+      // render drew it, instead of collapsing the full source string onto one baseline. x/y are
+      // absolute (layer origin + the captured per-line offset), so alignment, break points, and a
+      // single-line visible ellipsis are preserved on Figma import.
       val tspans =
         lines.joinToString("") { line ->
           val lineStart = line.start

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -82,9 +82,10 @@ data class FigmaSvgText(
   /** Effective styled UTF-16 ranges for annotated text; null for a uniform/plain run. */
   val spans: List<FigmaSvgTextSpan>? = null,
   /**
-   * Per-line runs for wrapped text, in px relative to the layer's top-left, in draw order. When
-   * present (2+ lines) the renderer emits one positioned `<tspan>` per line instead of a single
-   * baseline — so text wraps exactly where the render wrapped it. Null for single-line text.
+   * Per-line runs for wrapped or ellipsised text, in px relative to the layer's top-left, in draw
+   * order. The renderer emits one positioned `<tspan>` per line instead of the full source string,
+   * so wrapping and a single-line ellipsis match the render exactly. Null for ordinary single-line
+   * text.
    */
   val lines: List<FigmaSvgTextLine>? = null,
 )
@@ -2046,13 +2047,13 @@ data class FigmaSvgModel(
               color = span.foregroundColor?.let { argbToColor(it, emptyMap()) },
             )
           },
-        // Carry per-line runs only for genuinely wrapped text (2+ lines). The captured offsets are
+        // Carry per-line runs for wrapped and single-line ellipsised text. The captured offsets are
         // already in render px (same space as the node bounds), so they map straight to layer space
         // with no density conversion.
         lines =
           node.textOverflow
             ?.lines
-            ?.takeIf { it.size > 1 }
+            ?.takeIf { it.isNotEmpty() }
             ?.map {
               FigmaSvgTextLine(
                 content = it.text,

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -3000,6 +3000,54 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun singleLineEllipsisUsesTheCapturedVisibleRun() {
+    val layout =
+      layoutNode("Screen", 0, 0, 240, 80, children = listOf(layoutNode("Text", 8, 8, 160, 48)))
+    val semantics =
+      ComposeSemanticsNode(
+        nodeId = "root",
+        boundsInRoot = "0,0,240,80",
+        children =
+          listOf(
+            ComposeSemanticsNode(
+              nodeId = "t",
+              boundsInRoot = "8,8,160,48",
+              text = "Effectenbeurszaal",
+              typography = ComposeSemanticsTypography(fontSize = "16.0sp"),
+              textOverflow =
+                ComposeSemanticsTextOverflow(
+                  lineCount = 1,
+                  truncated = true,
+                  overflow = "Ellipsis",
+                  lines =
+                    listOf(
+                      ComposeSemanticsTextLine(
+                        text = "Effect…",
+                        left = 0,
+                        baseline = 24,
+                        start = 0,
+                        end = 6,
+                        width = 120,
+                      )
+                    ),
+                ),
+            )
+          ),
+      )
+
+    val svg = render(layout, semantics = semantics)
+    assertTrue(
+      svg.contains(
+        """<tspan x="8" y="32" textLength="120" lengthAdjust="spacing">Effect…</tspan>"""
+      )
+    )
+    assertFalse(
+      "full source string must not overflow its measured slot",
+      svg.contains("Effectenbeurszaal"),
+    )
+  }
+
+  @Test
   fun embedFamilyMapsGenericsToConcreteEmbeddableFaces() {
     // sans generics ride the default embedded face; serif/monospace get a real same-style face.
     assertEquals("Roboto", FigmaLayeredSvg.embedFamily(null, "Roboto"))


### PR DESCRIPTION
## Summary

- resolve intermediate Compose font weights to valid Google Fonts instances for embedded and web-mode SVGs
- preserve captured single-line ellipsis runs instead of exporting the full source string
- add regression coverage for Wear TimeText weight `599` and constrained room-name truncation

## Root cause

Wear TimeText resolves to font weight `599`, but the Google Fonts CSS2 request used that value directly. Static Roboto instances use conventional 100-step weights, so the font fetch failed and the browser fell back to a serif face. Separately, per-line text geometry was only retained for wrapped text; single-line ellipsized text therefore exported the full source string and overlapped adjacent content.

## Impact

Web SVG previews now match the raster output more closely: TimeText uses Roboto at the nearest supported weight, and constrained one-line labels retain Compose's visible ellipsis.

## Validation

- `:data-layoutinspector-core:test --tests ee.schimke.composeai.data.layoutinspector.FigmaLayeredSvgTest`
- `:data-layoutinspector-connector:test --tests ee.schimke.composeai.daemon.FigmaFontEmbedTest`
- `:cli:test --tests ee.schimke.composeai.cli.serve.ServeFigmaSvgWebModeTest`
- focused `ktfmtCheck` for all three modules