### PR TITLE
fix(serve): enable IR-backed live lanes

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -500,17 +500,17 @@ jobs:
       # maven-coordinate (re-resolved at serve time) and fonts resolve from the shared `bundle/res`
       # pool, a FULL split bundle stays small — only `classes/app.jar` repeats per preview.
       #
-      # The Android tiers (wear-m3 / remote-m3) have no runnable desktop daemon, so they stay
+      # An Android tier without `androidLiveBundle` has no runnable desktop daemon, so it stays
       # `--view-only`: the re-render classpath is dropped, keeping the baked image + every captured
-      # sidecar (semantics / layout / figma-svg, from the `--with-semantics` pack) at ~tens of KB —
-      # the right unit for an addressable, baked-only sticker.
+      # sidecar (semantics / layout / figma-svg, from the `--with-semantics` pack) at ~tens of KB.
+      # The reusable wear-m3 / remote-m3 jobs publish Android live bundles and split FULL instead.
       - name: Split into per-preview bundles
         env:
           SYSTEM: ${{ matrix.system }}
           EXTRA_RENDERS: ${{ matrix.androidExtraModule }}
           # FULL for any live-bundle tier (the CMP wasm row + an androidLiveBundle row),
           # so each per-preview bundle carries its re-render classpath; --view-only for
-          # the baked-only tiers (remote-m3).
+          # baked-only tiers.
           SPLIT_MODE: ${{ (matrix.wasmModule != '' || matrix.androidLiveBundle == '1') && 'full' || 'view-only' }}
         run: |
           set -euo pipefail

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -1,12 +1,8 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.io.composeAiCacheDir
-import java.io.ByteArrayInputStream
 import java.io.File
-import java.util.zip.ZipInputStream
 import kotlin.system.exitProcess
