### PR TITLE
feat: implement alpha16 ComponentValue in CMP player

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -133,10 +133,15 @@ on:
         type: boolean
         default: false
       rc-cmp-wasm-lane:
-        description: "Add the CMP/Wasm player lane to rc-compare.html. Builds :rc-player-wasm:wasmPlayerDist, loads each ir/*.rc in the real browser player, screenshots it, and folds its pixel diff into one compact column. No-op for a catalog that ships no ir/*.rc."
+        description: "Add the required CMP/Wasm player lane to rc-compare.html. When enabled, its distribution must build and every ir/*.rc must render unless named in rc-cmp-wasm-allowlist. Evidence is uploaded before a failed gate stops publication. No-op for a catalog that ships no ir/*.rc."
         required: false
         type: boolean
         default: false
+      rc-cmp-wasm-allowlist:
+        description: 'Optional caller-repo-relative JSON file containing temporary CMP/Wasm exceptions. Every entry requires id, reason, and a non-expired YYYY-MM-DD expires date.'
+        required: false
+        type: string
+        default: ''
       stage-font-globs:
         description: 'Whitespace-separated repo-relative globs of font files (.ttf/.otf) to stage into fontconfig BEFORE rendering — for a desktop (Skiko) render that must resolve glyphs (CJK/Arabic/…) from a bundled face rather than a system fallback. Empty ⇒ no staging.'
         required: false
@@ -600,8 +605,12 @@ jobs:
       # PNG — the browser-render-lane counterpart of the PNG↔figma-svg compare.
       # A no-op (and no Chromium download) for catalogs without `ir/*.rc`.
       - name: PNG vs Remote Compose parity page
+        id: rc-compare
         if: ${{ inputs.publish || inputs.upload-out }}
+        continue-on-error: ${{ inputs.rc-cmp-wasm-lane }}
         working-directory: compose-ai-tools/scripts/design-artifacts
+        env:
+          RC_CMP_WASM_ALLOWLIST: ${{ inputs.rc-cmp-wasm-allowlist }}
         run: |
           set -euo pipefail
           if ! python3 - "$GITHUB_WORKSPACE/bundle.png" <<'PY'
@@ -630,11 +639,26 @@ jobs:
           EMBEDDED_ARGS=()
 
           if [ "${{ inputs.rc-cmp-wasm-lane }}" = "true" ]; then
+            mkdir -p "$GITHUB_WORKSPACE/out/rc-cmp-wasm-errors"
+            wasm_build_log="$GITHUB_WORKSPACE/out/rc-cmp-wasm-errors/distribution-build.log"
             if (cd "$GITHUB_WORKSPACE/compose-ai-tools" && \
-                ./gradlew :rc-player-wasm:wasmPlayerDist --no-daemon --quiet); then
-              EMBEDDED_ARGS+=(--cmp-wasm "$GITHUB_WORKSPACE/compose-ai-tools/rc-player/wasm/build/wasmDist")
+                ./gradlew :rc-player-wasm:wasmPlayerDist --no-daemon --quiet) >"$wasm_build_log" 2>&1; then
+              EMBEDDED_ARGS+=(
+                --cmp-wasm "$GITHUB_WORKSPACE/compose-ai-tools/rc-player/wasm/build/wasmDist"
+                --require-cmp-wasm
+              )
+              if [ -n "$RC_CMP_WASM_ALLOWLIST" ]; then
+                EMBEDDED_ARGS+=(--cmp-wasm-allowlist "$GITHUB_WORKSPACE/$RC_CMP_WASM_ALLOWLIST")
+              fi
             else
-              echo "::warning::cmp-wasm player distribution failed to build; publishing rc-compare without the cmp-wasm column"
+              echo "::error title=CMP/Wasm distribution failed::The required player distribution did not build; see the uploaded distribution-build.log." >&2
+              tail -n 80 "$wasm_build_log" >&2
+              {
+                echo '### Remote Compose CMP/Wasm'
+                echo
+                echo '❌ Player distribution failed to build. See `distribution-build.log` in the evidence artifact.'
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
             fi
           fi
 
@@ -705,6 +729,27 @@ jobs:
             --system "${{ inputs.system }}" \
             --title "${{ inputs.system }}" \
             ${EMBEDDED_ARGS[@]+"${EMBEDDED_ARGS[@]}"}
+
+      - name: Upload CMP/Wasm parity evidence
+        if: ${{ always() && inputs.rc-cmp-wasm-lane && (inputs.publish || inputs.upload-out) }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.system }}-rc-cmp-wasm-evidence
+          path: |
+            ${{ github.workspace }}/out/rc-compare-summary.json
+            ${{ github.workspace }}/out/rc-compare.html
+            ${{ github.workspace }}/out/rc-cmp-wasm
+            ${{ github.workspace }}/out/rc-cmp-wasm-diff
+            ${{ github.workspace }}/out/rc-cmp-wasm-errors
+          if-no-files-found: warn
+
+      # `continue-on-error` above exists only so the evidence upload gets a chance to run. Convert
+      # the recorded outcome back into a hard gate before either artifact handoff or publication.
+      - name: Enforce required CMP/Wasm lane
+        if: ${{ always() && inputs.rc-cmp-wasm-lane && (inputs.publish || inputs.upload-out) && steps.rc-compare.outcome == 'failure' }}
+        run: |
+          echo "::error title=CMP/Wasm parity gate failed::The enabled lane did not build or render every non-allowlisted Remote Compose document."
+          exit 1
 
       - name: Upload catalog bundle
         if: ${{ inputs.upload-out }}

--- a/rc-player/compat-tests/build.gradle.kts
+++ b/rc-player/compat-tests/build.gradle.kts
@@ -38,3 +38,12 @@ tasks.register<JavaExec>("generateScrollFixture") {
   args(layout.buildDirectory.file("fixtures/androidx-scroll.rc").get().asFile.absolutePath)
   outputs.file(layout.buildDirectory.file("fixtures/androidx-scroll.rc"))
 }
+
+tasks.register<JavaExec>("generateComponentValueFixture") {
+  description = "Generate a ComponentValue .rc document using the authoritative AndroidX writer."
+  group = "verification"
+  classpath = sourceSets.main.get().runtimeClasspath
+  mainClass.set("ee.schimke.composeai.rcplayer.compat.GenerateComponentValueFixtureKt")
+  args(layout.buildDirectory.file("fixtures/androidx-component-value.rc").get().asFile.absolutePath)
+  outputs.file(layout.buildDirectory.file("fixtures/androidx-component-value.rc"))
+}

