### PR TITLE
perf(serve): serve baked pixels without entering render admission

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -415,6 +415,21 @@ class ServeBundleHost(
 
   private val fillLocks = java.util.concurrent.ConcurrentHashMap<String, Any>()
 
+  /**
+   * The local-pixels fast path. Deliberately [localBakedPng], not [bakedPngFile]: a declared
+   * preview whose PNG hasn't arrived yet needs a fetch, and fetching is work that belongs behind
+   * admission like any other. Answering null sends it down the ordinary [render] path, which fills
+   * it.
+   */
+  override fun bakedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? {
+    if (previewId !in previewIds) return null
+    val png = localBakedPng(previewId) ?: return null
+    return RenderOutcome.Ok(
+      fileSystem.read(png) { readByteArray() },
+      RenderOutcome.Generation.BAKED,
+    )
+  }
+
   override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
     if (previewId !in previewIds) return RenderOutcome.NotFound
     val png = bakedPngFile(previewId) ?: return RenderOutcome.NotFound

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -400,7 +400,10 @@ class ServeBundleHost(
       // truncated PNG.
       return runCatching {
           path.parent?.let(fileSystem::createDirectories)
-          val partial = path.parent!!.resolve("${'$'}{path.name}$PARTIAL_SUFFIX")
+          // Named per destination, not a shared temp: two ids filling concurrently hold
+          // different locks, so a single shared partial name would let one preview's bytes be
+          // published under another's id.
+          val partial = path.parent!!.resolve(path.name + PARTIAL_SUFFIX)
           fileSystem.write(partial) { write(bytes) }
           fileSystem.atomicMove(partial, path)
           path
@@ -411,7 +414,7 @@ class ServeBundleHost(
 
   /** [previewId]'s baked PNG only if it is already local — never fetches. */
   private fun localBakedPng(previewId: String): okio.Path? =
-    File(previewsDir, "${'$'}previewId${'$'}PNG_SUFFIX").toOkioPath().takeIf(fileSystem::exists)
+    File(previewsDir, previewId + PNG_SUFFIX).toOkioPath().takeIf(fileSystem::exists)
 
   private val fillLocks = java.util.concurrent.ConcurrentHashMap<String, Any>()
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -408,6 +408,21 @@ class ServeCatalogLiveHost(
    * pixels, while the default browse stays baked-instant. Only the mapped (daemon-twinned) ids can
    * re-render; an unmapped Android-only variant always replays baked.
    */
+  /**
+   * Answerable without admission only when this request would not have reached a daemon at all —
+   * the same [daemonIdForOverrideRender] predicate `render` routes on, so the fast path can never
+   * silently serve baked pixels for something that was supposed to be re-rendered. An override-free
+   * browse (the default page) always lands here, which is the point: a default page view must
+   * replay published pixels, never generate them.
+   */
+  override fun bakedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? {
+    cachedRender(previewId, overrides)?.let {
+      return it
+    }
+    if (daemonIdForOverrideRender(previewId, overrides) != null) return null
+    return baked.bakedRender(previewId, overrides)
+  }
+
   override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
     val themeCacheKey = themeCacheKey(previewId, overrides)
     cachedRender(previewId, overrides)?.let {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -115,6 +115,22 @@ interface ServeHost : AutoCloseable {
   fun cachedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
 
   /**
+   * Serve [previewId] from pixels **already on this box** — a baked PNG on disk — or null when
+   * answering would need work: a daemon render, or a fetch for a preview whose pixels haven't
+   * arrived yet.
+   *
+   * This is what keeps a busy, mostly-browsing box responsive. Every `/render` request otherwise
+   * competes for the same small pool of global render slots, so a handful of cold daemon renders —
+   * which can take a minute each — head-of-line block dozens of readers whose answer is a local
+   * file, and those readers eventually 503. A host that can answer from disk says so here and is
+   * served without ever entering admission.
+   *
+   * Must be cheap and non-blocking: no daemon, no network, no waiting. Returning null is always
+   * safe — the caller falls back to the admitted [render] path.
+   */
+  fun bakedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
+
+  /**
    * Aggregate render-performance counters for this host's live render lane, surfaced on `/status`
    * + `/status.json` (`runningServers[].renderStats`). Null when the host has no live render lane
    *   to measure — a static baked bundle never renders. Daemon-backed hosts ([ServeRenderHost])

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2604,7 +2604,17 @@ class ServeHttpServer(
           // close the race with a render that completes between these two calls.
           // A full-page request is a distinct daemon data product; a cached viewport PNG cannot
           // satisfy it even when the preview + overrides key is otherwise identical.
-          val cached = if (scroll) null else renderHost.cachedRender(previewId, overrides)
+          // Answerable without entering admission: a completed theme-cache entry, or pixels
+          // already baked on disk. This is what lets a mostly-browsing box stay responsive under
+          // load — otherwise every thumbnail read competes for the same handful of global render
+          // slots as the daemon renders, and a few cold ones (which can take a minute each)
+          // head-of-line block dozens of readers whose answer was a local file, until they 503.
+          // A `?scroll=` request is a distinct full-page product that baked pixels cannot satisfy.
+          val cached =
+            if (scroll) null
+            else
+              renderHost.cachedRender(previewId, overrides)
+                ?: renderHost.bakedRender(previewId, overrides)
           val pureThemeProvider =
             overrides.themeProvider?.takeIf {
               overrides == PreviewOverrides(themeProvider = it) &&

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1035,9 +1035,16 @@ object ServeWeb {
         var stored = null;
         try { stored = localStorage.getItem("$themeStorageKey"); } catch (e) {}
         var themeBtns = document.querySelectorAll(".cp-theme-btn");
+        // The GRID always opens on published pixels. A stored app-declared theme
+        // (`theme:<providerFqn>`) is deliberately NOT replayed here: restoring it would re-point
+        // every card at a `?themeProvider=` render and put the whole grid through the daemon on
+        // what is meant to be a default page view — the single most expensive thing an idle box
+        // can be made to do, and it happened on every return visit. Only the baked chips, whose
+        // pixels are already published, are restored. Stickiness for app-declared themes belongs
+        // to the individual preview, which reads this same key for its own Theme select.
         function validTheme(t) {
           if (!t) return false;
-          return t === "light" || t === "dark" || t === "default" || t.indexOf("theme:") === 0;
+          return t === "light" || t === "dark" || t === "default";
         }
         var theme = validTheme(stored) ? stored
           : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -21,6 +21,24 @@ class ServeBundleHostTest {
   }
 
   @Test
+  fun `the no-admission fast path serves real local pixels`() {
+    // Against the REAL host, not a fake. The fast path is only worth anything if it actually finds
+    // the file: a fake that returns bytes regardless would pass while the production path silently
+    // fell through to the admitted render queue for every request.
+    val host = ServeBundleHost(bundle("com.example.Red" to byteArrayOf(4, 2)), label = "b")
+
+    val ok = host.bakedRender("com.example.Red", PreviewOverrides())
+    assertTrue(ok != null, "local pixels must be servable without admission")
+    assertTrue(byteArrayOf(4, 2).contentEquals(ok!!.png))
+    assertEquals(RenderOutcome.Generation.BAKED, ok.generation)
+    // Nested ids resolve the same way.
+    val nested = ServeBundleHost(bundle("group/com.example.Blue" to byteArrayOf(7)), label = "b")
+    assertTrue(nested.bakedRender("group/com.example.Blue", PreviewOverrides()) != null)
+    // An id this host does not carry has nothing to serve.
+    assertNull(host.bakedRender("com.example.Missing", PreviewOverrides()))
+  }
+
+  @Test
   fun `nested preview ids (with slashes) are discovered and rendered`() {
     val host = ServeBundleHost(bundle("group/com.example.Red" to byteArrayOf(4, 2)), label = "b")
     assertEquals(listOf("group/com.example.Red"), host.previews.map { it.id })

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -66,6 +66,12 @@ class ServeCatalogLiveHostTest {
       return RenderOutcome.Ok("$tag:$previewId".encodeToByteArray())
     }
 
+    // Local pixels, served without admission. Deliberately does NOT count as a render call, so a
+    // test can assert the daemon was never reached.
+    override fun bakedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? =
+      if (previewId in liveOnlyPreviewIds) null
+      else RenderOutcome.Ok("$tag:$previewId".encodeToByteArray())
+
     override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
       lastSvgId = previewId
       lastRenderOverrides = overrides
@@ -849,6 +855,37 @@ class ServeCatalogLiveHostTest {
     assertEquals(0, replacementLive.renderCalls)
     val cached = replacement.render(catalogId, themeOverride()) as RenderOutcome.Ok
     assertEquals(RenderOutcome.Generation.CATALOG_CACHE, cached.generation)
+  }
+
+  @Test
+  fun `the no-admission fast path serves baked pixels but never a daemon render`() {
+    // `bakedRender` is what lets a mostly-browsing box skip the global render-slot queue. It must
+    // answer exactly the requests `render` would have replayed from baked pixels — and refuse the
+    // ones that were supposed to reach a daemon, or the fast path would silently serve stale
+    // pixels for a re-render.
+    val baked =
+      RecordingHost(
+        previews =
+          listOf(ServePreview(catalogId, catalogId), ServePreview(androidOnlyId, androidOnlyId)),
+        tag = "baked",
+      )
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId, overrides = listOf(labelKnob))),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+
+    // The default page view: no overrides, so it replays published pixels without admission.
+    assertTrue(composite.bakedRender(catalogId, PreviewOverrides()) != null)
+    // An unaliased variant has no daemon twin at all — always baked.
+    assertTrue(composite.bakedRender(androidOnlyId, PreviewOverrides()) != null)
+    // A knob and an app-declared theme both need the daemon, so the fast path must decline.
+    assertNull(composite.bakedRender(catalogId, knobOverride()))
+    assertNull(composite.bakedRender(catalogId, themeOverride()))
+    // None of that woke the daemon.
+    assertEquals(0, live.renderCalls)
   }
 
   @Test

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
@@ -132,9 +132,16 @@
       var stored = null;
 try { stored = localStorage.getItem("cp-theme:wear-m3"); } catch (e) {}
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
+// The GRID always opens on published pixels. A stored app-declared theme
+// (`theme:<providerFqn>`) is deliberately NOT replayed here: restoring it would re-point
+// every card at a `?themeProvider=` render and put the whole grid through the daemon on
+// what is meant to be a default page view — the single most expensive thing an idle box
+// can be made to do, and it happened on every return visit. Only the baked chips, whose
+// pixels are already published, are restored. Stickiness for app-declared themes belongs
+// to the individual preview, which reads this same key for its own Theme select.
 function validTheme(t) {
   if (!t) return false;
-  return t === "light" || t === "dark" || t === "default" || t.indexOf("theme:") === 0;
+  return t === "light" || t === "dark" || t === "default";
 }
 var theme = validTheme(stored) ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -97,9 +97,16 @@
       var stored = null;
 try { stored = localStorage.getItem("cp-theme:compose-m3"); } catch (e) {}
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
+// The GRID always opens on published pixels. A stored app-declared theme
+// (`theme:<providerFqn>`) is deliberately NOT replayed here: restoring it would re-point
+// every card at a `?themeProvider=` render and put the whole grid through the daemon on
+// what is meant to be a default page view — the single most expensive thing an idle box
+// can be made to do, and it happened on every return visit. Only the baked chips, whose
+// pixels are already published, are restored. Stickiness for app-declared themes belongs
+// to the individual preview, which reads this same key for its own Theme select.
 function validTheme(t) {
   if (!t) return false;
-  return t === "light" || t === "dark" || t === "default" || t.indexOf("theme:") === 0;
+  return t === "light" || t === "dark" || t === "default";
 }
 var theme = validTheme(stored) ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -180,9 +180,16 @@
       var stored = null;
 try { stored = localStorage.getItem("cp-theme:default"); } catch (e) {}
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
+// The GRID always opens on published pixels. A stored app-declared theme
+// (`theme:<providerFqn>`) is deliberately NOT replayed here: restoring it would re-point
+// every card at a `?themeProvider=` render and put the whole grid through the daemon on
+// what is meant to be a default page view — the single most expensive thing an idle box
+// can be made to do, and it happened on every return visit. Only the baked chips, whose
+// pixels are already published, are restored. Stickiness for app-declared themes belongs
+// to the individual preview, which reads this same key for its own Theme select.
 function validTheme(t) {
   if (!t) return false;
-  return t === "light" || t === "dark" || t === "default" || t.indexOf("theme:") === 0;
+  return t === "light" || t === "dark" || t === "default";
 }
 var theme = validTheme(stored) ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -84,9 +84,16 @@
       var stored = null;
 try { stored = localStorage.getItem("cp-theme:default"); } catch (e) {}
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
+// The GRID always opens on published pixels. A stored app-declared theme
+// (`theme:<providerFqn>`) is deliberately NOT replayed here: restoring it would re-point
+// every card at a `?themeProvider=` render and put the whole grid through the daemon on
+// what is meant to be a default page view — the single most expensive thing an idle box
+// can be made to do, and it happened on every return visit. Only the baked chips, whose
+// pixels are already published, are restored. Stickiness for app-declared themes belongs
+// to the individual preview, which reads this same key for its own Theme select.
 function validTheme(t) {
   if (!t) return false;
-  return t === "light" || t === "dark" || t === "default" || t.indexOf("theme:") === 0;
+  return t === "light" || t === "dark" || t === "default";
 }
 var theme = validTheme(stored) ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -94,9 +94,16 @@
       var stored = null;
 try { stored = localStorage.getItem("cp-theme:compose-m3"); } catch (e) {}
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
+// The GRID always opens on published pixels. A stored app-declared theme
+// (`theme:<providerFqn>`) is deliberately NOT replayed here: restoring it would re-point
+// every card at a `?themeProvider=` render and put the whole grid through the daemon on
+// what is meant to be a default page view — the single most expensive thing an idle box
+// can be made to do, and it happened on every return visit. Only the baked chips, whose
+// pixels are already published, are restored. Stickiness for app-declared themes belongs
+// to the individual preview, which reads this same key for its own Theme select.
 function validTheme(t) {
   if (!t) return false;
-  return t === "light" || t === "dark" || t === "default" || t.indexOf("theme:") === 0;
+  return t === "light" || t === "dark" || t === "default";
 }
 var theme = validTheme(stored) ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -69,9 +69,16 @@
       var stored = null;
 try { stored = localStorage.getItem("cp-theme:default"); } catch (e) {}
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
+// The GRID always opens on published pixels. A stored app-declared theme
+// (`theme:<providerFqn>`) is deliberately NOT replayed here: restoring it would re-point
+// every card at a `?themeProvider=` render and put the whole grid through the daemon on
+// what is meant to be a default page view — the single most expensive thing an idle box
+// can be made to do, and it happened on every return visit. Only the baked chips, whose
+// pixels are already published, are restored. Stickiness for app-declared themes belongs
+// to the individual preview, which reads this same key for its own Theme select.
 function validTheme(t) {
   if (!t) return false;
-  return t === "light" || t === "dark" || t === "default" || t.indexOf("theme:") === 0;
+  return t === "light" || t === "dark" || t === "default";
 }
 var theme = validTheme(stored) ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");


### PR DESCRIPTION
Two ways an idle box was made to do daemon work for pages that should have been free.

## 1. Baked reads competed with daemon renders for the same 8 slots

Every `/render` request took a global render slot (`ServeHttpServer.kt`, `renderSemaphore`), **including one whose answer is a local file**. Only theme-cache hits bypassed it.

With eight slots shared between file reads and daemon renders — and a cold Robolectric render measured at **68,803 ms** against a warm minimum of **356 ms** — a handful of cold renders head-of-line block dozens of readers, which then 503 after the 30s `RENDER_QUEUE_WAIT_SECONDS`. Forty people browsing baked catalogs is more than enough to trigger it.

Hosts can now answer from pixels already on the box via `ServeHost.bakedRender`, and the HTTP layer serves that *before* admission, alongside the theme-cache hit that already bypassed it.

Two deliberate limits on the fast path:

- **The composite answers only when the request would not have reached a daemon anyway** — it reuses the same `daemonIdForOverrideRender` predicate `render` routes on, so the fast path can never silently serve baked pixels for something that was supposed to be re-rendered. A knob or an app-declared theme declines; an override-free browse and an unaliased variant take it.
- **A declared preview whose PNG hasn't arrived yet returns null** and takes the ordinary admitted path. Fetching is work, and work belongs behind admission.

## 2. The catalog grid replayed a stored app theme on load

`ServeWeb.kt:1036` restored `localStorage["cp-theme:<system>"]`, and the validator accepted `theme:<providerFqn>`. So **revisiting a catalog re-pointed every card at a `?themeProvider=` render** and put the whole grid through the daemon — the most expensive thing an idle box can be asked to do, on what is meant to be a default page view.

The grid now restores only the baked light/dark chips, whose pixels are already published. Selecting an app theme still works and is still remembered for the *individual preview*, which reads the same key for its own Theme select — it is just never replayed across a grid load.

## Test plan

- `./gradlew :cli:test` — **1246 tests, 0 failures**.
- New: the fast path serves an override-free browse and an unaliased variant, declines a knob and an app-declared theme, and never touches the daemon.
- `serve-web` fixtures regenerated for the changed page script (the diff is exactly the validator change plus its comment).
- ktfmt clean.

Text-only evidence: this changes *when* work is admitted and which theme a grid opens on — no rendered surface changes. The grid's default appearance is the published light/dark pixels, which is what it showed before any app theme had ever been selected.

## Not included

The lease sizing discussed alongside this (two leases at 5 and 3, backend-aware because an Android per-preview daemon costs 2 live seats against a budget of 8) and daemon warming are **not** here — they change how much concurrent daemon work is allowed, where this PR is about not doing daemon work at all for pages that don't need it. Worth landing and measuring this first, since it removes most of the contention those settings were compensating for.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_