### PR TITLE
fix(serve): keep themes across snapshot overrides

### DIFF
--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -346,20 +346,46 @@
     var qs = withScroll(snapshotExt, query());
     var url =
       base + "/render/" + encodeURIComponent(previewId) + snapshotExt + (qs ? "?" + qs : "");
-    var next = new Image();
-    next.onload = function () {
-      if (gen !== snapshotGen) return;
-      img.src = url;
-      status.textContent = "";
-      setSnapshotLoading(false);
-      clearModeError();
-    };
-    next.onerror = function () {
-      if (gen !== snapshotGen) return;
-      setSnapshotLoading(false);
-      showModeError((snapshotExt === ".svg" ? "SVG" : "PNG") + " render failed for this preview.");
-    };
-    next.src = url;
+    var requestedExt = snapshotExt;
+    // Override-bearing renders are deliberately `no-store`. Preloading with `new Image()` and
+    // then assigning the same URL to the visible image therefore performs two server renders,
+    // and the second one can race the first through the daemon's shared override state. Fetch the
+    // bytes once and hand the resulting blob URL to the image instead. This also keeps the current
+    // frame visible until the replacement has decoded.
+    fetch(url, { credentials: "same-origin" })
+      .then(function (response) {
+        if (!response.ok) throw new Error("render " + response.status);
+        return response.blob();
+      })
+      .then(function (blob) {
+        if (gen !== snapshotGen) return;
+        var objectUrl = URL.createObjectURL(blob);
+        var next = new Image();
+        next.onload = function () {
+          if (gen !== snapshotGen) { URL.revokeObjectURL(objectUrl); return; }
+          var previous = img.getAttribute("data-cp-blob");
+          img.src = objectUrl;
+          img.setAttribute("data-cp-blob", objectUrl);
+          if (previous) URL.revokeObjectURL(previous);
+          status.textContent = "";
+          setSnapshotLoading(false);
+          clearModeError();
+        };
+        next.onerror = function () {
+          URL.revokeObjectURL(objectUrl);
+          if (gen !== snapshotGen) return;
+          setSnapshotLoading(false);
+          showModeError((requestedExt === ".svg" ? "SVG" : "PNG") +
+            " render failed for this preview.");
+        };
+        next.src = objectUrl;
+      })
+      .catch(function () {
+        if (gen !== snapshotGen) return;
+        setSnapshotLoading(false);
+        showModeError((requestedExt === ".svg" ? "SVG" : "PNG") +
+          " render failed for this preview.");
+      });
     refreshLinks();
   }
   // The copyable direct-link panel: rebuild the absolute /render URLs (PNG + optional SVG) from

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -292,7 +292,7 @@
   syncBg();
 })();</script>
       <script src="/assets/serve/61d1-bc55e9642f5f9e1e/format-compare.js"></script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
