### PR TITLE
fix(serve): publish supplement preview controls

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -217,8 +217,14 @@ class ServeBundleHost(
         ServePreview(
           id = id,
           label = id,
-          overrides = readOverrides(id),
-          remoteComposeKnobs = readRemoteComposeKnobs(id),
+          // A packed sidecar remains authoritative for ordinary uploaded bundles. Published
+          // catalogs additionally carry these declarations inline so a supplement-only preview's
+          // controls are visible before its per-preview daemon is opened lazily.
+          overrides = readOverrides(id).ifEmpty { meta?.overrides.orEmpty() },
+          remoteComposeKnobs =
+            readRemoteComposeKnobs(id).ifEmpty { meta?.remoteComposeKnobs.orEmpty() },
+          supportsFocus = meta?.supportsFocus == true,
+          supportsGestures = meta?.supportsGestures == true,
           // `state` comes only from a `catalog.json`-backed bundle's `variants.json`
           // (`meta.state`).
           // A plain module bundle has no manifest, so an `@OverrideVariant` synthetic preview

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -338,13 +340,21 @@ class ServeCatalogStore(
             image.theme != null ||
             props != null ||
             hasSectionInfo ||
-            planned.componentSourceFile != null
+            planned.componentSourceFile != null ||
+            image.overrides.isNotEmpty() ||
+            image.remoteComposeKnobs.isNotEmpty() ||
+            image.supportsFocus ||
+            image.supportsGestures
         ) {
           variants[id] =
             VariantMeta(
               state = image.state,
               theme = image.theme,
               props = props,
+              overrides = image.overrides,
+              remoteComposeKnobs = image.remoteComposeKnobs,
+              supportsFocus = image.supportsFocus,
+              supportsGestures = image.supportsGestures,
               section = planned.section,
               group = planned.group,
               order = if (hasSectionInfo) count else null,
@@ -1459,6 +1469,14 @@ class ServeCatalogStore(
      * the component's one card (like [state]) instead of showing each as its own tile.
      */
     val props: JsonObject? = null,
+    /** Author-declared plain-Compose knobs, lifted from this preview's bundle sidecar in CI. */
+    val overrides: List<PreviewOverrideDeclaration> = emptyList(),
+    /** Author-declared Remote Compose named-value knobs, lifted from its bundle sidecar in CI. */
+    val remoteComposeKnobs: List<RemoteComposeKnobDeclaration> = emptyList(),
+    /** Discovery-time `@FocusedPreview` support, recorded without opening the live bundle. */
+    val supportsFocus: Boolean = false,
+    /** Discovery-time `@GestureHintPreview` support, recorded without opening the live bundle. */
+    val supportsGestures: Boolean = false,
   )
 
   /**
@@ -1484,6 +1502,11 @@ class ServeCatalogStore(
      * (like [state]) and offer a variant switcher. Null for a catalog that varies on neither props.
      */
     val props: JsonObject? = null,
+    /** Catalog-published controls used before a lazy per-preview daemon has been opened. */
+    val overrides: List<PreviewOverrideDeclaration> = emptyList(),
+    val remoteComposeKnobs: List<RemoteComposeKnobDeclaration> = emptyList(),
+    val supportsFocus: Boolean = false,
+    val supportsGestures: Boolean = false,
     val section: String? = null,
     val group: String? = null,
     val order: Int? = null,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1369,7 +1369,10 @@ class ServeCatalogStoreTest {
 
   @Test
   fun `a per-system sourceRepo override fetches from that repo and attributes to it`() {
-    val urls = mutableListOf<String>()
+    // Catalog vectors continue fetching on the background executor after load() publishes the
+    // host. Keep the recorder safe while that pass appends, then assert against one locked
+    // snapshot rather than iterating a list that can still be changing.
+    val urls = Collections.synchronizedList(mutableListOf<String>())
     val trust =
       TrustStore(branches = listOf(TrustedBranch("yschimke/meshcore-mobile", "design-artifacts/*")))
     val store =
@@ -1383,15 +1386,16 @@ class ServeCatalogStoreTest {
         },
       )
     val result = store.load("meshcore-mobile", sourceRepo = "yschimke/meshcore-mobile")
+    val fetchedUrls = synchronized(urls) { urls.toList() }
 
     // Every fetch went to the override repo's design-artifacts/<system> branch, not the default.
     assertTrue(
-      urls.all {
+      fetchedUrls.all {
         it.startsWith(
           "https://raw.githubusercontent.com/yschimke/meshcore-mobile/design-artifacts/meshcore-mobile/"
         )
       },
-      "fetched from the override repo: $urls",
+      "fetched from the override repo: $fetchedUrls",
     )
     assertTrue(
       result is ServeCatalogStore.Result.Ok &&

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -554,6 +554,44 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `catalog image declarations reach the baked browse surface`() {
+    // A supplement-only preview's daemon is opened lazily, so these catalog fields are the only
+    // declaration source available when /api/previews and the initial viewer are built.
+    val declared =
+      """
+      {"schema":"design-parity-catalog/v1","system":"meshcore","components":[
+        {"componentId":"Device","images":[{
+          "path":"images/device/ideal__default__dark.png",
+          "previewId":"Device_Dark",
+          "overrides":[{"key":"count","type":"int","label":"Count",
+            "default":{"kind":"int","value":2}}],
+          "remoteComposeKnobs":[{"name":"label",
+            "default":{"kind":"string","value":"Hello"}}],
+          "supportsFocus":true,
+          "supportsGestures":true
+        }]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> declared.toByteArray()
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+
+    assertTrue(
+      store(TrustStore.EMPTY, fetch = fetch).load("meshcore") is ServeCatalogStore.Result.Ok
+    )
+
+    val preview = registered.getValue("meshcore").previews.single()
+    assertEquals(listOf("count"), preview.overrides.map { it.key })
+    assertEquals(listOf("label"), preview.remoteComposeKnobs.map { it.name })
+    assertTrue(preview.supportsFocus)
+    assertTrue(preview.supportsGestures)
+  }
+
+  @Test
   fun `catalog props preserve arbitrary JSON values through the variants manifest`() {
     val flexibleProps =
       """

--- a/scripts/design-artifacts/catalog-preview-declarations.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.mjs
@@ -1,0 +1,66 @@
+/**
+ * Lift authored, per-preview controls out of preview bundles and onto catalog images.
+ *
+ * A catalog's monolithic live daemon only knows the primary bundle. Supplement-only previews are
+ * rendered by lazily-opened per-preview bundles, so their declarations must be discoverable from
+ * catalog.json before that daemon is opened. The publisher already has both bundles in memory;
+ * recording the small declaration payloads here keeps catalog loading lazy on the serve side.
+ */
+
+const decoder = new TextDecoder();
+
+function sidecarDeclarations(bundle, previewId, suffix) {
+  const bytes = bundle?.entries?.[`previews/${previewId}.${suffix}.json`];
+  if (!bytes) return [];
+  try {
+    const payload = JSON.parse(decoder.decode(bytes));
+    return Array.isArray(payload?.declarations) ? payload.declarations : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Metadata that must be visible on the browse surface before a preview daemon is opened. */
+export function declarationsByPreviewId(bundles) {
+  const out = new Map();
+  for (const bundle of Array.isArray(bundles) ? bundles : [bundles]) {
+    if (!bundle) continue;
+    for (const preview of bundle.previews ?? []) {
+      if (!preview?.id || out.has(preview.id)) continue;
+      const overrides = sidecarDeclarations(bundle, preview.id, "overrides");
+      const remoteComposeKnobs = sidecarDeclarations(bundle, preview.id, "remotecompose");
+      const captures = preview.captures ?? [];
+      const supportsFocus = captures.some((capture) => capture?.focus || capture?.focusGif);
+      const supportsGestures = captures.some((capture) => capture?.gestureHint);
+      if (
+        overrides.length > 0 ||
+        remoteComposeKnobs.length > 0 ||
+        supportsFocus ||
+        supportsGestures
+      ) {
+        out.set(preview.id, {
+          ...(overrides.length > 0 ? { overrides } : {}),
+          ...(remoteComposeKnobs.length > 0 ? { remoteComposeKnobs } : {}),
+          ...(supportsFocus ? { supportsFocus: true } : {}),
+          ...(supportsGestures ? { supportsGestures: true } : {}),
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/** Stamp declarations onto every catalog image whose live-preview bridge names a daemon id. */
+export function applyCatalogPreviewDeclarations(manifest, bundles) {
+  const byId = declarationsByPreviewId(bundles);
+  let stamped = 0;
+  for (const component of manifest.components ?? []) {
+    for (const image of component.images ?? []) {
+      const declarations = byId.get(image.previewId);
+      if (!declarations) continue;
+      Object.assign(image, declarations);
+      stamped += 1;
+    }
+  }
+  return stamped;
+}

--- a/scripts/design-artifacts/catalog-preview-declarations.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.test.mjs
@@ -1,0 +1,86 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyCatalogPreviewDeclarations,
+  declarationsByPreviewId,
+} from "./catalog-preview-declarations.mjs";
+
+const bytes = (value) => new TextEncoder().encode(JSON.stringify(value));
+
+test("reads authored declarations and detected features from a preview bundle", () => {
+  const bundle = {
+    previews: [
+      {
+        id: "Device_Dark",
+        captures: [{ focus: {} }, { gestureHint: { direction: "UP" } }],
+      },
+    ],
+    entries: {
+      "previews/Device_Dark.overrides.json": bytes({
+        declarations: [{ key: "count", type: "int", default: { kind: "int", value: 2 } }],
+      }),
+      "previews/Device_Dark.remotecompose.json": bytes({
+        declarations: [{ name: "label", default: { kind: "string", value: "Hi" } }],
+      }),
+    },
+  };
+
+  assert.deepEqual(declarationsByPreviewId(bundle).get("Device_Dark"), {
+    overrides: [{ key: "count", type: "int", default: { kind: "int", value: 2 } }],
+    remoteComposeKnobs: [
+      { name: "label", default: { kind: "string", value: "Hi" } },
+    ],
+    supportsFocus: true,
+    supportsGestures: true,
+  });
+});
+
+test("stamps supplement-only image declarations by bridged daemon id", () => {
+  const manifest = {
+    components: [
+      {
+        images: [
+          { path: "images/device/dark.png", previewId: "Device_Dark" },
+          { path: "images/primary/light.png", previewId: "Primary_Light" },
+        ],
+      },
+    ],
+  };
+  const primary = { previews: [{ id: "Primary_Light", captures: [] }], entries: {} };
+  const supplement = {
+    previews: [{ id: "Device_Dark", captures: [{ focusGif: {} }] }],
+    entries: {
+      "previews/Device_Dark.overrides.json": bytes({
+        declarations: [
+          { key: "expanded", type: "bool", default: { kind: "bool", value: false } },
+        ],
+      }),
+    },
+  };
+
+  assert.equal(applyCatalogPreviewDeclarations(manifest, [primary, supplement]), 1);
+  assert.deepEqual(manifest.components[0].images[0], {
+    path: "images/device/dark.png",
+    previewId: "Device_Dark",
+    overrides: [
+      { key: "expanded", type: "bool", default: { kind: "bool", value: false } },
+    ],
+    supportsFocus: true,
+  });
+  assert.deepEqual(manifest.components[0].images[1], {
+    path: "images/primary/light.png",
+    previewId: "Primary_Light",
+  });
+});
+
+test("ignores missing and malformed sidecars", () => {
+  const bundle = {
+    previews: [{ id: "Bare", captures: [] }, { id: "Broken", captures: [] }],
+    entries: {
+      "previews/Broken.overrides.json": new TextEncoder().encode("not json"),
+    },
+  };
+
+  assert.deepEqual([...declarationsByPreviewId(bundle)], []);
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -124,6 +124,7 @@ import {
 } from "./catalog-breakpoints.mjs";
 import { applyCatalogPreviewAxes } from "./catalog-preview-axes.mjs";
 import { selectComponentImages, selectOf } from "./catalog-select.mjs";
+import { applyCatalogPreviewDeclarations } from "./catalog-preview-declarations.mjs";
 
 /**
  * Best-effort fetch + parse of a JSON URL, with a short timeout. Returns null on
@@ -1278,6 +1279,20 @@ if (values["publish-live-bundle"]) {
       [bundle, extraBundle],
       overriddenFunctions,
     );
+    // The shared live daemon opens only the primary bundle. An extra-only image renders through a
+    // per-preview supplement bundle that stays closed until first render, so the browse surface
+    // cannot discover its authored knobs / focus / gesture controls from the daemon. Record those
+    // small declarations beside the image while both bundles are already open in CI; serve can
+    // advertise them without eagerly parsing every supplement bundle.
+    const stampedDeclarations = applyCatalogPreviewDeclarations(
+      manifest,
+      [bundle, extraBundle],
+    );
+    if (stampedDeclarations > 0) {
+      console.log(
+        `[${spec.system}] stamped authored controls on ${stampedDeclarations} catalog image(s)`,
+      );
+    }
   }
   await writeFile(
     catalogJsonPath,


### PR DESCRIPTION
## Summary

- lift authored plain-Compose and Remote Compose knob declarations from preview bundle sidecars into each bridged catalog image
- publish focus and gesture capability flags alongside those declarations without eagerly opening supplement bundles
- round-trip catalog declarations through the baked host so supplement-only previews expose controls on `/api/previews` and the browse surface

Fixes #3266.

## Test plan

- [x] `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeCatalogStoreTest :cli:ktfmtCheckMain :cli:ktfmtCheckTest`
- [x] `node --test catalog-preview-declarations.test.mjs bridge-live-preview-ids.test.mjs extra-render-fold.test.mjs`

This is data-product plumbing only; it does not change rendered pixels.