### PR TITLE
fix(vscode): keep elided composition spans inspectable in the Performance tab

### DIFF
--- a/vscode-extension/src/test/performanceBundlePresenter.test.ts
+++ b/vscode-extension/src/test/performanceBundlePresenter.test.ts
@@ -184,6 +184,48 @@ describe("computePerformanceBundleData — render/trace", () => {
         assert.strictEqual(rt.repeats[0].count, 2);
     });
 
+    it("keeps single-hit aggregates so elided phases stay inspectable", () => {
+        // Composition tracing makes most spans unique call sites. The timeline caps at 200 rows, so
+        // if the summary also dropped count==1 entries, a slow composable past that cap would have
+        // no row anywhere — which is what the "see the totals below" note points at.
+        const phases = Array.from({ length: 250 }, (_, i) => ({
+            name: "Composable" + i + " (File.kt:" + i + ")",
+            startMs: 0,
+            durationMs: 0,
+            startUs: i * 10,
+            durationUs: 10,
+            depth: 1,
+            category: "compose.composition",
+        }));
+        const sections = phases.map((p) => ({
+            name: p.name,
+            category: p.category,
+            count: 1,
+            totalUs: 10,
+            meanUs: 10,
+            maxUs: 10,
+        }));
+        const data = computePerformanceBundleData(
+            null,
+            {
+                totalMs: 3,
+                totalUs: 2500,
+                source: "spans",
+                backend: "desktop",
+                phases,
+                sections,
+                metrics: {},
+            },
+            null,
+        );
+        const rt = data.renderTrace!;
+        // `repeats` stays repeats-only — that is what a complete timeline wants.
+        assert.strictEqual(rt.repeats.length, 0);
+        // …but every aggregate survives, so the renderer has something to show for the elided tail.
+        assert.strictEqual(rt.allSections.length, 250);
+        assert.strictEqual(rt.allSections[0].count, 1);
+    });
+
     it("reports a metrics-sourced payload as the fallback it is", () => {
         const data = computePerformanceBundleData(
             null,

--- a/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
@@ -78,6 +78,15 @@ export interface RenderTraceSection {
     source: "spans" | "metrics";
     /** v2: names that occurred more than once, with their aggregates. */
     repeats: readonly RenderTraceRepeat[];
+    /**
+     * v2: **every** per-name aggregate, including single-hit ones, ordered by total time.
+     *
+     * The timeline is capped for volume; the aggregates are not. When phases are elided this is the
+     * only place an elided span is still visible, and with composition tracing on most spans are
+     * unique call sites — so filtering to `count > 1` there would hide exactly the slow composable
+     * someone turned the feature on to find.
+     */
+    allSections: readonly RenderTraceRepeat[];
 }
 
 export interface ComposeAiTraceSummary {
@@ -111,6 +120,11 @@ const TOP_N_RECOMPOSITION = 10;
  * aggregates are the readable view at that volume, and they are unaffected by this cap.
  */
 const MAX_PHASE_ROWS = 200;
+/**
+ * Per-name summary rows shown when the timeline was elided. Ordered slowest-first by the daemon, so
+ * the truncation keeps the ones worth looking at.
+ */
+const MAX_SUMMARY_ROWS = 100;
 const TOP_N_PERFETTO_PHASES = 3;
 
 /**
@@ -324,7 +338,7 @@ function parseRenderTrace(raw: unknown): RenderTraceSection | null {
     }));
 
     const rawSections = Array.isArray(payload.sections) ? payload.sections : [];
-    const repeats: RenderTraceRepeat[] = [];
+    const allSections: RenderTraceRepeat[] = [];
     for (const entry of rawSections) {
         if (!entry || typeof entry !== "object") continue;
         const sec = entry as {
@@ -335,8 +349,8 @@ function parseRenderTrace(raw: unknown): RenderTraceSection | null {
             maxUs?: unknown;
         };
         if (typeof sec.name !== "string" || sec.name.length === 0) continue;
-        if (typeof sec.count !== "number" || sec.count <= 1) continue;
-        repeats.push({
+        if (typeof sec.count !== "number" || sec.count < 1) continue;
+        allSections.push({
             name: sec.name,
             count: sec.count,
             totalUs: typeof sec.totalUs === "number" ? sec.totalUs : 0,
@@ -344,6 +358,9 @@ function parseRenderTrace(raw: unknown): RenderTraceSection | null {
             maxUs: typeof sec.maxUs === "number" ? sec.maxUs : 0,
         });
     }
+    // Only repeats are worth a summary row when the timeline is complete — a single-hit span is
+    // already on it, and duplicating every one would double the tab for no information.
+    const repeats = allSections.filter((s) => s.count > 1);
 
     const rawMetrics =
         payload.metrics && typeof payload.metrics === "object"
@@ -360,7 +377,16 @@ function parseRenderTrace(raw: unknown): RenderTraceSection | null {
     if (phases.length === 0 && metrics.length === 0 && totalMs === null) {
         return null;
     }
-    return { totalMs, totalUs, backend, source, phases, metrics, repeats };
+    return {
+        totalMs,
+        totalUs,
+        backend,
+        source,
+        phases,
+        metrics,
+        repeats,
+        allSections,
+    };
 }
 
 /** Format a microsecond duration at the precision it deserves. */
@@ -606,17 +632,27 @@ function renderRenderTraceSection(trace: RenderTraceSection): HTMLElement {
             note.className = "perf-trace-note";
             note.textContent =
                 elided +
-                " more phases not shown — see the per-name totals below.";
+                " more phases not shown — the totals below cover every one, slowest first.";
             section.appendChild(note);
         }
     }
 
-    if (trace.repeats.length > 0) {
+    // With a complete timeline, only repeated names add anything. Once phases are elided the
+    // timeline no longer shows everything, so the summary has to — otherwise an elided single-hit
+    // composable (which is most of them under composition tracing) would be inspectable nowhere.
+    const elidedPhases = trace.phases.length > MAX_PHASE_ROWS;
+    const summary = elidedPhases
+        ? trace.allSections.slice(0, MAX_SUMMARY_ROWS)
+        : trace.repeats;
+    if (summary.length > 0) {
         const repeats = document.createElement("dl");
         repeats.className = "perf-trace-repeats";
-        for (const repeat of trace.repeats) {
+        for (const repeat of summary) {
             const dt = document.createElement("dt");
-            dt.textContent = repeat.name + " ×" + repeat.count;
+            dt.textContent =
+                repeat.count > 1
+                    ? repeat.name + " ×" + repeat.count
+                    : repeat.name;
             const dd = document.createElement("dd");
             dd.textContent =
                 formatTraceDuration(repeat.totalUs) +


### PR DESCRIPTION
## Summary

Codex review finding on #3352, which merged before it could be addressed.

The phase-row cap I added with composition tracing told users *"see the per-name totals below"* — but `parseRenderTrace` filtered the summary to `count > 1`. Under composition tracing most spans are unique call sites, so a slow composable past the 200th row had **no row anywhere**: the note pointed at a table that had deliberately excluded exactly what someone turning the feature on is looking for.

The parsed data now keeps every aggregate (`allSections`). The rendered summary:
- while the timeline is complete → still repeats-only, because a single-hit span is already visible on the timeline and duplicating every one would double the tab for no information;
- once phases are elided → the full list, slowest first (the daemon already orders `sections[]` by total time), capped at 100 rows.

The note is reworded to match what it now does: *"the totals below cover every one, slowest first."*

## Test plan

- [x] `vscode-extension` — 1626 passing, including a new test that feeds 250 single-hit composition spans and asserts `repeats` stays empty (correct for a complete timeline) while `allSections` keeps all 250, which is what the renderer falls back to
- [x] `npm run compile`, `npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3cKLFpHE64JLdZx8rWcm4)_