### PR TITLE
fix(serve): let the theme optimizer keep its turn while the server is quiet

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -183,6 +183,9 @@ class ServeCatalogLiveHost(
   // Whether the optimizer currently holds its turn: set once the full quiet window is met, cleared
   // the moment a request arrives. Without it the pass re-earned the whole window per render.
   private val optimizerHasTurn = AtomicBoolean(false)
+  // When the optimizer last checked for activity. Any activity newer than this happened while it
+  // was rendering, and must cost it the turn even if the server looks quiet again by now.
+  private val optimizerSampledAt = java.util.concurrent.atomic.AtomicLong(0)
   private val warmDaemonIds = ConcurrentHashMap.newKeySet<String>()
   private val warmingInFlight = ConcurrentHashMap.newKeySet<String>()
 
@@ -424,14 +427,32 @@ class ServeCatalogLiveHost(
     if (!optimizerHasTurn.get()) {
       if (!awaitServerIdle()) return false
       optimizerHasTurn.set(true)
+      optimizerSampledAt.set(clock())
       return true
     }
-    // Holding a turn: only step aside when someone is actually using the server right now.
+    // Holding a turn. The question is NOT "is the server idle right this instant" — sampling that
+    // misses every request that arrived *during* the render we just finished. A render can outlast
+    // OPTIMIZER_YIELD_MILLIS several times over, so by the time we look, a visitor's request has
+    // come and gone and the instantaneous idle reads as quiet again. That visitor never caused a
+    // yield, which is precisely the starvation this gate exists to prevent.
+    //
+    // Ask instead whether anything happened SINCE we last looked. `serverIdleMillis` is the age of
+    // the last activity, so `now - idle` is when that activity happened; if that timestamp is newer
+    // than our previous sample, a request landed while we were busy.
+    val now = clock()
     val idleMillis = serverIdleMillis()
-    if (idleMillis != null && idleMillis >= OPTIMIZER_YIELD_MILLIS) return true
+    val lastActivityAt = idleMillis?.let { now - it }
+    val quiet = lastActivityAt != null && lastActivityAt <= optimizerSampledAt.get()
+    optimizerSampledAt.set(now)
+    if (quiet) return true
     optimizerHasTurn.set(false)
     catalogThemeCache.markPaused()
-    return awaitServerIdle().also { if (it) optimizerHasTurn.set(true) }
+    return awaitServerIdle().also {
+      if (it) {
+        optimizerHasTurn.set(true)
+        optimizerSampledAt.set(clock())
+      }
+    }
   }
 
   private fun awaitServerIdle(): Boolean {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -180,6 +180,9 @@ class ServeCatalogLiveHost(
   // once a daemon id has produced one successful render it's warm and the per-variant lane kicks in
   // for it. [prewarm] closes the window off the request path so the first real browse is already
   // per-variant.
+  // Whether the optimizer currently holds its turn: set once the full quiet window is met, cleared
+  // the moment a request arrives. Without it the pass re-earned the whole window per render.
+  private val optimizerHasTurn = AtomicBoolean(false)
   private val warmDaemonIds = ConcurrentHashMap.newKeySet<String>()
   private val warmingInFlight = ConcurrentHashMap.newKeySet<String>()
 
@@ -368,7 +371,7 @@ class ServeCatalogLiveHost(
           var attempts = 0
           var lastFailure: String? = null
           while (catalogThemeCache.get(job.cacheKey) == null && attempts < 3) {
-            if (!awaitServerIdle()) return@execute
+            if (!awaitOptimizerTurn()) return@execute
             catalogThemeCache.markRunning(clock())
             // One background render server-wide: the permit is taken per job, not per pass, so a
             // catalog that parks for traffic hands it straight to the next one.
@@ -400,6 +403,35 @@ class ServeCatalogLiveHost(
         optimizationStarted.set(false)
       }
     }
+  }
+
+  /**
+   * Gate one background render.
+   *
+   * The pass *enters* on the full [themeOptimizationIdleMillis] quiet window — that is the "don't
+   * start work on a box someone is using" rule and it stays. What changed is what happens once it
+   * is running: it used to re-demand the whole 60s window before **every single render**, so any
+   * request anywhere in the process reset it and the pass could only ever advance during a full
+   * minute of total silence. On a public server with 21 catalogs that is close to never — measured
+   * throughput was one entry per ~105s against a sub-second render, i.e. ~99% waiting.
+   *
+   * Now it keeps its turn while the server stays quiet and yields as soon as a request actually
+   * arrives ([OPTIMIZER_YIELD_MILLIS]), which is the property that matters: a visitor never waits
+   * behind more than the render already in flight, and an idle box fills the cache at render speed
+   * instead of one entry a minute.
+   */
+  private fun awaitOptimizerTurn(): Boolean {
+    if (!optimizerHasTurn.get()) {
+      if (!awaitServerIdle()) return false
+      optimizerHasTurn.set(true)
+      return true
+    }
+    // Holding a turn: only step aside when someone is actually using the server right now.
+    val idleMillis = serverIdleMillis()
+    if (idleMillis != null && idleMillis >= OPTIMIZER_YIELD_MILLIS) return true
+    optimizerHasTurn.set(false)
+    catalogThemeCache.markPaused()
+    return awaitServerIdle().also { if (it) optimizerHasTurn.set(true) }
   }
 
   private fun awaitServerIdle(): Boolean {
@@ -952,6 +984,13 @@ class ServeCatalogLiveHost(
      * nearly done, and lets a genuinely cold one fall through to the previous behaviour.
      */
     internal const val FOREGROUND_WARM_AWAIT_MILLIS = 15_000L
+
+    /**
+     * How recently a request must have touched the server for the optimizer to give up its turn.
+     * Short: the point is to step aside for a live visitor within one render, not to re-earn the
+     * whole entry window after every request.
+     */
+    internal const val OPTIMIZER_YIELD_MILLIS = 1_500L
 
     private const val WARM_POLL_MILLIS = 50L
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1460,4 +1460,42 @@ class ServeCatalogLiveHostTest {
       "it must not burn the whole warm budget on a failing warm (took ${elapsedMs}ms)",
     )
   }
+
+  /**
+   * The optimizer used to re-demand the whole 60s entry window before EVERY render, so a server
+   * that was quiet-but-not-silent-for-a-minute advanced one entry and then stalled. On the public
+   * box that measured one entry per ~105s against a sub-second render — ~99% waiting.
+   *
+   * Modelled here by an idle clock that reports a full minute once (letting the pass start) and
+   * then a steady 10s: quiet by any reasonable measure, but under the entry window. The old gate
+   * caches exactly one entry and blocks; keeping the turn caches them all.
+   */
+  @Test
+  fun `the optimizer keeps its turn while the server stays quiet`() {
+    val secondTheme = ServeTheme("Brand Light", "com.example.BrandLight")
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme, secondTheme),
+      )
+    val cache = CatalogThemeCache()
+    val firstCall = java.util.concurrent.atomic.AtomicBoolean(true)
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = baked,
+        catalogThemeCache = cache,
+        // Quiet enough to keep a turn (>= OPTIMIZER_YIELD_MILLIS), never enough to re-earn entry.
+        serverIdleMillis = { if (firstCall.getAndSet(false)) 60_000L else 10_000L },
+        themeOptimizationIdleMillis = 60_000L,
+      )
+
+    composite.prewarm()
+
+    val snapshot = awaitOk(10_000) { cache.snapshot().takeIf { it.cached >= 2 } }
+    assertEquals(2, snapshot.cached, "both themes cached without re-earning the entry window")
+  }
 }


