### PR TITLE
fix(serve): park background theme optimization while catalogs load

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -23,6 +23,7 @@ import ee.schimke.composeai.cli.serve.PlaygroundSandbox
 import ee.schimke.composeai.cli.serve.PlaygroundSandboxProbe
 import ee.schimke.composeai.cli.serve.PlaygroundTokenStore
 import ee.schimke.composeai.cli.serve.RenderOutcome
+import ee.schimke.composeai.cli.serve.ServeBackgroundWork
 import ee.schimke.composeai.cli.serve.ServeBundle
 import ee.schimke.composeai.cli.serve.ServeBundleDaemon
 import ee.schimke.composeai.cli.serve.ServeBundleHost
@@ -508,6 +509,13 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val catalogRegistrationLock = Any()
 
   /**
+   * Server-wide admission for the catalogs' background theme optimization: it parks while any
+   * catalog is loading, and only one of them renders at a time. Shared by every catalog host this
+   * server opens — see [ServeBackgroundWork] for why both halves matter on a public box.
+   */
+  private val backgroundWork = ServeBackgroundWork()
+
+  /**
    * In-browser CMP tier (`--wasm-dir <system>=<dir>[,<system>=<dir>…]`): map a design system to the
    * assembled Wasm catalog app (`./gradlew :samples:cmp-wasm-catalog:wasmCatalogDist` →
    * `build/wasmDist`). Its viewer then offers a "Run in browser (Wasm)" toggle that mounts the app
@@ -943,6 +951,7 @@ class ServeCommand(args: List<String>) : Command(args) {
               perPreviewPoolStats = state.perPreviewPoolStats,
               catalogThemeCache = state.catalogThemeCache ?: CatalogThemeCache(),
               serverIdleMillis = state.serverIdleMillis,
+              backgroundWork = state.backgroundWork,
             )
             // Warm the daemon off the request path so the first browse already gets the per-variant
             // SVG lane instead of the baked fallback — critical for a slow-cold-starting Android
@@ -1857,6 +1866,12 @@ class ServeCommand(args: List<String>) : Command(args) {
     private val started = java.util.concurrent.atomic.AtomicBoolean(false)
     private val closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
+    init {
+      // Claimed at construction rather than at [start], so the window between the listener binding
+      // and the first catalog load isn't a gap the theme optimizer can start in.
+      backgroundWork.expectInitialCatalogLoad()
+    }
+
     fun start(onComplete: (Set<String>) -> Unit = {}) {
       if (!started.compareAndSet(false, true)) return
       executor.execute {
@@ -1894,6 +1909,9 @@ class ServeCommand(args: List<String>) : Command(args) {
           }
           System.err.println("serve: ${loads.startupSummary()}")
         } finally {
+          // However the pass ended — loaded, failed, or shut down mid-pass — background catalog
+          // work is free to start; leaving it claimed would park the optimizer forever.
+          backgroundWork.initialCatalogLoadFinished()
           if (!closed.get()) onComplete(loaded)
         }
       }
@@ -1901,6 +1919,7 @@ class ServeCommand(args: List<String>) : Command(args) {
 
     override fun close() {
       closed.set(true)
+      backgroundWork.initialCatalogLoadFinished()
       executor.shutdownNow()
     }
   }
@@ -2002,10 +2021,12 @@ class ServeCommand(args: List<String>) : Command(args) {
       configFile = catalogsFile,
       groups = catalogsConfig.groups,
       load = { system, repo ->
-        synchronized(catalogRegistrationLock) {
-          val result = store.load(system, sourceRepo = repo)
-          loads.record(result)
-          (result as? ServeCatalogStore.Result.Failed)?.reason
+        backgroundWork.whileLoadingCatalog {
+          synchronized(catalogRegistrationLock) {
+            val result = store.load(system, sourceRepo = repo)
+            loads.record(result)
+            (result as? ServeCatalogStore.Result.Failed)?.reason
+          }
         }
       },
       unload = { system ->
@@ -2051,13 +2072,14 @@ class ServeCommand(args: List<String>) : Command(args) {
     return ServeCatalogRefresher(
       entries = entries,
       reload = { system, repo ->
-        val result =
+        val result = backgroundWork.whileLoadingCatalog {
           synchronized(catalogRegistrationLock) {
             if (loads.configFor(system) == null) return@synchronized null
             val result = store.load(system, sourceRepo = repo)
             loads.record(result)
             result
           }
+        }
         if (result == null) {
           false
         } else if (result is ServeCatalogStore.Result.Failed) {
@@ -2145,7 +2167,8 @@ class ServeCommand(args: List<String>) : Command(args) {
           perPreviewRenderStats = perPreviewPool::renderPerfStats,
           perPreviewPoolStats = { listOf(perPreviewPool.snapshot()) },
           catalogThemeCache = CatalogThemeCache(),
-          serverIdleMillis = registry::idleMillis,
+          serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
+          backgroundWork = backgroundWork,
         ) ?: return false
     val host = openHost(state) ?: return false
     registry.register(system, state, host = host)
@@ -2229,7 +2252,8 @@ class ServeCommand(args: List<String>) : Command(args) {
         previewAliases = alias,
         bakedFallback = bakedFallback,
         catalogThemeCache = CatalogThemeCache(),
-        serverIdleMillis = registry::idleMillis,
+        serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
+        backgroundWork = backgroundWork,
         // A source-built Android/Robolectric catalog costs the same heavier live-seat weight as the
         // bundle path — read from the built daemon descriptor, since there's no bundle
         // manifest.backend here — so a from-source deployment keeps the OOM protection the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Server-wide admission for **background, best-effort catalog work** — today the catalog
+ * theme-cache optimizer ([ServeCatalogLiveHost]'s idle pass), which pre-renders every catalog
+ * preview under every declared theme so a later theme selection is instant.
+ *
+ * That work is worth doing and worth *never* doing at the expense of something a visitor is waiting
+ * for. Two things it must yield to, both learned from the deployed server:
+ *
+ * - **Catalog loading.** A public box brings its catalogs up one at a time, and each load fetches a
+ *   branch, resolves a live bundle's classpath and starts a render daemon. The optimizer reads the
+ *   registry's idle clock, which counts only *request* traffic — so on a freshly-rolled server with
+ *   no visitors yet, catalog #1's optimizer sees a perfectly idle server and starts hundreds of
+ *   renders while catalogs #2…#18 are still loading. Each loaded catalog adds another optimizer, so
+ *   the contention compounds: the later a catalog sits in the list, the longer its daemon waits for
+ *   a render slot, and a slow enough daemon start is recorded as `livebundle-unavailable` and
+ *   degrades the catalog to baked PNGs for the life of the process. [catalogsLoading] makes the
+ *   whole startup pass read as *busy* so the optimizer stays parked until the catalogs are up.
+ * - **Each other.** Once loading finishes, every catalog's optimizer becomes runnable at the same
+ *   instant. [withRenderPermit] caps the background lane at [maxConcurrentRenders] renders
+ *   server-wide (one by default), so the optimizers take turns instead of holding every live seat —
+ *   and a foreground render is never queued behind more than one background one.
+ *
+ * Both knobs are process-wide: one instance is built per `serve` run and shared by every catalog
+ * host it opens.
+ */
+class ServeBackgroundWork(maxConcurrentRenders: Int = 1) {
+  private val loadsInFlight = AtomicInteger()
+  private val initialLoadPending = AtomicBoolean(false)
+  private val renderPermits = Semaphore(maxConcurrentRenders.coerceAtLeast(1))
+
+  /**
+   * True while the server is bringing catalogs up: the startup pass hasn't finished, or a refresh /
+   * admin registration is fetching one right now. Background work treats this as "busy" even though
+   * no visitor is waiting, because a catalog that loads slowly enough loses its live lane.
+   */
+  val catalogsLoading: Boolean
+    get() = initialLoadPending.get() || loadsInFlight.get() > 0
+
+  /**
+   * Declare that a startup catalog pass is coming, before it starts. Called when the loader is
+   * built — not when it runs — so the window between "server up" and "first catalog load" is busy
+   * too, rather than a gap the optimizer can start in.
+   */
+  fun expectInitialCatalogLoad() {
+    initialLoadPending.set(true)
+  }
+
+  /** The startup pass is done (however it ended — loaded, failed, or shut down mid-pass). */
+  fun initialCatalogLoadFinished() {
+    initialLoadPending.set(false)
+  }
+
+  /** Run one catalog load, counted so background work stays parked for its duration. */
+  fun <T> whileLoadingCatalog(block: () -> T): T {
+    loadsInFlight.incrementAndGet()
+    try {
+      return block()
+    } finally {
+      loadsInFlight.decrementAndGet()
+    }
+  }
+
+  /**
+   * Wrap the registry's whole-server idle clock so a loading server reads as busy (`null`), which
+   * is how [ServeCatalogLiveHost]'s optimizer already spells "not now".
+   */
+  fun idleClock(idleMillis: () -> Long?): () -> Long? = {
+    if (catalogsLoading) null else idleMillis()
+  }
+
+  /**
+   * Run one background render under the server-wide permit. Returns null — and leaves the thread
+   * interrupted — when the wait was interrupted (shutdown), which the caller treats as "stop".
+   */
+  fun <T : Any> withRenderPermit(block: () -> T): T? {
+    try {
+      renderPermits.acquire()
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      return null
+    }
+    try {
+      return block()
+    } finally {
+      renderPermits.release()
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -89,6 +89,12 @@ class ServeCatalogLiveHost(
     System.getProperty("composeai.serve.warmInBackground")?.toBooleanStrictOrNull() ?: false,
   private val catalogThemeCache: CatalogThemeCache = CatalogThemeCache(),
   private val serverIdleMillis: () -> Long? = { Long.MAX_VALUE },
+  /**
+   * Server-wide admission for the idle theme optimizer below. Shared by every catalog host in a
+   * `serve` run, so their background passes take turns rather than each holding a live seat — see
+   * [ServeBackgroundWork].
+   */
+  private val backgroundWork: ServeBackgroundWork = ServeBackgroundWork(),
   private val themeOptimizationIdleMillis: Long =
     System.getProperty("composeai.serve.themeOptimizationIdleMillis")?.toLongOrNull() ?: 30_000L,
   private val clock: () -> Long = System::currentTimeMillis,
@@ -256,7 +262,11 @@ class ServeCatalogLiveHost(
           while (catalogThemeCache.get(job.cacheKey) == null && attempts < 3) {
             if (!awaitServerIdle()) return@execute
             catalogThemeCache.markRunning(clock())
-            val outcome = render(job.previewId, job.overrides)
+            // One background render server-wide: the permit is taken per job, not per pass, so a
+            // catalog that parks for traffic hands it straight to the next one.
+            val outcome =
+              backgroundWork.withRenderPermit { render(job.previewId, job.overrides) }
+                ?: return@execute
             if (outcome is RenderOutcome.Ok) break
             val daemonId = alias[job.previewId]
             if (

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -70,8 +70,12 @@ data class ServeSessionState(
   val catalogThemeCache: CatalogThemeCache? = null,
   /**
    * Whole-server idle clock used by background catalog optimization; null means traffic is active.
+   * The server wraps the registry clock in [ServeBackgroundWork.idleClock], so a catalog load in
+   * progress reads as active too.
    */
   val serverIdleMillis: () -> Long? = { Long.MAX_VALUE },
+  /** Server-wide admission for background catalog work (see [ServeBackgroundWork]). */
+  val backgroundWork: ServeBackgroundWork = ServeBackgroundWork(),
   /**
    * Optional reclaim hook invoked when the registry **removes** this session entirely — the
    * second-level GC of a long-idle *suspended* forked session (issue #2022), NOT ordinary

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
@@ -1,0 +1,128 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [ServeBackgroundWork] is the admission gate the catalogs' idle theme optimizer reads. Both halves
+ * exist because of the deployed public server: the *loading* gate keeps the optimizer from
+ * competing with catalog startup (which is when a live bundle's daemon is stood up, and a starved
+ * daemon start degrades that catalog to baked PNGs for the life of the process), and the render
+ * permit keeps every catalog's optimizer from becoming runnable at the same instant once loading
+ * ends.
+ */
+class ServeBackgroundWorkTest {
+
+  @Test
+  fun `a server is loading from the moment a startup pass is expected until it finishes`() {
+    val work = ServeBackgroundWork()
+    assertFalse(work.catalogsLoading, "a server with no catalogs is never loading")
+
+    work.expectInitialCatalogLoad()
+    assertTrue(work.catalogsLoading)
+
+    work.initialCatalogLoadFinished()
+    assertFalse(work.catalogsLoading)
+  }
+
+  @Test
+  fun `a refresh or admin registration counts as loading for its duration`() {
+    val work = ServeBackgroundWork()
+    work.initialCatalogLoadFinished()
+
+    val seenInside = work.whileLoadingCatalog { work.catalogsLoading }
+
+    assertTrue(seenInside, "the load itself must read as busy")
+    assertFalse(work.catalogsLoading, "and stop reading as busy once it returns")
+  }
+
+  @Test
+  fun `a load that throws still releases the gate`() {
+    val work = ServeBackgroundWork()
+    runCatching { work.whileLoadingCatalog { error("branch fetch failed") } }
+    assertFalse(work.catalogsLoading)
+  }
+
+  @Test
+  fun `the idle clock reports a loading server as busy and otherwise delegates`() {
+    val work = ServeBackgroundWork()
+    val clock = work.idleClock { 90_000L }
+
+    work.expectInitialCatalogLoad()
+    // Null is how the optimizer already spells "traffic is active" — startup borrows it, because
+    // the registry's own clock counts request traffic and sees a booting server as perfectly idle.
+    assertNull(clock())
+
+    work.initialCatalogLoadFinished()
+    assertEquals(90_000L, clock())
+  }
+
+  @Test
+  fun `the render permit admits one background render at a time`() {
+    val work = ServeBackgroundWork()
+    val inFlight = AtomicInteger()
+    val peak = AtomicInteger()
+    val done = CountDownLatch(4)
+    val pool = Executors.newFixedThreadPool(4)
+    try {
+      repeat(4) {
+        pool.execute {
+          work.withRenderPermit {
+            peak.accumulateAndGet(inFlight.incrementAndGet()) { a, b -> maxOf(a, b) }
+            Thread.sleep(25)
+            inFlight.decrementAndGet()
+          }
+          done.countDown()
+        }
+      }
+      assertTrue(done.await(10, TimeUnit.SECONDS), "background renders did not drain")
+    } finally {
+      pool.shutdownNow()
+    }
+
+    assertEquals(1, peak.get())
+  }
+
+  @Test
+  fun `an interrupted wait for the permit reports stop rather than rendering anyway`() {
+    val work = ServeBackgroundWork()
+    val held = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val holder = Thread {
+      work.withRenderPermit {
+        held.countDown()
+        release.await()
+      }
+    }
+    holder.start()
+    assertTrue(held.await(5, TimeUnit.SECONDS))
+
+    var rendered = false
+    var outcome: String? = "unset"
+    var interrupted = false
+    val waiter = Thread {
+      outcome = work.withRenderPermit { rendered = true }?.let { "ran" }
+      interrupted = Thread.currentThread().isInterrupted
+    }
+    waiter.start()
+    // Give the waiter a moment to actually block on the permit, then interrupt it the way shutdown
+    // does.
+    Thread.sleep(100)
+    waiter.interrupt()
+    waiter.join(5_000)
+
+    assertFalse(rendered, "an interrupted optimizer must not start another render")
+    assertNull(outcome)
+    assertTrue(interrupted, "the interrupt is left set so the caller's loop also exits")
+
+    release.countDown()
+    holder.join(5_000)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -12,6 +12,7 @@ import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -844,6 +845,80 @@ class ServeCatalogLiveHostTest {
     assertEquals(0, replacementLive.renderCalls)
     val cached = replacement.render(catalogId, themeOverride()) as RenderOutcome.Ok
     assertEquals(RenderOutcome.Generation.CATALOG_CACHE, cached.generation)
+  }
+
+  @Test
+  fun `idle optimizer stays parked until the server has finished loading its catalogs`() {
+    val backgroundWork = ServeBackgroundWork()
+    backgroundWork.expectInitialCatalogLoad()
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        // An idle server by the registry's reckoning — startup draws no request traffic, which is
+        // exactly how the optimizer used to end up competing with the catalogs still loading.
+        serverIdleMillis = backgroundWork.idleClock { Long.MAX_VALUE },
+        themeOptimizationIdleMillis = 0,
+        backgroundWork = backgroundWork,
+      )
+
+    composite.prewarm()
+    Thread.sleep(100)
+    assertEquals(0, live.renderCalls, "background renders must not run while catalogs load")
+    assertEquals("paused", composite.themeOptimizationSnapshot()?.state)
+
+    backgroundWork.initialCatalogLoadFinished()
+
+    assertTrue(awaitOptimization(composite).fullyOptimized)
+    assertEquals(1, live.renderCalls)
+  }
+
+  @Test
+  fun `catalog optimizers sharing one server render one at a time`() {
+    val inFlight = AtomicInteger()
+    val peak = AtomicInteger()
+    val backgroundWork = ServeBackgroundWork()
+    fun host(tag: String): ServeCatalogLiveHost {
+      val delegate =
+        RecordingHost(
+          previews = listOf(ServePreview(daemonId, daemonId)),
+          tag = tag,
+          declaredThemes = listOf(brandTheme, ServeTheme("Brand Light", "com.example.BrandLight")),
+        )
+      val counting =
+        object : ServeHost by delegate {
+          override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+            peak.accumulateAndGet(inFlight.incrementAndGet()) { a, b -> maxOf(a, b) }
+            try {
+              Thread.sleep(25)
+              return delegate.render(previewId, overrides)
+            } finally {
+              inFlight.decrementAndGet()
+            }
+          }
+        }
+      return ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = counting,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked-$tag"),
+        serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationIdleMillis = 0,
+        backgroundWork = backgroundWork,
+      )
+    }
+
+    val hosts = listOf(host("a"), host("b"), host("c"))
+    hosts.forEach { it.prewarm() }
+    hosts.forEach { assertTrue(awaitOptimization(it).fullyOptimized) }
+
+    assertEquals(1, peak.get(), "the background lane holds at most one render server-wide")
   }
 
   private fun awaitOptimization(host: ServeCatalogLiveHost): ThemeOptimizationSnapshot {

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -129,6 +129,28 @@ mixed theme-plus-knob renders remain in the daemon's bounded override cache rath
 this catalog-lifetime cache. Dynamic theme URLs remain `no-store`, preventing a browser or shared
 proxy from replaying old-catalog pixels after refresh.
 
+That cache is also filled **ahead of the first visitor**: while the server is idle, each catalog
+walks its `previews × declaredThemes` set and renders the missing entries, so a theme selection on a
+warm box is served from cache rather than waiting on a daemon. `/status` reports the pass per catalog
+(`themeOptimization`: `waiting` / `running` / `paused` / `complete`, plus cached/remaining counts).
+
+Being background work, it yields twice over — both learned from `preview.coo.ee`:
+
+- **It never runs while catalogs are loading.** A box brings its catalogs up one at a time, and each
+  load fetches a branch, resolves a live bundle's classpath and starts a render daemon. The idle
+  clock counts *request* traffic, so a freshly-rolled server with no visitors yet looks perfectly
+  idle — and the first catalog's optimizer used to start hundreds of renders while the remaining
+  catalogs were still loading, each loaded catalog adding another optimizer. The later a catalog sat
+  in the list, the longer its daemon start waited, and a slow enough start is recorded as
+  `livebundle-unavailable` — degrading that catalog to baked PNGs for the life of the process. The
+  whole startup pass (and any later refresh or admin registration) now reads as *busy*, so the
+  optimizers stay parked until the catalogs are up.
+- **Only one catalog optimizes at a time, server-wide.** Once loading ends every catalog's optimizer
+  becomes runnable at the same instant; the background lane holds a single render permit, so they
+  take turns instead of occupying every live seat, and a visitor's render is never queued behind
+  more than one background one. The permit is taken per render, so a catalog that parks for traffic
+  hands it straight to the next one.
+
 The grid is serial by default. Selecting an app-declared theme asks the server for a fixed,
 60-second page lease; at most one page server-wide receives a burst, clamped to five workers and
 the server's render-slot count. Other pages remain serial, queue completion/page exit releases the


### PR DESCRIPTION
## Summary

`preview.coo.ee` has been coming up **degraded** since 0.19.21, and staying that way for tens of minutes. Live `/status.json`, 21 minutes into an uptime:

```
status: "degraded"   uptimeSeconds: 1275
catalogs: total 18, loaded 11, pending 7, degraded 2
renderStats: 126 renders, coldRenders 36, avgMs 9884, firstRenderMs 68803
```

Seven catalogs (`reply`, both Confetti, `cadence`, both Pocket Casts, `horologist`) had never been *attempted*, and the gap between successive catalog loads grew steadily as the boot went on:

| # | catalog | gap from previous load |
|---|---|---|
| 2 | `wear-m3` | 39s |
| 3 | `remote-m3` | 33s |
| 4 | `meshcore-mobile` | 112s |
| 5 | `homeassistant-remotecompose` | 79s |
| 6 | `jetnews` | 124s |
| 7 | `jetcaster` | 95s |
| 8 | `jetcaster-wear` | 88s |
| 9 | `jetchat` | **191s** → `livebundle-unavailable` |
| 10 | `jetsnack` | **201s** |
| 11 | `jetlagged` | 170s → `livebundle-unavailable` |

Meanwhile four catalogs' theme optimizers were mid-pass (`meshcore-mobile` 224 renders remaining, `jetsnack` 198, `jetnews` 116, `wear-m3` 39).

### Cause

The catalog theme-cache optimizer added in #3206 parks on `ServeSessionRegistry.idleMillis()`, which counts **request** traffic only. A freshly-rolled public box has no visitors yet, so catalog #1's optimizer sees a perfectly idle server 30s in and starts hundreds of renders — while catalogs #2…#18 are still loading serially, each of which has to fetch a branch, resolve a live bundle's classpath and start a render daemon. Every catalog that loads adds another optimizer, so the contention compounds. A daemon start that is starved long enough is recorded as `livebundle-unavailable`, which degrades that catalog to baked PNGs **for the life of the process** — that's `jetchat` and `jetlagged` above.

### Fix

New `ServeBackgroundWork`, the server-wide admission gate for background catalog work. It yields twice over:

- **Catalog loading counts as busy.** The whole startup pass — plus any later refresh or admin registration — makes the idle clock read `null` (which is already how the optimizer spells "not now"), so optimizers stay parked until the catalogs are up. Claimed when the loader is *constructed*, released however the pass ends (loaded, failed, or shut down mid-pass), so there's no gap to start in and no way to park forever.
- **One background render server-wide.** Once loading ends, every catalog's optimizer becomes runnable at the same instant. The background lane now holds a single render permit, so they take turns instead of occupying every live seat, and a visitor's render is never queued behind more than one background one. The permit is taken per render, not per pass, so a catalog that parks for traffic hands it straight to the next one.

No behaviour change to what gets cached or when a warm box serves it — only to *when the filling is allowed to run*.

## Test plan

- `ServeBackgroundWorkTest` (new, 6 tests) — gate lifecycle, a load that throws still releases it, idle-clock delegation, permit serialization under 4 threads, and an interrupted permit wait reporting "stop" rather than rendering anyway.
- `ServeCatalogLiveHostTest` (2 new, 43 total) — the optimizer stays parked on an otherwise-idle server while catalogs load and completes once loading finishes; three hosts sharing one `ServeBackgroundWork` peak at exactly 1 concurrent render.
- `./gradlew :cli:test` green.

Text-only evidence is correct here: this changes background render admission, and no rendered surface.

## Not covered

- The **baseline** serial catalog load (~30–40s per catalog even uncontended, so ~10 min for 18) predates this regression and is untouched.
- `jetchat` / `jetlagged` may still lose their live lane on an 8 GB box for ordinary memory reasons — this removes the contention, not the underlying live-seat budget.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_