### PR TITLE
fix(serve): align kotlinx-io for live bundles

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1270,11 +1270,11 @@ class ServeCommand(args: List<String>) : Command(args) {
   /**
    * Open a bundle-less daemon for a first-frame render, partitioning the snippet's [userClasspath]
    * the way the live path ([ServeBundleDaemon.materializePlaygroundSnippet]) does: jars in the
-   * namespaces `UserClassLoaderHolder` delegates to the parent (`androidx.*`, `kotlinx-coroutines`)
-   * must precede the [sidecarClasspath] on the daemon (parent) `-cp`, or the daemon loads its own
-   * sidecar versions and a snippet built against the catalog's newer AndroidX fails with
-   * `NoSuchMethodError`/`NoSuchFieldError` (and the render service then silently returns no image).
-   * The snippet's own classes stay isolated on the child (user) loader.
+   * namespaces `UserClassLoaderHolder` delegates to the parent (`androidx.*`, `kotlinx-coroutines`,
+   * `kotlinx-io`) must precede the [sidecarClasspath] on the daemon (parent) `-cp`, or the daemon
+   * loads its own sidecar versions and a snippet built against the catalog's newer shared ABI fails
+   * with `NoSuchMethodError`/`NoSuchFieldError` (and the render service then silently returns no
+   * image). The snippet's own classes stay isolated on the child (user) loader.
    */
   private fun openPlaygroundFirstFrameDaemon(
     sidecarClasspath: List<String>,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -367,8 +367,9 @@ internal object ServeBundleDaemon {
     }
 
     // Partition the resolved catalog jars exactly as the bundle path does: the namespaces
-    // UserClassLoaderHolder delegates to the daemon parent (androidx.*, kotlinx-coroutines) must
-    // *precede* the sidecar on the parent -cp, or the daemon loads its own (possibly older) sidecar
+    // UserClassLoaderHolder delegates to the daemon parent (androidx.*, kotlinx-coroutines,
+    // kotlinx-io) must *precede* the sidecar on the parent -cp, or the daemon loads its own
+    // (possibly older) sidecar
     // versions and a snippet/catalog composable built against the catalog's newer AndroidX fails
     // with NoSuchMethodError/NoSuchFieldError. Everything else — including the snippet's own
     // classes
@@ -677,7 +678,8 @@ internal object ServeBundleDaemon {
       (coordinate.group == "org.jetbrains.compose.components" &&
         coordinate.artifact.startsWith("components-resources")) ||
       (coordinate.group == "org.jetbrains.kotlinx" &&
-        coordinate.artifact.startsWith("kotlinx-coroutines"))
+        (coordinate.artifact.startsWith("kotlinx-coroutines") ||
+          coordinate.artifact.startsWith("kotlinx-io")))
 
   /**
    * The [shouldPrecedeDaemonSidecar] rule applied to a resolved **jar path** rather than a
@@ -686,14 +688,15 @@ internal object ServeBundleDaemon {
    * Maven-local (`…/androidx/compose/…`) and Gradle-cache (`…/androidx.compose.material3/…`)
    * layouts put the dotted/slashed group right after a path separator, so a `/androidx` segment
    * identifies the AndroidX graph, `components-resources` the Compose resources runtime, and
-   * `kotlinx-coroutines` the coroutines artifacts — the namespaces `UserClassLoaderHolder`
-   * delegates to the daemon parent.
+   * `kotlinx-coroutines` / `kotlinx-io` the kotlinx artifacts whose namespaces
+   * `UserClassLoaderHolder` delegates to the daemon parent.
    */
   internal fun jarPrecedesDaemonSidecar(jar: File): Boolean {
     val path = jar.path.replace('\\', '/')
     return path.contains("/androidx") ||
       path.contains("components-resources") ||
-      path.contains("kotlinx-coroutines")
+      path.contains("kotlinx-coroutines") ||
+      path.contains("kotlinx-io")
   }
 
   private data class ResolvedBundleDependency(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -204,6 +204,12 @@ class ServeBundleDaemonTest {
     )
     assertTrue(
       ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("org.jetbrains.kotlinx", "kotlinx-io-bytestring-jvm")
+      ),
+      "bundle kotlinx-io must win because the child delegates its packages to the daemon parent",
+    )
+    assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(
         coordinate("org.jetbrains.compose.components", "components-resources")
       ),
       "bundle resource APIs must share the parent-loaded LocalResourceReader with the daemon",
@@ -224,6 +230,11 @@ class ServeBundleDaemonTest {
     assertTrue(
       ServeBundleDaemon.jarPrecedesDaemonSidecar(
         File("/cache/org.jetbrains.compose.components/components-resources-desktop/library.jar")
+      )
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/cache/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.9.1/library.jar")
       )
     )
   }


### PR DESCRIPTION
## What changed

- Promote bundled `kotlinx-io` artifacts onto the live daemon parent classpath, alongside the existing AndroidX and coroutines ABI overlays.
- Apply the same classification to playground sessions that reconstruct dependencies from cached jar paths.
- Add regression coverage for both Maven-coordinate and jar-path classification.

## Root cause

`UserClassLoaderHolder` delegates every `kotlinx.*` class to the daemon parent. The live preview server only moved bundled coroutines artifacts ahead of daemon sidecars, leaving `kotlinx-io` in the child loader where it could never win. For bundles such as `meshcore-mobile`, the daemon therefore loaded an incompatible `ByteStringKt` and rendering failed with `NoSuchMethodError: ByteString()`.

## Impact

Live bundle and playground previews now use the producer bundle's compatible `kotlinx-io` ABI while keeping protocol serialization pinned to the daemon sidecar.

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeBundleDaemonTest --no-daemon --no-configuration-cache --console=plain`
- repository pre-commit `ktfmtCheckAll`
- `git diff --check`