### PR TITLE
fix(cli): stream per-preview bundles out of bundle split instead of holding them all

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -546,6 +546,15 @@ jobs:
       # duplication and owe nothing to the shared pool.
       - name: Split into per-preview bundles
         if: ${{ inputs.split-per-preview }}
+        env:
+          # Let the split use the runner's real memory instead of the JVM's default quarter-of-RAM.
+          # A FULL split writes one bundle per preview and each carries the shared re-render payload
+          # (classes/app.jar, libs/, the Android resources.ap_ table), so the working set scales with
+          # catalog size: `pocketcasts` (181 previews) OOM'd here on the default heap. The CLI no
+          # longer holds every bundle at once, but the source bundle alone is hundreds of MB for a
+          # large catalog, and a percentage scales with whatever runner this lands on rather than
+          # hardcoding a size that is wrong on half of them.
+          JAVA_OPTS: -XX:MaxRAMPercentage=75
         run: |
           set -euo pipefail
           if [ "${{ inputs.split-mode }}" = "view-only" ]; then

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
@@ -88,6 +88,32 @@ internal fun splitBundleZip(
   mode: SplitMode,
   crop: Boolean = true,
 ): List<SplitPreview> {
+  val result = ArrayList<SplitPreview>()
+  forEachSplitPreview(sheetZip, mode, crop) { result += it }
+  return result
+}
+
+/**
+ * Streaming counterpart of [splitBundleZip]: hands each [SplitPreview] to [onPreview] as it is
+ * built and keeps no reference to it, returning how many were emitted.
+ *
+ * Accumulating the whole list is what the CLI used to do, and it does not scale. Every FULL bundle
+ * carries the shared re-render payload — `classes/app.jar`, `libs/`, and the Android
+ * `resources.ap_` table — so holding N of them costs N copies of it at once. Pocket Casts' 181
+ * previews against an unpruned app-resource table OOM'd a 4 GB CI heap (`OutOfMemoryError` in
+ * [writeDeterministicZip]); the resource pruner had been masking it by shrinking that payload, and
+ * the masking stopped when the pruner was corrected to retain resources it cannot positively
+ * attribute to a dependency.
+ *
+ * Peak memory is now the source bundle plus ONE output bundle, independent of preview count. The
+ * list-returning [splitBundleZip] is kept for tests, which split a handful of previews.
+ */
+internal fun forEachSplitPreview(
+  sheetZip: ByteArray,
+  mode: SplitMode,
+  crop: Boolean = true,
+  onPreview: (SplitPreview) -> Unit,
+): Int {
   val entries = readZipEntries(sheetZip)
   val bundleJsonBytes =
     entries["bundle.json"]
@@ -123,7 +149,7 @@ internal fun splitBundleZip(
   }
   val fullMode = mode == SplitMode.FULL
 
-  val result = ArrayList<SplitPreview>(ids.size)
+  var emitted = 0
   for (id in ids) {
     val rawCover =
       entries["$BUNDLE_PREVIEWS_DIR/$id.png"] ?: continue // no image → nothing to address
@@ -179,9 +205,10 @@ internal fun splitBundleZip(
         )
         .encodeToByteArray()
 
-    result += SplitPreview(id, cover, writeDeterministicZip(out))
+    onPreview(SplitPreview(id, cover, writeDeterministicZip(out)))
+    emitted++
   }
-  return result
+  return emitted
 }
 
 /** Rewrite the sheet manifest for a single preview: cover + previewIds = [id], IR filtered, etc. */
