### PR TITLE
feat(serve): add @FixedTheme so a theme specimen opts out anywhere

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/FixedTheme.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/FixedTheme.kt
@@ -1,0 +1,40 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Marks a `@Preview` whose **subject is a theme**, so a preview host must never re-render it under
+ * a theme override.
+ *
+ * A theme specimen — a card captioned *"MeshCore · Light · Orbitron / Space Grotesk / JetBrains
+ * Mono"*, a colour-role sheet, a typography scale — documents one named theme. Re-rendering it
+ * under a different `themeProvider` destroys the very thing it documents: the card still says
+ * "Light" and still names Orbitron while drawing dark in the default sans, pixels contradicting
+ * their own label.
+ *
+ * `serve` already exempts a card whose catalog **section** is `"Themes"`, because that section is
+ * the author's statement of what the tab *is*. This annotation is the per-preview override for
+ * everything else: a specimen that lives outside such a tab (an ungrouped bundle, a `Foundation`
+ * section that mixes swatches with components, a plain `compose-preview serve` of one module) has
+ * no section to speak for it and says so on the function instead.
+ *
+ * Discovery picks this up by FQN, like [ScrollingPreview] / [FocusedPreview] — a module that
+ * doesn't depend on `ee.schimke.composeai:preview-annotations` simply never surfaces it. The flag
+ * rides `previews.json` into the bundle and the published catalog, so the browse surface honours it
+ * before any daemon is opened.
+ *
+ * ```
+ * @Preview
+ * @FixedTheme
+ * @Composable
+ * fun MeshcoreLightSpecimen() {
+ *     MeshcoreTheme(darkTheme = false) { ThemeSpecimenSheet() }
+ * }
+ * ```
+ *
+ * It suppresses only the **theme** override. Every other control — state, locale, font scale,
+ * device — still applies, and the card keeps its baked pixels for the theme axis exactly as a
+ * preview with no live daemon twin already does.
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class FixedTheme

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -167,6 +167,14 @@ data class PreviewInfo(
   val captures: List<Capture> = listOf(Capture()),
   val dataProducts: List<PreviewDataProduct> = emptyList(),
   val catalog: CatalogEntry? = null,
+  /**
+   * `@FixedTheme` (or a `@ThemeCatalog`-synthesised sheet): this preview's subject **is** a theme,
+   * so a preview host must not re-render it under a `themeProvider` override. Mirrors
+   * `PreviewInfo.fixedTheme` in gradle-plugin/PreviewData.kt so this wire-format API exposes what
+   * discovery writes to `previews.json` — otherwise `ignoreUnknownKeys` would silently drop it for
+   * `compose-preview show --json`, contrib scripting, and MCP readers. False for ordinary previews.
+   */
+  val fixedTheme: Boolean = false,
 )
 
 @Serializable

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/CatalogEntryWireTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/CatalogEntryWireTest.kt
@@ -93,4 +93,37 @@ class CatalogEntryWireTest {
 
     assertEquals(false, manifest.previews.single().catalog?.perBreakpoint)
   }
