### PR TITLE
feat(serve): report prefetch rate, time split and observed batch width on /status

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -17,6 +17,34 @@ data class ThemeOptimizationSnapshot(
   val fullyOptimized: Boolean,
   val startedAtEpochMillis: Long? = null,
   val completedAtEpochMillis: Long? = null,
+  /**
+   * Entries cached per minute over the pass's lifetime, and the projected seconds to finish at that
+   * rate. Null before the pass has done enough to divide by.
+   *
+   * The point of publishing a RATE rather than only `cached`/`remaining`: a cumulative count read
+   * twice looks the same whether the pass is keeping up or crawling, and reading progress off a
+   * lifetime average (which includes the server's startup, when the pass is parked) understates the
+   * current rate. Both mistakes were made against this catalog before this existed.
+   */
+  val entriesPerMinute: Double? = null,
+  val etaSeconds: Long? = null,
+  /**
+   * Where the pass's wall-clock actually goes: inside renders vs. waiting for its turn at the idle
+   * gate. This is the split that says whether throughput is render-bound (nothing to fix without a
+   * faster renderer) or gate-bound (a scheduling problem), which `cached` alone cannot distinguish.
+   */
+  val renderMillis: Long = 0,
+  val waitingMillis: Long = 0,
+  /** How often the idle gate granted the pass its turn, and how often traffic took it back. */
+  val turnsGranted: Int = 0,
+  val turnsYielded: Int = 0,
+  /**
+   * Renders actually issued concurrently in the last batch, and the widest so far. Makes "five
+   * wide" an observed fact rather than an assumption — a batch that silently collapses to 1 (a
+   * single-daemon lane, or a seat budget that affords no replicas) is otherwise invisible.
+   */
+  val lastBatchWidth: Int = 0,
+  val maxBatchWidth: Int = 0,
 )
 
 /** Memory occupancy of one catalog generation's rendered-preview cache. */
@@ -59,6 +87,34 @@ class CatalogThemeCache(
   private val state = AtomicReference("waiting")
   private val startedAt = AtomicLong(0)
   private val completedAt = AtomicLong(0)
+  private val renderMillis = AtomicLong(0)
+  private val waitingMillis = AtomicLong(0)
+  private val turnsGranted = java.util.concurrent.atomic.AtomicInteger(0)
+  private val turnsYielded = java.util.concurrent.atomic.AtomicInteger(0)
+  private val lastBatchWidth = java.util.concurrent.atomic.AtomicInteger(0)
+  private val maxBatchWidth = java.util.concurrent.atomic.AtomicInteger(0)
+
+  /** The idle gate handed the pass its turn. */
+  fun recordTurnGranted() {
+    turnsGranted.incrementAndGet()
+  }
+
+  /** Traffic took the turn back. */
+  fun recordTurnYielded() {
+    turnsYielded.incrementAndGet()
+  }
+
+  /** Wall-clock spent waiting at the idle gate rather than rendering. */
+  fun recordWaiting(millis: Long) {
+    if (millis > 0) waitingMillis.addAndGet(millis)
+  }
+
+  /** One batch completed: how wide it actually ran, and how long its renders took. */
+  fun recordBatch(width: Int, millis: Long) {
+    lastBatchWidth.set(width)
+    maxBatchWidth.accumulateAndGet(width, ::maxOf)
+    if (millis > 0) renderMillis.addAndGet(millis)
+  }
 
   fun configureTargets(keys: Collection<String>) {
     targetKeys += keys
@@ -173,6 +229,20 @@ class CatalogThemeCache(
       fullyOptimized = complete,
       startedAtEpochMillis = startedAt.get().takeIf { it > 0 },
       completedAtEpochMillis = completedAt.get().takeIf { it > 0 },
+      // Rate over the pass's ACTIVE time (render + gate wait), not wall-clock since it started:
+      // wall-clock includes stretches where the pass held no turn at all, which drags the figure
+      // toward zero and hides whether it is keeping up while it runs.
+      entriesPerMinute = ratePerMinute(cachedTargets),
+      etaSeconds =
+        ratePerMinute(cachedTargets)
+          ?.takeIf { it > 0 }
+          ?.let { ((total - cachedTargets).coerceAtLeast(0) / it * 60).toLong() },
+      renderMillis = renderMillis.get(),
+      waitingMillis = waitingMillis.get(),
+      turnsGranted = turnsGranted.get(),
+      turnsYielded = turnsYielded.get(),
+      lastBatchWidth = lastBatchWidth.get(),
+      maxBatchWidth = maxBatchWidth.get(),
     )
   }
 
@@ -185,6 +255,12 @@ class CatalogThemeCache(
         evictions = evictionCount.get(),
       )
     }
