### PR TITLE
feat(preview): use device sizes for app screens

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3263,6 +3263,13 @@ object ServeWeb {
         val v = WebEscaping.htmlEscape(value)
         "<option value=\"$v\">${WebEscaping.htmlEscape(name)}</option>"
       }
+    val isAppScreen = preview.section.equals("Screens", ignoreCase = true)
+    val screenDeviceOptions =
+      SCREEN_DEVICES.joinToString("\n                  ") { device ->
+        val value = WebEscaping.htmlEscape(device.id)
+        val label = WebEscaping.htmlEscape("${device.name} · ${device.kind} (${device.sizeDp})")
+        "<option value=\"$value\">$label</option>"
+      }
     // A static bundle/catalog replays baked PNGs — the server can't re-render, so the override
     // controls that rebuild the /render URL (device/locale/font scale/orientation + the live
     // stream)
@@ -3449,6 +3456,95 @@ object ServeWeb {
         </details>
         """
           .trimIndent()
+    // Catalog app screens represent a whole device surface. Arbitrary min/max constraints are
+    // useful for components, but are a poor model for a screen; give screens four recognisable,
+    // deliberately varied Android device profiles instead. The select retains #cp-device, so the
+    // existing override transport and deep-link behaviour apply unchanged.
+    val sizeControlsHtml =
+      if (isAppScreen)
+        """
+        <details class="cp-group" data-cp-group="size">
+          <summary>Size</summary>
+          <div class="cp-group-body">
+            <label>Device size
+              <select id="cp-device"$serverDis>
+                <option value="">(preview default)</option>
+                SCREEN_DEVICE_OPTIONS_PLACEHOLDER
+              </select>
+            </label>
+            <label>Orientation
+              <select id="cp-orientation"$serverDis>
+                <option value="">(device default)</option>
+                <option value="portrait">Portrait</option>
+                <option value="landscape">Landscape</option>
+              </select>
+            </label>
+          </div>
+        </details>
+        """
+          .trimIndent()
+          .replace("\n", "\n          ")
+          .replace("SCREEN_DEVICE_OPTIONS_PLACEHOLDER", screenDeviceOptions)
+      else
+        """
+        <details class="cp-group" data-cp-group="size">
+          <summary>Size</summary>
+          <div class="cp-group-body">
+            <div class="cp-size">
+              <label>Size mode
+                <select id="cp-sizeMode"$serverDis>
+                  <option value="">(default)</option>
+                  <option value="fixed">Fixed size</option>
+                  <option value="max">Max</option>
+                  <option value="min">Min</option>
+                  <option value="within">Within (min–max)</option>
+                </select>
+              </label>
+              <div class="cp-size-row" id="cp-size-fixed" hidden>
+                <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+                <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              </div>
+              <div class="cp-size-row" id="cp-size-min" hidden>
+                <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+                <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              </div>
+              <div class="cp-size-row" id="cp-size-max" hidden>
+                <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+                <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              </div>
+            </div>
+          </div>
+        </details>
+        """
+          .trimIndent()
+          .replace("\n", "\n          ")
+    val deviceControlsHtml =
+      if (isAppScreen) ""
+      else
+        """
+        <details class="cp-group" data-cp-group="device">
+          <summary>Device</summary>
+          <div class="cp-group-body">
+            <label>Device
+              <select id="cp-device"$serverDis>
+                <option value="">(default)</option>
+                DEVICE_OPTIONS_PLACEHOLDER
+              </select>
+            </label>
+            <label>Orientation
+              <select id="cp-orientation"$serverDis>
+                <option value="">(default)</option>
+                <option value="portrait">Portrait</option>
+                <option value="landscape">Landscape</option>
+              </select>
+            </label>
+          </div>
+        </details>
+        """
+          .trimIndent()
+          .replace("\n", "\n          ")
+          .replace("DEVICE_OPTIONS_PLACEHOLDER", deviceOptions)
+          .let { "          $it" }
     // Left-hand component nav drawer (default closed) and its toggle — only when the session
     // carries
     // sibling previews to move between. The right-hand overrides drawer (.cp-controls) is always
@@ -3512,34 +3608,7 @@ object ServeWeb {
               </label>
             </div>
           </details>
-          <details class="cp-group" data-cp-group="size">
-            <summary>Size</summary>
-            <div class="cp-group-body">
-              <div class="cp-size">
-                <label>Size mode
-                  <select id="cp-sizeMode"$serverDis>
-                    <option value="">(default)</option>
-                    <option value="fixed">Fixed size</option>
-                    <option value="max">Max</option>
-                    <option value="min">Min</option>
-                    <option value="within">Within (min–max)</option>
-                  </select>
-                </label>
-                <div class="cp-size-row" id="cp-size-fixed" hidden>
-                  <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
-                  <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
-                </div>
-                <div class="cp-size-row" id="cp-size-min" hidden>
-                  <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
-                  <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
-                </div>
-                <div class="cp-size-row" id="cp-size-max" hidden>
-                  <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
-                  <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
-                </div>
-              </div>
-            </div>
-          </details>
+          $sizeControlsHtml
           ${scrollGroupHtml(hasSvgExport)}
           <details class="cp-group" data-cp-group="locale">
             <summary>Locale &amp; text</summary>
@@ -3575,24 +3644,7 @@ object ServeWeb {
               </label>
             </div>
           </details>
-          <details class="cp-group" data-cp-group="device">
-            <summary>Device</summary>
-            <div class="cp-group-body">
-              <label>Device
-                <select id="cp-device"$serverDis>
-                  <option value="">(default)</option>
-                  $deviceOptions
-                </select>
-              </label>
-              <label>Orientation
-                <select id="cp-orientation"$serverDis>
-                  <option value="">(default)</option>
-                  <option value="portrait">Portrait</option>
-                  <option value="landscape">Landscape</option>
-                </select>
-              </label>
-            </div>
-          </details>
+$deviceControlsHtml
           $overlaysHtml
           $featureControlsHtml
           ${overrideKnobsHtml(preview, canApplyOverrides || canRenderOverrides, wasmSrc != null)}
@@ -4107,6 +4159,21 @@ object ServeWeb {
    * hidden magic number.
    */
   private const val RENDER_DENSITY = 2
+
+  private data class ScreenDevice(
+    val id: String,
+    val name: String,
+    val kind: String,
+    val sizeDp: String,
+  )
+
+  private val SCREEN_DEVICES: List<ScreenDevice> =
+    listOf(
+      ScreenDevice("id:pixel_5", "Pixel 5", "compact phone", "393 × 851 dp"),
+      ScreenDevice("id:pixel_7", "Pixel 7", "standard phone", "411 × 914 dp"),
+      ScreenDevice("id:pixel_fold", "Pixel Fold", "foldable", "841 × 701 dp"),
+      ScreenDevice("id:pixel_tablet", "Pixel Tablet", "tablet", "1280 × 800 dp"),
+    )
 
   private val COMMON_DEVICES: List<Pair<String, String>> =
     listOf(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -493,7 +493,7 @@ class ServeWebFixtureTest {
       ServeWeb.viewerPage(
         previews
           .first { it.id.endsWith("ProfileScreenPreview") }
-          .copy(sourceFile = "src/main/kotlin/com/example/ProfileScreen.kt"),
+          .copy(sourceFile = "src/main/kotlin/com/example/ProfileScreen.kt", section = "Screens"),
         token,
         trust = "unverified",
         // The full preview list feeds the left-hand component nav drawer (default closed) so the
@@ -2130,6 +2130,36 @@ class ServeWebFixtureTest {
         assetText("viewer.js").contains("if (wasmActive()) positionWasmFrame();"),
       "changing zoom re-pins active live and Wasm overlays to the snapshot geometry",
     )
+  }
+
+  @Test
+  fun `screen previews move device and orientation into Size while components keep constraints`() {
+    val screen =
+      ServeWeb.viewerPage(
+        ServePreview("speaker-details", "Speaker details", section = "Screens"),
+        token,
+        canApplyOverrides = true,
+      )
+    val component =
+      ServeWeb.viewerPage(
+        ServePreview("speaker-card", "Speaker card", section = "Components"),
+        token,
+        canApplyOverrides = true,
+      )
+
+    assertTrue(screen.contains("<label>Device size"), "screen Size panel contains device presets")
+    assertTrue(screen.contains("id=\"cp-orientation\""), "screen Size panel contains orientation")
+    assertFalse(screen.contains("id=\"cp-sizeMode\""), "screen omits component constraints")
+    assertFalse(screen.contains("data-cp-group=\"device\""), "screen has no duplicate Device panel")
+    listOf("id:pixel_5", "id:pixel_7", "id:pixel_fold", "id:pixel_tablet").forEach {
+      assertTrue(screen.contains("value=\"$it\""), "screen offers $it")
+    }
+
+    assertTrue(component.contains("id=\"cp-sizeMode\""), "component keeps size constraints")
+    assertTrue(component.contains("id=\"cp-fixedW\""), "component keeps fixed sizing")
+    assertTrue(component.contains("id=\"cp-minW\""), "component keeps minimum sizing")
+    assertTrue(component.contains("id=\"cp-maxW\""), "component keeps maximum sizing")
+    assertTrue(component.contains("data-cp-group=\"device\""), "component keeps its Device panel")
   }
 
   @Test

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -61,29 +61,22 @@
           <details class="cp-group" data-cp-group="size">
             <summary>Size</summary>
             <div class="cp-group-body">
-              <div class="cp-size">
-                <label>Size mode
-                  <select id="cp-sizeMode" disabled>
-                    <option value="">(default)</option>
-                    <option value="fixed">Fixed size</option>
-                    <option value="max">Max</option>
-                    <option value="min">Min</option>
-                    <option value="within">Within (min–max)</option>
-                  </select>
-                </label>
-                <div class="cp-size-row" id="cp-size-fixed" hidden>
-                  <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-                  <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-                </div>
-                <div class="cp-size-row" id="cp-size-min" hidden>
-                  <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-                  <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-                </div>
-                <div class="cp-size-row" id="cp-size-max" hidden>
-                  <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-                  <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-                </div>
-              </div>
+              <label>Device size
+                <select id="cp-device" disabled>
+                  <option value="">(preview default)</option>
+                  <option value="id:pixel_5">Pixel 5 · compact phone (393 × 851 dp)</option>
+                  <option value="id:pixel_7">Pixel 7 · standard phone (411 × 914 dp)</option>
+                  <option value="id:pixel_fold">Pixel Fold · foldable (841 × 701 dp)</option>
+                  <option value="id:pixel_tablet">Pixel Tablet · tablet (1280 × 800 dp)</option>
+                </select>
+              </label>
+              <label>Orientation
+                <select id="cp-orientation" disabled>
+                  <option value="">(device default)</option>
+                  <option value="portrait">Portrait</option>
+                  <option value="landscape">Landscape</option>
+                </select>
+              </label>
             </div>
           </details>
           
@@ -121,29 +114,7 @@
               </label>
             </div>
           </details>
-          <details class="cp-group" data-cp-group="device">
-            <summary>Device</summary>
-            <div class="cp-group-body">
-              <label>Device
-                <select id="cp-device" disabled>
-                  <option value="">(default)</option>
-                  <option value="id:pixel_5">Pixel 5</option>
-<option value="id:pixel_7">Pixel 7</option>
-<option value="id:pixel_tablet">Pixel Tablet</option>
-<option value="id:pixel_fold">Pixel Fold</option>
-<option value="id:wearos_small_round">Wear OS (small round)</option>
-<option value="id:tv_1080p">TV 1080p</option>
-                </select>
-              </label>
-              <label>Orientation
-                <select id="cp-orientation" disabled>
-                  <option value="">(default)</option>
-                  <option value="portrait">Portrait</option>
-                  <option value="landscape">Landscape</option>
-                </select>
-              </label>
-            </div>
-          </details>
+
           
           
           


### PR DESCRIPTION
## What changed

- detect full app-screen previews from their `Screens` catalog section
- move Device and Orientation into the Size panel for screens
- offer four varied Android presets: Pixel 5, Pixel 7, Pixel Fold, and Pixel Tablet
- retain Fixed/Min/Max/Within sizing and the existing Device panel for component previews
- update the viewer fixture and add regression coverage

## Why

Constraint-based sizing is useful for components, but full-screen previews are easier to evaluate against recognizable device surfaces. This avoids duplicate Size and Device panels for app screens while preserving the component workflow.

## Validation

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'`
- repository ktfmt and commit hooks