### PR TITLE
fix(daemon): keep render/trace aggregates complete and ordinary-render recomposition in snapshot mode

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -276,7 +276,10 @@ fun runDaemon(
       // decides whether to attach an observer, and with no subscription this is a map write.
       sceneLifecycleListener = { previewId, scene ->
         if (extensions.isActive("data/recomposition")) {
-          recompositionRegistry.onSessionLifecycle(previewId, scene)
+          // `onRenderSceneLifecycle`, not `onSessionLifecycle`: a one-shot render's scene is gone
+          // before the payload is built, so the subscription must keep its `snapshot` mode rather
+          // than being promoted to the per-input `delta` contract a held session implies.
+          recompositionRegistry.onRenderSceneLifecycle(previewId, scene)
         }
       },
     )

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionRenderSceneTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionRenderSceneTest.kt
@@ -1,0 +1,111 @@
+@file:OptIn(androidx.compose.runtime.ExperimentalComposeRuntimeApi::class)
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.RecomposeScope
+import androidx.compose.runtime.tooling.CompositionObserverHandle
+import androidx.compose.ui.ImageComposeScene
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `compose/recomposition` against a *transient* render scene.
+ *
+ * Lives here rather than beside the registry because it needs a real [ImageComposeScene], which
+ * needs skiko's natives — the connector module's own tests deliberately stay fake-only so they run
+ * anywhere. `:daemon:desktop` already renders real scenes throughout.
+ */
+class RecompositionRenderSceneTest {
+
+  /** Registry whose observer install is a no-op, so mode and lifecycle can be asserted alone. */
+  private class RecordingRegistry : RecompositionDataProductRegistry() {
+    var installs: Int = 0
+    var disposals: Int = 0
+
+    override fun installObserver(
+      scene: ImageComposeScene,
+      onScopeRecomposed: (RecomposeScope) -> Unit,
+      onScopeInvalidatedByState: (RecomposeScope) -> Unit,
+      onScopeDisposed: (RecomposeScope) -> Unit,
+    ): CompositionObserverHandle {
+      installs++
+      return object : CompositionObserverHandle {
+        override fun dispose() {
+          disposals++
+        }
+      }
+    }
+  }
+
+  private fun subscribeParams(frameStreamId: String, mode: String): JsonObject = buildJsonObject {
+    put("frameStreamId", JsonPrimitive(frameStreamId))
+    put("mode", JsonPrimitive(mode))
+  }
+
+  @Test
+  fun ordinaryRenderSceneInstallsWithoutPromotingSnapshotToDelta() {
+    // A one-shot render's scene is gone before the payload is built, so reporting the result as a
+    // per-input `delta` — which is what the held-session hook promotes to — would misdescribe an
+    // initial-composition snapshot.
+    val registry = RecordingRegistry()
+    registry.onSubscribe(
+      previewId = "p",
+      kind = RecompositionDataProductRegistry.KIND,
+      params = subscribeParams(frameStreamId = "f1", mode = "snapshot"),
+    )
+    val scene = ImageComposeScene(width = 4, height = 4)
+    try {
+      registry.onRenderSceneLifecycle("p", scene)
+      assertEquals(1, registry.installs)
+
+      // Teardown disposes the observer but keeps the counters: `attachmentsFor` runs after
+      // teardown and still has to report the render it just measured.
+      registry.onRenderSceneLifecycle("p", null)
+      assertEquals(1, registry.disposals)
+
+      val payload =
+        registry
+          .attachmentsFor("p", setOf(RecompositionDataProductRegistry.KIND))
+          .single()
+          .payload
+          .toString()
+      assertTrue(payload, payload.contains("\"mode\":\"snapshot\""))
+    } finally {
+      scene.close()
+    }
+  }
+
+  @Test
+  fun ordinaryRenderSceneDoesNotRegisterAsALiveSession() {
+    // `liveScenes` answers "is there a live interactive session?" at subscribe time. A scene that
+    // will not outlive the render must not answer yes, or a later delta subscribe believes it can
+    // honour deltas when nothing is held.
+    val registry = RecordingRegistry()
+    val scene = ImageComposeScene(width = 4, height = 4)
+    try {
+      registry.onRenderSceneLifecycle("p", scene)
+
+      registry.onSubscribe(
+        previewId = "p",
+        kind = RecompositionDataProductRegistry.KIND,
+        params = subscribeParams(frameStreamId = "f1", mode = "delta"),
+      )
+
+      val payload =
+        registry
+          .attachmentsFor("p", setOf(RecompositionDataProductRegistry.KIND))
+          .single()
+          .payload
+          .toString()
+      assertTrue(payload, payload.contains("\"mode\":\"snapshot\""))
+      assertEquals(0, registry.installs)
+    } finally {
+      scene.close()
+    }
+  }
+}

