### PR TITLE
chore(design-artifacts): bump the driver to design-parity 0.1.38

### DIFF
--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -8,9 +8,9 @@
       "name": "design-artifacts-driver",
       "version": "0.0.0",
       "dependencies": {
-        "@design-parity/adapter-figma": "^0.1.37",
+        "@design-parity/adapter-figma": "^0.1.38",
         "@design-parity/candidate": "^0.1.25",
-        "@design-parity/catalog-export": "^0.1.37",
+        "@design-parity/catalog-export": "^0.1.38",
         "pixelmatch": "^7.0.0",
         "playwright": "^1.49.0",
         "pngjs": "^7.0.0"
@@ -20,12 +20,12 @@
       }
     },
     "node_modules/@design-parity/adapter-figma": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.37.tgz",
-      "integrity": "sha512-7/V8v2eZKWukF8zGSp3GRhe5s8D+4gGGfsl56Vldr8Uz2LKKHY0oNTisW9UfDPYNr5bgFhdoN/Raj0WwP6kNGw==",
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.38.tgz",
+      "integrity": "sha512-1IvMjWSWrfNt2yimWsxbtL8MxAhbMmKUXPJBgGfVE8z+PlBjd1vEgqoPqniO+vsVwsPzkIhSIBvWKoPkJVwSag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.37"
+        "@design-parity/core": "^0.1.38"
       }
     },
     "node_modules/@design-parity/candidate": {
@@ -39,18 +39,18 @@
       }
     },
     "node_modules/@design-parity/catalog-export": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.37.tgz",
-      "integrity": "sha512-zWC0LU8yPx10DshoNr2rkVunG1I+z8/m/AK+6gkiQdoRyDYtjPJMphnzLxf8huWugy6LfPLWNjCGZz+ghiD//g==",
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.38.tgz",
+      "integrity": "sha512-iVbuHt9vFh0jSoOyM+aOQ+ODt87AKb2jioMiNE8whBrBEh/p4E1dMNF5bnfVepg2JIRu72Id4NPnoQsnRFKccw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.37"
+        "@design-parity/core": "^0.1.38"
       }
     },
     "node_modules/@design-parity/core": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.37.tgz",
-      "integrity": "sha512-+GS13FKHhJik0inB88EK4Y+LLGD9XU7ljJgPh36z511qrcIdIFcutjCFRKC696/qMt28aiUiSKba2POComLj3w==",
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.38.tgz",
+      "integrity": "sha512-K62ly7ldYzPe4G79JS/rHt3HbL9+T6P7Yq2b2KS6eF/ahSdg0OwiV7OJtPonQGSvQMpoMF14cPJ0iP3JY+aJYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1"

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -11,9 +11,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@design-parity/adapter-figma": "^0.1.37",
+    "@design-parity/adapter-figma": "^0.1.38",
     "@design-parity/candidate": "^0.1.25",
-    "@design-parity/catalog-export": "^0.1.37",
+    "@design-parity/catalog-export": "^0.1.38",
     "pixelmatch": "^7.0.0",
     "playwright": "^1.49.0",
     "pngjs": "^7.0.0"


### PR DESCRIPTION
## Summary

Picks up the two annotation fixes from design-parity#277, both found by reading meshcore-mobile's **published** manifest rather than the tests — it had 19 annotated references and **zero** annotated previews, with type sizes like `52.5sp`.

**Preview annotations are keyed on the sticker id.** `previewId` holds the fully-qualified Compose id (`ee.schimke.…PreviewsKt.SomePreview_Foundation___MeshCore_light`), which the compare page never routes on; the server uses `device-populated__ideal__default__compact`. Keying on the former produced a manifest the server silently ignored, so the Actual column could not populate at all.

**A design tool's type sizes are quoted in `px`, not `sp`.** On the 3× Figma board here that turned ~17sp into `52.5sp` — a reader comparing against Compose would see a threefold discrepancy that doesn't exist.

## Verified against the installed packages

```
FIX 1  sticker id == server routing id: 91 match / 0 mismatch
FIX 2  [layout]     pad 24dp · gap 8dp · r 12dp
       [typography] text 52.5px/63.5   | unit: px
```

Fix 1 is checked against the live catalog's own `livePreview` URLs — the server's published routing, not an assumption about it — across every ideal image in the meshcore catalog.

## Test plan

- Full driver suite: **416 tests passing**.
- End-to-end smoke through `layoutFromNode` → `scaleTree` → `withReferenceAnnotations` and `stickerId` against the installed 0.1.38, output above.
- Lockfile regenerated in the same commit.

## After this

Re-dispatching meshcore-mobile's `design-artifacts.yml` should finally produce a manifest with **both** maps populated. I'll verify on the delivery branch (`annotations/index.json`), not `bundle.zip` — the portable download doesn't carry it, which is what made an earlier check report a false negative.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLvGJpTiL4T6hXMbUCq216)_