### PR TITLE
ci: enforce the CMP/Wasm parity lane

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -133,10 +133,15 @@ on:
         type: boolean
         default: false
       rc-cmp-wasm-lane:
-        description: "Add the CMP/Wasm player lane to rc-compare.html. Builds :rc-player-wasm:wasmPlayerDist, loads each ir/*.rc in the real browser player, screenshots it, and folds its pixel diff into one compact column. No-op for a catalog that ships no ir/*.rc."
+        description: "Add the required CMP/Wasm player lane to rc-compare.html. When enabled, its distribution must build and every ir/*.rc must render unless named in rc-cmp-wasm-allowlist. Evidence is uploaded before a failed gate stops publication. No-op for a catalog that ships no ir/*.rc."
         required: false
         type: boolean
         default: false
+      rc-cmp-wasm-allowlist:
+        description: 'Optional caller-repo-relative JSON file containing temporary CMP/Wasm exceptions. Every entry requires id, reason, and a non-expired YYYY-MM-DD expires date.'
+        required: false
+        type: string
+        default: ''
       stage-font-globs:
         description: 'Whitespace-separated repo-relative globs of font files (.ttf/.otf) to stage into fontconfig BEFORE rendering — for a desktop (Skiko) render that must resolve glyphs (CJK/Arabic/…) from a bundled face rather than a system fallback. Empty ⇒ no staging.'
         required: false
@@ -600,8 +605,12 @@ jobs:
       # PNG — the browser-render-lane counterpart of the PNG↔figma-svg compare.
       # A no-op (and no Chromium download) for catalogs without `ir/*.rc`.
       - name: PNG vs Remote Compose parity page
+        id: rc-compare
         if: ${{ inputs.publish || inputs.upload-out }}
+        continue-on-error: ${{ inputs.rc-cmp-wasm-lane }}
         working-directory: compose-ai-tools/scripts/design-artifacts
+        env:
+          RC_CMP_WASM_ALLOWLIST: ${{ inputs.rc-cmp-wasm-allowlist }}
         run: |
           set -euo pipefail
           if ! python3 - "$GITHUB_WORKSPACE/bundle.png" <<'PY'
@@ -630,11 +639,26 @@ jobs:
           EMBEDDED_ARGS=()
 
           if [ "${{ inputs.rc-cmp-wasm-lane }}" = "true" ]; then
+            mkdir -p "$GITHUB_WORKSPACE/out/rc-cmp-wasm-errors"
+            wasm_build_log="$GITHUB_WORKSPACE/out/rc-cmp-wasm-errors/distribution-build.log"
             if (cd "$GITHUB_WORKSPACE/compose-ai-tools" && \
-                ./gradlew :rc-player-wasm:wasmPlayerDist --no-daemon --quiet); then
-              EMBEDDED_ARGS+=(--cmp-wasm "$GITHUB_WORKSPACE/compose-ai-tools/rc-player/wasm/build/wasmDist")
+                ./gradlew :rc-player-wasm:wasmPlayerDist --no-daemon --quiet) >"$wasm_build_log" 2>&1; then
+              EMBEDDED_ARGS+=(
+                --cmp-wasm "$GITHUB_WORKSPACE/compose-ai-tools/rc-player/wasm/build/wasmDist"
+                --require-cmp-wasm
+              )
+              if [ -n "$RC_CMP_WASM_ALLOWLIST" ]; then
+                EMBEDDED_ARGS+=(--cmp-wasm-allowlist "$GITHUB_WORKSPACE/$RC_CMP_WASM_ALLOWLIST")
+              fi
             else
-              echo "::warning::cmp-wasm player distribution failed to build; publishing rc-compare without the cmp-wasm column"
+              echo "::error title=CMP/Wasm distribution failed::The required player distribution did not build; see the uploaded distribution-build.log." >&2
+              tail -n 80 "$wasm_build_log" >&2
+              {
+                echo '### Remote Compose CMP/Wasm'
+                echo
+                echo '❌ Player distribution failed to build. See `distribution-build.log` in the evidence artifact.'
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
             fi
           fi
 
@@ -705,6 +729,27 @@ jobs:
             --system "${{ inputs.system }}" \
             --title "${{ inputs.system }}" \
             ${EMBEDDED_ARGS[@]+"${EMBEDDED_ARGS[@]}"}
+
+      - name: Upload CMP/Wasm parity evidence
+        if: ${{ always() && inputs.rc-cmp-wasm-lane && (inputs.publish || inputs.upload-out) }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.system }}-rc-cmp-wasm-evidence
+          path: |
+            ${{ github.workspace }}/out/rc-compare-summary.json
+            ${{ github.workspace }}/out/rc-compare.html
+            ${{ github.workspace }}/out/rc-cmp-wasm
+            ${{ github.workspace }}/out/rc-cmp-wasm-diff
+            ${{ github.workspace }}/out/rc-cmp-wasm-errors
+          if-no-files-found: warn
+
+      # `continue-on-error` above exists only so the evidence upload gets a chance to run. Convert
+      # the recorded outcome back into a hard gate before either artifact handoff or publication.
+      - name: Enforce required CMP/Wasm lane
+        if: ${{ always() && inputs.rc-cmp-wasm-lane && (inputs.publish || inputs.upload-out) && steps.rc-compare.outcome == 'failure' }}
+        run: |
+          echo "::error title=CMP/Wasm parity gate failed::The enabled lane did not build or render every non-allowlisted Remote Compose document."
+          exit 1
 
       - name: Upload catalog bundle
         if: ${{ inputs.upload-out }}

