### PR TITLE
test(serve): keep the viewer's blob swap covered after #3317

### DIFF
--- a/vscode-extension/preview-harness/serve-lanes.spec.mjs
+++ b/vscode-extension/preview-harness/serve-lanes.spec.mjs
@@ -195,6 +195,12 @@ test("viewer wires the knob into every render lane", async ({ page }) => {
     "data-cp-src",
     new RegExp(`\\.png.*knob\\.label=${OVERRIDE}`),
   );
+  // …and `src` is still the object URL. With the override assertion moved off `src`, nothing else
+  // pins that the blob swap is happening at all: a regression to assigning the render URL straight
+  // to `img.src` would keep `data-cp-src` matching and leave this suite green, while quietly
+  // reinstating the double-fetch of an override-bearing `no-store` render that the swap exists to
+  // prevent.
+  await expect(page.locator("#cp-img")).toHaveAttribute("src", /^blob:/);
   await expect
     .poll(() => page.locator("#cp-img").evaluate((im) => im.naturalWidth), {
       timeout: 30000,


### PR DESCRIPTION
Replaces #3321, which GitHub wouldn't let me reopen once its branch was force-pushed. The conflicts are gone: this branch is now `main` plus **one assertion** (6 lines, 5 of them comment).

## What happened

#3321 originally carried the same `data-cp-src` fix as #3317, developed concurrently. #3317 landed first, so everything in it except one line became a duplicate — and a conflicting one, since both edited the same lines of `viewer.js` and `serve-lanes.spec.mjs`, and both regenerated the 12 page fixtures to different asset hashes.

Rather than resolve fourteen conflicting files hunk by hunk to arrive at code already on `main`, I reset the branch onto `main` so #3317's version wins wholesale, and re-applied only the part that isn't in it.

## What's left, and why it's worth having

#3317 moved the knob assertion from `src` to `data-cp-src`. That was right — `src` is an opaque `blob:` with nothing to match on. But with the assertion moved off `src` entirely, nothing pins that the blob swap is still happening:

```js
await expect(page.locator("#cp-img")).toHaveAttribute("src", /^blob:/);
```

A regression to assigning the render URL straight to `img.src` would keep `data-cp-src` matching, leave the suite green, and quietly reinstate the double-fetch of an override-bearing `no-store` render that the swap exists to prevent — two renders racing each other through the daemon's shared override state.

## Test plan

Not just "it passes" — I checked the assertion isn't vacuous, since a test that can't fail is worse than no test.

**Negative case.** Patched `viewer.js` to `img.src = url` (the exact regression), rebuilt, and ran against a real daemon-backed serve. `data-cp-src` still matched, so #3317's assertions alone would have passed — and the new line caught it:

```
Expected pattern: /^blob:/
Received string:  "/compose-m3/render/button-elevated__ideal__default__dark.png?knob.label=E2eKnobProof"

14 × locator resolved to ``&lt;img id="cp-img"·     data-cp-blob="blob:http://127.0.0.1:8725/e4dcf2c3-…"·     src="/compose-m3/render/…png?knob.label=E2eKnobProof"·     data-cp-src="/compose-m3/render/…png?knob.label=E2eKnobProof"/&gt;``
```

**Positive case.** Reverted, rebuilt, re-ran the full spec — the same job CI runs (`serve-lanes-boot.sh` + `serve-lanes.config.mjs`, compose-m3, warm daemon):

```
Running 6 tests using 1 worker
······
  6 passed (17.5s)
```

Test-only change to an e2e spec — no product code, no rendered pixels, no fixtures. Nothing visual to embed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0184U4iKHdJDcdTcC1Tm1UJA)_