### PR TITLE
feat(rc-player): enforce CMP/Wasm replacement gates

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -37,6 +37,14 @@
       "data/layoutinspector/**",
       "data/render/**"
     ],
+    "rc_player_tests": [
+      "rc-player/**",
+      "cli/src/main/kotlin/ee/schimke/composeai/cli/serve/**",
+      "cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js",
+      "cli/src/test/kotlin/ee/schimke/composeai/cli/serve/**",
+      "scripts/design-artifacts/rc-compare*",
+      ".github/workflows/design-artifacts-reusable.yml"
+    ],
     "module_unit_tests": [
       "api/**",
       "bundle-viewer/**",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
     outputs:
       plugin_tests: ${{ steps.scope.outputs.plugin_tests }}
       renderer_android_tests: ${{ steps.scope.outputs.renderer_android_tests }}
+      rc_player_tests: ${{ steps.scope.outputs.rc_player_tests }}
       module_unit_tests: ${{ steps.scope.outputs.module_unit_tests }}
       module_test_tasks: ${{ steps.test-scope.outputs.tasks }}
       functional_tests: ${{ steps.scope.outputs.functional_tests }}
@@ -292,6 +293,45 @@ jobs:
           path: |
             **/build/reports/tests/**
             **/build/test-results/**
+          retention-days: 7
+
+  rc-player-tests:
+    name: CMP Remote Compose Player
+    needs: changes
+    if: ${{ needs.changes.outputs.rc_player_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Run shared, Wasm, and iOS player tests
+        run: |
+          ./gradlew \
+            :rc-player-protocol:allTests \
+            :rc-player-runtime:allTests \
+            :rc-player-compose:allTests \
+            :rc-player-compat-tests:test \
+            :rc-player-wasm:wasmPlayerTestDist \
+            :rc-player-protocol:compileTestKotlinIosArm64 \
+            :rc-player-protocol:compileTestKotlinIosSimulatorArm64 \
+            :rc-player-protocol:compileTestKotlinIosX64 \
+            :rc-player-runtime:compileTestKotlinIosArm64 \
+            :rc-player-runtime:compileTestKotlinIosSimulatorArm64 \
+            :rc-player-runtime:compileTestKotlinIosX64 \
+            :rc-player-compose:compileTestKotlinIosArm64 \
+            :rc-player-compose:compileTestKotlinIosSimulatorArm64 \
+            :rc-player-compose:compileTestKotlinIosX64
+          ./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebTest
+          ./gradlew ktfmtCheck
+      - name: Upload player test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: rc-player-test-reports
+          path: |
+            rc-player/**/build/reports/tests/**
+            rc-player/**/build/test-results/**
           retention-days: 7
 
   functional-tests:

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -142,6 +142,21 @@ on:
         required: false
         type: string
         default: ''
+      rc-cmp-wasm-pixel-tolerances:
+        description: 'Optional caller-repo-relative JSON file containing reviewed per-preview pixel ceilings above the strict 1% default.'
+        required: false
+        type: string
+        default: ''
+      rc-cmp-wasm-max-cold-first-frame-ms:
+        description: 'Maximum cold CMP/Wasm navigation-to-painted-ready time. The strict lane fails above it.'
+        required: false
+        type: number
+        default: 10000
+      rc-cmp-wasm-max-warm-first-frame-ms:
+        description: 'Maximum cached CMP/Wasm navigation-to-painted-ready time. The strict lane fails above it.'
+        required: false
+        type: number
+        default: 5000
       stage-font-globs:
         description: 'Whitespace-separated repo-relative globs of font files (.ttf/.otf) to stage into fontconfig BEFORE rendering — for a desktop (Skiko) render that must resolve glyphs (CJK/Arabic/…) from a bundled face rather than a system fallback. Empty ⇒ no staging.'
         required: false
@@ -611,6 +626,7 @@ jobs:
         working-directory: compose-ai-tools/scripts/design-artifacts
         env:
           RC_CMP_WASM_ALLOWLIST: ${{ inputs.rc-cmp-wasm-allowlist }}
+          RC_CMP_WASM_PIXEL_TOLERANCES: ${{ inputs.rc-cmp-wasm-pixel-tolerances }}
         run: |
           set -euo pipefail
           if ! python3 - "$GITHUB_WORKSPACE/bundle.png" <<'PY'
@@ -646,9 +662,14 @@ jobs:
               EMBEDDED_ARGS+=(
                 --cmp-wasm "$GITHUB_WORKSPACE/compose-ai-tools/rc-player/wasm/build/wasmDist"
                 --require-cmp-wasm
+                --cmp-wasm-max-cold-first-frame-ms "${{ inputs.rc-cmp-wasm-max-cold-first-frame-ms }}"
+                --cmp-wasm-max-warm-first-frame-ms "${{ inputs.rc-cmp-wasm-max-warm-first-frame-ms }}"
               )
               if [ -n "$RC_CMP_WASM_ALLOWLIST" ]; then
                 EMBEDDED_ARGS+=(--cmp-wasm-allowlist "$GITHUB_WORKSPACE/$RC_CMP_WASM_ALLOWLIST")
+              fi
+              if [ -n "$RC_CMP_WASM_PIXEL_TOLERANCES" ]; then
+                EMBEDDED_ARGS+=(--cmp-wasm-pixel-tolerances "$GITHUB_WORKSPACE/$RC_CMP_WASM_PIXEL_TOLERANCES")
               fi
             else
               echo "::error title=CMP/Wasm distribution failed::The required player distribution did not build; see the uploaded distribution-build.log." >&2

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -629,5 +629,6 @@ jobs:
       # environment visitors use. This gives it an immediate per-document parity signal beside
       # the established JS, Android embedded, and cmp-jvm lanes.
       rc-cmp-wasm-lane: true
+      rc-cmp-wasm-pixel-tolerances: scripts/design-artifacts/fixtures/remote-m3-cmp-wasm-pixel-tolerances.json
     secrets:
       buildfetch_ro_token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4168,7 +4168,7 @@ $deviceControlsHtml
           $overlaysHtml
           $featureControlsHtml
           ${overrideKnobsHtml(preview, canApplyOverrides || canRenderOverrides, wasmSrc != null)}
-          ${remoteComposeKnobsHtml(preview, canApplyOverrides || canRenderOverrides)}
+          ${remoteComposeKnobsHtml(preview, canApplyOverrides || canRenderOverrides || hasRcWasm)}
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
@@ -4576,18 +4576,16 @@ $deviceControlsHtml
    * labelled control list — the RC counterpart of [overrideKnobsHtml]. One control per knob
    * (checkbox for bool, number for int / float / dp, text for string and `#AARRGGBB` colour), whose
    * edits round-trip through the `rc.<name>=<kind>:<value>` render param ([ServeOverrides] parses
-   * it back into `PreviewOverrides.remoteCompose.namedValues`). Live only when [canApplyOverrides]
-   * — Remote Compose has no in-browser (Wasm) runtime, so a plain static bundle shows the controls
-   * disabled with a one-line note (mirroring how declared knobs render on a static bundle). Empty
-   * string when the preview declared no RC knobs (the common case). The controls are marked
-   * `.cp-rc-knob` and carry `data-rc-name` / `data-rc-kind` / `data-rc-initial`; the viewer JS
-   * collects them into `rc.<name>=<kind>:<value>` params and routes an edit through the daemon-only
-   * path.
+   * it back into `PreviewOverrides.remoteCompose.namedValues`). Live when [canApplyOverrides]
+   * includes server rendering or the CMP/Wasm host; a plain static bundle without either player
+   * shows the controls disabled with a one-line note. Empty string when the preview declared no RC
+   * knobs (the common case). The controls are marked `.cp-rc-knob` and carry `data-rc-name` /
+   * `data-rc-kind` / `data-rc-initial`; the viewer JS collects them into typed values and routes
+   * edits through the active player.
    */
   private fun remoteComposeKnobsHtml(preview: ServePreview, canApplyOverrides: Boolean): String {
     if (preview.remoteComposeKnobs.isEmpty()) return ""
-    // RC is daemon-only (no Wasm tier), so the controls are live only when the session can
-    // re-render; a static bundle shows them disabled and informational.
+    // A static bundle without either a server renderer or CMP/Wasm keeps these informational.
     val dis = if (canApplyOverrides) "" else " disabled"
     val rows =
       preview.remoteComposeKnobs.joinToString("\n") { d ->

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -1041,12 +1041,29 @@
   // another implementation hidden behind the legacy canvas API: it receives the document URL and
   // explicitly announces its first rendered frame.
   function positionRcWasmFrame() { if (rcWasmFrame) positionOverlay(rcWasmFrame); }
+  function rcWasmNamedValues() {
+    var values = [];
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      var name = el.getAttribute("data-rc-name");
+      if (!name) return;
+      values.push({
+        name: name,
+        kind: el.getAttribute("data-rc-kind") || "string",
+        value: el.type === "checkbox" ? (el.checked ? "true" : "false") : el.value
+      });
+    });
+    return values;
+  }
   function rcWasmSrc() {
     var absoluteDoc = new URL(rcDocUrl(), location.origin).href;
     var src = "/rc-player-wasm/index.html?src=" + encodeURIComponent(absoluteDoc);
     var uiMode = document.getElementById("cp-uiMode");
     if (uiMode && (uiMode.value === "light" || uiMode.value === "dark")) {
       src += "&theme=" + encodeURIComponent(uiMode.value);
+    }
+    var namedValues = rcWasmNamedValues();
+    if (namedValues.length) {
+      src += "&namedValues=" + encodeURIComponent(JSON.stringify(namedValues));
     }
     return src;
   }
@@ -1085,10 +1102,18 @@
   }
   if (rcWasmFrame) {
     window.addEventListener("message", function (e) {
-      if (e.source !== rcWasmFrame.contentWindow || typeof e.data !== "string") return;
+      if (e.source !== rcWasmFrame.contentWindow || e.origin !== location.origin) return;
       if (e.data === "cp-rc-wasm-ready") revealRcWasm();
-      else if (e.data.indexOf("cp-rc-wasm-error:") === 0) {
+      else if (typeof e.data === "string" && e.data.indexOf("cp-rc-wasm-error:") === 0) {
         showModeError("Rendering the Remote Compose document failed in CMP Wasm.");
+      } else if (e.data && (e.data.type === "cp-rc-host-action" ||
+          e.data.type === "cp-rc-host-named-action")) {
+        // The viewer never executes an action payload. It exposes the validated event to an
+        // embedding host and leaves policy/navigation to that host.
+        window.dispatchEvent(new CustomEvent(e.data.type, { detail: e.data }));
+        status.textContent = e.data.type === "cp-rc-host-action"
+          ? "Remote Compose host action " + String(e.data.actionId)
+          : "Remote Compose named action “" + String(e.data.name || "") + "”";
       }
     });
   }
@@ -1286,12 +1311,11 @@
     }
     // Remote Compose knobs are LIVE in the RC canvas lane — an edit applies client-side via
     // setNamed*Override + repaint (onRcKnobChanged), no daemon needed — so enable them whenever
