### PR TITLE
feat(serve): publish Home Assistant and Thunderbird catalogs

### DIFF
--- a/deploy/preview.coo.ee/catalogs.json
+++ b/deploy/preview.coo.ee/catalogs.json
@@ -20,6 +20,11 @@
       "id": "pocket-casts",
       "heading": "Automattic/pocket-casts-android",
       "noun": "app(s)"
+    },
+    {
+      "id": "thunderbird",
+      "heading": "thunderbird/thunderbird-android",
+      "noun": "app(s)"
     }
   ],
   "catalogs": [
@@ -95,7 +100,11 @@
     {
       "system": "thunderbird",
       "repo": "yschimke/thunderbird-android",
-      "listed": true
+      "listed": true,
+      "group": "thunderbird",
+      "attributionRepos": [
+        "thunderbird/thunderbird-android"
+      ]
     },
     {
       "system": "jetnews",

--- a/deploy/preview.coo.ee/catalogs.json
+++ b/deploy/preview.coo.ee/catalogs.json
@@ -12,6 +12,11 @@
       "noun": "sample(s)"
     },
     {
+      "id": "home-assistant",
+      "heading": "home-assistant/android",
+      "noun": "app(s)"
+    },
+    {
       "id": "pocket-casts",
       "heading": "Automattic/pocket-casts-android",
       "noun": "app(s)"
@@ -45,6 +50,24 @@
       "system": "homeassistant-remotecompose",
       "repo": "yschimke/homeassistant-remotecompose",
       "listed": true
+    },
+    {
+      "system": "home-assistant-android",
+      "repo": "yschimke/home-assistant-android",
+      "listed": true,
+      "group": "home-assistant",
+      "attributionRepos": [
+        "home-assistant/android"
+      ]
+    },
+    {
+      "system": "home-assistant-wear",
+      "repo": "yschimke/home-assistant-android",
+      "listed": true,
+      "group": "home-assistant",
+      "attributionRepos": [
+        "home-assistant/android"
+      ]
     },
     {
       "system": "pocketcasts",

--- a/deploy/preview.coo.ee/catalogs.json
+++ b/deploy/preview.coo.ee/catalogs.json
@@ -93,6 +93,11 @@
       "listed": true
     },
     {
+      "system": "thunderbird",
+      "repo": "yschimke/thunderbird-android",
+      "listed": true
+    },
+    {
       "system": "jetnews",
       "repo": "yschimke/compose-samples",
       "listed": true,

--- a/deploy/preview.coo.ee/producers.json
+++ b/deploy/preview.coo.ee/producers.json
@@ -30,6 +30,10 @@
       "branch": "design-artifacts/*"
     },
     {
+      "repo": "yschimke/thunderbird-android",
+      "branch": "design-artifacts/*"
+    },
+    {
       "repo": "yschimke/pocket-casts-android",
       "branch": "design-artifacts/*"
     },

--- a/deploy/preview.coo.ee/producers.json
+++ b/deploy/preview.coo.ee/producers.json
@@ -14,6 +14,10 @@
       "branch": "design-artifacts/*"
     },
     {
+      "repo": "yschimke/home-assistant-android",
+      "branch": "design-artifacts/*"
+    },
+    {
       "repo": "yschimke/cadence",
       "branch": "design-artifacts/*"
     },


### PR DESCRIPTION
## Summary

- add dedicated Home Assistant and Thunderbird sections to the preview.coo.ee catalog index
- publish the Home Assistant Android and Wear catalogs from `yschimke/home-assistant-android`
- publish the Thunderbird catalog from `yschimke/thunderbird-android`
- trust both repos' `design-artifacts/*` delivery branches
- attribute the forked catalogs to `home-assistant/android` and `thunderbird/thunderbird-android`

## Test plan

- [x] Parse both deployment JSON files with `jq`
- [x] Verify every registered catalog repo has matching `design-artifacts/*` branch trust
- [x] Verify catalog group references resolve
- [x] Verify each fork's canonical upstream and published catalog `source.ref`
- [x] Run `.github/scripts/test-publish-config-to-box.sh`
- [x] Run `git diff --check`