### PR TITLE
fix(catalog): improve theme presentation

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -908,6 +908,19 @@ object ServeWeb {
     }
   }
 
+  /** A compact human label for the size/breakpoint token carried in a flattened catalog id. */
+  private fun previewSizeVariantLabel(id: String): String? =
+    id.split("__").asReversed().firstNotNullOfOrNull { token ->
+      when (token.lowercase()) {
+        "compact" -> "Compact"
+        "expanded" -> "Expanded"
+        "smallround" -> "Small Round"
+        "largeround" -> "Large Round"
+        "xlround" -> "XL Round"
+        else -> null
+      }
+    }
+
   /**
    * A **synthesized** sub-grouping for a section-less catalog: bucket [cards] by [cardFamily] so
    * the flat grid gains labelled dividers (Buttons, Cards, Text fields, …) like an authored catalog
@@ -951,6 +964,8 @@ object ServeWeb {
    * Progressive enhancement throughout — a no-JS client sees the full grid on its baked renders.
    */
   private fun themePickerHtml(hasBaked: Boolean, declared: List<ServeTheme>): String {
+    val builtInLabels = if (hasBaked) setOf("light", "dark") else setOf("default")
+    val declaredNameCounts = declared.groupingBy { it.name.lowercase() }.eachCount()
     val chips = buildString {
       if (hasBaked) {
         append("<button type=\"button\" class=\"cp-theme-btn\" data-theme-choice=\"light\">")
@@ -962,8 +977,16 @@ object ServeWeb {
         append("Default</button>")
       }
       declared.forEach { t ->
-        val label = WebEscaping.htmlEscape(t.name)
-        val title = t.group?.let { " title=\"${WebEscaping.htmlEscape(it)} · $label\"" } ?: ""
+        val qualified =
+          t.name.lowercase() in builtInLabels || declaredNameCounts.getValue(t.name.lowercase()) > 1
+        val displayName =
+          if (qualified) "${t.group?.takeIf { it.isNotBlank() } ?: "Custom"} · ${t.name}"
+          else t.name
+        val label = WebEscaping.htmlEscape(displayName)
+        val title =
+          t.group
+            ?.takeIf { !qualified }
+            ?.let { " title=\"${WebEscaping.htmlEscape(it)} · $label\"" } ?: ""
         append("\n        <button type=\"button\" class=\"cp-theme-btn\"")
         append(" data-theme-choice=\"theme:${WebEscaping.htmlEscape(t.providerFqn)}\"$title>")
         append("$label</button>")
@@ -2955,6 +2978,17 @@ object ServeWeb {
     // props) pass straight through.
     val groups =
       groupPreviews(previews.filterNot { isNonDefaultState(it) || hasNonDefaultProps(it) })
+    // Size/breakpoint variants intentionally remain separate cards, but catalog-authored labels
+    // often omit that axis (for example three "Edgebutton" cards at Small/Large/XL Round). Add a
+    // qualifier only when the base label actually collides, keeping ordinary one-card labels terse.
+    val duplicateGridLabels =
+      groups.groupingBy { previewDisplayName(it.default) }.eachCount().filterValues { it > 1 }.keys
+    fun gridDisplayName(preview: ServePreview): String {
+      val label = previewDisplayName(preview)
+      if (label !in duplicateGridLabels) return label
+      val size = previewSizeVariantLabel(preview.id) ?: return label
+      return "$label · $size"
+    }
     // A card's pixel URL. With a prebaked thumbnail it carries `?thumb=<hash>`, which the render
     // lane answers from memory with the downscaled image; the id and every other param stay
     // identical, so the SAME URL still serves a full render once anything is layered on it (a
@@ -2992,9 +3026,9 @@ object ServeWeb {
       // no URL-building in the browser.
       val def = if (darkFirst) d else l
       val defTheme = if (darkFirst) "dark" else "light"
-      val lightLabel = previewDisplayName(l)
-      val darkLabel = previewDisplayName(d)
-      val defaultLabel = previewDisplayName(def)
+      val lightLabel = gridDisplayName(l)
+      val darkLabel = gridDisplayName(d)
+      val defaultLabel = gridDisplayName(def)
       // `data-def` is the variant a DECLARED theme re-renders (the server-side default), so picking
       // one doesn't also flip the card's light/dark base.
       return """
@@ -3018,7 +3052,7 @@ object ServeWeb {
     }
     fun singleCard(p: ServePreview): String {
       val idSeg = WebEscaping.urlEncodeSegment(p.id)
-      val label = WebEscaping.htmlEscape(previewDisplayName(p))
+      val label = WebEscaping.htmlEscape(gridDisplayName(p))
       val src = renderSrc(p)
       val idText = WebEscaping.htmlEscape(p.id)
       // data-bg-theme is the thumbnail's background (explicit token, else the dark-first default).

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
@@ -108,4 +108,50 @@ class ServeWebGridThumbnailTest {
       "the themed-render base is the card's own thumbnail URL",
     )
   }
+
+  @Test
+  fun `declared theme labels are qualified when they collide with baked modes`() {
+    val html =
+      ServeWeb.landingPage(
+        "compose-m3",
+        listOf(
+          ServePreview("button__ideal__default__light", "Button", theme = "light"),
+          ServePreview("button__ideal__default__dark", "Button", theme = "dark"),
+        ),
+        token = "t",
+        declaredThemes =
+          listOf(
+            ServeTheme("Light", "com.example.LightTheme", group = "Example"),
+            ServeTheme("Dark", "com.example.DarkTheme", group = "Example"),
+          ),
+        canRenderThemeFor = { true },
+      )
+
+    assertTrue(html.contains("data-theme-choice=\"light\">Light</button>"))
+    assertTrue(html.contains("data-theme-choice=\"dark\">Dark</button>"))
+    assertTrue(
+      html.contains("data-theme-choice=\"theme:com.example.LightTheme\">Example · Light</button>")
+    )
+    assertTrue(
+      html.contains("data-theme-choice=\"theme:com.example.DarkTheme\">Example · Dark</button>")
+    )
+  }
+
+  @Test
+  fun `duplicate breakpoint cards include their size in the label`() {
+    val html =
+      ServeWeb.landingPage(
+        "wear-m3",
+        listOf(
+          ServePreview("edgebutton__ideal__default__smallround", "Edgebutton"),
+          ServePreview("edgebutton__ideal__default__largeround", "Edgebutton"),
+          ServePreview("edgebutton__ideal__default__xlround", "Edgebutton"),
+        ),
+        token = "t",
+      )
+
+    assertTrue(html.contains(">Edgebutton · Small Round</div>"))
+    assertTrue(html.contains(">Edgebutton · Large Round</div>"))
+    assertTrue(html.contains(">Edgebutton · XL Round</div>"))
+  }
 }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -56,6 +57,15 @@ fun WearSticker(content: @Composable () -> Unit) {
  */
 @Composable
 fun WearCatalogTheme(content: @Composable () -> Unit) {
+  // A server-selected @WearThemeCatalog provider already installed the requested theme outside
+  // this preview. Do not immediately replace it with the catalog default from inside the sticker.
+  // This mirrors Confetti Wear's PreviewThemeOverrideInstalled contract and is what makes a theme
+  // choice affect the component previews themselves, not only the generated theme specimen.
+  if (LocalWearCatalogThemeOverride.current) {
+    content()
+    return
+  }
+
   val font =
     wearCatalogFont(previewOverrideFont("theme.font", "Roboto Flex", suggestions = WEAR_FONT_NAMES))
   val colorScheme = wearColorScheme(previewOverrideString("theme.colors", "M3"), MaterialTheme.colorScheme)
@@ -84,10 +94,29 @@ fun wearCatalogFont(name: String): FontFamily =
  */
 fun wearColorScheme(name: String, base: ColorScheme): ColorScheme =
   when (name) {
+    // Confetti Wear's KotlinConf identity uses the JetBrains seed purple (#7F52FF) to build a
+    // dynamic dark scheme. This compact catalog keeps Wear's complete dark role ramp and applies
+    // that same signature seed to its primary family.
+    "KotlinConf" ->
+      base.copy(
+        primary = Color(0xFF7F52FF),
+        primaryDim = Color(0xFF633BDB),
+        primaryContainer = Color(0xFF3D247F),
+        onPrimary = Color.White,
+        onPrimaryContainer = Color(0xFFE8DDFF),
+        secondary = Color(0xFFFF8DA1),
+        secondaryDim = Color(0xFFD96C81),
+        secondaryContainer = Color(0xFF652936),
+        onSecondary = Color(0xFF3A0715),
+        onSecondaryContainer = Color(0xFFFFD9E0),
+      )
     "Coral" -> base.copy(primary = Color(0xFFFF6F61), secondary = Color(0xFFFFB4A9))
     "Teal" -> base.copy(primary = Color(0xFF4DD0E1), secondary = Color(0xFF80CBC4))
     else -> base
   }
+
+/** True while a preview-server theme provider owns the Wear Material theme for the sticker. */
+internal val LocalWearCatalogThemeOverride = compositionLocalOf { false }
 
 /**
  * The catalog's **component** multipreview: a single transparent capture, cropped to the component

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/WearThemeCatalogs.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/WearThemeCatalogs.kt
@@ -1,6 +1,7 @@
 package com.example.designcatalogwearm3
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 import androidx.wear.compose.material3.MaterialTheme
 import ee.schimke.composeai.preview.WearThemeCatalog
@@ -10,32 +11,47 @@ import ee.schimke.composeai.preview.WearThemeCatalog
  * the render-side proof that the Wear specimen reads the Wear theme.
  *
  * Each wraps the stock Wear [MaterialTheme] with one of the catalog's declared palettes (the same
- * `wearColorScheme` mapping the `knob.theme.colors` override uses), so the three rendered sheets —
- * `wearthemecatalog__M3`, `__Coral`, `__Teal` — differ in `primary` / `secondary`. Rendered by the
+ * `wearColorScheme` mapping the `knob.theme.colors` override uses), so the rendered sheets differ
+ * in their primary / secondary families. Rendered by the
  * `WEAR_THEME_CATALOG` strategy, which reads `androidx.wear.compose.material3.MaterialTheme`
  * reflectively; annotate these `@ThemeCatalog` instead and all three collapse to the identical
  * baseline mobile M3 palette, which is the bug this kind exists to fix.
  *
- * They also populate the preview server's **Theme** select for this module, so any Wear sticker can
- * be re-rendered live under any of the three.
+ * They also populate the preview server's **Theme** select for this module. The local marker keeps
+ * [WearCatalogTheme] inside each sticker from shadowing the selected outer provider.
  */
+@Composable
+private fun WearThemeOverride(name: String, content: @Composable () -> Unit) {
+  MaterialTheme(colorScheme = wearColorScheme(name, MaterialTheme.colorScheme)) {
+    CompositionLocalProvider(LocalWearCatalogThemeOverride provides true, content = content)
+  }
+}
+
 @WearThemeCatalog(name = "M3", group = "Wear")
 class WearM3ThemeCatalog : PreviewWrapperProvider {
   @Composable
   override fun Wrap(content: @Composable () -> Unit) =
-    MaterialTheme(colorScheme = wearColorScheme("M3", MaterialTheme.colorScheme)) { content() }
+    WearThemeOverride("M3", content)
 }
 
 @WearThemeCatalog(name = "Coral", group = "Wear")
 class WearCoralThemeCatalog : PreviewWrapperProvider {
   @Composable
   override fun Wrap(content: @Composable () -> Unit) =
-    MaterialTheme(colorScheme = wearColorScheme("Coral", MaterialTheme.colorScheme)) { content() }
+    WearThemeOverride("Coral", content)
 }
 
 @WearThemeCatalog(name = "Teal", group = "Wear")
 class WearTealThemeCatalog : PreviewWrapperProvider {
   @Composable
   override fun Wrap(content: @Composable () -> Unit) =
-    MaterialTheme(colorScheme = wearColorScheme("Teal", MaterialTheme.colorScheme)) { content() }
+    WearThemeOverride("Teal", content)
+}
+
+/** Confetti Wear's dark KotlinConf identity, using its JetBrains purple seed palette. */
+@WearThemeCatalog(name = "KotlinConf", group = "Confetti Wear")
+class WearKotlinConfThemeCatalog : PreviewWrapperProvider {
+  @Composable
+  override fun Wrap(content: @Composable () -> Unit) =
+    WearThemeOverride("KotlinConf", content)
 }


### PR DESCRIPTION
## Goal

Address the compose-ai-tools findings from the preview.coo.ee catalog audit in #3267: keep Wear dark-first, add a Confetti Wear-derived custom theme for testing, and remove ambiguous or duplicate catalog presentation.

## Summary

- add a dark KotlinConf palette to `wear-m3`, based on Confetti Wear's JetBrains purple identity
- make server-selected Wear theme providers reach the component previews instead of being shadowed by the catalog's inner default theme
- qualify declared theme chips when they collide with built-in Light/Dark/Default choices
- disambiguate duplicate breakpoint cards with Compact/Expanded and Wear round-size labels
- add regression tests for colliding theme names and duplicate Wear breakpoint labels
- leave `remote-m3` and `homeassistant-remotecompose` unchanged as requested

Things tried and abandoned:
- no artificial light palette was added to Wear; the catalog remains intentionally dark

Known gaps:
- catalog-source fixes for repositories outside compose-ai-tools remain tracked in #3267
- generic authored display-name cleanup remains with each catalog owner; this change only derives a suffix for proven size/breakpoint collisions

Verification:
- rendered and visually reviewed preview `wearthemecatalog__KotlinConf`
- `./gradlew :cli:ktfmtCheck :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebGridThumbnailTest :samples:design-catalog-wear-m3:ktfmtCheck`
- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebFixtureTest`
- `git diff --check`