### PR TITLE
fix(serve): make the playground repo gate visibility-aware

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -294,19 +294,23 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
   }
 
   /**
-   * Whether [login] has **write** access to [repository] — the gate on the playground, which
-   * compiles and runs a stranger's Kotlin.
+   * Whether [login] has access to [repository] that means something — the gate on the playground,
+   * which compiles and runs a stranger's Kotlin.
    *
-   * Write, not merely "not none". GitHub reports `read` from this endpoint for *any* authenticated
-   * user on a **public** repository, because reading is what public means — so the old `permission
-   * != "none"` test admitted every GitHub account whenever the configured `--github-auth-repo` was
-   * public, which is the documented setup. The legacy `permission` field collapses the finer roles
-   * onto `admin` / `write` / `read` / `none`, so `maintain` arrives as `write`; it is accepted by
-   * name too in case that ever changes.
+   * What "means something" is depends on the repository's visibility, and #3313 got this half
+   * right. On a **public** repo, `read` is what GitHub reports for *every* authenticated user,
+   * because reading is what public means — so a read-level gate there admits the whole of GitHub,
+   * which is the hole #3313 closed. On a **private** repo, `read` is the opposite: somebody
+   * deliberately granted this person access to a repository nobody else can see. Requiring write
+   * everywhere, as #3313 did, locked out read-only collaborators in the one case that was never
+   * broken.
    *
-   * This is deliberately narrower than before: a read-only collaborator on a private repo no longer
-   * reaches the playground. Live preview, which only needs a signed-in user, is unaffected — and
-   * `--github-auth-users` remains the way to admit named logins.
+   * So: public repo → require `admin` / `maintain` / `write`. Private repo → any permission other
+   * than `none`, exactly as before #3313. One extra API call per sign-in, on a path that already
+   * makes two.
+   *
+   * When visibility can't be determined the answer is **write**, the safe side: a token that can't
+   * read the repo metadata tells us nothing that should widen a gate on code execution.
    */
   private fun fetchRepositoryAccess(token: String, repository: String, login: String): Boolean {
     val request =
@@ -319,10 +323,36 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
       if (!response.isSuccessful) return@use false
       val payload =
         JSON.decodeFromString(GitHubPermissionResponse.serializer(), response.body.string())
+      val permission = payload.permission.lowercase()
       val role = payload.roleName?.trim()?.lowercase()
-      payload.permission.lowercase() in WRITE_PERMISSIONS ||
-        (role != null && role in WRITE_PERMISSIONS)
+      val write = permission in WRITE_PERMISSIONS || (role != null && role in WRITE_PERMISSIONS)
+      if (write) return@use true
+      // Not write. Only a private repo can still qualify, and only on a real (non-`none`) grant.
+      val readish = permission != "none" || (role != null && role != "none")
+      readish && !isPublicRepository(token, repository)
     }
