### PR TITLE
fix(serve): require write access for the playground repo gate

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -59,7 +59,13 @@ class ServeGithubAuth(
   suspend fun RoutingContext.handleStart() {
     val returnTo = safeReturnTo(call.request.queryParameters["return"] ?: "/")
     val state = signedState(nonce(), returnTo)
-    call.response.cookies.append(stateCookie(state, maxAge = STATE_TTL_SECONDS))
+    call.response.cookies.append(
+      stateCookie(
+        state,
+        maxAge = STATE_TTL_SECONDS,
+        secure = isSecure(call, config.callbackBaseUrl),
+      )
+    )
     call.respondRedirect(authorizeUrl(call, state))
   }
 
@@ -81,8 +87,9 @@ class ServeGithubAuth(
           return
         }
     val session = signedSession(user.login, user.repositoryAccess)
-    call.response.cookies.append(authCookie(session, maxAge = SESSION_TTL_SECONDS))
-    call.response.cookies.append(stateCookie("", maxAge = 0))
+    val secure = isSecure(call, config.callbackBaseUrl)
+    call.response.cookies.append(authCookie(session, maxAge = SESSION_TTL_SECONDS, secure = secure))
+    call.response.cookies.append(stateCookie("", maxAge = 0, secure = secure))
     call.respondRedirect(statePayload.returnTo)
   }
 
@@ -183,23 +190,24 @@ class ServeGithubAuth(
     return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
   }
 
-  private fun stateCookie(value: String, maxAge: Long): Cookie =
-    Cookie(
-      name = STATE_COOKIE,
-      value = value,
-      path = "/",
-      maxAge = maxAge.toInt(),
-      httpOnly = true,
-      encoding = CookieEncoding.URI_ENCODING,
-      extensions = mapOf("SameSite" to "Lax"),
-    )
+  private fun stateCookie(value: String, maxAge: Long, secure: Boolean): Cookie =
+    sessionCookie(STATE_COOKIE, value, maxAge, secure)
 
-  private fun authCookie(value: String, maxAge: Long): Cookie =
+  private fun authCookie(value: String, maxAge: Long, secure: Boolean): Cookie =
+    sessionCookie(AUTH_COOKIE, value, maxAge, secure)
+
+  /**
+   * [secure] is derived per request rather than hardcoded: a deployment terminates TLS at Caddy and
+   * must not hand the session cookie back over a plaintext downgrade, while `serve` on
+   * `http://localhost` would never see the cookie again if it were always set. See [isSecure].
+   */
+  private fun sessionCookie(name: String, value: String, maxAge: Long, secure: Boolean): Cookie =
     Cookie(
-      name = AUTH_COOKIE,
+      name = name,
       value = value,
       path = "/",
       maxAge = maxAge.toInt(),
+      secure = secure,
       httpOnly = true,
       encoding = CookieEncoding.URI_ENCODING,
       extensions = mapOf("SameSite" to "Lax"),
@@ -285,6 +293,21 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
     }
   }
 
+  /**
+   * Whether [login] has **write** access to [repository] — the gate on the playground, which
+   * compiles and runs a stranger's Kotlin.
+   *
+   * Write, not merely "not none". GitHub reports `read` from this endpoint for *any* authenticated
+   * user on a **public** repository, because reading is what public means — so the old `permission
+   * != "none"` test admitted every GitHub account whenever the configured `--github-auth-repo` was
+   * public, which is the documented setup. The legacy `permission` field collapses the finer roles
+   * onto `admin` / `write` / `read` / `none`, so `maintain` arrives as `write`; it is accepted by
+   * name too in case that ever changes.
+   *
+   * This is deliberately narrower than before: a read-only collaborator on a private repo no longer
+   * reaches the playground. Live preview, which only needs a signed-in user, is unaffected — and
+   * `--github-auth-users` remains the way to admit named logins.
+   */
   private fun fetchRepositoryAccess(token: String, repository: String, login: String): Boolean {
     val request =
       Request.Builder()
@@ -293,18 +316,24 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
         .header(HttpHeaders.Accept, "application/vnd.github+json")
         .build()
     return client.newCall(request).execute().use { response ->
-      if (response.code == 404) return@use false
       if (!response.isSuccessful) return@use false
-      val permission =
+      val payload =
         JSON.decodeFromString(GitHubPermissionResponse.serializer(), response.body.string())
-          .permission
-          .lowercase()
-      permission != "none"
+      val role = payload.roleName?.trim()?.lowercase()
+      payload.permission.lowercase() in WRITE_PERMISSIONS ||
+        (role != null && role in WRITE_PERMISSIONS)
     }
   }
 
   companion object {
     private val JSON = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Values meaning "can push", across both the legacy `permission` field and the fine-grained
+     * `role_name` one. `maintain` only ever appears in the latter today, but naming it in both
+     * costs nothing and survives GitHub widening the legacy field.
+     */
+    private val WRITE_PERMISSIONS = setOf("admin", "maintain", "write")
   }
 }
 
