### PR TITLE
fix(serve): render a cold-id theme request instead of abandoning it

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -231,6 +231,37 @@ class ServeCatalogLiveHost(
     return false
   }
 
+  /**
+   * Wait, briefly, for the background warm [daemonWarmOrScheduling] just scheduled for [daemonId],
+   * so a cold-id request can render instead of failing. Returns whether the daemon came up warm.
+   *
+   * Only for a **pure theme** request ([themeCacheKey] non-null): those have no useful fallback —
+   * serving baked pixels for a requested theme would show the wrong colours under a successful
+   * status — whereas an ordinary override request drops to baked and loses nothing by not waiting.
+   *
+   * Bounded by [FOREGROUND_WARM_AWAIT_MILLIS] rather than the full cold-start time: the caller is
+   * holding one of the server's render slots while it waits, so an unbounded wait would let a burst
+   * of cold ids consume every slot. Past the bound the caller still gets Busy — the same answer as
+   * before, just after actually trying.
+   */
+  private fun awaitForegroundWarm(daemonId: String, themeCacheKey: String?): Boolean {
+    if (themeCacheKey == null || !warmInBackground) return false
+    val deadline = clock() + FOREGROUND_WARM_AWAIT_MILLIS
+    while (clock() < deadline) {
+      if (warmDaemonIds.contains(daemonId)) return true
+      // The warm finished without succeeding (a genuinely failing preview): stop waiting and let
+      // the caller take its normal path rather than burning the whole budget on a lost cause.
+      if (!warmingInFlight.contains(daemonId)) return false
+      try {
+        Thread.sleep(WARM_POLL_MILLIS)
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        return false
+      }
+    }
+    return warmDaemonIds.contains(daemonId)
+  }
+
   private fun scheduleWarm(daemonId: String, host: ServeHost = live) {
     if (!warmInBackground || warmDaemonIds.contains(daemonId)) return
     if (warmingInFlight.add(daemonId)) {
@@ -584,7 +615,19 @@ class ServeCatalogLiveHost(
       // replicas cold-start on the request path if necessary; otherwise the per-id warm guard would
       // return Busy for every card and the pool would never grow. Ordinary renders retain the
       // baked-first/background-warm behaviour.
-      if (leased || daemonWarmOrScheduling(daemonId)) {
+      // A pure theme request on a cold id used to schedule a warm and then abandon its own render
+      // — returning Busy despite already holding a render slot it was prepared to wait 30s on. That
+      // made the theme cache load-bearing for correctness rather than an optimization: a cache miss
+      // was an error, so a restart (which empties the cache) broke the whole grid until the
+      // background pass refilled it, which on a busy box takes hours.
+      //
+      // A warm render is sub-second (p50 ~0.25-1.1s on the public box), so the honest answer is to
+      // render. The gate exists for the one case where that isn't true — a COLD daemon, 34-68s —
+      // so wait for the warm this request just scheduled, bounded, and only give up if the cold
+      // start really is going to outlast the request.
+      if (
+        leased || daemonWarmOrScheduling(daemonId) || awaitForegroundWarm(daemonId, themeCacheKey)
+      ) {
         val live = renderDaemon(daemonId, overrides, leased)
         // Count a real render failure against this theme key so a permanently broken preview stops
         // being re-attempted (see [CatalogThemeCache.recordRenderFailure]). Busy / NotFound are not
@@ -897,5 +940,19 @@ class ServeCatalogLiveHost(
     } finally {
       baked.close()
     }
+  }
+
+  companion object {
+    /**
+     * How long a pure-theme request will wait for the daemon warm it scheduled before giving up.
+     *
+     * Sized between the two render regimes: a warm render is sub-second, a cold Android start is
+     * 34-68s. Waiting the full cold start would tie up a render slot for a minute; not waiting at
+     * all is what made a cache miss an error. This covers a warm that is already in flight and
+     * nearly done, and lets a genuinely cold one fall through to the previous behaviour.
+     */
+    internal const val FOREGROUND_WARM_AWAIT_MILLIS = 15_000L
+
+    private const val WARM_POLL_MILLIS = 50L
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1390,4 +1390,74 @@ class ServeCatalogLiveHostTest {
       composite.render(catalogId, PreviewOverrides(themeProvider = "com.example.Brand")),
     )
   }
+
+  /**
+   * The theme cache is an optimization, not a correctness requirement. A cache miss on a cold
+   * daemon id used to schedule a warm and then abandon the request — returning Busy despite the
+   * caller already holding a render slot — which made a server restart (empty cache) break the
+   * whole grid until the hours-long background pass refilled it.
+   */
+  @Test
+  fun `a pure theme render on a cold id waits for its warm instead of reporting busy`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = baked,
+        warmInBackground = true,
+      )
+
+    // Nothing has warmed this id: under the old gate this returned Busy without rendering.
+    val outcome = composite.render(catalogId, themeOverride())
+
+    assertTrue(
+      outcome is RenderOutcome.Ok,
+      "a cold id must still produce themed pixels, got $outcome",
+    )
+    assertTrue(
+      live.renderCalls >= 2,
+      "one warm render plus the themed one, got ${live.renderCalls}",
+    )
+  }
+
+  /** A warm that never succeeds must not hold the request for the whole budget. */
+  @Test
+  fun `a pure theme render gives up when the warm itself fails`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        forcedRenderOutcome = RenderOutcome.Busy,
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = baked,
+        warmInBackground = true,
+      )
+
+    val startedAt = System.nanoTime()
+    val outcome = composite.render(catalogId, themeOverride())
+    val elapsedMs = (System.nanoTime() - startedAt) / 1_000_000
+
+    assertEquals(
+      RenderOutcome.Busy,
+      outcome,
+      "a theme render that cannot succeed still reports busy",
+    )
+    assertTrue(
+      elapsedMs < ServeCatalogLiveHost.FOREGROUND_WARM_AWAIT_MILLIS,
+      "it must not burn the whole warm budget on a failing warm (took ${elapsedMs}ms)",
+    )
+  }
 }


