### PR TITLE
fix(serve): overlay the whole Compose Multiplatform graph on the daemon parent

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -675,8 +675,15 @@ internal object ServeBundleDaemon {
    */
   internal fun shouldPrecedeDaemonSidecar(coordinate: BundleReader.ClasspathEntry.Maven): Boolean =
     coordinate.group.startsWith("androidx.") ||
-      (coordinate.group == "org.jetbrains.compose.components" &&
-        coordinate.artifact.startsWith("components-resources")) ||
+      // Compose Multiplatform artifacts are `org.jetbrains.compose.*` by GROUP but ship
+      // `androidx.compose.*` PACKAGES — the same overlap [ValidateComposePreviewClasspathTask]
+      // warns about. [UserClassLoaderHolder.mustDelegateToParent] keys on the package, so those
+      // classes are force-delegated to the parent; leaving the jars in the isolated child means
+      // the child copy is never consulted and the sidecar's own Compose answers instead. A
+      // consumer pinning a different version than the renderer ships then gets a hard
+      // `NoSuchMethodError` mid-render — meshcore-mobile on material3 1.10.0-alpha05 against a
+      // 1.11.x sidecar died on `AppBarKt.TopAppBar-gNPyAyM`. Group and package rule must agree.
+      coordinate.group.startsWith("org.jetbrains.compose") ||
       (coordinate.group == "org.jetbrains.kotlinx" &&
         (coordinate.artifact.startsWith("kotlinx-coroutines") ||
           coordinate.artifact.startsWith("kotlinx-io")))
@@ -687,16 +694,25 @@ internal object ServeBundleDaemon {
    * only the resolved files (the coordinates were dropped during catalog resolution). Both the
    * Maven-local (`…/androidx/compose/…`) and Gradle-cache (`…/androidx.compose.material3/…`)
    * layouts put the dotted/slashed group right after a path separator, so a `/androidx` segment
-   * identifies the AndroidX graph, `components-resources` the Compose resources runtime, and
+   * identifies the AndroidX graph, `org.jetbrains.compose` the Compose Multiplatform graph (whose
+   * artifacts ship `androidx.compose.*` packages — see [shouldPrecedeDaemonSidecar]), and
    * `kotlinx-coroutines` / `kotlinx-io` the kotlinx artifacts whose namespaces
    * `UserClassLoaderHolder` delegates to the daemon parent.
    */
   internal fun jarPrecedesDaemonSidecar(jar: File): Boolean {
     val path = jar.path.replace('\\', '/')
     return path.contains("/androidx") ||
-      path.contains("components-resources") ||
+      JETBRAINS_COMPOSE_ARTIFACT_PATH.containsMatchIn(path) ||
       KOTLINX_SHARED_ARTIFACT_PATH.containsMatchIn(path)
   }
+
+  /**
+   * The `org.jetbrains.compose.*` graph in either cache layout. Broader than the old
+   * `components-resources` check it replaces — every Compose Multiplatform artifact ships
+   * `androidx.compose.*` packages the child delegates to the parent, not just the resources one.
+   */
+  private val JETBRAINS_COMPOSE_ARTIFACT_PATH =
+    Regex("/(?:org\\.jetbrains\\.compose|org/jetbrains/compose)[./]")
 
   /** Matches Gradle-cache and Maven-local group layouts without inspecting unrelated path parts. */
   private val KOTLINX_SHARED_ARTIFACT_PATH =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -683,7 +683,16 @@ internal object ServeBundleDaemon {
       // consumer pinning a different version than the renderer ships then gets a hard
       // `NoSuchMethodError` mid-render — meshcore-mobile on material3 1.10.0-alpha05 against a
       // 1.11.x sidecar died on `AppBarKt.TopAppBar-gNPyAyM`. Group and package rule must agree.
+      //
+      // Skiko travels WITH Compose, and for the same reason: `org.jetbrains.skiko:skiko-awt`
+      // carries `org.jetbrains.skia.*` (bindings) as well as `org.jetbrains.skiko.*`, and
+      // `mustDelegateToParent` force-delegates `org.jetbrains.skia.`. Promoting Compose without it
+      // would pair the consumer's newer bindings with the sidecar's older native library — the
+      // `UnsatisfiedLinkError` on `skia.paragraph.TextStyleKt._nSetFontEdging` that
+      // [DesktopRendererGraphAlignmentFunctionalTest] documents (issue #1844). The two must move
+      // together or the graph is incoherent either way.
       coordinate.group.startsWith("org.jetbrains.compose") ||
+      coordinate.group.startsWith("org.jetbrains.skiko") ||
       (coordinate.group == "org.jetbrains.kotlinx" &&
         (coordinate.artifact.startsWith("kotlinx-coroutines") ||
           coordinate.artifact.startsWith("kotlinx-io")))
@@ -707,12 +716,14 @@ internal object ServeBundleDaemon {
   }
 
   /**
-   * The `org.jetbrains.compose.*` graph in either cache layout. Broader than the old
-   * `components-resources` check it replaces — every Compose Multiplatform artifact ships
-   * `androidx.compose.*` packages the child delegates to the parent, not just the resources one.
+   * The `org.jetbrains.compose.*` and `org.jetbrains.skiko` graphs in either cache layout. Broader
+   * than the old `components-resources` check it replaces — every Compose Multiplatform artifact
+   * ships `androidx.compose.*` packages the child delegates to the parent, not just the resources
+   * one, and Skiko ships the `org.jetbrains.skia.*` bindings that are delegated too. Both must be
+   * promoted together so the bindings and the native library stay one coherent version.
    */
   private val JETBRAINS_COMPOSE_ARTIFACT_PATH =
-    Regex("/(?:org\\.jetbrains\\.compose|org/jetbrains/compose)[./]")
+    Regex("/(?:org\\.jetbrains\\.(?:compose|skiko)|org/jetbrains/(?:compose|skiko))[./]")
 
   /** Matches Gradle-cache and Maven-local group layouts without inspecting unrelated path parts. */
   private val KOTLINX_SHARED_ARTIFACT_PATH =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -233,6 +233,15 @@ class ServeBundleDaemonTest {
         "$group ships androidx.compose.* packages, so the consumer ABI must win over the sidecar",
       )
     }
+    // Skiko must travel WITH Compose. `skiko-awt` carries the `org.jetbrains.skia.*` bindings that
+    // mustDelegateToParent force-delegates as well as `org.jetbrains.skiko.*`; promoting Compose
+    // without it pairs the consumer's newer bindings with the sidecar's older native library —
+    // the UnsatisfiedLinkError on skia.paragraph.TextStyleKt._nSetFontEdging that
+    // DesktopRendererGraphAlignmentFunctionalTest documents (#1844).
+    assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(coordinate("org.jetbrains.skiko", "skiko-awt")),
+      "Skiko bindings and native must stay version-coherent with the promoted Compose graph",
+    )
     assertTrue(
       !ServeBundleDaemon.shouldPrecedeDaemonSidecar(
         coordinate("org.jetbrains.kotlinx", "kotlinx-serialization-json-jvm")
@@ -272,6 +281,18 @@ class ServeBundleDaemonTest {
       ServeBundleDaemon.jarPrecedesDaemonSidecar(
         File("/m2/org/jetbrains/compose/ui/ui-desktop/1.11.1/ui-desktop-1.11.1.jar")
       )
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/cache/org.jetbrains.skiko/skiko-awt/0.9.4.2/skiko-awt-0.9.4.2.jar")
+      ),
+      "Skiko carries the parent-delegated org.jetbrains.skia bindings, so it moves with Compose",
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/m2/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.9.4.2/native.jar")
+      ),
+      "the native runtime artifact must not be split from its bindings",
     )
     assertTrue(
       !ServeBundleDaemon.jarPrecedesDaemonSidecar(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -214,6 +214,25 @@ class ServeBundleDaemonTest {
       ),
       "bundle resource APIs must share the parent-loaded LocalResourceReader with the daemon",
     )
+    // Compose Multiplatform is `org.jetbrains.compose.*` by group but ships `androidx.compose.*`
+    // packages, which `mustDelegateToParent` force-delegates. Keyed on the group alone, these fell
+    // into the isolated child, were never consulted, and the sidecar's own Compose answered — a
+    // consumer pinning a different version got NoSuchMethodError mid-render (meshcore-mobile on
+    // material3 1.10.0-alpha05: `AppBarKt.TopAppBar-gNPyAyM`).
+    for (group in
+      listOf(
+        "org.jetbrains.compose.material3",
+        "org.jetbrains.compose.ui",
+        "org.jetbrains.compose.foundation",
+        "org.jetbrains.compose.animation",
+        "org.jetbrains.compose.runtime",
+        "org.jetbrains.compose.material",
+      )) {
+      assertTrue(
+        ServeBundleDaemon.shouldPrecedeDaemonSidecar(coordinate(group, "whatever-desktop")),
+        "$group ships androidx.compose.* packages, so the consumer ABI must win over the sidecar",
+      )
+    }
     assertTrue(
       !ServeBundleDaemon.shouldPrecedeDaemonSidecar(
         coordinate("org.jetbrains.kotlinx", "kotlinx-serialization-json-jvm")
@@ -242,11 +261,29 @@ class ServeBundleDaemonTest {
         File("/m2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.9.1/library.jar")
       )
     )
+    // The whole Compose Multiplatform graph, in both cache layouts — not just components-resources.
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/cache/org.jetbrains.compose.material3/material3-desktop/1.10.0-alpha05/lib.jar")
+      ),
+      "material3-desktop ships androidx.compose.material3, which the child delegates to the parent",
+    )
+    assertTrue(
+      ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/m2/org/jetbrains/compose/ui/ui-desktop/1.11.1/ui-desktop-1.11.1.jar")
+      )
+    )
     assertTrue(
       !ServeBundleDaemon.jarPrecedesDaemonSidecar(
         File("/work/catalog-kotlinx-io-demo/cache/com.example/unrelated/library.jar")
       ),
       "a system or work-root name must not promote unrelated jars to the daemon parent",
+    )
+    assertTrue(
+      !ServeBundleDaemon.jarPrecedesDaemonSidecar(
+        File("/work/org.jetbrains.composure/thing/library.jar")
+      ),
+      "a group merely prefixed by org.jetbrains.compose must not be promoted",
     )
   }
 