@@ -313,7 +342,11 @@ private data class GitHubTokenResponse(@SerialName("access_token") val accessTok
 
 @Serializable private data class GitHubUserResponse(val login: String)
 
-@Serializable private data class GitHubPermissionResponse(val permission: String = "none")
+@Serializable
+private data class GitHubPermissionResponse(
+  val permission: String = "none",
+  @SerialName("role_name") val roleName: String? = null,
+)
 
 private fun ApplicationCall.uriWithQuery(): String = request.uri
 
@@ -325,6 +358,17 @@ private fun io.ktor.server.request.ApplicationRequest.cookieValue(name: String):
       val idx = part.indexOf('=')
       if (idx > 0 && part.substring(0, idx) == name) part.substring(idx + 1) else null
     }
+
+/**
+ * Whether this request reached us over TLS, so the cookies can be marked `secure`.
+ *
+ * The configured `callbackBaseUrl` is the authoritative answer where it exists — it is the operator
+ * stating the public origin — and it is what a reverse-proxied deployment is told to set. Otherwise
+ * fall back to the request's own view, which behind a proxy means `X-Forwarded-Proto`.
+ */
+internal fun isSecure(call: ApplicationCall, callbackBaseUrl: String? = null): Boolean =
+  callbackBaseUrl?.trim()?.takeIf { it.isNotEmpty() }?.startsWith("https://", ignoreCase = true)
+    ?: externalOrigin(call).startsWith("https://", ignoreCase = true)
 
 private fun externalOrigin(call: ApplicationCall): String {
   val forwardedProto = call.request.headers["X-Forwarded-Proto"]?.substringBefore(",")?.trim()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitHubOAuthVerifierTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitHubOAuthVerifierTest.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+/**
+ * The repo-access half of sign-in, which is what gates the playground (`/playground`, `POST
+ * /api/<v>/compiler/run`, `/pg/<token>`) — the surfaces that compile and run a stranger's Kotlin.
+ * Live preview only needs a signed-in user and is unaffected by any of this.
+ */
+class GitHubOAuthVerifierTest {
+
+  private val config =
+    ServeGithubAuthConfig(
+      clientId = "id",
+      clientSecret = "secret",
+      cookieSecret = "0123456789012345678901234567890123",
+      repository = "yschimke/compose-ai-tools",
+    )
+
+  /** Serves the three endpoints `verify` walks, with a caller-chosen permission payload. */
+  private fun verifierReporting(permissionJson: String): GitHubOAuthVerifier {
+    val client =
+      OkHttpClient.Builder()
+        .addInterceptor(
+          Interceptor { chain ->
+            val url = chain.request().url.toString()
+            val body =
+              when {
+                url.contains("login/oauth/access_token") -> """{"access_token":"t"}"""
+                url.endsWith("/user") -> """{"login":"octocat"}"""
+                url.contains("/collaborators/") -> permissionJson
+                else -> error("unexpected request to $url")
+              }
+            Response.Builder()
+              .request(chain.request())
+              .protocol(Protocol.HTTP_1_1)
+              .code(200)
+              .message("OK")
+              .body(body.toResponseBody("application/json".toMediaType()))
+              .build()
+          }
+        )
+        .build()
+    return GitHubOAuthVerifier(client)
+  }
+
+  private fun accessFor(permissionJson: String): Boolean {
+    val user =
+      verifierReporting(permissionJson)
+        .verify("code", "https://example.test/cb", config)
+        .getOrThrow()
+    assertEquals("octocat", user.login)
+    return user.repositoryAccess
+  }
+
+  /**
+   * The regression this exists for: GitHub answers `read` from the collaborator-permission endpoint
+   * for *any* authenticated user on a **public** repository, because reading is what public means.
+   * The old `permission != "none"` test therefore admitted every GitHub account to the playground
+   * whenever the configured `--github-auth-repo` was public — which is the documented setup.
+   */
+  @Test
+  fun `read on a public repo is not repository access`() {
+    assertFalse(accessFor("""{"permission":"read","role_name":"read"}"""))
+  }
+
+  @Test
+  fun `none is not repository access`() {
+    assertFalse(accessFor("""{"permission":"none","role_name":"none"}"""))
+  }
+
+  @Test
+  fun `triage is not repository access`() {
+    assertFalse(accessFor("""{"permission":"read","role_name":"triage"}"""))
+  }
+
+  @Test
+  fun `write is repository access`() {
+    assertTrue(accessFor("""{"permission":"write","role_name":"write"}"""))
+  }
+
+  @Test
+  fun `admin is repository access`() {
+    assertTrue(accessFor("""{"permission":"admin","role_name":"admin"}"""))
+  }
+
+  /** `maintain` collapses onto `write` in the legacy field; honour either spelling. */
+  @Test
+  fun `maintain is repository access`() {
+    assertTrue(accessFor("""{"permission":"write","role_name":"maintain"}"""))
+  }
+
+  /** An older payload with no `role_name` still decides off the legacy field alone. */
+  @Test
+  fun `a payload without a role name still reads the legacy permission`() {
+    assertTrue(accessFor("""{"permission":"write"}"""))
+    assertFalse(accessFor("""{"permission":"read"}"""))
+  }
+}

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -529,9 +529,15 @@ SERVE_GITHUB_AUTH_COOKIE_SECRET=... # at least 32 chars
 
 With those set, live preview WebSockets require a signed-in GitHub user. `/playground`,
 `POST /api/<version>/compiler/run`, and `/pg/<token>` require a signed-in GitHub user that also has
-access to `SERVE_GITHUB_AUTH_REPO` / `--github-auth-repo`. The browser cookie stores only a signed,
-expiring login plus the repo access verdict. The OAuth request includes GitHub's `repo` scope so
-private repository access can be checked during sign-in; the OAuth token is not stored.
+**write** access to `SERVE_GITHUB_AUTH_REPO` / `--github-auth-repo` — `admin`, `maintain`, or
+`write`. Read access is deliberately not enough: GitHub reports `read` for *any* authenticated user
+on a **public** repository, so a read-level gate on a public `SERVE_GITHUB_AUTH_REPO` would admit
+every GitHub account to a surface that compiles and runs submitted Kotlin. Use
+`SERVE_GITHUB_AUTH_USERS` to admit named logins who don't have write access. The browser cookie
+stores only a signed, expiring login plus the repo access verdict, and is marked `secure` whenever
+the request arrives over HTTPS (which is why a reverse-proxied box should set
+`SERVE_GITHUB_AUTH_CALLBACK_BASE_URL`). The OAuth request includes GitHub's `repo` scope so private
+repository access can be checked during sign-in; the OAuth token is not stored.
 Reverse-proxied deployments should also set
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL=https://preview.example.com` so the OAuth callback URL is stable.
 When `DOMAIN` is set, the prebuilt image derives


### PR DESCRIPTION
Found while reviewing the PRs that landed since Saturday.

## The problem

`GitHubOAuthVerifier.fetchRepositoryAccess` decided "does this person have access to the repo" with:

```kotlin
if (response.code == 404) return@use false
val permission = …permission.lowercase()
permission != "none"
```

GitHub's `GET /repos/{owner}/{repo}/collaborators/{login}/permission` answers `read` for **any** authenticated user on a **public** repository — reading is what public means. So whenever `--github-auth-repo` / `SERVE_GITHUB_AUTH_REPO` points at a public repo, which is exactly what `docs/public-preview-server.md` describes, `permission != "none"` was true for every GitHub account.

That gate is not decorative. `ServeHttpServer.rejectMissingGithubRepoAccess` uses it for `/playground`, `POST /api/<version>/compiler/run`, and `/pg/<token>` — the surfaces that compile and run submitted Kotlin. The `PlaygroundSandbox` jail still stands behind it, so this was a blast-radius gate rather than the last line of defence, but it was not gating what the docs claim it gates.

## The change

Require **write**: `admin` / `maintain` / `write`, read from either the legacy `permission` field or the fine-grained `role_name`. The legacy field collapses `maintain` onto `write`, so both spellings are accepted in case that ever widens.

This is deliberately narrower than before, and that is a behaviour change worth calling out:

- A read-only collaborator on a **private** repo no longer reaches the playground. `--github-auth-users` / `SERVE_GITHUB_AUTH_USERS` remains the way to admit named logins who don't have write access.
- Live preview WebSockets, which only require a signed-in GitHub user, are unaffected.

Also in the same file: mark the auth and state cookies `secure` when the request arrived over HTTPS. They were `httpOnly` + `SameSite=Lax` but not `secure`, so a plaintext downgrade in front of a TLS-terminating Caddy would put the session cookie on the wire. Derived per request — with the configured `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL` taken as authoritative where it is set — rather than hardcoded, so `serve` on `http://localhost` keeps working.

## Test plan

New `GitHubOAuthVerifierTest` drives the real `verify()` path through an `OkHttpClient` interceptor serving the three endpoints it walks, and pins the verdict for each permission shape:

| payload | access |
| --- | --- |
| `permission=read, role_name=read` (public-repo default) | ✗ |
| `permission=none` | ✗ |
| `permission=read, role_name=triage` | ✗ |
| `permission=write` | ✓ |
| `permission=admin` | ✓ |
| `permission=write, role_name=maintain` | ✓ |
| `permission=write`, no `role_name` | ✓ |

```
./gradlew :cli:test --tests "…GitHubOAuthVerifierTest" \
                    --tests "…ServeAuthTest" \
                    --tests "…PlaygroundRoutingTest" :cli:ktfmtCheck
```
BUILD SUCCESSFUL — 7 new tests, existing auth and playground-routing suites unchanged.

No visual surface is touched (auth verdict plumbing + docs), so there is no before/after render to embed.

## Follow-ups not in this PR

- The OAuth scope is `read:user repo`. `repo` grants full read/write on all of the user's private repositories, which is a very large consent prompt for a permission check on one repo.
- `PlaygroundJailedCompiler.wrap()` falls back to the **in-process** compiler with only a stderr log when `lib-bta/` jars are missing, even under `--public`. Its kdoc says a public host cannot reach there without a verified sandbox, but the code checks `sandbox.isActive`, not the public profile. That should probably be fatal at startup.

---
_Generated by [Claude Code](https://claude.ai/code/session_0184U4iKHdJDcdTcC1Tm1UJA)_