### PR TITLE
fix(serve): keep live-seat headroom for streams, not render pools

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -58,6 +58,31 @@ class LiveSeatLimiter(val totalPermits: Int) {
     return null
   }
 
+  /**
+   * Reserve [weight] permits for a **background** holder — a pooled render daemon — leaving at
+   * least [STREAM_RESERVE] free for an interactive stream. Returns null (without counting a
+   * refusal) when that headroom isn't there.
+   *
+   * Render pools and streams are not equal claims on the box. A pooled daemon exists to make a
+   * *thumbnail* faster and its caller always has a fallback — baked pixels, or the monolithic
+   * daemon — while a refused stream is a visitor staring at "Live preview is at capacity". Charging
+   * both against one flat budget let the cheap, deferrable work take the last seat and turn the
+   * valuable, undeferrable work away: on a `--live-seats 1` box the first pooled daemon refused
+   * every stream that followed.
+   *
+   * Implemented as "take weight + reserve atomically, then hand the reserve straight back", so it
+   * can never over-admit under a race — the worst case is a background holder briefly seeing less
+   * headroom than really exists and declining, which is the safe direction.
+   */
+  fun acquireBackground(weight: Int, reserve: Int = STREAM_RESERVE): Ticket? {
+    val sem = semaphore ?: return Ticket(0)
+    if (weight <= 0) return Ticket(0)
+    val permits = weight.coerceIn(1, totalPermits)
+    if (!sem.tryAcquire(permits + reserve.coerceAtLeast(0))) return null
+    if (reserve > 0) sem.release(reserve)
+    return Ticket(permits)
+  }
+
   /** Permits currently available — for tests/diagnostics. */
   fun availablePermits(): Int = semaphore?.availablePermits() ?: Int.MAX_VALUE
 