### PR DESCRIPTION
## Summary

Third and final layer of the meshcore-mobile render failures, after #3351 (dependency axis) and #3356 (class axis). Each fix let the render get further and uncovered the next one; this is where it stops.

`shouldPrecedeDaemonSidecar` decides which of a bundle's dependencies go in the daemon's **parent** loader, ahead of the renderer sidecar. Its documented contract:

> Dependencies whose packages `UserClassLoaderHolder` deliberately resolves from the parent and whose consumer ABI must therefore win over the baked sidecar.

It keyed on the Maven **group**. The delegation it mirrors keys on the **package**. For Compose Multiplatform those disagree.

## Proof

```
$ unzip -l org/jetbrains/compose/material3/material3-desktop/1.10.0-alpha05/…jar
androidx/compose/material3/AppBarKt.class
androidx/compose/material3/…
→ androidx/* packages: 6      org/jetbrains/* packages: 0
```

Group `org.jetbrains.compose.material3`, packages **entirely** `androidx.*` — the same overlap `ValidateComposePreviewClasspathTask` warns about. `mustDelegateToParent` force-delegates `androidx.*`, so those classes always load from the parent, while the group check left the jars in the isolated child, which is never consulted for them. The sidecar's own Compose answered instead.

A consumer pinning a different version than the renderer ships then dies mid-render. meshcore-mobile pins material3 `1.10.0-alpha05` against a 1.11.x sidecar, and after #3356 landed, every `:meshcore-components` render failed with:

