### PR TITLE
fix(daemon): report complete trace bounds past the span cap and drop delta fields from snapshots

### DIFF
--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionRenderSceneTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionRenderSceneTest.kt
@@ -75,6 +75,10 @@ class RecompositionRenderSceneTest {
           .payload
           .toString()
       assertTrue(payload, payload.contains("\"mode\":\"snapshot\""))
+      // Delta-only fields stay null: a snapshot has no previous input and no frame stream, so
+      // filling them in would describe it as the n-th step of a stream that isn't running.
+      assertTrue(payload, payload.contains("\"sinceFrameStreamId\":null"))
+      assertTrue(payload, payload.contains("\"inputSeq\":null"))
     } finally {
       scene.close()
     }

--- a/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -230,19 +230,28 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     // payload — the client sees no `compose/recomposition` entry on `renderFinished` and
     // greys out its panel, which is the honest signal.
     if (globallyUnavailable || state.instrumentationUnavailable) return emptyList()
-    // Bump the input-seq counter once per attachment build — that's exactly one per
-    // post-input renderFinished in the interactive path (the dispatcher calls attachmentsFor
-    // once per render). Snapshot the counter map *before* incrementing so the payload reads
-    // monotonically from the client's perspective: the n-th attachment carries inputSeq=n.
     val nodes = state.snapshotAndReset()
-    state.inputSeq += 1L
+    // `sinceFrameStreamId` and `inputSeq` are the delta contract: "counts since the previous input
+    // on this frame stream". A snapshot payload has no previous input and no frame stream, so both
+    // stay null — they are declared nullable for exactly this case, and filling them in would
+    // describe an initial-composition snapshot as the n-th step of a stream that isn't running.
+    // Ordinary (non-interactive) renders take this path on every render, so it is the common one.
     val payload =
