### PR TITLE
chore(renovate): reject -compat backport artifacts and temurin major bumps

### DIFF
--- a/.github/ci/test_affected_gradle_tests.py
+++ b/.github/ci/test_affected_gradle_tests.py
@@ -45,5 +45,19 @@ class AffectedGradleTestsTest(unittest.TestCase):
         self.assertEqual(mod.resolve(["new-root/x.kt"], self.config, self.projects, self.root), "full")
 
 
+class ModuleUnitTestsGateTest(unittest.TestCase):
+    """`none` is a real output of this script, and ci.yml has to honour it.
+
+    `path-scope.py` fails open on paths it doesn't recognise and switches the Module Unit Tests
+    job on, but this script reads a different config where the same path may be ignored — so the
+    job can be enabled with nothing to run. Without the gate below it invoked `gradlew none` and
+    failed the PR. Asserted as text so the test needs no YAML parser.
+    """
+
+    def test_ci_gates_module_unit_tests_on_a_non_none_task_list(self):
+        ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
+        self.assertIn("needs.changes.outputs.module_test_tasks != 'none'", ci)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,39 @@
       "groupName": "{{manager}} minor/patch"
     },
     {
+      "description": "Never take a `…-compat` backport artifact. JetBrains publishes compatibility variants of the kotlinx libraries under a `<version>-<oldline>.x-compat` suffix (e.g. `kotlinx-datetime:0.8.0-0.6.x-compat`, the 0.8.0 code recompiled against the 0.6.x API) and Renovate's gradle versioning ranks that suffix ABOVE the plain release, so it proposes a *downgrade of API surface* dressed as an upgrade (#3359). Filtering the suffix out of the candidate list — rather than disabling the update — keeps Renovate offering the next genuine release. Declared before the per-dep pins below so those stricter `allowedVersions` still win for their deps.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "allowedVersions": "!/-compat$/"
+    },
+    {
+      "description": "eclipse-temurin (cloudrun image): stay on the JDK 17 line. deploy/cloudrun/Dockerfile builds the tool from source inside the image, and the repo's Gradle daemon toolchain is pinned to 17 (gradle/gradle-daemon-jvm.properties) — a newer base JDK means Gradle's auto-detection finds no matching toolchain and the image build fails. Patch bumps inside 17.x are fine; changing the major is a manual decision that has to move the daemon toolchain with it (#3362).",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchFileNames": [
+        "deploy/cloudrun/Dockerfile"
+      ],
+      "matchDepNames": [
+        "eclipse-temurin"
+      ],
+      "allowedVersions": "/^17\\./"
+    },
+    {
+      "description": "eclipse-temurin (release image): stay on the JDK 21 line. deploy/image/Dockerfile runs the released CLI and the Android render daemon, which needs JDK 21+ for Robolectric SDK 36 (docs/SDK_COMPATIBILITY.md) and is built against 21. Patch bumps inside 21.x are fine; a major bump has to be validated against Gradle/AGP/Robolectric support first, so it stays manual (#3362).",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchFileNames": [
+        "deploy/image/Dockerfile"
+      ],
+      "matchDepNames": [
+        "eclipse-temurin"
+      ],
+      "allowedVersions": "/^21\\./"
+    },
+    {
       "description": "Freeze the AGP 8.x minimum-supported fixture: every pin here is deliberate and must be bumped by hand.",
       "matchFileNames": [
         ".github/ci/fixtures/agp8-min/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,13 @@ jobs:
   module-unit-tests:
     name: Module Unit Tests
     needs: changes
-    if: ${{ needs.changes.outputs.module_unit_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    # `module_test_tasks != 'none'` is load-bearing, not belt-and-braces: the two scopes are
+    # resolved from different configs and can disagree. `path-scope.py` fails OPEN on a path it
+    # doesn't recognise (turning every group on, this job included), while
+    # `affected-gradle-tests.py` reads `gradle-test-scope.json`, where e.g. `.github/**` is
+    # ignored — so a PR touching only such a path enabled the job with `tasks=none` and it died
+    # on `gradlew none` ("Task 'none' not found"). `none` means there is nothing to run: skip.
+    if: ${{ needs.changes.outputs.module_unit_tests == 'true' && needs.changes.outputs.module_test_tasks != 'none' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -281,6 +287,10 @@ jobs:
               -x :samples:wear-widget:test \
               -x :samples:xr-glimmer:test \
               -x :samples:xr-spatial:test
+          elif [ -z "$TEST_TASKS" ] || [ "$TEST_TASKS" = none ]; then
+            # The job `if` normally keeps this branch unreached; it's here so a future skew
+            # between the two scope configs is a no-op run, never a `gradlew none` failure.
+            echo "No affected module test tasks — nothing to run."
           else
             read -r -a tasks <<< "$TEST_TASKS"
             ./gradlew "${tasks[@]}" --continue


### PR DESCRIPTION
Two Renovate PRs this week were downgrades dressed as upgrades. Both are now blocked in `.github/renovate.json`. A third commit fixes the CI bug this PR tripped over.

## `…-compat` backport artifacts (#3359)

#3359 proposed `kotlinx-datetime` `0.8.0` → `0.8.0-0.6.x-compat`. JetBrains publishes compatibility variants of the kotlinx libraries under a `<version>-<oldline>.x-compat` suffix — the 0.8.0 code recompiled against the **0.6.x** API — and Renovate's gradle versioning ranks that suffix *above* the plain release, so the "upgrade" swaps our API surface backwards.

The new rule filters `-compat` out of the candidate list for all gradle deps rather than disabling the update, so Renovate still offers the next genuine release (e.g. a future `0.8.1`) instead of going silent on the dep. It's declared **before** the per-dep pins further down the list, since later `packageRules` override the same field — otherwise it would have clobbered the `compose-bom` / `material-kolor` / `compottie` pins' `allowedVersions`.

## `eclipse-temurin` major bumps (#3362)

#3362 collapsed both deploy images onto JDK 25. Each base tag is a deliberate floor:

- `deploy/cloudrun/Dockerfile` (17) builds the tool from source inside the image, so the base JDK has to match the daemon toolchain pin (`toolchainVersion=17` in `gradle/gradle-daemon-jvm.properties`) — otherwise Gradle's toolchain auto-detection finds nothing and the image build fails.
- `deploy/image/Dockerfile` (21) runs the released CLI and the Android render daemon, which is built against 21 and needs JDK 21+ for Robolectric SDK 36 (`docs/SDK_COMPATIBILITY.md`).

Each Dockerfile is now pinned to its own major line via `matchFileNames`, so patch bumps (`17.0.19` → `17.0.x`, `21.0.11` → `21.0.x`) still flow automatically; only the major becomes a manual decision.

## Drive-by: Module Unit Tests died on `gradlew none`

The config-only first commit turned **Module Unit Tests** red — not a flake, a latent bug in the job's scoping, and any PR touching only a path in the same position would hit it.

The job resolves its scope from two different configs. `path-scope.py` fails *open* on a path it doesn't recognise (`.github/renovate.json` matches nothing in `ci-paths.json`), which switches every group on including this job. `affected-gradle-tests.py` then reads `gradle-test-scope.json`, where `.github/**` *is* ignored, and correctly prints its documented `none`. The run step fed that straight to Gradle:

```
* What went wrong:
Selection failed
  Task 'none' not found in root project 'compose-ai-tools' and its subprojects.
```

Fixed by gating the job on a non-`none` task list (skip rather than boot a runner for nothing) and making the run step treat `none`/empty as a no-op, so a future skew between the two configs is a quiet run instead of a red PR.

## Test plan

- `renovate-config-validator` passes on the edited config.
- `python3 .github/ci/test_affected_gradle_tests.py` and `test_path_scope.py` pass; the former gains a case pinning the ci.yml gate, next to the resolver cases that already treat `none` as an expected output.
- No build or render surface is touched, so there's nothing visual to show. Note that editing `ci.yml` puts it in `gradle-test-scope.json`'s `globalPaths`, so this PR's own Module Unit Tests run the **full** suite — the empty-scope path is exercised by any later config-only PR, not this one.
- Real verification of the Renovate rules is the next Monday run: neither the `-compat` variant nor a temurin major should reappear, and unrelated minor/patch groups should be unaffected.