### PR TITLE
fix(gradle-plugin): pack desktop classes, not the android compilation

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -268,12 +268,29 @@ internal object ComposePreviewTasks {
     // `@Preview` functions in `androidMain` without any classic-AGP wiring.
     // [DiscoverPreviewsTask] silently skips dirs that don't exist, so listing
     // it on JVM-only consumers is harmless.
+    // `classes/kotlin/android/main` is the issue-#248 fallback for a module whose ONLY compilation
+    // is the KMP-Android one. It must not be packed alongside a real JVM/desktop compilation: on a
+    // dual-target module (KMP-Android *plus* `jvm("desktop")`, the `samples/cmp-shared` /
+    // `:meshcore-components` shape) both dirs exist and carry the same commonMain classes compiled
+    // for different targets. Packing both mixes them — the android-compiled `MeshcoreFontsKt`
+    // facade wins and calls `MeshcoreFonts_androidKt`, while the desktop pack carries
+    // `MeshcoreFonts_desktopKt` — so the render dies with `NoClassDefFoundError` on the module's
+    // OWN class, one layer past the `*-android` dependency problem.
+    //
+    // Gate it on the same resolution the dependency classpath uses, so the classes the bundle
+    // carries and the dependencies it resolves always describe one target. Lazy for the reason
+    // given at [desktopDependencyConfigName]: `desktopRuntimeClasspath` does not exist yet while
+    // `registerDesktopTasks` runs.
     val sourceClassDirs =
       project.files(
         project.layout.buildDirectory.dir("classes/kotlin/main"),
         project.layout.buildDirectory.dir("classes/kotlin/jvm/main"),
         project.layout.buildDirectory.dir("classes/kotlin/desktop/main"),
-        project.layout.buildDirectory.dir("classes/kotlin/android/main"),
+        project.provider {
+          if (desktopDependencyConfigName(project) == "androidRuntimeClasspath")
+            listOf(project.layout.buildDirectory.dir("classes/kotlin/android/main").get())
+          else emptyList()
+        },
       )
 
     // Processed-resources output dirs, in the same priority order as [sourceClassDirs]. Linked onto

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopClassDirTargetConsistencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopClassDirTargetConsistencyTest.kt
@@ -1,0 +1,66 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The classes a desktop bundle carries must describe the SAME target as the dependencies it
+ * resolves.
+ *
+ * `classes/kotlin/android/main` is the issue-#248 fallback for a module whose only compilation is
+ * the KMP-Android one. On a dual-target module (KMP-Android *plus* `jvm("desktop")` — the
+ * `samples/cmp-shared` / `:meshcore-components` shape) both that dir and `desktop/main` exist and
+ * hold the same commonMain classes compiled for different targets. Packing both mixes them: the
+ * android-compiled `MeshcoreFontsKt` facade wins and calls `MeshcoreFonts_androidKt`, while the
+ * desktop pack carries `MeshcoreFonts_desktopKt`, so the render dies with `NoClassDefFoundError:
+ * ee/schimke/meshcore/components/ui/theme/MeshcoreFonts_androidKt` — one layer past the `*-android`
+ * dependency problem that [BundleDependencyConfigDeferralTest] covers, and only reachable once that
+ * one is fixed.
+ */
+class DesktopClassDirTargetConsistencyTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private fun classDirsFor(configNames: List<String>): List<String> {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    // Both compilation outputs on disk — the dual-target shape.
+    project.layout.buildDirectory.dir("classes/kotlin/android/main").get().asFile.mkdirs()
+    project.layout.buildDirectory.dir("classes/kotlin/desktop/main").get().asFile.mkdirs()
+    configNames.forEach { name ->
+      project.configurations.create(name) {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+      }
+    }
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+    val discover = project.tasks.getByName("composePreviewDiscover") as DiscoverPreviewsTask
+    return discover.classDirs.files.map {
+      it.relativeTo(project.projectDir).invariantSeparatorsPath
+    }
+  }
+
+  @Test
+  fun `a dual-target module does not pack the android compilation output`() {
+    val dirs = classDirsFor(listOf("androidRuntimeClasspath", "desktopRuntimeClasspath"))
+    assertThat(dirs).contains("build/classes/kotlin/desktop/main")
+    // The whole point: mixing this in is what produced the NoClassDefFoundError.
+    assertThat(dirs).doesNotContain("build/classes/kotlin/android/main")
+  }
+
+  @Test
+  fun `a pure KMP-Android module still gets the android compilation output`() {
+    // Issue #248 must keep working — this module has no JVM compilation to fall back to.
+    val dirs = classDirsFor(listOf("androidRuntimeClasspath"))
+    assertThat(dirs).contains("build/classes/kotlin/android/main")
+  }
+
+  @Test
+  fun `a jvm target also excludes the android compilation output`() {
+    val dirs = classDirsFor(listOf("androidRuntimeClasspath", "jvmRuntimeClasspath"))
+    assertThat(dirs).doesNotContain("build/classes/kotlin/android/main")
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #3351, found by watching the live server after 0.19.37 reached meshcore-mobile.

#3351 aligned a desktop bundle's **dependencies** with the resolved runtime config. Its **classes** were still misaligned — and fixing the first exposed the second.

`sourceClassDirs` listed `classes/kotlin/android/main` unconditionally. That dir is the issue-#248 fallback for a module whose *only* compilation is the KMP-Android one. But on a dual-target module (KMP-Android **plus** `jvm("desktop")` — the `samples/cmp-shared` / `:meshcore-components` shape) both it and `classes/kotlin/desktop/main` exist and hold the same commonMain classes compiled for different targets. Packing both mixed them, and the android-compiled facade won.

## Evidence from the published catalog

After 0.19.37 republished `design-artifacts/meshcore-mobile`, the `:meshcore-components` desktop bundle is correct on the dependency axis — `producedBy 0.19.37`, 37 maven entries, **0** android-flavoured, down from 45/36. The `android/os/Parcelable` failures stopped.

They were replaced by a new one:

```
render failed: NoClassDefFoundError:
  ee/schimke/meshcore/components/ui/theme/MeshcoreFonts_androidKt
```

Disassembling what that bundle actually carries:

```
classes/app.jar
  MeshcoreFontsKt.class          ← android-compiled: constant pool references
                                    MeshcoreFonts_androidKt ×16
  MeshcoreFonts_desktopKt.class  ← the desktop actual
  (no MeshcoreFonts_androidKt anywhere in the bundle)
```

So the render got one layer further than before and died on the module's own class instead of a dependency's.

## Fix

Gate the android class dir on the same resolution the dependency classpath already uses, so the classes a bundle carries and the dependencies it resolves always describe one target. A pure KMP-Android module still gets it — `androidRuntimeClasspath` is then the resolved config — so #248 is unaffected.

## Test plan

New `DesktopClassDirTargetConsistencyTest`:
- dual-target (`androidRuntimeClasspath` + `desktopRuntimeClasspath`) → `desktop/main` in, `android/main` **out**
- pure KMP-Android (`androidRuntimeClasspath` only) → `android/main` still in (#248 regression guard)
- `jvmRuntimeClasspath` variant → `android/main` out

`./gradlew :gradle-plugin:test ktfmtCheckAll` green, including the existing `KmpAndroidDesktopRoutingTest`, which asserts the #248 behaviour this change deliberately preserves.

Repacked `samples/cmp-shared` — no regression: 4 previews discovered, 2/2 module classes kept, 23 maven entries, 0 android-flavoured, bundle packs clean. Note that sample has only `commonMain` and no `expect`/`actual`, so it has the same dir collision but cannot exhibit the symptom; the reproduction is `:meshcore-components`, which does have platform actuals. Confirming end-to-end needs a meshcore-mobile republish on the next release.

Text-only: build wiring, no rendered-output change of its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ff3PLh8x3QXsN1mMLn2vG)_