### PR TITLE
fix(gradle-plugin): make resource pruning fail safe

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidResourcePruner.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidResourcePruner.kt
@@ -21,7 +21,11 @@ import java.util.zip.ZipOutputStream
  *   `anim`, `animator`, `mipmap`. Compose draws from Kotlin — no `R.layout` inflation, no view
  *   animations, no launcher mipmaps — so a Compose render resolves none of these unless the module
  *   itself authored one — or a sibling project module did — which [firstPartyFileResources] always
- *   retains.
+ *   retains. An empty retain-set is treated as failed ownership discovery and disables pruning;
+ *   otherwise a missing or unrecognised AGP merge-blame file would remove every file resource.
+ * - A small set of dependency resources is retained explicitly. AppCompat loads
+ *   `drawable/abc_vector_test` at runtime to validate VectorDrawableCompat, so dropping it produces
+ *   the misleading "incorrect configuration" exception even though the consumer build is valid.
  * - The baked catalog PNGs are rendered from the **full** APK *before* packing, so they are
  *   unaffected. The pruned APK feeds only the live daemon re-render.
  *
@@ -57,6 +61,12 @@ internal object AndroidResourcePruner {
    *   [MergedResourceOwnership], which derives it from AGP's merge-blame file.
    */
   fun prune(apkBytes: ByteArray, firstPartyFileResources: Set<String>): Result {
+    // Empty is ambiguous: it can mean a genuinely resource-free module, but also that AGP moved,
+    // changed, or did not emit merger.xml. Correctness wins over the bundle-size optimisation.
+    // Pocket Casts exposed the unsafe failure mode: the packed resources.arsc still referenced
+    // sibling-module icons, while every drawable file had been removed.
+    if (firstPartyFileResources.isEmpty()) return Result(apkBytes, 0, 0)
+
     val out = ByteArrayOutputStream(apkBytes.size)
     var dropped = 0
     var saved = 0L
@@ -96,7 +106,8 @@ internal object AndroidResourcePruner {
     if (slash < 0) return false
     val typeBase = rest.substring(0, slash).substringBefore('-')
     if (typeBase !in PRUNABLE_TYPE_BASES) return false
-    return "$typeBase/${resourceNameOf(rest.substring(slash + 1))}" !in firstParty
+    val key = "$typeBase/${resourceNameOf(rest.substring(slash + 1))}"
+    return key !in firstParty && key !in REQUIRED_DEPENDENCY_RESOURCES
   }
 
   /**
@@ -108,4 +119,6 @@ internal object AndroidResourcePruner {
     val noExt = fileName.substringBefore('.')
     return if (noExt.startsWith('$')) noExt.drop(1).substringBefore("__") else noExt
   }
+
+  private val REQUIRED_DEPENDENCY_RESOURCES = setOf("drawable/abc_vector_test")
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidResourcePrunerTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidResourcePrunerTest.kt
@@ -100,6 +100,41 @@ class AndroidResourcePrunerTest {
   }
 
   @Test
+  fun `empty ownership set disables pruning rather than dropping every file resource`() {
+    val input =
+      apk(
+        Triple("resources.arsc", "T".toByteArray(), ZipEntry.STORED),
+        Triple("res/drawable/ic_filters_play.xml", "ICON".toByteArray(), ZipEntry.DEFLATED),
+        Triple("res/layout/player.xml", "LAYOUT".toByteArray(), ZipEntry.DEFLATED),
+      )
+
+    val result = AndroidResourcePruner.prune(input, firstPartyFileResources = emptySet())
+
+    assertThat(result.bytes).isEqualTo(input)
+    assertThat(result.droppedEntries).isEqualTo(0)
+    assertThat(result.bytesSaved).isEqualTo(0L)
+  }
+
+  @Test
+  fun `keeps AppCompat vector configuration probe`() {
+    val input =
+      apk(
+        Triple("res/drawable/abc_vector_test.xml", "VECTOR".toByteArray(), ZipEntry.DEFLATED),
+        Triple("res/drawable/dependency_icon.xml", "OTHER".toByteArray(), ZipEntry.DEFLATED),
+        Triple("res/drawable/my_icon.xml", "OWN".toByteArray(), ZipEntry.DEFLATED),
+      )
+
+    val result =
+      AndroidResourcePruner.prune(input, firstPartyFileResources = setOf("drawable/my_icon"))
+    val kept = entries(result.bytes)
+
+    assertThat(kept).containsKey("res/drawable/abc_vector_test.xml")
+    assertThat(kept).containsKey("res/drawable/my_icon.xml")
+    assertThat(kept).doesNotContainKey("res/drawable/dependency_icon.xml")
+    assertThat(result.droppedEntries).isEqualTo(1)
+  }
+
+  @Test
   fun `resourceNameOf strips extension and normalises generated splits`() {
     assertThat(AndroidResourcePruner.resourceNameOf("ic_foo.xml")).isEqualTo("ic_foo")
     assertThat(AndroidResourcePruner.resourceNameOf("ic_foo.9.png")).isEqualTo("ic_foo")


### PR DESCRIPTION
## Summary

- disable resource pruning when first-party ownership discovery returns an empty retain-set
- preserve AppCompat's `drawable/abc_vector_test` runtime configuration probe
- add regression coverage for both failure modes

## Root cause

Android preview bundles prune merged dependency file resources while retaining the compiled resource table. That optimisation had two unsafe cases visible in the Pocket Casts bundle:

1. Ownership discovery returned no retained file resources, so pruning removed every drawable, layout, animation, and mipmap. The resource table still referenced sibling-module icons such as `ic_filters_play`, causing `Resources.NotFoundException` during live renders.
2. Even when ownership discovery succeeds, AppCompat's `abc_vector_test` is a dependency drawable that it loads dynamically to verify VectorDrawableCompat. Pruning it causes AppCompat's misleading "incorrect configuration" exception.

## Impact

Live Android bundle renders retain correctness when AGP merge ownership metadata is unavailable or unrecognised. Safe pruning still runs when a non-empty first-party retain-set exists, while keeping AppCompat's required vector probe. Baked catalog PNGs are unchanged.

## Validation

- `./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.AndroidResourcePrunerTest`
- `./gradlew :gradle-plugin:ktfmtCheck`
- `git diff --check`