-      RecompositionPayload(
-        mode = state.mode,
-        sinceFrameStreamId = state.frameStreamId,
-        inputSeq = state.inputSeq,
-        nodes = nodes,
-      )
+      if (state.mode == MODE_DELTA) {
+        // Bump the input-seq counter once per attachment build — exactly one per post-input
+        // renderFinished (the dispatcher calls attachmentsFor once per render). The counter map is
+        // snapshotted *before* the increment so the payload reads monotonically from the client's
+        // perspective: the n-th attachment carries inputSeq=n.
+        state.inputSeq += 1L
+        RecompositionPayload(
+          mode = state.mode,
+          sinceFrameStreamId = state.frameStreamId,
+          inputSeq = state.inputSeq,
+          nodes = nodes,
+        )
+      } else {
+        RecompositionPayload(mode = state.mode, nodes = nodes)
+      }
     return listOf(
       DataProductAttachment(
         kind = KIND,

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
@@ -97,6 +97,15 @@ object PerfettoTraceDataProducer {
     private val aggregates = LinkedHashMap<String, MutableAggregate>()
 
     /**
+     * Bounds of *every* section the recorder saw, tracked alongside [aggregates] and for the same
+     * reason: once [spans] truncates, the retained prefix ends before the render does, so a total
+     * derived from it would be short — and the phase bars would be scaled against a window that
+     * closed early.
+     */
+    private var firstStartNs: Long = Long.MAX_VALUE
+    private var lastEndNs: Long = Long.MIN_VALUE
+
+    /**
      * Current nesting level. Incremented for the duration of each [section] body, so a section
      * records the depth it was *entered* at — see [RenderTrace.Recorded.depth] for why that beats
      * reconstructing containment afterwards.
@@ -145,6 +154,8 @@ object PerfettoTraceDataProducer {
     ) {
       val durationMicros = (endNs - startNs).coerceAtLeast(0L) / 1_000L
       aggregates.getOrPut(name) { MutableAggregate(category) }.add(durationMicros)
+      if (startNs < firstStartNs) firstStartNs = startNs
+      if (endNs > lastEndNs) lastEndNs = endNs
       if (spans.size < MAX_SPANS) {
         spans +=
           RenderTrace.Recorded(
@@ -184,6 +195,9 @@ object PerfettoTraceDataProducer {
           aggregates
             .map { (name, aggregate) -> aggregate.toSection(name) }
             .sortedByDescending { it.totalMicros },
+        totalMicros =
+          if (firstStartNs == Long.MAX_VALUE) null
+          else (lastEndNs - firstStartNs).coerceAtLeast(0L) / 1_000L,
         droppedSpans = droppedSpans,
       )
 

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
@@ -96,17 +96,24 @@ data class RenderTrace(
      * here would silently under-report exactly the hot repeated phase that hit the cap. Passing
      * `null` falls back to grouping [events], which is what a caller with no separate accumulator
      * (tests, and anything reconstructing a trace from a wire payload) wants.
+     *
+     * [totalMicros] is supplied for the same reason: once the cap truncates [events], the retained
+     * prefix no longer spans the whole render, so deriving the total from it would report complete
+     * section totals against a short wall time — and the phase bars would be scaled to a window
+     * that ends before the render did. `null` derives it from [events], correct whenever nothing
+     * was dropped.
      */
     fun of(
       backend: String,
       events: List<Recorded>,
       sections: List<RenderTraceSection>? = null,
+      totalMicros: Long? = null,
       droppedSpans: Int = 0,
     ): RenderTrace {
       if (events.isEmpty()) {
         return RenderTrace(
           backend = backend,
-          totalMicros = 0L,
+          totalMicros = totalMicros ?: 0L,
           spans = emptyList(),
           sections = sections.orEmpty(),
           droppedSpans = droppedSpans,
@@ -143,7 +150,7 @@ data class RenderTrace(
             .sortedByDescending { it.totalMicros }
       return RenderTrace(
         backend = backend,
-        totalMicros = (endNanos - originNanos).coerceAtLeast(0L) / 1_000L,
+        totalMicros = totalMicros ?: ((endNanos - originNanos).coerceAtLeast(0L) / 1_000L),
         spans = spans,
         sections = resolvedSections,
         droppedSpans = droppedSpans,

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
@@ -109,6 +109,18 @@ class RenderTraceTest {
       trace.sections.single { it.name == "compose:frame" }.count,
       "the summary must still count every section",
     )
+    // …and the total must span the whole run, not just the retained prefix. Deriving it from the
+    // capped spans would report complete section totals against a wall time that ends early, and
+    // scale every phase bar to a window that closed before the render did.
+    assertTrue(
+      trace.totalMicros >= trace.sections.single { it.name == "compose:frame" }.totalMicros,
+      "total (${trace.totalMicros}us) must cover every recorded section",
+    )
+    val lastRetained = trace.spans.last()
+    assertTrue(
+      trace.totalMicros >= lastRetained.startMicros + lastRetained.durationMicros,
+      "total must extend past the last retained span",
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two Codex review findings on #3344, which merged before they could be pushed onto it. Both are real.

### `totalUs` was still derived from the truncated span list

#3344 fixed `sections[]` to account for every span past the retention cap, but `RenderTrace.of` kept computing `totalUs` from the retained `events`. That left the payload internally inconsistent the moment anything dropped: complete section totals measured against a wall time that ends at the last *retained* span, with every phase bar scaled to that short window.

The recorder now tracks first-start and last-end across every section it sees — alongside the aggregates, for exactly the same reason — and passes the total in. `totalMicros = null` still derives from the events, which is correct whenever nothing was dropped and is what a caller reconstructing a trace from a wire payload wants.

### Snapshot payloads carried delta-only fields

`attachmentsFor` unconditionally incremented and serialized `inputSeq` and `sinceFrameStreamId`. Those are the delta contract — *"counts since the previous input on this frame stream"* — and `RecompositionPayload` declares both nullable precisely because a snapshot has neither a previous input nor a frame stream.

This was latent while only interactive sessions produced payloads. #3343 made `compose/recomposition` default-ON in the Performance chip and #3344 kept ordinary renders in `snapshot` mode, so it became the common path: every render emitted a snapshot describing itself as the n-th step of a stream that isn't running. Snapshot payloads now leave both fields null, and only the delta branch bumps the counter.

## Test plan

- [x] `:data-render-core:test` — the cap test now also asserts the total covers every recorded section and extends past the last retained span, which is exactly what the old derivation got wrong
- [x] `:daemon:desktop:test` — `RecompositionRenderSceneTest` additionally asserts `sinceFrameStreamId` and `inputSeq` serialize as null on the snapshot path
- [x] `:data-render-connector:test`, `:data-recomposition-connector:test`
- [x] `./gradlew ktfmtCheckAll`

On the Lottie flake noted in #3344: two *different* tests (`RenderEngineLottieScrubTest > scrubPersistsAcrossRenderWithoutOverride`, `RenderEngineLottieTest > lottieAssetRendersBlueSquare`) each failed once in a full `:daemon:desktop:test` run in this sandbox. The Lottie tests passed three times in isolation and the full suite passed three consecutive clean runs afterwards. Nothing in this diff or #3344 reaches the Lottie path (the GIF scenario returns before the recorder exists), so this reads as suite-level contention in this environment rather than a regression — worth a look with the repo's flake-detector if it shows up in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4)_