-import okio.Path.Companion.toPath
-import okio.source
 
 /**
  * `compose-preview bundle daemon <bundle.png>` — spawn the preview daemon JVM bound to a packed
@@ -108,7 +104,7 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     val irDir = if (hasIr) workDir.resolve("ir").apply { mkdirs() } else null
     val bundleManifestFile = if (hasIr) workDir.resolve("bundle.json") else null
     if (hasIr) {
-      extractIrArtifacts(zipBytes, irDir!!, bundleManifestFile!!, file)
+      extractBundleIrArtifacts(zipBytes, irDir!!, bundleManifestFile!!, file, fileSystem)
     }
 
     // Android resource carriage (ungated by IR): any `backend == "android"` bundle carries the
@@ -384,45 +380,6 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       """
         .trimIndent()
     )
-  }
-
-  /**
-   * Extract the v5 IR artefacts from [zipBytes]: every `ir/<leaf>` entry into [irDir] (flattened to
-   * its basename, since `BundleIr.path` is `ir/<previewId>.<ext>` and the daemon resolves by leaf),
-   * plus `bundle.json` into [manifestFile] so the daemon can read `intermediateRepresentations`.
-   * Each `ir/` destination is verified to live inside [irDir] — defeats Zip Slip on a hostile
-   * bundle, same guard as [extractEmbeddedLibs] / [expandBundleJarBytesSafely].
-   */
-  private fun extractIrArtifacts(
-    zipBytes: ByteArray,
-    irDir: File,
-    manifestFile: File,
-    bundleFile: File,
-  ) {
-    val canonicalIr = irDir.canonicalFile
-    var sawManifest = false
-    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
-      while (true) {
-        val entry = zin.nextEntry ?: break
-        val name = entry.name
-        when {
-          name == "bundle.json" -> {
-            fileSystem.write(manifestFile.path.toPath()) { write(zin.readBytes()) }
-            sawManifest = true
-          }
-          !entry.isDirectory && name.startsWith("ir/") -> {
-            val dest = File(irDir, File(name).name).canonicalFile
-            if (dest.path.startsWith(canonicalIr.path + File.separator)) {
-              fileSystem.write(dest.path.toPath()) { writeAll(zin.source()) }
-            }
-          }
-        }
-        zin.closeEntry()
-      }
-    }
-    require(sawManifest) {
-      "bundle daemon: bundle.json missing in ${bundleFile.path} — cannot resolve IR descriptors"
-    }
   }
 
   private fun createTempWorkDir(): File {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
@@ -58,6 +58,47 @@ internal fun extractBundleClassesAndManifest(
 }
 
 /**
+ * Extract the v5+ IR replay payload from [zipBytes]: every `ir/<leaf>` entry into [irDir]
+ * (flattened to its basename, matching [BundleIr.path]) plus `bundle.json` into [manifestFile].
+ *
+ * Both detached-daemon entry points need these files: `bundle daemon` passes them directly to its
+ * subprocess, while the public catalog server records them in `daemon-launch.json`. Keeping the
+ * extraction here prevents those two launch paths from silently diverging again.
+ */
+internal fun extractBundleIrArtifacts(
+  zipBytes: ByteArray,
+  irDir: File,
+  manifestFile: File,
+  bundleFile: File,
+  fileSystem: FileSystem = SystemFileSystem,
+) {
+  val canonicalIr = irDir.canonicalFile
+  var sawManifest = false
+  ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+    while (true) {
+      val entry = zin.nextEntry ?: break
+      val name = entry.name.replace('\\', '/')
+      when {
+        name == "bundle.json" -> {
+          fileSystem.write(manifestFile.path.toPath()) { write(zin.readBytes()) }
+          sawManifest = true
+        }
+        !entry.isDirectory && name.startsWith("ir/") && ".." !in name.split("/") -> {
+          val dest = File(irDir, File(name).name).canonicalFile
+          if (dest.path.startsWith(canonicalIr.path + File.separator)) {
+            fileSystem.write(dest.path.toPath()) { writeAll(zin.source()) }
+          }
+        }
+      }
+      zin.closeEntry()
+    }
+  }
+  require(sawManifest) {
+    "bundle daemon: bundle.json missing in ${bundleFile.path} — cannot resolve IR descriptors"
+  }
+}
+
+/**
  * Unpack an app jar's bytes into [targetDir], rejecting Zip Slip. Shares its containment-check
  * shape with `BundleCommand`'s `safeExtractZip` (a bundle's own zip) — duplicated rather than
  * reused since this one unpacks an in-memory *jar's* bytes, a different call shape.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.cli.CoordinateResolver
 import ee.schimke.composeai.cli.PreviewManifest
 import ee.schimke.composeai.cli.bundleSidecarSearchDescription
 import ee.schimke.composeai.cli.extractBundleClassesAndManifest
+import ee.schimke.composeai.cli.extractBundleIrArtifacts
 import ee.schimke.composeai.cli.locateBundleSidecarJars
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.composeAiCacheDir
@@ -143,9 +144,9 @@ internal object ServeBundleDaemon {
     val classesDir = File(destDir, "classes").apply { mkdirs() }
     val libsDir = File(destDir, "libs").apply { mkdirs() }
     val previewsJson = File(destDir, "previews.json")
-    // A fully IR-backed bundle (schema v5+) legitimately carries no classes/app.jar — mirrors
-    // BundleDaemonCommand's gate. Serve's live path doesn't replay IR (that's the Android/tile
-    // story), but a mixed bundle with at least one class-backed preview must still carry its jar.
+    // A fully IR-backed bundle (schema v5+) legitimately carries no classes/app.jar — its daemon
+    // replays the carried documents extracted below. A mixed bundle with at least one class-backed
+    // preview must still carry its jar.
     val irPreviewIds = manifest.intermediateRepresentations.mapTo(mutableSetOf()) { it.previewId }
     val requireAppJar = manifest.previewIds.any { it !in irPreviewIds }
     try {
@@ -160,6 +161,23 @@ internal object ServeBundleDaemon {
     } catch (e: Exception) {
       onLog("catalog $system: bundle extraction failed (${e.message})")
       return null
+    }
+
+    // v5+ IR replay: a Remote Compose preview has no consumer class to reflect. The Android
+    // daemon instead reads the captured document from `ir/` and resolves its descriptor through
+    // the carried bundle manifest. This is the same setup `compose-preview bundle daemon` uses;
+    // without it the public catalog path filtered IR previews out and falsely reported a daemon
+    // startup failure.
+    val hasIr = manifest.intermediateRepresentations.isNotEmpty()
+    val irDir = if (hasIr) File(destDir, "ir").apply { mkdirs() } else null
+    val bundleManifestFile = if (hasIr) File(destDir, "bundle.json") else null
+    if (hasIr) {
+      try {
+        extractBundleIrArtifacts(zipBytes, irDir!!, bundleManifestFile!!, bundleFile, fileSystem)
+      } catch (e: Exception) {
+        onLog("catalog $system: IR extraction failed (${e.message})")
+        return null
+      }
     }
 
     val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir, fileSystem)
@@ -212,6 +230,7 @@ internal object ServeBundleDaemon {
         childDependencyJars = childDependencies.map { it.file },
         daemonSidecarClasspath = backendLaunch.daemonClasspath,
         androidResourceClasspath = androidResourceClasspath,
+        hasIr = hasIr,
       )
     if (parentOverlayDependencies.isNotEmpty()) {
       onLog(
@@ -237,6 +256,8 @@ internal object ServeBundleDaemon {
           buildMap {
             put("composeai.daemon.userClassDirs", classpaths.userClassPath)
             put("composeai.daemon.previewsJsonPath", previewsJson.absolutePath)
+            irDir?.let { put(IR_DIR_PROPERTY, it.absolutePath) }
+            bundleManifestFile?.let { put(BUNDLE_MANIFEST_PATH_PROPERTY, it.absolutePath) }
             // Point the daemon's render output at `<destDir>/renders`. This is what makes
             // `DaemonMain.dataRoot` non-null (`<destDir>/data`), which is the gate that *registers*
             // the file-based data products — including `compose/figma-svg` (+ `-long`). Without it
@@ -368,6 +389,7 @@ internal object ServeBundleDaemon {
         childDependencyJars = childJars,
         daemonSidecarClasspath = backendLaunch.daemonClasspath,
         androidResourceClasspath = emptyList(),
+        hasIr = false,
       )
     val descriptor =
       DaemonLaunchDescriptor(
@@ -572,6 +594,10 @@ internal object ServeBundleDaemon {
    */
   private const val REMOTECOMPOSE_SUFFIX = ".remotecompose.json"
 
