### PR TITLE
feat(rc-player-jvm): apply a document's font-variation axes

### DIFF
--- a/docs/design/RC_PLAYER_TYPEFACES.md
+++ b/docs/design/RC_PLAYER_TYPEFACES.md
@@ -23,6 +23,7 @@ question:
 | **Java** (AOSP `remote-player-view`, server-side) | ✅ framework typefaces | ⚠️ `/system/fonts/` filename scan | ❌ no provider call at all | ✅ `Font.Builder(ByteBuffer)` |
 | **CMP Android** (vendored embedded player, server-side) | ✅ framework typefaces | ⚠️ `Typeface.create(name)` | ✅ `FontsContractCompat` | ❌ ignored |
 | **CMP JVM** (embedded player over Skiko, server-side) | ✅ | ⚠️ host families, else nearest standard | ✅ downloaded via `GoogleFontTypefaceResolver` | ❌ ignored |
+| **CMP JVM** — font-variation axes | ✅ layout ops, applied to the resolved face | — | ⚠️ `wght` picks the instance; Google serves static TTFs | ❌ canvas ops |
 
 Two rows of that table are worth stating as findings, because they make two chips in the *same*
 viewer disagree about the *same* document:
@@ -129,6 +130,18 @@ the figma-svg embed path use — and serves both jvm text seams from that one fi
 `FontFamily` for the layout ops (`RcPlayerTextLayoutJvm`), a skiko `Typeface` for the canvas ops
 (`RcPlayerTextPlatformJvm`). Sharing the cache is the point: `Orbitron` at 400 is the *same file*
 here as in every other lane, not a second face that merely shares a name.
