### PR TITLE
fix(serve): read the compile subprocess output under its own lock

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
@@ -183,13 +183,17 @@ class PlaygroundJailedCompiler(
       process.destroyForcibly()
       process.waitFor(5, TimeUnit.SECONDS)
     }
-    outThread.join(2_000)
-    errThread.join(2_000)
+    // Best-effort: a drain thread that outlives this is still appending, so both reads below stay
+    // under the same monitor its appends take. Without that, `toString()` copies the backing array
+    // while a concurrent `append` may be resizing it — a torn read, or an
+    // ArrayIndexOutOfBoundsException out of StringBuilder itself.
+    outThread.join(DRAIN_JOIN_MILLIS)
+    errThread.join(DRAIN_JOIN_MILLIS)
     return PlaygroundSandboxProbe.Launch(
       exitCode = if (finished) process.exitValue() else -1,
-      stdout = out.toString(),
+      stdout = synchronized(out) { out.toString() },
       stderr =
-        if (finished) err.toString()
+        if (finished) synchronized(err) { err.toString() }
         else "the compile exceeded its ${effectiveTimeoutSeconds}s budget",
     )
   }
@@ -228,6 +232,13 @@ class PlaygroundJailedCompiler(
 
     /** Long enough to ride out one in-flight compile, short enough that a client isn't stranded. */
     const val DEFAULT_SLOT_WAIT_SECONDS = 30L
+
+    /**
+     * How long to wait for a drain thread after the child exits. The pipes are closed by then, so
+     * this only ever expires on a wedged reader — and the reads it guards are synchronized, so
+     * expiring costs a truncated log rather than a corrupted one.
+     */
+    private const val DRAIN_JOIN_MILLIS = 2_000L
 
     private val JSON = Json { ignoreUnknownKeys = true }
 


### PR DESCRIPTION
Found while reviewing the PRs that landed since Saturday.

## The problem

`PlaygroundJailedCompiler.spawn` drains the child's stdout/stderr on two threads that append under a monitor:

```kotlin
stream.bufferedReader().forEachLine { synchronized(into) { into.appendLine(it) } }
```

…and then reads them without taking it:

```kotlin
outThread.join(2_000)
errThread.join(2_000)
return PlaygroundSandboxProbe.Launch(
  stdout = out.toString(),
  stderr = if (finished) err.toString() else …,
)
```

The `join` can expire — the child is force-destroyed on timeout, but a wedged reader outlives it — leaving a drain thread appending while `toString()` copies the backing array. That's a torn read at best, and an `ArrayIndexOutOfBoundsException` out of `StringBuilder` at worst, which `compile()`'s catch would turn into a bare `compile sandbox failed: …` for a snippet that compiled fine.

## The change

Take the same monitor for the two reads. A `join` that expires now costs a truncated log rather than a corrupted one. The join timeout moves to a named constant with a note on why expiring is now benign.

## Test plan

```
./gradlew :cli:test --tests "…PlaygroundJailedCompilerTest"
```
BUILD SUCCESSFUL — the existing 15-case suite (slot bounding, TTL clamping, jail argv shape, the `wrap` fallbacks, garbled/absent child output) is unchanged.

**No new test, deliberately.** The window needs a drain thread that outlives a 2s join on a force-destroyed child, which isn't reproducible without reshaping `spawn` into something that no longer tests the real thing. The fix is adding the monitor to reads whose corresponding writes already take it; I'd rather say that plainly than ship a test that passes either way.

No visual surface, so there is no before/after render to embed.

## Follow-up not in this PR

`compile()` reports "all $slots compile slots in use" as a `PlaygroundSeverity.ERROR` diagnostic, so a transient capacity condition is indistinguishable in the UI from "your snippet doesn't compile". That wants its own outcome type / 503 rather than a diagnostic.

---
_Generated by [Claude Code](https://claude.ai/code/session_0184U4iKHdJDcdTcC1Tm1UJA)_