### PR TITLE
fix(serve): stop asking every visitor for the repo OAuth scope

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -85,6 +85,7 @@ internal object CliFlags {
       "--github-auth-cookie-secret",
       "--github-auth-repo",
       "--github-auth-callback-base-url",
+      "--github-auth-scope",
       "--github-auth-users",
       "--catalog-repo",
       "--catalog-branch-prefix",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -469,6 +469,12 @@ class ServeCommand(args: List<String>) : Command(args) {
     args.flagValue("--github-auth-repo")?.takeIf { it.isNotBlank() }
   private val githubAuthCallbackBaseUrl: String? =
     args.flagValue("--github-auth-callback-base-url")?.takeIf { it.isNotBlank() }
+  /**
+   * Overrides the OAuth scope. Unset derives it from `--github-auth-repo`'s visibility, which is
+   * what a deployment wants unless its GitHub App or org policy demands something specific.
+   */
+  private val githubAuthScope: String? =
+    args.flagValue("--github-auth-scope")?.takeIf { it.isNotBlank() }
   private val githubAuthUsers: Set<String> =
     args
       .flagValue("--github-auth-users")
@@ -2545,6 +2551,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         repository = githubAuthRepo!!,
         allowedUsers = githubAuthUsers,
         callbackBaseUrl = githubAuthCallbackBaseUrl,
+        oauthScope = githubAuthScope,
       )
     )
   }