+
+  private fun ratePerMinute(cached: Int): Double? {
+    val activeMillis = renderMillis.get() + waitingMillis.get()
+    if (cached <= 0 || activeMillis <= 0) return null
+    return cached / (activeMillis / 60_000.0)
+  }
 
   private fun refreshCompletion() {
     if (

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -418,8 +418,13 @@ class ServeCatalogLiveHost(
               previewJobs.subList(index, minOf(index + optimizerBatchWidth(), previewJobs.size))
             index += batch.size
             catalogThemeCache.markRunning(clock())
+            val batchStartedAt = clock()
             val outcomes =
               backgroundWork.withRenderPermit { renderOptimizerBatch(batch) } ?: return@execute
+            // Width recorded from the batch actually issued, not the requested ceiling — a batch
+            // that collapses to 1 (single-daemon lane, or a seat budget with no replicas to spare)
+            // is exactly the case that is invisible from `cached` alone.
+            catalogThemeCache.recordBatch(batch.size, clock() - batchStartedAt)
             for ((job, outcome) in batch.zip(outcomes)) {
               if (catalogThemeCache.get(job.cacheKey) != null) continue
               // Busy is "ask again", not a failure: the warm above may still be settling. Leave it
@@ -508,7 +513,11 @@ class ServeCatalogLiveHost(
    */
   private fun awaitOptimizerTurn(): Boolean {
     if (!optimizerHasTurn.get()) {
-      if (!awaitServerIdle()) return false
+      val waitedFrom = clock()
+      val granted = awaitServerIdle()
+      catalogThemeCache.recordWaiting(clock() - waitedFrom)
+      if (!granted) return false
+      catalogThemeCache.recordTurnGranted()
       optimizerHasTurn.set(true)
       optimizerSampledAt.set(clock())
       return true
@@ -529,7 +538,9 @@ class ServeCatalogLiveHost(
     optimizerSampledAt.set(now)
     if (quiet) return true
     optimizerHasTurn.set(false)
+    catalogThemeCache.recordTurnYielded()
     catalogThemeCache.markPaused()
+    val resumeFrom = clock()
     // Re-enter on the SHORT window, not the full entry one. [themeOptimizationIdleMillis] answers
     // "may I start work on a box someone might be using?" — a cold-start question, asked once. Once
     // the pass has been running, the box has already proved it goes quiet, and the only question
@@ -537,6 +548,7 @@ class ServeCatalogLiveHost(
     // per interruption is what capped throughput: at a ~50% yield rate a 60s re-entry averages
     // ~30s/entry against a sub-second render, i.e. ~97% waiting.
     return awaitQuiet(OPTIMIZER_RESUME_MILLIS).also {
+      catalogThemeCache.recordWaiting(clock() - resumeFrom)
       if (it) {
         optimizerHasTurn.set(true)
         optimizerSampledAt.set(clock())

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
@@ -93,4 +93,46 @@ class CatalogThemeCacheTest {
     cache.recordRenderFailure("k", "boom")
     assertNull(cache.failureReason("k"))
   }
+
+  /**
+   * The instrumentation exists because `cached`/`remaining` alone cannot answer the question that
+   * actually matters — is the pass keeping up, and if not, is it render-bound or gate-bound. Two
+   * throughput readings against the live server were wrong before this existed: one measured a
+   * different lane entirely, one divided by lifetime instead of active time.
+   */
+  @Test
+  fun `optimizer stats report rate, ETA, time split and observed batch width`() {
+    val cache = CatalogThemeCache()
+    cache.configureTargets((1..10).map { "k$it" })
+
+    cache.recordTurnGranted()
+    cache.recordWaiting(30_000) // half the active time spent waiting for a turn
+    cache.recordBatch(width = 5, millis = 30_000)
+    cache.recordTurnYielded()
+    repeat(5) { cache.put("k${it + 1}", byteArrayOf(1)) }
+
+    val s = cache.snapshot()
+    assertEquals(5, s.cached)
+    // 5 entries over 60s of ACTIVE time = 5/min; 5 remaining at that rate = 60s.
+    assertEquals(5.0, s.entriesPerMinute)
+    assertEquals(60L, s.etaSeconds)
+    // The split is the diagnostic: half the time rendering, half waiting at the gate.
+    assertEquals(30_000L, s.renderMillis)
+    assertEquals(30_000L, s.waitingMillis)
+    assertEquals(1, s.turnsGranted)
+    assertEquals(1, s.turnsYielded)
+    // Width is what actually ran, so a batch collapsing to 1 is visible rather than assumed.
+    assertEquals(5, s.lastBatchWidth)
+    assertEquals(5, s.maxBatchWidth)
+  }
+
+  @Test
+  fun `rate and ETA stay null before the pass has done anything to divide by`() {
+    val cache = CatalogThemeCache()
+    cache.configureTargets(listOf("a", "b"))
+    val s = cache.snapshot()
+    assertNull(s.entriesPerMinute)
+    assertNull(s.etaSeconds)
+    assertEquals(0, s.maxBatchWidth)
+  }
 }


### PR DESCRIPTION
Answers the question `cached`/`remaining` can't: is the prefetcher keeping up, and if not, is it render-bound or gate-bound?

## Why

Reading progress off those two numbers went wrong **three times** against the live server during this round of work:

| misreading | error |
|---|---|
| timed the SVG lane (render **plus** figma-svg export) and treated it as PNG render cost | ~10× |
| divided by server uptime instead of the pass's active time | 3.5× |
| sampled a nine-minute-old restart and called a working change ineffective | inverted the conclusion |

Every one ran toward the story being told at the time. That's what instrumentation is for.

## What's added to `ThemeOptimizationSnapshot`

- **`entriesPerMinute` / `etaSeconds`** — a *rate*, over the pass's **active** time (render + gate wait) rather than wall-clock. Wall-clock includes stretches where the pass holds no turn at all, which drags the figure toward zero and hides whether it keeps up while running — that was misreading #2.
- **`renderMillis` / `waitingMillis`** — where the wall-clock actually goes. This is the split that separates "nothing to fix without a faster renderer" from "scheduling problem". No existing field distinguishes them, which is why the ~97%-waiting diagnosis took a stack of manual probes to reach.
- **`turnsGranted` / `turnsYielded`** — how often the idle gate grants a turn and how often traffic takes it back.
- **`lastBatchWidth` / `maxBatchWidth`** — the width *actually issued*, not the requested ceiling. A batch collapsing to 1 (single-daemon lane, or a seat budget with no replicas to spare) is otherwise invisible — and that exact collapse was a real bug Codex caught on #3363, found by reading code rather than by any signal the server emitted.

All fields are default-valued, so the JSON stays backward compatible.

## Test plan

- `:cli:test --rerun` — green. `--rerun` deliberately: the plain task resolved `UP-TO-DATE` and skipped execution during this work, exactly as #3280's verification notes warn.
- New tests pin the arithmetic — 5 entries over 60s of active time reports `5.0`/min with a `60`s ETA and a 50/50 render/wait split — and that rate and ETA stay null before there is anything to divide by.

## What this doesn't do

It doesn't render the numbers on the `/status` **HTML** page, only `/status.json`. The JSON is what I'd been probing by hand, so it's the surface that stops the misreadings; the HTML view is a follow-up if you want it visible without a curl.

Related: #3280 item 5 (15 catalogs still pinned below 0.19.35, carrying the pruner bug — `horologist` is failing live now).

No visual surfaces changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_