@@ -278,7 +278,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -246,7 +246,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -245,7 +245,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -243,7 +243,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -234,7 +234,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -239,7 +239,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -229,7 +229,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -212,7 +212,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14627-40a0435e3e09e3dd/viewer.js"></script>
+      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -395,3 +395,118 @@ test("contract · declared theme renders use bounded parallelism", async ({ page
     expect(Array.from(attempts.values())).toEqual([2, 2, 2]);
     await expect.poll(() => released).toBe(true);
 });
+
+test("contract · snapshot overrides stay composed with a declared theme", async ({
+    page,
+}) => {
+    const requests = [];
+    for (const [name, contentType] of SERVE_ASSETS) {
+        await page.route(`**/assets/serve/**/${name}`, (route) =>
+            route.fulfill({
+                path: resolve(serveAssetsDir, name),
+                contentType,
+            }),
+        );
+    }
+    await page.route("**/render/**", async (route) => {
+        requests.push(new URL(route.request().url()));
+        await route.fulfill({
+            path: renderPlaceholder,
+            contentType: "image/png",
+        });
+    });
+    await page.goto("/preview-harness/fixtures/pages/serve-viewer-themes.html");
+    await expect.poll(() => requests.length).toBeGreaterThan(0);
+    await page.waitForTimeout(100);
+    requests.length = 0;
+
+    for (const group of ["appearance", "size", "locale", "device"]) {
+        await page
+            .locator(`details[data-cp-group="${group}"]`)
+            .evaluate((details) => {
+                details.open = true;
+            });
+    }
+
+    const themeProvider = "com.example.BrandLightThemeCatalog";
+    const assertSingleRender = async (before, expected) => {
+        await expect
+            .poll(() => requests.length, { timeout: 5_000 })
+            .toBe(before + 1);
+        // A second assignment of the no-store render URL used to arrive immediately after the
+        // preload completed. Give it a beat so an accidental duplicate cannot pass this check.
+        await page.waitForTimeout(100);
+        expect(requests).toHaveLength(before + 1);
+        const params = requests.at(-1).searchParams;
+        expect(params.get("themeProvider")).toBe(themeProvider);
+        for (const [key, value] of Object.entries(expected)) {
+            expect(params.get(key), key).toBe(value);
+        }
+    };
+    const change = async (action, expected) => {
+        const before = requests.length;
+        await action();
+        await assertSingleRender(before, expected);
+    };
+
+    await change(
+        () => page.locator("#cp-theme").selectOption(`theme:${themeProvider}`),
+        {},
+    );
+    await change(() => page.locator("#cp-background").selectOption("clear"), {
+        background: "clear",
+    });
+    await change(() => page.locator("#cp-sizeMode").selectOption("fixed"), {
+        background: "clear",
+    });
+    await change(() => page.locator("#cp-fixedW").fill("120"), {
+        widthPx: "240",
+    });
+    await change(() => page.locator("#cp-fixedH").fill("80"), {
+        widthPx: "240",
+        heightPx: "160",
+    });
+    await change(() => page.locator("#cp-sizeMode").selectOption("within"), {
+        background: "clear",
+    });
+    await change(() => page.locator("#cp-minW").fill("100"), {
+        minWidthPx: "200",
+    });
+    await change(() => page.locator("#cp-minH").fill("60"), {
+        minWidthPx: "200",
+        minHeightPx: "120",
+    });
+    await change(() => page.locator("#cp-maxW").fill("300"), {
+        minWidthPx: "200",
+        minHeightPx: "120",
+        maxWidthPx: "600",
+    });
+    await change(() => page.locator("#cp-maxH").fill("200"), {
+        minWidthPx: "200",
+        minHeightPx: "120",
+        maxWidthPx: "600",
+        maxHeightPx: "400",
+    });
+    await change(
+        async () => {
+            await page.locator("#cp-localeTag").fill("ar-XB");
+            await page.locator("#cp-localeTag").press("Tab");
+        },
+        { localeTag: "ar-XB" },
+    );
+    await change(
+        () =>
+            page.locator("#cp-fontScale").evaluate((slider) => {
+                slider.value = "1.3";
+                slider.dispatchEvent(new Event("input", { bubbles: true }));
+            }),
+        { fontScale: "1.3" },
+    );
+    await change(() => page.locator("#cp-device").selectOption("id:pixel_7"), {
+        device: "id:pixel_7",
+    });
+    await change(
+        () => page.locator("#cp-orientation").selectOption("landscape"),
+        { orientation: "landscape" },
+    );
+});


### PR DESCRIPTION
## Goal

Fix the preview viewer so changing font scale with Classic Light selected does not render twice or fall back through the red/default themes, then test all standard overrides with the selected theme.

## Summary

- Changed `viewer.js` to fetch each no-store snapshot once and swap the decoded blob into the visible image, eliminating the duplicate daemon render and override-state race.
- Added a Playwright contract covering declared theme + background, fixed/min/max sizing, locale, font scale, device, and orientation; every edit must preserve `themeProvider` and issue exactly one render request.
- Regenerated the viewer HTML fixtures for the new asset hash.
- No static before/after image is included: the resting pixels are intentionally unchanged, and the regression was a transient two-request sequence. The new browser contract directly verifies the observable request/render behavior.

## Verification

- `./gradlew :cli:test --tests "ee.schimke.composeai.cli.serve.ServeWebFixtureTest"`
- `./node_modules/.bin/playwright test -c preview-harness/playwright.config.mjs pages-snapshot.spec.mjs --grep "snapshot overrides stay composed" --reporter=line`
- `node --check cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js`
- `node --check vscode-extension/preview-harness/pages-snapshot.spec.mjs`