### PR TITLE
feat(design-artifacts): publish reference-side annotations with the references

### DIFF
--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -53,6 +53,9 @@ import {
   referenceManifest,
 } from "./design-references.mjs";
 import { isRoundingDelta, resampleRgba } from "./png-resample.mjs";
+import { layoutFromNode } from "@design-parity/adapter-figma";
+import { scaleTree } from "./reference-layout.mjs";
+import { withReferenceAnnotations } from "@design-parity/catalog-export";
 
 function arg(name, def = undefined) {
   const i = process.argv.indexOf(`--${name}`);
@@ -224,7 +227,12 @@ async function rasterizeFigma(ref, target) {
   const png = await fetch(url);
   if (!png.ok) throw new Error(`figma image download ${png.status}`);
   const decoded = PNG.sync.read(Buffer.from(await png.arrayBuffer()));
-  return { width: decoded.width, height: decoded.height, data: decoded.data };
+  // The node document rides along so the caller can capture layout geometry from the same fetch
+  // that sized the raster — one round trip, and the geometry provably describes these pixels.
+  const document =
+    nodeJson?.nodes?.[parsed.nodeId]?.document ??
+    nodeJson?.nodes?.[parsed.nodeId.replace("-", ":")]?.document;
+  return { width: decoded.width, height: decoded.height, data: decoded.data, document };
 }
 
 /** A pre-rendered PNG for this ref under `--reference-images`, or null. */
@@ -278,6 +286,8 @@ const referencesDir = path.join(OUT, REFERENCES_DIR);
 fs.mkdirSync(referencesDir, { recursive: true });
 
 let written = 0;
+/** Reference id -> a `{ layout }` shim; `referenceAnnotations` reads only that field. */
+const annotatedReferences = {};
 for (const record of records) {
   const target = { width: record.raster.width, height: record.raster.height };
   let raster;
@@ -291,6 +301,9 @@ for (const record of records) {
     record.rastered = false;
     continue;
   }
+
+  // Captured before the resample rewrites `raster`, then scaled to the published size below.
+  const capturedLayout = raster.document ? layoutFromNode(raster.document) : undefined;
 
   if (raster.width !== target.width || raster.height !== target.height) {
     const rounding = isRoundingDelta(raster.width, raster.height, target.width, target.height);
@@ -315,6 +328,42 @@ for (const record of records) {
   // drops one row instead of showing the wrong design.
   record.raster.sha256 = crypto.createHash("sha256").update(bytes).digest("hex");
   written++;
+
+  const scaled = capturedLayout ? scaleTree(capturedLayout, target.width) : undefined;
+  if (scaled) annotatedReferences[record.id] = { layout: scaled };
+}
+
+/**
+ * Merge the reference-side annotation layers into the bundle's `annotations/index.json`.
+ *
+ * `writeCatalog` may already have written that file with the *preview* (actual) side, so this reads
+ * and merges rather than overwriting — dropping the other half would trade one annotated column for
+ * the other instead of getting both.
+ *
+ * Fail-soft like everything else here: an unreadable existing manifest is replaced rather than
+ * fatal, and no captured geometry simply leaves the file alone. A reference lane is an enhancement
+ * and must never cost a catalog its render.
+ */
+function writeReferenceAnnotations() {
+  if (Object.keys(annotatedReferences).length === 0) return;
+  const dir = path.join(OUT, "annotations");
+  const file = path.join(dir, "index.json");
+  let existing = { schema: "compose-preview-annotations/v1", previews: {}, references: {} };
+  if (fs.existsSync(file)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+      if (parsed?.schema === existing.schema) existing = parsed;
+      else warn(`annotations/index.json has schema '${parsed?.schema}'; replacing it`);
+    } catch (error) {
+      warn(`annotations/index.json is unreadable (${error.message}); replacing it`);
+    }
+  }
+  const merged = withReferenceAnnotations(existing, annotatedReferences);
+  const count = Object.keys(merged.references).length;
+  if (count === 0) return;
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(merged, null, 2)}\n`);
+  console.log(`design-references: annotated ${count} reference(s) in annotations/index.json`);
 }
 
 const manifest = referenceManifest(records);
@@ -322,6 +371,8 @@ fs.writeFileSync(
   path.join(referencesDir, "index.json"),
   `${JSON.stringify(manifest, null, 2)}\n`,
 );
+
+writeReferenceAnnotations();
 
 console.log(
   `design-references: published ${written}/${records.length} reference(s) to ` +

--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -8,14 +8,24 @@
       "name": "design-artifacts-driver",
       "version": "0.0.0",
       "dependencies": {
+        "@design-parity/adapter-figma": "^0.1.36",
         "@design-parity/candidate": "^0.1.25",
-        "@design-parity/catalog-export": "^0.1.25",
+        "@design-parity/catalog-export": "^0.1.36",
         "pixelmatch": "^7.0.0",
         "playwright": "^1.49.0",
         "pngjs": "^7.0.0"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@design-parity/adapter-figma": {
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.36.tgz",
+      "integrity": "sha512-k7uJKuigvFWTAR03r7Swi4ZPmrpncZHT4qcNrbbrpxI1+D/CGfcXBZIGAZhfWm7AUttsk1D032PLWvvyHO5XxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@design-parity/core": "^0.1.36"
       }
     },
     "node_modules/@design-parity/candidate": {
@@ -29,18 +39,18 @@
       }
     },
     "node_modules/@design-parity/catalog-export": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.30.tgz",
-      "integrity": "sha512-x7ZcCW0gAkpiRJTz81O5nOjIAYh5EH9AW/UNqKcj9e5s0SWi8XD2pd95v5bBzwjuD2338uIU7OMhTCiqGeB+Jg==",
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.36.tgz",
+      "integrity": "sha512-ChR3WSSxmd00Sw4ZRx5R3kkpFnBeECbZeLhRykIRmXwRK7uZ639eXZ4KiXdEGUtjvXGBoXa6VezvNHjVjvnOeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.30"
+        "@design-parity/core": "^0.1.36"
       }
     },
     "node_modules/@design-parity/core": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.30.tgz",
-      "integrity": "sha512-0IaxVKdsUQhg7K3TWfDQAwGJwTuwG3eZprsHLq7omj+zLOHRN9vWxdYVr6daTjAUczVJkqQ/wNgW73Rnunt5ug==",
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.36.tgz",
+      "integrity": "sha512-GNw2Oi2lrkOfzZm/aCZitCcfNe8RcYI3Gyra148zXVZBzFgXGl4DyhCckIp1h4l9MW3whOQ7dUgY9eRe6Wwqjw==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1"

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -11,8 +11,9 @@
     "test": "node --test"
   },
   "dependencies": {
+    "@design-parity/adapter-figma": "^0.1.36",
     "@design-parity/candidate": "^0.1.25",
-    "@design-parity/catalog-export": "^0.1.25",
+    "@design-parity/catalog-export": "^0.1.36",
     "pixelmatch": "^7.0.0",
     "playwright": "^1.49.0",
     "pngjs": "^7.0.0"

--- a/scripts/design-artifacts/reference-layout.mjs
+++ b/scripts/design-artifacts/reference-layout.mjs
@@ -1,0 +1,41 @@
+/**
+ * Rescale a captured design-reference layout tree into the published raster's pixel space.
+ *
+ * `layoutFromNode` (@design-parity/adapter-figma) returns root-relative dp measured off the Figma
+ * frame. The raster those annotations are drawn over is resampled to the catalog sticker's exact
+ * dimensions — see png-resample.mjs for why "exact" is load-bearing — so a frame authored at a
+ * different size would put every annotation box in the wrong place. Scaling by the same ratio the
+ * resample used keeps each annotation on top of the thing it describes.
+ *
+ * Split out of emit-design-references.mjs so it can be tested: that script self-executes on import.
+ */
+
+/**
+ * Rescale a captured layout tree into the published raster's pixel space.
+ *
+ * `layoutFromNode` returns root-relative dp off the Figma frame, but the raster this annotates is
+ * resampled to the catalog sticker's exact dimensions — so a frame authored at a different size
+ * would put every box in the wrong place. Scaling by the same ratio the resample used keeps the
+ * annotation on top of the thing it describes.
+ */
+export function scaleTree(tree, targetWidth) {
+  const frame = tree?.root?.bounds;
+  if (!frame?.width) return undefined;
+  const factor = targetWidth / frame.width;
+  if (!Number.isFinite(factor) || factor <= 0) return undefined;
+  const scaleBounds = (b) =>
+    b === undefined
+      ? undefined
+      : {
+          x: Math.round(b.x * factor),
+          y: Math.round(b.y * factor),
+          width: Math.round(b.width * factor),
+          height: Math.round(b.height * factor),
+        };
+  const visit = (node) => ({
+    ...node,
+    bounds: scaleBounds(node.bounds),
+    children: (node.children ?? []).map(visit),
+  });
+  return { ...tree, root: visit(tree.root) };
+}

--- a/scripts/design-artifacts/reference-layout.test.mjs
+++ b/scripts/design-artifacts/reference-layout.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { scaleTree } from "./reference-layout.mjs";
+
+const tree = {
+  root: {
+    role: "frame",
+    bounds: { x: 0, y: 0, width: 200, height: 48 },
+    children: [
+      { role: "text", bounds: { x: 46, y: 26, width: 108, height: 20 } },
+      { role: "icon" }, // no bounds — must survive the walk without inventing any
+    ],
+  },
+};
+
+test("scales every box by the ratio the resample used", () => {
+  // A 200dp frame published as a 400px sticker: everything doubles, or the annotations sit at half
+  // the position of what they describe.
+  const scaled = scaleTree(tree, 400);
+  assert.deepEqual(scaled.root.bounds, { x: 0, y: 0, width: 400, height: 96 });
+  assert.deepEqual(scaled.root.children[0].bounds, { x: 92, y: 52, width: 216, height: 40 });
+});
+
+test("is identity when the frame already matches the published width", () => {
+  const scaled = scaleTree(tree, 200);
+  assert.deepEqual(scaled.root.bounds, tree.root.bounds);
+  assert.deepEqual(scaled.root.children[0].bounds, tree.root.children[0].bounds);
+});
+
+test("leaves an unbounded node unbounded rather than inventing a box", () => {
+  assert.equal(scaleTree(tree, 400).root.children[1].bounds, undefined);
+});
+
+test("preserves non-geometry fields so labels and roles survive", () => {
+  const withTokens = {
+    root: {
+      ...tree.root,
+      tokens: { spacing: { padding: 16 } },
+      children: [{ role: "text", label: "Send", bounds: { x: 0, y: 0, width: 10, height: 10 } }],
+    },
+  };
+  const scaled = scaleTree(withTokens, 400);
+  assert.deepEqual(scaled.root.tokens, { spacing: { padding: 16 } });
+  assert.equal(scaled.root.children[0].label, "Send");
+});
+
+test("returns undefined when there is no frame to scale against", () => {
+  // Nothing to anchor a ratio to; annotating with an assumed scale would be worse than not at all.
+  assert.equal(scaleTree(undefined, 400), undefined);
+  assert.equal(scaleTree({ root: {} }, 400), undefined);
+  assert.equal(scaleTree({ root: { bounds: { x: 0, y: 0, width: 0, height: 0 } } }, 400), undefined);
+});


### PR DESCRIPTION
## Summary

The last link in the chain. #3242 taught the compare page to draw typography and layout layers over both panels; design-parity#270 made the catalog write the **actual** side of `annotations/index.json`. This writes the **reference** side, which is what makes the page readable as *reference spec against actual spec* rather than one annotated column beside a bare one.

## The geometry is already in hand

`rasterizeFigma` already calls `/v1/files/…/nodes` to size its raster. The node document now rides back with the pixels, and `layoutFromNode` (design-parity#273) turns it into the same `SemanticTree` the adapter builds — one round trip, and the geometry provably describes the pixels that were published rather than a separately-fetched version of them.

## Bounds are rescaled before they are written

This is the part that would silently produce garbage if skipped. `layoutFromNode` measures root-relative dp off the **Figma frame**, but the published raster is resampled to the **catalog sticker's exact dimensions**. A frame authored at a different size would put every annotation box in the wrong place — the boxes would look plausible and be wrong, which is the worst outcome for a page whose job is catching spec drift.

`scaleTree` applies the same ratio the resample used. It lives in its own module (`reference-layout.mjs`) because `emit-design-references.mjs` self-executes on import and could not otherwise be tested.

## Merged, not overwritten

`writeCatalog` may already have written the preview side of `annotations/index.json`. Clobbering it would trade one annotated column for the other instead of getting both, so this reads and merges through `withReferenceAnnotations`.

Fail-soft throughout, matching the rest of this script: an unreadable existing manifest is replaced with a `::warning::`, no captured geometry leaves the file alone, and nothing here can cost a catalog its render.

## Test plan

- `scripts/design-artifacts/reference-layout.test.mjs` — 5 tests: scaling by the resample ratio (200dp frame → 400px sticker doubles every box), identity when sizes already match, unbounded nodes staying unbounded rather than gaining an invented box, non-geometry fields (labels, roles, tokens) surviving the walk, and `undefined` when there is no frame to scale against.
- Full driver suite: **406 tests passing**.
- `node --check` on both changed scripts.

## Dependency

Requires **design-parity 0.1.36** for `withReferenceAnnotations` and `layoutFromNode` — that's design-parity#274, open at time of writing. `@design-parity/adapter-figma` is added as a dependency; `@design-parity/catalog-export` moves to `^0.1.36`.

**Do not merge before 0.1.36 is published to npm**, or the driver's `npm ci` will fail to resolve.

## After this

A catalog republish is what finally puts annotations on a served compare page — e.g. https://preview.coo.ee/meshcore-mobile/compare/device-populated__ideal__default__compact. Per the repo's export-driver rule, merging a `scripts/design-artifacts/` change triggers `design-artifacts.yml` on push to `main`, so the republish is automatic for the affected systems.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLvGJpTiL4T6hXMbUCq216)_