### PR TITLE
fix(bundle): honor semantics render timeout

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -89,6 +89,11 @@ internal class DaemonSemanticsFetcher(
         workspaceRoot = workspaceRoot.absoluteFile,
         workspaceName = workspaceRoot.name.ifBlank { moduleName },
         logSink = onLog,
+        // The daemon otherwise applies its fixed five-minute `host.submit(...)` deadline from the
+        // moment every render is queued. A wide sandbox-pooled catalog can leave tail requests in
+        // that queue for most of the window, so propagate the command's `--timeout` budget into
+        // the handshake as the effective per-render deadline (issue #3197).
+        maxRenderTime = renderTimeout,
       )
 
     val session: RenderSession =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -327,6 +327,21 @@ class DaemonSemanticsFetcherTest {
   }
 
   @Test
+  fun `render timeout is forwarded to the daemon session`() {
+    // Issue #3197: the fetcher honored --timeout while waiting for notifications, but the daemon
+    // still used its fixed 300-second host.submit deadline. Tail previews in a bounded sandbox pool
+    // therefore failed while queued even when the command was run with --timeout 600.
+    val projectDir = newTempFolder("semantics-daemon-timeout")
+    writeDescriptor(projectDir)
+    val factory = FakeFactory(produced = emptyMap())
+
+    DaemonSemanticsFetcher(factory = factory, renderTimeout = 600_000.milliseconds)
+      .fetch(projectDir = projectDir, moduleName = "sample", previewIds = listOf("Preview"))
+
+    assertEquals(600_000.milliseconds, factory.openedConfig?.maxRenderTime)
+  }
+
+  @Test
   fun `missing descriptor returns DescriptorMissing`() {
     val projectDir = newTempFolder("semantics-no-descriptor")
     val fetcher = DaemonSemanticsFetcher(factory = FakeFactory(emptyMap()))
@@ -372,9 +387,11 @@ class DaemonSemanticsFetcherTest {
     private val staggerMs: Long = 0,
   ) : RenderSessionFactory {
     override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+    var openedConfig: RenderSessionConfig? = null
 
-    override fun open(config: RenderSessionConfig): RenderSession =
-      FakeSession(
+    override fun open(config: RenderSessionConfig): RenderSession {
+      openedConfig = config
+      return FakeSession(
         workspaceRoot = config.workspaceRoot.absolutePath,
         produced = produced,
         fontsProduced = fontsProduced,
@@ -383,6 +400,7 @@ class DaemonSemanticsFetcherTest {
         staggerMs = staggerMs,
         dataRoot = File(config.workspaceRoot, "build/compose-previews/data"),
       )
+    }
   }
 
   private class OpenFailFactory : RenderSessionFactory {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -106,6 +106,7 @@ class DaemonClient(
     moduleProjectDir: String,
     capabilities: ClientCapabilities = ClientCapabilities(visibility = true, metrics = true),
     attachDataProducts: List<String>? = null,
+    maxRenderMs: Long? = null,
     timeout: Duration = 30.seconds,
   ): InitializeResult {
     val id = nextId.getAndIncrement()
@@ -117,13 +118,15 @@ class DaemonClient(
         moduleId = moduleId,
         moduleProjectDir = moduleProjectDir,
         capabilities = capabilities,
-        // D1 — only attach the option when the caller actually asked for ambient kinds; pre-D2
-        // daemons advertise nothing, so the daemon-side filter would silently drop these anyway,
-        // but keeping the field absent on `null` matches the `encodeDefaults = false` shape the
-        // rest of the protocol fixtures use.
+        // Keep options absent when the caller has no overrides. `encodeDefaults = false` then
+        // preserves the pre-options wire shape for ordinary interactive clients.
         options =
-          if (attachDataProducts.isNullOrEmpty()) null
-          else Options(attachDataProducts = attachDataProducts),
+          if (attachDataProducts.isNullOrEmpty() && maxRenderMs == null) null
+          else
+            Options(
+              attachDataProducts = attachDataProducts?.takeIf { it.isNotEmpty() },
+              maxRenderMs = maxRenderMs,
+            ),
       )
     val request =
       JsonRpcRequest(

--- a/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
+++ b/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
@@ -69,6 +69,12 @@ data class RenderSessionConfig(
   val logSink: (String) -> Unit = { System.err.println("[render-session] $it") },
   /** Upper bound on the initialize handshake. */
   val initializeTimeout: Duration = 60.seconds,
+  /**
+   * Optional per-render deadline advertised to the daemon during initialization. When absent, the
+   * daemon keeps its own default. Batch clients should set this to the same budget they expose to
+   * users so an internal `host.submit(...)` timeout cannot expire before the caller's wait does.
+   */
+  val maxRenderTime: Duration? = null,
 ) {
   companion object {
     private fun inferWorkspaceRoot(descriptorPath: File): File =

--- a/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
+++ b/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
@@ -138,6 +138,7 @@ object EmbeddedDesktopRenderSessions : RenderSessionFactory {
           workspaceRoot = canonicalRoot.absolutePath,
           moduleId = descriptor.modulePath,
           moduleProjectDir = descriptor.workingDirectory,
+          maxRenderMs = config.maxRenderTime?.inWholeMilliseconds,
           timeout = config.initializeTimeout,
         )
       } catch (e: Exception) {

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -68,6 +68,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
       workspaceName = config.workspaceName,
       canonicalRoot = canonicalRoot,
       initializeTimeout = config.initializeTimeout,
+      maxRenderTime = config.maxRenderTime,
       factory = factory,
     )
   }
@@ -157,6 +158,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
       workspaceName = canonicalRoot.name.ifBlank { "bundle" },
       canonicalRoot = canonicalRoot,
       initializeTimeout = initializeTimeout,
+      maxRenderTime = null,
       factory = factory,
     )
   }
@@ -167,6 +169,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
     workspaceName: String,
     canonicalRoot: File,
     initializeTimeout: Duration,
+    maxRenderTime: Duration?,
     factory: DaemonClientFactory,
   ): RenderSession {
     val project =
@@ -201,6 +204,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
           workspaceRoot = canonicalRoot.absolutePath,
           moduleId = descriptor.modulePath,
           moduleProjectDir = descriptor.workingDirectory,
+          maxRenderMs = maxRenderTime?.inWholeMilliseconds,
           timeout = initializeTimeout,
         )
       } catch (e: Exception) {


### PR DESCRIPTION
## What changed

- add an optional per-render deadline to `RenderSessionConfig`
- send that deadline as `initialize.options.maxRenderMs` for subprocess and embedded sessions
- make `bundle pack --with-semantics` propagate its `--timeout` value to the daemon
- add regression coverage proving a 600-second command timeout reaches the daemon session

## Root cause

`bundle pack --with-semantics` used `--timeout` only for the CLI's inactivity wait. The render-session initialize handshake did not forward that value, so the daemon retained its fixed 300-second `host.submit(...)` deadline. Because that deadline starts when each render is submitted, tail previews in a bounded sandbox pool could consume the deadline while queued and fail together at 300 seconds.

## Impact

A command run with `--timeout 600` now gives each daemon render the same 600-second budget, preventing the internal five-minute ceiling from prematurely dropping queued tail previews and their semantics sidecars.

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.DaemonSemanticsFetcherTest :render-session-subprocess:compileKotlin :render-session-embedded-desktop:compileKotlin`
- `./gradlew :mcp:test :render-session-subprocess:test :render-session-embedded-desktop:test :cli:ktfmtCheck :mcp:ktfmtCheck :render-session-api:ktfmtCheck :render-session-subprocess:ktfmtCheck :render-session-embedded-desktop:ktfmtCheck`

Closes #3197