-    // that lane is active. Outside it they're daemon-only (Remote Compose has no in-browser
-    // runtime), so, like the app-theme selector, they're dead in the Wasm lane and otherwise
-    // gated on the host being able to render an override.
+    // that lane is active. The CMP/Wasm lane applies the same typed values while reloading its
+    // isolated document; outside either browser RC lane they're gated on server rendering.
     document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
-      el.disabled = rcActive() ? false
-        : (onWasm || rcWasmActive() || !(!staticSnapshot || canRenderOverrides));
+      el.disabled = (rcActive() || rcWasmActive()) ? false
+        : (onWasm || !(!staticSnapshot || canRenderOverrides));
     });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
@@ -1560,12 +1584,11 @@
   document.querySelectorAll(".cp-feature").forEach(function (el) {
     el.addEventListener("change", onKnobChanged);
   });
-  // Remote Compose knobs apply live in the browser when the RC canvas lane is active
-  // (setNamed*Override + repaint on the client player, no round-trip); otherwise they route
-  // through the server daemon like the theme selector / feature toggles. A text/number edit
-  // debounces on "input", a bool toggle on "change".
+  // Remote Compose knobs apply in-browser in both RC lanes: repaint for JS, isolated reload for
+  // CMP/Wasm. Otherwise they route through the server daemon like theme/feature controls.
   function onRcKnobChanged() {
     if (rcActive()) { refreshLinks(); applyRcOverrides(); return; }
+    if (rcWasmActive()) { refreshLinks(); openRcWasm(); return; }
     onKnobChanged();
   }
   document.querySelectorAll(".cp-rc-knob").forEach(function (el) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -345,7 +347,13 @@ class ServeWebTest {
 
   @Test
   fun `cmp wasm backend gets its own iframe and mode`() {
-    val preview = ServePreview(id = "widget.Chip", label = "chip")
+    val preview =
+      ServePreview(
+        id = "widget.Chip",
+        label = "chip",
+        remoteComposeKnobs =
+          listOf(RemoteComposeKnobDeclaration("label", RemoteNamedValue.StringValue("Hello"))),
+      )
     val html =
       ServeWeb.viewerPage(
         preview,
@@ -361,6 +369,15 @@ class ServeWebTest {
     assertTrue(
       html.contains("sandbox=\"allow-scripts allow-same-origin\""),
       "repository-owned player can fetch the tokened document from its own origin",
+    )
+    val knob = Regex("<input[^>]*data-rc-name=\"label\"[^>]*>").find(html)?.value ?: ""
+    assertFalse(knob.contains(" disabled"), "CMP/Wasm can apply named values: '$knob'")
+    val viewerJs = ServeWebAssets.load("viewer.js")!!.bytes.decodeToString()
+    assertTrue(viewerJs.contains("namedValues="), "named values are passed to the isolated host")
+    assertTrue(viewerJs.contains("e.origin !== location.origin"), "messages are origin checked")
+    assertTrue(
+      viewerJs.contains("new CustomEvent(e.data.type"),
+      "validated host actions are exposed without executing their payload",
     )
   }
 

--- a/docs/design/RC_CMP_WASM_PLAYER.md
+++ b/docs/design/RC_CMP_WASM_PLAYER.md
@@ -542,6 +542,25 @@ Do not measure progress as “number of classes ported.” A cluster is complete
 - the public support matrix is regenerated and contains no unreviewed downgrade;
 - bundle size and first-frame time stay within a recorded budget.
 
+### Replacement-gate evidence
+
+The remote-m3 replacement corpus is guarded in CI, not recorded as a one-off manual result:
+
+- All 24/24 current documents render through CMP/Wasm. Pixel comparison uses a strict 1% default;
+  only WatchScreen (1.4%) and WidgetContainerSmall (1.5%) have reviewed, catalog-owned ceilings.
+  The tolerance file is stale-failing: an entry that is no longer measured above 1% must be removed.
+- The production distribution is capped at 23,000,000 raw bytes by `wasmPlayerDist`; the verified
+  distribution is 22,756,717 bytes. Source maps and development-only formatters are not shipped.
+- The strict comparison lane caps cold and warm navigation-to-painted-ready time at 10,000 ms and
+  5,000 ms respectively. The reviewed 24-document run measured 2,361 ms cold and 2,003 ms warm.
+- The live viewer forwards typed named overrides, reloads after knob changes, validates same-origin
+  host messages, and surfaces host/named actions as inert `CustomEvent` payloads. Decode, support,
+  and resource failures remain bounded inside the iframe instead of replacing the catalog page.
+- Protocol, runtime, Compose, compatibility, Wasm distribution, CLI host, and formatting checks run
+  in the dedicated player CI job. The shared renderer compiles/tests for iOS x64, device arm64, and
+  simulator arm64; the UIKit entry point reports decode/support/resource failures through `onError`
+  and forwards player events through its host callback.
+
 After cluster 1, wire the player behind an experimental viewer flag so real documents can find
 unknown operations early. Keep the static/snapshot player visible until the Wasm player posts a
 successful first-frame signal, matching the existing catalog's no-flash handoff.

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -2276,8 +2276,9 @@ private fun Modifier.applyHeightRange(
 private fun Modifier.applyPaintDecorator(
   operation: ee.schimke.composeai.rcplayer.protocol.RcOperation,
   state: RcPlayerState,
-): Modifier =
-  when (operation) {
+): Modifier {
+  val density = androidx.compose.ui.platform.LocalDensity.current.density
+  return when (operation) {
     is RcBackgroundModifier ->
       drawBehind {
         val color =
@@ -2351,10 +2352,13 @@ private fun Modifier.applyPaintDecorator(
       }
     is RcRoundedClipRectModifier ->
       drawWithContent {
-        val topStart = state.resolve(operation.topStart).coerceAtLeast(0f)
-        val topEnd = state.resolve(operation.topEnd).coerceAtLeast(0f)
-        val bottomStart = state.resolve(operation.bottomStart).coerceAtLeast(0f)
-        val bottomEnd = state.resolve(operation.bottomEnd).coerceAtLeast(0f)
+        val topStart =
+          rcRoundedClipRadius(operation.topStart, state.resolve(operation.topStart), density)
+        val topEnd = rcRoundedClipRadius(operation.topEnd, state.resolve(operation.topEnd), density)
+        val bottomStart =
+          rcRoundedClipRadius(operation.bottomStart, state.resolve(operation.bottomStart), density)
+        val bottomEnd =
+          rcRoundedClipRadius(operation.bottomEnd, state.resolve(operation.bottomEnd), density)
         val path =
           Path().apply {
             addRoundRect(
@@ -2375,6 +2379,11 @@ private fun Modifier.applyPaintDecorator(
       }
     else -> this
   }
+}
+
+/** Fixed radii are authored in dp; size-derived references already resolve to physical pixels. */
+internal fun rcRoundedClipRadius(word: RcFloatWord, resolved: Float, density: Float): Float =
+  (resolved * if (word.referencedId == null) density else 1f).coerceAtLeast(0f)
 
 @Composable
 private fun Modifier.applyAndroidXRipple(): Modifier {
@@ -3589,7 +3598,7 @@ private fun DrawScope.draw4(operation: RcDraw4, paint: RcPaintState, state: RcPl
         blendMode = paint.blendMode,
       )
     RcOpcodes.CLIP_RECT -> drawContext.canvas.clipRect(a, b, c, d)
-    RcOpcodes.MATRIX_SCALE -> drawContext.transform.scale(a, b, Offset(c, d))
+    RcOpcodes.MATRIX_SCALE -> drawContext.transform.scale(a, b, rcMatrixPivot(c, d))
   }
 }
 
@@ -3606,9 +3615,13 @@ private fun DrawScope.draw3(operation: RcDraw3, paint: RcPaintState, state: RcPl
         style = paint.style(),
         blendMode = paint.blendMode,
       )
-    RcOpcodes.MATRIX_ROTATE -> drawContext.transform.rotate(a, Offset(b, c))
+    RcOpcodes.MATRIX_ROTATE -> drawContext.transform.rotate(a, rcMatrixPivot(b, c))
   }
 }
+
+/** AndroidX encodes an omitted matrix pivot as NaN in the first pivot coordinate. */
+internal fun rcMatrixPivot(x: Float, y: Float): Offset =
+  if (x.isNaN()) Offset.Zero else Offset(x, y)
 
 private fun DrawScope.draw6(operation: RcDraw6, paint: RcPaintState, state: RcPlayerState) {
   val a = state.resolve(operation.first)

--- a/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupportTest.kt
+++ b/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupportTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.rcplayer.compose
 
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.Role
 import ee.schimke.composeai.rcplayer.protocol.RcAccessibilitySemantics
 import ee.schimke.composeai.rcplayer.protocol.RcAnimationSpec
@@ -61,6 +62,19 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class RcComposeSupportTest {
+  @Test
+  fun omittedMatrixPivotUsesTheOrigin() {
+    assertEquals(Offset.Zero, rcMatrixPivot(Float.NaN, Float.NaN))
+    assertEquals(Offset.Zero, rcMatrixPivot(Float.NaN, 12f))
+    assertEquals(Offset(3f, 4f), rcMatrixPivot(3f, 4f))
+  }
+
+  @Test
+  fun fixedRoundedClipRadiiScaleButSizeDerivedRadiiDoNot() {
+    assertEquals(104f, rcRoundedClipRadius(RcFloatWord.literal(52f), resolved = 52f, density = 2f))
+    assertEquals(110f, rcRoundedClipRadius(RcFloatWord(0x7fc0002a), resolved = 110f, density = 2f))
+  }
+
   @Test
   fun boundedControlFlowIsSharedByWasmAndIosProfiles() {
     val end = RcNoArg(RcOpcodes.CONTAINER_END)

--- a/rc-player/compose/src/iosMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeViewController.kt
+++ b/rc-player/compose/src/iosMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeViewController.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.rcplayer.compose
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.window.ComposeUIViewController
 import ee.schimke.composeai.rcplayer.protocol.RcDocumentCodec
 import ee.schimke.composeai.rcplayer.protocol.RcOperationProfiles
@@ -14,12 +15,35 @@ public fun RcComposeViewController(
   bytes: ByteArray,
   theme: Int = RcTheme.UNSPECIFIED,
   onEvent: (RcPlayerEvent) -> Unit = {},
+  fontFamilies: Map<String, FontFamily> = emptyMap(),
+  onError: (String) -> Unit = {},
 ): UIViewController {
   val document =
-    RcDocumentCodec.decode(bytes).also {
-      it.composeSupportReport(RcOperationProfiles.CMP_IOS_ALPHA16).requireFullyRenderable()
-    }
+    runCatching {
+        RcDocumentCodec.decode(bytes).also {
+          it
+            .composeSupportReport(
+              RcOperationProfiles.CMP_IOS_ALPHA16,
+              availableFontFamilies = fontFamilies.keys,
+            )
+            .requireFullyRenderable()
+        }
+      }
+      .getOrElse {
+        onError(it.message ?: "Remote Compose document failed to load")
+        return ComposeUIViewController {}
+      }
   return ComposeUIViewController {
-    RcComposePlayer(document, Modifier.fillMaxSize(), theme, onEvent = onEvent)
+    RcComposePlayer(
+      document,
+      Modifier.fillMaxSize(),
+      theme,
+      onEvent = { event -> forwardIosPlayerEvent(onEvent, event) },
+      fontFamilies = fontFamilies,
+    )
   }
+}
+
+internal fun forwardIosPlayerEvent(onEvent: (RcPlayerEvent) -> Unit, event: RcPlayerEvent) {
+  onEvent(event)
 }

--- a/rc-player/compose/src/iosTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeViewControllerTest.kt
+++ b/rc-player/compose/src/iosTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeViewControllerTest.kt
@@ -1,0 +1,55 @@
+package ee.schimke.composeai.rcplayer.compose
+
+import ee.schimke.composeai.rcplayer.protocol.RcDocument
+import ee.schimke.composeai.rcplayer.protocol.RcDocumentCodec
+import ee.schimke.composeai.rcplayer.protocol.RcHeader
+import ee.schimke.composeai.rcplayer.protocol.RcTextData
+import ee.schimke.composeai.rcplayer.protocol.RcTextStyle
+import ee.schimke.composeai.rcplayer.protocol.RcTextStyleProperty
+import ee.schimke.composeai.rcplayer.protocol.RcVersion
+import ee.schimke.composeai.rcplayer.runtime.RcPlayerEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class RcComposeViewControllerTest {
+  @Test
+  fun malformedDocumentReportsAHostErrorAndReturnsAFallbackController() {
+    val errors = mutableListOf<String>()
+
+    val controller = RcComposeViewController(byteArrayOf(1, 2, 3), onError = errors::add)
+
+    assertNotNull(controller)
+    assertEquals(1, errors.size)
+  }
+
+  @Test
+  fun unavailableExternalFontReportsAResourceError() {
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(1, 0, 0)),
+        listOf(
+          RcTextData(42, "google:Missing Face"),
+          RcTextStyle(
+            listOf(RcTextStyleProperty.IntValue(1, 100), RcTextStyleProperty.IntValue(8, 42))
+          ),
+        ),
+      )
+    val errors = mutableListOf<String>()
+
+    RcComposeViewController(RcDocumentCodec.encode(document), onError = errors::add)
+
+    assertTrue(errors.single().contains("Missing Face"), errors.single())
+  }
+
+  @Test
+  fun playerEventsReachTheIosHostCallback() {
+    val events = mutableListOf<RcPlayerEvent>()
+    val event = RcPlayerEvent.HostAction(17)
+
+    forwardIosPlayerEvent(events::add, event)
+
+    assertEquals(event, events.single())
+  }
+}

--- a/rc-player/wasm/build.gradle.kts
+++ b/rc-player/wasm/build.gradle.kts
@@ -25,10 +25,12 @@ kotlin {
 }
 
 tasks.register<Sync>("wasmPlayerDist") {
-  description = "Assemble the webpack-free CMP Remote Compose Wasm player distribution."
+  description = "Assemble and size-check the optimized CMP Remote Compose Wasm distribution."
   group = "distribution"
-  dependsOn("wasmJsDevelopmentExecutableCompileSync", "processSkikoRuntimeForKWasm")
-  from(layout.buildDirectory.dir("compileSync/wasmJs/main/developmentExecutable/kotlin"))
+  dependsOn("wasmJsProductionExecutableCompileSync", "processSkikoRuntimeForKWasm")
+  from(layout.buildDirectory.dir("compileSync/wasmJs/main/productionExecutable/kotlin")) {
+    exclude("*.map", "custom-formatters.js")
+  }
   from(layout.buildDirectory.dir("compose/skiko-runtime-processed-wasmjs")) {
     include("skiko.mjs", "skiko.wasm")
   }
@@ -46,6 +48,20 @@ tasks.register<Sync>("wasmPlayerDist") {
     )
   )
   into(layout.buildDirectory.dir("wasmDist"))
+  inputs.property(
+    "maximumDistributionBytes",
+    providers.gradleProperty("rcPlayerWasmMaxBytes").orElse("23000000"),
+  )
+  doLast {
+    val maximumBytes = inputs.properties.getValue("maximumDistributionBytes").toString().toLong()
+    val distribution = destinationDir
+    val actualBytes = distribution.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+    check(actualBytes <= maximumBytes) {
+      "CMP Remote Compose Wasm distribution is $actualBytes bytes; budget is $maximumBytes bytes " +
+        "(override deliberately with -PrcPlayerWasmMaxBytes=<bytes>)"
+    }
+    logger.lifecycle("CMP Remote Compose Wasm distribution: $actualBytes / $maximumBytes bytes")
+  }
 }
 
 tasks.register<Sync>("wasmPlayerTestDist") {

--- a/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
+++ b/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
@@ -28,6 +28,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcDocumentCodec
 import ee.schimke.composeai.rcplayer.protocol.RcOperationProfiles
 import ee.schimke.composeai.rcplayer.protocol.RcTheme
 import ee.schimke.composeai.rcplayer.runtime.RcHostActionValue
+import ee.schimke.composeai.rcplayer.runtime.RcNamedValue
 import ee.schimke.composeai.rcplayer.runtime.RcPlayerEvent
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -40,7 +41,11 @@ import kotlinx.coroutines.withTimeout
 private sealed interface LoadState {
   data object Loading : LoadState
 
-  data class Ready(val document: RcDocument, val fontFamilies: Map<String, FontFamily>) : LoadState
+  data class Ready(
+    val document: RcDocument,
+    val fontFamilies: Map<String, FontFamily>,
+    val namedValues: Map<String, RcNamedValue>,
+  ) : LoadState
 
   data class Failed(val message: String) : LoadState
 }
@@ -69,7 +74,7 @@ public fun main() {
                   availableFontFamilies = fontFamilies.keys,
                 )
                 .requireFullyRenderable()
-              LoadState.Ready(document, fontFamilies)
+              LoadState.Ready(document, fontFamilies, namedValuesFromLocation())
             }
             .fold(onSuccess = { it }, onFailure = { LoadState.Failed(it.message ?: "load failed") })
     }
@@ -85,6 +90,7 @@ public fun main() {
             drawContent()
           },
           theme = theme,
+          namedValues = state.namedValues,
           onEvent = ::postPlayerEvent,
           fontFamilies = state.fontFamilies,
         )
@@ -227,10 +233,54 @@ private fun queryParameter(name: String): String? =
 private fun queryParameterFromLocation(name: String): JsString? =
   js("new URL(window.location.href).searchParams.get(name)")
 
+private fun namedValuesFromLocation(): Map<String, RcNamedValue> {
+  val flat = flattenNamedValuesFromLocation()?.toString().orEmpty()
+  if (flat.isEmpty()) return emptyMap()
+  return buildMap {
+    flat.split('\u0001').forEach { row ->
+      val fields = row.split('\u0000')
+      if (fields.size != 3) return@forEach
+      val name = decodeUriComponent(fields[1])
+      val value = decodeUriComponent(fields[2])
+      val namedValue =
+        when (fields[0]) {
+          "string" -> RcNamedValue.Text(value)
+          "float",
+          "dp" -> value.toFloatOrNull()?.let(RcNamedValue::FloatValue)
+          "int" -> value.toIntOrNull()?.let(RcNamedValue::Integer)
+          "bool" -> RcNamedValue.Integer(if (value == "true") 1 else 0)
+          "color" -> value.removePrefix("#").toULongOrNull(16)?.toInt()?.let(RcNamedValue::Color)
+          "long" -> value.toLongOrNull()?.let(RcNamedValue::LongValue)
+          else -> null
+        }
+      if (name.isNotEmpty() && namedValue != null) put("USER:$name", namedValue)
+    }
+  }
+}
+
+private fun flattenNamedValuesFromLocation(): JsString? =
+  js(
+    """(function () {
+      try {
+        var raw = new URL(window.location.href).searchParams.get('namedValues') || '[]';
+        var values = JSON.parse(raw);
+        if (!Array.isArray(values)) return null;
+        return values.map(function (value) {
+          return [String(value.kind || ''), encodeURIComponent(String(value.name || '')),
+            encodeURIComponent(String(value.value == null ? '' : value.value))].join('\u0000');
+        }).join('\u0001');
+      } catch (error) { return null; }
+    })()"""
+  )
+
+private fun decodeUriComponent(value: String): String = decodeUriComponentJs(value).toString()
+
+private fun decodeUriComponentJs(value: String): JsString = js("decodeURIComponent(value)")
+
 private fun postReady(): Unit =
   js(
     "(document.documentElement.dataset.rcPlayerState = 'ready', " +
-      "window.parent.postMessage('cp-rc-wasm-ready', '*'))"
+      "window.parent.postMessage('cp-rc-wasm-ready', window.location.origin))"
   )
 
 private fun reportFailure(message: String): Unit =
@@ -238,7 +288,7 @@ private fun reportFailure(message: String): Unit =
     "(document.documentElement.dataset.rcPlayerState = 'error', " +
       "document.documentElement.dataset.rcPlayerError = message, " +
       "console.error('[rc-player-wasm] ' + message), " +
-      "window.parent.postMessage('cp-rc-wasm-error:' + message, '*'))"
+      "window.parent.postMessage('cp-rc-wasm-error:' + message, window.location.origin))"
   )
 
 private fun postPlayerEvent(event: RcPlayerEvent) {
@@ -265,7 +315,7 @@ private fun postDebugMessage(message: String, value: Float, flags: Int): Unit =
       "document.documentElement.dataset.rcPlayerDebugFlags = String(flags), " +
       "console.debug('[rc-player-wasm] ' + message + ' ' + String(value)), " +
       "window.parent.postMessage({ type: 'cp-rc-debug-message', message: message, " +
-      "value: value, flags: flags }, '*'))"
+      "value: value, flags: flags }, window.location.origin))"
   )
 
 private fun postHostAction(actionId: Int): Unit =
@@ -274,7 +324,8 @@ private fun postHostAction(actionId: Int): Unit =
       "document.documentElement.dataset.rcPlayerActionTrace = " +
       "(document.documentElement.dataset.rcPlayerActionTrace ? " +
       "document.documentElement.dataset.rcPlayerActionTrace + ',' : '') + String(actionId), " +
-      "window.parent.postMessage({ type: 'cp-rc-host-action', actionId: actionId }, '*'))"
+      "window.parent.postMessage({ type: 'cp-rc-host-action', actionId: actionId }, " +
+      "window.location.origin))"
   )
 
 private fun postHostMetadataAction(actionId: Int, metadata: String): Unit =
@@ -285,7 +336,7 @@ private fun postHostMetadataAction(actionId: Int, metadata: String): Unit =
       "document.documentElement.dataset.rcPlayerActionTrace + ',' : '') + String(actionId), " +
       "document.documentElement.dataset.rcPlayerMetadata = metadata, " +
       "window.parent.postMessage({ type: 'cp-rc-host-action', actionId: actionId, " +
-      "metadata: metadata }, '*'))"
+      "metadata: metadata }, window.location.origin))"
   )
 
 private fun postHostNamedActionNone(name: String): Unit =
@@ -293,7 +344,7 @@ private fun postHostNamedActionNone(name: String): Unit =
     "(document.documentElement.dataset.rcPlayerNamedAction = name, " +
       "document.documentElement.dataset.rcPlayerNamedActionValue = 'none', " +
       "window.parent.postMessage({ type: 'cp-rc-host-named-action', name: name, " +
-      "valueType: 'none', value: null }, '*'))"
+      "valueType: 'none', value: null }, window.location.origin))"
   )
 
 private fun postHostNamedActionFloat(name: String, value: Float): Unit =
@@ -301,7 +352,7 @@ private fun postHostNamedActionFloat(name: String, value: Float): Unit =
     "(document.documentElement.dataset.rcPlayerNamedAction = name, " +
       "document.documentElement.dataset.rcPlayerNamedActionValue = 'float:' + String(value), " +
       "window.parent.postMessage({ type: 'cp-rc-host-named-action', name: name, " +
-      "valueType: 'float', value: value }, '*'))"
+      "valueType: 'float', value: value }, window.location.origin))"
   )
 
 private fun postHostNamedActionInt(name: String, value: Int): Unit =
@@ -309,7 +360,7 @@ private fun postHostNamedActionInt(name: String, value: Int): Unit =
     "(document.documentElement.dataset.rcPlayerNamedAction = name, " +
       "document.documentElement.dataset.rcPlayerNamedActionValue = 'int:' + String(value), " +
       "window.parent.postMessage({ type: 'cp-rc-host-named-action', name: name, " +
-      "valueType: 'int', value: value }, '*'))"
+      "valueType: 'int', value: value }, window.location.origin))"
   )
 
 private fun postHostNamedActionText(name: String, value: String): Unit =
@@ -317,7 +368,7 @@ private fun postHostNamedActionText(name: String, value: String): Unit =
     "(document.documentElement.dataset.rcPlayerNamedAction = name, " +
       "document.documentElement.dataset.rcPlayerNamedActionValue = 'string:' + value, " +
       "window.parent.postMessage({ type: 'cp-rc-host-named-action', name: name, " +