+
+**Font-variation axes** reach the layout seam: a `CoreText` op's axis arrays become a Compose
+`FontVariation.Settings` and the resolved face is instanced at them, and a `wght` axis additionally
+decides *which file to fetch* — Google Fonts serves a named family as a static instance per weight,
+so applying `wght 1000` to the 400 file would vary nothing. The catalog's variable specimens still
+draw flat in this lane, and the reason is upstream of the player: `:data-fonts-google` asks the CSS
+API with a legacy user-agent to get a `.ttf` at all (Skia and Android can't parse the modern woff2),
+and for a variable-only family like Roboto Flex that response is a *static default instance* with no
+`fvar` table — there are no axes left in the file to vary. A host that supplies a real variable file
+(the browser lane's manifest does) gets true instancing through this same code. Fetching the
+variable file would mean decompressing woff2, which is the next step and lives in
+`:data-fonts-google`, not here. Canvas text ops carry no axes in the shared paint state at all.
 
 The resolver is switched on by `-Dcomposeai.fonts.cacheDir`, which `serve`'s cmp-jvm subprocess
 (`RcJvmServerRenderer`) passes; without it — and on an offline miss, a failed fetch, a `device:`

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerTextLayoutJvm.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerTextLayoutJvm.kt
@@ -19,6 +19,7 @@
 package androidx.compose.remote.player.compose.embedded
 
 import androidx.compose.material3.Text
+import androidx.compose.remote.core.RemoteContext
 import androidx.compose.remote.core.operations.layout.managers.CoreText
 import androidx.compose.remote.core.operations.layout.managers.TextLayout
 import androidx.compose.remote.player.compose.embedded.state.rememberRemoteStringAsState
@@ -30,6 +31,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontFamily
 import ee.schimke.composeai.rcembedded.jvm.GoogleFontTypefaceResolver
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontVariation
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -83,6 +85,7 @@ internal fun RcPlayerText(layout: CoreText, modifier: Modifier) {
             LocalRemoteContext.current.getText(fontFamilyType),
             fontWeight,
             fontStyle,
+            fontVariationSettings(data.fontAxis, data.fontAxisValues, LocalRemoteContext.current),
         )
 
     val textDecoration =
@@ -158,6 +161,9 @@ internal fun RcPlayerText(layout: TextLayout, modifier: Modifier) {
             LocalRemoteContext.current.getText(fontFamilyType),
             fontWeight,
             fontStyle,
+            // `TextLayout` carries no axis arrays upstream (only `CoreText` does), so there is
+            // nothing to apply here.
+            variationSettings = null,
         )
 
     Text(
@@ -200,11 +206,35 @@ internal fun RcPlayerText(layout: TextLayout, modifier: Modifier) {
  * (no cache configured, an offline miss, a `device:` family, a bare local name) still falls back to
  * the nearest standard family: a substitution, not an error.
  */
+/**
+ * The document's font-variation axes as a Compose [FontVariation.Settings], or null when the text
+ * declares none.
+ *
+ * Axis tags arrive as *text ids* — the document interns `"wght"` like any other string — so each is
+ * resolved through the [context] before it is paired with its value. Tags and values are positional,
+ * so an axis counts only when both halves are present: pairing a tag with a neighbour's value would
+ * draw a real face at silently the wrong instance, which is worse than dropping it.
+ */
+private fun fontVariationSettings(
+    axisTagIds: IntArray?,
+    axisValues: FloatArray?,
+    context: RemoteContext,
+): FontVariation.Settings? {
+    if (axisTagIds == null || axisValues == null) return null
+    val axes =
+        axisTagIds.asList().mapIndexedNotNull { index, tagId ->
+            val value = axisValues.getOrNull(index) ?: return@mapIndexedNotNull null
+            context.getText(tagId)?.takeIf { it.isNotBlank() }?.let { FontVariation.Setting(it, value) }
+        }
+    return if (axes.isEmpty()) null else FontVariation.Settings(*axes.toTypedArray())
+}
+
 private fun standardFontFamily(
     fontFamilyType: Int,
     customName: String?,
     weight: FontWeight,
     style: FontStyle,
+    variationSettings: FontVariation.Settings? = null,
 ): FontFamily {
     val name =
         when (fontFamilyType) {
@@ -218,6 +248,7 @@ private fun standardFontFamily(
             family = name,
             weight = weight.weight,
             italic = style == FontStyle.Italic,
+            settings = variationSettings,
         )
         ?.let {
             return it

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerTextLayoutJvm.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerTextLayoutJvm.kt
@@ -222,11 +222,35 @@ private fun fontVariationSettings(
 ): FontVariation.Settings? {
     if (axisTagIds == null || axisValues == null) return null
     val axes =
-        axisTagIds.asList().mapIndexedNotNull { index, tagId ->
+        axisTagIds.asList().mapIndexedNotNull { index, tag ->
             val value = axisValues.getOrNull(index) ?: return@mapIndexedNotNull null
-            context.getText(tagId)?.takeIf { it.isNotBlank() }?.let { FontVariation.Setting(it, value) }
+            axisName(tag, context)?.let { FontVariation.Setting(it, value) }
         }
     return if (axes.isEmpty()) null else FontVariation.Settings(*axes.toTypedArray())
+}
+
+/**
+ * The axis name an [tag] int stands for, in either encoding the format uses.
+ *
+ * A `CoreText` style interns its axis names like any other string, so the int is a **text id** — a
+ * captured `RemoteText` carrying `wght` writes `TextData(44, "wght")` and puts `44` in the array.
+ * The paint bundle's `setTextAxis` op instead carries the **raw OpenType tag** packed into four
+ * bytes (`0x77676874` = `wght`), which is how the baseline players decode that path. Reading the
+ * text table first and falling back to unpacking the bytes covers both without having to know which
+ * writer produced the document; anything that is neither is dropped rather than guessed at.
+ */
+private fun axisName(tag: Int, context: RemoteContext): String? =
+    context.getText(tag)?.takeIf { it.isNotBlank() } ?: packedAxisName(tag)
+
+/**
+ * The four-character axis name packed into [tag]'s bytes (`0x77676874` → `wght`), or null when the
+ * bytes aren't printable ASCII — a small text id, for instance, unpacks to control characters and is
+ * not a tag. Split out (and `internal`) so the unpacking is testable without a `RemoteContext`.
+ */
+internal fun packedAxisName(tag: Int): String? {
+    val packed =
+        CharArray(4) { index -> ((tag shr (24 - index * 8)) and 0xff).toChar() }.concatToString()
+    return packed.takeIf { name -> name.all { it in '!'..'~' } }
 }
 
 private fun standardFontFamily(

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/GoogleFontTypefaceResolver.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/GoogleFontTypefaceResolver.kt
@@ -18,6 +18,7 @@ package ee.schimke.composeai.rcembedded.jvm
 
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontVariation
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.platform.Font
 import ee.schimke.composeai.fonts.google.GoogleFontCache
@@ -64,7 +65,13 @@ internal class GoogleFontTypefaceResolver(private val fonts: GoogleFontSource?) 
    */
   private val files = ConcurrentHashMap<GoogleFontKey, File>()
   private val skiaTypefaces = ConcurrentHashMap<GoogleFontKey, SkiaTypeface>()
-  private val fontFamilies = ConcurrentHashMap<GoogleFontKey, FontFamily>()
+  /**
+   * Resolved families keyed by request *and* axis instance. A variable file serves many instances,
+   * and they are different faces — keying on the request alone would hand a `wght 100` line the
+   * `wght 1000` family the previous line built.
+   */
+  private val fontFamilies =
+    ConcurrentHashMap<Pair<GoogleFontKey, List<Pair<String, Float>>>, FontFamily>()
 
   /**
    * The Compose [FontFamily] for [family] at [weight]/[italic], or null when [family] is not a
@@ -73,25 +80,51 @@ internal class GoogleFontTypefaceResolver(private val fonts: GoogleFontSource?) 
    * One face per family, not a full ramp: the file the cache serves is already the one for this
    * exact `(family, weight, italic)`, so Compose has nothing left to select between — and asking
    * for the weights the document never draws would mean fetches nothing needs.
+   *
+   * [settings] are the document's font-variation axes. A variable file is one file serving many
+   * instances, so they are applied when the face is built rather than selected afterwards: Compose
+   * carries variations on a `Font`, and a family's faces cannot be re-instanced once built.
    */
-  fun composeFontFamily(family: String?, weight: Int, italic: Boolean): FontFamily? {
-    val key = googleFontKey(family, weight, italic) ?: return null
-    fontFamilies[key]?.let {
+  fun composeFontFamily(
+    family: String?,
+    weight: Int,
+    italic: Boolean,
+    settings: FontVariation.Settings? = null,
+  ): FontFamily? {
+    // A `wght` axis also decides *which file to fetch*. Google Fonts serves a named family as a
+    // static instance per weight, so asking for `Roboto Flex` at 400 and then applying `wght 1000`
+    // to it varies nothing — the file has no axes to vary. Reading the axis as the requested weight
+    // fetches the instance the document actually asked for; the settings are still passed through,
+    // so a host that supplies a genuinely variable file (the browser lane's manifest) also gets the
+    // exact instance rather than the nearest static one.
+    val axes = settings?.settings.orEmpty().map { it.axisName to it.toVariationValue(null) }
+    val effectiveWeight =
+      axes.firstOrNull { (tag, _) -> tag == WEIGHT_AXIS }?.second?.toInt()?.coerceIn(1, 1000)
+        ?: weight
+    val key = googleFontKey(family, effectiveWeight, italic) ?: return null
+    val instanceKey = key to axes
+    fontFamilies[instanceKey]?.let {
       return it
     }
     val file = resolveFile(key) ?: return null
+    val style = if (key.italic) FontStyle.Italic else FontStyle.Normal
     val resolved =
       runCatching {
           FontFamily(
-            Font(
-              file = file,
-              weight = FontWeight(key.weight),
-              style = if (key.italic) FontStyle.Italic else FontStyle.Normal,
-            )
+            if (settings == null || settings.settings.isEmpty()) {
+              Font(file = file, weight = FontWeight(key.weight), style = style)
+            } else {
+              Font(
+                file = file,
+                weight = FontWeight(key.weight),
+                style = style,
+                variationSettings = settings,
+              )
+            }
           )
         }
         .getOrNull() ?: return null
-    fontFamilies[key] = resolved
+    fontFamilies[instanceKey] = resolved
     return resolved
   }
 
@@ -127,6 +160,11 @@ internal class GoogleFontTypefaceResolver(private val fonts: GoogleFontSource?) 
     /** The namespace marking a family as one to fetch from Google Fonts. */
     const val GOOGLE_PREFIX = "google:"
 
+    /**
+     * The one axis that also selects a *file*: Google Fonts serves a static instance per weight.
+     */
+    private const val WEIGHT_AXIS = "wght"
+
     /** Negative-cache marker — a request the source could not serve. Never opened. */
     private val NO_FILE = File("")
 
@@ -158,9 +196,18 @@ internal class GoogleFontTypefaceResolver(private val fonts: GoogleFontSource?) 
      * throw away. `compose-preview serve` and the CLI's daemon launchers set the property; the
      * `cmp-jvm` subprocess is handed it by [RcJvmServerRenderer][the cli's cmp-jvm launcher].
      */
-    val Default: GoogleFontTypefaceResolver by lazy {
+    private val systemPropertyDefault: GoogleFontTypefaceResolver by lazy {
       GoogleFontTypefaceResolver(systemPropertyGoogleFontSource())
     }
+
+    /**
+     * Overrides [Default] for a test that must resolve hermetically (a vendored face, no network).
+     * Null — always, in production — restores the system-property-configured resolver.
+     */
+    internal var testOverride: GoogleFontTypefaceResolver? = null
+
+    val Default: GoogleFontTypefaceResolver
+      get() = testOverride ?: systemPropertyDefault
 
     private fun systemPropertyGoogleFontSource(): GoogleFontSource? {
       val cacheDir = System.getProperty("composeai.fonts.cacheDir")?.takeIf { it.isNotBlank() }

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmFontAxisTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmFontAxisTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded.jvm
+
+import androidx.compose.ui.text.font.FontVariation
+import ee.schimke.composeai.fonts.google.GoogleFontKey
+import ee.schimke.composeai.fonts.google.GoogleFontSource
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+
+/**
+ * A variable font's axes reach the family the jvm player draws with.
+ *
+ * The resolver is asked for the same face twice at different `wdth` instances: those are two
+ * different faces of one file, so they must be two different `FontFamily` objects. Handing the
+ * second request the first's family — which is what a cache keyed on `(family, weight, italic)`
+ * alone does — is exactly how a `wght` ramp ends up drawing every line at the first weight it saw.
+ *
+ * Hermetic: the [GoogleFontSource] is faked over the repo's vendored Roboto Flex, so nothing is
+ * fetched. (`RcFontAxisRenderTest` in `:rc-player-compose` measures the *rendered* ink for the same
+ * claim; this one pins the resolver's own contract.)
+ */
+class RcJvmFontAxisTest {
+
+  private class FakeFonts(private val file: File) : GoogleFontSource {
+    var loads = 0
+    val requested = mutableListOf<GoogleFontKey>()
+
+    override fun load(key: GoogleFontKey): File? {
+      loads++
+      requested += key
+      return file
+    }
+  }
+
+  @Test
+  fun `each axis instance is its own family, and the file is fetched once`() {
+    val face = File(VARIABLE_FACE_PATH)
+    assumeTrue("vendored Roboto Flex not found at $VARIABLE_FACE_PATH", face.isFile)
+    val fonts = FakeFonts(face)
+    val resolver = GoogleFontTypefaceResolver(fonts)
+
+    val narrow = resolver.composeFontFamily("google:Roboto Flex", 400, false, width(25f))
+    val wide = resolver.composeFontFamily("google:Roboto Flex", 400, false, width(151f))
+    val narrowAgain = resolver.composeFontFamily("google:Roboto Flex", 400, false, width(25f))
+
+    assertNotNull("a served file must produce a family", narrow)
+    assertNotEquals("wdth 25 and wdth 151 are different faces of one file", narrow, wide)
+    assertSame("a repeated axis instance is served from the cache", narrow, narrowAgain)
+    // One file, however many instances: the (possibly network-backed) source is asked once.
+    assertNotNull(wide)
+    assert(fonts.loads == 1) {
+      "expected one fetch for three instance requests, got ${fonts.loads}"
+    }
+  }
+
+  @Test
+  fun `no axes resolves to the plain family`() {
+    val face = File(VARIABLE_FACE_PATH)
+    assumeTrue("vendored Roboto Flex not found at $VARIABLE_FACE_PATH", face.isFile)
+    val resolver = GoogleFontTypefaceResolver(FakeFonts(face))
+
+    val plain = resolver.composeFontFamily("google:Roboto Flex", 400, false)
+    val alsoPlain =
+      resolver.composeFontFamily("google:Roboto Flex", 400, false, FontVariation.Settings())
+
+    assertNotNull(plain)
+    assertSame("an empty axis set is the same request as none", plain, alsoPlain)
+    assertNotEquals(plain, resolver.composeFontFamily("google:Roboto Flex", 400, false, width(25f)))
+  }
+
+  @Test
+  fun `a wght axis selects which instance is fetched`() {
+    // Google Fonts serves a named family as a static instance *per weight*, so an axis request has
+    // to reach the fetch as well as the face: asking for the 400 file and then applying `wght 700`
+    // to it varies nothing, because that file has no axes. The document's own `fontWeight` stays at
+    // its default while the axis carries the intent, which is why the axis has to win here.
+    val face = File(VARIABLE_FACE_PATH)
+    assumeTrue("vendored Roboto Flex not found at $VARIABLE_FACE_PATH", face.isFile)
+    val fonts = FakeFonts(face)
+    val resolver = GoogleFontTypefaceResolver(fonts)
+
+    resolver.composeFontFamily(
+      "google:Orbitron",
+      weight = 400,
+      italic = false,
+      settings = FontVariation.Settings(FontVariation.weight(700)),
+    )
+
+    assertEquals(listOf(GoogleFontKey("Orbitron", 700, false)), fonts.requested)
+  }
+
+  private fun width(value: Float) = FontVariation.Settings(FontVariation.width(value))
+
+  private companion object {
+    /**
+     * The wasm catalog's vendored variable face, read from the repo rather than copied — the same
+     * file the browser lane serves, so every lane's axis behaviour is measured against one font.
+     * Relative to this module's directory, which is a Gradle `Test` task's working directory.
+     */
+    const val VARIABLE_FACE_PATH =
+      "../../samples/cmp-wasm-catalog/src/wasmJsMain/resources/fonts/RobotoFlex.ttf"
+  }
+}

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmFontAxisTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmFontAxisTest.kt
@@ -16,6 +16,7 @@
 
 package ee.schimke.composeai.rcembedded.jvm
 
+import androidx.compose.remote.player.compose.embedded.packedAxisName
 import androidx.compose.ui.text.font.FontVariation
 import ee.schimke.composeai.fonts.google.GoogleFontKey
 import ee.schimke.composeai.fonts.google.GoogleFontSource
@@ -107,6 +108,18 @@ class RcJvmFontAxisTest {
     )
 
     assertEquals(listOf(GoogleFontKey("Orbitron", 700, false)), fonts.requested)
+  }
+
+  @Test
+  fun `a raw OpenType tag unpacks to its axis name, a text id does not`() {
+    // Two encodings reach the seam: a `CoreText` style interns its axis names, so the int is a text
+    // id; the paint bundle's `setTextAxis` carries the raw four-byte tag. Unpacking must answer for
+    // the second without claiming the first — a small id's bytes are control characters, not a
+    // name.
+    assertEquals("wght", packedAxisName(0x77676874))
+    assertEquals("wdth", packedAxisName(0x77647468))
+    assertEquals(null, packedAxisName(44))
+    assertEquals(null, packedAxisName(0))
   }
 
   private fun width(value: Float) = FontVariation.Settings(FontVariation.width(value))


### PR DESCRIPTION
Fourth of the per-lane PRs behind the typeface specimens (#3329) — the **cmp-jvm** lane's axis half (its typeface half was #3327).

The jvm player read a `CoreText` op's family and ignored the axis arrays beside it, so a document asking for `wght 1000` drew the family's default instance. The layout seam now turns those arrays into a Compose `FontVariation.Settings` and the resolver instances the face at them:

- axis **tags arrive as text ids**, so each is resolved through the document before it is paired with its value;
- an axis counts only when *both* halves are present — pairing a tag with a neighbour's value would draw a real face at silently the wrong instance, which is worse than dropping it;
- families are cached **per axis set**, not per family: a variable file serves many instances and they are different faces, so a cache keyed on `(family, weight, italic)` alone hands a `wght 100` line the `wght 1000` family the previous line built;
- a `wght` axis additionally decides **which file to fetch**, because Google Fonts serves a named family as a static instance per weight and the document's own `fontWeight` stays at its default while the axis carries the intent.

## What this does *not* fix, and why

The catalog's variable specimens still draw flat in this lane, and the reason is upstream of the player. `:data-fonts-google` asks the CSS API with a legacy user-agent to get a `.ttf` at all (Skia and Android can't parse the modern woff2 response), and for a variable-*only* family like Roboto Flex that response is a **static default instance with no `fvar` table** — verified by parsing the downloaded file: `has fvar: False`, and the wght@100 / wght@1000 downloads are byte-identical. There are no axes left in the file to vary.

So this PR is the plumbing being correct, not the specimen turning colourful: a host that supplies a real variable file (the browser lane's manifest does) gets true instancing through this same code, and fetching the variable file from Google means decompressing woff2 — a `:data-fonts-google` change, called out in the audit doc as the next step. I'd rather land the correct plumbing with the blocker named than leave the axes silently dropped.

## Test plan

- [x] `:third-party-rc-embedded-player-jvm:test` — new `RcJvmFontAxisTest`: two `wdth` instances of one file are two different families (and the source is asked once, not per instance); a repeated instance is served from the cache; an empty axis set is the same request as none; a `wght` axis selects which instance is fetched (`GoogleFontKey("Orbitron", 700, …)` from a document whose own weight is 400). Hermetic — the `GoogleFontSource` is faked over the repo's vendored Roboto Flex.
- [x] Full `:third-party-rc-embedded-player-jvm:test` suite and `./gradlew ktfmtCheckAll`.
- [x] End-to-end through `RcJvmRenderHarness` on the three catalog specimens: the four `wght` instances are now fetched as four separate cache entries (`roboto-flex-100/400/700/1000.ttf`) where before only the 400 file was requested — which is how the static-instance limit above was found.

Docs: `docs/design/RC_PLAYER_TYPEFACES.md` matrix + CMP JVM section.

Remaining: `cmp-android` (verify its axis path against the specimens) and `js` (inline `FontData`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtpQQWqQvxXcucxvvurfkd)_