### PR TITLE
perf(serve): fetch catalog assets concurrently and stop pre-rendering themes

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -88,6 +88,21 @@ class ServeCatalogLiveHost(
   private val warmInBackground: Boolean =
     System.getProperty("composeai.serve.warmInBackground")?.toBooleanStrictOrNull() ?: false,
   private val catalogThemeCache: CatalogThemeCache = CatalogThemeCache(),
+  /**
+   * Whether to **eagerly** fill [catalogThemeCache] on the idle pass below — off by default.
+   *
+   * The pass renders `previews × declaredThemes` for every catalog: hundreds of daemon renders,
+   * server-wide, for pixels no visitor has asked for. Even parked behind [ServeBackgroundWork] it
+   * competes with the work that is actually on a request path, and on the public box it is what
+   * turned a quiet server into a permanently busy one. The *reactive* half of the cache is
+   * untouched and is where the value was: a theme a visitor actually selects is still cached on
+   * completion (see [cachedRender]), so re-selecting it stays instant.
+   *
+   * `-Dcomposeai.serve.themeOptimization=true` turns the eager pass back on for a deployment that
+   * wants it.
+   */
+  private val themeOptimizationEnabled: Boolean =
+    System.getProperty("composeai.serve.themeOptimization")?.toBooleanStrictOrNull() ?: false,
   private val serverIdleMillis: () -> Long? = { Long.MAX_VALUE },
   /**
    * Server-wide admission for the idle theme optimizer below. Shared by every catalog host in a
@@ -238,6 +253,10 @@ class ServeCatalogLiveHost(
 
   /** Fill every catalog-preview × declared-theme cache entry while the whole server is idle. */
   private fun startThemeOptimization() {
+    // Off by default — see [themeOptimizationEnabled]. Returning before `configureTargets` leaves
+    // the cache with no targets, so `themeOptimizationSnapshot()` reports null and `/status` shows
+    // no optimization row at all rather than one stuck at "waiting" forever.
+    if (!themeOptimizationEnabled) return
     val catalogIds =
       previews.asSequence().map { it.id }.filter(alias::containsKey).sorted().toList()
     val jobs = catalogIds.flatMap { previewId ->

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -164,6 +164,23 @@ class ServeCatalogStore(
     return previewIdFor(path)
   }
 
+  /**
+   * One declared baked image, resolved to everything the load loop needs *before* any fetch: its
+   * route-safe [id], the staged [target] it writes to (null when that path escaped the previews dir
+   * — planned anyway so it still counts as declared, then skipped), and the component context that
+   * tags its variant metadata. Planning separately from fetching is what lets the fetch run
+   * concurrently while the loop that consumes it stays sequential and order-preserving.
+   */
+  private data class PlannedImage(
+    val path: String,
+    val id: String,
+    val target: File?,
+    val image: Image,
+    val section: String?,
+    val group: String?,
+    val componentSourceFile: String?,
+  )
+
   sealed interface Result {
     data class Ok(val system: String, val previewCount: Int, val trust: String) : Result
 
@@ -227,48 +244,59 @@ class ServeCatalogStore(
     // for
     // renders that actually carry a state or theme; plain (stateless) previews stay out of the map.
     val variants = LinkedHashMap<String, VariantMeta>()
-    // Every baked image the loop below could ask for, in catalog order, fetched concurrently up
-    // front. The loop then reads bytes out of this map rather than blocking on one request at a
-    // time — the single change that takes a large catalog's load from minutes to seconds. Planning
-    // applies the same containment filter the loop does (so nothing extra is fetched) and stops at
-    // [maxImages], the same ceiling the loop enforces.
-    val plannedImageUrls =
-      catalog.components
-        .asSequence()
-        .flatMap { it.images.asSequence() }
-        .map { it.path }
-        .filter { path ->
-          path.startsWith("$IMAGES_DIR/") && path.endsWith(".png") && ".." !in path.split("/")
+    // Every baked image the catalog declares, flattened into catalog order with the component
+    // context each one needs, WITHOUT fetching anything yet. The same containment filter the
+    // original loop applied runs here (so nothing extra is ever requested); an image whose
+    // destination escapes the staged previews dir is planned with a null target so it still counts
+    // toward `declaredImages` and is then skipped, exactly as before.
+    val plannedImages =
+      catalog.components.flatMap { component ->
+        // The component's section/group tag every one of its previews (a component maps to one
+        // section + group), so the tabbed landing can bucket + sub-head + order them.
+        val section = component.section?.takeIf { it.isNotBlank() }
+        val group = component.group?.takeIf { it.isNotBlank() }
+        val componentSourceFile = component.sourceFile?.takeIf { it.isNotBlank() }
+        component.images.mapNotNull { image ->
+          val path = image.path
+          // Only image-directory PNGs; reject traversal. The path is from a trusted branch, but a
+          // containment check costs nothing and guards a compromised/garbled catalog.
+          val segments = path.split("/")
+          if (!path.startsWith("$IMAGES_DIR/") || !path.endsWith(".png") || ".." in segments)
+            return@mapNotNull null
+          val id = previewIdFor(path)
+          val target =
+            File(previewsDir, "$id.png").takeIf {
+              it.canonicalFile.toPath().startsWith(previewsRoot)
+            }
+          PlannedImage(path, id, target, image, section, group, componentSourceFile)
         }
-        .take(maxImages)
-        .map { base + it }
-        .toList()
-    val fetchedImages = fetchCatalogAssets(plannedImageUrls)
-    for (component in catalog.components) {
-      // The component's section/group tag every one of its previews (a component maps to one
-      // section + group), so the tabbed landing can bucket + sub-head + order them.
-      val section = component.section?.takeIf { it.isNotBlank() }
-      val group = component.group?.takeIf { it.isNotBlank() }
-      val componentSourceFile = component.sourceFile?.takeIf { it.isNotBlank() }
-      for (image in component.images) {
+      }
+
+    // Fetch in waves, each sized to the images still needed. [maxImages] caps *successes*, not
+    // attempts — a wave that comes back short is followed by another — so a catalog whose leading
+    // images are missing still serves the ones behind them, as the sequential loop did. Peak memory
+    // stays at the in-flight assets because the workers write straight to disk.
+    var planIndex = 0
+    while (planIndex < plannedImages.size && count < maxImages) {
+      val waveSize = minOf(IMAGE_FETCH_WAVE, maxImages - count)
+      val wave = plannedImages.subList(planIndex, minOf(plannedImages.size, planIndex + waveSize))
+      planIndex += wave.size
+      val written =
+        fetchCatalogAssetsToFiles(
+          wave.mapNotNull { planned -> planned.target?.let { (base + planned.path) to it } }
+        )
+      for (planned in wave) {
         if (count >= maxImages) break
-        val path = image.path
-        // Only image-directory PNGs; reject traversal. The path is from a trusted branch, but a
-        // containment check costs nothing and guards a compromised/garbled catalog.
-        val segments = path.split("/")
-        if (!path.startsWith("$IMAGES_DIR/") || !path.endsWith(".png") || ".." in segments) continue
-        // Counted BEFORE the fetch: it's what the catalog claims to publish, which is how the
-        // completeness check below tells "this catalog bakes nothing" (legal, all-deferred) apart
-        // from "this catalog bakes things and none of them fetched" (an outage — must not swap).
+        // Counted BEFORE the fetch is consulted: it's what the catalog claims to publish, which is
+        // how the completeness check below tells "this catalog bakes nothing" (legal, all-deferred)
+        // apart from "this catalog bakes things and none of them fetched" (an outage — must not
+        // swap).
         declaredImages++
-        val bytes = fetchedImages[base + path] ?: continue
-        val id = previewIdFor(path)
-        val target = File(previewsDir, "$id.png")
-        if (!target.canonicalFile.toPath().startsWith(previewsRoot)) continue
-        target.parentFile?.mkdirs()
-        target.writeBytes(bytes)
+        if (planned.target == null || (base + planned.path) !in written) continue
+        val id = planned.id
+        val image = planned.image
         slugs.add(id.substringBefore(SLUG_SEPARATOR))
-        path
+        planned.path
           .removePrefix("$IMAGES_DIR/")
           .removeSuffix(".png")
           .takeIf { it.count { char -> char == '/' } == 1 }
@@ -279,24 +307,24 @@ class ServeCatalogStore(
         // with the section/group tags — it exists purely to order the tabbed landing, so a plain
         // state/theme catalog (design systems) is unaffected and its manifest stays {state,theme}.
         // A catalog with neither state/theme nor a section records nothing and stays a flat grid.
-        val hasSectionInfo = section != null || group != null
+        val hasSectionInfo = planned.section != null || planned.group != null
         val props = image.props?.takeIf { it.isNotEmpty() }
         if (
           image.state != null ||
             image.theme != null ||
             props != null ||
             hasSectionInfo ||
-            componentSourceFile != null
+            planned.componentSourceFile != null
         ) {
           variants[id] =
             VariantMeta(
               state = image.state,
               theme = image.theme,
               props = props,
-              section = section,
-              group = group,
+              section = planned.section,
+              group = planned.group,
               order = if (hasSectionInfo) count else null,
-              sourceFile = componentSourceFile,
+              sourceFile = planned.componentSourceFile,
             )
         }
         count++
@@ -981,41 +1009,35 @@ class ServeCatalogStore(
         ".." !in segments &&
         segments.size in 1..2
     }
-    val fetchedSvgs = fetchCatalogAssets(safeCandidates.map { "$base$FIGMA_DIR/$it" })
-    val fetchedCrops =
-      fetchCatalogAssets(
-        safeCandidates.flatMap { relativePath ->
-          val svg = fetchedSvgs["$base$FIGMA_DIR/$relativePath"] ?: return@flatMap emptyList()
-          val remoteParent = relativePath.substringBeforeLast('/', missingDelimiterValue = "")
-          figmaRasterHrefs(svg.toString(Charsets.UTF_8))
-            .filter { it.isNotEmpty() && ".." !in it.split("/") }
-            .map { href ->
-              "$base$FIGMA_DIR/${if (remoteParent.isEmpty()) href else "$remoteParent/$href"}"
-            }
+    // Wave 1: the vectors themselves, written straight to disk by the workers (so a catalog's
+    // whole vector set is never resident at once) and path-contained before planning.
+    val writtenSvgs =
+      fetchCatalogAssetsToFiles(
+        safeCandidates.mapNotNull { relativePath ->
+          val svgFile = File(figmaDir, relativePath)
+          if (!svgFile.canonicalFile.toPath().startsWith(figmaRoot)) return@mapNotNull null
+          "$base$FIGMA_DIR/$relativePath" to svgFile
         }
       )
-    for (relativePath in safeCandidates) {
-      val svgBytes = fetchedSvgs["$base$FIGMA_DIR/$relativePath"] ?: continue
+    // Wave 2: the crops, which can only be discovered by reading wave 1 — a hybrid SVG names its
+    // `figma-raster/` crops inside its own markup, and raw.githubusercontent has no directory
+    // listing. Each vector is re-read from the file just written (a local read, one at a time)
+    // rather than held from the fetch.
+    val cropPlan = safeCandidates.flatMap { relativePath ->
       val svgFile = File(figmaDir, relativePath)
-      if (!svgFile.canonicalFile.toPath().startsWith(figmaRoot)) continue
-      svgFile.parentFile?.mkdirs()
-      svgFile.writeBytes(svgBytes)
-      wrote++
-      // A hybrid SVG references external `figma-raster/<node>.png` crops; carry them so the host
-      // can
-      // inline them. Enumerate from the SVG itself (raw.githubusercontent has no directory
-      // listing).
-      for (href in figmaRasterHrefs(svgBytes.toString(Charsets.UTF_8))) {
-        if (href.isEmpty() || ".." in href.split("/")) continue
+      if ("$base$FIGMA_DIR/$relativePath" !in writtenSvgs) return@flatMap emptyList()
+      val svg = runCatching { svgFile.readText() }.getOrNull() ?: return@flatMap emptyList()
+      val remoteParent = relativePath.substringBeforeLast('/', missingDelimiterValue = "")
+      figmaRasterHrefs(svg).mapNotNull { href ->
+        if (href.isEmpty() || ".." in href.split("/")) return@mapNotNull null
         val cropFile = File(svgFile.parentFile, href)
-        if (!cropFile.canonicalFile.toPath().startsWith(figmaRoot)) continue
-        val remoteParent = relativePath.substringBeforeLast('/', missingDelimiterValue = "")
+        if (!cropFile.canonicalFile.toPath().startsWith(figmaRoot)) return@mapNotNull null
         val remoteCrop = if (remoteParent.isEmpty()) href else "$remoteParent/$href"
-        val cropBytes = fetchedCrops["$base$FIGMA_DIR/$remoteCrop"] ?: continue
-        cropFile.parentFile?.mkdirs()
-        cropFile.writeBytes(cropBytes)
+        "$base$FIGMA_DIR/$remoteCrop" to cropFile
       }
     }
+    fetchCatalogAssetsToFiles(cropPlan)
+    wrote = writtenSvgs.size
     return if (wrote > 0) figmaDir else null
   }
 
@@ -1026,24 +1048,28 @@ class ServeCatalogStore(
   ) {
     if (references.isEmpty()) return
     val seen = HashSet<String>()
-    val fetchedRasters =
-      fetchCatalogAssets(
-        references
-          .filter { ServeDesignReferenceStore.isSafeRelativePath(it.raster.path) }
-          .map { "$base${it.raster.path}" }
-      )
-    val accepted = references.mapNotNull { reference ->
-      if (!ServeDesignReferenceStore.isSafeRelativePath(reference.raster.path))
-        return@mapNotNull null
-      val bytes = fetchedRasters["$base${reference.raster.path}"] ?: return@mapNotNull null
-      if (!ServeDesignReferenceStore.isValid(reference, bytes) || !seen.add(reference.id))
-        return@mapNotNull null
-      val localPath = "${ServeDesignReferenceStore.DIRECTORY}/${reference.id}.png"
-      val file = File(staging, localPath)
-      file.parentFile?.mkdirs()
-      file.writeBytes(bytes)
-      reference.copy(raster = reference.raster.copy(path = localPath))
-    }
+    // Rasters are the one lane that genuinely needs the bytes in hand — a reference is accepted
+    // only if its declared dimensions and optional sha256 check out ([ServeDesignReferenceStore]) —
+    // so this keeps the byte-returning fetch, run one bounded wave at a time. Peak memory is a
+    // wave,
+    // not the catalog's whole reference set.
+    val accepted =
+      references
+        .filter { ServeDesignReferenceStore.isSafeRelativePath(it.raster.path) }
+        .chunked(ASSET_FETCH_CONCURRENCY)
+        .flatMap { wave ->
+          val fetched = fetchCatalogAssets(wave.map { "$base${it.raster.path}" })
+          wave.mapNotNull { reference ->
+            val bytes = fetched["$base${reference.raster.path}"] ?: return@mapNotNull null
+            if (!ServeDesignReferenceStore.isValid(reference, bytes) || !seen.add(reference.id))
+              return@mapNotNull null
+            val localPath = "${ServeDesignReferenceStore.DIRECTORY}/${reference.id}.png"
+            val file = File(staging, localPath)
+            file.parentFile?.mkdirs()
+            file.writeBytes(bytes)
+            reference.copy(raster = reference.raster.copy(path = localPath))
+          }
+        }
     if (accepted.isEmpty()) return
     val referenceDir = File(staging, ServeDesignReferenceStore.DIRECTORY)
     referenceDir.mkdirs()
@@ -1390,6 +1416,13 @@ class ServeCatalogStore(
      * count times the per-asset cap, not by the catalog's size.
      */
     private const val ASSET_FETCH_CONCURRENCY = 12
+
+    /**
+     * Images planned per fetch wave. Each wave is additionally clamped to the images still needed,
+     * so the `maxImages` ceiling keeps counting *successes* — a wave that comes back short is
+     * followed by another rather than truncating the catalog.
+     */
+    private const val IMAGE_FETCH_WAVE = 64
     internal const val MAX_LIVE_BUNDLE_FETCH_BYTES = 100L * 1024 * 1024
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -1441,6 +1474,46 @@ class ServeCatalogStore(
    * of this map instead of blocking on each request in turn — so preview ids, `count`, and the
    * authored tab/group ordering are all computed exactly as before.
    */
+  /**
+   * Concurrent fetch that **never accumulates**: each worker writes its bytes straight to the
+   * planned destination and drops them, so peak memory is the in-flight assets (at most
+   * [ASSET_FETCH_CONCURRENCY] of them) rather than the whole catalog. Returns the urls that were
+   * both fetched and written.
+   *
+   * This is the form every bulk lane uses. Returning a `url → bytes` map instead would hold the
+   * entire catalog resident — with the 1000-image ceiling and the 25 MB per-asset cap that is a
+   * multi-gigabyte worst case, where the original sequential loop held exactly one asset at a time.
+   * Destinations are path-contained by the caller before planning, so a worker never writes outside
+   * the staged catalog.
+   */
+  private fun fetchCatalogAssetsToFiles(plan: List<Pair<String, File>>): Set<String> {
+    if (plan.isEmpty()) return emptySet()
+    val pool =
+      Executors.newFixedThreadPool(minOf(ASSET_FETCH_CONCURRENCY, plan.size)) { r ->
+        Thread(r, "serve-catalog-fetch").apply { isDaemon = true }
+      }
+    return try {
+      val inFlight = plan.map { (url, target) ->
+        url to
+          pool.submit<Boolean> {
+            val bytes = runCatching { fetchCatalogAsset(url) }.getOrNull() ?: return@submit false
+            runCatching {
+                target.parentFile?.mkdirs()
+                target.writeBytes(bytes)
+              }
+              .isSuccess
+          }
+      }
+      buildSet {
+        for ((url, future) in inFlight) {
+          if (runCatching { future.get() }.getOrNull() == true) add(url)
+        }
+      }
+    } finally {
+      pool.shutdown()
+    }
+  }
+
   private fun fetchCatalogAssets(urls: List<String>): Map<String, ByteArray> {
     val distinct = urls.distinct()
     if (distinct.size <= 1) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
 import java.security.MessageDigest
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipInputStream
 import kotlinx.serialization.Serializable
@@ -226,6 +227,23 @@ class ServeCatalogStore(
     // for
     // renders that actually carry a state or theme; plain (stateless) previews stay out of the map.
     val variants = LinkedHashMap<String, VariantMeta>()
+    // Every baked image the loop below could ask for, in catalog order, fetched concurrently up
+    // front. The loop then reads bytes out of this map rather than blocking on one request at a
+    // time — the single change that takes a large catalog's load from minutes to seconds. Planning
+    // applies the same containment filter the loop does (so nothing extra is fetched) and stops at
+    // [maxImages], the same ceiling the loop enforces.
+    val plannedImageUrls =
+      catalog.components
+        .asSequence()
+        .flatMap { it.images.asSequence() }
+        .map { it.path }
+        .filter { path ->
+          path.startsWith("$IMAGES_DIR/") && path.endsWith(".png") && ".." !in path.split("/")
+        }
+        .take(maxImages)
+        .map { base + it }
+        .toList()
+    val fetchedImages = fetchCatalogAssets(plannedImageUrls)
     for (component in catalog.components) {
       // The component's section/group tag every one of its previews (a component maps to one
       // section + group), so the tabbed landing can bucket + sub-head + order them.
@@ -243,7 +261,7 @@ class ServeCatalogStore(
         // completeness check below tells "this catalog bakes nothing" (legal, all-deferred) apart
         // from "this catalog bakes things and none of them fetched" (an outage — must not swap).
         declaredImages++
-        val bytes = runCatching { fetchCatalogAsset(base + path) }.getOrNull() ?: continue
+        val bytes = fetchedImages[base + path] ?: continue
         val id = previewIdFor(path)
         val target = File(previewsDir, "$id.png")
         if (!target.canonicalFile.toPath().startsWith(previewsRoot)) continue
@@ -953,17 +971,31 @@ class ServeCatalogStore(
       addAll(variantPaths)
       addAll(slugs.map { "$it.svg" })
     }
-    for (relativePath in candidates) {
+    // Same concurrent prefetch the baked images get, in two waves because the second is discovered
+    // by reading the first: a hybrid SVG names its `figma-raster/` crops inside its own markup, and
+    // raw.githubusercontent has no directory listing to enumerate them from.
+    val safeCandidates = candidates.filter { relativePath ->
       val segments = relativePath.split("/")
-      if (
-        relativePath.isEmpty() ||
-          !relativePath.endsWith(".svg") ||
-          ".." in segments ||
-          segments.size !in 1..2
+      relativePath.isNotEmpty() &&
+        relativePath.endsWith(".svg") &&
+        ".." !in segments &&
+        segments.size in 1..2
+    }
+    val fetchedSvgs = fetchCatalogAssets(safeCandidates.map { "$base$FIGMA_DIR/$it" })
+    val fetchedCrops =
+      fetchCatalogAssets(
+        safeCandidates.flatMap { relativePath ->
+          val svg = fetchedSvgs["$base$FIGMA_DIR/$relativePath"] ?: return@flatMap emptyList()
+          val remoteParent = relativePath.substringBeforeLast('/', missingDelimiterValue = "")
+          figmaRasterHrefs(svg.toString(Charsets.UTF_8))
+            .filter { it.isNotEmpty() && ".." !in it.split("/") }
+            .map { href ->
+              "$base$FIGMA_DIR/${if (remoteParent.isEmpty()) href else "$remoteParent/$href"}"
+            }
+        }
       )
-        continue
-      val svgBytes =
-        runCatching { fetchCatalogAsset("$base$FIGMA_DIR/$relativePath") }.getOrNull() ?: continue
+    for (relativePath in safeCandidates) {
+      val svgBytes = fetchedSvgs["$base$FIGMA_DIR/$relativePath"] ?: continue
       val svgFile = File(figmaDir, relativePath)
       if (!svgFile.canonicalFile.toPath().startsWith(figmaRoot)) continue
       svgFile.parentFile?.mkdirs()
@@ -979,8 +1011,7 @@ class ServeCatalogStore(
         if (!cropFile.canonicalFile.toPath().startsWith(figmaRoot)) continue
         val remoteParent = relativePath.substringBeforeLast('/', missingDelimiterValue = "")
         val remoteCrop = if (remoteParent.isEmpty()) href else "$remoteParent/$href"
-        val cropBytes =
-          runCatching { fetchCatalogAsset("$base$FIGMA_DIR/$remoteCrop") }.getOrNull() ?: continue
+        val cropBytes = fetchedCrops["$base$FIGMA_DIR/$remoteCrop"] ?: continue
         cropFile.parentFile?.mkdirs()
         cropFile.writeBytes(cropBytes)
       }
@@ -995,12 +1026,16 @@ class ServeCatalogStore(
   ) {
     if (references.isEmpty()) return
     val seen = HashSet<String>()
+    val fetchedRasters =
+      fetchCatalogAssets(
+        references
+          .filter { ServeDesignReferenceStore.isSafeRelativePath(it.raster.path) }
+          .map { "$base${it.raster.path}" }
+      )
     val accepted = references.mapNotNull { reference ->
       if (!ServeDesignReferenceStore.isSafeRelativePath(reference.raster.path))
         return@mapNotNull null
-      val bytes =
-        runCatching { fetchCatalogAsset("$base${reference.raster.path}") }.getOrNull()
-          ?: return@mapNotNull null
+      val bytes = fetchedRasters["$base${reference.raster.path}"] ?: return@mapNotNull null
       if (!ServeDesignReferenceStore.isValid(reference, bytes) || !seen.add(reference.id))
         return@mapNotNull null
       val localPath = "${ServeDesignReferenceStore.DIRECTORY}/${reference.id}.png"
@@ -1346,6 +1381,15 @@ class ServeCatalogStore(
 
     private const val DEFAULT_MAX_IMAGES = 1000
     private const val MAX_FETCH_BYTES = 25L * 1024 * 1024 // 25 MB per catalog asset
+
+    /**
+     * How many catalog assets to fetch at once ([fetchCatalogAssets]). Twelve measured as the knee
+     * against `raw.githubusercontent.com` — it takes the largest published catalog's 197 images
+     * from ~92 s to ~8 s — while staying far short of anything a single origin would consider a
+     * burst. Each worker holds one small response at a time, so the memory cost is bounded by this
+     * count times the per-asset cap, not by the catalog's size.
+     */
+    private const val ASSET_FETCH_CONCURRENCY = 12
     internal const val MAX_LIVE_BUNDLE_FETCH_BYTES = 100L * 1024 * 1024
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -1383,6 +1427,44 @@ class ServeCatalogStore(
   /** Fetch an ordinary catalog asset using the existing tight per-file envelope. */
   private fun fetchCatalogAsset(url: String): ByteArray? =
     if (fetch != null) fetch.invoke(url) else networkFetch(url, MAX_FETCH_BYTES)
+
+  /**
+   * Fetch [urls] **concurrently**, returning `url → bytes` for the ones that came back. A URL that
+   * fails, throws, or 404s is simply absent from the map — exactly the `null` every call site
+   * already treats as "skip this asset", so the fail-soft behaviour per asset is unchanged.
+   *
+   * Why this exists: a catalog's assets are individually tiny and numerous — jetsnack publishes 197
+   * baked PNGs totalling 12 MB, plus a comparable number of figma vectors. Fetched one at a time
+   * against `raw.githubusercontent.com` that is ~0.5 s of round-trip each and ~130 s for the
+   * catalog; fetched twelve at a time it is ~8 s, because the cost was never bandwidth. Ordering is
+   * preserved by the callers, which keep their original sequential loop and merely read bytes out
+   * of this map instead of blocking on each request in turn — so preview ids, `count`, and the
+   * authored tab/group ordering are all computed exactly as before.
+   */
+  private fun fetchCatalogAssets(urls: List<String>): Map<String, ByteArray> {
+    val distinct = urls.distinct()
+    if (distinct.size <= 1) {
+      val only = distinct.firstOrNull() ?: return emptyMap()
+      return runCatching { fetchCatalogAsset(only) }.getOrNull()?.let { mapOf(only to it) }
+        ?: emptyMap()
+    }
+    val pool =
+      Executors.newFixedThreadPool(minOf(ASSET_FETCH_CONCURRENCY, distinct.size)) { r ->
+        Thread(r, "serve-catalog-fetch").apply { isDaemon = true }
+      }
+    return try {
+      val inFlight = distinct.map { url ->
+        url to pool.submit<ByteArray?> { runCatching { fetchCatalogAsset(url) }.getOrNull() }
+      }
+      buildMap {
+        for ((url, future) in inFlight) {
+          runCatching { future.get() }.getOrNull()?.let { put(url, it) }
+        }
+      }
+    } finally {
+      pool.shutdown()
+    }
+  }
 
   /**
    * Fetch an executable bundle using the 100 MB envelope shared by uploaded and startup bundles. A

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -700,6 +700,7 @@ class ServeCatalogLiveHostTest {
         live = live,
         baked = baked,
         serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
         themeOptimizationIdleMillis = 0,
       )
 
@@ -741,6 +742,7 @@ class ServeCatalogLiveHostTest {
         baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
         warmInBackground = true,
         serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
         themeOptimizationIdleMillis = 0,
       )
 
@@ -789,6 +791,7 @@ class ServeCatalogLiveHostTest {
           perPreview
         },
         serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
         themeOptimizationIdleMillis = 0,
       )
 
@@ -815,6 +818,7 @@ class ServeCatalogLiveHostTest {
         baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
         catalogThemeCache = cache,
         serverIdleMillis = { if (idle.get()) Long.MAX_VALUE else null },
+        themeOptimizationEnabled = true,
         themeOptimizationIdleMillis = 0,
       )
 
@@ -865,6 +869,7 @@ class ServeCatalogLiveHostTest {
         // An idle server by the registry's reckoning — startup draws no request traffic, which is
         // exactly how the optimizer used to end up competing with the catalogs still loading.
         serverIdleMillis = backgroundWork.idleClock { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
         themeOptimizationIdleMillis = 0,
         backgroundWork = backgroundWork,
       )
@@ -909,6 +914,7 @@ class ServeCatalogLiveHostTest {
         live = counting,
         baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked-$tag"),
         serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
         themeOptimizationIdleMillis = 0,
         backgroundWork = backgroundWork,
       )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -52,8 +52,10 @@ class ServeCatalogStoreTest {
     }
   }
 
+  // `fetch` stays the LAST parameter so the trailing-lambda call sites below keep binding to it.
   private fun store(
     trust: TrustStore,
+    maxImages: Int = 1000,
     fetch: (String) -> ByteArray? = fetcher(),
   ): ServeCatalogStore =
     ServeCatalogStore(
@@ -62,7 +64,48 @@ class ServeCatalogStoreTest {
       trust = { trust },
       fetch = fetch,
       registerWasm = { s, d -> registeredWasm[s] = d },
+      maxImages = maxImages,
     )
+
+  @Test
+  fun `a missing leading image does not cost the catalog the images behind it`() {
+    // The image cap counts previews actually served, not fetch attempts. With a cap of two and a
+    // first image that 404s, the catalog must still serve the two behind it — planning the fetch up
+    // front must not turn the ceiling into "the first two declared".
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    val missing = "images/button-filled/ideal__default__dark.png"
+    val result =
+      store(
+          trust,
+          fetch = { url ->
+            when {
+              url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+                threeImageCatalogJson.toByteArray()
+              url.endsWith(missing) -> null
+              url.endsWith(".png") -> png()
+              else -> null
+            }
+          },
+          maxImages = 2,
+        )
+        .load("compose-m3")
+
+    assertEquals(2, (result as ServeCatalogStore.Result.Ok).previewCount)
+  }
+
+  /** Three baked images across one component, so a cap of two leaves something behind it. */
+  private val threeImageCatalogJson =
+    """
+    {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+      {"componentId":"Button/Filled","images":[
+        {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"},
+        {"path":"images/button-filled/ideal__default__light.png","theme":"light"},
+        {"path":"images/button-filled/ideal__hover__light.png","theme":"light"}]}]}
+    """
+      .trimIndent()
 
   @Test
   fun `a catalog from a trusted branch is served and attributed by origin`() {
@@ -179,7 +222,9 @@ class ServeCatalogStoreTest {
       }
     }
 
-    assertTrue(store(TrustStore.EMPTY, fetch).load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertTrue(
+      store(TrustStore.EMPTY, fetch = fetch).load("compose-m3") is ServeCatalogStore.Result.Ok
+    )
 
     val reference = registered.getValue("compose-m3").designReferencesFor("button").single()
     assertEquals("button-design", reference.id)
@@ -237,7 +282,7 @@ class ServeCatalogStoreTest {
         else -> null
       }
     }
-    store(TrustStore.EMPTY, fetch).load("compose-m3")
+    store(TrustStore.EMPTY, fetch = fetch).load("compose-m3")
 
     val host = registered.getValue("compose-m3")
     val ok =
@@ -1198,7 +1243,7 @@ class ServeCatalogStoreTest {
   @Test
   fun `a complete catalog webRender fetches the wasm app and registers its dir`() {
     val catalog = wasmCatalog("\"index.html\",\"composeApp.wasm\",\"skiko.wasm\"")
-    store(TrustStore.EMPTY, wasmFetcher(catalog)).load("compose-m3")
+    store(TrustStore.EMPTY, fetch = wasmFetcher(catalog)).load("compose-m3")
 
     val wasmDir = registeredWasm.getValue("compose-m3")
     assertTrue(File(wasmDir, "index.html").isFile, "index.html landed")
@@ -1216,7 +1261,7 @@ class ServeCatalogStoreTest {
   fun `a webRender with a failed required-file fetch registers nothing (fail closed)`() {
     val catalog = wasmCatalog("\"index.html\",\"composeApp.wasm\",\"skiko.wasm\"")
     // composeApp.wasm 404s → the app is incomplete → don't advertise a tier whose iframe would 404.
-    store(TrustStore.EMPTY, wasmFetcher(catalog, missing = setOf("composeApp.wasm")))
+    store(TrustStore.EMPTY, fetch = wasmFetcher(catalog, missing = setOf("composeApp.wasm")))
       .load("compose-m3")
     assertTrue(registeredWasm.isEmpty(), "incomplete app must not register")
     // With no live lane (Wasm failed to register, no liveBundle), the session IS baked-only and

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -129,12 +129,16 @@ mixed theme-plus-knob renders remain in the daemon's bounded override cache rath
 this catalog-lifetime cache. Dynamic theme URLs remain `no-store`, preventing a browser or shared
 proxy from replaying old-catalog pixels after refresh.
 
-That cache is also filled **ahead of the first visitor**: while the server is idle, each catalog
-walks its `previews × declaredThemes` set and renders the missing entries, so a theme selection on a
-warm box is served from cache rather than waiting on a daemon. `/status` reports the pass per catalog
+The cache can also be filled **ahead of the first visitor** — an idle pass that walks each catalog's
+`previews × declaredThemes` set and renders the missing entries — but that pass is **off by
+default**. It is hundreds of daemon renders per catalog for pixels nobody has asked for, and on the
+public box it is what turned a quiet server into a permanently busy one. The reactive half is where
+the value was and is unchanged: a theme a visitor actually selects is cached on completion, so
+re-selecting it is instant. Turn the eager pass on with
+`-Dcomposeai.serve.themeOptimization=true`; when it runs, `/status` reports it per catalog
 (`themeOptimization`: `waiting` / `running` / `paused` / `complete`, plus cached/remaining counts).
 
-Being background work, it yields twice over — both learned from `preview.coo.ee`:
+When enabled, it yields twice over — both learned from `preview.coo.ee`:
 
 - **It never runs while catalogs are loading.** A box brings its catalogs up one at a time, and each
   load fetches a branch, resolves a live bundle's classpath and starts a render daemon. The idle


### PR DESCRIPTION
Follow-up to #3220. That fix stopped background theme renders from starving catalog startup, and it worked — `preview.coo.ee` on 0.19.22 reports `status: "ok"`, `degraded: 0`, every optimizer `paused`, `renderStats: null`, and jetchat's live lane recovered. But catalogs still take ~80s each to load, so the box is still ~24 minutes from a complete front door.

## Why it was slow

Per-catalog load time tracks preview count almost linearly:

| catalog | previews | load |
|---|---|---|
| remote-m3 | 24 | 30s |
| jetcaster-wear | 33 | 32s |
| wear-m3 | 43 | 43s |
| homeassistant | 62 | 68s |
| jetcaster | 150 | 74s |
| jetchat | 155 | 85s |
| meshcore-mobile | 175 | 110s |
| jetnews | 154 | 115s |
| jetsnack | 197 | 132s |

That's ~0.6s per preview — one blocking HTTPS GET per asset, in series. Measured against the real branch:

| | |
|---|---|
| 20 images, serial (what the server does) | **9.4s** → ~0.47s each |
| **all 197 images, 12-way parallel** | **8.3s** |
| total payload for all 197 | **12.0 MB** |

The cost was never bandwidth or data volume — only round-trip serialization. (A whole-branch archive isn't an option: the `design-artifacts` branch also carries the live bundle and wasm app, so its tarball runs past 1 GB.)

## Two commits

**1. `perf(serve): fetch catalog assets concurrently`** — new `fetchCatalogAssets` does a bounded 12-way fetch returning `url → bytes`, omitting anything that failed, which is the `null` every call site already treats as "skip this asset". The three per-asset loops (baked images, figma SVGs + their raster crops, design-reference rasters) keep their original sequential structure and read out of that map, so preview ids, the declared/usable counts, the staging completeness check and the authored tab/group ordering are computed exactly as before. The figma lane prefetches in two waves because the second is discovered by reading the first — a hybrid SVG names its crops inside its own markup, and raw.githubusercontent has no directory listing.

**2. `fix(serve): stop pre-rendering every catalog theme by default`** — the idle theme pass is hundreds of daemon renders per catalog for pixels nobody asked for, and it guesses which themes someone will select. Now behind `-Dcomposeai.serve.themeOptimization=true`, default off. The reactive half is untouched and is where the value was: a theme a visitor actually selects is still cached on completion, so re-selecting it stays instant. With the pass off no targets are configured, so `/status` shows no optimization row rather than one stuck at `waiting`.

## Test plan

- `./gradlew :cli:test --tests '*ServeCatalogStoreTest*' --tests '*ServeCatalogLiveHostTest*'` — **82 tests, 0 failures**. The 39 catalog-store tests exercise every rewritten fetch path (trust attribution, traversal rejection, staging/swap, deferred ids, wasm, references, live bundle).
- The optimizer's 6 tests opt in explicitly, so the eager pass keeps its coverage.
- `:cli:ktfmtCheckMain` / `:cli:ktfmtCheckTest` clean.

Text-only evidence is correct here: this changes asset fetching and background render admission, not any rendered surface.

## Next

This is the "parallel first" half. The follow-up makes startup seconds rather than minutes, by not fetching the bulk at startup at all:

1. `catalog.json` eager — it alone names every card, and publishes the catalog
2. hero image eager, so the front door paints
3. each catalog's default pre-baked previews in the background, using this PR's concurrent fetcher
4. remaining variants on demand
5. the catalog grid defaults to its pre-baked theme; the sticky theme belongs to the individual preview, not the grid


---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_