### PR TITLE
feat(preview): improve preview server layout

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1184,6 +1184,7 @@ class ServeHttpServer(
           engagement = previewEngagement(selectedSessionId, renderHost.previews),
           systemViews = systemViews,
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl(), imageUrl = heroUrl),
+          displayTitle = catalogBundleHost(renderHost)?.title,
         ),
         ContentType.Text.Html,
       )
@@ -1259,6 +1260,7 @@ class ServeHttpServer(
           hasRemoteComposeFor = renderHost::hasRemoteComposeDoc,
           referencesFor = renderHost::designReferencesFor,
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
+          displayTitle = catalogBundleHost(renderHost)?.title,
         ),
         ContentType.Text.Html,
       )
@@ -1315,6 +1317,7 @@ class ServeHttpServer(
           isPublic = isPublic,
           trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
+          displayTitle = catalogBundleHost(renderHost)?.title,
         ),
         ContentType.Text.Html,
       )
@@ -2476,6 +2479,7 @@ class ServeHttpServer(
               ServeUrls.githubBlobUrl(src.repo, src.ref, src.module, preview.sourceFile)
             },
           liveAuthPrompt = liveAuthPrompt,
+          catalogTitle = catalogBundleHost(renderHost)?.title,
         ),
         ContentType.Text.Html,
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -207,21 +207,42 @@ object ServeWeb {
         }
       } ?: ""
     return """
-    <section class="cp-about">
-      <p class="cp-about-title">compose-preview · public preview server</p>
-      <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-        catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-        everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-        — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-        and anything unverified is badged.</p>
-      <p class="cp-about-links">
-        <a href="https://github.com/$SOURCE_REPO">$GITHUB_ICON source</a> ·
-        <a href="/version">/version</a>$ver$auth
-      </p>
-    </section>
+    <details class="cp-about cp-disclosure">
+      <summary>
+        <span class="cp-about-title">About this preview server</span>
+        <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+      </summary>
+      <div class="cp-disclosure-body">
+        <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+          using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+          server never re-runs untrusted code. Catalogs are trusted by signature or their published
+          <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+        <p class="cp-about-links">
+          <a href="https://github.com/$SOURCE_REPO">$GITHUB_ICON source</a> ·
+          <a href="/version">/version</a>$ver$auth
+        </p>
+      </div>
+    </details>
     """
       .trimIndent()
   }
+
+  /** Shared, intentionally compact navigation for every browser-facing page. */
+  private fun siteHeader(navSuffix: String): String =
+    """
+    <header class="cp-site-header">
+      <a class="cp-site-brand" href="/$navSuffix" aria-label="compose-preview home">
+        <span class="cp-site-mark" aria-hidden="true">◇</span>
+        <span>compose-preview</span>
+      </a>
+      <nav class="cp-site-nav" aria-label="Primary navigation">
+        <a href="/$navSuffix">Catalogs</a>
+        <a href="/status$navSuffix">Status</a>
+        <a href="https://github.com/$SOURCE_REPO">GitHub</a>
+      </nav>
+    </header>
+    """
+      .trimIndent()
 
   /**
    * A "back to all design systems" button for a catalog landing — replaces the in-catalog
@@ -329,9 +350,15 @@ object ServeWeb {
       }
     }
     return """
-      <section class="cp-prov" aria-label="Catalog provenance">
-        ${items.joinToString("\n        ")}
-      </section>
+      <details class="cp-prov cp-disclosure">
+        <summary>
+          <span class="cp-prov-title">Catalog details</span>
+          <span class="cp-disclosure-hint">Source, generation time and tooling</span>
+        </summary>
+        <div class="cp-prov-body" aria-label="Catalog provenance">
+          ${items.joinToString("\n          ")}
+        </div>
+      </details>
       ${if (refreshUrl == null) "" else provenanceRefreshScript()}
       """
       .trimIndent()
@@ -540,6 +567,7 @@ object ServeWeb {
       }
     return """
       <nav class="cp-states" aria-label="Component state">
+        <span class="cp-axis-label">State</span>
         $links
       </nav>
       """
@@ -659,6 +687,7 @@ object ServeWeb {
       }
     return """
       <nav class="cp-states" aria-label="Component variant">
+        <span class="cp-axis-label">Variant</span>
         $links
       </nav>
       """
@@ -808,6 +837,16 @@ object ServeWeb {
   /** A human family heading: a curated name, else the token title-cased (`switch` → `Switch`). */
   private fun familyDisplayName(family: String): String =
     FAMILY_DISPLAY_NAMES[family] ?: family.replace('-', ' ').replaceFirstChar { it.uppercaseChar() }
+
+  /**
+   * Prefer catalog-authored labels; turn generated ids into readable component names as fallback.
+   */
+  private fun previewDisplayName(preview: ServePreview): String {
+    if (preview.label.isNotBlank() && preview.label != preview.id) return preview.label
+    return componentKey(preview).substringBefore("__").replace('-', ' ').replaceFirstChar {
+      it.uppercaseChar()
+    }
+  }
 
   /**
    * A **synthesized** sub-grouping for a section-less catalog: bucket [cards] by [cardFamily] so
@@ -1526,9 +1565,10 @@ object ServeWeb {
       val head = WebEscaping.htmlEscape(heading)
       val count = "${list.size} ${WebEscaping.htmlEscape(noun)}"
       return """
-      <h1 class="cp-head">$head</h1>
-      <p class="cp-sub">$count · pick one to browse its components and
-        open a live, customisable preview.</p>
+      <div class="cp-section-title">
+        <h1 class="cp-head">$head</h1>
+        <span class="cp-section-count">$count</span>
+      </div>
       <div class="cp-grid cp-syslist" id="$gridId">
       ${list.joinToString("\n") { card(it) }}
       </div>
@@ -1553,6 +1593,7 @@ object ServeWeb {
       unfurlDescription =
         "Browse ${systems.size} published Compose design system and app catalogs.",
       unfurl = unfurl,
+      navSuffix = suffix,
       body =
         """
         $about$body
@@ -1637,6 +1678,7 @@ object ServeWeb {
       title = "Not found — compose-preview",
       unfurlDescription = message,
       unfurl = unfurl,
+      navSuffix = suffix,
       body =
         """
         <h1 class="cp-head">Not found</h1>
@@ -1682,6 +1724,7 @@ object ServeWeb {
       title = "Playground — compose-preview",
       unfurlDescription = "Compile a Compose snippet against the live catalog and open a preview.",
       unfurl = unfurl,
+      navSuffix = suffix,
       body =
         """
         <link rel="stylesheet" href="${assetHref("playground.css")}">
@@ -1901,6 +1944,7 @@ object ServeWeb {
       title = "Playground unavailable — compose-preview",
       unfurlDescription = "The playground is not enabled on this server.",
       unfurl = unfurl,
+      navSuffix = suffix,
       body =
         """
         <h1 class="cp-head">Playground unavailable</h1>
@@ -1989,6 +2033,7 @@ object ServeWeb {
       title = "Share a document — compose-preview",
       unfurlDescription = "Upload a Remote Compose or Lottie document and get an expiring link.",
       unfurl = unfurl,
+      navSuffix = suffix,
       body =
         """
         <h1 class="cp-head">Share a document</h1>
@@ -2109,6 +2154,7 @@ object ServeWeb {
       title = "${doc.name} — compose-preview",
       unfurlDescription = "A shared ${doc.formatLabel} document, played back in your browser.",
       unfurl = unfurl,
+      navSuffix = suffix,
       body =
         """
         <h1 class="cp-head">${WebEscaping.htmlEscape(doc.name)}</h1>
@@ -2382,18 +2428,21 @@ object ServeWeb {
       """
       <h1 class="cp-head">Server status$healthBadge</h1>
       <p class="cp-sub">compose-preview serve · $mode$ver</p>
-      <section class="cp-about">
-        <p class="cp-about-title">Status &amp; monitoring</p>
-        <p class="cp-about-body">A live snapshot of this preview server — every configured catalog
-          and its latest load result, the render daemons running now, its configuration, and recent
-          daemon startup failures. The same data is available as JSON for a monitor or Home
-          Assistant sensor.</p>
-        <p class="cp-about-links">
-          <a href="/status.json$suffix">/status.json</a> ·
-          <a href="/version">/version</a> ·
-          <a href="/healthz">/healthz</a>
-        </p>
-      </section>
+      <details class="cp-about cp-disclosure">
+        <summary>
+          <span class="cp-about-title">Status &amp; monitoring details</span>
+          <span class="cp-disclosure-hint">JSON and health-check endpoints</span>
+        </summary>
+        <div class="cp-disclosure-body">
+          <p class="cp-about-body">Catalog load results, render daemons, configuration and recent
+            failures. The same data is available as JSON for monitors and Home Assistant.</p>
+          <p class="cp-about-links">
+            <a href="/status.json$suffix">/status.json</a> ·
+            <a href="/version">/version</a> ·
+            <a href="/healthz">/healthz</a>
+          </p>
+        </div>
+      </details>
 
       <div class="cp-status-grid">
       $summaryGrid
@@ -2434,6 +2483,7 @@ object ServeWeb {
       unfurlDescription =
         "Live catalog, render-daemon, and deployment status for this compose-preview server.",
       unfurl = unfurl,
+      navSuffix = suffix,
     )
   }
 
@@ -2645,10 +2695,18 @@ object ServeWeb {
     systemViews: Long = 0,
     /** Absolute page + representative preview URLs for Open Graph/Twitter link previews. */
     unfurl: UnfurlMetadata? = null,
