### PR TITLE
perf(serve): open a catalog's daemon on first use, not at registration

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -422,16 +422,21 @@ class ServeCatalogLiveHost(
     if (perPreviewResolve != null && !sharedDaemonRenders) 5 else 1
 
   /** The gesture override is honoured by the daemon lane, if that daemon is Android-backed. */
-  override val gesturesRenderable: Boolean = live.gesturesRenderable
+  // The four capability flags below are `by lazy` for one reason: reading them forces the daemon
+  // session open. `ServeRenderHost` defers its subprocess to first use so a registered catalog
+  // costs nothing until someone needs a live render — and an eager `val` here would have undone
+  // that at construction, which is exactly where every catalog builds its host. The browse surface
+  // never touches them; the viewer chrome that does is already a per-preview request.
+  override val gesturesRenderable: Boolean by lazy { live.gesturesRenderable }
 
   /**
    * SVG is exportable when either lane can produce it — the baked catalog carries
    * `figma/<slug>.svg` vectors, and the daemon exports a `compose/figma-svg` for a knob-bearing
    * render.
    */
-  override val hasSvgExport: Boolean = baked.hasSvgExport || live.hasSvgExport
+  override val hasSvgExport: Boolean by lazy { baked.hasSvgExport || live.hasSvgExport }
 
-  override val hasScrollExport: Boolean = live.hasScrollExport
+  override val hasScrollExport: Boolean by lazy { live.hasScrollExport }
 
   override fun hasScrollExportFor(previewId: String): Boolean =
     previewId in alias && live.hasScrollExportFor(alias.getValue(previewId))
@@ -559,7 +564,7 @@ class ServeCatalogLiveHost(
     baked.remoteComposeRenderSpec(previewId)
 
   /** The daemon lane honours the RC player override when the carried daemon is Android-backed. */
-  override val remoteComposePlayerSelectable: Boolean = live.remoteComposePlayerSelectable
+  override val remoteComposePlayerSelectable: Boolean by lazy { live.remoteComposePlayerSelectable }
 
   /**
    * The RC backend selector unions the two lanes: the client-side [RcPlayerBackend.JS] canvas

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -275,7 +275,18 @@ sealed interface SlotsOutcome {
  */
 class ServeRenderHost
 internal constructor(
-  private val session: RenderSession,
+  /**
+   * Opens the daemon session — called **once, on first use**, not at construction.
+   *
+   * Spawning here rather than in [Companion.open] is what keeps a registered catalog from costing a
+   * JVM nobody asked for. Every catalog registers its live host at startup and again on each
+   * republish, so an eager spawn meant ~18 daemons resident on the public box with zero active
+   * streams and the live-seat budget reading fully free. Everything the browse surface needs
+   * ([previews], [label], [declaredThemes]) comes from the module manifest via the constructor, so
+   * a visitor can browse a catalog end-to-end without waking anything; the first request that
+   * genuinely needs the daemon forces it.
+   */
+  openSession: () -> RenderSession,
   override val previews: List<ServePreview>,
   /** Human label for this tenant (e.g. the module's Gradle path); shown in the served pages. */
   override val label: String = "",
@@ -287,6 +298,52 @@ internal constructor(
   private val frameRenderTimeoutSeconds: Long = FRAME_RENDER_TIMEOUT_SECONDS,
 ) : ServeHost {
 
+  /**
+   * Wrap an already-open session. Nothing is deferred — the session exists — but the lazies below
+   * are shared with the deferred path, so their RPCs fire on first access rather than here.
+   */
+  internal constructor(
+    session: RenderSession,
+    previews: List<ServePreview>,
+    label: String = "",
+    declaredThemes: List<ServeTheme> = emptyList(),
+    fileSystem: FileSystem = SystemFileSystem,
+    onLog: (String) -> Unit = {},
+    renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
+    frameRenderTimeoutSeconds: Long = FRAME_RENDER_TIMEOUT_SECONDS,
+  ) : this(
+    { session },
+    previews,
+    label,
+    declaredThemes,
+    fileSystem,
+    onLog,
+    renderTimeoutSeconds,
+    frameRenderTimeoutSeconds,
+  )
+
+  /**
+   * Registered inside [sessionDelegate]'s initializer rather than as its own lazy, so it is always
+   * hooked up before any caller can issue a render — a `renderFinished` that arrived before the
+   * listener existed would strand that render waiting for an event already delivered.
+   */
+  private var notificationHandle: AutoCloseable? = null
+
+  private val sessionDelegate = lazy {
+    val opened = openSession()
+    notificationHandle = opened.onNotification(::onDaemonNotification)
+    opened
+  }
+
+  private val session: RenderSession by sessionDelegate
+
+  /**
+   * Whether the daemon subprocess has actually been started. Lets `/status` and [close] reason
+   * about a host that is registered but never woken, without waking it to find out.
+   */
+  internal val sessionStarted: Boolean
+    get() = sessionDelegate.isInitialized()
+
   // A daemon backs this host, so an override edit actually re-renders (unlike a static bundle).
   override val canApplyOverrides: Boolean = true
 
@@ -297,7 +354,7 @@ internal constructor(
   // `hasSvgExport` on whether the daemon actually has them (a backend without figma-svg reports
   // them in `unknown`), so a non-figma backend cleanly offers no SVG rather than dead-ending in a
   // 500. Best-effort: an enable RPC failure disables the export, it doesn't break the host.
-  private val exportEnableResult: ExtensionsEnableResult =
+  private val exportEnableResult: ExtensionsEnableResult by lazy {
     runCatching {
         session.enableExtensions(
           listOf(ComposeFigmaSvgProduct.KIND, ComposeFigmaSvgProduct.KIND_LONG, SCROLL_EXTENSION_ID)
@@ -314,12 +371,16 @@ internal constructor(
             )
         )
       }
+  }
 
-  override val hasSvgExport: Boolean = ComposeFigmaSvgProduct.KIND !in exportEnableResult.unknown
+  override val hasSvgExport: Boolean by lazy {
+    ComposeFigmaSvgProduct.KIND !in exportEnableResult.unknown
+  }
 
-  override val hasScrollExport: Boolean =
+  override val hasScrollExport: Boolean by lazy {
     SCROLL_EXTENSION_ID !in exportEnableResult.unknown &&
       exportEnableResult.dataProducts.any { it.kind == SCROLL_LONG_KIND }
+  }
 
   override fun hasScrollExportFor(previewId: String): Boolean =
     hasScrollExport &&
@@ -329,16 +390,18 @@ internal constructor(
   // The one-handed gesture override is honoured only by the Android (Robolectric) backend — the
   // desktop backend ignores `overrides.gestures`. Read the daemon's advertised capabilities so the
   // viewer offers the "Show gesture hints" control only when it would actually re-render.
-  override val gesturesRenderable: Boolean =
+  override val gesturesRenderable: Boolean by lazy {
     "gestures" in session.initializeResult.capabilities.supportedOverrides
+  }
 
   // The Remote Compose `player` override (VIEW ⇄ EMBEDDED server-side player) is meaningful only on
   // the Android backend, which is the only one carrying the Remote Compose runtime — the desktop
   // backend has no runtime and ignores it. Read the daemon's declared backend so the viewer offers
   // the server-side java / cmp-android backend chips only where they actually re-render.
-  override val remoteComposePlayerSelectable: Boolean =
+  override val remoteComposePlayerSelectable: Boolean by lazy {
     session.initializeResult.capabilities.backend ==
       ee.schimke.composeai.daemon.protocol.BackendKind.ANDROID
+  }
 
   /**
    * A daemon-backed host offers the server-side [RcPlayerBackend.JAVA] /
@@ -443,20 +506,25 @@ internal constructor(
   private val broadcast = ServeBroadcastHub(::startStream)
 
   private val closed = AtomicBoolean(false)
-  private val notificationHandle: AutoCloseable = session.onNotification { method, params ->
-    if (params == null) return@onNotification
+
+  /**
+   * Daemon render lifecycle events. A method rather than an inline lambda so [sessionDelegate] can
+   * register it the instant the session opens — see [notificationHandle].
+   */
+  private fun onDaemonNotification(method: String, params: JsonObject?) {
+    if (params == null) return
     val isFinished = method == "renderFinished"
     val isFailed = method == "renderFailed"
-    if (!isFinished && !isFailed) return@onNotification
-    val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
+    if (!isFinished && !isFailed) return
+    val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return
     // Drain the late event of a previously timed-out render (FIFO: it arrives before the current
     // render's own event) so it can't complete a fresh same-id render's latch with a stale PNG.
     // Either terminal event drains — the daemon owes exactly one (finished OR failed) per render.
     if ((staleRenders[id] ?: 0) > 0) {
       staleRenders.compute(id) { _, v -> ((v ?: 0) - 1).takeIf { it > 0 } }
-      return@onNotification
+      return
     }
-    if (id != pendingPreviewId.get()) return@onNotification
+    if (id != pendingPreviewId.get()) return
     if (isFinished) {
       // `unchanged` renders still carry a (re-used) pngPath, so this captures bytes either way.
       params["pngPath"]?.jsonPrimitive?.contentOrNull?.let { pendingPngPath.set(it) }
@@ -1039,8 +1107,13 @@ internal constructor(
 
   override fun close() {
     if (!closed.compareAndSet(false, true)) return
+    // A host that was never used has no subprocess to tear down — and touching `session` here would
+    // spawn one only to kill it, which on an Android backend is tens of seconds of pure waste. This
+    // is the common case now that catalogs register without opening: a republish closes and
+    // replaces every host, most of which nobody visited.
+    if (!sessionDelegate.isInitialized()) return
     try {
-      notificationHandle.close()
+      notificationHandle?.close()
     } catch (_: Exception) {
       // best effort
     }
@@ -1097,7 +1170,10 @@ internal constructor(
     /**
      * Open a long-lived session against a daemon launch descriptor and wrap it. Mirrors
      * [ee.schimke.composeai.cli.MatrixRenderFetcher] config; the caller supplies the servable
-     * [previews] read from the module manifest. Throws [RenderSessionException] on open failure.
+     * [previews] read from the module manifest.
+     *
+     * Does NOT spawn the daemon — the session opens on first use, so [RenderSessionException] now
+     * surfaces at the first request that needs it rather than here.
      */
     fun open(
       descriptorPath: File,
@@ -1109,17 +1185,15 @@ internal constructor(
       onLog: (String) -> Unit = {},
       factory: RenderSessionFactory = SubprocessRenderSessions,
     ): ServeRenderHost {
-      val session =
-        factory.open(
-          RenderSessionConfig(
-            descriptorPath = descriptorPath,
-            workspaceRoot = workspaceRoot.absoluteFile,
-            workspaceName = workspaceName.ifBlank { workspaceRoot.name },
-            logSink = onLog,
-          )
+      val config =
+        RenderSessionConfig(
+          descriptorPath = descriptorPath,
+          workspaceRoot = workspaceRoot.absoluteFile,
+          workspaceName = workspaceName.ifBlank { workspaceRoot.name },
+          logSink = onLog,
         )
       return ServeRenderHost(
-        session = session,
+        openSession = { factory.open(config) },
         previews = previews,
         label = label,
         declaredThemes = declaredThemes,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostLazyOpenTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostLazyOpenTest.kt
@@ -1,0 +1,120 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionFactory
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A registered catalog must not cost a JVM.
+ *
+ * Every catalog registers its live host at startup and again on each republish. While `open`
+ * spawned the daemon subprocess eagerly, that meant ~18 resident daemons on the public box with
+ * zero active streams — and because a prewarm never takes a live seat, the seat limiter reported
+ * itself fully free the whole time, so nothing could even see the over-commitment. Browsing a
+ * catalog needs nothing from the daemon (previews, label and themes all come from the module
+ * manifest), so the spawn belongs at first real use.
+ */
+class ServeRenderHostLazyOpenTest {
+
+  private class CountingFactory : RenderSessionFactory {
+    val opened = AtomicInteger(0)
+    lateinit var lastRoot: File
+
+    override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+    override fun open(config: RenderSessionConfig): RenderSession {
+      opened.incrementAndGet()
+      lastRoot = Files.createTempDirectory("lazy-open").toFile()
+      return FakeRenderSession(lastRoot)
+    }
+  }
+
+  private fun host(factory: CountingFactory): ServeRenderHost =
+    ServeRenderHost.open(
+      descriptorPath = File("descriptor.json"),
+      workspaceRoot = Files.createTempDirectory("lazy-open-ws").toFile(),
+      workspaceName = "w",
+      previews = listOf(ServePreview("Red", "Red")),
+      label = ":sample",
+      declaredThemes = listOf(ServeTheme(name = "Brand", providerFqn = "com.example.Brand")),
+      factory = factory,
+    )
+
+  @Test
+  fun `opening a host does not spawn the daemon`() {
+    val factory = CountingFactory()
+    host(factory)
+    assertEquals(0, factory.opened.get(), "the subprocess must wait for a caller that needs it")
+  }
+
+  @Test
+  fun `the browse surface answers without waking the daemon`() {
+    // What the landing grid and the catalog's own metadata are built from. All of it arrives
+    // through the constructor from the module manifest, so a visitor can browse a catalog nobody
+    // has rendered on and the daemon stays unspawned.
+    val factory = CountingFactory()
+    val host = host(factory)
+
+    assertEquals(listOf("Red"), host.previews.map { it.id })
+    assertEquals(":sample", host.label)
+    assertEquals(listOf("Brand"), host.declaredThemes.map { it.name })
+    assertTrue(host.canApplyOverrides)
+
+    assertEquals(0, factory.opened.get())
+  }
+
+  @Test
+  fun `a render spawns the daemon exactly once`() {
+    val factory = CountingFactory()
+    val host = host(factory)
+
+    repeat(3) { host.render("Red", ee.schimke.composeai.daemon.protocol.PreviewOverrides()) }
+
+    assertEquals(1, factory.opened.get(), "the session is opened once and reused")
+  }
+
+  @Test
+  fun `closing an unused host spawns nothing`() {
+    // The common case once registration is lazy: a republish closes and replaces every catalog's
+    // host, and most were never visited. Waking each one only to kill it would cost more than the
+    // eager spawn this change removes — tens of seconds apiece on an Android backend.
+    val factory = CountingFactory()
+    val host = host(factory)
+
+    host.close()
+
+    assertEquals(0, factory.opened.get())
+  }
+
+  @Test
+  fun `wrapping the host in a catalog composite still spawns nothing`() {
+    // `ServeCatalogLiveHost` is what every registered catalog actually builds, and it used to read
+    // four daemon capability flags into eager vals at construction — which would force the session
+    // open right back at registration and undo all of the above.
+    val factory = CountingFactory()
+    val live = host(factory)
+    val baked =
+      ServeRenderHost(
+        session = FakeRenderSession(Files.createTempDirectory("baked").toFile()),
+        // The baked lane keys by CATALOG id; the alias maps it to the daemon's own id.
+        previews = listOf(ServePreview("red", "Red")),
+        label = "baked",
+        renderTimeoutSeconds = 30,
+      )
+
+    val composite = ServeCatalogLiveHost(mapOf("red" to "Red"), live, baked)
+
+    assertEquals(listOf("red"), composite.previews.map { it.id })
+    assertEquals(0, factory.opened.get(), "building the composite must not wake the daemon")
+
+    composite.close()
+    assertEquals(0, factory.opened.get(), "closing an unused composite must not wake it either")
+  }
+}


### PR DESCRIPTION
## Why

#3258 made the catalog *warm* opt-in, but the warm was never what spawned the JVM. `ServeRenderHost.open` called `factory.open(...)` itself, so the subprocess existed before `prewarm()` was ever reached. Codex flagged this on that PR and I confirmed it by reading the code; the PR body was corrected but the code wasn't.

Measured on the public box at 77 minutes uptime:

```
daemons: known 18, running 17, activeStreams 0
liveSeatsTotal 8, liveSeatsAvailable 8
```

Seventeen resident JVMs, nothing streaming, and the seat limiter reporting itself completely free — a prewarm never takes a seat, so nothing could even observe the over-commitment. Individual daemon uptimes were 1300–2000s, well past the 10-minute idle reaper. And since every republish closes and rebuilds a catalog's host (`catalogRefreshSeconds: 600`), the churn repeats rather than settling: `meshcore-mobile` and `wear-m3` both showed ~100s uptimes right after their catalogs republished.

## What

Nothing on the browse path needs the daemon — `previews`, `label` and `declaredThemes` all arrive through the constructor from the module manifest. So the session moves behind a `lazy` and the first caller that genuinely needs it pays.

- **`ServeRenderHost`** takes `openSession: () -> RenderSession` and holds `session by sessionDelegate`. The existing direct-session constructor is kept as a secondary, so the ~19 test call sites are untouched.
- **The notification listener registers inside that initializer**, not as its own `lazy` — a `renderFinished` arriving before the listener existed would strand a render waiting on an event already delivered.
- **Four capability flags become lazy in *both* hosts**: `hasSvgExport`, `hasScrollExport`, `gesturesRenderable`, `remoteComposePlayerSelectable`. Reading any of them is a session touch, and `ServeCatalogLiveHost` read all four into eager vals at construction — which is exactly where every catalog builds its host, so leaving them would have re-forced the spawn at registration and undone the change entirely.
- **`close()` returns early on an unopened session.** That is now the common case: a republish replaces every catalog's host and most were never visited, so waking each one only to kill it would cost more than the eager spawn being removed — tens of seconds apiece on an Android backend.

## Consequence worth stating

`ServeRenderHost.open` no longer throws on a bad descriptor or a failed handshake, because it no longer performs one. Those surface at the first request that needs the daemon rather than at registration, where `ServeCommand.openHost`'s `runCatching { … }.onFailure { daemonLog.record(…) }` used to catch them. A catalog with a broken daemon now registers as live and degrades on first live render — falling back to baked pixels via the `NotFound` path added in #3264 — instead of being caught up front. That is the necessary price of not spawning to find out, but it does move a startup-visible failure to a request-visible one.

## Test plan

New `ServeRenderHostLazyOpenTest`, using a counting `RenderSessionFactory`:

- `open()` spawns nothing
- the browse surface (`previews` / `label` / `declaredThemes` / `canApplyOverrides`) answers with zero spawns
- three renders spawn exactly once
- closing an unused host spawns nothing
- wrapping in `ServeCatalogLiveHost` — what every registered catalog actually builds — still spawns nothing, and closing the composite doesn't either

`./gradlew :cli:test --tests '*Serve*'` green; `:cli:test --tests '*BundleRenderKnob*'` green; `ktfmtCheck` clean.

**Not measured on the box yet.** The claim this change is really making is that `daemons.running` tracks visitors instead of catalog count, and that needs a deploy to confirm. Current baseline to compare against is 17 running / 18 known at idle.

Text-only by design: no rendering code, no visual surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_