### PR TITLE
Record design-parity provenance from exported packages

### DIFF
--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -33,7 +33,6 @@
  */
 import { execFileSync } from "node:child_process";
 import { cp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
-import { createRequire } from "node:module";
 import { basename, dirname, resolve, join, relative } from "node:path";
 import { parseArgs } from "node:util";
 
@@ -82,6 +81,7 @@ import { targetsByFunction } from "./figma-code-connect-target.mjs";
 import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
 import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
+import { installedPackageVersion } from "./package-version.mjs";
 import {
   buildFontsManifest,
   fontsPayloadsFromBundle,
@@ -916,14 +916,10 @@ const themeTokens = catalogTokens
 // engine that built it (surfaced on the serve host's provenance strip). Best-effort: a resolution
 // failure just omits the field rather than sinking the render.
 function designParityVersion() {
-  try {
-    const require = createRequire(import.meta.url);
-    return (
-      require("@design-parity/catalog-export/package.json").version || undefined
-    );
-  } catch {
-    return undefined;
-  }
+  return installedPackageVersion(
+    "@design-parity/catalog-export",
+    import.meta.url,
+  );
 }
 
 // Render priority needs a live path or it isn't a cheaper build — it is coverage quietly missing

--- a/scripts/design-artifacts/package-version.mjs
+++ b/scripts/design-artifacts/package-version.mjs
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+/**
+ * Resolves an installed package's version without requiring it to export
+ * `./package.json`.
+ *
+ * Modern packages commonly expose only their public entry points. Resolve that
+ * entry point first, then walk up to the owning package manifest instead of
+ * depending on a package-json subpath that its exports map may reject.
+ */
+export function installedPackageVersion(packageName, fromUrl = import.meta.url) {
+  try {
+    const require = createRequire(fromUrl);
+    let current = dirname(require.resolve(packageName));
+
+    while (true) {
+      try {
+        const manifest = JSON.parse(
+          readFileSync(join(current, "package.json"), "utf8"),
+        );
+        if (manifest.name === packageName) {
+          return manifest.version || undefined;
+        }
+      } catch {
+        // Keep walking: package entry points often live below dist/ or lib/.
+      }
+
+      const parent = dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  } catch {
+    // Provenance is best-effort and must not sink catalog generation.
+  }
+
+  return undefined;
+}

--- a/scripts/design-artifacts/package-version.test.mjs
+++ b/scripts/design-artifacts/package-version.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { installedPackageVersion } from "./package-version.mjs";
+
+test("reads the catalog-export version when package.json is not exported", () => {
+  assert.equal(
+    installedPackageVersion("@design-parity/catalog-export", import.meta.url),
+    "0.1.38",
+  );
+});
+
+test("returns undefined for an unavailable package", () => {
+  assert.equal(
+    installedPackageVersion("@design-parity/does-not-exist", import.meta.url),
+    undefined,
+  );
+});


### PR DESCRIPTION
## Summary

- resolve an installed package through its public entry point
- walk up to the owning package manifest instead of requiring an unexported `./package.json` subpath
- use that resolver when stamping design-parity provenance into generated catalogs
- cover the real `@design-parity/catalog-export` 0.1.38 exports-map behavior

## Root cause

`@design-parity/catalog-export` exports its public API but not `./package.json`. The previous best-effort resolver therefore threw `ERR_PACKAGE_PATH_NOT_EXPORTED`, caught the error, and silently emitted catalogs with `designParity: null`.

This is visible in the regenerated Horologist catalog on preview.coo.ee: compose-ai-tools 0.19.30 is recorded, but design-parity 0.1.38 is absent.

## Validation

- reproduced `ERR_PACKAGE_PATH_NOT_EXPORTED` against the installed 0.1.38 package
- `node --test package-version.test.mjs`
- `node --check scripts/design-artifacts/package-version.mjs`
- `node --check scripts/design-artifacts/generate-design-catalog.mjs`
- broad `npm test` passed all reported non-browser tests; stopped after an unrelated Chromium-unavailable fixture left the process waiting