--- a/scripts/design-artifacts/rc-compare-gate.mjs
+++ b/scripts/design-artifacts/rc-compare-gate.mjs
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Read the deliberately small temporary-exception format used by the strict CMP/Wasm lane:
+ *
+ *   { "entries": [{ "id": "preview.id", "reason": "issue URL or explanation",
+ *                   "expires": "2026-08-10" }] }
+ */
+export function readCmpWasmAllowlist(file, today = new Date().toISOString().slice(0, 10)) {
+  if (!file) return new Map();
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!parsed || !Array.isArray(parsed.entries)) {
+    throw new Error("CMP/Wasm allowlist must be an object with an entries array");
+  }
+  const result = new Map();
+  for (const [index, entry] of parsed.entries.entries()) {
+    const label = `CMP/Wasm allowlist entry ${index + 1}`;
+    if (!entry || typeof entry.id !== "string" || !entry.id.trim()) {
+      throw new Error(`${label} must have a non-empty id`);
+    }
+    if (typeof entry.reason !== "string" || !entry.reason.trim()) {
+      throw new Error(`${label} (${entry.id}) must have a non-empty reason`);
+    }
+    if (typeof entry.expires !== "string" || !ISO_DATE.test(entry.expires)) {
+      throw new Error(`${label} (${entry.id}) must have an expires date in YYYY-MM-DD form`);
+    }
+    if (new Date(`${entry.expires}T00:00:00Z`).toISOString().slice(0, 10) !== entry.expires) {
+      throw new Error(`${label} (${entry.id}) has an invalid expires date ${entry.expires}`);
+    }
+    if (entry.expires < today) {
+      throw new Error(`${label} (${entry.id}) expired on ${entry.expires}`);
+    }
+    if (result.has(entry.id)) throw new Error(`${label} duplicates id ${entry.id}`);
+    result.set(entry.id, { reason: entry.reason.trim(), expires: entry.expires });
+  }
+  return result;
+}
+
+/** Return the strict-lane verdict without throwing, so callers can write all evidence first. */
+export function evaluateCmpWasmGate(expectedIds, rows, allowlist = new Map()) {
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const failures = [];
+  const allowed = [];
+  for (const id of expectedIds) {
+    const row = byId.get(id);
+    if (row?.cmpWasmRendered === true) continue;
+    const exception = allowlist.get(id);
+    const note = row?.cmpWasmNote || (row ? "CMP/Wasm produced no result" : "row was dropped");
+    if (exception) allowed.push({ id, note, ...exception });
+    else failures.push({ id, note });
+  }
+  return {
+    passed: failures.length === 0,
+    expected: expectedIds.length,
+    rendered: expectedIds.filter((id) => byId.get(id)?.cmpWasmRendered === true).length,
+    allowed,
+    failures,
+  };
+}
+
+export function formatCmpWasmGate(gate) {
+  const lines = [
+    `CMP/Wasm: ${gate.rendered}/${gate.expected} rendered, ${gate.allowed.length} temporarily allowed, ${gate.failures.length} failed.`,
+  ];
+  for (const failure of gate.failures) lines.push(`- ${failure.id}: ${failure.note}`);
+  for (const entry of gate.allowed) {
+    lines.push(`- ${entry.id}: allowed until ${entry.expires} — ${entry.reason} (${entry.note})`);
+  }
+  return lines.join("\n");
+}

