### PR TITLE
fix(gradle-plugin): require a recognised merge-blame schema before pruning

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnership.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnership.kt
@@ -51,6 +51,12 @@ internal object MergedResourceOwnership {
    * build that never merged resources, a malformed file, or a future AGP that stops writing them),
    * so the caller can distinguish unavailable ownership metadata from a valid result containing no
    * first-party file resources.
+   *
+   * "Usable" means the parse both completed *and* recognised the schema — see [collectInto]. Well-
+   * formed XML we can't read is the dangerous case: it yields zero keys without throwing, and an
+   * empty retain-set prunes every file resource while `resources.arsc` keeps pointing at them,
+   * which is issue #3260 all over again. Only a blame file that actually contained `<dataSet>`
+   * elements can prove the "this build has no first-party file resources" case.
    */
   fun firstPartyFileResourceKeys(moduleBuildDir: File): Set<String>? {
     val keys = mutableSetOf<String>()
@@ -60,9 +66,11 @@ internal object MergedResourceOwnership {
       // still make the overall result usable.
       val fileKeys = mutableSetOf<String>()
       runCatching { collectInto(fileKeys, blame) }
-        .onSuccess {
-          usableBlameFound = true
-          keys += fileKeys
+        .onSuccess { recognised ->
+          if (recognised) {
+            usableBlameFound = true
+            keys += fileKeys
+          }
         }
     }
     return keys.takeIf { usableBlameFound }
@@ -90,8 +98,15 @@ internal object MergedResourceOwnership {
    * `<dataSet>`. Streaming (StAX) rather than DOM on purpose: a merger.xml for an app-sized module
    * is megabytes of inlined `values` XML, and we only care about the element names and one
    * attribute.
+   *
+   * Returns whether the schema was recognised, i.e. whether the file carried at least one
+   * `<dataSet>`. AGP always writes one for the module's own source set, so a merger.xml with none
+   * is a file we don't understand — a future AGP that restructures it while keeping the name parses
+   * cleanly here and yields nothing, and the caller must not read that as "no first-party
+   * resources". Recognised-but-empty (data sets present, no file resources in them) stays a valid
+   * result.
    */
-  private fun collectInto(keys: MutableSet<String>, blame: File) {
+  private fun collectInto(keys: MutableSet<String>, blame: File): Boolean {
     val factory =
       XMLInputFactory.newInstance().apply {
         // Blame files are build output, not untrusted input, but a resource-merge XML never needs
@@ -99,16 +114,20 @@ internal object MergedResourceOwnership {
         setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
         setProperty(XMLInputFactory.SUPPORT_DTD, false)
       }
-    blame.inputStream().buffered().use { input ->
+    return blame.inputStream().buffered().use { input ->
       val reader = factory.createXMLStreamReader(input)
       // Data sets don't nest, so a single "are we inside a first-party one" flag is enough; it is
       // set on every <dataSet> open and consulted by the <file> entries that follow.
       var firstParty = false
+      var sawDataSet = false
       try {
         while (reader.hasNext()) {
           if (reader.next() != XMLStreamConstants.START_ELEMENT) continue
           when (reader.localName) {
-            "dataSet" -> firstParty = isFirstParty(reader.getAttributeValue(null, "config"))
+            "dataSet" -> {
+              sawDataSet = true
+              firstParty = isFirstParty(reader.getAttributeValue(null, "config"))
+            }
             "file" ->
               if (firstParty) {
                 // A single-file resource is written with its identity spelled out —
@@ -131,6 +150,7 @@ internal object MergedResourceOwnership {
       } finally {
         reader.close()
       }
+      sawDataSet
     }
   }
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnershipTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MergedResourceOwnershipTest.kt
@@ -195,4 +195,45 @@ class MergedResourceOwnershipTest {
     val keys = requireNotNull(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir()))
     assertThat(keys).isEmpty()
   }
+
+  @Test
+  fun `well-formed blame in an unrecognised schema returns null rather than an empty retain-set`() {
+    // A future AGP that keeps the file name but restructures its contents parses cleanly and yields
+    // no keys. Reading that as "this build has no first-party file resources" would prune every
+    // drawable while resources.arsc still pointed at them — issue #3260.
+    writeBlame(
+      "debug",
+      """
+      <merger version="4">
+        <contributor config=":modules:services:ui">
+          <resource name="ic_play" path="/repo/.../res/drawable/ic_play.xml" type="drawable"/>
+        </contributor>
+      </merger>
+      """
+        .trimIndent(),
+    )
+
+    assertThat(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir())).isNull()
+  }
+
+  @Test
+  fun `an unreadable blame file does not spoil a sibling one that parses`() {
+    writeBlame("debug", "<merger version=\"4\"><contributor config=\":app\"/></merger>")
+    writeBlame(
+      "debugUnitTest",
+      """
+      <merger version="3">
+        <dataSet config=":modules:services:ui">
+          <source path="/repo/modules/services/ui/res">
+            <file name="ic_play" path="/repo/modules/services/ui/res/drawable/ic_play.xml" type="drawable"/>
+          </source>
+        </dataSet>
+      </merger>
+      """
+        .trimIndent(),
+    )
+
+    val keys = requireNotNull(MergedResourceOwnership.firstPartyFileResourceKeys(buildDir()))
+    assertThat(keys).containsExactly("drawable/ic_play")
+  }
 }


### PR DESCRIPTION
Found while reviewing the PRs that landed since Saturday.

## The problem

#3297 and #3299 landed 29 minutes apart and pull in opposite directions.

- **#3297** added `if (firstPartyFileResources.isEmpty()) return Result(apkBytes, 0, 0)` to `AndroidResourcePruner.prune` — *"Empty is ambiguous… Correctness wins over the bundle-size optimisation. Pocket Casts exposed the unsafe failure mode."*
- **#3299** removed that guard and moved the decision to a `null` return from `MergedResourceOwnership.firstPartyFileResourceKeys`, on the grounds that `BundlePreviewTask` now disables pruning when ownership metadata is unavailable.

The kdoc claims null covers *"a future AGP that stops writing them"*. It doesn't, because of how null is produced:

```kotlin
runCatching { collectInto(fileKeys, blame) }
  .onSuccess { usableBlameFound = true; keys += fileKeys }
…
return keys.takeIf { usableBlameFound }
```

`usableBlameFound` is set whenever the StAX parse doesn't **throw**. A future AGP that keeps writing `merger.xml` but renames `<dataSet>`/`<file>` or restructures it parses cleanly, yields zero keys, and returns a non-null empty set. `BundlePreviewTask` then prunes with an empty retain-set, which drops every `drawable` / `raw` / `xml` / `layout` / `anim` / `animator` / `mipmap` file while `resources.arsc` keeps pointing at them — the dangling-entry `NotFoundException: File res/drawable/ic_play.xml …` from #3260, silently, on every consumer build.

So null only catches "the file is gone" and "the XML is malformed", not "the schema moved" — which is the likelier AGP change of the three.

## The change

Fix it at the source rather than reverting #3299's design. `collectInto` now reports whether it recognised the schema, i.e. whether the file carried at least one `<dataSet>`. AGP always writes one for the module's own source set, so a `merger.xml` with none is a file we don't understand, and the caller disables pruning.

The case #3299 wanted to keep working is untouched: a recognised-but-empty blame file (data sets present, no first-party file resources in them) still returns a valid empty set and pruning stays enabled.

## Test plan

```
./gradlew :gradle-plugin:test --tests "…MergedResourceOwnershipTest" \
                              --tests "…AndroidResourcePrunerTest"
```
BUILD SUCCESSFUL.

Two new cases in `MergedResourceOwnershipTest`, alongside the existing eight:

- `well-formed blame in an unrecognised schema returns null rather than an empty retain-set` — a `<merger version="4">` carrying `<contributor>`/`<resource>` instead of `<dataSet>`/`<file>`. Parses fine, yields nothing, must return null.
- `an unreadable blame file does not spoil a sibling one that parses` — the union across blame files still works when one of them is in the unknown shape.

The pre-existing `valid blame with no first-party file resources returns empty rather than unavailable` still passes, which is the check that #3299's intent survived.

Build-wiring change with no visual surface, so there is no before/after render to embed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0184U4iKHdJDcdTcC1Tm1UJA)_