--- a/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -331,6 +331,37 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     }
   }
 
+  /**
+   * One-shot render scene lifecycle — the *transient* counterpart of [onSessionLifecycle].
+   *
+   * The desktop `RenderEngine` announces every scene it builds, before `setContent` composes into
+   * it, so an ordinary (non-interactive) render can be instrumented too. That scene is torn down
+   * again a few milliseconds later, and the difference from a held session matters in two ways:
+   * - **No mode promotion.** [onSessionLifecycle] promotes a `snapshot` subscription to `delta`,
+   *   which is right when a live session means per-input deltas are about to become meaningful.
+   *   Here it would be a lie: the scene is gone before `attachmentsFor` builds the payload, so what
+   *   the panel receives is the initial composition of one render — a snapshot. Reporting it as
+   *   `delta` with an `inputSeq` would mislead every consumer of the wire contract.
+   * - **Not registered in [liveScenes].** That map answers "is there a live session for this
+   *   preview?" at subscribe time; a scene that will not outlive the render must not answer yes.
+   *
+   * `scene == null` disposes the observer and leaves the subscription (and its counters) in place,
+   * because `attachmentsFor` runs *after* teardown and still has to report the render it measured.
+   */
+  fun onRenderSceneLifecycle(previewId: String, scene: ImageComposeScene?) {
+    if (scene == null) {
+      subscriptions[previewId]?.disposeObserver()
+      return
+    }
+    val state = subscriptions[previewId] ?: return
+    if (state.observerHandle != null || state.instrumentationUnavailable) return
+    if (globallyUnavailable) {
+      state.instrumentationUnavailable = true
+      return
+    }
+    installObserverSafely(state, scene)
+  }
+
   private fun installObserverSafely(state: SubscriptionState, scene: ImageComposeScene) {
     val handle =
       try {

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
@@ -84,6 +84,19 @@ object PerfettoTraceDataProducer {
     private var droppedSpans: Int = 0
 
     /**
+     * Running per-name aggregates, accumulated for **every** section including the ones the
+     * retention cap sheds.
+     *
+     * Kept separately from [spans] rather than derived from them at the end, because those are two
+     * different promises. `spans` is a timeline and is allowed to truncate — a UI can only draw so
+     * many rows, and [RenderTrace.droppedSpans] says when it did. `sections` is the "where did the
+     * time actually go" summary, and a summary that silently omits phases is worse than no summary:
+     * it under-reports exactly the hot repeated phase that made a long session hit the cap in the
+     * first place.
+     */
+    private val aggregates = LinkedHashMap<String, MutableAggregate>()
+
+    /**
      * Current nesting level. Incremented for the duration of each [section] body, so a section
      * records the depth it was *entered* at — see [RenderTrace.Recorded.depth] for why that beats
      * reconstructing containment afterwards.
@@ -130,6 +143,8 @@ object PerfettoTraceDataProducer {
       endNs: Long,
       depth: Int = 0,
     ) {
+      val durationMicros = (endNs - startNs).coerceAtLeast(0L) / 1_000L
+      aggregates.getOrPut(name) { MutableAggregate(category) }.add(durationMicros)
       if (spans.size < MAX_SPANS) {
         spans +=
           RenderTrace.Recorded(
@@ -162,7 +177,38 @@ object PerfettoTraceDataProducer {
      * are simply absent. Cheap enough to call more than once.
      */
     fun renderTrace(): RenderTrace =
-      RenderTrace.of(backend = backend, events = spans.toList(), droppedSpans = droppedSpans)
+      RenderTrace.of(
+        backend = backend,
+        events = spans.toList(),
+        sections =
+          aggregates
+            .map { (name, aggregate) -> aggregate.toSection(name) }
+            .sortedByDescending { it.totalMicros },
+        droppedSpans = droppedSpans,
+      )
+
+    /** Mutable accumulator behind one [RenderTraceSection]. */
+    private class MutableAggregate(private val category: String) {
+      private var count: Int = 0
+      private var totalMicros: Long = 0L
+      private var maxMicros: Long = 0L
+
+      fun add(durationMicros: Long) {
+        count += 1
+        totalMicros += durationMicros
+        if (durationMicros > maxMicros) maxMicros = durationMicros
+      }
+
+      fun toSection(name: String): RenderTraceSection =
+        RenderTraceSection(
+          name = name,
+          category = category,
+          count = count,
+          totalMicros = totalMicros,
+          meanMicros = if (count == 0) 0L else totalMicros / count,
+          maxMicros = maxMicros,
+        )
+    }
 
     fun payload(): TracePayload =
       TracePayload(

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
@@ -87,14 +87,28 @@ data class RenderTrace(
   )
 
   companion object {
-    /** Build a trace from the recorder's closed sections, rebasing times onto the first span. */
-    fun of(backend: String, events: List<Recorded>, droppedSpans: Int = 0): RenderTrace {
+    /**
+     * Build a trace from the recorder's closed sections, rebasing times onto the first span.
+     *
+     * [sections] is supplied by the caller rather than derived from [events] because the two can
+     * legitimately disagree: [events] is a timeline that the recorder's retention cap may truncate,
+     * while the aggregates are accumulated for every section the recorder ever saw. Deriving them
+     * here would silently under-report exactly the hot repeated phase that hit the cap. Passing
+     * `null` falls back to grouping [events], which is what a caller with no separate accumulator
+     * (tests, and anything reconstructing a trace from a wire payload) wants.
+     */
+    fun of(
+      backend: String,
+      events: List<Recorded>,
+      sections: List<RenderTraceSection>? = null,
+      droppedSpans: Int = 0,
+    ): RenderTrace {
       if (events.isEmpty()) {
         return RenderTrace(
           backend = backend,
           totalMicros = 0L,
           spans = emptyList(),
-          sections = emptyList(),
+          sections = sections.orEmpty(),
           droppedSpans = droppedSpans,
         )
       }
@@ -112,25 +126,26 @@ data class RenderTrace(
             depth = event.depth,
           )
         }
-      val sections =
-        spans
-          .groupBy { it.name }
-          .map { (name, group) ->
-            RenderTraceSection(
-              name = name,
-              category = group.first().category,
-              count = group.size,
-              totalMicros = group.sumOf { it.durationMicros },
-              meanMicros = group.sumOf { it.durationMicros } / group.size,
-              maxMicros = group.maxOf { it.durationMicros },
-            )
-          }
-          .sortedByDescending { it.totalMicros }
+      val resolvedSections =
+        sections
+          ?: spans
+            .groupBy { it.name }
+            .map { (name, group) ->
+              RenderTraceSection(
+                name = name,
+                category = group.first().category,
+                count = group.size,
+                totalMicros = group.sumOf { it.durationMicros },
+                meanMicros = group.sumOf { it.durationMicros } / group.size,
+                maxMicros = group.maxOf { it.durationMicros },
+              )
+            }
+            .sortedByDescending { it.totalMicros }
       return RenderTrace(
         backend = backend,
         totalMicros = (endNanos - originNanos).coerceAtLeast(0L) / 1_000L,
         spans = spans,
-        sections = sections,
+        sections = resolvedSections,
         droppedSpans = droppedSpans,
       )
     }

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
@@ -91,6 +91,27 @@ class RenderTraceTest {
   }
 
   @Test
+  fun `aggregates survive the span retention cap`() {
+    // The cap truncates the *timeline*; it must not truncate the summary. A long interactive
+    // session hits the cap precisely because one phase repeats a lot, so aggregates built from the
+    // retained spans would under-report exactly the phase worth looking at.
+    val recorder =
+      PerfettoTraceDataProducer.recorder(previewId = "p", backend = "desktop", enabled = false)
+    val iterations = 5_000
+
+    repeat(iterations) { recorder.section("compose:frame") {} }
+
+    val trace = recorder.renderTrace()
+    assertTrue(trace.droppedSpans > 0, "timeline should have truncated")
+    assertTrue(trace.spans.size < iterations, "timeline should be capped")
+    assertEquals(
+      iterations,
+      trace.sections.single { it.name == "compose:frame" }.count,
+      "the summary must still count every section",
+    )
+  }
+
+  @Test
   fun `payload keeps the v1 shape when no spans were recorded`() {
     val payload = RenderTraceDataProduct.payloadFrom(mapOf("tookMs" to 7L), trace = null)
 


### PR DESCRIPTION
## Summary

Follow-up to #3343, which merged before these fixes could be pushed onto it. Both are Codex review findings on that PR, and both are real.

### `sections[]` under-reported once the span cap was hit

`RenderTrace.droppedSpans`'s own KDoc claimed *"`sections` still accounts for every span, so the aggregates stay honest when the timeline can't"* — and `RenderTrace.of` built `sections[]` by grouping the **retained** spans, so it did precisely the opposite. The failure mode is the worst possible one: a long interactive session hits `MAX_SPANS` because some phase repeats thousands of times, and the summary then omits exactly that phase.

The recorder now accumulates per-name aggregates as sections close, independent of retention, and passes them to `RenderTrace.of`. The two are genuinely different promises — `spans` is a timeline a UI can only draw so much of, `sections` is the "where did the time go" summary — so they're now computed separately rather than one derived from the other. `sections = null` still falls back to grouping the spans, which is what a caller reconstructing a trace from a wire payload wants.

### An ordinary render was reported as a delta

`onSessionLifecycle` promotes a `snapshot` subscription to `MODE_DELTA` — correct when a live interactive session means per-input deltas are about to become meaningful. Routing one-shot render scenes through it was not: the scene is released at teardown before `attachmentsFor` builds the payload, so what the panel received was an initial-composition snapshot labelled `mode: "delta"` with an `inputSeq`. #3343 made `compose/recomposition` default-ON in the Performance chip, and a chip subscribe carries no params — so it defaults to `snapshot` and hit this on every render.

New `onRenderSceneLifecycle` for transient scenes: installs the observer, leaves the mode alone, and deliberately stays out of `liveScenes` (that map answers "is a session held?" at subscribe time, and a scene that won't outlive the render must not answer yes). Teardown disposes the observer but keeps the counters, because `attachmentsFor` runs after teardown and still has to report the render it measured.

## Test plan

- [x] `:data-render-core:test` — new `aggregates survive the span retention cap`: 5,000 sections against a 4,096 cap, asserting the timeline truncates (`droppedSpans > 0`) while `sections[].count` still reports all 5,000
- [x] `:daemon:desktop:test` — new `RecompositionRenderSceneTest`: a snapshot subscription stays `snapshot` through a transient scene's install/dispose cycle and still yields an attachment afterwards; a transient scene does not make a later `delta` subscribe believe a session is held. Lives in `:daemon:desktop` rather than beside the registry because it needs a real `ImageComposeScene` (skiko natives) and the connector's own tests are deliberately fake-only.
- [x] `:data-render-connector:test`, `:data-recomposition-connector:test`
- [x] `./gradlew ktfmtCheckAll`

Note: `RenderEngineLottieScrubTest > scrubPersistsAcrossRenderWithoutOverride` failed once in a full `:daemon:desktop:test` run and passed on three subsequent clean runs, including on the pre-change tree. Untouched by this diff (the Lottie GIF path returns before the recorder is even created) — flagging it as a flake rather than chasing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4)_