### PR DESCRIPTION
Part 1 of making the theme cache an optimization rather than a correctness requirement. This is the change that actually makes the grid work; the throughput work follows separately.

## The bug

```kotlin
if (leased || daemonWarmOrScheduling(daemonId)) { …render… }
if (themeCacheKey != null) return RenderOutcome.Busy   // ← cold id: never even tried
```

`daemonWarmOrScheduling` returns false for any daemon id that hasn't yet completed one un-themed render (when `warmInBackground` is on, as the public deploy runs it). So the request **schedules a warm and then abandons its own render** — despite already holding a render slot it was prepared to wait 30s on.

That makes a cache miss an *error*. A server restart empties the theme cache, so the entire grid breaks until the background pass refills it — and on the public box that pass runs at roughly **one entry per 105s**, so "until" means hours. Observed on preview.coo.ee after the 0.19.35 rollout: `cached: 0 / 1267`, every themed thumbnail 503.

## Why the gate was wrong, not just unlucky

It was sized for a render cost that isn't real. The server's own `renderStats`:

```
p50Ms 238 / 815 / 1111    avgMs 951    minMs 195
coldRenders: 1    firstRenderMs: 34370–68211
```

A **warm render is sub-second**. Only a *cold* Android start is expensive, and it happens once. So for a warm-or-nearly-warm daemon the honest answer is simply to render; the gate should only protect against the cold case it was written for.

(I had previously estimated ~10s per render from the SVG lane. That was wrong — `renderSvg` does a live render *plus* the figma-svg export, so it's a ~10× overestimate of PNG render cost. The numbers above are the server's own instrumentation.)

## The fix

`awaitForegroundWarm` waits for the warm the request just scheduled, bounded by `FOREGROUND_WARM_AWAIT_MILLIS` (15s — between the two regimes), then falls through to Busy as before. It returns early if the warm finishes without succeeding, so a genuinely failing preview doesn't hold a render slot for the whole budget.

Scoped to **pure-theme requests only**. An ordinary override request drops to baked pixels and loses nothing by not waiting; serving baked pixels for a *requested theme* would show the wrong colours under a 200, which is why that path has no usable fallback and must either render or say so.

## Test plan

- `:cli:test` — green.
- Two new tests: a cold id now produces themed pixels rather than Busy, and a failing warm still reports Busy without burning the budget.
- Both **verified to fail against the unfixed gate**. Worth noting my first negative control was invalid — ktfmt had wrapped the condition so my edit silently didn't match, and the test "passed" against what I thought was unfixed code. Re-ran it against the real formatting and got the expected failure.

No visual surfaces changed.

## What this does not do

Throughput is unchanged: the optimizer still needs a 60s *server-wide* quiet window and shares one background render permit across all 21 catalogs. That's the follow-up — but with this in, the background pass is a genuine prefetch that can be starved without breaking anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_