### PR TITLE
fix(daemon-android): route preview parameters from bundles

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1147,6 +1147,20 @@ open class RobolectricHost(
       base.wrapperClassName
         ?.takeIf { it.isNotBlank() }
         ?.let { append("wrapperClassName=").append(it).append(';') }
+      // `@PreviewParameter` has BINARY retention, so the sandbox cannot recover its provider by
+      // reflecting on the preview method. The production bundle-daemon path resolves the provider
+      // from `previews.json` into [base]; carry it through this host-side payload reshape just like
+      // [PreviewManifestRouter] does. Dropping it makes the sandbox attempt the parameterless
+      // `(Composer, int)` lookup for a method compiled as `(<T>, Composer, int)`, producing the
+      // misleading `NoSuchMethodException: <class>.<function>` seen on published catalogs.
+      base.previewParameterProviderClassName
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          append("previewParameterProvider=").append(it).append(';')
+          if (base.previewParameterLimit != Int.MAX_VALUE) {
+            append("previewParameterLimit=").append(base.previewParameterLimit).append(';')
+          }
+        }
       // Key the output PNG on the (unique) previewId, like [PreviewManifestRouter]; the default
       // `className-functionName` stem would collide for the multiple `@Preview` / @WearPreview*
       // variants that share one function, overwriting each other's render.

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPayloadRoutingTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPayloadRoutingTest.kt
@@ -1,0 +1,56 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/** Regression guards for manifest-backed `previewId=…` payload reshaping. */
+class RobolectricHostPayloadRoutingTest {
+
+  @Test
+  fun `reshape forwards preview parameter provider from resolved manifest spec`() {
+    val host =
+      RobolectricHost(
+        previewSpecResolver = {
+          RenderSpec(
+            previewId = it,
+            className = "com.example.TimePlayButtonKt",
+            functionName = "TimePlayButtonPreview",
+            previewParameterProviderClassName = "com.example.ThemePreviewParameterProvider",
+            previewParameterLimit = 3,
+          )
+        }
+      )
+
+    val routed = host.reshapeRenderPayload("previewId=time-play-button;uiMode=dark")
+    val spec = RenderSpec.parseFromPayloadOrNull(routed)
+
+    assertNotNull("reshaped payload must remain a parseable RenderSpec: $routed", spec)
+    assertEquals(
+      "com.example.ThemePreviewParameterProvider",
+      spec!!.previewParameterProviderClassName,
+    )
+    assertEquals(3, spec.previewParameterLimit)
+    assertEquals(RenderSpec.SpecUiMode.DARK, spec.uiMode)
+  }
+
+  @Test
+  fun `reshape omits preview parameter tokens for an ordinary preview`() {
+    val host =
+      RobolectricHost(
+        previewSpecResolver = {
+          RenderSpec(
+            previewId = it,
+            className = "com.example.PlainPreviewKt",
+            functionName = "PlainPreview",
+          )
+        }
+      )
+
+    val routed = host.reshapeRenderPayload("previewId=plain")
+
+    assertFalse(routed.contains("previewParameterProvider="))
+    assertFalse(routed.contains("previewParameterLimit="))
+  }
+}


### PR DESCRIPTION
## Summary

- forward `@PreviewParameter` provider metadata through the Android bundle-daemon payload reshape
- preserve the provider limit alongside the provider FQN
- add regression coverage for parameterized and ordinary preview payloads

## Root cause

Published Android bundles correctly carried `previewParameterProviderClassName` in `previews.json`, but `RobolectricHost.reshapeRenderPayload()` dropped it while converting a manifest-backed `previewId` request into the sandbox `RenderSpec` payload. The sandbox therefore attempted a parameterless Compose method lookup for functions compiled as `(<T>, Composer, Int)`, producing `NoSuchMethodException` and breaking daemon-backed theme/override renders on preview.coo.ee.

## Impact

Hosted Android catalog previews that use `@PreviewParameter` can now be re-rendered through the live daemon. Baked PNG behavior is unchanged, and ordinary previews continue to omit provider tokens.

## Validation

- `ANDROID_HOME=/Users/yschimke/Library/Android/sdk ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.RobolectricHostPayloadRoutingTest`
- `ANDROID_HOME=/Users/yschimke/Library/Android/sdk ./gradlew :daemon:android:ktfmtCheck`
- `git diff --check`