--- a/scripts/design-artifacts/rc-compare-gate.test.mjs
+++ b/scripts/design-artifacts/rc-compare-gate.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  evaluateCmpWasmGate,
+  formatCmpWasmGate,
+  readCmpWasmAllowlist,
+} from "./rc-compare-gate.mjs";
+
+test("strict CMP/Wasm gate reports failed and dropped rows", () => {
+  const gate = evaluateCmpWasmGate(
+    ["ready", "error", "dropped"],
+    [
+      { id: "ready", cmpWasmRendered: true },
+      { id: "error", cmpWasmRendered: false, cmpWasmNote: "opcode 150 at byte 42" },
+    ],
+  );
+  assert.equal(gate.passed, false);
+  assert.deepEqual(gate.failures, [
+    { id: "error", note: "opcode 150 at byte 42" },
+    { id: "dropped", note: "row was dropped" },
+  ]);
+  assert.match(formatCmpWasmGate(gate), /1\/3 rendered.*2 failed[\s\S]*opcode 150 at byte 42/);
+});
+
+test("a reasoned, unexpired exception allows only its named row", () => {
+  const allowlist = new Map([
+    ["known", { reason: "tracked by #123", expires: "2026-08-10" }],
+  ]);
+  const gate = evaluateCmpWasmGate(
+    ["known", "unknown"],
+    [
+      { id: "known", cmpWasmRendered: false, cmpWasmNote: "known failure" },
+      { id: "unknown", cmpWasmRendered: false, cmpWasmNote: "new failure" },
+    ],
+    allowlist,
+  );
+  assert.equal(gate.passed, false);
+  assert.equal(gate.allowed.length, 1);
+  assert.deepEqual(gate.failures, [{ id: "unknown", note: "new failure" }]);
+  assert.equal(
+    evaluateCmpWasmGate(
+      ["known"],
+      [{ id: "known", cmpWasmRendered: false, cmpWasmNote: "known failure" }],
+      allowlist,
+    ).passed,
+    true,
+  );
+});
+
+test("allowlist requires reasons and rejects expired entries", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rc-cmp-wasm-gate-"));
+  const file = path.join(dir, "allowlist.json");
+  fs.writeFileSync(file, JSON.stringify({ entries: [{ id: "x", reason: "", expires: "2026-08-10" }] }));
+  assert.throws(() => readCmpWasmAllowlist(file, "2026-08-03"), /non-empty reason/);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({ entries: [{ id: "x", reason: "tracked", expires: "2026-08-02" }] }),
+  );
+  assert.throws(() => readCmpWasmAllowlist(file, "2026-08-03"), /expired/);
+});

--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -22,7 +22,8 @@
  * Usage:
  *   node rc-compare.mjs --bundle <bundle.png> --player <rc-player bundle.js> \
  *     --out <dir> [--system <id>] [--title <t>] [--threshold 0.1] [--theme light] \
- *     [--fonts <dir>] [--cmp-wasm <rc-player-wasm distribution>]
+ *     [--fonts <dir>] [--cmp-wasm <rc-player-wasm distribution>] \
+ *     [--require-cmp-wasm] [--cmp-wasm-allowlist <json>]
  *
  * `--fonts` defaults to the vendored faces the snapshot renderer itself rasterizes with (see
  * rc-fonts.mjs). Point it elsewhere to compare against a different font set, or at a
@@ -41,6 +42,11 @@ import pixelmatch from "pixelmatch";
 import { chromium } from "playwright";
 
 import { renderRcCompareHtml } from "./render-rc-compare-html.mjs";
+import {
+  evaluateCmpWasmGate,
+  formatCmpWasmGate,
+  readCmpWasmAllowlist,
+} from "./rc-compare-gate.mjs";
 import { BG, flattenOnto, isFullyTransparent } from "./rc-compare-pixels.mjs";
 import { DEFAULT_FONTS_DIR, fontFaceCss, loadAndVerifyFonts } from "./rc-fonts.mjs";
 
@@ -81,9 +87,15 @@ const EMBEDDED_JVM = arg("embedded-jvm");
 // complete Compose/Skiko application, so the driver serves its distribution over localhost and
 // screenshots its viewport after the player's readiness marker appears.
 const CMP_WASM = arg("cmp-wasm");
+const REQUIRE_CMP_WASM = process.argv.includes("--require-cmp-wasm");
+const CMP_WASM_ALLOWLIST = arg("cmp-wasm-allowlist");
 
 if (!BUNDLE || !PLAYER || !OUT) {
   console.error("rc-compare: --bundle, --player and --out are required");
+  process.exit(2);
+}
+if (REQUIRE_CMP_WASM && !CMP_WASM) {
+  console.error("rc-compare: --require-cmp-wasm requires --cmp-wasm");
   process.exit(2);
 }
 
