### PR TITLE
fix(serve): support shared daemon lease bursts

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -50,6 +50,7 @@ import ee.schimke.composeai.cli.serve.ServeRevisionFactory
 import ee.schimke.composeai.cli.serve.ServeSessionFactory
 import ee.schimke.composeai.cli.serve.ServeSessionRegistry
 import ee.schimke.composeai.cli.serve.ServeSessionState
+import ee.schimke.composeai.cli.serve.ServeSharedDaemonPool
 import ee.schimke.composeai.cli.serve.ServeStartupBundles
 import ee.schimke.composeai.cli.serve.ServeTrustAdmin
 import ee.schimke.composeai.cli.serve.ServeTrustStoreFile
@@ -946,7 +947,7 @@ class ServeCommand(args: List<String>) : Command(args) {
    */
   private fun openHost(state: ServeSessionState): ServeHost? =
     runCatching {
-        val daemon =
+        fun openDaemon(): ServeRenderHost =
           ServeRenderHost.open(
             descriptorPath = state.descriptor,
             workspaceRoot = state.workspaceRoot,
@@ -956,6 +957,7 @@ class ServeCommand(args: List<String>) : Command(args) {
             declaredThemes = state.declaredThemes,
             onLog = { System.err.println("[daemon serve] $it") },
           )
+        val daemon = openDaemon()
         val fallback = state.bakedFallback
         if (fallback != null)
           ServeCatalogLiveHost(
@@ -966,6 +968,8 @@ class ServeCommand(args: List<String>) : Command(args) {
               perPreviewStreamCount = state.perPreviewStreamCount,
               perPreviewRenderStats = state.perPreviewRenderStats,
               perPreviewPoolStats = state.perPreviewPoolStats,
+              sharedDaemonPool =
+                ServeSharedDaemonPool(primary = daemon, openReplica = ::openDaemon),
               catalogThemeCache = state.catalogThemeCache ?: CatalogThemeCache(),
               serverIdleMillis = state.serverIdleMillis,
               backgroundWork = state.backgroundWork,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -59,6 +59,7 @@ import ee.schimke.composeai.cli.serve.ServeWeb
 import ee.schimke.composeai.cli.serve.TrustStore
 import ee.schimke.composeai.cli.serve.declaredThemesFromPreviews
 import ee.schimke.composeai.cli.serve.detectedFeaturesOf
+import ee.schimke.composeai.cli.serve.openIsolatedSharedDaemonReplica
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
@@ -947,7 +948,7 @@ class ServeCommand(args: List<String>) : Command(args) {
    */
   private fun openHost(state: ServeSessionState): ServeHost? =
     runCatching {
-        fun openDaemon(): ServeRenderHost =
+        fun openDaemon(systemPropertyOverrides: Map<String, String> = emptyMap()): ServeRenderHost =
           ServeRenderHost.open(
             descriptorPath = state.descriptor,
             workspaceRoot = state.workspaceRoot,
@@ -955,6 +956,7 @@ class ServeCommand(args: List<String>) : Command(args) {
             previews = state.previews,
             label = state.label,
             declaredThemes = state.declaredThemes,
+            systemPropertyOverrides = systemPropertyOverrides,
             onLog = { System.err.println("[daemon serve] $it") },
           )
         val daemon = openDaemon()
@@ -969,7 +971,14 @@ class ServeCommand(args: List<String>) : Command(args) {
               perPreviewRenderStats = state.perPreviewRenderStats,
               perPreviewPoolStats = state.perPreviewPoolStats,
               sharedDaemonPool =
-                ServeSharedDaemonPool(primary = daemon, openReplica = ::openDaemon),
+                ServeSharedDaemonPool(primary = daemon) {
+                  // Every daemon writes <outputBaseName>.png and its data products below the
+                  // descriptor's output root. Replicas therefore need separate roots even though
+                  // they share the catalog classpath; otherwise overlapping themes can overwrite
+                  // one another between a completion notification and ServeRenderHost reading the
+                  // file.
+                  openIsolatedSharedDaemonReplica(state.descriptor, ::openDaemon)
+                },
               catalogThemeCache = state.catalogThemeCache ?: CatalogThemeCache(),
               serverIdleMillis = state.serverIdleMillis,
               backgroundWork = state.backgroundWork,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -78,6 +78,8 @@ class ServeCatalogLiveHost(
   private val perPreviewRenderStats: () -> List<RenderPerfSnapshot> = { emptyList() },
   /** Pool occupancy snapshots for `/status.json`, supplied by the pool. */
   private val perPreviewPoolStats: () -> List<DaemonPoolSnapshot> = { emptyList() },
+  /** Identical monolithic daemon replicas used only for a leased theme-render batch. */
+  private val sharedDaemonPool: ServeSharedDaemonPool? = null,
   /**
    * Serve the baked vector immediately and warm the daemon in the background rather than blocking a
    * browse on a cold (possibly minutes-long, esp. Android/Robolectric) first render — see the
@@ -410,16 +412,18 @@ class ServeCatalogLiveHost(
    */
   override fun canRenderOverridesFor(previewId: String): Boolean = previewId in alias
 
-  /** A leased burst is safe only when distinct previews have independent pooled daemons. */
+  /** A leased burst is safe only when requests can borrow independent daemon processes. */
   /**
-   * A burst is only real if the renders can actually proceed in parallel. The per-preview pool can
-   * — one daemon per preview — but the shared daemon has a single render lock, so advertising five
-   * there would funnel five workers into one lock, hand four of them `Busy`, and the page would
-   * exhaust its three retries and leave those cards on baked pixels. Worse than serial, not better.
-   * So capacity follows the lane snapshots actually use.
+   * Shared mode borrows identical monolithic replicas, retaining one warm catalog classpath per
+   * process while allowing a leased batch to render five cards at once. The older per-preview mode
+   * remains independently parallel. Without either pool the single daemon render lock is serial.
    */
   override val themeRenderBurstCapacity: Int =
-    if (perPreviewResolve != null && !sharedDaemonRenders) 5 else 1
+    when {
+      sharedDaemonRenders -> sharedDaemonPool?.capacity ?: 1
+      perPreviewResolve != null -> ThemeRenderLeaseManager.MAX_CONCURRENCY
+      else -> 1
+    }
 
   /** The gesture override is honoured by the daemon lane, if that daemon is Android-backed. */
   // The four capability flags below are `by lazy` for one reason: reading them forces the daemon
@@ -439,17 +443,23 @@ class ServeCatalogLiveHost(
    * so it contributes nothing.
    */
   /**
-   * The shared daemon (0 or 1) plus the per-preview pool's residents. Delegating to
-   * [live.daemonProcessCount] rather than adding one for [daemonStarted] matters: this host reports
-   * started when only a pooled child is up, so a flat `+1` would invent a monolithic daemon that
-   * does not exist.
+   * The primary shared daemon, its leased-batch replicas, plus the per-preview pool's residents.
+   * Delegating to [live.daemonProcessCount] rather than adding one for [daemonStarted] matters:
+   * this host reports started when only a pooled child is up, so a flat `+1` would invent a
+   * monolithic daemon that does not exist.
    */
   override val daemonProcessCount: Int
-    get() = live.daemonProcessCount + perPreviewPoolStats().sumOf { it.open }
+    get() =
+      live.daemonProcessCount +
+        (sharedDaemonPool?.replicaProcessCount() ?: 0) +
+        perPreviewPoolStats().sumOf { it.open }
 
   override val daemonStarted: Boolean
     get() =
-      live.daemonStarted || perPreviewStreamCount() > 0 || perPreviewPoolStats().any { it.open > 0 }
+      live.daemonStarted ||
+        (sharedDaemonPool?.replicaProcessCount() ?: 0) > 0 ||
+        perPreviewStreamCount() > 0 ||
+        perPreviewPoolStats().any { it.open > 0 }
 
   override val gesturesRenderable: Boolean by lazy { live.gesturesRenderable }
 
@@ -510,7 +520,17 @@ class ServeCatalogLiveHost(
     return baked.bakedRender(previewId, overrides)
   }
 
-  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+    renderInternal(previewId, overrides, leased = false)
+
+  override fun renderLeased(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+    renderInternal(previewId, overrides, leased = true)
+
+  private fun renderInternal(
+    previewId: String,
+    overrides: PreviewOverrides,
+    leased: Boolean,
+  ): RenderOutcome {
     val themeCacheKey = themeCacheKey(previewId, overrides)
     cachedRender(previewId, overrides)?.let {
       return it
@@ -525,15 +545,19 @@ class ServeCatalogLiveHost(
       // lane, so it must be awaited even cold and its outcome returned as-is. Everything below is
       // the baked-first routing, which such an id can't use.
       if (previewId in liveOnlyPreviewIds) {
-        return cacheThemeRender(themeCacheKey, renderDaemon(daemonId, overrides))
+        return cacheThemeRender(themeCacheKey, renderDaemon(daemonId, overrides, leased))
       }
       // Only await the daemon when it's warm and free. A cold Android render can take minutes, and
       // blocking the browse — and the HTTP render slot it holds — on it is what saturates the whole
       // server. Ordinary override requests may fall back to baked pixels while warming. A pure
       // theme request must instead report Busy: returning baked pixels as a successful 200 would
       // make the grid believe the requested theme had loaded and it would never retry.
-      if (daemonWarmOrScheduling(daemonId)) {
-        val live = renderDaemon(daemonId, overrides)
+      // A leased batch is an explicit request to pay for parallel live pixels now. Let its shared
+      // replicas cold-start on the request path if necessary; otherwise the per-id warm guard would
+      // return Busy for every card and the pool would never grow. Ordinary renders retain the
+      // baked-first/background-warm behaviour.
+      if (leased || daemonWarmOrScheduling(daemonId)) {
+        val live = renderDaemon(daemonId, overrides, leased)
         // NotFound joins Busy in falling through rather than being returned. It means no daemon on
         // either lane carries this id — the shared one never listed it and its per-preview bundle
         // didn't start (a classpath the box can't resolve, say). That is a statement about the
@@ -642,8 +666,17 @@ class ServeCatalogLiveHost(
    * Only [RenderOutcome.NotFound] falls through — a Busy or a failure is that daemon's real answer
    * and re-running it elsewhere would just double the work.
    */
-  private fun renderDaemon(daemonId: String, overrides: PreviewOverrides): RenderOutcome {
-    val outcome = renderHostFor(daemonId).render(daemonId, overrides)
+  private fun renderDaemon(
+    daemonId: String,
+    overrides: PreviewOverrides,
+    leased: Boolean = false,
+  ): RenderOutcome {
+    val outcome =
+      if (sharedDaemonRenders && leased && sharedDaemonPool != null) {
+        sharedDaemonPool.render(daemonId, overrides)
+      } else {
+        renderHostFor(daemonId).render(daemonId, overrides)
+      }
     if (outcome != RenderOutcome.NotFound || !sharedDaemonRenders) return outcome
     val perPreview = perPreviewResolve?.invoke(daemonId) ?: return outcome
     return perPreview.render(daemonId, overrides)
@@ -756,7 +789,7 @@ class ServeCatalogLiveHost(
    * render work (mirrors how [activeStreamCount] adds the pool's streams).
    */
   override fun renderPerfStats(): RenderPerfSnapshot? {
-    val pool = perPreviewRenderStats()
+    val pool = perPreviewRenderStats() + (sharedDaemonPool?.renderPerfStats() ?: emptyList())
     val monolithic = live.renderPerfStats()
     // Aggregating a single snapshot would null its percentiles (windows don't merge), so keep the
     // monolithic view verbatim until the pool actually has daemons to fold in.
@@ -764,7 +797,9 @@ class ServeCatalogLiveHost(
     return RenderPerfSnapshot.aggregate(listOfNotNull(monolithic) + pool)
   }
 
-  override fun daemonPoolStats(): List<DaemonPoolSnapshot> = perPreviewPoolStats()
+  override fun daemonPoolStats(): List<DaemonPoolSnapshot> =
+    listOfNotNull(sharedDaemonPool?.takeIf { sharedDaemonRenders }?.snapshot()) +
+      perPreviewPoolStats()
 
   /**
    * Graft the daemon previews' per-preview metadata onto the baked browse surface. The daemon knows
@@ -812,6 +847,7 @@ class ServeCatalogLiveHost(
       }
     }
     try {
+      sharedDaemonPool?.close()
       live.close()
     } finally {
       baked.close()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -111,7 +111,7 @@ interface ServeHost : AutoCloseable {
    * Maximum browser-side concurrency a short-lived themed-thumbnail burst may request. A plain
    * daemon has one render lock, so the default remains serial. A composite backed by independent
    * per-preview daemons may opt into a larger temporary burst; the HTTP server still clamps it to
-   * its render slots and grants at most one page a burst lease at a time.
+   * its render slots and shares that burst across every active page for the same catalog.
    */
   val themeRenderBurstCapacity: Int
     get() = 1

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -254,6 +254,14 @@ interface ServeHost : AutoCloseable {
   fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome
 
   /**
+   * Render a request admitted by the server's short-lived catalog theme lease. Hosts that cannot
+   * parallelise keep the ordinary [render] behaviour. A catalog backed by a replica pool overrides
+   * this to borrow an independent shared daemon, so only explicitly leased batches grow the pool.
+   */
+  fun renderLeased(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+    render(previewId, overrides)
+
+  /**
    * The captured Remote Compose document bytes for [previewId] — the bundle's `ir/<id>.rc` sidecar
    * — or null when this host carries none. Served over `GET /render/<id>.rc` so an in-browser
    * Remote Compose player can render the document client-side (the browser counterpart of the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1248,7 +1248,7 @@ class ServeHttpServer(
     }
   }
 
-  /** Grant one catalog page a short-lived themed-thumbnail burst; all other pages stay serial. */
+  /** Join this page to its catalog's short-lived themed-thumbnail burst allocation. */
   private suspend fun RoutingContext.handleThemeRenderLease(sessionInPath: Boolean) {
     if (rejectBadToken()) return
     val sessionId = selectedSessionId(sessionInPath)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2854,6 +2854,7 @@ class ServeHttpServer(
                   } else {
                     try {
                       if (scroll) renderHost.renderScrollPng(previewId, overrides)
+                      else if (leasePermit != null) renderHost.renderLeased(previewId, overrides)
                       else renderHost.render(previewId, overrides)
                     } finally {
                       renderSemaphore.release()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -1235,6 +1235,7 @@ internal constructor(
       previews: List<ServePreview>,
       label: String = "",
       declaredThemes: List<ServeTheme> = emptyList(),
+      systemPropertyOverrides: Map<String, String> = emptyMap(),
       onLog: (String) -> Unit = {},
       factory: RenderSessionFactory = SubprocessRenderSessions,
     ): ServeRenderHost {
@@ -1243,6 +1244,7 @@ internal constructor(
           descriptorPath = descriptorPath,
           workspaceRoot = workspaceRoot.absoluteFile,
           workspaceName = workspaceName.ifBlank { workspaceRoot.name },
+          systemPropertyOverrides = systemPropertyOverrides,
           logSink = onLog,
         )
       return ServeRenderHost(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -1,0 +1,77 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.util.concurrent.Semaphore
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * A lazy pool of identical monolithic catalog daemons used only by leased theme-render batches.
+ *
+ * Slot zero is the catalog's ordinary shared daemon. It stays the sole lane for browsing, knob
+ * edits, streams and unleased theme renders. Concurrent leased requests borrow it first, then
+ * lazily open up to [capacity] - 1 replicas from the same launch descriptor. A sequential batch
+ * therefore remains one warm process; only actual overlap creates replicas.
+ *
+ * The primary is owned by [ServeCatalogLiveHost]. This pool owns and closes replicas only.
+ */
+class ServeSharedDaemonPool(
+  private val primary: ServeHost,
+  val capacity: Int = DEFAULT_CAPACITY,
+  private val openReplica: () -> ServeHost,
+) : AutoCloseable {
+  private val lock = ReentrantLock()
+  private val permits = Semaphore(capacity, true)
+  private val available = ArrayDeque<ServeHost>().apply { add(primary) }
+  private val replicas = mutableListOf<ServeHost>()
+  private var closed = false
+
+  init {
+    require(capacity >= 1) { "capacity must be >= 1, got $capacity" }
+  }
+
+  fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+    permits.acquire()
+    var borrowed: ServeHost? = null
+    try {
+      borrowed = lock.withLock {
+        check(!closed) { "shared daemon pool is closed" }
+        available.removeFirstOrNull() ?: openReplica().also { replicas += it }
+      }
+      return borrowed.render(previewId, overrides)
+    } finally {
+      borrowed?.let { host -> lock.withLock { if (!closed) available.addLast(host) } }
+      permits.release()
+    }
+  }
+
+  /** Actual replica subprocesses (the primary is counted separately by the composite host). */
+  fun replicaProcessCount(): Int = lock.withLock { replicas.sumOf { it.daemonProcessCount } }
+
+  fun renderPerfStats(): List<RenderPerfSnapshot> = lock.withLock {
+    replicas.mapNotNull { it.renderPerfStats() }
+  }
+
+  fun snapshot(): DaemonPoolSnapshot = lock.withLock {
+    DaemonPoolSnapshot(
+      name = "shared-replicas",
+      open = replicas.count { it.daemonProcessCount > 0 },
+      maxOpen = capacity - 1,
+      activeStreams = 0,
+    )
+  }
+
+  override fun close() {
+    val toClose = lock.withLock {
+      if (closed) return
+      closed = true
+      available.clear()
+      replicas.toList().also { replicas.clear() }
+    }
+    toClose.forEach { runCatching { it.close() } }
+  }
+
+  companion object {
+    const val DEFAULT_CAPACITY = 5
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonReplica.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonReplica.kt
@@ -1,0 +1,35 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.file.Files
+
+/** Open one daemon replica with private render and data output directories. */
+internal fun openIsolatedSharedDaemonReplica(
+  descriptorPath: File,
+  open: (systemPropertyOverrides: Map<String, String>) -> ServeHost,
+): ServeHost {
+  val replicaRoot =
+    Files.createTempDirectory(descriptorPath.parentFile.toPath(), "serve-shared-replica-").toFile()
+  val replica =
+    try {
+      open(
+        mapOf(
+          // Both engines derive their data root as outputDir.parent/data, so this isolates PNGs
+          // and every file-backed data product in one override.
+          "composeai.render.outputDir" to File(replicaRoot, "renders").absolutePath
+        )
+      )
+    } catch (t: Throwable) {
+      replicaRoot.deleteRecursively()
+      throw t
+    }
+  return object : ServeHost by replica {
+    override fun close() {
+      try {
+        replica.close()
+      } finally {
+        replicaRoot.deleteRecursively()
+      }
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1606,7 +1606,7 @@ object ServeWeb {
         el.textContent = label;
         el.setAttribute("data-cp-daemon-running", state.running ? "1" : "0");
         el.title = state.pooled
-          ? state.pooled + " of " + state.poolCapacity + " per-preview daemons resident"
+          ? state.pooled + " of " + state.poolCapacity + " pooled daemons resident"
           : "";
       }
       function pollDaemons() {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1102,9 +1102,9 @@ object ServeWeb {
         """
           .trimIndent()
       else ""
-    // The declared-theme lane is serial unless the server grants this page a short-lived burst
-    // lease. The server clamps a grant to its render capacity and one page at a time, so opening
-    // another catalog tab cannot multiply a five-worker burst into a JVM storm. Each worker
+    // The declared-theme lane is serial unless the server grants this page a short-lived claim on
+    // its catalog's burst allocation. All users and tabs for that catalog share the same width, so
+    // opening another page cannot multiply a five-worker burst into a JVM storm. Each worker
     // advances only after its image settles; failures get bounded delayed retries with
     // cache-busting URLs. Baked light/dark swaps never queue. themeGen abandons all workers the
     // moment a new theme is chosen and releases that generation's lease.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManager.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManager.kt
@@ -9,21 +9,22 @@ import kotlin.concurrent.withLock
  * Grants short-lived, server-wide bursts for catalog pages' themed thumbnail renders.
  *
  * This is deliberately separate from [ServeSessionRegistry.Lease]: a session lease keeps a host
- * resident, whereas this lease limits how much parallel render work one browser page may admit. A
- * grant is bound to both its session and the exact host instance, so replacing a catalog host
- * invalidates its outstanding token without relying on a generation string.
+ * resident, whereas this lease limits how much parallel render work one catalog may admit. Browser
+ * pages receive distinct capability tokens, but tokens for the same session and exact host share
+ * one catalog allocation and one in-flight counter. Capacity is therefore never multiplied by
+ * users, tabs, or reconnects. Replacing a catalog host invalidates its outstanding tokens without
+ * relying on a generation string.
  *
  * Releasing or expiring a lease stops new admissions immediately. Existing [Permit]s may finish;
- * the lease remains in a draining state until the last one closes, preventing a replacement page
- * from overlapping the old burst. The fixed TTL cannot be renewed, so a lost page cannot retain
- * burst capacity indefinitely.
+ * its claim remains in a draining state until its last permit closes. The catalog allocation is
+ * retained while any page claim or admitted render remains. The fixed TTL cannot be renewed, so a
+ * lost page cannot retain burst capacity indefinitely.
  *
- * There are [LEASE_TIERS] slots rather than one. A single grant meant that the moment two people
- * (or two tabs) looked at catalogs, the second fell all the way back to the strictly serial
- * baseline — on a box whose whole job is showing catalogs, that is the common case, not the edge
- * one. The tiers are unequal on purpose: the first page gets the full burst and a second gets a
- * smaller one, so two pages can make progress together without their combined width exceeding what
- * the box can actually render at once. A third page still falls back to serial.
+ * There are [LEASE_TIERS] catalog slots rather than one. The tiers are unequal on purpose: the
+ * first active catalog gets the full burst and a second gets a smaller one, so two catalogs can
+ * make progress together without their combined width exceeding what the box can render at once.
+ * Every page viewing either catalog shares its catalog's width. A third catalog falls back to the
+ * serial path and retries for a catalog slot.
  *
  * Thread-safe. The caller must still use the server's ordinary global render semaphore: this
  * manager narrows admission for the privileged pages and never expands the server-wide limit.
@@ -35,31 +36,41 @@ internal class ThemeRenderLeaseManager(
 ) {
   data class Grant(val token: String, val concurrency: Int, val expiresAtMillis: Long)
 
-  private class Lease(
-    /** Which of [LEASE_TIERS] this lease occupies, so the slot is freed for the same width. */
-    val tier: Int,
+  private class Claim(
     val token: String,
-    val sessionId: String,
-    val hostIdentity: Any,
-    val concurrency: Int,
     val expiresAtMillis: Long,
     var inFlight: Int = 0,
     var released: Boolean = false,
   )
 
+  private class CatalogAllocation(
+    /** Which of [LEASE_TIERS] this catalog occupies, so the slot is freed at the same width. */
+    val tier: Int,
+    val sessionId: String,
+    val hostIdentity: Any,
+    val concurrency: Int,
+    var inFlight: Int = 0,
+    val claims: MutableList<Claim> = mutableListOf(),
+  )
+
   private val lock = ReentrantLock()
-  private val active = mutableListOf<Lease>()
+  private val active = mutableListOf<CatalogAllocation>()
 
   /**
-   * Try to grant a burst for [sessionId] and this exact [hostIdentity]. At most [LEASE_TIERS]
-   * grants exist server-wide, and the widest free tier is handed out — so a page arriving after
-   * another has drained gets the full burst back rather than being stuck on the narrow one.
-   * Capacities that cannot exceed the serial baseline are denied: a grant that admits no more than
-   * the unleased path would is not worth the round-trip.
+   * Try to grant a page a capability for [sessionId] and this exact [hostIdentity]. All pages for
+   * an already-active catalog join its allocation. Otherwise, at most [LEASE_TIERS] catalogs are
+   * active server-wide and the widest free tier is handed out. Capacities that cannot exceed the
+   * serial baseline are denied: a grant that admits no more than the unleased path would is not
+   * worth the round-trip.
    */
   fun acquire(sessionId: String, hostIdentity: Any, requestedCapacity: Int): Grant? =
     lock.withLock {
       reapTerminalLease()
+      val existing = active.firstOrNull {
+        it.sessionId == sessionId && it.hostIdentity === hostIdentity
+      }
+      if (existing != null) return existing.addClaim()
+
       val tier =
         LEASE_TIERS.indices.firstOrNull { t -> active.none { it.tier == t } } ?: return null
 
@@ -73,18 +84,23 @@ internal class ThemeRenderLeaseManager(
       val concurrency = minOf(requestedCapacity, remaining, LEASE_TIERS[tier])
       if (concurrency <= BASELINE_CONCURRENCY) return null
 
-      val lease =
-        Lease(
+      val allocation =
+        CatalogAllocation(
           tier = tier,
-          token = tokenSource(),
           sessionId = sessionId,
           hostIdentity = hostIdentity,
           concurrency = concurrency,
-          expiresAtMillis = clock() + TTL_MILLIS,
         )
-      active += lease
-      Grant(lease.token, lease.concurrency, lease.expiresAtMillis)
+      active += allocation
+      allocation.addClaim()
     }
+
+  /** Caller holds [lock]. */
+  private fun CatalogAllocation.addClaim(): Grant {
+    val claim = Claim(token = tokenSource(), expiresAtMillis = clock() + TTL_MILLIS)
+    claims += claim
+    return Grant(claim.token, concurrency, claim.expiresAtMillis)
+  }
 
   /**
    * Admit one render under [token]. A token is valid only for its original session and exact host
@@ -92,24 +108,28 @@ internal class ThemeRenderLeaseManager(
    * The returned permit must be closed after the render finishes.
    */
   fun admit(token: String, sessionId: String, hostIdentity: Any): Permit? = lock.withLock {
-    val lease = active.firstOrNull { it.token == token } ?: return null
-    if (
-      lease.token != token || lease.sessionId != sessionId || lease.hostIdentity !== hostIdentity
-    ) {
+    val lease =
+      active.firstOrNull { allocation -> allocation.claims.any { it.token == token } }
+        ?: return null
+    val claim = lease.claims.first { it.token == token }
+    if (lease.sessionId != sessionId || lease.hostIdentity !== hostIdentity) {
       return null
     }
-    if (lease.released || clock() >= lease.expiresAtMillis) {
-      lease.released = true
+    if (claim.released || clock() >= claim.expiresAtMillis) {
+      claim.released = true
       reapTerminalLease()
       return null
     }
     if (lease.inFlight >= lease.concurrency) return null
 
     lease.inFlight++
+    claim.inFlight++
     Permit {
       lock.withLock {
         check(lease.inFlight > 0) { "theme render lease permit underflow" }
+        check(claim.inFlight > 0) { "theme render lease claim permit underflow" }
         lease.inFlight--
+        claim.inFlight--
         reapTerminalLease()
       }
     }
@@ -121,8 +141,10 @@ internal class ThemeRenderLeaseManager(
    * closes. Repeated releases are harmless.
    */
   fun release(token: String): Boolean = lock.withLock {
-    val lease = active.firstOrNull { it.token == token } ?: return false
-    lease.released = true
+    val lease =
+      active.firstOrNull { allocation -> allocation.claims.any { it.token == token } }
+        ?: return false
+    lease.claims.first { it.token == token }.released = true
     reapTerminalLease()
     true
   }
@@ -138,18 +160,22 @@ internal class ThemeRenderLeaseManager(
 
   /** Caller holds [lock]. Expiry drains just like an explicit release. */
   private fun reapTerminalLease() {
-    for (lease in active) if (clock() >= lease.expiresAtMillis) lease.released = true
-    active.removeAll { it.released && it.inFlight == 0 }
+    for (lease in active) {
+      for (claim in lease.claims) {
+        if (clock() >= claim.expiresAtMillis) claim.released = true
+      }
+      lease.claims.removeAll { it.released && it.inFlight == 0 }
+    }
+    active.removeAll { it.claims.isEmpty() && it.inFlight == 0 }
   }
 
   companion object {
     const val BASELINE_CONCURRENCY = 1
 
     /**
-     * Burst width per concurrent grant, widest first. Two slots so a second viewer isn't dropped to
-     * the serial baseline, and unequal so their combined width stays inside what the box can render
-     * at once — each grant is additionally clamped to the server's render slots, and to what the
-     * host says it can actually parallelise.
+     * Burst width per concurrently active catalog, widest first. All users of a catalog share one
+     * tier. Two slots let a second catalog progress, and unequal widths keep their combined work
+     * inside what the box can render at once.
      */
     val LEASE_TIERS = intArrayOf(5, 3)
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -625,6 +625,41 @@ class ServeCatalogLiveHostTest {
   }
 
   @Test
+  fun `shared replica pool enables a five-wide lease and is used only by leased renders`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val primary =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId, overrides = listOf(labelKnob))),
+        tag = "primary",
+        declaredThemes = listOf(brandTheme),
+      )
+    val replica =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "replica",
+        declaredThemes = listOf(brandTheme),
+      )
+    val pool = ServeSharedDaemonPool(primary = primary, openReplica = { replica })
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = primary,
+        baked = baked,
+        sharedDaemonPool = pool,
+      )
+
+    assertEquals(5, composite.themeRenderBurstCapacity)
+
+    composite.render(catalogId, knobOverride())
+    assertEquals(1, primary.renderCalls)
+    assertEquals(0, replica.renderCalls)
+
+    composite.renderLeased(catalogId, themeOverride())
+    assertEquals(2, primary.renderCalls, "a sequential lease reuses the warm primary")
+    assertEquals(0, replica.renderCalls, "replicas open only when leased requests overlap")
+  }
+
+  @Test
   fun `pure theme render propagates busy from monolithic fallback`() {
     val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
     val monolithic =
@@ -1014,8 +1049,7 @@ class ServeCatalogLiveHostTest {
     val live = RecordingHost(previews = listOf(ServePreview(daemonId, daemonId)), tag = "mono")
     val perPreview = RecordingHost(previews = emptyList(), tag = "per")
 
-    // Sharing one daemon means one render lock: a wide burst would funnel workers into it, hand
-    // most of them Busy, and the page would exhaust its retries with cards still on baked pixels.
+    // A shared daemon without replicas still has one render lock.
     assertEquals(
       1,
       ServeCatalogLiveHost(
@@ -1023,6 +1057,17 @@ class ServeCatalogLiveHostTest {
           live = live,
           baked = baked,
           perPreviewResolve = { perPreview },
+        )
+        .themeRenderBurstCapacity,
+    )
+    // Shared mode becomes genuinely parallel when it carries identical monolithic replicas.
+    assertEquals(
+      5,
+      ServeCatalogLiveHost(
+          alias = mapOf(catalogId to daemonId),
+          live = live,
+          baked = baked,
+          sharedDaemonPool = ServeSharedDaemonPool(live, openReplica = { perPreview }),
         )
         .themeRenderBurstCapacity,
     )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverrideType
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
@@ -14,12 +17,15 @@ import java.nio.file.Files
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import javax.imageio.ImageIO
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -41,6 +47,39 @@ class ServeHttpRoutingTest {
   @Volatile private var blockRefresh = false
   private val refreshStarted = CountDownLatch(1)
   private val releaseRefresh = CountDownLatch(1)
+  private val ordinaryBurstHostRenders = AtomicInteger()
+  private val leasedBurstHostRenders = AtomicInteger()
+
+  private val burstHost =
+    object : ServeHost {
+      override val previews = listOf(ServePreview(previewId, previewId))
+      override val label = "burst"
+      override val declaredThemes = listOf(ServeTheme("Brand", "com.example.Brand"))
+      override val themeRenderBurstCapacity = 5
+
+      override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+        ordinaryBurstHostRenders.incrementAndGet()
+        return RenderOutcome.Ok(png())
+      }
+
+      override fun renderLeased(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+        leasedBurstHostRenders.incrementAndGet()
+        return RenderOutcome.Ok(png())
+      }
+
+      override fun subscribeStream(
+        previewId: String,
+        overrides: PreviewOverrides,
+        codec: StreamCodec?,
+        maxFps: Int?,
+        onUnavailable: ((String) -> Unit)?,
+        onFrame: (StreamFrameParams) -> Unit,
+      ): StreamHandle? = null
+
+      override fun activeStreamCount(): Int = 0
+
+      override fun close() {}
+    }
 
   private fun png(): ByteArray =
     ByteArrayOutputStream()
@@ -159,6 +198,7 @@ class ServeHttpRoutingTest {
       host = bundle("baked-only", degradations = listOf(ServeDegradation.catalogBakedOnly())),
       pinned = true,
     )
+    registry.register("burst", host = burstHost, pinned = true)
     ServeHttpServer(
         host = "127.0.0.1",
         requestedPort = 0,
@@ -235,6 +275,21 @@ class ServeHttpRoutingTest {
     assertEquals(409, post("/compose-m3/api/theme-render-lease").first)
     assertEquals(409, post("/api/theme-render-lease?session=compose-m3").first)
     assertEquals(400, post("/compose-m3/api/theme-render-lease/release").first)
+  }
+
+  @Test
+  fun `a valid theme lease routes the render through the leased host lane`() {
+    val (grantCode, grantBody) = post("/burst/api/theme-render-lease")
+    assertEquals(200, grantCode)
+    val lease =
+      Json.parseToJsonElement(grantBody).jsonObject.getValue("lease").jsonPrimitive.content
+
+    val (renderCode, _) =
+      get("/burst/render/$previewId.png" + "?themeProvider=com.example.Brand&_themeLease=$lease")
+
+    assertEquals(200, renderCode)
+    assertEquals(1, leasedBurstHostRenders.get())
+    assertEquals(0, ordinaryBurstHostRenders.get())
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ServeSharedDaemonPoolTest {
+  private class BlockingHost(
+    private val name: String,
+    private val entered: CountDownLatch,
+    private val release: CountDownLatch,
+  ) : ServeHost {
+    override val previews: List<ServePreview> = emptyList()
+    override val label: String = name
+    override val daemonProcessCount: Int = 1
+    var closed = false
+
+    override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+      entered.countDown()
+      assertTrue(release.await(5, TimeUnit.SECONDS), "timed out waiting to release $name")
+      return RenderOutcome.Ok(name.encodeToByteArray())
+    }
+
+    override fun subscribeStream(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
+      onFrame: (StreamFrameParams) -> Unit,
+    ): StreamHandle? = null
+
+    override fun activeStreamCount(): Int = 0
+
+    override fun close() {
+      closed = true
+    }
+  }
+
+  @Test
+  fun `five overlapping leased renders use five shared daemon instances`() {
+    val entered = CountDownLatch(5)
+    val release = CountDownLatch(1)
+    val opened = AtomicInteger()
+    val replicas = Collections.synchronizedList(mutableListOf<BlockingHost>())
+    val primary = BlockingHost("primary", entered, release)
+    val pool =
+      ServeSharedDaemonPool(primary = primary) {
+        BlockingHost("replica-${opened.incrementAndGet()}", entered, release).also(replicas::add)
+      }
+    val executor = Executors.newFixedThreadPool(5)
+
+    try {
+      val results =
+        (0 until 5).map { i ->
+          executor.submit<RenderOutcome> { pool.render("preview-$i", PreviewOverrides()) }
+        }
+
+      assertTrue(entered.await(5, TimeUnit.SECONDS), "all five daemon renders should overlap")
+      assertEquals(4, opened.get())
+      assertEquals(5, 1 + pool.replicaProcessCount())
+      assertEquals(DaemonPoolSnapshot("shared-replicas", 4, 4, 0), pool.snapshot())
+
+      release.countDown()
+      results.forEach { assertTrue(it.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok) }
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+      pool.close()
+    }
+
+    assertEquals(4, replicas.count { it.closed })
+    assertEquals(false, primary.closed, "the composite owns the primary daemon")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import java.io.File
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -10,6 +11,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ServeSharedDaemonPoolTest {
@@ -43,6 +45,34 @@ class ServeSharedDaemonPoolTest {
     override fun close() {
       closed = true
     }
+  }
+
+  @Test
+  fun `replicas use distinct output roots and remove them when closed`() {
+    val descriptorDir = java.nio.file.Files.createTempDirectory("serve-replica-descriptor").toFile()
+    val descriptor = File(descriptorDir, "daemon-launch.json").apply { writeText("unused") }
+    val outputRoots = mutableListOf<File>()
+    val delegates = mutableListOf<BlockingHost>()
+    val entered = CountDownLatch(0)
+    val release = CountDownLatch(0)
+
+    fun openReplica(): ServeHost =
+      openIsolatedSharedDaemonReplica(descriptor) { properties ->
+        outputRoots += File(properties.getValue("composeai.render.outputDir")).parentFile
+        BlockingHost("replica", entered, release).also(delegates::add)
+      }
+
+    val first = openReplica()
+    val second = openReplica()
+    assertEquals(2, outputRoots.distinct().size)
+    assertTrue(outputRoots.all { it.isDirectory })
+
+    first.close()
+    second.close()
+    assertTrue(delegates.all { it.closed })
+    assertTrue(outputRoots.none { it.exists() })
+    descriptorDir.deleteRecursively()
+    assertFalse(descriptorDir.exists())
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManagerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeRenderLeaseManagerTest.kt
@@ -19,19 +19,42 @@ class ThemeRenderLeaseManagerTest {
     )
 
   @Test
-  fun `two leases are active server-wide and each is bound to session and host identity`() {
+  fun `users and tabs share one catalog allocation while another catalog gets the narrow tier`() {
     val manager = manager()
     val host = Any()
     val grant = assertNotNull(manager.acquire("wear", host, requestedCapacity = 5))
+    val sameCatalog = assertNotNull(manager.acquire("wear", host, requestedCapacity = 5))
+    assertEquals(5, sameCatalog.concurrency)
 
-    // A second page gets the narrower tier rather than falling back to the serial baseline…
+    // A second catalog gets the narrower tier rather than falling back to the serial baseline…
     val second = assertNotNull(manager.acquire("material", Any(), requestedCapacity = 5))
     assertEquals(3, second.concurrency)
     // …and a third finds no free tier.
     assertNull(manager.acquire("third", Any(), requestedCapacity = 5))
     assertNull(manager.admit(grant.token, "material", host))
     assertNull(manager.admit(grant.token, "wear", Any()))
-    assertNotNull(manager.admit(grant.token, "wear", host)).close()
+    val sharedPermits =
+      List(3) { assertNotNull(manager.admit(grant.token, "wear", host)) } +
+        List(2) { assertNotNull(manager.admit(sameCatalog.token, "wear", host)) }
+    assertNull(
+      manager.admit(sameCatalog.token, "wear", host),
+      "all page claims share the catalog's five in-flight slots",
+    )
+    sharedPermits.forEach { it.close() }
+  }
+
+  @Test
+  fun `releasing one page claim does not release its catalog allocation`() {
+    val manager = manager()
+    val host = Any()
+    val first = assertNotNull(manager.acquire("wear", host, requestedCapacity = 5))
+    val second = assertNotNull(manager.acquire("wear", host, requestedCapacity = 5))
+
+    assertTrue(manager.release(first.token))
+    assertNull(manager.admit(first.token, "wear", host))
+    assertNotNull(manager.admit(second.token, "wear", host)).close()
+    assertEquals(3, assertNotNull(manager.acquire("material", Any(), 5)).concurrency)
+    assertNull(manager.acquire("third", Any(), 5))
   }
 
   @Test

--- a/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
+++ b/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
@@ -63,6 +63,12 @@ data class RenderSessionConfig(
    */
   val forceEnabled: Boolean = true,
   /**
+   * Per-session launch property overrides merged over the descriptor. This is primarily used by
+   * callers that intentionally open more than one daemon from the same descriptor: each process can
+   * be given its own render/data output root without copying or mutating the source descriptor.
+   */
+  val systemPropertyOverrides: Map<String, String> = emptyMap(),
+  /**
    * Log sink for the backend's diagnostic output (subprocess stderr, embedded driver
    * stderr-equivalent). Defaults to forwarding to `System.err` with a `[render-session]` prefix.
    */

--- a/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
+++ b/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
@@ -48,7 +48,7 @@ object EmbeddedDesktopRenderSessions : RenderSessionFactory {
           "Run `:<modulePath>:composePreviewDaemonStart` to materialise it."
       )
     }
-    val descriptor =
+    var descriptor =
       try {
         DaemonLaunchDescriptor.parse(fileSystem.read(descriptorFile.path.toPath()) { readUtf8() })
       } catch (e: Exception) {
@@ -58,6 +58,12 @@ object EmbeddedDesktopRenderSessions : RenderSessionFactory {
           cause = e,
         )
       }
+    if (config.systemPropertyOverrides.isNotEmpty()) {
+      descriptor =
+        descriptor.copy(
+          systemProperties = descriptor.systemProperties + config.systemPropertyOverrides
+        )
+    }
 
     // Apply the descriptor's system properties to the calling JVM. These drive PreviewIndex
     // lookup, history paths, classpath fingerprint sources etc. — the daemon code reads them

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -57,9 +57,15 @@ object SubprocessRenderSessions : RenderSessionFactory {
           cause = e,
         )
       }
-    val effectiveDescriptor =
+    var effectiveDescriptor =
       if (config.forceEnabled && !descriptor.enabled) descriptor.copy(enabled = true)
       else descriptor
+    if (config.systemPropertyOverrides.isNotEmpty()) {
+      effectiveDescriptor =
+        effectiveDescriptor.copy(
+          systemProperties = effectiveDescriptor.systemProperties + config.systemPropertyOverrides
+        )
+    }
     val workspaceRoot = config.workspaceRoot
     val canonicalRoot =
       runCatching { workspaceRoot.canonicalFile }.getOrDefault(workspaceRoot.absoluteFile)

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -455,7 +455,7 @@ applyThemeChoice();
         el.textContent = label;
         el.setAttribute("data-cp-daemon-running", state.running ? "1" : "0");
         el.title = state.pooled
-          ? state.pooled + " of " + state.poolCapacity + " per-preview daemons resident"
+          ? state.pooled + " of " + state.poolCapacity + " pooled daemons resident"
           : "";
       }
       function pollDaemons() {


### PR DESCRIPTION
## Summary

- add a lazy five-instance pool for shared catalog daemons
- allocate burst widths by catalog, not by browser user or tab
- let all active pages for the same catalog share one in-flight limit
- give the first active catalog up to 5 lanes, a second up to 3, and keep additional catalogs on the serialized path
- route only valid theme-lease renders through replicas while ordinary renders stay on the primary daemon
- isolate every replica's PNG and data output root and remove it when the replica closes
- include shared replicas in daemon status and performance accounting

## Root cause

Shared catalog rendering had moved back to the monolithic daemon, but burst capacity remained gated on per-preview routing. Shared mode therefore advertised capacity 1 and omitted the theme-render lease endpoint, leaving batch leases dormant.

The first implementation also treated each page lease as an independent allocation and cloned the daemon's output directory. That could multiply capacity across tabs and let overlapping daemon processes overwrite the same rendered PNG.

## Impact

Burst mode is a property of the active catalog host:

- all users and tabs viewing catalog A share its catalog-wide capacity
- catalog A can use one primary plus four lazy replicas
- catalog B can receive a smaller three-wide allocation
- further catalogs remain serialized until capacity frees
- replicas share the catalog classpath but have isolated render/data directories

Sequential and unleased traffic continues to use one daemon.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test`
- focused shared-pool, catalog-host, lease-manager, and HTTP routing tests
- `:render-session-subprocess:test`
- `:render-session-embedded-desktop:test`
- `git diff --check`