+  }
+
+  /**
+   * Whether [repository] is public. Defaults to **true** when the lookup fails or the field is
+   * absent — see [fetchRepositoryAccess]: public is the stricter branch, so an unknown visibility
+   * falls back to requiring write rather than accepting a bare `read`.
+   */
+  private fun isPublicRepository(token: String, repository: String): Boolean {
+    val request =
+      Request.Builder()
+        .url("https://api.github.com/repos/$repository")
+        .header(HttpHeaders.Authorization, "Bearer $token")
+        .header(HttpHeaders.Accept, "application/vnd.github+json")
+        .build()
+    return runCatching {
+        client.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) return@use true
+          JSON.decodeFromString(GitHubRepositoryResponse.serializer(), response.body.string())
+            .private != true
+        }
+      }
+      .getOrDefault(true)
   }
 
   companion object {
@@ -347,6 +377,9 @@ private data class GitHubPermissionResponse(
   val permission: String = "none",
   @SerialName("role_name") val roleName: String? = null,
 )
+
+/** Only [private] is read; absent means "couldn't tell", which resolves to public. */
+@Serializable private data class GitHubRepositoryResponse(val private: Boolean? = null)
 
 private fun ApplicationCall.uriWithQuery(): String = request.uri
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitHubOAuthVerifierTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitHubOAuthVerifierTest.kt
@@ -26,8 +26,15 @@ class GitHubOAuthVerifierTest {
       repository = "yschimke/compose-ai-tools",
     )
 
-  /** Serves the three endpoints `verify` walks, with a caller-chosen permission payload. */
-  private fun verifierReporting(permissionJson: String): GitHubOAuthVerifier {
+  /**
+   * Serves the endpoints `verify` walks, with a caller-chosen permission payload and repository
+   * visibility. [repoJson] null makes the repo lookup fail, which must resolve to the strict
+   * (public) rule.
+   */
+  private fun verifierReporting(
+    permissionJson: String,
+    repoJson: String? = PUBLIC_REPO,
+  ): GitHubOAuthVerifier {
     val client =
       OkHttpClient.Builder()
         .addInterceptor(
@@ -38,14 +45,15 @@ class GitHubOAuthVerifierTest {
                 url.contains("login/oauth/access_token") -> """{"access_token":"t"}"""
                 url.endsWith("/user") -> """{"login":"octocat"}"""
                 url.contains("/collaborators/") -> permissionJson
+                url.endsWith("/repos/${config.repository}") -> repoJson
                 else -> error("unexpected request to $url")
               }
             Response.Builder()
               .request(chain.request())
               .protocol(Protocol.HTTP_1_1)
-              .code(200)
-              .message("OK")
-              .body(body.toResponseBody("application/json".toMediaType()))
+              .code(if (body == null) 404 else 200)
+              .message(if (body == null) "Not Found" else "OK")
+              .body((body ?: "{}").toResponseBody("application/json".toMediaType()))
               .build()
           }
         )
@@ -53,9 +61,9 @@ class GitHubOAuthVerifierTest {
     return GitHubOAuthVerifier(client)
   }
 
-  private fun accessFor(permissionJson: String): Boolean {
+  private fun accessFor(permissionJson: String, repoJson: String? = PUBLIC_REPO): Boolean {
     val user =
-      verifierReporting(permissionJson)
+      verifierReporting(permissionJson, repoJson)
         .verify("code", "https://example.test/cb", config)
         .getOrThrow()
     assertEquals("octocat", user.login)
@@ -104,5 +112,42 @@ class GitHubOAuthVerifierTest {
   fun `a payload without a role name still reads the legacy permission`() {
     assertTrue(accessFor("""{"permission":"write"}"""))
     assertFalse(accessFor("""{"permission":"read"}"""))
+  }
+
+  // ── Visibility split ───────────────────────────────────────────────────────────────────────────
+  // `read` means opposite things either side of it: on a public repo GitHub hands it to everyone,
+  // on a private one somebody deliberately granted it. #3313 required write on both, which locked
+  // out read-only collaborators in the case that was never broken.
+
+  @Test
+  fun `read on a private repo is repository access`() {
+    assertTrue(accessFor("""{"permission":"read","role_name":"read"}""", PRIVATE_REPO))
+  }
+
+  @Test
+  fun `triage on a private repo is repository access`() {
+    assertTrue(accessFor("""{"permission":"read","role_name":"triage"}""", PRIVATE_REPO))
+  }
+
+  @Test
+  fun `none on a private repo is still not repository access`() {
+    assertFalse(accessFor("""{"permission":"none","role_name":"none"}""", PRIVATE_REPO))
+  }
+
+  @Test
+  fun `write on a private repo is repository access`() {
+    assertTrue(accessFor("""{"permission":"write","role_name":"write"}""", PRIVATE_REPO))
+  }
+
+  /** Unknown visibility takes the strict branch: an unreadable repo must not widen the gate. */
+  @Test
+  fun `an unreadable repo falls back to requiring write`() {
+    assertFalse(accessFor("""{"permission":"read","role_name":"read"}""", repoJson = null))
+    assertTrue(accessFor("""{"permission":"write","role_name":"write"}""", repoJson = null))
+  }
+
+  private companion object {
+    const val PUBLIC_REPO = """{"private":false}"""
+    const val PRIVATE_REPO = """{"private":true}"""
   }
 }

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -529,12 +529,17 @@ SERVE_GITHUB_AUTH_COOKIE_SECRET=... # at least 32 chars
 
 With those set, live preview WebSockets require a signed-in GitHub user. `/playground`,
 `POST /api/<version>/compiler/run`, and `/pg/<token>` require a signed-in GitHub user that also has
-**write** access to `SERVE_GITHUB_AUTH_REPO` / `--github-auth-repo` — `admin`, `maintain`, or
-`write`. Read access is deliberately not enough: GitHub reports `read` for *any* authenticated user
-on a **public** repository, so a read-level gate on a public `SERVE_GITHUB_AUTH_REPO` would admit
-every GitHub account to a surface that compiles and runs submitted Kotlin. Use
-`SERVE_GITHUB_AUTH_USERS` to admit named logins who don't have write access. The browser cookie
-stores only a signed, expiring login plus the repo access verdict, and is marked `secure` whenever
+access to `SERVE_GITHUB_AUTH_REPO` / `--github-auth-repo`, where what counts as access depends on
+that repository's visibility:
+
+- **Public repo** — `admin`, `maintain`, or `write`. Read is deliberately not enough, because GitHub
+  reports `read` for *any* authenticated user on a public repository; a read-level gate there would
+  admit every GitHub account to a surface that compiles and runs submitted Kotlin.
+- **Private repo** — any permission other than `none`. On a private repo a `read` grant is a real
+  decision somebody made, so read-only collaborators keep playground access.
+
+If the repository's visibility can't be determined, the stricter (public) rule applies. The browser
+cookie stores only a signed, expiring login plus the repo access verdict, and is marked `secure` whenever
 the request arrives over HTTPS (which is why a reverse-proxied box should set
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL`). The OAuth request includes GitHub's `repo` scope so private
 repository access can be checked during sign-in; the OAuth token is not stored.
@@ -544,7 +549,8 @@ When `DOMAIN` is set, the prebuilt image derives
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL=https://$DOMAIN`. Empty `SERVE_GITHUB_AUTH_USERS` allows any
 signed-in GitHub user to use live previews; playground still requires access to
 `SERVE_GITHUB_AUTH_REPO`. Set `SERVE_GITHUB_AUTH_USERS=alice,bob` to narrow sign-in to named logins
-for both surfaces.
+for both surfaces. The allowlist only ever **restricts** — naming a login does not grant it
+playground access, which always comes from the repo check above.
 
 ### The catalog set is config, not image content
 


### PR DESCRIPTION
Follow-up to #3313, which merged before this refinement was ready — so it's a fresh branch off `main` rather than more commits on the merged one.

## Two problems with #3313

**1. It over-corrected.** #3313 required write access on every repo. That closed the real hole — GitHub reports `read` for any authenticated user on a **public** repository, so a read-level gate on a public `--github-auth-repo` admitted every GitHub account to a surface that compiles and runs submitted Kotlin.

But `read` means the opposite thing on a **private** repo: somebody deliberately granted this person access to a repository nobody else can see. Requiring write there locked out read-only collaborators in the one case that was never broken.

**2. It documented an escape hatch that doesn't exist.** Caught by Codex on #3313, after it had merged. #3313's docs and kdoc said `SERVE_GITHUB_AUTH_USERS` was the way to admit named logins without write access. It isn't — `allowedUsers` is checked in `GitHubOAuthVerifier.verify` to gate *sign-in* and never touches `repositoryAccess`, so `rejectMissingGithubRepoAccess` still 403s such a login. The claim was false as written.

## The change

Split the verdict on repository visibility:

| repo | accepted |
| --- | --- |
| public | `admin` / `maintain` / `write` |
| private | anything other than `none` |
| visibility unreadable | `admin` / `maintain` / `write` (strict branch) |

The unknown case going strict is deliberate: a token that can't read the repo metadata tells us nothing that should *widen* a gate on code execution. Costs one extra API call on a sign-in path that already makes two.

For the second problem, the false sentence is gone from both the docs and the kdoc, replaced with an explicit statement that the allowlist only ever **restricts** — naming a login does not grant playground access. That's the "remove the promise" half of Codex's suggestion rather than the "fold the allowlist into the verdict" half, because the latter would change `SERVE_GITHUB_AUTH_USERS` from a restriction into a grant, and an operator using it purely to narrow sign-in would not expect it to hand out playground rights.

## Test plan

```
./gradlew :cli:test --tests "…GitHubOAuthVerifierTest" \
                    --tests "…ServeAuthTest" \
                    --tests "…PlaygroundRoutingTest" :cli:ktfmtCheck
```
BUILD SUCCESSFUL — 12 tests in `GitHubOAuthVerifierTest`, 0 failures.

Five new cases on top of #3313's seven, all driving the real `verify()` path through an interceptor that now serves repo visibility as well as the permission payload:

- `read` on a private repo → access (the #3313 regression)
- `triage` on a private repo → access
- `none` on a private repo → still no access
- `write` on a private repo → access
- unreadable repo → `read` denied, `write` allowed (strict fallback)

The seven public-repo cases from #3313 are unchanged and still pass, so the original hole stays closed.

Auth verdict plumbing and docs — no visual surface, so no before/after render to embed.

## Unrelated: `main` is currently red

While checking CI on the earlier batch I found **Serve render lanes honor overrides** and **Android (Robolectric) serve lane honors overrides** failing on `main` itself — run [30976700883](https://github.com/yschimke/compose-ai-tools/actions/runs/30976700883) @ `45e2981`. `serve-lanes.spec.mjs:186` expects `#cp-img` to carry the override PNG URL but gets `blob:…`, so the viewer's move to blob-URL swapping (#3274 / #3301 look like the candidates) outran the harness assertion. Not from this PR; flagged in #3316 too.

---
_Generated by [Claude Code](https://claude.ai/code/session_0184U4iKHdJDcdTcC1Tm1UJA)_