### PR TITLE
ci: run one cheap integration cell on PRs, the rest on main

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,6 +23,19 @@ name: Integration
 # Each external-repo job runs independently (`fail-fast: false`) so one broken
 # consumer does not mask regressions in the others.
 #
+# PRs run ONE cell, everything else runs on `main` + the nightly cron. The
+# matrix cell flagged `pr_blocking: true` — currently just `wear-os-samples
+# (ComposeStarter)` — is the only one that does build/discover/render work on
+# `pull_request`; `agp8-min` is skipped there too. ComposeStarter is both the
+# cheapest real cell and the widest one: measured on recent PR runs it takes
+# ~2.6 min (discover 53s + render 23s + daemon round-trip 34s) against
+# androidify ~3.4-4.1 min, nowinandroid ~3.4-3.6 min and agp8-min ~3.3-4.2 min,
+# while covering the full render pipeline, the daemon, and isolated-projects +
+# configuration-cache end-to-end. Every other cell still spins up on a PR (so
+# its check reports) but skips the expensive steps. The daily cron and pushes
+# to `main` run the full matrix, so consumer/AGP-floor drift still surfaces
+# within a day — it just doesn't sit on the PR critical path.
+#
 # Change-scoped on PRs (.github/ci/integration-safe-paths.json): the `changes` job
 # classifies the diff first. A PR that touches only paths which provably cannot
 # alter what the plugin discovers/renders in the external consumers — docs,
@@ -299,15 +312,20 @@ jobs:
             ref: main
             workdir: ComposeStarter
             module: app
-            # PR-blocking sample. All matrix cells run on the daily cron (drift
-            # signal against live upstream repos); on `pull_request` only the
-            # cells flagged `pr_blocking: true` do their build/discover/render
-            # work (gated at step level — see the `Discover`/`Verify`/`Render`
-            # steps below). The other cells still spin up but skip the expensive
-            # gradle steps, so their check still reports (branch-protection-safe)
-            # while ~5 external builds drop off the PR critical path. This cell is
-            # the widest coverage: full render pipeline + daemon round-trip +
-            # IP/CC end-to-end.
+            # THE PR cell — the only one flagged `pr_blocking: true`, so on
+            # `pull_request` this is the sole cell that does build/discover/
+            # render work (gated at step level — see the `Discover`/`Verify`/
+            # `Render` steps below). Every other cell still spins up but skips
+            # the expensive gradle steps, so its check still reports
+            # (branch-protection-safe) while the rest of the external builds
+            # drop off the PR critical path and run on push-to-main + the
+            # nightly cron instead.
+            #
+            # It earns the slot on both axes: cheapest real cell (~2.6 min
+            # measured, vs ~3.4-4.2 for androidify / nowinandroid / agp8-min)
+            # AND the widest coverage — full render pipeline + daemon
+            # round-trip + IP/CC end-to-end. Before adding a second
+            # `pr_blocking` cell, check it buys signal this one can't.
             pr_blocking: true
             # ComposeStarter enables isolated-projects + configuration-cache. The plugin used to
             # need `-Dorg.gradle.unsafe.isolated-projects=false -Dorg.gradle.isolated-projects
@@ -399,8 +417,11 @@ jobs:
             ref: main
             workdir: .
             module: app
-            # PR-blocking sample: a large modern single-module app.
-            pr_blocking: true
+            # Main-only (no `pr_blocking`): a large modern single-module app,
+            # ~3.4-4.1 min per run. Its coverage — a big AGP app configuring
+            # and discovering against the locally-published plugin — overlaps
+            # what the ComposeStarter PR cell already proves, so it rides the
+            # push-to-main + nightly-cron lane instead of the PR critical path.
             # No opt-outs after #1546's IP-cleanup pass (#1549 tracks the cross-project-metadata
             # follow-up). Re-add specific flags here (with a fresh comment naming the regression)
             # if the consumer's build surfaces a new CC / IP gap.
@@ -438,9 +459,11 @@ jobs:
             repo: android/nowinandroid
             ref: main
             workdir: .
-            # PR-blocking sample: flavored multi-module discovery (guards the
-            # #1546 variant-matching fix against a large real project).
-            pr_blocking: true
+            # Main-only (no `pr_blocking`): flavored multi-module discovery
+            # (guards the #1546 variant-matching fix against a large real
+            # project), ~3.4-3.6 min per run. The fix itself is pinned by unit
+            # tests in the plugin; this cell is the real-project confirmation,
+            # which the push-to-main + nightly lane catches within a day.
             # `:app` declares productFlavors `demo` / `prod` with build types
             # `debug` / `release`, so its variants are `demoDebug`, `prodDebug`,
             # `demoRelease`, `prodRelease` — no plain `debug`. `:app-nia-catalog`
@@ -1444,10 +1467,16 @@ jobs:
           key: android-all-instrumented-${{ runner.os }}-${{ matrix.slug }}-${{ steps.android-all.outputs.coordinate }}
 
   agp8-min:
