### PR TITLE
perf(serve): gzip the text lanes

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -200,6 +200,7 @@ dependencies {
   implementation(libs.ktor.server.cio)
   // WebSockets plugin: the `serve` streamed-frame lane (`/ws/{id}`) — tier-2 streaming spike.
   implementation(libs.ktor.server.websockets)
+  implementation(libs.ktor.server.compression)
 
   // Bundle the MCP server so `compose-preview mcp serve` can invoke it in-process —
   // the consumer install story stays a single tarball + a single launcher.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -14,6 +14,10 @@ import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.compression.Compression
+import io.ktor.server.plugins.compression.gzip
+import io.ktor.server.plugins.compression.matchContentType
+import io.ktor.server.plugins.compression.minimumSize
 import io.ktor.server.plugins.origin
 import io.ktor.server.request.queryString
 import io.ktor.server.request.receiveStream
@@ -317,6 +321,33 @@ class ServeHttpServer(
             onCall { call -> auth.refreshSession(call) }
           }
         )
+      }
+      // Compress the text-ish lanes only. Every page, `/status.json`, the figma-svg exports and
+      // the baked CSS/JS are markup that gzips 3-8x, and the biggest of them (a vendored editor,
+      // an SVG export) dominate their page's transfer.
+      //
+      // Deliberately an ALLOWLIST, not "everything except a few": this host's heavy lanes are
+      // already-compressed bytes — catalog PNGs (`/render`, `/hero`), packed `.bundle` images,
+      // and the multi-megabyte Wasm app tier. Gzip cannot shrink those, so compressing them would
+      // burn CPU per request on a box that is also running render daemons, and re-encoding an
+      // 8 MB Wasm payload on every visit is exactly the kind of cost this change is meant to
+      // avoid. An unlisted type is served through untouched.
+      //
+      // `minimumSize` keeps the small stuff alone: `/healthz` ("ok") and `/readyz` are polled on a
+      // ~10s healthcheck loop, and framing a 2-byte body costs more than it saves.
+      install(Compression) {
+        gzip {
+          matchContentType(
+            ContentType.Text.Html,
+            ContentType.Text.CSS,
+            ContentType.Text.Plain,
+            ContentType.Text.JavaScript,
+            ContentType.Application.JavaScript,
+            ContentType.Application.Json,
+            ContentType.Image.SVG,
+          )
+          minimumSize(1024)
+        }
       }
       routing {
         // `/healthz` — ungated liveness: "ok" the moment the listener is up. Leaks nothing, and

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -276,6 +276,10 @@ ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
 # WebSockets plugin for the embedded server — backs the `serve` streamed-frame lane (`/ws/{id}`).
 # Same `ktor` version ref so it can't skew the slf4j pin in :cli.
 ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
+# Response compression for the embedded server. Text-ish payloads only (see ServeHttpServer) —
+# the catalog PNG/bundle lanes are already-compressed bytes and are excluded. Same `ktor` version
+# ref so it can't skew the slf4j pin in :cli.
+ktor-server-compression = { module = "io.ktor:ktor-server-compression", version.ref = "ktor" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
 # Coil 2 / coil 3 — see the version comments above. `coil-compose` (not `coil-base`) because the


### PR DESCRIPTION
The serve host installed no compression, so every page, `/status.json`, every figma-svg export and every baked CSS/JS asset went out uncompressed. Those are markup payloads that gzip 3–8×, and on a catalog page they are most of the transfer.

Fell out of the CodeMirror spike (`agent/spike-codemirror-playground`), where a 429 KB vendored editor made the absence obvious — but the win here is independent of that and larger.

## Measured against a live host serving `compose-m3`

| lane | raw | gzip | saved |
|---|---:|---:|---:|
| catalog page | 52,796 B | 8,942 B | **83%** |
| `serve.css` | 58,770 B | 14,780 B | **75%** |
| home page | 3,488 B | 1,202 B | 66% |
| `status.json` | 1,310 B | 676 B | 48% |
| figma-svg export | 46,401 B | 35,130 B | 24% |

## Why an allowlist, not "everything except a few"

This host's heavy lanes are **already-compressed bytes** — catalog PNGs (`/render`, `/hero`), packed `.bundle` images, and the multi-megabyte Wasm app tier. Gzip can't shrink those, so compressing them would burn CPU per request on a box that is simultaneously running render daemons, and re-encoding an 8 MB Wasm payload on every visit is precisely the cost this change exists to avoid.

So the config names the types that benefit (`text/html`, `text/css`, `text/plain`, JS, JSON, `image/svg+xml`) and anything unlisted is served through untouched. `minimumSize(1024)` keeps the small stuff alone — `/healthz` and `/readyz` are polled on a ~10 s Docker healthcheck loop, and framing a 2-byte body costs more than it saves.

## Verified, including the lanes that must NOT change

Against a running server, not just unit tests:

```
PNG (1,479 B) + Accept-Encoding: gzip
  -> raw=1479  gzip-requested=1479   IDENTICAL, no Content-Encoding
/healthz (2 B)
  -> no Content-Encoding (below minimumSize)
homepage / status.json
  -> Content-Encoding: gzip · Vary: Accept-Encoding
If-None-Match on a compressed asset
  -> HTTP 304
WebSocket upgrade on the live-stream lane
  -> HTTP 101
```

The last two are the regression risks worth naming: compression adds `Vary`, so ETag revalidation had to keep working, and the live `/ws/` lane had to keep upgrading. Both do.

## Test plan

- [x] `./gradlew :cli:test` — full CLI suite green
- [x] `./gradlew ktfmtCheckAll`
- [x] Live-server measurements above, covering compressed lanes, excluded lanes, caching, and WebSockets

No visual evidence: transfer encoding only — no rendered surface is touched, and every response is byte-identical after decoding.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr)_