### PR TITLE
test(vscode): filter interactive e2e renders to the fixture previews

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -83,6 +83,55 @@ import { RealGradleApi } from "../realGradleApi";
 const E2E = process.env.COMPOSE_PREVIEW_E2E === "1";
 const describeE2E = E2E ? describe : describe.skip;
 
+/**
+ * Preview-name filter (`-PcomposePreview.filter`, issue #2066) handed to
+ * every `gradlew` invocation this suite drives. Names exactly the previews
+ * the scenarios below display and assert on.
+ *
+ * Without it the disk assertions can't hold on CI hardware. `triggerRefresh`
+ * runs the production `composePreviewRenderAll`, which renders the *whole*
+ * module, and `gradleService` caps every Gradle task at `TASK_TIMEOUT_MS`
+ * (5 minutes) — `:samples:android` alone carries 160+ `@Preview`s behind
+ * Robolectric, so a cold full-module render is killed at the cap long before
+ * it reaches `TypographyGallery.kt`. The extension then behaves exactly as
+ * designed (`renderWithDiskFallback` paints the on-disk manifest and records
+ * a partial-render failure), which leaves scenario A's "every capture
+ * resolves to a PNG on disk" invariant a lottery over how far the truncated
+ * render happened to get — it lost 4 of 5 consecutive `main` runs.
+ *
+ * Filtering leaves the loop under test intact — real plugin, real
+ * Robolectric, real manifest, real panel — and only shrinks the render to
+ * something that finishes inside the cap, so the disk checks mean what they
+ * say. Only *rendering* is narrowed: `composePreviewDiscover` still writes
+ * the module's complete `previews.json`, so the id-set invariants (A2/A4)
+ * keep seeing every preview in the module, and unfiltered previews keep
+ * whatever PNGs they already had on disk. Full-module render coverage lives
+ * in the `cmp-smoke` shard (`e2e.test.ts`), which renders `:samples:cmp`
+ * unfiltered.
+ *
+ * Patterns are package-qualified so one can't substring-match a same-named
+ * preview elsewhere in the repo. A non-empty filter that matches *nothing*
+ * fails the render task outright, so every module this suite renders
+ * (`:samples:cmp`, `:samples:android`) must keep at least one entry here.
+ */
+const FIXTURE_PREVIEW_FILTER = [
+    // `samples/cmp/.../Previews.kt` — the cmp fixture every scenario
+    // refreshes on. The glob also covers scenario E's rename of
+    // `RedBoxPreview` → `RedBoxPreviewRenamed`.
+    "com.example.samplecmp.RedBoxPreview*",
+    "com.example.samplecmp.BlueBoxPreview",
+    "com.example.samplecmp.AppPreview",
+    "com.example.samplecmp.WallpaperDemoPreview",
+    "com.example.samplecmp.Pixel8SystemUiPreview",
+    // Scenario B appends `fun Interactive<timestamp>()` to that same file.
+    "com.example.samplecmp.Interactive*",
+    // `samples/android/.../TypographyGallery.kt` — the android fixture
+    // scenarios A/D/E switch to.
+    "com.example.sampleandroid.TypographySpecimenPreview",
+    "com.example.sampleandroid.FontFamilySpecimenPreview",
+    "com.example.sampleandroid.FallbackCoverageSpecimenPreview",
+];
+
 interface PostedMessage {
     command: string;
     [key: string]: unknown;
@@ -235,7 +284,9 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         assert.ok(exported, "activate() must return ComposePreviewTestApi");
         api = exported;
         api.injectGradleApi(
-            new RealGradleApi(repoRoot, (line) => console.log(line)),
+            new RealGradleApi(repoRoot, (line) => console.log(line), [
+                `-PcomposePreview.filter=${FIXTURE_PREVIEW_FILTER.join(",")}`,
+            ]),
         );
 
         await vscode.commands.executeCommand("composePreview.panel.focus");
@@ -348,7 +399,13 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         );
 
         // Invariant A3: every capture renderOutput resolves to a file under