-    # Consumes build-plugin's bundle, so it rides the same change-scope gate:
-    # skipped on out-of-scope PRs (not a required check, so a plain skip is
-    # fine — nothing needs to re-emit it).
-    if: ${{ needs.changes.outputs.run == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    # Main-only, like every non-`pr_blocking` matrix cell: PRs run just the
+    # ComposeStarter cell, and this job's three-phase BOM-floor dance costs
+    # ~3.3-4.2 min. Skipping it on `pull_request` is safe for branch protection
+    # because it is not a required check (nothing needs to re-emit it, unlike
+    # the two `wear-os-samples` legs the gate jobs above cover). AGP-floor
+    # drift surfaces on the next push to main / nightly cron.
+    #
+    # Also consumes build-plugin's bundle, so it rides the same change-scope
+    # gate: skipped on out-of-scope PRs too.
+    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.run == 'true' }}
     # Floor-coverage job for AGP 8.x consumers. Uses the in-repo fixture under
     # `.github/ci/fixtures/agp8-min/` (Gradle 8.13 + AGP 8.13.0 + Kotlin 2.0.21
     # + compileSdk 36) so we exercise the bottom of our publicly-supported

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -157,10 +157,14 @@ Consumer (what your project needs to apply the plugin):
   by tapmoc on every plugin/renderer build)
 - Compose Multiplatform 1.10.3+ (Desktop projects)
 
-The bottom edge is exercised end-to-end on every push by the `agp8-min`
-job in [`.github/workflows/integration.yml`](../.github/workflows/integration.yml)
+The bottom edge is exercised end-to-end on every push to `main` (plus the
+nightly cron) by the `agp8-min` job in
+[`.github/workflows/integration.yml`](../.github/workflows/integration.yml)
 against the fixture under
-[`.github/ci/fixtures/agp8-min/`](../.github/ci/fixtures/agp8-min/). The
+[`.github/ci/fixtures/agp8-min/`](../.github/ci/fixtures/agp8-min/). It does
+not run on pull requests — PRs run a single cheap integration cell
+(`wear-os-samples (ComposeStarter)`) and everything else in that workflow
+lands on `main`. The
 project's own build toolchain (what contributors use) is documented in
 [`AGENTS.md`](AGENTS.md) and is intentionally much newer than the
 consumer floor.


### PR DESCRIPTION
## Summary

`integration.yml` was doing real build/discover/render work for **three** matrix cells on every PR — `wear-os-samples (ComposeStarter)`, `androidify`, `nowinandroid` — plus the full three-phase `agp8-min` BOM-floor job. That's ~13 job-minutes of external builds sitting behind a ~4 min `build-plugin`, for coverage that overlaps heavily.

Now exactly **one** cell is PR-blocking, and everything else runs on push-to-`main` + the nightly cron.

### Why `wear-os-samples (ComposeStarter)` gets the slot

It wins on both axes — cheapest *and* widest. Measured from the last two successful in-scope PR runs ([`30794811185`](https://github.com/yschimke/compose-ai-tools/actions/runs/30794811185), [`30792880438`](https://github.com/yschimke/compose-ai-tools/actions/runs/30792880438)):

| PR job | duration | runs on PRs after this change |
| --- | --- | --- |
| `wear-os-samples (ComposeStarter)` | 2.6–2.7 min | ✅ yes |
| `nowinandroid` | 3.4–3.6 min | ❌ main + cron |
| `androidify` | 3.4–4.1 min | ❌ main + cron |
| `agp8-min (Gradle 8.13)` | 3.3–4.2 min | ❌ main + cron |
| `build-plugin` (dependency, unchanged) | 3.6–4.1 min | ✅ yes |

ComposeStarter's 2.6 min breaks down as discover 53s + render 23s + daemon round-trip 34s, and it covers the full render pipeline (`renderer-android` AAR resolution + Robolectric), the daemon spawn → render → edit → re-render loop, and isolated-projects + configuration-cache end-to-end. The cells being moved off the PR path prove narrower things — a large AGP app configuring (`androidify`), flavored multi-module variant matching (`nowinandroid`, itself pinned by plugin unit tests), and the AGP 8.x floor (`agp8-min`).

## Changes

- Drop `pr_blocking: true` from the `androidify` and `nowinandroid` matrix cells. They still spin up on PRs and report their check, but skip the expensive gradle steps — same shape as the five cells that were already non-blocking.
- Gate `agp8-min` on `github.event_name != 'pull_request'`. It is not a required status check, so a plain skip needs no gate job to re-emit it. The release-please clause in its `if:` is now redundant (those are PRs too) and drops out.
- Document the policy in the workflow header, on the ComposeStarter cell ("before adding a second `pr_blocking` cell, check it buys signal this one can't"), and in `docs/HOW_IT_WORKS.md`, which said the AGP floor was exercised "on every push".

## Branch protection

Unaffected. The two required contexts are `wear-os-samples (ComposeStarter)` and `wear-os-samples (WearTilesKotlin)`: the first still does real work, the second still reports from its skipped-step spin-up as it did before, and both `release-please-gate` / `integration-scope-gate` are untouched. Neither `androidify`, `nowinandroid`, nor `agp8-min` is a required check, and the first two keep posting their check runs regardless.

## Test plan

- [x] `yaml.safe_load` parses the workflow; `pr_blocking` is `True` on exactly one cell (ComposeStarter) and absent on the other seven.
- [x] `agp8-min` `if:` resolves to `github.event_name != 'pull_request' && needs.changes.outputs.run == 'true'`.
- [ ] This PR's own Integration run is the check: `agp8-min` skipped, `androidify` / `nowinandroid` green at ~0.1 min (spin-up only), `wear-os-samples (ComposeStarter)` green with discover + render + daemon steps actually executed.
- [ ] Post-merge, the push-to-`main` run exercises the full matrix + `agp8-min` as before.

No visual surfaces touched — CI wiring only.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FC68HeEsiXX7qABdUr2fj)_