+    /** Human catalog title from catalog.json; [moduleLabel] remains the stable technical id. */
+    displayTitle: String? = null,
   ): String {
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
     val themeLeaseUrl =
       if (themeRenderBurstCapacity > 1) "$basePath/api/theme-render-lease$q" else ""
+    val navSuffix =
+      querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
+    val heading = displayTitle?.takeIf { it.isNotBlank() } ?: moduleLabel
+    val catalogId =
+      if (heading == moduleLabel) ""
+      else "<p class=\"cp-catalog-id\">${WebEscaping.htmlEscape(moduleLabel)}</p>"
     // A dark-first system (Wear) puts every unthemed card on the dark stage; explicit light/dark
     // variants keep their own token. Only affects the background — the Light/Dark filter axis below
     // still keys off the explicit-only [cardTheme].
@@ -2689,20 +2747,23 @@ object ServeWeb {
       // no URL-building in the browser.
       val def = if (darkFirst) d else l
       val defTheme = if (darkFirst) "dark" else "light"
+      val lightLabel = previewDisplayName(l)
+      val darkLabel = previewDisplayName(d)
+      val defaultLabel = previewDisplayName(def)
       // `data-def` is the variant a DECLARED theme re-renders (the server-side default), so picking
       // one doesn't also flip the card's light/dark base.
       return """
         <a class="cp-card" data-swap="1" data-bg-theme="$defTheme" data-def="${if (darkFirst) "d" else "l"}"
           data-l-src="${renderSrc(l)}" data-l-href="${viewerHref(l)}"
-          data-l-id="${WebEscaping.htmlEscape(l.id)}" data-l-label="${WebEscaping.htmlEscape(l.label)}"
+          data-l-id="${WebEscaping.htmlEscape(l.id)}" data-l-label="${WebEscaping.htmlEscape(lightLabel)}"
           data-d-src="${renderSrc(d)}" data-d-href="${viewerHref(d)}"
-          data-d-id="${WebEscaping.htmlEscape(d.id)}" data-d-label="${WebEscaping.htmlEscape(d.label)}"
+          data-d-id="${WebEscaping.htmlEscape(d.id)}" data-d-label="${WebEscaping.htmlEscape(darkLabel)}"
           href="${viewerHref(def)}">
           <div class="cp-imgwrap">
-            <img loading="lazy" alt="${WebEscaping.htmlEscape(def.label)}" src="${renderSrc(def)}">
+            <img loading="lazy" alt="${WebEscaping.htmlEscape(defaultLabel)}" src="${renderSrc(def)}">
           </div>
           <div class="cp-meta">
-            <div class="cp-label" title="${WebEscaping.htmlEscape(def.label)}">${WebEscaping.htmlEscape(def.label)}</div>
+            <div class="cp-label" title="${WebEscaping.htmlEscape(def.id)}">${WebEscaping.htmlEscape(defaultLabel)}</div>
             <div class="cp-id">${WebEscaping.htmlEscape(def.id)}</div>
             ${viewCountHtml(cardViews(card))}
           </div>
@@ -2712,7 +2773,7 @@ object ServeWeb {
     }
     fun singleCard(p: ServePreview): String {
       val idSeg = WebEscaping.urlEncodeSegment(p.id)
-      val label = WebEscaping.htmlEscape(p.label)
+      val label = WebEscaping.htmlEscape(previewDisplayName(p))
       val idText = WebEscaping.htmlEscape(p.id)
       // data-bg-theme is the thumbnail's background (explicit token, else the dark-first default).
       val bgAttr = bgTheme(p.id, darkFirst)?.let { " data-bg-theme=\"$it\"" } ?: ""
@@ -2866,16 +2927,19 @@ object ServeWeb {
         " · <a class=\"cp-format-link\" href=\"$basePath/compare$q\">compare formats</a>"
       else ""
     return document(
-      title = "$moduleLabel — compose-preview",
-      unfurlTitle = moduleLabel,
-      unfurlDescription = "${previews.size} Compose previews in $moduleLabel",
+      title = "$heading — compose-preview",
+      unfurlTitle = heading,
+      unfurlDescription = "${previews.size} Compose previews in $heading",
       unfurl = unfurl,
+      navSuffix = navSuffix,
       body =
         """
-        $back<h1 class="cp-head">${WebEscaping.htmlEscape(moduleLabel)}${trustBadge(trust)}</h1>
-        ${degradeBanner(degradations)}$prov$themeToggle<p class="cp-sub">${previews.size} preview(s)${if (systemViews > 0) " · ${formatViews(systemViews)}" else ""} · click one to view with overrides ·
+        $back<h1 class="cp-head cp-catalog-head">${WebEscaping.htmlEscape(heading)}${compactTrustBadge(trust)}</h1>
+        $catalogId${degradeBanner(degradations)}$prov<p class="cp-sub">${previews.size} preview(s)${if (systemViews > 0) " · ${formatViews(systemViews)}" else ""} ·
           <a href="$basePath/bundle.zip$q">download all (.zip)</a>$formatLink</p>
-        $searchBox$tabBar$gridBlock$emptyState$filterScript$about
+        <div class="cp-catalog-tools">
+        $themeToggle$searchBox</div>
+        $tabBar$gridBlock$emptyState$filterScript$about
         """
           .trimIndent(),
     )
@@ -2895,8 +2959,12 @@ object ServeWeb {
     hasRemoteComposeFor: (String) -> Boolean = { false },
     referencesFor: (String) -> List<DesignReference> = { emptyList() },
     unfurl: UnfurlMetadata? = null,
+    displayTitle: String? = null,
   ): String {
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
+    val navSuffix =
+      querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
+    val heading = displayTitle?.takeIf { it.isNotBlank() } ?: moduleLabel
     // Native-format rows retain the catalog's one-default-card presentation. A design reference,
     // however, names one exact preview state/props mapping, so that referenced variant must remain
     // independently visible instead of being folded out with the landing-page variants.
@@ -3036,15 +3104,17 @@ object ServeWeb {
         "data-has-reference=\"${if (hasReference) "1" else "0"}\""
 
     return document(
-      title = "$moduleLabel — format comparison",
-      unfurlTitle = "$moduleLabel format comparison",
-      unfurlDescription = "Compare rendered PNG, SVG, and Remote Compose output for $moduleLabel",
+      title = "$heading — format comparison",
+      unfurlTitle = "$heading format comparison",
+      unfurlDescription = "Compare rendered PNG, SVG, and Remote Compose output for $heading",
       unfurl = unfurl,
+      navSuffix = navSuffix,
       body =
         """
         <div id="cp-compare" $rootAttrs>
-          <h1 class="cp-head"><a href="$basePath/$q">← previews</a>${trustBadge(trust)}</h1>
-          <p class="cp-sub">Format comparison · scores use structural similarity on a fixed backdrop</p>
+          <p class="cp-breadcrumb"><a href="$basePath/$q">${WebEscaping.htmlEscape(heading)}</a> / Compare formats</p>
+          <h1 class="cp-head">Format comparison${compactTrustBadge(trust)}</h1>
+          <p class="cp-sub">PNG, SVG and Remote Compose fidelity · scores use structural similarity on a fixed backdrop</p>
           <div class="cp-compare-controls">
             <span class="cp-theme" role="group" aria-label="Comparison format">$formatControls</span>
             $themeControls
@@ -3073,8 +3143,12 @@ object ServeWeb {
     isPublic: Boolean = false,
     trust: String? = null,
     unfurl: UnfurlMetadata? = null,
+    displayTitle: String? = null,
   ): String {
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
+    val navSuffix =
+      querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
+    val heading = displayTitle?.takeIf { it.isNotBlank() } ?: moduleLabel
     val actual = "$basePath/render/${WebEscaping.urlEncodeSegment(preview.id)}.png$q"
     val raster = "$basePath/reference/${WebEscaping.urlEncodeSegment(reference.id)}.png$q"
     val source = WebEscaping.htmlEscape(reference.source.provider)
@@ -3114,14 +3188,16 @@ object ServeWeb {
       }
     return document(
       title = "${reference.label} — design comparison",
-      unfurlTitle = "$moduleLabel design comparison",
+      unfurlTitle = "$heading design comparison",
       unfurlDescription = "Reference, diff, and Compose output for ${preview.id}",
       unfurl = unfurl,
+      navSuffix = navSuffix,
       body =
         """
         <div id="cp-reference-compare" data-reference="$raster" data-actual="$actual">
-          <h1 class="cp-head"><a href="$basePath/compare$q">← comparisons</a>${trustBadge(trust)}</h1>
-          <p class="cp-sub">${WebEscaping.htmlEscape(reference.label)} · ${WebEscaping.htmlEscape(preview.id)}</p>
+          <p class="cp-breadcrumb"><a href="$basePath/compare$q">${WebEscaping.htmlEscape(heading)}</a> / Design comparison</p>
+          <h1 class="cp-head cp-catalog-head">${WebEscaping.htmlEscape(reference.label)}${compactTrustBadge(trust)}</h1>
+          <p class="cp-sub">${WebEscaping.htmlEscape(previewDisplayName(preview))} · ${WebEscaping.htmlEscape(preview.id)}</p>
           $referencePicker
           <div class="cp-reference-meta"><strong>Source:</strong> $source$revision</div>
           <div class="cp-reference-grid">
@@ -3283,11 +3359,17 @@ object ServeWeb {
     sourceHref: String? = null,
     /** GitHub sign-in prompt shown when the daemon live stream is present but requires auth. */
     liveAuthPrompt: LiveAuthPrompt? = null,
+    /** Human catalog title used in the breadcrumb; falls back to a generic "Previews" label. */
+    catalogTitle: String? = null,
   ): String {
     val idSeg = WebEscaping.urlEncodeSegment(preview.id)
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
-    val label = WebEscaping.htmlEscape(preview.label)
+    val navSuffix =
+      querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
+    val displayName = previewDisplayName(preview)
+    val label = WebEscaping.htmlEscape(displayName)
     val idText = WebEscaping.htmlEscape(preview.id)
+    val catalogName = WebEscaping.htmlEscape(catalogTitle?.takeIf { it.isNotBlank() } ?: "Previews")
     val modes = preview.modes.joinToString(",") { it.wire }
     // Wear OS is an always-dark surface. Do not expose the generic day/night override: besides
     // being meaningless for Wear, an old light choice within the Wear catalog must not turn into a
@@ -3731,12 +3813,34 @@ object ServeWeb {
     val variantSwitcher = variantSwitcherHtml(preview, siblings, basePath, q)
     val switchers =
       listOf(stateSwitcher, variantSwitcher).filter { it.isNotBlank() }.joinToString("\n")
+    val primaryControls =
+      listOf(liveToggleHtml, wasmToggleBtn, rcBackendSelector, svgFmtToggle, svgMatch)
+        .filter { it.isNotBlank() }
+        .joinToString("\n")
+    val modeInputs =
+      listOf(
+          "<input type=\"radio\" name=\"cp-mode\" value=\"png\" id=\"cp-mode-png\" tabindex=\"-1\" checked>",
+          "<input type=\"radio\" name=\"cp-mode\" value=\"live\" id=\"cp-live\" tabindex=\"-1\"$liveDis>",
+          wasmModeInput,
+          rcModeInput,
+        )
+        .filter { it.isNotBlank() }
+        .joinToString("\n")
     val body =
       """
-      <h1 class="cp-head"><a href="$basePath/$q">← previews</a>${trustBadge(trust)}</h1>
-      ${degradeBanner(degradations)}<p class="cp-sub" title="$idText">$label</p>${sourceLinkHtml(sourceHref, preview.sourceFile)}
+      <p class="cp-breadcrumb"><a href="$basePath/$q">$catalogName</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">$label${compactTrustBadge(trust)}</h1>
+      <p class="cp-preview-id" title="$idText"><code>$idText</code></p>
+      ${degradeBanner(degradations)}${sourceLinkHtml(sourceHref, preview.sourceFile)}
       ${viewerViewCountHtml(engagement.views)}
       $switchers
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      $primaryControls
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      $modeInputs
+        </span>
+      </div>
       <div class="cp-viewer-bar">
         $navToggle
         <span class="cp-bg" role="group" aria-label="Preview zoom">
@@ -3805,28 +3909,9 @@ $deviceControlsHtml
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          $liveToggleHtml
-          $wasmToggleBtn
-          $rcBackendSelector
-          $svgFmtToggle
-          ${if (svgMatch.isNotEmpty()) "$svgMatch\n          " else ""}<span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1"$liveDis>
-            $wasmModeInput
-            $rcModeInput
-          </span>
-        </div>
         $snapshotNote
         ${downloadLinksHtml(hasSvgExport)}
       </div>
@@ -3840,12 +3925,15 @@ $deviceControlsHtml
       ${scriptTag("backend-badge.js")}
       """
         .trimIndent()
+        .lineSequence()
+        .joinToString("\n") { it.trimEnd() }
     return document(
-      title = "${preview.label} — compose-preview",
+      title = "$displayName — compose-preview",
       body = body,
-      unfurlTitle = preview.label,
-      unfurlDescription = "Compose preview for ${preview.label}",
+      unfurlTitle = displayName,
+      unfurlDescription = "Compose preview for $displayName",
       unfurl = unfurl,
+      navSuffix = navSuffix,
     )
   }
 
@@ -3894,7 +3982,7 @@ $deviceControlsHtml
     val items =
       representatives.joinToString("\n") { p ->
         val segItem = WebEscaping.urlEncodeSegment(p.id)
-        val labelItem = WebEscaping.htmlEscape(p.label)
+        val labelItem = WebEscaping.htmlEscape(previewDisplayName(p))
         val idItem = WebEscaping.htmlEscape(p.id)
         // data-search folds label + id so the drawer filter matches either. aria-current pins the
         // one we're viewing (styled as active, and it stays visible even under a filter miss so the
@@ -3928,6 +4016,7 @@ $deviceControlsHtml
     unfurlTitle: String? = null,
     unfurlDescription: String? = null,
     unfurl: UnfurlMetadata? = null,
+    navSuffix: String = "",
   ): String {
     val unfurlHtml =
       if (unfurl == null) ""
@@ -3981,6 +4070,7 @@ $deviceControlsHtml
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        ${siteHeader(navSuffix)}
         <main class="cp-main">
         $body
         </main>
@@ -4024,13 +4114,13 @@ $deviceControlsHtml
     // "Full page (scroll)" toggle over in the overrides drawer's Scroll group.
     val svgRow = if (hasSvgExport) "\n" + row("SVG", "svg") else ""
     return """
-      <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+      <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           ${row("PNG", "png")}$svgRow
         </div>
-      </section>
+      </details>
       """
       .trimIndent()
   }

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -4,16 +4,32 @@ body { margin: 0; padding: 24px; font-family: system-ui, -apple-system, Segoe UI
   color: #1b1b1f; background: #fafafb; }
 a { color: #5b5bd6; text-decoration: none; }
 a:hover { text-decoration: underline; }
+.cp-main, .cp-site-header { width: 100%; max-width: 1440px; margin-left: auto; margin-right: auto; }
+.cp-site-header { min-height: 44px; margin-bottom: 24px; padding: 0 0 12px; border-bottom: 1px solid #e3e3e8;
+  display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+.cp-site-brand { display: inline-flex; align-items: center; gap: 8px; color: #1b1b1f;
+  font-size: 0.92rem; font-weight: 700; }
+.cp-site-brand:hover { text-decoration: none; color: #3a3a8a; }
+.cp-site-mark { display: grid; place-items: center; width: 24px; height: 24px; border-radius: 7px;
+  color: #fff; background: #5b5bd6; font-size: 0.9rem; }
+.cp-site-nav { display: flex; align-items: center; gap: 18px; font-size: 0.8rem; }
+.cp-site-nav a { color: #56565f; }
 .cp-head { margin: 0 0 4px; font-size: 1.2rem; font-weight: 600; }
 .cp-sub { margin: 0 0 20px; font-size: 0.82rem; color: #6b6b70; }
+.cp-breadcrumb { margin: 0 0 8px; color: #8a8a92; font-size: 0.78rem; }
+.cp-section-title { margin: 0 0 12px; display: flex; align-items: baseline; gap: 10px; }
+.cp-section-title .cp-head { margin: 0; }
+.cp-section-count, .cp-catalog-id { color: #8a8a92; font-size: 0.75rem; }
+.cp-catalog-id { margin: 0 0 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.cp-catalog-head { font-size: 1.35rem; }
 /* Per-preview link to the source file on GitHub, under the viewer title. */
-.cp-source { margin: -12px 0 20px; font-size: 0.8rem; }
+.cp-source { margin: 0 0 8px; font-size: 0.8rem; }
 .cp-source-link { display: inline-flex; align-items: center; gap: 5px; color: #6b6b70;
   text-decoration: none; }
 .cp-source-link:hover { text-decoration: underline; }
 .cp-about { margin: 0 0 24px; padding: 14px 16px; border: 1px solid #e3e3e8; border-radius: 10px;
   background: #fff; max-width: 720px; }
-.cp-about-title { margin: 0 0 6px; font-size: 0.95rem; font-weight: 600; }
+.cp-about-title { font-size: 0.88rem; font-weight: 600; }
 .cp-about-body { margin: 0 0 8px; font-size: 0.84rem; line-height: 1.45; color: #45454c; }
 .cp-about-body code { font-size: 0.8rem; padding: 0 3px; border-radius: 4px; background: #f0f0f3; }
 .cp-about-links { margin: 0; font-size: 0.8rem; color: #6b6b70; display: flex; flex-wrap: wrap;
@@ -24,6 +40,13 @@ a:hover { text-decoration: underline; }
   padding: 1px 7px; border-radius: 999px; border: 1px solid #d7d7de; background: #fff;
   color: #45454c; }
 .cp-gh-auth--signed { color: #45454c; }
+.cp-disclosure > summary { cursor: pointer; list-style: none; display: flex; align-items: center;
+  justify-content: space-between; gap: 12px; }
+.cp-disclosure > summary::-webkit-details-marker { display: none; }
+.cp-disclosure > summary::after { content: "Show"; color: #5b5bd6; font-size: 0.72rem; font-weight: 600; }
+.cp-disclosure[open] > summary::after { content: "Hide"; }
+.cp-disclosure-hint { flex: 1; color: #8a8a92; font-size: 0.75rem; font-weight: 400; }
+.cp-disclosure-body { margin-top: 12px; }
 /* Catalog "back to home" button — replaces the in-catalog design-systems nav row. */
 .cp-back { display: inline-flex; align-items: center; gap: 6px; margin: 0 0 14px;
   font-size: 0.82rem; padding: 5px 12px; border-radius: 999px; border: 1px solid #d7d7de;
@@ -31,9 +54,10 @@ a:hover { text-decoration: underline; }
 .cp-back:hover { background: #f0f0f3; text-decoration: none; }
 /* Provenance strip: how/when/from-what this catalog was generated (branch, date, versions,
    a link to re-run the generating workflow). Shown near the catalog header. */
-.cp-prov { margin: 0 0 18px; padding: 10px 14px; border: 1px solid #e3e3e8; border-radius: 10px;
-  background: #fff; display: flex; flex-wrap: wrap; gap: 6px 16px; font-size: 0.78rem;
-  color: #6b6b70; max-width: 720px; }
+.cp-prov { margin: 0 0 14px; padding: 10px 14px; border: 1px solid #e3e3e8; border-radius: 10px;
+  background: #fff; font-size: 0.78rem; color: #6b6b70; max-width: 720px; }
+.cp-prov-title { color: #45454c; font-weight: 600; }
+.cp-prov-body { display: flex; flex-wrap: wrap; gap: 8px 16px; }
 .cp-prov-item { display: inline-flex; align-items: center; gap: 5px; }
 .cp-prov-item .cp-prov-key { color: #8a8a92; }
 .cp-prov-item code { font-size: 0.74rem; padding: 0 4px; border-radius: 4px; background: #f0f0f3; }
@@ -48,8 +72,10 @@ a:hover { text-decoration: underline; }
 .cp-systems a, .cp-systems-cur { padding: 3px 10px; border-radius: 999px; border: 1px solid #d7d7de; }
 .cp-systems a { background: #fff; }
 .cp-systems-cur { background: #ececff; border-color: #c4c4f5; color: #3a3a8a; font-weight: 600; }
-.cp-toolbar { margin: 0 0 16px; }
-.cp-searchbar { margin: 0 0 16px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.cp-toolbar { margin: 0; }
+.cp-searchbar { margin: 0; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; flex: 1 1 440px; }
+.cp-catalog-tools { position: sticky; top: 0; z-index: 18; margin: 0 0 16px; padding: 8px 0;
+  display: flex; align-items: center; flex-wrap: wrap; gap: 10px 16px; background: #fafafb; }
 .cp-search { flex: 1 1 260px; max-width: 420px; padding: 7px 12px; font: inherit; font-size: 0.85rem;
   border: 1px solid #d7d7de; border-radius: 999px; background: #fff; color: inherit; }
 .cp-search:focus { outline: 2px solid #c4c4f5; outline-offset: 1px; }
@@ -88,6 +114,8 @@ html.cp-js .cp-section-head { display: none; }
 .cp-theme-btn + .cp-theme-btn { border-left: 1px solid #ececf1; }
 .cp-theme-btn[aria-pressed="true"] { background: #ececff; color: #3a3a8a; font-weight: 600; }
 .cp-states { display: inline-flex; flex-wrap: wrap; gap: 6px; margin: 0 0 10px; }
+.cp-axis-label { align-self: center; margin-right: 2px; color: #8a8a92; font-size: 0.68rem;
+  font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
 .cp-state-btn { border: 1px solid #d7d7de; border-radius: 999px; background: #fff; color: #6b6b70;
   font: inherit; font-size: 0.78rem; padding: 3px 14px; cursor: pointer; text-decoration: none; }
 .cp-state-btn:hover { border-color: #b9b9c6; color: #3a3a8a; }
@@ -120,7 +148,9 @@ html.cp-js .cp-section-head { display: none; }
 .cp-muted { color: #8a8a92; font-size: 0.76rem; }
 .cp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; }
 .cp-syslist { grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
-.cp-syslist .cp-imgwrap { min-height: 120px; }
+.cp-sys { display: grid; grid-template-rows: 220px auto; }
+.cp-syslist .cp-imgwrap { min-height: 0; height: 220px; overflow: hidden; }
+.cp-syslist .cp-imgwrap > img { width: 100%; height: 100%; max-height: none; object-fit: contain; }
 .cp-sys-title { font-size: 0.98rem; font-weight: 600; }
 .cp-sys-desc { margin-top: 4px; font-size: 0.76rem; color: #6b6b70; line-height: 1.4; }
 .cp-sys-foot { margin-top: 8px; font-size: 0.74rem; color: #6b6b70; }
@@ -174,6 +204,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
 .cp-id { color: #6b6b70; font-size: 0.7rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cp-engage { margin-top: 3px; color: #8a8a92; font-size: 0.7rem; }
 .cp-viewer-engage { margin: -14px 0 16px; color: #8a8a92; font-size: 0.78rem; }
+.cp-preview-title { font-size: 1.35rem; }
+.cp-preview-id { margin: 2px 0 8px; color: #6b6b70; font-size: 0.75rem; }
+.cp-preview-id code { padding: 1px 5px; border-radius: 4px; background: #f0f0f3; }
+.cp-preview-primary { margin: 2px 0 10px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .cp-viewer { display: flex; gap: 24px; flex-wrap: wrap; align-items: flex-start; }
 .cp-stage { position: relative; flex: 1 1 360px; min-width: 280px; border: 1px solid #e3e3e8;
   border-radius: 10px;
@@ -212,7 +246,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
 .cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
   font-size: 0.8rem; }
-.cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
+.cp-controls { position: sticky; top: 16px; flex: 0 0 240px; max-height: calc(100vh - 32px);
+  overflow: auto; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
 .cp-status { font-size: 0.75rem; color: #6b6b70; min-height: 1em; }
@@ -246,7 +281,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
    dropped inside it. */
 .cp-export { padding: 12px 14px; border: 1px solid #e3e3e8;
   border-radius: 10px; background: #fff; }
-.cp-export-head { margin: 0 0 10px; font-size: 0.78rem; font-weight: 600; color: #45454c; }
+.cp-export > summary { color: #45454c; font-size: 0.78rem; font-weight: 600; }
 .cp-export .cp-links { border-top: 0; padding-top: 0; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }
 .cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
@@ -434,6 +469,9 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   font-weight: 600; background: #fdf0e3; color: #8a5300; border: 1px solid #f0d3a8; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
+  .cp-site-header { border-bottom-color: #34343a; }
+  .cp-site-brand { color: #e6e6e9; }
+  .cp-site-nav a { color: #b6b6bf; }
   .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
   .cp-engage, .cp-viewer-engage { color: #7a7a82; }
   .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
@@ -444,6 +482,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   .cp-copyimg, .cp-dl { background: #1d1d20; border-color: #34343a; }
   .cp-copyimg:hover, .cp-dl:hover { background: #26262b; }
   .cp-card, .cp-about { background: #1d1d20; }
+  .cp-catalog-tools { background: #161618; }
+  .cp-preview-id code { background: #2a2a30; }
   .cp-about-body { color: #c9c9d0; }
   .cp-about-body code { background: #2a2a30; }
   .cp-systems-label { color: #a0a0a8; }
@@ -534,6 +574,12 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   .cp-compare-score--bad { color: #ef9292; }
   .cp-mode-hint { color: #a0a0a8; }
 }
+
+@media (min-width: 1100px) {
+  /* Component discovery is part of the desktop workspace; drawers remain opt-in below this. */
+  .cp-viewer:not(.cp-nav-open) .cp-nav { display: flex; }
+  #cp-nav-toggle, .cp-nav-close { display: none; }
+}
 /* Mobile / narrow viewports. The viewer is a flex row of stage + overrides (+ optional nav);
    on a phone we collapse it to a single stacked column and — crucially for usability on a tall
    preview — turn the two drawers into bottom sheets reachable from a sticky toggle bar, so the
@@ -542,6 +588,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
    grids, size rows and copyable link rows to fit a ~320px screen without horizontal scrolling. */
 @media (max-width: 640px) {
   body { padding: 14px; }
+  .cp-site-header { margin-bottom: 18px; }
+  .cp-site-mark { width: 22px; height: 22px; }
+  .cp-site-nav { gap: 12px; }
+  .cp-site-nav a:last-child { display: none; }
+  .cp-disclosure > summary { align-items: flex-start; }
+  .cp-disclosure-hint { display: none; }
+  .cp-section-title { margin-bottom: 10px; }
+  .cp-catalog-tools { margin-left: -14px; margin-right: -14px; padding: 8px 14px; }
   /* The trust badge can carry a long branch string; constrain it to the viewport and let it
      wrap instead of forcing a horizontal scroll. */
   .cp-badge { max-width: 100%; white-space: normal; overflow-wrap: anywhere; }
@@ -552,6 +606,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   /* Stage, overrides and nav each stack full-width; min-width:0 lets the flex items (and their
      selects/inputs) shrink below their content's intrinsic width instead of overflowing. */
   .cp-stage, .cp-controls, .cp-nav { flex: 1 1 100%; min-width: 0; }
+  .cp-controls { position: static; max-height: none; }
   .cp-controls label, .cp-group, .cp-group-body { min-width: 0; }
   .cp-controls select, .cp-controls input { max-width: 100%; }
   /* Open drawers overlay the preview as bottom sheets (with the scrim below), so overrides and
@@ -572,7 +627,9 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     background: rgba(0, 0, 0, 0.38); }
   .cp-grid, .cp-cards { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 12px; }
   .cp-syslist, .cp-syslist.cp-grid { grid-template-columns: 1fr; }
+  .cp-sys { grid-template-rows: 220px auto; }
   .cp-imgwrap img { max-height: 200px; }
+  .cp-syslist .cp-imgwrap > img { max-height: none; }
   /* Copyable direct-link rows: the URL field takes its own line above the Copy/Download
      buttons instead of squeezing all three onto one narrow row. */
   .cp-link-row { flex-wrap: wrap; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -65,6 +65,7 @@ class ServeHttpRoutingTest {
 
   private fun bundle(
     label: String,
+    title: String? = null,
     overrides: List<PreviewOverrideDeclaration> = emptyList(),
     remoteComposeKnobs: List<RemoteComposeKnobDeclaration> = emptyList(),
     degradations: List<ServeDegradation> = emptyList(),
@@ -126,7 +127,7 @@ class ServeHttpRoutingTest {
         )
       File(dir, "previews/$previewId.remotecompose.json").writeText(sidecar)
     }
-    return ServeBundleHost(dir, label = label, degradations = degradations)
+    return ServeBundleHost(dir, label = label, title = title, degradations = degradations)
   }
 
   private val registry = ServeSessionRegistry(open = { null })
@@ -137,6 +138,7 @@ class ServeHttpRoutingTest {
       host =
         bundle(
           "compose-m3",
+          "Compose Material 3",
           listOf(labelKnob),
           listOf(rcColorKnob),
           rcDoc = rcDocBytes,
@@ -898,6 +900,10 @@ class ServeHttpRoutingTest {
     val (pathCode, pathBody) = get("/compose-m3/compare")
     assertEquals(200, pathCode)
     assertTrue(pathBody.contains("id=\"cp-compare\""), "canonical comparison page: $pathBody")
+    assertTrue(
+      pathBody.contains(">Compose Material 3</a> / Compare formats"),
+      "the comparison breadcrumb uses the catalog's human title: $pathBody",
+    )
     assertTrue(
       pathBody.contains("data-compare-format=\"rc\"") &&
         !pathBody.contains("data-compare-format=\"svg\""),

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1169,6 +1169,19 @@ class ServeWebFixtureTest {
         formatComparison.contains("data-compare-theme=\"dark\""),
       "the comparison page exposes only its available formats and its baked theme pair",
     )
+    val escapedComparison =
+      ServeWeb.comparisonPage(
+        moduleLabel = "compose-m3",
+        previews = themedPreviews,
+        token = token,
+        displayTitle = "<script>alert('title')</script>",
+        hasSvgFor = { true },
+      )
+    assertTrue(
+      escapedComparison.contains("&lt;script&gt;alert(&#39;title&#39;)&lt;/script&gt;</a>") &&
+        !escapedComparison.contains("<script>alert('title')</script></a>"),
+      "the catalog-authored comparison breadcrumb title is HTML-escaped",
+    )
     assertTrue(
       referenceComparison.contains(">Reference</h2>") &&
         referenceComparison.contains(">Diff</h2>") &&
@@ -1678,7 +1691,7 @@ class ServeWebFixtureTest {
         Regex("<main class=\"cp-main\">").findAll(html).count(),
         "the $name page has exactly one <main> landmark",
       )
-      assertTrue(html.contains("<h1 class=\"cp-head\""), "the $name page leads with an <h1>")
+      assertTrue(html.contains("<h1 class=\"cp-head"), "the $name page leads with an <h1>")
     }
     assertTrue(
       File(pagesDir, "_render-placeholder.png").isFile,
@@ -2356,6 +2369,16 @@ class ServeWebFixtureTest {
       assetText("serve.css").contains("@media (max-width: 640px) {"),
       "landing is responsive too",
     )
+    assertTrue(
+      assetText("serve.css")
+        .contains(".cp-sys { display: grid; grid-template-rows: 220px auto; }") &&
+        assetText("serve.css").contains(".cp-syslist .cp-imgwrap { min-height: 0; height: 220px;"),
+      "system cards reserve one consistent hero region so metadata aligns across aspect ratios",
+    )
+    assertTrue(
+      landing.contains("class=\"cp-site-header\"") && landing.contains(">Catalogs</a>"),
+      "all pages carry the shared catalog/status navigation",
+    )
   }
 
   @Test
@@ -2411,7 +2434,7 @@ class ServeWebFixtureTest {
           ),
         refreshUrl = "/compose-m3/refresh",
       )
-    assertTrue(landing.contains("class=\"cp-prov\""), "the provenance strip renders")
+    assertTrue(landing.contains("class=\"cp-prov cp-disclosure\""), "the provenance details render")
     // Links to the delivery branch and the regenerating workflow.
     assertTrue(
       landing.contains(
@@ -2552,8 +2575,8 @@ class ServeWebFixtureTest {
   @Test
   fun `public landing shows the about intro, default landing does not`() {
     val public = ServeWeb.landingPage(moduleLabel, previews, token, isPublic = true)
-    assertTrue(public.contains("class=\"cp-about\""), "expected the about section")
-    assertTrue(public.contains("public preview server"), "expected the about title")
+    assertTrue(public.contains("class=\"cp-about cp-disclosure\""), "expected the about disclosure")
+    assertTrue(public.contains("About this preview server"), "expected the about title")
     assertTrue(public.contains("href=\"/version\""), "expected a link to /version")
 
     val default = ServeWeb.landingPage(moduleLabel, previews, token)
@@ -2867,7 +2890,10 @@ class ServeWebFixtureTest {
     // can
     // export SVG (a catalog / daemon) also offers an SVG row. The URLs are built client-side from
     // location.origin with the current overrides so a copied link reproduces the on-screen render.
-    assertTrue(catalogKnobs.contains("class=\"cp-links\""), "the direct-links panel is shown")
+    assertTrue(
+      catalogKnobs.contains("class=\"cp-links cp-disclosure-body\""),
+      "the direct-links panel is shown",
+    )
     assertTrue(
       catalogKnobs.contains("id=\"cp-url-png\"") && catalogKnobs.contains("id=\"cp-dl-png\""),
       "the PNG URL row has a copyable field and a download link",
@@ -2984,7 +3010,8 @@ class ServeWebFixtureTest {
   fun `trust badge renders trusted and unverified variants and is absent for a live module`() {
     val trusted = ServeWeb.landingPage(moduleLabel, previews, token, trust = "branch:repo@b")
     assertTrue(trusted.contains("cp-badge--trusted"), "expected a trusted badge")
-    assertTrue(trusted.contains("✓ branch:repo@b"))
+    assertTrue(trusted.contains("✓ trusted"))
+    assertTrue(trusted.contains("producer trust: branch:repo@b"))
 
     val unverified = ServeWeb.viewerPage(previews.first(), token, trust = "unverified")
     assertTrue(unverified.contains("cp-badge--unverified"), "expected an unverified badge")

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
@@ -4,11 +4,22 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>loading-spinner.json — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <h1 class="cp-head">loading-spinner.json</h1>
         <p class="cp-sub">Lottie · 48 kB

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
@@ -4,11 +4,22 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>watchface.rc — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <h1 class="cp-head">watchface.rc</h1>
         <p class="cp-sub">Remote Compose · 12 kB

--- a/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
@@ -4,11 +4,22 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Share a document — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <h1 class="cp-head">Share a document</h1>
         <p class="cp-sub">Upload a generated document and get a link that plays it in the browser and

--- a/vscode-extension/preview-harness/fixtures/pages/serve-format-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-format-compare.html
@@ -4,15 +4,27 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — format comparison</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <div id="cp-compare" data-default-format="svg" data-default-theme="light" data-theme-key="cp-theme:compose-m3" data-has-svg="1" data-has-rc="1" data-has-reference="1">
-          <h1 class="cp-head"><a href="/?session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-          <p class="cp-sub">Format comparison · scores use structural similarity on a fixed backdrop</p>
+          <p class="cp-breadcrumb"><a href="/?session=compose-m3">compose-m3</a> / Compare formats</p>
+          <h1 class="cp-head">Format comparison <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+          <p class="cp-sub">PNG, SVG and Remote Compose fidelity · scores use structural similarity on a fixed backdrop</p>
           <div class="cp-compare-controls">
             <span class="cp-theme" role="group" aria-label="Comparison format"><button type="button" class="cp-theme-btn" data-compare-format="svg" aria-pressed="true">PNG ↔ SVG</button><button type="button" class="cp-theme-btn" data-compare-format="rc" aria-pressed="false">PNG ↔ Remote Compose</button><button type="button" class="cp-theme-btn" data-compare-format="reference" aria-pressed="false">PNG ↔ Design reference</button></span>
             <span class="cp-compare-control-label">Theme</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -4,27 +4,43 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Design systems — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-                <section class="cp-about">
-  <p class="cp-about-title">compose-preview · public preview server</p>
-  <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-    catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-    everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-    — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-    and anything unverified is badged.</p>
-  <p class="cp-about-links">
-    <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
-    <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
-  </p>
-</section>
-      <h1 class="cp-head">Design Systems</h1>
-      <p class="cp-sub">3 design system(s) · pick one to browse its components and
-        open a live, customisable preview.</p>
+                <details class="cp-about cp-disclosure">
+  <summary>
+    <span class="cp-about-title">About this preview server</span>
+    <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+  </summary>
+  <div class="cp-disclosure-body">
+    <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+      using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+      server never re-runs untrusted code. Catalogs are trusted by signature or their published
+      <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+    <p class="cp-about-links">
+      <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
+      <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
+    </p>
+  </div>
+</details>
+      <div class="cp-section-title">
+        <h1 class="cp-head">Design Systems</h1>
+        <span class="cp-section-count">3 design system(s)</span>
+      </div>
       <div class="cp-grid cp-syslist" id="cp-grid">
       <a class="cp-card cp-sys" href="/compose-m3/">
   <div class="cp-imgwrap"><img loading="eager" decoding="async" width="168" height="68" alt="Compose Material 3 preview" src="/hero/compose-m3/1f0c9a4b7d2e6503.png"></div>
@@ -54,9 +70,10 @@
   </div>
 </a>
       </div>
-      <h1 class="cp-head">yschimke org</h1>
-      <p class="cp-sub">2 catalog(s) · pick one to browse its components and
-        open a live, customisable preview.</p>
+      <div class="cp-section-title">
+        <h1 class="cp-head">yschimke org</h1>
+        <span class="cp-section-count">2 catalog(s)</span>
+      </div>
       <div class="cp-grid cp-syslist" id="cp-grid-1">
       <a class="cp-card cp-sys" href="/meshcore-mobile/">
   <div class="cp-imgwrap"><img loading="lazy" alt="MeshCore preview" src="/meshcore-mobile/render/device-manycontacts__ideal__default__compact.png"></div>
@@ -77,9 +94,10 @@
   </div>
 </a>
       </div>
-      <h1 class="cp-head">joreilly org</h1>
-      <p class="cp-sub">1 catalog(s) · pick one to browse its components and
-        open a live, customisable preview.</p>
+      <div class="cp-section-title">
+        <h1 class="cp-head">joreilly org</h1>
+        <span class="cp-section-count">1 catalog(s)</span>
+      </div>
       <div class="cp-grid cp-syslist" id="cp-grid-2">
       <a class="cp-card cp-sys" data-bg-theme="dark" href="/confetti-wear/">
   <div class="cp-imgwrap"><img loading="lazy" alt="Confetti (Wear) preview" src="/confetti-wear/render/conference-screen__ideal__default__dark.png"></div>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -4,14 +4,28 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <a class="cp-back" href="/">← All design systems</a>
-<h1 class="cp-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
+<h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+        <p class="cp-sub">5 preview(s) ·
+          <a href="/bundle.zip?session=compose-m3">download all (.zip)</a></p>
+        <div class="cp-catalog-tools">
         <div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
@@ -21,9 +35,7 @@
     <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.HighContrastThemeCatalog">High Contrast</button>
   </span>
 </div>
-<p class="cp-sub">5 preview(s) · click one to view with overrides ·
-          <a href="/bundle.zip?session=compose-m3">download all (.zip)</a></p>
-        <div class="cp-searchbar">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
   <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="5"></span>
@@ -32,7 +44,8 @@
     <button type="button" class="cp-bg-btn" data-bg-choice="off">Transparent</button>
   </span>
 </div>
-<div class="cp-grid" id="cp-grid">
+</div>
+        <div class="cp-grid" id="cp-grid">
         <a class="cp-card" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/button-filled__ideal__default__light.png?session=compose-m3" data-l-href="/p/button-filled__ideal__default__light?session=compose-m3"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
@@ -43,7 +56,7 @@
     <img loading="lazy" alt="Button · Filled (light)" src="/render/button-filled__ideal__default__light.png?session=compose-m3">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Button · Filled (light)">Button · Filled (light)</div>
+    <div class="cp-label" title="button-filled__ideal__default__light">Button · Filled (light)</div>
     <div class="cp-id">button-filled__ideal__default__light</div>
     
   </div>
@@ -58,7 +71,7 @@
     <img loading="lazy" alt="Switch · On (light)" src="/render/switch-on__ideal__default__light.png?session=compose-m3">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Switch · On (light)">Switch · On (light)</div>
+    <div class="cp-label" title="switch-on__ideal__default__light">Switch · On (light)</div>
     <div class="cp-id">switch-on__ideal__default__light</div>
     
   </div>
@@ -289,18 +302,22 @@ applyThemeChoice();
       reflectBg();
       apply();
     })();</script>
-<section class="cp-about">
-  <p class="cp-about-title">compose-preview · public preview server</p>
-  <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-    catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-    everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-    — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-    and anything unverified is badged.</p>
-  <p class="cp-about-links">
-    <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
-    <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
-  </p>
-</section>
+<details class="cp-about cp-disclosure">
+  <summary>
+    <span class="cp-about-title">About this preview server</span>
+    <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+  </summary>
+  <div class="cp-disclosure-body">
+    <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+      using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+      server never re-runs untrusted code. Catalogs are trusted by signature or their published
+      <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+    <p class="cp-about-links">
+      <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
+      <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
+    </p>
+  </div>
+</details>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -4,23 +4,35 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <a class="cp-back" href="/">← All design systems</a>
-<h1 class="cp-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
+<h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+        <p class="cp-sub">14 preview(s) ·
+          <a href="/bundle.zip">download all (.zip)</a></p>
+        <div class="cp-catalog-tools">
         <div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
   </span>
 </div>
-<p class="cp-sub">14 preview(s) · click one to view with overrides ·
-          <a href="/bundle.zip">download all (.zip)</a></p>
-        <div class="cp-searchbar">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
   <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="14"></span>
@@ -29,7 +41,8 @@
     <button type="button" class="cp-bg-btn" data-bg-choice="off">Transparent</button>
   </span>
 </div>
-<div class="cp-grid-groups" id="cp-grid">
+</div>
+        <div class="cp-grid-groups" id="cp-grid">
 <div class="cp-subgroup">
 <h2 class="cp-group-head">Button</h2>
 <div class="cp-cards">
@@ -43,7 +56,7 @@
     <img loading="lazy" alt="Button filled (light)" src="/render/button-filled__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Button filled (light)">Button filled (light)</div>
+    <div class="cp-label" title="button-filled__ideal__default__light">Button filled (light)</div>
     <div class="cp-id">button-filled__ideal__default__light</div>
     
   </div>
@@ -58,7 +71,7 @@
     <img loading="lazy" alt="Button outlined (light)" src="/render/button-outlined__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Button outlined (light)">Button outlined (light)</div>
+    <div class="cp-label" title="button-outlined__ideal__default__light">Button outlined (light)</div>
     <div class="cp-id">button-outlined__ideal__default__light</div>
     
   </div>
@@ -73,7 +86,7 @@
     <img loading="lazy" alt="Button tonal (light)" src="/render/button-tonal__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Button tonal (light)">Button tonal (light)</div>
+    <div class="cp-label" title="button-tonal__ideal__default__light">Button tonal (light)</div>
     <div class="cp-id">button-tonal__ideal__default__light</div>
     
   </div>
@@ -93,7 +106,7 @@
     <img loading="lazy" alt="Card elevated (light)" src="/render/card-elevated__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Card elevated (light)">Card elevated (light)</div>
+    <div class="cp-label" title="card-elevated__ideal__default__light">Card elevated (light)</div>
     <div class="cp-id">card-elevated__ideal__default__light</div>
     
   </div>
@@ -108,7 +121,7 @@
     <img loading="lazy" alt="Card filled (light)" src="/render/card-filled__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Card filled (light)">Card filled (light)</div>
+    <div class="cp-label" title="card-filled__ideal__default__light">Card filled (light)</div>
     <div class="cp-id">card-filled__ideal__default__light</div>
     
   </div>
@@ -128,7 +141,7 @@
     <img loading="lazy" alt="FAB (light)" src="/render/fab__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="FAB (light)">FAB (light)</div>
+    <div class="cp-label" title="fab__ideal__default__light">FAB (light)</div>
     <div class="cp-id">fab__ideal__default__light</div>
     
   </div>
@@ -148,7 +161,7 @@
     <img loading="lazy" alt="Badge (light)" src="/render/badge__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Badge (light)">Badge (light)</div>
+    <div class="cp-label" title="badge__ideal__default__light">Badge (light)</div>
     <div class="cp-id">badge__ideal__default__light</div>
     
   </div>
@@ -253,18 +266,22 @@ applyThemeChoice();
       reflectBg();
       apply();
     })();</script>
-<section class="cp-about">
-  <p class="cp-about-title">compose-preview · public preview server</p>
-  <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-    catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-    everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-    — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-    and anything unverified is badged.</p>
-  <p class="cp-about-links">
-    <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
-    <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
-  </p>
-</section>
+<details class="cp-about cp-disclosure">
+  <summary>
+    <span class="cp-about-title">About this preview server</span>
+    <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+  </summary>
+  <div class="cp-disclosure-body">
+    <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+      using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+      server never re-runs untrusted code. Catalogs are trusted by signature or their published
+      <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+    <p class="cp-about-links">
+      <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
+      <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
+    </p>
+  </div>
+</details>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -4,16 +4,28 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <a class="cp-back" href="/">← All design systems</a>
-<h1 class="cp-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile</span></h1>
-        <p class="cp-sub">6 preview(s) · click one to view with overrides ·
+<h1 class="cp-head cp-catalog-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></h1>
+        <p class="cp-sub">6 preview(s) ·
           <a href="/meshcore-mobile/bundle.zip">download all (.zip)</a></p>
+        <div class="cp-catalog-tools">
         <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
@@ -23,7 +35,8 @@
     <button type="button" class="cp-bg-btn" data-bg-choice="off">Transparent</button>
   </span>
 </div>
-<div class="cp-grid" id="cp-grid">
+</div>
+        <div class="cp-grid" id="cp-grid">
         <a class="cp-card" href="/meshcore-mobile/p/com.example.ButtonPreview">
   <div class="cp-imgwrap">
     <img loading="lazy" alt="Button" src="/meshcore-mobile/render/com.example.ButtonPreview.png">
@@ -131,18 +144,22 @@
   reflectBg();
   apply();
 })();</script>
-<section class="cp-about">
-  <p class="cp-about-title">compose-preview · public preview server</p>
-  <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-    catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-    everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-    — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-    and anything unverified is badged.</p>
-  <p class="cp-about-links">
-    <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
-    <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
-  </p>
-</section>
+<details class="cp-about cp-disclosure">
+  <summary>
+    <span class="cp-about-title">About this preview server</span>
+    <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+  </summary>
+  <div class="cp-disclosure-body">
+    <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+      using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+      server never re-runs untrusted code. Catalogs are trusted by signature or their published
+      <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+    <p class="cp-about-links">
+      <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
+      <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
+    </p>
+  </div>
+</details>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -4,21 +4,38 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <a class="cp-back" href="/">← All design systems</a>
-<h1 class="cp-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-              <section class="cp-prov" aria-label="Catalog provenance">
-        <span class="cp-prov-item"><span class="cp-prov-key">catalog</span> <a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/compose-m3"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> yschimke/compose-ai-tools@design-artifacts/compose-m3</a></span>
-        <span class="cp-prov-item"><span class="cp-prov-key">generated</span> 2026-07-17 09:30 UTC</span>
-        <span class="cp-prov-item"><span class="cp-prov-key">rendered by</span> compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></span>
-        <span class="cp-prov-item"><a href="https://github.com/yschimke/compose-ai-tools/actions/workflows/design-artifacts.yml">regenerate ↗</a></span>
-        <span class="cp-prov-item"><button type="button" class="cp-prov-refresh" data-refresh-url="/compose-m3/refresh">refresh</button><span class="cp-prov-refresh-status" role="status" aria-live="polite"></span></span>
-      </section>
+<h1 class="cp-head cp-catalog-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+              <details class="cp-prov cp-disclosure">
+        <summary>
+          <span class="cp-prov-title">Catalog details</span>
+          <span class="cp-disclosure-hint">Source, generation time and tooling</span>
+        </summary>
+        <div class="cp-prov-body" aria-label="Catalog provenance">
+          <span class="cp-prov-item"><span class="cp-prov-key">catalog</span> <a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/compose-m3"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> yschimke/compose-ai-tools@design-artifacts/compose-m3</a></span>
+          <span class="cp-prov-item"><span class="cp-prov-key">generated</span> 2026-07-17 09:30 UTC</span>
+          <span class="cp-prov-item"><span class="cp-prov-key">rendered by</span> compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></span>
+          <span class="cp-prov-item"><a href="https://github.com/yschimke/compose-ai-tools/actions/workflows/design-artifacts.yml">regenerate ↗</a></span>
+          <span class="cp-prov-item"><button type="button" class="cp-prov-refresh" data-refresh-url="/compose-m3/refresh">refresh</button><span class="cp-prov-refresh-status" role="status" aria-live="polite"></span></span>
+        </div>
+      </details>
       <script>
 (() => {
   const button = document.querySelector('.cp-prov-refresh');
@@ -44,8 +61,9 @@
   });
 })();
 </script>
-<p class="cp-sub">6 preview(s) · click one to view with overrides ·
+<p class="cp-sub">6 preview(s) ·
           <a href="/bundle.zip">download all (.zip)</a></p>
+        <div class="cp-catalog-tools">
         <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
@@ -55,7 +73,8 @@
     <button type="button" class="cp-bg-btn" data-bg-choice="off">Transparent</button>
   </span>
 </div>
-<div class="cp-grid" id="cp-grid">
+</div>
+        <div class="cp-grid" id="cp-grid">
         <a class="cp-card" href="/p/com.example.ButtonPreview">
   <div class="cp-imgwrap">
     <img loading="lazy" alt="Button" src="/render/com.example.ButtonPreview.png">
@@ -163,18 +182,22 @@
   reflectBg();
   apply();
 })();</script>
-<section class="cp-about">
-  <p class="cp-about-title">compose-preview · public preview server</p>
-  <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-    catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-    everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-    — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-    and anything unverified is badged.</p>
-  <p class="cp-about-links">
-    <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
-    <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
-  </p>
-</section>
+<details class="cp-about cp-disclosure">
+  <summary>
+    <span class="cp-about-title">About this preview server</span>
+    <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+  </summary>
+  <div class="cp-disclosure-body">
+    <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+      using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+      server never re-runs untrusted code. Catalogs are trusted by signature or their published
+      <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+    <p class="cp-about-links">
+      <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
+      <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
+    </p>
+  </div>
+</details>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -4,16 +4,28 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <a class="cp-back" href="/">← All design systems</a>
-<h1 class="cp-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile</span></h1>
-        <p class="cp-sub">9 preview(s) · click one to view with overrides ·
+<h1 class="cp-head cp-catalog-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></h1>
+        <p class="cp-sub">9 preview(s) ·
           <a href="/meshcore-mobile/bundle.zip">download all (.zip)</a></p>
+        <div class="cp-catalog-tools">
         <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
@@ -23,7 +35,8 @@
     <button type="button" class="cp-bg-btn" data-bg-choice="off">Transparent</button>
   </span>
 </div>
-<nav class="cp-tabs" id="cp-tabs" role="tablist" aria-label="Catalog sections">
+</div>
+        <nav class="cp-tabs" id="cp-tabs" role="tablist" aria-label="Catalog sections">
   <a class="cp-tab" role="tab" id="cp-tab-themes" href="#cp-panel-themes" data-tab="themes" aria-controls="cp-panel-themes" aria-selected="true">Themes<span class="cp-tab-count">2</span></a>
   <a class="cp-tab" role="tab" id="cp-tab-components" href="#cp-panel-components" data-tab="components" aria-controls="cp-panel-components" aria-selected="false">Components<span class="cp-tab-count">4</span></a>
   <a class="cp-tab" role="tab" id="cp-tab-screens" href="#cp-panel-screens" data-tab="screens" aria-controls="cp-panel-screens" aria-selected="false">Screens<span class="cp-tab-count">3</span></a>
@@ -227,18 +240,22 @@
   reflectBg();
   apply();
 })();</script>
-<section class="cp-about">
-  <p class="cp-about-title">compose-preview · public preview server</p>
-  <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-    catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-    everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-    — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-    and anything unverified is badged.</p>
-  <p class="cp-about-links">
-    <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
-    <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
-  </p>
-</section>
+<details class="cp-about cp-disclosure">
+  <summary>
+    <span class="cp-about-title">About this preview server</span>
+    <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+  </summary>
+  <div class="cp-disclosure-body">
+    <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+      using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+      server never re-runs untrusted code. Catalogs are trusted by signature or their published
+      <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+    <p class="cp-about-links">
+      <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
+      <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
+    </p>
+  </div>
+</details>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -4,23 +4,35 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <a class="cp-back" href="/">← All design systems</a>
-<h1 class="cp-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
+<h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+        <p class="cp-sub">8 preview(s) ·
+          <a href="/bundle.zip">download all (.zip)</a></p>
+        <div class="cp-catalog-tools">
         <div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
   </span>
 </div>
-<p class="cp-sub">8 preview(s) · click one to view with overrides ·
-          <a href="/bundle.zip">download all (.zip)</a></p>
-        <div class="cp-searchbar">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
   <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="8"></span>
@@ -29,7 +41,8 @@
     <button type="button" class="cp-bg-btn" data-bg-choice="off">Transparent</button>
   </span>
 </div>
-<div class="cp-grid" id="cp-grid">
+</div>
+        <div class="cp-grid" id="cp-grid">
         <a class="cp-card" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/checkbox__ideal__default__light.png" data-l-href="/p/checkbox__ideal__default__light"
   data-l-id="checkbox__ideal__default__light" data-l-label="Checkbox · Checked (light)"
@@ -40,7 +53,7 @@
     <img loading="lazy" alt="Checkbox · Checked (light)" src="/render/checkbox__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Checkbox · Checked (light)">Checkbox · Checked (light)</div>
+    <div class="cp-label" title="checkbox__ideal__default__light">Checkbox · Checked (light)</div>
     <div class="cp-id">checkbox__ideal__default__light</div>
     
   </div>
@@ -55,7 +68,7 @@
     <img loading="lazy" alt="Radio · Selected (light)" src="/render/radiobutton__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Radio · Selected (light)">Radio · Selected (light)</div>
+    <div class="cp-label" title="radiobutton__ideal__default__light">Radio · Selected (light)</div>
     <div class="cp-id">radiobutton__ideal__default__light</div>
     
   </div>
@@ -156,18 +169,22 @@ applyThemeChoice();
       reflectBg();
       apply();
     })();</script>
-<section class="cp-about">
-  <p class="cp-about-title">compose-preview · public preview server</p>
-  <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-    catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-    everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-    — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-    and anything unverified is badged.</p>
-  <p class="cp-about-links">
-    <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
-    <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
-  </p>
-</section>
+<details class="cp-about cp-disclosure">
+  <summary>
+    <span class="cp-about-title">About this preview server</span>
+    <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+  </summary>
+  <div class="cp-disclosure-body">
+    <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+      using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+      server never re-runs untrusted code. Catalogs are trusted by signature or their published
+      <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+    <p class="cp-about-links">
+      <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
+      <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
+    </p>
+  </div>
+</details>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -4,23 +4,35 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <a class="cp-back" href="/">← All design systems</a>
-<h1 class="cp-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
+<h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+        <p class="cp-sub">5 preview(s) ·
+          <a href="/bundle.zip?session=compose-m3">download all (.zip)</a> · <a class="cp-format-link" href="/compare?session=compose-m3">compare formats</a></p>
+        <div class="cp-catalog-tools">
         <div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
   </span>
 </div>
-<p class="cp-sub">5 preview(s) · click one to view with overrides ·
-          <a href="/bundle.zip?session=compose-m3">download all (.zip)</a> · <a class="cp-format-link" href="/compare?session=compose-m3">compare formats</a></p>
-        <div class="cp-searchbar">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
   <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="5"></span>
@@ -29,7 +41,8 @@
     <button type="button" class="cp-bg-btn" data-bg-choice="off">Transparent</button>
   </span>
 </div>
-<div class="cp-grid" id="cp-grid">
+</div>
+        <div class="cp-grid" id="cp-grid">
         <a class="cp-card" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/button-filled__ideal__default__light.png?session=compose-m3" data-l-href="/p/button-filled__ideal__default__light?session=compose-m3"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
@@ -40,7 +53,7 @@
     <img loading="lazy" alt="Button · Filled (light)" src="/render/button-filled__ideal__default__light.png?session=compose-m3">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Button · Filled (light)">Button · Filled (light)</div>
+    <div class="cp-label" title="button-filled__ideal__default__light">Button · Filled (light)</div>
     <div class="cp-id">button-filled__ideal__default__light</div>
     
   </div>
@@ -55,7 +68,7 @@
     <img loading="lazy" alt="Switch · On (light)" src="/render/switch-on__ideal__default__light.png?session=compose-m3">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Switch · On (light)">Switch · On (light)</div>
+    <div class="cp-label" title="switch-on__ideal__default__light">Switch · On (light)</div>
     <div class="cp-id">switch-on__ideal__default__light</div>
     
   </div>
@@ -166,18 +179,22 @@ applyThemeChoice();
       reflectBg();
       apply();
     })();</script>
-<section class="cp-about">
-  <p class="cp-about-title">compose-preview · public preview server</p>
-  <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-    catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-    everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-    — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-    and anything unverified is badged.</p>
-  <p class="cp-about-links">
-    <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
-    <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
-  </p>
-</section>
+<details class="cp-about cp-disclosure">
+  <summary>
+    <span class="cp-about-title">About this preview server</span>
+    <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+  </summary>
+  <div class="cp-disclosure-body">
+    <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+      using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+      server never re-runs untrusted code. Catalogs are trusted by signature or their published
+      <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+    <p class="cp-about-links">
+      <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
+      <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
+    </p>
+  </div>
+</details>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -4,23 +4,35 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <a class="cp-back" href="/">← All design systems</a>
-<h1 class="cp-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
+<h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+        <p class="cp-sub">8 preview(s) ·
+          <a href="/bundle.zip">download all (.zip)</a></p>
+        <div class="cp-catalog-tools">
         <div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
   </span>
 </div>
-<p class="cp-sub">8 preview(s) · click one to view with overrides ·
-          <a href="/bundle.zip">download all (.zip)</a></p>
-        <div class="cp-searchbar">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
   <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="8"></span>
@@ -29,7 +41,8 @@
     <button type="button" class="cp-bg-btn" data-bg-choice="off">Transparent</button>
   </span>
 </div>
-<div class="cp-grid" id="cp-grid">
+</div>
+        <div class="cp-grid" id="cp-grid">
         <a class="cp-card" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/button-filled__ideal__default__light.png" data-l-href="/p/button-filled__ideal__default__light"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
@@ -40,7 +53,7 @@
     <img loading="lazy" alt="Button · Filled (light)" src="/render/button-filled__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="Button · Filled (light)">Button · Filled (light)</div>
+    <div class="cp-label" title="button-filled__ideal__default__light">Button · Filled (light)</div>
     <div class="cp-id">button-filled__ideal__default__light</div>
     
   </div>
@@ -141,18 +154,22 @@ applyThemeChoice();
       reflectBg();
       apply();
     })();</script>
-<section class="cp-about">
-  <p class="cp-about-title">compose-preview · public preview server</p>
-  <p class="cp-about-body">Browse rendered Compose &amp; Compose&nbsp;Multiplatform design
-    catalogs live. CMP components run <strong>in your browser</strong> (Kotlin/Wasm, sandboxed);
-    everything else is served as pre-rendered snapshots. The server never re-runs untrusted code
-    — catalogs are trusted via signature or their published <code>design-artifacts</code> branch,
-    and anything unverified is badged.</p>
-  <p class="cp-about-links">
-    <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
-    <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
-  </p>
-</section>
+<details class="cp-about cp-disclosure">
+  <summary>
+    <span class="cp-about-title">About this preview server</span>
+    <span class="cp-disclosure-hint">How previews run and catalogs are trusted</span>
+  </summary>
+  <div class="cp-disclosure-body">
+    <p class="cp-about-body">Compose Multiplatform components can run <strong>in your browser</strong>
+      using sandboxed Kotlin/Wasm; other previews are published as pre-rendered snapshots. The
+      server never re-runs untrusted code. Catalogs are trusted by signature or their published
+      <code>design-artifacts</code> branch, and anything unverified is badged.</p>
+    <p class="cp-about-links">
+      <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·
+      <a href="/version">/version</a> · <span class="cp-about-ver" title="running preview-server build">server v0.0.0-fixture</span>
+    </p>
+  </div>
+</details>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -4,15 +4,27 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-                <h1 class="cp-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: signature:compose-ai-tools-ci">✓ signature:compose-ai-tools-ci</span></h1>
-        <p class="cp-sub">6 preview(s) · click one to view with overrides ·
+                <h1 class="cp-head cp-catalog-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: signature:compose-ai-tools-ci">✓ trusted</span></h1>
+        <p class="cp-sub">6 preview(s) ·
           <a href="/bundle.zip?token=demo-token-fixture">download all (.zip)</a></p>
+        <div class="cp-catalog-tools">
         <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
@@ -22,7 +34,8 @@
     <button type="button" class="cp-bg-btn" data-bg-choice="off">Transparent</button>
   </span>
 </div>
-<div class="cp-grid" id="cp-grid">
+</div>
+        <div class="cp-grid" id="cp-grid">
         <a class="cp-card" href="/p/com.example.ButtonPreview?token=demo-token-fixture">
   <div class="cp-imgwrap">
     <img loading="lazy" alt="Button" src="/render/com.example.ButtonPreview.png?token=demo-token-fixture">

--- a/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
@@ -4,11 +4,22 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Not found — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
         <h1 class="cp-head">Not found</h1>
 <p class="cp-sub">That preview does not exist in this catalog.</p>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -4,11 +4,22 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Playground — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <link rel="stylesheet" href="/assets/serve/954-ad255d6ac505634d/playground.css">
         <h1 class="cp-head">Playground</h1>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
@@ -4,15 +4,27 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Figma filled button — design comparison</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
                 <div id="cp-reference-compare" data-reference="/reference/design-button-filled-light.png?session=compose-m3" data-actual="/render/button-filled__ideal__default__light.png?session=compose-m3">
-          <h1 class="cp-head"><a href="/compare?session=compose-m3">← comparisons</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-          <p class="cp-sub">Figma filled button · button-filled__ideal__default__light</p>
+          <p class="cp-breadcrumb"><a href="/compare?session=compose-m3">compose-m3</a> / Design comparison</p>
+          <h1 class="cp-head cp-catalog-head">Figma filled button <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+          <p class="cp-sub">Button · Filled (light) · button-filled__ideal__default__light</p>
                   <nav class="cp-reference-picker" aria-label="Design references">
           <span>Design references</span>
           <a class="cp-reference-choice" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light" aria-current="page">Figma filled button</a>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-status.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-status.html
@@ -4,26 +4,40 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Server status — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/">Catalogs</a>
+    <a href="/status">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
               <h1 class="cp-head">Server status <span class="cp-badge cp-badge--unverified">⚠ degraded</span></h1>
       <p class="cp-sub">compose-preview serve · public (open) <span class="cp-about-ver">v0.0.0-fixture</span></p>
-      <section class="cp-about">
-        <p class="cp-about-title">Status &amp; monitoring</p>
-        <p class="cp-about-body">A live snapshot of this preview server — every configured catalog
-          and its latest load result, the render daemons running now, its configuration, and recent
-          daemon startup failures. The same data is available as JSON for a monitor or Home
-          Assistant sensor.</p>
-        <p class="cp-about-links">
-          <a href="/status.json">/status.json</a> ·
-          <a href="/version">/version</a> ·
-          <a href="/healthz">/healthz</a>
-        </p>
-      </section>
+      <details class="cp-about cp-disclosure">
+        <summary>
+          <span class="cp-about-title">Status &amp; monitoring details</span>
+          <span class="cp-disclosure-hint">JSON and health-check endpoints</span>
+        </summary>
+        <div class="cp-disclosure-body">
+          <p class="cp-about-body">Catalog load results, render daemons, configuration and recent
+            failures. The same data is available as JSON for monitors and Home Assistant.</p>
+          <p class="cp-about-links">
+            <a href="/status.json">/status.json</a> ·
+            <a href="/version">/version</a> ·
+            <a href="/healthz">/healthz</a>
+          </p>
+        </div>
+      </details>
 
       <div class="cp-status-grid">
       <div class="cp-stat"><div class="cp-stat-key">Catalogs</div><div class="cp-stat-val">4</div></div>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -4,18 +4,46 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-      <p class="cp-sub" title="button-filled__ideal__default__light">Button · Filled (light)</p>
-      
-      
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture&session=compose-m3">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Button · Filled (light) <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+      <p class="cp-preview-id" title="button-filled__ideal__default__light"><code>button-filled__ideal__default__light</code></p>
+
+
+
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+<button type="button" id="cp-wasm-btn" class="cp-live-toggle" aria-pressed="false" title="Run this component in your browser (Kotlin/Wasm)"><span class="cp-live-dot" aria-hidden="true"></span><span>In-browser (Wasm)</span></button>
+<button type="button" id="cp-svg-toggle" class="cp-fmt-toggle" aria-pressed="false" title="Show the vector (SVG) render">SVG</button>
+<span id="cp-svg-match" class="cp-match" role="status" aria-live="polite" hidden></span><a id="cp-svg-diff" class="cp-format-link" href="/compare?format=svg&preview=button-filled__ideal__default__light&token=demo-token-fixture&session=compose-m3" hidden>view diff →</a>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
+<input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle" tabindex="-1">
+        </span>
+      </div>
       <div class="cp-viewer-bar">
-        
+
         <span class="cp-bg" role="group" aria-label="Preview zoom">
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
@@ -23,7 +51,7 @@
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-bg-theme="light" data-preview-id="button-filled__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2" data-wasm-src="/wasm/compose-m3/?id=button-filled">
-        
+
         <div class="cp-stage"><span class="cp-backend" id="cp-backend" role="status" aria-live="polite"></span><img id="cp-img" alt="Button · Filled (light)"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Button · Filled (light) (Wasm)"></iframe><div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         <div class="cp-controls" id="cp-controls">
           <details class="cp-group" data-cp-group="appearance">
@@ -147,7 +175,7 @@
     </div>
   </div>
 </details>
-          
+
                 <details class="cp-group" data-cp-group="overrides">
         <summary>Overrides</summary>
         <div class="cp-group-body">
@@ -187,36 +215,13 @@
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          <button type="button" id="cp-wasm-btn" class="cp-live-toggle" aria-pressed="false" title="Run this component in your browser (Kotlin/Wasm)"><span class="cp-live-dot" aria-hidden="true"></span><span>In-browser (Wasm)</span></button>
-          
-          <button type="button" id="cp-svg-toggle" class="cp-fmt-toggle" aria-pressed="false" title="Show the vector (SVG) render">SVG</button>
-          <span id="cp-svg-match" class="cp-match" role="status" aria-live="polite" hidden></span><a id="cp-svg-diff" class="cp-format-link" href="/compare?format=svg&preview=button-filled__ideal__default__light&token=demo-token-fixture&session=compose-m3" hidden>view diff →</a>
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
-            <input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle" tabindex="-1">
-            
-          </span>
-        </div>
-        
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -235,7 +240,7 @@
   <a id="cp-dl-svg" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -4,18 +4,42 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Focus ring — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a></h1>
-      <p class="cp-sub" title="com.example.FocusRingPreview">Focus ring</p>
-      
-      
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture&session=compose-m3">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Focus ring</h1>
+      <p class="cp-preview-id" title="com.example.FocusRingPreview"><code>com.example.FocusRingPreview</code></p>
+
+
+
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
+        </span>
+      </div>
       <div class="cp-viewer-bar">
-        
+
         <span class="cp-bg" role="group" aria-label="Preview zoom">
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
@@ -23,7 +47,7 @@
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.FocusRingPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
-        
+
         <div class="cp-stage"><span class="cp-backend" id="cp-backend" role="status" aria-live="polite"></span><img id="cp-img" alt="Focus ring"><canvas id="cp-canvas" hidden></canvas><div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         <div class="cp-controls" id="cp-controls">
           <details class="cp-group" data-cp-group="appearance">
@@ -71,7 +95,7 @@
               </div>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -149,40 +173,18 @@
     </div>
   </div>
 </details>
-          
-          
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
-            
-            
-          </span>
-        </div>
-        
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -193,7 +195,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -4,18 +4,42 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>One-handed — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture&session=wear-m3">← previews</a></h1>
-      <p class="cp-sub" title="com.example.OneHandedPreview">One-handed</p>
-      
-      
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture&session=wear-m3">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">One-handed</h1>
+      <p class="cp-preview-id" title="com.example.OneHandedPreview"><code>com.example.OneHandedPreview</code></p>
+
+
+
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
+        </span>
+      </div>
       <div class="cp-viewer-bar">
-        
+
         <span class="cp-bg" role="group" aria-label="Preview zoom">
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
@@ -23,7 +47,7 @@
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-bg-theme="dark" data-always-dark="1" data-preview-id="com.example.OneHandedPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
-        
+
         <div class="cp-stage"><span class="cp-backend" id="cp-backend" role="status" aria-live="polite"></span><img id="cp-img" alt="One-handed"><canvas id="cp-canvas" hidden></canvas><div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         <div class="cp-controls" id="cp-controls">
           <details class="cp-group" data-cp-group="appearance">
@@ -70,7 +94,7 @@
               </div>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -148,40 +172,18 @@
     </div>
   </div>
 </details>
-          
-          
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
-            
-            
-          </span>
-        </div>
-        
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -192,7 +194,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -4,21 +4,46 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-      <p class="cp-sub" title="button-filled__ideal__default__light">Button · Filled (light)</p>
-      
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture&session=compose-m3">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Button · Filled (light) <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+      <p class="cp-preview-id" title="button-filled__ideal__default__light"><code>button-filled__ideal__default__light</code></p>
+
+
             <nav class="cp-states" aria-label="Component variant">
+        <span class="cp-axis-label">Variant</span>
         <a class="cp-state-btn" href="/p/button-filled__ideal__default__light?token=demo-token-fixture&session=compose-m3" aria-current="page">Default</a>
 <a class="cp-state-btn" href="/p/button-filled__ideal__default__light__direction-rtl?token=demo-token-fixture&session=compose-m3">RTL</a>
 <a class="cp-state-btn" href="/p/button-filled__ideal__default__light__locale-ar-xb?token=demo-token-fixture&session=compose-m3">Locale ar-XB</a>
 <a class="cp-state-btn" href="/p/button-filled__ideal__default__light__fontscale-2.0?token=demo-token-fixture&session=compose-m3">Font 2.0×</a>
       </nav>
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
+        </span>
+      </div>
       <div class="cp-viewer-bar">
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
         <span class="cp-bg" role="group" aria-label="Preview zoom">
@@ -85,7 +110,7 @@
               </div>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -143,42 +168,20 @@
               </label>
             </div>
           </details>
-          
-          
-          
-          
+
+
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
-            
-            
-          </span>
-        </div>
         <div class="cp-note">Pre-rendered snapshot — overrides (size, device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -189,7 +192,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -4,16 +4,40 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/meshcore-mobile/?token=demo-token-fixture">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile</span></h1>
-      <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
-      
-      
+              <p class="cp-breadcrumb"><a href="/meshcore-mobile/?token=demo-token-fixture">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Profile screen <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></h1>
+      <p class="cp-preview-id" title="com.example.ProfileScreenPreview"><code>com.example.ProfileScreenPreview</code></p>
+
+
+
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
+        </span>
+      </div>
       <div class="cp-viewer-bar">
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
         <span class="cp-bg" role="group" aria-label="Preview zoom">
@@ -83,7 +107,7 @@
               </div>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -141,42 +165,20 @@
               </label>
             </div>
           </details>
-          
-          
-          
-          
+
+
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
-            
-            
-          </span>
-        </div>
         <div class="cp-note">Pre-rendered snapshot — overrides (size, device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -187,7 +189,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -4,19 +4,44 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Checkbox · Checked (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-      <p class="cp-sub" title="checkbox__ideal__default__light">Checkbox · Checked (light)</p>
-      
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture&session=compose-m3">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Checkbox · Checked (light) <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+      <p class="cp-preview-id" title="checkbox__ideal__default__light"><code>checkbox__ideal__default__light</code></p>
+
+
             <nav class="cp-states" aria-label="Component state">
+        <span class="cp-axis-label">State</span>
         <a class="cp-state-btn" href="/p/checkbox__ideal__default__light?token=demo-token-fixture&session=compose-m3" aria-current="page">Default</a>
 <a class="cp-state-btn" href="/p/checkbox__ideal__unchecked__light?token=demo-token-fixture&session=compose-m3">Unchecked</a>
       </nav>
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
+        </span>
+      </div>
       <div class="cp-viewer-bar">
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
         <span class="cp-bg" role="group" aria-label="Preview zoom">
@@ -82,7 +107,7 @@
               </div>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -140,42 +165,20 @@
               </label>
             </div>
           </details>
-          
-          
-          
-          
+
+
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
-            
-            
-          </span>
-        </div>
         <div class="cp-note">Pre-rendered snapshot — overrides (size, device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -186,7 +189,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -4,18 +4,42 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a></h1>
-      <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
-      
-      
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture&session=compose-m3">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Profile screen</h1>
+      <p class="cp-preview-id" title="com.example.ProfileScreenPreview"><code>com.example.ProfileScreenPreview</code></p>
+
+
+
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
+        </span>
+      </div>
       <div class="cp-viewer-bar">
-        
+
         <span class="cp-bg" role="group" aria-label="Preview zoom">
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
@@ -23,7 +47,7 @@
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
-        
+
         <div class="cp-stage"><span class="cp-backend" id="cp-backend" role="status" aria-live="polite"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas><div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         <div class="cp-controls" id="cp-controls">
           <details class="cp-group" data-cp-group="appearance">
@@ -74,7 +98,7 @@
               </div>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -142,41 +166,19 @@
     </div>
   </div>
 </details>
-          
-          
-          
+
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
-            
-            
-          </span>
-        </div>
-        
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -187,7 +189,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -4,23 +4,48 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-      <p class="cp-sub" title="button-filled__ideal__default__light">Button · Filled (light)</p>
-      
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture&session=compose-m3">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Button · Filled (light) <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+      <p class="cp-preview-id" title="button-filled__ideal__default__light"><code>button-filled__ideal__default__light</code></p>
+
+
             <nav class="cp-states" aria-label="Component variant">
+        <span class="cp-axis-label">Variant</span>
         <a class="cp-state-btn" href="/p/button-filled__ideal__default__light?token=demo-token-fixture&session=compose-m3" aria-current="page">Default</a>
 <a class="cp-state-btn" href="/p/button-filled__ideal__default__light__direction-rtl?token=demo-token-fixture&session=compose-m3">RTL</a>
 <a class="cp-state-btn" href="/p/button-filled__ideal__default__light__locale-ar-xb?token=demo-token-fixture&session=compose-m3">Locale ar-XB</a>
 <a class="cp-state-btn" href="/p/button-filled__ideal__default__light__fontscale-2.0?token=demo-token-fixture&session=compose-m3">Font 2.0×</a>
       </nav>
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
+        </span>
+      </div>
       <div class="cp-viewer-bar">
-        
+
         <span class="cp-bg" role="group" aria-label="Preview zoom">
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
@@ -28,7 +53,7 @@
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-bg-theme="light" data-preview-id="button-filled__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
-        
+
         <div class="cp-stage"><span class="cp-backend" id="cp-backend" role="status" aria-live="polite"></span><img id="cp-img" alt="Button · Filled (light)"><canvas id="cp-canvas" hidden></canvas><div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         <div class="cp-controls" id="cp-controls">
           <details class="cp-group" data-cp-group="appearance">
@@ -76,7 +101,7 @@
               </div>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -134,42 +159,20 @@
               </label>
             </div>
           </details>
-          
-          
-          
-          
+
+
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
-            
-            
-          </span>
-        </div>
         <div class="cp-note">Pre-rendered snapshot — overrides (size, device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -180,7 +183,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -4,18 +4,44 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-      <p class="cp-sub" title="com.example.CardPreview">Card</p>
-      
-      
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture&session=compose-m3">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Card <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+      <p class="cp-preview-id" title="com.example.CardPreview"><code>com.example.CardPreview</code></p>
+
+
+
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+<button type="button" id="cp-wasm-btn" class="cp-live-toggle" aria-pressed="false" title="Run this component in your browser (Kotlin/Wasm)"><span class="cp-live-dot" aria-hidden="true"></span><span>In-browser (Wasm)</span></button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
+<input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle" tabindex="-1">
+        </span>
+      </div>
       <div class="cp-viewer-bar">
-        
+
         <span class="cp-bg" role="group" aria-label="Preview zoom">
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
@@ -23,7 +49,7 @@
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2" data-wasm-src="/wasm/compose-m3/?id=card-filled">
-        
+
         <div class="cp-stage"><span class="cp-backend" id="cp-backend" role="status" aria-live="polite"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Card (Wasm)"></iframe><div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         <div class="cp-controls" id="cp-controls">
           <details class="cp-group" data-cp-group="appearance">
@@ -71,7 +97,7 @@
               </div>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -139,41 +165,19 @@
     </div>
   </div>
 </details>
-          
-          
-          
+
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          <button type="button" id="cp-wasm-btn" class="cp-live-toggle" aria-pressed="false" title="Run this component in your browser (Kotlin/Wasm)"><span class="cp-live-dot" aria-hidden="true"></span><span>In-browser (Wasm)</span></button>
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1">
-            <input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle" tabindex="-1">
-            
-          </span>
-        </div>
         <div class="cp-note">Pre-rendered snapshot — turn on <strong>Live preview</strong> to interact. Day/Night, Font scale, Locale, background &amp; declared knob values apply in the browser; Size, Device &amp; Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -184,7 +188,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -4,18 +4,43 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></h1>
-      <p class="cp-sub" title="com.example.CardPreview">Card</p>
-      
-      
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture&session=compose-m3">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Card <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+      <p class="cp-preview-id" title="com.example.CardPreview"><code>com.example.CardPreview</code></p>
+
+
+
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
+<input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle" tabindex="-1">
+        </span>
+      </div>
       <div class="cp-viewer-bar">
-        
+
         <span class="cp-bg" role="group" aria-label="Preview zoom">
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
           <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
@@ -23,7 +48,7 @@
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2" data-wasm-src="/wasm/compose-m3/?id=card-filled">
-        
+
         <div class="cp-stage"><span class="cp-backend" id="cp-backend" role="status" aria-live="polite"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Card (Wasm)"></iframe><div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         <div class="cp-controls" id="cp-controls">
           <details class="cp-group" data-cp-group="appearance">
@@ -71,7 +96,7 @@
               </div>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -129,42 +154,20 @@
               </label>
             </div>
           </details>
-          
-          
-          
-          
+
+
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false">
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
-            <input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle" tabindex="-1">
-            
-          </span>
-        </div>
         <div class="cp-note">Pre-rendered snapshot — turn on <strong>Live preview</strong> to interact. Day/Night, Font scale, Locale, background &amp; declared knob values apply in the browser; Size, Device &amp; Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -175,7 +178,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -4,17 +4,41 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/a5e8-3fa78bf7c43ab640/serve.css">
+        <link rel="stylesheet" href="/assets/serve/b429-434fef1056806367/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
       <body>
+        <header class="cp-site-header">
+  <a class="cp-site-brand" href="/?token=demo-token-fixture" aria-label="compose-preview home">
+    <span class="cp-site-mark" aria-hidden="true">◇</span>
+    <span>compose-preview</span>
+  </a>
+  <nav class="cp-site-nav" aria-label="Primary navigation">
+    <a href="/?token=demo-token-fixture">Catalogs</a>
+    <a href="/status?token=demo-token-fixture">Status</a>
+    <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>
+  </nav>
+</header>
         <main class="cp-main">
-              <h1 class="cp-head"><a href="/?token=demo-token-fixture">← previews</a> <span class="cp-badge cp-badge--unverified" title="producer trust: unverified">⚠ unverified</span></h1>
-      <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
+              <p class="cp-breadcrumb"><a href="/?token=demo-token-fixture">Previews</a> / Component</p>
+      <h1 class="cp-head cp-preview-title">Profile screen <span class="cp-badge cp-badge--unverified" title="producer trust: unverified">⚠ unverified</span></h1>
+      <p class="cp-preview-id" title="com.example.ProfileScreenPreview"><code>com.example.ProfileScreenPreview</code></p>
+
       <p class="cp-source"><a class="cp-source-link" href="https://github.com/yschimke/compose-ai-tools/blob/design-artifacts-source/samples/design-catalog-compose-m3/src/main/kotlin/com/example/ProfileScreen.kt" title="src/main/kotlin/com/example/ProfileScreen.kt"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a></p>
-      
-      
+
+
+      <div class="cp-preview-primary" aria-label="Preview renderer">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
+            <span class="cp-live-dot" aria-hidden="true"></span>
+            <span id="cp-live-toggle-label">Live preview</span>
+          </button>
+        <span class="cp-mode-hint" id="cp-mode-hint"></span>
+        <span class="cp-modes-inputs" aria-hidden="true">
+      <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
+<input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
+        </span>
+      </div>
       <div class="cp-viewer-bar">
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
         <span class="cp-bg" role="group" aria-label="Preview zoom">
@@ -77,7 +101,7 @@
               </label>
             </div>
           </details>
-          
+
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
             <div class="cp-group-body">
@@ -113,42 +137,20 @@
             </div>
           </details>
 
-          
-          
-          
-          
+
+
+
+
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
-      <!-- What you get *out* of the preview lives in the page under the stage, outside the
-           collapsible overrides drawer: the lane toggles (Live / Wasm / SVG) that pick what the
-           stage shows, and the copyable /render URLs. Closing ⚙ Overrides — or never opening the
-           mobile bottom sheet — no longer hides them. The drawer keeps only the render *overrides*
-           (appearance, size, scroll, locale, device, knobs). -->
+      <!-- Export remains below the workspace; renderer selection is kept beside the preview
+           heading so it is visible before a tall stage. -->
       <div class="cp-below">
-        <div class="cp-preview-mode">
-          <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" disabled>
-            <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Live preview</span>
-          </button>
-          
-          
-          
-          <span class="cp-mode-hint" id="cp-mode-hint"></span>
-          <!-- The mode radios the transport JS drives; visually removed (the toggle above is the
-               only visible mode control). png = static snapshot, live = daemon stream, wasm =
-               in-browser app. -->
-          <span class="cp-modes-inputs" aria-hidden="true">
-            <input type="radio" name="cp-mode" value="png" id="cp-mode-png" tabindex="-1" checked>
-            <input type="radio" name="cp-mode" value="live" id="cp-live" tabindex="-1" disabled>
-            
-            
-          </span>
-        </div>
         <div class="cp-note">Pre-rendered snapshot — overrides (size, device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-              <section class="cp-export" aria-labelledby="cp-export-head">
-        <h2 class="cp-export-head" id="cp-export-head">Export &amp; direct links</h2>
-        <div class="cp-links">
+              <details class="cp-export cp-disclosure">
+        <summary id="cp-export-head">Export &amp; direct links</summary>
+        <div class="cp-links cp-disclosure-body">
           <div class="cp-knobs-head">The current view as a URL (overrides applied)</div>
           <div class="cp-link-row">
   <span class="cp-link-kind">PNG</span>
@@ -159,7 +161,7 @@
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
 </div>
         </div>
-      </section>
+      </details>
       </div>
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->


### PR DESCRIPTION
## What changed

- standardize catalog preview cards with a fixed media region so titles and metadata align
- collapse introductory, provenance, and export details to recover useful screen space
- add consistent navigation and clearer human-readable catalog and preview titles
- improve sticky controls, viewer navigation, renderer placement, and responsive behavior
- regenerate preview harness fixtures and add layout regression assertions

## Why

Preview content with short or unusually proportioned hero images caused card labels to start at inconsistent heights. Several pages also devoted persistent space to explanatory or secondary controls that are only occasionally needed.

## Impact

Catalog browsing is denser and more predictable across desktop and mobile. Preview imagery remains contained without changing where card metadata begins, and secondary information remains available through disclosures.

## Validation

- `./gradlew :cli:test --tests '*ServeWeb*' --tests '*ServeHttpRoutingTest*' --tests '*ServeStatusTest*'` (95 tests)
- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'`
- desktop and 390px mobile visual inspection
- `git diff --check`