-      "valueType: 'string', value: value }, '*'))"
+      "valueType: 'string', value: value }, window.location.origin))"
   )
 
 private fun postHostNamedActionFloatList(name: String, encoded: String): Unit =
@@ -326,5 +377,5 @@ private fun postHostNamedActionFloatList(name: String, encoded: String): Unit =
       "document.documentElement.dataset.rcPlayerNamedActionValue = 'float-array:' + encoded, " +
       "window.parent.postMessage({ type: 'cp-rc-host-named-action', name: name, " +
       "valueType: 'float-array', " +
-      "value: encoded === '' ? [] : encoded.split(',').map(Number) }, '*'))"
+      "value: encoded === '' ? [] : encoded.split(',').map(Number) }, window.location.origin))"
   )

--- a/scripts/design-artifacts/fixtures/remote-m3-cmp-wasm-pixel-tolerances.json
+++ b/scripts/design-artifacts/fixtures/remote-m3-cmp-wasm-pixel-tolerances.json
@@ -1,0 +1,16 @@
+{
+  "entries": [
+    {
+      "id": "com.example.designcatalogremotem3.CatalogPreviewsKt.WatchScreenRemote_width_227dp_height_227dp_dpi_320",
+      "maxMismatchPct": 1.4,
+      "classification": "backend",
+      "reason": "Reviewed baked/CMP/diff images show matching circular clip, card bounds, and text placement; the residual 1.11% is confined to one-pixel Skia-vs-Android circle edges and glyph coverage."
+    },
+    {
+      "id": "com.example.designcatalogremotem3.WidgetContainerPreviewsKt.WidgetContainerSmallRemote",
+      "maxMismatchPct": 1.5,
+      "classification": "backend",
+      "reason": "Reviewed baked/CMP/diff images show matching bounds, corner radii, and text placement; at density 2.625 the residual 1.25% is limited to subpixel rounded-edge and glyph coverage."
+    }
+  ]
+}

