### PR TITLE
fix(design-artifacts): don't publish a light reference against a dark sticker

### DIFF
--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -159,6 +159,43 @@ function providerFor(source) {
 }
 
 /**
+ * Narrow a function's matched stickers to the one the design-map entry's `previewId` names.
+ *
+ * [imagesByPreviewFunction] partitions a component's images between its default `preview` and its
+ * declared `variants`, which separates light from dark when they are two *different* `@Preview`
+ * functions. It cannot separate them when they are two `@Preview` annotations on the SAME function
+ * — the multipreview shape (`@Preview(name = "Light")` + `@Preview(name = "Dark", uiMode = …)`),
+ * where both stickers legitimately belong to one function name. A design-map entry maps one code
+ * handle to one reference, so without this narrowing a light-only reference is published against
+ * the dark sticker too, and the server scores a dark render against a light design.
+ *
+ * The entry's `previewId` is exactly the discriminator: it names the rendered preview, so a
+ * component-level `…_Light` entry keeps the light sticker and drops the dark one.
+ *
+ * Applied only when the matched images actually carry `previewId`s. Renders folded in through the
+ * generator's `--extra-renders` don't, and narrowing on an absent field would silently unmap every
+ * one of them — so an unlabelled match set is passed through whole, exactly as before.
+ */
+function narrowToMappedPreviewId(matches, mappedPreviewId, fn, warnings) {
+  if (typeof mappedPreviewId !== "string" || mappedPreviewId === "") return matches;
+  const labelled = matches.filter(({ image }) => typeof image?.previewId === "string");
+  if (labelled.length === 0) return matches;
+
+  const narrowed = labelled.filter(({ image }) => image.previewId === mappedPreviewId);
+  if (narrowed.length === 0) {
+    warnings.push(
+      `design-map '${fn}' names previewId '${mappedPreviewId}', which matches none of its ` +
+        `published stickers (${labelled.map(({ image }) => image.previewId).join(", ")})`,
+    );
+    return [];
+  }
+  // Anything the catalog left unlabelled stays in: it can't be ruled out, and dropping it would
+  // lose a reference the old behaviour published.
+  const unlabelled = matches.filter(({ image }) => typeof image?.previewId !== "string");
+  return [...narrowed, ...unlabelled];
+}
+
+/**
  * Plan the reference records for a repo: which design-map entries map onto which published
  * stickers, and what each one's raster has to look like.
  *
@@ -185,14 +222,16 @@ export function planDesignReferences({ designMap, spec, catalog }) {
       warnings.push(`design-map entry has no 'path#Member' code handle: ${entry?.code ?? "?"}`);
       continue;
     }
-    const matches = index.get(fn);
-    if (!matches || matches.length === 0) {
+    const allMatches = index.get(fn);
+    if (!allMatches || allMatches.length === 0) {
       warnings.push(
         `design-map '${fn}' matches no published sticker — no catalog.spec.json ` +
           `preview names that @Preview function, or its component rendered nothing`,
       );
       continue;
     }
+    const matches = narrowToMappedPreviewId(allMatches, entry?.previewId, fn, warnings);
+    if (matches.length === 0) continue;
     for (const { componentId, image } of matches) {
       const previewId = servePreviewId(image.path);
       const ordinal = ordinals.get(previewId) ?? 0;

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -310,3 +310,136 @@ test("referenceManifest emits the served schema and drops driver-only fields", (
   assert.equal("origin" in manifest.references[0], false);
   assert.equal("rastered" in manifest.references[0], false);
 });
+
+// A multipreview component: light and dark are two @Preview annotations on ONE function, so
+// imagesByPreviewFunction cannot split them the way it splits a declared `variants` entry.
+const MULTIPREVIEW_SPEC = {
+  groups: [
+    {
+      name: "Contacts",
+      components: [{ componentId: "ContactRow/Chat", preview: "ContactRowChatPreview" }],
+    },
+  ],
+};
+
+const MULTIPREVIEW_CATALOG = {
+  components: [
+    {
+      componentId: "ContactRow/Chat",
+      images: [
+        {
+          path: "images/contactrow-chat/ideal__default__light__compact.png",
+          state: "default",
+          theme: "light",
+          size: "compact",
+          width: 805,
+          height: 147,
+          previewId: "ee.app.ui.ComponentPreviewsKt.ContactRowChatPreview_Light",
+        },
+        {
+          path: "images/contactrow-chat/ideal__default__dark__compact.png",
+          state: "default",
+          theme: "dark",
+          size: "compact",
+          width: 805,
+          height: 147,
+          previewId: "ee.app.ui.ComponentPreviewsKt.ContactRowChatPreview_Dark",
+        },
+      ],
+    },
+  ],
+};
+
+test("planDesignReferences narrows a multipreview function to the previewId the entry names", () => {
+  const designMap = {
+    components: [
+      {
+        code: "app/src/main/kotlin/ui/ComponentPreviews.kt#ContactRowChatPreview",
+        source: "figma",
+        ref: "figma:abc/87:477",
+        previewId: "ee.app.ui.ComponentPreviewsKt.ContactRowChatPreview_Light",
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({
+    designMap,
+    spec: MULTIPREVIEW_SPEC,
+    catalog: MULTIPREVIEW_CATALOG,
+  });
+
+  assert.deepEqual(warnings, []);
+  // Without the narrowing the light-only Figma node is published against the dark sticker too,
+  // and the server scores a dark render against a light design.
+  assert.deepEqual(
+    records.map((r) => r.previewId),
+    ["contactrow-chat__ideal__default__light__compact"],
+  );
+});
+
+test("planDesignReferences keeps both stickers when the entry names no previewId", () => {
+  const designMap = {
+    components: [
+      {
+        code: "app/src/main/kotlin/ui/ComponentPreviews.kt#ContactRowChatPreview",
+        source: "figma",
+        ref: "figma:abc/87:477",
+      },
+    ],
+  };
+
+  const { records } = planDesignReferences({
+    designMap,
+    spec: MULTIPREVIEW_SPEC,
+    catalog: MULTIPREVIEW_CATALOG,
+  });
+
+  assert.equal(records.length, 2);
+});
+
+test("planDesignReferences ignores previewId when the catalog images carry none", () => {
+  // The `--extra-renders` case: images folded in from a second module have no previewId, so
+  // narrowing on an absent field would silently unmap every one of them.
+  const designMap = {
+    components: [
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatPreview",
+        source: "figma",
+        ref: "figma:abc/73:5",
+        previewId: "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview_Contact chat",
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({ designMap, spec: SPEC, catalog: CATALOG });
+
+  assert.deepEqual(warnings, []);
+  assert.deepEqual(
+    records.map((r) => r.previewId),
+    ["chat-contact__ideal__default__compact"],
+  );
+});
+
+test("planDesignReferences warns when the entry's previewId matches no published sticker", () => {
+  const designMap = {
+    components: [
+      {
+        code: "app/src/main/kotlin/ui/ComponentPreviews.kt#ContactRowChatPreview",
+        source: "figma",
+        ref: "figma:abc/87:477",
+        previewId: "ee.app.ui.ComponentPreviewsKt.ContactRowChatPreview_Typo",
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({
+    designMap,
+    spec: MULTIPREVIEW_SPEC,
+    catalog: MULTIPREVIEW_CATALOG,
+  });
+
+  assert.deepEqual(records, []);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /ContactRowChatPreview_Typo/);
+  assert.match(warnings[0], /ContactRowChatPreview_Light/);
+});


### PR DESCRIPTION
## Summary

`planDesignReferences` joins `design-map.json` entries to published stickers by `@Preview` function name. `imagesByPreviewFunction` can split light from dark when they are two *different* functions — that's what `catalog.spec.json`'s `variants` are for — but not when they are two `@Preview` annotations on the **same** function:

```kotlin
@Preview(name = "Light", showBackground = true, widthDp = 340)
@Preview(name = "Dark",  showBackground = true, widthDp = 340, uiMode = UI_MODE_NIGHT_YES)
@Composable
fun ContactRowChatPreview() { … }
```

Both stickers land on the one function name. Since a design-map entry maps one code handle to one reference, a light-only reference was published against the dark sticker too — and the server duly scored a dark render against a light design.

Narrow the match set with the entry's own `previewId`, which is exactly the discriminator: it names the rendered preview, so a `…_Light` entry keeps the light sticker and drops the dark one. A `previewId` that matches none of the published stickers warns and maps nothing, rather than silently falling back to publishing all of them.

Applied **only** when the matched images actually carry `previewId`s. Renders folded in through the generator's `--extra-renders` don't, and narrowing on an absent field would silently unmap every one of them — so an unlabelled match set is passed through whole, exactly as before.

## Context

Surfaced mapping meshcore-mobile's component sticker sheet (yschimke/meshcore-mobile#339), where all 28 component / Scanner / SavedDevices entries are light-only multipreviews. Without this, that repo's compare page would show 28 dark rows scored against light designs.

## Test plan

`node --test scripts/design-artifacts/design-references.test.mjs` — 15 pass, 0 fail.

Four new cases, covering each branch:

- narrows a multipreview function to the `previewId` the entry names;
- keeps both stickers when the entry names no `previewId` (unchanged behaviour);
- ignores `previewId` when the catalog images carry none (the `--extra-renders` case);
- warns when the entry's `previewId` matches no published sticker.

Verified non-vacuous: reverting the narrowing call makes exactly cases 1 and 4 fail (13 pass / 2 fail). The 11 pre-existing tests pass unchanged.

Text-only PR — this is export-driver plumbing with no rendered surface of its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7y5mqUrhYdxFFWpq1ECrU)_