### PR TITLE
fix(serve): expose the logical render URL behind the viewer's blob image

### DIFF
--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -366,6 +366,11 @@
           var previous = img.getAttribute("data-cp-blob");
           img.src = objectUrl;
           img.setAttribute("data-cp-blob", objectUrl);
+          // The blob is opaque: once `src` is an object URL, nothing in the DOM says which render
+          // these pixels came from. Record the logical /render URL alongside it so "what produced
+          // this image" stays answerable — from devtools, and from the serve-lanes harness, which
+          // asserts the knobs reached the render URL and can no longer read that off `src`.
+          img.setAttribute("data-cp-src", url);
           if (previous) URL.revokeObjectURL(previous);
           status.textContent = "";
           setSnapshotLoading(false);

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -292,7 +292,7 @@
   syncBg();
 })();</script>
       <script src="/assets/serve/61d1-bc55e9642f5f9e1e/format-compare.js"></script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
@@ -278,7 +278,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -246,7 +246,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -245,7 +245,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -243,7 +243,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -240,7 +240,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -234,7 +234,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -239,7 +239,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -229,7 +229,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -212,7 +212,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/14b77-986284cca07a5d17/viewer.js"></script>
+      <script src="/assets/serve/14d2f-093b5c2b8c2fe261/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/serve-lanes.spec.mjs
+++ b/vscode-extension/preview-harness/serve-lanes.spec.mjs
@@ -183,10 +183,14 @@ test("viewer wires the knob into every render lane", async ({ page }) => {
   );
 
   // PNG mode (default): the on-screen <img> points at the override PNG and loads.
+  // The viewer fetches the render and shows it as an object URL (so the previous frame stays up
+  // until the replacement decodes), which makes `src` a `blob:` with no knobs in it. `data-cp-src`
+  // is the logical /render URL behind those pixels — that's what carries the override.
   await expect(page.locator("#cp-img")).toHaveAttribute(
-    "src",
+    "data-cp-src",
     new RegExp(`\\.png.*knob\\.label=${OVERRIDE}`),
   );
+  await expect(page.locator("#cp-img")).toHaveAttribute("src", /^blob:/);
   await expect
     .poll(() => page.locator("#cp-img").evaluate((im) => im.naturalWidth), {
       timeout: 30000,
@@ -196,7 +200,7 @@ test("viewer wires the knob into every render lane", async ({ page }) => {
   // SVG format toggle: the same <img> repoints at the override SVG and loads.
   await page.click("#cp-svg-toggle");
   await expect(page.locator("#cp-img")).toHaveAttribute(
-    "src",
+    "data-cp-src",
     new RegExp(`\\.svg.*knob\\.label=${OVERRIDE}`),
   );
   await expect


### PR DESCRIPTION
Reopened and rebuilt on top of `main`. The conflicts are gone: this branch is now `main` plus **one assertion** (6 lines, 5 of them comment).

## What happened

This PR originally carried the same `data-cp-src` fix as #3317, developed concurrently. #3317 landed first, so everything here except one line became a duplicate — and a conflicting one, since both edited the same lines of `viewer.js` and the spec and both regenerated the 12 page fixtures to different asset hashes.

Rather than resolve those hunk by hunk, I reset the branch onto `main` so #3317's version wins wholesale, and re-applied only the part that isn't in it.

## What's left, and why it's worth having

#3317 moved the knob assertion from `src` to `data-cp-src`. That was right — `src` is an opaque `blob:` with nothing to match on. But with the assertion moved off `src` entirely, nothing pins that the blob swap is still happening:

```js
await expect(page.locator("#cp-img")).toHaveAttribute("src", /^blob:/);
```

A regression to assigning the render URL straight to `img.src` would keep `data-cp-src` matching, leave the suite green, and quietly reinstate the double-fetch of an override-bearing `no-store` render that the swap exists to prevent — two renders racing each other through the daemon's shared override state.

## Test plan

Not just "it passes" — I checked the assertion isn't vacuous, since a test that can't fail is worse than no test.

**Negative case.** Patched `viewer.js` to `img.src = url` (the exact regression), rebuilt, and ran against a real daemon-backed serve. `data-cp-src` still matched, so #3317's assertions alone would have passed — and the new line caught it:

```
Expected pattern: /^blob:/
Received string:  "/compose-m3/render/button-elevated__ideal__default__dark.png?knob.label=E2eKnobProof"

14 × locator resolved to ``&lt;img id="cp-img"·     data-cp-blob="blob:http://127.0.0.1:8725/e4dcf2c3-…"·     src="/compose-m3/render/…png?knob.label=E2eKnobProof"·     data-cp-src="/compose-m3/render/…png?knob.label=E2eKnobProof"/&gt;``
```

**Positive case.** Reverted, rebuilt, re-ran the full spec — the same job CI runs (`serve-lanes-boot.sh` + `serve-lanes.config.mjs`, compose-m3, warm daemon):

```
Running 6 tests using 1 worker
······
  6 passed (17.5s)
```

Test-only change to an e2e spec — no product code, no rendered pixels, no fixtures. Nothing visual to embed.