--- a/scripts/design-artifacts/rc-compare-gate.mjs
+++ b/scripts/design-artifacts/rc-compare-gate.mjs
@@ -38,6 +38,34 @@ export function readCmpWasmAllowlist(file, today = new Date().toISOString().slic
   return result;
 }
 
+/** Read reviewed, catalog-specific mismatch ceilings for rows above the strict 1% default. */
+export function readCmpWasmPixelTolerances(file) {
+  if (!file) return new Map();
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!parsed || !Array.isArray(parsed.entries)) {
+    throw new Error("CMP/Wasm pixel tolerances must be an object with an entries array");
+  }
+  const result = new Map();
+  for (const [index, entry] of parsed.entries.entries()) {
+    const label = `CMP/Wasm pixel tolerance ${index + 1}`;
+    if (!entry || typeof entry.id !== "string" || !entry.id.trim()) {
+      throw new Error(`${label} must have a non-empty id`);
+    }
+    if (!Number.isFinite(entry.maxMismatchPct) || entry.maxMismatchPct <= 1) {
+      throw new Error(`${label} (${entry.id}) must set maxMismatchPct above the strict 1% default`);
+    }
+    if (typeof entry.classification !== "string" || !entry.classification.trim()) {
+      throw new Error(`${label} (${entry.id}) must have a classification`);
+    }
+    if (typeof entry.reason !== "string" || !entry.reason.trim()) {
+      throw new Error(`${label} (${entry.id}) must have a reason`);
+    }
+    if (result.has(entry.id)) throw new Error(`${label} duplicates id ${entry.id}`);
+    result.set(entry.id, entry);
+  }
+  return result;
+}
+
 /** Return the strict-lane verdict without throwing, so callers can write all evidence first. */
 export function evaluateCmpWasmGate(expectedIds, rows, allowlist = new Map()) {
   const byId = new Map(rows.map((row) => [row.id, row]));
@@ -60,6 +88,82 @@ export function evaluateCmpWasmGate(expectedIds, rows, allowlist = new Map()) {
   };
 }
 
