### PR TITLE
feat(design-artifacts): give an extra-module render its own live lane

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -98,7 +98,7 @@ on:
         type: boolean
         default: false
       split-per-preview:
-        description: 'After generate, split the render into one addressable bundle per preview under bundle/previews/<id>, for the serve host per-preview live lane. The extra module (if any) is split --view-only (baked, no per-preview re-render classpath). full mode requires publish-live-bundle (see split-mode).'
+        description: 'After generate, split the render into one addressable bundle per preview under bundle/previews/<id>, for the serve host per-preview live lane. The extra module (if any) is split --view-only unless extra-split-mode says otherwise. full mode requires publish-live-bundle (see split-mode).'
         required: false
         type: boolean
         default: false
@@ -107,6 +107,11 @@ on:
         required: false
         type: string
         default: 'full'
+      extra-split-mode:
+        description: "Per-preview split mode for the extra-module render: 'view-only' (the default — its previews are pixels-only, with no live lane) or 'full' (the extra bundle is externalised beside the primary and split with its re-render classpath, and the driver aliases its extra-ONLY functions to daemon ids so the viewer offers real overrides on them instead of the 'Pre-rendered snapshot' note). 'full' requires publish-live-bundle and split-per-preview. Functions the extra bundle OVERRIDES rather than adds stay baked-only either way — the primary daemon would draw them differently."
+        required: false
+        type: string
+        default: 'view-only'
       cli-source:
         description: "How to obtain the compose-preview CLI: 'released' installs it via the install action (the default; what external consumers use), or 'build' builds it from the checked-out compose-ai-tools (driver-ref) with ./gradlew :cli:installDist — for compose-ai-tools' own catalogs, which must publish HEAD's renderer output, not a released one."
         required: false
@@ -503,6 +508,17 @@ jobs:
           if [ "${{ inputs.allow-incomplete }}" = "true" ]; then incomplete=(--allow-incomplete); fi
           live=()
           if [ "${{ inputs.publish-live-bundle }}" = "true" ]; then live=(--publish-live-bundle); fi
+          if [ "${{ inputs.extra-split-mode }}" = "full" ]; then
+            # The driver checks --extra-renders / --publish-live-bundle itself; the split flag is
+            # only knowable here. Without it the extra module's stickers would carry previewIds
+            # pointing at per-preview bundles nobody wrote, so every one of them would 404 its
+            # live render — worse than the baked-only lane this replaces.
+            if [ "${{ inputs.split-per-preview }}" != "true" ]; then
+              echo "::error title=extra-split-mode::'full' requires split-per-preview: true — the extra module's live lane IS the per-preview split."
+              exit 1
+            fi
+            live+=(--extra-live-bundle)
+          fi
           node compose-ai-tools/scripts/design-artifacts/generate-design-catalog.mjs \
             --spec "${{ inputs.spec }}" \
             --renders "$GITHUB_WORKSPACE/bundle.png" \
@@ -521,7 +537,10 @@ jobs:
       #               font pool and serve can re-render it. Needs publish-live-bundle.
       #   view-only → split the raw render (no live bundle), dropping the classpath
       #               but keeping the baked image + sidecars — for an Android/baked tier.
-      # The extra module (if any) is always split --view-only.
+      # The extra module (if any) follows `extra-split-mode`, defaulting to --view-only.
+      # Under `full` it is split from the externalised copy the generate step carried to
+      # out/bundle/, so its per-preview bundles inherit the same shared font pool the
+      # primary's do — serve rehydrates bundle/res/ once and both lanes use it.
       - name: Split into per-preview bundles
         if: ${{ inputs.split-per-preview }}
         run: |
@@ -534,8 +553,13 @@ jobs:
               -o "$GITHUB_WORKSPACE/out/bundle/previews"
           fi
           if [ -n "${{ inputs.extra-module }}" ] && [ -f "$GITHUB_WORKSPACE/extra-bundle.png" ]; then
-            compose-preview bundle split "$GITHUB_WORKSPACE/extra-bundle.png" --view-only \
-              -o "$GITHUB_WORKSPACE/out/bundle/previews"
+            if [ "${{ inputs.extra-split-mode }}" = "full" ]; then
+              compose-preview bundle split "$GITHUB_WORKSPACE/out/bundle/extra-bundle.png" \
+                -o "$GITHUB_WORKSPACE/out/bundle/previews"
+            else
+              compose-preview bundle split "$GITHUB_WORKSPACE/extra-bundle.png" --view-only \
+                -o "$GITHUB_WORKSPACE/out/bundle/previews"
+            fi
           fi
 
       - name: Download section bundle to fold in

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -108,7 +108,7 @@ on:
         type: string
         default: 'full'
       extra-split-mode:
