### PR TITLE
test(serve): put the render-server badge and the themed-render swap under the diff bot

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -840,6 +840,11 @@ class ServeWebFixtureTest {
           ),
         canRenderThemeFor = { true },
         themeRenderBurstCapacity = 5,
+        // Carries the presence script, which is also what injects the render-server badge. Without
+        // a fixture that emits it, neither the badge nor the themed-render swap it sits beside has
+        // any visual-diff coverage — the harness shoots this page for both (see FIXTURE_STATES in
+        // pages-snapshot.spec.mjs).
+        presenceUrl = "/compose-m3/api/presence",
       )
     // A catalog whose components carry baked non-default states: the landing folds each to ONE card
     // (the default), the non-default states reachable via the viewer switcher.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -405,6 +405,75 @@ applyThemeChoice();
       });
       reflectBg();
       apply();
+
+      var presenceUrl = "/compose-m3/api/presence";
+      function ping() {
+        if (document.visibilityState !== "visible") return;
+        fetch(presenceUrl, { method: "POST", credentials: "same-origin", keepalive: true })
+          .catch(function () {});
+      }
+      setInterval(ping, 240 * 1000);
+      document.addEventListener("visibilitychange", ping);
+      // Fired on arrival, not only every interval. Catalogs are no longer warmed at boot (see
+      // ServeCatalogLiveHost.eagerWarmOnOpen), so this ping is what gets a daemon ready for the
+      // catalog the visitor actually opened — while they read the grid, rather than when they
+      // first click a theme and wait out a cold start.
+      ping();
+
+      // Render-server badge. Catalogs open their daemon on first real use, so whether one is up is
+      // now a genuine question with a visible answer — a theme switch is instant against a warm
+      // daemon and pays a cold start against none. Same URL family as the presence ping, and the
+      // endpoint reads through `peekHost`, so polling it never wakes what it is reporting on.
+      var daemonUrl = presenceUrl.replace("/api/presence", "/api/daemons");
+      var daemonBadge = null;
+      function daemonBadgeEl() {
+        if (daemonBadge) return daemonBadge;
+        daemonBadge = document.getElementById("cp-daemon-status");
+        if (!daemonBadge) {
+          daemonBadge = document.createElement("span");
+          daemonBadge.id = "cp-daemon-status";
+          daemonBadge.className = "cp-daemon-status";
+          var host = document.querySelector(".cp-header-meta") || document.querySelector("header");
+          (host || document.body).appendChild(daemonBadge);
+        }
+        return daemonBadge;
+      }
+      function paintDaemonStatus(state) {
+        var el = daemonBadgeEl();
+        if (!state) { el.hidden = true; return; }
+        el.hidden = false;
+        // "not running" is a normal resting state, not a fault — a catalog nobody has rendered on
+        // simply has no process yet. Word it so it doesn't read as an error.
+        var label = state.running
+          ? "Render server: connected"
+          : "Render server: not running";
+        var count = state.instances || 0;
+        if (state.running) {
+          label += " \u00b7 " + count + (count === 1 ? " instance" : " instances");
+          if (state.activeStreams > 0) label += ", " + state.activeStreams + " live";
+        }
+        el.textContent = label;
+        el.setAttribute("data-cp-daemon-running", state.running ? "1" : "0");
+        el.title = state.pooled
+          ? state.pooled + " of " + state.poolCapacity + " per-preview daemons resident"
+          : "";
+      }
+      function pollDaemons() {
+        if (!daemonUrl || document.visibilityState !== "visible") return;
+        fetch(daemonUrl, { credentials: "same-origin" })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(paintDaemonStatus)
+          .catch(function () {});
+      }
+      setInterval(pollDaemons, 20000);
+      document.addEventListener("visibilitychange", pollDaemons);
+      pollDaemons();
+      // A theme switch is exactly when the daemon comes up, so refresh the badge shortly after one.
+      document.addEventListener("click", function (e) {
+        if (e.target && e.target.closest && e.target.closest(".cp-theme-btn")) {
+          setTimeout(pollDaemons, 1500);
+        }
+      });
     })();</script>
 <details class="cp-about cp-disclosure">
   <summary>

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -111,6 +111,90 @@ const FIXTURE_STATES = [
         },
     },
     {
+        // The render-server badge (#3274). Catalogs open their daemon on first use, so whether one
+        // is up is a real question the page now answers — and "connected" is the state a visitor
+        // sees while anything is warm. Stubbed rather than faked: the pill's text and styling come
+        // from the real `presenceScript`, this only supplies the JSON it polls for.
+        fixture: "serve-landing-declared-themes",
+        suffix: "daemon-connected",
+        apply: async (page) => {
+            await page.route("**/api/daemons*", (route) =>
+                route.fulfill({
+                    status: 200,
+                    contentType: "application/json",
+                    body: JSON.stringify({
+                        running: true,
+                        instances: 2,
+                        pooled: 1,
+                        poolCapacity: 8,
+                        activeStreams: 0,
+                    }),
+                }),
+            );
+            await page.evaluate(() => document.dispatchEvent(new Event("visibilitychange")));
+            await page.waitForFunction(
+                () =>
+                    document
+                        .getElementById("cp-daemon-status")
+                        ?.getAttribute("data-cp-daemon-running") === "1",
+            );
+        },
+    },
+    {
+        // The resting state, and the one most catalogs are in: registered, nobody has rendered on
+        // it, so no process exists. It must read as neutral information rather than a fault, which
+        // is a styling claim only a screenshot can hold honest.
+        fixture: "serve-landing-declared-themes",
+        suffix: "daemon-idle",
+        apply: async (page) => {
+            await page.route("**/api/daemons*", (route) =>
+                route.fulfill({
+                    status: 200,
+                    contentType: "application/json",
+                    body: JSON.stringify({
+                        running: false,
+                        instances: 0,
+                        pooled: 0,
+                        poolCapacity: 8,
+                        activeStreams: 0,
+                    }),
+                }),
+            );
+            await page.evaluate(() => document.dispatchEvent(new Event("visibilitychange")));
+            await page.waitForFunction(
+                () =>
+                    document
+                        .getElementById("cp-daemon-status")
+                        ?.getAttribute("data-cp-daemon-running") === "0",
+            );
+        },
+    },
+    {
+        // Mid-swap: a themed render is in flight and has NOT come back yet. This is the frame the
+        // visitor stared at for ~1s while it showed a broken-image glyph, and it is invisible to an
+        // ordinary end-state screenshot — the finished pixels are identical either way. Hold the
+        // render open and shoot: every card must still be showing its previous render under the
+        // spinner, never an empty or broken image.
+        fixture: "serve-landing-declared-themes",
+        suffix: "theme-inflight",
+        apply: async (page) => {
+            await page.route("**/render/**", (route) => {
+                const url = new URL(route.request().url());
+                // Only the themed re-renders stall; the baked pixels must still load, since the
+                // whole point is that they are what stays on screen.
+                if (!url.searchParams.has("themeProvider")) {
+                    return route.fulfill({
+                        path: renderPlaceholder,
+                        contentType: "image/png",
+                    });
+                }
+                return new Promise(() => {});
+            });
+            await page.getByRole("button", { name: "Brand Light" }).click();
+            await page.waitForSelector(".cp-reloading");
+        },
+    },
+    {
         // Keep the full-page export control expanded so its supported formats and future visual
         // changes are visible to the screenshot diff instead of hidden in a closed <details>.
         fixture: "serve-viewer-catalog-knobs",

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -67,6 +67,11 @@ const STYLED_FIXTURES = new Set([
     "serve-viewer-catalog-knobs",
     "serve-landing-catalog-palette",
     "serve-viewer-catalog-palette",
+    // The render-server badge is a `.cp-daemon-status` pill whose whole diffable claim is its
+    // STYLING — that "not running" reads as neutral information rather than a fault. Without the
+    // real stylesheet routed in, `/assets/serve/.../serve.css` 404s and the daemon captures shoot
+    // an unstyled span, so a change to that styling would move no baseline at all.
+    "serve-landing-declared-themes",
 ]);
 const SERVE_ASSETS = [
     ["serve.css", "text/css"],


### PR DESCRIPTION
Closes the visual-coverage gap #3274 flagged in its own body rather than fixed.

## Why neither surface was reachable

- **The badge** is injected by `presenceScript`, and no committed fixture emitted a `presenceUrl` — so it appeared in no `serve-*.html` at all.
- **The themed-render swap** improves a frame in the *middle* of a render. The finished pixels are identical before and after the fix; what changed is that the intermediate frame is the previous render instead of a broken-image glyph. An end-state screenshot cannot show that.

## What

`serve-landing-declared-themes` now carries a `presenceUrl`, which is what puts the badge in a fixture in the first place. Three `FIXTURE_STATES` captures ride on it:

| capture | what it pins |
|---|---|
| `daemon-connected` | stubs `/api/daemons` running, and lets the real `presenceScript` paint the pill |
| `daemon-idle` | the resting state — registered catalog, no process |
| `theme-inflight` | a themed render held open, shot while `.cp-reloading` is up |

`daemon-idle` matters more than it looks. After the lazy open (#3270/#3272), a catalog nobody has rendered on having no daemon is the *intended* steady state, so the badge must read as neutral information rather than a fault. That is a styling claim, and only a screenshot keeps it honest.

`theme-inflight` stalls only the themed requests — the baked renders still resolve, because those are exactly the pixels that must stay on screen. If someone reintroduces the direct `img.src` assignment, this shot goes from showing real cards to showing broken ones, which a string assertion in `ServeWebFixtureTest` would not necessarily catch (as it happens, that assertion *did* go stale during #3274 and only CI noticed).

## Test plan

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*' --rerun-tasks` — green; the regenerated `serve-landing-declared-themes.html` carries the badge markup and the `/api/daemons` URL.
- `node --check pages-snapshot.spec.mjs` — clean.

**`--rerun-tasks` is load-bearing here.** During #3274 Gradle was resolving `:cli:test` as `UP-TO-DATE` and skipping execution entirely, so local runs reported green without running anything and a stale assertion reached CI. Any verification of this repo's test tasks needs the flag.

The regenerated fixture was the only `.html` to change; a byte-different-but-identical `_render-placeholder.png` that the update pass also rewrote has been reverted, since it would shift every harness screenshot for no reason.

## Note on the new PNGs

The three captures produce baselines on first CI run — there is nothing to diff against yet, by construction. Their value starts with the next change to either surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6UQGrhoWJxqVYDzAXcwY)_