### PR TITLE
perf(serve): route snapshot renders back to the shared daemon

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -112,6 +112,13 @@ class ServeCatalogLiveHost(
   private val backgroundWork: ServeBackgroundWork = ServeBackgroundWork(),
   private val themeOptimizationIdleMillis: Long =
     System.getProperty("composeai.serve.themeOptimizationIdleMillis")?.toLongOrNull() ?: 30_000L,
+  /**
+   * Route snapshot renders to the shared monolithic daemon rather than the per-preview pool — see
+   * [renderHostFor]. `-Dcomposeai.serve.sharedDaemonRenders=false` restores per-preview routing for
+   * a deployment that wants each preview isolated at the cost of a cold start per card.
+   */
+  private val sharedDaemonRenders: Boolean =
+    System.getProperty("composeai.serve.sharedDaemonRenders")?.toBooleanStrictOrNull() ?: true,
   private val clock: () -> Long = System::currentTimeMillis,
 ) : ServeHost {
 
@@ -185,7 +192,7 @@ class ServeCatalogLiveHost(
     if (warmingInFlight.add(daemonId)) {
       warmExecutor.execute {
         try {
-          if (liveHostFor(daemonId).render(daemonId, PreviewOverrides()) is RenderOutcome.Ok) {
+          if (renderHostFor(daemonId).render(daemonId, PreviewOverrides()) is RenderOutcome.Ok) {
             warmDaemonIds.add(daemonId)
           }
         } catch (_: Throwable) {
@@ -438,7 +445,7 @@ class ServeCatalogLiveHost(
       // lane, so it must be awaited even cold and its outcome returned as-is. Everything below is
       // the baked-first routing, which such an id can't use.
       if (previewId in liveOnlyPreviewIds) {
-        return cacheThemeRender(themeCacheKey, liveHostFor(daemonId).render(daemonId, overrides))
+        return cacheThemeRender(themeCacheKey, renderDaemon(daemonId, overrides))
       }
       // Only await the daemon when it's warm and free. A cold Android render can take minutes, and
       // blocking the browse — and the HTTP render slot it holds — on it is what saturates the whole
@@ -446,7 +453,7 @@ class ServeCatalogLiveHost(
       // theme request must instead report Busy: returning baked pixels as a successful 200 would
       // make the grid believe the requested theme had loaded and it would never retry.
       if (daemonWarmOrScheduling(daemonId)) {
-        val live = liveHostFor(daemonId).render(daemonId, overrides)
+        val live = renderDaemon(daemonId, overrides)
         if (live !is RenderOutcome.Busy) return cacheThemeRender(themeCacheKey, live)
       }
       if (themeCacheKey != null) return RenderOutcome.Busy
@@ -523,6 +530,39 @@ class ServeCatalogLiveHost(
    * that one preview's closure — so callers pass the daemon id either way.
    */
   private fun liveHostFor(daemonId: String): ServeHost = perPreviewResolve?.invoke(daemonId) ?: live
+
+  /**
+   * Which daemon answers a **snapshot render** — the grid, and every themed thumbnail on it.
+   *
+   * The shared monolithic daemon, by default, because a grid is a *batch*: one cold start and then
+   * every remaining card is warm. Routing these to the per-preview pool instead made each card pay
+   * its own cold start, which on an Android catalog is tens of seconds apiece — measured at 68s
+   * cold against 356ms warm — so selecting a theme across a 42-card grid went from "fills in at
+   * about one a second" to "mostly stalled". The pool's LRU cap of 8 made it worse than linear: a
+   * grid larger than the cap evicts daemons while the same page is still using them, so scrolling
+   * back can pay the cold start a second time.
+   *
+   * Interactive streams keep the per-preview lane ([liveHostFor]) — there the isolation is the
+   * point, one long-lived session per preview being edited, and there is no batch to amortise.
+   *
+   * A per-preview daemon that the monolithic one cannot serve still resolves: an id the shared
+   * daemon reports as unknown falls back to the pool rather than failing.
+   */
+  /**
+   * Render [daemonId] on the shared daemon, falling back to its per-preview daemon for an id the
+   * shared one doesn't carry (a split/IR-backed bundle the monolithic descriptor never listed).
+   * Only [RenderOutcome.NotFound] falls through — a Busy or a failure is that daemon's real answer
+   * and re-running it elsewhere would just double the work.
+   */
+  private fun renderDaemon(daemonId: String, overrides: PreviewOverrides): RenderOutcome {
+    val outcome = renderHostFor(daemonId).render(daemonId, overrides)
+    if (outcome != RenderOutcome.NotFound || !sharedDaemonRenders) return outcome
+    val perPreview = perPreviewResolve?.invoke(daemonId) ?: return outcome
+    return perPreview.render(daemonId, overrides)
+  }
+
+  private fun renderHostFor(daemonId: String): ServeHost =
+    if (sharedDaemonRenders) live else liveHostFor(daemonId)
 
   /**
    * SVG export mirrors [render]'s knob routing, plus a fallback: the SVG row is advertised whenever

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -192,7 +192,7 @@ class ServeCatalogLiveHost(
     if (warmingInFlight.add(daemonId)) {
       warmExecutor.execute {
         try {
-          if (renderHostFor(daemonId).render(daemonId, PreviewOverrides()) is RenderOutcome.Ok) {
+          if (renderDaemon(daemonId, PreviewOverrides()) is RenderOutcome.Ok) {
             warmDaemonIds.add(daemonId)
           }
         } catch (_: Throwable) {
@@ -232,7 +232,12 @@ class ServeCatalogLiveHost(
   fun prewarm() {
     startThemeOptimization()
     if (!warmInBackground) return
-    if (perPreviewResolve != null) return
+    // A per-preview catalog deliberately skips eager warming — one JVM per preview would make
+    // startup fan out into dozens of them. But when snapshots share the monolithic daemon, that
+    // daemon is exactly what the first theme selection will wait on, and its cold start (~68s on
+    // Android) outlasts the page's three 2/4/8s retries — so the grid would sit unchanged until
+    // someone selected the theme a second time. One warm render, off the request path, closes it.
+    if (perPreviewResolve != null && !sharedDaemonRenders) return
     alias.values.firstOrNull()?.let { scheduleWarm(it, live) }
   }
 
@@ -368,7 +373,15 @@ class ServeCatalogLiveHost(
   override fun canRenderOverridesFor(previewId: String): Boolean = previewId in alias
 
   /** A leased burst is safe only when distinct previews have independent pooled daemons. */
-  override val themeRenderBurstCapacity: Int = if (perPreviewResolve != null) 5 else 1
+  /**
+   * A burst is only real if the renders can actually proceed in parallel. The per-preview pool can
+   * — one daemon per preview — but the shared daemon has a single render lock, so advertising five
+   * there would funnel five workers into one lock, hand four of them `Busy`, and the page would
+   * exhaust its three retries and leave those cards on baked pixels. Worse than serial, not better.
+   * So capacity follows the lane snapshots actually use.
+   */
+  override val themeRenderBurstCapacity: Int =
+    if (perPreviewResolve != null && !sharedDaemonRenders) 5 else 1
 
   /** The gesture override is honoured by the daemon lane, if that daemon is Android-backed. */
   override val gesturesRenderable: Boolean = live.gesturesRenderable

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -634,6 +634,7 @@ class ServeCatalogLiveHostTest {
         live = monolithic,
         baked = baked,
         perPreviewResolve = { perPreview },
+        sharedDaemonRenders = false,
       )
 
     val first = composite.render(catalogId, themeOverride()) as RenderOutcome.Ok
@@ -796,6 +797,7 @@ class ServeCatalogLiveHostTest {
           resolved += id
           perPreview
         },
+        sharedDaemonRenders = false,
         serverIdleMillis = { Long.MAX_VALUE },
         themeOptimizationEnabled = true,
         themeOptimizationIdleMillis = 0,
@@ -978,7 +980,33 @@ class ServeCatalogLiveHostTest {
   }
 
   @Test
-  fun `an override render prefers the per-preview daemon over the monolithic one`() {
+  fun `snapshot renders go to the shared daemon by default`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val monolithic =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId, overrides = listOf(labelKnob))),
+        tag = "mono",
+        streaming = true,
+      )
+    val perPreview = RecordingHost(previews = emptyList(), tag = "per")
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = monolithic,
+        baked = baked,
+        perPreviewResolve = { perPreview },
+      )
+
+    // A grid is a batch: one cold start on the shared daemon, then every remaining card is warm.
+    // Routing each card to its own per-preview daemon made every card pay its own cold start.
+    val out = composite.render(catalogId, knobOverride()) as RenderOutcome.Ok
+    assertEquals("mono:$daemonId", out.png.decodeToString())
+    assertEquals(daemonId, monolithic.lastRenderId)
+    assertNull(perPreview.lastRenderId)
+  }
+
+  @Test
+  fun `per-preview routing is still available behind its flag`() {
     val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
     val monolithic =
       RecordingHost(
@@ -993,10 +1021,11 @@ class ServeCatalogLiveHostTest {
         live = monolithic,
         baked = baked,
         perPreviewResolve = { id -> if (id == daemonId) perPreview else null },
+        sharedDaemonRenders = false,
       )
 
-    // A knob edit resolves the per-preview daemon FIRST — the monolithic one is never touched, so
-    // the small per-preview bundle is the routinely-exercised default lane.
+    // With per-preview routing selected, a knob edit resolves the per-preview daemon FIRST and the
+    // monolithic one is never touched.
     val out = composite.render(catalogId, knobOverride()) as RenderOutcome.Ok
     assertEquals("per:$daemonId", out.png.decodeToString())
     assertEquals(daemonId, perPreview.lastRenderId)
@@ -1067,6 +1096,7 @@ class ServeCatalogLiveHostTest {
         live = monolithic,
         baked = baked,
         perPreviewResolve = { perPreview },
+        sharedDaemonRenders = false,
       )
     val handle = composite.subscribeStream(catalogId, PreviewOverrides(), null, null) {}
     assertTrue(handle != null)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -591,6 +591,7 @@ class ServeCatalogLiveHostTest {
         live = live,
         baked = baked,
         perPreviewResolve = { null },
+        sharedDaemonRenders = false,
       )
     assertEquals(5, pooled.themeRenderBurstCapacity)
   }
@@ -977,6 +978,43 @@ class ServeCatalogLiveHostTest {
       Thread.sleep(25)
     }
     error("theme optimization did not finish: ${host.themeOptimizationSnapshot()}")
+  }
+
+  @Test
+  fun `burst capacity follows the lane snapshots actually render on`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live = RecordingHost(previews = listOf(ServePreview(daemonId, daemonId)), tag = "mono")
+    val perPreview = RecordingHost(previews = emptyList(), tag = "per")
+
+    // Sharing one daemon means one render lock: a wide burst would funnel workers into it, hand
+    // most of them Busy, and the page would exhaust its retries with cards still on baked pixels.
+    assertEquals(
+      1,
+      ServeCatalogLiveHost(
+          alias = mapOf(catalogId to daemonId),
+          live = live,
+          baked = baked,
+          perPreviewResolve = { perPreview },
+        )
+        .themeRenderBurstCapacity,
+    )
+    // Per-preview routing genuinely parallelises — one daemon per preview — so it keeps the burst.
+    assertEquals(
+      5,
+      ServeCatalogLiveHost(
+          alias = mapOf(catalogId to daemonId),
+          live = live,
+          baked = baked,
+          perPreviewResolve = { perPreview },
+          sharedDaemonRenders = false,
+        )
+        .themeRenderBurstCapacity,
+    )
+    // No pool at all was always serial.
+    assertEquals(
+      1,
+      ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked).themeRenderBurstCapacity,
+    )
   }
 
   @Test


### PR DESCRIPTION
## Why

A catalog used to have exactly **one** daemon: a grid paid one cold start and every card after it was warm. `perPreviewResolve` arrived in `98003e1` (2 Aug 07:56, #3153) and became the **default render path**, so each card now resolves its own daemon and pays its own cold start.

Measured on the deployed box: **68,803 ms cold vs 356 ms warm**. That's why selecting a theme across a 42-card grid went from filling in at about one a second to mostly stalled. Watched live while measuring:

| | |
|---|---|
| first themed request | **503**, `Retry-After: 2` |
| …daemon warms, same card | **0.9s** ✅ |
| **different card, same theme** | **503 again** |

The pool's LRU cap of 8 makes it worse than linear — a grid larger than the cap evicts daemons while the same page is still using them, so scrolling back can pay the cold start a second time.

## What

Snapshot renders — the grid and every themed thumbnail on it — go to the shared monolithic daemon, the lane that actually amortises a cold start across a batch.

- **Fallback preserved:** an id the shared daemon reports `NotFound` still resolves its per-preview daemon, so a split or IR-backed bundle the monolithic descriptor never listed keeps working. Only `NotFound` falls through — a `Busy` or a failure is that daemon's real answer, and re-running it elsewhere would double the work.
- **Interactive streams keep the per-preview lane.** There the isolation is the point — one long-lived session per preview being edited — and there's no batch to amortise over.
- `-Dcomposeai.serve.sharedDaemonRenders=false` restores the previous routing.

## Correcting the earlier diagnosis

I originally attributed the slowdown to the lease clamp in #3187 (`Semaphore(1)`, 2 Aug 18:25). That's real and it serialises the retries, but it's the **second** factor. The per-preview lane, ten hours earlier, is what turned one cold start per catalog into one per card. #3231's wider leases divide the queue; this changes the constant.

It also means "warm the catalog's daemon" was the wrong plan while renders fanned out — there were 42 daemons to warm at 2 live seats each against a budget of 8. With renders shared again, warming becomes tractable.

## Test plan

- `./gradlew :cli:test` — **1249 tests, 0 failures**.
- New: snapshot renders reach the shared daemon and never touch the per-preview one.
- The three tests that encoded per-preview-first routing now **pin `sharedDaemonRenders = false`**, so that lane keeps its coverage instead of being deleted along with the default — including the ordering test and the theme-cache-across-reuse test.
- ktfmt clean.

Text-only evidence: this changes which daemon answers, not what it draws.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_