-        description: "Per-preview split mode for the extra-module render: 'view-only' (the default — its previews are pixels-only, with no live lane) or 'full' (the extra bundle is externalised beside the primary and split with its re-render classpath, and the driver aliases its extra-ONLY functions to daemon ids so the viewer offers real overrides on them instead of the 'Pre-rendered snapshot' note). 'full' requires publish-live-bundle and split-per-preview. Functions the extra bundle OVERRIDES rather than adds stay baked-only either way — the primary daemon would draw them differently."
+        description: "Per-preview split mode for the extra-module render: 'view-only' (the default — its previews are pixels-only, with no live lane) or 'full' (the extra bundle is split per preview WITH its re-render classpath, self-contained, and the driver aliases its extra-ONLY functions to daemon ids so the viewer offers real overrides on them instead of the 'Pre-rendered snapshot' note). 'full' requires publish-live-bundle and split-per-preview. Functions the extra bundle OVERRIDES rather than adds stay baked-only either way — the primary daemon would draw them differently."
         required: false
         type: string
         default: 'view-only'
@@ -538,9 +538,12 @@ jobs:
       #   view-only → split the raw render (no live bundle), dropping the classpath
       #               but keeping the baked image + sidecars — for an Android/baked tier.
       # The extra module (if any) follows `extra-split-mode`, defaulting to --view-only.
-      # Under `full` it is split from the externalised copy the generate step carried to
-      # out/bundle/, so its per-preview bundles inherit the same shared font pool the
-      # primary's do — serve rehydrates bundle/res/ once and both lanes use it.
+      # Under `full` it is split from the RAW render, not from an externalised copy:
+      # serve rehydrates exactly one externalResources manifest (the primary liveBundle's)
+      # and shares that single materialized dir with every pooled per-preview daemon, so a
+      # supplement resource the primary doesn't also declare would be published to
+      # bundle/res/ and never materialized. Self-contained per-preview bundles cost
+      # duplication and owe nothing to the shared pool.
       - name: Split into per-preview bundles
         if: ${{ inputs.split-per-preview }}
         run: |
@@ -554,7 +557,7 @@ jobs:
           fi
           if [ -n "${{ inputs.extra-module }}" ] && [ -f "$GITHUB_WORKSPACE/extra-bundle.png" ]; then
             if [ "${{ inputs.extra-split-mode }}" = "full" ]; then
-              compose-preview bundle split "$GITHUB_WORKSPACE/out/bundle/extra-bundle.png" \
+              compose-preview bundle split "$GITHUB_WORKSPACE/extra-bundle.png" \
                 -o "$GITHUB_WORKSPACE/out/bundle/previews"
             else
               compose-preview bundle split "$GITHUB_WORKSPACE/extra-bundle.png" --view-only \

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -505,7 +505,15 @@ class ServeCatalogLiveHost(
       // make the grid believe the requested theme had loaded and it would never retry.
       if (daemonWarmOrScheduling(daemonId)) {
         val live = renderDaemon(daemonId, overrides)
-        if (live !is RenderOutcome.Busy) return cacheThemeRender(themeCacheKey, live)
+        // NotFound joins Busy in falling through rather than being returned. It means no daemon on
+        // either lane carries this id — the shared one never listed it and its per-preview bundle
+        // didn't start (a classpath the box can't resolve, say). That is a statement about the
+        // daemons, not about the pixels: the preview has a baked PNG right there, and showing the
+        // visitor a broken image instead of the un-overridden snapshot helps nobody. Matters most
+        // for a catalog whose supplement module carries its own live lane, where an id can be
+        // aliased yet reachable only through the pool.
+        if (live !is RenderOutcome.Busy && live !is RenderOutcome.NotFound)
+          return cacheThemeRender(themeCacheKey, live)
       }
       if (themeCacheKey != null) return RenderOutcome.Busy
       return baked.render(previewId, overrides)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1231,4 +1231,49 @@ class ServeCatalogLiveHostTest {
     assertEquals("baked:$catalogId", baked1.png.decodeToString())
     assertNull(live.lastRenderId)
   }
+
+  @Test
+  fun `a daemon that carries no such id falls back to the baked snapshot`() {
+    // Both lanes can miss an aliased id: the shared monolithic daemon lists only the primary
+    // bundle's previews, and the per-preview daemon that would cover the rest fails to start when
+    // its classpath won't resolve on this box. That is a fact about the daemons, not about the
+    // pixels — the preview has a baked PNG, so an override request must degrade to the snapshot
+    // rather than hand the browser a broken image.
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        streaming = true,
+        forcedRenderOutcome = RenderOutcome.NotFound,
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+
+    val out = composite.render(catalogId, PreviewOverrides(fontScale = 1.5f)) as RenderOutcome.Ok
+
+    assertEquals("baked:$catalogId", out.png.decodeToString())
+    assertEquals(daemonId, live.lastRenderId, "the daemon was tried first")
+  }
+
+  @Test
+  fun `a theme render on an id no daemon carries reports Busy, never baked pixels`() {
+    // The grid retries a Busy card; a 200 carrying baked pixels would make it believe the requested
+    // theme had loaded and it would sit on the wrong palette forever. So the NotFound fallback
+    // above must stop short of the theme lane.
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        streaming = true,
+        declaredThemes = listOf(ServeTheme(name = "Brand", providerFqn = "com.example.Brand")),
+        forcedRenderOutcome = RenderOutcome.NotFound,
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+
+    assertEquals(
+      RenderOutcome.Busy,
+      composite.render(catalogId, PreviewOverrides(themeProvider = "com.example.Brand")),
+    )
+  }
 }

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -180,18 +180,31 @@ its whole `Screens` section lives in `:meshcore-components`.
 
 `extra-split-mode: full` fixes that half:
 
