### PR TITLE
feat(serve): count live-seat refusals on status

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Bounds concurrent **live** (daemon-backed) stream sessions by a *permit budget* rather than a
@@ -47,11 +48,28 @@ class LiveSeatLimiter(val totalPermits: Int) {
     val sem = semaphore ?: return Ticket(0)
     if (weight <= 0) return Ticket(0)
     val permits = weight.coerceIn(1, totalPermits)
-    return if (sem.tryAcquire(permits)) Ticket(permits) else null
+    if (sem.tryAcquire(permits)) return Ticket(permits)
+    refusals.incrementAndGet()
+    return null
   }
 
   /** Permits currently available — for tests/diagnostics. */
   fun availablePermits(): Int = semaphore?.availablePermits() ?: Int.MAX_VALUE
+
+  /**
+   * How many live sessions this limiter has turned away since startup, monotonic.
+   *
+   * Deliberately a **counter, not a gauge**: a refusal is an event lasting as long as it takes the
+   * caller to give up, while [availablePermits] is a level you happen to sample. On a box with a
+   * handful of viewers, polling the level essentially never catches the moment of pressure, so "is
+   * the seat budget actually too small here?" was unanswerable from `/status` — you would read a
+   * comfortable-looking figure whatever the truth. This is the number that answers it, and it is
+   * the evidence any change to the budget (or to evicting an idle daemon in favour of an active
+   * one) should be argued from.
+   */
+  fun refusalCount(): Long = refusals.get()
+
+  private val refusals = AtomicLong()
 
   /** A held reservation of [permits] live-seat permits; [close] returns them (idempotent). */
   inner class Ticket internal constructor(val permits: Int) : AutoCloseable {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1877,6 +1877,7 @@ class ServeHttpServer(
             liveSeatsTotal = if (liveSeats.unbounded) 0 else liveSeats.totalPermits,
             liveSeatsAvailable = if (liveSeats.unbounded) -1 else liveSeats.availablePermits(),
             liveSeatsUnbounded = liveSeats.unbounded,
+            liveSeatRefusals = liveSeats.refusalCount(),
           ),
         config =
           ConfigDto(
@@ -3303,6 +3304,14 @@ private data class DaemonSummaryDto(
   /** Free permits; `-1` ⇒ unbounded. */
   val liveSeatsAvailable: Int,
   val liveSeatsUnbounded: Boolean,
+  /**
+   * Live sessions turned away for want of seats since startup, monotonic. A counter rather than a
+   * gauge because a refusal is an event: [liveSeatsAvailable] beside it is a level, and on a
+   * lightly-used box sampling that level almost never coincides with the pressure. Zero over a long
+   * uptime is the evidence that the seat budget is comfortable; a climbing figure is what would
+   * justify raising it, or evicting an idle daemon in favour of an active one.
+   */
+  val liveSeatRefusals: Long = 0,
 )
 
 @Serializable

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
@@ -15,6 +15,31 @@ import kotlin.test.assertTrue
 class LiveSeatLimiterTest {
 
   @Test
+  fun `refusals are counted so seat pressure is visible after the fact`() {
+    val limiter = LiveSeatLimiter(totalPermits = 2)
+    assertEquals(0L, limiter.refusalCount())
+
+    val held = assertNotNull(limiter.acquire(2))
+    // Two refusals while the budget is fully held…
+    assertNull(limiter.acquire(1))
+    assertNull(limiter.acquire(1))
+    assertEquals(2L, limiter.refusalCount())
+
+    // …and the count is monotonic: releasing does not rewind history, which is the point of a
+    // counter over the availablePermits gauge beside it.
+    held.close()
+    assertNotNull(limiter.acquire(1)).close()
+    assertEquals(2L, limiter.refusalCount())
+  }
+
+  @Test
+  fun `an unbounded limiter never refuses and so never counts`() {
+    val limiter = LiveSeatLimiter(totalPermits = 0)
+    repeat(5) { assertNotNull(limiter.acquire(2)) }
+    assertEquals(0L, limiter.refusalCount())
+  }
+
+  @Test
   fun `zero budget is unbounded — every acquire is a free ticket`() {
     val limiter = LiveSeatLimiter(0)
     assertTrue(limiter.unbounded)


### PR DESCRIPTION
Step one of the memory-management plan: make the decision measurable before making it.

## The gap

Whether the seat budget is actually too small on a given box **cannot be answered from `/status` today**. It reports `liveSeatsAvailable` — a *level*, read whenever someone happens to look. A refusal is an *event*, lasting only as long as it takes the caller to give up: `ServeHttpServer.kt:2894` closes the socket with 1013 "live preview at capacity" and nothing records it.

On a box with a handful of viewers those two almost never coincide. Polling the gauge would read a comfortable 8/8 whatever the truth, so "did seat pressure survive the shared-daemon fix?" was unanswerable — and any answer would have been a guess dressed as evidence.

## The change

`LiveSeatLimiter` counts what it turns away, exposed as `liveSeatRefusals` beside the existing gauges. Monotonic, so releasing permits doesn't rewind the history — which is precisely the difference from the gauge next to it.

**This is measurement, not policy.** Nothing changes about who gets a seat.

## Why it matters now

#3232 cut daemon demand by roughly 40× — a catalog needs ~1 daemon instead of up to 42 — so the pressure that motivated demand-driven eviction may simply have evaporated. This makes that checkable rather than assumed:

- **stays 0** over a few days → the fan-out was the whole problem; eviction is unnecessary and we've avoided building a memory manager for a dead issue.
- **climbs** → the demand signal is real, and LRU eviction is justified with a number behind it.

Either way the next decision gets argued from evidence.

## Test plan

- `./gradlew :cli:test` — **1252 tests, 0 failures**.
- New: refusals counted while the budget is held, and the count is **monotonic** across a release-and-reacquire — pinning the property that distinguishes it from `availablePermits`.
- New: an unbounded limiter never refuses and so never counts.
- ktfmt clean.

Text-only: adds a status field, changes no rendered surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_