+  /** IR replay properties consumed by BundleIrReplayStore in the daemon. */
+  private const val IR_DIR_PROPERTY = "composeai.daemon.irDir"
+  private const val BUNDLE_MANIFEST_PATH_PROPERTY = "composeai.daemon.bundleManifestPath"
+
   private val json = Json { encodeDefaults = true }
   private val overridesJson = Json { ignoreUnknownKeys = true }
   private val previewsManifestJson = Json {
@@ -604,6 +630,7 @@ internal object ServeBundleDaemon {
     childDependencyJars: List<File>,
     daemonSidecarClasspath: List<String>,
     androidResourceClasspath: List<String>,
+    hasIr: Boolean,
   ): BundleDaemonClasspaths {
     // The carried r-classes.jar belongs to the catalog's AndroidX graph too. It must precede the
     // sidecar's generated R.jar or newer Compose UI bytecode can resolve an older R$id class and
@@ -611,7 +638,13 @@ internal object ServeBundleDaemon {
     val parentEntries =
       (parentOverlayJars.map { it.absolutePath } +
           androidResourceClasspath +
-          daemonSidecarClasspath)
+          daemonSidecarClasspath +
+          // Parent-loaded IR replay connectors link the carried player/runtime libraries
+          // directly. Mirror BundleDaemonCommand.composeDaemonClasspath by making every carried
+          // dependency visible to the parent after the authoritative daemon sidecars. Shared ABI
+          // overlays above still precede the sidecar and retain their version priority.
+          (if (hasIr) (embeddedLibJars + childDependencyJars).map { it.absolutePath }
+          else emptyList()))
         .distinct()
     // The rehydrated external-resource dirs go right after the bundle's own classes so a lifted
     // font resolves at the same `/fonts/…` path it did when carried inline.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -163,35 +163,6 @@ class ServeCatalogStore(
     return previewIdFor(path)
   }
 
-  /**
-   * Restrict a carried bundle's server-side alias to previews that still have executable bytecode.
-   *
-   * An IR-backed preview (currently Remote Compose) is intentionally omitted from
-   * `classes/app.jar`: the bundle carries its captured document under `ir/` instead. It remains in
-   * the full alias while [extractCatalogRcDocs] re-keys that document for browser replay, but
-   * handing it to the daemon would deterministically fail with `ClassNotFoundException`.
-   *
-   * Metadata failures retain the original alias; the bundle builder owns diagnostics and rejection
-   * for malformed bundles, and this filter must not hide that more useful failure path.
-   */
-  private fun classBackedAliasForBundle(
-    bundleFile: File,
-    alias: Map<String, String>,
-  ): Map<String, String> {
-    val irPreviewIds =
-      try {
-        BundleReader.readMetadata(bundleFile).manifest.intermediateRepresentations.mapTo(
-          mutableSetOf()
-        ) {
-          it.previewId
-        }
-      } catch (_: Exception) {
-        return alias
-      }
-    if (irPreviewIds.isEmpty()) return alias
-    return alias.filterValues { it !in irPreviewIds }
-  }
-
   sealed interface Result {
     data class Ok(val system: String, val previewCount: Int, val trust: String) : Result
 
@@ -482,9 +453,9 @@ class ServeCatalogStore(
         // can serve them. Done regardless of the rehydrate/daemon outcome below — the client-side
         // `.rc` lane needs no daemon, so it must survive a live-tier fallback.
         extractCatalogRcDocs(bundleFile, alias, dir)
-        // IR-backed previews have no class in app.jar by design. Preserve their full alias above
-        // for `.rc` extraction, but never advertise them to either daemon lane.
-        val classBackedAlias = classBackedAliasForBundle(bundleFile, alias)
+        // IR-backed previews have no class in app.jar by design. The bundle daemon replays them
+        // from the extracted `ir/` document + bundle manifest, so they remain in this alias just
+        // like class-backed previews and can expose Java / CMP Android renderer selection.
         // Rehydrate any resources the bundle externalized (fonts lifted out of classes/app.jar)
         // from
         // the branch's content-addressed pool into a shared cache + a materialized classpath dir.
@@ -506,19 +477,19 @@ class ServeCatalogStore(
             // which suffix maps to which id without the publisher's ordering, so we only serve the
             // per-preview lane for ids with an unambiguous stem; a colliding id resolves null and
             // falls back to the monolithic daemon (which serves every preview correctly).
-            val safeStems = uniquePerPreviewStems(classBackedAlias.values)
+            val safeStems = uniquePerPreviewStems(alias.values)
             val fetchPerPreview: (String) -> File? = { daemonId ->
               safeStems[daemonId]?.let { stem ->
                 fetchPerPreviewBundle(stem, liveBundle, base, dir, safe)
               }
             }
             if (
-              classBackedAlias.isNotEmpty() &&
+              alias.isNotEmpty() &&
                 buildTrustedBundle(
                   safe,
                   bundleFile,
                   res.dir,
-                  classBackedAlias,
+                  alias,
                   { bakedFallback(emptyList(), deferredIds.toList()) },
                   fetchPerPreview,
                 )
@@ -579,7 +550,7 @@ class ServeCatalogStore(
     // Priority when we DO record one: a specific liveBundle failure (fetched/rehydrated/started) >
     // an
     // unverified catalog that DID declare a live lane (trust is the blocker) > the plain "no live
-    // bundle published" case (meshcore's app catalog, remote-m3, …).
+    // bundle published" case (meshcore's app catalog, …).
     // Recorded whenever the catalog declares live-only coverage this terminal (no server-side
     // daemon) registration can't produce: those previews are omitted rather than listed as cards
     // whose every request 404s, and this is what tells the visitor the sheet is thinner than the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -194,8 +194,8 @@ interface ServeHost : AutoCloseable {
    * The Remote Compose render backends the viewer may offer for [previewId] as **enabled** options
    * — the subset of the fixed [RcPlayerBackend.UNIVERSE] this host can actually produce pixels
    * through. The viewer renders every backend as a chip and enables the ones returned here; the
-   * rest (e.g. [RcPlayerBackend.CMP_JVM], whose Skiko draw path isn't ported) are shown disabled,
-   * so a planned lane is visible without pretending it works.
+   * rest (e.g. [RcPlayerBackend.CMP_JVM] when its sidecar is not installed) are shown disabled, so
+   * an unavailable lane remains visible without pretending it works.
    *
    * Empty for a non–Remote Compose preview (the viewer then shows no backend selector at all).
    * Defaults to the client-side [RcPlayerBackend.JS] lane whenever [hasRemoteComposeDoc] is true —

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2338,8 +2338,7 @@ class ServeHttpServer(
           // `/render/<id>.rc`).
           hasRemoteComposeDoc = renderHost.hasRemoteComposeDoc(preview.id),
           // Per-preview: the Remote Compose backend selector's enabled lanes (js / java /
-          // cmp-android; cmp-jvm is always shown disabled). Empty for a non-RC preview ⇒ no
-          // selector.
+          // cmp-android / cmp-jvm). Empty for a non-RC preview ⇒ no selector.
           enabledRcPlayers = renderHost.enabledRcPlayersFor(preview.id).map { it.wire },
           wasmSrc = wasmSrc,
           wasmSameOrigin = wasmSameOrigin,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3003,10 +3003,10 @@ object ServeWeb {
      * **backend selector** — the [RcPlayerBackend.wire] ids the host reports via
      * [ServeHost.enabledRcPlayersFor]. Non-empty for a Remote Compose preview: the viewer renders
      * one chip per [RcPlayerBackend.UNIVERSE] entry, enables those in this list, and disables the
-     * rest (`cmp-jvm` is always disabled until its Skiko draw path lands). The `js` chip drives the
-     * client-side `<canvas>` lane (so [hasRemoteComposeDoc] is what carries the doc for it), while
-     * `java` / `cmp-android` re-render server-side via the `rcPlayer=<wire>` render param. Empty ⇒
-     * no selector at all (not a Remote Compose preview).
+     * rest. The `js` chip drives the client-side `<canvas>` lane (so [hasRemoteComposeDoc] is what
+     * carries the doc for it), while `java` / `cmp-android` re-render through the Android daemon
+     * and `cmp-jvm` through its isolated desktop-player subprocess. Empty ⇒ no selector at all (not
+     * a Remote Compose preview).
      */
     enabledRcPlayers: List<String> = emptyList(),
     wasmSrc: String? = null,
@@ -3189,8 +3189,7 @@ object ServeWeb {
     // enabled for those the host reports in [enabledRcPlayers] and disabled otherwise. It replaces
     // the former single "RC (browser)" button — the `js` chip drives the same in-browser canvas
     // lane (setMode("rc")), while `java` / `cmp-android` re-render the PNG server-side via
-    // `rcPlayer=<wire>`. `cmp-jvm` is present-but-disabled until its Skiko draw path lands.
-    // Rendered
+    // `rcPlayer=<wire>`. `cmp-jvm` uses the same URL through its isolated subprocess lane. Rendered
     // only for a Remote Compose preview (a non-empty enabled set). `data-default` seeds the
     // initially-current chip: the server-side `java` player when it's available (the default
     // snapshot lane), else the client `js` canvas.
@@ -3213,7 +3212,8 @@ object ServeWeb {
                 on ->
                   "Render this component's Remote Compose document with the ${backend.label} player"
                 backend == RcPlayerBackend.CMP_JVM ->
-                  "CMP JVM player — not available yet (its Skiko draw path isn't implemented)"
+                  "CMP JVM player — not available for this session (install lib-rcjvm and " +
+                    "lib-daemon-desktop)"
                 else -> "${backend.label} player — not available for this session"
               }
             "<button type=\"button\" class=\"cp-live-toggle cp-rc-backend\" " +

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleDaemonClasspathTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleDaemonClasspathTest.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.cli
 
 import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -52,5 +55,34 @@ class BundleDaemonClasspathTest {
       sidecar,
       BundleDaemonCommand.composeDaemonClasspath(sidecar, emptyList(), hasIr = true),
     )
+  }
+
+  @Test
+  fun `shared IR extraction materializes the document and bundle manifest`() {
+    val root = Files.createTempDirectory("bundle-ir-extraction").toFile()
+    val bundle = File(root, "bundle.png")
+    val manifest = """{"schemaVersion":8,"intermediateRepresentations":[]}""".toByteArray()
+    val document = byteArrayOf(0x52, 0x43, 0x01)
+    val zipBytes =
+      java.io
+        .ByteArrayOutputStream()
+        .also { bytes ->
+          ZipOutputStream(bytes).use { zip ->
+            zip.putNextEntry(ZipEntry("bundle.json"))
+            zip.write(manifest)
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("ir/com.example.Remote.rc"))
+            zip.write(document)
+            zip.closeEntry()
+          }
+        }
+        .toByteArray()
+    val irDir = File(root, "ir").apply { mkdirs() }
+    val extractedManifest = File(root, "bundle.json")
+
+    extractBundleIrArtifacts(zipBytes, irDir, extractedManifest, bundle)
+
+    assertTrue(extractedManifest.readBytes().contentEquals(manifest))
+    assertTrue(File(irDir, "com.example.Remote.rc").readBytes().contentEquals(document))
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -59,6 +59,7 @@ class ServeBundleDaemonTest {
         childDependencyJars = listOf(catalogSerialization),
         daemonSidecarClasspath = listOf(sidecarMaterial.absolutePath, daemon.absolutePath),
         androidResourceClasspath = listOf(androidResources.absolutePath),
+        hasIr = false,
       )
 
     assertEquals(
@@ -82,6 +83,106 @@ class ServeBundleDaemonTest {
       catalogMaterial.absolutePath !in result.userClassPath,
       "parent-loaded framework dependencies must not be duplicated in the user child loader",
     )
+  }
+
+  @Test
+  fun `IR replay dependencies are visible to the daemon parent after its sidecars`() {
+    val root = Files.createTempDirectory("serve-bundle-ir-classpaths").toFile()
+    val classes = File(root, "classes").apply { mkdirs() }
+    val embeddedPlayer = File(root, "embedded-player.jar")
+    val childRuntime = File(root, "child-runtime.jar")
+    val sharedOverlay = File(root, "shared-overlay.jar")
+    val daemon = File(root, "daemon.jar")
+
+    val result =
+      ServeBundleDaemon.bundleDaemonClasspaths(
+        classesDir = classes,
+        extraClasspathDirs = emptyList(),
+        embeddedLibJars = listOf(embeddedPlayer),
+        parentOverlayJars = listOf(sharedOverlay),
+        childDependencyJars = listOf(childRuntime),
+        daemonSidecarClasspath = listOf(daemon.absolutePath),
+        androidResourceClasspath = emptyList(),
+        hasIr = true,
+      )
+
+    assertEquals(
+      listOf(
+        sharedOverlay.absolutePath,
+        daemon.absolutePath,
+        embeddedPlayer.absolutePath,
+        childRuntime.absolutePath,
+      ),
+      result.daemonClasspath,
+      "IR replay connectors are parent-loaded and must see every carried player dependency",
+    )
+    assertTrue(embeddedPlayer.absolutePath in result.userClassPath)
+    assertTrue(childRuntime.absolutePath in result.userClassPath)
+  }
+
+  @Test
+  fun `materialize wires carried IR into the daemon descriptor`() {
+    val root = Files.createTempDirectory("serve-bundle-ir-descriptor").toFile()
+    val daemonDir = File(root, "daemon").apply { mkdirs() }
+    val rendererDir = File(root, "renderer").apply { mkdirs() }
+    File(daemonDir, "daemon.jar").writeBytes(byteArrayOf())
+    File(rendererDir, "renderer.jar").writeBytes(byteArrayOf())
+    val previewId = "com.example.CatalogKt.RemotePreview"
+    val document = byteArrayOf(0x52, 0x43, 0x01)
+    val manifest =
+      """
+      {"schemaVersion":8,"backend":"desktop","previewIds":["$previewId"],
+       "coverPreviewId":"$previewId","classpath":[],"modulePath":":remote",
+       "producedBy":"test","intermediateRepresentations":[
+         {"previewId":"$previewId","format":"remotecompose","path":"ir/$previewId.rc"}]}
+      """
+        .trimIndent()
+        .toByteArray()
+    val previews =
+      """
+      {"module":":remote","variant":"debug","previews":[
+        {"id":"$previewId","functionName":"RemotePreview","className":"com.example.CatalogKt"}]}
+      """
+        .trimIndent()
+        .toByteArray()
+    val bundle = File(root, "remote-bundle.zip")
+    java.util.zip.ZipOutputStream(bundle.outputStream()).use { zip ->
+      for ((name, bytes) in
+        listOf(
+          "bundle.json" to manifest,
+          "previews.json" to previews,
+          "ir/$previewId.rc" to document,
+        )) {
+        zip.putNextEntry(java.util.zip.ZipEntry(name))
+        zip.write(bytes)
+        zip.closeEntry()
+      }
+    }
+
+    System.setProperty("composeai.cli.libDaemonDesktopDir", daemonDir.absolutePath)
+    System.setProperty("composeai.cli.libRendererDir", rendererDir.absolutePath)
+    try {
+      val state =
+        assertNotNull(
+          ServeBundleDaemon.materialize(bundle, File(root, "session"), "remote"),
+          "a fully IR-backed bundle should materialize without classes/app.jar",
+        )
+      val descriptor =
+        descriptorJson.decodeFromString(
+          DaemonLaunchDescriptor.serializer(),
+          state.descriptor.readText(),
+        )
+      val irDir = assertNotNull(descriptor.systemProperties["composeai.daemon.irDir"])
+      val bundleManifest =
+        assertNotNull(descriptor.systemProperties["composeai.daemon.bundleManifestPath"])
+
+      assertTrue(File(irDir, "$previewId.rc").readBytes().contentEquals(document))
+      assertTrue(File(bundleManifest).readBytes().contentEquals(manifest))
+      assertEquals(listOf(previewId), state.previews.map { it.id })
+    } finally {
+      System.clearProperty("composeai.cli.libDaemonDesktopDir")
+      System.clearProperty("composeai.cli.libRendererDir")
+    }
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -395,7 +395,7 @@ class ServeCatalogStoreTest {
   }
 
   @Test
-  fun `a mixed liveBundle routes only class-backed previews to the daemon`() {
+  fun `a mixed liveBundle routes class-backed and IR previews to the daemon`() {
     val remoteId = "com.example.CatalogKt.RemotePreview"
     val widgetId = "com.example.WidgetKt.WidgetPreview"
     val rcBytes = byteArrayOf(0x52, 0x43, 0x01)
@@ -453,7 +453,11 @@ class ServeCatalogStoreTest {
       )
 
     assertTrue(store.load("remote-m3") is ServeCatalogStore.Result.Ok)
-    assertEquals(mapOf("widget__ideal__default" to widgetId), captured)
+    assertEquals(
+      mapOf("remote__ideal__default" to remoteId, "widget__ideal__default" to widgetId),
+      captured,
+      "the daemon replays IR previews from the carried document instead of reflecting a class",
+    )
     assertContentEquals(
       rcBytes,
       File(root, "remote-m3/ir/remote__ideal__default.rc").readBytes(),

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -292,7 +292,7 @@ class ServeWebTest {
   @Test
   fun `the rc backend selector renders every backend with the unavailable ones disabled`() {
     // A Remote Compose preview on an Android daemon: js (client canvas) + java + cmp-android are
-    // enabled; cmp-jvm is always present-but-disabled (no Skiko draw path yet).
+    // enabled; cmp-jvm is present-but-disabled when the host doesn't advertise its sidecar lane.
     val preview = ServePreview(id = "widget.Chip", label = "chip")
     val html =
       ServeWeb.viewerPage(

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -85,10 +85,10 @@ services:
       # mem_limit below ⇒ physical RAM; e.g. an 8 GB host — what preview.coo.ee runs — derives 5
       # permits). Fail-closed: only Trusted catalogs execute. wear-m3 publishes an Android liveBundle
       # and this image bakes the Robolectric Android daemon + SDK, so it CAN render live (2 seat
-      # permits) — but only once its stickers carry the `previewId` daemon mapping (the published
-      # wear-m3 catalog doesn't yet, so the viewer serves it baked; see docs/public-preview-server.md).
-      # remote-m3 carries no runnable bundle → baked PNG. Set SERVE_ALLOW_RENDER_TRUSTED=0
-      # in .env to opt out (Wasm still carries CMP).
+      # permits). remote-m3 publishes an IR-backed Android liveBundle: the daemon replays its
+      # carried `ir/*.rc` documents directly, enabling Java / CMP Android selection alongside the
+      # browser JS and isolated CMP JVM players. Set SERVE_ALLOW_RENDER_TRUSTED=0 in .env to opt out
+      # (Wasm and browser-side Remote Compose still work).
       #
       # SERVE_CATALOG_SOURCE_REPO is the OPTIONAL source-build fallback only (a catalog with a Gradle
       # `source` but no bundle): setting it makes the entrypoint clone that repo and pay a one-time

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -659,11 +659,13 @@ image pull "just works" with live CMP, no clone and no build. Set `SERVE_ALLOW_R
 opt out (the Wasm tier still carries CMP). The other published catalogs (`wear-m3`, `remote-m3`) are
 **Android** — no desktop-runnable bundle — so their live lane runs a heavier Robolectric daemon
 (2 live-seat permits) instead of the desktop one. The prebuilt `deploy/image` (**what `preview.coo.ee`
-runs**) bakes that Robolectric Android daemon + a minimal Android SDK, so `wear-m3` — which publishes
-an Android `liveBundle` — *can* be rendered live and per-variant there. A box **without** the Android
-runtime — the desktop-only from-source `deploy/vps` — instead falls back to baked PNGs for these
-catalogs, fail-closed: no error, just no daemon tier. (`remote-m3` carries no runnable bundle, so it
-stays baked-PNG on either box.)
+runs**) bakes that Robolectric Android daemon + a minimal Android SDK, so `wear-m3` and `remote-m3`
+— which publish Android `liveBundle`s — can be rendered live and per-variant there. `remote-m3` is
+fully IR-backed: its bundle carries `ir/*.rc` documents instead of preview classes, and the daemon
+replays those documents directly. A box **without** the Android runtime — the desktop-only
+from-source `deploy/vps` — instead falls back to baked PNGs for these catalogs, fail-closed: no
+error, just no daemon tier; browser-side JS and installed CMP JVM Remote Compose players remain
+available from the carried documents.
 
 > **The live lane also needs a `previewId` sticker→daemon mapping — and, for Android, the app's
 > resource table.** The viewer only exposes live/override controls for a preview whose baked sticker
@@ -680,7 +682,8 @@ stays baked-PNG on either box.)
 > crashing) as a safety net — shipped in **0.16.50**. So `wear-m3` renders live and per-variant once
 > the box has **rolled the 0.16.50 image** (Watchtower) **and** re-fetched the `design-artifacts/wear-m3`
 > bundle regenerated to carry the `android/` resources (catalog auto-refresh). `compose-m3` carried
-> `previewId` already; `remote-m3` stays baked-PNG — it publishes no runnable bundle.
+> `previewId` already. `remote-m3` also carries the mapping, but its daemon ids resolve through the
+> bundle's IR replay manifest rather than `classes/app.jar`.
 
 > **Font parity with the baked PNG.** A live daemon must resolve fonts the same way the render that
 > baked the PNG did, or the same preview shows two typefaces depending on which lane you're viewing.


### PR DESCRIPTION
## Goal

Make the published `remote-m3` catalog genuinely live: allow selecting the JS, Java, CMP Android, and CMP JVM Remote Compose renderers instead of reporting a broken daemon and snapshot-only state.

## Summary

- Share IR extraction between the standalone bundle daemon and served catalog materialization.
- Wire carried `ir/` artifacts and `bundle.json` into the daemon launch descriptor and parent classpath.
- Keep IR preview aliases daemon-addressable so the Android host exposes Java and CMP Android while JS and CMP JVM remain available.
- Correct stale deployment, documentation, and CMP JVM unavailability messaging.
- Abandoned filtering IR previews out of the daemon lane; that caused false daemon startup failure and blocked those backends.
- Known gap: hosted behavior requires the updated server image to be deployed; no Compose image diff is expected because this changes preview routing rather than composable output.
- Verification: focused `:cli:test` coverage for bundle daemon classpaths, daemon materialization, catalog routing, and viewer state; `:cli:ktfmtCheckMain`; `:cli:ktfmtCheckTest`; `git diff --check`.