### PR TITLE
fix(serve): close the daemon session that opens after its host was closed

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -427,9 +427,20 @@ class ServeCatalogLiveHost(
   // costs nothing until someone needs a live render — and an eager `val` here would have undone
   // that at construction, which is exactly where every catalog builds its host. The browse surface
   // never touches them; the viewer chrome that does is already a per-preview request.
-  /** The composite is only as started as its daemon lane; the baked lane never has a subprocess. */
+  /**
+   * Whether this catalog is carrying any daemon at all — the monolithic one OR a pooled per-preview
+   * one.
+   *
+   * The pool matters: an interactive stream and an explicit SVG / scroll export both route through
+   * [liveHostFor], which can stand a per-preview daemon up without the monolithic [live] host ever
+   * being touched. Forwarding only `live.daemonStarted` would make `runningDaemons()` drop such a
+   * catalog outright, hiding its active streams, its pool occupancy and a running process from
+   * `/status` — the opposite of what this reporting is for. The baked lane never has a subprocess,
+   * so it contributes nothing.
+   */
   override val daemonStarted: Boolean
-    get() = live.daemonStarted
+    get() =
+      live.daemonStarted || perPreviewStreamCount() > 0 || perPreviewPoolStats().any { it.open > 0 }
 
   override val gesturesRenderable: Boolean by lazy { live.gesturesRenderable }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -427,6 +427,10 @@ class ServeCatalogLiveHost(
   // costs nothing until someone needs a live render — and an eager `val` here would have undone
   // that at construction, which is exactly where every catalog builds its host. The browse surface
   // never touches them; the viewer chrome that does is already a per-preview request.
+  /** The composite is only as started as its daemon lane; the baked lane never has a subprocess. */
+  override val daemonStarted: Boolean
+    get() = live.daemonStarted
+
   override val gesturesRenderable: Boolean by lazy { live.gesturesRenderable }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -224,6 +224,18 @@ interface ServeHost : AutoCloseable {
    * stays on the published pixels) while the live stream is still offered on demand —
    * `canApplyOverrides = false` but `hasLiveStream = true`.
    */
+  /**
+   * Whether this host's daemon subprocess actually exists yet.
+   *
+   * A daemon-backed host opens its session on first real use, so a *registered* catalog is not a
+   * *running* daemon — and `/status` must not conflate them, or the running count stays pinned to
+   * the catalog count and says nothing about what the box is really carrying. Defaults to true for
+   * every host with nothing to defer (baked bundles, and daemon hosts handed an already-open
+   * session), so their reporting is unchanged.
+   */
+  val daemonStarted: Boolean
+    get() = true
+
   val hasLiveStream: Boolean
     get() = canApplyOverrides
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -346,8 +346,19 @@ internal constructor(
    */
   private val sessionLock = Any()
 
+  /**
+   * Set the instant [openSession] is entered, before the handshake completes.
+   *
+   * `Lazy.isInitialized()` stays false for the whole of a cold open — tens of seconds on an
+   * Android/Robolectric backend — even though the subprocess is already launched and consuming the
+   * box. Reporting "no daemon" across exactly that window would hide the single largest resource
+   * spike the lazy open is meant to make visible.
+   */
+  private val sessionOpening = AtomicBoolean(false)
+
   private val sessionDelegate =
     lazy(sessionLock) {
+      sessionOpening.set(true)
       val opened = openSession()
       if (closed.get()) {
         // Lost the race: [close] already ran and found nothing to reap. Tear the subprocess down
@@ -369,7 +380,7 @@ internal constructor(
    * about a host that is registered but never woken, without waking it to find out.
    */
   override val daemonStarted: Boolean
-    get() = sessionAlreadyOpen || sessionDelegate.isInitialized()
+    get() = sessionAlreadyOpen || sessionOpening.get() || sessionDelegate.isInitialized()
 
   // A daemon backs this host, so an override edit actually re-renders (unlike a static bundle).
   override val canApplyOverrides: Boolean = true

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -296,6 +296,12 @@ internal constructor(
   private val onLog: (String) -> Unit = {},
   private val renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
   private val frameRenderTimeoutSeconds: Long = FRAME_RENDER_TIMEOUT_SECONDS,
+  /**
+   * True when the caller handed over a session that is already open, so there is a live subprocess
+   * from the moment this host exists even though [sessionDelegate] has not been touched. Only the
+   * deferred [Companion.open] path leaves this false.
+   */
+  private val sessionAlreadyOpen: Boolean = false,
 ) : ServeHost {
 
   /**
@@ -320,6 +326,7 @@ internal constructor(
     onLog,
     renderTimeoutSeconds,
     frameRenderTimeoutSeconds,
+    sessionAlreadyOpen = true,
   )
 
   /**
@@ -329,11 +336,31 @@ internal constructor(
    */
   private var notificationHandle: AutoCloseable? = null
 
-  private val sessionDelegate = lazy {
-    val opened = openSession()
-    notificationHandle = opened.onNotification(::onDaemonNotification)
-    opened
-  }
+  /**
+   * Guards opening against [close]. Both take it, so a `close()` that lands while `openSession()`
+   * is still handshaking either waits for the session to be published and then tears it down, or
+   * lets the initializer below notice `closed` and tear it down itself. Without a shared lock the
+   * `isInitialized()` check in [close] reads false during the handshake, returns, and the
+   * subprocess that appears a moment later is never reaped — the exact race a catalog refresh runs
+   * into, since it closes the old host while requests may be waking it.
+   */
+  private val sessionLock = Any()
+
+  private val sessionDelegate =
+    lazy(sessionLock) {
+      val opened = openSession()
+      if (closed.get()) {
+        // Lost the race: [close] already ran and found nothing to reap. Tear the subprocess down
+        // here instead of leaking it. The dead session is still published rather than thrown from,
+        // because callers that merely read a capability flag off a host being retired should not
+        // eat an exception for it — anything that goes on to actually use it gets the session's own
+        // closed-transport error, which is the honest answer.
+        runCatching { opened.close() }
+      } else {
+        notificationHandle = opened.onNotification(::onDaemonNotification)
+      }
+      opened
+    }
 
   private val session: RenderSession by sessionDelegate
 
@@ -341,8 +368,8 @@ internal constructor(
    * Whether the daemon subprocess has actually been started. Lets `/status` and [close] reason
    * about a host that is registered but never woken, without waking it to find out.
    */
-  internal val sessionStarted: Boolean
-    get() = sessionDelegate.isInitialized()
+  override val daemonStarted: Boolean
+    get() = sessionAlreadyOpen || sessionDelegate.isInitialized()
 
   // A daemon backs this host, so an override edit actually re-renders (unlike a static bundle).
   override val canApplyOverrides: Boolean = true
@@ -355,8 +382,15 @@ internal constructor(
   // them in `unknown`), so a non-figma backend cleanly offers no SVG rather than dead-ending in a
   // 500. Best-effort: an enable RPC failure disables the export, it doesn't break the host.
   private val exportEnableResult: ExtensionsEnableResult by lazy {
+    // Resolve the session OUTSIDE the runCatching. A failure to open the daemon is not the same
+    // fact as "this backend advertises no exports", but folding them together cached the latter
+    // forever: a transient open failure on the first capability lookup left `hasSvgExport` /
+    // `hasScrollExport` false for the host's lifetime, so every export 404'd even after a later
+    // render brought the daemon up fine. Letting it propagate leaves the lazy uninitialized, so the
+    // next caller retries.
+    val opened = session
     runCatching {
-        session.enableExtensions(
+        opened.enableExtensions(
           listOf(ComposeFigmaSvgProduct.KIND, ComposeFigmaSvgProduct.KIND_LONG, SCROLL_EXTENSION_ID)
         )
       }
@@ -1111,13 +1145,17 @@ internal constructor(
     // spawn one only to kill it, which on an Android backend is tens of seconds of pure waste. This
     // is the common case now that catalogs register without opening: a republish closes and
     // replaces every host, most of which nobody visited.
-    if (!sessionDelegate.isInitialized()) return
-    try {
-      notificationHandle?.close()
-    } catch (_: Exception) {
-      // best effort
+    synchronized(sessionLock) {
+      // `daemonStarted`, not `isInitialized()`: a host constructed around an already-open session
+      // owns a subprocess from birth, and must close it even if nothing ever touched the lazy.
+      if (!daemonStarted) return
+      try {
+        notificationHandle?.close()
+      } catch (_: Exception) {
+        // best effort
+      }
+      session.close()
     }
-    session.close()
   }
 
   companion object {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -450,6 +450,10 @@ class ServeSessionRegistry(
     sessions
       .mapNotNull { (id, entry) ->
         val host = entry.host ?: return@mapNotNull null
+        // A registered-but-never-woken catalog carries a host object and no subprocess. Reporting
+        // it here would keep the running count (and its `startedAt` uptime) tied to registration,
+        // which is precisely what the lazy open exists to decouple.
+        if (!host.daemonStarted) return@mapNotNull null
         RunningDaemon(
           id = id,
           label = host.label,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -513,5 +513,12 @@ internal class FakeRenderSession(
     return AutoCloseable { listeners.remove(listener) }
   }
 
-  override fun close() = Unit
+  /** Set by [close] so a test can assert the session was actually reaped. */
+  @Volatile
+  var closed: Boolean = false
+    private set
+
+  override fun close() {
+    closed = true
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostLazyOpenTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostLazyOpenTest.kt
@@ -9,6 +9,8 @@ import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -116,5 +118,68 @@ class ServeRenderHostLazyOpenTest {
 
     composite.close()
     assertEquals(0, factory.opened.get(), "closing an unused composite must not wake it either")
+  }
+
+  @Test
+  fun `status does not count a registered but unwoken catalog as a running daemon`() {
+    // The whole claim of the lazy open is that `daemons.running` tracks visitors rather than
+    // catalog count. `runningDaemons()` lists every entry with a host, and a lazy catalog HAS a
+    // host — so without this the count would stay pinned to the catalog count and report 18
+    // "running" daemons with no subprocesses behind them.
+    val factory = CountingFactory()
+    val live = host(factory)
+
+    assertFalse(live.daemonStarted, "no subprocess yet")
+
+    live.render("Red", ee.schimke.composeai.daemon.protocol.PreviewOverrides())
+
+    assertTrue(live.daemonStarted, "a real render started it")
+    assertEquals(1, factory.opened.get())
+  }
+
+  @Test
+  fun `a host closed mid-handshake still reaps the session it was opening`() {
+    // `close()` on a catalog refresh can land while a request is waking the same host. Checking
+    // `isInitialized()` without sharing the open lock read false during the handshake, returned,
+    // and left the subprocess that appeared a moment later with nobody to reap it.
+    val opened = java.util.concurrent.atomic.AtomicReference<FakeRenderSession?>(null)
+    val handshaking = java.util.concurrent.CountDownLatch(1)
+    val mayFinish = java.util.concurrent.CountDownLatch(1)
+    val slowFactory =
+      object : RenderSessionFactory {
+        override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+        override fun open(config: RenderSessionConfig): RenderSession {
+          handshaking.countDown()
+          mayFinish.await()
+          return FakeRenderSession(Files.createTempDirectory("slow").toFile()).also(opened::set)
+        }
+      }
+    val host =
+      ServeRenderHost.open(
+        descriptorPath = File("descriptor.json"),
+        workspaceRoot = Files.createTempDirectory("slow-ws").toFile(),
+        workspaceName = "w",
+        previews = listOf(ServePreview("Red", "Red")),
+        factory = slowFactory,
+      )
+
+    val waker = Thread {
+      runCatching {
+        host.daemonStarted
+        host.gesturesRenderable
+      }
+    }
+    waker.start()
+    handshaking.await()
+    // close() lands mid-handshake, then the handshake completes.
+    val closer = Thread { host.close() }
+    closer.start()
+    mayFinish.countDown()
+    waker.join(10_000)
+    closer.join(10_000)
+
+    assertNotNull(opened.get(), "the factory did produce a session")
+    assertTrue(opened.get()!!.closed, "the session opened after close() must still be reaped")
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostLazyOpenTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostLazyOpenTest.kt
@@ -182,4 +182,42 @@ class ServeRenderHostLazyOpenTest {
     assertNotNull(opened.get(), "the factory did produce a session")
     assertTrue(opened.get()!!.closed, "the session opened after close() must still be reaped")
   }
+
+  @Test
+  fun `a daemon mid-handshake already counts as started`() {
+    // The subprocess is launched the moment `openSession()` is entered, but `isInitialized()` stays
+    // false until it returns — tens of seconds on an Android backend. Reporting "no daemon" across
+    // that window would hide the single biggest resource spike on the box.
+    val handshaking = java.util.concurrent.CountDownLatch(1)
+    val mayFinish = java.util.concurrent.CountDownLatch(1)
+    val slowFactory =
+      object : RenderSessionFactory {
+        override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+        override fun open(config: RenderSessionConfig): RenderSession {
+          handshaking.countDown()
+          mayFinish.await()
+          return FakeRenderSession(Files.createTempDirectory("slow2").toFile())
+        }
+      }
+    val host =
+      ServeRenderHost.open(
+        descriptorPath = File("descriptor.json"),
+        workspaceRoot = Files.createTempDirectory("slow2-ws").toFile(),
+        workspaceName = "w",
+        previews = listOf(ServePreview("Red", "Red")),
+        factory = slowFactory,
+      )
+    assertFalse(host.daemonStarted, "nothing launched yet")
+
+    val waker = Thread { runCatching { host.gesturesRenderable } }
+    waker.start()
+    handshaking.await()
+
+    assertTrue(host.daemonStarted, "the subprocess exists even though the lazy has not published")
+
+    mayFinish.countDown()
+    waker.join(10_000)
+    host.close()
+  }
 }


### PR DESCRIPTION
Follow-up to #3270, which merged while this review round was still being applied — so `main` currently carries the lazy daemon open **with** the leak below. Worth landing promptly for that reason.

## 1. Session leak on the close/open race (Codex P1)

`close()` checked `sessionDelegate.isInitialized()` without sharing the lazy's lock. A `close()` landing while `openSession()` was still handshaking read false, returned, and left the subprocess that appeared a moment later with nobody to reap it.

Not hypothetical — it is the refresh path: a catalog republish closes the old host while requests may be waking it.

```kotlin
private val sessionLock = Any()

private val sessionDelegate =
  lazy(sessionLock) {
    sessionOpening.set(true)
    val opened = openSession()
    if (closed.get()) {
      runCatching { opened.close() }   // lost the race — reap it here
    } else {
      notificationHandle = opened.onNotification(::onDaemonNotification)
    }
    opened
  }
```

`close()` takes the same lock, so both orderings are covered: it either waits for the handshake and then closes normally, or the initializer sees `closed` and tears down itself.

The initializer deliberately does **not** throw. My first attempt did, and it broke two existing tests — the exception escaped to callers merely reading a capability flag off a host being retired. Publishing the dead session instead means anything that actually uses it gets the transport's own closed error, which is the honest answer.

## 2. `/status` counted registered hosts as running (Codex P2)

`sessionStarted` was added in #3270 and never consumed, so `runningDaemons()` would have kept reporting one "running" daemon per registered catalog with no subprocess behind any of them — the exact metric the lazy open exists to decouple, and the one I said I'd measure the change by.

Promoted to `ServeHost.daemonStarted`, defaulting true so hosts with nothing to defer report as before; overridden in both daemon hosts; filtered in `runningDaemons()`. Its only consumer is `ServeHttpServer.kt:2195` (the status endpoint) — the idle reaper and seat accounting walk `sessions` directly, so suspension is untouched.

## 3. Export capability cached as unsupported after a failed open (Codex P2)

`session` was referenced *inside* the `runCatching`, so a transient handshake failure was recorded as "this backend advertises no exports" for the host's lifetime and every export 404'd even after a later render brought the daemon up fine. Resolving the session outside lets that failure propagate, leaving the lazy uninitialized so the next caller retries.

## 4. Already-open sessions reported as not started (found while fixing the above)

A host built by the direct-session constructor reported `daemonStarted = false`, because the secondary constructor wraps the session in a lambda the lazy has not touched. That broke `runningDaemons snapshots resident hosts`, and would also have meant `close()` never closing a directly-supplied session. Carried as `sessionAlreadyOpen`, honoured by both `daemonStarted` and `close()`.

## 5. A catalog running purely on its per-preview pool vanished from `/status` (Codex P2, second round)

An interactive stream or an explicit SVG / scroll export routes through `liveHostFor` and can stand a **pooled** per-preview daemon up without the monolithic host ever being touched. Forwarding only `live.daemonStarted` made `runningDaemons()` drop that catalog whole — hiding its active streams, its pool occupancy and a running process. A regression, not just an under-report: before this field existed the catalog was always listed.

```kotlin
override val daemonStarted: Boolean
  get() =
    live.daemonStarted ||
      perPreviewStreamCount() > 0 ||
      perPreviewPoolStats().any { it.open > 0 }
```

## 6. Mid-handshake daemons reported as absent (Codex P2, second round)

`isInitialized()` stays false for the whole of a cold open — tens of seconds on an Android/Robolectric backend — while the subprocess is already launched and consuming the box. `/status` would have gone blind across exactly the largest startup spike there is. `sessionOpening` is set on entry to the initializer, before the handshake, and counts toward `daemonStarted`.

## A pattern worth naming

All six findings are in **status reporting**, none in the lazy mechanism itself. The core change — defer the spawn, share a lock with `close()` — held. What kept breaking is the assumption that `Lazy.isInitialized()` is a faithful proxy for "a daemon exists". It isn't, in three distinct ways: not for an already-open session, not during a handshake, and not for a pooled daemon on another lane.

That matters more than usual here, because the justification for the lazy open rests on measuring `daemons.running` afterwards. Shipping it mis-reporting would have meant verifying the change against a number that was lying.

## Test plan

`./gradlew :cli:test --tests '*Serve*'` — green on a clean serial run.

Four new cases in `ServeRenderHostLazyOpenTest`, on top of the five from #3270:

- **`a host closed mid-handshake still reaps the session it was opening`** — a latch-gated factory holds the handshake open, `close()` runs on another thread, the latch releases, and the session that appears afterwards must be closed. `FakeRenderSession.close()` now records the fact so the assertion can observe it.
- **`a daemon mid-handshake already counts as started`** — `daemonStarted` false before, true while the handshake is still blocked, with the lazy unpublished.
- **`status does not count a registered but unwoken catalog as a running daemon`** — false on a fresh host, true after one render.
- plus the composite and close-path cases from the first commit.

Note on earlier red runs in this branch's history: two full-suite failures were Gradle infrastructure (`java.io.EOFException`, `NoSuchFileException: in-progress-results-generic.bin`) caused by concurrent `gradlew` invocations sharing a build dir, not test failures. The serial rerun is clean.