### PR TITLE
fix(serve): count only real seat demand as a refusal

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -44,12 +44,16 @@ class LiveSeatLimiter(val totalPermits: Int) {
    * coerced down to [totalPermits], so a backend heavier than the whole budget can still run alone
    * rather than being permanently refused.
    */
-  fun acquire(weight: Int): Ticket? {
+  fun acquire(weight: Int, countRefusal: Boolean = true): Ticket? {
     val sem = semaphore ?: return Ticket(0)
     if (weight <= 0) return Ticket(0)
     val permits = weight.coerceIn(1, totalPermits)
     if (sem.tryAcquire(permits)) return Ticket(permits)
-    refusals.incrementAndGet()
+    // [countRefusal] is false for an attempt that was never going to be served anyway — a request
+    // naming a session this box doesn't have. Seats are reserved before the session is leased (see
+    // the stream lane), so such requests do reach the budget; letting them move [refusalCount]
+    // would mean anyone could manufacture the evidence a capacity decision rests on.
+    if (countRefusal) refusals.incrementAndGet()
     return null
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -44,16 +44,17 @@ class LiveSeatLimiter(val totalPermits: Int) {
    * coerced down to [totalPermits], so a backend heavier than the whole budget can still run alone
    * rather than being permanently refused.
    */
-  fun acquire(weight: Int, countRefusal: Boolean = true): Ticket? {
+  fun acquire(weight: Int, verified: Boolean = true): Ticket? {
     val sem = semaphore ?: return Ticket(0)
     if (weight <= 0) return Ticket(0)
     val permits = weight.coerceIn(1, totalPermits)
     if (sem.tryAcquire(permits)) return Ticket(permits)
-    // [countRefusal] is false for an attempt that was never going to be served anyway — a request
-    // naming a session this box doesn't have. Seats are reserved before the session is leased (see
-    // the stream lane), so such requests do reach the budget; letting them move [refusalCount]
-    // would mean anyone could manufacture the evidence a capacity decision rests on.
-    if (countRefusal) refusals.incrementAndGet()
+    // Seats are reserved before the session is leased (see the stream lane), so a request naming
+    // a session the registry doesn't have reaches the budget too. Those are split off rather than
+    // dropped: on a public box they are mostly noise anyone could generate, but on a `--revisions`
+    // box a valid revision is *legitimately* unknown until its first lease builds it, and its
+    // refusals are real demand. Two counters keep both readings honest.
+    if (verified) refusals.incrementAndGet() else unverifiedRefusals.incrementAndGet()
     return null
   }
 
@@ -73,7 +74,19 @@ class LiveSeatLimiter(val totalPermits: Int) {
    */
   fun refusalCount(): Long = refusals.get()
 
+  /**
+   * Refusals for a session id the registry did not have at admission time, monotonic.
+   *
+   * Two populations share this bucket and only the caller's deployment tells them apart: a request
+   * for something that was never here (noise on a public box — anyone can generate it, which is why
+   * it must not touch [refusalCount]), and a lazily-created session that is valid but unbuilt, as
+   * `--revisions` produces on its first request. Read it alongside [refusalCount] rather than
+   * instead of it.
+   */
+  fun unverifiedRefusalCount(): Long = unverifiedRefusals.get()
+
   private val refusals = AtomicLong()
+  private val unverifiedRefusals = AtomicLong()
 
   /** A held reservation of [permits] live-seat permits; [close] returns them (idempotent). */
   inner class Ticket internal constructor(val permits: Int) : AutoCloseable {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2931,7 +2931,11 @@ class ServeHttpServer(
     // --revisions), unregistered until its build runs, defaults to weight 1 — a desktop-cost
     // daemon.
     val weight = if (sessions.isKnownStatic(sessionId)) 0 else sessions.liveSeatWeight(sessionId)
-    val seatTicket = liveSeats.acquire(weight)
+    // Only a request for a session this box actually has counts as real seat demand: the
+    // reservation
+    // happens before the lease, so a bogus id reaches the budget too, and an inflatable counter is
+    // not evidence.
+    val seatTicket = liveSeats.acquire(weight, countRefusal = sessions.isKnownSession(sessionId))
     if (seatTicket == null) {
       close(CloseReason(1013.toShort(), "live preview at capacity — try again shortly"))
       return

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1912,6 +1912,7 @@ class ServeHttpServer(
             liveSeatsAvailable = if (liveSeats.unbounded) -1 else liveSeats.availablePermits(),
             liveSeatsUnbounded = liveSeats.unbounded,
             liveSeatRefusals = liveSeats.refusalCount(),
+            liveSeatRefusalsUnverified = liveSeats.unverifiedRefusalCount(),
           ),
         config =
           ConfigDto(
@@ -2931,11 +2932,11 @@ class ServeHttpServer(
     // --revisions), unregistered until its build runs, defaults to weight 1 — a desktop-cost
     // daemon.
     val weight = if (sessions.isKnownStatic(sessionId)) 0 else sessions.liveSeatWeight(sessionId)
-    // Only a request for a session this box actually has counts as real seat demand: the
-    // reservation
-    // happens before the lease, so a bogus id reaches the budget too, and an inflatable counter is
-    // not evidence.
-    val seatTicket = liveSeats.acquire(weight, countRefusal = sessions.isKnownSession(sessionId))
+    // The reservation happens before the lease, so a bogus id reaches the budget too. A refusal for
+    // a session the registry doesn't have is counted separately rather than as demand: an
+    // inflatable counter is not evidence, but a `--revisions` session is legitimately unknown until
+    // its first lease builds it, so the number is kept rather than dropped.
+    val seatTicket = liveSeats.acquire(weight, verified = sessions.isKnownSession(sessionId))
     if (seatTicket == null) {
       close(CloseReason(1013.toShort(), "live preview at capacity — try again shortly"))
       return
@@ -3357,6 +3358,13 @@ private data class DaemonSummaryDto(
    * justify raising it, or evicting an idle daemon in favour of an active one.
    */
   val liveSeatRefusals: Long = 0,
+  /**
+   * Refusals for a session id the registry did not have — see
+   * [LiveSeatLimiter.unverifiedRefusalCount]. Kept apart from [liveSeatRefusals] because anyone can
+   * generate these against a public box, while on a `--revisions` box they are genuine
+   * first-request demand.
+   */
+  val liveSeatRefusalsUnverified: Long = 0,
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -254,6 +254,18 @@ class ServeSessionRegistry(
   }
 
   /**
+   * Whether [sessionId] names a session this registry actually has. Cheap and non-opening — it does
+   * not lease, resume, or spawn anything.
+   *
+   * Exists so the live-seat budget can tell a real admission attempt from a request for something
+   * that was never here. The seat is reserved *before* the session is leased (leasing resumes the
+   * host and spawns its daemon, so a later check would be too late to bound anything), which means
+   * a request for a nonexistent session reaches the budget too — harmless for admission, but it
+   * would let anyone inflate the refusal counter that budget decisions are supposed to rest on.
+   */
+  fun isKnownSession(sessionId: String): Boolean = lock.withLock { sessions.containsKey(sessionId) }
+
+  /**
    * Live-seat cost of [sessionId]'s daemon in [LiveSeatLimiter] permits — its session state's
    * [ServeSessionState.liveSeatWeight], or `1` for an unknown / lazily-forked session (whose
    * on-demand build hasn't run yet, so it's treated as a default desktop-weight daemon). Read

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
@@ -40,12 +40,16 @@ class LiveSeatLimiterTest {
     // Seats are reserved before the session is leased, so a request naming a session this box does
     // not have still reaches the budget. It is refused like any other — but it must not move the
     // counter, or anyone could manufacture the evidence a capacity decision rests on.
-    assertNull(limiter.acquire(1, countRefusal = false))
+    assertNull(limiter.acquire(1, verified = false))
     assertEquals(0L, limiter.refusalCount())
+    // Not dropped, though: a `--revisions` session is legitimately unknown until its first lease
+    // builds it, so the number is kept in its own bucket rather than lost.
+    assertEquals(1L, limiter.unverifiedRefusalCount())
 
-    // A real one still counts.
+    // A real one still counts as demand.
     assertNull(limiter.acquire(1))
     assertEquals(1L, limiter.refusalCount())
+    assertEquals(1L, limiter.unverifiedRefusalCount())
     held.close()
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
@@ -33,6 +33,23 @@ class LiveSeatLimiterTest {
   }
 
   @Test
+  fun `an attempt for an unknown session is refused without counting`() {
+    val limiter = LiveSeatLimiter(totalPermits = 1)
+    val held = assertNotNull(limiter.acquire(1))
+
+    // Seats are reserved before the session is leased, so a request naming a session this box does
+    // not have still reaches the budget. It is refused like any other — but it must not move the
+    // counter, or anyone could manufacture the evidence a capacity decision rests on.
+    assertNull(limiter.acquire(1, countRefusal = false))
+    assertEquals(0L, limiter.refusalCount())
+
+    // A real one still counts.
+    assertNull(limiter.acquire(1))
+    assertEquals(1L, limiter.refusalCount())
+    held.close()
+  }
+
+  @Test
   fun `an unbounded limiter never refuses and so never counts`() {
     val limiter = LiveSeatLimiter(totalPermits = 0)
     repeat(5) { assertNotNull(limiter.acquire(2)) }


### PR DESCRIPTION
Follow-up to #3233, which merged before this landed on it.

## The problem

**The refusal counter could be inflated by anyone.** Seats are reserved *before* the session is leased — deliberately, and the comment at the call site says why: leasing resumes the host and spawns its daemon, so a later check would be too late to bound anything. The consequence is that a request naming a session this box doesn't have still reaches the budget, and an unknown id defaults to weight 1 (`ServeSessionRegistry.liveSeatWeight`).

So on a bounded public server, a request like `/bogus/ws/bogus` moved `liveSeatRefusals` whenever real capacity happened to be occupied.

That matters more than it would for most counters, because of what this one is *for*: it exists so that raising the seat budget — or evicting an idle daemon in favour of an active one — can be argued from evidence. **A number a stranger can manufacture is not evidence**, and a counter that only over-reports under load would have pointed at exactly the wrong conclusion.

## The change

Refusals are counted only for a session the registry actually has, via a new non-opening `isKnownSession` check. **Admission is unchanged** — such a request is still refused; it just no longer claims to be demand.

The reservation-before-lease ordering is untouched, since it's load-bearing for the budget itself.

## Test plan

- `./gradlew :cli:test` — **1253 tests, 0 failures** (verified on the pre-merge base; the changed classes re-verified against current `main`: `LiveSeatLimiterTest` 10, `ServeStatusTest` 8, `ServeHttpRoutingTest` all green).
- New: an attempt for an unknown session is refused **without** counting, while a real one immediately after still counts — pinning both halves.
- ktfmt clean.

Text-only: changes what a counter counts, no rendered surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_