-- the supplement is externalised beside the primary bundle, sharing its
-  content-addressed `bundle/res/` font pool, and split per preview **with** its
-  re-render classpath;
+- the supplement is split per preview **with** its re-render classpath;
 - the driver aliases only its extra-**only** functions. A function present in both
   bundles is a true override and stays baked-only, exactly as before;
 - serve reaches those ids through the per-preview pool — its shared monolithic daemon
   answers `NotFound` for an id it never listed, and `renderDaemon` falls through.
 
-Requires `publish-live-bundle: true` and `split-per-preview: true`. It costs a second
-externalised bundle on the delivery branch plus one pooled daemon per supplement
-preview actually opened, so leave it off for a supplement that only overrides — it
-would add weight and change nothing.
+The supplement is split from the **raw** render, not from an externalised copy, and
+that is load-bearing: `ServeCatalogStore` rehydrates exactly one `externalResources`
+manifest — the primary `liveBundle`'s — and hands that single materialized directory
+to every pooled per-preview daemon. Externalising the supplement into the same
+content-addressed `bundle/res/` pool would publish blobs nobody materializes for any
+resource the primary doesn't also declare, so a supplement carrying its own faces
+would yield daemons that start with a missing classpath entry. Self-contained
+per-preview bundles cost duplication and owe nothing to the pool.
+
+Requires `publish-live-bundle: true` and `split-per-preview: true`. It costs one
+pooled daemon per supplement preview actually opened, plus the per-preview bundle
+weight, so leave it off for a supplement that only overrides — it would add weight and
+change nothing.
+
+Known gap: `ServeCatalogLiveHost.mergeDeclaredKnobs` grafts knob / focus / gesture
+metadata from the **monolithic** daemon's preview list, which by definition can't
+contain a supplement-only id. Those previews get their display-axis overrides (size,
+device, locale, font scale, orientation) but not author-declared knobs beyond whatever
+the catalog's own `previews/<id>.overrides.json` sidecar carries.
 
 ### Convention: the reference caller drives common features
 

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -146,6 +146,7 @@ jobs:
       spec: catalog.spec.json
       module: ':app'
       # extra-module: ':your-components'   # optional, folded in via --extra-renders
