### PR TITLE
feat(serve): report playground health on /status.json

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -16,6 +16,7 @@ import ee.schimke.composeai.cli.serve.PlaygroundBundleSource
 import ee.schimke.composeai.cli.serve.PlaygroundCatalogClasspath
 import ee.schimke.composeai.cli.serve.PlaygroundClasspathSupplier
 import ee.schimke.composeai.cli.serve.PlaygroundCompileService
+import ee.schimke.composeai.cli.serve.PlaygroundHealth
 import ee.schimke.composeai.cli.serve.PlaygroundJailedCompiler
 import ee.schimke.composeai.cli.serve.PlaygroundMode
 import ee.schimke.composeai.cli.serve.PlaygroundPreviewDiscoverer
@@ -1108,14 +1109,20 @@ class ServeCommand(args: List<String>) : Command(args) {
           )
           .also { System.err.println("serve: ${it.summary()}") }
       } else null
+    // Kept, not just logged: `/status.json` reports which posture admitted the lane, so an
+    // operator reading it later doesn't have to find the startup log to tell "admitted because
+    // collaborators only" from "admitted because contained".
+    val admittedBy: String
     when (val decision = PlaygroundPublicGate.decide(public, repoAccessGated, sandbox, probe)) {
       is PlaygroundPublicGate.Decision.Refuse -> {
         System.err.println("serve: ${decision.reason}")
         workRoot.deleteRecursively()
         return null
       }
-      is PlaygroundPublicGate.Decision.Allow ->
+      is PlaygroundPublicGate.Decision.Allow -> {
         System.err.println("serve: playground admitted — ${decision.detail}")
+        admittedBy = decision.detail
+      }
     }
     // A repo-access-gated lane is admitted without consulting the probe, so a broken jail would
     // otherwise pass unremarked — the operator asked for defence in depth and isn't getting it.
@@ -1310,13 +1317,58 @@ class ServeCommand(args: List<String>) : Command(args) {
         java.util.concurrent.TimeUnit.SECONDS,
       )
 