--- a/rc-player/compat-tests/src/main/kotlin/ee/schimke/composeai/rcplayer/compat/GenerateComponentValueFixture.kt
+++ b/rc-player/compat-tests/src/main/kotlin/ee/schimke/composeai/rcplayer/compat/GenerateComponentValueFixture.kt
@@ -1,0 +1,46 @@
+@file:Suppress("RestrictedApiAndroidX")
+
+package ee.schimke.composeai.rcplayer.compat
+
+import androidx.compose.remote.core.WireBuffer
+import androidx.compose.remote.core.operations.ComponentValue
+import androidx.compose.remote.core.operations.DrawRect
+import androidx.compose.remote.core.operations.Header
+import androidx.compose.remote.core.operations.PaintData
+import androidx.compose.remote.core.operations.Utils
+import androidx.compose.remote.core.operations.layout.ContainerEnd
+import androidx.compose.remote.core.operations.layout.LayoutComponentContent
+import androidx.compose.remote.core.operations.layout.RootLayoutComponent
+import androidx.compose.remote.core.operations.layout.managers.CanvasLayout
+import androidx.compose.remote.core.operations.layout.modifiers.DimensionModifierOperation
+import androidx.compose.remote.core.operations.layout.modifiers.HeightModifierOperation
+import androidx.compose.remote.core.operations.layout.modifiers.OffsetModifierOperation
+import androidx.compose.remote.core.operations.layout.modifiers.WidthModifierOperation
+import androidx.compose.remote.core.operations.paint.PaintBundle
+import java.io.File
+
+/** Alpha16 AndroidX-authored browser fixture whose drawing depends on ComponentValue geometry. */
+public fun main(args: Array<String>) {
+  val output = File(requireNotNull(args.firstOrNull()) { "output path required" })
+  val buffer = WireBuffer()
+  Header.apply(buffer, 80, 60, 1f, 0L)
+  RootLayoutComponent.apply(buffer, -2)
+  LayoutComponentContent.apply(buffer, -3)
+  CanvasLayout.apply(buffer, -4, 40)
+  WidthModifierOperation.apply(buffer, DimensionModifierOperation.Type.EXACT.ordinal, 40f)
+  HeightModifierOperation.apply(buffer, DimensionModifierOperation.Type.EXACT.ordinal, 30f)
+  OffsetModifierOperation.apply(buffer, 7f, 9f)
+  LayoutComponentContent.apply(buffer, -6)
+  ComponentValue.apply(buffer, ComponentValue.WIDTH, -6, 42)
+  ComponentValue.apply(buffer, ComponentValue.HEIGHT, -6, 43)
+  val paint = PaintBundle().apply { setColor(0xff00ff00.toInt()) }
+  PaintData.apply(buffer, paint)
+  DrawRect.apply(buffer, 0f, 0f, Utils.asNan(42), Utils.asNan(43))
+  ContainerEnd.apply(buffer) // layout content
+  ContainerEnd.apply(buffer) // canvas layout
+  ContainerEnd.apply(buffer) // root content
+  ContainerEnd.apply(buffer) // root layout
+
+  output.parentFile?.mkdirs()
+  output.writeBytes(buffer.buffer.copyOf(buffer.size()))
+}

--- a/rc-player/compat-tests/src/test/kotlin/ee/schimke/composeai/rcplayer/compat/AndroidxWireCompatibilityTest.kt
+++ b/rc-player/compat-tests/src/test/kotlin/ee/schimke/composeai/rcplayer/compat/AndroidxWireCompatibilityTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.remote.core.operations.ColorAttribute
 import androidx.compose.remote.core.operations.ColorConstant
 import androidx.compose.remote.core.operations.ColorExpression as AndroidxColorExpression
 import androidx.compose.remote.core.operations.ColorTheme as AndroidxColorTheme
+import androidx.compose.remote.core.operations.ComponentValue as AndroidxComponentValue
 import androidx.compose.remote.core.operations.ConditionalOperations as AndroidxConditionalOperations
 import androidx.compose.remote.core.operations.DataDynamicListFloat
 import androidx.compose.remote.core.operations.DataListFloat
@@ -172,6 +173,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcColorAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcColorExpression
 import ee.schimke.composeai.rcplayer.protocol.RcColorTheme
 import ee.schimke.composeai.rcplayer.protocol.RcColumnLayout
+import ee.schimke.composeai.rcplayer.protocol.RcComponentValue
 import ee.schimke.composeai.rcplayer.protocol.RcConditionalOperations
 import ee.schimke.composeai.rcplayer.protocol.RcCoreText
 import ee.schimke.composeai.rcplayer.protocol.RcDebugMessage
