### PR TITLE
feat(design-artifacts): add extra-split-mode to the reusable workflow

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -98,7 +98,7 @@ on:
         type: boolean
         default: false
       split-per-preview:
-        description: 'After generate, split the render into one addressable bundle per preview under bundle/previews/<id>, for the serve host per-preview live lane. The extra module (if any) is split --view-only (baked, no per-preview re-render classpath). full mode requires publish-live-bundle (see split-mode).'
+        description: 'After generate, split the render into one addressable bundle per preview under bundle/previews/<id>, for the serve host per-preview live lane. The extra module (if any) follows extra-split-mode, defaulting to view-only. full mode requires publish-live-bundle (see split-mode).'
         required: false
         type: boolean
         default: false
@@ -107,6 +107,11 @@ on:
         required: false
         type: string
         default: 'full'
+      extra-split-mode:
+        description: "Per-preview split mode for the extra module: 'view-only' (the default, and what every caller got before this input existed — baked stickers with no re-render classpath) or 'full' (each per-preview bundle carries the classpath from its pack, so the serve host's per-preview pool can re-render those ids instead of replaying snapshots). Unlike the primary module there is no externalisation pass for the extra render, so 'full' splits the packed bundle directly: the shared jars repeat per preview, making the output larger."
+        required: false
+        type: string
+        default: 'view-only'
       cli-source:
         description: "How to obtain the compose-preview CLI: 'released' installs it via the install action (the default; what external consumers use), or 'build' builds it from the checked-out compose-ai-tools (driver-ref) with ./gradlew :cli:installDist — for compose-ai-tools' own catalogs, which must publish HEAD's renderer output, not a released one."
         required: false
@@ -521,7 +526,10 @@ jobs:
       #               font pool and serve can re-render it. Needs publish-live-bundle.
       #   view-only → split the raw render (no live bundle), dropping the classpath
       #               but keeping the baked image + sidecars — for an Android/baked tier.
-      # The extra module (if any) is always split --view-only.
+      # The extra module (if any) follows extra-split-mode. Its 'full' differs from the primary
+      # module's: there is no externalisation pass for the extra render, so it splits the packed
+      # bundle directly. Each per-preview bundle then carries the shared classpath (and can
+      # re-render) at the cost of repeating those jars per preview.
       - name: Split into per-preview bundles
         if: ${{ inputs.split-per-preview }}
         run: |
@@ -534,7 +542,9 @@ jobs:
               -o "$GITHUB_WORKSPACE/out/bundle/previews"
           fi
           if [ -n "${{ inputs.extra-module }}" ] && [ -f "$GITHUB_WORKSPACE/extra-bundle.png" ]; then
-            compose-preview bundle split "$GITHUB_WORKSPACE/extra-bundle.png" --view-only \
+            extra_view=(--view-only)
+            if [ "${{ inputs.extra-split-mode }}" = "full" ]; then extra_view=(); fi
+            compose-preview bundle split "$GITHUB_WORKSPACE/extra-bundle.png" "${extra_view[@]}" \
               -o "$GITHUB_WORKSPACE/out/bundle/previews"
           fi
 


### PR DESCRIPTION
## Summary

**meshcore-mobile currently cannot publish its catalog at all.** Its `design-artifacts.yml` passes `extra-split-mode: full` to this reusable workflow, and the input has never existed here:

```
$ git log -S"extra-split-mode" -- .github/workflows/design-artifacts-reusable.yml
(no commits, ever)
```

so the workflow fails validation before any job starts:

```
Invalid input, extra-split-mode is not defined in the referenced workflow
```

The caller side came from meshcore-mobile#342 ("serve the :meshcore-components screens live"); the compose-ai-tools half was never written. This is that half. It blocks every publish for that repo — dispatch, cron, and release chain alike — not just one run.

## Why `split-mode` isn't the answer

`split-mode` governs the **primary** module; the extra module was hardcoded `--view-only`. #342 wants the *supplement* split live — it was "the 32-of-70 components whose viewer said 'Pre-rendered snapshot'" — so a genuinely new input is required, not a rename.

## Semantics, from the CLI's own contract

`bundle split --view-only` "drop[s] the re-render classpath", and without it "each bundle carries the shared classpath and can re-render". So `full` simply omits the flag, which is precisely what lets those ids resolve through the serve host's per-preview pool.

## Two deliberate departures from the primary module's `full`

**No externalisation pass.** The extra render has no `--publish-live-bundle` equivalent, so `full` splits the packed bundle directly rather than a slimmed liveBundle. The shared jars repeat per preview and the output is larger — stated in the input description rather than left to be discovered at 200 MB.

**Default is `view-only`, not `full`.** Every existing caller — including this repo's own `design-artifacts.yml`, which passes `split-mode` but not this — keeps byte-identical behaviour. Only a caller that opts in changes.

## Test plan

- Workflow YAML parses; the new input resolves as `{type: string, required: false, default: view-only}` among 38 inputs.
- The rendered split step passes `bash -n` with both modes substituted.
- No behaviour change without the new input, verified by the default and by this repo's own caller not setting it.

Not verifiable here: an actual `full` extra split needs a full catalog render on a runner. The first real exercise is meshcore-mobile's next publish, which is currently unable to start at all — this is what lets it run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLvGJpTiL4T6hXMbUCq216)_