### PR TITLE
fix(serve): revalidate stable CMP Wasm assets

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -414,7 +414,10 @@ class ServeHttpServer(
           }
           val file = resolved.toFile()
           val etag = "\"${file.length().toString(16)}-${file.lastModified().toString(16)}\""
-          call.response.headers.append(HttpHeaders.CacheControl, "public, max-age=3600")
+          // These filenames are stable across preview-host releases. Revalidate every use so a
+          // rollout cannot leave an already-open browser executing an older protocol decoder for
+          // another hour; unchanged multi-megabyte assets still take the cheap ETag/304 path.
+          call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
           call.response.headers.append(HttpHeaders.ETag, etag)
           if (call.request.headers[HttpHeaders.IfNoneMatch] == etag) {
             call.respond(HttpStatusCode.NotModified)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -728,6 +728,8 @@ class ServeHttpRoutingTest {
     client.newCall(req).execute().use { response ->
       assertEquals(200, response.code)
       assertEquals("application/wasm", response.body?.contentType().toString())
+      assertEquals("no-cache", response.header("Cache-Control"))
+      assertTrue(response.header("ETag")?.isNotBlank() == true, "wasm response carries an ETag")
       assertTrue(
         byteArrayOf(0x00, 0x61, 0x73, 0x6d).contentEquals(response.body?.bytes()),
         "wasm bytes served verbatim",


### PR DESCRIPTION
## What changed

- serve the stable `/rc-player-wasm/*` URLs with `Cache-Control: no-cache`
- retain ETags so unchanged multi-megabyte Wasm assets still use cheap `304 Not Modified` responses
- assert the cache contract in `ServeHttpRoutingTest`

## Root cause

The alpha16 opcode 174 decoder fix shipped in preview-host 0.19.27, but existing browsers kept the previous `/rc-player-wasm/rcPlayer.wasm` binary because the stable URL was cached for one hour. That left the live viewer reporting `Unsupported operation at byte 341, opcode=174` after a successful rollout.

## Verification

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeHttpRoutingTest --no-daemon`
- `git diff --check`