### PR TITLE
fix: correct the theme-optimizer prefetch stats

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -93,6 +93,10 @@ class CatalogThemeCache(
   private val turnsYielded = java.util.concurrent.atomic.AtomicInteger(0)
   private val lastBatchWidth = java.util.concurrent.atomic.AtomicInteger(0)
   private val maxBatchWidth = java.util.concurrent.atomic.AtomicInteger(0)
+  // Entries the OPTIMIZER produced. The rate's denominator is optimizer time, so its numerator has
+  // to be optimizer output: foreground renders land in this same cache via `cacheCatalogRender`,
+  // and counting them would report a prefetch rate the prefetcher never achieved.
+  private val optimizerProduced = java.util.concurrent.atomic.AtomicInteger(0)
 
   /** The idle gate handed the pass its turn. */
   fun recordTurnGranted() {
@@ -113,6 +117,20 @@ class CatalogThemeCache(
   fun recordBatch(width: Int, millis: Long) {
     lastBatchWidth.set(width)
     maxBatchWidth.accumulateAndGet(width, ::maxOf)
+    if (millis > 0) renderMillis.addAndGet(millis)
+  }
+
+  /** Entries this batch actually produced — the rate's numerator. */
+  fun recordProduced(count: Int) {
+    if (count > 0) optimizerProduced.addAndGet(count)
+  }
+
+  /**
+   * A cold daemon warm the optimizer waited out. Real render work and often the most expensive part
+   * of the pass, so it belongs in [renderMillis] — leaving it out of both buckets shrank the rate's
+   * denominator and made a cold catalog report a rate it was nowhere near.
+   */
+  fun recordWarm(millis: Long) {
     if (millis > 0) renderMillis.addAndGet(millis)
   }
 
@@ -232,9 +250,9 @@ class CatalogThemeCache(
       // Rate over the pass's ACTIVE time (render + gate wait), not wall-clock since it started:
       // wall-clock includes stretches where the pass held no turn at all, which drags the figure
       // toward zero and hides whether it is keeping up while it runs.
-      entriesPerMinute = ratePerMinute(cachedTargets),
+      entriesPerMinute = ratePerMinute(),
       etaSeconds =
-        ratePerMinute(cachedTargets)
+        ratePerMinute()
           ?.takeIf { it > 0 }
           ?.let { ((total - cachedTargets).coerceAtLeast(0) / it * 60).toLong() },
       renderMillis = renderMillis.get(),
@@ -256,10 +274,11 @@ class CatalogThemeCache(
       )
     }
 
-  private fun ratePerMinute(cached: Int): Double? {
+  private fun ratePerMinute(): Double? {
+    val produced = optimizerProduced.get()
     val activeMillis = renderMillis.get() + waitingMillis.get()
-    if (cached <= 0 || activeMillis <= 0) return null
-    return cached / (activeMillis / 60_000.0)
+    if (produced <= 0 || activeMillis <= 0) return null
+    return produced / (activeMillis / 60_000.0)
   }
 
   private fun refreshCompletion() {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -402,11 +402,17 @@ class ServeCatalogLiveHost(
           // old per-job loop spent retry budget on this; here it is a precondition of the batch.
           if (previewDaemonId != null && !warmDaemonIds.contains(previewDaemonId)) {
             daemonWarmOrScheduling(previewDaemonId)
+            // A cold warm is real render work and can run to minutes. Excluding it from both
+            // buckets shrank the rate's denominator, so a cold catalog reported a rate it was
+            // nowhere near.
+            val warmFrom = clock()
             if (
               warmingInFlight.contains(previewDaemonId) && !awaitWarmCompletion(previewDaemonId)
             ) {
+              catalogThemeCache.recordWarm(clock() - warmFrom)
               return@execute
             }
+            catalogThemeCache.recordWarm(clock() - warmFrom)
           }
           var index = 0
           while (index < previewJobs.size) {
@@ -418,13 +424,22 @@ class ServeCatalogLiveHost(
               previewJobs.subList(index, minOf(index + optimizerBatchWidth(), previewJobs.size))
             index += batch.size
             catalogThemeCache.markRunning(clock())
-            val batchStartedAt = clock()
+            // Time the RENDER inside the permit. Starting the clock before `withRenderPermit`
+            // charged the server-wide queue to renderMillis, which would make a permit-bound
+            // deployment read as render-bound — defeating the one diagnostic this exists for.
+            val permitWaitFrom = clock()
             val outcomes =
-              backgroundWork.withRenderPermit { renderOptimizerBatch(batch) } ?: return@execute
-            // Width recorded from the batch actually issued, not the requested ceiling — a batch
-            // that collapses to 1 (single-daemon lane, or a seat budget with no replicas to spare)
-            // is exactly the case that is invisible from `cached` alone.
-            catalogThemeCache.recordBatch(batch.size, clock() - batchStartedAt)
+              backgroundWork.withRenderPermit {
+                val renderFrom = clock()
+                catalogThemeCache.recordWaiting(renderFrom - permitWaitFrom)
+                renderOptimizerBatch(batch).also {
+                  // Width from the batch actually issued, not the requested ceiling — a batch that
+                  // collapses to 1 (single-daemon lane, or a seat budget with no replicas to spare)
+                  // is exactly the case that is invisible from `cached` alone.
+                  catalogThemeCache.recordBatch(batch.size, clock() - renderFrom)
+                }
+              } ?: return@execute
+            catalogThemeCache.recordProduced(outcomes.count { it is RenderOutcome.Ok })
             for ((job, outcome) in batch.zip(outcomes)) {
               if (catalogThemeCache.get(job.cacheKey) != null) continue
               // Busy is "ask again", not a failure: the warm above may still be settling. Leave it
@@ -550,6 +565,9 @@ class ServeCatalogLiveHost(
     return awaitQuiet(OPTIMIZER_RESUME_MILLIS).also {
       catalogThemeCache.recordWaiting(clock() - resumeFrom)
       if (it) {
+        // A resume IS a grant. Counting only cold entries made yields exceed grants after any
+        // interrupted pass, which reads as the gate losing turns it never handed out.
+        catalogThemeCache.recordTurnGranted()
         optimizerHasTurn.set(true)
         optimizerSampledAt.set(clock())
       }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
@@ -108,6 +108,7 @@ class CatalogThemeCacheTest {
     cache.recordTurnGranted()
     cache.recordWaiting(30_000) // half the active time spent waiting for a turn
     cache.recordBatch(width = 5, millis = 30_000)
+    cache.recordProduced(5)
     cache.recordTurnYielded()
     repeat(5) { cache.put("k${it + 1}", byteArrayOf(1)) }
 
@@ -134,5 +135,25 @@ class CatalogThemeCacheTest {
     assertNull(s.entriesPerMinute)
     assertNull(s.etaSeconds)
     assertEquals(0, s.maxBatchWidth)
+  }
+
+  /**
+   * Codex review on #3373. Foreground renders land in this same cache via `cacheCatalogRender`, so
+   * counting them toward the rate reports a prefetch throughput the prefetcher never achieved —
+   * against a denominator made only of optimizer time. The numerator has to be optimizer output.
+   */
+  @Test
+  fun `foreground-filled entries do not inflate the prefetch rate`() {
+    val cache = CatalogThemeCache()
+    cache.configureTargets((1..10).map { "k$it" })
+    cache.recordWaiting(60_000)
+
+    // Five entries arrive from foreground requests; the optimizer produced none of them.
+    repeat(5) { cache.put("k${it + 1}", byteArrayOf(1)) }
+
+    val s = cache.snapshot()
+    assertEquals(5, s.cached, "they are cached, and `cached` should say so")
+    assertNull(s.entriesPerMinute, "but the prefetcher produced nothing, so it has no rate")
+    assertNull(s.etaSeconds)
   }
 }


### PR DESCRIPTION
Follow-up to #3373. Four review findings arrived on that PR after auto-merge had already landed it, so they go here instead. Each one skewed the numbers in the flattering direction, which is precisely what those stats exist to prevent.

## Changes

**Rate numerator is optimizer output, not `cached`.** Foreground renders land in the same cache via `cacheCatalogRender`. Counting them against a denominator made only of optimizer time reported a prefetch rate the prefetcher never achieved — worst exactly when a user is browsing, i.e. when you'd be looking. New `recordProduced(count)`, fed from the batch's `RenderOutcome.Ok` count.

**Time the render inside `withRenderPermit`.** The clock started before the permit was acquired, charging the server-wide render queue to `renderMillis`. A permit-bound deployment would read as render-bound, defeating the one diagnostic this is for. Permit queue time now goes to `recordWaiting`, where contention is supposed to show.

**The resume path is a turn grant.** Only cold grants were counted, so `turnsYielded` exceeded `turnsGranted` after any interrupted pass — reading as the idle gate losing turns it never handed out.

**Cold-daemon warm time counts as render time.** A warm can run to minutes and was in neither bucket, shrinking the denominator so a cold catalog reported a rate it was nowhere near. New `recordWarm(millis)`, added to `renderMillis` since a warm is real render work.

## Test plan

- `./gradlew :cli:test` — green.
- New test `foreground-filled entries do not inflate the prefetch rate`: ten targets, 60s of optimizer wait time, five entries arriving via `put()` (the foreground path). `cached` reports 5; `entriesPerMinute` and `etaSeconds` are null, because the prefetcher produced nothing. On `main` today this reports 5/min with an ETA.
- The existing stats test needed `recordProduced(5)` added — it previously relied on `put()` alone standing in for optimizer output, which is exactly the conflation being fixed.

Not visual — JSON stats plumbing only, no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_