+      # extra-split-mode: full             # give that module its own live lane (see below)
       # desktop-render: true               # for a CMP desktop (Skiko) render
     secrets: inherit               # optional; only for buildfetch_ro_token
 ```
@@ -162,6 +163,35 @@ top-level section after generate. A caller runs its bespoke lane (e.g. re-themin
 a sibling catalog) in a prior job that uploads the bundle artifact, then passes it
 to the reusable workflow — so the render/generate/publish stays shared while the
 bespoke step lives in the caller. A Wasm tier still needs a bespoke workflow.
+
+#### Giving `extra-module` its own live lane
+
+An `extra-module` render exists to **override** same-named functions in the primary
+render — an Android-only render of a control CMP can't draw, folded into an
+otherwise-CMP catalog. Its previews are pixels-only, because the daemon serving the
+catalog runs the *primary* bundle and would redraw those functions differently.
+
+That is the wrong answer for a supplement that mostly **adds**. A module whose
+`@Preview`s the primary module doesn't carry at all overrides nothing, so there is no
+disagreement to protect against — yet those stickers still got no `previewId`, hence
+no daemon twin, hence a viewer that told visitors to "Enable a local preview server"
+for a catalog that already has one. On meshcore-mobile that was 32 of 70 components:
+its whole `Screens` section lives in `:meshcore-components`.
+
+`extra-split-mode: full` fixes that half:
+
+- the supplement is externalised beside the primary bundle, sharing its
+  content-addressed `bundle/res/` font pool, and split per preview **with** its
+  re-render classpath;
+- the driver aliases only its extra-**only** functions. A function present in both
+  bundles is a true override and stays baked-only, exactly as before;
+- serve reaches those ids through the per-preview pool — its shared monolithic daemon
+  answers `NotFound` for an id it never listed, and `renderDaemon` falls through.
+
+Requires `publish-live-bundle: true` and `split-per-preview: true`. It costs a second
+externalised bundle on the delivery branch plus one pooled daemon per supplement
+preview actually opened, so leave it off for a supplement that only overrides — it
+would add weight and change nothing.
 
 ### Convention: the reference caller drives common features
 

--- a/scripts/design-artifacts/extra-render-fold.mjs
+++ b/scripts/design-artifacts/extra-render-fold.mjs
@@ -1,0 +1,52 @@
+/**
+ * How an `--extra-renders` supplement folds into the primary render — specifically, which of its
+ * functions the live-preview bridge must refuse to alias.
+ *
+ * Extracted from the driver so it is unit-testable (the driver runs top-level on import), and
+ * because the distinction it draws is easy to get wrong: the supplement carries two kinds of
+ * function, and only one of them has to lose its live lane.
+ *
+ *   OVERRIDE — the function exists in BOTH bundles and the supplement's pixels win. An Android-only
+ *              render replacing a CMP one (the material3 inset focus ring CMP can't draw) is the
+ *              canonical case. The daemon that serves this catalog runs the PRIMARY bundle, so it
+ *              would redraw the ring-less version: aliasing it would make the live lane disagree
+ *              with the baked sticker beside it. Stays baked-only, always.
+ *
+ *   ADDITION — the function exists ONLY in the supplement. Nothing was overridden and there is no
+ *              disagreement to protect against; the supplement can render it itself. Historically
+ *              these were lumped in with the overrides, which is why meshcore-mobile's
+ *              `:meshcore-components` screens (32 of 70 components) browsed as baked PNGs and the
+ *              viewer told visitors to "Enable a local preview server" for a catalog that has one.
+ *              Bridgeable once the supplement is published with its own per-preview live lane.
+ */
+
+/**
+ * Functions the live-preview bridge must NOT map to a daemon preview id.
+ *
+ * @param primaryFunctions function names carried by the `--renders` bundle
+ * @param extraFunctions   function names carried by the `--extra-renders` bundle
+ * @param extraIsLive      whether the supplement is published with its own live lane
+ *                         (`--extra-live-bundle`). When false — every catalog published before that
+ *                         flag existed — the whole supplement stays unbridged, exactly as before.
+ * @returns a Set of function names to withhold from the bridge
+ */
+export function unbridgeableFunctions(
+  primaryFunctions,
+  extraFunctions,
+  extraIsLive,
+) {
+  const extra = new Set(extraFunctions);
+  if (!extraIsLive) return extra;
+  const primary = new Set(primaryFunctions);
+  return new Set([...extra].filter((fn) => primary.has(fn)));
+}
+
+/**
+ * The supplement's ADDITIONS — functions it carries that the primary bundle does not. These are the
+ * ones that gain a live lane under `--extra-live-bundle`; reported so a render's log says how much
+ * of the supplement actually became live rather than leaving it to be inferred from the catalog.
+ */
+export function extraOnlyFunctions(primaryFunctions, extraFunctions) {
+  const primary = new Set(primaryFunctions);
+  return [...new Set(extraFunctions)].filter((fn) => !primary.has(fn));
+}

--- a/scripts/design-artifacts/extra-render-fold.test.mjs
+++ b/scripts/design-artifacts/extra-render-fold.test.mjs
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extraOnlyFunctions,
+  unbridgeableFunctions,
+} from "./extra-render-fold.mjs";
+
+const PRIMARY = ["FilledButton", "Checkbox", "ThemeFoundation"];
+const EXTRA = ["FilledButton", "DeviceBody", "ContactChat"];
+
+test("without a live lane the whole supplement stays unbridged", () => {
+  // The behaviour every catalog published before --extra-live-bundle was generated under: the
+  // supplement is pixels-only, so none of its functions may claim a daemon twin.
+  assert.deepEqual([...unbridgeableFunctions(PRIMARY, EXTRA, false)].sort(), [
+    "ContactChat",
+    "DeviceBody",
+    "FilledButton",
+  ]);
+});
+
+test("with a live lane only the true overrides stay unbridged", () => {
+  // `FilledButton` is in both bundles: the supplement replaced the primary's pixels, and the
+  // catalog's monolithic daemon runs the primary — so a live render would contradict the sticker.
+  assert.deepEqual(
+    [...unbridgeableFunctions(PRIMARY, EXTRA, true)],
+    ["FilledButton"],
+  );
+});
+
+test("a supplement that only adds keeps every function live", () => {
+  // meshcore-mobile's shape: `:meshcore-components` screens that `:app` doesn't carry at all.
+  // Nothing was overridden, so nothing has to lose its live lane.
+  assert.deepEqual(
+    [...unbridgeableFunctions(PRIMARY, ["DeviceBody", "ContactChat"], true)],
+    [],
+  );
+});
+
+test("a supplement that only overrides gains nothing", () => {
+  // The original design-catalog-m3 case — every extra function replaces a primary one. Turning the
+  // flag on must not quietly hand those a live lane.
+  const extra = ["FilledButton", "Checkbox"];
+  assert.deepEqual([...unbridgeableFunctions(PRIMARY, extra, true)].sort(), [
+    "Checkbox",
+    "FilledButton",
+  ]);
+  assert.deepEqual(extraOnlyFunctions(PRIMARY, extra), []);
+});
+
+test("additions are reported separately from overrides", () => {
+  assert.deepEqual(extraOnlyFunctions(PRIMARY, EXTRA), [
+    "DeviceBody",
+    "ContactChat",
+  ]);
+});
+
+test("a duplicated function name is counted once", () => {
+  // `extra.map(functionOf)` yields one entry per RENDER, so a function with several previews
+  // (light/dark, per-size) appears repeatedly. The counts in the render log must not multiply.
+  const extra = ["DeviceBody", "DeviceBody", "DeviceBody", "FilledButton"];
+  assert.deepEqual(extraOnlyFunctions(PRIMARY, extra), ["DeviceBody"]);
+  assert.deepEqual(
+    [...unbridgeableFunctions(PRIMARY, extra, true)],
+    ["FilledButton"],
+  );
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -1079,26 +1079,34 @@ if (values["wasm-dist"]) {
 // systems whose bundle is a DESKTOP bundle serve can run (compose-m3); the
 // Android catalogs stay baked-PNG.
 let liveBundle = null;
-
-/**
- * Copy one executable bundle onto the branch under `bundle/` and lift its heavy font resources out.
- *
- * The fonts go content-addressed under bundle/res/<sha256>, so the ~600 KB bundle drops to ~30 KB
- * and the fonts (which rarely change and are identical across variants) are fetched once per
- * branch. The `bundle externalize` step records each in the bundle's own manifest by
- * name+sha256+size; a trusted `serve --allow-render-trusted` box rehydrates them from bundle/res/
- * into a shared cache and back onto the daemon classpath. Non-fatal: if the CLI can't externalize
- * (older CLI, no fonts), the self-contained bundle is still published as-is.
- *
- * Two bundles can share one `bundle/res/` pool because the names are content hashes — a face both
- * modules embed is stored once and rehydrates identically for either daemon.
- */
-async function carryLiveBundle(sourcePath, label) {
-  const file = basename(sourcePath);
+if (values["publish-live-bundle"]) {
+  const file = basename(rendersPath);
   const dest = join(outPath, "bundle", file);
   await mkdir(dirname(dest), { recursive: true });
-  await cp(sourcePath, dest);
-  console.log(`[${spec.system}] carried ${label} → bundle/${file}`);
+  await cp(rendersPath, dest);
+  liveBundle = { path: "bundle/", file };
+  console.log(`[${spec.system}] carried live bundle → bundle/${file}`);
+
+  // Lift the heavy font resources out of the carried bundle's classes/app.jar and publish them
+  // content-addressed under bundle/res/<sha256>, so the ~600 KB bundle drops to ~30 KB and the
+  // fonts (which rarely change and are identical across variants) are fetched once per branch. The
+  // `bundle externalize` step records each in the bundle's own manifest by name+sha256+size; a
+  // trusted `serve --allow-render-trusted` box rehydrates them from bundle/res/ into a shared cache
+  // and back onto the daemon classpath. Non-fatal: if the CLI can't externalize (older CLI, no
+  // fonts), the self-contained bundle is still published as-is.
+  //
+  // Only the PRIMARY bundle is externalised, and deliberately so — including under
+  // `--extra-live-bundle`. `ServeCatalogStore` rehydrates exactly one `externalResources` manifest,
+  // the one it reads from `liveBundle.file`, and hands that single materialized directory to every
+  // per-preview daemon it pools. Externalising the supplement too would publish its blobs into the
+  // same content-addressed pool with nobody materializing the ones the primary doesn't also
+  // declare, so a supplement carrying its own faces would yield per-preview daemons that start with
+  // a resource missing from their classpath — worse than the baked lane this replaces. The
+  // workflow therefore splits the supplement RAW: each of its per-preview bundles keeps its
+  // resources embedded and depends on no shared pool. That is the shape the primary lane already
+  // ships in practice (meshcore-mobile's delivery branch has no bundle/res/ at all and its 110
+  // per-preview bundles are self-contained); the cost is duplication for a font-heavy supplement,
+  // against a live lane that otherwise intermittently can't start.
   try {
     const resOut = join(outPath, "bundle", "res");
     const out = execFileSync(
@@ -1113,26 +1121,13 @@ async function carryLiveBundle(sourcePath, label) {
     );
     console.log(
       `[${spec.system}] externalized ${(summary.externalized ?? []).length} font resource(s) ` +
-        `(${total} B) → bundle/res/  (${label} now ${summary.size} B)`,
+        `(${total} B) → bundle/res/  (bundle now ${summary.size} B)`,
     );
   } catch (err) {
     console.warn(
       `[${spec.system}] bundle externalize skipped (${err.message?.split("\n")[0] ?? err}) — ` +
-        `publishing the self-contained ${label}`,
+        `publishing the self-contained bundle`,
     );
-  }
-  return { path: "bundle/", file };
-}
-
-if (values["publish-live-bundle"]) {
-  liveBundle = await carryLiveBundle(rendersPath, "live bundle");
-  // The supplement gets the same treatment when it has its own live lane: externalised beside the
-  // primary and sharing its font pool, so the workflow's per-preview split produces runnable
-  // bundles for the functions only IT carries. It is deliberately NOT recorded as `liveBundle` in
-  // catalog.json — that field names the ONE monolithic daemon serve stands up, and the extra
-  // module's previews are reached through the per-preview lane instead.
-  if (values["extra-live-bundle"]) {
-    await carryLiveBundle(resolve(values["extra-renders"]), "extra live bundle");
   }
 }
 

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -111,6 +111,10 @@ import {
   catalogImagePath,
   derivationMismatches,
 } from "./catalog-image-path.mjs";
+import {
+  extraOnlyFunctions,
+  unbridgeableFunctions,
+} from "./extra-render-fold.mjs";
 import { applySpecSections } from "./apply-spec-sections.mjs";
 import { applySourceFiles } from "./apply-source-files.mjs";
 import {
@@ -636,6 +640,29 @@ const { values } = parseArgs({
     // checkout). Only for systems whose bundle is a DESKTOP bundle serve can run
     // (compose-m3); the Android catalogs (wear/remote) stay baked-PNG.
     "publish-live-bundle": { type: "boolean", default: false },
+    // Give `--extra-renders` its own live lane instead of treating it as a
+    // pixels-only supplement.
+    //
+    // Without this, EVERY function the extra bundle carries is marked overridden and
+    // skipped by the live-preview bridge, so none of its stickers get a `previewId`
+    // and `ServeCatalogStore` can build no alias for them — they browse as baked PNGs
+    // and the viewer shows "Pre-rendered snapshot — overrides need the live server".
+    // That is right for a function the extra bundle genuinely OVERRIDES (its pixels
+    // differ from what the primary daemon would draw), but wrong for one it only ADDS:
+    // nothing was overridden, and the extra bundle can render it itself.
+    //
+    // With this set, only the true overrides (functions present in BOTH bundles) stay
+    // unbridged; extra-ONLY functions are aliased to their daemon ids in the extra
+    // bundle, and the extra bundle is externalised alongside the primary so the
+    // workflow can split it per preview with a runnable classpath. Serve reaches those
+    // ids through the per-preview lane — its shared monolithic daemon answers
+    // `NotFound` for an id it never listed and `renderDaemon` falls through to the
+    // pool (see ServeCatalogLiveHost.renderDaemon).
+    //
+    // Requires --extra-renders and --publish-live-bundle: the per-preview bundles are
+    // fetched from the same `bundle/` prefix the primary live bundle declares, so
+    // without a declared liveBundle serve never opens the lane that would reach them.
+    "extra-live-bundle": { type: "boolean", default: false },
     // Optional buildable source for TRUSTED server-side re-render. When
     // --source-module is given, a `source: {repo, ref, module}` is written into
     // catalog.json so a `serve --allow-render-trusted` box (one with the toolchain
@@ -657,6 +684,25 @@ if (!values.spec || !values.renders || !values.out) {
     "usage: generate-design-catalog --spec <catalog.spec.json> --renders <dir|zip> --out <dir> [--renderer <s>] [--preview-base <url>]",
   );
   process.exit(2);
+}
+
+// Fail loudly rather than publish a catalog whose extra-only stickers claim a live lane
+// nothing can serve. Both prerequisites are silent when violated: with no --extra-renders
+// there is no second bundle to alias against, and with no --publish-live-bundle serve
+// never opens the per-preview lane the aliases resolve through, so every one of those
+// previews would 404 its live render instead of falling back to baked pixels.
+if (values["extra-live-bundle"]) {
+  const missing = [
+    !values["extra-renders"] && "--extra-renders",
+    !values["publish-live-bundle"] && "--publish-live-bundle",
+  ].filter(Boolean);
+  if (missing.length > 0) {
+    console.error(
+      `--extra-live-bundle requires ${missing.join(" and ")} — the extra bundle's per-preview ` +
+        `splits are served from the primary liveBundle's prefix, so both must be present.`,
+    );
+    process.exit(2);
+  }
 }
 
 const specPath = resolve(values.spec);