```
render failed: NoSuchMethodError:
  androidx.compose.material3.AppBarKt.TopAppBar-gNPyAyM(...)
```

The split was also internally incoherent. From that same published bundle:

```
androidx.compose.runtime:runtime-desktop:1.11.2      ← androidx group → already overlaid
org.jetbrains.compose.ui:ui-desktop:1.11.1           ← child
org.jetbrains.compose.material3:material3-desktop    ← child
```

Half the Compose graph on the parent, half in the child — exactly the shape that produces linkage errors. Both groups now overlay, so the graph stays consistent.

`jarPrecedesDaemonSidecar` (the path-keyed twin used by the playground lane) had the same blind spot: it matched only `components-resources`, one artifact of that graph. It now matches the whole `org.jetbrains.compose` group in both cache layouts, anchored on a `[./]` boundary so a lookalike group isn't promoted.

## Test plan

Extended the two existing rules' tests rather than adding a parallel file:

- `only consumer shared ABI dependencies overlay daemon internals` — now asserts material3 / ui / foundation / animation / runtime / material all precede the sidecar, alongside the existing `androidx.*`, kotlinx and components-resources cases and the negative cases (`kotlinx-serialization`, `okhttp`) that must stay in the child.
- `playground shared runtimes overlay daemon sidecar by artifact path` — adds `material3-desktop` and `ui-desktop` in both Gradle-cache and Maven-local layouts, plus a negative for a group merely *prefixed* by `org.jetbrains.compose`.

`./gradlew :cli:test` — full suite green.

Text-only: this is classpath ordering, not rendered output. The behavioural change is real though — the consumer's Compose now wins over the renderer's for the whole graph rather than half of it, which is the documented intent of the rule but worth a reviewer's eye. The Bundle Render E2E / serve-lanes-e2e jobs exercise the daemon path.

I have not reproduced the `NoSuchMethodError` locally — it needs the daemon sidecar and a consumer pinning a skewed Compose. The diagnosis is from the production failure plus the jar contents above; final confirmation is a meshcore-mobile republish on the next release.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ff3PLh8x3QXsN1mMLn2vG)_