### PR TITLE
fix(bundle): keep sibling-module drawables out of the resource prune

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidResourcePruner.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidResourcePruner.kt
@@ -20,11 +20,21 @@ import java.util.zip.ZipOutputStream
  * - Only View-system file types are candidates ([PRUNABLE_TYPE_BASES]): `drawable`, `layout`,
  *   `anim`, `animator`, `mipmap`. Compose draws from Kotlin — no `R.layout` inflation, no view
  *   animations, no launcher mipmaps — so a Compose render resolves none of these unless the module
- *   itself authored one, which [moduleOwnFileResources] always retains.
+ *   itself authored one — or a sibling project module did — which [firstPartyFileResources] always
+ *   retains.
  * - The baked catalog PNGs are rendered from the **full** APK *before* packing, so they are
- *   unaffected. The pruned APK feeds only the live daemon re-render, which degrades any miss to a
- *   `⟦res 0x…⟧` placeholder rather than throwing (see the daemon's `PlaceholderFallbackResources`),
- *   so even an over-aggressive drop is graceful, never a crash or a wrong sticker.
+ *   unaffected. The pruned APK feeds only the live daemon re-render.
+ *
+ * An over-aggressive drop is **not** graceful, so the retain-set is what carries the safety here.
+ * `PlaceholderFallbackResources` degrades a miss to a `⟦res 0x…⟧` placeholder only on the accessors
+ * it wraps (`getText` / `getColor` / the dimension family / every `getDrawable*` overload); Compose
+ * resolves a vector through `Resources.getValue` + `getXml`, which that wrapper's own kdoc lists as
+ * uncovered, so a pruned vector drawable aborts the whole render with `NotFoundException: File
+ * res/drawable/<name>.xml from xml type xml resource ID #0x7f…` rather than drawing a magenta box.
+ * That is issue #3260: [firstPartyFileResources] used to carry only the rendering module's own
+ * `src/<sourceSet>/res`, so a multi-module app whose icons live in sibling project modules had
+ * every one of them pruned. The retain-set now comes from AGP's merge-blame file
+ * (`MergedResourceOwnership`) and covers the whole build's first-party resources.
  *
  * For a Compose-only catalog (e.g. `:samples:design-catalog-wear-m3`, which authors no file
  * resources of its own) this drops the entire merged AAR drawable/layout payload — ~140 KB of Wear
@@ -41,11 +51,12 @@ internal object AndroidResourcePruner {
   /**
    * Re-emit [apkBytes] without the prunable merged-AAR file resources.
    *
-   * @param moduleOwnFileResources resource identities the module declares in its own
-   *   `src/<sourceSet>/res`, each `"<typeBase>/<name>"` (e.g. `"drawable/ic_logo"`); always
-   *   retained.
+   * @param firstPartyFileResources resource identities authored anywhere in this build — the
+   *   rendering module's own `src/<sourceSet>/res` and every sibling project module's — each
+   *   `"<typeBase>/<name>"` (e.g. `"drawable/ic_logo"`); always retained. See
+   *   [MergedResourceOwnership], which derives it from AGP's merge-blame file.
    */
-  fun prune(apkBytes: ByteArray, moduleOwnFileResources: Set<String>): Result {
+  fun prune(apkBytes: ByteArray, firstPartyFileResources: Set<String>): Result {
     val out = ByteArrayOutputStream(apkBytes.size)
     var dropped = 0
     var saved = 0L
@@ -54,7 +65,7 @@ internal object AndroidResourcePruner {
         while (true) {
           val entry = zis.nextEntry ?: break
           val data = zis.readBytes()
-          if (shouldDrop(entry.name, moduleOwnFileResources)) {
+          if (shouldDrop(entry.name, firstPartyFileResources)) {
             dropped++
             saved += data.size.toLong()
             continue
@@ -78,20 +89,20 @@ internal object AndroidResourcePruner {
     return Result(out.toByteArray(), dropped, saved)
   }
 
-  private fun shouldDrop(entryName: String, moduleOwn: Set<String>): Boolean {
+  private fun shouldDrop(entryName: String, firstParty: Set<String>): Boolean {
     if (!entryName.startsWith("res/")) return false
     val rest = entryName.removePrefix("res/")
     val slash = rest.indexOf('/')
     if (slash < 0) return false
     val typeBase = rest.substring(0, slash).substringBefore('-')
     if (typeBase !in PRUNABLE_TYPE_BASES) return false
-    return "$typeBase/${resourceNameOf(rest.substring(slash + 1))}" !in moduleOwn
+    return "$typeBase/${resourceNameOf(rest.substring(slash + 1))}" !in firstParty
   }
 
   /**
    * Resource name from a packed file entry: drop the extension, and normalise AAPT-generated
    * animated-vector split names (`$base__12.xml`) back to their `base` so a module-authored
-   * animated vector is matched against [moduleOwnFileResources] and kept.
+   * animated vector is matched against [firstPartyFileResources] and kept.
    */
   internal fun resourceNameOf(fileName: String): String {
     val noExt = fileName.substringBefore('.')

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -202,6 +202,18 @@ abstract class BundlePreviewTask : DefaultTask() {
   @get:Internal abstract val moduleProjectDir: DirectoryProperty
 
   /**
+   * (v6 Android) The consumer module's **configured** build directory — where
+   * [MergedResourceOwnership] looks for AGP's resource-merge blame files. Wired from
+   * `project.layout.buildDirectory` rather than assumed to be `<moduleProjectDir>/build`, because a
+   * consumer is free to relocate it (a shared root-level build dir is the common case) and AGP
+   * writes `intermediates/incremental/**/merger.xml` wherever it actually points. Getting this
+   * wrong is silent: the blame lookup finds nothing, the retain-set quietly narrows to the
+   * module-own source scan, and the sibling drawables this task exists to keep get pruned again.
+   * `@Internal` for the same reason as [moduleProjectDir] — a resolution base, not carried content.
+   */
+  @get:Internal abstract val moduleBuildDir: DirectoryProperty
+
+  /**
    * Renders directory from the preceding `composePreviewRender` task. Each selected preview's PNG
    * is read from here: the cover is prepended to the polyglot, and every selected preview is baked
    * into `previews/<id>.png`. When missing or empty, the cover falls back to a stub gray PNG so the
@@ -981,10 +993,10 @@ abstract class BundlePreviewTask : DefaultTask() {
    * merged yet.
    */
   private fun firstPartyFileResourceKeys(): Set<String> {
+    val buildDir =
+      moduleBuildDir.asFile.orNull ?: moduleProjectDir.asFile.orNull?.let { File(it, "build") }
     val fromBlame =
-      moduleProjectDir.asFile.orNull?.let {
-        MergedResourceOwnership.firstPartyFileResourceKeys(File(it, "build"))
-      } ?: emptySet()
+      buildDir?.let { MergedResourceOwnership.firstPartyFileResourceKeys(it) } ?: emptySet()
     return fromBlame + moduleOwnSourceSetResourceKeys()
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -943,9 +943,10 @@ abstract class BundlePreviewTask : DefaultTask() {
     }
     // Drop merged-AAR file resources a Compose render never inflates (Wear gesture-animation
     // vectors, call icons, notification templates, …) before packing. The compiled `resources.arsc`
-    // is left byte-for-byte intact — this only stops shipping file bytes nothing resolves — and the
-    // module's own `res/` files are always retained. See [AndroidResourcePruner].
-    val prunedApk = AndroidResourcePruner.prune(apkFile.readBytes(), moduleOwnFileResourceKeys())
+    // is left byte-for-byte intact — this only stops shipping file bytes nothing resolves — and
+    // every file resource authored in this build (this module's AND its sibling project modules')
+    // is retained. See [AndroidResourcePruner] and [MergedResourceOwnership].
+    val prunedApk = AndroidResourcePruner.prune(apkFile.readBytes(), firstPartyFileResourceKeys())
     zipFiles[ANDROID_RESOURCE_APK_PATH] = prunedApk.bytes
     zipFiles[ANDROID_MERGED_MANIFEST_PATH] = manifestFile.readBytes()
     val rClassesJar = packAndroidRClasses()
@@ -966,12 +967,32 @@ abstract class BundlePreviewTask : DefaultTask() {
   }
 
   /**
-   * Resource identities (`"<typeBase>/<name>"`) the module authors in its own `src/<sourceSet>/res`
-   * — the file resources [AndroidResourcePruner] must retain (a catalog's own icons its code may
+   * Resource identities (`"<typeBase>/<name>"`) authored **anywhere in this build** — the file
+   * resources [AndroidResourcePruner] must retain (an icon the catalog's code may
    * `painterResource`) as opposed to the merged-dependency file resources it drops. `values`
    * directories are skipped: those compile into `resources.arsc`, which the pruner never touches.
+   *
+   * Two sources, unioned. [MergedResourceOwnership] reads AGP's merge-blame file and so covers the
+   * **sibling project modules** a real app's catalog renders against — Pocket Casts renders from
+   * `:modules:services:compose` while its icons live in `:modules:services:ui`, and pruning those
+   * left the live daemon throwing `NotFoundException: File res/drawable/ic_play.xml …` on the first
+   * `painterResource` (issue #3260). The `src/<sourceSet>/res` scan below is the fallback for when
+   * no blame file was written, and keeps this correct for a module whose own resources haven't been
+   * merged yet.
    */
-  private fun moduleOwnFileResourceKeys(): Set<String> {
+  private fun firstPartyFileResourceKeys(): Set<String> {
+    val fromBlame =
+      moduleProjectDir.asFile.orNull?.let {
+        MergedResourceOwnership.firstPartyFileResourceKeys(File(it, "build"))
+      } ?: emptySet()
+    return fromBlame + moduleOwnSourceSetResourceKeys()
+  }
+
+  /**
+   * Resource identities the module authors in its own `src/<sourceSet>/res`. The narrow half of
+   * [firstPartyFileResourceKeys] — see there for why it is no longer the whole retain-set.
+   */
+  private fun moduleOwnSourceSetResourceKeys(): Set<String> {
     val srcDir = moduleProjectDir.asFile.orNull?.let { File(it, "src") } ?: return emptySet()
     if (!srcDir.isDirectory) return emptySet()
     val keys = mutableSetOf<String>()

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -550,6 +550,11 @@ internal object ComposePreviewTasks {
       // (v6 Android) base dir for resolving test_config.properties' module-relative apk/manifest
       // paths. Harmless on desktop. See [BundlePreviewTask.moduleProjectDir].
       moduleProjectDir.set(project.layout.projectDirectory)
+      // Where AGP's resource-merge blame files actually land. Read from the layout rather than
+      // assumed to be `<projectDir>/build` — a consumer that relocates `buildDirectory` would
+      // otherwise silently lose the sibling-module retain-set. See
+      // [BundlePreviewTask.moduleBuildDir].
+      moduleBuildDir.set(project.layout.buildDirectory)
       backend.set(backendId)
       producedBy.set("compose-preview $pluginVersionProperty")
       output.set(project.layout.file(resolvedOutput))

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnership.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnership.kt
@@ -1,0 +1,176 @@
+package ee.schimke.composeai.plugin
+
+import java.io.File
+import javax.xml.stream.XMLInputFactory
+import javax.xml.stream.XMLStreamConstants
+
+/**
+ * Reads AGP's resource-merge blame file (`merger.xml`) to answer one question for
+ * [AndroidResourcePruner]: which merged file resources are **first-party** — authored somewhere in
+ * this Gradle build — as opposed to merged in from a third-party AAR.
+ *
+ * ## Why this exists
+ *
+ * The pruner's job is to drop the merged-**dependency** file resources a Compose render never
+ * inflates, and it needs a retain-set to protect everything else. That retain-set used to be "the
+ * rendering module's own `src/<sourceSet>/res`" (now only the fallback half of
+ * `BundlePreviewTask.firstPartyFileResourceKeys`), which is right only for a single-module catalog.
+ * A real app's catalog module renders composables whose icons live in **sibling project modules** —
+ * Pocket Casts renders from `:modules:services:compose` while `ic_play` / `ic_filters_play` live in
+ * `:modules:services:ui` — so every one of those was pruned, `resources.arsc` kept its now-dangling
+ * entry, and the live daemon's first `painterResource(...)` threw `NotFoundException: File
+ * res/drawable/ic_play.xml from xml type xml resource ID #0x7f080346` instead of rendering
+ * (issue #3260). The same over-prune took out `pocketcasts-wear`'s `splash_background`.
+ *
+ * Enumerating sibling projects from the plugin is not an option: this build keeps its plugin code
+ * Isolated-Projects-clean (see `gradle.properties`), and `rootProject.allprojects` is exactly the
+ * cross-project configuration IP rejects. AGP has already done the work for us, though — the
+ * resource merger writes every contributing data set, with provenance, into `merger.xml` under the
+ * **rendering module's own** build dir, so reading it involves no cross-project access at all.
+ *
+ * ## The discriminator
+ *
+ * Each `<dataSet>` carries a `config` attribute naming where it came from:
+ * - a bare **source-set name** — `main`, `debug`, `test` (and its `$Generated` twin) — for the
+ *   rendering module's own `src/<sourceSet>/res`: first-party;
+ * - a **Gradle project path** — `:modules:services:ui` — for every project module it depends on:
+ *   first-party;
+ * - a **Maven coordinate** — `androidx.cardview:cardview:1.0.0` — for an AAR: third-party.
+ *
+ * Only the last of those carries a `:` with something before it, so "contains a `:` that isn't the
+ * first character" identifies an AAR and nothing else. Everything we can't classify that way is
+ * treated as first-party: this is a retain-set, and the failure mode of retaining too much is a
+ * slightly larger bundle, while retaining too little is a dead render.
+ */
+internal object MergedResourceOwnership {
+
+  /**
+   * Resource identities (`"<typeBase>/<name>"`, e.g. `"drawable/ic_play"`) contributed by
+   * first-party data sets across every `merger.xml` under [moduleBuildDir], in the shape
+   * [AndroidResourcePruner.prune] expects. Empty when no blame file is present (a build that never
+   * merged resources, or a future AGP that stops writing them) — the caller then falls back to its
+   * own-source-set scan, i.e. exactly the pre-existing behaviour.
+   */
+  fun firstPartyFileResourceKeys(moduleBuildDir: File): Set<String> {
+    val keys = mutableSetOf<String>()
+    for (blame in blameFiles(moduleBuildDir)) {
+      runCatching { collectInto(keys, blame) }
+    }
+    return keys
+  }
+
+  /**
+   * The merge-blame files AGP wrote for this module, at
+   * `build/intermediates/incremental/<variant>/merge<Variant>Resources/merger.xml` (and the
+   * `…UnitTest…` variant the render actually runs against). The exact path is variant- and
+   * AGP-version-dependent, so walk for the filename rather than reconstructing it; there are a
+   * handful per module and each is read once.
+   */
+  private fun blameFiles(moduleBuildDir: File): List<File> {
+    val incremental = File(moduleBuildDir, "intermediates/incremental")
+    if (!incremental.isDirectory) return emptyList()
+    return incremental
+      .walkTopDown()
+      .maxDepth(BLAME_WALK_DEPTH)
+      .filter { it.isFile && it.name == BLAME_FILE_NAME }
+      .toList()
+  }
+
+  /**
+   * Stream [blame], adding a key for every `<file path="…"/>` that sits inside a first-party
+   * `<dataSet>`. Streaming (StAX) rather than DOM on purpose: a merger.xml for an app-sized module
+   * is megabytes of inlined `values` XML, and we only care about the element names and one
+   * attribute.
+   */
+  private fun collectInto(keys: MutableSet<String>, blame: File) {
+    val factory =
+      XMLInputFactory.newInstance().apply {
+        // Blame files are build output, not untrusted input, but a resource-merge XML never needs
+        // external entities or DTDs — refuse them rather than letting a malformed one reach out.
+        setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+        setProperty(XMLInputFactory.SUPPORT_DTD, false)
+      }
+    blame.inputStream().buffered().use { input ->
+      val reader = factory.createXMLStreamReader(input)
+      // Data sets don't nest, so a single "are we inside a first-party one" flag is enough; it is
+      // set on every <dataSet> open and consulted by the <file> entries that follow.
+      var firstParty = false
+      try {
+        while (reader.hasNext()) {
+          if (reader.next() != XMLStreamConstants.START_ELEMENT) continue
+          when (reader.localName) {
+            "dataSet" -> firstParty = isFirstParty(reader.getAttributeValue(null, "config"))
+            "file" ->
+              if (firstParty) {
+                // A single-file resource is written with its identity spelled out —
+                // `<file name="ic_play" path="…/res/drawable/ic_play.xml" type="drawable"/>` — so
+                // prefer those attributes and fall back to reading the path's type directory. A
+                // `values` file carries neither (its contents are the child elements), and is
+                // skipped either way: those compile into `resources.arsc`, which the pruner never
+                // touches.
+                val declared =
+                  declaredResourceKey(
+                    reader.getAttributeValue(null, "type"),
+                    reader.getAttributeValue(null, "name"),
+                  )
+                val key =
+                  declared ?: reader.getAttributeValue(null, "path")?.let { resourceKeyOf(it) }
+                key?.let(keys::add)
+              }
+          }
+        }
+      } finally {
+        reader.close()
+      }
+    }
+  }
+
+  /**
+   * Whether a `<dataSet config="…">` is authored in this build — everything except a Maven
+   * coordinate, which is the only config shape carrying a `:` with a group in front of it. That
+   * admits both a bare source-set name (`test`, the module's own `src/test/res`) and a Gradle
+   * project path (`:modules:services:ui`, a sibling module). An absent/blank config is first-party
+   * for the retain-set reason in the class kdoc. AGP appends `$Generated` to the config of a data
+   * set's generated twin, which changes none of this.
+   */
+  private fun isFirstParty(config: String?): Boolean {
+    val value = config?.trim().orEmpty()
+    return value.isEmpty() || value.startsWith(":") || !value.contains(':')
+  }
+
+  /**
+   * `"<typeBase>/<name>"` from a `<file>`'s own `type` / `name` attributes, or null when it doesn't
+   * carry them (a `values` file) — the qualifier-free type is what [AndroidResourcePruner.prune]'s
+   * retain-set is keyed by, so `type="drawable"` needs no normalising.
+   */
+  private fun declaredResourceKey(type: String?, name: String?): String? {
+    val typeBase = type?.trim()?.substringBefore('-').orEmpty()
+    val resourceName = name?.trim().orEmpty()
+    if (typeBase.isEmpty() || resourceName.isEmpty() || typeBase == "values") return null
+    return "$typeBase/$resourceName"
+  }
+
+  /**
+   * `"<typeBase>/<name>"` for a merged resource file path, or null when it isn't one we can key — a
+   * `values` file (those compile into `resources.arsc`, which the pruner never touches) or a path
+   * with no resource-type parent directory.
+   */
+  private fun resourceKeyOf(path: String): String? {
+    val normalized = path.replace('\\', '/')
+    val fileName = normalized.substringAfterLast('/')
+    val typeDir = normalized.substringBeforeLast('/', "").substringAfterLast('/')
+    if (fileName.isEmpty() || typeDir.isEmpty()) return null
+    val typeBase = typeDir.substringBefore('-')
+    if (typeBase.isEmpty() || typeBase == "values") return null
+    return "$typeBase/${AndroidResourcePruner.resourceNameOf(fileName)}"
+  }
+
+  private const val BLAME_FILE_NAME = "merger.xml"
+
+  /**
+   * `intermediates/incremental/<variant>/merge<Variant>Resources/merger.xml` is three levels below
+   * the walk root; a couple of levels of headroom absorbs AGP layout changes without turning this
+   * into a walk of the whole build directory.
+   */
+  private const val BLAME_WALK_DEPTH = 5
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidResourcePrunerTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidResourcePrunerTest.kt
@@ -56,7 +56,7 @@ class AndroidResourcePrunerTest {
       )
 
     val result =
-      AndroidResourcePruner.prune(input, moduleOwnFileResources = setOf("drawable/my_icon"))
+      AndroidResourcePruner.prune(input, firstPartyFileResources = setOf("drawable/my_icon"))
     val kept = entries(result.bytes)
 
     // Dropped: the four AAR file resources of prunable types (drawable, layout, mipmap).
@@ -82,7 +82,7 @@ class AndroidResourcePrunerTest {
         Triple("res/drawable/my_anim.xml", "Y".repeat(20).toByteArray(), ZipEntry.DEFLATED),
       )
     val result =
-      AndroidResourcePruner.prune(input, moduleOwnFileResources = setOf("drawable/my_anim"))
+      AndroidResourcePruner.prune(input, firstPartyFileResources = setOf("drawable/my_anim"))
     assertThat(result.droppedEntries).isEqualTo(0)
   }
 
@@ -94,7 +94,7 @@ class AndroidResourcePrunerTest {
         Triple("res/color/csl.xml", "C".toByteArray(), ZipEntry.DEFLATED),
         Triple("res/raw/data.json", "R".toByteArray(), ZipEntry.DEFLATED),
       )
-    val result = AndroidResourcePruner.prune(input, moduleOwnFileResources = emptySet())
+    val result = AndroidResourcePruner.prune(input, firstPartyFileResources = emptySet())
     assertThat(result.droppedEntries).isEqualTo(0)
     assertThat(result.bytesSaved).isEqualTo(0L)
   }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnershipTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnershipTest.kt
@@ -1,0 +1,179 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class MergedResourceOwnershipTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  /** Writes a blame file at the real AGP location so the walk is exercised, not just the parse. */
+  private fun writeBlame(variant: String, body: String): File {
+    val dir =
+      File(tmp.root, "build/intermediates/incremental/$variant/merge${variant}Resources").apply {
+        mkdirs()
+      }
+    return File(dir, "merger.xml").apply { writeText(body) }
+  }
+
+  private fun buildDir() = File(tmp.root, "build")
+
+  @Test
+  fun `keeps project-module resources and drops aar ones`() {
+    writeBlame(
+      "debugUnitTest",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <merger version="3">
+        <dataSet config="androidx.cardview:cardview:1.0.0">
+          <source path="/caches/transforms/abc/transformed/cardview-1.0.0/res">
+            <file path="/caches/transforms/abc/transformed/cardview-1.0.0/res/drawable/aar_bg.xml" qualifiers=""/>
+          </source>
+        </dataSet>
+        <dataSet config=":modules:services:ui">
+          <source path="/repo/modules/services/ui/build/intermediates/packaged_res/debug/out">
+            <file path="/repo/modules/services/ui/build/.../res/drawable/ic_play.xml" qualifiers=""/>
+            <file path="/repo/modules/services/ui/build/.../res/drawable-hdpi/ic_logo.png" qualifiers="hdpi"/>
+          </source>
+        </dataSet>
+      </merger>
+      """
+        .trimIndent(),
+    )
+
+    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+
+    assertThat(keys).containsAtLeast("drawable/ic_play", "drawable/ic_logo")
+    assertThat(keys).doesNotContain("drawable/aar_bg")
+  }
+
+  @Test
+  fun `treats the generated twin of a project data set as first-party`() {
+    writeBlame(
+      "debug",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <merger version="3">
+        <dataSet config=":modules:services:ui${'$'}Generated" generated="true">
+          <source path="/repo/generated/res">
+            <file path="/repo/generated/res/drawable/ic_generated.xml" qualifiers=""/>
+          </source>
+        </dataSet>
+        <dataSet config="androidx.core:core:1.0.0${'$'}Generated" generated="true">
+          <source path="/caches/transforms/x/res">
+            <file path="/caches/transforms/x/res/drawable/core_bg.xml" qualifiers=""/>
+          </source>
+        </dataSet>
+      </merger>
+      """
+        .trimIndent(),
+    )
+
+    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+
+    assertThat(keys).contains("drawable/ic_generated")
+    assertThat(keys).doesNotContain("drawable/core_bg")
+  }
+
+  @Test
+  fun `skips values files and normalises animated-vector split names`() {
+    writeBlame(
+      "debug",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <merger version="3">
+        <dataSet config=":app">
+          <source path="/repo/app/src/main/res">
+            <file path="/repo/app/src/main/res/values/strings.xml" qualifiers="">
+              <string name="app_name">Demo</string>
+            </file>
+            <file path="/repo/app/src/main/res/drawable/${'$'}avd_spin__0.xml" qualifiers=""/>
+          </source>
+        </dataSet>
+      </merger>
+      """
+        .trimIndent(),
+    )
+
+    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+
+    assertThat(keys).contains("drawable/avd_spin")
+    assertThat(keys.none { it.startsWith("values/") }).isTrue()
+  }
+
+  @Test
+  fun `unions every blame file under the module build dir`() {
+    writeBlame(
+      "debug",
+      """
+      <merger version="3"><dataSet config=":app"><source path="/a">
+        <file path="/a/drawable/from_debug.xml"/>
+      </source></dataSet></merger>
+      """
+        .trimIndent(),
+    )
+    writeBlame(
+      "debugUnitTest",
+      """
+      <merger version="3"><dataSet config=":app"><source path="/b">
+        <file path="/b/drawable/from_unit_test.xml"/>
+      </source></dataSet></merger>
+      """
+        .trimIndent(),
+    )
+
+    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+
+    assertThat(keys).containsAtLeast("drawable/from_debug", "drawable/from_unit_test")
+  }
+
+  /**
+   * The exact shapes AGP 9 writes, captured from a real `mergeDebugUnitTestResources` run: a
+   * single-file resource spells out `name`/`type`, and the module's OWN source set is configured by
+   * bare source-set name (`test`) rather than a project path — so "first-party" cannot just mean
+   * "starts with `:`".
+   */
+  @Test
+  fun `keeps a single-file resource from the module's own bare-named source set`() {
+    writeBlame(
+      "debugUnitTest",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <merger version="3">
+        <dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="test" generated-set="test${'$'}Generated">
+          <source path="/repo/daemon/android/src/test/res">
+            <file name="probe_icon" path="/repo/daemon/android/src/test/res/drawable/probe_icon.xml" qualifiers="" type="drawable"/>
+          </source>
+        </dataSet>
+        <dataSet config="androidx.cardview:cardview:1.0.0">
+          <source path="/caches/transforms/abc/res">
+            <file name="aar_bg" path="/caches/transforms/abc/res/drawable/aar_bg.xml" qualifiers="" type="drawable"/>
+          </source>
+        </dataSet>
+      </merger>
+      """
+        .trimIndent(),
+    )
+
+    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+
+    assertThat(keys).contains("drawable/probe_icon")
+    assertThat(keys).doesNotContain("drawable/aar_bg")
+  }
+
+  @Test
+  fun `returns empty when no blame file exists so the caller can fall back`() {
+    assertThat(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())).isEmpty()
+  }
+
+  @Test
+  fun `a malformed blame file yields no keys instead of failing the pack`() {
+    writeBlame("debug", "<merger><dataSet config=\":app\"><source path=\"/a\">")
+
+    // Truncated XML: whatever was parsed before the error is dropped, but the pack survives.
+    MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+  }
+}


### PR DESCRIPTION
Fixes the `pocketcasts` / `pocketcasts-wear` live-preview failures on preview.coo.ee:

```
input requires a live stream — unavailable: UnsupportedOperationException:
RobolectricHost.acquireInteractiveSession failed for
previewId='…buttons.TimePlayButtonKt.TimePlayButtonPreview':
NotFoundException: File res/drawable/ic_play.xml from xml type xml resource ID #0x7f080346
```

## What's wrong

`AndroidResourcePruner` drops merged `drawable`/`layout`/`anim`/`animator`/`mipmap` file resources from a bundle's `android/resources.ap_`, protected by a retain-set. That retain-set was the **rendering module's own `src/<sourceSet>/res`** only — correct for a single-module catalog like `:samples:design-catalog-wear-m3`, wrong for an app. Pocket Casts renders from `:modules:services:compose` while `ic_play` / `ic_filters_play` live in sibling project modules, so all of them were pruned while `resources.arsc` kept the now-dangling entries.

Confirmed against the published bundle (`design-artifacts/pocketcasts` → `bundle/bundle.png`):

```
res/ entries in resources.ap_, by type:
  color 225 · color-v31 35 · interpolator 20 · xml 10 · color-v23 9 · raw 8 · font 3 · color-night-v8 3
  res/drawable/**: 0

resources.arsc still names: res/drawable/ic_play.xml, res/drawable/ic_filters_play.xml, 60+ more
```

Reproduced end-to-end by driving that exact published bundle through the Android daemon locally (`compose-preview bundle render`), which throws the same failure on a different icon of the same catalog:

```
NotFoundException: File res/drawable/ic_plus.xml from xml type xml resource ID #0x7f080354
```

The pruner's kdoc claimed an over-prune degrades gracefully. It does not: `PlaceholderFallbackResources` wraps `getText` / `getColor` / dimensions / every `getDrawable*` overload, but Compose resolves a vector drawable through `Resources.getValue` + `getXml` — which that class's own kdoc lists as uncovered — so the miss aborts the whole render rather than drawing a magenta box. The kdoc is corrected here to say so.

## The fix

Derive the retain-set from AGP's resource-merge blame file (`merger.xml`) instead. Each `<dataSet config=…>` names its contributor:

| config shape | example | verdict |
| --- | --- | --- |
| bare source-set name | `test`, `main` | first-party (module's own res) |
| Gradle project path | `:modules:services:ui` | first-party (sibling module) |
| Maven coordinate | `androidx.cardview:cardview:1.0.0` | third-party AAR → prunable |

A config carrying a `:` with a group in front of it is the only prunable shape, so the AAR payload the pruner exists to drop still gets dropped. The blame file sits under the **rendering module's own** build dir, so this needs no cross-project access and keeps the plugin Isolated-Projects-clean — unlike enumerating `rootProject.allprojects`, which IP rejects (see `gradle.properties`). The old source-set scan stays as the fallback when no blame file was written.

Both real AGP 9 shapes were captured from an actual `mergeDebugUnitTestResources` run rather than guessed — a single-file resource is written as `<file name="probe_icon" path="…/res/drawable/probe_icon.xml" qualifiers="" type="drawable"/>`, and the module's own source set is configured as `config="test"`, which is why "first-party" can't just mean "starts with `:`".

## Test plan

- `:gradle-plugin:test` — green. 7 new `MergedResourceOwnershipTest` cases (project module vs AAR, `$Generated` twins, bare source-set config with the real `name`/`type` attribute shape, `values` skipping, animated-vector split-name normalisation, multi-blame union, absent/malformed blame files) plus the 4 existing `AndroidResourcePrunerTest` cases with the renamed parameter.
- `:gradle-plugin:ktfmtCheck` — green.

Text-only evidence is right here: this changes bundle packing, not rendered output. The visible effect is previews that render at all instead of failing, and that only shows once a republished catalog carries the un-pruned drawables.

## Known gaps, not fixed here

- **No functional-test coverage** that a sibling-module drawable survives the pack. The existing Android bundle e2e tests consume prebuilt sample bundles, and no sample here has a sibling module authoring a drawable. Worth closing so this can't silently regress.
- **`NoSuchMethodException: …TimePlayButtonKt.TimePlayButtonPreview`**, the other failure on that catalog, is untouched. It reproduced locally but *contaminated*: this container can't resolve the private `com.automattic:eventhorizon` dependency, so `Theme$ThemeType` fails static init, the `@PreviewParameter` provider can't load, and resolution falls back to the parameterless overload. The server has that dependency, so its cause may well be different. Needs its own investigation rather than a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkHoMsR91y2SukvgjkCwz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkHoMsR91y2SukvgjkCwz1)_