### PR TITLE
feat(rc-player): support alpha16 CoreText fonts

### DIFF
--- a/rc-player/compat-tests/src/test/kotlin/ee/schimke/composeai/rcplayer/compat/AndroidxWireCompatibilityTest.kt
+++ b/rc-player/compat-tests/src/test/kotlin/ee/schimke/composeai/rcplayer/compat/AndroidxWireCompatibilityTest.kt
@@ -40,6 +40,7 @@ import androidx.compose.remote.core.operations.FloatConstant
 import androidx.compose.remote.core.operations.FloatExpression
 import androidx.compose.remote.core.operations.FloatFunctionCall as AndroidxFloatFunctionCall
 import androidx.compose.remote.core.operations.FloatFunctionDefine as AndroidxFloatFunctionDefine
+import androidx.compose.remote.core.operations.FontData as AndroidxFontData
 import androidx.compose.remote.core.operations.HapticFeedback as AndroidxHapticFeedback
 import androidx.compose.remote.core.operations.Header
 import androidx.compose.remote.core.operations.IdLookup
@@ -194,6 +195,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcFloatFunctionCall
 import ee.schimke.composeai.rcplayer.protocol.RcFloatFunctionDefine
 import ee.schimke.composeai.rcplayer.protocol.RcFloatWord
 import ee.schimke.composeai.rcplayer.protocol.RcFlowLayout
+import ee.schimke.composeai.rcplayer.protocol.RcFontData
 import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerModifier
 import ee.schimke.composeai.rcplayer.protocol.RcHapticFeedback