@@ -84,6 +109,15 @@ class LiveSeatLimiter(val totalPermits: Int) {
    * instead of it.
    */
   fun unverifiedRefusalCount(): Long = unverifiedRefusals.get()
+
+  companion object {
+    /**
+     * Permits [acquireBackground] must leave free for interactive streams. Sized at
+     * [ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT] — the most expensive single stream — so one can
+     * always start no matter how much render residency has built up.
+     */
+    const val STREAM_RESERVE: Int = ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT
+  }
 
   private val refusals = AtomicLong()
   private val unverifiedRefusals = AtomicLong()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPool.kt
@@ -73,7 +73,7 @@ class ServePerPreviewDaemonPool(
     // Take the seat BEFORE opening: a refused daemon must not have been spawned. A miss returns
     // null exactly like an unusable bundle does, so the caller replays the baked PNG — a slightly
     // stale thumbnail under memory pressure, rather than a process the box can't afford.
-    val ticket = liveSeats?.let { it.acquire(seatWeight()) ?: return null }
+    val ticket = liveSeats?.let { it.acquireBackground(seatWeight()) ?: return null }
     // A null open (no usable per-preview bundle) and a throwing one both have to hand the seat
     // back: neither leaves a daemon behind, and a leaked ticket shrinks the whole box's budget for
     // the life of the server.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -77,7 +77,7 @@ class ServeSharedDaemonPool(
   private fun openSeatedReplica(): ServeHost {
     var ticket: LiveSeatLimiter.Ticket? = null
     if (liveSeats != null) {
-      ticket = liveSeats.acquire(seatWeight())
+      ticket = liveSeats.acquireBackground(seatWeight())
       if (ticket == null) {
         while (available.isEmpty() && !closed) hostReturned.await()
         check(!closed) { "shared daemon pool is closed" }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPoolTest.kt
@@ -201,7 +201,8 @@ class ServePerPreviewDaemonPoolTest {
    */
   @Test
   fun `a daemon is not opened when the live-seat budget is exhausted`() {
-    val seats = LiveSeatLimiter(totalPermits = 2)
+    // Two seats for daemons on top of the reserve the pools must leave for streams.
+    val seats = LiveSeatLimiter(totalPermits = 2 + LiveSeatLimiter.STREAM_RESERVE)
     val opens = mutableListOf<String>()
     val pool =
       ServePerPreviewDaemonPool(liveSeats = seats, seatWeight = { 1 }) { id ->
@@ -211,33 +212,59 @@ class ServePerPreviewDaemonPoolTest {
     assertTrue(pool.get("B") != null)
     assertNull(pool.get("C"), "the budget is spent, so no third daemon is spawned")
     assertEquals(listOf("A", "B"), opens, "the refused open never reached the opener")
-    assertEquals(0, seats.availablePermits())
+    assertEquals(
+      LiveSeatLimiter.STREAM_RESERVE,
+      seats.availablePermits(),
+      "the stream headroom survives a pool that would otherwise have taken everything",
+    )
   }
 
   @Test
   fun `reaping and eviction return their seats to the budget`() {
     var now = 0L
-    val seats = LiveSeatLimiter(totalPermits = 2)
+    val seats = LiveSeatLimiter(totalPermits = 2 + LiveSeatLimiter.STREAM_RESERVE)
     val pool =
       ServePerPreviewDaemonPool(maxOpen = 8, clock = { now }, liveSeats = seats) { _ -> FakeHost() }
     pool.get("A")
     pool.get("B")
-    assertEquals(0, seats.availablePermits())
+    assertEquals(LiveSeatLimiter.STREAM_RESERVE, seats.availablePermits())
 
     now = 100_000
     assertEquals(2, pool.reapIdle(idleMillis = 1_000))
-    assertEquals(2, seats.availablePermits(), "reaped daemons hand their seats back")
+    assertEquals(
+      2 + LiveSeatLimiter.STREAM_RESERVE,
+      seats.availablePermits(),
+      "reaped daemons hand their seats back",
+    )
     assertTrue(pool.get("C") != null, "the freed budget admits a new daemon")
   }
 
   @Test
   fun `a throwing open hands its seat back`() {
-    val seats = LiveSeatLimiter(totalPermits = 1)
+    val total = 1 + LiveSeatLimiter.STREAM_RESERVE
+    val seats = LiveSeatLimiter(totalPermits = total)
     val pool =
       ServePerPreviewDaemonPool(liveSeats = seats) { _ -> throw IllegalStateException("launch") }
     repeat(3) {
       runCatching { pool.get("A") }
-      assertEquals(1, seats.availablePermits(), "a failed launch must not consume the budget")
+      assertEquals(total, seats.availablePermits(), "a failed launch must not consume the budget")
     }
+  }
+
+  /**
+   * The regression that broke the `serve-lanes` E2E: on a `--live-seats 1` box the pool took the
+   * only seat for a *thumbnail* and every live stream after it was refused with "Live preview is at
+   * capacity". A pooled daemon always has a fallback (baked pixels, or the monolithic daemon); a
+   * refused stream has none, so background render residency must never spend the last seats.
+   */
+  @Test
+  fun `a pool never takes the seats a stream needs`() {
+    val seats = LiveSeatLimiter(totalPermits = 1)
+    val pool = ServePerPreviewDaemonPool(liveSeats = seats) { _ -> FakeHost() }
+
+    assertNull(pool.get("A"), "a one-seat box keeps that seat for the stream")
+    assertEquals(1, seats.availablePermits())
+    // ...and the stream, which acquires in the ordinary (foreground) way, still gets in.
+    assertTrue(seats.acquire(1) != null)
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -179,8 +179,8 @@ class ServeSharedDaemonPoolTest {
 
   @Test
   fun `does not open a replica the live-seat budget cannot afford`() {
-    val seats = LiveSeatLimiter(totalPermits = 1)
-    // Spend the whole budget elsewhere — a stream, another catalog's pool, anything.
+    val seats = LiveSeatLimiter(totalPermits = 1 + LiveSeatLimiter.STREAM_RESERVE)
+    // Spend everything above the stream reserve elsewhere — a stream, another catalog's pool.
     val held = requireNotNull(seats.acquire(1))
     val primary = InstantHost("primary")
     val opened = AtomicInteger()
@@ -208,7 +208,8 @@ class ServeSharedDaemonPoolTest {
 
   @Test
   fun `a replica whose launch throws hands its seat back`() {
-    val seats = LiveSeatLimiter(totalPermits = 4)
+    val total = 4 + LiveSeatLimiter.STREAM_RESERVE
+    val seats = LiveSeatLimiter(totalPermits = total)
     val entered = CountDownLatch(1)
     val release = CountDownLatch(1)
     // The primary is held mid-render, so a concurrent request has nothing to borrow and must go
@@ -227,7 +228,7 @@ class ServeSharedDaemonPoolTest {
       val thrown = runCatching { failed.get(5, TimeUnit.SECONDS) }.exceptionOrNull()
       assertTrue(thrown != null, "the launch failure reaches the caller")
 
-      assertEquals(4, seats.availablePermits(), "no seat is stranded on a failed launch")
+      assertEquals(total, seats.availablePermits(), "no seat is stranded on a failed launch")
 
       release.countDown()
       assertTrue(holder.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok)


### PR DESCRIPTION
Follow-up to #3322, which merged with `Serve render lanes honor overrides` red. This fixes that failure — it was a real regression, not a flake.

## What went wrong

#3322 made pooled render daemons charge the live-seat budget, which was the right idea, but let them charge it on **equal terms with interactive streams**. They aren't equal claims on the box:

- a pooled daemon exists to make a *thumbnail* faster, and its caller always has a fallback (baked pixels, or the monolithic daemon);
- a refused stream is a visitor looking at `Live preview is at capacity — try again shortly`.

The serve-lanes e2e boots `serve --catalogs compose-m3 --live-seats 1`. Under #3322 the first pooled daemon took the only seat, and every stream after it was refused:

```
locator resolved to <div role="alert" id="cp-error" class="cp-error">Live preview is at capacity — try again shortly.</div>
2 failed
  › Live WebSocket lane upgrades and pushes a frame
  › viewer wires the knob into every render lane
```

The same shape would bite production, which is the part that matters more than the test: eight pooled daemons across catalogs could turn away every stream on an eight-seat box — the exact starvation the budget exists to prevent, just with the priorities inverted.

## The fix

Both pools now acquire through `LiveSeatLimiter.acquireBackground`, which must leave `STREAM_RESERVE` permits free. The reserve is sized at `ANDROID_LIVE_SEAT_WEIGHT` — the most expensive single stream — so one can always start no matter how much render residency has accumulated.

It's implemented as "take `weight + reserve` atomically, then hand the reserve straight back", so it can never over-admit under a race. The worst case is a background holder briefly seeing less headroom than really exists and declining, which is the safe direction. A refused pool falls back exactly as it does for an unusable bundle, so no render lane regresses — with `--live-seats 1` the pools simply never open and renders serve from the monolithic daemon, which is the documented contract.

## Test plan

Verified in **both** directions locally against a real daemon-backed server (`serve --catalogs compose-m3 --allow-render-trusted --live-seats 1`), rather than assuming the fix works:

| | Result |
| --- | --- |
| With this change | `6 passed (24.2s)` |
| Without it (`main` as merged) | `2 failed` — the same two CI failed on, `4 passed` |

- `:cli:test` — green.
- New unit test pins the priority rule directly: on a one-seat box the pool declines and the stream still gets its seat. Existing seat tests updated to account for the reserve.

No visual surfaces changed — this is admission-control plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_