### PR TITLE
perf(serve): enable gentle theme optimization

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -19,6 +19,15 @@ data class ThemeOptimizationSnapshot(
   val completedAtEpochMillis: Long? = null,
 )
 
+/** Memory occupancy of one catalog generation's rendered-preview cache. */
+@Serializable
+data class CatalogRenderCacheSnapshot(
+  val entries: Int,
+  val bytes: Long,
+  val maxBytes: Long,
+  val evictions: Long,
+)
+
 /**
  * Rendered PNGs and theme-optimization progress shared by every host incarnation of one catalog
  * generation.
@@ -30,11 +39,19 @@ data class ThemeOptimizationSnapshot(
  * builds a fresh session state and therefore a fresh cache, so entries accumulate for exactly as
  * long as the catalog content they were rendered from remains current.
  */
-class CatalogThemeCache {
-  private val renders = ConcurrentHashMap<String, ByteArray>()
+class CatalogThemeCache(
+  maxBytes: Long =
+    System.getProperty("composeai.serve.catalogRenderCacheMaxBytes")?.toLongOrNull()
+      ?: DEFAULT_MAX_BYTES
+) {
+  val maxBytes: Long = maxBytes.coerceAtLeast(0)
+  private val renderLock = Any()
+  // Access-order map: the byte cap evicts the least-recently-read render first.
+  private val renders = LinkedHashMap<String, ByteArray>(16, 0.75f, true)
   private val targetKeys = ConcurrentHashMap.newKeySet<String>()
   private val failedKeys = ConcurrentHashMap.newKeySet<String>()
   private val byteCount = AtomicLong(0)
+  private val evictionCount = AtomicLong(0)
   private val state = AtomicReference("waiting")
   private val startedAt = AtomicLong(0)
   private val completedAt = AtomicLong(0)
@@ -44,10 +61,25 @@ class CatalogThemeCache {
     refreshCompletion()
   }
 
-  fun get(key: String): ByteArray? = renders[key]
+  fun get(key: String): ByteArray? = synchronized(renderLock) { renders[key] }
 
   fun put(key: String, png: ByteArray) {
-    if (renders.putIfAbsent(key, png) == null) byteCount.addAndGet(png.size.toLong())
+    synchronized(renderLock) {
+      if (renders.containsKey(key)) return@synchronized
+      if (png.size.toLong() > maxBytes) return@synchronized
+      renders[key] = png
+      byteCount.addAndGet(png.size.toLong())
+      while (byteCount.get() > maxBytes && renders.isNotEmpty()) {
+        val eldest = renders.entries.iterator().next()
+        renders.remove(eldest.key)
+        byteCount.addAndGet(-eldest.value.size.toLong())
+        evictionCount.incrementAndGet()
+        if (eldest.key in targetKeys) {
+          state.set("paused")
+          completedAt.set(0)
+        }
+      }
+    }
     failedKeys.remove(key)
     refreshCompletion()
   }
@@ -66,7 +98,7 @@ class CatalogThemeCache {
   }
 
   fun markPassFinished(nowMillis: Long) {
-    if (targetKeys.all(renders::containsKey)) {
+    if (synchronized(renderLock) { targetKeys.all(renders::containsKey) }) {
       completedAt.compareAndSet(0, nowMillis)
       state.set("complete")
     } else {
@@ -75,15 +107,19 @@ class CatalogThemeCache {
   }
 
   fun snapshot(): ThemeOptimizationSnapshot {
-    val cachedTargets = targetKeys.count(renders::containsKey)
+    val cachedTargets = synchronized(renderLock) { targetKeys.count(renders::containsKey) }
     val total = targetKeys.size
     val complete = total > 0 && cachedTargets == total
     return ThemeOptimizationSnapshot(
-      state = if (complete) "complete" else state.get(),
+      state =
+        if (complete) "complete" else state.get().let { if (it == "complete") "paused" else it },
       total = total,
       cached = cachedTargets,
       remaining = (total - cachedTargets).coerceAtLeast(0),
-      failed = failedKeys.count { it in targetKeys && !renders.containsKey(it) },
+      failed =
+        synchronized(renderLock) {
+          failedKeys.count { it in targetKeys && !renders.containsKey(it) }
+        },
       cachedBytes = byteCount.get(),
       fullyOptimized = complete,
       startedAtEpochMillis = startedAt.get().takeIf { it > 0 },
@@ -91,9 +127,25 @@ class CatalogThemeCache {
     )
   }
 
+  fun renderCacheSnapshot(): CatalogRenderCacheSnapshot =
+    synchronized(renderLock) {
+      CatalogRenderCacheSnapshot(
+        entries = renders.size,
+        bytes = byteCount.get(),
+        maxBytes = maxBytes,
+        evictions = evictionCount.get(),
+      )
+    }
+
   private fun refreshCompletion() {
-    if (targetKeys.isNotEmpty() && targetKeys.all(renders::containsKey)) {
+    if (
+      targetKeys.isNotEmpty() && synchronized(renderLock) { targetKeys.all(renders::containsKey) }
+    ) {
       state.set("complete")
     }
+  }
+
+  companion object {
+    const val DEFAULT_MAX_BYTES: Long = 128L * 1024 * 1024
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Server-wide admission for **background, best-effort catalog work** — today the catalog
@@ -29,10 +30,14 @@ import java.util.concurrent.atomic.AtomicInteger
  * Both knobs are process-wide: one instance is built per `serve` run and shared by every catalog
  * host it opens.
  */
-class ServeBackgroundWork(maxConcurrentRenders: Int = 1) {
+class ServeBackgroundWork(
+  maxConcurrentRenders: Int = 1,
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
   private val loadsInFlight = AtomicInteger()
   private val initialLoadPending = AtomicBoolean(false)
   private val renderPermits = Semaphore(maxConcurrentRenders.coerceAtLeast(1))
+  private val lastCatalogLoadFinishedAt = AtomicLong(Long.MIN_VALUE)
 
   /**
    * True while the server is bringing catalogs up: the startup pass hasn't finished, or a refresh /
@@ -54,6 +59,7 @@ class ServeBackgroundWork(maxConcurrentRenders: Int = 1) {
   /** The startup pass is done (however it ended — loaded, failed, or shut down mid-pass). */
   fun initialCatalogLoadFinished() {
     initialLoadPending.set(false)
+    lastCatalogLoadFinishedAt.set(clock())
   }
 
   /** Run one catalog load, counted so background work stays parked for its duration. */
@@ -63,15 +69,30 @@ class ServeBackgroundWork(maxConcurrentRenders: Int = 1) {
       return block()
     } finally {
       loadsInFlight.decrementAndGet()
+      lastCatalogLoadFinishedAt.set(clock())
     }
   }
 
   /**
-   * Wrap the registry's whole-server idle clock so a loading server reads as busy (`null`), which
-   * is how [ServeCatalogLiveHost]'s optimizer already spells "not now".
+   * Wrap the registry's whole-server idle clock so a loading server reads as busy (`null`) and the
+   * clock restarts at zero when startup, refresh, or admin registration finishes. The catalog host
+   * applies its quiet-window threshold to the smaller of this and request/render idleness.
    */
   fun idleClock(idleMillis: () -> Long?): () -> Long? = {
-    if (catalogsLoading) null else idleMillis()
+    if (catalogsLoading) {
+      null
+    } else {
+      val requestIdleMillis = idleMillis()
+      if (requestIdleMillis == null || catalogsLoading) {
+        null
+      } else {
+        val finishedAt = lastCatalogLoadFinishedAt.get()
+        val catalogIdleMillis =
+          if (finishedAt == Long.MIN_VALUE) Long.MAX_VALUE
+          else (clock() - finishedAt).coerceAtLeast(0)
+        minOf(requestIdleMillis, catalogIdleMillis)
+      }
+    }
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -91,20 +91,18 @@ class ServeCatalogLiveHost(
     System.getProperty("composeai.serve.warmInBackground")?.toBooleanStrictOrNull() ?: false,
   private val catalogThemeCache: CatalogThemeCache = CatalogThemeCache(),
   /**
-   * Whether to **eagerly** fill [catalogThemeCache] on the idle pass below — off by default.
+   * Whether to **eagerly** fill [catalogThemeCache] on the idle pass below — on by default.
    *
-   * The pass renders `previews × declaredThemes` for every catalog: hundreds of daemon renders,
-   * server-wide, for pixels no visitor has asked for. Even parked behind [ServeBackgroundWork] it
-   * competes with the work that is actually on a request path, and on the public box it is what
-   * turned a quiet server into a permanently busy one. The *reactive* half of the cache is
-   * untouched and is where the value was: a theme a visitor actually selects is still cached on
-   * completion (see [cachedRender]), so re-selecting it stays instant.
+   * The pass renders `previews × declaredThemes` for every catalog: potentially hundreds of daemon
+   * renders. It used to start too eagerly and could keep a public box permanently busy. The
+   * default-on version is guarded by [ServeBackgroundWork], the one-minute quiet window below, and
+   * the cache's byte-bounded LRU; foreground traffic or catalog loading parks it between images.
    *
-   * `-Dcomposeai.serve.themeOptimization=true` turns the eager pass back on for a deployment that
-   * wants it.
+   * The pass is deliberately gentle: it waits for the server-wide quiet window and takes one
+   * background render permit at a time. `-Dcomposeai.serve.themeOptimization=false` disables it.
    */
   private val themeOptimizationEnabled: Boolean =
-    System.getProperty("composeai.serve.themeOptimization")?.toBooleanStrictOrNull() ?: false,
+    System.getProperty("composeai.serve.themeOptimization")?.toBooleanStrictOrNull() ?: true,
   private val serverIdleMillis: () -> Long? = { Long.MAX_VALUE },
   /**
    * Server-wide admission for the idle theme optimizer below. Shared by every catalog host in a
@@ -113,7 +111,7 @@ class ServeCatalogLiveHost(
    */
   private val backgroundWork: ServeBackgroundWork = ServeBackgroundWork(),
   private val themeOptimizationIdleMillis: Long =
-    System.getProperty("composeai.serve.themeOptimizationIdleMillis")?.toLongOrNull() ?: 30_000L,
+    System.getProperty("composeai.serve.themeOptimizationIdleMillis")?.toLongOrNull() ?: 60_000L,
   /**
    * Route snapshot renders to the shared monolithic daemon rather than the per-preview pool — see
    * [renderHostFor]. `-Dcomposeai.serve.sharedDaemonRenders=false` restores per-preview routing for
@@ -292,6 +290,9 @@ class ServeCatalogLiveHost(
 
   override fun themeOptimizationSnapshot(): ThemeOptimizationSnapshot? =
     catalogThemeCache.snapshot().takeIf { it.total > 0 }
+
+  override fun catalogRenderCacheSnapshot(): CatalogRenderCacheSnapshot =
+    catalogThemeCache.renderCacheSnapshot()
 
   override val backgroundWorkActive: Boolean
     get() = optimizationActive.get()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -174,6 +174,9 @@ interface ServeHost : AutoCloseable {
   /** Server-side catalog theme optimization progress, or null for hosts without that cache. */
   fun themeOptimizationSnapshot(): ThemeOptimizationSnapshot? = null
 
+  /** Memory occupancy of this catalog generation's durable rendered-preview cache. */
+  fun catalogRenderCacheSnapshot(): CatalogRenderCacheSnapshot? = null
+
   /** True while low-priority work still needs this host resident. */
   val backgroundWorkActive: Boolean
     get() = false

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1869,6 +1869,7 @@ class ServeHttpServer(
     val loadError: String?,
     val lastLoadAttemptEpochMillis: Long?,
     val themeOptimization: ThemeOptimizationSnapshot?,
+    val renderCache: CatalogRenderCacheSnapshot?,
     /**
      * The metadata above is a **last-known snapshot** of a now-suspended catalog
      * ([catalogMetaSeen]) rather than a live read, because the session's daemon is idle. Facts a
@@ -1920,6 +1921,7 @@ class ServeHttpServer(
     val degradation: String?,
     val provenance: ServeWeb.CatalogProvenance?,
     val themeOptimization: ThemeOptimizationSnapshot?,
+    val renderCache: CatalogRenderCacheSnapshot?,
   )
 
   init {
@@ -1952,6 +1954,7 @@ class ServeHttpServer(
         degradation = host.degradations.firstOrNull()?.detail,
         provenance = bundle.provenance,
         themeOptimization = host.themeOptimizationSnapshot(),
+        renderCache = host.catalogRenderCacheSnapshot(),
       )
   }
 
@@ -2033,6 +2036,7 @@ class ServeHttpServer(
               loadError = c.loadError,
               lastLoadAttemptEpochMillis = c.lastLoadAttemptEpochMillis,
               themeOptimization = c.themeOptimization,
+              renderCache = c.renderCache,
             )
           },
         runningServers =
@@ -2140,6 +2144,7 @@ class ServeHttpServer(
               loadState = c.loadState,
               loadError = c.loadError,
               themeOptimization = c.themeOptimization,
+              renderCache = c.renderCache,
             )
           },
         servers =
@@ -2230,6 +2235,7 @@ class ServeHttpServer(
         loadError = load?.error,
         lastLoadAttemptEpochMillis = load?.lastAttemptEpochMillis,
         themeOptimization = host?.themeOptimizationSnapshot() ?: seen?.themeOptimization,
+        renderCache = host?.catalogRenderCacheSnapshot() ?: seen?.renderCache,
         stale = seen != null,
       )
     }
@@ -3611,6 +3617,8 @@ private data class CatalogDto(
   val lastLoadAttemptEpochMillis: Long? = null,
   /** Server-side idle theme-cache fill progress for this catalog generation. */
   val themeOptimization: ThemeOptimizationSnapshot? = null,
+  /** Bounded rendered-preview cache occupancy for this catalog generation. */
+  val renderCache: CatalogRenderCacheSnapshot? = null,
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2575,6 +2575,14 @@ object ServeWeb {
       else -> "${seconds}s"
     }
 
+  private fun humanBytes(bytes: Long): String =
+    when {
+      bytes >= 1024L * 1024 * 1024 -> "${bytes / (1024L * 1024 * 1024)} GiB"
+      bytes >= 1024L * 1024 -> "${bytes / (1024L * 1024)} MiB"
+      bytes >= 1024L -> "${bytes / 1024L} KiB"
+      else -> "$bytes B"
+    }
+
   /** A JS string literal for [value] — escaped via the JSON encoder, so quotes/slashes are safe. */
   private fun jsString(value: String): String = JsonPrimitive(value).toString()
 
@@ -2605,6 +2613,8 @@ object ServeWeb {
     val loadError: String? = null,
     /** Server-side idle theme-cache fill progress for this catalog generation. */
     val themeOptimization: ThemeOptimizationSnapshot? = null,
+    /** Bounded rendered-preview cache occupancy for this catalog generation. */
+    val renderCache: CatalogRenderCacheSnapshot? = null,
     /**
      * The row's facts are a last-known snapshot of a catalog whose daemon is idle, not a live read
      * (`/status` never resumes one). Rendered as a "last known" qualifier next to the trust badge,
@@ -2715,6 +2725,14 @@ object ServeWeb {
                 }
               "<div class=\"cp-muted\">${esc(detail)}</div>"
             } ?: ""
+          val renderCache =
+            c.renderCache?.let { cache ->
+              val detail =
+                "preview cache ${cache.entries} entries · " +
+                  "${humanBytes(cache.bytes)} / ${humanBytes(cache.maxBytes)}" +
+                  if (cache.evictions > 0) " · ${cache.evictions} evicted" else ""
+              "<div class=\"cp-muted\">${esc(detail)}</div>"
+            } ?: ""
           // An idle catalog's facts are last-known, not live — say so next to the badge rather than
           // leaving the cell blank, which would read as untrusted.
           val staleNote = if (c.stale) "<div class=\"cp-muted\">last known</div>" else ""
@@ -2728,7 +2746,7 @@ object ServeWeb {
             "<div class=\"cp-muted\">${esc(c.id)}</div>$prov</td>" +
             "<td>$trustCell</td>" +
             "<td>${c.previews}</td>" +
-            "<td>$stateCell$themeOptimization$loadError$degrade</td>" +
+            "<td>$stateCell$themeOptimization$renderCache$loadError$degrade</td>" +
             "</tr>"
         }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
@@ -1,0 +1,36 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CatalogThemeCacheTest {
+  @Test
+  fun `render cache evicts least recently used entries at its byte cap`() {
+    val cache = CatalogThemeCache(maxBytes = 6)
+    cache.put("a", byteArrayOf(1, 1, 1))
+    cache.put("b", byteArrayOf(2, 2, 2))
+    assertContentEquals(byteArrayOf(1, 1, 1), cache.get("a")) // a is now newest
+
+    cache.put("c", byteArrayOf(3, 3, 3))
+
+    assertNull(cache.get("b"))
+    assertContentEquals(byteArrayOf(1, 1, 1), cache.get("a"))
+    assertContentEquals(byteArrayOf(3, 3, 3), cache.get("c"))
+    assertEquals(
+      CatalogRenderCacheSnapshot(entries = 2, bytes = 6, maxBytes = 6, evictions = 1),
+      cache.renderCacheSnapshot(),
+    )
+  }
+
+  @Test
+  fun `a render larger than the byte cap is not retained`() {
+    val cache = CatalogThemeCache(maxBytes = 2)
+    cache.put("large", byteArrayOf(1, 2, 3))
+
+    assertNull(cache.get("large"))
+    assertEquals(0, cache.renderCacheSnapshot().entries)
+    assertEquals(0, cache.renderCacheSnapshot().bytes)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
@@ -51,8 +51,9 @@ class ServeBackgroundWorkTest {
   }
 
   @Test
-  fun `the idle clock reports a loading server as busy and otherwise delegates`() {
-    val work = ServeBackgroundWork()
+  fun `the idle clock starts fresh when catalog loading finishes`() {
+    var now = 1_000L
+    val work = ServeBackgroundWork(clock = { now })
     val clock = work.idleClock { 90_000L }
 
     work.expectInitialCatalogLoad()
@@ -61,7 +62,24 @@ class ServeBackgroundWorkTest {
     assertNull(clock())
 
     work.initialCatalogLoadFinished()
-    assertEquals(90_000L, clock())
+    assertEquals(0L, clock())
+    now += 59_999
+    assertEquals(59_999L, clock())
+    now++
+    assertEquals(60_000L, clock())
+  }
+
+  @Test
+  fun `a catalog refresh resets the idle clock after it returns`() {
+    var now = 100_000L
+    val work = ServeBackgroundWork(clock = { now })
+    val clock = work.idleClock { 90_000L }
+
+    work.whileLoadingCatalog { now += 5_000 }
+
+    assertEquals(0L, clock())
+    now += 60_000
+    assertEquals(60_000L, clock())
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -795,6 +796,32 @@ class ServeCatalogLiveHostTest {
     val refreshedHost = ServeCatalogLiveHost(mapOf(catalogId to daemonId), refreshedLive, baked)
     refreshedHost.render(catalogId, themeOverride())
     assertEquals(1, refreshedLive.renderCalls)
+  }
+
+  @Test
+  fun `idle theme optimization is enabled by default after the quiet window`() {
+    val idleMillis = AtomicLong(59_999)
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        serverIdleMillis = idleMillis::get,
+      )
+
+    composite.prewarm()
+    Thread.sleep(100)
+    assertEquals(0, live.renderCalls)
+
+    idleMillis.set(60_000)
+    assertTrue(awaitOptimization(composite).fullyOptimized)
+    assertEquals(1, live.renderCalls)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -131,7 +131,7 @@ class ServeStatusTest {
     val daemonId = "FilledButton"
     val theme = ServeTheme("Brand Dark", "com.example.BrandDark")
     val overrides = PreviewOverrides(themeProvider = theme.providerFqn)
-    val cache = CatalogThemeCache()
+    val cache = CatalogThemeCache(maxBytes = 1024)
     val key = ServeOverrides.cacheKey(catalogId, overrides)
     cache.configureTargets(listOf(key))
     cache.put(key, png())
@@ -175,6 +175,15 @@ class ServeStatusTest {
     assertTrue(body.contains("\"themeOptimization\":{\"state\":\"complete\""), body)
     assertTrue(body.contains("\"fullyOptimized\":true"), body)
     assertTrue(body.contains("\"cached\":1"), body)
+    assertTrue(body.contains("\"renderCache\":{"), body)
+    assertTrue(body.contains("\"entries\":1"), body)
+    assertTrue(body.contains("\"maxBytes\":1024"), body)
+    assertTrue(body.contains("\"evictions\":0"), body)
+
+    val (htmlCode, html) = get("/status")
+    assertEquals(200, htmlCode)
+    assertTrue(html.contains("preview cache 1 entries"), html)
+    assertTrue(html.contains("/ 1 KiB"), html)
   }
 
   @Test


### PR DESCRIPTION
## What changed

- enable idle declared-theme optimization by default
- require one minute of quiet after the last foreground request/render or catalog startup/refresh/registration finishes before background work resumes
- continue limiting optimization to one server-wide background render at a time and pause between images whenever foreground activity returns
- bound each catalog-generation render cache with a 128 MiB access-order LRU
- allow the byte cap to be configured with `composeai.serve.catalogRenderCacheMaxBytes`
- expose cache entries, bytes, maximum bytes, and eviction count in JSON and HTML `/status`

## Why

The generation-scoped cache merged in #3298 makes paused background work durable: completed theme renders survive daemon suspension and are discarded when catalog content refreshes. This follow-up enables that optimizer with guardrails for foreground latency and memory.

## Impact

Theme images fill gradually while the server is genuinely quiet, pause for user work and catalog loading, and remain available afterward. Operators can monitor cache occupancy and evictions through `/status`.

An individual render is not preempted mid-flight; pausing occurs between images.

## Validation

- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest`
- `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.CatalogThemeCacheTest' --tests 'ee.schimke.composeai.cli.serve.ServeBackgroundWorkTest' --tests 'ee.schimke.composeai.cli.serve.ServeCatalogLiveHostTest' --tests 'ee.schimke.composeai.cli.serve.ServeStatusTest'`
- repository commit hooks