-    return PlaygroundLane(compile = service, redeem = redeem)
+    // Everything an operator needs to diagnose a half-up playground from `/status.json` — the
+    // admission posture, whether the configured jail actually contains anything HERE, and each
+    // mode's lazy-resolution state. Captured as a lambda so the mode rows are read fresh (a
+    // deferred classpath resolves minutes after this point) while staying side-effect free:
+    // `isResolved` reports the memo without forcing a resolve onto the status request path.
+    val health = {
+      PlaygroundHealth(
+        admittedBy = admittedBy,
+        sandboxProfile = sandbox.profile.id,
+        sandboxActive = sandbox.isActive,
+        sandboxMemoryMb = sandbox.memoryMb,
+        sandboxCpus = sandbox.cpus,
+        sandboxTtlSeconds = sandbox.ttlSeconds,
+        probe = probe,
+        compilerJailed = compiler !== inProcessCompiler,
+        compileSlots = playgroundCompileSlots,
+        modes = {
+          listOfNotNull(
+            cmpSupplier?.let {
+              PlaygroundHealth.Mode(PlaygroundMode.CMP.name, it.describeSource(), it.isResolved)
+            },
+            androidSupplier
+              ?.takeIf { androidRender != null }
+              ?.let {
+                PlaygroundHealth.Mode(
+                  PlaygroundMode.ANDROID.name,
+                  it.describeSource(),
+                  it.isResolved,
+                )
+              },
+            androidSupplier
+              ?.takeIf { rcCapture != null }
+              ?.let {
+                PlaygroundHealth.Mode(
+                  PlaygroundMode.REMOTE_COMPOSE.name,
+                  it.describeSource(),
+                  it.isResolved,
+                )
+              },
+          )
+        },
+      )
+    }
+    return PlaygroundLane(compile = service, redeem = redeem, health = health)
   }
 
   /** The playground's Stage-1 compile lane + Stage-2 redeem lane, sharing one token store. */
   private class PlaygroundLane(
     val compile: PlaygroundCompileService,
     val redeem: PlaygroundRedeemService,
+    /** Read by `/status.json` to report why the lane is (or isn't) fully up. */
+    val health: () -> PlaygroundHealth,
   )
 
   /**
@@ -1706,6 +1758,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         adminToken = adminToken,
         docStore = docStore,
         playgroundService = playgroundLane?.compile,
+        playgroundHealth = playgroundLane?.health,
         playgroundRedeem = playgroundLane?.redeem,
         githubAuth = githubAuth,
         engagementStore = ServeEngagementStore(engagementFile),

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBundleSource.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBundleSource.kt
@@ -112,6 +112,9 @@ class PlaygroundClasspathSupplier(
   val isResolved: Boolean
     get() = resolved != null
 
+  /** How this mode's bundle was named, for `/status.json` and startup logs. */
+  fun describeSource(): String = source.describe()
+
   fun classpath(): PlaygroundCompileService.Classpath? {
     resolved?.let {
       return it

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundHealth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundHealth.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.cli.serve
+
+/**
+ * What the playground lane looks like from the outside, for `/status.json`.
+ *
+ * The playground has more ways to be *half* up than any other lane on the host, and until now none
+ * of them were observable without shell access to the box: the admission gate can let the lane
+ * serve on either of two postures ([PlaygroundPublicGate]), a configured jail may be silently
+ * failing to contain anything, a mode's classpath resolves lazily and may not have resolved yet
+ * (issue #3212), and the compiler runs jailed or in-process depending on whether a sandbox is
+ * active. An operator away from the box — or reading `/status.json` from a monitor — could see only
+ * that `/playground` answered 503, never *why*.
+ *
+ * Every field here is therefore a question someone asks when the playground misbehaves, answered
+ * without signing in. In particular [probe] is how you find out whether the configured jail
+ * actually launches **on this host**: under the repo-access posture a jail that fails its preflight
+ * does not refuse the lane, so this is the only place the failure surfaces after the startup log
+ * has scrolled away.
+ *
+ * Read cheaply and without side effects: [modes] reports each mode's *memoized* resolution state
+ * ([PlaygroundClasspathSupplier.isResolved]) rather than forcing a resolve, so polling `/status`
+ * never unpacks a bundle on the request path.
+ */
+data class PlaygroundHealth(
+  /** The gate's `Allow.detail` — which posture admitted the lane, in the operator's words. */
+  val admittedBy: String,
+  /** The configured sandbox profile id (`none`, `unshare`, `bwrap`, `strict`, `custom`). */
+  val sandboxProfile: String,
+  /** False for `none`: no jail argv, and **no JVM caps or hard TTL either**. */
+  val sandboxActive: Boolean,
+  /** Per-snippet-JVM heap/CPU/pid budget. Only applied when [sandboxActive]. */
+  val sandboxMemoryMb: Int,
+  val sandboxCpus: Double,
+  val sandboxTtlSeconds: Long,
+  /**
+   * The startup containment preflight, when one ran (`--public` + an active sandbox). Null means it
+   * was never attempted, which is expected on a token-gated host or with no sandbox — not a
+   * failure.
+   */
+  val probe: PlaygroundSandboxProbe.Report?,
+  /**
+   * True when snippet *compiles* run in a disposable jailed child. False means they run in the
+   * serve JVM — which is what an inactive sandbox gets you, and it also makes the compile-slot
+   * budget inert (`PlaygroundJailedCompiler.wrap` hands back the in-process compiler untouched).
+   */
+  val compilerJailed: Boolean,
+  /** `--playground-compile-slots`; only meaningful when [compilerJailed]. */
+  val compileSlots: Int,
+  /** One entry per wired mode, evaluated fresh on each read. */
+  val modes: () -> List<Mode>,
+) {
+  /**
+   * A wired playground mode. "Wired" means configured with a bundle source *and* backed by an
+   * available render backend — it does not mean the classpath has resolved, which for a served
+   * catalog happens on first use.
+   */
+  data class Mode(
+    /** `CMP`, `ANDROID`, `REMOTE_COMPOSE`. */
+    val mode: String,
+    /** How the bundle was named — a path, or `served catalog '<system>'`. */
+    val source: String,
+    /**
+     * True once the compile classpath has resolved. False on a freshly started host whose catalog
+     * hasn't loaded yet (expected, self-healing) **or** on one whose bundle never materialised
+     * (not). [PlaygroundHealth]'s `admittedBy` plus the startup log distinguish them.
+     */
+    val resolved: Boolean,
+  )
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -226,6 +226,12 @@ class ServeHttpServer(
    * (playground + live WebSocket sessions) require a signed-in GitHub account.
    */
   private val githubAuth: ServeGithubAuth? = null,
+  /**
+   * Observability for the playground lane on `/status.json` — which posture admitted it, whether
+   * the configured jail actually contains anything on this host, and whether each mode's classpath
+   * has resolved. Null when the lane isn't wired at all. See [PlaygroundHealth].
+   */
+  private val playgroundHealth: (() -> PlaygroundHealth)? = null,
   /** Aggregate view counts; pass a file-backed store to keep them across server restarts. */
   private val engagementStore: ServeEngagementStore = ServeEngagementStore(),
 ) {
@@ -2071,6 +2077,38 @@ class ServeHttpServer(
               .mapNotNull { it.renderStats }
               .filter { it.renders + it.cacheHits + it.busy > 0 }
           ),
+        playground =
+          playgroundHealth?.invoke()?.let { h ->
+            PlaygroundDto(
+              admittedBy = h.admittedBy,
+              sandbox =
+                SandboxDto(
+                  profile = h.sandboxProfile,
+                  active = h.sandboxActive,
+                  memoryMb = h.sandboxMemoryMb,
+                  cpus = h.sandboxCpus,
+                  ttlSeconds = h.sandboxTtlSeconds,
+                  probe =
+                    h.probe?.let { p ->
+                      ProbeDto(
+                        ran = p.ran,
+                        detail = p.detail,
+                        failedChecks = p.failedChecks(),
+                        egressBlocked = p.egressBlocked,
+                        filesystemContained = p.filesystemContained,
+                        processIsolated = p.processIsolated,
+                        workDirWritable = p.workDirWritable,
+                      )
+                    },
+                ),
+              compilerJailed = h.compilerJailed,
+              compileSlots = h.compileSlots,
+              modes =
+                h.modes().map {
+                  ModeDto(mode = it.mode, source = it.source, resolved = it.resolved)
+                },
+            )
+          },
       )
 
     fun toView(): ServeWeb.StatusView {
@@ -3530,7 +3568,58 @@ private data class StatusResponse(
    * `compose-preview-serve/status/v1`; per-daemon detail is on `runningServers[].renderStats`.
    */
   val renderStats: RenderPerfSnapshot? = null,
+  /**
+   * Playground lane health, or null when the lane isn't wired. Additive on
+   * `compose-preview-serve/status/v1`, like [renderStats]. See [PlaygroundHealth] for why each
+   * field is here — in short, the playground can be half-up in several ways that were previously
+   * invisible without shell access to the box.
+   */
+  val playground: PlaygroundDto? = null,
 )
+
+@Serializable
+private data class PlaygroundDto(
+  /** Which admission posture let the lane serve (the gate's own words). */
+  val admittedBy: String,
+  val sandbox: SandboxDto,
+  /** True when compiles run in a jailed child rather than in the serve JVM. */
+  val compilerJailed: Boolean,
+  /** Concurrent jailed compiles allowed; inert unless [compilerJailed]. */
+  val compileSlots: Int,
+  val modes: List<ModeDto>,
+)
+
+@Serializable
+private data class SandboxDto(
+  val profile: String,
+  /**
+   * False ⇒ `none`: no jail, and **no `-Xmx`, CPU cap, or hard TTL on snippet JVMs either**. On a
+   * host with a large cgroup limit that matters — an uncapped JVM sizes its default max heap at a
+   * quarter of the limit.
+   */
+  val active: Boolean,
+  val memoryMb: Int,
+  val cpus: Double,
+  val ttlSeconds: Long,
+  /** Null when no preflight ran (token-gated host, or no sandbox configured). */
+  val probe: ProbeDto? = null,
+)
+
+@Serializable
+private data class ProbeDto(
+  /** False ⇒ the jail could not even launch here; [detail] says why. */
+  val ran: Boolean,
+  val detail: String,
+  /** Empty ⇒ the jail contained the preflight on every measured axis. */
+  val failedChecks: List<String>,
+  val egressBlocked: Boolean,
+  val filesystemContained: Boolean,
+  val processIsolated: Boolean,
+  val workDirWritable: Boolean,
+)
+
+@Serializable
+private data class ModeDto(val mode: String, val source: String, val resolved: Boolean)
 
 @Serializable
 private data class CatalogSummaryDto(


### PR DESCRIPTION
Makes the playground lane diagnosable from outside the box. Motivated by enabling it on `preview.coo.ee` (#3215) with the operator away from a computer — every question you'd want to ask when it misbehaves currently needs shell access.

## Why

After #3320 the playground can be half-up in four ways that all look identical from the outside (`/playground` answers 503, or it doesn't):

- the gate now admits on **two** postures, so a lane may be serving *without* containment;
- a configured jail can **fail its preflight and still serve** under the repo-access posture — warning only into a startup log that scrolls away;
- a mode's classpath resolves **lazily** (#3212), so "unavailable" means either "not yet" or "never", and those need different responses;
- the compiler runs jailed or in-process depending on whether a sandbox is active — which silently decides whether `--playground-compile-slots` does anything at all.

## What

`/status.json` grows a `playground` object. Live output from a real server, `--public` + repo-access-gated + `--playground-sandbox unshare`:

```json
"playground": {
  "admittedBy": "public host, repo-access-gated (GitHub sign-in with write access to --github-auth-repo); sandbox=unshare mem=1536MB heap=1152MB cpus=1.0 pids=256 ttl=900s — defence in depth, not the admission basis",
  "sandbox": {
    "profile": "unshare", "active": true,
    "memoryMb": 1536, "cpus": 1.0, "ttlSeconds": 900,
    "probe": {
      "ran": true, "detail": "probed from pid 1",
      "failedChecks": ["host files outside the session work dir are readable"],
      "egressBlocked": true, "filesystemContained": false,
      "processIsolated": true, "workDirWritable": true
    }
  },
  "compilerJailed": true,
  "compileSlots": 1,
  "modes": [
    { "mode": "CMP", "source": "served catalog 'compose-m3'", "resolved": false }
  ]
}
```

`sandbox.probe` is the field that earns this PR: it's the only place, after startup, that reveals whether the configured jail actually launches **on this host** — and under the repo-access posture a failed jail doesn't refuse the lane, so nothing else would tell you.

`sandbox.active: false` is the other one worth reading: it means `Profile.NONE`, which is not just "no jail" but **no `-Xmx`, no CPU cap, no `ExitOnOutOfMemoryError` and no hard TTL** on snippet JVMs. On a host with a large cgroup limit that's load-bearing — an uncapped JVM sizes its default max heap at a quarter of the limit, so on a 48 GiB container each snippet is entitled to 12 GiB.

## Design notes

- **Side-effect free.** Mode rows report the memoized `PlaygroundClasspathSupplier.isResolved` rather than calling `classpath()`, so polling `/status` never unpacks a bundle on the request path. That's what `isResolved` was documented for ("for status/logging, never for gating").
- **Fresh per read.** The health is a `() -> PlaygroundHealth` lambda, not a snapshot taken at wiring time — a deferred classpath resolves minutes later and the status must follow it.
- **Additive** on `compose-preview-serve/status/v1`, exactly like `renderStats`. Null when the lane isn't wired.
- **JSON only.** The HTML status page has golden fixtures; leaving them untouched keeps this change off the visual-diff surface entirely.
- The gate's `Allow.detail` is now *kept* rather than only logged, which is what makes `admittedBy` possible.

## Test plan

- [x] `./gradlew :cli:test` — full CLI suite green against current `main`
- [x] `./gradlew ktfmtCheckAll`
- [x] **Verified against a real running server**, not just unit tests — the JSON above is actual `curl` output from `serve --public --catalogs compose-m3 --playground-bundle compose-m3 --playground-sandbox unshare` with GitHub auth configured.
- [x] Confirmed the same server compiles a Material3 `@Preview` snippet end to end **through the `unshare` jail** — no exception, `previewId: SnippetKt.Hello`, token minted, 11.8 s cold (vs ~7 s unjailed, consistent with PLAYGROUND.md §6.3's cold-compile note).

No visual evidence: this adds a JSON field and touches no rendered surface.

Refs #3210, #3212, #3215

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr)_