### PR DESCRIPTION
Part 2, after #3345 made a cache miss recoverable. With that in, the background pass is a genuine prefetch — this makes it actually keep up.

## The bug

```kotlin
while (cache.get(job.cacheKey) == null && attempts < 3) {
  if (!awaitServerIdle()) return@execute      // ← the FULL 60s window, every render
```

`awaitServerIdle` waits for `themeOptimizationIdleMillis` (60s) of quiet — and it's called **per render attempt**, not once per pass. `serverIdleMillis` is process-wide, so a request to *any* of 21 catalogs resets it. The pass could only advance during a full minute of total silence, which on a public server is close to never.

Measured on preview.coo.ee: **one entry per ~105s** against a sub-second render — roughly 99% waiting. For pocketcasts' 1267 entries that's ~37 hours.

## The fix

Entry is unchanged: the pass still earns the whole quiet window before starting work on a box someone is using. What changes is that it **keeps** that turn while the server stays quiet, and yields as soon as a request actually arrives (`OPTIMIZER_YIELD_MILLIS`, 1.5s).

Both properties still hold:
- a visitor never waits behind more than the render already in flight (the yield is checked between jobs, and the per-render background permit is unchanged);
- an idle box fills the cache at render speed rather than one entry a minute.

## What I found was already right

I'd planned to reorder the job list preview-major so one daemon warm amortises across all themes for a preview. It already is:

```kotlin
catalogIds.flatMap { previewId -> declaredThemes.map { theme -> … } }
```

All 7 themes for a preview render consecutively, so the warm is already shared. No change needed — worth recording so nobody re-proposes it.

## Test plan

- `:cli:test` — green.
- New test models a server that is *quiet but not silent-for-a-minute* (10s idle, 60s entry window): the old gate caches one entry then blocks, the new one caches both themes. **Verified to fail against the unfixed gate.**

## Deliberately not in this PR

Leased bursts still take seats via `acquireBackground`, so they're bounded by the stream reserve rather than competing as foreground work. That's arguably wrong — a leased burst is a user waiting, not background residency — but changing it is exactly the shape of the change that broke the `serve-lanes` E2E on a `--live-seats 1` box earlier today. I'd want to re-run that E2E locally against the change before proposing it, rather than ship it on reasoning alone.

Also unchanged: the single process-wide background render permit. Worth revisiting (contention that matters is per-daemon, and different catalogs' daemons don't block each other), but it's a separate tuning question with its own blast radius.

No visual surfaces changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_