### PR TITLE
fix(design-artifacts): merge annotation manifests when folding a catalog section

### DIFF
--- a/scripts/design-artifacts/merge-catalog-section.mjs
+++ b/scripts/design-artifacts/merge-catalog-section.mjs
@@ -102,6 +102,40 @@ async function sameBytes(a, b) {
  * in the host. Skipping *every* top-level file (rather than a fixed denylist)
  * stays correct if the generator grows a new top-level artifact.
  */
+/**
+ * The one nested asset that is a *map*, not a per-component file.
+ *
+ * `annotations/index.json` is keyed by preview and reference id, so two catalogs
+ * legitimately carry different copies — the host's own and the folded section's.
+ * Byte-comparing them aborts the fold (which is exactly what happened the first
+ * time the host catalog produced a non-empty one). Union the two maps instead:
+ * the folded section's components become tabs in the host, so their annotations
+ * belong alongside the host's rather than replacing or blocking them.
+ */
+const ANNOTATIONS_REL = join("annotations", "index.json");
+
+async function mergeAnnotationManifests(src, dest) {
+  const read = async (p) => {
+    try {
+      return JSON.parse(await readFile(p, "utf8"));
+    } catch {
+      return null;
+    }
+  };
+  const a = (await read(dest)) ?? {};
+  const b = (await read(src)) ?? {};
+  const schema = a.schema ?? b.schema;
+  // Host entries win a key collision: the fold is additive, and a borrowed
+  // catalog must never silently redefine an id the host already published.
+  const merged = {
+    schema,
+    previews: { ...(b.previews ?? {}), ...(a.previews ?? {}) },
+    references: { ...(b.references ?? {}), ...(a.references ?? {}) },
+  };
+  await mkdir(dirname(dest), { recursive: true });
+  await writeFile(dest, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
+}
+
 async function copyAssets(fromDir, intoDir) {
   let copied = 0;
   for (const src of await listFiles(fromDir)) {
@@ -111,6 +145,11 @@ async function copyAssets(fromDir, intoDir) {
     // foldable asset lives in a subdirectory (images/ / wireframes/ / figma/).
     if (!rel.includes(sep)) continue;
     const dest = join(intoDir, rel);
+    if (rel === ANNOTATIONS_REL) {
+      await mergeAnnotationManifests(src, dest);
+      copied += 1;
+      continue;
+    }
     const existing = await stat(dest).catch(() => null);
     if (existing) {
       if (!(await sameBytes(src, dest))) {

--- a/scripts/design-artifacts/merge-catalog-section.test.mjs
+++ b/scripts/design-artifacts/merge-catalog-section.test.mjs
@@ -178,3 +178,67 @@ test("mergeCatalogSection refuses to overwrite a differing asset", async () => {
     /differs between the two catalogs/,
   );
 });
+
+test("mergeCatalogSection unions annotation manifests instead of colliding", async () => {
+  // Regression: once the host catalog emitted a non-empty annotations/index.json,
+  // the fold aborted with "differs between the two catalogs" — both sides legitimately
+  // carry one, keyed by preview/reference id rather than being a per-component file.
+  const root = await mkdtemp(join(tmpdir(), "merge-catalog-annotations-"));
+  const into = join(root, "into");
+  const from = join(root, "from");
+  await mkdir(join(into, "annotations"), { recursive: true });
+  await mkdir(join(from, "annotations"), { recursive: true });
+  await writeFile(join(into, "catalog.json"), JSON.stringify(manifest([comp("Host/One")])));
+  await writeFile(join(from, "catalog.json"), JSON.stringify(manifest([comp("M3/Two")])));
+  await writeFile(
+    join(into, "annotations/index.json"),
+    JSON.stringify({
+      schema: "compose-preview-annotations/v1",
+      previews: { "host-one__ideal__default": [{ kind: "layout", label: "pad 8dp" }] },
+      references: { "ref-host": [{ kind: "typography", label: "text 14px/20" }] },
+    }),
+  );
+  await writeFile(
+    join(from, "annotations/index.json"),
+    JSON.stringify({
+      schema: "compose-preview-annotations/v1",
+      previews: { "m3-two__ideal__default": [{ kind: "layout", label: "pad 16dp" }] },
+      references: {},
+    }),
+  );
+
+  await mergeCatalogSection({ into, from, section: "Material 3" });
+
+  const merged = JSON.parse(await readFile(join(into, "annotations/index.json"), "utf8"));
+  assert.equal(merged.schema, "compose-preview-annotations/v1");
+  assert.deepEqual(Object.keys(merged.previews).sort(), [
+    "host-one__ideal__default",
+    "m3-two__ideal__default",
+  ]);
+  // The host's reference layer survives the fold.
+  assert.deepEqual(Object.keys(merged.references), ["ref-host"]);
+});
+
+test("a folded catalog cannot redefine an id the host already published", async () => {
+  const root = await mkdtemp(join(tmpdir(), "merge-catalog-annotations-win-"));
+  const into = join(root, "into");
+  const from = join(root, "from");
+  await mkdir(join(into, "annotations"), { recursive: true });
+  await mkdir(join(from, "annotations"), { recursive: true });
+  await writeFile(join(into, "catalog.json"), JSON.stringify(manifest([comp("Host/One")])));
+  await writeFile(join(from, "catalog.json"), JSON.stringify(manifest([comp("M3/Two")])));
+  const shared = { schema: "compose-preview-annotations/v1", references: {} };
+  await writeFile(
+    join(into, "annotations/index.json"),
+    JSON.stringify({ ...shared, previews: { shared__id: [{ kind: "layout", label: "HOST" }] } }),
+  );
+  await writeFile(
+    join(from, "annotations/index.json"),
+    JSON.stringify({ ...shared, previews: { shared__id: [{ kind: "layout", label: "BORROWED" }] } }),
+  );
+
+  await mergeCatalogSection({ into, from, section: "Material 3" });
+
+  const merged = JSON.parse(await readFile(join(into, "annotations/index.json"), "utf8"));
+  assert.equal(merged.previews.shared__id[0].label, "HOST");
+});


### PR DESCRIPTION
## Summary

meshcore-mobile's republish **failed**, and it's self-inflicted by the annotation work:

```
Error: merge-catalog-section: asset 'annotations/index.json' differs between the two
       catalogs — refusing to overwrite …/out/annotations/index.json
```

`copyAssets` treats every nested file as a per-component asset that must be byte-identical or absent. `annotations/index.json` is neither — it's a **map** keyed by preview and reference id, so a host catalog and a folded section legitimately carry different copies.

## Why it appeared only now

meshcore folds `compose-m3-meshcore` in as a Material 3 tab, so two catalogs meet at fold time. The collision stayed hidden while meshcore's *host* manifest was empty — an empty manifest isn't written at all, so only one file existed. design-parity#277 made the host manifest non-empty (the sticker-id fix), and the very next run aborted.

So the failure is a direct consequence of the preview layer starting to work.

## The fix

Union the two maps instead of comparing bytes. The folded section's components become tabs in the host, so their annotations belong alongside the host's — not replacing them, and not blocking the fold.

**Host entries win a key collision.** The fold is additive, and a borrowed catalog must never silently redefine an id the host already published. A test pins that direction so a future refactor can't quietly invert it.

## Test plan

Two regressions added to `merge-catalog-section.test.mjs`:

- **Unions both manifests** — reproduces the exact failure (both sides carrying a manifest) and asserts the merged result has both preview keys and keeps the host's reference layer.
- **Host wins a collision** — same id on both sides resolves to the host's entry.

The pre-existing "refuses to overwrite a differing asset" test still passes, so ordinary per-component assets keep their strict byte-identity guard; only this one map is special-cased.

Full driver suite: **418 tests passing**.

## After this

Re-dispatch meshcore's `design-artifacts.yml`. This was the last blocker between the merged chain and a compare page with both columns annotated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLvGJpTiL4T6hXMbUCq216)_