### PR TITLE
test: preserve out-of-order daemon messages

### DIFF
--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderNowAppPreviewGateTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderNowAppPreviewGateTest.kt
@@ -172,13 +172,21 @@ class RenderNowAppPreviewGateTest {
     timeoutMs: Long = 10_000,
     matcher: (JsonObject) -> Boolean,
   ): JsonObject? {
+    val unmatched = mutableListOf<JsonObject>()
     val deadline = System.currentTimeMillis() + timeoutMs
-    while (System.currentTimeMillis() < deadline) {
-      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
-      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
-      if (matcher(msg)) return msg
+    try {
+      while (System.currentTimeMillis() < deadline) {
+        val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+        val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+        if (matcher(msg)) return msg
+        // Notifications and responses can arrive in either order. Preserve messages that belong
+        // to the next assertion instead of silently consuming them while looking for this one.
+        unmatched += msg
+      }
+      return null
+    } finally {
+      unmatched.forEach { queue.offer(it) }
     }
-    return null
   }
 }
 


### PR DESCRIPTION
## Summary

- preserve unmatched JSON-RPC messages in `RenderNowAppPreviewGateTest.pollUntil`
- prevent `renderFinished` from being discarded when it races ahead of the `renderNow` response

## Root cause

PR #3253's Module Unit Tests failure was in `RenderNowAppPreviewGateTest`. The daemon log showed that `renderFinished` was sent successfully, but the test helper consumed and discarded it while polling for response id 2. The later assertion then timed out despite the successful render.

## Validation

- `./gradlew :daemon:core:ktfmtCheck`
- `./gradlew :daemon:core:test`
- uncached targeted run: `./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.RenderNowAppPreviewGateTest --rerun-tasks`
- RC-JVM SVG export, CLI serve integration, and layered SVG raster tests remained green before the original PR merged