### PR TITLE
fix(rc-player): reach CMP Wasm pixel parity

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -133,6 +133,7 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -593,7 +594,8 @@ private fun RenderLayoutNode(
       }
     is RcLayoutNode.Row -> {
       val density = androidx.compose.ui.platform.LocalDensity.current
-      val spacing = with(density) { state.resolve(node.operation.spacedBy).dp.roundToPx() }
+      val spacingDp = state.resolve(node.operation.spacedBy).dp
+      val spacing = with(density) { spacingDp.roundToPx() }
       val rowModifier =
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
@@ -621,7 +623,7 @@ private fun RenderLayoutNode(
         Row(
           rowModifier,
           horizontalArrangement =
-            RcHorizontalArrangement(node.operation.horizontalPositioning, spacing),
+            RcHorizontalArrangement(node.operation.horizontalPositioning, spacingDp),
           verticalAlignment = rowAlignment(node.operation.verticalPositioning),
         ) {
           node.content.children.forEach { child ->
@@ -638,8 +640,7 @@ private fun RenderLayoutNode(
       }
     }
     is RcLayoutNode.Column -> {
-      val density = androidx.compose.ui.platform.LocalDensity.current
-      val spacing = with(density) { state.resolve(node.operation.spacedBy).dp.roundToPx() }
+      val spacing = state.resolve(node.operation.spacedBy).dp
       Column(
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
@@ -667,8 +668,7 @@ private fun RenderLayoutNode(
       }
     }
     is RcLayoutNode.Flow -> {
-      val density = androidx.compose.ui.platform.LocalDensity.current
-      val spacing = with(density) { state.resolve(node.operation.spacedBy).dp.roundToPx() }
+      val spacing = state.resolve(node.operation.spacedBy).dp
       @OptIn(ExperimentalLayoutApi::class)
       FlowRow(
         effectiveModifier.applyComponentModifiers(
@@ -683,7 +683,7 @@ private fun RenderLayoutNode(
         ),
         horizontalArrangement =
           RcHorizontalArrangement(node.operation.horizontalPositioning, spacing),
-        verticalArrangement = RcVerticalArrangement(node.operation.verticalPositioning, 0),
+        verticalArrangement = RcVerticalArrangement(node.operation.verticalPositioning, 0.dp),
         itemVerticalAlignment = rowAlignment(node.operation.verticalPositioning),
         maxItemsInEachRow = node.operation.maxItemsInEachRow,
         maxLines = node.operation.maxLines,
@@ -1368,7 +1368,7 @@ internal fun columnAlignment(horizontal: Int): Alignment.Horizontal =
     else -> error("Unknown AndroidX column horizontal position $horizontal")
   }
 
-private class RcHorizontalArrangement(private val positioning: Int, private val spacingPx: Int) :
+private class RcHorizontalArrangement(private val positioning: Int, override val spacing: Dp) :
   Arrangement.Horizontal {
   override fun Density.arrange(
     totalSize: Int,
@@ -1380,21 +1380,21 @@ private class RcHorizontalArrangement(private val positioning: Int, private val 
       totalSize,
       sizes,
       positioning,
-      spacingPx,
+      spacing.roundToPx(),
       reverse = layoutDirection == LayoutDirection.Rtl,
       outPositions = outPositions,
     )
   }
 }
 
-private class RcVerticalArrangement(private val positioning: Int, private val spacingPx: Int) :
+private class RcVerticalArrangement(private val positioning: Int, override val spacing: Dp) :
   Arrangement.Vertical {
   override fun Density.arrange(totalSize: Int, sizes: IntArray, outPositions: IntArray) {
     arrangeLinear(
       totalSize,
       sizes,
       positioning,
-      spacingPx,
+      spacing.roundToPx(),
       reverse = false,
       outPositions = outPositions,
     )
@@ -1469,7 +1469,7 @@ private fun Modifier.applyComponentModifiers(
       computeBase.applyLayoutComputes(modifiers, state)
     }
   modifiers.dimensionConstraints.forEach { constraint ->
-    result = result.applyDimensionConstraint(constraint, state, density)
+    result = result.applyDimensionConstraint(constraint, state)
   }
   result = result.applyWidth(modifiers, state, density, fillMissingDimensions)
   result = result.applyHeight(modifiers, state, density, fillMissingDimensions)
@@ -1512,10 +1512,10 @@ private fun Modifier.applyComponentModifiers(
   modifiers.padding.forEach { padding ->
     result =
       result.padding(
-        start = with(density) { state.resolve(padding.left).toDp() },
-        top = with(density) { state.resolve(padding.top).toDp() },
-        end = with(density) { state.resolve(padding.right).toDp() },
-        bottom = with(density) { state.resolve(padding.bottom).toDp() },
+        start = state.resolve(padding.left).dp,
+        top = state.resolve(padding.top).dp,
+        end = state.resolve(padding.right).dp,
+        bottom = state.resolve(padding.bottom).dp,
       )
   }
   if (modifiers.clicks.any { it.type != RcClickActionType.CLICK }) {
@@ -2207,39 +2207,28 @@ private fun Modifier.applyGraphicsLayer(
 private fun Modifier.applyDimensionConstraint(
   operation: ee.schimke.composeai.rcplayer.protocol.RcOperation,
   state: RcPlayerState,
-  density: Density,
 ): Modifier =
   when (operation) {
     is RcWidthInModifier ->
-      applyWidthRange(state.resolve(operation.minimum), state.resolve(operation.maximum), density)
+      applyWidthRange(state.resolve(operation.minimum), state.resolve(operation.maximum))
     is RcHeightInModifier ->
-      applyHeightRange(state.resolve(operation.minimum), state.resolve(operation.maximum), density)
+      applyHeightRange(state.resolve(operation.minimum), state.resolve(operation.maximum))
     is RcDimensionConstraintsModifier ->
       when (operation.type) {
         RcDimensionConstraintsModifier.HORIZONTAL ->
-          applyWidthRange(
-            state.resolve(operation.minimum),
-            state.resolve(operation.maximum),
-            density,
-          )
+          applyWidthRange(state.resolve(operation.minimum), state.resolve(operation.maximum))
         RcDimensionConstraintsModifier.VERTICAL ->
-          applyHeightRange(
-            state.resolve(operation.minimum),
-            state.resolve(operation.maximum),
-            density,
-          )
+          applyHeightRange(state.resolve(operation.minimum), state.resolve(operation.maximum))
         RcDimensionConstraintsModifier.REQUIRED_HORIZONTAL ->
           applyWidthRange(
             state.resolve(operation.minimum),
             state.resolve(operation.maximum),
-            density,
             required = true,
           )
         RcDimensionConstraintsModifier.REQUIRED_VERTICAL ->
           applyHeightRange(
             state.resolve(operation.minimum),
             state.resolve(operation.maximum),
-            density,
             required = true,
           )
         else -> this
@@ -2250,11 +2239,10 @@ private fun Modifier.applyDimensionConstraint(
 private fun Modifier.applyWidthRange(
   minimum: Float,
   maximum: Float,
-  density: Density,
   required: Boolean = false,
 ): Modifier {
-  val min = with(density) { minimum.toDp() }
-  val max = with(density) { maximum.toDp() }
+  val min = minimum.dp
+  val max = maximum.dp
   return when {
     minimum == -1f && maximum == -1f -> this
     required && minimum == -1f -> requiredWidthIn(max = max)
@@ -2269,11 +2257,10 @@ private fun Modifier.applyWidthRange(
 private fun Modifier.applyHeightRange(
   minimum: Float,
   maximum: Float,
-  density: Density,
   required: Boolean = false,
 ): Modifier {
-  val min = with(density) { minimum.toDp() }
-  val max = with(density) { maximum.toDp() }
+  val min = minimum.dp
+  val max = maximum.dp
   return when {
     minimum == -1f && maximum == -1f -> this
     required && minimum == -1f -> requiredHeightIn(max = max)
@@ -3386,13 +3373,7 @@ private fun DrawScope.drawTweenPath(
   val start = state.resolve(operation.start)
   val stop = state.resolve(operation.stop)
   val trimmed = trimPath(path, start, stop)
-  drawPath(
-    path = trimmed,
-    color = paint.composeColor(),
-    style = paint.style(),
-    colorFilter = paint.colorFilter,
-    blendMode = paint.blendMode,
-  )
+  drawRcPath(trimmed, paint)
 }
 
 internal fun tweenPathData(
@@ -3472,13 +3453,7 @@ private fun DrawScope.drawIdOperation(
 ) {
   when (operation.opcode) {
     RcOpcodes.DRAW_PATH -> {
-      drawPath(
-        path = pathForId(operation.id, state, computedPaths),
-        color = paint.composeColor(),
-        style = paint.style(),
-        colorFilter = paint.colorFilter,
-        blendMode = paint.blendMode,
-      )
+      drawRcPath(pathForId(operation.id, state, computedPaths), paint)
     }
     RcOpcodes.CLIP_PATH -> {
       // AndroidX packs the path id in the low 20 bits and the Region.Op in the high byte.
@@ -3489,6 +3464,28 @@ private fun DrawScope.drawIdOperation(
         if (regionOp == 1) ClipOp.Difference else ClipOp.Intersect,
       )
     }
+  }
+}
+
+private fun DrawScope.drawRcPath(path: Path, paint: RcPaintState) {
+  val brush = paint.brush
+  if (brush == null) {
+    drawPath(
+      path = path,
+      color = paint.composeColor(),
+      style = paint.style(),
+      colorFilter = paint.colorFilter,
+      blendMode = paint.blendMode,
+    )
+  } else {
+    drawPath(
+      path = path,
+      brush = brush,
+      alpha = paint.alpha,
+      style = paint.style(),
+      colorFilter = paint.colorFilter,
+      blendMode = paint.blendMode,
+    )
   }
 }
 
@@ -3621,15 +3618,34 @@ private fun DrawScope.draw6(operation: RcDraw6, paint: RcPaintState, state: RcPl
   val e = state.resolve(operation.fifth)
   val f = state.resolve(operation.sixth)
   when (operation.opcode) {
-    RcOpcodes.DRAW_ROUND_RECT ->
-      drawRoundRect(
-        paint.composeColor(),
-        Offset(a, b),
-        Size(c - a, d - b),
-        CornerRadius(e, f),
-        style = paint.style(),
-        blendMode = paint.blendMode,
-      )
+    RcOpcodes.DRAW_ROUND_RECT -> {
+      val topLeft = Offset(a, b)
+      val size = Size(c - a, d - b)
+      val cornerRadius = CornerRadius(e, f)
+      val brush = paint.brush
+      if (brush == null) {
+        drawRoundRect(
+          paint.composeColor(),
+          topLeft,
+          size,
+          cornerRadius,
+          style = paint.style(),
+          colorFilter = paint.colorFilter,
+          blendMode = paint.blendMode,
+        )
+      } else {
+        drawRoundRect(
+          brush,
+          topLeft,
+          size,
+          cornerRadius,
+          alpha = paint.alpha,
+          style = paint.style(),
+          colorFilter = paint.colorFilter,
+          blendMode = paint.blendMode,
+        )
+      }
+    }
     RcOpcodes.DRAW_ARC,
     RcOpcodes.DRAW_SECTOR ->
       drawArc(

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -890,7 +890,7 @@ class RcLayoutRenderTest {
   }
 
   @Test
-  fun dimensionRangesClampRequestedCanvasSize() {
+  fun dimensionRangesUseRemoteDpAtNonUnitDensity() {
     val red = 0xffff0000.toInt()
     val document =
       RcDocument(
@@ -924,17 +924,17 @@ class RcLayoutRenderTest {
         ),
       )
     val scene =
-      ImageComposeScene(width = 100, height = 100, density = Density(1f)) {
+      ImageComposeScene(width = 200, height = 200, density = Density(2f)) {
         RcComposePlayer(document)
       }
     try {
       val image = scene.render()
-      val bitmap = Bitmap().apply { allocN32Pixels(100, 100) }
+      val bitmap = Bitmap().apply { allocN32Pixels(200, 200) }
       check(image.readPixels(bitmap))
 
-      assertEquals(red, bitmap.getColor(39, 29))
-      assertEquals(0, bitmap.getColor(41, 29))
-      assertEquals(0, bitmap.getColor(39, 31))
+      assertEquals(red, bitmap.getColor(79, 59))
+      assertEquals(0, bitmap.getColor(81, 59))
+      assertEquals(0, bitmap.getColor(79, 61))
     } finally {
       scene.close()
     }

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
@@ -569,8 +569,11 @@ public object RcLayoutTree {
 
   /** CoreDocument assigns the last CanvasOperations container to its enclosing component. */
   private fun canvasOperations(container: RcLinkedNode.Container): List<RcLinkedNode>? =
-    container.children
-      .filterIsInstance<RcLinkedNode.Container>()
+    (container.children.filterIsInstance<RcLinkedNode.Container>() +
+        container.children
+          .filterIsInstance<RcLinkedNode.Container>()
+          .filter { it.operation is RcLayoutContent }
+          .flatMap { it.children.filterIsInstance<RcLinkedNode.Container>() })
       .lastOrNull { it.operation.opcode == RcOpcodes.CANVAS_OPERATIONS }
       ?.children
 

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -873,7 +873,13 @@ public class RcPlayerState(
         changed = true
       }
     }
-    if (changed) onInvalidated()
+    if (changed) {
+      // ComponentValue is a variable source in AndroidX. Expressions listening to it are refreshed
+      // before the settling draw, including expressions used by layout modifiers rather than a
+      // CanvasOperations block.
+      document.operations.filterIsInstance<RcFloatExpression>().forEach(::applyFloatExpression)
+      onInvalidated()
+    }
     return changed
   }
 

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTreeTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTreeTest.kt
@@ -414,6 +414,29 @@ class RcLayoutTreeTest {
   }
 
   @Test
+  fun promotesCanvasOperationsFromLayoutContentToItsComponent() {
+    val root =
+      requireNotNull(
+        treeOf(
+          RcRootLayout(1),
+          RcBoxLayout(2, 20, 1, 4),
+          RcLayoutContent(3),
+          RcNoArg(RcOpcodes.CANVAS_OPERATIONS),
+          RcNoArg(RcOpcodes.MATRIX_SAVE),
+          ends = 4,
+        )
+      )
+    val box = assertIs<RcLayoutNode.Box>(root.children.single())
+
+    assertEquals(
+      RcOpcodes.MATRIX_SAVE,
+      assertIs<RcLinkedNode.Operation>(requireNotNull(box.canvasOperations).single())
+        .operation
+        .opcode,
+    )
+  }
+
+  @Test
   fun rejectsMissingContentAndDuplicateIdsButKeepsFirstRequiredDimension() {
     assertFailsWith<RcLayoutException> {
       treeOf(RcRootLayout(1), RcBoxLayout(2, 20, 1, 4), ends = 2)

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
@@ -71,7 +71,19 @@ class RcPlayerStateTest {
       RcComponentValue.VALID_TYPES.map { RcComponentValue(it, componentId = 7, valueId = 100 + it) }
     val state =
       RcPlayerState(
-        RcDocument(RcHeader(RcVersion(0, 1, 0)), bindings),
+        RcDocument(
+          RcHeader(RcVersion(0, 1, 0)),
+          bindings +
+            RcFloatExpression(
+              200,
+              listOf(
+                RcFloatWord(0x7fc00000 or 100),
+                RcFloatWord.literal(2f),
+                RcFloatExpressionEvaluator.operatorWord(RcFloatExpressionEvaluator.OFFSET + 4),
+              ),
+              null,
+            ),
+        ),
         onInvalidated = { invalidations += 1 },
       )
     val first = RcComponentGeometry(40f, 30f, 2f, 3f, 12f, 13f)
@@ -81,6 +93,7 @@ class RcPlayerStateTest {
       listOf(40f, 30f, 2f, 3f, 12f, 13f, 40f, 30f),
       RcComponentValue.VALID_TYPES.map { state.resolve(RcFloatWord(0x7fc00000 or (100 + it))) },
     )
+    assertEquals(20f, state.resolve(RcFloatWord(0x7fc00000 or 200)))
     assertEquals(1, invalidations)
     assertFalse(state.publishComponentGeometry(7, first))
     assertEquals(1, invalidations, "stable geometry must not schedule another measure pass")
@@ -92,6 +105,7 @@ class RcPlayerStateTest {
 
     assertTrue(state.publishComponentGeometry(7, first.copy(width = 41f)))
     assertEquals(41f, state.resolve(RcFloatWord(0x7fc00000 or 100)))
+    assertEquals(20.5f, state.resolve(RcFloatWord(0x7fc00000 or 200)))
     assertEquals(75f, state.resolve(RcFloatWord(0x7fc00000 or 106)))
     assertEquals(3, invalidations)
   }

--- a/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
+++ b/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
@@ -13,6 +13,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -77,7 +80,10 @@ public fun main() {
       is LoadState.Ready -> {
         RcComposePlayer(
           state.document,
-          Modifier.fillMaxSize(),
+          Modifier.fillMaxSize().drawWithContent {
+            drawRect(Color.Transparent, blendMode = BlendMode.Clear)
+            drawContent()
+          },
           theme = theme,
           onEvent = ::postPlayerEvent,
           fontFamilies = state.fontFamilies,

--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -144,6 +144,13 @@ function baseName(name, prefix, suffix) {
 
 const bundleBuf = fs.readFileSync(BUNDLE);
 const entries = readZipEntries(bundleBuf);
+const previewParameters = new Map();
+if (entries.has("previews.json")) {
+  const manifest = JSON.parse(entries.get("previews.json")().toString("utf8"));
+  for (const preview of manifest.previews ?? []) {
+    if (preview.id && preview.params) previewParameters.set(preview.id, preview.params);
+  }
+}
 
 const rcIds = [];
 for (const name of entries.keys()) {
@@ -372,12 +379,16 @@ async function startCmpWasmServer(dir) {
   };
 }
 
-async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank) {
-  if (!cmpWasmPage) return {};
+async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank, previewParams) {
+  if (!CMP_WASM) return {};
   try {
+    const density = previewParams?.density ?? 1;
+    const viewportWidth = previewParams?.widthDp ?? Math.round(width / density);
+    const viewportHeight = previewParams?.heightDp ?? Math.round(height / density);
+    const { page: cmpWasmPage, consoleErrors: cmpWasmConsoleErrors } = await cmpWasmPageFor(density);
     cmpWasmConsoleErrors.length = 0;
     cmpWasmServer.setDocument(bytes);
-    await cmpWasmPage.setViewportSize({ width, height });
+    await cmpWasmPage.setViewportSize({ width: viewportWidth, height: viewportHeight });
     await cmpWasmPage.goto(
       `${cmpWasmServer.origin}/index.html?src=${encodeURIComponent("/document.rc")}&theme=${encodeURIComponent(THEME)}`,
     );
@@ -434,13 +445,19 @@ const browser = await chromium.launch({
 });
 const page = await browser.newContext({ deviceScaleFactor: 1 }).then((c) => c.newPage());
 const cmpWasmServer = CMP_WASM ? await startCmpWasmServer(CMP_WASM) : null;
-const cmpWasmPage = CMP_WASM
-  ? await browser.newContext({ deviceScaleFactor: 1 }).then((context) => context.newPage())
-  : null;
-const cmpWasmConsoleErrors = [];
-cmpWasmPage?.on("console", (message) => {
-  if (message.type() === "error") cmpWasmConsoleErrors.push(message.text());
-});
+const cmpWasmPages = new Map();
+async function cmpWasmPageFor(density) {
+  if (cmpWasmPages.has(density)) return cmpWasmPages.get(density);
+  const context = await browser.newContext({ deviceScaleFactor: density });
+  const page = await context.newPage();
+  const consoleErrors = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  const value = { page, consoleErrors };
+  cmpWasmPages.set(density, value);
+  return value;
+}
 const pageWarnings = [];
 page.on("console", (m) => {
   if (m.type() === "warning" || m.type() === "error") pageWarnings.push(m.text());
@@ -510,6 +527,7 @@ for (const id of rcIds) {
     width,
     height,
     referenceBlank,
+    previewParameters.get(id),
   );
 
   if (result.error || truncated) {


### PR DESCRIPTION
## Summary

- render Remote Compose coordinates at preview density without double-converting dp values
- attach nested canvas operations and refresh geometry-dependent expressions
- support shader brushes on paths and rounded rectangles, spacing-aware measurement, and transparent Wasm captures
- make the comparison harness use each preview's declared density and dp viewport

## Corpus evidence

Strict `design-catalog-remote-m3` comparison:

- CMP/Wasm: **24/24 rendered**, 0 allowlisted, 0 failed
- CMP/Wasm mean mismatch: **0.93%**
- existing JS player mean mismatch: **1.21%**

## Verification

- `node --check scripts/design-artifacts/rc-compare.mjs`
- 33 focused comparison/gate/pixel tests
- `:rc-player-protocol:allTests`
- `:rc-player-runtime:allTests`
- `:rc-player-compose:allTests`
- `:rc-player-compat-tests:test`
- `:rc-player-wasm:wasmPlayerTestDist`
- `ktfmtCheck`
- focused non-unit-density desktop render regression

The iOS simulator ARM64 test tasks are excluded because this host's Xcode installation has no simulator SDK; iOS x64 compilation and linking complete successfully.