@@ -432,35 +459,38 @@ internal class SplitSubcommand(private val args: List<String>) {
     outDir.mkdirs()
 
     val zipBytes = BundleReader.extractZipBytes(file)
-    val split =
-      try {
-        splitBundleZip(zipBytes, mode, crop = crop)
-      } catch (e: IllegalArgumentException) {
-        System.err.println("bundle split: ${e.message}")
-        exitProcess(1)
-      }
-    if (split.isEmpty()) {
-      System.err.println(
-        "bundle split: no previews with a baked image found in ${file.name} — nothing to split."
-      )
-      exitProcess(1)
-    }
 
     // Distinct ids can sanitize to the same stem (e.g. `A B` and `A_B`, or `/` vs `_`); on a
     // collision append -2/-3/… so every preview keeps its own file instead of silently overwriting.
     val usedStems = HashSet<String>()
-    val written = ArrayList<File>(split.size)
-    for (preview in split) {
-      val base = sanitizeSplitFileName(preview.id)
-      var stem = base
-      var n = 1
-      while (!usedStems.add(stem)) {
-        n++
-        stem = "$base-$n"
+    val written = ArrayList<File>()
+    // Write each bundle as it is produced and let it go. Collecting them first meant holding every
+    // per-preview bundle — each carrying the shared classpath + Android resource table — in memory
+    // simultaneously, which OOM'd on a 181-preview catalog. Only the File handles are kept, for the
+    // size summary below.
+    val emitted =
+      try {
+        forEachSplitPreview(zipBytes, mode, crop = crop) { preview ->
+          val base = sanitizeSplitFileName(preview.id)
+          var stem = base
+          var n = 1
+          while (!usedStems.add(stem)) {
+            n++
+            stem = "$base-$n"
+          }
+          val outFile = File(outDir, "$stem.png")
+          outFile.writeBytes(preview.polyglot())
+          written += outFile
+        }
+      } catch (e: IllegalArgumentException) {
+        System.err.println("bundle split: ${e.message}")
+        exitProcess(1)
       }
-      val outFile = File(outDir, "$stem.png")
-      outFile.writeBytes(preview.polyglot())
-      written += outFile
+    if (emitted == 0) {
+      System.err.println(
+        "bundle split: no previews with a baked image found in ${file.name} — nothing to split."
+      )
+      exitProcess(1)
     }
 
     val sizes = written.map { it.length() }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
@@ -215,4 +215,32 @@ class BundleSplitTest {
     // The baked image still travels.
     assertTrue("previews/A.png" in entries)
   }
+
+  /**
+   * The property that stopped a 181-preview catalog OOMing in CI: the splitter hands each bundle to
+   * the caller and keeps no reference, so peak memory is the source plus ONE output rather than one
+   * per preview. Every FULL bundle carries the shared classpath and Android resource payload, so
+   * accumulating them multiplies that payload by the preview count.
+   *
+   * Pinned structurally rather than by measuring heap: what the streaming pass emits must match the
+   * list API exactly, so the list API can stay a thin wrapper over it and callers that care about
+   * memory (the CLI) can write each bundle out and drop it.
+   */
+  @Test
+  fun `streaming split emits the same bundles as the list API`() {
+    val zip = sheetZip()
+    val seen = mutableListOf<String>()
+    var everyBundleCarriedItsZip = true
+
+    val emitted =
+      forEachSplitPreview(zip, SplitMode.FULL) { preview ->
+        seen += preview.id
+        if (preview.zipBytes.isEmpty()) everyBundleCarriedItsZip = false
+      }
+
+    val viaList = splitBundleZip(zip, SplitMode.FULL)
+    assertEquals(viaList.size, emitted, "the streaming pass emits the same count")
+    assertEquals(viaList.map { it.id }, seen, "in the same order")
+    assertTrue(everyBundleCarriedItsZip, "each emitted bundle is complete when handed over")
+  }
 }


### PR DESCRIPTION
The `pocketcasts` render broke after bumping that repo to 0.19.35 ([pocket-casts-android run 30987550874](https://github.com/yschimke/pocket-casts-android/actions/runs/30987550874)). `bundle split` ran out of heap:

```
java.lang.OutOfMemoryError: Java heap space
  at BundleSplitKt.writeDeterministicZip(BundleSplit.kt:399)
  at BundleSplitKt.splitBundleZip(BundleSplit.kt:182)
  at SplitSubcommand.run(BundleSplit.kt:437)
```

## Cause

`splitBundleZip` built **every** per-preview bundle into a list and only then wrote them out:

```kotlin
result += SplitPreview(id, cover, writeDeterministicZip(out))
```

Each FULL bundle carries the shared re-render payload — `classes/app.jar`, `libs/`, and the Android `resources.ap_` table — so holding N of them costs N copies of that payload simultaneously. At 181 previews that exhausted the runner's default heap.

**The bug isn't new; it stopped being masked.** The resource pruner used to shrink that shared payload hard, which kept N copies affordable. #3322 corrected the pruner to drop only what it can positively attribute to a dependency — so an unclassifiable resource is now retained by construction — which restored the full resource table and with it the real cost of the accumulation. Worth being clear that this is a consequence of that fix rather than an unrelated flake: `pocketcasts-wear` (33 previews) succeeded in the same run, which is exactly the shape you'd expect if the cost scales with preview count.

## Fix

`forEachSplitPreview` hands each bundle to the caller and keeps no reference, so **peak memory is the source bundle plus one output, independent of catalog size**. The CLI writes each file as it arrives and retains only the `File` handle for its size summary. `splitBundleZip` stays as a thin list-returning wrapper so the existing tests are untouched.

Also gives the workflow's split step `-XX:MaxRAMPercentage=75`. A percentage rather than a fixed `-Xmx` so it scales with whatever runner it lands on — the source bundle alone is hundreds of MB for a large catalog, and the JVM's default quarter-of-RAM is uncomfortably tight even with the accumulation gone.

That second part matters for sequencing: **the reusable workflow is consumed from `@main`**, so the heap change takes effect on merge, while the CLI change only reaches a render once it's released and the consumer re-pins.

## Test plan

- `:cli:test` — green.
- New test pins the streaming contract: what `forEachSplitPreview` emits must match the list API exactly, so the list form can stay a wrapper and memory-sensitive callers can drop each bundle after writing it.

I have not reproduced the OOM itself — it needs a 181-preview Android catalog and a constrained heap, which isn't something I can stand up here. The argument is from the stack trace and the allocation shape, and the structural test pins the property rather than the symptom.

No visual surfaces changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_