### PR TITLE
feat(serve): grant two theme-render bursts instead of one

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManager.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManager.kt
@@ -63,7 +63,14 @@ internal class ThemeRenderLeaseManager(
       val tier =
         LEASE_TIERS.indices.firstOrNull { t -> active.none { it.tier == t } } ?: return null
 
-      val concurrency = minOf(requestedCapacity, serverRenderSlots, LEASE_TIERS[tier])
+      // Sized from what is left of the shared budget, not from the whole of it. Clamping each
+      // grant independently would promise more total width than the server has permits for — a
+      // four-slot box would hand out 4 and then 3 — and the second page's renders would simply
+      // queue on the global semaphore and 503, which is the outcome the second tier exists to
+      // avoid. A tier that cannot beat the serial baseline out of the remainder is refused.
+      val promised = active.sumOf { it.concurrency }
+      val remaining = serverRenderSlots - promised
+      val concurrency = minOf(requestedCapacity, remaining, LEASE_TIERS[tier])
       if (concurrency <= BASELINE_CONCURRENCY) return null
 
       val lease =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManager.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManager.kt
@@ -6,7 +6,7 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 /**
- * Grants one short-lived, server-wide burst for a catalog page's themed thumbnail renders.
+ * Grants short-lived, server-wide bursts for catalog pages' themed thumbnail renders.
  *
  * This is deliberately separate from [ServeSessionRegistry.Lease]: a session lease keeps a host
  * resident, whereas this lease limits how much parallel render work one browser page may admit. A
@@ -18,8 +18,15 @@ import kotlin.concurrent.withLock
  * from overlapping the old burst. The fixed TTL cannot be renewed, so a lost page cannot retain
  * burst capacity indefinitely.
  *
+ * There are [LEASE_TIERS] slots rather than one. A single grant meant that the moment two people
+ * (or two tabs) looked at catalogs, the second fell all the way back to the strictly serial
+ * baseline — on a box whose whole job is showing catalogs, that is the common case, not the edge
+ * one. The tiers are unequal on purpose: the first page gets the full burst and a second gets a
+ * smaller one, so two pages can make progress together without their combined width exceeding what
+ * the box can actually render at once. A third page still falls back to serial.
+ *
  * Thread-safe. The caller must still use the server's ordinary global render semaphore: this
- * manager narrows admission for the privileged page and never expands the server-wide limit.
+ * manager narrows admission for the privileged pages and never expands the server-wide limit.
  */
 internal class ThemeRenderLeaseManager(
   private val serverRenderSlots: Int,
@@ -29,6 +36,8 @@ internal class ThemeRenderLeaseManager(
   data class Grant(val token: String, val concurrency: Int, val expiresAtMillis: Long)
 
   private class Lease(
+    /** Which of [LEASE_TIERS] this lease occupies, so the slot is freed for the same width. */
+    val tier: Int,
     val token: String,
     val sessionId: String,
     val hostIdentity: Any,
@@ -39,29 +48,34 @@ internal class ThemeRenderLeaseManager(
   )
 
   private val lock = ReentrantLock()
-  private var active: Lease? = null
+  private val active = mutableListOf<Lease>()
 
   /**
-   * Try to grant a burst for [sessionId] and this exact [hostIdentity]. Only one grant can exist
-   * server-wide. Capacities that cannot exceed the serial baseline are denied.
+   * Try to grant a burst for [sessionId] and this exact [hostIdentity]. At most [LEASE_TIERS]
+   * grants exist server-wide, and the widest free tier is handed out — so a page arriving after
+   * another has drained gets the full burst back rather than being stuck on the narrow one.
+   * Capacities that cannot exceed the serial baseline are denied: a grant that admits no more than
+   * the unleased path would is not worth the round-trip.
    */
   fun acquire(sessionId: String, hostIdentity: Any, requestedCapacity: Int): Grant? =
     lock.withLock {
       reapTerminalLease()
-      if (active != null) return null
+      val tier =
+        LEASE_TIERS.indices.firstOrNull { t -> active.none { it.tier == t } } ?: return null
 
-      val concurrency = minOf(requestedCapacity, serverRenderSlots, MAX_CONCURRENCY)
+      val concurrency = minOf(requestedCapacity, serverRenderSlots, LEASE_TIERS[tier])
       if (concurrency <= BASELINE_CONCURRENCY) return null
 
       val lease =
         Lease(
+          tier = tier,
           token = tokenSource(),
           sessionId = sessionId,
           hostIdentity = hostIdentity,
           concurrency = concurrency,
           expiresAtMillis = clock() + TTL_MILLIS,
         )
-      active = lease
+      active += lease
       Grant(lease.token, lease.concurrency, lease.expiresAtMillis)
     }
 
@@ -71,7 +85,7 @@ internal class ThemeRenderLeaseManager(
    * The returned permit must be closed after the render finishes.
    */
   fun admit(token: String, sessionId: String, hostIdentity: Any): Permit? = lock.withLock {
-    val lease = active ?: return null
+    val lease = active.firstOrNull { it.token == token } ?: return null
     if (
       lease.token != token || lease.sessionId != sessionId || lease.hostIdentity !== hostIdentity
     ) {
@@ -100,8 +114,7 @@ internal class ThemeRenderLeaseManager(
    * closes. Repeated releases are harmless.
    */
   fun release(token: String): Boolean = lock.withLock {
-    val lease = active ?: return false
-    if (lease.token != token) return false
+    val lease = active.firstOrNull { it.token == token } ?: return false
     lease.released = true
     reapTerminalLease()
     true
@@ -118,13 +131,21 @@ internal class ThemeRenderLeaseManager(
 
   /** Caller holds [lock]. Expiry drains just like an explicit release. */
   private fun reapTerminalLease() {
-    val lease = active ?: return
-    if (clock() >= lease.expiresAtMillis) lease.released = true
-    if (lease.released && lease.inFlight == 0) active = null
+    for (lease in active) if (clock() >= lease.expiresAtMillis) lease.released = true
+    active.removeAll { it.released && it.inFlight == 0 }
   }
 
   companion object {
     const val BASELINE_CONCURRENCY = 1
+
+    /**
+     * Burst width per concurrent grant, widest first. Two slots so a second viewer isn't dropped to
+     * the serial baseline, and unequal so their combined width stays inside what the box can render
+     * at once — each grant is additionally clamped to the server's render slots, and to what the
+     * host says it can actually parallelise.
+     */
+    val LEASE_TIERS = intArrayOf(5, 3)
+
     const val MAX_CONCURRENCY = 5
     const val TTL_MILLIS = 60_000L
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManagerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManagerTest.kt
@@ -19,12 +19,16 @@ class ThemeRenderLeaseManagerTest {
     )
 
   @Test
-  fun `one lease is active server-wide and is bound to session and host identity`() {
+  fun `two leases are active server-wide and each is bound to session and host identity`() {
     val manager = manager()
     val host = Any()
     val grant = assertNotNull(manager.acquire("wear", host, requestedCapacity = 5))
 
-    assertNull(manager.acquire("material", Any(), requestedCapacity = 5))
+    // A second page gets the narrower tier rather than falling back to the serial baseline…
+    val second = assertNotNull(manager.acquire("material", Any(), requestedCapacity = 5))
+    assertEquals(3, second.concurrency)
+    // …and a third finds no free tier.
+    assertNull(manager.acquire("third", Any(), requestedCapacity = 5))
     assertNull(manager.admit(grant.token, "material", host))
     assertNull(manager.admit(grant.token, "wear", Any()))
     assertNotNull(manager.admit(grant.token, "wear", host)).close()
@@ -60,6 +64,9 @@ class ThemeRenderLeaseManagerTest {
   @Test
   fun `release drains in-flight work before permitting a replacement`() {
     val manager = manager()
+    // Occupy the narrow tier so the assertions below are about the released tier draining, not
+    // about a spare tier being handed out.
+    manager.acquire("filler", Any(), requestedCapacity = 5)
     val host = Any()
     val grant = assertNotNull(manager.acquire("app", host, requestedCapacity = 5))
     val permit = assertNotNull(manager.admit(grant.token, "app", host))
@@ -89,6 +96,10 @@ class ThemeRenderLeaseManagerTest {
   @Test
   fun `expired lease with in-flight work drains before replacement`() {
     val manager = manager()
+    // Both tiers are occupied with work in flight, so no tier can be handed out until they drain.
+    val fillerHost = Any()
+    val filler = assertNotNull(manager.acquire("filler", fillerHost, requestedCapacity = 5))
+    val fillerPermit = assertNotNull(manager.admit(filler.token, "filler", fillerHost))
     val host = Any()
     val grant = assertNotNull(manager.acquire("app", host, requestedCapacity = 5))
     val permit = assertNotNull(manager.admit(grant.token, "app", host))
@@ -98,6 +109,7 @@ class ThemeRenderLeaseManagerTest {
     assertNull(manager.acquire("other", Any(), requestedCapacity = 5))
 
     permit.close()
+    fillerPermit.close()
     assertNotNull(manager.acquire("other", Any(), requestedCapacity = 5))
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManagerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManagerTest.kt
@@ -35,6 +35,21 @@ class ThemeRenderLeaseManagerTest {
   }
 
   @Test
+  fun `concurrent grants never promise more width than the server has slots`() {
+    // Eight slots is the real box: the tiers fit exactly, 5 + 3.
+    val roomy = manager(serverSlots = 8)
+    assertEquals(5, assertNotNull(roomy.acquire("a", Any(), requestedCapacity = 5)).concurrency)
+    assertEquals(3, assertNotNull(roomy.acquire("b", Any(), requestedCapacity = 5)).concurrency)
+
+    // Four slots: the first grant takes them all, so there is nothing left to promise a second
+    // page. Handing it 3 anyway would admit 7 renders against 4 permits and the extra three would
+    // queue on the global semaphore until they 503.
+    val tight = manager(serverSlots = 4)
+    assertEquals(4, assertNotNull(tight.acquire("a", Any(), requestedCapacity = 5)).concurrency)
+    assertNull(tight.acquire("b", Any(), requestedCapacity = 5))
+  }
+
+  @Test
   fun `grant is capped by requested capacity server slots and the burst ceiling`() {
     assertEquals(3, manager().acquire("app", Any(), requestedCapacity = 3)?.concurrency)
     assertEquals(2, manager(serverSlots = 2).acquire("app", Any(), 5)?.concurrency)


### PR DESCRIPTION
The two lease tiers (5 and 3) from the startup-performance thread.

## Why

A single server-wide grant meant that the moment two people — or two tabs — looked at catalogs, the second fell all the way back to the strictly serial baseline of **one render at a time** (`unleasedThemeSemaphore = Semaphore(1)`). On a box whose whole job is showing catalogs, that's the common case, not the edge one.

There are now two tiers, **5 and 3**. Unequal on purpose: the first page gets the full burst and a second gets a smaller one, so their combined width stays inside what the box can actually render at once, and a third page still falls back to serial. The **widest free tier** is handed out, so a page arriving after another has drained gets the full burst back rather than inheriting the narrow one.

Unchanged: each grant is still clamped by the server's render slots and by what the host says it can parallelise (`themeRenderBurstCapacity`), and draining still works the same way — a released or expired lease holds its tier until its last permit closes.

## Measurement that motivated this, and one caveat

Live box before this change, per-catalog load gaps after the lazy work shipped in 0.19.24:

```
compose-m3 → wear-m3   7s     jetnews         10s
wear-m3 → remote-m3    7s     jetcaster       12s
homeassistant          11s    jetcaster-wear   9s
```

Down from 30–132s; all 18 catalogs loaded, 0 pending, 0 degraded — about **3 minutes to a complete front door instead of ~24**.

**The caveat is worth stating plainly: widening the lease does not fix the thing that actually makes a themed render slow.** Measured on the same box, a warm render is **356 ms** and a cold one **68,803 ms** — a 170× spread — and with `daemons: known 18, running 0` on an idle box, a theme selection starts cold. Concurrency divides the queue; it doesn't touch the constant. An Android per-preview daemon also costs 2 live seats against a budget of 8, so a 5-wide burst on an Android catalog can't actually be 5-wide — it converts "serialised at the semaphore" into "refused at the `LiveSeatLimiter`".

So this is worth having, and daemon warming is the larger remaining lever. I'd land this, let it roll out, and re-measure before sizing anything else.

## Test plan

- `./gradlew :cli:test` — **1247 tests, 0 failures**.
- The manager's tests move to the new invariant: two grants, a third refused, the second sized to the narrow tier.
- The two drain cases now occupy **both** tiers with work in flight, so they still assert draining rather than a spare tier being handed out — without that they passed for the wrong reason.
- ktfmt clean.

Text-only evidence: this changes admission width, not any rendered surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_