### PR TITLE
fix(gradle-plugin): distinguish unavailable resource ownership

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidResourcePruner.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidResourcePruner.kt
@@ -21,8 +21,8 @@ import java.util.zip.ZipOutputStream
  *   `anim`, `animator`, `mipmap`. Compose draws from Kotlin — no `R.layout` inflation, no view
  *   animations, no launcher mipmaps — so a Compose render resolves none of these unless the module
  *   itself authored one — or a sibling project module did — which [firstPartyFileResources] always
- *   retains. An empty retain-set is treated as failed ownership discovery and disables pruning;
- *   otherwise a missing or unrecognised AGP merge-blame file would remove every file resource.
+ *   retains. [BundlePreviewTask] disables pruning before calling this when ownership metadata is
+ *   unavailable; an empty set here is therefore a valid, verified resource-free build.
  * - A small set of dependency resources is retained explicitly. AppCompat loads
  *   `drawable/abc_vector_test` at runtime to validate VectorDrawableCompat, so dropping it produces
  *   the misleading "incorrect configuration" exception even though the consumer build is valid.
@@ -61,12 +61,6 @@ internal object AndroidResourcePruner {
    *   [MergedResourceOwnership], which derives it from AGP's merge-blame file.
    */
   fun prune(apkBytes: ByteArray, firstPartyFileResources: Set<String>): Result {
-    // Empty is ambiguous: it can mean a genuinely resource-free module, but also that AGP moved,
-    // changed, or did not emit merger.xml. Correctness wins over the bundle-size optimisation.
-    // Pocket Casts exposed the unsafe failure mode: the packed resources.arsc still referenced
-    // sibling-module icons, while every drawable file had been removed.
-    if (firstPartyFileResources.isEmpty()) return Result(apkBytes, 0, 0)
-
     val out = ByteArrayOutputStream(apkBytes.size)
     var dropped = 0
     var saved = 0L

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -958,7 +958,16 @@ abstract class BundlePreviewTask : DefaultTask() {
     // is left byte-for-byte intact — this only stops shipping file bytes nothing resolves — and
     // every file resource authored in this build (this module's AND its sibling project modules')
     // is retained. See [AndroidResourcePruner] and [MergedResourceOwnership].
-    val prunedApk = AndroidResourcePruner.prune(apkFile.readBytes(), firstPartyFileResourceKeys())
+    val apkBytes = apkFile.readBytes()
+    val firstPartyFileResources = firstPartyFileResourceKeys()
+    val prunedApk =
+      if (firstPartyFileResources != null) {
+        AndroidResourcePruner.prune(apkBytes, firstPartyFileResources)
+      } else {
+        // Without usable merge ownership metadata we cannot distinguish sibling-project resources
+        // from dependency resources. Keep the full APK rather than create dangling table entries.
+        AndroidResourcePruner.Result(apkBytes, droppedEntries = 0, bytesSaved = 0)
+      }
     zipFiles[ANDROID_RESOURCE_APK_PATH] = prunedApk.bytes
     zipFiles[ANDROID_MERGED_MANIFEST_PATH] = manifestFile.readBytes()
     val rClassesJar = packAndroidRClasses()
@@ -988,15 +997,15 @@ abstract class BundlePreviewTask : DefaultTask() {
    * **sibling project modules** a real app's catalog renders against — Pocket Casts renders from
    * `:modules:services:compose` while its icons live in `:modules:services:ui`, and pruning those
    * left the live daemon throwing `NotFoundException: File res/drawable/ic_play.xml …` on the first
-   * `painterResource` (issue #3260). The `src/<sourceSet>/res` scan below is the fallback for when
-   * no blame file was written, and keeps this correct for a module whose own resources haven't been
-   * merged yet.
+   * `painterResource` (issue #3260). Null means the blame metadata is unavailable or unusable and
+   * disables pruning; an empty non-null set means metadata successfully proved that the build has
+   * no first-party file resources, so pruning remains safe.
    */
-  private fun firstPartyFileResourceKeys(): Set<String> {
+  private fun firstPartyFileResourceKeys(): Set<String>? {
     val buildDir =
       moduleBuildDir.asFile.orNull ?: moduleProjectDir.asFile.orNull?.let { File(it, "build") }
     val fromBlame =
-      buildDir?.let { MergedResourceOwnership.firstPartyFileResourceKeys(it) } ?: emptySet()
+      buildDir?.let { MergedResourceOwnership.firstPartyFileResourceKeys(it) } ?: return null
     return fromBlame + moduleOwnSourceSetResourceKeys()
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnership.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnership.kt
@@ -47,16 +47,25 @@ internal object MergedResourceOwnership {
   /**
    * Resource identities (`"<typeBase>/<name>"`, e.g. `"drawable/ic_play"`) contributed by
    * first-party data sets across every `merger.xml` under [moduleBuildDir], in the shape
-   * [AndroidResourcePruner.prune] expects. Empty when no blame file is present (a build that never
-   * merged resources, or a future AGP that stops writing them) — the caller then falls back to its
-   * own-source-set scan, i.e. exactly the pre-existing behaviour.
+   * [AndroidResourcePruner.prune] expects. Returns null when no usable blame file is present (a
+   * build that never merged resources, a malformed file, or a future AGP that stops writing them),
+   * so the caller can distinguish unavailable ownership metadata from a valid result containing no
+   * first-party file resources.
    */
-  fun firstPartyFileResourceKeys(moduleBuildDir: File): Set<String> {
+  fun firstPartyFileResourceKeys(moduleBuildDir: File): Set<String>? {
     val keys = mutableSetOf<String>()
+    var usableBlameFound = false
     for (blame in blameFiles(moduleBuildDir)) {
-      runCatching { collectInto(keys, blame) }
+      // Do not retain keys partially parsed from a malformed file. A second valid blame file can
+      // still make the overall result usable.
+      val fileKeys = mutableSetOf<String>()
+      runCatching { collectInto(fileKeys, blame) }
+        .onSuccess {
+          usableBlameFound = true
+          keys += fileKeys
+        }
     }
-    return keys
+    return keys.takeIf { usableBlameFound }
   }
 
   /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidResourcePrunerTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidResourcePrunerTest.kt
@@ -100,7 +100,7 @@ class AndroidResourcePrunerTest {
   }
 
   @Test
-  fun `empty ownership set disables pruning rather than dropping every file resource`() {
+  fun `verified empty ownership set prunes dependency file resources`() {
     val input =
       apk(
         Triple("resources.arsc", "T".toByteArray(), ZipEntry.STORED),
@@ -110,9 +110,10 @@ class AndroidResourcePrunerTest {
 
     val result = AndroidResourcePruner.prune(input, firstPartyFileResources = emptySet())
 
-    assertThat(result.bytes).isEqualTo(input)
-    assertThat(result.droppedEntries).isEqualTo(0)
-    assertThat(result.bytesSaved).isEqualTo(0L)
+    assertThat(entries(result.bytes)).doesNotContainKey("res/drawable/ic_filters_play.xml")
+    assertThat(entries(result.bytes)).doesNotContainKey("res/layout/player.xml")
+    assertThat(result.droppedEntries).isEqualTo(2)
+    assertThat(result.bytesSaved).isEqualTo(10L)
   }
 
   @Test

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnershipTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnershipTest.kt
@@ -44,7 +44,7 @@ class MergedResourceOwnershipTest {
         .trimIndent(),
     )
 
-    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+    val keys = requireNotNull(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir()))
 
     assertThat(keys).containsAtLeast("drawable/ic_play", "drawable/ic_logo")
     assertThat(keys).doesNotContain("drawable/aar_bg")
@@ -72,7 +72,7 @@ class MergedResourceOwnershipTest {
         .trimIndent(),
     )
 
-    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+    val keys = requireNotNull(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir()))
 
     assertThat(keys).contains("drawable/ic_generated")
     assertThat(keys).doesNotContain("drawable/core_bg")
@@ -98,7 +98,7 @@ class MergedResourceOwnershipTest {
         .trimIndent(),
     )
 
-    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+    val keys = requireNotNull(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir()))
 
     assertThat(keys).contains("drawable/avd_spin")
     assertThat(keys.none { it.startsWith("values/") }).isTrue()
@@ -125,7 +125,7 @@ class MergedResourceOwnershipTest {
         .trimIndent(),
     )
 
-    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+    val keys = requireNotNull(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir()))
 
     assertThat(keys).containsAtLeast("drawable/from_debug", "drawable/from_unit_test")
   }
@@ -158,22 +158,41 @@ class MergedResourceOwnershipTest {
         .trimIndent(),
     )
 
-    val keys = MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+    val keys = requireNotNull(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir()))
 
     assertThat(keys).contains("drawable/probe_icon")
     assertThat(keys).doesNotContain("drawable/aar_bg")
   }
 
   @Test
-  fun `returns empty when no blame file exists so the caller can fall back`() {
-    assertThat(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())).isEmpty()
+  fun `returns null when no blame file exists so the caller disables pruning`() {
+    assertThat(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())).isNull()
   }
 
   @Test
-  fun `a malformed blame file yields no keys instead of failing the pack`() {
+  fun `a malformed blame file returns null instead of trusting partial ownership`() {
     writeBlame("debug", "<merger><dataSet config=\":app\"><source path=\"/a\">")
 
-    // Truncated XML: whatever was parsed before the error is dropped, but the pack survives.
-    MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())
+    assertThat(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())).isNull()
+  }
+
+  @Test
+  fun `valid blame with no first-party file resources returns empty rather than unavailable`() {
+    writeBlame(
+      "debug",
+      """
+      <merger version="3">
+        <dataSet config="androidx.cardview:cardview:1.0.0">
+          <source path="/caches/cardview/res">
+            <file name="aar_bg" path="/caches/cardview/res/drawable/aar_bg.xml" type="drawable"/>
+          </source>
+        </dataSet>
+      </merger>
+      """
+        .trimIndent(),
+    )
+
+    val keys = requireNotNull(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir()))
+    assertThat(keys).isEmpty()
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3297:

- distinguish unavailable or malformed AGP merge-ownership metadata from a valid empty ownership result
- disable resource pruning only when ownership cannot be established safely
- continue pruning when metadata successfully proves there are zero first-party file resources
- retain AppCompat's required vector probe from #3297

## Why

#3297 made an empty retain-set fail safe by keeping the full resource APK. That fixed correctness for missing ownership metadata, but the empty set was ambiguous: Compose-only catalogs can legitimately have zero first-party file resources.

Treating both cases alike would regress the Wear catalog resource payload from 57 KB to 156 KB. This follow-up represents metadata availability separately, preserving that optimisation while still preventing Pocket Casts-style dangling resource-table entries when ownership metadata is missing or malformed.

Malformed files no longer contribute partially parsed keys. If any valid merge-blame file exists, its result remains usable; a valid result may intentionally be empty.

## Impact

- valid empty ownership: pruning remains enabled; no Wear bundle-size regression
- unavailable or entirely malformed ownership: full resource APK retained for correctness
- normal ownership: existing first-party retention and dependency pruning remain unchanged
- AppCompat vector probe overhead remains approximately 1 KB or less

## Validation

- `./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.AndroidResourcePrunerTest --tests ee.schimke.composeai.plugin.MergedResourceOwnershipTest`
- `./gradlew :gradle-plugin:ktfmtCheck`
- `git diff --check origin/main...HEAD`
