### PR TITLE
fix(bundle): preserve semantics inactivity timeout

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -89,11 +89,11 @@ internal class DaemonSemanticsFetcher(
         workspaceRoot = workspaceRoot.absoluteFile,
         workspaceName = workspaceRoot.name.ifBlank { moduleName },
         logSink = onLog,
-        // The daemon otherwise applies its fixed five-minute `host.submit(...)` deadline from the
-        // moment every render is queued. A wide sandbox-pooled catalog can leave tail requests in
-        // that queue for most of the window, so propagate the command's `--timeout` budget into
-        // the handshake as the effective per-render deadline (issue #3197).
-        maxRenderTime = renderTimeout,
+        // The daemon's `host.submit(...)` deadline starts while each render is still queued. Let a
+        // long command timeout extend that deadline (issue #3197), but never let a short inactivity
+        // window reduce the daemon's five-minute default: doing so would make queued tail previews
+        // expire even while the fetcher continues to observe steady progress.
+        maxRenderTime = maxOf(renderTimeout, DEFAULT_RENDER_TIMEOUT),
       )
 
     val session: RenderSession =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -94,6 +94,10 @@ internal class DaemonSemanticsFetcher(
         // window reduce the daemon's five-minute default: doing so would make queued tail previews
         // expire even while the fetcher continues to observe steady progress.
         maxRenderTime = maxOf(renderTimeout, DEFAULT_RENDER_TIMEOUT),
+        // A genuinely stuck render must not add the subprocess backend's normal 15s shutdown RPC
+        // plus process-exit grace after this fetcher's inactivity timeout. Give the daemon a short
+        // graceful window, then let the subprocess owner terminate the outstanding render.
+        shutdownTimeout = SEMANTICS_SHUTDOWN_TIMEOUT,
       )
 
     val session: RenderSession =
