### PR TITLE
chore(design-artifacts): bump the driver to design-parity 0.1.37

### DIFF
--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -8,9 +8,9 @@
       "name": "design-artifacts-driver",
       "version": "0.0.0",
       "dependencies": {
-        "@design-parity/adapter-figma": "^0.1.36",
+        "@design-parity/adapter-figma": "^0.1.37",
         "@design-parity/candidate": "^0.1.25",
-        "@design-parity/catalog-export": "^0.1.36",
+        "@design-parity/catalog-export": "^0.1.37",
         "pixelmatch": "^7.0.0",
         "playwright": "^1.49.0",
         "pngjs": "^7.0.0"
@@ -20,12 +20,12 @@
       }
     },
     "node_modules/@design-parity/adapter-figma": {
-      "version": "0.1.36",
-      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.36.tgz",
-      "integrity": "sha512-k7uJKuigvFWTAR03r7Swi4ZPmrpncZHT4qcNrbbrpxI1+D/CGfcXBZIGAZhfWm7AUttsk1D032PLWvvyHO5XxQ==",
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.37.tgz",
+      "integrity": "sha512-7/V8v2eZKWukF8zGSp3GRhe5s8D+4gGGfsl56Vldr8Uz2LKKHY0oNTisW9UfDPYNr5bgFhdoN/Raj0WwP6kNGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.36"
+        "@design-parity/core": "^0.1.37"
       }
     },
     "node_modules/@design-parity/candidate": {
@@ -39,18 +39,18 @@
       }
     },
     "node_modules/@design-parity/catalog-export": {
-      "version": "0.1.36",
-      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.36.tgz",
-      "integrity": "sha512-ChR3WSSxmd00Sw4ZRx5R3kkpFnBeECbZeLhRykIRmXwRK7uZ639eXZ4KiXdEGUtjvXGBoXa6VezvNHjVjvnOeg==",
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.37.tgz",
+      "integrity": "sha512-zWC0LU8yPx10DshoNr2rkVunG1I+z8/m/AK+6gkiQdoRyDYtjPJMphnzLxf8huWugy6LfPLWNjCGZz+ghiD//g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.36"
+        "@design-parity/core": "^0.1.37"
       }
     },
     "node_modules/@design-parity/core": {
-      "version": "0.1.36",
-      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.36.tgz",
-      "integrity": "sha512-GNw2Oi2lrkOfzZm/aCZitCcfNe8RcYI3Gyra148zXVZBzFgXGl4DyhCckIp1h4l9MW3whOQ7dUgY9eRe6Wwqjw==",
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.37.tgz",
+      "integrity": "sha512-+GS13FKHhJik0inB88EK4Y+LLGD9XU7ljJgPh36z511qrcIdIFcutjCFRKC696/qMt28aiUiSKba2POComLj3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1"

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -11,9 +11,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@design-parity/adapter-figma": "^0.1.36",
+    "@design-parity/adapter-figma": "^0.1.37",
     "@design-parity/candidate": "^0.1.25",
-    "@design-parity/catalog-export": "^0.1.36",
+    "@design-parity/catalog-export": "^0.1.37",
     "pixelmatch": "^7.0.0",
     "playwright": "^1.49.0",
     "pngjs": "^7.0.0"


### PR DESCRIPTION
## Summary

Picks up the `layoutFromNode` fix from design-parity#275 (released as 0.1.37). The capture now reads Figma's `padding*` / `itemSpacing` / `cornerRadius` / text `style` into resolved tokens, not just bounds.

Without it, #3252's reference lane wrote an **empty** `references` map — the redline walk drops any box with no spacing spec — so a compare page would have shown an annotated Actual column beside a permanently bare Reference one.

## Verified against the published packages

Not just the unit tests. Testing the real chain is how the gap surfaced in the first place, so the same check was repeated against 0.1.37:

| | reference annotations produced |
| --- | --- |
| 0.1.36 | `0` |
| 0.1.37 | `2` |

```
[layout]     pad 16dp · gap 8dp · r 20dp  @ {x:0,y:0,width:400,height:96}
[typography] text 14sp/20                 @ {x:92,y:52,width:216,height:40}
```

Bounds are correctly scaled into the published raster's space — a 200dp Figma frame published as a 400px sticker doubles every box — and the existing `previews` map is preserved through the merge rather than clobbered.

## Test plan

- Full driver suite: **410 tests passing**.
- End-to-end smoke through `layoutFromNode` → `scaleTree` → `withReferenceAnnotations` against the installed 0.1.37 packages, output above.
- **Lockfile regenerated in the same commit** — the omission that cost #3252 a red round and drew a P1.

## After this

Dispatching meshcore-mobile's `design-artifacts.yml` republishes its bundle with a fully-populated `annotations/index.json`, which is what puts both annotated columns on https://preview.coo.ee/meshcore-mobile/compare/… — meshcore consumes this driver via `design-artifacts-reusable.yml@main`, so no meshcore-side change is needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLvGJpTiL4T6hXMbUCq216)_