-        // :samples:android's project dir and exists on disk.
+        // :samples:android's project dir and exists on disk. The
+        // "missing on disk" half only holds because `FIXTURE_PREVIEW_FILTER`
+        // keeps this module's render small enough to finish inside
+        // `gradleService`'s 5-minute task cap — if the whole set turns up
+        // missing, suspect a render killed at that cap (the log carries a
+        // `cancel :samples:android:composePreviewRenderAll` line ~300s after
+        // it started) before suspecting the panel.
         const androidBadCaptures: Array<{
             id: string;
             renderOutput: string;


### PR DESCRIPTION
## Summary

`VS Code Extension E2E (interactive-a-d)` has been red on `main` for **4 of its last 5 completed runs** — always on scenario A's invariant A3 (*"every android capture resolves to a PNG on disk"*), always with the same three `TypographyGallery.kt` specimens reported missing.

**The panel is behaving correctly.** `triggerRefresh` runs the production `composePreviewRenderAll`, which renders the *whole* module, and `gradleService` caps every Gradle task at `TASK_TIMEOUT_MS` (5 minutes). `:samples:android` carries 160+ `@Preview`s behind Robolectric, so a cold full-module render never finishes inside the cap — the job log shows the kill exactly 300s after the render starts, in **every** run, passing and failing alike:

| run | scenario A, android leg | A3 |
|---|---|---|
| [30793472887](https://github.com/yschimke/compose-ai-tools/actions/runs/30793472887) (fail) | `07:37:53` start → `07:42:53` `cancel :samples:android:composePreviewRenderAll` | ❌ 3 specimens missing |
| [30770175014](https://github.com/yschimke/compose-ai-tools/actions/runs/30770175014) (pass) | `22:43:40` start → `22:48:40` `cancel :samples:android:composePreviewRenderAll` | ✅ |

On that timeout `renderWithDiskFallback` paints the on-disk manifest and records a partial-render failure — exactly as designed — which leaves A3 a lottery over how far the truncated render happened to get before it was killed. Same story for the cmp legs; `cmp-smoke` and scenarios B/C survive only because their disk checks are looser (`pngs.length > 0`) or read a PNG a previous scenario already left behind.

## What changed

Hand the interactive suite a `-PcomposePreview.filter` (issue #2066) via `RealGradleApi`'s `extraArgs`, naming exactly the previews its two fixture files display, so the render is small enough to finish inside the cap and the disk assertions mean what they say:

- `samples/cmp/.../Previews.kt` — `RedBoxPreview*` (the glob covers scenario E's rename to `RedBoxPreviewRenamed`), `BlueBoxPreview`, `AppPreview`, `WallpaperDemoPreview`, `Pixel8SystemUiPreview`, plus `Interactive*` for the preview scenario B appends.
- `samples/android/.../TypographyGallery.kt` — the three specimen previews.

The loop under test is unchanged — real plugin, real Robolectric, real manifest, real panel. Only *rendering* is narrowed: `composePreviewDiscover` still writes each module's complete `previews.json`, so the id-set invariants (A2/A4) keep seeing every preview in the module, and unfiltered previews keep whatever PNGs they already had on disk. Full-module render coverage stays in the `cmp-smoke` shard, which renders `:samples:cmp` unfiltered.

A3 also picks up a note recording the dependency, so the next person to see the whole capture set turn up missing suspects a render killed at the cap before suspecting the panel.

## Test plan

- [x] `npm run compile` — clean.
- [x] `npm test` — 1622 passing.
- [x] `npm run format:check` — clean (also enforced by the `pre-commit` hook).
- [x] Filter patterns checked against `PreviewNameFilter`'s documented glob/substring semantics for all ten fixture preview FQNs (glob patterns full-match the package-qualified name; `com.example.samplecmp.RedBoxPreview*` matches both `RedBoxPreview` and `RedBoxPreviewRenamed`). A non-empty filter matching *nothing* fails the render task, and both rendered modules keep entries, so a mis-typed pattern fails loudly rather than silently rendering zero.
- [ ] `VS Code Extension E2E` on this PR — the real verification. It can't be run in a sandbox (no Android SDK, and the full suite is a ~40 min job), so the `interactive-a-d` and `interactive-e-g` shards here are the signal. Expect both green **and** materially faster, since the android leg no longer burns a doomed 300s.

Text-only PR: no rendered surface changes — this only narrows which previews the e2e harness asks Gradle to render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMcGNX8mDKbjWKX6BsP2cp)_