### PR TITLE
feat(serve): keep a catalog's session alive while a visitor is reading it

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -241,6 +241,22 @@ class ServeCatalogLiveHost(
     alias.values.firstOrNull()?.let { scheduleWarm(it, live) }
   }
 
+  /**
+   * A visitor is on this catalog's pages: make sure the shared daemon is up, so their first theme
+   * selection is a warm render rather than a cold start.
+   *
+   * This is [prewarm]'s warming half without the theme-optimization pass — the same [scheduleWarm]
+   * call, under the same conditions. It is safe to call on every heartbeat because `scheduleWarm`
+   * returns immediately once the id is warm or a warm is already in flight; a suspended session is
+   * rebuilt with a fresh host (and so a fresh warm set) on resume, which is exactly when a
+   * heartbeat should warm it again.
+   */
+  override fun keepLiveWarm() {
+    if (!warmInBackground) return
+    if (perPreviewResolve != null && !sharedDaemonRenders) return
+    alias.values.firstOrNull()?.let { scheduleWarm(it, live) }
+  }
+
   override val label: String = baked.label
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -131,6 +131,22 @@ interface ServeHost : AutoCloseable {
   fun bakedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? = null
 
   /**
+   * A visitor is present on this session's pages right now (see `POST /api/presence`) — get its
+   * live render lane ready, if it has one and isn't ready already.
+   *
+   * Leasing the session is what keeps it from being reaped; this is the other half, for the common
+   * case where the visitor has only browsed **prebaked** pixels and so has never woken a daemon at
+   * all. Their first live render — picking a declared theme, opening a knob — would otherwise pay a
+   * cold start (~68 s on Android) that no page-level retry outlasts. Warming while they read the
+   * grid turns that into the warm path (~350 ms).
+   *
+   * Best-effort, non-blocking and idempotent: called every few minutes by every open tab, so an
+   * implementation must return immediately and do nothing at all once its lane is ready. Hosts with
+   * no live lane (a static baked bundle) keep the default no-op.
+   */
+  fun keepLiveWarm() {}
+
+  /**
    * Aggregate render-performance counters for this host's live render lane, surfaced on `/status`
    * + `/status.json` (`runningServers[].renderStats`). Null when the host has no live render lane
    *   to measure — a static baked bundle never renders. Daemon-backed hosts ([ServeRenderHost])

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2618,6 +2618,10 @@ class ServeHttpServer(
             },
           liveAuthPrompt = liveAuthPrompt,
           catalogTitle = catalogBundleHost(renderHost)?.title,
+          // The same heartbeat the grid sends. The viewer needs it at least as much: it is where a
+          // visitor settles on one preview and reads, making no further requests, and where the
+          // theme and knob actions that want a warm daemon are actually taken.
+          presenceUrl = "$basePath/api/presence${requestQuerySuffix()}",
         ),
         ContentType.Text.Html,
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -649,6 +649,8 @@ class ServeHttpServer(
 
         get("/api/previews") { handleApiPreviews(sessionInPath = false) }
         get("/{system}/api/previews") { handleApiPreviews(sessionInPath = true) }
+        post("/api/presence") { handlePresence(sessionInPath = false) }
+        post("/{system}/api/presence") { handlePresence(sessionInPath = true) }
         post("/api/theme-render-lease") { handleThemeRenderLease(sessionInPath = false) }
         post("/{system}/api/theme-render-lease") { handleThemeRenderLease(sessionInPath = true) }
         post("/api/theme-render-lease/release") { handleThemeRenderLeaseRelease() }
@@ -1213,6 +1215,10 @@ class ServeHttpServer(
               .gridThumbFor(renderHost, id, catalogBundleHost(renderHost)?.contentCrop(id))
               ?.hash
           },
+          // A heartbeat while the tab is open, so a visitor reading the grid keeps their session —
+          // and its daemon — alive. Especially now: the cards above are cacheable, so browsing this
+          // page can make no requests at all for as long as someone cares to read it.
+          presenceUrl = "$basePath/api/presence${requestQuerySuffix()}",
           // The catalog's declared stage surface (`display.surface`), so a dark-first system's
           // unthemed cards sit on the dark stage instead of the default white.
           declaredSurface = catalogBundleHost(renderHost)?.stageSurface,
@@ -1257,6 +1263,44 @@ class ServeHttpServer(
           ContentType.Application.Json,
         )
       }
+    }
+  }
+
+  /**
+   * `POST /api/presence` (and its `/{system}/` form): a heartbeat from an open catalog tab.
+   *
+   * Sessions are reaped after an idle window ([ServeSessionRegistry.DEFAULT_IDLE_TIMEOUT_MILLIS]),
+   * and idleness is measured in *requests*. A visitor reading one catalog page makes none — the
+   * more so now that its thumbnails and heroes are `immutable` and repaint from cache — so a tab
+   * that has been open for a quarter of an hour looks exactly like an abandoned one, and the daemon
+   * behind it is shut down under a visitor who is still there. This is the signal that says
+   * otherwise.
+   *
+   * Two things happen, and the cheap one is the important one:
+   * - Leasing the session marks it as in use, which is what actually keeps it (and its daemon)
+   *   resident, and resumes it if it had already been suspended.
+   * - [ServeHost.keepLiveWarm] then gets its live lane ready, for the visitor who has only browsed
+   *   prebaked pixels and so has never woken a daemon at all — the common case by design.
+   *
+   * Deliberately silent: 204 with no body, no error surface. A heartbeat is not something a page
+   * can act on, and one that fails (offline, a catalog since removed) simply means the next one
+   * tries again.
+   */
+  private suspend fun RoutingContext.handlePresence(sessionInPath: Boolean) {
+    if (rejectBadToken()) return
+    withLeasedSession(
+      selectedSessionId(sessionInPath),
+      onMissing = { call.respond(HttpStatusCode.NoContent) },
+    ) { renderHost ->
+      // Warming is the only part that can cost anything, so it is gated on the live-seat budget: on
+      // a busy box a browsing visitor's *convenience* ranks below someone else's actual request.
+      // A load signal, not a reservation — the warm runs off the request path and takes no seat of
+      // its own — but it is enough to stop a room full of idle tabs from each waking a daemon while
+      // the box is already saturated. The keepalive's other half (the lease above) is
+      // unconditional:
+      // holding on to a daemon that is already up costs nothing and is the whole point.
+      if (liveSeats.availablePermits() > 0) renderHost.keepLiveWarm()
+      call.respond(HttpStatusCode.NoContent)
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -466,8 +466,14 @@ class ServeSessionRegistry(
       .sortedBy { it.id }
   }
 
-  private companion object {
-    /** Default idle window before a resident session's daemon is suspended. */
+  internal companion object {
+    /**
+     * Default idle window before a resident session's daemon is suspended.
+     *
+     * Visible beyond this class because the page-side presence heartbeat
+     * ([ServeWeb.PRESENCE_INTERVAL_SECONDS]) has to fit inside it with room for a dropped ping — a
+     * relationship worth asserting rather than restating.
+     */
     const val DEFAULT_IDLE_TIMEOUT_MILLIS = 10 * 60 * 1000L
 
     /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1416,6 +1416,22 @@ object ServeWeb {
    * - **Errors ignored.** A heartbeat is not something a page can act on — offline, a catalog since
    *   removed, a server restarted. The next one tries again.
    */
+  /**
+   * [presenceScript] as a standalone `<script>` tag, for a page that has no script of its own to
+   * splice it into (the viewer). Empty — not an empty tag — when there is no presence URL, so a
+   * page without the heartbeat is byte-for-byte what it always was.
+   */
+  private fun presenceScriptTag(presenceUrl: String): String {
+    val script = presenceScript(presenceUrl)
+    if (script.isEmpty()) return ""
+    // Emitted with the surrounding body's own indentation, including the leading newline: the tag
+    // is interpolated *adjacent* to the previous one rather than on a line of its own, so the empty
+    // case leaves no stray blank line, and every injected line stays at or past the template's
+    // common indent (which `trimIndent` measures across the interpolated result, not the source).
+    val indented = script.lines().joinToString("") { if (it.isEmpty()) "\n" else "\n        $it" }
+    return "\n      <script>(function () {$indented\n      })();</script>"
+  }
+
   private fun presenceScript(presenceUrl: String): String {
     if (presenceUrl.isEmpty()) return ""
     return """
@@ -3555,6 +3571,13 @@ object ServeWeb {
     liveAuthPrompt: LiveAuthPrompt? = null,
     /** Human catalog title used in the breadcrumb; falls back to a generic "Previews" label. */
     catalogTitle: String? = null,
+    /**
+     * `POST` URL that keeps this session (and its daemon) alive while the visitor has the viewer
+     * open — see [presenceScript]. The viewer needs this at least as much as the grid does: it is
+     * where someone settles on one preview, and where the theme and knob actions that *need* a warm
+     * daemon are taken. Empty (the default) omits the heartbeat.
+     */
+    presenceUrl: String = "",
   ): String {
     val idSeg = WebEscaping.urlEncodeSegment(preview.id)
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
@@ -4125,7 +4148,7 @@ $deviceControlsHtml
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
       ${scriptTag("viewer-groups.js")}
       ${scriptTag("viewer-drawers.js")}
-      <script>${viewerThemeStickyScript(themeStorageKey(sessionId, basePath))}</script>
+      <script>${viewerThemeStickyScript(themeStorageKey(sessionId, basePath))}</script>${presenceScriptTag(presenceUrl)}
       ${if (hasSvgExport) "${scriptTag("format-compare.js")}\n      " else ""}${scriptTag("viewer.js")}
       ${scriptTag("backend-badge.js")}
       """

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -165,6 +165,15 @@ object ServeWeb {
   /** Canonical source repo, used for the "source" / branch / workflow links. */
   private const val SOURCE_REPO = "yschimke/compose-ai-tools"
 
+  /**
+   * How often an open catalog page tells the server a visitor is still there ([presenceScript]).
+   *
+   * Comfortably under the session reaper's ten-minute idle window, and by enough that a single
+   * dropped ping — a sleeping laptop, a flaky connection, a tab briefly backgrounded — doesn't let
+   * the session lapse. Cheap at this rate: one empty POST per open tab per four minutes.
+   */
+  internal const val PRESENCE_INTERVAL_SECONDS = 240
+
   // android.content.res.Configuration values, kept local so the CLI has no Android dependency.
   private const val UI_MODE_NIGHT_MASK = 0x30
   private const val UI_MODE_NIGHT_NO = 0x10
@@ -1023,9 +1032,22 @@ object ServeWeb {
      */
     themeBaseJs: String = "",
     themeLeaseUrl: String = "",
+    /**
+     * `POST` URL that tells the server a visitor is still on this page ([presenceScript]). Empty
+     * omits the heartbeat entirely — the default, so a fixture golden or a plain-module landing
+     * emits exactly the script it always did.
+     */
+    presenceUrl: String = "",
   ): String {
     val hasDeclaredThemes = themeBaseJs.isNotEmpty()
     val themeLeaseUrlJs = WebEscaping.jsString(themeLeaseUrl)
+    // Spliced one level in, so a page with no presence URL emits the script byte-for-byte as
+    // before.
+    val presenceWiring =
+      presenceScript(presenceUrl).let { script ->
+        if (script.isEmpty()) ""
+        else script.lines().joinToString("") { if (it.isEmpty()) "\n" else "\n      $it" }
+      }
     // The stored choice is one of `light` / `dark` (a baked swap), `default` (the catalog's own
     // renders), or `theme:<providerFqn>` (an app-declared @ThemeCatalog theme, applied by
     // re-pointing each daemon-twinned card's thumbnail at a `?themeProvider=` render).
@@ -1367,8 +1389,45 @@ object ServeWeb {
         });
       });
       reflectBg();
-      apply();
+      apply();$presenceWiring
     })();
+    """
+      .trimIndent()
+  }
+
+  /**
+   * A heartbeat telling the server that a visitor is still on this catalog's pages.
+   *
+   * The server reaps an idle session — and the daemon behind it — after ten minutes, and measures
+   * idleness in *requests*. Someone reading one catalog page makes none: the grid's thumbnails and
+   * the front door's heroes are content-addressed and repaint from cache, which is the whole point
+   * of prebaking them. So a tab that has been open a quarter of an hour is indistinguishable from
+   * an abandoned one, and the visitor's next theme click pays a cold start. A ping every
+   * [PRESENCE_INTERVAL_SECONDS] says otherwise; see `handlePresence` for what the server does with
+   * it.
+   *
+   * Deliberately quiet about failure and about tabs nobody is looking at:
+   * - **Only while visible.** A backgrounded tab is not a visitor, and keeping a daemon resident
+   *   for one is exactly the waste the reaper exists to prevent. It resumes on `visibilitychange`,
+   *   and pings immediately on becoming visible so a tab returned to after an hour doesn't wait out
+   *   another interval before saying so.
+   * - **No first ping.** Loading the page *was* a request; the heartbeat only matters once the
+   *   visitor has gone quiet.
+   * - **Errors ignored.** A heartbeat is not something a page can act on — offline, a catalog since
+   *   removed, a server restarted. The next one tries again.
+   */
+  private fun presenceScript(presenceUrl: String): String {
+    if (presenceUrl.isEmpty()) return ""
+    return """
+
+      var presenceUrl = ${WebEscaping.jsString(presenceUrl)};
+      function ping() {
+        if (document.visibilityState !== "visible") return;
+        fetch(presenceUrl, { method: "POST", credentials: "same-origin", keepalive: true })
+          .catch(function () {});
+      }
+      setInterval(ping, ${PRESENCE_INTERVAL_SECONDS} * 1000);
+      document.addEventListener("visibilitychange", ping);
     """
       .trimIndent()
   }
@@ -2726,6 +2785,11 @@ object ServeWeb {
      */
     thumbHash: (String) -> String? = { null },
     /**
+     * `POST` URL that keeps this catalog's session (and its daemon) alive while a visitor has the
+     * page open — see [presenceScript]. Empty (the default) omits the heartbeat.
+     */
+    presenceUrl: String = "",
+    /**
      * Running server version (the CLI's `BUNDLE_VERSION`), surfaced in the (now bottom-of-page)
      * about box beside the source/`/version` links. Null omits it; the fixture golden passes a
      * fixed string so a release never churns the committed HTML.
@@ -3026,6 +3090,7 @@ object ServeWeb {
           tabStorageKey(sessionId, basePath),
           themeBaseJs,
           themeLeaseUrl,
+          presenceUrl,
         )}</script>"
       else ""
     val formatLink =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -409,6 +409,34 @@ class ServeCatalogLiveHostTest {
   }
 
   @Test
+  fun `a presence heartbeat gets the daemon ready for a visitor who has only browsed baked pixels`() {
+    // The point of the keepalive's warming half. Browsing a catalog is entirely baked by design, so
+    // a visitor reading the grid has never woken the daemon — and their first theme click would pay
+    // its cold start. A heartbeat while they read turns that into a warm render.
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        streaming = true,
+      )
+    val composite =
+      ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked, warmInBackground = true)
+    // Every open tab calls this every few minutes, so it must be safe to repeat — the warm set and
+    // the in-flight guard collapse the repeats into the one render below.
+    repeat(5) { composite.keepLiveWarm() }
+
+    val out =
+      awaitOk(2_000) {
+        (composite.renderSvg(catalogId, PreviewOverrides()) as? SvgOutcome.Ok)?.takeIf {
+          it.svg.decodeToString() == "live-svg:$daemonId"
+        }
+      }
+    assertEquals("live-svg:$daemonId", out.svg.decodeToString())
+    assertEquals(daemonId, live.lastRenderId, "the warm went through the daemon")
+  }
+
+  @Test
   fun `prewarm does not open per-preview daemons eagerly`() {
     var resolved = false
     val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -905,6 +905,18 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `a presence heartbeat keeps a session alive and answers with nothing`() {
+    // 204, no body: a heartbeat isn't something a page can act on. Leasing the session is the
+    // point — that is what stops the reaper closing a daemon under a visitor who is still reading.
+    val (code, body) = post("/compose-m3/api/presence")
+    assertEquals(204, code)
+    assertEquals("", body)
+    // A catalog this server doesn't have is not an error either: an open tab whose catalog was
+    // since removed should go quiet, not start reporting failures at the visitor.
+    assertEquals(204, post("/no-such-system/api/presence").first)
+  }
+
+  @Test
   fun `an unknown hero name 404s`() {
     assertEquals(404, get("/hero/compose-m3/0000000000000000.png").first)
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPresenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPresenceTest.kt
@@ -67,4 +67,41 @@ class ServeWebPresenceTest {
     assertFalse(html.contains("presenceUrl"), "no heartbeat for a plain-module landing")
     assertFalse(html.contains("visibilitychange"), "and none of its wiring")
   }
+
+  @Test
+  fun `the viewer beats too — it is where a visitor actually settles`() {
+    // Following a card into the viewer must not drop the heartbeat. The viewer is where someone
+    // stops and reads one preview (making no further requests), and where the theme and knob
+    // actions that want a warm daemon are taken — so losing presence here would reintroduce
+    // exactly the cold start this exists to prevent, on the page it hurts most.
+    val html =
+      ServeWeb.viewerPage(
+        ServePreview(id = "filled-button", label = "Filled"),
+        token = "t",
+        isPublic = true,
+        basePath = "/compose-m3",
+        presenceUrl = "/compose-m3/api/presence",
+      )
+    assertTrue(html.contains("var presenceUrl = \"/compose-m3/api/presence\""), "viewer pings")
+    assertTrue(
+      html.contains("setInterval(ping, ${ServeWeb.PRESENCE_INTERVAL_SECONDS} * 1000)"),
+      "on the same interval as the grid",
+    )
+    assertTrue(
+      html.contains("if (document.visibilityState !== \"visible\") return;"),
+      "and skips hidden tabs the same way",
+    )
+  }
+
+  @Test
+  fun `a viewer with no presence URL emits no heartbeat tag at all`() {
+    val html =
+      ServeWeb.viewerPage(
+        ServePreview(id = "filled-button", label = "Filled"),
+        token = "t",
+        isPublic = true,
+        basePath = "/compose-m3",
+      )
+    assertFalse(html.contains("presenceUrl"), "no heartbeat, and no empty script tag either")
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPresenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPresenceTest.kt
@@ -1,0 +1,70 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The presence heartbeat: an open catalog page tells the server a visitor is still there, so its
+ * session — and the daemon behind it — isn't reaped out from under them.
+ *
+ * This matters more the better the page caches. A grid of prebaked thumbnails repaints from cache
+ * and makes no requests at all, so "no requests for ten minutes" stopped meaning "nobody is here".
+ */
+class ServeWebPresenceTest {
+
+  private val previews = listOf(ServePreview(id = "filled-button", label = "Filled"))
+
+  private fun page(presenceUrl: String = "") =
+    ServeWeb.landingPage(
+      "compose-m3",
+      previews,
+      token = "t",
+      isPublic = true,
+      basePath = "/compose-m3",
+      presenceUrl = presenceUrl,
+    )
+
+  @Test
+  fun `a catalog page pings the server well inside the idle window`() {
+    val html = page("/compose-m3/api/presence")
+    assertTrue(
+      html.contains("fetch(presenceUrl, { method: \"POST\", credentials: \"same-origin\""),
+      "the page posts a heartbeat",
+    )
+    assertTrue(
+      html.contains("setInterval(ping, ${ServeWeb.PRESENCE_INTERVAL_SECONDS} * 1000)"),
+      "on the presence interval",
+    )
+    // The reaper's window is ten minutes and the heartbeat has to survive a dropped ping — a
+    // sleeping laptop, a flaky connection — so the interval must leave room for at least two
+    // before the session would lapse.
+    assertTrue(
+      ServeWeb.PRESENCE_INTERVAL_SECONDS * 2 * 1000L <
+        ServeSessionRegistry.DEFAULT_IDLE_TIMEOUT_MILLIS,
+      "two heartbeats fit inside the idle window",
+    )
+  }
+
+  @Test
+  fun `a backgrounded tab is not a visitor`() {
+    // Holding a daemon resident for a tab nobody is looking at is precisely the waste the reaper
+    // exists to prevent — so the ping is skipped while hidden, and fires on the way back.
+    val html = page("/compose-m3/api/presence")
+    assertTrue(
+      html.contains("if (document.visibilityState !== \"visible\") return;"),
+      "hidden tabs don't ping",
+    )
+    assertTrue(
+      html.contains("document.addEventListener(\"visibilitychange\", ping)"),
+      "and a tab returned to says so at once, rather than waiting out an interval",
+    )
+  }
+
+  @Test
+  fun `a page with no presence URL emits no heartbeat at all`() {
+    val html = page()
+    assertFalse(html.contains("presenceUrl"), "no heartbeat for a plain-module landing")
+    assertFalse(html.contains("visibilitychange"), "and none of its wiring")
+  }
+}


### PR DESCRIPTION
The server reaps an idle session — and the daemon behind it — after ten minutes, and measures idleness in **requests**. Someone reading one catalog page makes none: its thumbnails and heroes are content-addressed and repaint from cache, which is the whole point of prebaking them (#3240). So a tab that has been open a quarter of an hour is indistinguishable from an abandoned one, and the visitor's next theme click pays a ~68 s cold start.

An open catalog page now posts to `/api/presence` every 4 minutes — well inside the idle window, with room for a dropped ping.

## What a heartbeat does

Two things, and the cheap one matters most:

- **Leasing the session** marks it as in use. That is what actually keeps it (and its daemon) resident, and resumes it if it had already been suspended.
- **`keepLiveWarm()`** then gets the shared daemon ready — for the visitor who has only browsed baked pixels and so has never woken one at all, which is the common case by design. Idempotent: the warm set and in-flight guard collapse every heartbeat after the first into nothing.

## Bounded on both sides

- The page **skips the ping while the tab is hidden** — holding a daemon resident for a tab nobody is looking at is exactly the waste the reaper exists to prevent — and fires one on `visibilitychange`, so a tab returned to after an hour doesn't wait out another interval before saying so.
- **No first ping.** Loading the page *was* a request; the heartbeat only matters once the visitor has gone quiet.
- The server **only warms when the live-seat budget has headroom**. A browsing visitor's convenience ranks below someone else's actual render. This is a load signal, not a reservation — the warm runs off the request path and takes no seat — but it stops a room full of idle tabs each waking a daemon on an already-saturated box. Keeping an *already-resident* daemon costs nothing, so that half is unconditional.
- **Errors ignored end to end.** A heartbeat isn't something a page can act on (offline, a server restarted, a catalog since removed), and an unknown catalog answers `204` rather than making an open tab start reporting failures.

## Notes

- `ServeSessionRegistry.DEFAULT_IDLE_TIMEOUT_MILLIS` becomes `internal` so the interval/window relationship is asserted rather than restated in the test.
- Not visual: no rendered surface changes. The page gains a script block and nothing else — the fixture goldens are unchanged, because a page with no presence URL (a plain-module landing, and every golden) emits the script byte-for-byte as before.

## Test plan

- `ServeWebPresenceTest` (new) — the page pings on the interval, skips hidden tabs and pings on return, and emits nothing at all without a presence URL; plus the invariant that two heartbeats fit inside the reaper's window.
- `ServeCatalogLiveHostTest` — a heartbeat warms the shared daemon so a visitor who has only browsed baked pixels gets a warm first render, and repeated heartbeats collapse to one warm.
- `ServeHttpRoutingTest` — `POST /<system>/api/presence` answers 204 with no body, and an unknown system answers 204 too.
- `./gradlew :cli:test` green (full module, `--rerun-tasks` after rebase); `ktfmtCheck` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_