### PR TITLE
perf(serve): make eager warm-on-open opt-in, and ping presence on arrival

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -119,6 +119,22 @@ class ServeCatalogLiveHost(
    */
   private val sharedDaemonRenders: Boolean =
     System.getProperty("composeai.serve.sharedDaemonRenders")?.toBooleanStrictOrNull() ?: true,
+  /**
+   * Whether [prewarm] warms this catalog's daemon when its session is **opened** — off by default.
+   *
+   * Opening happens for every catalog at boot, so this used to launch one JVM per catalog
+   * simultaneously: measured on the public box, 18 daemons resident at 6 minutes uptime against a
+   * live-seat budget that models ~1.2 GB each and permits 8. It settles — the reaper had it down to
+   * 3 by 85 minutes — so this was never permanent over-commitment, but the spike lands exactly when
+   * the box is also fetching all 18 catalogs, and for pixels nobody has asked for.
+   *
+   * The case eager warming existed for is now served on demand: a visitor's presence heartbeat
+   * ([keepLiveWarm]) warms the catalog they actually opened, and fires as soon as the page loads.
+   * `-Dcomposeai.serve.eagerWarmOnOpen=true` restores boot-time warming for a deployment that would
+   * rather pay the memory than the first visitor's cold start.
+   */
+  private val eagerWarmOnOpen: Boolean =
+    System.getProperty("composeai.serve.eagerWarmOnOpen")?.toBooleanStrictOrNull() ?: false,
   private val clock: () -> Long = System::currentTimeMillis,
 ) : ServeHost {
 
@@ -237,7 +253,7 @@ class ServeCatalogLiveHost(
    */
   fun prewarm() {
     startThemeOptimization()
-    if (!warmInBackground) return
+    if (!warmInBackground || !eagerWarmOnOpen) return
     // A per-preview catalog deliberately skips eager warming — one JVM per preview would make
     // startup fan out into dozens of them. But when snapshots share the monolithic daemon, that
     // daemon is exactly what the first theme selection will wait on, and its cold start (~68s on

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1471,8 +1471,9 @@ object ServeWeb {
    *   for one is exactly the waste the reaper exists to prevent. It resumes on `visibilitychange`,
    *   and pings immediately on becoming visible so a tab returned to after an hour doesn't wait out
    *   another interval before saying so.
-   * - **No first ping.** Loading the page *was* a request; the heartbeat only matters once the
-   *   visitor has gone quiet.
+   * - **Fires on arrival.** The page load itself is a request, but a *baked* one — it warms no
+   *   daemon. Since catalogs are no longer warmed at boot, this first ping is what readies the one
+   *   the visitor actually opened.
    * - **Errors ignored.** A heartbeat is not something a page can act on — offline, a catalog since
    *   removed, a server restarted. The next one tries again.
    */
@@ -1504,6 +1505,11 @@ object ServeWeb {
       }
       setInterval(ping, ${PRESENCE_INTERVAL_SECONDS} * 1000);
       document.addEventListener("visibilitychange", ping);
+      // Fired on arrival, not only every interval. Catalogs are no longer warmed at boot (see
+      // ServeCatalogLiveHost.eagerWarmOnOpen), so this ping is what gets a daemon ready for the
+      // catalog the visitor actually opened — while they read the grid, rather than when they
+      // first click a theme and wait out a cold start.
+      ping();
     """
       .trimIndent()
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -292,7 +292,7 @@
   syncBg();
 })();</script>
       <script src="/assets/serve/61d1-bc55e9642f5f9e1e/format-compare.js"></script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
@@ -278,7 +278,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -246,7 +246,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -245,7 +245,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -243,7 +243,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -234,7 +234,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -239,7 +239,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -229,7 +229,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -212,7 +212,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/141fe-a57192e9b4c7669e/viewer.js"></script>
+      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>


### PR DESCRIPTION
> **Corrected after review.** This PR was opened claiming it fixed the boot-time daemon spike. It does not — see "What this does not fix" below. The change is still worth having, but the title and framing have been narrowed to what it actually does.

## What this does

1. **Eager warm-on-open becomes opt-in** (`-Dcomposeai.serve.eagerWarmOnOpen=true`). At boot the server no longer issues 18 warm *renders* — one per catalog — for pixels nobody has asked for.
2. **The presence heartbeat fires on arrival**, not only every 4 minutes. That reverses the "no first ping" rule from #3243, whose justification was wrong: the page load *is* a request, but a **baked** one, so it warms no daemon. This ping is what readies the daemon for the catalog a visitor actually opened, while they read the grid rather than when they first click a theme.

## What this does *not* fix

The boot-time JVM spike. `ServeCommand.openHost` calls `ServeRenderHost.open`, which calls `factory.open(...)` → `SubprocessRenderSessions` — **the subprocess is spawned there**, and `prewarm()` only runs afterwards via `.also`. Both live-catalog registration paths call `openHost(state)` before registering. So every catalog daemon is still spawned and initialised at boot; this only skips its first render.

The real fix is to open the daemon host **lazily** — on presence or first live use — rather than at registration. `ServeSessionRegistry` is already built for that (its `open` lambda is meant to be called on demand); the catalogs bypass it by opening eagerly. That's a separate change.

## Measurements (still accurate, and still the motivation)

| uptime | `daemons.running` |
|---|---|
| 6 min | **18** |
| 85 min | **3** |

The live-seat budget (`deploy/image/entrypoint.sh`) models ~1.2 GB per resident daemon and permits 8, so 18 at once is ~2–3× the ceiling — arriving while the box is also fetching all 18 catalogs. It is a **startup spike, not steady-state over-commitment**: the reaper reclaims to 3, comfortably inside budget. `liveSeatsAvailable` reads `8 free / 8` throughout, because prewarm never acquires a seat — the limiter cannot see the residency it nominally bounds.

## Test plan

- `./gradlew :cli:test` green (1288); `ktfmtCheck` clean; `serve-landing-declared-themes.html` golden regenerated for the added `ping()`.
- Playwright harness run locally: `pages-snapshot.spec.mjs` **65 passed**, including the bounded-parallelism contract.
- Verified on the live box: presence returns 204 for known *and* unknown catalogs; grid and viewer both carry the heartbeat.