@@ -691,7 +737,17 @@ if (values["extra-renders"]) {
   );
   extraBundle = extraRenderBundle;
   const overridden = new Set(extra.map(functionOf));
-  for (const fn of overridden) overriddenFunctions.add(fn);
+  // Which of those the supplement actually REPLACED, as opposed to added — see
+  // extra-render-fold.mjs. Read `candidates` before the splice below, while it is still
+  // exactly the primary bundle's functions.
+  const primaryFunctions = candidates.map(functionOf);
+  const extraFunctions = [...overridden];
+  const unbridgeable = unbridgeableFunctions(
+    primaryFunctions,
+    extraFunctions,
+    values["extra-live-bundle"],
+  );
+  for (const fn of unbridgeable) overriddenFunctions.add(fn);
   for (let i = candidates.length - 1; i >= 0; i--) {
     if (overridden.has(functionOf(candidates[i]))) candidates.splice(i, 1);
   }
@@ -700,6 +756,13 @@ if (values["extra-renders"]) {
     `[${spec.system}] folded ${extra.length} extra render(s), overriding: ` +
       `${[...overridden].join(", ")}`,
   );
+  if (values["extra-live-bundle"]) {
+    const added = extraOnlyFunctions(primaryFunctions, extraFunctions);
+    console.log(
+      `[${spec.system}] extra live lane: ${added.length} extra-only function(s) keep a live ` +
+        `lane, ${unbridgeable.size} true override(s) stay baked-only`,
+    );
+  }
 }
 
 // Annotation-derived inventory (compose-ai-tools Phase 2): components discovery
