### PR TITLE
feat(daemon): give render/trace real phase spans and reach recomposition from ordinary renders

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -1061,6 +1061,9 @@ class RenderEngine(
       metrics = metrics,
       previewContext = previewContext,
       outputBaseName = spec.outputBaseName,
+      // Phase timings for `render/trace` v2. Taken here, after the last section closed, so it
+      // covers classloading, composable resolution, setContent, the clock advance and the capture.
+      trace = trace.renderTrace(),
     )
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.RenderTrace
 import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import java.util.concurrent.atomic.AtomicLong
 
@@ -334,6 +335,13 @@ sealed interface RenderRequest {
  * [outputBaseName] is the concrete artifact identity selected by the renderer. It can differ from
  * the protocol preview id when one discovered function expands into multiple annotation or catalog
  * variants; file-backed products use it to resolve the artifact produced by this exact render.
+ *
+ * [trace] carries the phase timings the engine's own `trace.section(...)` calls recorded — what
+ * `render/trace` v2 reports. It rides on the result rather than through a process-global the
+ * registry reads, because the recorder is created per render deep inside the engine and the result
+ * is the channel that already runs from there to the daemon. Null from hosts that don't run a
+ * recorder (the harness fake, sandbox-worker replies), which is exactly when `render/trace` falls
+ * back to its v1 single-phase shape over `metrics["tookMs"]`.
  */
 data class RenderResult(
   val id: Long,
@@ -343,4 +351,5 @@ data class RenderResult(
   val metrics: Map<String, Long>? = null,
   val previewContext: PreviewContext? = null,
   val outputBaseName: String? = null,
+  val trace: RenderTrace? = null,
 )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -269,6 +269,16 @@ fun runDaemon(
             extensions.isActive("data/theme") && themeRegistry.shouldCapture(previewId, renderMode)
         },
       previewOverrideExtensions = extensions.activeOverrideExtensions(),
+      // Lets `compose/recomposition` instrument an *ordinary* render, not only a held interactive
+      // session — the engine announces each scene before it composes, which is the only moment the
+      // observer can be installed in time to see the initial composition. Gated on the extension
+      // being active so an untoggled panel pays nothing: the registry's own subscribe bookkeeping
+      // decides whether to attach an observer, and with no subscription this is a map write.
+      sceneLifecycleListener = { previewId, scene ->
+        if (extensions.isActive("data/recomposition")) {
+          recompositionRegistry.onSessionLifecycle(previewId, scene)
+        }
+      },
     )
 
   // `composeai.harness.previewsManifest` is set unconditionally by the gradle plugin for production

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -119,6 +119,22 @@ class RenderEngine(
   private val frameNanoTime: () -> Long = System::nanoTime,
   private val fileSystem: FileSystem = SystemFileSystem,
   /**
+   * Scene lifecycle hook — fires with the freshly allocated [ImageComposeScene] **before**
+   * `setContent` composes into it, and again with `null` at tearDown.
+   *
+   * This exists so `compose/recomposition` can answer for an ordinary render. That producer
+   * instruments a scene's `Recomposer`, and until now the only scene it could reach was the one a
+   * *live interactive session* held (`DesktopHost.InteractiveSessionListener`), so recomposition
+   * counts were unavailable for the plain render path — which is the path almost every preview
+   * takes. The install has to happen before `setContent` or the initial composition, the very thing
+   * worth counting, has already run by the time the observer attaches.
+   *
+   * Deliberately a plain function type rather than `DesktopHost.InteractiveSessionListener`: the
+   * engine has no business knowing about interactive sessions, and the two callers converge on the
+   * same producer method anyway. Null (the default) keeps every test's behaviour.
+   */
+  private val sceneLifecycleListener: ((String, ImageComposeScene?) -> Unit)? = null,
+  /**
    * Always-on post-capture data-artifact extensions, mirroring the Android engine's
    * `builtDataArtifactExtensions` seam. Each [PostCaptureProcessor] runs after the PNG capture,
    * reading the [RenderArtifactContextKeys] the engine populates. Defaults to the portable
@@ -196,14 +212,20 @@ class RenderEngine(
       trace.section("compose:setUp") {
         setUp(spec, classLoader, inspectionMode = spec.inspectionMode ?: true, trace = trace)
       }
-    try {
-      return trace.section("render:once") {
-        renderOnce(state, requestId, sandboxStats = sandboxStats, trace = trace)
+    val result =
+      try {
+        trace.section("render:once") {
+          renderOnce(state, requestId, sandboxStats = sandboxStats, trace = trace)
+        }
+      } finally {
+        trace.section("compose:tearDown") { tearDown(state) }
+        trace.write(dataDir)
       }
-    } finally {
-      trace.section("compose:tearDown") { tearDown(state) }
-      trace.write(dataDir)
-    }
+    // Re-stamp the trace here rather than taking `renderOnce`'s: `finally` has run by now, so this
+    // snapshot is the only one that includes `compose:setUp`, `render:once` and `compose:tearDown`.
+    // `renderOnce` still stamps its own, which is what the interactive session (which calls it
+    // directly, once per input) reports.
+    return result.copy(trace = trace.renderTrace())
   }
 
   /**
@@ -375,6 +397,19 @@ class RenderEngine(
     // interactive/recording
     // session leak its locale onto every other render in the same daemon until it closed;
     // [renderOnce] re-applies it around each frame instead. See [overrideJvmDefaultLocale].
+    // Announce the scene before anything composes into it — see [sceneLifecycleListener]. Guarded
+    // because a producer-side failure must never fail the render it is only observing.
+    val lifecyclePreviewId = spec.previewId
+    if (sceneLifecycleListener != null && lifecyclePreviewId != null) {
+      try {
+        sceneLifecycleListener.invoke(lifecyclePreviewId, scene)
+      } catch (t: Throwable) {
+        System.err.println(
+          "RenderEngine: scene lifecycle listener failed for $lifecyclePreviewId: " +
+            "${t.javaClass.simpleName}: ${t.message}"
+        )
+      }
+    }
     val previousDefaultLocale = overrideJvmDefaultLocale(effectiveLocaleTag(spec.localeTag))
     try {
       trace.section("compose:setContent") {
@@ -783,6 +818,10 @@ class RenderEngine(
       metrics = metrics,
       previewContext = previewContext,
       outputBaseName = state.spec.outputBaseName,
+      // The interactive session calls this directly, once per input, and never goes through
+      // `render`'s setUp/tearDown wrapper — so this is the trace that path reports. The one-shot
+      // `render` overwrites it with a wider snapshot that also covers setUp and tearDown.
+      trace = trace.renderTrace(),
     )
   }
 
@@ -866,6 +905,15 @@ class RenderEngine(
    */
   fun tearDown(state: SceneState) {
     try {
+      val previewId = state.spec.previewId
+      if (sceneLifecycleListener != null && previewId != null) {
+        try {
+          sceneLifecycleListener.invoke(previewId, null)
+        } catch (_: Throwable) {
+          // Already reported at install time; a teardown failure has nowhere useful to go and must
+          // not stop the scene from closing.
+        }
+      }
       state.scene.close()
     } finally {
       Thread.currentThread().contextClassLoader = state.previousContext

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTraceTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTraceTest.kt
@@ -1,0 +1,103 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.ImageComposeScene
+import java.util.concurrent.CopyOnWriteArrayList
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The two seams that make the advanced performance surface work:
+ * - `RenderResult.trace` — real phase spans, which `render/trace` v2 reports;
+ * - `sceneLifecycleListener` — the hook that lets `compose/recomposition` instrument an ordinary
+ *   render rather than only a held interactive session.
+ *
+ * Both are asserted against a real Compose Desktop render, because both are about *when* things
+ * happen relative to composition and a fake host can't tell you that.
+ */
+class RenderEngineTraceTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private fun redSquareSpec(outputBaseName: String) =
+    RenderSpec(
+      previewId = "ee.schimke.composeai.daemon.RedFixturePreviewsKt.RedSquare",
+      className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+      functionName = "RedSquare",
+      widthPx = 64,
+      heightPx = 64,
+      density = 1.0f,
+      showBackground = true,
+      outputBaseName = outputBaseName,
+    )
+
+  @Test
+  fun `a render carries its own phase spans`() {
+    val engine = RenderEngine(outputDir = tempFolder.newFolder("renders"))
+
+    val result = engine.render(redSquareSpec("trace-spans"), requestId = 1L)
+
+    val trace = result.trace
+    assertNotNull("a desktop render must carry phase spans for render/trace v2", trace)
+    assertEquals("desktop", trace!!.backend)
+    val names = trace.spans.map { it.name }
+    // The three phases the one-shot wrapper owns. Their presence is what proves the trace is
+    // snapshotted after `finally`, not from inside `renderOnce` — `compose:tearDown` runs there.
+    assertTrue("expected compose:setUp in $names", "compose:setUp" in names)
+    assertTrue("expected render:once in $names", "render:once" in names)
+    assertTrue("expected compose:tearDown in $names", "compose:tearDown" in names)
+    // …and at least one phase nested inside `render:once`, which is the structure v1 could not
+    // express at all.
+    assertTrue("expected a nested phase in $names", trace.spans.any { it.depth > 0 })
+    assertTrue("total time must be positive", trace.totalMicros > 0)
+    assertEquals(
+      "every span must be accounted for in the aggregates",
+      trace.spans.size,
+      trace.sections.sumOf { it.count },
+    )
+  }
+
+  @Test
+  fun `the scene is announced before composition and released at teardown`() {
+    // `compose/recomposition` installs a CompositionObserver on the scene's recomposer. Installing
+    // after `setContent` would miss the initial composition — the very thing worth counting — so
+    // the ordering here is the contract, not an implementation detail.
+    val events = CopyOnWriteArrayList<Pair<String, Boolean>>()
+    var sceneAtAnnounce: ImageComposeScene? = null
+    val engine =
+      RenderEngine(
+        outputDir = tempFolder.newFolder("renders"),
+        sceneLifecycleListener = { previewId, scene ->
+          events += previewId to (scene != null)
+          if (scene != null) sceneAtAnnounce = scene
+        },
+      )
+
+    engine.render(redSquareSpec("trace-lifecycle"), requestId = 1L)
+
+    assertEquals(
+      listOf(
+        "ee.schimke.composeai.daemon.RedFixturePreviewsKt.RedSquare" to true,
+        "ee.schimke.composeai.daemon.RedFixturePreviewsKt.RedSquare" to false,
+      ),
+      events.toList(),
+    )
+    assertNotNull("the listener must be handed the live scene, not null", sceneAtAnnounce)
+  }
+
+  @Test
+  fun `a listener that throws cannot fail the render it is observing`() {
+    val engine =
+      RenderEngine(
+        outputDir = tempFolder.newFolder("renders"),
+        sceneLifecycleListener = { _, _ -> error("producer blew up") },
+      )
+
+    val result = engine.render(redSquareSpec("trace-listener-throws"), requestId = 1L)
+
+    assertNotNull("the render must still produce a PNG", result.pngPath)
+  }
+}

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/PerfettoTraceDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/PerfettoTraceDataProduct.kt
@@ -23,6 +23,8 @@ typealias TraceMetadata = ee.schimke.composeai.data.render.TraceMetadata
 
 typealias TracePayload = ee.schimke.composeai.data.render.TracePayload
 
+typealias RenderTrace = ee.schimke.composeai.data.render.RenderTrace
+
 object PerfettoTraceDataProducer {
   const val KIND: String = ee.schimke.composeai.data.render.PerfettoTraceDataProducer.KIND
   const val SCHEMA_VERSION: Int =
@@ -56,9 +58,24 @@ object PerfettoTraceDataProducer {
     fun <T> section(name: String, category: String = "compose-preview", block: () -> T): T =
       delegate.section(name = name, category = category, block = block)
 
-    fun record(name: String, category: String = "compose-preview", startNs: Long, endNs: Long) {
-      delegate.record(name = name, category = category, startNs = startNs, endNs = endNs)
+    fun record(
+      name: String,
+      category: String = "compose-preview",
+      startNs: Long,
+      endNs: Long,
+      depth: Int = 0,
+    ) {
+      delegate.record(
+        name = name,
+        category = category,
+        startNs = startNs,
+        endNs = endNs,
+        depth = depth,
+      )
     }
+
+    /** Structured phase timings for `RenderResult.trace` — see [RenderTrace]. */
+    fun renderTrace(): RenderTrace = delegate.renderTrace()
 
     fun payload(): TracePayload = delegate.payload()
 

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProduct.kt
@@ -11,10 +11,13 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonElement
 
 /**
- * `render/trace` v1 backed by the latest host render metrics.
+ * `render/trace` v2 backed by the latest host render: the engine's recorded phase spans, with the
+ * render metrics alongside.
  *
  * The payload builder lives in `:data-render-core`; this class only adapts it to the daemon
- * registry surface.
+ * registry surface. A result with no [RenderResult.trace] still produces a payload — the v1
+ * single-phase shape over `tookMs` — so hosts that don't run a recorder degrade rather than
+ * disappear.
  */
 class RenderTraceDataProductRegistry : DataProductRegistry {
 
@@ -37,10 +40,11 @@ class RenderTraceDataProductRegistry : DataProductRegistry {
 
   override fun onRender(previewId: String, result: RenderResult) {
     val metrics = result.metrics
-    if (metrics == null) {
+    if (metrics == null && result.trace == null) {
       latestPayloads.remove(previewId)
     } else {
-      latestPayloads[previewId] = RenderTraceDataProduct.payloadFrom(metrics)
+      latestPayloads[previewId] =
+        RenderTraceDataProduct.payloadFrom(metrics.orEmpty(), result.trace)
     }
   }
 

--- a/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProductRegistryTest.kt
+++ b/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProductRegistryTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.RenderTrace
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -16,7 +17,7 @@ class RenderTraceDataProductRegistryTest {
 
     val cap = registry.capabilities.single()
     assertEquals(RenderTraceDataProductRegistry.KIND, cap.kind)
-    assertEquals(1, cap.schemaVersion)
+    assertEquals(2, cap.schemaVersion)
     assertEquals(DataProductTransport.INLINE, cap.transport)
     assertTrue(cap.attachable)
     assertTrue(cap.fetchable)
@@ -70,6 +71,127 @@ class RenderTraceDataProductRegistryTest {
     assertEquals("0", renderPhase["startMs"]!!.jsonPrimitive.content)
     assertEquals("42", renderPhase["durationMs"]!!.jsonPrimitive.content)
     assertEquals("9", payload["metrics"]!!.jsonObject["heapAfterGcMb"]!!.jsonPrimitive.content)
+    // v2 tells the client which shape it got rather than making it infer from `phases.size == 1`.
+    assertEquals("metrics", payload["source"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `onRender projects engine spans into real phases and sections`() {
+    val registry = RenderTraceDataProductRegistry()
+    val originNanos = 5_000_000L
+    registry.onRender(
+      previewId = "preview",
+      result =
+        RenderResult(
+          id = 1L,
+          classLoaderHashCode = 2,
+          classLoaderName = "test",
+          metrics = mapOf("tookMs" to 12L),
+          trace =
+            RenderTrace.of(
+              backend = "desktop",
+              events =
+                listOf(
+                  // `render:once` encloses two `compose:frame` passes — the nesting and the repeat
+                  // are the two things v1 could not express at all.
+                  RenderTrace.Recorded(
+                    "render:once",
+                    "compose-preview",
+                    originNanos,
+                    originNanos + 9_000_000L,
+                    depth = 0,
+                  ),
+                  RenderTrace.Recorded(
+                    "compose:frame",
+                    "compose-preview",
+                    originNanos + 1_000_000L,
+                    originNanos + 3_000_000L,
+                    depth = 1,
+                  ),
+                  RenderTrace.Recorded(
+                    "compose:frame",
+                    "compose-preview",
+                    originNanos + 4_000_000L,
+                    originNanos + 8_000_000L,
+                    depth = 1,
+                  ),
+                ),
+            ),
+        ),
+    )
+
+    val outcome =
+      registry.fetch(
+        previewId = "preview",
+        kind = RenderTraceDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+
+    assertEquals("spans", payload["source"]!!.jsonPrimitive.content)
+    assertEquals("desktop", payload["backend"]!!.jsonPrimitive.content)
+
+    val phases = payload["phases"] as JsonArray
+    assertEquals(3, phases.size)
+    assertEquals("render:once", phases[0].jsonObject["name"]!!.jsonPrimitive.content)
+    assertEquals("0", phases[0].jsonObject["depth"]!!.jsonPrimitive.content)
+    assertEquals("1", phases[1].jsonObject["depth"]!!.jsonPrimitive.content)
+    // Microseconds sit alongside the v1 millisecond fields; a 2ms phase must not round to nothing.
+    assertEquals("1000", phases[1].jsonObject["startUs"]!!.jsonPrimitive.content)
+    assertEquals("2000", phases[1].jsonObject["durationUs"]!!.jsonPrimitive.content)
+
+    val sections = payload["sections"] as JsonArray
+    val frame =
+      sections
+        .map { it.jsonObject }
+        .single { s -> s["name"]!!.jsonPrimitive.content == "compose:frame" }
+    assertEquals("2", frame["count"]!!.jsonPrimitive.content)
+    assertEquals("6000", frame["totalUs"]!!.jsonPrimitive.content)
+    assertEquals("3000", frame["meanUs"]!!.jsonPrimitive.content)
+    assertEquals("4000", frame["maxUs"]!!.jsonPrimitive.content)
+
+    // v1 fields keep their v1 meaning so a v1 client reads the same numbers it always did.
+    assertEquals("12", payload["totalMs"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `a render with spans but no metrics still reports a trace`() {
+    val registry = RenderTraceDataProductRegistry()
+    registry.onRender(
+      previewId = "preview",
+      result =
+        RenderResult(
+          id = 1L,
+          classLoaderHashCode = 2,
+          classLoaderName = "test",
+          trace =
+            RenderTrace.of(
+              backend = "android",
+              events =
+                listOf(
+                  RenderTrace.Recorded(
+                    "render:captureRoboImage",
+                    "compose-preview",
+                    0L,
+                    2_000_000L,
+                    0,
+                  )
+                ),
+            ),
+        ),
+    )
+
+    val outcome =
+      registry.fetch(
+        previewId = "preview",
+        kind = RenderTraceDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+    assertEquals("spans", payload["source"]!!.jsonPrimitive.content)
+    assertEquals("0", payload["totalMs"]!!.jsonPrimitive.content)
   }
 
   @Test
@@ -90,7 +212,7 @@ class RenderTraceDataProductRegistryTest {
       registry.attachmentsFor("preview", setOf(RenderTraceDataProductRegistry.KIND)).single()
 
     assertEquals(RenderTraceDataProductRegistry.KIND, attachment.kind)
-    assertEquals(1, attachment.schemaVersion)
+    assertEquals(2, attachment.schemaVersion)
     assertNull(attachment.path)
     assertEquals("17", attachment.payload!!.jsonObject["totalMs"]!!.jsonPrimitive.content)
   }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
@@ -68,6 +68,28 @@ object PerfettoTraceDataProducer {
     private val originNs: Long = System.nanoTime()
     private val events = mutableListOf<TraceEvent>()
 
+    /**
+     * Closed sections, always collected — this is what [renderTrace] turns into the `render/trace`
+     * data product.
+     *
+     * Deliberately *not* gated on [enabled]. That flag is the opt-in for writing the Perfetto JSON
+     * artefact to disk, which is a different question from whether the daemon can answer "how long
+     * did each phase of this render take" over the wire. The cost of always collecting is one
+     * `System.nanoTime()` pair and one small object per section, and a render opens on the order of
+     * a dozen — far below the noise floor of the work each section wraps.
+     */
+    private val spans = mutableListOf<RenderTrace.Recorded>()
+
+    /** Sections shed once [MAX_SPANS] was reached. Reported on [RenderTrace.droppedSpans]. */
+    private var droppedSpans: Int = 0
+
+    /**
+     * Current nesting level. Incremented for the duration of each [section] body, so a section
+     * records the depth it was *entered* at — see [RenderTrace.Recorded.depth] for why that beats
+     * reconstructing containment afterwards.
+     */
+    private var depth: Int = 0
+
     fun <T> section(name: String, category: String = "compose-preview", block: () -> T): T {
       // Mirror the span onto the platform tracer when one is installed (see [sectionBackend]).
       // Independent of [enabled] — the JSON recorder and an atrace capture are separate opt-ins —
@@ -78,15 +100,20 @@ object PerfettoTraceDataProducer {
           platform.begin(name)
         } catch (_: Throwable) {}
       }
+      val enteredDepth = depth
+      depth = enteredDepth + 1
+      val startNs = System.nanoTime()
       try {
-        if (!enabled) return block()
-        val startNs = System.nanoTime()
-        try {
-          return block()
-        } finally {
-          record(name = name, category = category, startNs = startNs, endNs = System.nanoTime())
-        }
+        return block()
       } finally {
+        depth = enteredDepth
+        record(
+          name = name,
+          category = category,
+          startNs = startNs,
+          endNs = System.nanoTime(),
+          depth = enteredDepth,
+        )
         if (platform != null) {
           try {
             platform.end()
@@ -95,7 +122,28 @@ object PerfettoTraceDataProducer {
       }
     }
 
-    fun record(name: String, category: String = "compose-preview", startNs: Long, endNs: Long) {
+    @JvmOverloads
+    fun record(
+      name: String,
+      category: String = "compose-preview",
+      startNs: Long,
+      endNs: Long,
+      depth: Int = 0,
+    ) {
+      if (spans.size < MAX_SPANS) {
+        spans +=
+          RenderTrace.Recorded(
+            name = name,
+            category = category,
+            startNanos = startNs,
+            endNanos = endNs,
+            depth = depth,
+          )
+      } else {
+        droppedSpans += 1
+      }
+      // The Chrome-trace event list stays behind the disk opt-in: it exists only to be written out
+      // as `render-perfetto-trace.json`, and building it for every render would be pure waste.
       if (!enabled) return
       events +=
         TraceEvent(
@@ -106,6 +154,15 @@ object PerfettoTraceDataProducer {
           args = mapOf("previewId" to previewId, "backend" to backend),
         )
     }
+
+    /**
+     * The structured phase timings for this render, for `RenderResult.trace`.
+     *
+     * Snapshot semantics: call it after the outermost section has closed, or the phases still open
+     * are simply absent. Cheap enough to call more than once.
+     */
+    fun renderTrace(): RenderTrace =
+      RenderTrace.of(backend = backend, events = spans.toList(), droppedSpans = droppedSpans)
 
     fun payload(): TracePayload =
       TracePayload(
@@ -120,6 +177,15 @@ object PerfettoTraceDataProducer {
 
     fun write(rootDir: File) {
       if (enabled) writeArtifacts(rootDir = rootDir, previewId = previewId, trace = payload())
+    }
+
+    private companion object {
+      /**
+       * Retention cap on the in-memory span list. A one-shot render opens a dozen sections; a long
+       * interactive session reuses one recorder across many frames, so the bound exists to keep a
+       * pathological case from growing without limit rather than to constrain normal use.
+       */
+      const val MAX_SPANS = 4_096
     }
   }
 

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
@@ -1,0 +1,138 @@
+package ee.schimke.composeai.data.render
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * One completed phase of a render, as the engines' own `trace.section(...)` calls recorded it.
+ *
+ * Times are microseconds relative to the start of the render, which is the resolution the panel and
+ * the wire payload both work in — nanoseconds would put jitter in the last digits of a number
+ * nobody reads that precisely, and milliseconds would round most of a render's phases to zero.
+ */
+@Serializable
+data class RenderTraceSpan(
+  val name: String,
+  val category: String,
+  @SerialName("startUs") val startMicros: Long,
+  @SerialName("durationUs") val durationMicros: Long,
+  /**
+   * Nesting level, 0 for a top-level phase. The engines nest their sections (`render:once` contains
+   * `compose:setContent` contains …), and that structure is most of what makes a trace readable — a
+   * flat list of thirteen phases says far less than the same thirteen indented.
+   */
+  val depth: Int,
+)
+
+/**
+ * Aggregate timings for every span sharing a name within one render.
+ *
+ * Repeated phases are the norm, not the exception: an animated preview opens `compose:frame` once
+ * per sampled frame, and `dataArtifact:<id>` fires once per active extension. A flat span list
+ * makes those hard to compare; this is the "where did the time actually go" view over the same
+ * data.
+ */
+@Serializable
+data class RenderTraceSection(
+  val name: String,
+  val category: String,
+  val count: Int,
+  @SerialName("totalUs") val totalMicros: Long,
+  @SerialName("meanUs") val meanMicros: Long,
+  @SerialName("maxUs") val maxMicros: Long,
+)
+
+/**
+ * A render's phase timings, structured.
+ *
+ * This is the payload behind `render/trace` v2. Where v1 could only report `tookMs` and synthesised
+ * a single phase spanning the whole render, this carries what the engines already measure: every
+ * `trace.section(...)` they open, nested, with per-name aggregates alongside.
+ *
+ * Produced by [PerfettoTraceDataProducer.Recorder.renderTrace] and carried to the daemon on
+ * `RenderResult.trace`. Independent of the Perfetto JSON artefact the same recorder can also write
+ * to disk: that one is a file for an external viewer and is opt-in behind a system property, this
+ * one is structured data on the wire and is always available.
+ */
+@Serializable
+data class RenderTrace(
+  /** Which engine produced it — `"desktop"`, `"android"`, `"android-live"`. */
+  val backend: String,
+  /** Wall time from the first span opening to the last one closing. */
+  @SerialName("totalUs") val totalMicros: Long,
+  /** Every span, ordered by start time (parents before the children they enclose). */
+  val spans: List<RenderTraceSpan>,
+  /** Per-name aggregates over [spans], ordered by total time descending. */
+  val sections: List<RenderTraceSection>,
+  /**
+   * Spans dropped because the recorder hit its retention cap. Non-zero means [spans] is truncated;
+   * [sections] still accounts for every span, so the aggregates stay honest when the timeline
+   * can't.
+   */
+  val droppedSpans: Int = 0,
+) {
+  /**
+   * A closed section as the recorder captured it.
+   *
+   * [depth] is recorded at section *entry* rather than derived afterwards from containment: the
+   * recorder appends spans as they **close**, so a parent lands after its children and containment
+   * would have to be reconstructed. A counter on the section stack is exact and costs nothing.
+   */
+  data class Recorded(
+    val name: String,
+    val category: String,
+    val startNanos: Long,
+    val endNanos: Long,
+    val depth: Int,
+  )
+
+  companion object {
+    /** Build a trace from the recorder's closed sections, rebasing times onto the first span. */
+    fun of(backend: String, events: List<Recorded>, droppedSpans: Int = 0): RenderTrace {
+      if (events.isEmpty()) {
+        return RenderTrace(
+          backend = backend,
+          totalMicros = 0L,
+          spans = emptyList(),
+          sections = emptyList(),
+          droppedSpans = droppedSpans,
+        )
+      }
+      val originNanos = events.minOf { it.startNanos }
+      val endNanos = events.maxOf { it.endNanos }
+      // Start time ascending, and where two spans start together the enclosing one first, so the
+      // list reads top-down as the nesting does.
+      val spans =
+        events.sortedWith(compareBy({ it.startNanos }, { it.depth })).map { event ->
+          RenderTraceSpan(
+            name = event.name,
+            category = event.category,
+            startMicros = (event.startNanos - originNanos) / 1_000L,
+            durationMicros = (event.endNanos - event.startNanos).coerceAtLeast(0L) / 1_000L,
+            depth = event.depth,
+          )
+        }
+      val sections =
+        spans
+          .groupBy { it.name }
+          .map { (name, group) ->
+            RenderTraceSection(
+              name = name,
+              category = group.first().category,
+              count = group.size,
+              totalMicros = group.sumOf { it.durationMicros },
+              meanMicros = group.sumOf { it.durationMicros } / group.size,
+              maxMicros = group.maxOf { it.durationMicros },
+            )
+          }
+          .sortedByDescending { it.totalMicros }
+      return RenderTrace(
+        backend = backend,
+        totalMicros = (endNanos - originNanos).coerceAtLeast(0L) / 1_000L,
+        spans = spans,
+        sections = sections,
+        droppedSpans = droppedSpans,
+      )
+    }
+  }
+}

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTraceDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTraceDataProduct.kt
@@ -6,26 +6,109 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 
+/**
+ * `render/trace` — per-preview render phase timings.
+ *
+ * ## v2
+ *
+ * v1 could only report `tookMs`, so it synthesised a single `render` phase spanning the whole
+ * render: the shape of a trace with none of the content. v2 carries what the engines have been
+ * measuring all along — every `trace.section(...)` they open, nested, with per-name aggregates —
+ * because those spans now ride to the daemon on `RenderResult.trace` instead of only reaching disk
+ * behind the Perfetto opt-in.
+ *
+ * **The v1 fields are unchanged and still populated**, so a client written against v1 keeps working
+ * against a v2 payload without knowing it. `phases[]` is the same array of `{ name, startMs,
+ * durationMs }`; it just contains the real phases now. v2 adds:
+ * - `category` and `depth` on each phase,
+ * - `startUs` / `durationUs` alongside the millisecond fields, because most phases of a fast render
+ *   round to `0ms` and a table of zeroes is worse than no table,
+ * - a `sections[]` array of per-name aggregates,
+ * - `source`, which says whether the phases are real (`"spans"`) or the v1 single-phase fallback
+ *   (`"metrics"`) — a client should not have to infer that from `phases.size == 1`,
+ * - `droppedSpans`, non-zero only if a pathologically long render blew the recorder's cap.
+ */
 object RenderTraceDataProduct {
   const val KIND: String = "render/trace"
-  const val SCHEMA_VERSION: Int = 1
+  const val SCHEMA_VERSION: Int = 2
 
-  fun payloadFrom(metrics: Map<String, Long>): JsonElement {
+  /** `source` value when [payloadFrom] had real spans to work from. */
+  const val SOURCE_SPANS: String = "spans"
+
+  /** `source` value for the v1-shaped fallback: one synthetic phase covering `tookMs`. */
+  const val SOURCE_METRICS: String = "metrics"
+
+  /**
+   * Build the payload for one render.
+   *
+   * [trace] is the engine's recorded phases; when it is null or empty the result is the v1 payload
+   * — a single `render` phase over `metrics["tookMs"]`. That fallback is not dead code: hosts that
+   * don't run the recorder (sandbox worker replies that carry metrics but no spans, and any future
+   * backend) still get a usable, if coarse, answer.
+   */
+  @JvmOverloads
+  fun payloadFrom(metrics: Map<String, Long>, trace: RenderTrace? = null): JsonElement {
     val totalMs = metrics["tookMs"]?.coerceAtLeast(0L) ?: 0L
+    val spans = trace?.spans.orEmpty()
     return buildJsonObject {
       put("totalMs", totalMs)
+      put("source", if (spans.isEmpty()) SOURCE_METRICS else SOURCE_SPANS)
+      if (trace != null) {
+        put("backend", trace.backend)
+        put("totalUs", trace.totalMicros)
+        if (trace.droppedSpans > 0) put("droppedSpans", trace.droppedSpans)
+      }
       put(
         "phases",
         buildJsonArray {
-          add(
-            buildJsonObject {
-              put("name", "render")
-              put("startMs", 0L)
-              put("durationMs", totalMs)
+          if (spans.isEmpty()) {
+            add(
+              buildJsonObject {
+                put("name", "render")
+                put("startMs", 0L)
+                put("durationMs", totalMs)
+                put("startUs", 0L)
+                put("durationUs", totalMs * 1_000L)
+                put("category", "render")
+                put("depth", 0)
+              }
+            )
+          } else {
+            spans.forEach { span ->
+              add(
+                buildJsonObject {
+                  put("name", span.name)
+                  put("startMs", span.startMicros / 1_000L)
+                  put("durationMs", span.durationMicros / 1_000L)
+                  put("startUs", span.startMicros)
+                  put("durationUs", span.durationMicros)
+                  put("category", span.category)
+                  put("depth", span.depth)
+                }
+              )
             }
-          )
+          }
         },
       )
+      if (spans.isNotEmpty()) {
+        put(
+          "sections",
+          buildJsonArray {
+            trace?.sections?.forEach { section ->
+              add(
+                buildJsonObject {
+                  put("name", section.name)
+                  put("category", section.category)
+                  put("count", section.count)
+                  put("totalUs", section.totalMicros)
+                  put("meanUs", section.meanMicros)
+                  put("maxUs", section.maxMicros)
+                }
+              )
+            }
+          },
+        )
+      }
       putJsonObject("metrics") {
         metrics.toSortedMap().forEach { (name, value) -> put(name, value) }
       }

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
@@ -1,0 +1,102 @@
+package ee.schimke.composeai.data.render
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RenderTraceTest {
+  @Test
+  fun `spans are rebased onto the first span and ordered parents-first`() {
+    val trace =
+      RenderTrace.of(
+        backend = "desktop",
+        events =
+          listOf(
+            // Recorded in closing order — the child closes before the parent it sits inside.
+            RenderTrace.Recorded("compose:setContent", "c", 1_500_000L, 2_500_000L, depth = 1),
+            RenderTrace.Recorded("render:once", "c", 1_000_000L, 4_000_000L, depth = 0),
+          ),
+      )
+
+    assertEquals(listOf("render:once", "compose:setContent"), trace.spans.map { it.name })
+    assertEquals(0L, trace.spans[0].startMicros)
+    assertEquals(500L, trace.spans[1].startMicros)
+    assertEquals(3000L, trace.spans[0].durationMicros)
+    assertEquals(3000L, trace.totalMicros)
+  }
+
+  @Test
+  fun `sections aggregate repeated phases and sort by total time`() {
+    val trace =
+      RenderTrace.of(
+        backend = "desktop",
+        events =
+          listOf(
+            RenderTrace.Recorded("compose:frame", "c", 0L, 1_000_000L, depth = 1),
+            RenderTrace.Recorded("compose:frame", "c", 2_000_000L, 5_000_000L, depth = 1),
+            RenderTrace.Recorded("render:encodePng", "c", 6_000_000L, 6_500_000L, depth = 1),
+          ),
+      )
+
+    assertEquals(listOf("compose:frame", "render:encodePng"), trace.sections.map { it.name })
+    val frame = trace.sections.first()
+    assertEquals(2, frame.count)
+    assertEquals(4000L, frame.totalMicros)
+    assertEquals(2000L, frame.meanMicros)
+    assertEquals(3000L, frame.maxMicros)
+  }
+
+  @Test
+  fun `an empty trace is well-formed rather than absent`() {
+    val trace = RenderTrace.of(backend = "android", events = emptyList())
+
+    assertEquals(0L, trace.totalMicros)
+    assertTrue(trace.spans.isEmpty())
+    assertTrue(trace.sections.isEmpty())
+  }
+
+  @Test
+  fun `recorder collects spans with nesting even when the disk artefact is off`() {
+    // The whole point of the v2 split: `enabled = false` means "don't write the Perfetto JSON",
+    // not "don't measure". A daemon with the artefact switched off must still answer render/trace.
+    val recorder =
+      PerfettoTraceDataProducer.recorder(previewId = "p", backend = "desktop", enabled = false)
+
+    recorder.section("render:once") {
+      recorder.section("compose:setContent") {}
+      recorder.section("compose:frame") {}
+      recorder.section("compose:frame") {}
+    }
+
+    val trace = recorder.renderTrace()
+    assertEquals("desktop", trace.backend)
+    assertEquals(listOf(0, 1, 1, 1), trace.spans.map { it.depth })
+    assertEquals("render:once", trace.spans.first().name)
+    assertEquals(2, trace.sections.single { it.name == "compose:frame" }.count)
+    // The Chrome-trace event list stays empty — that one really is behind the disk opt-in.
+    assertTrue(recorder.payload().traceEvents.isEmpty())
+  }
+
+  @Test
+  fun `a section that throws still closes its span and restores depth`() {
+    val recorder =
+      PerfettoTraceDataProducer.recorder(previewId = "p", backend = "desktop", enabled = false)
+
+    runCatching { recorder.section("render:once") { error("boom") } }
+    recorder.section("compose:tearDown") {}
+
+    val trace = recorder.renderTrace()
+    assertEquals(listOf("render:once", "compose:tearDown"), trace.spans.map { it.name })
+    assertEquals(listOf(0, 0), trace.spans.map { it.depth })
+  }
+
+  @Test
+  fun `payload keeps the v1 shape when no spans were recorded`() {
+    val payload = RenderTraceDataProduct.payloadFrom(mapOf("tookMs" to 7L), trace = null)
+
+    val json = payload.toString()
+    assertTrue(json.contains("\"source\":\"metrics\""), json)
+    assertTrue(json.contains("\"name\":\"render\""), json)
+    assertTrue(json.contains("\"durationMs\":7"), json)
+  }
+}

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -291,7 +291,7 @@ A `data/fetch` that needs a re-render:
 | `i18n/translations` | default | low | Per-string locale coverage from `values*/strings.xml`. Android only. |
 | _(pseudolocale, no kind)_ | default | low | Triggered by `localeTag` in `{en-XA, ar-XB}` on a `@Preview` or `renderNow.overrides`. Visual-only — Android wraps `LocalContext.resources` to pseudolocalise `getString*` returns and (for `ar-XB`) provides `LayoutDirection.Rtl`; CMP Desktop provides `LayoutDirection.Rtl` only (string-resource interception not viable through `compose.components.resources`). No build-time `pseudoLocalesEnabled` / `resConfigs` required. Modules: `:data-pseudolocale-core`, `:data-pseudolocale-connector` (Android), `:data-pseudolocale-connector-desktop` (CMP Desktop). |
 | `render/composeAiTrace` | default/live | low | Render pipeline trace as Perfetto-importable Chrome trace JSON. |
-| `render/trace` | default | low | Phase breakdown from render metrics. |
+| `render/trace` | default | low | schemaVersion 2: the engine's own `trace.section(...)` phases — `phases: [{name, category, depth, startMs, durationMs, startUs, durationUs}]`, nested, plus `sections[]` per-name aggregates (`count`/`totalUs`/`meanUs`/`maxUs`), `backend`, and `source`. `source` is `"spans"` for real phases and `"metrics"` for the v1 fallback (one synthetic `render` phase over `tookMs`) used by hosts that run no recorder. The v1 field shapes (`totalMs`, `phases[].name/startMs/durationMs`, `metrics{}`) are unchanged and still populated, so a v1 client reads a v2 payload without noticing. Collected on every render — unlike `render/composeAiTrace`, which is the same spans written to disk as Chrome trace JSON behind a system property. |
 | `fonts/used` | default | low | Font families with weight/style fallback chain. |
 | `history/diff/regions` | default | low | Per-pixel bbox of changed regions vs. another history entry. |
 | `test/failure` | failed render | low | Postmortem bundle: phase, error type/message/stack, fallback fields for what's not yet captured. Fetch-only after `renderFailed`. |
@@ -332,13 +332,13 @@ Which `kind` strings each backend's `extensions/list` advertises and serves thro
 | `kind` | Android | Desktop (CMP) | Notes |
 |---|---|---|---|
 | `render/deviceClip` / `render/deviceBackground` | ✅ | ✅ | Renderer-agnostic device-bound previewer. |
-| `render/trace` | ✅ | ✅ | Phase breakdown from render metrics. |
+| `render/trace` | ✅ | ✅ | schemaVersion 2 — real nested phase spans from the engine's recorder, with per-name aggregates. Falls back to the v1 single-phase shape when a host carries no spans. |
 | `render/composeAiTrace` | ✅ | ✅ | Both backends, gated on `composeai.perfetto.enabled` + `composeai.render.outputDir`. |
 | `test/failure` | ✅ | ✅ | Postmortem bundle on `renderFailed`. Renderer-agnostic. |
 | `compose/theme` | ✅ | ✅ | Material 3 theme tokens. Override-extension shape. |
 | `compose/wallpaper` | ✅ | ✅ | Wallpaper override shape. |
 | `compose/permissions` | ✅ | ❌ Android-only | Runtime-permissions surface — Robolectric `ShadowApplication` grant seed + `ContextWrapper.checkPermission` query tracker. Desktop has no Android permission model; CMP panel chip greys out on `serverCapabilities.backend == "desktop"`. |
-| `compose/recomposition` | ✅ producer | ✅ producer | Compose-runtime observer install on both backends (desktop in-process; Android via the in-sandbox bridge). schemaVersion 2 adds the per-scope `reason` (#1605), derived symmetrically from `onScopeInvalidated`. |
+| `compose/recomposition` | ✅ producer | ✅ producer | Compose-runtime observer install on both backends (desktop in-process; Android via the in-sandbox bridge). schemaVersion 2 adds the per-scope `reason` (#1605), derived symmetrically from `onScopeInvalidated`. Desktop no longer needs a held interactive session: `RenderEngine` announces each scene through its `sceneLifecycleListener` **before** `setContent`, which is the only moment an observer can attach in time to see the initial composition — so an ordinary render answers too. |
 | `displayfilter/variants` | ✅ | ✅ | Both backends, gated on `composeai.displayfilter.filters`. Producer is pure `BufferedImage` post-capture. |
 | `fonts/used` | ✅ producer | 📁 registry-only | Android: `GoogleFontInterceptor` + Typeface accounting. Desktop: registry returns `NotAvailable` until a Skia-side font producer ports. |
 | `compose/semantics` / `layout/inspector` | ✅ producer | ✅ producer | Android producer reads the Robolectric semantics tree. Desktop drives both from the held `ImageComposeScene`'s `semanticsOwners` unmerged root after `scene.render()`: `compose/semantics` via `ComposeSemanticsDataProducer` (#1885 follow-up), `layout/inspector` via the CMP-portable `LayoutInspectorDataProducer.writeArtifacts(root, slotTables, density)` overload — `ComposeLayoutInspector` reflects the `LayoutNode` reachable from the semantics root identically on both backends (#1903). |

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2915,6 +2915,74 @@ bundle-chip-bar {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+/* Render-trace v2 phase list — one row per span, indented by nesting depth,
+   with a proportional bar and a right-aligned duration. Replaces the single
+   stacked bar the v1 payload could support: with real nested phases the
+   structure is the information, and a stacked bar flattens it away. */
+.perf-phase-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    font-size: 11px;
+}
+.perf-phase-row {
+    display: grid;
+    grid-template-columns: minmax(90px, max-content) 1fr max-content;
+    align-items: center;
+    gap: 8px;
+    padding: 1px 0;
+}
+.perf-phase-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--vscode-editor-font-family, "SF Mono", Menlo, monospace);
+}
+/* Nested phases read as supporting detail, not as peers of the phase that
+   contains them. */
+.perf-phase-row[data-depth="0"] .perf-phase-name {
+    font-weight: 600;
+}
+.perf-phase-row:not([data-depth="0"]) .perf-phase-name {
+    opacity: 0.75;
+}
+.perf-phase-track {
+    height: 6px;
+    min-width: 24px;
+    background: var(--vscode-editorWidget-background, rgba(128, 128, 128, 0.1));
+    border-radius: 3px;
+    overflow: hidden;
+}
+.perf-phase-fill {
+    height: 100%;
+    background: var(--vscode-progressBar-background, #0e639c);
+    border-radius: 3px;
+}
+.perf-phase-duration {
+    font-variant-numeric: tabular-nums;
+    opacity: 0.85;
+}
+.perf-trace-note {
+    font-size: 11px;
+    opacity: 0.7;
+    font-style: italic;
+}
+.perf-trace-repeats {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 2px 12px;
+    margin: 0;
+    font-size: 11px;
+    opacity: 0.85;
+}
+.perf-trace-repeats dt {
+    font-family: var(--vscode-editor-font-family, "SF Mono", Menlo, monospace);
+    opacity: 0.8;
+}
+.perf-trace-repeats dd {
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+}
 .perf-metrics-list {
     display: grid;
     grid-template-columns: max-content 1fr;

--- a/vscode-extension/src/test/performanceBundlePresenter.test.ts
+++ b/vscode-extension/src/test/performanceBundlePresenter.test.ts
@@ -105,6 +105,119 @@ describe("computePerformanceBundleData — render/trace", () => {
         assert.strictEqual(data.renderTrace, null);
     });
 
+    it("projects v2 nested phases, µs precision and repeat aggregates", () => {
+        const data = computePerformanceBundleData(
+            null,
+            {
+                totalMs: 1,
+                totalUs: 1800,
+                backend: "desktop",
+                source: "spans",
+                phases: [
+                    {
+                        name: "render:once",
+                        startMs: 0,
+                        durationMs: 1,
+                        startUs: 0,
+                        durationUs: 1800,
+                        depth: 0,
+                        category: "compose-preview",
+                    },
+                    {
+                        name: "compose:frame",
+                        startMs: 0,
+                        durationMs: 0,
+                        startUs: 200,
+                        durationUs: 400,
+                        depth: 1,
+                        category: "compose-preview",
+                    },
+                    {
+                        name: "compose:frame",
+                        startMs: 0,
+                        durationMs: 0,
+                        startUs: 700,
+                        durationUs: 500,
+                        depth: 1,
+                        category: "compose-preview",
+                    },
+                ],
+                sections: [
+                    {
+                        name: "compose:frame",
+                        category: "compose-preview",
+                        count: 2,
+                        totalUs: 900,
+                        meanUs: 450,
+                        maxUs: 500,
+                    },
+                    {
+                        name: "render:once",
+                        category: "compose-preview",
+                        count: 1,
+                        totalUs: 1800,
+                        meanUs: 1800,
+                        maxUs: 1800,
+                    },
+                ],
+                metrics: { tookMs: 1 },
+            },
+            null,
+        );
+        const rt = data.renderTrace!;
+        assert.strictEqual(rt.source, "spans");
+        assert.strictEqual(rt.backend, "desktop");
+        assert.strictEqual(rt.totalUs, 1800);
+        assert.deepStrictEqual(
+            rt.phases.map((p) => p.depth),
+            [0, 1, 1],
+        );
+        // Sub-millisecond phases must keep their resolution: scaling on the
+        // millisecond fields would make both frames 0% of a 1ms render.
+        assert.strictEqual(rt.phases[0].widthPct, 100);
+        assert.ok(rt.phases[1].widthPct > 20 && rt.phases[1].widthPct < 24);
+        // Only names that actually repeat are worth a summary row.
+        assert.deepStrictEqual(
+            rt.repeats.map((r) => r.name),
+            ["compose:frame"],
+        );
+        assert.strictEqual(rt.repeats[0].count, 2);
+    });
+
+    it("reports a metrics-sourced payload as the fallback it is", () => {
+        const data = computePerformanceBundleData(
+            null,
+            {
+                totalMs: 40,
+                source: "metrics",
+                phases: [{ name: "render", startMs: 0, durationMs: 40 }],
+                metrics: { tookMs: 40 },
+            },
+            null,
+        );
+        assert.strictEqual(data.renderTrace!.source, "metrics");
+        assert.strictEqual(data.renderTrace!.repeats.length, 0);
+    });
+
+    it("treats a v1 payload with no v2 fields as metrics-sourced with sane defaults", () => {
+        const data = computePerformanceBundleData(
+            null,
+            {
+                totalMs: 10,
+                phases: [{ name: "render", startMs: 0, durationMs: 10 }],
+                metrics: {},
+            },
+            null,
+        );
+        const rt = data.renderTrace!;
+        assert.strictEqual(rt.source, "metrics");
+        assert.strictEqual(rt.backend, null);
+        assert.strictEqual(rt.phases[0].depth, 0);
+        // Derived from the millisecond field, so the bar and the label agree.
+        assert.strictEqual(rt.phases[0].durationUs, 10000);
+        assert.strictEqual(rt.totalUs, 10000);
+    });
+
     it("derives per-phase widthPct from totalMs as the chart scale", () => {
         const data = computePerformanceBundleData(
             null,

--- a/vscode-extension/src/webview/preview/bundleRegistry.ts
+++ b/vscode-extension/src/webview/preview/bundleRegistry.ts
@@ -173,13 +173,21 @@ export const BUNDLES: readonly BundleDescriptor[] = [
         id: "performance",
         label: "Performance",
         icon: "pulse",
+        // The Performance chip is itself the advanced surface: it only paints
+        // when the panel isn't in basic mode (`availableBundles`), so every
+        // press is already a deliberate act by someone asking a perf question.
+        // The two kinds that answer that question are therefore default-ON —
+        // a chip that toggles on and shows an empty tab until you find the
+        // Configure expander isn't subtle, it's broken. `render/composeAiTrace`
+        // stays expander-only: it's the raw Perfetto blob behind a sysprop,
+        // useful for a handoff to ui.perfetto.dev rather than for reading here.
         kinds: [
             {
                 kind: "compose/recomposition",
                 label: "Recomposition",
-                defaultOn: false,
+                defaultOn: true,
             },
-            { kind: "render/trace", label: "Render trace", defaultOn: false },
+            { kind: "render/trace", label: "Render trace", defaultOn: true },
             {
                 kind: "render/composeAiTrace",
                 label: "Perfetto trace",

--- a/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
@@ -31,9 +31,29 @@ export interface RenderTracePhase {
     name: string;
     startMs: number;
     durationMs: number;
+    /** v2: microseconds. Most phases of a fast render round to `0ms`,
+     *  and a column of zeroes is worse than no column — the label
+     *  formats from this and falls back to the ms fields on a v1
+     *  payload. */
+    durationUs: number;
+    startUs: number;
+    /** v2: nesting level. `render:once` encloses `compose:setContent`
+     *  encloses …; the indent is most of what makes the list readable. */
+    depth: number;
+    /** v2: span category, for grouping/filtering. */
+    category: string;
     /** Per-phase % of `chartScale`, pre-computed so the renderer
      *  doesn't redo the divide on each paint. */
     widthPct: number;
+}
+
+/** v2: aggregate over every phase sharing a name within one render. */
+export interface RenderTraceRepeat {
+    name: string;
+    count: number;
+    totalUs: number;
+    meanUs: number;
+    maxUs: number;
 }
 
 export interface RenderTraceMetric {
@@ -45,6 +65,19 @@ export interface RenderTraceSection {
     totalMs: number | null;
     phases: readonly RenderTracePhase[];
     metrics: readonly RenderTraceMetric[];
+    /** Total render wall time in microseconds. From the v2 `totalUs`
+     *  field, or derived from the v1 `totalMs` so the bar scale and the
+     *  header label behave identically on either payload. */
+    totalUs: number | null;
+    /** v2: which engine produced the trace (`desktop` / `android`). */
+    backend: string | null;
+    /** v2 `source`: `"spans"` when the phases are the engine's real
+     *  sections, `"metrics"` for the v1-shaped single synthetic phase.
+     *  Surfaced rather than inferred so the panel can say plainly that
+     *  a one-phase trace is a fallback, not a one-phase render. */
+    source: "spans" | "metrics";
+    /** v2: names that occurred more than once, with their aggregates. */
+    repeats: readonly RenderTraceRepeat[];
 }
 
 export interface ComposeAiTraceSummary {
@@ -192,25 +225,44 @@ function parseRenderTrace(raw: unknown): RenderTraceSection | null {
     if (!raw || typeof raw !== "object") return null;
     const payload = raw as {
         totalMs?: unknown;
+        totalUs?: unknown;
+        backend?: unknown;
+        source?: unknown;
         phases?: unknown;
+        sections?: unknown;
         metrics?: unknown;
     };
     const totalMs =
         typeof payload.totalMs === "number" && Number.isFinite(payload.totalMs)
             ? payload.totalMs
             : null;
+    // v2 carries microseconds; a v1 payload only has milliseconds, so derive
+    // from those rather than dropping to null — the bar scale and the header
+    // label both read this, and a v1 trace must keep rendering exactly as it
+    // did before.
+    const totalUs =
+        typeof payload.totalUs === "number" && Number.isFinite(payload.totalUs)
+            ? payload.totalUs
+            : totalMs !== null
+              ? totalMs * 1000
+              : null;
+    const backend =
+        typeof payload.backend === "string" && payload.backend.length > 0
+            ? payload.backend
+            : null;
+    const source = payload.source === "spans" ? "spans" : "metrics";
     const rawPhases = Array.isArray(payload.phases) ? payload.phases : [];
-    const phasesNoWidth: Array<{
-        name: string;
-        startMs: number;
-        durationMs: number;
-    }> = [];
+    const phasesNoWidth: Array<Omit<RenderTracePhase, "widthPct">> = [];
     for (const p of rawPhases) {
         if (!p || typeof p !== "object") continue;
         const ph = p as {
             name?: unknown;
             startMs?: unknown;
             durationMs?: unknown;
+            startUs?: unknown;
+            durationUs?: unknown;
+            depth?: unknown;
+            category?: unknown;
         };
         if (typeof ph.name !== "string" || ph.name.length === 0) continue;
         if (
@@ -223,24 +275,66 @@ function parseRenderTrace(raw: unknown): RenderTraceSection | null {
             typeof ph.startMs === "number" && Number.isFinite(ph.startMs)
                 ? ph.startMs
                 : 0;
+        // Fall back to the millisecond fields so a v1 payload still
+        // produces sane microsecond values rather than zeroes.
+        const durationUs =
+            typeof ph.durationUs === "number" && Number.isFinite(ph.durationUs)
+                ? ph.durationUs
+                : ph.durationMs * 1000;
+        const startUs =
+            typeof ph.startUs === "number" && Number.isFinite(ph.startUs)
+                ? ph.startUs
+                : startMs * 1000;
         phasesNoWidth.push({
             name: ph.name,
             startMs,
             durationMs: ph.durationMs,
+            startUs,
+            durationUs,
+            depth:
+                typeof ph.depth === "number" && Number.isFinite(ph.depth)
+                    ? Math.max(0, Math.trunc(ph.depth))
+                    : 0,
+            category: typeof ph.category === "string" ? ph.category : "",
         });
     }
-    const maxDuration = phasesNoWidth.reduce(
-        (acc, p) => (p.durationMs > acc ? p.durationMs : acc),
+    // Scale the bars in microseconds: a render whose phases are all
+    // sub-millisecond has a `totalMs` of 0 or 1, and dividing by that
+    // makes every bar either empty or full.
+    const maxDurationUs = phasesNoWidth.reduce(
+        (acc, p) => (p.durationUs > acc ? p.durationUs : acc),
         0,
     );
-    const chartScale = totalMs && totalMs > 0 ? totalMs : maxDuration;
+    const chartScale = totalUs && totalUs > 0 ? totalUs : maxDurationUs;
     const phases: RenderTracePhase[] = phasesNoWidth.map((p) => ({
         ...p,
         widthPct:
             chartScale > 0
-                ? Math.max(0, Math.min(100, (p.durationMs / chartScale) * 100))
+                ? Math.max(0, Math.min(100, (p.durationUs / chartScale) * 100))
                 : 0,
     }));
+
+    const rawSections = Array.isArray(payload.sections) ? payload.sections : [];
+    const repeats: RenderTraceRepeat[] = [];
+    for (const entry of rawSections) {
+        if (!entry || typeof entry !== "object") continue;
+        const sec = entry as {
+            name?: unknown;
+            count?: unknown;
+            totalUs?: unknown;
+            meanUs?: unknown;
+            maxUs?: unknown;
+        };
+        if (typeof sec.name !== "string" || sec.name.length === 0) continue;
+        if (typeof sec.count !== "number" || sec.count <= 1) continue;
+        repeats.push({
+            name: sec.name,
+            count: sec.count,
+            totalUs: typeof sec.totalUs === "number" ? sec.totalUs : 0,
+            meanUs: typeof sec.meanUs === "number" ? sec.meanUs : 0,
+            maxUs: typeof sec.maxUs === "number" ? sec.maxUs : 0,
+        });
+    }
 
     const rawMetrics =
         payload.metrics && typeof payload.metrics === "object"
@@ -257,7 +351,16 @@ function parseRenderTrace(raw: unknown): RenderTraceSection | null {
     if (phases.length === 0 && metrics.length === 0 && totalMs === null) {
         return null;
     }
-    return { totalMs, phases, metrics };
+    return { totalMs, totalUs, backend, source, phases, metrics, repeats };
+}
+
+/** Format a microsecond duration at the precision it deserves. */
+export function formatTraceDuration(micros: number): string {
+    if (!Number.isFinite(micros) || micros < 0) return "—";
+    if (micros >= 10000) return (micros / 1000).toFixed(1) + " ms";
+    if (micros >= 1000) return (micros / 1000).toFixed(2) + " ms";
+    if (micros >= 10) return Math.round(micros) + " µs";
+    return micros.toFixed(1) + " µs";
 }
 
 function parseComposeAiTrace(raw: unknown): ComposeAiTraceSummary | null {
@@ -420,29 +523,94 @@ function renderRenderTraceSection(trace: RenderTraceSection): HTMLElement {
     title.className = "perf-section-title";
     title.textContent = "Render trace";
     header.appendChild(title);
-    if (trace.totalMs !== null) {
+    const totalLabel =
+        trace.totalUs !== null
+            ? formatTraceDuration(trace.totalUs)
+            : trace.totalMs !== null
+              ? trace.totalMs + " ms"
+              : null;
+    if (totalLabel !== null) {
         const total = document.createElement("span");
         total.className = "perf-section-summary";
-        total.textContent = trace.totalMs + " ms total";
+        total.textContent =
+            totalLabel +
+            " total" +
+            (trace.backend ? " · " + trace.backend : "");
         header.appendChild(total);
     }
     section.appendChild(header);
 
+    // A `metrics`-sourced trace has one synthetic phase covering the whole
+    // render. Say so — otherwise it reads as "this render had exactly one
+    // phase", which is a very different claim.
+    if (trace.source === "metrics" && trace.phases.length > 0) {
+        const note = document.createElement("div");
+        note.className = "perf-trace-note";
+        note.textContent =
+            "No phase spans for this render — showing total time only.";
+        section.appendChild(note);
+    }
+
     if (trace.phases.length > 0) {
-        const bar = document.createElement("div");
-        bar.className = "perf-phase-bar";
+        const list = document.createElement("div");
+        list.className = "perf-phase-list";
         for (const phase of trace.phases) {
-            const seg = document.createElement("div");
-            seg.className = "perf-phase-bar-segment";
-            seg.style.width = phase.widthPct + "%";
-            seg.title = phase.name + ": " + phase.durationMs + " ms";
-            const label = document.createElement("span");
-            label.className = "perf-phase-bar-segment-label";
-            label.textContent = phase.name + " · " + phase.durationMs + " ms";
-            seg.appendChild(label);
-            bar.appendChild(seg);
+            const row = document.createElement("div");
+            row.className = "perf-phase-row";
+            row.dataset.depth = String(Math.min(phase.depth, 6));
+            // Indent by nesting depth. The structure is the point: a flat
+            // list of thirteen phases says far less than the same thirteen
+            // showing what contains what.
+            row.style.paddingInlineStart = phase.depth * 12 + "px";
+
+            const name = document.createElement("span");
+            name.className = "perf-phase-name";
+            name.textContent = phase.name;
+            if (phase.category) name.title = phase.category;
+            row.appendChild(name);
+
+            const track = document.createElement("div");
+            track.className = "perf-phase-track";
+            const fill = document.createElement("div");
+            fill.className = "perf-phase-fill";
+            fill.style.width = Math.max(phase.widthPct, 0.5) + "%";
+            track.appendChild(fill);
+            row.appendChild(track);
+
+            const duration = document.createElement("span");
+            duration.className = "perf-phase-duration";
+            duration.textContent = formatTraceDuration(phase.durationUs);
+            row.appendChild(duration);
+
+            row.title =
+                phase.name +
+                " · " +
+                formatTraceDuration(phase.durationUs) +
+                " · starts at " +
+                formatTraceDuration(phase.startUs);
+            list.appendChild(row);
         }
-        section.appendChild(bar);
+        section.appendChild(list);
+    }
+
+    if (trace.repeats.length > 0) {
+        const repeats = document.createElement("dl");
+        repeats.className = "perf-trace-repeats";
+        for (const repeat of trace.repeats) {
+            const dt = document.createElement("dt");
+            dt.textContent = repeat.name + " ×" + repeat.count;
+            const dd = document.createElement("dd");
+            dd.textContent =
+                formatTraceDuration(repeat.totalUs) +
+                " total · " +
+                formatTraceDuration(repeat.meanUs) +
+                " mean · " +
+                formatTraceDuration(repeat.maxUs) +
+                " max";
+            repeats.appendChild(dt);
+            repeats.appendChild(dd);
+        }
+        section.appendChild(repeats);
     }
 
     if (trace.metrics.length > 0) {


### PR DESCRIPTION
## Summary

`render/trace` advertised a phase breakdown and delivered one synthetic `render` phase spanning `tookMs` — the shape of a trace with none of the content. Meanwhile both render engines have been measuring a dozen real phases all along (`compose:setUp`, `compose:setContent`, `compose:frame`, `render:captureRoboImage`, `dataArtifact:<id>`, …) and throwing them away unless the Perfetto disk artefact was switched on with a system property.

This makes those spans the data product, and makes `compose/recomposition` answer for an ordinary render.

### The producer side

`PerfettoTraceDataProducer.Recorder` now **always** collects sections — a `nanoTime` pair and a small object each, against work measured in milliseconds. Only the Chrome-trace JSON event list stays behind `composeai.daemon.perfettoTrace`; whether the daemon can answer "how long did each phase take" is a different question from whether it writes a file for an external viewer.

Spans reach the daemon on a new `RenderResult.trace` rather than through a process-global the registry reads: the recorder is created per render deep inside the engine, and the result is the channel that already runs from there to the registry. Nesting depth is recorded at section *entry* rather than reconstructed from containment afterwards — the recorder appends spans as they **close**, so a parent lands after its children.

`render/trace` goes to schemaVersion 2:

| field | |
| --- | --- |
| `phases[].category` / `.depth` | v2 — the nesting is most of what makes a trace readable |
| `phases[].startUs` / `.durationUs` | v2 — most phases of a fast render round to `0ms`, and a table of zeroes is worse than no table |
| `sections[]` | v2 — per-name aggregates (`count`/`totalUs`/`meanUs`/`maxUs`) for phases that repeat, e.g. `compose:frame` once per sampled frame |
| `backend`, `droppedSpans` | v2 |
| `source` | v2 — `"spans"` or `"metrics"`, so a client isn't left inferring the fallback from `phases.size == 1` |
| `totalMs`, `phases[].name/startMs/durationMs`, `metrics{}` | **unchanged and still populated** — a v1 client reads a v2 payload without noticing |

The v1 single-phase fallback isn't dead code: hosts that run no recorder (sandbox-worker replies carrying metrics but no spans) still get a coarse but usable answer, now labelled as such.

### Recomposition

`compose/recomposition` instruments a scene's `Recomposer`, and the only scene it could reach was one a **live interactive session** held — so recomposition counts were unavailable on the plain render path, which is the path almost every preview takes.

`RenderEngine` now announces each scene through a `sceneLifecycleListener` **before** `setContent`, and again with `null` at tearDown. Before `setContent` is the only moment an observer can attach in time to see the initial composition — the very thing worth counting. `DaemonMain` wires it to the existing `RecompositionDataProductRegistry.onSessionLifecycle`, gated on the extension's active state, so an untoggled panel pays one map write. A listener that throws can't fail the render it's only observing.

The existing teardown ordering happens to be exactly right: `disposeObserver` drops the handle but leaves the counters, and `attachmentsFor` runs after teardown — so the snapshot still sees the render it measured.

### The UI

The Performance chip is *already* the subtle/advanced surface — it only paints when the panel isn't in basic mode. So its two readable kinds become default-ON: a chip that toggles on and shows an empty tab until you find the Configure expander isn't subtle, it's broken. `render/composeAiTrace` stays expander-only — it's the raw Perfetto blob for a handoff to ui.perfetto.dev, not something to read in a side panel.

The tab body drops the single stacked bar (which flattened the nesting away the moment there was real nesting to show) for a phase list: one row per span, indented by depth, with a proportional bar and a right-aligned duration formatted at the precision it deserves (`µs` under 1ms, `ms` above). Repeated phases get a summary line. A `metrics`-sourced trace says so in plain words rather than reading as "this render had exactly one phase".

## Test plan

- [x] `:data-render-core:test` — new `RenderTraceTest`: rebasing and parents-first ordering, aggregate maths, the empty trace, **the recorder collecting spans with correct nesting while the disk artefact is off**, a throwing section still closing its span and restoring depth, and the v1 payload shape
- [x] `:data-render-connector:test` — extended for v2: real phases + sections + `source`, a spans-but-no-metrics render, and the v1 fallback still labelled `metrics`
- [x] `:daemon:desktop:test` — new `RenderEngineTraceTest` against a **real Compose Desktop render**: the trace carries `compose:setUp`/`render:once`/`compose:tearDown` (proving it's snapshotted after `finally`, not from inside `renderOnce`) plus a nested phase; the scene is announced with a live scene before composition and `null` at teardown, in that order; a throwing listener still produces a PNG. Full suite green (220 tests)
- [x] `:daemon:core:test`, `:daemon:android:compileDebugKotlin`
- [x] `vscode-extension` — 1625 passing, including three new presenter tests: v2 nested phases with µs-scaled bars and repeat aggregates, a `metrics`-sourced payload reported as the fallback, and a bare v1 payload keeping its existing bar scale (that last one caught a regression where scaling on `totalUs` broke v1 traces)
- [x] `./gradlew ktfmtCheckAll`, `npm run format:check`

Not visually captured: the Performance tab is a focus-mode data tab in the VS Code webview, which the `@Preview` PNG pipeline doesn't reach and the preview-harness fixtures don't currently cover (their seeds are `grid-default` and `a11y-findings`). The rendering is unit-tested at the data level above; a harness fixture for the data-tab bodies would be the right way to diff it and is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4)_