### PR TITLE
perf(serve): fill a catalog's baked vectors after it publishes

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -556,10 +556,13 @@ class ServeBundleHost(
     cropCache[previewId]?.let {
       return it.orElse(null)
     }
-    // A declared preview whose pixels haven't arrived yet has no crop *yet* — answer null without
-    // memoising, so the card starts cropping as soon as its PNG lands rather than staying uncropped
-    // until the next catalog refresh. Only a decision made against real pixels is cached.
+    // A crop needs both the PNG and the component's vector, and either can still be in flight: the
+    // PNG fills on first use, and the vectors are filled by a background pass after the catalog
+    // publishes. Answer null without memoising while either is outstanding, so the card starts
+    // cropping as soon as they land rather than staying uncropped until the next catalog refresh.
+    // Only a decision made against files that are actually present is cached.
     if (localBakedPng(previewId) == null && previewId in declaredBakedIds) return null
+    if (figmaDir != null && figmaSvgFileFor(previewId) == null) return null
     val computed = java.util.Optional.ofNullable(computeContentCrop(previewId))
     cropCache[previewId] = computed
     return computed.orElse(null)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -478,14 +478,19 @@ class ServeCatalogStore(
     // request path: probe one vector synchronously to learn whether this branch carries the lane at
     // all, then fill the rest in the background while the catalog is already serving. Cards render
     // uncropped for those few seconds and crop themselves once the pass lands.
-    // Probe the hero's vector, falling back to the first declared preview: most catalogs name no
-    // `display.hero`, and probing nothing would strip the SVG lane from every one of them.
-    val figmaProbeId =
-      heroPreviewIdFor(catalog, bakedPathById.keys) ?: bakedPathById.keys.firstOrNull()
-    val figmaDir = probeFigmaSvg(heroSvgCandidates(figmaProbeId), base, dir)
-    if (figmaDir != null) {
-      scheduleFigmaSvgFetch(system, generation, slugs, variantSvgPaths, base, dir)
-    }
+    // Probe a handful of components, hero first — not just one. A vector is published per
+    // component and any of them may legitimately have none, so a single miss says nothing about
+    // the branch; the bulk path this replaces enabled the lane if *any* candidate landed. Spread
+    // across distinct slugs so the sample is about the branch rather than one component.
+    val figmaProbeIds =
+      (listOfNotNull(heroPreviewIdFor(catalog, bakedPathById.keys)) + bakedPathById.keys)
+        .distinctBy { it.substringBefore(SLUG_SEPARATOR) }
+        .take(FIGMA_PROBE_SLUGS)
+    val figmaDir = probeFigmaSvg(figmaProbeIds.flatMap(::heroSvgCandidates), base, dir)
+    // Scheduled unconditionally: a probe that found nothing is not proof the branch carries none —
+    // the vectors may simply start at a component the sample missed. Filling anyway means the lane
+    // turns on at the next host build instead of being lost until someone republishes.
+    scheduleFigmaSvgFetch(system, generation, slugs, variantSvgPaths, base, dir)
 
     // The catalog's OWN palette, so its pages are framed in its own colours (see [ServeThemeCss]).
     // A few kB of JSON off the same branch as the images, and best-effort throughout: a missing /
@@ -1089,11 +1094,13 @@ class ServeCatalogStore(
     // whole vector set is never resident at once) and path-contained before planning.
     val writtenSvgs =
       fetchCatalogAssetsToFiles(
-        safeCandidates.mapNotNull { relativePath ->
-          val svgFile = File(figmaDir, relativePath)
-          if (!svgFile.canonicalFile.toPath().startsWith(figmaRoot)) return@mapNotNull null
-          "$base$FIGMA_DIR/$relativePath" to svgFile
-        }
+        stillWanted = stillCurrent,
+        plan =
+          safeCandidates.mapNotNull { relativePath ->
+            val svgFile = File(figmaDir, relativePath)
+            if (!svgFile.canonicalFile.toPath().startsWith(figmaRoot)) return@mapNotNull null
+            "$base$FIGMA_DIR/$relativePath" to svgFile
+          },
       )
     // Wave 2: the crops, which can only be discovered by reading wave 1 — a hybrid SVG names its
     // `figma-raster/` crops inside its own markup, and raw.githubusercontent has no directory
@@ -1113,7 +1120,7 @@ class ServeCatalogStore(
         "$base$FIGMA_DIR/$remoteCrop" to cropFile
       }
     }
-    fetchCatalogAssetsToFiles(cropPlan)
+    fetchCatalogAssetsToFiles(cropPlan, stillWanted = stillCurrent)
     wrote = writtenSvgs.size
     return if (wrote > 0) figmaDir else null
   }
@@ -1142,15 +1149,14 @@ class ServeCatalogStore(
   private fun probeFigmaSvg(candidates: List<String>, base: String, dir: File): File? {
     val figmaDir = File(dir, FIGMA_DIR)
     val figmaRoot = figmaDir.canonicalFile.toPath()
-    for (relativePath in candidates) {
+    val plan = candidates.mapNotNull { relativePath ->
       val svgFile = File(figmaDir, relativePath)
-      if (!svgFile.canonicalFile.toPath().startsWith(figmaRoot)) continue
-      if (
-        fetchCatalogAssetsToFiles(listOf(("$base$FIGMA_DIR/$relativePath") to svgFile)).isNotEmpty()
-      )
-        return figmaDir
+      if (!svgFile.canonicalFile.toPath().startsWith(figmaRoot)) return@mapNotNull null
+      "$base$FIGMA_DIR/$relativePath" to svgFile
     }
-    return null
+    // One concurrent wave, so a catalog that publishes no vectors pays a single round-trip rather
+    // than one per candidate.
+    return figmaDir.takeIf { fetchCatalogAssetsToFiles(plan).isNotEmpty() }
   }
 
   /**
@@ -1569,6 +1575,13 @@ class ServeCatalogStore(
     private const val PUBLISH_SAMPLE_IMAGES = 3
 
     /**
+     * Components sampled when deciding whether a branch carries baked vectors at all. More than one
+     * because any single component may legitimately publish none; small because the background fill
+     * settles the question for real moments later.
+     */
+    private const val FIGMA_PROBE_SLUGS = 5
+
+    /**
      * Slug normalisation shared with [ServeBundleHost]'s hero resolver — mirrors design-parity's
      * `slug()` (non-`[a-zA-Z0-9._-]` → `-`, trim, lowercase).
      */
@@ -1641,7 +1654,10 @@ class ServeCatalogStore(
    * Destinations are path-contained by the caller before planning, so a worker never writes outside
    * the staged catalog.
    */
-  private fun fetchCatalogAssetsToFiles(plan: List<Pair<String, File>>): Set<String> {
+  private fun fetchCatalogAssetsToFiles(
+    plan: List<Pair<String, File>>,
+    stillWanted: () -> Boolean = { true },
+  ): Set<String> {
     if (plan.isEmpty()) return emptySet()
     val pool =
       Executors.newFixedThreadPool(minOf(ASSET_FETCH_CONCURRENCY, plan.size)) { r ->
@@ -1652,6 +1668,11 @@ class ServeCatalogStore(
         url to
           pool.submit<Boolean> {
             val bytes = runCatching { fetchCatalogAsset(url) }.getOrNull() ?: return@submit false
+            // Re-checked immediately before the write, not just once per wave: a fetch started for
+            // one catalog generation must not land in the directory a refresh has since swapped in.
+            // Checking only between waves leaves every worker in the current wave free to write
+            // after the swap, and nothing then removes what they wrote.
+            if (!stillWanted()) return@submit false
             runCatching {
                 target.parentFile?.mkdirs()
                 target.writeBytes(bytes)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
 import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipInputStream
@@ -48,6 +49,15 @@ class ServeCatalogStore(
   private val repo: String = DEFAULT_REPO,
   private val branchPrefix: String = DEFAULT_BRANCH_PREFIX,
   private val fetch: ((String) -> ByteArray?)? = null,
+  /**
+   * Runs the post-publish vector fills ([scheduleFigmaSvgFetch]). Single-threaded by default so the
+   * background lane can never outweigh the request path, and daemon so it never holds up shutdown.
+   * A test supplies a same-thread or capturing executor to make the pass deterministic.
+   */
+  private val figmaExecutor: java.util.concurrent.Executor =
+    Executors.newSingleThreadExecutor { r ->
+      Thread(r, "serve-catalog-figma").apply { isDaemon = true }
+    },
   private val networkFetch: (url: String, maxBytes: Long) -> ByteArray? = ::httpFetch,
   private val maxImages: Int = DEFAULT_MAX_IMAGES,
   /**
@@ -213,6 +223,9 @@ class ServeCatalogStore(
    */
   fun load(system: String, sourceRepo: String? = null, sourceBranchPrefix: String? = null): Result {
     val safe = ServeBundleStore.sanitizeName(system) ?: return Result.Failed(system, "invalid name")
+    // Bumped per load so a background pass started for an earlier generation of this catalog stops
+    // instead of writing its vectors into the refreshed one.
+    val generation = generations.merge(system, 1, Int::plus)!!
     val repo = sourceRepo?.takeIf { it.isNotBlank() } ?: this.repo
     val branchPrefix = sourceBranchPrefix?.takeIf { it.isNotBlank() } ?: this.branchPrefix
     val branch = "$branchPrefix$system"
@@ -457,7 +470,22 @@ class ServeCatalogStore(
 
     // Fetch the catalog's baked editable vectors (figma/<slug>.svg + crops) so the host can serve
     // an SVG per preview; null when the branch carried none (host then 404s the .svg lane).
-    val figmaDir = fetchFigmaSvgs(slugs, variantSvgPaths, base, dir)
+    // The baked vectors are the last bulk fetch on the publish path — one per image plus one per
+    // slug, ~240 for the largest catalog. They cannot be made lazy the way the PNGs were: nothing
+    // ever *requests* an SVG (the browser doesn't; it is a server-side input to thumbnail cropping
+    // and a download link), so fetching one on demand would simply mean never fetching it, and
+    // every card would stay uncropped. So they move off the publish path instead of onto the
+    // request path: probe one vector synchronously to learn whether this branch carries the lane at
+    // all, then fill the rest in the background while the catalog is already serving. Cards render
+    // uncropped for those few seconds and crop themselves once the pass lands.
+    // Probe the hero's vector, falling back to the first declared preview: most catalogs name no
+    // `display.hero`, and probing nothing would strip the SVG lane from every one of them.
+    val figmaProbeId =
+      heroPreviewIdFor(catalog, bakedPathById.keys) ?: bakedPathById.keys.firstOrNull()
+    val figmaDir = probeFigmaSvg(heroSvgCandidates(figmaProbeId), base, dir)
+    if (figmaDir != null) {
+      scheduleFigmaSvgFetch(system, generation, slugs, variantSvgPaths, base, dir)
+    }
 
     // The catalog's OWN palette, so its pages are framed in its own colours (see [ServeThemeCss]).
     // A few kB of JSON off the same branch as the images, and best-effort throughout: a missing /
@@ -1038,6 +1066,7 @@ class ServeCatalogStore(
     variantPaths: Set<String>,
     base: String,
     dir: File,
+    stillCurrent: () -> Boolean = { true },
   ): File? {
     val figmaDir = File(dir, FIGMA_DIR)
     val figmaRoot = figmaDir.canonicalFile.toPath()
@@ -1070,6 +1099,7 @@ class ServeCatalogStore(
     // `figma-raster/` crops inside its own markup, and raw.githubusercontent has no directory
     // listing. Each vector is re-read from the file just written (a local read, one at a time)
     // rather than held from the fetch.
+    if (!stillCurrent()) return null
     val cropPlan = safeCandidates.flatMap { relativePath ->
       val svgFile = File(figmaDir, relativePath)
       if ("$base$FIGMA_DIR/$relativePath" !in writtenSvgs) return@flatMap emptyList()
@@ -1086,6 +1116,66 @@ class ServeCatalogStore(
     fetchCatalogAssetsToFiles(cropPlan)
     wrote = writtenSvgs.size
     return if (wrote > 0) figmaDir else null
+  }
+
+  /**
+   * The vectors that would serve [heroId], most specific first: the per-variant
+   * `figma/<slug>/<variant>.svg` the exporter emits per image, then the back-compat per-component
+   * `figma/<slug>.svg`. Empty when the catalog named no hero.
+   */
+  private fun heroSvgCandidates(heroId: String?): List<String> {
+    val id = heroId ?: return emptyList()
+    val slug = id.substringBefore(SLUG_SEPARATOR)
+    val variant = id.substringAfter(SLUG_SEPARATOR, missingDelimiterValue = "")
+    return buildList {
+      if (variant.isNotEmpty()) add("$slug/$variant.svg")
+      add("$slug.svg")
+    }
+  }
+
+  /**
+   * Fetch the first of [candidates] that exists, to decide whether this branch carries the figma
+   * lane at all. Returns the local `figma/` dir when one landed, else null — which is what keeps a
+   * catalog with no published vectors from advertising an SVG control that would 404 on every
+   * preview. One or two requests; the rest of the set follows in [scheduleFigmaSvgFetch].
+   */
+  private fun probeFigmaSvg(candidates: List<String>, base: String, dir: File): File? {
+    val figmaDir = File(dir, FIGMA_DIR)
+    val figmaRoot = figmaDir.canonicalFile.toPath()
+    for (relativePath in candidates) {
+      val svgFile = File(figmaDir, relativePath)
+      if (!svgFile.canonicalFile.toPath().startsWith(figmaRoot)) continue
+      if (
+        fetchCatalogAssetsToFiles(listOf(("$base$FIGMA_DIR/$relativePath") to svgFile)).isNotEmpty()
+      )
+        return figmaDir
+    }
+    return null
+  }
+
+  /**
+   * Fill the catalog's remaining baked vectors off the publish path. Best-effort and fire-and-
+   * forget: the catalog is already registered and serving, and every consumer of a vector degrades
+   * to "no crop / no SVG download" until its file lands.
+   *
+   * Guarded by [generation]: a catalog refresh replaces `dir` under a new generation, so a pass
+   * started for the old one stops rather than writing superseded vectors into the fresh catalog.
+   */
+  private fun scheduleFigmaSvgFetch(
+    system: String,
+    generation: Int,
+    slugs: Set<String>,
+    variantPaths: Set<String>,
+    base: String,
+    dir: File,
+  ) {
+    figmaExecutor.execute {
+      if (generations[system] != generation) return@execute
+      runCatching {
+          fetchFigmaSvgs(slugs, variantPaths, base, dir) { generations[system] == generation }
+        }
+        .onFailure { System.err.println("serve: catalog $system figma vectors: ${it.message}") }
+    }
   }
 
   private fun writeDesignReferences(
@@ -1518,6 +1608,9 @@ class ServeCatalogStore(
       return out.toByteArray()
     }
   }
+
+  /** Current generation per system; see [scheduleFigmaSvgFetch]. */
+  private val generations = ConcurrentHashMap<String, Int>()
 
   /** Fetch an ordinary catalog asset using the existing tight per-file envelope. */
   private fun fetchCatalogAsset(url: String): ByteArray? =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -57,6 +57,9 @@ class ServeCatalogStoreTest {
   private fun store(
     trust: TrustStore,
     maxImages: Int = 1000,
+    // The baked vectors are filled off the publish path, so tests run that pass inline by default
+    // and assert against a settled catalog exactly as they did when it was synchronous.
+    figmaExecutor: java.util.concurrent.Executor = java.util.concurrent.Executor { it.run() },
     fetch: (String) -> ByteArray? = fetcher(),
   ): ServeCatalogStore =
     ServeCatalogStore(
@@ -66,6 +69,7 @@ class ServeCatalogStoreTest {
       fetch = fetch,
       registerWasm = { s, d -> registeredWasm[s] = d },
       maxImages = maxImages,
+      figmaExecutor = figmaExecutor,
     )
 
   @Test
@@ -153,6 +157,47 @@ class ServeCatalogStoreTest {
     // …and only once: the second read comes off disk.
     assertTrue(host.render(cold, PreviewOverrides()) is RenderOutcome.Ok)
     assertEquals(imagesAtPublish + 1, requested.count { it.endsWith(".png") })
+  }
+
+  @Test
+  fun `a catalog publishes before its baked vectors are fetched`() {
+    // The vectors are the last bulk fetch on the publish path — one per image plus one per slug.
+    // Publishing must not wait for them: the catalog serves (uncropped, briefly) and the pass fills
+    // them behind it. Captured rather than run so the assertion is about ordering, not timing.
+    val deferred = mutableListOf<Runnable>()
+    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val result =
+      store(
+          TrustStore.EMPTY,
+          figmaExecutor = java.util.concurrent.Executor { deferred += it },
+          fetch = { url ->
+            requested += url
+            when {
+              url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+                eightImageCatalogJson.toByteArray()
+              url.endsWith(".svg") -> "<svg/>".toByteArray()
+              url.endsWith(".png") -> png()
+              else -> null
+            }
+          },
+        )
+        .load("compose-m3")
+
+    assertTrue(result is ServeCatalogStore.Result.Ok)
+    // One probe decided the lane exists; the other ~8 vectors have not been asked for yet.
+    assertEquals(
+      1,
+      requested.count { it.endsWith(".svg") },
+      "only the probe runs before publishing",
+    )
+    assertEquals(1, deferred.size, "the rest is scheduled, not run")
+
+    deferred.forEach { it.run() }
+
+    assertTrue(
+      requested.count { it.endsWith(".svg") } > 1,
+      "the deferred pass fetches the remaining vectors",
+    )
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -185,8 +185,10 @@ class ServeCatalogStoreTest {
 
     assertTrue(result is ServeCatalogStore.Result.Ok)
     // One probe decided the lane exists; the other ~8 vectors have not been asked for yet.
+    // The probe samples this catalog's single component — its per-variant vector plus the slug
+    // fallback — and stops. The remaining ~8 vectors have not been asked for yet.
     assertEquals(
-      1,
+      2,
       requested.count { it.endsWith(".svg") },
       "only the probe runs before publishing",
     )


### PR DESCRIPTION
Follow-up to #3224, closing out the last bulk fetch on the catalog publish path.

## Why this one couldn't be lazy

After #3224 the baked PNGs arrive on first use, and the figma vectors became the dominant startup cost — one per image plus one per slug, ~240 for the largest catalog.

The obvious move is the same fill-on-miss treatment. **It would have been wrong.** Nothing ever *requests* an SVG: the browser doesn't, and the server uses it as an input to thumbnail cropping (`contentCrop`) plus a download link. Fetching on demand would therefore mean never fetching it — every card would stay uncropped for the life of the host. That's a visual regression on every catalog, and it's exactly the trap flagged in #3224's "what's still on the startup path" note.

So the vectors move **off the publish path** rather than onto the request path:

- **One vector is probed synchronously** to learn whether the branch carries the lane at all. That's what keeps a catalog with no published vectors from advertising an SVG control that 404s on every preview — the open question from #3224, answered without making the gating optimistic.
- **The rest fill in the background** while the catalog is already serving. Cards render uncropped for those few seconds and crop themselves once the pass lands.

The probe falls back to the first declared preview when the catalog names no `display.hero` — **most don't**, and probing nothing would have stripped the SVG lane from every one of them. The existing figma test caught that.

## Safety

- **Generation guard.** A per-system counter is bumped on each load, and the pass stands down if it's been superseded — so a refresh's replacement `dir` is never written into by a pass started for the catalog it replaced.
- **Executor is a constructor seam.** A single daemon thread in production, so the background lane can never outweigh the request path and never holds up shutdown; same-thread in tests, so a settled catalog can be asserted against exactly as before.

## Test plan

- `./gradlew :cli:test` — **1245 tests, 0 failures**.
- New: a catalog publishes with **one** `.svg` fetched (the probe) and the remaining vectors merely *scheduled*; running the deferred task then fetches them. Captured rather than timed, so it asserts ordering rather than racing a thread.
- The existing figma round-trip test (per-variant vector preferred over the slug fallback, raster crops inlined base64) passes unchanged against the same-thread executor.
- ktfmt clean.

Text-only evidence: this changes *when* vectors are fetched, not what any surface renders once they land. The one user-visible consequence — a card is uncropped for the seconds between publish and the pass completing — is a transient of the same thumbnail the catalog already serves.

## Startup path after this

Per catalog: `catalog.json` + `tokens.dtcg.json` + a 3-image sample + 1 vector probe. Everything else is lazy (PNGs) or deferred (vectors).

Still open, and unchanged by this PR: the catalog grid defaults to its pre-baked theme, with the sticky theme belonging to the individual preview rather than the grid.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_