### PR TITLE
fix(serve): keep a Themes-tab specimen out of the theme override

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3372,19 +3372,23 @@ object ServeWeb {
     // The app-declared themes join the header's Theme control only when this session can actually
     // re-render a card under one — otherwise the chips would redraw nothing.
     fun themeRenderable(p: ServePreview) = canRenderThemeFor(p.id)
+    // Whether a declared theme actually redraws this preview: it needs a daemon twin AND must not
+    // be a theme specimen, which has a twin but must keep its baked pixels ([isThemeSpecimen]).
+    // ONE predicate feeding both the chip gate and the per-card URL, deliberately: gating the chips
+    // on mere renderability while the URLs also excluded specimens would offer the control on a
+    // catalog whose only twinned cards are specimens — every `themeBase` empty, the browser's
+    // `if (!img || !base) return` skipping every card, and the chips a no-op.
+    fun themeOverridable(p: ServePreview) = themeRenderable(p) && !isThemeSpecimen(p)
     // The variant a card shows by default (server-side) — the one a declared theme re-renders.
     fun renderedVariant(card: GridCard) =
       if (card.swappable && darkFirst) card.dark!! else card.default
     val declaredThemeChips =
       if (declaredThemes.isEmpty()) emptyList()
-      else if (groups.any { themeRenderable(renderedVariant(it)) }) declaredThemes else emptyList()
-    // A card's themed-render base URL — "" when the session has no daemon twin for it, so it keeps
-    // its baked pixels (a themed render would ignore the theme anyway), and "" for a theme
-    // SPECIMEN, which has a daemon twin but must not use it (see [isThemeSpecimen]).
+      else if (groups.any { themeOverridable(renderedVariant(it)) }) declaredThemes else emptyList()
+    // A card's themed-render base URL — "" when a declared theme wouldn't redraw it, so it keeps
+    // its baked pixels.
     fun themeBase(card: GridCard) =
-      renderedVariant(card).let {
-        if (themeRenderable(it) && !isThemeSpecimen(it)) renderSrc(it) else ""
-      }
+      renderedVariant(card).let { if (themeOverridable(it)) renderSrc(it) else "" }
     fun cardViews(card: GridCard): Long =
       listOfNotNull(card.light, card.dark, card.neutral).sumOf { engagement[it.id]?.views ?: 0L }
     fun swapCard(card: GridCard): String {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -908,6 +908,32 @@ object ServeWeb {
   /** Fallback tab for section-bearing catalogs whose stray card carries no section of its own. */
   private const val OTHER_SECTION = "Other"
 
+  /**
+   * The catalog section whose cards ARE theme specimens — a colour-role/type sheet that exists to
+   * show one specific theme.
+   */
+  private const val THEMES_SECTION = "Themes"
+
+  /**
+   * Whether [p] is a theme **specimen**: a card that renders a named theme as its subject, so
+   * re-rendering it under a `themeProvider` override destroys the very thing it documents.
+   *
+   * meshcore-mobile's `Theme/MeshCore-Light` is the case that surfaced this. Its caption reads
+   * "MeshCore · Light · Orbitron / Space Grotesk / JetBrains Mono", and under a Dynamic Dark
+   * override the card drew dark, in the default sans — pixels contradicting their own label. Every
+   * card in a Themes tab has that property by construction.
+   *
+   * Deliberately keyed on the section rather than the id: `theme-…` id prefixes are a catalog
+   * authoring convention, not a contract, whereas `section` is the authored statement of what the
+   * tab IS (`catalog.spec.json`'s `section: "Themes"`). Specimens that live outside such a tab need
+   * an explicit per-preview opt-out, which is a separate change.
+   *
+   * This does NOT remove the theme chips: the rest of the catalog still re-renders, and a specimen
+   * simply keeps its baked pixels — the same treatment a card with no daemon twin already gets.
+   */
+  private fun isThemeSpecimen(p: ServePreview): Boolean =
+    p.section?.equals(THEMES_SECTION, ignoreCase = true) == true
+
   /** One sub-heading group inside a section tab: its [name] (null ⇒ ungrouped) and its cards. */
   private class LandingGroup(val name: String?) {
     val cards = mutableListOf<GridCard>()
@@ -3353,9 +3379,12 @@ object ServeWeb {
       if (declaredThemes.isEmpty()) emptyList()
       else if (groups.any { themeRenderable(renderedVariant(it)) }) declaredThemes else emptyList()
     // A card's themed-render base URL — "" when the session has no daemon twin for it, so it keeps
-    // its baked pixels (a themed render would ignore the theme anyway).
+    // its baked pixels (a themed render would ignore the theme anyway), and "" for a theme
+    // SPECIMEN, which has a daemon twin but must not use it (see [isThemeSpecimen]).
     fun themeBase(card: GridCard) =
-      renderedVariant(card).let { if (themeRenderable(it)) renderSrc(it) else "" }
+      renderedVariant(card).let {
+        if (themeRenderable(it) && !isThemeSpecimen(it)) renderSrc(it) else ""
+      }
     fun cardViews(card: GridCard): Long =
       listOfNotNull(card.light, card.dark, card.neutral).sumOf { engagement[it.id]?.views ?: 0L }
     fun swapCard(card: GridCard): String {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThemeSpecimenTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThemeSpecimenTest.kt
@@ -1,0 +1,95 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A card in a **Themes** tab renders a named theme as its subject. Re-rendering it under a
+ * `themeProvider` override destroys the very thing it documents, so it keeps its baked pixels.
+ *
+ * The case that surfaced this, on meshcore-mobile: `Theme/MeshCore-Light` is captioned "MeshCore ·
+ * Light · Orbitron / Space Grotesk / JetBrains Mono", and under a Dynamic Dark override the card
+ * drew dark in the default sans — a specimen whose pixels contradicted its own label.
+ */
+class ServeWebThemeSpecimenTest {
+
+  private val themes = listOf(ServeTheme(name = "Brand", providerFqn = "com.example.BrandTheme"))
+
+  private fun page(previews: List<ServePreview>) =
+    ServeWeb.landingPage(
+      "meshcore-mobile",
+      previews,
+      token = "t",
+      isPublic = true,
+      basePath = "/meshcore-mobile",
+      declaredThemes = themes,
+      canRenderThemeFor = { true },
+    )
+
+  /**
+   * The page emits its themed-render URLs as one JS array in grid document order (`var themeBase =
+   * ["…", "", …]`). An entry is the URL that card re-requests under a declared theme; `""` means it
+   * keeps its baked pixels.
+   */
+  private fun themeBases(html: String): List<String> {
+    val decl =
+      Regex("var themeBase = \\[(.*?)\\];", RegexOption.DOT_MATCHES_ALL)
+        .find(html)
+        ?.groupValues
+        ?.get(1)
+        ?: error("page emitted no themeBase array — declared themes were not offered at all")
+    return Regex("\"((?:[^\"\\\\]|\\\\.)*)\"").findAll(decl).map { it.groupValues[1] }.toList()
+  }
+
+  @Test
+  fun `a themes-section specimen is not re-rendered under an override`() {
+    val html =
+      page(
+        listOf(
+          ServePreview(
+            id = "theme-meshcore-light",
+            label = "Theme MeshCore Light",
+            section = "Themes",
+          )
+        )
+      )
+    assertEquals(
+      listOf(""),
+      themeBases(html),
+      "a theme specimen must keep its baked pixels, not gain a themeProvider render URL",
+    )
+  }
+
+  @Test
+  fun `an ordinary card in the same catalog still re-renders`() {
+    // The fix must not disable the whole Theme control — only the specimens opt out.
+    val html =
+      page(
+        listOf(
+          ServePreview(id = "theme-meshcore-light", label = "Theme", section = "Themes"),
+          ServePreview(id = "contactrow-chat", label = "Contact row", section = "Components"),
+        )
+      )
+    val bases = themeBases(html)
+    assertTrue(bases.any { it.isEmpty() }, "the specimen opts out")
+    assertTrue(
+      bases.any { it.contains("/render/contactrow-chat.png") },
+      "the component card still has a themed-render base",
+    )
+    assertTrue(html.contains("cp-theme-btn"), "the declared-theme chips remain offered")
+  }
+
+  @Test
+  fun `the section match is case-insensitive`() {
+    val html = page(listOf(ServePreview(id = "t", label = "T", section = "themes")))
+    assertEquals(listOf(""), themeBases(html))
+  }
+
+  @Test
+  fun `a sectionless catalog is unaffected`() {
+    // Plain bundles and uploaded catalogs carry no section at all; they must keep re-rendering.
+    val html = page(listOf(ServePreview(id = "a", label = "A")))
+    assertTrue(themeBases(html).any { it.contains("/render/a.png") })
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThemeSpecimenTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThemeSpecimenTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -42,39 +43,34 @@ class ServeWebThemeSpecimenTest {
     return Regex("\"((?:[^\"\\\\]|\\\\.)*)\"").findAll(decl).map { it.groupValues[1] }.toList()
   }
 
+  /**
+   * A specimen alongside an ordinary card — the real catalog shape, and the only one that emits a
+   * `themeBase` array at all (a specimen-only catalog offers no chips, covered separately below).
+   */
+  private fun specimenAndComponent(specimenSection: String) =
+    page(
+      listOf(
+        ServePreview(id = "theme-meshcore-light", label = "Theme", section = specimenSection),
+        ServePreview(id = "contactrow-chat", label = "Contact row", section = "Components"),
+      )
+    )
+
   @Test
   fun `a themes-section specimen is not re-rendered under an override`() {
-    val html =
-      page(
-        listOf(
-          ServePreview(
-            id = "theme-meshcore-light",
-            label = "Theme MeshCore Light",
-            section = "Themes",
-          )
-        )
-      )
-    assertEquals(
-      listOf(""),
-      themeBases(html),
-      "a theme specimen must keep its baked pixels, not gain a themeProvider render URL",
+    val bases = themeBases(specimenAndComponent("Themes"))
+    assertTrue(
+      bases.none { it.contains("/render/theme-meshcore-light.png") },
+      "a theme specimen must never gain a themeProvider render URL",
     )
+    assertEquals(1, bases.count { it.isEmpty() }, "exactly the specimen keeps its baked pixels")
   }
 
   @Test
   fun `an ordinary card in the same catalog still re-renders`() {
     // The fix must not disable the whole Theme control — only the specimens opt out.
-    val html =
-      page(
-        listOf(
-          ServePreview(id = "theme-meshcore-light", label = "Theme", section = "Themes"),
-          ServePreview(id = "contactrow-chat", label = "Contact row", section = "Components"),
-        )
-      )
-    val bases = themeBases(html)
-    assertTrue(bases.any { it.isEmpty() }, "the specimen opts out")
+    val html = specimenAndComponent("Themes")
     assertTrue(
-      bases.any { it.contains("/render/contactrow-chat.png") },
+      themeBases(html).any { it.contains("/render/contactrow-chat.png") },
       "the component card still has a themed-render base",
     )
     assertTrue(html.contains("cp-theme-btn"), "the declared-theme chips remain offered")
@@ -82,8 +78,26 @@ class ServeWebThemeSpecimenTest {
 
   @Test
   fun `the section match is case-insensitive`() {
-    val html = page(listOf(ServePreview(id = "t", label = "T", section = "themes")))
-    assertEquals(listOf(""), themeBases(html))
+    val bases = themeBases(specimenAndComponent("themes"))
+    assertTrue(bases.none { it.contains("/render/theme-meshcore-light.png") })
+  }
+
+  @Test
+  fun `a catalog of only specimens offers no declared-theme chips`() {
+    // Otherwise the header advertises a control that redraws nothing: every themeBase would be "",
+    // and the browser's `if (!img || !base) return` would skip every card. The chip gate and the
+    // per-card URL must agree on eligibility.
+    val html =
+      page(
+        listOf(
+          ServePreview(id = "theme-light", label = "Theme Light", section = "Themes"),
+          ServePreview(id = "theme-dark", label = "Theme Dark", section = "Themes"),
+        )
+      )
+    assertFalse(
+      html.contains("data-theme-choice=\"theme:com.example.BrandTheme\""),
+      "no declared-theme chip when nothing the theme could redraw is renderable",
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary

A card in a catalog's **Themes** tab renders a named theme *as its subject*. Re-rendering it under a `themeProvider` override destroys the very thing it documents.

Reported on [preview.coo.ee/meshcore-mobile](https://preview.coo.ee/meshcore-mobile/): picking an alternate theme re-themed the four `Theme/*` specimens along with everything else.

## Visual evidence

Both images below are live renders of the **same preview**, `theme-meshcore-light__ideal__default__light__compact`. The card is captioned *"MeshCore · Light · Orbitron / Space Grotesk / JetBrains Mono"*.

| Correct (baked) — what the fix keeps | Current bug — same card under `themeProvider=…MeshcoreDynamicDarkThemeCatalog` |
|---|---|
| ``&lt;img src="https://preview.coo.ee/meshcore-mobile/render/theme-meshcore-light__ideal__default__light__compact.png" width="330" /&gt;`` | ``&lt;img src="https://preview.coo.ee/meshcore-mobile/render/theme-meshcore-light__ideal__default__light__compact.png?themeProvider=ee.schimke.meshcore.app.ui.theme.MeshcoreDynamicDarkThemeCatalog" width="330" /&gt;`` |

The right-hand card still says "Light" and still names Orbitron, while drawing dark in the default sans — pixels contradicting their own label, brand typeface included. After this change the card keeps the left-hand pixels under every theme.

Verified against the live server before fixing: the two renders are byte-different (`identical=False`) for both `theme-meshcore-light` and `theme-material3-light`, so all four specimens were affected.

## Fix

The gate was `canRenderThemeFor(id)` — which only asks whether a card *can* be re-rendered live. A specimen answers **yes** to that and **no** to the question that actually matters, so it needed a separate one.

`themeBase` now yields `""` for a specimen, which is the existing *"keep your baked pixels"* path that a card with no daemon twin already takes. No new rendering path, no new state.

Keyed on the authored `section` rather than a `theme-…` id prefix: the prefix is a catalog authoring convention, whereas the section is the author's statement of what the tab **is** (`catalog.spec.json`'s `section: "Themes"`). A specimen living outside such a tab needs an explicit per-preview opt-out — deliberately a **separate change**, since that one has to travel from an annotation through discovery, `previews.json` and the bundle before serve can honour it.

## Test plan

New `ServeWebThemeSpecimenTest`, asserting on the `var themeBase = [...]` array the page emits in grid document order (`""` = keeps baked pixels):

- a `section = "Themes"` card gets `""` — no `themeProvider` URL
- an ordinary `section = "Components"` card in the *same* catalog still gets its themed-render base, and the chips stay offered — the control is not disabled wholesale
- the section match is case-insensitive
- a section-less catalog (plain/uploaded bundle) is unaffected

`./gradlew :cli:test --tests '*Serve*' --tests '*Theme*'` green, including the existing `ServeWebDeferredThemeTest` / `CatalogThemeCacheTest` / `ThemeRenderLeaseManagerTest`.

## Not in this PR

Separately reported on the same page: `BlePermissionPanelDenied` showing *"Theme preview unavailable"*. That is **not** a broken preview — it renders 8/8 theme × mode combinations in 1–2s, and `renderStats` is `failed: 0`. It's cache coverage: `themeOptimization` for meshcore-mobile reads `state=paused, cached=71/372`, so most themed variants need a live render at page load and some cards exhaust `themeRenderRetries = 3` under lease contention. Worth watching whether #3363's batched prefetch drains that backlog now it's deployed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ff3PLh8x3QXsN1mMLn2vG)_