### PR TITLE
fix(serve): resolve Pocket Casts' eventhorizon from a8c-libs

### DIFF
--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -292,10 +292,13 @@ fi
 # meshcore-mobile's jitpack.io deps like usb-serial-for-android) otherwise has those coordinates
 # skipped, so its live daemon can't build its classpath and the catalog falls back to baked PNGs.
 # Defaults to the repos every baked live catalog needs: jitpack.io (meshcore-mobile's
-# usb-serial-for-android etc.) and the Apollo snapshots repo (Confetti's mapped Apollo artifacts).
-# Override with your own comma list to add another catalog's repo, or set `none` to send only
-# Central + Google. Empty inherits this baked default.
-: "${SERVE_EXTRA_MAVEN_REPOS:=https://jitpack.io,https://storage.googleapis.com/apollo-snapshots/m2}"
+# usb-serial-for-android etc.), the Apollo snapshots repo (Confetti's mapped Apollo artifacts), and
+# Automattic's a8c-libs S3 repo (Pocket Casts' `com.automattic:eventhorizon`, which its
+# `Theme.ThemeType` links against — without it the /pocketcasts live daemon dies on
+# `NoClassDefFoundError: com/automattic/eventhorizon/AppThemeType` the moment a themed preview
+# renders). Override with your own comma list to add another catalog's repo, or set `none` to send
+# only Central + Google. Empty inherits this baked default.
+: "${SERVE_EXTRA_MAVEN_REPOS:=https://jitpack.io,https://storage.googleapis.com/apollo-snapshots/m2,https://a8c-libs.s3.amazonaws.com/android}"
 [[ "${SERVE_EXTRA_MAVEN_REPOS}" != "none" && -n "${SERVE_EXTRA_MAVEN_REPOS}" ]] &&
   args+=(--extra-maven-repos "${SERVE_EXTRA_MAVEN_REPOS}")
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -804,9 +804,12 @@ There are two ways to stand that daemon up, both fail-closed on the `Trusted` ve
    Central + Google** (e.g. `meshcore-mobile`'s `jitpack.io` deps like `usb-serial-for-android`)
    needs those repos supplied via `--extra-maven-repos <url>[,<url>…]` (env `SERVE_EXTRA_MAVEN_REPOS`;
    the prebuilt image defaults it to the repos its baked catalogs need — `https://jitpack.io`
-   (meshcore-mobile) + the Apollo snapshots repo (Confetti); `none` to disable) — otherwise the
+   (meshcore-mobile), the Apollo snapshots repo (Confetti) and `https://a8c-libs.s3.amazonaws.com/android`
+   (Pocket Casts' `com.automattic:eventhorizon`); `none` to disable) — otherwise the
    resolver skips those coordinates and the daemon can't build its classpath, so the catalog falls
-   back to baked PNGs (`livebundle-unavailable`). Only list repos you trust; the server fetches
+   back to baked PNGs (`livebundle-unavailable`), or — when the missing class is only linked at
+   render time rather than at daemon bootstrap — every render fails with `NoClassDefFoundError`
+   while the daemon itself stays up. Only list repos you trust; the server fetches
    artifacts from them when resolving a trusted catalog's live bundle. Both backends are supported
    ([`ServeBundleDaemon.materialize`](../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt)):
    a **desktop** bundle spawns the Skiko desktop daemon, and an **android** bundle spawns the


### PR DESCRIPTION
## Summary

Every live render of the `/pocketcasts` catalog on preview.coo.ee fails with:

```
render failed: NoClassDefFoundError: com/automattic/eventhorizon/AppThemeType
```

`pocket-casts-android`'s `modules/services/ui` declares `Theme.ThemeType` with an `analyticsValue: AppThemeType` on every entry, so `com.automattic:eventhorizon` is linked from the class initializer of the type every themed preview in that catalog touches. That artifact is published **only** to `https://a8c-libs.s3.amazonaws.com/android` — not Maven Central, not Google Maven.

`ServeBundleDaemon.materialize` resolves the bundle's recorded Maven coordinates through `CoordinateResolver`, whose `DEFAULT_REMOTE_REPOSITORIES` is Central + Google. The coordinate is skipped, the jar never reaches the daemon's classpath, and the class is missing at composition time.

This is the failure mode `--extra-maven-repos` already exists for — the image bakes jitpack.io for meshcore-mobile and the Apollo snapshots repo for Confetti for exactly the same reason. Pocket Casts' repo was simply never added. So: add it to the baked default.

Worth noting because it made this read as a renderer bug rather than a classpath gap: the miss is a **render-time** link failure, not a bootstrap one. The daemon starts fine and the catalog does *not* degrade to `livebundle-unavailable`/baked PNGs — it stays "live" and fails every single render. The docs paragraph is updated to say that out loud.

## Test plan

- `bash -n deploy/image/entrypoint.sh` passes.
- Config-only change to a baked env default; no Kotlin touched, so no unit/functional test covers it. The default is consumed as a plain comma list by the same `--extra-maven-repos` path the existing two entries use.
- Verifiable after deploy: `https://a8c-libs.s3.amazonaws.com/android/com/automattic/eventhorizon/pocket-casts-2026-07-14_22-15-37/eventhorizon-pocket-casts-2026-07-14_22-15-37.pom` returns 200 (checked), and a `/pocketcasts/` live render should stop throwing `NoClassDefFoundError`.
- `SERVE_EXTRA_MAVEN_REPOS=none` and explicit overrides are unaffected.

## Not fixed here

The other failure from the same investigation — `pocketcasts-wear`:

```
render failed: NotFoundException: Drawable au.com.shiftyjelly.pocketcasts.debug:drawable/splash_background with resource ID #0x7f0806b5
```

is a separate, real bug in `AndroidResourcePruner` and needs its own change:

- `:wear`'s merged manifest carries `<application android:theme="@style/SplashTheme">`, so `PreviewHostTheme` resolves it and the host activity's window resolves `android:windowBackground` → `@drawable/splash_background`.
- `wear/src/main/res/drawable/splash_background.xml` is a `<layer-list>` whose second item is `@mipmap/ic_launcher`.
- `splash_background` is module-own so the pruner retains it; `mipmap/ic_launcher` lives in `:modules:services:images`, is therefore a merged-dependency file resource of a prunable type, and is dropped. Inflating the retained layer-list then throws, reported against the outer id.
- `PlaceholderFallbackResources` can't catch it: the failure is inside `ResourcesImpl.loadDrawable` for a *retained* drawable reached through `TypedArray.getDrawable` on the theme, not through any guarded `Resources.getDrawable*` overload.
- Retaining `mipmap/ic_launcher` alone is not enough — at `sdkVersion 35` the selected variant is `mipmap-anydpi-v26/ic_launcher.xml`, an `<adaptive-icon>` referencing three further `@drawable/ic_launcher_*` from the same dependency module.

The pruner's retain set needs to be a **closure**, not a flat module-own set. That is a policy call about bundle size (the honest conservative fallback — stop pruning `drawable`/`mipmap` entirely once a retained resource references outside the module — could re-add the ~140 KB the pruner was written to drop), so I've left it for a follow-up rather than picking for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB3To299sbTCUiYeWphV8U

---
_Generated by [Claude Code](https://claude.ai/code/session_01AB3To299sbTCUiYeWphV8U)_