@@ -269,6 +271,39 @@ import kotlin.test.assertTrue
  * from this test module: AndroidX remote-core/Java player is the protocol authority.
  */
 class AndroidxWireCompatibilityTest {
+  @Test
+  fun androidXComponentValueBoundaryStreamsRoundTripExactly() {
+    val buffer = WireBuffer()
+    Header.apply(buffer, 120, 60, 1f, 0L)
+    listOf(
+        AndroidxComponentValue.WIDTH,
+        AndroidxComponentValue.HEIGHT,
+        AndroidxComponentValue.POS_X,
+        AndroidxComponentValue.POS_Y,
+        AndroidxComponentValue.POS_ROOT_X,
+        AndroidxComponentValue.POS_ROOT_Y,
+        AndroidxComponentValue.CONTENT_WIDTH,
+        AndroidxComponentValue.CONTENT_HEIGHT,
+      )
+      .forEachIndexed { index, type ->
+        AndroidxComponentValue.apply(
+          buffer,
+          type,
+          if (index == 0) Int.MIN_VALUE else Int.MAX_VALUE,
+          index + 90,
+        )
+      }
+    val bytes = buffer.buffer.copyOf(buffer.size())
+
+    val document = RcDocumentCodec.decode(bytes)
+    val values = document.operations.filterIsInstance<RcComponentValue>()
+
+    assertEquals(RcComponentValue.VALID_TYPES.toList(), values.map { it.type })
+    assertEquals(Int.MIN_VALUE, values.first().componentId)
+    assertEquals(Int.MAX_VALUE, values.last().componentId)
+    assertContentEquals(bytes, RcDocumentCodec.encode(document))
+  }
+
   @Test
   fun androidXConditionalAndLoopContainersRoundTripExactly() {
     val buffer = WireBuffer()

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -90,6 +90,9 @@ import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.LookaheadScope
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
@@ -220,6 +223,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcZIndexModifier
 import ee.schimke.composeai.rcplayer.runtime.RcAnimationTimeline
 import ee.schimke.composeai.rcplayer.runtime.RcClickActionBlock
 import ee.schimke.composeai.rcplayer.runtime.RcClickActionType
+import ee.schimke.composeai.rcplayer.runtime.RcComponentGeometry
 import ee.schimke.composeai.rcplayer.runtime.RcDocumentLinker
 import ee.schimke.composeai.rcplayer.runtime.RcImpulsePhase
 import ee.schimke.composeai.rcplayer.runtime.RcLayoutModifiers
@@ -448,14 +452,21 @@ private fun RenderLayoutNode(
     } else {
       animateRcVisibility(visibility, node.modifiers.animationSpec, boundsModifier)
     }
-  if (!animatedVisibility.shouldRender) return
-  val effectiveModifier = animatedVisibility.modifier
+  val geometryIds = node.geometryComponentIds()
+  if (!animatedVisibility.shouldRender) {
+    if (geometryIds.any(state::hasComponentValues)) {
+      Layout(Modifier.trackComponentGeometry(geometryIds, state)) { _, _ -> layout(0, 0) {} }
+    }
+    return
+  }
+  val effectiveModifier = animatedVisibility.modifier.trackComponentGeometry(geometryIds, state)
   when (node) {
     is RcLayoutNode.Root ->
       Box(
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
           state,
+          geometryIds,
           fillMissingDimensions = true,
           node.canvasOperations,
           textMeasurer,
@@ -492,6 +503,7 @@ private fun RenderLayoutNode(
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
           state,
+          geometryIds,
           fillMissingDimensions = true,
           node.canvasOperations,
           textMeasurer,
@@ -499,6 +511,24 @@ private fun RenderLayoutNode(
           theme,
         )
       ) {
+        node.content
+          ?.operations
+          ?.takeIf { it.isNotEmpty() }
+          ?.let { operations ->
+            Canvas(Modifier.fillMaxSize()) {
+              drawOperations(
+                operations,
+                state,
+                RcPaintState(),
+                mutableMapOf(),
+                textMeasurer,
+                images,
+                RcFloatFunctionRuntime(),
+                theme,
+                filterTheme = true,
+              )
+            }
+          }
         node.content?.let {
           RenderLayoutNode(
             it,
@@ -528,6 +558,7 @@ private fun RenderLayoutNode(
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
           state,
+          geometryIds,
           fillMissingDimensions = false,
           node.canvasOperations,
           textMeasurer,
@@ -552,6 +583,7 @@ private fun RenderLayoutNode(
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
           state,
+          geometryIds,
           fillMissingDimensions = false,
           node.canvasOperations,
           textMeasurer,
@@ -594,6 +626,7 @@ private fun RenderLayoutNode(
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
           state,
+          geometryIds,
           fillMissingDimensions = false,
           node.canvasOperations,
           textMeasurer,
@@ -620,6 +653,7 @@ private fun RenderLayoutNode(
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
           state,
+          geometryIds,
           fillMissingDimensions = false,
           node.canvasOperations,
           textMeasurer,
@@ -654,6 +688,7 @@ private fun RenderLayoutNode(
           effectiveModifier.applyComponentModifiers(
             node.modifiers,
             state,
+            geometryIds,
             fillMissingDimensions = false,
             node.canvasOperations,
             textMeasurer,
@@ -678,6 +713,7 @@ private fun RenderLayoutNode(
           effectiveModifier.applyComponentModifiers(
             node.modifiers,
             state,
+            geometryIds,
             fillMissingDimensions = false,
             node.canvasOperations,
             textMeasurer,
@@ -697,6 +733,7 @@ private fun RenderLayoutNode(
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
           state,
+          geometryIds,
           fillMissingDimensions = false,
           canvasOperations = null,
           textMeasurer,
@@ -748,6 +785,7 @@ private fun RenderLayoutNode(
           effectiveModifier.applyComponentModifiers(
             node.modifiers,
             state,
+            geometryIds,
             fillMissingDimensions = false,
             canvasOperations = null,
             textMeasurer,
@@ -787,6 +825,7 @@ private fun RenderLayoutNode(
           effectiveModifier.applyComponentModifiers(
             node.modifiers,
             state,
+            geometryIds,
             fillMissingDimensions = false,
             canvasOperations = null,
             textMeasurer,
@@ -818,6 +857,7 @@ private fun RenderLayoutNode(
           effectiveModifier.applyComponentModifiers(
             node.modifiers,
             state,
+            geometryIds,
             fillMissingDimensions = false,
             node.canvasOperations,
             textMeasurer,
@@ -1373,6 +1413,7 @@ internal fun arrangeLinear(
 private fun Modifier.applyComponentModifiers(
   modifiers: RcLayoutModifiers,
   state: RcPlayerState,
+  geometryComponentIds: List<Int>,
   fillMissingDimensions: Boolean,
   canvasOperations: List<RcLinkedNode>?,
   textMeasurer: TextMeasurer,
@@ -1397,7 +1438,7 @@ private fun Modifier.applyComponentModifiers(
   result = result.applyWidth(modifiers, state, density, fillMissingDimensions)
   result = result.applyHeight(modifiers, state, density, fillMissingDimensions)
   modifiers.marquee?.let { result = result.applyAndroidXMarquee(it, state) }
-  modifiers.scroll?.let { result = result.applyAndroidXScroll(it, state) }
+  modifiers.scroll?.let { result = result.applyAndroidXScroll(it, state, geometryComponentIds) }
   modifiers.graphicsLayer?.let { result = result.applyGraphicsLayer(it, state) }
   modifiers.placementModifiers.forEach { placement ->
     result =
@@ -1916,7 +1957,11 @@ private fun Modifier.applyAndroidXMarquee(
 }
 
 @Composable
-private fun Modifier.applyAndroidXScroll(block: RcScrollBlock, state: RcPlayerState): Modifier {
+private fun Modifier.applyAndroidXScroll(
+  block: RcScrollBlock,
+  state: RcPlayerState,
+  geometryComponentIds: List<Int> = emptyList(),
+): Modifier {
   val operation = block.operation
   val touch =
     block.children
@@ -1934,6 +1979,14 @@ private fun Modifier.applyAndroidXScroll(block: RcScrollBlock, state: RcPlayerSt
         operation.max.referencedId?.let { state.setFloat(it, maximum.toFloat()) }
         operation.notchMax.referencedId?.let {
           state.setFloat(it, (maximum + scrollState.viewportSize).toFloat())
+        }
+        val contentExtent = (maximum + scrollState.viewportSize).toFloat()
+        geometryComponentIds.forEach { componentId ->
+          if (operation.direction == RcScrollModifier.VERTICAL) {
+            state.publishComponentContentSize(componentId, height = contentExtent)
+          } else {
+            state.publishComponentContentSize(componentId, width = contentExtent)
+          }
         }
       }
   }
@@ -1964,6 +2017,44 @@ private fun Modifier.applyAndroidXScroll(block: RcScrollBlock, state: RcPlayerSt
     verticalScroll(scrollState)
   } else {
     horizontalScroll(scrollState)
+  }
+}
+
+private fun RcLayoutNode.geometryComponentIds(): List<Int> =
+  when (this) {
+    is RcLayoutNode.Root ->
+      listOf(componentId) + children.filterIsInstance<RcLayoutNode.Content>().map { it.componentId }
+    is RcLayoutNode.Canvas -> listOfNotNull(componentId, content?.componentId)
+    is RcLayoutNode.Box -> listOf(componentId, content.componentId)
+    is RcLayoutNode.Row -> listOf(componentId, content.componentId)
+    is RcLayoutNode.Column -> listOf(componentId, content.componentId)
+    is RcLayoutNode.Flow -> listOf(componentId, content.componentId)
+    is RcLayoutNode.CollapsibleRow -> listOf(componentId, content.componentId)
+    is RcLayoutNode.CollapsibleColumn -> listOf(componentId, content.componentId)
+    is RcLayoutNode.FitBox -> listOf(componentId, content.componentId)
+    is RcLayoutNode.Content -> emptyList() // Its layout manager publishes the wrapper geometry.
+    else -> listOf(componentId)
+  }
+
+private fun Modifier.trackComponentGeometry(
+  componentIds: List<Int>,
+  state: RcPlayerState,
+): Modifier {
+  val tracked = componentIds.distinct().filter(state::hasComponentValues)
+  if (tracked.isEmpty()) return this
+  return onGloballyPositioned { coordinates ->
+    val local = coordinates.positionInParent()
+    val root = coordinates.positionInRoot()
+    val geometry =
+      RcComponentGeometry(
+        width = coordinates.size.width.toFloat(),
+        height = coordinates.size.height.toFloat(),
+        localX = local.x,
+        localY = local.y,
+        rootX = root.x,
+        rootY = root.y,
+      )
+    tracked.forEach { state.publishComponentGeometry(it, geometry) }
   }
 }
 

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -20,6 +20,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcCanvasLayout
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsibleColumnLayout
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsiblePriorityModifier
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsibleRowLayout
+import ee.schimke.composeai.rcplayer.protocol.RcComponentValue
 import ee.schimke.composeai.rcplayer.protocol.RcCoreText
 import ee.schimke.composeai.rcplayer.protocol.RcDimensionConstraintsModifier
 import ee.schimke.composeai.rcplayer.protocol.RcDimensionType
@@ -675,6 +676,56 @@ class RcLayoutRenderTest {
 
       assertEquals(green, bitmap.getColor(99, 79))
       assertEquals(0, bitmap.getColor(101, 81))
+    } finally {
+      scene.close()
+    }
+  }
+
+  @Test
+  fun nestedComponentValuesDriveDirectLayoutContentDrawingAfterGeometrySettles() {
+    val green = 0xff00ff00.toInt()
+    val reference: (Int) -> RcFloatWord = { RcFloatWord(0x7fc00000 or it) }
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(1, 0, 0), legacyWidth = 80, legacyHeight = 60, modern = false),
+        listOf(
+          RcRootLayout(-2),
+          RcLayoutContent(-3),
+          RcCanvasLayout(-4, 40),
+          width(40f),
+          height(30f),
+          RcOffsetModifier(RcFloatWord.literal(7f), RcFloatWord.literal(9f)),
+          RcLayoutContent(-6),
+          RcComponentValue(RcComponentValue.WIDTH, componentId = -6, valueId = 42),
+          RcComponentValue(RcComponentValue.HEIGHT, componentId = -6, valueId = 43),
+          RcPaintData(listOf(4, green)),
+          RcDraw4(
+            RcOpcodes.DRAW_RECT,
+            RcFloatWord.literal(0f),
+            RcFloatWord.literal(0f),
+            reference(42),
+            reference(43),
+          ),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+        ),
+      )
+    val scene =
+      ImageComposeScene(width = 80, height = 60, density = Density(1f)) {
+        RcComposePlayer(document)
+      }
+    try {
+      // The first layout publishes geometry; subsequent frames observe the stable dynamic floats.
+      scene.render()
+      val image = scene.render()
+      val bitmap = Bitmap().apply { allocN32Pixels(80, 60) }
+      check(image.readPixels(bitmap))
+
+      assertEquals(green, bitmap.getColor(7, 9))
+      assertEquals(green, bitmap.getColor(46, 38))
+      assertEquals(0, bitmap.getColor(47, 39))
     } finally {
       scene.close()
     }

--- a/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodec.kt
+++ b/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodec.kt
@@ -33,6 +33,7 @@ public object RcDocumentCodec {
         IntegerExpressionCodec,
         FloatFunctionDefineCodec,
         FloatFunctionCallCodec,
+        ComponentValueCodec,
         BooleanConstantCodec,
         LongConstantCodec,
         IdMapCodec,
@@ -212,6 +213,23 @@ public object RcDocumentCodec {
     operation: RcOperation,
   ) {
     (codec as RcOperationCodec<RcOperation>).encode(output, operation)
+  }
+}
+
+private object ComponentValueCodec : RcOperationCodec<RcComponentValue> {
+  override val spec = RcOperationSpec(RcOpcodes.COMPONENT_VALUE, "ComponentValue")
+
+  override fun decode(input: RcWireReader): RcComponentValue =
+    RcComponentValue(
+      type = input.readInt("type"),
+      componentId = input.readInt("componentId"),
+      valueId = input.readInt("valueId"),
+    )
+
+  override fun encode(output: RcWireWriter, value: RcComponentValue) {
+    output.writeInt(value.type)
+    output.writeInt(value.componentId)
+    output.writeInt(value.valueId)
   }
 }
 

--- a/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcModel.kt
+++ b/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcModel.kt
@@ -263,6 +263,24 @@ public data class RcFloatFunctionCall(val functionId: Int, val arguments: List<R
   override val opcode: Int = RcOpcodes.FUNCTION_CALL
 }
 
+/** Publishes one alpha16 component geometry property into a runtime float id. */
+public data class RcComponentValue(val type: Int, val componentId: Int, val valueId: Int) :
+  RcOperation {
+  override val opcode: Int = RcOpcodes.COMPONENT_VALUE
+
+  public companion object {
+    public const val WIDTH: Int = 0
+    public const val HEIGHT: Int = 1
+    public const val LOCAL_X: Int = 2
+    public const val LOCAL_Y: Int = 3
+    public const val ROOT_X: Int = 4
+    public const val ROOT_Y: Int = 5
+    public const val CONTENT_WIDTH: Int = 6
+    public const val CONTENT_HEIGHT: Int = 7
+    public val VALID_TYPES: IntRange = WIDTH..CONTENT_HEIGHT
+  }
+}
+
 public data class RcBooleanConstant(val id: Int, val value: Boolean) : RcOperation {
   override val opcode: Int = RcOpcodes.DATA_BOOLEAN
 }
@@ -1506,6 +1524,7 @@ public object RcOpcodes {
   public const val FLOAT_LIST: Int = 147
   public const val DATA_LONG: Int = 148
   public const val DRAW_BITMAP_SCALED: Int = 149
+  public const val COMPONENT_VALUE: Int = 150
   public const val TEXT_LOOKUP: Int = 151
   public const val TEXT_LOOKUP_INT: Int = 153
   public const val DATA_MAP_LOOKUP: Int = 154

--- a/rc-player/protocol/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodecTest.kt
+++ b/rc-player/protocol/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodecTest.kt
@@ -9,6 +9,24 @@ import kotlin.test.assertTrue
 
 class RcDocumentCodecTest {
   @Test
+  fun componentValuesRoundTripEveryAlpha16GeometryKindAndSignedIds() {
+    val values =
+      RcComponentValue.VALID_TYPES.map { type ->
+        RcComponentValue(
+          type,
+          componentId = if (type == 0) Int.MIN_VALUE else 42,
+          valueId = type + 90,
+        )
+      }
+    val document = RcDocument(RcHeader(RcVersion(1, 0, 0), modern = false), values)
+
+    val bytes = RcDocumentCodec.encode(document)
+
+    assertEquals(document, RcDocumentCodec.decode(bytes))
+    assertContentEquals(bytes, RcDocumentCodec.encode(RcDocumentCodec.decode(bytes)))
+  }
+
+  @Test
   fun controlFlowContainersRoundTripSignedTypesAndFloatReferenceBits() {
     val operations =
       listOf(

--- a/rc-player/protocol/src/main/rc-operations.manifest
+++ b/rc-player/protocol/src/main/rc-operations.manifest
@@ -66,7 +66,7 @@
 147|FLOAT_LIST|5|implemented
 148|DATA_LONG|5|implemented
 149|DRAW_BITMAP_SCALED|4|implemented
-150|COMPONENT_VALUE|5|unsupported
+150|COMPONENT_VALUE|5|implemented
 151|TEXT_LOOKUP|3|implemented
 152|DRAW_ARC|1|implemented
 153|TEXT_LOOKUP_INT|3|implemented

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
@@ -14,6 +14,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcCollapsibleColumnLayout
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsiblePriorityModifier
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsibleRowLayout
 import ee.schimke.composeai.rcplayer.protocol.RcColumnLayout
+import ee.schimke.composeai.rcplayer.protocol.RcComponentValue
 import ee.schimke.composeai.rcplayer.protocol.RcCoreText
 import ee.schimke.composeai.rcplayer.protocol.RcDimensionConstraintsModifier
 import ee.schimke.composeai.rcplayer.protocol.RcFitBoxLayout
@@ -117,6 +118,8 @@ public sealed interface RcLayoutNode {
     override val componentId: Int,
     override val modifiers: RcLayoutModifiers,
     val children: List<RcLayoutNode>,
+    /** Non-component data/paint operations retained for CanvasLayout's legacy direct content. */
+    val operations: List<RcLinkedNode>,
   ) : RcLayoutNode {
     override val animationId: Int? = null
   }
@@ -257,7 +260,35 @@ public object RcLayoutTree {
     }
     val stylesById = styles.toMap()
     val seenIds = mutableSetOf<Int>()
-    return parse(roots.single(), seenIds, stylesById) as RcLayoutNode.Root
+    val root = parse(roots.single(), seenIds, stylesById) as RcLayoutNode.Root
+    validateComponentValues(
+      document.source.operations.filterIsInstance<RcComponentValue>(),
+      seenIds,
+    )
+    return root
+  }
+
+  private fun validateComponentValues(values: List<RcComponentValue>, componentIds: Set<Int>) {
+    values.forEach { value ->
+      if (value.type !in RcComponentValue.VALID_TYPES) {
+        throw RcLayoutException("ComponentValue ${value.valueId} has unknown type ${value.type}")
+      }
+      if (value.componentId !in componentIds) {
+        throw RcLayoutException(
+          "ComponentValue ${value.valueId} references missing component ${value.componentId}"
+        )
+      }
+    }
+    values
+      .groupBy { it.valueId }
+      .forEach { (valueId, bindings) ->
+        val targets = bindings.map { it.componentId to it.type }.distinct()
+        if (targets.size > 1) {
+          throw RcLayoutException(
+            "ComponentValue output $valueId has conflicting bindings $targets"
+          )
+        }
+      }
   }
 
   private fun parse(
@@ -280,6 +311,9 @@ public object RcLayoutTree {
             operation.componentId,
             modifiers,
             childComponents(container, seenIds, styles),
+            container.children.filterNot { child ->
+              child is RcLinkedNode.Container && child.operation.isLayoutComponent()
+            },
           )
         is RcCanvasLayout -> {
           RcLayoutNode.Canvas(

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcColorAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcColorConstant
 import ee.schimke.composeai.rcplayer.protocol.RcColorExpression
 import ee.schimke.composeai.rcplayer.protocol.RcColorTheme
+import ee.schimke.composeai.rcplayer.protocol.RcComponentValue
 import ee.schimke.composeai.rcplayer.protocol.RcConditionalOperations
 import ee.schimke.composeai.rcplayer.protocol.RcDataMapLookup
 import ee.schimke.composeai.rcplayer.protocol.RcDebugMessage
@@ -61,6 +62,16 @@ import ee.schimke.composeai.rcplayer.protocol.RcWakeIn
 
 private const val MAX_LOOP_ITERATIONS = 10_000
 
+/** Final component geometry in Remote Compose's pixel coordinate space. */
+public data class RcComponentGeometry(
+  val width: Float,
+  val height: Float,
+  val localX: Float,
+  val localY: Float,
+  val rootX: Float,
+  val rootY: Float,
+)
+
 /** Typed runtime values for the CMP player; independent from AndroidX `RemoteContext`. */
 public class RcPlayerState(
   public val document: RcDocument,
@@ -71,6 +82,11 @@ public class RcPlayerState(
   private val timeSource: RcTimeSource = RcTimeSource.System,
 ) {
   private val floats = mutableMapOf<Int, Float>()
+  private val componentValues =
+    document.operations.filterIsInstance<RcComponentValue>().distinct().groupBy { it.componentId }
+  private val componentGeometries = mutableMapOf<Int, RcComponentGeometry>()
+  private val componentContentWidths = mutableMapOf<Int, Float>()
+  private val componentContentHeights = mutableMapOf<Int, Float>()
   private val colors = mutableMapOf<Int, Int>()
   private val baseTexts = mutableMapOf<Int, String>()
   private val textOverrides = mutableMapOf<Int, String>()
@@ -149,6 +165,7 @@ public class RcPlayerState(
         else -> Unit
       }
     }
+    componentValues.values.flatten().forEach { if (it.valueId !in floats) floats[it.valueId] = 0f }
     document.operations.filterIsInstance<RcDynamicFloatList>().forEach(::applyDataOperation)
     document.operations.filterIsInstance<RcTouchExpression>().forEach { operation ->
       if (operation.id !in floats) floats[operation.id] = resolve(operation.defaultValue)
@@ -808,6 +825,53 @@ public class RcPlayerState(
 
   public fun setFloat(id: Int, value: Float) {
     floats[id] = value
+  }
+
+  public fun hasComponentValues(componentId: Int): Boolean = componentId in componentValues
+
+  /**
+   * Publishes geometry after placement. The callback fires only when an exposed float changes, so
+   * the first layout schedules one settling pass and stable geometry cannot form a measure loop.
+   */
+  public fun publishComponentGeometry(componentId: Int, geometry: RcComponentGeometry): Boolean {
+    componentGeometries[componentId] = geometry
+    return publishComponentValues(componentId, geometry)
+  }
+
+  /** Supplies the scrollable content extent used by alpha16 CONTENT_WIDTH/CONTENT_HEIGHT. */
+  public fun publishComponentContentSize(
+    componentId: Int,
+    width: Float? = null,
+    height: Float? = null,
+  ): Boolean {
+    width?.let { componentContentWidths[componentId] = it }
+    height?.let { componentContentHeights[componentId] = it }
+    return componentGeometries[componentId]?.let { publishComponentValues(componentId, it) }
+      ?: false
+  }
+
+  private fun publishComponentValues(componentId: Int, geometry: RcComponentGeometry): Boolean {
+    var changed = false
+    componentValues[componentId].orEmpty().forEach { binding ->
+      val value =
+        when (binding.type) {
+          RcComponentValue.WIDTH -> geometry.width
+          RcComponentValue.HEIGHT -> geometry.height
+          RcComponentValue.LOCAL_X -> geometry.localX
+          RcComponentValue.LOCAL_Y -> geometry.localY
+          RcComponentValue.ROOT_X -> geometry.rootX
+          RcComponentValue.ROOT_Y -> geometry.rootY
+          RcComponentValue.CONTENT_WIDTH -> componentContentWidths[componentId] ?: geometry.width
+          RcComponentValue.CONTENT_HEIGHT -> componentContentHeights[componentId] ?: geometry.height
+          else -> error("Unknown ComponentValue type ${binding.type}")
+        }
+      if (floats[binding.valueId]?.toRawBits() != value.toRawBits()) {
+        floats[binding.valueId] = value
+        changed = true
+      }
+    }
+    if (changed) onInvalidated()
+    return changed
   }
 
   public fun setColor(id: Int, argb: Int) {

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTreeTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTreeTest.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcCanvasLayout
 import ee.schimke.composeai.rcplayer.protocol.RcClickModifier
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsiblePriorityModifier
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsibleRowLayout
+import ee.schimke.composeai.rcplayer.protocol.RcComponentValue
 import ee.schimke.composeai.rcplayer.protocol.RcCoreText
 import ee.schimke.composeai.rcplayer.protocol.RcDimensionType
 import ee.schimke.composeai.rcplayer.protocol.RcDocument
@@ -43,6 +44,37 @@ import kotlin.test.assertIs
 
 class RcLayoutTreeTest {
   private val header = RcHeader(RcVersion(1, 0, 0), modern = false)
+
+  @Test
+  fun validatesNestedComponentValueTargetsAndConflictingOutputs() {
+    // CoreDocument discovers ComponentValue recursively, including inside CanvasOperations.
+    requireNotNull(
+      treeOf(
+        RcRootLayout(1),
+        RcLayoutContent(2),
+        RcCanvasLayout(3, 30),
+        RcNoArg(RcOpcodes.CANVAS_OPERATIONS),
+        RcComponentValue(RcComponentValue.WIDTH, componentId = 3, valueId = 90),
+        ends = 4,
+      )
+    )
+    assertFailsWith<RcLayoutException> {
+      treeOf(
+        RcRootLayout(1),
+        RcComponentValue(RcComponentValue.WIDTH, componentId = 404, valueId = 90),
+        ends = 1,
+      )
+    }
+    assertFailsWith<RcLayoutException> {
+      treeOf(
+        RcRootLayout(1),
+        RcLayoutContent(2),
+        RcComponentValue(RcComponentValue.WIDTH, componentId = 1, valueId = 90),
+        RcComponentValue(RcComponentValue.HEIGHT, componentId = 2, valueId = 90),
+        ends = 2,
+      )
+    }
+  }
 
   @Test
   fun retainsRippleInPaintDecoratorWireOrder() {

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcColorAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcColorConstant
 import ee.schimke.composeai.rcplayer.protocol.RcColorExpression
 import ee.schimke.composeai.rcplayer.protocol.RcColorTheme
+import ee.schimke.composeai.rcplayer.protocol.RcComponentValue
 import ee.schimke.composeai.rcplayer.protocol.RcConditionalOperations
 import ee.schimke.composeai.rcplayer.protocol.RcDataMapEntry
 import ee.schimke.composeai.rcplayer.protocol.RcDataMapLookup
@@ -63,6 +64,38 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class RcPlayerStateTest {
+  @Test
+  fun componentGeometryPublishesAllEightKindsAndConverges() {
+    var invalidations = 0
+    val bindings =
+      RcComponentValue.VALID_TYPES.map { RcComponentValue(it, componentId = 7, valueId = 100 + it) }
+    val state =
+      RcPlayerState(
+        RcDocument(RcHeader(RcVersion(0, 1, 0)), bindings),
+        onInvalidated = { invalidations += 1 },
+      )
+    val first = RcComponentGeometry(40f, 30f, 2f, 3f, 12f, 13f)
+
+    assertTrue(state.publishComponentGeometry(7, first))
+    assertEquals(
+      listOf(40f, 30f, 2f, 3f, 12f, 13f, 40f, 30f),
+      RcComponentValue.VALID_TYPES.map { state.resolve(RcFloatWord(0x7fc00000 or (100 + it))) },
+    )
+    assertEquals(1, invalidations)
+    assertFalse(state.publishComponentGeometry(7, first))
+    assertEquals(1, invalidations, "stable geometry must not schedule another measure pass")
+
+    assertTrue(state.publishComponentContentSize(7, width = 75f, height = 80f))
+    assertEquals(75f, state.resolve(RcFloatWord(0x7fc00000 or 106)))
+    assertEquals(80f, state.resolve(RcFloatWord(0x7fc00000 or 107)))
+    assertEquals(2, invalidations)
+
+    assertTrue(state.publishComponentGeometry(7, first.copy(width = 41f)))
+    assertEquals(41f, state.resolve(RcFloatWord(0x7fc00000 or 100)))
+    assertEquals(75f, state.resolve(RcFloatWord(0x7fc00000 or 106)))
+    assertEquals(3, invalidations)
+  }
+
   @Test
   fun evaluatesEveryAndroidXConditionalTypeIncludingChangedState() {
     val state = RcPlayerState(RcDocument(RcHeader(RcVersion(1, 0, 0)), emptyList()))

--- a/rc-player/wasm/build.gradle.kts
+++ b/rc-player/wasm/build.gradle.kts
@@ -47,12 +47,19 @@ tasks.register<Sync>("wasmPlayerTestDist") {
   dependsOn(
     "wasmPlayerDist",
     ":rc-player-compat-tests:generateBaselineFixture",
+    ":rc-player-compat-tests:generateComponentValueFixture",
     ":rc-player-compat-tests:generateLayoutFixture",
     ":rc-player-compat-tests:generateScrollFixture",
   )
   from(layout.buildDirectory.dir("wasmDist"))
   from(
     project(":rc-player-compat-tests").layout.buildDirectory.file("fixtures/androidx-baseline.rc")
+  )
+  from(
+    project(":rc-player-compat-tests")
+      .layout
+      .buildDirectory
+      .file("fixtures/androidx-component-value.rc")
   )
   from(project(":rc-player-compat-tests").layout.buildDirectory.file("fixtures/androidx-layout.rc"))
   from(project(":rc-player-compat-tests").layout.buildDirectory.file("fixtures/androidx-scroll.rc"))

--- a/rc-player/wasm/src/wasmJsMain/resources/index.html
+++ b/rc-player/wasm/src/wasmJsMain/resources/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
     <title>Remote Compose CMP player</title>
     <style>
       html,

--- a/scripts/design-artifacts/rc-compare-gate.mjs
+++ b/scripts/design-artifacts/rc-compare-gate.mjs
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Read the deliberately small temporary-exception format used by the strict CMP/Wasm lane:
+ *
+ *   { "entries": [{ "id": "preview.id", "reason": "issue URL or explanation",
+ *                   "expires": "2026-08-10" }] }
+ */
+export function readCmpWasmAllowlist(file, today = new Date().toISOString().slice(0, 10)) {
+  if (!file) return new Map();
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!parsed || !Array.isArray(parsed.entries)) {
+    throw new Error("CMP/Wasm allowlist must be an object with an entries array");
+  }
+  const result = new Map();
+  for (const [index, entry] of parsed.entries.entries()) {
+    const label = `CMP/Wasm allowlist entry ${index + 1}`;
+    if (!entry || typeof entry.id !== "string" || !entry.id.trim()) {
+      throw new Error(`${label} must have a non-empty id`);
+    }
+    if (typeof entry.reason !== "string" || !entry.reason.trim()) {
+      throw new Error(`${label} (${entry.id}) must have a non-empty reason`);
+    }
+    if (typeof entry.expires !== "string" || !ISO_DATE.test(entry.expires)) {
+      throw new Error(`${label} (${entry.id}) must have an expires date in YYYY-MM-DD form`);
+    }
+    if (new Date(`${entry.expires}T00:00:00Z`).toISOString().slice(0, 10) !== entry.expires) {
+      throw new Error(`${label} (${entry.id}) has an invalid expires date ${entry.expires}`);
+    }
+    if (entry.expires < today) {
+      throw new Error(`${label} (${entry.id}) expired on ${entry.expires}`);
+    }
+    if (result.has(entry.id)) throw new Error(`${label} duplicates id ${entry.id}`);
+    result.set(entry.id, { reason: entry.reason.trim(), expires: entry.expires });
+  }
+  return result;
+}
+
+/** Return the strict-lane verdict without throwing, so callers can write all evidence first. */
+export function evaluateCmpWasmGate(expectedIds, rows, allowlist = new Map()) {
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const failures = [];
+  const allowed = [];
+  for (const id of expectedIds) {
+    const row = byId.get(id);
+    if (row?.cmpWasmRendered === true) continue;
+    const exception = allowlist.get(id);
+    const note = row?.cmpWasmNote || (row ? "CMP/Wasm produced no result" : "row was dropped");
+    if (exception) allowed.push({ id, note, ...exception });
+    else failures.push({ id, note });
+  }
+  return {
+    passed: failures.length === 0,
+    expected: expectedIds.length,
+    rendered: expectedIds.filter((id) => byId.get(id)?.cmpWasmRendered === true).length,
+    allowed,
+    failures,
+  };
+}
+
+export function formatCmpWasmGate(gate) {
+  const lines = [
+    `CMP/Wasm: ${gate.rendered}/${gate.expected} rendered, ${gate.allowed.length} temporarily allowed, ${gate.failures.length} failed.`,
+  ];
+  for (const failure of gate.failures) lines.push(`- ${failure.id}: ${failure.note}`);
+  for (const entry of gate.allowed) {
+    lines.push(`- ${entry.id}: allowed until ${entry.expires} — ${entry.reason} (${entry.note})`);
+  }
+  return lines.join("\n");
+}

--- a/scripts/design-artifacts/rc-compare-gate.test.mjs
+++ b/scripts/design-artifacts/rc-compare-gate.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  evaluateCmpWasmGate,
+  formatCmpWasmGate,
+  readCmpWasmAllowlist,
+} from "./rc-compare-gate.mjs";
+
+test("strict CMP/Wasm gate reports failed and dropped rows", () => {
+  const gate = evaluateCmpWasmGate(
+    ["ready", "error", "dropped"],
+    [
+      { id: "ready", cmpWasmRendered: true },
+      { id: "error", cmpWasmRendered: false, cmpWasmNote: "opcode 150 at byte 42" },
+    ],
+  );
+  assert.equal(gate.passed, false);
+  assert.deepEqual(gate.failures, [
+    { id: "error", note: "opcode 150 at byte 42" },
+    { id: "dropped", note: "row was dropped" },
+  ]);
+  assert.match(formatCmpWasmGate(gate), /1\/3 rendered.*2 failed[\s\S]*opcode 150 at byte 42/);
+});
+
+test("a reasoned, unexpired exception allows only its named row", () => {
+  const allowlist = new Map([
+    ["known", { reason: "tracked by #123", expires: "2026-08-10" }],
+  ]);
+  const gate = evaluateCmpWasmGate(
+    ["known", "unknown"],
+    [
+      { id: "known", cmpWasmRendered: false, cmpWasmNote: "known failure" },
+      { id: "unknown", cmpWasmRendered: false, cmpWasmNote: "new failure" },
+    ],
+    allowlist,
+  );
+  assert.equal(gate.passed, false);
+  assert.equal(gate.allowed.length, 1);
+  assert.deepEqual(gate.failures, [{ id: "unknown", note: "new failure" }]);
+  assert.equal(
+    evaluateCmpWasmGate(
+      ["known"],
+      [{ id: "known", cmpWasmRendered: false, cmpWasmNote: "known failure" }],
+      allowlist,
+    ).passed,
+    true,
+  );
+});
+
+test("allowlist requires reasons and rejects expired entries", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rc-cmp-wasm-gate-"));
+  const file = path.join(dir, "allowlist.json");
+  fs.writeFileSync(file, JSON.stringify({ entries: [{ id: "x", reason: "", expires: "2026-08-10" }] }));
+  assert.throws(() => readCmpWasmAllowlist(file, "2026-08-03"), /non-empty reason/);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({ entries: [{ id: "x", reason: "tracked", expires: "2026-08-02" }] }),
+  );
+  assert.throws(() => readCmpWasmAllowlist(file, "2026-08-03"), /expired/);
+});

--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -22,7 +22,8 @@
  * Usage:
  *   node rc-compare.mjs --bundle <bundle.png> --player <rc-player bundle.js> \
  *     --out <dir> [--system <id>] [--title <t>] [--threshold 0.1] [--theme light] \
- *     [--fonts <dir>] [--cmp-wasm <rc-player-wasm distribution>]
+ *     [--fonts <dir>] [--cmp-wasm <rc-player-wasm distribution>] \
+ *     [--require-cmp-wasm] [--cmp-wasm-allowlist <json>]
  *
  * `--fonts` defaults to the vendored faces the snapshot renderer itself rasterizes with (see
  * rc-fonts.mjs). Point it elsewhere to compare against a different font set, or at a
@@ -41,6 +42,11 @@ import pixelmatch from "pixelmatch";
 import { chromium } from "playwright";
 
 import { renderRcCompareHtml } from "./render-rc-compare-html.mjs";
+import {
+  evaluateCmpWasmGate,
+  formatCmpWasmGate,
+  readCmpWasmAllowlist,
+} from "./rc-compare-gate.mjs";
 import { BG, flattenOnto, isFullyTransparent } from "./rc-compare-pixels.mjs";
 import { DEFAULT_FONTS_DIR, fontFaceCss, loadAndVerifyFonts } from "./rc-fonts.mjs";
 
@@ -81,9 +87,15 @@ const EMBEDDED_JVM = arg("embedded-jvm");
 // complete Compose/Skiko application, so the driver serves its distribution over localhost and
 // screenshots its viewport after the player's readiness marker appears.
 const CMP_WASM = arg("cmp-wasm");
+const REQUIRE_CMP_WASM = process.argv.includes("--require-cmp-wasm");
+const CMP_WASM_ALLOWLIST = arg("cmp-wasm-allowlist");
 
 if (!BUNDLE || !PLAYER || !OUT) {
   console.error("rc-compare: --bundle, --player and --out are required");
+  process.exit(2);
+}
+if (REQUIRE_CMP_WASM && !CMP_WASM) {
+  console.error("rc-compare: --require-cmp-wasm requires --cmp-wasm");
   process.exit(2);
 }
 
@@ -154,6 +166,7 @@ const dirs = {
   embeddedJvmDiff: path.join(OUT, "rc-embedded-jvm-diff"),
   cmpWasm: path.join(OUT, "rc-cmp-wasm"),
   cmpWasmDiff: path.join(OUT, "rc-cmp-wasm-diff"),
+  cmpWasmErrors: path.join(OUT, "rc-cmp-wasm-errors"),
 };
 for (const d of Object.values(dirs)) fs.mkdirSync(d, { recursive: true });
 
@@ -362,6 +375,7 @@ async function startCmpWasmServer(dir) {
 async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank) {
   if (!cmpWasmPage) return {};
   try {
+    cmpWasmConsoleErrors.length = 0;
     cmpWasmServer.setDocument(bytes);
     await cmpWasmPage.setViewportSize({ width, height });
     await cmpWasmPage.goto(
@@ -378,6 +392,9 @@ async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank) {
     }));
     if (state.state !== "ready") throw new Error(state.error || "player reported an error");
     const png = flattenOnto(PNG.sync.read(await cmpWasmPage.screenshot({ omitBackground: true })), BG);
+    if (cmpWasmConsoleErrors.length) {
+      throw new Error(`unexpected console error: ${cmpWasmConsoleErrors.join(" | ")}`);
+    }
     if (png.width !== width || png.height !== height) {
       throw new Error(`size ${png.width}×${png.height} ≠ baked ${width}×${height}`);
     }
@@ -393,9 +410,13 @@ async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank) {
       cmpWasmDiff: `rc-cmp-wasm-diff/${id}.png`,
     };
   } catch (error) {
+    const detail = String(error?.stack || error?.message || error);
+    const errorFile = `${encodeURIComponent(id)}.txt`;
+    fs.writeFileSync(path.join(dirs.cmpWasmErrors, errorFile), detail);
     return {
       cmpWasmRendered: false,
-      cmpWasmNote: String(error?.message || error).slice(0, 200),
+      cmpWasmNote: String(error?.message || error).slice(0, 500),
+      cmpWasmError: `rc-cmp-wasm-errors/${errorFile}`,
       cmpWasmMismatchPct: null,
       cmpWasmMismatchPx: null,
       cmpWasm: "",
@@ -416,6 +437,10 @@ const cmpWasmServer = CMP_WASM ? await startCmpWasmServer(CMP_WASM) : null;
 const cmpWasmPage = CMP_WASM
   ? await browser.newContext({ deviceScaleFactor: 1 }).then((context) => context.newPage())
   : null;
+const cmpWasmConsoleErrors = [];
+cmpWasmPage?.on("console", (message) => {
+  if (message.type() === "error") cmpWasmConsoleErrors.push(message.text());
+});
 const pageWarnings = [];
 page.on("console", (m) => {
   if (m.type() === "warning" || m.type() === "error") pageWarnings.push(m.text());
@@ -582,6 +607,19 @@ const rendered = rows.filter((r) => r.rendered);
 // `isFullyTransparent`. Left in `rendered` because the player did in fact render them.
 const scored = rendered.filter((r) => !r.referenceBlank);
 const meanPct = scored.length ? scored.reduce((s, r) => s + r.mismatchPct, 0) / scored.length : null;
+let cmpWasmGate = null;
+if (REQUIRE_CMP_WASM) {
+  try {
+    cmpWasmGate = evaluateCmpWasmGate(rcIds, rows, readCmpWasmAllowlist(CMP_WASM_ALLOWLIST));
+  } catch (error) {
+    cmpWasmGate = evaluateCmpWasmGate(rcIds, rows);
+    cmpWasmGate.passed = false;
+    cmpWasmGate.failures.unshift({
+      id: "allowlist",
+      note: String(error?.message || error),
+    });
+  }
+}
 fs.writeFileSync(
   path.join(OUT, "rc-compare-summary.json"),
   JSON.stringify(
@@ -595,6 +633,7 @@ fs.writeFileSync(
       meanMismatchPct: meanPct,
       threshold: THRESHOLD,
       theme: THEME,
+      cmpWasmGate,
       embedded: EMBEDDED
         ? {
             rendered: rows.filter((r) => r.embeddedRendered).length,
@@ -650,6 +689,7 @@ fs.writeFileSync(
         cmpWasmMismatchPct: r.cmpWasmMismatchPct ?? null,
         cmpWasmMismatchPx: r.cmpWasmMismatchPx ?? null,
         cmpWasmNote: r.cmpWasmNote ?? null,
+        cmpWasmError: r.cmpWasmError ?? null,
       })),
     },
     null,
@@ -679,3 +719,12 @@ console.log(
       : `, ${rendered.length - scored.length} unscored (blank reference)`) +
     (meanPct == null ? "" : `, mean mismatch ${meanPct.toFixed(2)}%`),
 );
+
+if (REQUIRE_CMP_WASM) {
+  const message = formatCmpWasmGate(cmpWasmGate);
+  console.log(message);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n### Remote Compose CMP/Wasm\n\n${message}\n`);
+  }
+  if (!cmpWasmGate.passed) process.exitCode = 1;
+}

--- a/scripts/design-artifacts/render-rc-compare-html.mjs
+++ b/scripts/design-artifacts/render-rc-compare-html.mjs
@@ -221,7 +221,7 @@ function cellWithDiff(label, src, diffSrc, extraClass = "") {
  * `referenceBlank` short-circuits both players: the baked PNG is empty, so there is no comparison to
  * report and any number here would be a lie in either direction.
  */
-function scoreBlock(label, rendered, pct, px, note, referenceBlank = false) {
+function scoreBlock(label, rendered, pct, px, note, referenceBlank = false, errorHref = "") {
   const scorable = rendered && !referenceBlank;
   const text = scorable
     ? `${(pct ?? 0).toFixed(2)}%`
@@ -230,10 +230,12 @@ function scoreBlock(label, rendered, pct, px, note, referenceBlank = false) {
       : note || "no render";
   const pxTxt =
     scorable && px != null ? `<span class="px">${px.toLocaleString("en-US")} px</span>` : "";
+  const detail = !rendered && errorHref ? `<a href="${esc(errorHref)}">details</a>` : "";
   return `<div class="scoreline">
       <span class="scorelabel">${esc(label)}</span>
       <span class="score ${band(scorable ? pct : null)}">${esc(text)}</span>
       ${pxTxt}
+      ${detail}
     </div>`;
 }
 
@@ -271,6 +273,7 @@ function rowHtml(r, withEmbedded, withEmbeddedJvm, withCmpWasm) {
           r.cmpWasmMismatchPx,
           r.cmpWasmNote,
           r.referenceBlank,
+          r.cmpWasmError,
         )
       : "") +
     (r.referenceBlank

--- a/scripts/design-artifacts/render-rc-compare-html.test.mjs
+++ b/scripts/design-artifacts/render-rc-compare-html.test.mjs
@@ -26,6 +26,7 @@ function withCmpWasm(base) {
       cmpWasmMismatchPct: index !== 2 ? 3 + index : null,
       cmpWasmMismatchPx: index !== 2 ? 8_268 + index : null,
       cmpWasmNote: index === 2 ? "unsupported operation" : undefined,
+      cmpWasmError: index === 2 ? `rc-cmp-wasm-errors/${r.id}.txt` : undefined,
       cmpWasm: index !== 2 ? `rc-cmp-wasm/${r.id}.png` : "",
       cmpWasmDiff: index !== 2 ? `rc-cmp-wasm-diff/${r.id}.png` : "",
     })),
@@ -230,6 +231,10 @@ test("the cmp-wasm lane adds one folded-diff column and independent parity stats
   assert.match(html, /<span class="scorelabel">cmp-wasm<\/span>/);
   assert.match(html, /\(JS \+ cmp-wasm players\)/);
   assert.match(html, /runs the new Compose Multiplatform \/ Skiko player in browser Wasm/);
+  assert.match(
+    html,
+    /href="rc-cmp-wasm-errors\/pkg\.CatalogPreviewsKt\.Undecodable\.txt">details<\/a>/,
+  );
 });
 
 test("all rc-compare lanes can coexist without hiding the cmp-wasm result", () => {


### PR DESCRIPTION
## Summary

- decode and byte-exactly encode alpha16 `ComponentValue` (opcode 150), including all eight geometry kinds
- publish final Compose geometry and scrollable content extents into dynamic float IDs with stable two-pass convergence
- validate missing targets and conflicting output bindings, including records nested in layout/canvas content
- retain and render alpha16 paint operations stored directly in `LayoutComponentContent`
- add an AndroidX-authored ComponentValue fixture to the Wasm browser test distribution

This PR is intentionally stacked on #3241 (`codex/cmp-wasm-parity-gate`).

## Verification

- `./gradlew :rc-player-protocol:desktopTest :rc-player-runtime:desktopTest :rc-player-compose:desktopTest :rc-player-compat-tests:test :rc-player-wasm:wasmPlayerTestDist ktfmtCheckAll --no-daemon`
- strict Chrome `rc-compare --require-cmp-wasm` over the AndroidX-authored fixture: **1/1 rendered, 0.00% mismatch**
- live remote-m3 alpha16 corpus checkpoint: ComponentValue is no longer a reported blocker; 18/24 documents now stop at opcode 174 and 6/24 reach later text/paint/layout validation blockers