@@ -1016,21 +1079,26 @@ if (values["wasm-dist"]) {
 // systems whose bundle is a DESKTOP bundle serve can run (compose-m3); the
 // Android catalogs stay baked-PNG.
 let liveBundle = null;
-if (values["publish-live-bundle"]) {
-  const file = basename(rendersPath);
+
+/**
+ * Copy one executable bundle onto the branch under `bundle/` and lift its heavy font resources out.
+ *
+ * The fonts go content-addressed under bundle/res/<sha256>, so the ~600 KB bundle drops to ~30 KB
+ * and the fonts (which rarely change and are identical across variants) are fetched once per
+ * branch. The `bundle externalize` step records each in the bundle's own manifest by
+ * name+sha256+size; a trusted `serve --allow-render-trusted` box rehydrates them from bundle/res/
+ * into a shared cache and back onto the daemon classpath. Non-fatal: if the CLI can't externalize
+ * (older CLI, no fonts), the self-contained bundle is still published as-is.
+ *
+ * Two bundles can share one `bundle/res/` pool because the names are content hashes — a face both
+ * modules embed is stored once and rehydrates identically for either daemon.
+ */
+async function carryLiveBundle(sourcePath, label) {
+  const file = basename(sourcePath);
   const dest = join(outPath, "bundle", file);
   await mkdir(dirname(dest), { recursive: true });
-  await cp(rendersPath, dest);
-  liveBundle = { path: "bundle/", file };
-  console.log(`[${spec.system}] carried live bundle → bundle/${file}`);
-
-  // Lift the heavy font resources out of the carried bundle's classes/app.jar and publish them
-  // content-addressed under bundle/res/<sha256>, so the ~600 KB bundle drops to ~30 KB and the
-  // fonts (which rarely change and are identical across variants) are fetched once per branch. The
-  // `bundle externalize` step records each in the bundle's own manifest by name+sha256+size; a
-  // trusted `serve --allow-render-trusted` box rehydrates them from bundle/res/ into a shared cache
-  // and back onto the daemon classpath. Non-fatal: if the CLI can't externalize (older CLI, no
-  // fonts), the self-contained bundle is still published as-is.
+  await cp(sourcePath, dest);
+  console.log(`[${spec.system}] carried ${label} → bundle/${file}`);
   try {
     const resOut = join(outPath, "bundle", "res");
     const out = execFileSync(
@@ -1045,13 +1113,26 @@ if (values["publish-live-bundle"]) {
     );
     console.log(
       `[${spec.system}] externalized ${(summary.externalized ?? []).length} font resource(s) ` +
-        `(${total} B) → bundle/res/  (bundle now ${summary.size} B)`,
+        `(${total} B) → bundle/res/  (${label} now ${summary.size} B)`,
     );
   } catch (err) {
     console.warn(
       `[${spec.system}] bundle externalize skipped (${err.message?.split("\n")[0] ?? err}) — ` +
-        `publishing the self-contained bundle`,
+        `publishing the self-contained ${label}`,
     );
+  }
+  return { path: "bundle/", file };
+}
+
+if (values["publish-live-bundle"]) {
+  liveBundle = await carryLiveBundle(rendersPath, "live bundle");
+  // The supplement gets the same treatment when it has its own live lane: externalised beside the
+  // primary and sharing its font pool, so the workflow's per-preview split produces runnable
+  // bundles for the functions only IT carries. It is deliberately NOT recorded as `liveBundle` in
+  // catalog.json — that field names the ONE monolithic daemon serve stands up, and the extra
+  // module's previews are reached through the per-preview lane instead.
+  if (values["extra-live-bundle"]) {
+    await carryLiveBundle(resolve(values["extra-renders"]), "extra live bundle");
   }
 }
 


### PR DESCRIPTION
## Why

`https://preview.coo.ee/meshcore-mobile/p/device-populated__ideal__default__dark__compact` says:

> Pre-rendered snapshot — overrides (size, device, locale, font scale, orientation) need the live server, not a published catalog. Enable a local preview server.

That catalog **has** a live server. Its daemon is warm and answering (`renders: 76, ok: 76, coldRenders: 1, p50: 923ms`), and 38 of its 70 grid cards re-theme on demand. The other 32 don't, and the banner blames the catalog for it.

Traced through:

- the banner is `overridesLive = canApplyOverrides || canRenderOverrides` (`ServeWeb.kt:3859`);
- `canRenderOverrides` comes from `ServeCatalogLiveHost.canRenderOverridesFor(id)`, which is `previewId in alias`;
- `alias` is built purely from `image.previewId` in `catalog.json`;
- `bridgeLivePreviewIds` skips every function in `overriddenFunctions` — and the driver put **every** function the `--extra-renders` supplement carries into that set.

That is correct for a genuine **override**: the catalog's daemon runs the *primary* bundle, so aliasing a function whose pixels came from the supplement would make the live render disagree with the baked sticker beside it (the material3 inset focus ring CMP can't draw is the canonical case).

It is wrong for a supplement that **adds**. A module whose `@Preview`s the primary doesn't carry at all overrides nothing — there is no disagreement to protect against, and the supplement can render them itself. meshcore-mobile is exactly that shape: its entire `Screens` section lives in `:meshcore-components`, which `:app` has no copy of.

Measured on the published catalog:

| origin | components | live lane before |
|---|---|---|
| `:app` previews (`ee.schimke.meshcore.app.ui.*`) | 38 | ✅ |
| `:meshcore-components` previews (`…meshcore.components.ui.*`) | 5 | ❌ |
| folded-in `Material 3` section (`samples/design-catalog-m3`) | 27 | ❌ |

(The folded section is a different mechanism — a pre-rendered bundle from another repo — and is out of scope here.)

## What

New reusable-workflow input **`extra-split-mode`**, default `view-only` so every existing caller is byte-identical. Under `full`:

- the supplement is split per preview **with** its re-render classpath, self-contained;
- the driver aliases only its extra-**ONLY** functions. A function present in both bundles is a true override and stays baked-only, exactly as today.

Serve needs no new contract. Its shared monolithic daemon already answers `NotFound` for an id it never listed, and `renderDaemon` already falls through to the per-preview pool — the path was built for "a split/IR-backed bundle the monolithic descriptor never listed", which is precisely this.

The supplement is split from the **raw** render rather than an externalised copy, and that is load-bearing (Codex P1, fixed in 41c4e6c): `ServeCatalogStore.rehydrateExternalResources` reads exactly one `externalResources` manifest — the primary `liveBundle`'s — and hands that single materialized directory to every pooled per-preview daemon. Externalising the supplement into the shared `bundle/res/` pool would publish blobs nobody materializes for any resource the primary doesn't also declare, producing daemons that start with a missing classpath entry. Self-contained per-preview bundles owe nothing to the pool. This is also the lane already shipping: meshcore-mobile's delivery branch has **no `bundle/res/` at all** and its 110 per-preview bundles are self-contained at ~1.7 MB each.

One hardening ships with it: `ServeCatalogLiveHost.render` now treats a `NotFound` from the daemon lane like `Busy` and falls through to the baked snapshot instead of returning it. If a per-preview bundle can't start, the visitor gets the published pixels rather than a broken image. The theme lane is deliberately excluded — baked pixels returned as a `200` would make the grid believe the requested theme had loaded and it would never retry.

The `unbridgeableFunctions` / `extraOnlyFunctions` decision is extracted to `extra-render-fold.mjs` with its own tests, following the same "the driver runs top-level on import" pattern as `bridge-live-preview-ids.mjs`.

### Known gap (Codex P2, not fixed here)

`ServeCatalogLiveHost.mergeDeclaredKnobs` grafts knob / focus / gesture metadata from the **monolithic** daemon's preview list, which by construction can't hold a supplement-only id. Those previews get their display-axis overrides — the reported bug — but not author-declared knobs beyond what the catalog's own `previews/<id>.overrides.json` sidecar carries (`ServeBundleHost.readOverrides` already sources those by catalog id). Not a regression: before this change they had no live lane at all. Fixing it properly means either recording supplement declarations into `catalog.json` per image or opening per-preview bundles at load, and the latter would defeat the lazy-open that bounds daemon residency. Documented in `docs/design/DESIGN_CATALOGS.md`; follow-up to file.

## Test plan

- `node --test` in `scripts/design-artifacts/` — **416 pass, 0 fail**, including 6 new cases in `extra-render-fold.test.mjs`: flag off ⇒ whole supplement unbridged (the behaviour every published catalog was generated under); flag on ⇒ only true overrides unbridged; an add-only supplement; an override-only supplement (gains nothing); duplicate function names counted once.
- `./gradlew :cli:test --tests '*Serve*'` — green, including 2 new `ServeCatalogLiveHostTest` cases for the `NotFound` fallback and for the theme lane still reporting `Busy`.
- YAML parse-checked both workflows; the driver guards `--extra-live-bundle` without `--extra-renders` / `--publish-live-bundle`, and the workflow guards it without `split-per-preview` (aliases pointing at per-preview bundles nobody wrote would 404 every live render — worse than the baked lane it replaces).

**Not verified end-to-end here**: the actual render + split needs a `design-artifacts` run (8–30 min). Caller change is meshcore-mobile#342, **already merged** — so meshcore's `design-artifacts.yml` currently passes an input this workflow doesn't yet declare and fails at parse time. Landing this unblocks it. After that I'll dispatch the render and confirm `catalog.json` maps 70 of 70 components and the viewer drops the banner.

**No visual evidence embedded, deliberately.** This PR changes no rendering code and adds no visual surface — it changes which catalog previews get a `previewId`. The visible outcome is the *existing*, already-fixture-covered live viewer chrome appearing on 32 more previews instead of the *existing*, already-fixture-covered snapshot chrome (`serve-viewer`, `serve-viewer-catalog-knobs`). There is no before/after to diff until a catalog is republished, and this container's headless Chromium has no egress through the agent proxy to shoot the live page. The republished catalog is the evidence, and I'll post it on the follow-up.