@@ -2677,11 +2684,17 @@ class ServeCommand(args: List<String>) : Command(args) {
                           signed-in GitHub user (unless --github-auth-users narrows sign-in);
                           playground additionally requires access to <owner/repo>. After sign-in
                           the server stores only a signed, expiring login cookie plus the repo
-                          access verdict. The OAuth request includes GitHub's repo scope so private
-                          repositories can be checked. All four flags are required together.
+                          access verdict. The OAuth scope follows the repo's visibility: a public
+                          <owner/repo> needs only read:user, a private one also needs repo (classic
+                          OAuth apps have no read-only repository scope). All four flags are
+                          required together.
         --github-auth-callback-base-url <url>
                           External origin for the OAuth callback, e.g. https://preview.example.com.
                           Omit for local use; reverse-proxied deploys should set it explicitly.
+        --github-auth-scope <scope>
+                          Override the OAuth scope instead of deriving it from --github-auth-repo's
+                          visibility. Only needed when a GitHub App or org policy demands a specific
+                          one; the derived value is already the narrowest that works.
         --github-auth-users <login>[,<login>…]
                           Optional sign-in allowlist. Empty means any signed-in GitHub user may use
                           live sessions; playground still requires access to --github-auth-repo.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -34,6 +34,12 @@ data class ServeGithubAuthConfig(
   val repository: String,
   val allowedUsers: Set<String> = emptySet(),
   val callbackBaseUrl: String? = null,
+  /**
+   * Overrides the OAuth scope entirely. Null (the default) derives it from the gating repo's
+   * visibility — see [ServeGithubAuth.requestedScope], which is what an operator wants unless their
+   * GitHub App or org policy needs something specific.
+   */
+  val oauthScope: String? = null,
 ) {
   init {
     require(clientId.isNotBlank()) { "GitHub OAuth client id is required" }
@@ -55,6 +61,8 @@ class ServeGithubAuth(
   private val config: ServeGithubAuthConfig,
   private val verifier: GitHubOAuthVerifier = GitHubOAuthVerifier(),
   private val clock: Clock = Clock.systemUTC(),
+  /** Unauthenticated client for the one-shot visibility probe behind [requestedScope]. */
+  private val anonymousClient: OkHttpClient = OkHttpClient(),
 ) {
   suspend fun RoutingContext.handleStart() {
     val returnTo = safeReturnTo(call.request.queryParameters["return"] ?: "/")
@@ -121,11 +129,58 @@ class ServeGithubAuth(
       listOf(
           "client_id" to config.clientId,
           "redirect_uri" to callbackUrl(call),
-          "scope" to "read:user repo",
+          "scope" to requestedScope(),
           "state" to state,
         )
         .joinToString("&") { (k, v) -> "$k=${urlEncode(v)}" }
     return "https://github.com/login/oauth/authorize?$params"
+  }
+
+  /**
+   * The OAuth scope to ask a visitor to consent to.
+   *
+   * This used to be a flat `read:user repo`. `repo` is GitHub's *full control of private
+   * repositories* — read and write, code and issues and settings, across every private repo the
+   * visitor can touch — and we were asking every signer-in for it in order to answer one question
+   * about one repository. On a public `--github-auth-repo` it buys nothing at all: `GET
+   * /repos/{owner}/{repo}`, which is now the only call the access check needs
+   * ([fetchRepositoryAccess]), is readable there by a token carrying no repo scope whatsoever.
+   *
+   * So the scope follows the gating repo: `read:user` alone when it is public, `read:user repo`
+   * when it is private or we couldn't tell. Classic OAuth apps have no read-only repository scope,
+   * so the private case genuinely needs `repo` — there is nothing narrower to ask for.
+   *
+   * [ServeGithubAuthConfig.oauthScope] overrides this outright for a deployment that needs
+   * something else.
+   */
+  internal fun requestedScope(): String =
+    config.oauthScope?.trim()?.takeIf { it.isNotEmpty() }
+      ?: if (gatingRepoIsPublic.value) PUBLIC_REPO_SCOPE else PRIVATE_REPO_SCOPE
+
+  /**
+   * Whether the gating repo is publicly readable, probed **anonymously** and once.
+   *
+   * Anonymous on purpose: this runs before anyone has signed in, so there is no token to use, and a
+   * 200 from an unauthenticated read is exactly the definition of "public". Anything else — 404, a
+   * network failure, a rate limit — is treated as not-public, which asks for the *wider* scope.
+   * That is the safe direction here: over-requesting inconveniences the visitor, while
+   * under-requesting would fail their sign-in outright.
+   *
+   * Note this is the opposite default from the visibility check inside [fetchRepositoryAccess],
+   * deliberately. That one decides whether `read` is good enough to run code, so its unknown case
+   * has to fall to the stricter *access* rule; this one only decides what to ask consent for, so
+   * its unknown case falls to the wider *scope*. Same principle, opposite directions.
+   */
+  private val gatingRepoIsPublic: Lazy<Boolean> = lazy {
+    runCatching {
+        val request =
+          Request.Builder()
+            .url("https://api.github.com/repos/${config.repository}")
+            .header(HttpHeaders.Accept, "application/vnd.github+json")
+            .build()
+        anonymousClient.newCall(request).execute().use { it.isSuccessful }
+      }
+      .getOrDefault(false)
   }
 
   private fun callbackUrl(call: ApplicationCall?): String =
@@ -222,6 +277,17 @@ class ServeGithubAuth(
     const val CALLBACK_PATH = "/auth/github/callback"
     private const val AUTH_COOKIE = "cp_gh_auth"
     private const val STATE_COOKIE = "cp_gh_state"
+    /**
+     * Enough to read `/user` and a public repo's payload. No repository write, no private repos.
+     */
+    const val PUBLIC_REPO_SCOPE = "read:user"
+
+    /**
+     * A private gating repo needs `repo` to read at all. Classic OAuth apps have no read-only
+     * repository scope, so this is already the narrowest thing that works.
+     */
+    const val PRIVATE_REPO_SCOPE = "read:user repo"
+
     private const val STATE_TTL_SECONDS = 10L * 60
     private const val SESSION_TTL_SECONDS = 12L * 60 * 60
     private val SECURE_RANDOM = SecureRandom()
@@ -313,6 +379,16 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
    * read the repo metadata tells us nothing that should widen a gate on code execution.
    */
   private fun fetchRepositoryAccess(token: String, repository: String, login: String): Boolean {
+    // `GET /repos/{owner}/{repo}` answers both halves at once: `private` is the visibility, and
+    // `permissions` is *this* user's access as GitHub computes it. That matters for scope as much
+    // as for round-trips — this endpoint is readable on a public repo by a token carrying no repo
+    // scope at all, where `/collaborators/{login}/permission` is not. See [scopeFor].
+    repositoryView(token, repository)?.let { repo ->
+      val access = repo.permissions ?: return@let // no permissions block — fall through below
+      return if (repo.private == true) access.any() else access.write()
+    }
+    // Fallback for a payload that carries no `permissions` block. Same logic as before, and the
+    // same two calls, so a deployment where the block is absent behaves exactly as it did.
     val request =
       Request.Builder()
         .url("https://api.github.com/repos/$repository/collaborators/$login/permission")
@@ -331,6 +407,23 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
       val readish = permission != "none" || (role != null && role != "none")
       readish && !isPublicRepository(token, repository)
     }
+  }
+
+  /** The repo payload, or null when it can't be read — which denies, the safe side. */
+  private fun repositoryView(token: String, repository: String): GitHubRepositoryResponse? {
+    val request =
+      Request.Builder()
+        .url("https://api.github.com/repos/$repository")
+        .header(HttpHeaders.Authorization, "Bearer $token")
+        .header(HttpHeaders.Accept, "application/vnd.github+json")
+        .build()
+    return runCatching {
+        client.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) return@use null
+          JSON.decodeFromString(GitHubRepositoryResponse.serializer(), response.body.string())
+        }
+      }
+      .getOrNull()
   }
 
   /**
@@ -379,7 +472,28 @@ private data class GitHubPermissionResponse(
 )
 
 /** Only [private] is read; absent means "couldn't tell", which resolves to public. */
-@Serializable private data class GitHubRepositoryResponse(val private: Boolean? = null)
+@Serializable
+private data class GitHubRepositoryResponse(
+  val private: Boolean? = null,
+  /** The *authenticated* user's access, as GitHub computes it. Absent on an anonymous read. */
+  val permissions: GitHubRepositoryPermissions? = null,
+)
+
+/** GitHub's per-user permission flags on a repo payload. All default false: absent means no. */
+@Serializable
+private data class GitHubRepositoryPermissions(
+  val admin: Boolean = false,
+  val maintain: Boolean = false,
+  val push: Boolean = false,
+  val triage: Boolean = false,
+  val pull: Boolean = false,
+) {
+  /** Write access — the bar on a public repo, where `pull` is true for all of GitHub. */
+  fun write(): Boolean = admin || maintain || push
+
+  /** Any real grant — the bar on a private repo, where even `pull` was a deliberate decision. */
+  fun any(): Boolean = write() || triage || pull
+}
 
 private fun ApplicationCall.uriWithQuery(): String = request.uri
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitHubOAuthVerifierTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitHubOAuthVerifierTest.kt
@@ -146,8 +146,78 @@ class GitHubOAuthVerifierTest {
     assertTrue(accessFor("""{"permission":"write","role_name":"write"}""", repoJson = null))
   }
 
+  // ── The repo payload's own `permissions` block ────────────────────────────────────────────────
+  // Preferred over /collaborators/{login}/permission because it answers visibility AND access in
+  // one call, and — the point of the change — is readable on a public repo by a token carrying no
+  // `repo` scope. The cases above, whose payloads carry no `permissions`, still exercise the
+  // collaborator-endpoint fallback unchanged.
+
+  @Test
+  fun `pull-only on a public repo is not repository access`() {
+    assertFalse(accessFor(NEVER_CALLED, publicRepo(pull = true)))
+  }
+
+  @Test
+  fun `push on a public repo is repository access`() {
+    assertTrue(accessFor(NEVER_CALLED, publicRepo(pull = true, push = true)))
+  }
+
+  @Test
+  fun `admin on a public repo is repository access`() {
+    assertTrue(accessFor(NEVER_CALLED, publicRepo(pull = true, admin = true)))
+  }
+
+  @Test
+  fun `maintain on a public repo is repository access`() {
+    assertTrue(accessFor(NEVER_CALLED, publicRepo(pull = true, maintain = true)))
+  }
+
+  @Test
+  fun `pull-only on a private repo is repository access`() {
+    assertTrue(accessFor(NEVER_CALLED, privateRepo(pull = true)))
+  }
+
+  @Test
+  fun `no permissions at all on a private repo is not repository access`() {
+    assertFalse(accessFor(NEVER_CALLED, privateRepo()))
+  }
+
+  private fun publicRepo(
+    pull: Boolean = false,
+    push: Boolean = false,
+    admin: Boolean = false,
+    maintain: Boolean = false,
+    triage: Boolean = false,
+  ) = repo(private = false, pull, push, admin, maintain, triage)
+
+  private fun privateRepo(
+    pull: Boolean = false,
+    push: Boolean = false,
+    admin: Boolean = false,
+    maintain: Boolean = false,
+    triage: Boolean = false,
+  ) = repo(private = true, pull, push, admin, maintain, triage)
+
+  private fun repo(
+    private: Boolean,
+    pull: Boolean,
+    push: Boolean,
+    admin: Boolean,
+    maintain: Boolean,
+    triage: Boolean,
+  ) =
+    """{"private":$private,"permissions":{"admin":$admin,"maintain":$maintain,""" +
+      """"push":$push,"triage":$triage,"pull":$pull}}"""
+
   private companion object {
     const val PUBLIC_REPO = """{"private":false}"""
     const val PRIVATE_REPO = """{"private":true}"""
+
+    /**
+     * Handed to the collaborator endpoint in the `permissions`-block cases. If the code ever falls
+     * back to it there the verdict flips to `true`, so a test asserting `false` would fail loudly
+     * rather than passing for the wrong reason.
+     */
+    const val NEVER_CALLED = """{"permission":"admin","role_name":"admin"}"""
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -324,6 +324,9 @@ class PlaygroundRoutingTest {
         repository = "yschimke/compose-ai-tools",
       ),
       verifier = GitHubOAuthVerifier(fakeGitHub),
+      // Also the scope probe's client: without it that anonymous GET would leave the sandbox and
+      // make this test depend on api.github.com being reachable.
+      anonymousClient = fakeGitHub,
     )
   }
 
@@ -342,9 +345,18 @@ class PlaygroundRoutingTest {
           resp.header("Location").orEmpty() to
             resp.header("Set-Cookie").orEmpty().substringBefore(";")
         }
+    // The fake answers the anonymous repo probe 200, i.e. a public gating repo — so the sign-in
+    // asks for `read:user` and NOT `repo`. `repo` is full control of the visitor's private
+    // repositories and buys nothing when the gating repo is public; see ServeGithubAuthScopeTest
+    // for the private and unreachable cases.
     assertTrue(
-      start.first.contains("scope=read%3Auser+repo"),
-      "GitHub OAuth requests repo scope so private-repo playground access can be checked: ${start.first}",
+      start.first.contains("scope=read%3Auser&") || start.first.endsWith("scope=read%3Auser"),
+      "a public gating repo must not ask for the repo scope: ${start.first}",
+    )
+    assertTrue(
+      !start.first.contains("repo", ignoreCase = true) ||
+        !start.first.substringAfter("scope=").substringBefore("&").contains("repo"),
+      "the requested scope must not include repo: ${start.first}",
     )
     val state = start.first.substringAfter("state=").substringBefore("&")
     return noRedirect

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuthScopeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuthScopeTest.kt
@@ -1,0 +1,137 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+/**
+ * What we ask a visitor to consent to at sign-in.
+ *
+ * This used to be a flat `read:user repo` for every deployment. `repo` is full control of *private*
+ * repositories — read and write, code and settings, across every private repo the visitor can reach
+ * — requested from everyone in order to answer one question about one repository. On a public
+ * gating repo it buys nothing: the repo payload the access check now reads is available there to a
+ * token with no repository scope at all.
+ */
+class ServeGithubAuthScopeTest {
+
+  private fun config(repository: String = "yschimke/compose-ai-tools", scope: String? = null) =
+    ServeGithubAuthConfig(
+      clientId = "id",
+      clientSecret = "secret",
+      cookieSecret = "0123456789012345678901234567890123",
+      repository = repository,
+      oauthScope = scope,
+    )
+
+  /** An anonymous GET of the gating repo answering [code] — 200 is the definition of public. */
+  private fun probing(code: Int): OkHttpClient =
+    OkHttpClient.Builder()
+      .addInterceptor { chain ->
+        Response.Builder()
+          .request(chain.request())
+          .protocol(Protocol.HTTP_1_1)
+          .code(code)
+          .message(if (code == 200) "OK" else "Not Found")
+          .body("{}".toResponseBody("application/json".toMediaType()))
+          .build()
+      }
+      .build()
+
+  private fun scopeFor(code: Int, scope: String? = null): String =
+    ServeGithubAuth(config(scope = scope), anonymousClient = probing(code)).requestedScope()
+
+  @Test
+  fun `a public gating repo asks for no repository scope at all`() {
+    assertEquals("read:user", scopeFor(200))
+    assertEquals(ServeGithubAuth.PUBLIC_REPO_SCOPE, scopeFor(200))
+  }
+
+  /**
+   * A private repo genuinely needs `repo` — classic OAuth apps have no read-only repository scope,
+   * so this is already the narrowest thing that works, not an oversight.
+   */
+  @Test
+  fun `a private gating repo still needs repo`() {
+    assertEquals("read:user repo", scopeFor(404))
+    assertEquals(ServeGithubAuth.PRIVATE_REPO_SCOPE, scopeFor(404))
+  }
+
+  /**
+   * Unknown visibility asks for the *wider* scope. Over-requesting inconveniences the visitor;
+   * under-requesting would fail their sign-in outright — and this probe runs before anyone has
+   * signed in, so a rate limit or a network blip is a realistic way to land here.
+   *
+   * Deliberately the opposite default from the visibility check inside the access decision, which
+   * falls to the stricter *access* rule. Same principle — fail towards the safe side — pointing in
+   * opposite directions because the two questions are different.
+   */
+  @Test
+  fun `an unreachable gating repo asks for the wider scope`() {
+    assertEquals(ServeGithubAuth.PRIVATE_REPO_SCOPE, scopeFor(500))
+    assertEquals(ServeGithubAuth.PRIVATE_REPO_SCOPE, scopeFor(403))
+  }
+
+  @Test
+  fun `an explicit override wins over the probe`() {
+    assertEquals("read:org", scopeFor(200, scope = "read:org"))
+    assertEquals("read:org", scopeFor(404, scope = "read:org"))
+  }
+
+  @Test
+  fun `a blank override falls back to the derived scope`() {
+    assertEquals(ServeGithubAuth.PUBLIC_REPO_SCOPE, scopeFor(200, scope = "   "))
+  }
+
+  /** The probe is one-shot: a sign-in burst must not become a burst of GitHub calls. */
+  @Test
+  fun `the visibility probe runs once however often the scope is read`() {
+    var calls = 0
+    val counting =
+      OkHttpClient.Builder()
+        .addInterceptor { chain ->
+          calls++
+          Response.Builder()
+            .request(chain.request())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body("{}".toResponseBody("application/json".toMediaType()))
+            .build()
+        }
+        .build()
+    val auth = ServeGithubAuth(config(), anonymousClient = counting)
+
+    repeat(5) { auth.requestedScope() }
+
+    assertEquals(1, calls)
+  }
+
+  /** An override must not probe GitHub at all — there is nothing for the answer to change. */
+  @Test
+  fun `an override does not probe`() {
+    var calls = 0
+    val counting =
+      OkHttpClient.Builder()
+        .addInterceptor { chain ->
+          calls++
+          Response.Builder()
+            .request(chain.request())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body("{}".toResponseBody("application/json".toMediaType()))
+            .build()
+        }
+        .build()
+    val auth = ServeGithubAuth(config(scope = "read:user"), anonymousClient = counting)
+
+    auth.requestedScope()
+
+    assertEquals(0, calls)
+  }
+}

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -131,6 +131,9 @@ if [[ -n "${SERVE_GITHUB_AUTH_CLIENT_ID:-}" ||
   [[ -n "${github_auth_callback_base_url}" ]] &&
     args+=(--github-auth-callback-base-url "${github_auth_callback_base_url}")
   [[ -n "${SERVE_GITHUB_AUTH_USERS:-}" ]] && args+=(--github-auth-users "${SERVE_GITHUB_AUTH_USERS}")
+  # Unset derives the scope from the gating repo's visibility (public -> read:user, private ->
+  # read:user repo). Only set this when a GitHub App or org policy demands a specific scope.
+  [[ -n "${SERVE_GITHUB_AUTH_SCOPE:-}" ]] && args+=(--github-auth-scope "${SERVE_GITHUB_AUTH_SCOPE}")
 fi
 # The producer-trust store is CONFIG, on the same /config volume as catalogs.json — for the
 # same reason. It used to live only in the image, which meant trusting a new producer needed a

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -551,8 +551,23 @@ that repository's visibility:
 If the repository's visibility can't be determined, the stricter (public) rule applies. The browser
 cookie stores only a signed, expiring login plus the repo access verdict, and is marked `secure` whenever
 the request arrives over HTTPS (which is why a reverse-proxied box should set
-`SERVE_GITHUB_AUTH_CALLBACK_BASE_URL`). The OAuth request includes GitHub's `repo` scope so private
-repository access can be checked during sign-in; the OAuth token is not stored.
+`SERVE_GITHUB_AUTH_CALLBACK_BASE_URL`). The OAuth token is not stored.
+
+**The requested OAuth scope follows the gating repo's visibility**, so a visitor is asked to consent
+to as little as the check actually needs:
+
+| `SERVE_GITHUB_AUTH_REPO` | scope requested |
+| --- | --- |
+| public | `read:user` |
+| private, or visibility unreadable | `read:user repo` |
+
+`repo` is GitHub's *full control of private repositories* — read and write, across every private
+repo the visitor can reach. On a public gating repo it buys nothing: the access check reads
+`GET /repos/{owner}/{repo}`, which is available there to a token with no repository scope at all. A
+private gating repo genuinely needs `repo`, because classic OAuth apps have no read-only repository
+scope. Visibility is probed once, anonymously, at first sign-in; if that probe can't answer, the
+wider scope is requested, since over-requesting inconveniences a visitor while under-requesting
+would fail their sign-in. Set `SERVE_GITHUB_AUTH_SCOPE` / `--github-auth-scope` to override.
 Reverse-proxied deployments should also set
 `SERVE_GITHUB_AUTH_CALLBACK_BASE_URL=https://preview.example.com` so the OAuth callback URL is stable.
 When `DOMAIN` is set, the prebuilt image derives


### PR DESCRIPTION
The last open item from the review that produced #3313–#3318: sign-in requested a flat `read:user repo`.

`repo` is GitHub's **full control of private repositories** — read *and write*, code, issues, settings, across every private repo the visitor can reach. We asked every person who signed in to consent to that in order to answer one question about one repository. On `preview.coo.ee`, whose gating repo is public, it bought precisely nothing.

## Why it can just go

`GET /repos/{owner}/{repo}` turns out to answer both halves of the access check in a single call:

```
$ curl -s https://api.github.com/repos/yschimke/compose-ai-tools   # no auth at all
private: False
has permissions block: True
permissions: {"admin":false,"maintain":false,"push":false,"triage":false,"pull":false}
```

`private` is the visibility; `permissions` is *that user's* access as GitHub computes it. So `fetchRepositoryAccess` now reads that one payload and needs neither `/collaborators/{login}/permission` nor the separate visibility call #3318 added. Same verdicts, one round-trip instead of two — and, the point here, that endpoint is readable on a public repo by a token carrying no repository scope whatsoever.

The collaborator endpoint stays as a **fallback** for a payload with no `permissions` block, so any deployment where it's absent behaves exactly as it does today. Nothing regresses if my reading of the API is wrong somewhere.

## The scope

| `--github-auth-repo` | requested |
| --- | --- |
| public | `read:user` |
| private, or unreadable | `read:user repo` |

A private gating repo genuinely needs `repo` — classic OAuth apps have no read-only repository scope, so that's already the narrowest thing that works, not an oversight.

Visibility is probed **once, anonymously**. Anonymous because the probe runs before anyone has signed in, so there's no token to use, and a 200 from an unauthenticated read is exactly what "public" means.

An unanswerable probe asks for the **wider** scope. That's deliberately the opposite default from the visibility check inside the access decision (which falls to the stricter *access* rule), because the two questions fail in opposite directions: over-requesting scope inconveniences a visitor, under-requesting fails their sign-in outright, whereas over-granting access is the thing #3313 existed to stop. Both comments say so at their site.

`--github-auth-scope` / `SERVE_GITHUB_AUTH_SCOPE` overrides it for a GitHub App or org policy that demands something specific.

## Test plan

```
./gradlew :cli:test :cli:ktfmtCheck     # BUILD SUCCESSFUL, full CLI suite
```

- **`ServeGithubAuthScopeTest`** (new, 7 cases) — public → `read:user`; private → `read:user repo`; unreachable (500, 403) → wider; override wins and *suppresses the probe entirely*; blank override falls back; and the probe runs **once** across repeated reads, so a sign-in burst isn't a burst of GitHub calls.
- **`GitHubOAuthVerifierTest`** — 6 new cases over the `permissions` block (pull-only public → denied, push/admin/maintain public → allowed, pull-only private → allowed, no permissions private → denied). The 12 existing cases carry payloads with no `permissions` block, so they now exercise the fallback path unchanged — which is exactly the coverage that fallback needs.

One assertion I wrote and deleted rather than shipped: I'd initially asserted an unreadable repo "denies outright". It doesn't — it falls back to the collaborator endpoint by design, and the existing `an unreadable repo falls back to requiring write` already covers it correctly. Two contradictory assertions in one suite is worse than one.

**`PlaygroundRoutingTest` needed changing, and that's worth flagging rather than burying:** it asserted the old scope string verbatim (`"GitHub OAuth requests repo scope…"`). That assertion is the behaviour this PR changes, so it now asserts the *absence* of `repo` for its (public) gating repo. Fixing it also surfaced a real defect in my first cut — the test was reaching `api.github.com` for the probe, because it built `ServeGithubAuth` without injecting a client. It now injects the same fake, so the suite is hermetic again.

Auth plumbing, docs and a shell wiring line — no rendered output, so nothing visual to embed.

## Also updated

`docs/public-preview-server.md` (the scope table and the reasoning, replacing the old "includes GitHub's `repo` scope" line) and `deploy/image/entrypoint.sh` (passes `SERVE_GITHUB_AUTH_SCOPE` when set; `bash -n` clean).

---
_Generated by [Claude Code](https://claude.ai/code/session_0184U4iKHdJDcdTcC1Tm1UJA)_