### PR TITLE
fix(serve): stop caching signed-in pages, and slide the GitHub session

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -94,7 +94,10 @@ class ServeGithubAuth(
           call.respondText("GitHub sign-in failed.", status = HttpStatusCode.Forbidden)
           return
         }
-    val session = signedSession(user.login, user.repositoryAccess)
+    // This is the moment GitHub actually vouched for the visitor, so it anchors the absolute cap
+    // that [refreshSession] may never slide a session past.
+    val authenticatedAt = clock.millis()
+    val session = signedSession(user.login, user.repositoryAccess, authenticatedAt)
     val secure = isSecure(call, config.callbackBaseUrl)
     call.response.cookies.append(authCookie(session, maxAge = SESSION_TTL_SECONDS, secure = secure))
     call.response.cookies.append(stateCookie("", maxAge = 0, secure = secure))
@@ -107,14 +110,21 @@ class ServeGithubAuth(
 
   /**
    * Slide a still-valid session forward, so an active visitor stays signed in instead of being
-   * bounced through GitHub on a fixed cadence.
+   * bounced through GitHub on a fixed cadence — but never past the absolute cap stamped at sign-in.
    *
-   * The session is a self-contained signed cookie: there is no server-side store to touch, so the
-   * only way to extend one is to mint a fresh cookie carrying a later expiry. This re-mints once a
-   * session is past [SESSION_REFRESH_AFTER_SECONDS] — half its life — which keeps someone who
-   * visits regularly signed in indefinitely while still re-checking their GitHub identity and
-   * repository access whenever they've been away longer than a full [SESSION_TTL_SECONDS]. Under
-   * that threshold it does nothing at all, so an ordinary page view sets no cookie.
+   * The session is a self-contained signed cookie: there is no server-side store to touch and the
+   * access token is deliberately not kept, so the only way to extend one is to mint a fresh cookie
+   * carrying a later expiry, and there is nothing to re-ask GitHub with at refresh time. That is
+   * precisely why the cap exists. A refreshed cookie copies the `repositoryAccess` flag GitHub
+   * computed at sign-in, and that flag is the playground gate; without a ceiling, somebody whose
+   * access to the gating repo was revoked would keep it for as long as they kept visiting —
+   * forever, for a daily visitor. [SESSION_ABSOLUTE_TTL_SECONDS] from [handleCallback] is the
+   * ceiling, and reaching it costs the visitor one silent redirect through GitHub (an OAuth app
+   * they have already approved re-authorises without a consent screen) which re-computes the flag.
+   *
+   * So: idle expiry [SESSION_TTL_SECONDS] slides on every visit past its half-life
+   * ([SESSION_REFRESH_AFTER_SECONDS]); the absolute expiry never moves. Under the half-life, or
+   * once the cap is reached, this does nothing at all — an ordinary page view sets no cookie.
    *
    * Skipped on the OAuth routes: [handleCallback] mints the authoritative cookie itself, and a
    * second `Set-Cookie` for the same name in one response is a coin flip between them.
@@ -122,12 +132,20 @@ class ServeGithubAuth(
   fun refreshSession(call: ApplicationCall) {
     if (call.request.uri.substringBefore('?').startsWith(AUTH_PATH_PREFIX)) return
     val session = call.request.cookieValue(AUTH_COOKIE)?.let { verifySession(it) } ?: return
-    val remaining = session.expiresAt - clock.millis()
-    if (remaining > SESSION_REFRESH_AFTER_SECONDS * 1000) return
+    val now = clock.millis()
+    if (session.expiresAt - now > SESSION_REFRESH_AFTER_SECONDS * 1000) return
+    // Legacy cookies (minted before the sign-in stamp existed) carry no anchor, so they cannot be
+    // shown to be inside the cap and are left to expire on their own terms.
+    val authenticatedAt = session.authenticatedAt ?: return
+    val expiresAt =
+      minOf(now + SESSION_TTL_SECONDS * 1000, authenticatedAt + SESSION_ABSOLUTE_TTL_SECONDS * 1000)
+    if (expiresAt <= session.expiresAt) return
     call.response.cookies.append(
       authCookie(
-        signedSession(session.login, session.repositoryAccess),
-        maxAge = SESSION_TTL_SECONDS,
+        signedSession(session.login, session.repositoryAccess, authenticatedAt, expiresAt),
+        // The cookie dies with the payload it carries, rather than outliving it as a cookie the
+        // browser keeps sending and the server keeps rejecting.
+        maxAge = (expiresAt - now) / 1000,
         secure = isSecure(call, config.callbackBaseUrl),
       )
     )
@@ -226,10 +244,14 @@ class ServeGithubAuth(
     return StatePayload(returnTo)
   }
 
-  private fun signedSession(login: String, repositoryAccess: Boolean): String {
-    val expiresAt = clock.millis() + SESSION_TTL_SECONDS * 1000
+  private fun signedSession(
+    login: String,
+    repositoryAccess: Boolean,
+    authenticatedAt: Long,
+    expiresAt: Long = clock.millis() + SESSION_TTL_SECONDS * 1000,
+  ): String {
     val repoFlag = if (repositoryAccess) "repo" else "no-repo"
-    return sign("${login.lowercase()}|$repoFlag|$expiresAt")
+    return sign("${login.lowercase()}|$repoFlag|$expiresAt|$authenticatedAt")
   }
 
   private fun verifySession(value: String): SessionPayload? {
@@ -241,10 +263,14 @@ class ServeGithubAuth(
         // authenticated for live preview, but do not satisfy the stricter playground gate.
         2 -> Triple(parts[0], false, parts[1].toLongOrNull())
         3 -> Triple(parts[0], parts[1] == "repo", parts[2].toLongOrNull())
+        4 -> Triple(parts[0], parts[1] == "repo", parts[2].toLongOrNull())
         else -> return null
       }
     if (expiresAt == null || expiresAt <= clock.millis() || login.isBlank()) return null
-    return SessionPayload(login, repositoryAccess, expiresAt)
+    // Absent on the 2- and 3-part forms: those predate the sign-in stamp, so their session simply
+    // can't be slid ([refreshSession]) and runs out at its own expiry.
+    val authenticatedAt = parts.getOrNull(3)?.toLongOrNull()
+    return SessionPayload(login, repositoryAccess, expiresAt, authenticatedAt)
   }
 
   private fun sign(payload: String): String {
@@ -302,6 +328,8 @@ class ServeGithubAuth(
     val login: String,
     val repositoryAccess: Boolean,
     val expiresAt: Long,
+    /** When GitHub last vouched for this visitor; null on a cookie minted before the stamp. */
+    val authenticatedAt: Long?,
   )
 
   companion object {
@@ -326,24 +354,35 @@ class ServeGithubAuth(
     private const val STATE_TTL_SECONDS = 10L * 60
 
     /**
-     * How long a session survives *without a visit*.
+     * The **idle** expiry: how long a session survives without a visit. [refreshSession] slides it
+     * forward on each visit, up to [SESSION_ABSOLUTE_TTL_SECONDS].
      *
-     * This was 12 hours, which is shorter than the gap between one working day and the next: a
-     * visitor who signed in yesterday afternoon was reliably signed out this morning, and the
-     * server is a preview gallery people drop into occasionally, not a console they live in. Two
-     * weeks with [refreshSession] sliding it forward means regular visitors effectively never see
-     * the GitHub round-trip again, while anyone who stays away longer than a fortnight is
-     * re-verified.
-     *
-     * It is also the ceiling on how stale the cached repository-access flag can be — revoking
-     * someone's access to the gating repo takes up to this long to close the playground behind them
-     * — which is why it is a fortnight rather than the year a pure "remember me" would use.
+     * This was 12 hours *absolute*, which is shorter than the gap between one working day and the
+     * next: a visitor who signed in yesterday afternoon was reliably signed out this morning, and
+     * the server is a preview gallery people drop into occasionally, not a console they live in. A
+     * week of idle means the normal rhythm of visiting — daily, or on Monday after a quiet weekend
+     * — never lands on a sign-in.
      */
-    internal const val SESSION_TTL_SECONDS = 14L * 24 * 60 * 60
+    internal const val SESSION_TTL_SECONDS = 7L * 24 * 60 * 60
 
     /**
-     * Sessions are re-minted once they are this old (half of [SESSION_TTL_SECONDS]). Half-life
-     * rather than every request: the cookie is only worth rewriting when the extension is
+     * The **absolute** expiry, measured from the sign-in itself and never extended: however
+     * regularly someone visits, GitHub gets asked about them again this often.
+     *
+     * It is the ceiling on how stale the cached `repositoryAccess` flag — the playground gate — can
+     * be, so revoking someone's access to the gating repo closes the playground behind them within
+     * a fortnight rather than never. That is what makes the sliding idle expiry above safe: an
+     * entitlement decided once at sign-in cannot ride along indefinitely on the strength of the
+     * visitor simply continuing to visit.
+     *
+     * Reaching it is cheap for the visitor: an OAuth app they have already approved re-authorises
+     * without a consent screen, so it reads as a page load rather than a sign-in.
+     */
+    internal const val SESSION_ABSOLUTE_TTL_SECONDS = 14L * 24 * 60 * 60
+
+    /**
+     * Sessions are re-minted once their idle expiry is this close (half of [SESSION_TTL_SECONDS]).
+     * Half-life rather than every request: the cookie is only worth rewriting when the extension is
      * meaningful, and a `Set-Cookie` on every page view is noise on responses that are otherwise
      * identical.
      */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -105,6 +105,34 @@ class ServeGithubAuth(
     return currentLogin(call) != null
   }
 
+  /**
+   * Slide a still-valid session forward, so an active visitor stays signed in instead of being
+   * bounced through GitHub on a fixed cadence.
+   *
+   * The session is a self-contained signed cookie: there is no server-side store to touch, so the
+   * only way to extend one is to mint a fresh cookie carrying a later expiry. This re-mints once a
+   * session is past [SESSION_REFRESH_AFTER_SECONDS] — half its life — which keeps someone who
+   * visits regularly signed in indefinitely while still re-checking their GitHub identity and
+   * repository access whenever they've been away longer than a full [SESSION_TTL_SECONDS]. Under
+   * that threshold it does nothing at all, so an ordinary page view sets no cookie.
+   *
+   * Skipped on the OAuth routes: [handleCallback] mints the authoritative cookie itself, and a
+   * second `Set-Cookie` for the same name in one response is a coin flip between them.
+   */
+  fun refreshSession(call: ApplicationCall) {
+    if (call.request.uri.substringBefore('?').startsWith(AUTH_PATH_PREFIX)) return
+    val session = call.request.cookieValue(AUTH_COOKIE)?.let { verifySession(it) } ?: return
+    val remaining = session.expiresAt - clock.millis()
+    if (remaining > SESSION_REFRESH_AFTER_SECONDS * 1000) return
+    call.response.cookies.append(
+      authCookie(
+        signedSession(session.login, session.repositoryAccess),
+        maxAge = SESSION_TTL_SECONDS,
+        secure = isSecure(call, config.callbackBaseUrl),
+      )
+    )
+  }
+
   fun currentLogin(call: ApplicationCall): String? {
     val cookie = call.request.cookieValue(AUTH_COOKIE) ?: return null
     return verifySession(cookie)?.login
@@ -216,7 +244,7 @@ class ServeGithubAuth(
         else -> return null
       }
     if (expiresAt == null || expiresAt <= clock.millis() || login.isBlank()) return null
-    return SessionPayload(login, repositoryAccess)
+    return SessionPayload(login, repositoryAccess, expiresAt)
   }
 
   private fun sign(payload: String): String {
@@ -270,7 +298,11 @@ class ServeGithubAuth(
 
   private data class StatePayload(val returnTo: String)
 
-  private data class SessionPayload(val login: String, val repositoryAccess: Boolean)
+  private data class SessionPayload(
+    val login: String,
+    val repositoryAccess: Boolean,
+    val expiresAt: Long,
+  )
 
   companion object {
     const val START_PATH = "/auth/github/start"
@@ -288,8 +320,34 @@ class ServeGithubAuth(
      */
     const val PRIVATE_REPO_SCOPE = "read:user repo"
 
+    /** Both OAuth routes, so [refreshSession] can leave the cookie-minting ones alone. */
+    private const val AUTH_PATH_PREFIX = "/auth/github/"
+
     private const val STATE_TTL_SECONDS = 10L * 60
-    private const val SESSION_TTL_SECONDS = 12L * 60 * 60
+
+    /**
+     * How long a session survives *without a visit*.
+     *
+     * This was 12 hours, which is shorter than the gap between one working day and the next: a
+     * visitor who signed in yesterday afternoon was reliably signed out this morning, and the
+     * server is a preview gallery people drop into occasionally, not a console they live in. Two
+     * weeks with [refreshSession] sliding it forward means regular visitors effectively never see
+     * the GitHub round-trip again, while anyone who stays away longer than a fortnight is
+     * re-verified.
+     *
+     * It is also the ceiling on how stale the cached repository-access flag can be — revoking
+     * someone's access to the gating repo takes up to this long to close the playground behind them
+     * — which is why it is a fortnight rather than the year a pure "remember me" would use.
+     */
+    internal const val SESSION_TTL_SECONDS = 14L * 24 * 60 * 60
+
+    /**
+     * Sessions are re-minted once they are this old (half of [SESSION_TTL_SECONDS]). Half-life
+     * rather than every request: the cookie is only worth rewriting when the extension is
+     * meaningful, and a `Set-Cookie` on every page view is noise on responses that are otherwise
+     * identical.
+     */
+    internal const val SESSION_REFRESH_AFTER_SECONDS = SESSION_TTL_SECONDS / 2
     private val SECURE_RANDOM = SecureRandom()
 
     fun safeReturnTo(value: String): String =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -9,6 +9,7 @@ import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.createApplicationPlugin
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
@@ -306,6 +307,17 @@ class ServeHttpServer(
   private val server: EmbeddedServer<*, *> =
     embeddedServer(CIO, host = host, port = port) {
       install(WebSockets)
+      // Sliding sessions: any request carrying a session past its half-life gets a freshly signed
+      // cookie, so a visitor who keeps coming back is never bounced through GitHub. Runs before
+      // routing so it covers every response, and no-ops (no `Set-Cookie` at all) for a young
+      // session or no session. See [ServeGithubAuth.refreshSession].
+      githubAuth?.let { auth ->
+        install(
+          createApplicationPlugin("github-session-refresh") {
+            onCall { call -> auth.refreshSession(call) }
+          }
+        )
+      }
       routing {
         // `/healthz` — ungated liveness: "ok" the moment the listener is up. Leaks nothing, and
         // proves nothing beyond "the process is answering HTTP". The rolling-update gate is
@@ -1149,6 +1161,12 @@ class ServeHttpServer(
   private fun RoutingContext.markGeneration(generation: String, cacheControl: String? = null) {
     call.response.headers.append(GENERATION_HEADER, generation)
     cacheControl?.let { call.response.headers.append(HttpHeaders.CacheControl, it) }
+    // Belt to `private, no-store`'s braces: an intermediary that under-honours the directive still
+    // learns the body turns on the session cookie, rather than keying one visitor's HTML by URL
+    // alone.
+    if (cacheControl == SIGNED_IN_PAGE_CACHE_CONTROL) {
+      call.response.headers.append(HttpHeaders.Vary, HttpHeaders.Cookie)
+    }
   }
 
   private fun incrementPreviewViews(
@@ -2668,11 +2686,7 @@ class ServeHttpServer(
           }
       markGeneration(
         "static-page",
-        viewerCacheControl(
-          githubAuthConfigured = githubAuth != null,
-          hasLiveStream = renderHost.hasLiveStream,
-          isPublic = isPublic,
-        ),
+        viewerCacheControl(githubAuthConfigured = githubAuth != null, isPublic = isPublic),
       )
       call.respondText(
         ServeWeb.viewerPage(
@@ -3075,7 +3089,7 @@ class ServeHttpServer(
   }
 
   private fun pageCacheControl(): String =
-    if (isPublic) STATIC_PAGE_CACHE_CONTROL else DYNAMIC_RESOURCE_CACHE_CONTROL
+    pageCacheControl(githubAuthConfigured = githubAuth != null, isPublic = isPublic)
 
   private fun prebakedImageCacheControl(): String = prebakedImageCacheControl(isPublic)
 
@@ -3364,13 +3378,43 @@ class ServeHttpServer(
     /** Variant renders and all token-gated responses stay out of shared and browser caches. */
     private const val DYNAMIC_RESOURCE_CACHE_CONTROL = "no-store"
 
-    internal fun viewerCacheControl(
-      githubAuthConfigured: Boolean,
-      hasLiveStream: Boolean,
-      isPublic: Boolean,
-    ): String =
-      if (githubAuthConfigured && hasLiveStream) DYNAMIC_RESOURCE_CACHE_CONTROL
+    /**
+     * Caching for HTML whose body depends on *who is asking* — every page on a server with
+     * `--github-auth-*` configured, because they all render the sign-in chip (signed out → "Sign
+     * in"; signed in → the visitor's login), and some render more besides (the live-preview auth
+     * prompt, the issue-reporter's "filed as @you" tooltip).
+     *
+     * It cannot be [STATIC_PAGE_CACHE_CONTROL]. `public` licenses the CDN in front of the deployed
+     * server to store one visitor's HTML and hand it to the next, so a signed-in visitor's login
+     * leaks to strangers and a stranger's signed-out page comes back to them. And even with no
+     * shared cache at all, `max-age=60, stale-while-revalidate=300` means the *browser's own* cache
+     * replays the pre-sign-in HTML for a minute — served stale for five more while it revalidates
+     * behind the scenes — so returning from the GitHub callback to a page visited moments earlier
+     * paints it signed-out. That is the "it says I'm logged out until I hit refresh" report: a
+     * reload revalidates, which is why the state looks right the moment you ask for it again.
+     *
+     * `no-store` rather than `no-cache` on purpose: these pages carry no ETag, so a revalidation
+     * costs a full re-render anyway, and `no-store` additionally keeps the signed-out HTML out of
+     * the back/forward cache, where a plain Back would otherwise resurrect it.
+     */
+    internal const val SIGNED_IN_PAGE_CACHE_CONTROL = "private, no-store"
+
+    /**
+     * Caching for an assembled HTML page. Public and auth-free ⇒ short edge caching; otherwise the
+     * response is personal (sign-in state) or token-bearing, and is not stored at all.
+     */
+    internal fun pageCacheControl(githubAuthConfigured: Boolean, isPublic: Boolean): String =
+      if (githubAuthConfigured) SIGNED_IN_PAGE_CACHE_CONTROL
       else if (isPublic) STATIC_PAGE_CACHE_CONTROL else DYNAMIC_RESOURCE_CACHE_CONTROL
+
+    /**
+     * The viewer page follows [pageCacheControl]. It used to drop to `no-store` only for a
+     * *live-streaming* preview under GitHub auth, on the theory that the live lane was the only
+     * personalised thing on the page — but the sign-in chip is on every viewer, live or not, so the
+     * non-live viewer was being cached with one visitor's identity baked in.
+     */
+    internal fun viewerCacheControl(githubAuthConfigured: Boolean, isPublic: Boolean): String =
+      pageCacheControl(githubAuthConfigured, isPublic)
 
     /** Classpath location of the vendored Remote Compose player IIFE bundle (global `RC`). */
     private const val RC_PLAYER_RESOURCE = "/rc-player/bundle.js"

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAuthTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAuthTest.kt
@@ -84,30 +84,40 @@ class ServeAuthTest {
   }
 
   @Test
-  fun `github protected live viewer pages are not cached`() {
+  fun `pages carrying sign-in state are never cached, shared or private`() {
+    // Every page on a GitHub-auth server renders the visitor's sign-in state, so none of them may
+    // be stored: `public` would let the CDN hand one visitor's login to the next, and even a purely
+    // private `max-age` replays the pre-sign-in HTML after the OAuth round-trip — the "still shows
+    // me logged out until I refresh" bug.
     assertEquals(
-      "no-store",
-      ServeHttpServer.viewerCacheControl(
-        githubAuthConfigured = true,
-        hasLiveStream = true,
-        isPublic = true,
-      ),
+      "private, no-store",
+      ServeHttpServer.pageCacheControl(githubAuthConfigured = true, isPublic = true),
     )
     assertEquals(
       "public, max-age=60, stale-while-revalidate=300",
-      ServeHttpServer.viewerCacheControl(
-        githubAuthConfigured = true,
-        hasLiveStream = false,
-        isPublic = true,
-      ),
+      ServeHttpServer.pageCacheControl(githubAuthConfigured = false, isPublic = true),
     )
     assertEquals(
       "no-store",
-      ServeHttpServer.viewerCacheControl(
-        githubAuthConfigured = false,
-        hasLiveStream = true,
-        isPublic = false,
-      ),
+      ServeHttpServer.pageCacheControl(githubAuthConfigured = false, isPublic = false),
+    )
+  }
+
+  @Test
+  fun `the viewer page follows the same personalisation rule as every other page`() {
+    // Not just the live-streaming viewer: the sign-in chip and the issue reporter's "filed as @you"
+    // are on the static viewer too.
+    assertEquals(
+      "private, no-store",
+      ServeHttpServer.viewerCacheControl(githubAuthConfigured = true, isPublic = true),
+    )
+    assertEquals(
+      "public, max-age=60, stale-while-revalidate=300",
+      ServeHttpServer.viewerCacheControl(githubAuthConfigured = false, isPublic = true),
+    )
+    assertEquals(
+      "no-store",
+      ServeHttpServer.viewerCacheControl(githubAuthConfigured = false, isPublic = false),
     )
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubSessionTest.kt
@@ -1,0 +1,185 @@
+package ee.schimke.composeai.cli.serve
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+/**
+ * How long a GitHub sign-in lasts, and how it renews.
+ *
+ * The session is a signed cookie with a baked-in expiry and no server-side store, so the only way
+ * to keep an active visitor signed in is to hand back a fresh cookie as the old one ages. Before
+ * this existed the expiry was a flat 12 hours from sign-in with no renewal at all, which is shorter
+ * than the gap between one working day and the next — a visitor who signed in yesterday was
+ * reliably signed out this morning.
+ */
+class ServeGithubSessionTest {
+
+  /** Advanceable, so a fortnight of session ageing costs a field assignment. */
+  private var now: Instant = Instant.parse("2026-01-01T00:00:00Z")
+  private val clock =
+    object : Clock() {
+      override fun getZone() = ZoneOffset.UTC
+
+      override fun withZone(zone: java.time.ZoneId?) = this
+
+      override fun instant(): Instant = now
+    }
+
+  private val fakeGitHub =
+    OkHttpClient.Builder()
+      .addInterceptor { chain ->
+        val request = chain.request()
+        val body =
+          when (request.url.encodedPath) {
+            "/login/oauth/access_token" -> """{"access_token":"token"}"""
+            "/user" -> """{"login":"octo"}"""
+            else -> """{"private":false,"permissions":{"push":true}}"""
+          }
+        Response.Builder()
+          .request(request)
+          .protocol(Protocol.HTTP_1_1)
+          .code(200)
+          .message("OK")
+          .body(body.toResponseBody("application/json".toMediaType()))
+          .build()
+      }
+      .build()
+
+  private val auth =
+    ServeGithubAuth(
+      ServeGithubAuthConfig(
+        clientId = "client",
+        clientSecret = "secret",
+        cookieSecret = "x".repeat(32),
+        repository = "yschimke/compose-ai-tools",
+      ),
+      verifier = GitHubOAuthVerifier(fakeGitHub),
+      clock = clock,
+      anonymousClient = fakeGitHub,
+    )
+
+  private val registry = ServeSessionRegistry(open = { null })
+
+  private val server: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "unused-in-public",
+        sessions = registry,
+        defaultSessionId = "none",
+        isPublic = true,
+        githubAuth = auth,
+      )
+      .also { it.start() }
+  }
+
+  private val client = OkHttpClient()
+  private val noRedirect by lazy { client.newBuilder().followRedirects(false).build() }
+
+  @AfterTest
+  fun stop() {
+    runCatching { server.stop() }
+    runCatching { registry.close() }
+  }
+
+  /** Runs the OAuth round-trip against the fake GitHub and returns the raw `Set-Cookie` line. */
+  private fun signIn(): String {
+    val start =
+      noRedirect
+        .newCall(Request.Builder().url("http://127.0.0.1:${server.port}/auth/github/start").build())
+        .execute()
+        .use { resp ->
+          assertEquals(302, resp.code)
+          resp.header("Location").orEmpty() to
+            resp.header("Set-Cookie").orEmpty().substringBefore(";")
+        }
+    val state = start.first.substringAfter("state=").substringBefore("&")
+    return noRedirect
+      .newCall(
+        Request.Builder()
+          .url("http://127.0.0.1:${server.port}/auth/github/callback?code=ok&state=$state")
+          .header("Cookie", start.second)
+          .build()
+      )
+      .execute()
+      .use { resp ->
+        assertEquals(302, resp.code)
+        resp.headers("Set-Cookie").first { it.startsWith("cp_gh_auth=") }
+      }
+  }
+
+  /** A plain gated-server request, returning the re-issued session cookie line if there was one. */
+  private fun visit(cookie: String): String? =
+    client
+      .newCall(
+        Request.Builder()
+          .url("http://127.0.0.1:${server.port}/version")
+          .header("Cookie", cookie.substringBefore(";"))
+          .build()
+      )
+      .execute()
+      .use { resp -> resp.headers("Set-Cookie").firstOrNull { it.startsWith("cp_gh_auth=") } }
+
+  private fun maxAge(setCookie: String): Long =
+    setCookie
+      .split(";")
+      .map { it.trim() }
+      .first { it.startsWith("Max-Age=", ignoreCase = true) }
+      .substringAfter("=")
+      .toLong()
+
+  @Test
+  fun `a sign-in lasts a fortnight, not an afternoon`() {
+    assertEquals(14L * 24 * 60 * 60, ServeGithubAuth.SESSION_TTL_SECONDS)
+    assertEquals(ServeGithubAuth.SESSION_TTL_SECONDS, maxAge(signIn()))
+  }
+
+  @Test
+  fun `a young session is left alone`() {
+    val cookie = signIn()
+    now = now.plusSeconds(60 * 60)
+    // Nothing to extend yet, so the response carries no Set-Cookie at all — a page view under a
+    // fresh session is byte-identical to one with none.
+    assertNull(visit(cookie))
+  }
+
+  @Test
+  fun `visiting past the half-life slides the session forward`() {
+    val cookie = signIn()
+    now = now.plusSeconds(ServeGithubAuth.SESSION_REFRESH_AFTER_SECONDS + 60)
+    val refreshed = visit(cookie)
+    assertTrue(refreshed != null, "a session past its half-life must be re-minted")
+    assertEquals(ServeGithubAuth.SESSION_TTL_SECONDS, maxAge(refreshed))
+    assertTrue(
+      refreshed.substringAfter("cp_gh_auth=").substringBefore(";") !=
+        cookie.substringAfter("cp_gh_auth=").substringBefore(";"),
+      "the re-minted cookie must carry a later expiry than the one it replaces",
+    )
+    // …and the slid session is still live a full TTL past the expiry the original cookie carried,
+    // which is the point of the exercise: a regular visitor never sees GitHub again.
+    now = now.plusSeconds(ServeGithubAuth.SESSION_TTL_SECONDS - 120)
+    assertTrue(
+      visit(refreshed) != null,
+      "the slid session must outlive the expiry baked into the cookie it replaced",
+    )
+  }
+
+  @Test
+  fun `an expired session is not resurrected`() {
+    val cookie = signIn()
+    now = now.plusSeconds(ServeGithubAuth.SESSION_TTL_SECONDS + 60)
+    assertNull(visit(cookie), "an expired cookie must be re-authenticated, not extended")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubSessionTest.kt
@@ -6,6 +6,7 @@ import java.time.ZoneOffset
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import okhttp3.MediaType.Companion.toMediaType
@@ -14,6 +15,8 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
 
 /**
  * How long a GitHub sign-in lasts, and how it renews.
@@ -72,6 +75,24 @@ class ServeGithubSessionTest {
 
   private val registry = ServeSessionRegistry(open = { null })
 
+  private val fs = FakeFileSystem()
+
+  /**
+   * Wired only so `/playground` exists: it is the route that actually *consults* the session (302
+   * to sign-in when there is none, 200 for a signed-in visitor whom the fake GitHub grants repo
+   * rights), which makes it the honest probe for "is this cookie still an authenticated visitor
+   * with playground rights". No compile is performed.
+   */
+  private val playground =
+    PlaygroundCompileService(
+      catalogClasspath = { _ -> null },
+      compiler = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() },
+      discoverer = PlaygroundCompileService.PreviewDiscoverer { _, _ -> emptyList() },
+      tokenStore = PlaygroundTokenStore(fileSystem = fs),
+      newWorkDir = { "/work/run".toPath() },
+      fileSystem = fs,
+    )
+
   private val server: ServeHttpServer by lazy {
     ServeHttpServer(
         host = "127.0.0.1",
@@ -81,6 +102,7 @@ class ServeGithubSessionTest {
         defaultSessionId = "none",
         isPublic = true,
         githubAuth = auth,
+        playgroundService = playground,
       )
       .also { it.start() }
   }
@@ -141,8 +163,8 @@ class ServeGithubSessionTest {
       .toLong()
 
   @Test
-  fun `a sign-in lasts a fortnight, not an afternoon`() {
-    assertEquals(14L * 24 * 60 * 60, ServeGithubAuth.SESSION_TTL_SECONDS)
+  fun `a sign-in lasts a week idle, not an afternoon`() {
+    assertEquals(7L * 24 * 60 * 60, ServeGithubAuth.SESSION_TTL_SECONDS)
     assertEquals(ServeGithubAuth.SESSION_TTL_SECONDS, maxAge(signIn()))
   }
 
@@ -182,4 +204,54 @@ class ServeGithubSessionTest {
     now = now.plusSeconds(ServeGithubAuth.SESSION_TTL_SECONDS + 60)
     assertNull(visit(cookie), "an expired cookie must be re-authenticated, not extended")
   }
+
+  /**
+   * The cap that makes the sliding expiry safe. A refreshed cookie copies the `repositoryAccess`
+   * flag GitHub computed at sign-in — the playground gate — and there is no stored access token to
+   * re-ask with, so without an absolute ceiling somebody whose repo access was revoked would keep
+   * the gate open simply by continuing to visit. Sliding must therefore run out.
+   */
+  @Test
+  fun `sliding never carries a session past its absolute cap`() {
+    val signedInAt = now
+    var cookie = signIn()
+    assertTrue(signedIn(cookie), "the front door greets a fresh session by name")
+    // Visit diligently, every half-life, for well past the cap.
+    var slides = 0
+    while (now < signedInAt.plusSeconds(ServeGithubAuth.SESSION_ABSOLUTE_TTL_SECONDS * 2)) {
+      now = now.plusSeconds(ServeGithubAuth.SESSION_REFRESH_AFTER_SECONDS + 60)
+      val refreshed = visit(cookie) ?: continue
+      slides++
+      cookie = refreshed
+      assertTrue(
+        now.plusSeconds(maxAge(refreshed)) <=
+          signedInAt.plusSeconds(ServeGithubAuth.SESSION_ABSOLUTE_TTL_SECONDS),
+        "a slide must never push the expiry past the cap stamped at sign-in",
+      )
+    }
+    assertTrue(slides > 0, "the session must have slid at least once before the cap bit")
+    // Past the cap the visitor is signed out and has to go through GitHub again, which is what
+    // re-computes their repository access.
+    assertNull(visit(cookie), "a session at its absolute cap must not be extended")
+    assertFalse(signedIn(cookie), "a session past its absolute cap must not authenticate")
+  }
+
+  /**
+   * Whether this cookie still opens the repo-gated playground — 200 for a signed-in visitor the
+   * fake GitHub granted push rights, a redirect to the sign-in for anyone the session no longer
+   * authenticates. This is the gate the absolute cap exists to close.
+   */
+  private fun signedIn(cookie: String): Boolean =
+    client
+      .newBuilder()
+      .followRedirects(false)
+      .build()
+      .newCall(
+        Request.Builder()
+          .url("http://127.0.0.1:${server.port}/playground")
+          .header("Cookie", cookie.substringBefore(";"))
+          .build()
+      )
+      .execute()
+      .use { resp -> resp.code == 200 }
 }


### PR DESCRIPTION
Two separate bugs behind "sign-in on the preview server feels flaky, often not prompting to login but staying logged out — and sessions are short, I need to log in again on the next visit". The tell was **"refreshing the page shows the right status; before a refresh it still shows logged out"** — that is a cache, not an auth failure.

## It shows me signed out until I refresh

Every ServeWeb page renders the visitor's sign-in state — the header chip (signed out → "Sign in", signed in → the login), the live-preview auth prompt, the issue reporter's "filed as @you" tooltip — yet a public server marked them all:

```
Cache-Control: public, max-age=60, stale-while-revalidate=300
```

So returning from the GitHub callback to a page visited moments earlier replays the **browser's own** pre-sign-in copy for a minute, then serves it stale for five more while revalidating in the background. An explicit reload revalidates, which is exactly why the state looks right the instant you ask for it again.

`public` was the worse half: it also licenses the CDN in front of the deployed server to store one visitor's HTML — login and all — and hand it to the next.

Pages now fall to `private, no-store` (plus `Vary: Cookie`) whenever GitHub auth is configured. `no-store` rather than `no-cache` because these pages carry no ETag, so a revalidation costs a full re-render anyway — and `no-store` additionally keeps the signed-out HTML out of the back/forward cache, where a plain Back would resurrect it.

`viewerCacheControl` previously made this exception for the **live-streaming** viewer only, on the theory that the live lane was the only personalised thing on the page. The sign-in chip is on every viewer, so the static one was being cached with a visitor's identity baked in; it now follows the same rule as every other page. A server with no `--github-auth-*` keeps the short edge caching exactly as before.

## Sessions were 12 hours, absolute

Shorter than the gap between one working day and the next, on a gallery people drop into occasionally, and with no renewal at all — so a sign-in from yesterday afternoon was reliably gone this morning.

Sessions now have two expiries:

| | | |
|---|---|---|
| **Idle** | 7 days, slides | Extended on any visit past its half-life, so the normal rhythm of visiting — daily, or Monday after a quiet weekend — never lands on a sign-in. |
| **Absolute** | 14 days, fixed | Stamped at sign-in and never extended, however diligently someone visits. |

The absolute cap is what makes the sliding one safe, and it closes a hole [Codex flagged](https://github.com/yschimke/compose-ai-tools/pull/3375#discussion_r3724513444) on the first revision of this PR: a refreshed cookie copies the `repositoryAccess` flag GitHub computed at sign-in — the playground gate — and the access token is deliberately not stored, so there is nothing to re-ask GitHub with at refresh time. Without a ceiling, somebody whose access to the gating repo was revoked would have kept the gate open simply by continuing to visit. With one, GitHub re-computes that flag at least fortnightly, and reaching it costs the visitor a single silent redirect (an OAuth app they have already approved re-authorises without a consent screen).

Refresh no-ops — no `Set-Cookie` at all — for a young session, a session at its cap, or no session, and skips `/auth/github/*` where the callback mints the authoritative cookie itself. Cookies minted before the sign-in stamp existed carry no anchor, so they're left to expire on their own terms rather than slid.

## Test plan

`./gradlew :cli:test` — green (1421 tests). One unrelated flake seen once in `ServeCatalogStoreTest > the per-preview fetcher fetches a daemon-id's own split bundle beside the liveBundle`; passes in isolation and on a full re-run.

- New `ServeGithubSessionTest` drives the OAuth round-trip over real HTTP against a fake GitHub with an advanceable `Clock`, and asserts: the minted cookie's `Max-Age` is the idle week; a young session gets no `Set-Cookie`; a session past its half-life is re-minted and outlives the expiry baked into the cookie it replaced; an expired one is not resurrected; and — visiting diligently every half-life for twice the cap — that no slide ever pushes the expiry past the sign-in anchor, and that past the cap the session neither extends nor opens the repo-gated `/playground`. That signed-in probe is asserted positive immediately after sign-in, so the negative can't pass vacuously.
- `ServeAuthTest` pins the cache-control policy for both the page and viewer lanes across the auth-configured / public / token-gated combinations.

**Not a visual change** — no rendered surface, `@Preview`, or ServeWeb markup is touched; the diff is response headers and cookie lifetime, so there are no before/after pixels to embed.