@@ -154,6 +166,7 @@ const dirs = {
   embeddedJvmDiff: path.join(OUT, "rc-embedded-jvm-diff"),
   cmpWasm: path.join(OUT, "rc-cmp-wasm"),
   cmpWasmDiff: path.join(OUT, "rc-cmp-wasm-diff"),
+  cmpWasmErrors: path.join(OUT, "rc-cmp-wasm-errors"),
 };
 for (const d of Object.values(dirs)) fs.mkdirSync(d, { recursive: true });
 
@@ -362,6 +375,7 @@ async function startCmpWasmServer(dir) {
 async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank) {
   if (!cmpWasmPage) return {};
   try {
+    cmpWasmConsoleErrors.length = 0;
     cmpWasmServer.setDocument(bytes);
     await cmpWasmPage.setViewportSize({ width, height });
     await cmpWasmPage.goto(
@@ -378,6 +392,9 @@ async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank) {
     }));
     if (state.state !== "ready") throw new Error(state.error || "player reported an error");
     const png = flattenOnto(PNG.sync.read(await cmpWasmPage.screenshot({ omitBackground: true })), BG);
+    if (cmpWasmConsoleErrors.length) {
+      throw new Error(`unexpected console error: ${cmpWasmConsoleErrors.join(" | ")}`);
+    }
     if (png.width !== width || png.height !== height) {
       throw new Error(`size ${png.width}×${png.height} ≠ baked ${width}×${height}`);
     }