@@ -272,6 +274,23 @@ import kotlin.test.assertTrue
  * from this test module: AndroidX remote-core/Java player is the protocol authority.
  */
 class AndroidxWireCompatibilityTest {
+  @Test
+  fun androidXEmbeddedFontPayloadRoundTripsExactly() {
+    val buffer = WireBuffer()
+    Header.apply(buffer, 120, 60, 1f, 0L)
+    val data = byteArrayOf(0, 1, -1, 127)
+    AndroidxFontData.apply(buffer, 42, 7, data)
+    val bytes = buffer.buffer.copyOf(buffer.size())
+
+    val document = RcDocumentCodec.decode(bytes)
+    val font = assertIs<RcFontData>(document.operations.single())
+
+    assertEquals(42, font.fontId)
+    assertEquals(7, font.type)
+    assertContentEquals(data, font.data)
+    assertContentEquals(bytes, RcDocumentCodec.encode(document))
+  }
+
   @Test
   fun androidXComponentValueBoundaryStreamsRoundTripExactly() {
     val buffer = WireBuffer()

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -123,6 +123,7 @@ import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.platform.Font
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -130,6 +131,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
@@ -169,6 +171,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcFloatExpression
 import ee.schimke.composeai.rcplayer.protocol.RcFloatFunctionCall
 import ee.schimke.composeai.rcplayer.protocol.RcFloatFunctionDefine
 import ee.schimke.composeai.rcplayer.protocol.RcFloatWord
+import ee.schimke.composeai.rcplayer.protocol.RcFontData
 import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerModifier
 import ee.schimke.composeai.rcplayer.protocol.RcHapticFeedback
@@ -258,9 +261,10 @@ public fun RcComposePlayer(
   theme: Int = RcTheme.UNSPECIFIED,
   namedValues: Map<String, RcNamedValue> = emptyMap(),
   onEvent: (RcPlayerEvent) -> Unit = {},
+  fontFamilies: Map<String, FontFamily> = emptyMap(),
 ) {
   val document = remember(bytes) { RcDocumentCodec.decode(bytes) }
-  RcComposePlayer(document, modifier, theme, namedValues, onEvent)
+  RcComposePlayer(document, modifier, theme, namedValues, onEvent, fontFamilies)
 }
 
 @Composable
@@ -270,6 +274,7 @@ public fun RcComposePlayer(
   theme: Int = RcTheme.UNSPECIFIED,
   namedValues: Map<String, RcNamedValue> = emptyMap(),
   onEvent: (RcPlayerEvent) -> Unit = {},
+  fontFamilies: Map<String, FontFamily> = emptyMap(),
 ) {
   val latestEventSink by rememberUpdatedState(onEvent)
   val latestHapticFeedback by rememberUpdatedState(LocalHapticFeedback.current)
@@ -349,6 +354,7 @@ public fun RcComposePlayer(
     }
   }
   val images = remember(document) { decodeInlineImages(document) }
+  val fonts = remember(document) { decodeInlineFonts(document) }
   val textMeasurer = rememberTextMeasurer()
   val semanticsModifier =
     state.rootContentDescription?.let { description ->
@@ -376,6 +382,8 @@ public fun RcComposePlayer(
       CompositionLocalProvider(
         LocalRcLookaheadScope provides this,
         LocalRcLayoutVersion provides invalidationVersion,
+        LocalRcFonts provides fonts,
+        LocalRcNamedFonts provides fontFamilies,
       ) {
         RenderLayoutNode(
           node = layout,
@@ -430,6 +438,8 @@ private fun RenderLayoutNode(
 ) {
   val layoutVersion = LocalRcLayoutVersion.current
   val lookaheadScope = LocalRcLookaheadScope.current
+  val fontFamilies = LocalRcFonts.current
+  val namedFontFamilies = LocalRcNamedFonts.current
   val visibility =
     if (layoutVersion == Int.MIN_VALUE) {
       error("unreachable layout invalidation version")
@@ -803,7 +813,8 @@ private fun RenderLayoutNode(
             fontSize = (state.resolve(operation.fontSize) / density.density).sp,
             fontWeight = FontWeight(boldWeight),
             fontStyle = if (operation.fontStyle and 2 != 0) FontStyle.Italic else FontStyle.Normal,
-            fontFamily = FontFamily.Default,
+            fontFamily =
+              resolveFontFamily(operation.fontFamilyId, state, fontFamilies, namedFontFamilies),
             textAlign = operation.composeTextAlign(),
           ),
         overflow = operation.composeTextOverflow(),
@@ -814,6 +825,8 @@ private fun RenderLayoutNode(
       val density = androidx.compose.ui.platform.LocalDensity.current
       val properties = node.resolvedStyle
       val fontSize = state.resolve(properties.floatProperty(5, 36f))
+      val lineHeightAdd = state.resolve(properties.floatProperty(13, 0f))
+      val lineHeightMultiplier = state.resolve(properties.floatProperty(14, 1f))
       val fontStyle = properties.intProperty(6, 0)
       val fontWeight =
         state.resolve(properties.floatProperty(7, 400f)).roundToInt().coerceIn(1, 1000)
@@ -840,9 +853,19 @@ private fun RenderLayoutNode(
                 else state.color(colorId)
               ),
             fontSize = (fontSize / density.density).sp,
+            letterSpacing = (state.resolve(properties.floatProperty(12, 0f)) / density.density).sp,
+            lineHeight =
+              if (lineHeightAdd == 0f && lineHeightMultiplier == 1f) TextUnit.Unspecified
+              else ((fontSize * lineHeightMultiplier + lineHeightAdd) / density.density).sp,
             fontWeight = FontWeight(boldWeight),
             fontStyle = if (fontStyle and 2 != 0) FontStyle.Italic else FontStyle.Normal,
-            fontFamily = FontFamily.Default,
+            fontFamily =
+              resolveFontFamily(
+                properties.intProperty(8, -1),
+                state,
+                fontFamilies,
+                namedFontFamilies,
+              ),
             textAlign = androidXTextAlign(properties.intProperty(9, RcTextLayout.ALIGN_LEFT)),
           ),
         overflow = androidXTextOverflow(properties.intProperty(10, RcTextLayout.OVERFLOW_CLIP)),
@@ -916,6 +939,8 @@ private data class RcAnimatedVisibility(val shouldRender: Boolean, val modifier:
 
 private val LocalRcLookaheadScope = compositionLocalOf<LookaheadScope?> { null }
 private val LocalRcLayoutVersion = compositionLocalOf { 0 }
+private val LocalRcFonts = compositionLocalOf<Map<Int, FontFamily>> { emptyMap() }
+private val LocalRcNamedFonts = compositionLocalOf<Map<String, FontFamily>> { emptyMap() }
 
 private val DefaultRcAnimationSpec =
   RcAnimationSpec(
@@ -2781,6 +2806,33 @@ private fun decodeInlineImages(document: RcDocument): Map<Int, ImageBitmap> =
       else runCatching { bitmap.imageId to decodeInlineImage(bitmap) }.getOrNull()
     }
     .toMap()
+
+private fun decodeInlineFonts(document: RcDocument): Map<Int, FontFamily> =
+  document.operations
+    .filterIsInstance<RcFontData>()
+    .mapNotNull { font ->
+      runCatching { font.fontId to FontFamily(Font("remote-compose-${font.fontId}", font.data)) }
+        .getOrNull()
+    }
+    .toMap()
+
+private fun resolveFontFamily(
+  fontFamilyId: Int,
+  state: RcPlayerState,
+  embeddedFonts: Map<Int, FontFamily>,
+  namedFonts: Map<String, FontFamily>,
+): FontFamily =
+  when (val family = state.text(fontFamilyId)?.lowercase()) {
+    null,
+    "default" -> FontFamily.Default
+    "sans-serif" -> namedFonts[family] ?: FontFamily.SansSerif
+    "serif" -> namedFonts[family] ?: FontFamily.Serif
+    "monospace" -> namedFonts[family] ?: FontFamily.Monospace
+    else ->
+      embeddedFonts[fontFamilyId]
+        ?: namedFonts[family.removePrefix("google:")]
+        ?: FontFamily.Default
+  }
 
 private fun decodeInlineImage(bitmap: RcBitmapData): ImageBitmap =
   when (bitmap.type) {

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupport.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupport.kt
@@ -21,6 +21,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcFitBoxLayout
 import ee.schimke.composeai.rcplayer.protocol.RcFloatFunctionCall
 import ee.schimke.composeai.rcplayer.protocol.RcFloatFunctionDefine
 import ee.schimke.composeai.rcplayer.protocol.RcFlowLayout
+import ee.schimke.composeai.rcplayer.protocol.RcFontData
 import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerModifier
 import ee.schimke.composeai.rcplayer.protocol.RcHapticFeedback
@@ -83,16 +84,17 @@ public data class RcComposeSupportReport(val issues: List<RcComposeSupportIssue>
 
 /** Backend-specific coverage, including nested PaintBundle commands hidden behind one RC opcode. */
 public fun RcDocument.composeSupportReport(
-  profile: RcOperationProfile? = null
+  profile: RcOperationProfile? = null,
+  availableFontFamilies: Set<String> = emptySet(),
 ): RcComposeSupportReport {
   val issues = mutableListOf<RcComposeSupportIssue>()
   val bitmapIds = operations.filterIsInstance<RcBitmapData>().mapTo(mutableSetOf()) { it.imageId }
-  val textIds =
-    operations.filterIsInstance<ee.schimke.composeai.rcplayer.protocol.RcTextData>().mapTo(
-      mutableSetOf()
-    ) {
-      it.id
+  val fontIds = operations.filterIsInstance<RcFontData>().mapTo(mutableSetOf()) { it.fontId }
+  val texts =
+    operations.filterIsInstance<ee.schimke.composeai.rcplayer.protocol.RcTextData>().associate {
+      it.id to it.text
     }
+  val textIds = texts.keys
   val colorIds =
     operations.filterIsInstance<ee.schimke.composeai.rcplayer.protocol.RcColorConstant>().mapTo(
       mutableSetOf()
@@ -250,12 +252,14 @@ public fun RcDocument.composeSupportReport(
               "TextLayout",
               "font style ${operation.fontStyle} is not implemented",
             )
-        operation.fontFamilyId != -1 ->
+        fontFamilyIssue(operation.fontFamilyId, texts, fontIds, availableFontFamilies) != null ->
           issues +=
             RcComposeSupportIssue(
               index,
               "TextLayout",
-              "font family ${operation.fontFamilyId} requires DataFont",
+              requireNotNull(
+                fontFamilyIssue(operation.fontFamilyId, texts, fontIds, availableFontFamilies)
+              ),
             )
         operation.textAlign !in RcTextLayout.ALIGN_LEFT..RcTextLayout.ALIGN_END ->
           issues +=
@@ -295,13 +299,13 @@ public fun RcDocument.composeSupportReport(
           issues +=
             RcComposeSupportIssue(index, "CoreText", "text id ${operation.textId} is not declared")
         else ->
-          textStyleIssue(operation.properties, colorIds)?.let { detail ->
-            issues += RcComposeSupportIssue(index, "CoreText", detail)
-          }
+          textStyleIssue(operation.properties, colorIds, texts, fontIds, availableFontFamilies)
+            ?.let { detail -> issues += RcComposeSupportIssue(index, "CoreText", detail) }
       }
     }
     if (operation is RcTextStyle) {
-      textStyleIssue(operation.properties, colorIds)?.let { detail ->
+      textStyleIssue(operation.properties, colorIds, texts, fontIds, availableFontFamilies)?.let {
+        detail ->
         issues += RcComposeSupportIssue(index, "TextStyle", detail)
       }
     }
@@ -949,7 +953,13 @@ private fun RcLinkedNode.operation(): ee.schimke.composeai.rcplayer.protocol.RcO
     is RcLinkedNode.Container -> operation
   }
 
-private fun textStyleIssue(properties: List<RcTextStyleProperty>, colorIds: Set<Int>): String? {
+private fun textStyleIssue(
+  properties: List<RcTextStyleProperty>,
+  colorIds: Set<Int>,
+  texts: Map<Int, String>,
+  fontIds: Set<Int>,
+  availableFontFamilies: Set<String>,
+): String? {
   fun int(id: Int, default: Int): Int =
     properties.filterIsInstance<RcTextStyleProperty.IntValue>().lastOrNull { it.id == id }?.value
       ?: default
@@ -967,7 +977,9 @@ private fun textStyleIssue(properties: List<RcTextStyleProperty>, colorIds: Set<
   val fontStyle = int(6, 0)
   if (fontStyle !in 0..3) return "font style $fontStyle is not implemented"
   val fontFamily = int(8, -1)
-  if (fontFamily != -1) return "font family $fontFamily requires DataFont"
+  fontFamilyIssue(fontFamily, texts, fontIds, availableFontFamilies)?.let {
+    return it
+  }
   val alignment = int(9, RcTextLayout.ALIGN_LEFT)
   if (alignment !in RcTextLayout.ALIGN_LEFT..RcTextLayout.ALIGN_END) {
     return "text alignment $alignment is not implemented"
@@ -978,15 +990,6 @@ private fun textStyleIssue(properties: List<RcTextStyleProperty>, colorIds: Set<
   }
   val maxLines = int(11, Int.MAX_VALUE)
   if (maxLines <= 0) return "maxLines must be positive"
-  if (float(12, 0f) != ee.schimke.composeai.rcplayer.protocol.RcFloatWord.literal(0f)) {
-    return "letter spacing is not implemented"
-  }
-  if (float(13, 0f) != ee.schimke.composeai.rcplayer.protocol.RcFloatWord.literal(0f)) {
-    return "line height addition is not implemented"
-  }
-  if (float(14, 1f) != ee.schimke.composeai.rcplayer.protocol.RcFloatWord.literal(1f)) {
-    return "line height multiplier is not implemented"
-  }
   val breakStrategy = int(15, 0)
   if (breakStrategy != 0) return "line break strategy $breakStrategy is not implemented"
   val hyphenation = int(16, 0)
@@ -1013,6 +1016,26 @@ private fun textStyleIssue(properties: List<RcTextStyleProperty>, colorIds: Set<
   }
   val flags = int(23, 0)
   if (flags != 0) return "flags $flags are not implemented"
+  return null
+}
+
+private fun fontFamilyIssue(
+  fontFamilyId: Int,
+  texts: Map<Int, String>,
+  embeddedFontIds: Set<Int>,
+  availableFontFamilies: Set<String>,
+): String? {
+  if (fontFamilyId == -1) return null
+  val family = texts[fontFamilyId] ?: return "font family name id $fontFamilyId is not declared"
+  val normalized = family.lowercase().removePrefix("google:")
+  val available = availableFontFamilies.mapTo(mutableSetOf()) { it.lowercase() }
+  if (
+    normalized !in setOf("default", "sans-serif", "serif", "monospace") &&
+      normalized !in available &&
+      fontFamilyId !in embeddedFontIds
+  ) {
+    return "custom font family $family ($fontFamilyId) has no DataFont"
+  }
   return null
 }
 

--- a/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupportTest.kt
+++ b/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupportTest.kt
@@ -17,6 +17,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcDocument
 import ee.schimke.composeai.rcplayer.protocol.RcFloatFunctionCall
 import ee.schimke.composeai.rcplayer.protocol.RcFloatFunctionDefine
 import ee.schimke.composeai.rcplayer.protocol.RcFloatWord
+import ee.schimke.composeai.rcplayer.protocol.RcFontData
 import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerModifier
 import ee.schimke.composeai.rcplayer.protocol.RcHapticFeedback
@@ -439,10 +440,7 @@ class RcComposeSupportTest {
         header,
         listOf(
           RcTextStyle(
-            listOf(
-              RcTextStyleProperty.IntValue(1, 100),
-              RcTextStyleProperty.FloatValue(12, RcFloatWord.literal(1f)),
-            )
+            listOf(RcTextStyleProperty.IntValue(1, 100), RcTextStyleProperty.BooleanValue(18, true))
           )
         ),
       )
@@ -450,7 +448,36 @@ class RcComposeSupportTest {
     val issue = document.composeSupportReport().issues.single()
 
     assertEquals("TextStyle", issue.operation)
-    assertEquals("letter spacing is not implemented", issue.detail)
+    assertEquals("underline is not implemented", issue.detail)
+  }
+
+  @Test
+  fun acceptsEmbeddedFontReferencesAndRejectsMissingOnes() {
+    fun document(fonts: List<RcFontData>, family: String? = "BrandFace") =
+      RcDocument(
+        header,
+        fonts +
+          (family?.let { listOf(RcTextData(42, it)) } ?: emptyList()) +
+          RcTextStyle(
+            listOf(RcTextStyleProperty.IntValue(1, 100), RcTextStyleProperty.IntValue(8, 42))
+          ),
+      )
+
+    val missingName = document(emptyList(), family = null).composeSupportReport().issues.single()
+    assertEquals("TextStyle", missingName.operation)
+    assertEquals("font family name id 42 is not declared", missingName.detail)
+    val missing = document(emptyList()).composeSupportReport().issues.single()
+    assertEquals("TextStyle", missing.operation)
+    assertEquals("custom font family BrandFace (42) has no DataFont", missing.detail)
+    assertTrue(
+      document(listOf(RcFontData(42, 0, byteArrayOf(1)))).composeSupportReport().fullyRenderable
+    )
+    assertTrue(document(emptyList(), family = "sans-serif").composeSupportReport().fullyRenderable)
+    assertTrue(
+      document(emptyList(), family = "google:Orbitron")
+        .composeSupportReport(availableFontFamilies = setOf("Orbitron"))
+        .fullyRenderable
+    )
   }
 
   @Test

--- a/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodec.kt
+++ b/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodec.kt
@@ -23,6 +23,7 @@ public object RcDocumentCodec {
         ConditionalOperationsCodec,
         LoopOperationCodec,
         BitmapDataCodec,
+        FontDataCodec,
         FloatConstantCodec,
         FloatExpressionCodec,
         TouchExpressionCodec,
@@ -2305,6 +2306,23 @@ private object BitmapDataCodec : RcOperationCodec<RcBitmapData> {
     output.writeInt(value.imageId)
     output.writeInt(value.type shl 16 or value.width)
     output.writeInt(value.encoding shl 16 or value.height)
+    output.writeByteArray(value.data)
+  }
+}
+
+private object FontDataCodec : RcOperationCodec<RcFontData> {
+  override val spec = RcOperationSpec(RcOpcodes.DATA_FONT, "FontData")
+
+  override fun decode(input: RcWireReader): RcFontData =
+    RcFontData(
+      fontId = input.readInt("fontId"),
+      type = input.readInt("type"),
+      data = input.readByteArray("data"),
+    )
+
+  override fun encode(output: RcWireWriter, value: RcFontData) {
+    output.writeInt(value.fontId)
+    output.writeInt(value.type)
     output.writeByteArray(value.data)
   }
 }

--- a/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcModel.kt
+++ b/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcModel.kt
@@ -616,6 +616,23 @@ public data class RcBitmapData(
   }
 }
 
+/** Embedded font bytes loaded by AndroidX's alpha16 `FontData` operation. */
+public class RcFontData(public val fontId: Int, public val type: Int, public val data: ByteArray) :
+  RcOperation {
+  override val opcode: Int = RcOpcodes.DATA_FONT
+
+  override fun equals(other: Any?): Boolean =
+    other is RcFontData &&
+      fontId == other.fontId &&
+      type == other.type &&
+      data.contentEquals(other.data)
+
+  override fun hashCode(): Int = 31 * (31 * fontId + type) + data.contentHashCode()
+
+  override fun toString(): String =
+    "RcFontData(fontId=$fontId, type=$type, data=${data.size} bytes)"
+}
+
 public data class RcDrawBitmap(
   val imageId: Int,
   val left: RcFloatWord,
@@ -1568,6 +1585,7 @@ public object RcOpcodes {
   public const val LAYOUT_BOX: Int = 202
   public const val LAYOUT_ROW: Int = 203
   public const val LAYOUT_COLUMN: Int = 204
+  public const val DATA_FONT: Int = 189
   public const val LAYOUT_CANVAS: Int = 205
   public const val CANVAS_OPERATIONS: Int = 173
   /** Alpha16's zero-payload DrawContentOperation modifier; the Java player treats it as a no-op. */

--- a/rc-player/protocol/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodecTest.kt
+++ b/rc-player/protocol/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodecTest.kt
@@ -9,6 +9,19 @@ import kotlin.test.assertTrue
 
 class RcDocumentCodecTest {
   @Test
+  fun embeddedFontRoundTripsAlpha16PayloadExactly() {
+    val font = RcFontData(fontId = 42, type = 7, data = byteArrayOf(0, 1, -1, 127))
+    val document = RcDocument(RcHeader(RcVersion(1, 0, 0), modern = false), listOf(font))
+
+    val bytes = RcDocumentCodec.encode(document)
+    val decoded = RcDocumentCodec.decode(bytes)
+
+    assertEquals(document, decoded)
+    assertContentEquals(font.data, assertIs<RcFontData>(decoded.operations.single()).data)
+    assertContentEquals(bytes, RcDocumentCodec.encode(decoded))
+  }
+
+  @Test
   fun modifierDrawContentIsAZeroPayloadAlpha16Operation() {
     val document =
       RcDocument(

--- a/rc-player/protocol/src/main/rc-operations.manifest
+++ b/rc-player/protocol/src/main/rc-operations.manifest
@@ -105,7 +105,7 @@
 186|MATRIX_CONSTANT|2|implemented
 187|MATRIX_EXPRESSION|2|implemented
 188|MATRIX_VECTOR_MATH|2|implemented
-189|DATA_FONT|3|unsupported
+189|DATA_FONT|3|implemented
 190|DRAW_TO_BITMAP|4|unsupported
 191|WAKE_IN|8|implemented
 192|ID_LOOKUP|5|implemented

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
@@ -425,9 +425,6 @@ public object RcLayoutTree {
     operation: RcCoreText,
     styles: Map<Int, RcTextStyle>,
   ): List<RcTextStyleProperty> {
-    if (operation.componentId < 0 || operation.animationId < 0) {
-      throw RcLayoutException("CoreText requires component and animation ids")
-    }
     val merged = linkedMapOf<Int, RcTextStyleProperty>()
     operation.textStyleId?.let { styleId ->
       resolveTextStyle(styleId, styles, linkedSetOf()).forEach { merged[it.id] = it }

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTreeTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTreeTest.kt
@@ -491,6 +491,23 @@ class RcLayoutTreeTest {
     )
   }
 
+  @Test
+  fun acceptsAlpha16CoreTextWithoutOptionalComponentOrAnimationIds() {
+    val core =
+      RcCoreText(
+        textId = 7,
+        properties = listOf(RcTextStyleProperty.FloatValue(5, RcFloatWord.literal(18f))),
+      )
+
+    val root = requireNotNull(treeOf(RcRootLayout(1), RcLayoutContent(2), core, ends = 3))
+    val content = assertIs<RcLayoutNode.Content>(root.children.single())
+    val text = assertIs<RcLayoutNode.CoreText>(content.children.single())
+
+    assertEquals(-1, text.operation.componentId)
+    assertEquals(-1, text.operation.animationId)
+    assertEquals(core.properties, text.resolvedStyle)
+  }
+
   private fun treeOf(
     vararg operations: ee.schimke.composeai.rcplayer.protocol.RcOperation,
     ends: Int,

--- a/rc-player/wasm/build.gradle.kts
+++ b/rc-player/wasm/build.gradle.kts
@@ -34,6 +34,13 @@ tasks.register<Sync>("wasmPlayerDist") {
   }
   from(layout.projectDirectory.dir("src/wasmJsMain/resources")) { include("index.html") }
   from(
+    rootProject.layout.projectDirectory.dir(
+      "samples/cmp-wasm-catalog/src/wasmJsMain/resources/fonts"
+    )
+  ) {
+    into("fonts")
+  }
+  from(
     rootProject.layout.projectDirectory.file(
       "samples/cmp-wasm-catalog/src/wasmJsMain/resources/js-joda.esm.js"
     )

--- a/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
+++ b/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
@@ -13,6 +13,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.platform.Font
 import androidx.compose.ui.window.ComposeViewport
 import ee.schimke.composeai.rcplayer.compose.RcComposePlayer
 import ee.schimke.composeai.rcplayer.compose.composeSupportReport
@@ -28,11 +32,12 @@ import kotlin.io.encoding.Base64
 import kotlin.js.Promise
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
 
 private sealed interface LoadState {
   data object Loading : LoadState
 
-  data class Ready(val document: RcDocument) : LoadState
+  data class Ready(val document: RcDocument, val fontFamilies: Map<String, FontFamily>) : LoadState
 
   data class Failed(val message: String) : LoadState
 }
@@ -53,16 +58,17 @@ public fun main() {
         if (source == null) LoadState.Failed("Missing ?src=<document.rc>")
         else
           runCatching {
-              RcDocumentCodec.decode(fetchBytes(source)).also {
-                it
-                  .composeSupportReport(RcOperationProfiles.CMP_WASM_ALPHA16)
-                  .requireFullyRenderable()
-              }
+              val document = RcDocumentCodec.decode(fetchBytes(source))
+              val fontFamilies = withTimeout(8_000) { loadHostFontFamilies() }
+              document
+                .composeSupportReport(
+                  RcOperationProfiles.CMP_WASM_ALPHA16,
+                  availableFontFamilies = fontFamilies.keys,
+                )
+                .requireFullyRenderable()
+              LoadState.Ready(document, fontFamilies)
             }
-            .fold(
-              onSuccess = LoadState::Ready,
-              onFailure = { LoadState.Failed(it.message ?: "load failed") },
-            )
+            .fold(onSuccess = { it }, onFailure = { LoadState.Failed(it.message ?: "load failed") })
     }
 
     when (val state = loadState) {
@@ -74,6 +80,7 @@ public fun main() {
           Modifier.fillMaxSize(),
           theme = theme,
           onEvent = ::postPlayerEvent,
+          fontFamilies = state.fontFamilies,
         )
         LaunchedEffect(state.document) {
           // Compose schedules Skiko's raster work after composition. One frame only proves the
@@ -118,6 +125,95 @@ private suspend fun fetchBytes(url: String): ByteArray =
         null
       }
   }
+
+private data class ManifestFont(
+  val role: String,
+  val family: String,
+  val file: String,
+  val weight: Int,
+  val italic: Boolean,
+)
+
+private suspend fun loadHostFontFamilies(): Map<String, FontFamily> {
+  val rawBase = queryParameter("fontsBase") ?: "./fonts/"
+  val base =
+    (if (rawBase.endsWith('/')) rawBase else "$rawBase/").takeIf {
+      !it.contains(':') || it.startsWith("http:") || it.startsWith("https:")
+    } ?: "./fonts/"
+  val entries = parseFontsManifest(fetchText(base + "fonts.json"))
+  suspend fun load(entry: ManifestFont) =
+    Font(
+      identity = entry.file,
+      data = fetchBytes(base + entry.file),
+      weight = FontWeight(entry.weight),
+      style = if (entry.italic) FontStyle.Italic else FontStyle.Normal,
+    )
+  return buildMap {
+    entries
+      .filter { it.role == "named" || it.role == "generic" }
+      .groupBy { it.family }
+      .forEach { (family, faces) ->
+        runCatching { FontFamily(faces.map { load(it) }) }.onSuccess { put(family.lowercase(), it) }
+      }
+  }
+}
+
+private fun parseFontsManifest(json: String): List<ManifestFont> {
+  val flat = flattenFontsManifest(json)?.toString().orEmpty()
+  if (flat.isEmpty()) return emptyList()
+  return flat.split('\u0001').mapNotNull { row ->
+    val fields = row.split('\u0000')
+    if (fields.size != 5) return@mapNotNull null
+    val file =
+      fields[2].takeIf { it.isNotEmpty() && ".." !in it.split('/') && !it.contains(':') }
+        ?: return@mapNotNull null
+    ManifestFont(
+      role = fields[0],
+      family = fields[1],
+      file = file,
+      weight = fields[3].toIntOrNull()?.coerceIn(1, 1000) ?: 400,
+      italic = fields[4] == "italic",
+    )
+  }
+}
+
+private fun flattenFontsManifest(json: String): JsString? =
+  js(
+    """(function () {
+      try {
+        var manifest = JSON.parse(json), rows = [];
+        (manifest.families || []).forEach(function (family) {
+          (family.fonts || []).forEach(function (font) {
+            rows.push([family.role || 'default', family.name || '', String(font.file || ''),
+              String(font.weight || 400), String(font.style || 'normal')].join('\u0000'));
+          });
+        });
+        return rows.join('\u0001');
+      } catch (error) { return null; }
+    })()"""
+  )
+
+private fun fetchTextPromise(url: String): Promise<JsString> =
+  js(
+    """fetch(url).then(function (response) {
+      if (!response.ok) throw new Error('HTTP ' + response.status);
+      return response.text();
+    })"""
+  )
+
+private suspend fun fetchText(url: String): String = suspendCancellableCoroutine { continuation ->
+  fetchTextPromise(url)
+    .then { value ->
+      if (continuation.isActive) continuation.resume(value.toString())
+      null
+    }
+    .catch { failure ->
+      if (continuation.isActive) {
+        continuation.resumeWithException(IllegalStateException(failure.toString()))
+      }
+      null
+    }
+}
 
 private fun queryParameter(name: String): String? =
   queryParameterFromLocation(name).toString().takeUnless { it == "null" }


### PR DESCRIPTION
## Summary
- implement alpha16 `DATA_FONT` (opcode 189) with byte-exact protocol support
- accept authoritative ID-less `CoreText` records and resolve built-in, embedded, and host-provided font families
- add letter spacing and line-height semantics used by the current catalog
- package deterministic font faces and a bounded manifest loader in the Wasm player

## Compatibility evidence
- AndroidX-authored `FontData.apply` stream round-trips byte-for-byte
- decompiled alpha16 `CoreText.read` defaults component/animation IDs to `-1`
- alpha16 family IDs resolve through `TextData`; custom names fall through to font resources
- unavailable custom host fonts remain a deterministic capability error

## Verification
- protocol, runtime, Compose desktop, and AndroidX compatibility suites pass
- Compose/Wasm compiles and `wasmPlayerDist` assembles
- iOS arm64, simulator-arm64, and x64 compile
- ktfmt checks pass
- live 24-row Chromium checkpoint: all four text-first rows reach first frame:
  - BrandedTextRemote
  - RemoteTextSticker
  - TruncatedTextRemote
  - TypographyRemote

The remaining 20 rows now fail on later packets (PaintData commands, dimension type 3, click nesting, and layout normalization).

Stacked on #3245.