### PR TITLE
fix(serve): charge leased burst replicas as foreground seats

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -44,7 +44,7 @@ class LiveSeatLimiter(val totalPermits: Int) {
    * coerced down to [totalPermits], so a backend heavier than the whole budget can still run alone
    * rather than being permanently refused.
    */
-  fun acquire(weight: Int, verified: Boolean = true): Ticket? {
+  fun acquire(weight: Int, verified: Boolean = true, countRefusal: Boolean = true): Ticket? {
     val sem = semaphore ?: return Ticket(0)
     if (weight <= 0) return Ticket(0)
     val permits = weight.coerceIn(1, totalPermits)
@@ -54,7 +54,13 @@ class LiveSeatLimiter(val totalPermits: Int) {
     // dropped: on a public box they are mostly noise anyone could generate, but on a `--revisions`
     // box a valid revision is *legitimately* unknown until its first lease builds it, and its
     // refusals are real demand. Two counters keep both readings honest.
-    if (verified) refusals.incrementAndGet() else unverifiedRefusals.incrementAndGet()
+    // Only count callers that actually turn someone away. A caller that degrades instead — the
+    // shared replica pool narrows its burst onto a host already in circulation and still serves the
+    // render — must not inflate this, or the one number that answers "is the budget too small here"
+    // starts reporting throttled batches as refused visitors.
+    if (countRefusal) {
+      if (verified) refusals.incrementAndGet() else unverifiedRefusals.incrementAndGet()
+    }
     return null
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -23,6 +23,13 @@ class ServeSharedDaemonPool(
    * Whole-box daemon budget ([LiveSeatLimiter]). A replica holds [seatWeight] permits for as long
    * as it is open, so burst width is bounded by what the box can actually afford and not only by
    * [capacity], which is per catalog. Null keeps the historical unbudgeted behaviour.
+   *
+   * Charged as **foreground** ([LiveSeatLimiter.acquire]), unlike the per-preview pool. A replica
+   * opens only when *leased* renders overlap — a visitor is sitting in front of the grid waiting
+   * for those pixels — so it is the same class of demand as a stream, not background residency. It
+   * is also short-lived: the burst ends, the replica goes idle, and [reapIdle] returns the seat.
+   * Making it compete for the background remainder instead capped a visitor's burst at whatever the
+   * prefetcher had left over, which is backwards.
    */
   private val liveSeats: LiveSeatLimiter? = null,
   private val seatWeight: () -> Int = { 1 },
@@ -77,7 +84,7 @@ class ServeSharedDaemonPool(
   private fun openSeatedReplica(): ServeHost {
     var ticket: LiveSeatLimiter.Ticket? = null
     if (liveSeats != null) {
-      ticket = liveSeats.acquireBackground(seatWeight())
+      ticket = liveSeats.acquire(seatWeight())
       if (ticket == null) {
         while (available.isEmpty() && !closed) hostReturned.await()
         check(!closed) { "shared daemon pool is closed" }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -84,7 +84,11 @@ class ServeSharedDaemonPool(
   private fun openSeatedReplica(): ServeHost {
     var ticket: LiveSeatLimiter.Ticket? = null
     if (liveSeats != null) {
-      ticket = liveSeats.acquire(seatWeight())
+      // countRefusal = false: a miss here does NOT refuse the render. The burst simply narrows
+      // onto a host already in circulation (below), so counting it would report throttled widening
+      // as visitors turned away — and `liveSeatRefusals` is the evidence any budget change rests
+      // on.
+      ticket = liveSeats.acquire(seatWeight(), countRefusal = false)
       if (ticket == null) {
         while (available.isEmpty() && !closed) hostReturned.await()
         check(!closed) { "shared daemon pool is closed" }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -279,4 +279,40 @@ class ServeSharedDaemonPoolTest {
       pool.close()
     }
   }
+
+  /**
+   * Codex review on #3355. `liveSeatRefusals` is the evidence any change to the seat budget rests
+   * on, so it must only count callers that actually turned someone away. A leased burst that can't
+   * widen still serves its render off a host already in circulation — throttled, not refused.
+   */
+  @Test
+  fun `replica backpressure is not counted as a live-seat refusal`() {
+    val seats = LiveSeatLimiter(totalPermits = 1)
+    val held = requireNotNull(seats.acquire(1))
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val primary = BlockingHost("primary", entered, release)
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 2, liveSeats = seats) {
+        InstantHost("replica")
+      }
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      val first = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      assertTrue(entered.await(5, TimeUnit.SECONDS))
+      // Wants to widen, cannot (budget spent elsewhere), so it waits for the primary instead.
+      val second = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+
+      release.countDown()
+      assertTrue(first.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok)
+      assertTrue(second.get(10, TimeUnit.SECONDS) is RenderOutcome.Ok, "the render still succeeded")
+      assertEquals(0L, seats.refusalCount(), "narrowing a burst is not a refusal")
+      assertEquals(0L, seats.unverifiedRefusalCount())
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+      pool.close()
+      held.close()
+    }
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ServeSharedDaemonPoolTest {
@@ -232,6 +233,46 @@ class ServeSharedDaemonPoolTest {
 
       release.countDown()
       assertTrue(holder.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok)
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+      pool.close()
+    }
+  }
+
+  /**
+   * A leased burst is a visitor waiting on the grid, so its replicas draw on the FOREGROUND budget
+   * — the same class as a stream — rather than the background remainder the prefetcher leaves. The
+   * per-preview pool stays on the background path, so the stream reserve still protects streams.
+   */
+  @Test
+  fun `a leased replica may use the seats reserved against background work`() {
+    // Exactly the stream reserve free: a background holder (the per-preview pool) would be refused
+    // here, but a leased burst is foreground and may take it.
+    val seats = LiveSeatLimiter(totalPermits = LiveSeatLimiter.STREAM_RESERVE)
+    assertNull(seats.acquireBackground(1), "precondition: background cannot touch the reserve")
+
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val primary = BlockingHost("primary", entered, release)
+    val opened = AtomicInteger()
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 2, liveSeats = seats) {
+        opened.incrementAndGet()
+        InstantHost("replica")
+      }
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      val held = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      assertTrue(entered.await(5, TimeUnit.SECONDS), "primary is mid-render")
+
+      // Overlapping leased render: the primary is out, so this must open a replica.
+      val second = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      assertTrue(second.get(10, TimeUnit.SECONDS) is RenderOutcome.Ok)
+      assertEquals(1, opened.get(), "the burst widened onto a replica")
+
+      release.countDown()
+      assertTrue(held.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok)
     } finally {
       release.countDown()
       executor.shutdownNow()


### PR DESCRIPTION
Last of the four items from the browsing-performance design. #3345 made a cache miss recoverable, #3347 made the prefetcher keep up — this restores the burst width for the first visitor who picks a theme.

## The bug

A leased burst is a visitor sitting in front of the grid waiting for pixels. Its replicas were charged via `acquireBackground`, so they could only use what the theme optimizer had left behind:

```
budget 8, STREAM_RESERVE 2  →  background ceiling 6, shared across every catalog's pools
```

That caps a visitor's burst at the prefetcher's leftovers, which is backwards — the whole point of the lease tier is that *someone is waiting*.

## The fix

Shared-pool replicas acquire as **foreground** (`LiveSeatLimiter.acquire`), the same class as a stream.

**Scoped to the shared pool only.** The per-preview pool keeps `acquireBackground`, so the stream reserve still does its job: a pooled *render* daemon must never take the last seat from a live *stream*. A shared replica is a different animal — it opens only when leased renders actually overlap, and it's short-lived (burst ends → replica idles → `reapIdle` returns the seat).

## Test plan

I said I wouldn't propose this without running the E2E, because a seat change of exactly this shape broke `serve-lanes` on a `--live-seats 1` box earlier today and I shipped that one on reasoning alone.

Ran against a real daemon-backed `serve --catalogs compose-m3 --allow-render-trusted --live-seats 1` — the same configuration that broke:

```
✓ PNG lane re-renders on knob override (7.5s)
✓ SVG lane bakes the override text into the vector (320ms)
✓ Live WebSocket lane upgrades and pushes a frame (1.3s)
✓ viewer wires the knob into every render lane (7.0s)
✓ Live mode surfaces a visible error when the stream can't activate (461ms)
✓ Wasm iframe re-renders on knob override (3.0s)
6 passed (22.4s)
```

Plus:
- `:cli:test` — green.
- New unit test: with exactly `STREAM_RESERVE` permits free, a background acquire is refused (asserted as a precondition) while an overlapping leased render still widens onto a replica. **Verified to fail with `acquireBackground`.**

## Where this leaves the four requirements

| | Status |
| --- | --- |
| 1. Default theme prebaked | already held; grid opens on baked pixels, never touches the daemon |
| 2. Background fills fast when idle | #3347 (and the job list was already preview-major) |
| 3. First browser gets a burst | **this PR** |
| 4. Single high-priority render on an individual page | #3345 |

Still open, deliberately: the single process-wide background render permit in `ServeBackgroundWork`. Raising it is defensible — the contention that matters is per-daemon, and different catalogs' daemons don't block each other — but it's a separate tuning question and I'd rather it not ride along with a seat change.

No visual surfaces changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_