### PR TITLE
fix(gradle-plugin): resolve the desktop bundle classpath lazily

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -410,6 +410,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     val classpath = assembleClasspath(jarsList, depDecisions, embed = embedDeps.getOrElse(false))
     val classpathEntries = classpath.entries
     val inlinedJars = classpath.inlinedJars
+    failOnAndroidClasspathInDesktopBundle(backend.get(), classpathEntries)
 
     val report =
       MinimizationReport(
@@ -1278,6 +1279,55 @@ abstract class BundlePreviewTask : DefaultTask() {
    * SHA-256 is recorded so a player can verify the bytes after re-resolving the coordinate from any
    * source; [src] = null leaves the entry resolvable-but-unverifiable.
    */
+  /**
+   * Fails a `backend: desktop` pack that carries Android-only artifacts.
+   *
+   * A desktop bundle is replayed on a plain host JVM with no `android.jar`, so an `*-android` AAR
+   * on its classpath means every render dies at class-load with `NoClassDefFoundError:
+   * android/os/Parcelable` — instantly, and only once the bundle is already published and being
+   * served. That is exactly what shipped when [ComposePreviewTasks.registerBundleTask] resolved its
+   * consumer runtime config eagerly and fell through to `androidRuntimeClasspath` on a KMP-Android
+   * module that *does* declare `jvm("desktop")`.
+   *
+   * Checked against resolved Maven coordinates rather than file-path substrings: the
+   * `artifactType=jar` view hands back AGP-transformed `…/transformed/<name>/jars/classes.jar`
+   * paths, in which nothing of the original artifact id survives — which is why the desktop
+   * classpath guard's path matcher could not have caught this.
+   */
+  internal fun failOnAndroidClasspathInDesktopBundle(
+    backendId: String,
+    entries: List<ClasspathEntry>,
+  ) {
+    if (backendId != "desktop") return
+    val offenders =
+      entries
+        .filterIsInstance<ClasspathEntry.Maven>()
+        .filter { it.type.equals("aar", ignoreCase = true) || it.artifact.endsWith("-android") }
+        .map { "${it.group}:${it.artifact}:${it.version} (${it.type})" }
+        .distinct()
+        .sorted()
+    if (offenders.isEmpty()) return
+    throw GradleException(
+      buildString {
+        appendLine(
+          "composePreviewBundle: refusing to pack a desktop bundle whose classpath carries " +
+            "${offenders.size} Android-only artifact(s). A desktop bundle replays on a host JVM " +
+            "with no android.jar, so every render would fail with " +
+            "NoClassDefFoundError: android/os/Parcelable."
+        )
+        offenders.take(8).forEach { appendLine(" - $it") }
+        if (offenders.size > 8) appendLine(" - (+${offenders.size - 8} more)")
+        appendLine()
+        appendLine(
+          "This means the module's desktop runtime classpath resolved to androidRuntimeClasspath. " +
+            "If it is a com.android.kotlin.multiplatform.library (:shared) module, add a " +
+            "`jvm(\"desktop\")` target to its `kotlin { }` block. See " +
+            "compose-preview/references/cmp-shared.md."
+        )
+      }
+    )
+  }
+
   private fun parseMavenCoord(coord: String, src: File?): ClasspathEntry.Maven {
     val parts = coord.split(':')
     require(parts.size >= 3) { "composePreviewBundle: malformed Maven coordinate: $coord" }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -410,7 +410,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     val classpath = assembleClasspath(jarsList, depDecisions, embed = embedDeps.getOrElse(false))
     val classpathEntries = classpath.entries
     val inlinedJars = classpath.inlinedJars
-    failOnAndroidClasspathInDesktopBundle(backend.get(), classpathEntries)
+    failOnAndroidClasspathInDesktopBundle(backend.get(), depDecisions)
 
     val report =
       MinimizationReport(
@@ -1200,7 +1200,7 @@ abstract class BundlePreviewTask : DefaultTask() {
   }
 
   /** The classpath manifest entries, the jars to inline under `libs/`, and the resolution mode. */
-  private data class AssembledClasspath(
+  internal data class AssembledClasspath(
     val entries: List<ClasspathEntry>,
     val inlinedJars: Map<String, File>,
     val resolution: String,
@@ -1218,7 +1218,7 @@ abstract class BundlePreviewTask : DefaultTask() {
    * carried in `libs/`, `mixed` when some Maven deps are embedded and others referenced (it isn't
    * today, but the field stays accurate if that changes), else `coordinates`.
    */
-  private fun assembleClasspath(
+  internal fun assembleClasspath(
     jars: List<File>,
     deps: List<DependencyDecision>,
     embed: Boolean,
@@ -1293,17 +1293,33 @@ abstract class BundlePreviewTask : DefaultTask() {
    * `artifactType=jar` view hands back AGP-transformed `…/transformed/<name>/jars/classes.jar`
    * paths, in which nothing of the original artifact id survives — which is why the desktop
    * classpath guard's path matcher could not have caught this.
+   *
+   * Takes [DependencyDecision]s rather than the assembled [ClasspathEntry] list so the check is
+   * mode-independent. Under `--embed-deps` / `-PbundleEmbedDeps=true`, `assembleClasspath` turns
+   * every kept Maven dep into a metadata-free [ClasspathEntry.Embedded] pointing at `libs/…`, so an
+   * entry-based filter would find no coordinates to inspect and wave the same broken bundle through
+   * — just with the AGP-transformed `classes.jar` carried inside it instead of referenced.
+   * `DependencyDecision.coordinate` is populated identically in both modes.
    */
   internal fun failOnAndroidClasspathInDesktopBundle(
     backendId: String,
-    entries: List<ClasspathEntry>,
+    decisions: List<DependencyDecision>,
   ) {
     if (backendId != "desktop") return
     val offenders =
-      entries
-        .filterIsInstance<ClasspathEntry.Maven>()
-        .filter { it.type.equals("aar", ignoreCase = true) || it.artifact.endsWith("-android") }
-        .map { "${it.group}:${it.artifact}:${it.version} (${it.type})" }
+      decisions
+        .filter { it.kept }
+        .mapNotNull { it.coordinate }
+        .mapNotNull { coord ->
+          // "<group>:<artifact>:<version>[:<type>]" — the `maven:`-stripped shape.
+          val parts = coord.split(':')
+          if (parts.size < 3) return@mapNotNull null
+          val (group, artifact, version) = parts
+          val type = parts.getOrNull(3) ?: "jar"
+          if (type.equals("aar", ignoreCase = true) || artifact.endsWith("-android")) {
+            "$group:$artifact:$version ($type)"
+          } else null
+        }
         .distinct()
         .sorted()
     if (offenders.isEmpty()) return

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -108,6 +108,40 @@ internal object ComposePreviewTasks {
     configName != "androidRuntimeClasspath"
 
   /**
+   * The consumer runtime configuration the desktop pipeline resolves against, in preference order.
+   * `androidRuntimeClasspath` is the LAST-RESORT KMP-Android fallback — it carries `*-android`
+   * Compose AARs the JVM renderer can't load, so anything with a real JVM-flavoured runtime must
+   * win ahead of it.
+   *
+   * MUST be called lazily (from inside a `tasks.register {}` block or an `afterEvaluate`), never
+   * from [registerDesktopTasks]'s body: a KMP-Android module reaches that body via
+   * `pluginManager.withPlugin`, which fires before the consumer's `kotlin { jvm("desktop") }` block
+   * has created `desktopRuntimeClasspath`. `internal` for unit testing.
+   */
+  internal fun desktopDependencyConfigName(project: Project): String =
+    listOf(
+        "jvmRuntimeClasspath",
+        "desktopRuntimeClasspath",
+        "androidRuntimeClasspath",
+        "runtimeClasspath",
+      )
+      .firstOrNull { project.configurations.findByName(it) != null } ?: "runtimeClasspath"
+
+  /**
+   * The dependency-classpath inputs [registerBundleTask] feeds `BundlePreviewTask`: the jars the
+   * closure walk sees, and the coordinate map folded into `bundle.json`'s `classpath`.
+   *
+   * Bundled together so both are derived from ONE resolution of the consumer runtime config — see
+   * the note at the [registerBundleTask] call site for the `backend: desktop` / `*-android`
+   * classpath mismatch that eager resolution produced.
+   */
+  internal class DependencyClasspathBinding(
+    val configName: String,
+    val jarFiles: org.gradle.api.file.FileCollection?,
+    val coordinates: Provider<Map<String, String>>,
+  )
+
+  /**
    * Lazily-resolved, config-cache-safe view of the consumer runtime classpath [configName], pinned
    * to `artifactType=jar`.
    *
@@ -131,6 +165,94 @@ internal object ComposePreviewTasks {
         attributes.attribute(consumerArtifactTypeAttribute, "jar")
       }
       .files
+  }
+
+  /** Builds the [DependencyClasspathBinding] for consumer runtime config [configName]. */
+  private fun dependencyClasspathBinding(
+    project: Project,
+    configName: String,
+    artifactTypeAttr: Attribute<String>,
+  ): DependencyClasspathBinding {
+    val depConfig = project.configurations.findByName(configName)
+    // Only the KMP-Android fallback (`androidRuntimeClasspath`, a `:shared` module with no
+    // `jvm("desktop")` target) needs a lenient artifact view — its single AGP `android` variant
+    // can't satisfy a forced `artifactType=jar` selection and would otherwise raise
+    // `AmbiguousArtifactsFailure` and sink the whole bundle. Normal JVM/desktop classpaths stay
+    // STRICT so an unresolved/unselectable runtime dep fails the task loudly instead of silently
+    // dropping out of the bundle's closure + coordinate map (Codex review on #1850).
+    val depViewLenient = configName == "androidRuntimeClasspath"
+    // `artifactType=jar` view: AAR consumers transform to extracted classes.jar; pure JVM consumers
+    // pass through. Either way we get real jars on the closure walk. The coordinate map below MUST
+    // be built from THIS SAME view's resolvedArtifacts, not the configuration's untransformed
+    // artifacts — otherwise an AAR dep's transformed classes.jar path (what `dependencyJars` and
+    // the
+    // closure walk see) wouldn't match the coordinate-map key (the untransformed `.aar` path), so
+    // the task would treat the Maven dep as an anonymous/project jar and inline it instead of
+    // recording a `ClasspathEntry.Maven`. On JVM this view is a passthrough, so desktop is
+    // unchanged; on Android it's what makes coordinate-mode bundles stay small + re-resolvable.
+    val depJarView =
+      depConfig?.incoming?.artifactView {
+        // Lenient ONLY for the androidRuntimeClasspath fallback (see [depViewLenient]); strict for
+        // normal JVM/desktop classpaths so a broken dep surfaces here instead of in the player.
+        if (depViewLenient) lenient(true)
+        attributes.attribute(artifactTypeAttr, "jar")
+      }
+    // The `artifactType=jar` view extracts every AAR to its `classes.jar`, erasing the aar/jar
+    // distinction — but the player's `CoordinateResolver` needs the real packaging to find the
+    // artifact (`<artifact>-<version>.aar`) in a Maven/Gradle cache and unpack its classes. So read
+    // the *untransformed* artifacts too and key each component's packaging off its file extension
+    // (Android deps resolve to `.aar`, JVM deps to `.jar`), then stamp it into the coordinate
+    // below.
+    //
+    // This read goes through a `lenient(true)` artifactView rather than the raw
+    // `incoming.artifacts`. The raw read selects artifacts using the configuration's full runtime
+    // attributes, which a dependency exposing AGP secondary variants without the standard
+    // `org.gradle.category` / jvm-environment / `kotlin.platform.type` attributes (e.g. an Android
+    // library relying on AGP's built-in Kotlin, consumed on an app's `…RuntimeClasspath`) can't
+    // satisfy — turning packaging detection into a hard `AmbiguousArtifactsFailure` that fails the
+    // whole bundle. `lenient(true)` skips any such unselectable dep here; it simply isn't keyed in
+    // the packaging map and falls back to the `"jar"` default at the coordinate below. The
+    // `artifactType=jar` view that feeds the actual classpath/closure walk is unaffected — it
+    // selects each dep's `jar` secondary variant unambiguously.
+    val typeByComponent: Provider<Map<String, String>> =
+      depConfig
+        ?.incoming
+        ?.artifactView { lenient(true) }
+        ?.artifacts
+        ?.resolvedArtifacts
+        ?.map { artifacts ->
+          artifacts.associate { artifact ->
+            artifact.id.componentIdentifier.displayName to
+              if (artifact.file.name.endsWith(".aar", ignoreCase = true)) "aar" else "jar"
+          }
+        } ?: project.providers.provider { emptyMap<String, String>() }
+    // Map each resolved dependency jar to a coordinate string the task action can fold into
+    // `bundle.json`'s `classpath`:
+    // - `maven:<group>:<artifact>:<version>:<aar|jar>` for Maven-resolved deps (the player resolves
+    //   at open time — small bundle, no inlined jars).
+    // - `project:<gradle path>` for project-local deps (the task inlines those into the bundle
+    //   since they can't be re-resolved from Maven).
+    //
+    // Resolution happens via `Provider` transformations, so this stays config-cache-safe. The
+    // transformed artifact keeps its original `componentIdentifier` (the Maven module / project),
+    // so coordinates resolve correctly even though `.file` points at the extracted classes.jar.
+    val coordMapProvider: Provider<Map<String, String>> =
+      depJarView?.artifacts?.resolvedArtifacts?.zip(typeByComponent) { artifacts, typeByComponentMap
+        ->
+        artifacts.associate { artifact ->
+          val id = artifact.id.componentIdentifier
+          val value =
+            when (id) {
+              is org.gradle.api.artifacts.component.ModuleComponentIdentifier ->
+                "maven:${id.group}:${id.module}:${id.version}:${typeByComponentMap[id.displayName] ?: "jar"}"
+              is org.gradle.api.artifacts.component.ProjectComponentIdentifier ->
+                "project:${id.projectPath}"
+              else -> "unknown:${id.displayName}"
+            }
+          artifact.file.absolutePath to value
+        }
+      } ?: project.providers.provider { emptyMap<String, String>() }
+    return DependencyClasspathBinding(configName, depJarView?.files, coordMapProvider)
   }
 
   fun registerDesktopTasks(project: Project, extension: PreviewExtension) {
@@ -185,15 +307,7 @@ internal object ComposePreviewTasks {
     // `androidx.compose.ui:ui-android` AAR variants, which the new
     // [ValidateComposePreviewClasspathTask] correctly rejects (and
     // `ImageComposeScene` would crash on too).
-    val resolveDependencyConfigName: () -> String = {
-      listOf(
-          "jvmRuntimeClasspath",
-          "desktopRuntimeClasspath",
-          "androidRuntimeClasspath",
-          "runtimeClasspath",
-        )
-        .firstOrNull { project.configurations.findByName(it) != null } ?: "runtimeClasspath"
-    }
+    val resolveDependencyConfigName: () -> String = { desktopDependencyConfigName(project) }
 
     val discoverTask =
       registerDiscoverTask(
@@ -373,87 +487,21 @@ internal object ComposePreviewTasks {
     val pluginVersionProperty = PluginVersion.value
 
     val artifactTypeAttr = Attribute.of("artifactType", String::class.java)
-    val depConfigName = resolveDependencyConfigName()
-    val depConfig = project.configurations.findByName(depConfigName)
-    // Only the KMP-Android fallback (`androidRuntimeClasspath`, a `:shared` module with no
-    // `jvm("desktop")` target) needs a lenient artifact view — its single AGP `android` variant
-    // can't satisfy a forced `artifactType=jar` selection and would otherwise raise
-    // `AmbiguousArtifactsFailure` and sink the whole bundle. Normal JVM/desktop classpaths stay
-    // STRICT so an unresolved/unselectable runtime dep fails the task loudly instead of silently
-    // dropping out of the bundle's closure + coordinate map (Codex review on #1850).
-    val depViewLenient = depConfigName == "androidRuntimeClasspath"
-    // `artifactType=jar` view: AAR consumers transform to extracted classes.jar; pure JVM consumers
-    // pass through. Either way we get real jars on the closure walk. The coordinate map below MUST
-    // be built from THIS SAME view's resolvedArtifacts, not the configuration's untransformed
-    // artifacts — otherwise an AAR dep's transformed classes.jar path (what `dependencyJars` and
-    // the
-    // closure walk see) wouldn't match the coordinate-map key (the untransformed `.aar` path), so
-    // the task would treat the Maven dep as an anonymous/project jar and inline it instead of
-    // recording a `ClasspathEntry.Maven`. On JVM this view is a passthrough, so desktop is
-    // unchanged; on Android it's what makes coordinate-mode bundles stay small + re-resolvable.
-    val depJarView =
-      depConfig?.incoming?.artifactView {
-        // Lenient ONLY for the androidRuntimeClasspath fallback (see [depViewLenient]); strict for
-        // normal JVM/desktop classpaths so a broken dep surfaces here instead of in the player.
-        if (depViewLenient) lenient(true)
-        attributes.attribute(artifactTypeAttr, "jar")
-      }
-    val depJarFiles = depJarView?.files
-    // The `artifactType=jar` view extracts every AAR to its `classes.jar`, erasing the aar/jar
-    // distinction — but the player's `CoordinateResolver` needs the real packaging to find the
-    // artifact (`<artifact>-<version>.aar`) in a Maven/Gradle cache and unpack its classes. So read
-    // the *untransformed* artifacts too and key each component's packaging off its file extension
-    // (Android deps resolve to `.aar`, JVM deps to `.jar`), then stamp it into the coordinate
-    // below.
-    //
-    // This read goes through a `lenient(true)` artifactView rather than the raw
-    // `incoming.artifacts`. The raw read selects artifacts using the configuration's full runtime
-    // attributes, which a dependency exposing AGP secondary variants without the standard
-    // `org.gradle.category` / jvm-environment / `kotlin.platform.type` attributes (e.g. an Android
-    // library relying on AGP's built-in Kotlin, consumed on an app's `…RuntimeClasspath`) can't
-    // satisfy — turning packaging detection into a hard `AmbiguousArtifactsFailure` that fails the
-    // whole bundle. `lenient(true)` skips any such unselectable dep here; it simply isn't keyed in
-    // the packaging map and falls back to the `"jar"` default at the coordinate below. The
-    // `artifactType=jar` view that feeds the actual classpath/closure walk is unaffected — it
-    // selects each dep's `jar` secondary variant unambiguously.
-    val typeByComponent: Provider<Map<String, String>> =
-      depConfig
-        ?.incoming
-        ?.artifactView { lenient(true) }
-        ?.artifacts
-        ?.resolvedArtifacts
-        ?.map { artifacts ->
-          artifacts.associate { artifact ->
-            artifact.id.componentIdentifier.displayName to
-              if (artifact.file.name.endsWith(".aar", ignoreCase = true)) "aar" else "jar"
-          }
-        } ?: project.providers.provider { emptyMap<String, String>() }
-    // Map each resolved dependency jar to a coordinate string the task action can fold into
-    // `bundle.json`'s `classpath`:
-    // - `maven:<group>:<artifact>:<version>:<aar|jar>` for Maven-resolved deps (the player resolves
-    //   at open time — small bundle, no inlined jars).
-    // - `project:<gradle path>` for project-local deps (the task inlines those into the bundle
-    //   since they can't be re-resolved from Maven).
-    //
-    // Resolution happens via `Provider` transformations, so this stays config-cache-safe. The
-    // transformed artifact keeps its original `componentIdentifier` (the Maven module / project),
-    // so coordinates resolve correctly even though `.file` points at the extracted classes.jar.
-    val coordMapProvider: Provider<Map<String, String>> =
-      depJarView?.artifacts?.resolvedArtifacts?.zip(typeByComponent) { artifacts, typeByComponentMap
-        ->
-        artifacts.associate { artifact ->
-          val id = artifact.id.componentIdentifier
-          val value =
-            when (id) {
-              is org.gradle.api.artifacts.component.ModuleComponentIdentifier ->
-                "maven:${id.group}:${id.module}:${id.version}:${typeByComponentMap[id.displayName] ?: "jar"}"
-              is org.gradle.api.artifacts.component.ProjectComponentIdentifier ->
-                "project:${id.projectPath}"
-              else -> "unknown:${id.displayName}"
-            }
-          artifact.file.absolutePath to value
-        }
-      } ?: project.providers.provider { emptyMap<String, String>() }
+    // Resolved at task-realization time, NOT here. `registerBundleTask` runs from
+    // [registerDesktopTasks], which a KMP-Android module reaches via
+    // `pluginManager.withPlugin("com.android.kotlin.multiplatform.library")` — and that fires
+    // BEFORE the consumer's `kotlin { jvm("desktop") }` block creates `desktopRuntimeClasspath`.
+    // Resolving eagerly therefore fell through to the `androidRuntimeClasspath` fallback on a
+    // `samples/cmp-shared`-shape module (KMP-Android *plus* a `jvm("desktop")` target) and packed
+    // its `*-android` Compose AARs into a bundle stamped `backend: desktop`. Nothing failed the
+    // build — the `onlyIf` renderability gate below already re-resolved lazily and so saw the
+    // correct `desktopRuntimeClasspath` — but every render of the published bundle then died on the
+    // host JVM with `NoClassDefFoundError: android/os/Parcelable` (no `android.jar` outside a
+    // Robolectric sandbox). Deferring makes the classpath the bundle *carries* agree with the
+    // config the renderability gate *checks*.
+    val depBinding: () -> DependencyClasspathBinding = {
+      dependencyClasspathBinding(project, resolveDependencyConfigName(), artifactTypeAttr)
+    }
 
     val defaultOutput = previewOutputDir.map { it.file("bundle.png").asFile }
     val resolvedOutput = outputProperty.map { java.io.File(it) }.orElse(defaultOutput)
@@ -486,7 +534,10 @@ internal object ComposePreviewTasks {
       // literal
       // `androidRuntimeClasspath` fallback, so this is a no-op on the Android bundle path and on
       // real desktop modules.
-      val bundleRenderable = isDesktopRenderableConfig(resolveDependencyConfigName())
+      // ONE lazy resolution feeds both the renderability gate and the classpath the bundle carries,
+      // so the two can no longer disagree about which consumer runtime config this module has.
+      val deps = depBinding()
+      val bundleRenderable = isDesktopRenderableConfig(deps.configName)
       onlyIf { extension.enabled.get() && bundleRenderable }
       previewsJson.set(previewOutputDir.map { it.file("previews.json") })
       moduleClassDirs.from(sourceClassDirs)
@@ -509,8 +560,8 @@ internal object ComposePreviewTasks {
           project.layout.buildDirectory.dir("processedResources/desktop/main"),
         )
       )
-      depJarFiles?.let { dependencyJars.from(it) }
-      dependencyCoordinates.set(coordMapProvider)
+      deps.jarFiles?.let { dependencyJars.from(it) }
+      dependencyCoordinates.set(deps.coordinates)
       // (v6 Android) Inputs for protolayout resource carriage; null on desktop (no-op). The
       // unit-test classpath supplier is invoked here (inside the task-config lambda) so AGP's
       // `test<Variant>UnitTest` task is registered by the time we query its classpath.

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/BundleDependencyConfigDeferralTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/BundleDependencyConfigDeferralTest.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * `composePreviewBundle` must resolve its consumer runtime configuration at TASK-REALIZATION time,
+ * not while [ComposePreviewTasks.registerBundleTask] is running.
+ *
+ * A `com.android.kotlin.multiplatform.library` module reaches `registerDesktopTasks` through
+ * `pluginManager.withPlugin`, which fires BEFORE the consumer's `kotlin { jvm("desktop") }` block
+ * has created `desktopRuntimeClasspath`. Resolving eagerly therefore fell through to the
+ * `androidRuntimeClasspath` last-resort fallback even on a module that *does* declare a desktop
+ * target — and packed that module's `*-android` Compose AARs into a bundle stamped `backend:
+ * desktop`. Nothing failed the build (the `onlyIf` renderability gate re-resolved lazily and
+ * correctly saw `desktopRuntimeClasspath`), so the broken bundle published, and every live render
+ * of it died on the host JVM with `NoClassDefFoundError: android/os/Parcelable`.
+ *
+ * These tests pin the deferral by creating `desktopRuntimeClasspath` AFTER registration — exactly
+ * the ordering the real KMP-Android + `jvm("desktop")` shape produces.
+ */
+class BundleDependencyConfigDeferralTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private fun jar(name: String): java.io.File = tmp.newFile(name).apply { writeText("stub") }
+
+  @Test
+  fun `bundle binds the desktop classpath when the desktop target configures after registration`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+
+    // The KMP-Android plugin's configuration exists at withPlugin time...
+    val androidOnly = jar("android-only.jar")
+    project.configurations.create("androidRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+    project.dependencies.add("androidRuntimeClasspath", project.files(androidOnly))
+
+    // ...and registration happens right there, with the real candidate resolver.
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = project.layout.buildDirectory.dir("compose-previews"),
+      sourceClassDirs = project.files("build/classes/kotlin/android/main"),
+      resolveDependencyConfigName = { ComposePreviewTasks.desktopDependencyConfigName(project) },
+      discoverTaskName = "composePreviewDiscover",
+    )
+
+    // Only NOW does `kotlin { jvm("desktop") }` create the JVM-flavoured runtime classpath.
+    val desktopOnly = jar("desktop-only.jar")
+    project.configurations.create("desktopRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+    project.dependencies.add("desktopRuntimeClasspath", project.files(desktopOnly))
+
+    // Realising the task is what triggers the deferred resolution.
+    val task = project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
+    val wired = task.dependencyJars.files
+
+    assertThat(wired).contains(desktopOnly)
+    assertThat(wired).doesNotContain(androidOnly)
+  }
+
+  @Test
+  fun `a pure KMP-Android module still falls back to androidRuntimeClasspath`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+
+    // No `jvm("desktop")` target ever appears — the #1852 shape. The fallback must stay, so
+    // discovery and the Tooling-API model keep working on such a module.
+    val androidOnly = jar("android-only.jar")
+    project.configurations.create("androidRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+    project.dependencies.add("androidRuntimeClasspath", project.files(androidOnly))
+
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = project.layout.buildDirectory.dir("compose-previews"),
+      sourceClassDirs = project.files("build/classes/kotlin/android/main"),
+      resolveDependencyConfigName = { ComposePreviewTasks.desktopDependencyConfigName(project) },
+      discoverTaskName = "composePreviewDiscover",
+    )
+
+    val task = project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
+    assertThat(task.dependencyJars.files).contains(androidOnly)
+  }
+
+  @Test
+  fun `desktop config wins over the android fallback once both exist`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    project.configurations.create("androidRuntimeClasspath")
+    assertThat(ComposePreviewTasks.desktopDependencyConfigName(project))
+      .isEqualTo("androidRuntimeClasspath")
+
+    project.configurations.create("desktopRuntimeClasspath")
+    assertThat(ComposePreviewTasks.desktopDependencyConfigName(project))
+      .isEqualTo("desktopRuntimeClasspath")
+
+    // A `jvm()` target (rather than `jvm("desktop")`) outranks both.
+    project.configurations.create("jvmRuntimeClasspath")
+    assertThat(ComposePreviewTasks.desktopDependencyConfigName(project))
+      .isEqualTo("jvmRuntimeClasspath")
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopBundleAndroidClasspathGuardTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopBundleAndroidClasspathGuardTest.kt
@@ -35,37 +35,87 @@ class DesktopBundleAndroidClasspathGuardTest {
     return project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
   }
 
-  private fun maven(group: String, artifact: String, type: String) =
-    ClasspathEntry.Maven(group = group, artifact = artifact, version = "1.0", type = type)
+  /**
+   * Backs each decision with a real file, so `assembleClasspath(embed = true)` takes its genuine
+   * embedding branch rather than the "no file to embed" coordinate fallback.
+   */
+  private fun dep(
+    coordinate: String?,
+    kept: Boolean = true,
+    projectPath: String? = null,
+  ): DependencyDecision {
+    val name = (coordinate ?: projectPath!!).replace(':', '_').replace('.', '_') + ".jar"
+    val file = tmp.newFile(name).apply { writeText("stub") }
+    return DependencyDecision(
+      sourcePath = file.absolutePath,
+      coordinate = coordinate,
+      projectPath = projectPath,
+      totalClasses = 10,
+      reachableClasses = if (kept) 5 else 0,
+      originalBytes = 1024,
+      kept = kept,
+    )
+  }
 
-  /** The exact shape that shipped in the meshcore-mobile `:meshcore-components` bundle. */
-  private val androidComposeClasspath =
+  private fun jarsFor(deps: List<DependencyDecision>) = deps.map { java.io.File(it.sourcePath) }
+
+  /**
+   * The exact shape that shipped in the meshcore-mobile `:meshcore-components` bundle.
+   *
+   * A function, not a field: [dep] writes into [tmp], whose root only exists once the JUnit rule
+   * has run — a field initializer would evaluate at construction time and fail every test.
+   */
+  private fun androidComposeDeps() =
     listOf(
-      ClasspathEntry.Module(path = "classes/app.jar"),
-      maven("androidx.compose.ui", "ui-android", "aar"),
-      maven("androidx.compose.material3", "material3-android", "aar"),
-      maven("org.jetbrains.kotlin", "kotlin-stdlib", "jar"),
+      dep("androidx.compose.ui:ui-android:1.11.4:aar"),
+      dep("androidx.compose.material3:material3-android:1.5.0-alpha08:aar"),
+      dep("org.jetbrains.kotlin:kotlin-stdlib:2.4.10:jar"),
     )
 
   @Test
   fun `desktop bundle carrying android artifacts fails the pack`() {
     val e =
       assertThrows(GradleException::class.java) {
-        task().failOnAndroidClasspathInDesktopBundle("desktop", androidComposeClasspath)
+        task().failOnAndroidClasspathInDesktopBundle("desktop", androidComposeDeps())
       }
     assertThat(e).hasMessageThat().contains("NoClassDefFoundError: android/os/Parcelable")
-    assertThat(e).hasMessageThat().contains("androidx.compose.ui:ui-android:1.0")
-    assertThat(e).hasMessageThat().contains("androidx.compose.material3:material3-android:1.0")
+    assertThat(e).hasMessageThat().contains("androidx.compose.ui:ui-android:1.11.4")
+    assertThat(e).hasMessageThat().contains("androidx.compose.material3:material3-android")
     // Actionable next step, not just a diagnosis.
     assertThat(e).hasMessageThat().contains("jvm(\"desktop\")")
     // Pure-JVM entries are not reported as offenders.
     assertThat(e).hasMessageThat().doesNotContain("kotlin-stdlib")
   }
 
+  /**
+   * Regression for the `--embed-deps` hole: `assembleClasspath` rewrites every kept Maven dep into
+   * a metadata-free `ClasspathEntry.Embedded`, so a guard reading the assembled entries would find
+   * no coordinates and pass a bundle that is just as broken — the AGP-transformed `classes.jar` is
+   * then carried *inside* `libs/` rather than referenced. Keying on
+   * [DependencyDecision.coordinate], which is identical in both modes, is what closes it.
+   */
+  @Test
+  fun `embed mode is covered because the check reads decisions not assembled entries`() {
+    val deps = androidComposeDeps()
+    val embedded =
+      task()
+        .assembleClasspath(jars = jarsFor(deps), deps = deps, embed = true)
+        .entries
+        .filterIsInstance<ClasspathEntry.Maven>()
+    // Precondition: embed mode really does erase the Maven metadata the naive guard relied on.
+    assertThat(embedded).isEmpty()
+
+    val e =
+      assertThrows(GradleException::class.java) {
+        task().failOnAndroidClasspathInDesktopBundle("desktop", deps)
+      }
+    assertThat(e).hasMessageThat().contains("ui-android")
+  }
+
   @Test
   fun `an android bundle may carry android artifacts`() {
     // The Robolectric sandbox supplies android.jar, so this is the correct, expected shape.
-    task().failOnAndroidClasspathInDesktopBundle("android", androidComposeClasspath)
+    task().failOnAndroidClasspathInDesktopBundle("android", androidComposeDeps())
   }
 
   @Test
@@ -74,11 +124,20 @@ class DesktopBundleAndroidClasspathGuardTest {
       .failOnAndroidClasspathInDesktopBundle(
         "desktop",
         listOf(
-          ClasspathEntry.Module(path = "classes/app.jar"),
-          maven("org.jetbrains.compose.ui", "ui-desktop", "jar"),
-          maven("org.jetbrains.kotlin", "kotlin-stdlib", "jar"),
-          ClasspathEntry.Project(path = ":meshcore-core", inlinedAs = "libs/full.jar"),
+          dep("org.jetbrains.compose.ui:ui-desktop:1.11.1:jar"),
+          dep("org.jetbrains.kotlin:kotlin-stdlib:2.4.10:jar"),
+          dep(coordinate = null, projectPath = ":meshcore-core"),
         ),
+      )
+  }
+
+  @Test
+  fun `a dropped dependency is not an offender`() {
+    // Not on the bundle's classpath at all — nothing to fail over.
+    task()
+      .failOnAndroidClasspathInDesktopBundle(
+        "desktop",
+        listOf(dep("androidx.compose.ui:ui-android:1.11.4:aar", kept = false)),
       )
   }
 
@@ -89,7 +148,7 @@ class DesktopBundleAndroidClasspathGuardTest {
         task()
           .failOnAndroidClasspathInDesktopBundle(
             "desktop",
-            listOf(maven("androidx.versionedparcelable", "versionedparcelable", "aar")),
+            listOf(dep("androidx.versionedparcelable:versionedparcelable:1.1.1:aar")),
           )
       }
     assertThat(e).hasMessageThat().contains("versionedparcelable")

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopBundleAndroidClasspathGuardTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopBundleAndroidClasspathGuardTest.kt
@@ -1,0 +1,97 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pack-time backstop for the `backend: desktop` / `*-android` classpath mismatch.
+ *
+ * The desktop classpath guard ([ValidateComposePreviewClasspathTask]) matches on file-path
+ * substrings, which cannot see this: the `artifactType=jar` artifact view hands back
+ * AGP-transformed `…/transforms/<hash>/transformed/<name>/jars/classes.jar` paths, in which nothing
+ * of the original artifact id survives. So the check lives where the resolved Maven coordinates are
+ * still exact — inside the pack itself.
+ */
+class DesktopBundleAndroidClasspathGuardTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private fun task(): BundlePreviewTask {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = project.layout.buildDirectory.dir("compose-previews"),
+      sourceClassDirs = project.files("build/classes/kotlin/main"),
+      resolveDependencyConfigName = { "runtimeClasspath" },
+      discoverTaskName = "composePreviewDiscover",
+    )
+    return project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
+  }
+
+  private fun maven(group: String, artifact: String, type: String) =
+    ClasspathEntry.Maven(group = group, artifact = artifact, version = "1.0", type = type)
+
+  /** The exact shape that shipped in the meshcore-mobile `:meshcore-components` bundle. */
+  private val androidComposeClasspath =
+    listOf(
+      ClasspathEntry.Module(path = "classes/app.jar"),
+      maven("androidx.compose.ui", "ui-android", "aar"),
+      maven("androidx.compose.material3", "material3-android", "aar"),
+      maven("org.jetbrains.kotlin", "kotlin-stdlib", "jar"),
+    )
+
+  @Test
+  fun `desktop bundle carrying android artifacts fails the pack`() {
+    val e =
+      assertThrows(GradleException::class.java) {
+        task().failOnAndroidClasspathInDesktopBundle("desktop", androidComposeClasspath)
+      }
+    assertThat(e).hasMessageThat().contains("NoClassDefFoundError: android/os/Parcelable")
+    assertThat(e).hasMessageThat().contains("androidx.compose.ui:ui-android:1.0")
+    assertThat(e).hasMessageThat().contains("androidx.compose.material3:material3-android:1.0")
+    // Actionable next step, not just a diagnosis.
+    assertThat(e).hasMessageThat().contains("jvm(\"desktop\")")
+    // Pure-JVM entries are not reported as offenders.
+    assertThat(e).hasMessageThat().doesNotContain("kotlin-stdlib")
+  }
+
+  @Test
+  fun `an android bundle may carry android artifacts`() {
+    // The Robolectric sandbox supplies android.jar, so this is the correct, expected shape.
+    task().failOnAndroidClasspathInDesktopBundle("android", androidComposeClasspath)
+  }
+
+  @Test
+  fun `a clean desktop classpath passes`() {
+    task()
+      .failOnAndroidClasspathInDesktopBundle(
+        "desktop",
+        listOf(
+          ClasspathEntry.Module(path = "classes/app.jar"),
+          maven("org.jetbrains.compose.ui", "ui-desktop", "jar"),
+          maven("org.jetbrains.kotlin", "kotlin-stdlib", "jar"),
+          ClasspathEntry.Project(path = ":meshcore-core", inlinedAs = "libs/full.jar"),
+        ),
+      )
+  }
+
+  @Test
+  fun `an aar is flagged even when its artifact id does not end in -android`() {
+    val e =
+      assertThrows(GradleException::class.java) {
+        task()
+          .failOnAndroidClasspathInDesktopBundle(
+            "desktop",
+            listOf(maven("androidx.versionedparcelable", "versionedparcelable", "aar")),
+          )
+      }
+    assertThat(e).hasMessageThat().contains("versionedparcelable")
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the `NoClassDefFoundError: android/os/Parcelable` render failures visible on [preview.coo.ee/status](https://preview.coo.ee/status) — 35 of meshcore-mobile's 164 renders, each failing in 2–4 ms.

`registerBundleTask` resolved its consumer runtime configuration **eagerly**, in the function body. A `com.android.kotlin.multiplatform.library` module reaches that body via `pluginManager.withPlugin`, which fires **before** the consumer's `kotlin { jvm("desktop") }` block has created `desktopRuntimeClasspath` — so resolution fell through to the last-resort `androidRuntimeClasspath` fallback even on a module that *does* declare a desktop target, and packed that module's `*-android` Compose AARs into a bundle stamped `backend: desktop`.

Nothing failed the build, because the two checks disagreed:

| | resolution | saw |
|---|---|---|
| `onlyIf` renderability gate | lazy | `desktopRuntimeClasspath` → "yes, bundle this" |
| the classpath actually packed | **eager** | `androidRuntimeClasspath` → `*-android` AARs |

So the bad bundle packed, published, and only died at serve time: a desktop bundle replays on a plain host JVM with no `android.jar`, so the first AAR class load throws. That is what `yschimke/meshcore-mobile`'s `:meshcore-components` per-preview bundles are doing in production right now — `backend: desktop`, classpath of `ui-android`, `material3-android`, `androidx.core`, `versionedparcelable`, even `kotlinx-coroutines-android` (an `androidMain`-only dep).

Deferring the resolution to task realization makes the classpath the bundle *carries* agree with the config the renderability gate *checks*.

## Also: a pack-time backstop

A `backend: desktop` pack now fails outright if its classpath carries Android-only artifacts, with an actionable message.

`ValidateComposePreviewClasspathTask` could not have caught this — it matches on **file-path substrings**, and the `artifactType=jar` artifact view hands back AGP-transformed `…/transforms/<hash>/transformed/<name>/jars/classes.jar` paths, in which nothing of the original artifact id survives. The backstop keys on resolved **Maven coordinates** instead, where group/artifact/packaging are still exact.

## Test plan

`samples/cmp-shared` — the canonical KMP-Android + `jvm("desktop")` sample — had the same latent breakage, so it doubles as the regression proof. Packing it before/after:

| | Maven entries | android-flavoured |
|---|---|---|
| before | 40 | **34** (`ui-android`, `material3-android`, `ui-graphics-android`, …) |
| after | 23 | **0** (`ui-desktop`, `material3-desktop`, `foundation-desktop`, …) |

Backstop verified against a real build, not just a unit test — with the guard in place and the deferral reverted, `:samples:cmp-shared:composePreviewBundle` fails with:

```
composePreviewBundle: refusing to pack a desktop bundle whose classpath carries 33
Android-only artifact(s). A desktop bundle replays on a host JVM with no android.jar,
so every render would fail with NoClassDefFoundError: android/os/Parcelable.
 - androidx.compose.material3:material3-android:1.5.0-alpha08 (aar)
 ...
This means the module's desktop runtime classpath resolved to androidRuntimeClasspath.
If it is a com.android.kotlin.multiplatform.library (:shared) module, add a
`jvm("desktop")` target to its `kotlin { }` block.
```

New unit tests:
- `BundleDependencyConfigDeferralTest` — pins the deferral by creating `desktopRuntimeClasspath` *after* registration (the real ordering), and asserts a pure-KMP-Android module still falls back to `androidRuntimeClasspath` so the #1852 shape keeps working.
- `DesktopBundleAndroidClasspathGuardTest` — covers the backstop, including that an `android` backend may legitimately carry AARs.

`./gradlew :gradle-plugin:test ktfmtCheckAll` — green.

Text-only PR: this changes build wiring, not rendered output. The fix's effect on pixels is that the 21 `:meshcore-components` previews start rendering at all instead of erroring.

## Follow-up

meshcore-mobile needs a plugin bump plus a `design-artifacts` re-run to republish the bundles; its currently-published `design-artifacts/meshcore-mobile` branch carries the broken ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ff3PLh8x3QXsN1mMLn2vG)_