+/** Add cold/warm first-frame budget failures to an existing strict-lane verdict. */
+export function applyCmpWasmPerformanceBudgets(gate, rows, coldBudgetMs, warmBudgetMs) {
+  gate.performance = {};
+  const budgets = [
+    ["cold", coldBudgetMs],
+    ["warm", warmBudgetMs],
+  ];
+  for (const [kind, budget] of budgets) {
+    if (budget == null) continue;
+    const measured = rows.filter(
+      (row) => row.cmpWasmRendered && row.cmpWasmStartup === kind,
+    );
+    const slowest = measured.reduce(
+      (current, row) =>
+        current == null || row.cmpWasmFirstFrameMs > current.cmpWasmFirstFrameMs ? row : current,
+      null,
+    );
+    gate.performance[kind] =
+      slowest == null
+        ? null
+        : {
+            count: measured.length,
+            maxMs: slowest.cmpWasmFirstFrameMs,
+            budgetMs: budget,
+          };
+    if (slowest == null) {
+      gate.failures.push({
+        id: `performance-${kind}`,
+        note: `no ${kind} first-frame measurement was recorded`,
+      });
+    } else if (slowest.cmpWasmFirstFrameMs > budget) {
+      gate.failures.push({
+        id: `performance-${kind}`,
+        note:
+          `${kind} first frame ${slowest.cmpWasmFirstFrameMs.toFixed(0)} ms exceeds ` +
+          `${budget.toFixed(0)} ms budget (${slowest.id})`,
+      });
+    }
+  }
+  gate.passed = gate.failures.length === 0;
+  return gate;
+}
+
+/** Enforce 1% by default, with reviewed per-preview ceilings for classified backend variance. */
+export function applyCmpWasmPixelTolerances(gate, rows, tolerances = new Map()) {
+  gate.pixelTolerances = [];
+  const seen = new Set();
+  for (const row of rows) {
+    if (!row.cmpWasmRendered || row.referenceBlank || row.cmpWasmMismatchPct <= 1) continue;
+    const tolerance = tolerances.get(row.id);
+    if (tolerance) seen.add(row.id);
+    if (!tolerance) {
+      gate.failures.push({
+        id: `pixels-${row.id}`,
+        note: `${row.cmpWasmMismatchPct.toFixed(2)}% exceeds 1% without a reviewed tolerance`,
+      });
+    } else if (row.cmpWasmMismatchPct > tolerance.maxMismatchPct) {
+      gate.failures.push({
+        id: `pixels-${row.id}`,
+        note:
+          `${row.cmpWasmMismatchPct.toFixed(2)}% exceeds reviewed ` +
+          `${tolerance.maxMismatchPct.toFixed(2)}% tolerance`,
+      });
+    } else {
+      gate.pixelTolerances.push({ id: row.id, actualPct: row.cmpWasmMismatchPct, ...tolerance });
+    }
+  }
+  for (const id of tolerances.keys()) {
+    if (!seen.has(id)) {
+      gate.failures.push({ id: `pixels-${id}`, note: "reviewed tolerance is stale or unmeasured" });
+    }
+  }
+  gate.passed = gate.failures.length === 0;
+  return gate;
+}
+
 export function formatCmpWasmGate(gate) {
   const lines = [
     `CMP/Wasm: ${gate.rendered}/${gate.expected} rendered, ${gate.allowed.length} temporarily allowed, ${gate.failures.length} failed.`,
@@ -67,6 +171,21 @@ export function formatCmpWasmGate(gate) {
   for (const failure of gate.failures) lines.push(`- ${failure.id}: ${failure.note}`);
   for (const entry of gate.allowed) {
     lines.push(`- ${entry.id}: allowed until ${entry.expires} — ${entry.reason} (${entry.note})`);
+  }
+  for (const kind of ["cold", "warm"]) {
+    const performance = gate.performance?.[kind];
+    if (performance) {
+      lines.push(
+        `- ${kind} first frame: ${performance.maxMs.toFixed(0)} ms max / ` +
+          `${performance.budgetMs.toFixed(0)} ms budget (${performance.count} measured)`,
+      );
+    }
+  }
+  if (gate.pixelTolerances?.length) {
+    lines.push(
+      `- pixel parity: strict 1% default; ${gate.pixelTolerances.length} reviewed ` +
+        `per-preview tolerance(s) applied`,
+    );
   }
   return lines.join("\n");
 }

--- a/scripts/design-artifacts/rc-compare-gate.test.mjs
+++ b/scripts/design-artifacts/rc-compare-gate.test.mjs
@@ -5,10 +5,73 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  applyCmpWasmPerformanceBudgets,
+  applyCmpWasmPixelTolerances,
   evaluateCmpWasmGate,
   formatCmpWasmGate,
   readCmpWasmAllowlist,
+  readCmpWasmPixelTolerances,
 } from "./rc-compare-gate.mjs";
+
+test("pixel parity uses a strict default and only reviewed per-preview exceptions", () => {
+  const rows = [
+    { id: "exact", cmpWasmRendered: true, cmpWasmMismatchPct: 0.4 },
+    { id: "accepted", cmpWasmRendered: true, cmpWasmMismatchPct: 2.4 },
+    { id: "drifted", cmpWasmRendered: true, cmpWasmMismatchPct: 3.1 },
+    { id: "unreviewed", cmpWasmRendered: true, cmpWasmMismatchPct: 1.1 },
+  ];
+  const tolerances = new Map([
+    ["accepted", { maxMismatchPct: 2.5, classification: "backend", reason: "Skia edge" }],
+    ["drifted", { maxMismatchPct: 3, classification: "font", reason: "font metrics" }],
+  ]);
+
+  const gate = applyCmpWasmPixelTolerances(
+    evaluateCmpWasmGate(rows.map((row) => row.id), rows),
+    rows,
+    tolerances,
+  );
+
+  assert.equal(gate.passed, false);
+  assert.equal(gate.pixelTolerances.length, 1);
+  assert.match(gate.failures[0].note, /exceeds reviewed 3.00%/);
+  assert.match(gate.failures[1].note, /without a reviewed tolerance/);
+});
+
+test("cold and warm first-frame budgets fail on the slowest measured render", () => {
+  const rows = [
+    { id: "cold", cmpWasmRendered: true, cmpWasmStartup: "cold", cmpWasmFirstFrameMs: 9001 },
+    { id: "warm-a", cmpWasmRendered: true, cmpWasmStartup: "warm", cmpWasmFirstFrameMs: 1200 },
+    { id: "warm-b", cmpWasmRendered: true, cmpWasmStartup: "warm", cmpWasmFirstFrameMs: 5200 },
+  ];
+  const gate = applyCmpWasmPerformanceBudgets(
+    evaluateCmpWasmGate(rows.map((row) => row.id), rows),
+    rows,
+    10_000,
+    5_000,
+  );
+
+  assert.equal(gate.passed, false);
+  assert.deepEqual(gate.failures, [
+    {
+      id: "performance-warm",
+      note: "warm first frame 5200 ms exceeds 5000 ms budget (warm-b)",
+    },
+  ]);
+});
+
+test("an enabled first-frame budget requires a measurement", () => {
+  const gate = applyCmpWasmPerformanceBudgets(
+    evaluateCmpWasmGate([], []),
+    [],
+    10_000,
+    null,
+  );
+
+  assert.equal(gate.passed, false);
+  assert.deepEqual(gate.failures, [
+    { id: "performance-cold", note: "no cold first-frame measurement was recorded" },
+  ]);
+});
 
 test("strict CMP/Wasm gate reports failed and dropped rows", () => {
   const gate = evaluateCmpWasmGate(
@@ -61,4 +124,23 @@ test("allowlist requires reasons and rejects expired entries", () => {
     JSON.stringify({ entries: [{ id: "x", reason: "tracked", expires: "2026-08-02" }] }),
   );
   assert.throws(() => readCmpWasmAllowlist(file, "2026-08-03"), /expired/);
+});
+
+test("pixel tolerance entries require a widened ceiling and rationale", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rc-cmp-wasm-pixels-"));
+  const file = path.join(dir, "tolerances.json");
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      entries: [{ id: "x", maxMismatchPct: 1, classification: "backend", reason: "known" }],
+    }),
+  );
+  assert.throws(() => readCmpWasmPixelTolerances(file), /above the strict 1%/);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      entries: [{ id: "x", maxMismatchPct: 2, classification: "backend", reason: "known" }],
+    }),
+  );
+  assert.equal(readCmpWasmPixelTolerances(file).get("x").maxMismatchPct, 2);
 });

