### PR TITLE
fix: count only fresh renders as optimizer production

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -439,7 +439,16 @@ class ServeCatalogLiveHost(
                   catalogThemeCache.recordBatch(batch.size, clock() - renderFrom)
                 }
               } ?: return@execute
-            catalogThemeCache.recordProduced(outcomes.count { it is RenderOutcome.Ok })
+            // Only a FRESH daemon render is optimizer production. The batch is filtered for cache
+            // misses when it is built, but a foreground request can fill a target while this
+            // catalog queues for the render permit — `renderLeased` then short-circuits through
+            // `cachedRender` and hands back an Ok stamped CATALOG_CACHE. Counting that would
+            // re-open the same inflated rate this counter exists to close.
+            catalogThemeCache.recordProduced(
+              outcomes.count {
+                it is RenderOutcome.Ok && it.generation == RenderOutcome.Generation.DAEMON
+              }
+            )
             for ((job, outcome) in batch.zip(outcomes)) {
               if (catalogThemeCache.get(job.cacheKey) != null) continue
               // Busy is "ask again", not a failure: the warm above may still be settling. Leave it

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -180,28 +180,48 @@ class ServeSharedDaemonPoolTest {
 
   @Test
   fun `does not open a replica the live-seat budget cannot afford`() {
-    val seats = LiveSeatLimiter(totalPermits = 1 + LiveSeatLimiter.STREAM_RESERVE)
-    // Spend everything above the stream reserve elsewhere — a stream, another catalog's pool.
+    // Budget fully spent elsewhere — a stream, another catalog's pool. Since a leased replica is
+    // charged as FOREGROUND (see the test below), "cannot afford" means literally nothing free:
+    // leaving the stream reserve open would leave a replica affordable, and the test would then
+    // pass or fail on whether the renders happened to overlap.
+    val seats = LiveSeatLimiter(totalPermits = 1)
     val held = requireNotNull(seats.acquire(1))
-    val primary = InstantHost("primary")
+    assertEquals(0, seats.availablePermits(), "precondition: nothing left to spend")
+
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    // Held mid-render, so the overlapping request has nothing to borrow and MUST reach the
+    // replica-launch path. With an InstantHost primary the overlap was a race, which is why this
+    // used to pass locally and fail on a loaded runner.
+    val primary = BlockingHost("primary", entered, release)
     val opened = AtomicInteger()
     val pool =
       ServeSharedDaemonPool(primary = primary, capacity = 3, liveSeats = seats) {
         opened.incrementAndGet()
         InstantHost("replica")
       }
+    val executor = Executors.newFixedThreadPool(2)
     try {
-      val executor = Executors.newFixedThreadPool(3)
-      try {
-        val results =
-          (1..3).map { executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) } }
-        // Every render still succeeds — they serialise onto the primary instead of spawning JVMs.
-        results.forEach { assertTrue(it.get(10, TimeUnit.SECONDS) is RenderOutcome.Ok) }
-      } finally {
-        executor.shutdownNow()
-      }
+      val first = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      assertTrue(entered.await(5, TimeUnit.SECONDS), "the primary should be mid-render")
+
+      val second = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      // It must still be waiting: the only host is out and the budget affords no replica. Had one
+      // been spawned this would have completed, so the timeout is the assertion.
+      assertTrue(
+        runCatching { second.get(1, TimeUnit.SECONDS) }.isFailure,
+        "the overlapping render waits for the primary instead of spawning a replica",
+      )
       assertEquals(0, opened.get(), "no replica was spawned against an exhausted budget")
+
+      // Both still succeed — the second serialises onto the primary instead of spawning a JVM.
+      release.countDown()
+      assertTrue(first.get(10, TimeUnit.SECONDS) is RenderOutcome.Ok)
+      assertTrue(second.get(10, TimeUnit.SECONDS) is RenderOutcome.Ok)
+      assertEquals(0, opened.get(), "still no replica once the burst drains")
     } finally {
+      release.countDown()
+      executor.shutdownNow()
       pool.close()
       held.close()
     }


### PR DESCRIPTION
Two follow-ups to #3376, which merged before either could land on it.

## Only a fresh daemon render is optimizer production

Review finding on #3376. The optimizer's batch is filtered for cache misses when it is built, but a foreground request can fill a target while the catalog queues for the shared render permit. `renderLeased` then short-circuits through `cachedRender` and hands back an `Ok` stamped `Generation.CATALOG_CACHE` — so counting every `Ok` attributed that foreground-filled entry to the prefetcher, re-opening exactly the inflated rate #3376 exists to close. `recordProduced` now counts only `Generation.DAEMON`.

## Fix the flaky `does not open a replica the live-seat budget cannot afford`

This failed CI on #3376 (`Module Unit Tests`), unrelated to that diff. Its premise went stale when #3326 moved leased replicas onto the **foreground** seat path:

- The test built `LiveSeatLimiter(totalPermits = 1 + STREAM_RESERVE)` and held one permit — leaving 2 free, which comfortably affords a `seatWeight = 1` foreground replica. The budget was never exhausted.
- It passed anyway because an `InstantHost` primary made three concurrent renders rarely overlap, so `openSeatedReplica` was rarely reached. A loaded runner reaches it, and the test fails.

Now the budget is genuinely exhausted (`totalPermits = 1`, one held, zero free) and a `BlockingHost` primary holds the only host mid-render, so the overlapping request *must* take the replica path. The wait itself is the assertion: had a replica been spawned, the second render would have completed instead of blocking.

## Test plan

- `./gradlew :cli:test` — green (1416 tests).
- `ServeSharedDaemonPoolTest` run 3× locally, green each time.
- **Negative control**: reverting only the seat budget to the old `1 + STREAM_RESERVE` fails the rewritten test deterministically at the `opened == 0` assertion — confirming the replica path is now genuinely exercised and that the old premise was wrong, not merely under-tested.

Not visual — stats plumbing and a unit test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_