### PR TITLE
fix(daemon): carry the trace origin alongside the overridden total

### DIFF
--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
@@ -198,6 +198,10 @@ object PerfettoTraceDataProducer {
         totalMicros =
           if (firstStartNs == Long.MAX_VALUE) null
           else (lastEndNs - firstStartNs).coerceAtLeast(0L) / 1_000L,
+        // Must travel with the total: the cap sheds the outermost section first (it closes last),
+        // so the retained spans can start after the render did. Rebasing them onto their own
+        // minimum would place every phase at the wrong offset under a correctly-scaled total.
+        originNanos = firstStartNs.takeIf { it != Long.MAX_VALUE },
         droppedSpans = droppedSpans,
       )
 

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
@@ -102,12 +102,19 @@ data class RenderTrace(
      * section totals against a short wall time — and the phase bars would be scaled to a window
      * that ends before the render did. `null` derives it from [events], correct whenever nothing
      * was dropped.
+     *
+     * [originNanos] travels with [totalMicros] and must not be omitted when that is supplied.
+     * Sections are appended as they **close**, so the outermost one closes last and is the first
+     * thing the cap sheds — leaving the retained spans starting *after* the render began. Rebasing
+     * them onto their own minimum while reporting the full duration would scale the bars correctly
+     * but place every phase at the wrong offset.
      */
     fun of(
       backend: String,
       events: List<Recorded>,
       sections: List<RenderTraceSection>? = null,
       totalMicros: Long? = null,
+      originNanos: Long? = null,
       droppedSpans: Int = 0,
     ): RenderTrace {
       if (events.isEmpty()) {
@@ -119,7 +126,7 @@ data class RenderTrace(
           droppedSpans = droppedSpans,
         )
       }
-      val originNanos = events.minOf { it.startNanos }
+      val origin = originNanos ?: events.minOf { it.startNanos }
       val endNanos = events.maxOf { it.endNanos }
       // Start time ascending, and where two spans start together the enclosing one first, so the
       // list reads top-down as the nesting does.
@@ -128,7 +135,7 @@ data class RenderTrace(
           RenderTraceSpan(
             name = event.name,
             category = event.category,
-            startMicros = (event.startNanos - originNanos) / 1_000L,
+            startMicros = (event.startNanos - origin).coerceAtLeast(0L) / 1_000L,
             durationMicros = (event.endNanos - event.startNanos).coerceAtLeast(0L) / 1_000L,
             depth = event.depth,
           )
@@ -150,7 +157,7 @@ data class RenderTrace(
             .sortedByDescending { it.totalMicros }
       return RenderTrace(
         backend = backend,
-        totalMicros = totalMicros ?: ((endNanos - originNanos).coerceAtLeast(0L) / 1_000L),
+        totalMicros = totalMicros ?: ((endNanos - origin).coerceAtLeast(0L) / 1_000L),
         spans = spans,
         sections = resolvedSections,
         droppedSpans = droppedSpans,

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
@@ -124,6 +124,29 @@ class RenderTraceTest {
   }
 
   @Test
+  fun `dropping the outermost section keeps the retained offsets on the real origin`() {
+    // Sections are appended as they close, so an enclosing section closes last and is the first
+    // thing the cap sheds. Its children then start *after* the render did — and rebasing them onto
+    // their own minimum while reporting the full duration would place every phase at 0.
+    val recorder =
+      PerfettoTraceDataProducer.recorder(previewId = "p", backend = "desktop", enabled = false)
+
+    recorder.section("render:once") { repeat(5_000) { recorder.section("compose:frame") {} } }
+
+    val trace = recorder.renderTrace()
+    assertTrue(trace.droppedSpans > 0, "the enclosing section should have been shed")
+    assertTrue(
+      trace.spans.none { it.name == "render:once" },
+      "the outermost section closes last, so it is the one dropped",
+    )
+    // The first retained child began after the render did, so its offset must not be zero.
+    assertTrue(
+      trace.spans.first().startMicros > 0,
+      "retained spans must stay on the render's origin, not their own",
+    )
+  }
+
+  @Test
   fun `payload keeps the v1 shape when no spans were recorded`() {
     val payload = RenderTraceDataProduct.payloadFrom(mapOf("tookMs" to 7L), trace = null)
 

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/RenderTraceTest.kt
@@ -128,6 +128,48 @@ class RenderTraceTest {
     // Sections are appended as they close, so an enclosing section closes last and is the first
     // thing the cap sheds. Its children then start *after* the render did — and rebasing them onto
     // their own minimum while reporting the full duration would place every phase at 0.
+    //
+    // Explicit timestamps rather than a live recorder: real elapsed time between two adjacent
+    // `section` calls can be under a microsecond, and `startMicros` truncates — so a wall-clock
+    // version of this test would pass or fail on how fast the machine is.
+    val originNanos = 1_000_000L
+    val trace =
+      RenderTrace.of(
+        backend = "desktop",
+        // Only the children survived the cap; the enclosing `render:once` was shed.
+        events =
+          listOf(
+            RenderTrace.Recorded(
+              "compose:frame",
+              "c",
+              originNanos + 5_000_000L,
+              originNanos + 6_000_000L,
+              1,
+            ),
+            RenderTrace.Recorded(
+              "compose:frame",
+              "c",
+              originNanos + 7_000_000L,
+              originNanos + 8_000_000L,
+              1,
+            ),
+          ),
+        totalMicros = 20_000L,
+        originNanos = originNanos,
+        droppedSpans = 1,
+      )
+
+    // 5ms after the render began — not 0, which is where rebasing onto the retained minimum
+    // would have put it.
+    assertEquals(5_000L, trace.spans.first().startMicros)
+    assertEquals(7_000L, trace.spans.last().startMicros)
+    assertEquals(20_000L, trace.totalMicros)
+  }
+
+  @Test
+  fun `a live recorder that sheds its enclosing section still reports every child`() {
+    // The wall-clock half of the pair above: no offset assertions (those truncate at microsecond
+    // resolution), just that the cap sheds the enclosing section and the aggregates survive it.
     val recorder =
       PerfettoTraceDataProducer.recorder(previewId = "p", backend = "desktop", enabled = false)
 
@@ -139,11 +181,8 @@ class RenderTraceTest {
       trace.spans.none { it.name == "render:once" },
       "the outermost section closes last, so it is the one dropped",
     )
-    // The first retained child began after the render did, so its offset must not be zero.
-    assertTrue(
-      trace.spans.first().startMicros > 0,
-      "retained spans must stay on the render's origin, not their own",
-    )
+    assertEquals(1, trace.sections.single { it.name == "render:once" }.count)
+    assertEquals(5_000, trace.sections.single { it.name == "compose:frame" }.count)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Final Codex finding on #3346, which merged before this could be pushed onto it.

#3346 started passing a complete `totalUs` into `RenderTrace.of` so the reported duration survives the span cap — but `of` still rebased every retained span onto `events.minOf { startNanos }`. The two then disagree in exactly the case the override exists for.

Sections are appended as they **close**, so the outermost one closes last and is therefore the *first* thing the cap sheds. What survives is its children, which began after the render did. Reporting the full duration while rebasing onto the first retained child scales the bars correctly and places every phase at the wrong offset — the trace looks plausible and is wrong.

The recorder now passes `originNanos` with the total, and `of` uses it for both the rebase and the fallback duration. Both stay `null`-able together: with nothing dropped, deriving from `events` is correct and remains the default.

## Test plan

- [x] `:data-render-core:test` — new `dropping the outermost section keeps the retained offsets on the real origin`: 5,000 children inside one `render:once`, asserting the enclosing section really is the one shed and that the first retained child's `startUs` is non-zero (the old code put it at 0)
- [x] `:data-render-core:test`, `:data-render-connector:test`, `:daemon:desktop:test` full suites
- [x] `./gradlew ktfmtCheckAll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4)_