### PR TITLE
fix(daemon): honour the wrap sandbox in PreviewIndex-backed resolvers

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -836,14 +836,19 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
       ((params.kind ?: defaults.kind)?.let { it != "COMPOSE" } ?: false)
   val wrapWidth = explicitWidthPx == null && !pinned
   val wrapHeight = explicitHeightPx == null && !pinned
+  // A per-preview wrap sandbox narrows the generic 400×800 dp bound without pinning the axis, so
+  // this lane measures a Wear sticker against the same 227 dp watch screen the batch bake used.
+  // See `PreviewParamsDto.wrapSandboxWidthDp`.
+  val sandboxWidthDp =
+    params.wrapSandboxWidthDp?.takeIf { it > 0 } ?: PreviewManifestEntry.WRAP_SANDBOX_WIDTH_DP
+  val sandboxHeightDp =
+    params.wrapSandboxHeightDp?.takeIf { it > 0 } ?: PreviewManifestEntry.WRAP_SANDBOX_HEIGHT_DP
   val widthPx =
     explicitWidthPx
-      ?: if (wrapWidth) (PreviewManifestEntry.WRAP_SANDBOX_WIDTH_DP * density).roundHalfUpPx()
-      else defaults.widthPx
+      ?: if (wrapWidth) (sandboxWidthDp * density).roundHalfUpPx() else defaults.widthPx
   val heightPx =
     explicitHeightPx
