### PR TITLE
fix(serve): normalize Gradle source paths

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeUrls.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeUrls.kt
@@ -95,9 +95,11 @@ object ServeUrls {
    * `https://github.com/<repo>/blob/<ref>/<module>/<sourceFile>`. [repo] is `owner/name`; [ref] is
    * the **source** branch/tag/sha the catalog was built from (its `catalog.json` `source.ref`, NOT
    * the `design-artifacts/<system>` delivery branch, which carries generated assets rather than
-   * Kotlin); [module] is the source module subdirectory (`source.module`, e.g.
-   * `samples/design-catalog-compose-m3`), joined ahead of the module-relative [sourceFile] that
-   * discovery recorded.
+   * Kotlin); [module] is the source module's Gradle project path (`source.module`, e.g.
+   * `:samples:design-catalog-compose-m3`) or repository-relative subdirectory, joined ahead of the
+   * module-relative [sourceFile] that discovery recorded. Gradle project separators are converted
+   * to repository path separators, so `:previews` links under `previews/` rather than the literal
+   * (and invalid) `%3Apreviews/` directory.
    *
    * Returns null when [repo], [ref], or [sourceFile] is missing/blank, so a caller can `?.let` the
    * link into existence only when it resolves. [module] is optional (a source with no module
@@ -111,7 +113,11 @@ object ServeUrls {
     val f = ref?.trim()?.takeIf { it.isNotEmpty() } ?: return null
     val rel =
       sourceFile?.replace('\\', '/')?.trim()?.trim('/')?.takeIf { it.isNotEmpty() } ?: return null
-    val mod = module?.replace('\\', '/')?.trim()?.trim('/')?.takeIf { it.isNotEmpty() }
+    val rawModule = module?.replace('\\', '/')?.trim()?.trim('/')?.takeIf { it.isNotEmpty() }
+    val mod =
+      rawModule
+        ?.let { if (it.startsWith(':')) it.trim(':').replace(':', '/') else it }
+        ?.takeIf { it.isNotEmpty() }
     val path = if (mod != null) "$mod/$rel" else rel
     val encoded = path.split('/').joinToString("/") { WebEscaping.urlEncodeSegment(it) }
     return "https://github.com/$r/blob/$f/$encoded"

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeUrlsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeUrlsTest.kt
@@ -113,6 +113,20 @@ class ServeUrlsTest {
       "https://github.com/o/r/blob/main/mod/src/main/A.kt",
       ServeUrls.githubBlobUrl("o/r", "main", "/mod/", "\\src\\main\\A.kt"),
     )
+    // Catalogs conventionally publish Gradle project paths, not repository directory paths.
+    assertEquals(
+      "https://github.com/o/r/blob/main/previews/src/main/A.kt",
+      ServeUrls.githubBlobUrl("o/r", "main", ":previews", "src/main/A.kt"),
+    )
+    assertEquals(
+      "https://github.com/o/r/blob/main/samples/android/src/main/A.kt",
+      ServeUrls.githubBlobUrl("o/r", "main", ":samples:android", "src/main/A.kt"),
+    )
+    // The root Gradle project contributes no directory prefix.
+    assertEquals(
+      "https://github.com/o/r/blob/main/src/main/A.kt",
+      ServeUrls.githubBlobUrl("o/r", "main", ":", "src/main/A.kt"),
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary

- normalize catalog Gradle project paths such as `:previews` before constructing GitHub source URLs
- support nested project paths such as `:samples:android`
- treat the root Gradle project path (`:`) as having no directory prefix

## Root cause

Catalogs publish `source.module` as a Gradle project path. The preview server previously treated that value as a literal repository directory, so `:previews` became `%3Apreviews` and the **View Source** link pointed to a non-existent GitHub path.

## Impact

Published preview pages now link to the actual Kotlin source file. For example, `:previews` resolves to `previews/` rather than `%3Apreviews/`.

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeUrlsTest`
- `./gradlew ktfmtCheckAll`
- `git diff --check`