### PR TITLE
fix(serve): scope kotlinx path matching

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -695,9 +695,15 @@ internal object ServeBundleDaemon {
     val path = jar.path.replace('\\', '/')
     return path.contains("/androidx") ||
       path.contains("components-resources") ||
-      path.contains("kotlinx-coroutines") ||
-      path.contains("kotlinx-io")
+      KOTLINX_SHARED_ARTIFACT_PATH.containsMatchIn(path)
   }
+
+  /** Matches Gradle-cache and Maven-local group layouts without inspecting unrelated path parts. */
+  private val KOTLINX_SHARED_ARTIFACT_PATH =
+    Regex(
+      "/(?:org\\.jetbrains\\.kotlinx|org/jetbrains/kotlinx)/" +
+        "kotlinx-(?:coroutines|io)(?:-[^/]+)?(?:/|$)"
+    )
 
   private data class ResolvedBundleDependency(
     val coordinate: BundleReader.ClasspathEntry.Maven,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -226,7 +226,7 @@ class ServeBundleDaemonTest {
   }
 
   @Test
-  fun `playground resource runtime overlays daemon sidecar`() {
+  fun `playground shared runtimes overlay daemon sidecar by artifact path`() {
     assertTrue(
       ServeBundleDaemon.jarPrecedesDaemonSidecar(
         File("/cache/org.jetbrains.compose.components/components-resources-desktop/library.jar")
@@ -236,6 +236,17 @@ class ServeBundleDaemonTest {
       ServeBundleDaemon.jarPrecedesDaemonSidecar(
         File("/cache/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.9.1/library.jar")
       )
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/m2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.9.1/library.jar")
+      )
+    )
+    assertTrue(
+      !ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/work/catalog-kotlinx-io-demo/cache/com.example/unrelated/library.jar")
+      ),
+      "a system or work-root name must not promote unrelated jars to the daemon parent",
     )
   }
 


### PR DESCRIPTION
## What changed

- Match playground `kotlinx-coroutines` and `kotlinx-io` overlays only beneath their actual `org.jetbrains.kotlinx` Maven/Gradle group path.
- Support both Gradle-cache (`org.jetbrains.kotlinx`) and Maven-local (`org/jetbrains/kotlinx`) layouts.
- Add a regression case proving a work root such as `catalog-kotlinx-io-demo` does not promote unrelated jars to the daemon parent.

## Root cause

PR #3204 initially detected playground `kotlinx-io` artifacts with a substring search across the entire absolute path. A system or work-root name containing `kotlinx-io` could therefore classify every nested class directory and unrelated library as a parent overlay, bypassing the disposable child loader and breaking dependency resolution.

## Impact

The live preview server retains the `kotlinx-io` ABI fix from #3204 without misclassifying unrelated catalog entries whose ancestor directories happen to contain that text.

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeBundleDaemonTest --no-daemon --no-configuration-cache --console=plain`
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest --console=plain`
- repository pre-commit `ktfmtCheckAll`

Follow-up to the actionable review thread on #3204, which arrived after that PR had already been merged.