--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -23,7 +23,9 @@
  *   node rc-compare.mjs --bundle <bundle.png> --player <rc-player bundle.js> \
  *     --out <dir> [--system <id>] [--title <t>] [--threshold 0.1] [--theme light] \
  *     [--fonts <dir>] [--cmp-wasm <rc-player-wasm distribution>] \
- *     [--require-cmp-wasm] [--cmp-wasm-allowlist <json>]
+ *     [--require-cmp-wasm] [--cmp-wasm-allowlist <json>] \
+ *     [--cmp-wasm-pixel-tolerances <json>] \
+ *     [--cmp-wasm-max-cold-first-frame-ms <ms>] [--cmp-wasm-max-warm-first-frame-ms <ms>]
  *
  * `--fonts` defaults to the vendored faces the snapshot renderer itself rasterizes with (see
  * rc-fonts.mjs). Point it elsewhere to compare against a different font set, or at a
@@ -43,9 +45,12 @@ import { chromium } from "playwright";
 
 import { renderRcCompareHtml } from "./render-rc-compare-html.mjs";
 import {
+  applyCmpWasmPerformanceBudgets,
+  applyCmpWasmPixelTolerances,
   evaluateCmpWasmGate,
   formatCmpWasmGate,
   readCmpWasmAllowlist,
+  readCmpWasmPixelTolerances,
 } from "./rc-compare-gate.mjs";
 import { BG, flattenOnto, isFullyTransparent } from "./rc-compare-pixels.mjs";
 import { DEFAULT_FONTS_DIR, fontFaceCss, loadAndVerifyFonts } from "./rc-fonts.mjs";
@@ -89,6 +94,24 @@ const EMBEDDED_JVM = arg("embedded-jvm");
 const CMP_WASM = arg("cmp-wasm");
 const REQUIRE_CMP_WASM = process.argv.includes("--require-cmp-wasm");
 const CMP_WASM_ALLOWLIST = arg("cmp-wasm-allowlist");
+const CMP_WASM_PIXEL_TOLERANCES = arg("cmp-wasm-pixel-tolerances");
+const CMP_WASM_MAX_COLD_FIRST_FRAME_MS = optionalNumber(
+  "cmp-wasm-max-cold-first-frame-ms",
+);
+const CMP_WASM_MAX_WARM_FIRST_FRAME_MS = optionalNumber(
+  "cmp-wasm-max-warm-first-frame-ms",
+);
+
+function optionalNumber(name) {
+  const value = arg(name);
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(`rc-compare: --${name} must be a positive number`);
+    process.exit(2);
+  }
+  return parsed;
+}
 
 if (!BUNDLE || !PLAYER || !OUT) {
   console.error("rc-compare: --bundle, --player and --out are required");
@@ -385,10 +408,13 @@ async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank, previ
     const density = previewParams?.density ?? 1;
     const viewportWidth = previewParams?.widthDp ?? Math.round(width / density);
     const viewportHeight = previewParams?.heightDp ?? Math.round(height / density);
-    const { page: cmpWasmPage, consoleErrors: cmpWasmConsoleErrors } = await cmpWasmPageFor(density);
+    const pageState = await cmpWasmPageFor(density);
+    const { page: cmpWasmPage, consoleErrors: cmpWasmConsoleErrors } = pageState;
+    const startup = pageState.renders++ === 0 ? "cold" : "warm";
     cmpWasmConsoleErrors.length = 0;
     cmpWasmServer.setDocument(bytes);
     await cmpWasmPage.setViewportSize({ width: viewportWidth, height: viewportHeight });
+    const startedAt = performance.now();
     await cmpWasmPage.goto(
       `${cmpWasmServer.origin}/index.html?src=${encodeURIComponent("/document.rc")}&theme=${encodeURIComponent(THEME)}`,
     );
@@ -401,6 +427,7 @@ async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank, previ
       state: document.documentElement.dataset.rcPlayerState,
       error: document.documentElement.dataset.rcPlayerError,
     }));
