### PR TITLE
fix(serve): only badge untrusted catalogs

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -145,14 +145,14 @@ object ServeWeb {
   }
 
   /**
-   * The public front door is discovery, not a trust decision: keep its catalog cards deliberately
-   * orange and labelled `untrusted`. The real producer verdict remains available on `/status` and
-   * on the catalog's own pages, where there is enough context to explain its basis.
+   * The public front door only calls out a negative producer verdict: unverified catalogs are
+   * orange and labelled `untrusted`, while trusted catalogs carry no badge. The full verdict and
+   * its basis remain available on `/status` and on the catalog's own pages.
    */
   private fun homeTrustBadge(trust: String?): String {
-    if (trust.isNullOrBlank()) return ""
+    if (trust != "unverified") return ""
     return " <span class=\"cp-badge cp-badge--unverified\" " +
-      "title=\"Producer trust details are available on /status\">⚠ untrusted</span>"
+      "title=\"producer trust: unverified\">⚠ untrusted</span>"
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1910,12 +1910,29 @@ class ServeWebFixtureTest {
       "a card with no prebaked hero falls back to its /render endpoint",
     )
     assertTrue(
-      homeIndex.contains("cp-badge--unverified") && homeIndex.contains("⚠ untrusted"),
-      "the discovery index deliberately presents catalog cards as untrusted",
+      !homeIndex.contains("cp-badge--trusted") && !homeIndex.contains("⚠ untrusted"),
+      "the discovery index omits badges for trusted catalog cards",
     )
-    assertFalse(
-      homeIndex.contains("cp-badge--trusted"),
-      "the discovery index leaves the actual producer verdict to /status and catalog pages",
+    val untrustedHomeIndex =
+      ServeWeb.homeIndexPage(
+        systems =
+          listOf(
+            ServeWeb.HomeSystem(
+              system = "unverified",
+              title = "Unverified catalog",
+              subtitle = null,
+              previewCount = 1,
+              trust = "unverified",
+              heroPreviewId = null,
+            )
+          ),
+        token = token,
+        isPublic = true,
+      )
+    assertTrue(
+      untrustedHomeIndex.contains("cp-badge--unverified") &&
+        untrustedHomeIndex.contains("⚠ untrusted"),
+      "the discovery index calls out a genuinely unverified catalog",
     )
     // meshcore-mobile + homeassistant-remotecompose are LISTED (`--catalogs`), so they show on the
     // front door in the "Design systems" grid — served from their own repos.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -42,7 +42,7 @@
       <a class="cp-card cp-sys" href="/compose-m3/">
   <div class="cp-imgwrap"><img loading="eager" decoding="async" width="168" height="68" alt="Compose Material 3 preview" src="/hero/compose-m3/1f0c9a4b7d2e6503.png"></div>
   <div class="cp-meta">
-    <div class="cp-sys-title">Compose Material 3 <span class="cp-badge cp-badge--unverified" title="Producer trust details are available on /status">⚠ untrusted</span></div>
+    <div class="cp-sys-title">Compose Material 3</div>
     <div class="cp-id">compose-m3</div>
       <div class="cp-sys-desc">androidx.compose.material3:material3</div>
     <div class="cp-sys-foot">42 preview(s)</div>
@@ -51,7 +51,7 @@
 <a class="cp-card cp-sys" data-bg-theme="dark" href="/wear-m3/">
   <div class="cp-imgwrap"><img loading="eager" decoding="async" width="132" height="132" alt="Wear Compose Material 3 preview" src="/hero/wear-m3/9b3d51ca08e7f264.png"></div>
   <div class="cp-meta">
-    <div class="cp-sys-title">Wear Compose Material 3 <span class="cp-badge cp-badge--unverified" title="Producer trust details are available on /status">⚠ untrusted</span></div>
+    <div class="cp-sys-title">Wear Compose Material 3</div>
     <div class="cp-id">wear-m3</div>
       <div class="cp-sys-desc">androidx.wear.compose:compose-material3</div>
     <div class="cp-sys-foot">18 preview(s)</div>
@@ -60,7 +60,7 @@
 <a class="cp-card cp-sys" data-bg-theme="dark" href="/remote-m3/">
   <div class="cp-imgwrap"><img loading="lazy" alt="Remote Compose Material 3 preview" src="/remote-m3/render/Button-Filled__ideal__default__light.png"></div>
   <div class="cp-meta">
-    <div class="cp-sys-title">Remote Compose Material 3 <span class="cp-badge cp-badge--unverified" title="Producer trust details are available on /status">⚠ untrusted</span></div>
+    <div class="cp-sys-title">Remote Compose Material 3</div>
     <div class="cp-id">remote-m3</div>
       <div class="cp-sys-desc">androidx.wear.compose.remote:remote-material3</div>
     <div class="cp-sys-foot">6 preview(s)</div>
@@ -75,7 +75,7 @@
       <a class="cp-card cp-sys" href="/meshcore-mobile/">
   <div class="cp-imgwrap"><img loading="lazy" alt="MeshCore preview" src="/meshcore-mobile/render/device-manycontacts__ideal__default__compact.png"></div>
   <div class="cp-meta">
-    <div class="cp-sys-title">MeshCore <span class="cp-badge cp-badge--unverified" title="Producer trust details are available on /status">⚠ untrusted</span></div>
+    <div class="cp-sys-title">MeshCore</div>
     <div class="cp-id">meshcore-mobile</div>
       <div class="cp-sys-desc">ee.schimke.meshcore</div>
     <div class="cp-sys-foot">33 preview(s)</div>
@@ -84,7 +84,7 @@
 <a class="cp-card cp-sys" href="/homeassistant-remotecompose/">
   <div class="cp-imgwrap"><span class="cp-sys-noimg">no preview</span></div>
   <div class="cp-meta">
-    <div class="cp-sys-title">HomeAssistant RemoteCompose <span class="cp-badge cp-badge--unverified" title="Producer trust details are available on /status">⚠ untrusted</span></div>
+    <div class="cp-sys-title">HomeAssistant RemoteCompose</div>
     <div class="cp-id">homeassistant-remotecompose</div>
       <div class="cp-sys-desc">ee.schimke.homeassistant</div>
     <div class="cp-sys-foot">9 preview(s)</div>
@@ -99,7 +99,7 @@
       <a class="cp-card cp-sys" data-bg-theme="dark" href="/confetti-wear/">
   <div class="cp-imgwrap"><img loading="lazy" alt="Confetti (Wear) preview" src="/confetti-wear/render/conference-screen__ideal__default__dark.png"></div>
   <div class="cp-meta">
-    <div class="cp-sys-title">Confetti (Wear) <span class="cp-badge cp-badge--unverified" title="Producer trust details are available on /status">⚠ untrusted</span></div>
+    <div class="cp-sys-title">Confetti (Wear)</div>
     <div class="cp-id">confetti-wear</div>
       <div class="cp-sys-desc">dev.johnoreilly.confetti</div>
     <div class="cp-sys-foot">12 preview(s)</div>


### PR DESCRIPTION
## What changed

- omit trust badges from trusted catalog cards on the public homepage
- show the orange “untrusted” badge only when the catalog verdict is actually unverified
- keep the full real trust verdict on `/status` and catalog pages
- update the homepage fixture and add coverage for both trusted and unverified cards

## Why

The merged change interpreted “show untrusted instead” too broadly and labelled trusted catalogs as untrusted on the homepage. This makes the label conditional on the actual verdict.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests '*ServeStatusTest*' --tests '*ServeWebFixtureTest*'`
- committed ServeWeb homepage fixture drift check
