### PR TITLE
feat(serve): embed the render in the prefilled issue body instead of only linking it

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2644,6 +2644,9 @@ class ServeHttpServer(
           toolVersion = bundleHost?.provenance?.toolVersion,
           viewerUrl = ServeIssueReport.withoutToken(externalPageUrl()),
           renderUrl = ServeIssueReport.withoutToken(imageUrl),
+          // A token-gated box 404s the tokenless render URL this body carries, so its report keeps
+          // the link form rather than embedding an image that could never load.
+          publicRender = isPublic,
         )
       val reportIssue =
         ServeWeb.ReportIssue(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
@@ -99,25 +99,77 @@ internal object ServeIssueReport {
     }
     val render =
       if (renderPlaceholder) RENDER_PLACEHOLDER else ctx.renderUrl?.takeIf { it.isNotBlank() }
+    // Whether the render can be *embedded* is decided by the real URL even when the body is the
+    // JS template, so both forms of the body have the same shape and the placeholder swap can't
+    // turn a working image into a broken one.
+    val embed = render != null && isEmbeddable(ctx.renderUrl)
     val links = buildList {
       ctx.viewerUrl?.takeIf { it.isNotBlank() }?.let { add("[Open this preview]($it)") }
-      render?.let { add("[PNG at these settings]($it)") }
+      // Only worth its own line when the image isn't already showing it.
+      if (!embed) render?.let { add("[PNG at these settings]($it)") }
     }
     return buildString {
       append("### What's wrong\n\n")
       append("<!-- What did you expect to see, and what did you get? -->\n\n\n")
       append("### Screenshot\n\n")
-      append(
-        "<!-- Paste it here. The viewer's \"Export & direct links\" panel has a Copy PNG button " +
-          "that puts the image itself on your clipboard, so Ctrl-V / Cmd-V lands the exact render " +
-          "in this issue. -->\n\n\n"
-      )
+      if (embed) {
+        append("![${altText(ctx)}]($render)\n\n")
+        append(
+          "<!-- That image is a LIVE render: it re-renders if the catalog changes, so it may " +
+            "stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer's " +
+            "\"Export & direct links\" panel and paste it here — GitHub then hosts the pixels " +
+            "itself. -->\n\n\n"
+        )
+      } else {
+        append(
+          "<!-- Paste it here. The viewer's \"Export & direct links\" panel has a Copy PNG " +
+            "button that puts the image itself on your clipboard, so Ctrl-V / Cmd-V lands the " +
+            "exact render in this issue. -->\n\n\n"
+        )
+      }
       append("### Which preview\n\n")
       append("| | |\n| --- | --- |\n")
       append(rows.joinToString("\n"))
       if (links.isNotEmpty()) append("\n\n").append(links.joinToString(" · "))
       append("\n")
     }
+  }
+
+  /** Markdown-safe alt text: the preview's label or id, with `]` and `[` stripped. */
+  private fun altText(ctx: Context): String {
+    val what = ctx.previewLabel?.trim()?.takeIf { it.isNotEmpty() } ?: ctx.previewId
+    return what.replace('[', ' ').replace(']', ' ').trim()
+  }
+
+  /**
+   * Whether [url] is one GitHub can actually render inline.
+   *
+   * An embedded image is fetched **by GitHub's camo proxy, not by the reader's browser**, so it has
+   * to be reachable from the public internet over HTTPS. A developer's `compose-preview serve` on
+   * `http://127.0.0.1:8080` (or a box on a private LAN, or a plain-HTTP host) fails that, and an
+   * embed would put a broken-image icon in their issue where a working link belongs — so those
+   * bodies keep the link form instead. Deliberately conservative: anything not clearly public is
+   * treated as not embeddable.
+   */
+  fun isEmbeddable(url: String?): Boolean {
+    val u = url?.trim() ?: return false
+    if (!u.startsWith("https://")) return false
+    val host = u.removePrefix("https://").substringBefore('/').substringBefore('?').lowercase()
+    val name = host.substringBeforeLast(':').trim('[', ']')
+    if (name.isEmpty()) return false
+    // A public host is a dotted name. Single-label intranet names, `.local`, and raw loopback /
+    // private addresses are all unreachable from camo.
+    if (!name.contains('.') || name.endsWith(".local") || name.endsWith(".internal")) return false
+    if (name == "localhost" || name.endsWith(".localhost")) return false
+    return !isPrivateIpv4(name)
+  }
+
+  /** Loopback and RFC 1918 literals, which are dotted but still unreachable from outside. */
+  private fun isPrivateIpv4(host: String): Boolean {
+    val parts = host.split('.')
+    if (parts.size != 4 || parts.any { it.toIntOrNull() == null }) return false
+    val (a, b) = parts[0].toInt() to parts[1].toInt()
+    return a == 127 || a == 10 || a == 0 || (a == 192 && b == 168) || (a == 172 && b in 16..31)
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
@@ -59,6 +59,16 @@ internal object ServeIssueReport {
     val viewerUrl: String? = null,
     /** Absolute `/render/<id>.png` URL at the overrides in force when the page was served. */
     val renderUrl: String? = null,
+    /**
+     * Whether the render lane answers **without a session token** — i.e. the server is `--public`.
+     *
+     * [withoutToken] strips the token from every URL that reaches an issue body, because the token
+     * is the capability to drive the server. On a token-gated box that makes [renderUrl] a URL the
+     * lane itself 404s ([ServeHttpServer]'s render handler rejects a tokenless request), so an
+     * embedded image would be broken in every filed issue no matter how reachable the host is.
+     * Defaults to false so a caller that doesn't know keeps the link form.
+     */
+    val publicRender: Boolean = false,
   )
 
   /**
@@ -101,8 +111,10 @@ internal object ServeIssueReport {
       if (renderPlaceholder) RENDER_PLACEHOLDER else ctx.renderUrl?.takeIf { it.isNotBlank() }
     // Whether the render can be *embedded* is decided by the real URL even when the body is the
     // JS template, so both forms of the body have the same shape and the placeholder swap can't
-    // turn a working image into a broken one.
-    val embed = render != null && isEmbeddable(ctx.renderUrl)
+    // turn a working image into a broken one. Two independent conditions have to hold: GitHub's
+    // proxy must be able to *reach* the URL, and the lane must *answer* it without the token this
+    // body strips.
+    val embed = render != null && ctx.publicRender && isEmbeddable(ctx.renderUrl)
     val links = buildList {
       ctx.viewerUrl?.takeIf { it.isNotBlank() }?.let { add("[Open this preview]($it)") }
       // Only worth its own line when the image isn't already showing it.
@@ -150,6 +162,9 @@ internal object ServeIssueReport {
    * embed would put a broken-image icon in their issue where a working link belongs — so those
    * bodies keep the link form instead. Deliberately conservative: anything not clearly public is
    * treated as not embeddable.
+   *
+   * This is **reachability only**. Whether the lane will actually serve the request is a separate
+   * question — see [Context.publicRender], which [body] requires as well.
    */
   fun isEmbeddable(url: String?): Boolean {
     val u = url?.trim() ?: return false

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -79,15 +79,70 @@ class ServeIssueReportTest {
       body.contains("[Open this preview](https://preview.coo.ee/jetnews/p/Article__dark)"),
       body,
     )
-    assertTrue(
-      body.contains(
-        "[PNG at these settings](https://preview.coo.ee/jetnews/render/Article__dark.png?uiMode=dark)"
-      ),
-      body,
-    )
     // The screenshot is asked for as a paste, because that lands the pixels on GitHub's own CDN
     // rather than leaving the evidence pointed at a URL that re-renders later.
     assertTrue(body.contains("Copy PNG"), "the body tells the reporter how to attach the render")
+  }
+
+  @Test
+  fun `a public render is embedded as an image, not just linked`() {
+    val body = ServeIssueReport.body(full)
+    // GitHub renders this inline (via its camo proxy), so the reporter's evidence is visible in the
+    // issue without anyone clicking through.
+    assertTrue(
+      body.contains(
+        "![Article](https://preview.coo.ee/jetnews/render/Article__dark.png?uiMode=dark)"
+      ),
+      body,
+    )
+    // …and the separate link is dropped, since the image already carries that URL.
+    assertFalse(body.contains("[PNG at these settings]"), body)
+    // The embed is honest about what it is: a live render that moves when the catalog does.
+    assertTrue(body.contains("LIVE render"), body)
+    assertTrue(body.contains("Copy PNG"), "the durable paste path is still offered")
+  }
+
+  @Test
+  fun `a render GitHub cannot reach stays a link rather than a broken image`() {
+    // A developer's local `compose-preview serve`. Camo cannot fetch this, so an embed would put a
+    // broken-image icon in their issue where a working link belongs.
+    val local = full.copy(renderUrl = "http://127.0.0.1:8080/render/Article__dark.png")
+    val body = ServeIssueReport.body(local)
+    assertFalse(body.contains("!["), body)
+    assertTrue(body.contains("[PNG at these settings](http://127.0.0.1:8080/"), body)
+  }
+
+  @Test
+  fun `only a publicly reachable https URL is embeddable`() {
+    assertTrue(ServeIssueReport.isEmbeddable("https://preview.coo.ee/x/render/a.png"))
+    assertTrue(ServeIssueReport.isEmbeddable("https://previews.example.com:8443/render/a.png"))
+    // Plain HTTP, loopback, RFC 1918, single-label intranet names and `.local` are all unreachable
+    // from GitHub's proxy.
+    assertFalse(ServeIssueReport.isEmbeddable("http://preview.coo.ee/x.png"))
+    assertFalse(ServeIssueReport.isEmbeddable("https://localhost:8080/x.png"))
+    assertFalse(ServeIssueReport.isEmbeddable("https://127.0.0.1/x.png"))
+    assertFalse(ServeIssueReport.isEmbeddable("https://10.1.2.3/x.png"))
+    assertFalse(ServeIssueReport.isEmbeddable("https://192.168.1.10/x.png"))
+    assertFalse(ServeIssueReport.isEmbeddable("https://172.20.0.5/x.png"))
+    assertFalse(ServeIssueReport.isEmbeddable("https://build-box/x.png"))
+    assertFalse(ServeIssueReport.isEmbeddable("https://previews.local/x.png"))
+    assertFalse(ServeIssueReport.isEmbeddable(null))
+    assertFalse(ServeIssueReport.isEmbeddable("  "))
+    // …but a public address that merely looks private-ish is fine.
+    assertTrue(ServeIssueReport.isEmbeddable("https://172.32.0.5/x.png"))
+  }
+
+  @Test
+  fun `the template keeps the shape the real URL earned`() {
+    // The placeholder is not itself a URL, so embeddability is decided by the real render URL —
+    // otherwise the JS swap could turn a working image into a broken one, or vice versa.
+    assertTrue(
+      ServeIssueReport.body(full, renderPlaceholder = true).contains("![Article]({{render}})")
+    )
+    val local = full.copy(renderUrl = "http://127.0.0.1:8080/render/a.png")
+    val tpl = ServeIssueReport.body(local, renderPlaceholder = true)
+    assertFalse(tpl.contains("!["), tpl)
+    assertTrue(tpl.contains("[PNG at these settings]({{render}})"), tpl)
   }
 
   @Test
@@ -113,7 +168,7 @@ class ServeIssueReportTest {
   @Test
   fun `the template form leaves the render link as a placeholder the viewer JS can substitute`() {
     val tpl = ServeIssueReport.body(full, renderPlaceholder = true)
-    assertTrue(tpl.contains("[PNG at these settings]({{render}})"), tpl)
+    assertTrue(tpl.contains("({{render}})"), tpl)
     assertFalse(
       tpl.contains("Article__dark.png?uiMode=dark"),
       "the served render URL is not baked into the template",

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -19,6 +19,7 @@ class ServeIssueReportTest {
       toolVersion = "0.19.37",
       viewerUrl = "https://preview.coo.ee/jetnews/p/Article__dark",
       renderUrl = "https://preview.coo.ee/jetnews/render/Article__dark.png?uiMode=dark",
+      publicRender = true,
     )
 
   @Test
@@ -110,6 +111,22 @@ class ServeIssueReportTest {
     val body = ServeIssueReport.body(local)
     assertFalse(body.contains("!["), body)
     assertTrue(body.contains("[PNG at these settings](http://127.0.0.1:8080/"), body)
+  }
+
+  @Test
+  fun `a token-gated server keeps the link form even on a public hostname`() {
+    // withoutToken strips the session token from every URL in the body, and a non-public render
+    // lane 404s a tokenless request — so camo would fetch a 404 and every filed issue would show a
+    // broken screenshot. Reachability is not authorization.
+    val gated = full.copy(publicRender = false)
+    val body = ServeIssueReport.body(gated)
+    assertFalse(body.contains("!["), body)
+    assertTrue(
+      body.contains("[PNG at these settings](https://preview.coo.ee/jetnews/render/"),
+      body,
+    )
+    // …and the template agrees, so the viewer's live swap cannot reintroduce the embed.
+    assertFalse(ServeIssueReport.body(gated, renderPlaceholder = true).contains("!["))
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -103,6 +103,9 @@ class ServeWebFixtureTest {
         toolVersion = provenance.toolVersion,
         viewerUrl = "https://preview.coo.ee/compose-m3/p/$previewId",
         renderUrl = "https://preview.coo.ee/compose-m3/render/$previewId.png",
+        // The goldens stand in for preview.coo.ee, whose render lane is token-free — so they
+        // capture the embedded-image form of the body.
+        publicRender = true,
       )
       .let { ctx ->
         ServeWeb.ReportIssue(

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -279,12 +279,21 @@ in — `catalog.json`'s `source.repo`), falling back to the delivery repo and fi
 `yschimke/compose-ai-tools`, whose renderer produced the pixels either way. A source repo that is a
 fork is still the right target: that fork is where the preview code that misrendered lives.
 
-**The screenshot is pasted, not linked.** The body links the render URL for convenience, but that
-URL re-renders against whatever the catalog is when someone reads the issue. So the template asks
-for a paste, and **Copy PNG** (in *Export & direct links*) now puts real `image/png` bytes on the
-clipboard rather than a base64 `data:` URI — one Ctrl-V/Cmd-V in the issue box uploads the exact
-pixels to GitHub's own CDN, where they stay put. Browsers without `ClipboardItem` fall back to the
-data URI.
+**The render is embedded, and a paste is still offered.** The body carries the render as a markdown
+image (`![…](…/render/<id>.png?…)`), so GitHub shows the pixels inline and a triager sees the
+problem without clicking anything. That embed is a **live** render, though: it re-renders against
+whatever the catalog is when someone reads the issue, so it can drift away from what the reporter
+saw. The template says so, and still asks for a paste — **Copy PNG** (in *Export & direct links*)
+puts real `image/png` bytes on the clipboard rather than a base64 `data:` URI, so one Ctrl-V/Cmd-V
+uploads the exact pixels to GitHub's own CDN, where they stay put. Browsers without `ClipboardItem`
+fall back to the data URI.
+
+**The embed appears only when GitHub can actually fetch the URL.** An inline image is loaded by
+GitHub's camo proxy, not by the reader's browser, so it must be reachable from the public internet
+over HTTPS. A developer's `compose-preview serve` on `http://127.0.0.1:8080` — or a box on a private
+LAN, or plain HTTP — would put a broken-image icon in the issue, so those bodies keep the
+`[PNG at these settings](…)` link form instead. The choice is made from the server's own external
+URL, so the viewer's live re-substitution can never turn a working image into a broken one.
 
 **The server never files the issue itself**, and asks for no extra OAuth scope to offer this. The
 auth cookie holds only a login and a repo-access verdict — [the OAuth token is discarded after the

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -288,12 +288,15 @@ puts real `image/png` bytes on the clipboard rather than a base64 `data:` URI, s
 uploads the exact pixels to GitHub's own CDN, where they stay put. Browsers without `ClipboardItem`
 fall back to the data URI.
 
-**The embed appears only when GitHub can actually fetch the URL.** An inline image is loaded by
-GitHub's camo proxy, not by the reader's browser, so it must be reachable from the public internet
-over HTTPS. A developer's `compose-preview serve` on `http://127.0.0.1:8080` — or a box on a private
-LAN, or plain HTTP — would put a broken-image icon in the issue, so those bodies keep the
-`[PNG at these settings](…)` link form instead. The choice is made from the server's own external
-URL, so the viewer's live re-substitution can never turn a working image into a broken one.
+**The embed appears only when GitHub can actually load the URL**, which takes two things.
+*Reachable*: an inline image is fetched by GitHub's camo proxy, not by the reader's browser, so it
+must be reachable from the public internet over HTTPS — a `compose-preview serve` on
+`http://127.0.0.1:8080`, a box on a private LAN, or plain HTTP is not. *Answerable*: the render lane
+must serve the URL **without a session token**, because the token is stripped from everything that
+reaches an issue body. A token-gated (`--public` off) server 404s that tokenless request however
+public its hostname is, so its reports keep the `[PNG at these settings](…)` link form too. Both
+conditions are evaluated against the server's own external URL and mode, so the viewer's live
+re-substitution can never turn a working image into a broken one.
 
 **The server never files the issue itself**, and asks for no extra OAuth scope to offer this. The
 auth cookie holds only a login and a repo-access verdict — [the OAuth token is discarded after the

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -35,7 +35,9 @@
 
 ### Screenshot
 
-&lt;!-- Paste it here. The viewer&#39;s &quot;Export &amp; direct links&quot; panel has a Copy PNG button that puts the image itself on your clipboard, so Ctrl-V / Cmd-V lands the exact render in this issue. --&gt;
+![Button · Filled (light)](https://preview.coo.ee/compose-m3/render/button-filled__ideal__default__light.png)
+
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview
@@ -48,7 +50,7 @@
 | Catalog | `yschimke/compose-ai-tools@design-artifacts/compose-m3` |
 | Rendered by | compose-ai-tools 0.16.54 |
 
-[Open this preview](https://preview.coo.ee/compose-m3/p/button-filled__ideal__default__light) · [PNG at these settings](https://preview.coo.ee/compose-m3/render/button-filled__ideal__default__light.png)
+[Open this preview](https://preview.coo.ee/compose-m3/p/button-filled__ideal__default__light)
 " data-report-template="### What&#39;s wrong
 
 &lt;!-- What did you expect to see, and what did you get? --&gt;
@@ -56,7 +58,9 @@
 
 ### Screenshot
 
-&lt;!-- Paste it here. The viewer&#39;s &quot;Export &amp; direct links&quot; panel has a Copy PNG button that puts the image itself on your clipboard, so Ctrl-V / Cmd-V lands the exact render in this issue. --&gt;
+![Button · Filled (light)]({{render}})
+
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview
@@ -69,7 +73,7 @@
 | Catalog | `yschimke/compose-ai-tools@design-artifacts/compose-m3` |
 | Rendered by | compose-ai-tools 0.16.54 |
 
-[Open this preview](https://preview.coo.ee/compose-m3/p/button-filled__ideal__default__light) · [PNG at these settings]({{render}})
+[Open this preview](https://preview.coo.ee/compose-m3/p/button-filled__ideal__default__light)
 "><button type="submit" class="cp-report-link" title="File an issue on yschimke/compose-ai-tools as @yschimke"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> report an issue</button></form>
       <p class="cp-figma"><a class="cp-figma-link" href="https://www.figma.com/design/gYzowY4cQ7rNr2gYoco1M6?node-id=73-6" target="_blank" rel="noopener noreferrer" title="Open the Figma node this preview is specified by — Contact chat"><svg class="cp-gh cp-figma-mark" viewBox="0 0 38 57" aria-hidden="true" fill="currentColor"><path d="M19 28.5a9.5 9.5 0 1 1 19 0 9.5 9.5 0 0 1-19 0z"/><path d="M0 47.5A9.5 9.5 0 0 1 9.5 38H19v9.5a9.5 9.5 0 0 1-19 0z"/><path d="M19 0v19h9.5a9.5 9.5 0 1 0 0-19H19z"/><path d="M0 9.5A9.5 9.5 0 0 0 9.5 19H19V0H9.5A9.5 9.5 0 0 0 0 9.5z"/><path d="M0 28.5A9.5 9.5 0 0 0 9.5 38H19V19H9.5A9.5 9.5 0 0 0 0 28.5z"/></svg> figma spec</a></p>
       </div>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -35,7 +35,9 @@
 
 ### Screenshot
 
-&lt;!-- Paste it here. The viewer&#39;s &quot;Export &amp; direct links&quot; panel has a Copy PNG button that puts the image itself on your clipboard, so Ctrl-V / Cmd-V lands the exact render in this issue. --&gt;
+![Profile screen](https://preview.coo.ee/compose-m3/render/com.example.ProfileScreenPreview.png)
+
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview
@@ -48,7 +50,7 @@
 | Catalog | `yschimke/compose-ai-tools@design-artifacts/compose-m3` |
 | Rendered by | compose-ai-tools 0.16.54 |
 
-[Open this preview](https://preview.coo.ee/compose-m3/p/com.example.ProfileScreenPreview) · [PNG at these settings](https://preview.coo.ee/compose-m3/render/com.example.ProfileScreenPreview.png)
+[Open this preview](https://preview.coo.ee/compose-m3/p/com.example.ProfileScreenPreview)
 " data-report-template="### What&#39;s wrong
 
 &lt;!-- What did you expect to see, and what did you get? --&gt;
@@ -56,7 +58,9 @@
 
 ### Screenshot
 
-&lt;!-- Paste it here. The viewer&#39;s &quot;Export &amp; direct links&quot; panel has a Copy PNG button that puts the image itself on your clipboard, so Ctrl-V / Cmd-V lands the exact render in this issue. --&gt;
+![Profile screen]({{render}})
+
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview
@@ -69,7 +73,7 @@
 | Catalog | `yschimke/compose-ai-tools@design-artifacts/compose-m3` |
 | Rendered by | compose-ai-tools 0.16.54 |
 
-[Open this preview](https://preview.coo.ee/compose-m3/p/com.example.ProfileScreenPreview) · [PNG at these settings]({{render}})
+[Open this preview](https://preview.coo.ee/compose-m3/p/com.example.ProfileScreenPreview)
 "><button type="submit" class="cp-report-link" title="File an issue on yschimke/compose-ai-tools as @yschimke"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> report an issue</button></form>
       </div>
 


### PR DESCRIPTION
Follow-up to #3357. The "report an issue" body carried the render as a link; now it carries it as a **markdown image**, so GitHub renders the pixels inline and a triager sees the problem without clicking through.

## What the Screenshot section becomes

Before — a link, one section down from the paste instruction:

```markdown
### Screenshot

<!-- Paste it here. The viewer's "Export & direct links" panel has a Copy PNG button… -->

…
[Open this preview](…) · [PNG at these settings](https://preview.coo.ee/…/render/x.png?uiMode=dark)
```

After — the render itself, with the separate link dropped since the image already carries that URL:

```markdown
### Screenshot

[Article](https://preview.coo.ee/jetnews/render/Article__dark.png?uiMode=dark)

<!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing
     what you saw. For a copy that stays put, use Copy PNG in the viewer's "Export & direct
     links" panel and paste it here — GitHub then hosts the pixels itself. -->
```

Captured from a real browser by clicking the affordance on the committed fixture and intercepting the submission:

```
SCREENSHOT SECTION:
[Button · Filled (light)](http://127.0.0.1:5599/…/render/button-filled__ideal__default__light.png)

<!-- That image is a LIVE render: … -->
```

## Only where GitHub can fetch it

An inline image is loaded by **GitHub's camo proxy, not the reader's browser**, so the URL has to be reachable from the public internet over HTTPS. A developer's `compose-preview serve` on `http://127.0.0.1:8080`, a box on a private LAN, or plain HTTP would put a **broken-image icon** in the issue where a working link belongs — so those bodies keep the `[PNG at these settings](…)` form. `isEmbeddable` is deliberately conservative: HTTPS, a dotted public hostname, and not loopback / RFC 1918 / `.local` / `.internal` / single-label intranet names.

Embeddability is decided from the server's **real** external URL rather than the `{{render}}` placeholder, so the viewer's live re-substitution can never flip a working image into a broken one — both forms of the body have the same shape.

## No visual change

The affordance itself is untouched: this only changes the value of the form's hidden `body` input, so the fixture diffs are confined to that attribute and the rendered viewer is pixel-identical. Expect the visual-diff bot to report **0 changed captures** — that's correct here, not a gap.

## Test plan

- `./gradlew :cli:test` — green (full module). `./gradlew ktfmtCheckAll` — green.
- `ServeIssueReportTest`: the public render embeds and drops the redundant link; a `127.0.0.1` render stays a link with no `![`; `isEmbeddable` over https/http, loopback, all three RFC 1918 ranges, `.local`, single-label hosts, null/blank, and a public `172.32.x` that merely looks private; and the template keeping whatever shape the real URL earned.
- Browser check (Playwright against the committed fixture, harness Chromium): clicking the affordance submits to the GitHub issue form with the image markdown in the query and no leftover placeholder (output above).

Docs: the "Reporting a bad render" section in `docs/public-preview-server.md` updated for both the embed and the reachability rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QK5GUrkxyAZZj69fmj2VEn)_