@@ -393,9 +410,13 @@ async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank) {
       cmpWasmDiff: `rc-cmp-wasm-diff/${id}.png`,
     };
   } catch (error) {
+    const detail = String(error?.stack || error?.message || error);
+    const errorFile = `${encodeURIComponent(id)}.txt`;
+    fs.writeFileSync(path.join(dirs.cmpWasmErrors, errorFile), detail);
     return {
       cmpWasmRendered: false,
-      cmpWasmNote: String(error?.message || error).slice(0, 200),
+      cmpWasmNote: String(error?.message || error).slice(0, 500),
+      cmpWasmError: `rc-cmp-wasm-errors/${errorFile}`,
       cmpWasmMismatchPct: null,
       cmpWasmMismatchPx: null,
       cmpWasm: "",
@@ -416,6 +437,10 @@ const cmpWasmServer = CMP_WASM ? await startCmpWasmServer(CMP_WASM) : null;
 const cmpWasmPage = CMP_WASM
   ? await browser.newContext({ deviceScaleFactor: 1 }).then((context) => context.newPage())
   : null;
+const cmpWasmConsoleErrors = [];
+cmpWasmPage?.on("console", (message) => {
+  if (message.type() === "error") cmpWasmConsoleErrors.push(message.text());
+});
 const pageWarnings = [];
 page.on("console", (m) => {
   if (m.type() === "warning" || m.type() === "error") pageWarnings.push(m.text());
@@ -582,6 +607,19 @@ const rendered = rows.filter((r) => r.rendered);
 // `isFullyTransparent`. Left in `rendered` because the player did in fact render them.
 const scored = rendered.filter((r) => !r.referenceBlank);
 const meanPct = scored.length ? scored.reduce((s, r) => s + r.mismatchPct, 0) / scored.length : null;
+let cmpWasmGate = null;
+if (REQUIRE_CMP_WASM) {
+  try {
+    cmpWasmGate = evaluateCmpWasmGate(rcIds, rows, readCmpWasmAllowlist(CMP_WASM_ALLOWLIST));
+  } catch (error) {
+    cmpWasmGate = evaluateCmpWasmGate(rcIds, rows);
+    cmpWasmGate.passed = false;
+    cmpWasmGate.failures.unshift({
+      id: "allowlist",
+      note: String(error?.message || error),
+    });
+  }
+}
 fs.writeFileSync(
   path.join(OUT, "rc-compare-summary.json"),
   JSON.stringify(
@@ -595,6 +633,7 @@ fs.writeFileSync(
       meanMismatchPct: meanPct,
       threshold: THRESHOLD,
       theme: THEME,
+      cmpWasmGate,
       embedded: EMBEDDED
         ? {
             rendered: rows.filter((r) => r.embeddedRendered).length,
@@ -650,6 +689,7 @@ fs.writeFileSync(
         cmpWasmMismatchPct: r.cmpWasmMismatchPct ?? null,
         cmpWasmMismatchPx: r.cmpWasmMismatchPx ?? null,
         cmpWasmNote: r.cmpWasmNote ?? null,
+        cmpWasmError: r.cmpWasmError ?? null,
       })),
     },
     null,
@@ -679,3 +719,12 @@ console.log(
       : `, ${rendered.length - scored.length} unscored (blank reference)`) +
     (meanPct == null ? "" : `, mean mismatch ${meanPct.toFixed(2)}%`),
 );
+
+if (REQUIRE_CMP_WASM) {
+  const message = formatCmpWasmGate(cmpWasmGate);
+  console.log(message);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n### Remote Compose CMP/Wasm\n\n${message}\n`);
+  }
+  if (!cmpWasmGate.passed) process.exitCode = 1;
+}

--- a/scripts/design-artifacts/render-rc-compare-html.mjs
+++ b/scripts/design-artifacts/render-rc-compare-html.mjs
@@ -221,7 +221,7 @@ function cellWithDiff(label, src, diffSrc, extraClass = "") {
  * `referenceBlank` short-circuits both players: the baked PNG is empty, so there is no comparison to
  * report and any number here would be a lie in either direction.
  */
-function scoreBlock(label, rendered, pct, px, note, referenceBlank = false) {
+function scoreBlock(label, rendered, pct, px, note, referenceBlank = false, errorHref = "") {
   const scorable = rendered && !referenceBlank;
   const text = scorable
     ? `${(pct ?? 0).toFixed(2)}%`
@@ -230,10 +230,12 @@ function scoreBlock(label, rendered, pct, px, note, referenceBlank = false) {
       : note || "no render";
   const pxTxt =
     scorable && px != null ? `<span class="px">${px.toLocaleString("en-US")} px</span>` : "";
+  const detail = !rendered && errorHref ? `<a href="${esc(errorHref)}">details</a>` : "";
   return `<div class="scoreline">
       <span class="scorelabel">${esc(label)}</span>
       <span class="score ${band(scorable ? pct : null)}">${esc(text)}</span>
       ${pxTxt}
+      ${detail}
     </div>`;
 }
 
@@ -271,6 +273,7 @@ function rowHtml(r, withEmbedded, withEmbeddedJvm, withCmpWasm) {
           r.cmpWasmMismatchPx,
           r.cmpWasmNote,
           r.referenceBlank,
+          r.cmpWasmError,
         )
       : "") +
     (r.referenceBlank

--- a/scripts/design-artifacts/render-rc-compare-html.test.mjs
+++ b/scripts/design-artifacts/render-rc-compare-html.test.mjs
@@ -26,6 +26,7 @@ function withCmpWasm(base) {
       cmpWasmMismatchPct: index !== 2 ? 3 + index : null,
       cmpWasmMismatchPx: index !== 2 ? 8_268 + index : null,
       cmpWasmNote: index === 2 ? "unsupported operation" : undefined,
+      cmpWasmError: index === 2 ? `rc-cmp-wasm-errors/${r.id}.txt` : undefined,
       cmpWasm: index !== 2 ? `rc-cmp-wasm/${r.id}.png` : "",
       cmpWasmDiff: index !== 2 ? `rc-cmp-wasm-diff/${r.id}.png` : "",
     })),
@@ -230,6 +231,10 @@ test("the cmp-wasm lane adds one folded-diff column and independent parity stats
   assert.match(html, /<span class="scorelabel">cmp-wasm<\/span>/);
   assert.match(html, /\(JS \+ cmp-wasm players\)/);
   assert.match(html, /runs the new Compose Multiplatform \/ Skiko player in browser Wasm/);
+  assert.match(
+    html,
+    /href="rc-cmp-wasm-errors\/pkg\.CatalogPreviewsKt\.Undecodable\.txt">details<\/a>/,
+  );
 });
 
 test("all rc-compare lanes can coexist without hiding the cmp-wasm result", () => {


### PR DESCRIPTION
## What changed

- make `rc-cmp-wasm-lane: true` a required lane rather than optional enrichment
- fail on distribution build failures, dropped/missing rows, player errors, readiness timeouts, and unexpected Chromium console errors
- support narrowly scoped temporary allowlists with a required reason and expiry date
- persist the JSON summary, screenshots, diffs, build log, and full per-row errors before failing publication
- add an Actions summary and links from the HTML report to full error details

## Why

The deployed `remote-m3` comparison currently reports 0/24 CMP/Wasm renders while the workflow remains green. That makes later player work impossible to evaluate reliably. This turns the lane into the parity gate described by the CMP/Wasm handover.

## Validation

- `npm test` in `scripts/design-artifacts` (browser-dependent existing test skipped when Chromium is unavailable)
- `bash scripts/design-artifacts/test-scope-systems.sh`
- workflow YAML parse
- `node --check scripts/design-artifacts/rc-compare.mjs`
- `git diff --check`

PR #3201 has merged; this is the first follow-up milestone from its handover.