### PR TITLE
perf(serve): cache previews and optimize themes when idle

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -20,11 +20,15 @@ data class ThemeOptimizationSnapshot(
 )
 
 /**
- * Theme PNGs and optimization progress shared by every host incarnation of one catalog generation.
+ * Rendered PNGs and theme-optimization progress shared by every host incarnation of one catalog
+ * generation.
  *
  * A live catalog host is normally suspended after an idle window. Keeping this object in
  * [ServeSessionState] lets the optimized PNGs survive that daemon suspension and be reused when the
- * catalog resumes. A catalog refresh builds a fresh session state and therefore a fresh cache.
+ * catalog resumes. Although the optimizer only targets declared themes, the render map also keeps
+ * successful on-demand override renders (knobs, locale, font scale, and so on). A catalog refresh
+ * builds a fresh session state and therefore a fresh cache, so entries accumulate for exactly as
+ * long as the catalog content they were rendered from remains current.
  */
 class CatalogThemeCache {
   private val renders = ConcurrentHashMap<String, ByteArray>()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -181,13 +181,12 @@ class ServeCatalogLiveHost(
   private val warmingInFlight = ConcurrentHashMap.newKeySet<String>()
 
   /**
-   * Completed catalog-grid theme renders are retained in [catalogThemeCache] for this catalog
-   * generation. The per-preview daemon pool is deliberately LRU and may evict the daemon (and its
-   * local cache) between theme selections; keeping the pure `themeProvider` result here makes a
-   * repeat selection instant without pinning every preview daemon. The shared cache survives idle
-   * host suspension; a catalog refresh creates a new generation and cache. Only pure theme
-   * selections participate, so the key space is bounded by `previews × declaredThemes`; arbitrary
-   * knob combinations stay in the daemon's bounded cache.
+   * Completed catalog renders are retained in [catalogThemeCache] for this catalog generation. The
+   * per-preview daemon pool is deliberately LRU and may evict the daemon (and its local cache)
+   * between selections; keeping every successful override result here makes repeat theme, knob,
+   * locale, font-scale, and other selections instant without pinning every preview daemon. The
+   * shared cache survives idle host suspension and accumulates for the generation; a catalog
+   * refresh creates a new generation and cache, flushing pixels produced from the old content.
    */
   private val themeRendersInFlight = ConcurrentHashMap.newKeySet<String>()
   private val optimizationStarted = AtomicBoolean()
@@ -531,6 +530,7 @@ class ServeCatalogLiveHost(
     overrides: PreviewOverrides,
     leased: Boolean,
   ): RenderOutcome {
+    val catalogCacheKey = catalogCacheKey(previewId, overrides)
     val themeCacheKey = themeCacheKey(previewId, overrides)
     cachedRender(previewId, overrides)?.let {
       return it
@@ -545,7 +545,7 @@ class ServeCatalogLiveHost(
       // lane, so it must be awaited even cold and its outcome returned as-is. Everything below is
       // the baked-first routing, which such an id can't use.
       if (previewId in liveOnlyPreviewIds) {
-        return cacheThemeRender(themeCacheKey, renderDaemon(daemonId, overrides, leased))
+        return cacheCatalogRender(catalogCacheKey, renderDaemon(daemonId, overrides, leased))
       }
       // Only await the daemon when it's warm and free. A cold Android render can take minutes, and
       // blocking the browse — and the HTTP render slot it holds — on it is what saturates the whole
@@ -566,7 +566,7 @@ class ServeCatalogLiveHost(
         // for a catalog whose supplement module carries its own live lane, where an id can be
         // aliased yet reachable only through the pool.
         if (live !is RenderOutcome.Busy && live !is RenderOutcome.NotFound)
-          return cacheThemeRender(themeCacheKey, live)
+          return cacheCatalogRender(catalogCacheKey, live)
       }
       if (themeCacheKey != null) return RenderOutcome.Busy
       return baked.render(previewId, overrides)
@@ -576,12 +576,12 @@ class ServeCatalogLiveHost(
   }
 
   override fun cachedRender(previewId: String, overrides: PreviewOverrides): RenderOutcome.Ok? =
-    themeCacheKey(previewId, overrides)?.let(catalogThemeCache::get)?.let { bytes ->
+    catalogCacheKey(previewId, overrides)?.let(catalogThemeCache::get)?.let { bytes ->
       RenderOutcome.Ok(bytes, RenderOutcome.Generation.CATALOG_CACHE)
     }
 
-  /** Cache only the catalog grid's pure theme selection, never a baked fallback or a failure. */
-  private fun cacheThemeRender(key: String?, outcome: RenderOutcome): RenderOutcome {
+  /** Cache every successful live catalog render, never a baked fallback or a failure. */
+  private fun cacheCatalogRender(key: String?, outcome: RenderOutcome): RenderOutcome {
     if (
       key != null &&
         outcome is RenderOutcome.Ok &&
@@ -590,6 +590,17 @@ class ServeCatalogLiveHost(
       catalogThemeCache.put(key, outcome.png)
     }
     return outcome
+  }
+
+  /**
+   * A content-generation cache entry exists for every request that actually routes to the daemon.
+   * Override-free baked browsing stays on disk and needs no duplicate entry here. The surrounding
+   * [ServeSessionState] owns this map, so ordinary idle daemon suspension leaves it intact while a
+   * catalog refresh replaces the state (and therefore the whole map) atomically.
+   */
+  private fun catalogCacheKey(previewId: String, overrides: PreviewOverrides): String? {
+    if (daemonIdForOverrideRender(previewId, overrides) == null) return null
+    return ServeOverrides.cacheKey(previewId, overrides)
   }
 
   private fun themeCacheKey(previewId: String, overrides: PreviewOverrides): String? {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -66,7 +66,9 @@ data class ServeSessionState(
   val perPreviewRenderStats: () -> List<RenderPerfSnapshot> = { emptyList() },
   /** Occupancy snapshots of the pooled per-preview daemons, surfaced on `/status.json`. */
   val perPreviewPoolStats: () -> List<DaemonPoolSnapshot> = { emptyList() },
-  /** Theme PNG cache retained across this catalog generation's daemon suspend/resume cycles. */
+  /**
+   * Rendered PNG cache retained for this catalog generation across daemon suspend/resume cycles.
+   */
   val catalogThemeCache: CatalogThemeCache? = null,
   /**
    * Whole-server idle clock used by background catalog optimization; null means traffic is active.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -712,7 +712,7 @@ class ServeCatalogLiveHostTest {
   }
 
   @Test
-  fun `catalog theme cache excludes mixed overrides`() {
+  fun `catalog generation cache accumulates mixed overrides`() {
     val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
     val live =
       RecordingHost(
@@ -726,8 +726,50 @@ class ServeCatalogLiveHostTest {
     val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
 
     composite.render(catalogId, mixed)
-    composite.render(catalogId, mixed)
-    assertEquals(2, live.renderCalls)
+    val cached = composite.render(catalogId, mixed) as RenderOutcome.Ok
+    assertEquals(1, live.renderCalls)
+    assertEquals(RenderOutcome.Generation.CATALOG_CACHE, cached.generation)
+  }
+
+  @Test
+  fun `mixed override cache survives host replacement within the catalog generation`() {
+    val cache = CatalogThemeCache()
+    val mixed =
+      themeOverride()
+        .copy(namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("First")))
+    val firstLive =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "first",
+        declaredThemes = listOf(brandTheme),
+      )
+    val first =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = firstLive,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        catalogThemeCache = cache,
+      )
+    first.render(catalogId, mixed)
+    first.close()
+
+    val replacementLive =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "replacement",
+        declaredThemes = listOf(brandTheme),
+      )
+    val replacement =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = replacementLive,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked2"),
+        catalogThemeCache = cache,
+      )
+
+    val cached = replacement.render(catalogId, mixed) as RenderOutcome.Ok
+    assertEquals(RenderOutcome.Generation.CATALOG_CACHE, cached.generation)
+    assertEquals(0, replacementLive.renderCalls)
   }
 
   @Test


### PR DESCRIPTION
## What changed

- retain successful daemon-produced catalog PNGs across themes, knobs, locale, font scale, and other overrides for the lifetime of a catalog generation
- enable idle declared-theme optimization by default
- require one minute of quiet after the last foreground request/render or catalog startup/refresh/registration finishes before background work resumes
- continue limiting optimization to one server-wide background render at a time and pause between images whenever foreground activity returns
- bound each catalog-generation cache with a 128 MiB access-order LRU
- allow the byte cap to be configured with `composeai.serve.catalogRenderCacheMaxBytes`
- expose cache entries, bytes, maximum bytes, and eviction count in JSON and HTML `/status`
- continue excluding baked fallbacks and failed renders from the cache

## Why

Override renders previously lived primarily in a daemon-local bounded cache, so idle daemon replacement discarded most combinations. Only pure declared-theme renders survived at the catalog-session level.

The cache is now scoped to catalog content: it survives daemon suspension and host replacement, but catalog refresh installs a fresh generation and flushes old pixels. That durability makes low-priority theme generation useful, while the quiet window, single background permit, and byte-bounded LRU prevent it from dominating foreground work or memory.

## Impact

Repeat preview selections become instant without keeping every per-preview daemon resident. Theme images fill gradually while the server is genuinely quiet, pause for user work and catalog loading, and remain available afterward. Operators can monitor occupancy and evictions through `/status`.

## Validation

- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest`
- `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.CatalogThemeCacheTest' --tests 'ee.schimke.composeai.cli.serve.ServeBackgroundWorkTest' --tests 'ee.schimke.composeai.cli.serve.ServeCatalogLiveHostTest' --tests 'ee.schimke.composeai.cli.serve.ServeStatusTest'`
- repository commit hooks