@@ -297,5 +301,8 @@ internal class DaemonSemanticsFetcher(
      * single render may take before the daemon is presumed stalled, not a whole-batch budget.
      */
     val DEFAULT_RENDER_TIMEOUT = 300.seconds
+
+    /** Graceful close budget before a stalled one-shot semantics daemon is terminated. */
+    val SEMANTICS_SHUTDOWN_TIMEOUT = 2.seconds
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -327,7 +327,7 @@ class DaemonSemanticsFetcherTest {
   }
 
   @Test
-  fun `render timeout is forwarded to the daemon session`() {
+  fun `long render timeout is forwarded to the daemon session`() {
     // Issue #3197: the fetcher honored --timeout while waiting for notifications, but the daemon
     // still used its fixed 300-second host.submit deadline. Tail previews in a bounded sandbox pool
     // therefore failed while queued even when the command was run with --timeout 600.
@@ -339,6 +339,21 @@ class DaemonSemanticsFetcherTest {
       .fetch(projectDir = projectDir, moduleName = "sample", previewIds = listOf("Preview"))
 
     assertEquals(600_000.milliseconds, factory.openedConfig?.maxRenderTime)
+  }
+
+  @Test
+  fun `short inactivity timeout does not reduce the daemon render deadline`() {
+    // Review follow-up for #3198: host.submit starts its deadline while a render waits behind
+    // earlier previews. Forwarding a short inactivity window directly would therefore turn it
+    // back into a batch-wide cutoff for queued tail previews even when renders keep completing.
+    val projectDir = newTempFolder("semantics-short-daemon-timeout")
+    writeDescriptor(projectDir)
+    val factory = FakeFactory(produced = emptyMap())
+
+    DaemonSemanticsFetcher(factory = factory, renderTimeout = 150.milliseconds)
+      .fetch(projectDir = projectDir, moduleName = "sample", previewIds = listOf("Preview"))
+
+    assertEquals(300_000.milliseconds, factory.openedConfig?.maxRenderTime)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -34,6 +34,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
@@ -339,6 +340,7 @@ class DaemonSemanticsFetcherTest {
       .fetch(projectDir = projectDir, moduleName = "sample", previewIds = listOf("Preview"))
 
     assertEquals(600_000.milliseconds, factory.openedConfig?.maxRenderTime)
+    assertEquals(2.seconds, factory.openedConfig?.shutdownTimeout)
   }
 
   @Test
@@ -354,6 +356,7 @@ class DaemonSemanticsFetcherTest {
       .fetch(projectDir = projectDir, moduleName = "sample", previewIds = listOf("Preview"))
 
     assertEquals(300_000.milliseconds, factory.openedConfig?.maxRenderTime)
+    assertEquals(2.seconds, factory.openedConfig?.shutdownTimeout)
   }
 
   @Test

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.io.classpathArgFile
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import java.io.File
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -247,7 +248,7 @@ class SubprocessDaemonClientFactory : DaemonClientFactory {
   }
 }
 
-private class SubprocessDaemonSpawn(private val process: Process) : DaemonSpawn {
+internal class SubprocessDaemonSpawn(private val process: Process) : DaemonSpawn {
   private lateinit var _client: DaemonClient
 
   override val client: DaemonClient
@@ -274,5 +275,26 @@ private class SubprocessDaemonSpawn(private val process: Process) : DaemonSpawn 
       if (!process.waitFor(2, TimeUnit.SECONDS)) process.destroyForcibly()
     }
     runCatching { _client.close() }
+  }
+
+  override fun shutdown(timeout: Duration) {
+    require(!timeout.isNegative()) { "shutdown timeout must not be negative" }
+    val deadlineNanos = System.nanoTime() + timeout.inWholeNanoseconds
+
+    runCatching { _client.shutdownAndExit(timeout) }
+    waitForUntil(deadlineNanos)
+
+    if (process.isAlive) {
+      process.destroy()
+      waitForUntil(deadlineNanos)
+      if (process.isAlive) process.destroyForcibly()
+    }
+    runCatching { _client.close() }
+  }
+
+  private fun waitForUntil(deadlineNanos: Long) {
+    if (!process.isAlive) return
+    val remainingMillis = (deadlineNanos - System.nanoTime()).coerceAtLeast(0L) / 1_000_000L
+    if (remainingMillis > 0L) process.waitFor(remainingMillis, TimeUnit.MILLISECONDS)
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -786,6 +787,12 @@ interface DaemonSpawn {
   ): DaemonClient
 
   fun shutdown()
+
+  /**
+   * Shuts down within [timeout] when the owner has a stricter lifecycle budget. Implementations
+   * that do not own a subprocess retain their ordinary shutdown behaviour.
+   */
+  fun shutdown(timeout: Duration) = shutdown()
 }
 
 // -----------------------------------------------------------------------------

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/SubprocessDaemonSpawnTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/SubprocessDaemonSpawnTest.kt
@@ -1,0 +1,61 @@
+package ee.schimke.composeai.mcp
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
+import org.junit.Test
+
+class SubprocessDaemonSpawnTest {
+  @Test
+  fun `bounded shutdown force kills after one total deadline`() {
+    val process = NonTerminatingProcess()
+    val spawn = SubprocessDaemonSpawn(process)
+    spawn.client(onNotification = { _, _ -> }, onClose = {})
+
+    val startedNanos = System.nanoTime()
+    spawn.shutdown(50.milliseconds)
+    val elapsedMillis = (System.nanoTime() - startedNanos) / 1_000_000L
+
+    assertThat(process.forciblyDestroyed).isTrue()
+    assertThat(elapsedMillis).isLessThan(1_000L)
+  }
+
+  private class NonTerminatingProcess : Process() {
+    private val stdin = ByteArrayOutputStream()
+    private val stdout = ByteArrayInputStream(ByteArray(0))
+    private val stderr = ByteArrayInputStream(ByteArray(0))
+    private var alive = true
+
+    var forciblyDestroyed = false
+      private set
+
+    override fun getOutputStream(): OutputStream = stdin
+
+    override fun getInputStream(): InputStream = stdout
+
+    override fun getErrorStream(): InputStream = stderr
+
+    override fun waitFor(): Int = throw InterruptedException("process does not exit")
+
+    override fun waitFor(timeout: Long, unit: TimeUnit): Boolean {
+      Thread.sleep(unit.toMillis(timeout))
+      return false
+    }
+
+    override fun exitValue(): Int = throw IllegalThreadStateException("process is still running")
+
+    override fun destroy() = Unit
+
+    override fun destroyForcibly(): Process {
+      forciblyDestroyed = true
+      alive = false
+      return this
+    }
+
+    override fun isAlive(): Boolean = alive
+  }
+}

--- a/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
+++ b/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
@@ -75,6 +75,12 @@ data class RenderSessionConfig(
    * users so an internal `host.submit(...)` timeout cannot expire before the caller's wait does.
    */
   val maxRenderTime: Duration? = null,
+  /**
+   * Optional total budget for shutting down a subprocess-backed session. When absent, the backend
+   * keeps its normal graceful-shutdown policy. Short-lived batch clients may set this so a render
+   * that outlives their own inactivity timeout cannot add the backend's full shutdown grace.
+   */
+  val shutdownTimeout: Duration? = null,
 ) {
   companion object {
     private fun inferWorkspaceRoot(descriptorPath: File): File =

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -69,6 +69,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
       canonicalRoot = canonicalRoot,
       initializeTimeout = config.initializeTimeout,
       maxRenderTime = config.maxRenderTime,
+      shutdownTimeout = config.shutdownTimeout,
       factory = factory,
     )
   }
@@ -159,6 +160,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
       canonicalRoot = canonicalRoot,
       initializeTimeout = initializeTimeout,
       maxRenderTime = null,
+      shutdownTimeout = null,
       factory = factory,
     )
   }
@@ -170,6 +172,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
     canonicalRoot: File,
     initializeTimeout: Duration,
     maxRenderTime: Duration?,
+    shutdownTimeout: Duration?,
     factory: DaemonClientFactory,
   ): RenderSession {
     val project =
@@ -224,7 +227,9 @@ object SubprocessRenderSessions : RenderSessionFactory {
       client = client,
       notificationFanout = fanout,
       closeAction = {
-        runCatching { spawn.shutdown() }
+        runCatching {
+          if (shutdownTimeout == null) spawn.shutdown() else spawn.shutdown(shutdownTimeout)
+        }
         fanout.clear()
       },
     )


### PR DESCRIPTION
## What changed

- clamp the daemon per-render deadline to at least its existing five-minute default
- continue forwarding longer `bundle pack --with-semantics --timeout` values so large queued catalogs can extend the deadline
- add regression coverage for both the 600-second extension and a short 150ms inactivity window

## Why

Follow-up to #3198 and its unresolved review thread. The CLI timeout is an inactivity window, but the daemon's `host.submit(...)` deadline begins while renders are queued. Forwarding a short CLI timeout directly could therefore expire tail previews even while the batch continued making progress.

The CLI still uses the exact user value as its inactivity window; only the daemon's per-render deadline is floored at five minutes.

## Validation

- `./gradlew :cli:ktfmtFormat :cli:test --tests ee.schimke.composeai.cli.DaemonSemanticsFetcherTest`
- `./gradlew :cli:ktfmtCheck`
