### PR TITLE
fix(serve): humanize catalog component names

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -217,6 +217,7 @@ class ServeBundleHost(
         ServePreview(
           id = id,
           label = id,
+          componentId = meta?.componentId,
           // A packed sidecar remains authoritative for ordinary uploaded bundles. Published
           // catalogs additionally carry these declarations inline so a supplement-only preview's
           // controls are visible before its per-preview daemon is opened lazily.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -188,6 +188,7 @@ class ServeCatalogStore(
     val id: String,
     val target: File?,
     val image: Image,
+    val componentId: String?,
     val section: String?,
     val group: String?,
     val componentSourceFile: String?,
@@ -285,6 +286,7 @@ class ServeCatalogStore(
         // section + group), so the tabbed landing can bucket + sub-head + order them.
         val section = component.section?.takeIf { it.isNotBlank() }
         val group = component.group?.takeIf { it.isNotBlank() }
+        val componentId = component.componentId?.takeIf { it.isNotBlank() }
         val componentSourceFile = component.sourceFile?.takeIf { it.isNotBlank() }
         component.images.mapNotNull { image ->
           val path = image.path
@@ -298,7 +300,7 @@ class ServeCatalogStore(
             File(previewsDir, "$id.png").takeIf {
               it.canonicalFile.toPath().startsWith(previewsRoot)
             }
-          PlannedImage(path, id, target, image, section, group, componentSourceFile)
+          PlannedImage(path, id, target, image, componentId, section, group, componentSourceFile)
         }
       }
 
@@ -339,6 +341,7 @@ class ServeCatalogStore(
           image.state != null ||
             image.theme != null ||
             props != null ||
+            planned.componentId != null ||
             hasSectionInfo ||
             planned.componentSourceFile != null ||
             image.overrides.isNotEmpty() ||
@@ -351,6 +354,7 @@ class ServeCatalogStore(
               state = image.state,
               theme = image.theme,
               props = props,
+              componentId = planned.componentId,
               overrides = image.overrides,
               remoteComposeKnobs = image.remoteComposeKnobs,
               supportsFocus = image.supportsFocus,
@@ -387,6 +391,7 @@ class ServeCatalogStore(
           state = record.state,
           theme = record.theme,
           props = record.props?.takeIf { it.isNotEmpty() },
+          componentId = record.componentId?.takeIf { it.isNotBlank() },
           section = section,
           group = group,
           order = if (section != null || group != null) count + deferredIds.size - 1 else null,
@@ -1421,6 +1426,7 @@ class ServeCatalogStore(
 
   @Serializable
   private data class Component(
+    val componentId: String? = null,
     val images: List<Image> = emptyList(),
     /**
      * Top-level **section** (the tab a preview host buckets this component under — `"Themes"`,
@@ -1502,6 +1508,8 @@ class ServeCatalogStore(
      * (like [state]) and offer a variant switcher. Null for a catalog that varies on neither props.
      */
     val props: JsonObject? = null,
+    /** Original catalog component id, retained for human-readable display labels. */
+    val componentId: String? = null,
     /** Catalog-published controls used before a lazy per-preview daemon has been opened. */
     val overrides: List<PreviewOverrideDeclaration> = emptyList(),
     val remoteComposeKnobs: List<RemoteComposeKnobDeclaration> = emptyList(),

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -146,6 +146,12 @@ data class ServePreview(
   val sourceFile: String? = null,
   /** Discovery-time `@Preview(uiMode=…)`; used to identify the baked Day/Night default. */
   val uiMode: Int = 0,
+  /**
+   * The catalog's original component identifier (`SessionDetails`, `Button/Filled`, …). Unlike
+   * [id], this retains word boundaries and casing after the image path is flattened into a
+   * route-safe slug. Null for ordinary uploaded bundles and live discovery previews.
+   */
+  val componentId: String? = null,
 )
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -902,11 +902,25 @@ object ServeWeb {
    * Prefer catalog-authored labels; turn generated ids into readable component names as fallback.
    */
   private fun previewDisplayName(preview: ServePreview): String {
+    preview.componentId
+      ?.takeIf { it.isNotBlank() }
+      ?.let {
+        return humanizeComponentId(it)
+      }
     if (preview.label.isNotBlank() && preview.label != preview.id) return preview.label
     return componentKey(preview).substringBefore("__").replace('-', ' ').replaceFirstChar {
       it.uppercaseChar()
     }
   }
+
+  /** Splits catalog identifiers without changing their stable route-safe preview ids. */
+  private fun humanizeComponentId(componentId: String): String =
+    componentId
+      .replace(Regex("[/_-]+"), " ")
+      .replace(Regex("(?<=[a-z0-9])(?=[A-Z])"), " ")
+      .replace(Regex("(?<=[A-Z])(?=[A-Z][a-z])"), " ")
+      .trim()
+      .replace(Regex("\\s+"), " ")
 
   /** A compact human label for the size/breakpoint token carried in a flattened catalog id. */
   private fun previewSizeVariantLabel(id: String): String? =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -107,6 +107,10 @@ class ServeCatalogStoreTest {
       listOf("button-filled__ideal__default__dark", "button-filled__ideal__default__light"),
       host.previews.map { it.id },
     )
+    assertTrue(
+      host.previews.all { it.componentId == "Button/Filled" },
+      "the original component id survives route slug generation",
+    )
     // The declared-but-unfetchable card reports NotFound; its sibling still serves.
     assertEquals(
       RenderOutcome.NotFound,
@@ -535,7 +539,8 @@ class ServeCatalogStoreTest {
     val text = manifest.readText()
     assertTrue(
       text.contains(
-        "\"checkbox__ideal__unchecked__light\":{\"state\":\"unchecked\",\"theme\":\"light\"}"
+        "\"checkbox__ideal__unchecked__light\":{" +
+          "\"state\":\"unchecked\",\"theme\":\"light\",\"componentId\":\"Checkbox\"}"
       ),
       "manifest carries the unchecked/light entry: $text",
     )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -44,6 +44,46 @@ class ServeWebTest {
     )
 
   @Test
+  fun `catalog component ids become readable labels without changing preview routes`() {
+    val previews =
+      listOf(
+          "appcard" to "AppCard",
+          "buttongroup" to "ButtonGroup",
+          "edgebutton" to "EdgeButton",
+          "transforminglazycolumn" to "TransformingLazyColumn",
+          "podcastdetails" to "PodcastDetails",
+          "listitem" to "ListItem",
+          "urlbutton" to "URLButton",
+        )
+        .map { (slug, componentId) ->
+          ServePreview(
+            id = "${slug}__ideal__default__light",
+            label = "${slug}__ideal__default__light",
+            componentId = componentId,
+          )
+        }
+
+    val html = ServeWeb.landingPage("catalog", previews, token = "t", basePath = "/catalog")
+
+    for (label in
+      listOf(
+        "App Card",
+        "Button Group",
+        "Edge Button",
+        "Transforming Lazy Column",
+        "Podcast Details",
+        "List Item",
+        "URL Button",
+      )) {
+      assertTrue(html.contains(">$label</"), "$label is shown with readable word boundaries")
+    }
+    assertTrue(
+      html.contains("/catalog/p/appcard__ideal__default__light"),
+      "the human label does not alter the stable preview route",
+    )
+  }
+
+  @Test
   fun `the grid folds a non-default state into the default card`() {
     val html = ServeWeb.landingPage("compose-m3", checkbox, token = "t", basePath = "/compose-m3")
 


### PR DESCRIPTION
## Summary

- retain each catalog's original `componentId` alongside its stable route-safe preview id
- derive display labels from the original CamelCase/path identifier
- preserve explicitly authored labels and all existing preview URLs

## Root cause

The catalog server generated card titles from lowercase image-path slugs. Names such as `SessionDetails` had already become `sessiondetails`, so the UI could no longer recover their word boundaries.

## Impact

Generated labels now render as `App Card`, `Button Group`, `Transforming Lazy Column`, `Podcast Details`, and similar readable names. Existing design-artifact branches already contain `componentId`, so catalogs do not need to be regenerated.

Addresses the naming-consistency portion of #3267.

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeCatalogStoreTest --tests ee.schimke.composeai.cli.serve.ServeWebTest :cli:ktfmtCheck`