+    const firstFrameMs = performance.now() - startedAt;
     if (state.state !== "ready") throw new Error(state.error || "player reported an error");
     const png = flattenOnto(PNG.sync.read(await cmpWasmPage.screenshot({ omitBackground: true })), BG);
     if (cmpWasmConsoleErrors.length) {
@@ -417,6 +444,8 @@ async function cmpWasmFor(id, bytes, baked, width, height, referenceBlank, previ
       cmpWasmRendered: true,
       cmpWasmMismatchPct: referenceBlank ? null : (100 * px) / (width * height),
       cmpWasmMismatchPx: referenceBlank ? null : px,
+      cmpWasmFirstFrameMs: firstFrameMs,
+      cmpWasmStartup: startup,
       cmpWasm: `rc-cmp-wasm/${id}.png`,
       cmpWasmDiff: `rc-cmp-wasm-diff/${id}.png`,
     };
@@ -454,7 +483,7 @@ async function cmpWasmPageFor(density) {
   page.on("console", (message) => {
     if (message.type() === "error") consoleErrors.push(message.text());
   });
-  const value = { page, consoleErrors };
+  const value = { page, consoleErrors, renders: 0 };
   cmpWasmPages.set(density, value);
   return value;
 }
@@ -604,7 +633,8 @@ for (const id of rcIds) {
     cmpWasm.cmpWasmRendered === undefined
       ? ""
       : cmpWasm.cmpWasmRendered
-        ? `  |  cmp-wasm ${cmpWasm.cmpWasmMismatchPct.toFixed(2)}%`
+        ? `  |  cmp-wasm ${cmpWasm.cmpWasmMismatchPct.toFixed(2)}% ` +
+          `(${cmpWasm.cmpWasmStartup} ${cmpWasm.cmpWasmFirstFrameMs.toFixed(0)} ms)`
         : `  |  cmp-wasm NOT RENDERED`;
   console.log(
     `  ${name}: ${mismatchPct.toFixed(2)}% (${mismatchPx} px, ${width}×${height})${embNote}${embJvmNote}${cmpWasmNote}`,
@@ -629,6 +659,17 @@ let cmpWasmGate = null;
 if (REQUIRE_CMP_WASM) {
   try {
     cmpWasmGate = evaluateCmpWasmGate(rcIds, rows, readCmpWasmAllowlist(CMP_WASM_ALLOWLIST));
+    applyCmpWasmPerformanceBudgets(
+      cmpWasmGate,
+      rows,
+      CMP_WASM_MAX_COLD_FIRST_FRAME_MS,
+      CMP_WASM_MAX_WARM_FIRST_FRAME_MS,
+    );
+    applyCmpWasmPixelTolerances(
+      cmpWasmGate,
+      rows,
+      readCmpWasmPixelTolerances(CMP_WASM_PIXEL_TOLERANCES),
+    );
   } catch (error) {
     cmpWasmGate = evaluateCmpWasmGate(rcIds, rows);
     cmpWasmGate.passed = false;
@@ -684,6 +725,25 @@ fs.writeFileSync(
                 ? ok.reduce((s, r) => s + r.cmpWasmMismatchPct, 0) / ok.length
                 : null;
             })(),
+            firstFrame: (() => {
+              const summarize = (kind) => {
+                const values = rows
+                  .filter((row) => row.cmpWasmRendered && row.cmpWasmStartup === kind)
+                  .map((row) => row.cmpWasmFirstFrameMs);
+                return values.length
+                  ? {
+                      count: values.length,
+                      meanMs: values.reduce((sum, value) => sum + value, 0) / values.length,
+                      maxMs: Math.max(...values),
+                      budgetMs:
+                        kind === "cold"
+                          ? CMP_WASM_MAX_COLD_FIRST_FRAME_MS
+                          : CMP_WASM_MAX_WARM_FIRST_FRAME_MS,
+                    }
+                  : null;
+              };
+              return { cold: summarize("cold"), warm: summarize("warm") };
+            })(),
           }
         : null,
       rows: rows.map((r) => ({
@@ -706,6 +766,8 @@ fs.writeFileSync(
         cmpWasmRendered: r.cmpWasmRendered ?? null,
         cmpWasmMismatchPct: r.cmpWasmMismatchPct ?? null,
         cmpWasmMismatchPx: r.cmpWasmMismatchPx ?? null,
+        cmpWasmFirstFrameMs: r.cmpWasmFirstFrameMs ?? null,
+        cmpWasmStartup: r.cmpWasmStartup ?? null,
         cmpWasmNote: r.cmpWasmNote ?? null,
         cmpWasmError: r.cmpWasmError ?? null,
       })),


### PR DESCRIPTION
## Summary

- enforce 24/24 CMP/Wasm rendering with a strict 1% pixel default and two reviewed, stale-failing fixture ceilings
- fix AndroidX matrix sentinel and density-aware rounded-clip semantics found during visual review
- ship the optimized production Wasm distribution under a 23 MB raw-size budget and guard cold/warm first-frame times
- make typed named overrides and validated inert host actions work in the live CMP/Wasm viewer
- add bounded iOS decode/support/resource fallback, event forwarding, all-target test compilation, and a dedicated player CI job

## Why

The prior milestone rendered the complete corpus, but replacement was not yet safe: visual exceptions were not classified, startup and size had no hard budgets, named values/actions were incomplete in the live host, iOS failures were unbounded, and the player modules lacked a dedicated CI path. Visual review also found a blank icon and incorrect fixed corner radii that percentage-only review had initially obscured.

## Impact

CMP/Wasm now satisfies the product replacement gates for the current remote-m3 corpus. The legacy TypeScript player remains in this PR; its removal is intentionally isolated in the next stacked cleanup PR.

## Validation

- current remote-m3 corpus: 24/24 rendered; 0 failures; strict 1% default plus WatchScreen 1.4% and WidgetContainerSmall 1.5% reviewed ceilings
- startup: 2361 ms cold / 10000 ms budget; 2003 ms warm / 5000 ms budget
- distribution: 22,756,717 / 23,000,000 raw bytes
- 42/42 focused Node comparison tests
- protocol/runtime/Compose desktop and Wasm tests
- compatibility fixture tests and optimized Wasm test distribution
- CLI `ServeWebTest`
- iOS test compilation for x64, device arm64, and simulator arm64
- `ktfmtCheck`, workflow YAML parsing, path-scope and design-artifact scope tests

Local iOS simulator execution is unavailable in this checkout's Xcode installation; the dedicated macOS CI job runs the host tests on its supported simulator architecture.