-      ?: if (wrapHeight) (PreviewManifestEntry.WRAP_SANDBOX_HEIGHT_DP * density).roundHalfUpPx()
-      else defaults.heightPx
+      ?: if (wrapHeight) (sandboxHeightDp * density).roundHalfUpPx() else defaults.heightPx
   val uiMode = if (uiModeIsNight(params.uiMode)) RenderSpec.SpecUiMode.DARK else defaults.uiMode
   return RenderSpec(
     previewId = info.id,

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -35,4 +35,52 @@ class RenderSpecFromInfoTest {
     assertEquals("preview-id", spec.previewId)
     assertEquals(300, spec.widthPx)
   }
+
+  @Test
+  fun `a wrap sandbox narrows the bound without pinning either axis`() {
+    // The Wear lane: `retargetWearStickers` hands a Wear module's device-less previews the 227dp
+    // watch screen as their wrap sandbox. `bundle daemon` / `compose-preview serve` resolve through
+    // PreviewIndex rather than PreviewManifestRouter, so this resolver must honour it too —
+    // otherwise a fillMaxWidth sticker measures against 400dp live while its baked render used
+    // 227dp. Both axes must STILL wrap: the sandbox is a bound, not a frame.
+    val spec =
+      renderSpecFromInfo(
+        PreviewInfoDto(
+          id = "FilledButton",
+          className = "com.example.CatalogPreviewsKt",
+          methodName = "FilledButton",
+          params =
+            PreviewParamsDto(
+              wrapSandboxWidthDp = 227,
+              wrapSandboxHeightDp = 227,
+              density = 2.0f,
+            ),
+        )
+      )
+
+    assertEquals(true, spec.wrapWidth)
+    assertEquals(true, spec.wrapHeight)
+    assertEquals(454, spec.widthPx)
+    assertEquals(454, spec.heightPx)
+  }
+
+  @Test
+  fun `an explicit widthDp still wins over the wrap sandbox`() {
+    val spec =
+      renderSpecFromInfo(
+        PreviewInfoDto(
+          id = "Specimen",
+          className = "com.example.CatalogPreviewsKt",
+          methodName = "Specimen",
+          params = PreviewParamsDto(widthDp = 120, wrapSandboxWidthDp = 227, density = 2.0f),
+        )
+      )
+
+    assertEquals(false, spec.wrapWidth)
+    assertEquals(240, spec.widthPx)
+    // Per-axis: only the width carried a sandbox, so the height axis still wraps against the
+    // generic default rather than inheriting the width's 227dp.
+    assertEquals(true, spec.wrapHeight)
+    assertEquals(PreviewManifestEntry.WRAP_SANDBOX_HEIGHT_DP * 2, spec.heightPx)
+  }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -173,6 +173,22 @@ data class ScrollCaptureDto(
 data class PreviewParamsDto(
   val widthDp: Int? = null,
   val heightDp: Int? = null,
+  /**
+   * Bound a **wrapped** axis is measured against, replacing
+   * [PreviewManifestEntry.WRAP_SANDBOX_WIDTH_DP] / `WRAP_SANDBOX_HEIGHT_DP`. Mirrors the plugin's
+   * `PreviewParams.wrapSandboxWidthDp`: unlike [widthDp] it does NOT pin the axis, so
+   * `renderSpecFromInfo` still reports `wrapWidth = true` and the capture still crops to measured
+   * size.
+   *
+   * Must be declared here, not just on the manifest router's own DTO: `bundle daemon` and
+   * `compose-preview serve` launch with only `composeai.daemon.previewsJsonPath`, so they resolve
+   * through [PreviewIndex] rather than the router. Without these fields `ignoreUnknownKeys` drops
+   * them and a Wear `fillMaxWidth` sticker measures against 400 dp live while its baked render used
+   * 227 dp — the exact PNG↔Live divergence the wrap plumbing exists to prevent.
+   */
+  val wrapSandboxWidthDp: Int? = null,
+  /** See [wrapSandboxWidthDp]. */
+  val wrapSandboxHeightDp: Int? = null,
   val density: Float? = null,
   val fontScale: Float? = null,
   /** BCP-47 locale tag — the plugin's `PreviewParams.locale`. */

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -540,14 +540,19 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
   val pinned = (params.device ?: defaults.device) != null
   val wrapWidth = explicitWidthPx == null && !pinned
   val wrapHeight = explicitHeightPx == null && !pinned
+  // A per-preview wrap sandbox narrows the generic 400×800 dp bound without pinning the axis, so
+  // this lane measures against the same bound the batch bake used (227 dp on a Wear sticker). See
+  // `PreviewParamsDto.wrapSandboxWidthDp`.
+  val sandboxWidthDp =
+    params.wrapSandboxWidthDp?.takeIf { it > 0 } ?: PreviewManifestEntry.WRAP_SANDBOX_WIDTH_DP
+  val sandboxHeightDp =
+    params.wrapSandboxHeightDp?.takeIf { it > 0 } ?: PreviewManifestEntry.WRAP_SANDBOX_HEIGHT_DP
   val widthPx =
     explicitWidthPx
-      ?: if (wrapWidth) (PreviewManifestEntry.WRAP_SANDBOX_WIDTH_DP * density).roundHalfUpPx()
-      else defaults.widthPx
+      ?: if (wrapWidth) (sandboxWidthDp * density).roundHalfUpPx() else defaults.widthPx
   val heightPx =
     explicitHeightPx
-      ?: if (wrapHeight) (PreviewManifestEntry.WRAP_SANDBOX_HEIGHT_DP * density).roundHalfUpPx()
-      else defaults.heightPx
+      ?: if (wrapHeight) (sandboxHeightDp * density).roundHalfUpPx() else defaults.heightPx
   val uiMode = if (uiModeIsNight(params.uiMode)) RenderSpec.SpecUiMode.DARK else defaults.uiMode
   return RenderSpec(
     previewId = info.id,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -54,6 +54,32 @@ class RenderSpecFromInfoTest {
   }
 
   @Test
+  fun `a wrap sandbox narrows the bound without pinning either axis`() {
+    // A Wear module's device-less previews carry the 227dp watch screen as their wrap sandbox
+    // (PreviewDiscovery.retargetWearStickers). This lane must honour it, or a fillMaxWidth sticker
+    // measures against 400dp live while its baked render used 227dp, and the viewer's PNG↔Live
+    // toggle visibly resizes it. Both axes must STILL wrap — the sandbox is a bound, not a frame.
+    val spec =
+      renderSpecFromInfo(
+        info(params = PreviewParamsDto(wrapSandboxWidthDp = 227, wrapSandboxHeightDp = 227))
+      )
+    assertEquals(true, spec.wrapWidth)
+    assertEquals(true, spec.wrapHeight)
+    assertEquals(454, spec.widthPx)
+    assertEquals(454, spec.heightPx)
+  }
+
+  @Test
+  fun `an explicit widthDp still wins over the wrap sandbox`() {
+    val spec =
+      renderSpecFromInfo(info(params = PreviewParamsDto(widthDp = 120, wrapSandboxWidthDp = 227)))
+    assertEquals(false, spec.wrapWidth)
+    assertEquals(240, spec.widthPx)
+    // The untouched height axis still wraps, at its own sandbox bound.
+    assertEquals(true, spec.wrapHeight)
+  }
+
+  @Test
   fun `a null params block falls back to the fixed frame and never wraps`() {
     // A *missing* params block means "params unknown", not "params empty": the incremental
     // source-change path (IncrementalDiscovery.toDto → PreviewIndex.applyDiff) swaps an edited


### PR DESCRIPTION
Follow-up to #3278, which merged before this landed. Closes a gap Codex flagged on that PR and I confirmed.

## The gap

#3278 plumbed `wrapSandboxWidthDp` / `wrapSandboxHeightDp` through `PreviewManifestEntry.resolved()` in both daemon routers — but not through the `PreviewIndex` path.

`bundle daemon` and `compose-preview serve` launch with only `composeai.daemon.previewsJsonPath`, so they resolve via `PreviewIndex`, not the manifest router. `PreviewParamsDto` didn't declare either field, so `ignoreUnknownKeys` silently dropped them and both `DaemonMain.renderSpecFromInfo` implementations kept measuring wrapped content against the generic 400×800 dp bound.

Net effect: a Wear `fillMaxWidth` sticker measured against 400 dp in the live/bundled view while its baked PNG used 227 dp — so the viewer's PNG↔Live toggle visibly resized it. That is precisely the lane divergence the wrap plumbing exists to prevent, which is what makes this worth a fast follow rather than leaving it.

The silent-drop shape is the reason it slipped: nothing fails, the field just evaporates at parse time and the lane quietly measures against the wrong bound.

## Change

- Declare both fields on `PreviewParamsDto` (`daemon/core/PreviewIndex.kt`).
- Apply them in `renderSpecFromInfo` on both the android and desktop `DaemonMain`.

Same semantics as everywhere else in the feature — per-axis and non-pinning:

- an axis with a sandbox still reports `wrap = true` and still crops to measured size
- an explicit `widthDp` still wins over the sandbox
- an axis *without* a sandbox still falls back to the generic bound (it does not inherit the other axis's)

## Test plan

- New cases in **both** `RenderSpecFromInfoTest`s (android + desktop): sandbox narrows the bound without pinning either axis (227 dp @ 2× → 454 px, both still wrapping), and explicit `widthDp` wins while the sandbox-less height axis stays on the generic bound.
- `:daemon:core:test`, `:daemon:desktop:test`, `:daemon:android:testDebugUnitTest`, `ktfmtCheckAll` — all green.

No visual evidence: this is data plumbing with no new rendered surface. The user-visible behaviour it restores is the one already evidenced in #3278; this makes the serve/bundle lanes agree with that baked output instead of diverging from it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeYyABj4mgATWb8ZxCvBts)_