### PR TITLE
feat(catalog): select one breakpoint of a multipreview without splitting the @Preview

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -340,6 +340,59 @@ The spec shape is described by
 [`scripts/design-artifacts/catalog.spec.schema.json`](../../scripts/design-artifacts/catalog.spec.schema.json)
 (referenced via `$schema` in each sample spec for editor validation).
 
+### Breakpoints and multipreviews: `select`, not a split `@Preview`
+
+A multipreview annotation (`@WearPreviewDevices`, a local `@CatalogWearBreakpoints`)
+renders one function at several device sizes. The candidate join keys on **function
+name**, so all of those renders fold into one spec entry carrying one image per size,
+tagged from the spec's `breakpoints`:
+
+```jsonc
+"breakpoints": [
+  { "size": "smallRound", "device": "id:wearos_small_round", "widthDp": 192 },
+  { "size": "largeRound", "device": "id:wearos_large_round", "widthDp": 227 }
+]
+```
+
+Declare each breakpoint by `device` (the `@Preview(device = …)` id, matched first) as
+well as by `widthDp` (the fallback, and what the live-preview bridge scores a
+candidate annotation against). The device is the expansion's own identity; a width is
+a fingerprint two devices can share, and a device no breakpoint names keeps the
+generic Material width class — which makes two distinct renders indistinguishable on
+one axis. The export warns when it sees one. A Wear catalog that declares no
+`breakpoints` inherits the standard round table (`smallRound` / `largeRound` /
+`xlRound` / `smallSquare`, by device id and width).
+
+Folding every size onto one entry is right when the entry means "this component, at
+every breakpoint we document". When a catalog wants a **card per breakpoint** — its
+own id and caption — use `select` rather than splitting the `@Preview` function in
+the module:
+
+```jsonc
+{ "componentId": "Home/SmallRound", "preview": "HomeListViewPreview",
+  "select": { "size": "smallRound" }, "caption": "Home — small round." },
+{ "componentId": "Home/LargeRound", "preview": "HomeListViewPreview",
+  "select": { "size": "largeRound" }, "caption": "Home — large round." }
+```
+
+Two entries may share one `preview` as long as each selects a different value; the
+validator's "these fold into one sticker" warning stands down for that case, and
+fires as before when one of the references selects nothing (it would fold in the
+renders its sibling selected). A variant may `select` too, and a selection counts as
+its distinguishing axis. A selection that matches no render is reported as a missing
+render naming what the function *did* produce, so a typo — or an undeclared
+breakpoint — reads as itself rather than as a broken `preview`.
+
+Splitting the Kotlin instead costs more than the boilerplate: two `@Preview`
+functions delegating to a shared private composable replace *one* multipreview, so
+the annotation's other axes go with it (`@WearPreviewFontScales`, whose non-default
+scales the export promotes to a `props.fontScale` switcher, is the usual casualty).
+
+`select` applies to spec-authored `groups`. An annotation-led inventory
+(`@CatalogComponent`) has no equivalent yet — it fans out one card per breakpoint,
+which the preview server disambiguates by appending the breakpoint to a **colliding**
+card label (`Edgebutton · Small Round`).
+
 ### Render priority: deferring the long tail to the live server
 
 A catalog that publishes with a live path — `publish-live-bundle: true` (the bundle

--- a/scripts/design-artifacts/bridge-live-preview-ids.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.mjs
@@ -10,6 +10,8 @@
  * driver so it is unit-testable (the driver runs top-level on import).
  */
 
+import { breakpointMatcher, catalogBreakpoints } from "./catalog-breakpoints.mjs";
+
 /**
  * Theme of a daemon preview id. The catalog's multipreview (`@CatalogModes` /
  * `@CatalogTemplate`) renders each function in `name = "Light"` / `name = "Dark"`
@@ -100,6 +102,10 @@ function variantIdentity(preview) {
   return {
     id: preview.id,
     night,
+    // The annotation's own device id — the axis a multipreview expansion actually varies. Scored
+    // ahead of width below: two Wear round devices can render at the same width, and a device the
+    // annotation names is a statement rather than a fingerprint.
+    device: typeof params.device === "string" ? params.device : null,
     widthDp: typeof params.widthDp === "number" ? params.widthDp : null,
     fontScale:
       typeof params.fontScale === "number" && params.fontScale !== 1
@@ -148,12 +154,14 @@ function resolveFunction(previewForState, componentId, image, state) {
   return undefined;
 }
 
-function pickVariantId(candidates, image, widthForSize) {
+function pickVariantId(candidates, image, breakpointForSize) {
   if (candidates.length === 0) return undefined;
   if (candidates.length === 1) return candidates[0].id;
   const wantNight =
     image.theme === "dark" ? true : image.theme === "light" ? false : null;
-  const wantWidth = widthForSize(image.size);
+  const wantBreakpoint = breakpointForSize(image.size);
+  const wantDevice = wantBreakpoint.device ?? null;
+  const wantWidth = wantBreakpoint.widthDp ?? null;
   const wantFontScale = requestedFontScale(image.props);
   let best;
   let bestConstraint = -Infinity;
@@ -187,6 +195,9 @@ function pickVariantId(candidates, image, widthForSize) {
     // so a candidate declaring exactly that width IS, by construction, the annotation that rendered
     // this sticker. A candidate declaring no width stays neutral rather than wrong: a
     // single-annotation component whose sticker carries a size must still resolve.
+    if (wantDevice !== null && candidate.device !== null) {
+      constraint += candidate.device === wantDevice ? 2 : -2;
+    }
     if (wantWidth !== null && candidate.widthDp !== null) {
       constraint += candidate.widthDp === wantWidth ? 2 : -2;
     }
@@ -254,27 +265,34 @@ function previewsByFunction(bundles, allPreviewIds = new Set()) {
 }
 
 /**
- * `size` → the width the spec's breakpoints declare for it, so a sticker's size axis can be compared
- * against a candidate's `@Preview(widthDp = …)`. Yields null for a spec with no breakpoints, in
- * which case the size axis simply doesn't constrain the pick.
+ * `size` → the breakpoint the spec declares for it, so a sticker's size axis can be compared against
+ * a candidate's `@Preview(device = …)` / `@Preview(widthDp = …)`. Yields an empty breakpoint for a
+ * spec that declares none (or a size it doesn't name), in which case the size axis simply doesn't
+ * constrain the pick.
+ *
+ * Reads `catalogBreakpoints`, not `spec.breakpoints`: a Wear catalog that declares none is tagged
+ * with the standard round table when its stickers are baked, so resolving the live lane against an
+ * empty table would leave every size unconstrained on exactly the catalogs the axis matters most to.
  */
-function widthForSizeOf(spec) {
-  const widthBySize = new Map(
-    (spec?.breakpoints ?? [])
-      .filter((b) => typeof b?.size === "string" && typeof b?.widthDp === "number")
-      .map((b) => [b.size, b.widthDp]),
+function breakpointForSizeOf(spec) {
+  const bySize = new Map(
+    (catalogBreakpoints(spec) ?? [])
+      .filter((b) => typeof b?.size === "string")
+      .map((b) => [b.size, b]),
   );
-  return (size) => (size == null ? null : (widthBySize.get(size) ?? null));
+  return (size) => (size == null ? EMPTY_BREAKPOINT : (bySize.get(size) ?? EMPTY_BREAKPOINT));
 }
 
-/** The breakpoint `size` a candidate's `@Preview(widthDp = …)` renders, or undefined. */
-function sizeForWidthOf(spec) {
-  const sizeByWidth = new Map(
-    (spec?.breakpoints ?? [])
-      .filter((b) => typeof b?.size === "string" && typeof b?.widthDp === "number")
-      .map((b) => [b.widthDp, b.size]),
-  );
-  return (widthDp) => (widthDp == null ? undefined : sizeByWidth.get(widthDp));
+const EMPTY_BREAKPOINT = Object.freeze({});
+
+/**
+ * The breakpoint `size` a candidate annotation renders, or undefined — by its `@Preview(device = …)`
+ * id first, then its width, through the same matcher that tagged the baked stickers.
+ */
+function sizeForCandidateOf(spec) {
+  const matcher = breakpointMatcher(catalogBreakpoints(spec));
+  return (candidate) =>
+    matcher ? matcher({ device: candidate?.device, widthDp: candidate?.widthDp }) : undefined;
 }
 
 /**
@@ -301,8 +319,8 @@ function sizeForWidthOf(spec) {
  */
 export function expandDeferredRecords(deferred, spec, bundles) {
   const previewsByFn = previewsByFunction(bundles);
-  const widthForSize = widthForSizeOf(spec);
-  const sizeForWidth = sizeForWidthOf(spec);
+  const breakpointForSize = breakpointForSizeOf(spec);
+  const sizeForCandidate = sizeForCandidateOf(spec);
   const out = [];
   for (const record of deferred ?? []) {
     const candidates = previewsByFn.get(record?.preview) ?? [];
@@ -313,7 +331,7 @@ export function expandDeferredRecords(deferred, spec, bundles) {
     // Axes already known (a mode deferral), or a single-annotation function: one record, routed to
     // the annotation those axes select — exactly a baked sticker's resolution.
     if (record?.theme || candidates.length === 1) {
-      const daemonId = pickVariantId(candidates, record ?? {}, widthForSize);
+      const daemonId = pickVariantId(candidates, record ?? {}, breakpointForSize);
       out.push(daemonId ? { ...record, previewId: daemonId } : { ...record });
       continue;
     }
@@ -331,7 +349,7 @@ export function expandDeferredRecords(deferred, spec, bundles) {
     for (const candidate of pool) {
       const theme =
         candidate.night === true ? "dark" : candidate.night === false ? "light" : undefined;
-      const size = record?.size ?? sizeForWidth(candidate.widthDp);
+      const size = record?.size ?? sizeForCandidate(candidate);
       // Only a RECOVERED scale becomes props; a record that named its own keeps it verbatim, so the
       // spec's exact spelling ("1.5x", "2.0") is what reaches the path.
       const scale = wantedScale === null ? candidate.fontScale : null;
@@ -413,7 +431,7 @@ export function bridgeLivePreviewIds(
   // as `previewsByFunction` folds the bundles.
   const allPreviewIds = new Set();
   const previewsByFn = previewsByFunction(bundles, allPreviewIds);
-  const widthForSize = widthForSizeOf(spec);
+  const breakpointForSize = breakpointForSizeOf(spec);
   let mapped = 0;
   for (const component of manifest.components ?? []) {
     for (const image of component.images ?? []) {
@@ -430,7 +448,7 @@ export function bridgeLivePreviewIds(
         const daemonId = pickVariantId(
           previewsByFn.get(fn) ?? [],
           image,
-          widthForSize,
+          breakpointForSize,
         );
         if (daemonId) {
           image.previewId = daemonId;
@@ -457,7 +475,7 @@ export function bridgeLivePreviewIds(
           const baseDaemonId = pickVariantId(
             previewsByFn.get(baseFn) ?? [],
             image,
-            widthForSize,
+            breakpointForSize,
           );
           const variantId = baseDaemonId && `${baseDaemonId}_VARIANT_${state}`;
           if (variantId && allPreviewIds.has(variantId)) {

--- a/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
@@ -1150,3 +1150,106 @@ test("a record that already names a font scale selects that annotation, keeping 
     [["2.0", "Filled_Light_2x"]],
   );
 });
+
+test("a Wear sticker resolves by device id, not by the width two devices share", () => {
+  // `@WearPreviewDevices` fans one function across two round devices. Scoring on width alone was
+  // enough while the two widths differed, but the axis the annotations actually vary is the device
+  // — and a catalog can document a breakpoint (a square face, a custom device spec) whose width
+  // collides with a sibling's. The device is the annotation's own identity; the width is a
+  // fingerprint.
+  const spec = {
+    system: "confetti-wear",
+    breakpoints: [
+      { size: "smallRound", device: "id:wearos_small_round", widthDp: 192 },
+      { size: "smallSquare", device: "id:wearos_square", widthDp: 192 },
+    ],
+    groups: [
+      { components: [{ componentId: "Screens/Home", preview: "HomeListViewPreview" }] },
+    ],
+  };
+  const bundle = {
+    previews: [
+      {
+        id: "wear.HomeScreenKt.HomeListViewPreview_Devices - Small Round",
+        functionName: "HomeListViewPreview",
+        params: { device: "id:wearos_small_round", widthDp: 192 },
+      },
+      {
+        id: "wear.HomeScreenKt.HomeListViewPreview_Devices - Small Square",
+        functionName: "HomeListViewPreview",
+        params: { device: "id:wearos_square", widthDp: 192 },
+      },
+    ],
+  };
+  const manifest = {
+    system: "confetti-wear",
+    components: [
+      {
+        componentId: "Screens/Home",
+        images: [
+          { state: "default", size: "smallRound" },
+          { state: "default", size: "smallSquare" },
+        ],
+      },
+    ],
+  };
+
+  bridgeLivePreviewIds(manifest, spec, bundle, new Set());
+
+  assert.deepEqual(
+    manifest.components[0].images.map((i) => i.previewId),
+    [
+      "wear.HomeScreenKt.HomeListViewPreview_Devices - Small Round",
+      "wear.HomeScreenKt.HomeListViewPreview_Devices - Small Square",
+    ],
+  );
+});
+
+test("a Wear catalog that declares no breakpoints still resolves through the default table", () => {
+  // The baked stickers are tagged with the default Wear names (`catalogBreakpoints`), so resolving
+  // the live lane against `spec.breakpoints` alone left every size unconstrained on exactly the
+  // catalogs the axis matters most to — and both stickers took the first-listed annotation.
+  const spec = {
+    system: "confetti-wear",
+    library: ["androidx.wear.compose:compose-material3"],
+    groups: [
+      { components: [{ componentId: "Screens/Home", preview: "HomeListViewPreview" }] },
+    ],
+  };
+  const bundle = {
+    previews: [
+      {
+        id: "wear.HomeScreenKt.HomeListViewPreview_Devices - Large Round",
+        functionName: "HomeListViewPreview",
+        params: { device: "id:wearos_large_round", widthDp: 227 },
+      },
+      {
+        id: "wear.HomeScreenKt.HomeListViewPreview_Devices - Small Round",
+        functionName: "HomeListViewPreview",
+        params: { device: "id:wearos_small_round", widthDp: 192 },
+      },
+    ],
+  };
+  const manifest = {
+    system: "confetti-wear",
+    components: [
+      {
+        componentId: "Screens/Home",
+        images: [
+          { state: "default", size: "smallRound" },
+          { state: "default", size: "largeRound" },
+        ],
+      },
+    ],
+  };
+
+  bridgeLivePreviewIds(manifest, spec, bundle, new Set());
+
+  assert.deepEqual(
+    manifest.components[0].images.map((i) => i.previewId),
+    [
+      "wear.HomeScreenKt.HomeListViewPreview_Devices - Small Round",
+      "wear.HomeScreenKt.HomeListViewPreview_Devices - Large Round",
+    ],
+  );
+});

--- a/scripts/design-artifacts/catalog-breakpoints.mjs
+++ b/scripts/design-artifacts/catalog-breakpoints.mjs
@@ -1,5 +1,5 @@
 /**
- * Apply a catalog spec's named width breakpoints to candidate images.
+ * Apply a catalog spec's named breakpoints to candidate images.
  *
  * The candidate reader classifies numeric `widthDp` values with Material window
  * size classes (`compact` / `medium` / `expanded`). Catalog specs may declare a
@@ -7,51 +7,149 @@
  * `largeRound`. Re-tag matching images after the bundle has been read so those
  * declared names become the catalog's size axis.
  *
+ * A breakpoint may be declared by `device` (the `@Preview(device = …)` id the render actually ran
+ * under, e.g. `id:wearos_small_round`) as well as by `widthDp`. Prefer the device: it is the
+ * annotation's own identity, carried verbatim through discovery from the multipreview expansion
+ * table, whereas a width is a fingerprint that two devices can share and that a device the spec
+ * never listed silently fails to match — leaving the image on the generic `compact` class and
+ * collapsing two distinct renders onto one output axis. `widthDp` stays supported (and is still
+ * worth declaring: the live-preview bridge scores a candidate annotation's width against it), but
+ * it is now the fallback rather than the only key.
+ *
  * @param {Array<{previewId?: string, componentId: string, images?: Array<object>}>} candidates
  * @param {Array<{id: string, params?: object, captures?: Array<{params?: object}>}>} previews
- * @param {Array<{size: string, widthDp: number}> | undefined} breakpoints
+ * @param {Array<{size: string, widthDp?: number, device?: string}> | undefined} breakpoints
  * @returns {number} number of images assigned a declared breakpoint name
  */
 export function applySpecBreakpoints(candidates, previews, breakpoints) {
-  const sizeByWidth = new Map(
-    (breakpoints ?? [])
-      .filter(
-        ({ size, widthDp }) =>
-          typeof size === "string" &&
-          size.length > 0 &&
-          typeof widthDp === "number" &&
-          Number.isFinite(widthDp),
-      )
-      .map(({ size, widthDp }) => [widthDp, size]),
-  );
-  if (sizeByWidth.size === 0) return 0;
+  const sizeOf = breakpointMatcher(breakpoints);
+  if (!sizeOf) return 0;
 
-  const previewById = new Map(previews.map((preview) => [preview.id, preview]));
   let applied = 0;
-  for (const candidate of candidates) {
-    const preview = previewById.get(candidate.previewId ?? candidate.componentId);
-    if (!preview) continue;
-    const captures =
-      Array.isArray(preview.captures) && preview.captures.length > 0
-        ? preview.captures
-        : [{}];
-    for (let index = 0; index < (candidate.images ?? []).length; index += 1) {
-      const params = {
-        ...(preview.params ?? {}),
-        ...(captures[index]?.params ?? {}),
-      };
-      const size = sizeByWidth.get(params.widthDp);
-      if (size === undefined) continue;
-      candidate.images[index].size = size;
-      applied += 1;
-    }
+  for (const { image, params } of eachCandidateImage(candidates, previews)) {
+    const size = sizeOf(params);
+    if (size === undefined) continue;
+    image.size = size;
+    applied += 1;
   }
   return applied;
 }
 
+/**
+ * The `@Preview(device = …)` ids a render used that NO declared breakpoint names, sorted.
+ *
+ * A device id in the render is a deliberate statement that this capture is a different screen from
+ * its siblings; if the spec's breakpoints don't name it, the image keeps the generic width class
+ * and — for a multipreview whose expansions differ only by device — becomes indistinguishable from
+ * the sibling that did match. That collapse used to surface much later, as an overwritten sticker
+ * or a duplicate-axis failure, so report it up front. Only meaningful once a catalog declares
+ * breakpoints at all: a catalog with none has opted out of the axis entirely.
+ *
+ * @param {Array<{id: string, params?: object, captures?: Array<{params?: object}>}>} previews
+ * @param {Array<{size: string, widthDp?: number, device?: string}> | undefined} breakpoints
+ * @returns {string[]}
+ */
+export function undeclaredBreakpointDevices(previews, breakpoints) {
+  const sizeOf = breakpointMatcher(breakpoints);
+  if (!sizeOf) return [];
+  const undeclared = new Set();
+  for (const preview of previews ?? []) {
+    for (const params of eachCaptureParams(preview)) {
+      if (typeof params.device !== "string" || params.device.length === 0) continue;
+      if (sizeOf(params) === undefined) undeclared.add(params.device);
+    }
+  }
+  return [...undeclared].sort();
+}
+
+/**
+ * `params` → the declared breakpoint name, or undefined. Null when the spec declares no usable
+ * breakpoint, so callers can skip the whole pass rather than walk every image for nothing.
+ *
+ * Exported because the live-preview bridge has to answer the same question in reverse (which
+ * breakpoint did this candidate annotation render?), and a second implementation there would drift
+ * from this one — which is precisely how a device-keyed breakpoint would end up tagging a baked
+ * sticker while the live lane still resolved it by width.
+ */
+export function breakpointMatcher(breakpoints) {
+  const named = (breakpoints ?? []).filter(
+    ({ size }) => typeof size === "string" && size.length > 0,
+  );
+  const sizeByDevice = new Map(
+    named
+      .filter(({ device }) => typeof device === "string" && device.length > 0)
+      .map(({ device, size }) => [device, size]),
+  );
+  const sizeByWidth = new Map(
+    named
+      .filter(({ widthDp }) => typeof widthDp === "number" && Number.isFinite(widthDp))
+      .map(({ widthDp, size }) => [widthDp, size]),
+  );
+  if (sizeByDevice.size === 0 && sizeByWidth.size === 0) return null;
+  return (params) => {
+    // Device first: an image whose device IS declared must never fall through to a width lookup
+    // that could name a different breakpoint (two round devices can render at the same width).
+    if (typeof params?.device === "string") {
+      const byDevice = sizeByDevice.get(params.device);
+      if (byDevice !== undefined) return byDevice;
+      // A declared-device catalog that also lists this device's siblings by width still resolves
+      // through the width table below — the two keys are alternatives, not a mode switch.
+    }
+    return sizeByWidth.get(params?.widthDp);
+  };
+}
+
+/** The captures of a preview, or a single implicit one for a preview that declares none. */
+function capturesOf(preview) {
+  return Array.isArray(preview?.captures) && preview.captures.length > 0
+    ? preview.captures
+    : [{}];
+}
+
+/**
+ * The effective params of one capture: the preview's params, overlaid by the capture's own. An
+ * index past the capture list falls back to the preview's params alone — a candidate can carry
+ * more images than the manifest lists captures (a scroll/animation sequence), and those extra
+ * frames come from the same annotation.
+ */
+function captureParams(preview, index) {
+  return {
+    ...(preview?.params ?? {}),
+    ...(capturesOf(preview)[index]?.params ?? {}),
+  };
+}
+
+/** Each capture's effective params. */
+function* eachCaptureParams(preview) {
+  for (let index = 0; index < capturesOf(preview).length; index += 1) {
+    yield captureParams(preview, index);
+  }
+}
+
+/** Each candidate image paired with the effective params of the capture that produced it. */
+function* eachCandidateImage(candidates, previews) {
+  const previewById = new Map((previews ?? []).map((preview) => [preview.id, preview]));
+  for (const candidate of candidates ?? []) {
+    const preview = previewById.get(candidate.previewId ?? candidate.componentId);
+    if (!preview) continue;
+    for (let index = 0; index < (candidate.images ?? []).length; index += 1) {
+      yield { image: candidate.images[index], params: captureParams(preview, index) };
+    }
+  }
+}
+
+/**
+ * Wear's standard round devices, keyed by the `@Preview(device = …)` ids the built-in multipreview
+ * expansions carry (`PreviewDiscovery.BUILT_IN_MULTIPREVIEW_EXPANSIONS`) as well as by width.
+ * `xlRound` and `smallSquare` are here even though `@WearPreviewDevices` fans out to only the two
+ * round sizes: `@WearPreviewSquare` and a hand-written `@CatalogWearBreakpoints` reach them, and
+ * an undeclared device is exactly the silent collapse this table exists to prevent.
+ */
 export const DEFAULT_WEAR_BREAKPOINTS = Object.freeze([
-  Object.freeze({ size: "smallRound", widthDp: 192 }),
-  Object.freeze({ size: "largeRound", widthDp: 227 }),
+  Object.freeze({ size: "smallRound", widthDp: 192, device: "id:wearos_small_round" }),
+  Object.freeze({ size: "largeRound", widthDp: 227, device: "id:wearos_large_round" }),
+  Object.freeze({ size: "xlRound", widthDp: 240, device: "id:wearos_xl_round" }),
+  Object.freeze({ size: "smallSquare", widthDp: 180, device: "id:wearos_square" }),
 ]);
 
 /**
@@ -63,8 +161,8 @@ export const DEFAULT_WEAR_BREAKPOINTS = Object.freeze([
  * Compose library and omits `breakpoints`; any explicit array (including `[]`) remains
  * authoritative.
  *
- * @param {{library?: string[], breakpoints?: Array<{size: string, widthDp: number}>}} spec
- * @returns {Array<{size: string, widthDp: number}> | undefined}
+ * @param {{library?: string[], breakpoints?: Array<{size: string, widthDp?: number, device?: string}>}} spec
+ * @returns {Array<{size: string, widthDp?: number, device?: string}> | undefined}
  */
 export function catalogBreakpoints(spec) {
   if (Array.isArray(spec?.breakpoints)) return spec.breakpoints;

--- a/scripts/design-artifacts/catalog-breakpoints.test.mjs
+++ b/scripts/design-artifacts/catalog-breakpoints.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   applySpecBreakpoints,
   catalogBreakpoints,
+  undeclaredBreakpointDevices,
   DEFAULT_WEAR_BREAKPOINTS,
 } from "./catalog-breakpoints.mjs";
 
@@ -12,9 +13,14 @@ test("Wear catalogs default to standard round device breakpoints", () => {
     catalogBreakpoints({ library: ["androidx.wear.compose:compose-material3"] }),
     DEFAULT_WEAR_BREAKPOINTS,
   );
+  // Every default carries BOTH keys: the device id is what the built-in multipreview expansions
+  // (`@WearPreviewDevices` → `id:wearos_small_round` + `id:wearos_large_round`) actually set, and
+  // the width is what the live-preview bridge scores a candidate annotation against.
   assert.deepEqual(DEFAULT_WEAR_BREAKPOINTS, [
-    { size: "smallRound", widthDp: 192 },
-    { size: "largeRound", widthDp: 227 },
+    { size: "smallRound", widthDp: 192, device: "id:wearos_small_round" },
+    { size: "largeRound", widthDp: 227, device: "id:wearos_large_round" },
+    { size: "xlRound", widthDp: 240, device: "id:wearos_xl_round" },
+    { size: "smallSquare", widthDp: 180, device: "id:wearos_square" },
   ]);
 });
 
@@ -119,4 +125,71 @@ test("undeclared widths keep the candidate reader's canonical size", () => {
 
   assert.equal(applied, 0);
   assert.equal(candidates[0].images[0].size, "medium");
+});
+
+test("a breakpoint's device id matches even when two devices share a width", () => {
+  const candidates = [
+    {
+      componentId: "Screen",
+      previewId: "Screen_Devices",
+      images: [{ size: "compact" }, { size: "compact" }],
+    },
+  ];
+  const previews = [
+    {
+      id: "Screen_Devices",
+      params: { device: "id:wearos_small_round", widthDp: 192 },
+      // Both expansions render 192 dp wide — only the device tells them apart, which is exactly
+      // the case a width table silently collapses.
+      captures: [{}, { params: { device: "id:wearos_square", widthDp: 192 } }],
+    },
+  ];
+
+  const applied = applySpecBreakpoints(candidates, previews, [
+    { size: "smallRound", device: "id:wearos_small_round", widthDp: 192 },
+    { size: "smallSquare", device: "id:wearos_square", widthDp: 192 },
+  ]);
+
+  assert.equal(applied, 2);
+  assert.deepEqual(
+    candidates[0].images.map((image) => image.size),
+    ["smallRound", "smallSquare"],
+  );
+});
+
+test("width remains the fallback for a device the breakpoints do not name", () => {
+  const candidates = [
+    { componentId: "Screen", previewId: "Screen", images: [{ size: "compact" }] },
+  ];
+  const previews = [
+    { id: "Screen", params: { device: "id:wearos_rect", widthDp: 227 } },
+  ];
+
+  applySpecBreakpoints(candidates, previews, [{ size: "largeRound", widthDp: 227 }]);
+
+  assert.equal(candidates[0].images[0].size, "largeRound");
+});
+
+test("undeclaredBreakpointDevices names the devices no breakpoint claims", () => {
+  const previews = [
+    {
+      id: "Screen_Devices",
+      params: { device: "id:wearos_small_round", widthDp: 192 },
+      captures: [{}, { params: { device: "id:wearos_xl_round", widthDp: 240 } }],
+    },
+    { id: "Other", params: { device: "id:wearos_xl_round", widthDp: 240 } },
+  ];
+  const breakpoints = [{ size: "smallRound", device: "id:wearos_small_round", widthDp: 192 }];
+
+  assert.deepEqual(undeclaredBreakpointDevices(previews, breakpoints), ["id:wearos_xl_round"]);
+  // A catalog with no size axis has opted out — nothing to report against.
+  assert.deepEqual(undeclaredBreakpointDevices(previews, []), []);
+  // A device resolved by width alone is declared, just not by id.
+  assert.deepEqual(
+    undeclaredBreakpointDevices(previews, [
+      { size: "smallRound", widthDp: 192 },
+      { size: "xlRound", widthDp: 240 },
+    ]),
+    [],
+  );
 });

--- a/scripts/design-artifacts/catalog-select.mjs
+++ b/scripts/design-artifacts/catalog-select.mjs
@@ -1,0 +1,110 @@
+/**
+ * Pick ONE axis value out of a multipreview's fan-out, so a catalog entry can target a single
+ * breakpoint without the module splitting its `@Preview` function in two.
+ *
+ * A multipreview annotation (`@WearPreviewDevices`, a local `@CatalogWearBreakpoints`, …) renders
+ * one function at several device sizes. The join keys candidates on function name, so all of those
+ * renders fold into ONE spec entry carrying one image per size — which is right when the entry
+ * means "this component, at every breakpoint we document", and wrong when the catalog wants a card
+ * per breakpoint with its own id and caption. Without a selector the only way to get the latter is
+ * to hand-split the Kotlin: two `@Preview` functions delegating to a shared private composable, two
+ * spec entries, and the multipreview's other axes (font scales) dropped on the floor.
+ *
+ * `select` removes that surgery. Two entries may name the SAME `preview` as long as they select
+ * different values, and each keeps its own `componentId`, caption, and sticker path:
+ *
+ *     { "componentId": "Home/SmallRound", "preview": "HomeListViewPreview",
+ *       "select": { "size": "smallRound" }, "caption": "Home — small round." }
+ *     { "componentId": "Home/LargeRound", "preview": "HomeListViewPreview",
+ *       "select": { "size": "largeRound" }, "caption": "Home — large round." }
+ *
+ * Only the `size` axis is selectable today: it is the one axis the serve grid keeps as separate
+ * cards (theme, state and props fold into one card with a switcher), so it is the only one an
+ * author currently has to reach for Kotlin to control. The shape is an object rather than a bare
+ * string so a second axis needs no spec migration.
+ *
+ * Pure and dependency-free (no `@design-parity/*`, no I/O) so it unit-tests without an `npm ci`,
+ * like its siblings `catalog-variants.mjs` / `catalog-priority.mjs`.
+ */
+
+/** The image axes a `select` may name. Anything else is a spec error, not a silent no-op. */
+export const SELECT_AXES = Object.freeze(["size"]);
+
+/**
+ * The `select` an entry (component or variant) declares, or undefined when it selects nothing.
+ * An empty object counts as "no selection" so `{}` behaves like an absent key rather than
+ * filtering everything away.
+ */
+export function selectOf(entry) {
+  const select = entry?.select;
+  if (!select || typeof select !== "object" || Array.isArray(select)) return undefined;
+  return Object.keys(select).length > 0 ? select : undefined;
+}
+
+/**
+ * Keep only the images matching every axis [select] names. An image that carries NO value for a
+ * selected axis never matches: a selector is a positive statement about which render is wanted, and
+ * an untagged image is precisely the one whose axis couldn't be resolved (see
+ * `applySpecBreakpoints` — a width no breakpoint declares leaves the candidate reader's canonical
+ * size in place). Silently letting it through would hand the entry a render from the wrong device.
+ */
+export function selectImages(images, select) {
+  const axes = selectOf({ select });
+  if (!axes) return [...(images ?? [])];
+  return (images ?? []).filter((image) =>
+    Object.entries(axes).every(([axis, value]) => image?.[axis] === value),
+  );
+}
+
+/** A short human tag for a selection — `size=largeRound` — for missing-render reports. */
+export function selectLabel(select) {
+  return Object.entries(select ?? {})
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([axis, value]) => `${axis}=${value}`)
+    .join(", ");
+}
+
+/**
+ * Apply a spec component's `select` to the candidate its `preview` resolved to.
+ *
+ * Returns the images the entry should be built from, plus a `missing` label when the selection
+ * matched nothing. That case is deliberately NOT the same report as "the preview never rendered":
+ * the function did render, just not at the axis value asked for, so the message names what it DID
+ * produce — turning a hunt through the module into a typo fix (or the discovery that a breakpoint
+ * is undeclared, see `undeclaredBreakpointDevices`).
+ *
+ * With no selection the candidate's own array is returned BY IDENTITY, not copied: `foldVariants`
+ * recognises a same-function variant partly by identity, and a defensive copy here would quietly
+ * change the fold for every catalog that selects nothing.
+ *
+ * @returns {{images: Array<object>, missing: string | null}}
+ */
+export function selectComponentImages(component, candidate) {
+  const select = selectOf(component);
+  if (!select) return { images: candidate?.images ?? [], missing: null };
+  const images = selectImages(candidate?.images, select);
+  if (images.length > 0) return { images, missing: null };
+  const detail = Object.keys(select)
+    .map((axis) => `${axis} ∈ {${availableAxisValues(candidate?.images, axis).join(", ")}}`)
+    .join("; ");
+  return {
+    images,
+    missing:
+      `${component.componentId} [select ${selectLabel(select)}; ` +
+      `${component.preview} renders ${detail}]`,
+  };
+}
+
+/**
+ * The distinct values an axis actually took across [images], sorted — the "you asked for X, this
+ * function renders Y and Z" half of a failed selection's error message. Untagged images are
+ * reported as `<untagged>` rather than dropped, because "the function rendered two images and
+ * neither carries a size" is the likeliest cause of a miss (an undeclared breakpoint width) and
+ * hiding it would send the author hunting in the wrong file.
+ */
+export function availableAxisValues(images, axis) {
+  const values = new Set(
+    (images ?? []).map((image) => image?.[axis] ?? "<untagged>"),
+  );
+  return [...values].sort();
+}

--- a/scripts/design-artifacts/catalog-select.test.mjs
+++ b/scripts/design-artifacts/catalog-select.test.mjs
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SELECT_AXES,
+  availableAxisValues,
+  selectComponentImages,
+  selectImages,
+  selectLabel,
+  selectOf,
+} from "./catalog-select.mjs";
+import { foldVariants } from "./catalog-variants.mjs";
+
+const img = (size, extra = {}) => ({ variant: "ideal", state: "default", size, ...extra });
+
+test("selectOf reads a selection and treats an empty one as none", () => {
+  assert.deepEqual(selectOf({ select: { size: "largeRound" } }), { size: "largeRound" });
+  assert.equal(selectOf({ select: {} }), undefined);
+  assert.equal(selectOf({}), undefined);
+  assert.equal(selectOf({ select: null }), undefined);
+  assert.equal(selectOf({ select: ["largeRound"] }), undefined, "an array is not a selection");
+});
+
+test("selectImages keeps only the named axis value", () => {
+  const images = [img("smallRound"), img("largeRound")];
+  assert.deepEqual(selectImages(images, { size: "largeRound" }), [img("largeRound")]);
+  assert.deepEqual(selectImages(images, { size: "xlRound" }), []);
+});
+
+test("selectImages returns every image when nothing is selected", () => {
+  const images = [img("smallRound"), img("largeRound")];
+  assert.deepEqual(selectImages(images, undefined), images);
+  assert.deepEqual(selectImages(images, {}), images);
+});
+
+test("an untagged image never satisfies a selection", () => {
+  // The untagged case IS the failure mode worth being strict about: a width no breakpoint declares
+  // leaves the candidate reader's canonical size in place, so letting it through would hand the
+  // entry a render from a device it did not ask for.
+  assert.deepEqual(selectImages([{ variant: "ideal" }], { size: "largeRound" }), []);
+});
+
+test("selectLabel and availableAxisValues describe a failed selection", () => {
+  assert.equal(selectLabel({ size: "largeRound" }), "size=largeRound");
+  assert.deepEqual(
+    availableAxisValues([img("smallRound"), img("largeRound"), { variant: "ideal" }], "size"),
+    ["<untagged>", "largeRound", "smallRound"],
+  );
+});
+
+test("only `size` is selectable today", () => {
+  assert.deepEqual(SELECT_AXES, ["size"]);
+});
+
+// --- foldVariants ------------------------------------------------------------
+
+test("a variant may select one breakpoint of another function's multipreview", () => {
+  const byFunction = new Map([
+    ["ScreenLoading", { images: [img("smallRound"), img("largeRound")] }],
+  ]);
+  const component = {
+    componentId: "Screen/Home",
+    preview: "Screen",
+    variants: [{ state: "loading", preview: "ScreenLoading", select: { size: "largeRound" } }],
+  };
+
+  const { ideal, missing } = foldVariants([img("largeRound")], component, byFunction);
+
+  assert.deepEqual(missing, []);
+  assert.deepEqual(ideal, [img("largeRound"), img("largeRound", { state: "loading" })]);
+});
+
+test("a variant selection that matches nothing is a missing render, labelled with the axis", () => {
+  const byFunction = new Map([["ScreenLoading", { images: [img("smallRound")] }]]);
+  const component = {
+    componentId: "Screen/Home",
+    preview: "Screen",
+    variants: [{ state: "loading", preview: "ScreenLoading", select: { size: "largeRound" } }],
+  };
+
+  const { ideal, missing } = foldVariants([img("largeRound")], component, byFunction);
+
+  assert.deepEqual(ideal, [img("largeRound")]);
+  assert.deepEqual(missing, ["Screen/Home [loading, size=largeRound]"]);
+});
+
+test("a same-function variant is satisfied by an already-selected default image", () => {
+  // The component selected `largeRound` out of its own multipreview, so the fold was handed a
+  // FILTERED view rather than the candidate's own array — the identity check alone would miss it
+  // and re-append a duplicate.
+  const candidate = { images: [img("smallRound"), img("largeRound")] };
+  const byFunction = new Map([["Screen", candidate]]);
+  const component = {
+    componentId: "Screen/Home",
+    preview: "Screen",
+    variants: [{ preview: "Screen", select: { size: "largeRound" } }],
+  };
+
+  const { ideal, missing } = foldVariants([img("largeRound")], component, byFunction);
+
+  assert.deepEqual(missing, []);
+  assert.deepEqual(ideal, [img("largeRound")], "no duplicate appended");
+});
+
+// --- selectComponentImages: the driver's entry-level step --------------------
+
+test("selectComponentImages narrows an entry to the breakpoint it selects", () => {
+  const candidate = { images: [img("smallRound"), img("largeRound")] };
+  const { images, missing } = selectComponentImages(
+    { componentId: "Home/Large", preview: "HomeListViewPreview", select: { size: "largeRound" } },
+    candidate,
+  );
+  assert.equal(missing, null);
+  assert.deepEqual(images, [img("largeRound")]);
+});
+
+test("selectComponentImages returns the candidate's own array when nothing is selected", () => {
+  const candidate = { images: [img("smallRound"), img("largeRound")] };
+  const { images, missing } = selectComponentImages(
+    { componentId: "Home", preview: "HomeListViewPreview" },
+    candidate,
+  );
+  assert.equal(missing, null);
+  // Identity, not a copy: foldVariants recognises a same-function variant partly by it.
+  assert.equal(images, candidate.images);
+});
+
+test("a selection matching nothing reports what the function did render", () => {
+  const candidate = { images: [img("smallRound"), img("largeRound")] };
+  const { images, missing } = selectComponentImages(
+    { componentId: "Home/XL", preview: "HomeListViewPreview", select: { size: "xlRound" } },
+    candidate,
+  );
+  assert.deepEqual(images, []);
+  assert.equal(
+    missing,
+    "Home/XL [select size=xlRound; HomeListViewPreview renders size ∈ {largeRound, smallRound}]",
+  );
+});

--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -11,6 +11,8 @@
 // init-catalog-spec.mjs.
 
 import { CAPTURE_MODES, exportsNoSticker } from "./capture-mode.mjs";
+import { catalogBreakpoints } from "./catalog-breakpoints.mjs";
+import { SELECT_AXES, selectOf } from "./catalog-select.mjs";
 import {
   DEFERRED,
   MODE_WILDCARD,
@@ -558,7 +560,15 @@ export function validateSpec(spec, opts = {}) {
   }
 
   const componentIds = new Map(); // componentId -> first path
+  // The breakpoint names a `select.size` may legitimately name — the spec's own, or the Wear
+  // default table it inherits. Undefined for a catalog with no size axis at all, in which case a
+  // selection can't be checked against anything and the shape check alone applies.
+  const declaredSizes = declaredBreakpointSizes(spec);
   const previewToPaths = new Map(); // preview name -> [paths]
+  // `preview name -> Set of select signatures`, so the "referenced twice" warning below can tell a
+  // copy-paste duplicate from the legitimate case this exists for: two entries splitting one
+  // multipreview's breakpoints between them.
+  const previewToSelects = new Map();
   // The subset of the above whose referring entry did NOT declare `"capture": "none"`. A PNG-less
   // preview is only an error for those: a `"none"` entry is *declaring* the absence.
   const staticRefPaths = new Map(); // preview name -> [paths]
@@ -584,6 +594,7 @@ export function validateSpec(spec, opts = {}) {
         componentIds.set(comp.componentId, cp);
       }
       errors.push(...captureErrors(comp, cp));
+      errors.push(...selectErrors(comp, cp, declaredSizes));
       if (typeof comp?.preview !== "string" || comp.preview.length === 0) {
         errors.push(`${cp}.preview is required (an exact @Preview function name)`);
       } else {
@@ -591,6 +602,7 @@ export function validateSpec(spec, opts = {}) {
         // the same module, so a `preview` that matches no @Preview function is just as broken when
         // it is deferred — it is simply broken later, on a viewer's request, instead of in CI.
         pushMulti(previewToPaths, comp.preview, cp);
+        recordSelect(previewToSelects, comp.preview, comp);
         if (!exportsNoSticker(comp)) pushMulti(staticRefPaths, comp.preview, cp);
       }
       errors.push(...priorityErrors(comp, cp));
@@ -607,6 +619,7 @@ export function validateSpec(spec, opts = {}) {
               "state",
               "props",
               "theme",
+              "select",
               "capture",
               "priority",
             ]);
@@ -624,11 +637,21 @@ export function validateSpec(spec, opts = {}) {
               errors.push(`${vp}.preview is required`);
             } else {
               pushMulti(previewToPaths, v.preview, vp);
+              recordSelect(previewToSelects, v.preview, v);
               if (!exportsNoSticker(v)) pushMulti(staticRefPaths, v.preview, vp);
             }
-            if (v?.state === undefined && v?.props === undefined && v?.theme === undefined) {
+            errors.push(...selectErrors(v, vp, declaredSizes));
+            // A `select` distinguishes a variant as surely as a tag does: its images carry the
+            // selected axis value, so they land on their own `…__<size>.png` rather than over the
+            // default's.
+            if (
+              v?.state === undefined &&
+              v?.props === undefined &&
+              v?.theme === undefined &&
+              selectOf(v) === undefined
+            ) {
               errors.push(
-                `${vp} has neither \`state\`, \`props\` nor \`theme\` — it would overwrite the default artifact`,
+                `${vp} has neither \`state\`, \`props\`, \`theme\` nor \`select\` — it would overwrite the default artifact`,
               );
             }
             if (v?.theme !== undefined && v.theme !== "light" && v.theme !== "dark") {
@@ -643,9 +666,12 @@ export function validateSpec(spec, opts = {}) {
 
   // A preview name used by two components folds both into one candidate at
   // render time (the join keys on function name) — almost always a copy-paste
-  // bug, so flag it.
+  // bug, so flag it. UNLESS every reference `select`s a different value: that is the
+  // supported way to split a multipreview's breakpoints across entries without splitting
+  // the @Preview function, and each reference then names its own sticker rather than
+  // folding onto one.
   for (const [preview, paths] of previewToPaths) {
-    if (paths.length > 1) {
+    if (paths.length > 1 && !selectsAreDistinct(previewToSelects.get(preview), paths.length)) {
       warnings.push(
         `preview "${preview}" is referenced ${paths.length}× (${paths.join(", ")}) — these fold into one sticker`,
       );
@@ -814,6 +840,93 @@ function pushMulti(map, key, value) {
   const arr = map.get(key);
   if (arr) arr.push(value);
   else map.set(key, [value]);
+}
+
+/**
+ * Structural checks for an entry's optional `select` (component or variant).
+ *
+ * All errors rather than warnings, for the same reason `capture` and `priority` are: an unusable
+ * selection doesn't degrade gracefully. An unknown axis would be ignored by `selectImages` and the
+ * entry would quietly fold in every render of its function — the opposite of what it asked for —
+ * while a mistyped breakpoint name matches nothing and sinks the publish much later, as a missing
+ * render on an entry whose `preview` is demonstrably fine.
+ *
+ * [declaredSizes] is undefined for a catalog with no size axis (no `breakpoints`, no Wear default),
+ * where a `select.size` can't be checked against anything; the value check is skipped rather than
+ * guessed at.
+ */
+function selectErrors(entry, path, declaredSizes) {
+  const select = entry?.select;
+  if (select === undefined) return [];
+  if (typeof select !== "object" || select === null || Array.isArray(select)) {
+    return [`${path}.select must be an object, e.g. { "size": "largeRound" }`];
+  }
+  const errors = [];
+  if (Object.keys(select).length === 0) {
+    errors.push(
+      `${path}.select is empty — drop it, or name an axis (${SELECT_AXES.map((a) => `\`${a}\``).join(", ")})`,
+    );
+  }
+  for (const [axis, value] of Object.entries(select)) {
+    if (!SELECT_AXES.includes(axis)) {
+      errors.push(
+        `${path}.select.${axis} is not a selectable axis; expected only ` +
+          `${SELECT_AXES.map((a) => `\`${a}\``).join(", ")}`,
+      );
+      continue;
+    }
+    if (typeof value !== "string" || value.length === 0) {
+      errors.push(`${path}.select.${axis} must be a non-empty string`);
+      continue;
+    }
+    if (axis === "size" && declaredSizes && !declaredSizes.has(value)) {
+      const hint = closest(value, [...declaredSizes]);
+      errors.push(
+        `${path}.select.size "${value}" is not a declared breakpoint` +
+          (hint ? ` — did you mean "${hint}"?` : ` (declared: ${[...declaredSizes].join(", ")})`),
+      );
+    }
+  }
+  return errors;
+}
+
+/** Record one reference's `select` signature (`""` for an unselected reference). */
+function recordSelect(map, preview, entry) {
+  const select = selectOf(entry);
+  const signature = select
+    ? Object.entries(select)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([axis, value]) => `${axis}=${value}`)
+        .join(",")
+    : "";
+  const seen = map.get(preview);
+  if (seen) seen.add(signature);
+  else map.set(preview, new Set([signature]));
+}
+
+/**
+ * Whether every reference to one preview selects a DIFFERENT value — the deliberate split of a
+ * multipreview across entries. Requires each reference to select something: an unselected reference
+ * folds in every render including the ones its siblings selected, so mixing the two forms really
+ * does double up stickers and stays worth a warning.
+ */
+function selectsAreDistinct(signatures, references) {
+  if (!signatures || signatures.size !== references) return false;
+  return !signatures.has("");
+}
+
+/**
+ * The breakpoint names a `select.size` may name, or undefined when the catalog declares no size
+ * axis at all — including the Wear default table a Wear catalog inherits by omitting `breakpoints`,
+ * since the export tags its stickers with those names and a spec must be able to select them.
+ */
+function declaredBreakpointSizes(spec) {
+  const declared = catalogBreakpoints(spec);
+  if (declared === undefined) return undefined;
+  const sizes = new Set(
+    declared.filter((b) => typeof b?.size === "string" && b.size.length > 0).map((b) => b.size),
+  );
+  return sizes.size > 0 ? sizes : undefined;
 }
 
 /**

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -282,7 +282,7 @@ test("validateSpec rejects a variant with no distinguishing axis", () => {
     ],
   };
   const { errors } = validateSpec(spec);
-  assert.ok(errors.some((e) => e.includes("neither `state`, `props` nor `theme`")));
+  assert.ok(errors.some((e) => e.includes("neither `state`, `props`, `theme` nor `select`")));
   assert.ok(errors.some((e) => e.includes("overwrite the default artifact")));
 });
 
@@ -832,4 +832,100 @@ test("validateSpec accepts modePriority on a cover-sheet spec with no groups", (
     { liveBundle: true },
   );
   assert.deepEqual(errors, []);
+});
+
+// --- select: one breakpoint of a multipreview, without splitting the function ---
+
+const wearSpecWith = (components) => ({
+  system: "confetti-wear",
+  title: "Confetti Wear",
+  library: ["androidx.wear.compose:compose-material3"],
+  groups: [{ name: "Screens", components }],
+});
+
+test("validateSpec accepts two entries splitting one multipreview by select", () => {
+  const { errors, warnings } = validateSpec(
+    wearSpecWith([
+      { componentId: "Home/Small", preview: "HomeListViewPreview", select: { size: "smallRound" } },
+      { componentId: "Home/Large", preview: "HomeListViewPreview", select: { size: "largeRound" } },
+    ]),
+  );
+  assert.deepEqual(errors, []);
+  assert.ok(
+    !warnings.some((w) => w.includes("fold into one sticker")),
+    "distinct selections are the supported split, not a copy-paste bug",
+  );
+});
+
+test("validateSpec still warns when one of the references selects nothing", () => {
+  const { warnings } = validateSpec(
+    wearSpecWith([
+      { componentId: "Home", preview: "HomeListViewPreview" },
+      { componentId: "Home/Large", preview: "HomeListViewPreview", select: { size: "largeRound" } },
+    ]),
+  );
+  // The unselected entry folds in every render, including the one its sibling selected — so the
+  // two really do double up and the warning still earns its place.
+  assert.ok(warnings.some((w) => w.includes("fold into one sticker")));
+});
+
+test("validateSpec rejects a select.size that names no declared breakpoint", () => {
+  const { errors } = validateSpec(
+    wearSpecWith([
+      { componentId: "Home", preview: "HomeListViewPreview", select: { size: "largeRund" } },
+    ]),
+  );
+  assert.ok(
+    errors.some((e) => e.includes('select.size "largeRund"') && e.includes('did you mean "largeRound"')),
+    `expected a suggestion, got ${JSON.stringify(errors)}`,
+  );
+});
+
+test("validateSpec rejects an unknown select axis and a malformed select", () => {
+  const { errors } = validateSpec(
+    wearSpecWith([
+      { componentId: "A", preview: "P", select: { theme: "dark" } },
+      { componentId: "B", preview: "Q", select: "largeRound" },
+      { componentId: "C", preview: "R", select: {} },
+    ]),
+  );
+  assert.ok(errors.some((e) => e.includes("select.theme is not a selectable axis")));
+  assert.ok(errors.some((e) => e.includes("select must be an object")));
+  assert.ok(errors.some((e) => e.includes("select is empty")));
+});
+
+test("validateSpec accepts a select as a variant's only distinguishing axis", () => {
+  const { errors } = validateSpec(
+    wearSpecWith([
+      {
+        componentId: "Home",
+        preview: "HomeListViewPreview",
+        variants: [{ preview: "HomeListViewLoading", select: { size: "largeRound" } }],
+      },
+    ]),
+  );
+  assert.deepEqual(errors, []);
+});
+
+test("validateSpec checks select.size against an explicit breakpoint table", () => {
+  const spec = {
+    system: "s",
+    title: "T",
+    breakpoints: [{ size: "compact", widthDp: 412 }],
+    groups: [
+      { name: "G", components: [{ componentId: "A", preview: "P", select: { size: "expanded" } }] },
+    ],
+  };
+  assert.ok(validateSpec(spec).errors.some((e) => e.includes('select.size "expanded"')));
+});
+
+test("validateSpec leaves select.size unchecked for a catalog with no size axis", () => {
+  const spec = {
+    system: "s",
+    title: "T",
+    groups: [
+      { name: "G", components: [{ componentId: "A", preview: "P", select: { size: "whatever" } }] },
+    ],
+  };
+  assert.deepEqual(validateSpec(spec).errors, []);
 });

--- a/scripts/design-artifacts/catalog-variants.mjs
+++ b/scripts/design-artifacts/catalog-variants.mjs
@@ -1,4 +1,5 @@
 import { exportsNoSticker } from "./capture-mode.mjs";
+import { selectImages, selectLabel, selectOf } from "./catalog-select.mjs";
 
 /**
  * Fold a catalog spec component's `variants` onto its default render.
@@ -52,7 +53,13 @@ export function foldVariants(defaultImages, component, byFunction) {
   }
   for (const variant of component.variants ?? []) {
     const candidate = byFunction.get(variant.preview);
-    if (!candidate || candidate.images.length === 0) {
+    // A variant may `select` ONE value of a multipreview's fan-out (a single breakpoint out of
+    // `@WearPreviewDevices`, say), so a spec can fold one device's render onto a component without
+    // the module splitting that function into per-device siblings. Applied before the emptiness
+    // check below so a selection that matches nothing is reported as the missing render it is,
+    // with the same label and through the same gate as an unrendered variant.
+    const images = candidate ? selectImages(candidate.images, selectOf(variant)) : [];
+    if (images.length === 0) {
       // A variant that declares `"capture": "none"` has no sticker to fold in by design — record it
       // so the export can say so, but keep it out of the completeness gate.
       const label = `${component.componentId} [${variantLabel(variant)}]`;
@@ -67,13 +74,16 @@ export function foldVariants(defaultImages, component, byFunction) {
     // variant axes and create duplicate output keys. Treat an already-tagged image as satisfying
     // the same-function variant; variants backed by a different function still retain the
     // authoritative re-tagging behavior below.
+    // `candidate.images === defaultImages` holds whenever the two name the same function AND the
+    // component selected nothing; the name comparison keeps the check true for a component whose
+    // `select` handed this fold a filtered view of the very same candidate.
     if (
-      candidate.images === defaultImages &&
+      (candidate.images === defaultImages || variant.preview === component.preview) &&
       defaultImages.some((image) => imageHasVariantAxes(image, variant))
     ) {
       continue;
     }
-    for (const image of candidate.images) {
+    for (const image of images) {
       const tagged = { ...image };
       if (variant.state !== undefined) tagged.state = variant.state;
       if (variant.props) tagged.props = { ...image.props, ...variant.props };
@@ -97,6 +107,14 @@ export function foldVariants(defaultImages, component, byFunction) {
  */
 export function imageHasVariantAxes(image, variant) {
   let hasExplicitAxis = false;
+  // A `select` is an axis like any other here: a same-function variant that picks one breakpoint is
+  // satisfied by the default images ALREADY carrying that breakpoint's render, which is the whole
+  // point of selecting instead of splitting the function. Without this the fold would re-tag and
+  // re-append the very image it matched.
+  for (const [axis, expected] of Object.entries(selectOf(variant) ?? {})) {
+    hasExplicitAxis = true;
+    if (image?.[axis] !== expected) return false;
+  }
   if (variant.state !== undefined) {
     hasExplicitAxis = true;
     if ((image.state ?? "default") !== variant.state) return false;
@@ -155,6 +173,7 @@ export function variantLabel(variant) {
     ...(variant.state ? [variant.state] : []),
     ...Object.entries(variant.props ?? {}).map(([k, v]) => `${k}=${v}`),
     ...(variant.theme ? [variant.theme] : []),
+    ...(selectOf(variant) ? [selectLabel(selectOf(variant))] : []),
   ];
   return parts.join(", ") || variant.preview;
 }

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -41,13 +41,17 @@
     },
     "breakpoints": {
       "type": "array",
-      "description": "The named width breakpoints the sticker sheet documents and uses as image size axes. When omitted, a catalog whose library includes androidx.wear.compose defaults to smallRound at 192 dp and largeRound at 227 dp. An explicit array, including an empty array, overrides that Wear default.",
+      "description": "The named breakpoints the sticker sheet documents and uses as image size axes. Each entry names the breakpoint (`size`) and identifies the renders that belong to it by `device` (the @Preview(device = …) id, matched first — a multipreview expansion's own identity) and/or `widthDp` (matched as a fallback, and used by the live-preview lane to score which annotation produced a sticker), so declaring both is the most robust. When omitted, a catalog whose library includes androidx.wear.compose defaults to the standard Wear round devices (smallRound / largeRound / xlRound / smallSquare, by device id and width). An explicit array, including an empty array, overrides that Wear default. A device id no breakpoint names keeps the generic Material width class, which collapses two distinct renders onto one axis — the export warns when it sees one.",
       "items": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "size": { "type": "string" },
-          "widthDp": { "type": "number" }
+          "widthDp": { "type": "number" },
+          "device": {
+            "type": "string",
+            "description": "The @Preview(device = …) id this breakpoint names, e.g. \"id:wearos_small_round\"."
+          }
         }
       }
     },
@@ -127,6 +131,7 @@
           "minLength": 1,
           "description": "EXACT @Preview function name that renders this component. Must match a discovered @Preview (or multipreview) function in `module`."
         },
+        "select": { "$ref": "#/definitions/select" },
         "caption": {
           "type": "string",
           "description": "One-line description shown under the sticker."
@@ -164,17 +169,30 @@
         }
       }
     },
+    "select": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "description": "Pick ONE value of a multipreview's fan-out for this entry, instead of folding every render of `preview` onto it. Lets two entries share a @Preview function and stay separate cards with their own componentId and caption — the alternative being to split the function in the module into per-breakpoint siblings (which also drops the multipreview's other axes, e.g. @WearPreviewFontScales). A selection that matches no render is reported as a missing render, naming the values the function did produce.",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "The breakpoint name (from `breakpoints`) this entry renders at, e.g. \"largeRound\"."
+        }
+      }
+    },
     "variant": {
       "type": "object",
       "required": ["preview"],
       "additionalProperties": false,
-      "description": "A secondary render of the parent component, tagged by `state` (pressed/focused/disabled/…), named `props` content axes, or a `theme` (light/dark, for a screen whose two themes are separate @Preview functions). Give at least one so it's distinguishable from the default.",
+      "description": "A secondary render of the parent component, tagged by `state` (pressed/focused/disabled/…), named `props` content axes, or a `theme` (light/dark, for a screen whose two themes are separate @Preview functions), and optionally narrowed to one breakpoint with `select`. Give at least one so it's distinguishable from the default.",
       "properties": {
         "preview": {
           "type": "string",
           "minLength": 1,
           "description": "EXACT @Preview function name for this variant render."
         },
+        "select": { "$ref": "#/definitions/select" },
         "caption": { "type": "string" },
         "capture": {
           "enum": ["static", "none"],

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -120,8 +120,10 @@ import { applySourceFiles } from "./apply-source-files.mjs";
 import {
   applySpecBreakpoints,
   catalogBreakpoints,
+  undeclaredBreakpointDevices,
 } from "./catalog-breakpoints.mjs";
 import { applyCatalogPreviewAxes } from "./catalog-preview-axes.mjs";
+import { selectComponentImages, selectOf } from "./catalog-select.mjs";
 
 /**
  * Best-effort fetch + parse of a JSON URL, with a short timeout. Returns null on
@@ -227,6 +229,19 @@ async function loadCandidates(path, breakpoints) {
     candidateBundle.previews,
     breakpoints,
   );
+  // A `@Preview(device = …)` the breakpoints don't name leaves its render on the generic width
+  // class, where it is indistinguishable from the sibling expansion that DID match — the collapse
+  // that otherwise surfaces much later as an overwritten sticker or a duplicate-axis failure. Say so
+  // here, while the fix (one more `breakpoints` entry) is still obvious.
+  const undeclaredDevices = undeclaredBreakpointDevices(candidateBundle.previews, breakpoints);
+  if (undeclaredDevices.length > 0) {
+    console.warn(
+      `[${basename(path)}] ${undeclaredDevices.length} @Preview device id(s) match no declared ` +
+        `breakpoint, so their renders keep the generic width class: ${undeclaredDevices.join(", ")}. ` +
+        `Add them to the spec's \`breakpoints\` (\`{ "size": …, "device": … }\`) to give each its ` +
+        `own size axis.`,
+    );
+  }
   // Return the ORIGINAL (unfiltered) bundle: its raw `entries` carry the per-preview
   // `previews/<id>.layout.json` (layout-inspector tree) the wireframe is built from, and its full
   // `previews` list carries the catalog-token sheets `catalogTokensFromBundle` needs.
@@ -488,6 +503,15 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
         else missing.push(component.componentId);
         continue;
       }
+      // An entry may `select` ONE value of a multipreview's fan-out, so two entries can share a
+      // `@Preview` function and still be separate cards with their own ids and captions — the
+      // alternative being to split the function in the module (see catalog-select.mjs).
+      const select = selectOf(component);
+      const { images: selected, missing: unselected } = selectComponentImages(component, candidate);
+      if (unselected) {
+        missing.push(unselected);
+        continue;
+      }
       if (!hasSemantics(candidate))
         withoutSemantics.push(component.componentId);
       // Fold the component's state `variants` (pressed / focused / disabled / off
@@ -499,7 +523,7 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
         ideal,
         missing: missingVariants,
         noSticker: noStickerVariants,
-      } = foldVariants(candidate.images, component, byFunction);
+      } = foldVariants(selected, component, byFunction);
       missing.push(...missingVariants);
       noSticker.push(...noStickerVariants);
       // Thin the palette fan-out per `modePriority`: a themed sticker whose mode is deferred is
@@ -538,13 +562,16 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
           .filter((image) => image.theme)
           .map((image) => deferralAxisKey(image.theme, image.state, image.props, image.size)),
       );
+      // A `select`ed entry covers ONE breakpoint of its function, so its deferred-mode record has to
+      // name that size — otherwise the sibling entry selecting the other breakpoint dedupes against
+      // the same axis key and only one of the two is declared live-only.
       const modeSources = [
-        { preview: component.preview },
+        { preview: component.preview, size: select?.size },
         ...(component.variants ?? []).map((v) => ({
           preview: v.preview,
           state: v.state,
           props: v.props,
-          size: v.size,
+          size: selectOf(v)?.size ?? v.size,
         })),
       ];
       for (const source of modeSources) {


### PR DESCRIPTION
## Goal

Make a catalog able to say "this card is the large-round render" without the module hand-splitting its multipreview into per-device `@Preview` siblings — the workaround [joreilly/Confetti#1778](https://github.com/joreilly/Confetti/pull/1778) reaches for, which costs 111 lines, five shared-fixture indirections, and the `@WearPreviewFontScales` coverage on all five screens.

## Summary

A multipreview (`@WearPreviewDevices`, a local `@CatalogWearBreakpoints`) renders one function at several device sizes, and the candidate join keys on **function name** — so every size folds onto one spec entry. Right when the entry means "this component, at every breakpoint we document"; wrong when the catalog wants a card per breakpoint with its own id and caption.

**`select`** — a spec component or variant may pick one value of its function's fan-out, so two entries can share one `preview` and stay separate cards:

```jsonc
{ "componentId": "Home/SmallRound", "preview": "HomeListViewPreview",
  "select": { "size": "smallRound" }, "caption": "Home — small round." },
{ "componentId": "Home/LargeRound", "preview": "HomeListViewPreview",
  "select": { "size": "largeRound" }, "caption": "Home — large round." }
```

- `selectComponentImages` / `selectImages` narrow an entry to one axis value. A selection matching nothing is a **missing render that names what the function did produce** (`Home/XL [select size=xlRound; HomeListViewPreview renders size ∈ {largeRound, smallRound}]`), not a silent fold of everything.
- `foldVariants` accepts `select` on a variant, counts it as a distinguishing axis, and still recognises a same-function variant now that the fold can be handed a filtered view.
- The validator checks the shape, rejects an unknown axis or an undeclared breakpoint name (with a did-you-mean), and stands down the existing "these fold into one sticker" warning when every reference selects a distinct value — it still fires when one reference selects nothing, since that one really does fold in its sibling's renders.
- Only `size` is selectable today: it is the one axis the serve grid keeps as separate cards (theme/state/props fold into one card with a switcher), so it is the only one an author had to reach for Kotlin to control. The object shape means a second axis needs no spec migration.

**The size axis becomes exact rather than width-derived.** A `breakpoints` entry may now name the `@Preview(device = …)` id, matched ahead of `widthDp`:

```jsonc
{ "size": "smallRound", "device": "id:wearos_small_round", "widthDp": 192 }
```

The device is the expansion's own identity (carried verbatim from `BUILT_IN_MULTIPREVIEW_EXPANSIONS`); a width is a fingerprint two devices can share, and a device no breakpoint names silently keeps the generic `compact` class — indistinguishable from the sibling that did match. Alongside that:

- the live-preview bridge scores the same device id, and reads `catalogBreakpoints(spec)` rather than `spec.breakpoints`, so a Wear catalog declaring no breakpoints no longer leaves every size unconstrained and resolves both stickers to the first-listed annotation;
- the Wear default table gains device ids plus `xlRound` / `smallSquare`;
- the export **warns** about any device id no breakpoint claims, instead of collapsing it onto `compact` and surfacing it much later as an overwritten sticker or a duplicate-axis failure.

## Scope notes

- `select` applies to spec-authored `groups`. An annotation-led inventory (`@CatalogComponent`, which is what this repo's own catalogs use) has no equivalent yet — it fans out one card per breakpoint, which the serve grid disambiguates by appending the breakpoint to a *colliding* card label (`Edgebutton · Small Round`, #3268). Noted in the docs; a `@CatalogComponent` selector is the natural follow-up.
- No committed catalog changes shape here, so no rendered output moves — this is opt-in spec vocabulary plus a strictly-better axis resolution. Text-only PR: nothing visual changes until a catalog adopts `select`.

## Test plan

- `node --test` in `scripts/design-artifacts`: **422 pass, 1 fail**, the failure being the pre-existing `rc-compare-pixels.test.mjs` `ERR_MODULE_NOT_FOUND: pngjs` in this container (no `npm ci`); it fails identically on a clean tree.
- New coverage: `catalog-select.test.mjs` (12 tests — selection semantics, the untagged-image strictness, the failed-selection report, and the `foldVariants` interactions), plus device-matching / undeclared-device tests in `catalog-breakpoints.test.mjs` and two Wear resolution tests in `bridge-live-preview-ids.test.mjs` (both fail before this change — the two annotations tie and the first-listed id wins for both stickers).
- `validate-samples.test.mjs` still validates all three committed sample specs unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mwx5Kh8gyDeZ5Ua2Yukx46)_