### PR TITLE
fix(android): serialize the native-runtime cache lock within one JVM

### DIFF
--- a/renderers/android/src/main/java/ee/schimke/composeai/renderer/SharedNativeRuntimeLoader.java
+++ b/renderers/android/src/main/java/ee/schimke/composeai/renderer/SharedNativeRuntimeLoader.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -55,6 +56,12 @@ public final class SharedNativeRuntimeLoader extends DefaultNativeRuntimeLoader 
 
   private static final String COMPLETE_MARKER = ".complete";
   private static final String HYPHEN_DATA_DIR = "hyphen-data";
+
+  /** Serializes cache initialization for every sandbox that shares this class — see below. */
+  private static final Object EXTRACTION_MONITOR = new Object();
+
+  private static final int LOCK_RETRY_LIMIT = 600;
+  private static final long LOCK_RETRY_MILLIS = 100L;
 
   @Override
   public synchronized void ensureLoaded() {
@@ -111,39 +118,97 @@ public final class SharedNativeRuntimeLoader extends DefaultNativeRuntimeLoader 
     Path destination = root.resolve(key);
     Path lockPath = root.resolve(key + ".lock");
 
-    try (FileChannel channel =
-            FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-        FileLock ignored = channel.lock()) {
-      if (isComplete(destination)) {
-        return destination;
-      }
-
-      deleteRecursively(destination);
-      Path staging = root.resolve(key + ".staging");
-      deleteRecursively(staging);
-      Files.createDirectories(staging);
-      try {
-        SharedTempDirectory extraction = new SharedTempDirectory(staging);
-        if (Build.VERSION.SDK_INT >= O) {
-          invokeExtraction("maybeCopyFonts", extraction);
-          invokeExtraction("maybeCopyHyphenData", extraction);
-        }
-        invokeExtraction("maybeCopyIcuData", extraction);
-        maybeCopyExtraResources(extraction);
-        copyNativeLibrary(staging);
-        Files.writeString(
-            staging.resolve(COMPLETE_MARKER), key, StandardCharsets.UTF_8);
-        try {
-          Files.move(staging, destination, StandardCopyOption.ATOMIC_MOVE);
-        } catch (java.nio.file.AtomicMoveNotSupportedException ignoredMove) {
-          Files.move(staging, destination);
-        }
-      } catch (IOException | ReflectiveOperationException | RuntimeException e) {
-        deleteRecursively(staging);
-        throw e;
-      }
+    // Warm-cache fast path, deliberately outside the lock. The cache directory only ever appears
+    // via the atomic move below, so a complete marker means a fully published directory — there is
+    // nothing to serialize against. This is the overwhelmingly common case (every sandbox after the
+    // first, in every process after the first), and taking a file lock for it is what made the
+    // intra-JVM overlap below reachable at all.
+    if (isComplete(destination)) {
       return destination;
     }
+
+    return withExclusiveCacheLock(lockPath, () -> extractUnderLock(destination, key, root));
+  }
+
+  /** Work that runs while this JVM holds the cache lock exclusively. */
+  @FunctionalInterface
+  interface CacheWork<T> {
+    T run() throws IOException, ReflectiveOperationException;
+  }
+
+  /**
+   * Run {@code body} while holding {@code lockPath} against both other processes and other
+   * sandboxes in this one.
+   *
+   * <p>A {@link FileLock} belongs to the JVM, not to the thread or the classloader: a second
+   * sandbox locking the same region in the same process gets {@link OverlappingFileLockException}
+   * rather than blocking, and that is an unchecked exception the caller's {@code ensureLoaded}
+   * catch does not cover. Robolectric builds a classloader per sandbox, so {@code synchronized} on
+   * a field of this class only covers sandboxes that happen to share our copy of it — the retry is
+   * what makes the cross-classloader case correct, and the monitor is what stops the common
+   * same-classloader case from spinning to get there.
+   *
+   * <p>Visible for testing.
+   */
+  static <T> T withExclusiveCacheLock(Path lockPath, CacheWork<T> body)
+      throws IOException, ReflectiveOperationException {
+    synchronized (EXTRACTION_MONITOR) {
+      for (int attempt = 0; ; attempt++) {
+        try (FileChannel channel =
+                FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            FileLock ignored = channel.lock()) {
+          return body.run();
+        } catch (OverlappingFileLockException contended) {
+          if (attempt >= LOCK_RETRY_LIMIT) {
+            throw new IOException(
+                "Another sandbox in this JVM held "
+                    + lockPath
+                    + " for over "
+                    + (LOCK_RETRY_LIMIT * LOCK_RETRY_MILLIS)
+                    + "ms",
+                contended);
+          }
+          try {
+            Thread.sleep(LOCK_RETRY_MILLIS);
+          } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted waiting for " + lockPath, interrupted);
+          }
+        }
+      }
+    }
+  }
+
+  private Path extractUnderLock(Path destination, String key, Path root)
+      throws IOException, ReflectiveOperationException {
+    if (isComplete(destination)) {
+      return destination;
+    }
+
+    deleteRecursively(destination);
+    Path staging = root.resolve(key + ".staging");
+    deleteRecursively(staging);
+    Files.createDirectories(staging);
+    try {
+      SharedTempDirectory extraction = new SharedTempDirectory(staging);
+      if (Build.VERSION.SDK_INT >= O) {
+        invokeExtraction("maybeCopyFonts", extraction);
+        invokeExtraction("maybeCopyHyphenData", extraction);
+      }
+      invokeExtraction("maybeCopyIcuData", extraction);
+      maybeCopyExtraResources(extraction);
+      copyNativeLibrary(staging);
+      Files.writeString(staging.resolve(COMPLETE_MARKER), key, StandardCharsets.UTF_8);
+      try {
+        Files.move(staging, destination, StandardCopyOption.ATOMIC_MOVE);
+      } catch (java.nio.file.AtomicMoveNotSupportedException ignoredMove) {
+        Files.move(staging, destination);
+      }
+    } catch (IOException | ReflectiveOperationException | RuntimeException e) {
+      deleteRecursively(staging);
+      throw e;
+    }
+    return destination;
   }
 
   private static boolean isComplete(Path directory) {

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/SharedNativeRuntimeLockTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/SharedNativeRuntimeLockTest.kt
@@ -1,0 +1,75 @@
+package ee.schimke.composeai.renderer
+
+import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Concurrency contract of the cache lock. Deliberately a plain JVM test rather than a Robolectric
+ * one: the bug it covers is that a `FileLock` is held per *JVM*, so two Robolectric sandboxes
+ * initializing the cache at once used to get `OverlappingFileLockException` — an unchecked
+ * exception `ensureLoaded`'s `IOException | ReflectiveOperationException` catch does not cover, so
+ * it escaped raw instead of as the intended `AssertionError`.
+ */
+class SharedNativeRuntimeLockTest {
+
+  @Test
+  fun `concurrent callers serialize instead of overlapping the file lock`() {
+    val lockPath = Files.createTempDirectory("cache-lock").resolve("runtime.lock")
+    val threads = 8
+    val start = CyclicBarrier(threads)
+    val done = CountDownLatch(threads)
+    val concurrent = AtomicInteger()
+    val peak = AtomicInteger()
+    val completed = AtomicInteger()
+    val failure = AtomicReference<Throwable>()
+
+    repeat(threads) {
+      Thread {
+          try {
+            start.await()
+            SharedNativeRuntimeLoader.withExclusiveCacheLock(lockPath) {
+              peak.accumulateAndGet(concurrent.incrementAndGet(), ::maxOf)
+              // Long enough that an overlapping acquisition would land inside this window.
+              Thread.sleep(25)
+              concurrent.decrementAndGet()
+              completed.incrementAndGet()
+            }
+          } catch (t: Throwable) {
+            failure.compareAndSet(null, t)
+          } finally {
+            done.countDown()
+          }
+        }
+        .apply { isDaemon = true }
+        .start()
+    }
+
+    assertTrue("threads did not finish", done.await(60, TimeUnit.SECONDS))
+    assertNull("a caller failed: ${failure.get()}", failure.get())
+    assertEquals(threads, completed.get())
+    assertEquals("callers overlapped inside the lock", 1, peak.get())
+  }
+
+  @Test
+  fun `the lock is released when the body throws`() {
+    val lockPath = Files.createTempDirectory("cache-lock").resolve("runtime.lock")
+
+    runCatching {
+      SharedNativeRuntimeLoader.withExclusiveCacheLock<Unit>(lockPath) {
+        throw java.io.IOException("boom")
+      }
+    }
+
+    // A leaked lock would make this second acquisition throw rather than return.
+    val second = SharedNativeRuntimeLoader.withExclusiveCacheLock(lockPath) { "ok" }
+    assertEquals("ok", second)
+  }
+}


### PR DESCRIPTION
Found while reviewing the PRs that landed since Saturday — follow-up to #3296.

## The problem

`SharedNativeRuntimeLoader.ensureSharedExtraction` took a `FileLock` on **every** call, including the warm-cache fast path:

```java
try (FileChannel channel = FileChannel.open(lockPath, CREATE, WRITE);
     FileLock ignored = channel.lock()) {
  if (isComplete(destination)) return destination;
  …
```

A `FileLock` is held by the **JVM**, not by the thread or the classloader. Two Robolectric sandboxes initializing the cache in one process therefore get `OverlappingFileLockException` rather than blocking — and that is an unchecked exception, which `ensureLoaded`'s `catch (IOException | ReflectiveOperationException e)` does not cover, so it escapes raw instead of as the intended `AssertionError`.

`ensureLoaded` is `synchronized`, but on the *instance*: Robolectric builds a classloader per sandbox, so different sandboxes hold different monitors and, for the cross-classloader case, different copies of the class entirely.

## The change

Three parts, none redundant:

1. **Check the completion marker before taking the lock at all.** The cache directory only ever appears via the atomic move, so a complete marker means a fully published directory — there is nothing to serialize against. This is the overwhelmingly common case (every sandbox after the first, in every process after the first) and removes the contention rather than handling it.
2. **Serialize the cold path on a static monitor**, so sandboxes that share our copy of the class queue instead of spinning.
3. **Retry on `OverlappingFileLockException`** for sandboxes that don't share it. This is what makes the cross-classloader case *correct* rather than merely rarer; a bounded wait surfaces as an `IOException`, which the existing catch does handle.

The lock acquisition moved into a `withExclusiveCacheLock` seam so it is testable without a Robolectric sandbox.

## Test plan

```
./gradlew :renderer-android:testDebugUnitTest --tests "…SharedNativeRuntimeLockTest"
```
BUILD SUCCESSFUL.

New `SharedNativeRuntimeLockTest` — a plain JVM test, deliberately, since the bug is about JVM-scoped lock ownership:

- eight concurrent callers complete, none throws, and the peak observed concurrency inside the lock is 1 (against the old code, seven of the eight take `OverlappingFileLockException`);
- the lock is released when the body throws, verified by a second acquisition succeeding.

**Note on the existing suite:** `SharedNativeRuntimeLoaderTest` fails in this container — but it fails identically on unmodified `origin/main` (verified by stashing), because the SDK-34 Robolectric native runtime isn't available here. Not caused by this change; CI should be the judge of it.

No visual surface, so there is no before/after render to embed.

## Follow-ups not in this PR

Two more things in this file worth a look, both from #3296:

- `deleteRecursively(destination)` runs under a lock that other processes' *readers* don't hold. Once past `isComplete`, a process reads fonts/ICU from that directory by path for the life of the JVM; if the marker goes missing (external cache eviction, a partial disk-full write), a second process wipes it out from under them, and the native runtime resolves fonts lazily — so it crashes later, somewhere unrelated.
- `cacheKey()` hashes `resource.toExternalForm()`, the URL, not the bytes. The kdoc says it "changes whenever either half of the extracted payload changes", which isn't true for a locally rebuilt jar at the same path — that yields a stale ~185 MB entry which is never invalidated and never pruned.

---
_Generated by [Claude Code](https://claude.ai/code/session_0184U4iKHdJDcdTcC1Tm1UJA)_