### PR TITLE
fix(serve): hold a card's pixels until its themed render arrives, and show the render server

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -438,6 +438,15 @@ class ServeCatalogLiveHost(
    * `/status` — the opposite of what this reporting is for. The baked lane never has a subprocess,
    * so it contributes nothing.
    */
+  /**
+   * The shared daemon (0 or 1) plus the per-preview pool's residents. Delegating to
+   * [live.daemonProcessCount] rather than adding one for [daemonStarted] matters: this host reports
+   * started when only a pooled child is up, so a flat `+1` would invent a monolithic daemon that
+   * does not exist.
+   */
+  override val daemonProcessCount: Int
+    get() = live.daemonProcessCount + perPreviewPoolStats().sumOf { it.open }
+
   override val daemonStarted: Boolean
     get() =
       live.daemonStarted || perPreviewStreamCount() > 0 || perPreviewPoolStats().any { it.open > 0 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -225,6 +225,17 @@ interface ServeHost : AutoCloseable {
    * `canApplyOverrides = false` but `hasLiveStream = true`.
    */
   /**
+   * How many render subprocesses this host is actually carrying right now.
+   *
+   * Distinct from [daemonStarted], which is a host-level "is anything up" used to keep `/status`
+   * from listing catalogs that own no process. This is a count, and a host with no daemon lane at
+   * all — a static baked bundle — must report 0 rather than inherit a truthy default, or the page
+   * would tell a visitor a purely static catalog has a render server connected.
+   */
+  val daemonProcessCount: Int
+    get() = 0
+
+  /**
    * Whether this host's daemon subprocess actually exists yet.
    *
    * A daemon-backed host opens its session on first real use, so a *registered* catalog is not a

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2297,10 +2297,12 @@ class ServeHttpServer(
       host?.let { runCatching { it.daemonPoolStats() }.getOrDefault(emptyList()) }.orEmpty()
     val dto =
       DaemonStatusDto(
-        // A registered catalog with no subprocess reports false — see ServeHost.daemonStarted.
-        running = host?.daemonStarted ?: false,
-        // The shared monolithic daemon (0 or 1) plus whatever the per-preview pool is holding.
-        instances = (if (host?.daemonStarted == true) 1 else 0) + pools.sumOf { it.open },
+        // Counted from real subprocesses, not from `daemonStarted`: that is a host-level flag a
+        // static baked bundle inherits as true, and it is already true for a catalog whose only
+        // process is a pooled child. Either would have the page claim a render server that isn't
+        // there.
+        running = (host?.daemonProcessCount ?: 0) > 0,
+        instances = host?.daemonProcessCount ?: 0,
         pooled = pools.sumOf { it.open },
         poolCapacity = pools.sumOf { it.maxOpen },
         activeStreams = host?.let { runCatching { it.activeStreamCount() }.getOrDefault(0) } ?: 0,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -652,6 +652,8 @@ class ServeHttpServer(
 
         get("/api/previews") { handleApiPreviews(sessionInPath = false) }
         get("/{system}/api/previews") { handleApiPreviews(sessionInPath = true) }
+        get("/api/daemons") { handleDaemonStatus(sessionInPath = false) }
+        get("/{system}/api/daemons") { handleDaemonStatus(sessionInPath = true) }
         post("/api/presence") { handlePresence(sessionInPath = false) }
         post("/{system}/api/presence") { handlePresence(sessionInPath = true) }
         post("/api/theme-render-lease") { handleThemeRenderLease(sessionInPath = false) }
@@ -2281,6 +2283,36 @@ class ServeHttpServer(
   }
 
   /**
+   * `GET /api/daemons` (query) and `GET /{system}/api/daemons` (path): whether this catalog is
+   * currently backed by a live render server, and how many processes that amounts to.
+   *
+   * Deliberately reads through [ServeSessionRegistry.peekHost], which never resumes a suspended
+   * session. A status probe that woke the daemon it is reporting on would defeat the lazy open it
+   * exists to make visible — the page would create the very process it is asking about.
+   */
+  private suspend fun RoutingContext.handleDaemonStatus(sessionInPath: Boolean) {
+    if (rejectBadToken()) return
+    val host = sessions.peekHost(selectedSessionId(sessionInPath))
+    val pools =
+      host?.let { runCatching { it.daemonPoolStats() }.getOrDefault(emptyList()) }.orEmpty()
+    val dto =
+      DaemonStatusDto(
+        // A registered catalog with no subprocess reports false — see ServeHost.daemonStarted.
+        running = host?.daemonStarted ?: false,
+        // The shared monolithic daemon (0 or 1) plus whatever the per-preview pool is holding.
+        instances = (if (host?.daemonStarted == true) 1 else 0) + pools.sumOf { it.open },
+        pooled = pools.sumOf { it.open },
+        poolCapacity = pools.sumOf { it.maxOpen },
+        activeStreams = host?.let { runCatching { it.activeStreamCount() }.getOrDefault(0) } ?: 0,
+      )
+    call.response.headers.append(HttpHeaders.CacheControl, DYNAMIC_RESOURCE_CACHE_CONTROL)
+    call.respondText(
+      JSON.encodeToString(DaemonStatusDto.serializer(), dto),
+      ContentType.Application.Json,
+    )
+  }
+
+  /**
    * `GET /api/previews` (query) and `GET /{system}/api/previews` (path): the session's preview
    * JSON.
    */
@@ -3623,6 +3655,16 @@ private data class PreviewsResponse(
 )
 
 @Serializable private data class DegradationDto(val code: String, val detail: String)
+
+/** What `/api/daemons` reports: is a render server up for this catalog, and how many processes. */
+@Serializable
+private data class DaemonStatusDto(
+  val running: Boolean,
+  val instances: Int,
+  val pooled: Int,
+  val poolCapacity: Int,
+  val activeStreams: Int,
+)
 
 @Serializable
 private data class PreviewDto(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -379,6 +379,10 @@ internal constructor(
    * Whether the daemon subprocess has actually been started. Lets `/status` and [close] reason
    * about a host that is registered but never woken, without waking it to find out.
    */
+  /** One subprocess, once it exists. */
+  override val daemonProcessCount: Int
+    get() = if (daemonStarted) 1 else 0
+
   override val daemonStarted: Boolean
     get() = sessionAlreadyOpen || sessionOpening.get() || sessionDelegate.isInitialized()
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1350,7 +1350,7 @@ object ServeWeb {
       if (hasDeclaredThemes)
         "\n            var img = c.querySelector(\"img\");" +
           "\n            var base = themeBase[i];" +
-          "\n            if (img && base) img.src = base;"
+          "\n            if (img && base) setCardSrc(img, base);"
       else ""
     val applyTheme =
       if (hasThemes)
@@ -1360,6 +1360,19 @@ object ServeWeb {
         });
         // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
         // supplying themed ones), alt text, label, id, viewer link and stage backing.
+        // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.
+        // A themed render is handed over as an object URL (see runThemeWorker); leaving a declared
+        // theme for Light / Dark / Default replaces that source, and without this the blob behind
+        // it would stay resident until the page unloaded — one full-resolution PNG per card, on
+        // catalogs that routinely run to 80+ cards.
+        function setCardSrc(img, url) {
+          var previous = img.getAttribute("data-cp-blob");
+          img.src = url;
+          if (previous) {
+            img.removeAttribute("data-cp-blob");
+            URL.revokeObjectURL(previous);
+          }
+        }
         function applyVariant(c, k, withSrc) {
           var src = c.getAttribute("data-" + k + "-src");
           if (!src) return;
@@ -1367,7 +1380,7 @@ object ServeWeb {
           var lab = c.querySelector(".cp-label");
           var idn = c.querySelector(".cp-id");
           var lbl = c.getAttribute("data-" + k + "-label");
-          if (img) { if (withSrc) img.src = src; img.setAttribute("alt", lbl); }
+          if (img) { if (withSrc) setCardSrc(img, src); img.setAttribute("alt", lbl); }
           c.setAttribute("href", c.getAttribute("data-" + k + "-href"));
           if (lab) { lab.textContent = lbl; lab.setAttribute("title", lbl); }
           if (idn) idn.textContent = c.getAttribute("data-" + k + "-id");

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1151,11 +1151,9 @@ object ServeWeb {
           if (!job) return;
           var img = job.img;
           var settled = false;
-          function next(ok) {
+          function finish(ok) {
             if (settled || gen !== themeGen) return;
             settled = true;
-            img.onload = null;
-            img.onerror = null;
             if (!ok && job.retries < themeRenderRetries) {
               // Re-request rather than re-assign the identical (failed, uncached) URL. Exponential
               // backoff gives a busy daemon time to finish without stalling the other worker.
@@ -1173,9 +1171,35 @@ object ServeWeb {
             finishThemeJob(batch);
             runThemeWorker(queue, gen, batch);
           }
-          img.onload = function () { next(true); };
-          img.onerror = function () { next(false); };
-          img.src = job.src;
+          // Fetch the bytes FIRST and only then put them on the card.
+          //
+          // Assigning `src` on the live <img> dropped the pixels it was showing the instant the
+          // request started, so the visitor watched the old theme's render vanish and sat looking
+          // at a broken-image glyph under the spinner for the whole ~1s daemon round trip. Holding
+          // the previous render until the new one is in hand means the card only ever shows real
+          // pixels: the old theme's, then the new theme's, swapped in a single paint.
+          //
+          // A detached `new Image()` preload would do the same job, except a themed render is
+          // `no-store` (it carries overrides), so handing its URL to the visible <img> afterwards
+          // is not reliably a cache hit and can cost a second round trip. Fetching to a blob is one
+          // request by construction.
+          fetch(job.src, { credentials: "same-origin" })
+            .then(function (response) {
+              if (!response.ok) throw new Error("render " + response.status);
+              return response.blob();
+            })
+            .then(function (blob) {
+              if (gen !== themeGen) return;
+              var url = URL.createObjectURL(blob);
+              // Release the blob this card was holding, if any. Without this every theme switch
+              // would strand one object URL per card for the life of the page.
+              var previous = img.getAttribute("data-cp-blob");
+              img.src = url;
+              img.setAttribute("data-cp-blob", url);
+              if (previous) URL.revokeObjectURL(previous);
+              finish(true);
+            })
+            .catch(function () { finish(false); });
         }
         function runThemeQueue(queue, gen, lease, concurrency) {
           var batch = { lease: lease, remaining: queue.length };
@@ -1533,6 +1557,61 @@ object ServeWeb {
       // catalog the visitor actually opened — while they read the grid, rather than when they
       // first click a theme and wait out a cold start.
       ping();
+
+      // Render-server badge. Catalogs open their daemon on first real use, so whether one is up is
+      // now a genuine question with a visible answer — a theme switch is instant against a warm
+      // daemon and pays a cold start against none. Same URL family as the presence ping, and the
+      // endpoint reads through `peekHost`, so polling it never wakes what it is reporting on.
+      var daemonUrl = presenceUrl.replace("/api/presence", "/api/daemons");
+      var daemonBadge = null;
+      function daemonBadgeEl() {
+        if (daemonBadge) return daemonBadge;
+        daemonBadge = document.getElementById("cp-daemon-status");
+        if (!daemonBadge) {
+          daemonBadge = document.createElement("span");
+          daemonBadge.id = "cp-daemon-status";
+          daemonBadge.className = "cp-daemon-status";
+          var host = document.querySelector(".cp-header-meta") || document.querySelector("header");
+          (host || document.body).appendChild(daemonBadge);
+        }
+        return daemonBadge;
+      }
+      function paintDaemonStatus(state) {
+        var el = daemonBadgeEl();
+        if (!state) { el.hidden = true; return; }
+        el.hidden = false;
+        // "not running" is a normal resting state, not a fault — a catalog nobody has rendered on
+        // simply has no process yet. Word it so it doesn't read as an error.
+        var label = state.running
+          ? "Render server: connected"
+          : "Render server: not running";
+        var count = state.instances || 0;
+        if (state.running) {
+          label += " \u00b7 " + count + (count === 1 ? " instance" : " instances");
+          if (state.activeStreams > 0) label += ", " + state.activeStreams + " live";
+        }
+        el.textContent = label;
+        el.setAttribute("data-cp-daemon-running", state.running ? "1" : "0");
+        el.title = state.pooled
+          ? state.pooled + " of " + state.poolCapacity + " per-preview daemons resident"
+          : "";
+      }
+      function pollDaemons() {
+        if (!daemonUrl || document.visibilityState !== "visible") return;
+        fetch(daemonUrl, { credentials: "same-origin" })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(paintDaemonStatus)
+          .catch(function () {});
+      }
+      setInterval(pollDaemons, 20000);
+      document.addEventListener("visibilitychange", pollDaemons);
+      pollDaemons();
+      // A theme switch is exactly when the daemon comes up, so refresh the badge shortly after one.
+      document.addEventListener("click", function (e) {
+        if (e.target && e.target.closest && e.target.closest(".cp-theme-btn")) {
+          setTimeout(pollDaemons, 1500);
+        }
+      });
     """
       .trimIndent()
   }

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -697,3 +697,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   .cp-viewer.cp-controls-open .cp-controls::before,
   .cp-viewer.cp-nav-open .cp-nav::before { background: var(--cp-border-strong); }
 }
+
+/* Render-server badge (see ServeWeb.presenceScript). Catalogs open their daemon on first real use,
+   so "not running" is a normal resting state — styled as neutral information, not a fault. */
+.cp-daemon-status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  line-height: 1.6;
+  border: 1px solid currentColor;
+  opacity: 0.7;
+}
+.cp-daemon-status[data-cp-daemon-running="1"] {
+  opacity: 1;
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebDeferredThemeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebDeferredThemeTest.kt
@@ -118,4 +118,15 @@ class ServeWebDeferredThemeTest {
     assertTrue(html.contains("img.getAttribute(\"data-cp-blob\")"))
     assertTrue(html.contains("URL.revokeObjectURL(previous)"))
   }
+
+  @Test
+  fun `leaving a declared theme releases the blob too, not just switching between them`() {
+    // Revoking only on the next successful themed fetch left every card's full-resolution PNG
+    // retained when the visitor went back to Light / Dark / Default — on an 80+ card catalog that
+    // is a lot of blobs held until the page unloads.
+    val html = page()
+    assertTrue(html.contains("function setCardSrc(img, url)"), "one setter owns the release")
+    assertTrue(html.contains("if (withSrc) setCardSrc(img, src);"), "swap cards restore through it")
+    assertTrue(html.contains("if (img && base) setCardSrc(img, base);"), "so do non-swap cards")
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebDeferredThemeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebDeferredThemeTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -97,5 +98,24 @@ class ServeWebDeferredThemeTest {
     // Each theme choice bumps themeGen; a stale observer must not paint the previous theme's pixels
     // over the new one as the visitor scrolls.
     assertTrue(page().contains("stopDeferredTheme();"), "torn down on a theme change")
+  }
+
+  @Test
+  fun `a themed card keeps its old pixels until the new render has arrived`() {
+    // Assigning `src` on the live <img> drops what it is showing the moment the request starts, so
+    // the card went blank and showed a broken-image glyph under the spinner for the whole ~1s
+    // daemon round trip. The bytes are fetched first and only then handed to the element.
+    val html = page()
+    assertTrue(html.contains("fetch(job.src, { credentials: \"same-origin\" })"), "bytes first")
+    assertTrue(html.contains("URL.createObjectURL(blob)"), "swapped from the fetched blob")
+    assertFalse(html.contains("img.src = job.src"), "never assigned straight to the visible image")
+  }
+
+  @Test
+  fun `each theme switch releases the blob the card was holding`() {
+    // One object URL per card per switch would otherwise be stranded for the life of the page.
+    val html = page()
+    assertTrue(html.contains("img.getAttribute(\"data-cp-blob\")"))
+    assertTrue(html.contains("URL.revokeObjectURL(previous)"))
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -2052,7 +2052,7 @@ class ServeWebFixtureTest {
     // The swap re-points the image + viewer link + id + label to the chosen theme's baked render.
     assertTrue(
       landingThemed.contains(
-        "if (img) { if (withSrc) img.src = src; img.setAttribute(\"alt\", lbl); }"
+        "if (img) { if (withSrc) setCardSrc(img, src); img.setAttribute(\"alt\", lbl); }"
       ) &&
         landingThemed.contains(
           "c.setAttribute(\"href\", c.getAttribute(\"data-\" + k + \"-href\"))"

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>loading-spinner.json — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>watchface.rc — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Share a document — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-format-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-format-compare.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — format comparison</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Design systems — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>wear-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <style>
         :root {
           --cp-bg: #fafafb;
@@ -157,6 +157,19 @@ var appliedTheme = null;
 });
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
+// Point a card's <img> at a plain URL, releasing whatever blob it was holding first.
+// A themed render is handed over as an object URL (see runThemeWorker); leaving a declared
+// theme for Light / Dark / Default replaces that source, and without this the blob behind
+// it would stay resident until the page unloaded — one full-resolution PNG per card, on
+// catalogs that routinely run to 80+ cards.
+function setCardSrc(img, url) {
+  var previous = img.getAttribute("data-cp-blob");
+  img.src = url;
+  if (previous) {
+    img.removeAttribute("data-cp-blob");
+    URL.revokeObjectURL(previous);
+  }
+}
 function applyVariant(c, k, withSrc) {
   var src = c.getAttribute("data-" + k + "-src");
   if (!src) return;
@@ -164,7 +177,7 @@ function applyVariant(c, k, withSrc) {
   var lab = c.querySelector(".cp-label");
   var idn = c.querySelector(".cp-id");
   var lbl = c.getAttribute("data-" + k + "-label");
-  if (img) { if (withSrc) img.src = src; img.setAttribute("alt", lbl); }
+  if (img) { if (withSrc) setCardSrc(img, src); img.setAttribute("alt", lbl); }
   c.setAttribute("href", c.getAttribute("data-" + k + "-href"));
   if (lab) { lab.textContent = lbl; lab.setAttribute("title", lbl); }
   if (idn) idn.textContent = c.getAttribute("data-" + k + "-id");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -156,11 +156,9 @@ function runThemeWorker(queue, gen, batch) {
   if (!job) return;
   var img = job.img;
   var settled = false;
-  function next(ok) {
+  function finish(ok) {
     if (settled || gen !== themeGen) return;
     settled = true;
-    img.onload = null;
-    img.onerror = null;
     if (!ok && job.retries < themeRenderRetries) {
       // Re-request rather than re-assign the identical (failed, uncached) URL. Exponential
       // backoff gives a busy daemon time to finish without stalling the other worker.
@@ -178,9 +176,35 @@ function runThemeWorker(queue, gen, batch) {
     finishThemeJob(batch);
     runThemeWorker(queue, gen, batch);
   }
-  img.onload = function () { next(true); };
-  img.onerror = function () { next(false); };
-  img.src = job.src;
+  // Fetch the bytes FIRST and only then put them on the card.
+  //
+  // Assigning `src` on the live <img> dropped the pixels it was showing the instant the
+  // request started, so the visitor watched the old theme's render vanish and sat looking
+  // at a broken-image glyph under the spinner for the whole ~1s daemon round trip. Holding
+  // the previous render until the new one is in hand means the card only ever shows real
+  // pixels: the old theme's, then the new theme's, swapped in a single paint.
+  //
+  // A detached `new Image()` preload would do the same job, except a themed render is
+  // `no-store` (it carries overrides), so handing its URL to the visible <img> afterwards
+  // is not reliably a cache hit and can cost a second round trip. Fetching to a blob is one
+  // request by construction.
+  fetch(job.src, { credentials: "same-origin" })
+    .then(function (response) {
+      if (!response.ok) throw new Error("render " + response.status);
+      return response.blob();
+    })
+    .then(function (blob) {
+      if (gen !== themeGen) return;
+      var url = URL.createObjectURL(blob);
+      // Release the blob this card was holding, if any. Without this every theme switch
+      // would strand one object URL per card for the life of the page.
+      var previous = img.getAttribute("data-cp-blob");
+      img.src = url;
+      img.setAttribute("data-cp-blob", url);
+      if (previous) URL.revokeObjectURL(previous);
+      finish(true);
+    })
+    .catch(function () { finish(false); });
 }
 function runThemeQueue(queue, gen, lease, concurrency) {
   var batch = { lease: lease, remaining: queue.length };
@@ -240,6 +264,19 @@ window.addEventListener("pagehide", function () { releaseThemeLease(themeLease, 
 });
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
+// Point a card's <img> at a plain URL, releasing whatever blob it was holding first.
+// A themed render is handed over as an object URL (see runThemeWorker); leaving a declared
+// theme for Light / Dark / Default replaces that source, and without this the blob behind
+// it would stay resident until the page unloaded — one full-resolution PNG per card, on
+// catalogs that routinely run to 80+ cards.
+function setCardSrc(img, url) {
+  var previous = img.getAttribute("data-cp-blob");
+  img.src = url;
+  if (previous) {
+    img.removeAttribute("data-cp-blob");
+    URL.revokeObjectURL(previous);
+  }
+}
 function applyVariant(c, k, withSrc) {
   var src = c.getAttribute("data-" + k + "-src");
   if (!src) return;
@@ -247,7 +284,7 @@ function applyVariant(c, k, withSrc) {
   var lab = c.querySelector(".cp-label");
   var idn = c.querySelector(".cp-id");
   var lbl = c.getAttribute("data-" + k + "-label");
-  if (img) { if (withSrc) img.src = src; img.setAttribute("alt", lbl); }
+  if (img) { if (withSrc) setCardSrc(img, src); img.setAttribute("alt", lbl); }
   c.setAttribute("href", c.getAttribute("data-" + k + "-href"));
   if (lab) { lab.textContent = lbl; lab.setAttribute("title", lbl); }
   if (idn) idn.textContent = c.getAttribute("data-" + k + "-id");
@@ -323,7 +360,7 @@ function applyThemeChoice() {
     if (c.getAttribute("data-swap") === "1") { applyVariant(c, k, true); return; }
     var img = c.querySelector("img");
     var base = themeBase[i];
-    if (img && base) img.src = base;
+    if (img && base) setCardSrc(img, base);
   });
 }
 applyThemeChoice();

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -205,6 +205,19 @@ var appliedTheme = null;
 });
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
+// Point a card's <img> at a plain URL, releasing whatever blob it was holding first.
+// A themed render is handed over as an object URL (see runThemeWorker); leaving a declared
+// theme for Light / Dark / Default replaces that source, and without this the blob behind
+// it would stay resident until the page unloaded — one full-resolution PNG per card, on
+// catalogs that routinely run to 80+ cards.
+function setCardSrc(img, url) {
+  var previous = img.getAttribute("data-cp-blob");
+  img.src = url;
+  if (previous) {
+    img.removeAttribute("data-cp-blob");
+    URL.revokeObjectURL(previous);
+  }
+}
 function applyVariant(c, k, withSrc) {
   var src = c.getAttribute("data-" + k + "-src");
   if (!src) return;
@@ -212,7 +225,7 @@ function applyVariant(c, k, withSrc) {
   var lab = c.querySelector(".cp-label");
   var idn = c.querySelector(".cp-id");
   var lbl = c.getAttribute("data-" + k + "-label");
-  if (img) { if (withSrc) img.src = src; img.setAttribute("alt", lbl); }
+  if (img) { if (withSrc) setCardSrc(img, src); img.setAttribute("alt", lbl); }
   c.setAttribute("href", c.getAttribute("data-" + k + "-href"));
   if (lab) { lab.textContent = lbl; lab.setAttribute("title", lbl); }
   if (idn) idn.textContent = c.getAttribute("data-" + k + "-id");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -109,6 +109,19 @@ var appliedTheme = null;
 });
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
+// Point a card's <img> at a plain URL, releasing whatever blob it was holding first.
+// A themed render is handed over as an object URL (see runThemeWorker); leaving a declared
+// theme for Light / Dark / Default replaces that source, and without this the blob behind
+// it would stay resident until the page unloaded — one full-resolution PNG per card, on
+// catalogs that routinely run to 80+ cards.
+function setCardSrc(img, url) {
+  var previous = img.getAttribute("data-cp-blob");
+  img.src = url;
+  if (previous) {
+    img.removeAttribute("data-cp-blob");
+    URL.revokeObjectURL(previous);
+  }
+}
 function applyVariant(c, k, withSrc) {
   var src = c.getAttribute("data-" + k + "-src");
   if (!src) return;
@@ -116,7 +129,7 @@ function applyVariant(c, k, withSrc) {
   var lab = c.querySelector(".cp-label");
   var idn = c.querySelector(".cp-id");
   var lbl = c.getAttribute("data-" + k + "-label");
-  if (img) { if (withSrc) img.src = src; img.setAttribute("alt", lbl); }
+  if (img) { if (withSrc) setCardSrc(img, src); img.setAttribute("alt", lbl); }
   c.setAttribute("href", c.getAttribute("data-" + k + "-href"));
   if (lab) { lab.textContent = lbl; lab.setAttribute("title", lbl); }
   if (idn) idn.textContent = c.getAttribute("data-" + k + "-id");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -119,6 +119,19 @@ var appliedTheme = null;
 });
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
+// Point a card's <img> at a plain URL, releasing whatever blob it was holding first.
+// A themed render is handed over as an object URL (see runThemeWorker); leaving a declared
+// theme for Light / Dark / Default replaces that source, and without this the blob behind
+// it would stay resident until the page unloaded — one full-resolution PNG per card, on
+// catalogs that routinely run to 80+ cards.
+function setCardSrc(img, url) {
+  var previous = img.getAttribute("data-cp-blob");
+  img.src = url;
+  if (previous) {
+    img.removeAttribute("data-cp-blob");
+    URL.revokeObjectURL(previous);
+  }
+}
 function applyVariant(c, k, withSrc) {
   var src = c.getAttribute("data-" + k + "-src");
   if (!src) return;
@@ -126,7 +139,7 @@ function applyVariant(c, k, withSrc) {
   var lab = c.querySelector(".cp-label");
   var idn = c.querySelector(".cp-id");
   var lbl = c.getAttribute("data-" + k + "-label");
-  if (img) { if (withSrc) img.src = src; img.setAttribute("alt", lbl); }
+  if (img) { if (withSrc) setCardSrc(img, src); img.setAttribute("alt", lbl); }
   c.setAttribute("href", c.getAttribute("data-" + k + "-href"));
   if (lab) { lab.textContent = lbl; lab.setAttribute("title", lbl); }
   if (idn) idn.textContent = c.getAttribute("data-" + k + "-id");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>
@@ -94,6 +94,19 @@ var appliedTheme = null;
 });
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
+// Point a card's <img> at a plain URL, releasing whatever blob it was holding first.
+// A themed render is handed over as an object URL (see runThemeWorker); leaving a declared
+// theme for Light / Dark / Default replaces that source, and without this the blob behind
+// it would stay resident until the page unloaded — one full-resolution PNG per card, on
+// catalogs that routinely run to 80+ cards.
+function setCardSrc(img, url) {
+  var previous = img.getAttribute("data-cp-blob");
+  img.src = url;
+  if (previous) {
+    img.removeAttribute("data-cp-blob");
+    URL.revokeObjectURL(previous);
+  }
+}
 function applyVariant(c, k, withSrc) {
   var src = c.getAttribute("data-" + k + "-src");
   if (!src) return;
@@ -101,7 +114,7 @@ function applyVariant(c, k, withSrc) {
   var lab = c.querySelector(".cp-label");
   var idn = c.querySelector(".cp-id");
   var lbl = c.getAttribute("data-" + k + "-label");
-  if (img) { if (withSrc) img.src = src; img.setAttribute("alt", lbl); }
+  if (img) { if (withSrc) setCardSrc(img, src); img.setAttribute("alt", lbl); }
   c.setAttribute("href", c.getAttribute("data-" + k + "-href"));
   if (lab) { lab.textContent = lbl; lab.setAttribute("title", lbl); }
   if (idn) idn.textContent = c.getAttribute("data-" + k + "-id");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Not found — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Playground — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Figma filled button — design comparison</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-status.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-status.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Server status — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <style>
         :root {
           --cp-bg: #f8f4f8;

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Focus ring — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>One-handed — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Checkbox · Checked (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/cb81-5672d1e3fedc454c/serve.css">
+        <link rel="stylesheet" href="/assets/serve/cd3b-09f02ab04f95830d/serve.css">
         <!-- Apply the sticky Background/Transparent choice before first paint (no checkerboard flash). -->
         <script>try{if(localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
       </head>


### PR DESCRIPTION
Two things a visitor sees on a catalog page.

## 1. The broken image on a theme switch

Reported: *"when switching theme, the spinners come up, 2 seconds pass or so, and a broken image shows until it works."*

The theme worker assigned the new URL straight onto the visible `<img>`:

```js
img.onload = function () { next(true); };
img.src = job.src;          // <- the card goes blank right here
```

A browser drops the pixels an element is showing the instant a new `src` starts loading. So the card blanked, showed a broken-image glyph under the spinner for the whole ~1s daemon round trip, and only then painted. Nothing was failing — the card simply had nothing to show while the render ran.

Now the bytes are fetched first and handed to the element only once they are in hand, so a card only ever shows a real render: the old theme's, then the new theme's, swapped in a single paint.

**Why a blob and not a detached `new Image()` preload.** A themed render carries overrides, so it is served `no-store`. Handing the same URL to the visible element after preloading is therefore not reliably a cache hit and can cost a second round trip to the daemon lane. Fetching to a blob is one request by construction. Each swap revokes the object URL the card was holding, or a switch would strand one per card for the life of the page.

Retry/backoff, lease stamping, generation guards and the deferred-viewport queue are all unchanged — only the transport and the moment of the swap moved.

## 2. Whether a render server is up

Requested: *"can we show the render server instances. connected, or not running. how many for this app catalog."*

Timely, because since #3270/#3272 catalogs open their daemon on first real use, so this is now a genuine question with a visible answer — a theme switch is instant against a warm daemon and pays a cold start against none.

New `GET /{system}/api/daemons` (and the `?session=` form):

```json
{ "running": true, "instances": 2, "pooled": 1, "poolCapacity": 8, "activeStreams": 0 }
```

`instances` is the shared monolithic daemon (0 or 1) plus whatever the per-preview pool is holding. A badge on the catalog and viewer pages paints it — "Render server: connected · 2 instances" or "Render server: not running" — refreshing on arrival, every 20s while the tab is visible, and shortly after a theme click, which is exactly when a daemon comes up.

**The endpoint reads through `peekHost`, which never resumes a suspended session.** A status probe that woke the daemon it reports on would defeat the lazy open it exists to make visible — the page would create the very process it was asking about.

"not running" is deliberately worded as a resting state rather than a fault, and styled as neutral information: a catalog nobody has rendered on simply has no process yet, which is now the intended steady state.

## Test plan

`./gradlew :cli:test --tests '*Serve*'` — green.

Two new cases in `ServeWebDeferredThemeTest`:

- **`a themed card keeps its old pixels until the new render has arrived`** — asserts the fetch-then-swap shape *and* that `img.src = job.src` no longer appears anywhere, which is the regression that would bring the broken image back.
- **`each theme switch releases the blob the card was holding`** — the revoke path.

## Visual evidence

Not embedded, and I want to be straight about why rather than wave it through. Both changes are visible, so this would normally need before/after pixels:

- The theme-swap fix is a change in *timing*, not in rendered output. The end state is byte-identical; what changed is that the intermediate frame is the previous render instead of a broken-image glyph. A static screenshot pair cannot show it — it needs a capture mid-flight against a real daemon, which the `@Preview` PNG pipeline doesn't reach.
- The badge is new page chrome and *should* be diffed. It is injected by `presenceScript`, which the committed page fixtures don't exercise, so it doesn't appear in `serve-*.html` yet.

I'd rather flag that than claim coverage I don't have. The right follow-up is a `FIXTURE_STATES` entry in `pages-snapshot.spec.mjs` that stubs `/api/daemons` and shoots both badge states, plus one that stalls a themed `/render/` and shoots the mid-swap frame — that would put both of these under the visual-diff bot permanently rather than leaving them manual. Happy to do it in this PR if you'd prefer it not land uncaptured.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_