+
+  @Test
+  fun `fixedTheme survives the wire and defaults off`() {
+    // `ignoreUnknownKeys` would drop the flag silently if this API didn't mirror it, and a serve
+    // host reading the manifest would re-theme a specimen that discovery had already marked.
+    val manifest =
+      Json.decodeFromString<PreviewManifest>(
+        """
+        {
+          "module": ":sample",
+          "variant": "debug",
+          "previews": [
+            {
+              "id": "themecatalog__Brand_Light",
+              "functionName": "Brand Light theme",
+              "className": "test.BrandLightTheme",
+              "fixedTheme": true
+            },
+            {
+              "id": "test.ContactRow",
+              "functionName": "ContactRow",
+              "className": "test.PreviewsKt"
+            }
+          ]
+        }
+        """
+          .trimIndent()
+      )
+
+    val byId = manifest.previews.associateBy { it.id }
+    assertEquals(true, byId.getValue("themecatalog__Brand_Light").fixedTheme)
+    assertEquals(false, byId.getValue("test.ContactRow").fixedTheme)
+  }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -727,6 +727,7 @@ class ServeCommand(args: List<String>) : Command(args) {
             uiMode = it.params.uiMode,
             supportsFocus = focus,
             supportsGestures = gestures,
+            fixedTheme = it.fixedTheme,
           )
         }
     // The module's declared @ThemeCatalog themes — the Theme selector renders them so a preview can

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
@@ -57,6 +57,7 @@ class GradleRevisionBuilder(
           uiMode = it.params.uiMode,
           supportsFocus = focus,
           supportsGestures = gestures,
+          fixedTheme = it.fixedTheme,
         )
       } ?: emptyList()
     if (previews.isEmpty()) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -505,6 +505,7 @@ internal object ServeBundleDaemon {
         remoteComposeKnobs = readRemoteComposeSidecar(previewsDir, it.id, fileSystem),
         supportsFocus = focus,
         supportsGestures = gestures,
+        fixedTheme = it.fixedTheme,
       )
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -226,6 +226,7 @@ class ServeBundleHost(
             readRemoteComposeKnobs(id).ifEmpty { meta?.remoteComposeKnobs.orEmpty() },
           supportsFocus = meta?.supportsFocus == true,
           supportsGestures = meta?.supportsGestures == true,
+          fixedTheme = meta?.fixedTheme == true,
           // `state` comes only from a `catalog.json`-backed bundle's `variants.json`
           // (`meta.state`).
           // A plain module bundle has no manifest, so an `@OverrideVariant` synthetic preview

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -1102,6 +1102,10 @@ class ServeCatalogLiveHost(
         remoteComposeKnobs = twin.remoteComposeKnobs,
         supportsFocus = twin.supportsFocus,
         supportsGestures = twin.supportsGestures,
+        // OR rather than overwrite: the baked side may already know this card is a specimen from
+        // its catalog `section`/`fixedTheme` metadata, and a daemon twin built from an older
+        // bundle (no `fixedTheme` in its `previews.json`) must not be able to clear that.
+        fixedTheme = p.fixedTheme || twin.fixedTheme,
         uiMode = twin.uiMode,
       )
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -347,7 +347,8 @@ class ServeCatalogStore(
             image.overrides.isNotEmpty() ||
             image.remoteComposeKnobs.isNotEmpty() ||
             image.supportsFocus ||
-            image.supportsGestures
+            image.supportsGestures ||
+            image.fixedTheme
         ) {
           variants[id] =
             VariantMeta(
@@ -359,6 +360,7 @@ class ServeCatalogStore(
               remoteComposeKnobs = image.remoteComposeKnobs,
               supportsFocus = image.supportsFocus,
               supportsGestures = image.supportsGestures,
+              fixedTheme = image.fixedTheme,
               section = planned.section,
               group = planned.group,
               order = if (hasSectionInfo) count else null,
@@ -1483,6 +1485,13 @@ class ServeCatalogStore(
     val supportsFocus: Boolean = false,
     /** Discovery-time `@GestureHintPreview` support, recorded without opening the live bundle. */
     val supportsGestures: Boolean = false,
+    /**
+     * Discovery-time `@FixedTheme` (or a `@ThemeCatalog`-synthesised sheet): this render's subject
+     * IS a theme, so the browse surface must not re-render it under a `themeProvider` override.
+     * Recorded here so a specimen outside a `"Themes"` section is honoured before its per-preview
+     * daemon is ever opened.
+     */
+    val fixedTheme: Boolean = false,
   )
 
   /**
@@ -1515,6 +1524,8 @@ class ServeCatalogStore(
     val remoteComposeKnobs: List<RemoteComposeKnobDeclaration> = emptyList(),
     val supportsFocus: Boolean = false,
     val supportsGestures: Boolean = false,
+    /** Discovery-time `@FixedTheme` — see [Image.fixedTheme]. */
+    val fixedTheme: Boolean = false,
     val section: String? = null,
     val group: String? = null,
     val order: Int? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -93,6 +93,16 @@ data class ServePreview(
    */
   val supportsGestures: Boolean = false,
   /**
+   * Whether this preview's **subject is a theme** — it carries `@FixedTheme`, or discovery
+   * synthesised it from a `@ThemeCatalog` / `@WearThemeCatalog`. Re-rendering such a card under a
+   * `themeProvider` override destroys the very thing it documents, so the landing keeps its baked
+   * pixels for the theme axis (the same "no themed base" path a card with no daemon twin takes).
+   *
+   * The catalog-wide counterpart is [section] == `"Themes"`, which speaks for a whole tab; this is
+   * the per-preview signal for a specimen that lives outside such a tab.
+   */
+  val fixedTheme: Boolean = false,
+  /**
    * The baked component **state** this preview render represents — `"unchecked"`, `"pressed"`,
    * `"disabled"`, `"unselected"`, … — or `null`/`"default"` for the default render (and for plain
    * bundles / app screens that carry no state). Carried from the catalog's `previews/variants.json`

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -923,16 +923,21 @@ object ServeWeb {
    * override the card drew dark, in the default sans — pixels contradicting their own label. Every
    * card in a Themes tab has that property by construction.
    *
-   * Deliberately keyed on the section rather than the id: `theme-…` id prefixes are a catalog
-   * authoring convention, not a contract, whereas `section` is the authored statement of what the
-   * tab IS (`catalog.spec.json`'s `section: "Themes"`). Specimens that live outside such a tab need
-   * an explicit per-preview opt-out, which is a separate change.
+   * Two signals, either of which is enough:
+   * * the catalog **section** — deliberately keyed on that rather than the id, because `theme-…` id
+   *   prefixes are an authoring convention while `section` is the authored statement of what the
+   *   tab IS (`catalog.spec.json`'s `section: "Themes"`). It speaks for a whole tab at once.
+   * * the per-preview [ServePreview.fixedTheme] flag, from `@FixedTheme` on the function (or a
+   *   `@ThemeCatalog`-synthesised sheet). This is what a specimen living OUTSIDE a Themes tab says
+   *   for itself — an ungrouped bundle, a `Foundation` section that mixes swatches with components,
+   *   a plain `compose-preview serve` of one module, none of which have a section to speak for
+   *   them.
    *
    * This does NOT remove the theme chips: the rest of the catalog still re-renders, and a specimen
    * simply keeps its baked pixels — the same treatment a card with no daemon twin already gets.
    */
   private fun isThemeSpecimen(p: ServePreview): Boolean =
-    p.section?.equals(THEMES_SECTION, ignoreCase = true) == true
+    p.fixedTheme || p.section?.equals(THEMES_SECTION, ignoreCase = true) == true
 
   /** One sub-heading group inside a section tab: its [name] (null ⇒ ungrouped) and its cards. */
   private class LandingGroup(val name: String?) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -597,6 +597,36 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a fixedTheme image reaches the browse surface with nothing else declared`() {
+    // A theme specimen declares no knobs and detects no features. `fixedTheme` therefore has to
+    // carry a variants-manifest entry on its own — if it didn't, the specimen would arrive with no
+    // metadata at all and the landing would happily re-render it under a themeProvider override.
+    val declared =
+      """
+      {"schema":"design-parity-catalog/v1","system":"meshcore","components":[
+        {"componentId":"Theme","images":[{
+          "path":"images/theme/meshcore-light.png",
+          "previewId":"themecatalog__MeshCore_Light",
+          "fixedTheme":true
+        }]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> declared.toByteArray()
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+
+    assertTrue(
+      store(TrustStore.EMPTY, fetch = fetch).load("meshcore") is ServeCatalogStore.Result.Ok
+    )
+
+    assertTrue(registered.getValue("meshcore").previews.single().fixedTheme)
+  }
+
+  @Test
   fun `catalog props preserve arbitrary JSON values through the variants manifest`() {
     val flexibleProps =
       """

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThemeSpecimenTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThemeSpecimenTest.kt
@@ -106,4 +106,65 @@ class ServeWebThemeSpecimenTest {
     val html = page(listOf(ServePreview(id = "a", label = "A")))
     assertTrue(themeBases(html).any { it.contains("/render/a.png") })
   }
+
+  @Test
+  fun `a fixedTheme preview opts out with no section at all`() {
+    // The `@FixedTheme` half: a specimen in a plain bundle (or a section that isn't "Themes") has
+    // nothing but the annotation to speak for it.
+    val html =
+      page(
+        listOf(
+          ServePreview(id = "themecatalog__brand", label = "Brand theme", fixedTheme = true),
+          ServePreview(id = "contactrow-chat", label = "Contact row"),
+        )
+      )
+    val bases = themeBases(html)
+    assertTrue(
+      bases.none { it.contains("/render/themecatalog__brand.png") },
+      "an @FixedTheme preview must never gain a themeProvider render URL",
+    )
+    assertTrue(
+      bases.any { it.contains("/render/contactrow-chat.png") },
+      "its neighbours still re-render — the control is not disabled wholesale",
+    )
+  }
+
+  @Test
+  fun `a fixedTheme preview in a Components section still opts out`() {
+    // Section and annotation are independent signals; the wrong section must not override the
+    // author's explicit per-preview statement.
+    val bases =
+      themeBases(
+        page(
+          listOf(
+            ServePreview(
+              id = "swatches",
+              label = "Swatches",
+              section = "Foundation",
+              fixedTheme = true,
+            ),
+            ServePreview(id = "contactrow-chat", label = "Contact row", section = "Components"),
+          )
+        )
+      )
+    assertTrue(bases.none { it.contains("/render/swatches.png") })
+    assertTrue(bases.any { it.contains("/render/contactrow-chat.png") })
+  }
+
+  @Test
+  fun `a catalog of only fixedTheme previews offers no declared-theme chips`() {
+    // Same dead-control guard as the section-only case: the chip gate and the per-card URL must
+    // agree on eligibility, whichever signal decided it.
+    val html =
+      page(
+        listOf(
+          ServePreview(id = "themecatalog__light", label = "Light", fixedTheme = true),
+          ServePreview(id = "themecatalog__dark", label = "Dark", fixedTheme = true),
+        )
+      )
+    assertFalse(
+      html.contains("data-theme-choice=\"theme:com.example.BrandTheme\""),
+      "no declared-theme chip when nothing the theme could redraw is renderable",
+    )
+  }
 }

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -644,6 +644,40 @@ can render it on demand*, and needs a live path to be legal. `capture: "none"` s
 *nothing can render this to a PNG at all*, live path or not. A deferred entry is
 still coverage the sheet can produce; a `"none"` entry is a recorded gap.
 
+## Theme specimens (`section: "Themes"` / `@FixedTheme`)
+
+A card whose **subject is a theme** — a colour-role sheet, a typography scale, a
+`MeshCore · Light · Orbitron / Space Grotesk / JetBrains Mono` swatch — must not
+be re-rendered when a visitor picks a different theme on the browse surface.
+Doing so destroys the very thing it documents: the card still says "Light" and
+still names Orbitron while drawing dark in the default sans, pixels contradicting
+their own label.
+
+`serve` recognises two signals, either of which is enough:
+
+- **`section: "Themes"`** in `catalog.spec.json` — the author's statement of what
+  the tab *is*. It exempts every card in that tab at once, which is the right
+  granularity for a design system whose Themes tab is nothing but specimens.
+  Deliberately keyed on the section rather than a `theme-…` id prefix: the prefix
+  is an authoring convention, the section is a declaration.
+- **`@FixedTheme`** on the `@Preview` function
+  (`ee.schimke.composeai:preview-annotations`) — the per-preview override for a
+  specimen with no such tab to speak for it: an ungrouped bundle, a `Foundation`
+  section that mixes swatches with components, a plain `compose-preview serve` of
+  one module. Discovery matches it by FQN and writes `"fixedTheme": true` into
+  `previews.json`; the design-artifacts export lifts it onto the catalog image, so
+  the browse surface honours it before any daemon is opened.
+
+Sheets that discovery *synthesises* from `@ThemeCatalog` / `@WearThemeCatalog`
+(`themecatalog__<name>`) are theme-fixed by construction — the annotation already
+says the sheet's subject is one named theme, so no consumer-side `@FixedTheme` is
+needed.
+
+Neither signal disables the theme control: the rest of the catalog still
+re-renders, and a specimen simply keeps its baked pixels — the same treatment a
+card with no live daemon twin already gets. A catalog made up *only* of specimens
+offers no theme chips at all, since there would be nothing for them to redraw.
+
 
 1. Author a `@Composable` wrapped in the module's sticker theme, annotated with
    `@CatalogModes` (and extra `@Preview`s for states / breakpoints). Full-screen

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -891,6 +891,13 @@ data class PreviewInfo(
    * case) — the field is purely additive, so older manifests and non-catalog modules are unchanged.
    */
   val catalog: CatalogEntry? = null,
+  /**
+   * `@FixedTheme` — this preview's subject **is** a theme, so a preview host must not re-render it
+   * under a `themeProvider` override. `serve` already exempts a card whose catalog section is
+   * `"Themes"`; this is the per-preview override for a specimen that lives outside such a tab.
+   * False for every ordinary preview, so older manifests and unannotated modules are unchanged.
+   */
+  val fixedTheme: Boolean = false,
 )
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -218,6 +218,9 @@ object PreviewDiscovery {
   // Wear one-handed-gesture hint capture — sibling annotation to @AmbientPreview, same FQN-match
   // policy. See `GestureHintPreview.kt`.
   private const val GESTURE_HINT_PREVIEW_FQN = "ee.schimke.composeai.preview.GestureHintPreview"
+  // "this preview's subject IS a theme — never re-render it under a themeProvider override". A
+  // marker with no parameters, matched by FQN like its siblings. See `FixedTheme.kt`.
+  private const val FIXED_THEME_FQN = "ee.schimke.composeai.preview.FixedTheme"
   private const val LAUNCHER_WIDGET_PREVIEW_FQN =
     "ee.schimke.composeai.preview.LauncherWidgetPreview"
   // `@OverrideVariant` — repeatable; emits one extra synthetic preview per variant with
@@ -1198,6 +1201,11 @@ object PreviewDiscovery {
             wrapperClassName = theme.className,
           ),
         captures = listOf(Capture(renderOutput = "renders/$id.png", optional = !renderSupported)),
+        // A `@ThemeCatalog` sheet renders ONE named theme as its subject — that is the whole point
+        // of the annotation. Re-rendering it under a different `themeProvider` would leave a sheet
+        // captioned with this theme's name drawing another theme's colours and type, so it is
+        // fixed by construction rather than needing `@FixedTheme` on every consumer's sheet.
+        fixedTheme = true,
       )
     }
   }
@@ -3156,6 +3164,11 @@ object PreviewDiscovery {
       captures = outputPlan.captures,
       dataProducts = outputPlan.dataProducts,
       targets = targets,
+      // Read off the METHOD rather than the `@Preview` annotation being expanded: a multi-preview
+      // fans one function out into several `PreviewInfo`s, and a theme specimen is fixed for every
+      // one of them. Reading it here also covers the built-in multi-preview expansion path, which
+      // never sees a real `@Preview` [AnnotationInfo].
+      fixedTheme = method.annotationInfo.any { it.name == FIXED_THEME_FQN },
     )
   }
 

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -680,6 +680,66 @@ class DiscoveryFunctionalTest {
     // (expected-absent
     // rather than a missing-render regression) — same backend-aware policy as the token catalogs.
     assertThat(light.captures.single().optional).isTrue()
+    // A theme sheet's SUBJECT is the theme, so it is fixed by construction: a preview host that
+    // re-rendered it under another `themeProvider` would leave a sheet captioned "Brand Light"
+    // drawing Brand Dark's colours. No `@FixedTheme` needed on the consumer's side.
+    assertThat(themes.map { it.fixedTheme }).containsExactly(true, true)
+  }
+
+  @Test
+  fun `composePreviewDiscover marks an @FixedTheme preview as theme-fixed`() {
+    val projectDir = createCmpTestProject()
+
+    // Declared locally with the discovered FQN — discovery matches by FQN + target and nothing
+    // else, so the test needs no external `preview-annotations` artifact.
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    annDir.mkdirs()
+    File(annDir, "FixedTheme.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION)
+        annotation class FixedTheme
+        """
+          .trimIndent()
+      )
+    File(projectDir, "src/main/kotlin/test/Specimens.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+        import ee.schimke.composeai.preview.FixedTheme
+
+        // A specimen with no catalog section to speak for it — the annotation is the only signal.
+        @FixedTheme
+        @Preview @Composable fun BrandLightSpecimen() {}
+
+        // Its ordinary neighbour keeps re-rendering under a theme override.
+        @Preview @Composable fun ContactRow() {}
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val byFn = manifest.previews.associateBy { it.functionName }
+    assertThat(byFn.getValue("BrandLightSpecimen").fixedTheme).isTrue()
+    assertThat(byFn.getValue("ContactRow").fixedTheme).isFalse()
   }
 
   @Test

--- a/scripts/design-artifacts/catalog-preview-declarations.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.mjs
@@ -32,17 +32,23 @@ export function declarationsByPreviewId(bundles) {
       const captures = preview.captures ?? [];
       const supportsFocus = captures.some((capture) => capture?.focus || capture?.focusGif);
       const supportsGestures = captures.some((capture) => capture?.gestureHint);
+      // `@FixedTheme` / a `@ThemeCatalog`-synthesised sheet: the browse surface must not re-render
+      // this card under a theme override, and it has to know that from catalog.json alone —
+      // deciding it lazily would mean the specimen re-themes until its daemon happens to be opened.
+      const fixedTheme = preview.fixedTheme === true;
       if (
         overrides.length > 0 ||
         remoteComposeKnobs.length > 0 ||
         supportsFocus ||
-        supportsGestures
+        supportsGestures ||
+        fixedTheme
       ) {
         out.set(preview.id, {
           ...(overrides.length > 0 ? { overrides } : {}),
           ...(remoteComposeKnobs.length > 0 ? { remoteComposeKnobs } : {}),
           ...(supportsFocus ? { supportsFocus: true } : {}),
           ...(supportsGestures ? { supportsGestures: true } : {}),
+          ...(fixedTheme ? { fixedTheme: true } : {}),
         });
       }
     }

--- a/scripts/design-artifacts/catalog-preview-declarations.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.test.mjs
@@ -74,6 +74,31 @@ test("stamps supplement-only image declarations by bridged daemon id", () => {
   });
 });
 
+test("carries @FixedTheme onto the catalog image on its own", () => {
+  // A theme specimen declares no knobs and detects no features, so `fixedTheme` has to be enough
+  // on its own to produce a declaration entry — otherwise the flag never reaches catalog.json and
+  // the specimen re-themes on the browse surface until its daemon happens to be opened.
+  const bundle = {
+    previews: [{ id: "themecatalog__Brand", captures: [], fixedTheme: true }],
+    entries: {},
+  };
+
+  assert.deepEqual(declarationsByPreviewId(bundle).get("themecatalog__Brand"), {
+    fixedTheme: true,
+  });
+});
+
+test("leaves fixedTheme off an ordinary preview", () => {
+  const bundle = {
+    previews: [{ id: "Primary_Light", captures: [{ focus: {} }] }],
+    entries: {},
+  };
+
+  assert.deepEqual(declarationsByPreviewId(bundle).get("Primary_Light"), {
+    supportsFocus: true,
+  });
+});
+
 test("ignores missing and malformed sidecars", () => {
   const bundle = {
     previews: [{ id: "Bare", captures: [] }, { id: "Broken", captures: [] }],


### PR DESCRIPTION
## Summary

A card whose subject **is** a theme must not be re-rendered under a `themeProvider` override. #3369 exempted a catalog's `section: "Themes"` tab — the right granularity for a design system, but it leaves a specimen with no such tab unable to say so: an ungrouped bundle, a `Foundation` section that mixes swatches with components, a plain `compose-preview serve` of one module.

`@FixedTheme` is that per-preview signal. It completes the pair: **section** speaks for a whole tab, **annotation** speaks for one preview.

## Visual evidence

Both images are live renders of the **same** preview, `theme-meshcore-light__ideal__default__light__compact`, fetched from `preview.coo.ee` — the right-hand one served `x-compose-preview-generation: daemon`, so it is a real re-render under the override rather than a cached artifact.

| Correct (baked) — what the marker keeps | Same card under `themeProvider=…MeshcoreDynamicDarkThemeCatalog` |
|---|---|
| ``&lt;img src="https://preview.coo.ee/meshcore-mobile/render/theme-meshcore-light__ideal__default__light__compact.png" width="360" /&gt;`` | ``&lt;img src="```https://preview.coo.ee/meshcore-mobile/render/theme-meshcore-light__ideal__default__light__compact.png?themeProvider=ee.schimke.meshcore.app.ui.theme.MeshcoreDynamicDarkThemeCatalog"``` width="360" /&gt;`` |

The right-hand card still reads *"Light · Orbitron / Space Grotesk / JetBrains Mono"* while drawing dark, in the default sans, with M3 dynamic pastels in place of the MeshCore greens — a specimen whose pixels contradict its own label, brand typeface included.

That exact card is already protected on `preview.coo.ee`, because meshcore-mobile authors it in a `Themes` section. This PR is what protects the identical card in a catalog that doesn't.

## The path

| stage | what carries it |
|---|---|
| author | `@FixedTheme` on the `@Preview` function (`api/preview-annotations`) |
| discovery | FQN match, like `@ScrollingPreview` / `@FocusedPreview` → `PreviewInfo.fixedTheme` |
| wire | `previews.json` + the `:preview-data-api` mirror (without it `ignoreUnknownKeys` drops the flag for `show --json` / MCP readers) |
| catalog | `catalog-preview-declarations.mjs` lifts it onto the catalog image, so the browse surface knows **before** any daemon is opened |
| serve | `Image.fixedTheme` → `VariantMeta` → `ServePreview.fixedTheme` → `ServeWeb.isThemeSpecimen` |

`ServeWeb` ORs it with the section check — either signal is enough — and the chip gate reuses the same predicate as the per-card URL, so a catalog of only specimens still offers no dead control (the guard #3369's review added).

Two smaller decisions worth flagging:

- **`@ThemeCatalog` / `@WearThemeCatalog` sheets are fixed by construction.** A `themecatalog__<name>` sheet's subject is one named theme — that is what the annotation declares. Requiring consumers to add `@FixedTheme` to it as well would be asking them to restate what they already said.
- **`mergeDeclaredKnobs` ORs rather than overwrites.** The baked side may already know a card is a specimen from its catalog metadata; a daemon twin built from an older bundle (no `fixedTheme` in its `previews.json`) must not be able to clear that.

It suppresses only the **theme** override. State, locale, font scale and device controls are untouched.

## Test plan

- `ServeWebThemeSpecimenTest` — four new cases: a `fixedTheme` preview with no section at all; one in a `Foundation` section (annotation wins over the wrong section); neighbours still re-render; an all-specimen catalog offers no chips.
- `ServeCatalogStoreTest` — a catalog image carrying **only** `fixedTheme` still produces a variants-manifest entry and reaches the browse surface. Without this it would arrive with no metadata at all, since a specimen declares no knobs and detects no features.
- `DiscoveryFunctionalTest` — `@FixedTheme` on a function lands in `previews.json`, its unannotated neighbour stays `false`; and the existing `@ThemeCatalog` test now asserts both synthesised sheets are theme-fixed.
- `CatalogEntryWireTest` — the flag survives the wire and defaults off.
- `catalog-preview-declarations.test.mjs` — `fixedTheme` alone produces a declaration entry; an ordinary preview stays without it.

`:cli:test`, `:gradle-plugin:test`, `:gradle-plugin:functionalTest --tests '*DiscoveryFunctionalTest*'` (38/38), `:preview-data-api:test` and `node --test scripts/design-artifacts/*.test.mjs` all green. The two `.mjs` failures in that last run (`package-version`, `rc-compare-pixels`) reproduce on `main` and are unrelated to this diff.

## Context

Fourth and last item from the meshcore-mobile render-error investigation. The three render failures — `android/os/Parcelable` (#3351), `MeshcoreFonts_androidKt` (#3356), `TopAppBar-gNPyAyM` (#3378) — are released in 0.19.39 and `preview.coo.ee` is serving it with `renderStats.failed: 0`. This one is the cosmetic half, and it is the "explicit per-preview opt-out … deliberately a separate change" that #3369's body promised.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ff3PLh8x3QXsN1mMLn2vG)_