### PR TITLE
fix(serve): re-enter the theme prefetch, and give Busy a ceiling

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -82,6 +82,9 @@ class CatalogThemeCache(
   // successful [put], so a key only stays latched while it keeps failing.
   private val failureCounts = ConcurrentHashMap<String, Int>()
   private val failureReasons = ConcurrentHashMap<String, String>()
+  // Consecutive background `Busy` outcomes per key. Separate from [failureCounts] because the two
+  // have very different tolerances — see [BUSY_LATCH]. Cleared by a successful [put] like the rest.
+  private val busyCounts = ConcurrentHashMap<String, Int>()
   private val byteCount = AtomicLong(0)
   private val evictionCount = AtomicLong(0)
   private val state = AtomicReference("waiting")
@@ -161,6 +164,7 @@ class CatalogThemeCache(
     failedKeys.remove(key)
     failureCounts.remove(key)
     failureReasons.remove(key)
+    busyCounts.remove(key)
     refreshCompletion()
   }
 
@@ -205,6 +209,31 @@ class CatalogThemeCache(
     val count = failureCounts.merge(key, 1, Int::plus) ?: 1
     if (count < FAILURE_LATCH) return false
     failedKeys += key
+    return true
+  }
+
+  /**
+   * Record one **background** `Busy` outcome for [key] and report whether it has now latched
+   * ([BUSY_LATCH] consecutive).
+   *
+   * `Busy` is "ask again", and for a warming daemon that is exactly right — which is why the
+   * optimizer deliberately left it unmarked. But "ask again" with no ceiling is indistinguishable
+   * from "never", and the optimizer has no other way to notice: it does not re-enter a finished
+   * pass, so a key that answers `Busy` on the one pass it gets is simply abandoned, uncounted.
+   *
+   * Latching supplies the missing terminal state. Once latched the key gets a [reason], so
+   * [failureReason] answers the request lane immediately instead of sending the browser back into a
+   * `retry-after` loop it can never win, `markPassFinished` reports `degraded` rather than a
+   * `paused` that looks like ordinary throttling, and `/status` shows a non-zero `failed` naming
+   * how many previews are stuck. A successful [put] clears the count, so a genuinely contended key
+   * that eventually renders is never penalised.
+   */
+  fun recordBackgroundBusy(key: String): Boolean {
+    val count = busyCounts.merge(key, 1, Int::plus) ?: 1
+    if (count < BUSY_LATCH) return false
+    failedKeys += key
+    failureReasons[key] =
+      "no live lane produced this theme render after $count attempts (daemon busy or absent)"
     return true
   }
 
@@ -296,5 +325,25 @@ class CatalogThemeCache(
      * Consecutive on-demand render failures before a key is treated as permanently unrenderable.
      */
     const val FAILURE_LATCH = 3
+
+    /**
+     * Consecutive `Busy` outcomes on the BACKGROUND lane before a key is treated as one the
+     * optimizer cannot fill.
+     *
+     * Deliberately far looser than [FAILURE_LATCH]: `Busy` really does mean "ask again" for a
+     * warming daemon, and a key that is merely contended must survive a long run of them. What it
+     * must not have is *no* ceiling. Without one the pass can never converge — `markPassFinished`
+     * only reports `complete` when every target is cached, and a key that answers `Busy` forever is
+     * neither cached nor failed, so the catalog sits at `paused` with `failed: 0` and nothing ever
+     * says which previews are stuck.
+     *
+     * Observed on meshcore-mobile: 84 of 372 targets (21 previews x 4 declared themes) pinned at
+     * `paused 288/372, failed: 0` across two server lifetimes, while all fourteen other catalogs on
+     * the same box reached `complete`. On the request lane those same previews answered `503 render
+     * busy; retry shortly` on 39 of 39 attempts spread over several minutes — a `retry-after` the
+     * server could never honour, which the grid's three retries then burned before showing "Theme
+     * preview unavailable".
+     */
+    const val BUSY_LATCH = 12
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -320,13 +320,33 @@ class ServeCatalogLiveHost(
    * A visitor is on this catalog's pages: make sure the shared daemon is up, so their first theme
    * selection is a warm render rather than a cold start.
    *
-   * This is [prewarm]'s warming half without the theme-optimization pass — the same [scheduleWarm]
-   * call, under the same conditions. It is safe to call on every heartbeat because `scheduleWarm`
-   * returns immediately once the id is warm or a warm is already in flight; a suspended session is
-   * rebuilt with a fresh host (and so a fresh warm set) on resume, which is exactly when a
-   * heartbeat should warm it again.
+   * This is [prewarm]'s warming half — the same [scheduleWarm] call, under the same conditions. It
+   * is safe to call on every heartbeat because `scheduleWarm` returns immediately once the id is
+   * warm or a warm is already in flight; a suspended session is rebuilt with a fresh host (and so a
+   * fresh warm set) on resume, which is exactly when a heartbeat should warm it again.
+   *
+   * It also **re-enters the theme-optimization pass**. That pass used to run exactly once, from
+   * [prewarm] at catalog open, and `startThemeOptimization` clears `optimizationStarted` in its
+   * `finally` — so a pass that ended with targets still unfilled left them unfilled for the life of
+   * the catalog generation, with nothing to start another. Anything the one pass could not get on
+   * its single attempt (a daemon still warming, a replica the seat budget could not afford, a
+   * preview whose live lane was momentarily contended) was simply abandoned.
+   *
+   * meshcore-mobile sat at `paused 288/372, failed: 0` across two server lifetimes because of it,
+   * stopping at the same 288 both times while the other fourteen catalogs on the box reached
+   * `complete`. `failed: 0` is what makes this hard to see: the missing 84 were never *attempted*
+   * again, so nothing was ever recorded against them.
+   *
+   * Re-entering here is safe and self-limiting: `startThemeOptimization` returns immediately when
+   * the cache is already `fullyOptimized` or a pass is in flight (`optimizationStarted` is a CAS),
+   * and the pass's own [awaitOptimizerTurn] still holds the idle gate — so a heartbeat arriving
+   * while a visitor is browsing schedules work that waits for quiet rather than competing with
+   * them.
    */
   override fun keepLiveWarm() {
+    // Ahead of the `warmInBackground` guard, exactly as in [prewarm]: the two are independent
+    // switches, and a box that has disabled background warming still wants its prefetch to finish.
+    startThemeOptimization()
     if (!warmInBackground) return
     if (perPreviewResolve != null && !sharedDaemonRenders) return
     alias.values.firstOrNull()?.let { scheduleWarm(it, live) }
@@ -454,9 +474,13 @@ class ServeCatalogLiveHost(
               // Busy is "ask again", not a failure: the warm above may still be settling. Leave it
               // unmarked so a later pass retries instead of spending the `failed` count on it.
               when (outcome) {
-                // "ask again" — the warm above may still be settling. Left unmarked so a later
-                // pass retries rather than spending the catalog's `failed` count on it.
-                RenderOutcome.Busy -> Unit
+                // "ask again" — the warm above may still be settling, so a later pass retries
+                // rather than spending the catalog's `failed` count on it. Counted, though: "ask
+                // again" with no ceiling is indistinguishable from "never", and this is the only
+                // lane that can tell them apart. After `BUSY_LATCH` consecutive passes the key
+                // latches with a reason, so /status names it instead of reporting `failed: 0`
+                // beside a `remaining` that never moves. A successful render clears the count.
+                RenderOutcome.Busy -> catalogThemeCache.recordBackgroundBusy(job.cacheKey)
                 // Count the failure but do NOT latch on the first one. `failureReason` treats a
                 // latched key as terminal and answers foreground requests with a 409, so a single
                 // flaky background render — a cold-start timeout, a daemon restart — would

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
@@ -3,7 +3,9 @@ package ee.schimke.composeai.cli.serve
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class CatalogThemeCacheTest {
   @Test
@@ -84,6 +86,65 @@ class CatalogThemeCacheTest {
     cache.markFailed("really-broken", "NotFoundException: ic_play.xml")
     assertEquals("NotFoundException: ic_play.xml", cache.failureReason("really-broken"))
     assertNull(cache.failureReason("never-seen"))
+  }
+
+  /**
+   * `Busy` means "ask again", and for a warming daemon that is right — but with no ceiling it is
+   * indistinguishable from "never". meshcore-mobile sat at `paused 288/372, failed: 0` across two
+   * server lifetimes on exactly that: 84 targets that answered `Busy`, were left unmarked, and so
+   * were never counted, never reported, and never given up on.
+   */
+  @Test
+  fun `a long run of background Busy latches with a readable reason`() {
+    val cache = CatalogThemeCache()
+
+    repeat(CatalogThemeCache.BUSY_LATCH - 1) {
+      assertEquals(false, cache.recordBackgroundBusy("k"), "a contended key must survive a run")
+      assertNull(cache.failureReason("k"))
+    }
+
+    assertEquals(true, cache.recordBackgroundBusy("k"))
+    val reason = cache.failureReason("k")
+    assertNotNull(reason, "a latched key must answer the request lane terminally")
+    assertTrue(reason.contains("busy or absent"), "the reason names the condition: $reason")
+  }
+
+  @Test
+  fun `Busy tolerance is far looser than the render-failure latch`() {
+    // Otherwise a daemon that is merely slow to warm would be reported as permanently broken.
+    assertTrue(CatalogThemeCache.BUSY_LATCH > CatalogThemeCache.FAILURE_LATCH)
+    val cache = CatalogThemeCache()
+    repeat(CatalogThemeCache.FAILURE_LATCH) { cache.recordBackgroundBusy("k") }
+    assertNull(cache.failureReason("k"), "a Busy run as long as FAILURE_LATCH is not yet terminal")
+  }
+
+  @Test
+  fun `a successful render clears the Busy run`() {
+    val cache = CatalogThemeCache()
+    repeat(CatalogThemeCache.BUSY_LATCH) { cache.recordBackgroundBusy("k") }
+    assertNotNull(cache.failureReason("k"))
+
+    cache.put("k", byteArrayOf(1, 2, 3))
+
+    assertNull(cache.failureReason("k"), "a key that eventually rendered is never penalised")
+    assertEquals(false, cache.recordBackgroundBusy("k"), "and the run restarts from zero")
+  }
+
+  @Test
+  fun `a latched Busy key is reported in the failed count and ends the pass degraded`() {
+    // The point of latching: /status names the stuck previews instead of showing `failed: 0`
+    // beside a `remaining` that never moves, and the state stops reading like ordinary throttling.
+    val cache = CatalogThemeCache()
+    cache.configureTargets(listOf("stuck", "fine"))
+    cache.put("fine", byteArrayOf(1))
+    repeat(CatalogThemeCache.BUSY_LATCH) { cache.recordBackgroundBusy("stuck") }
+
+    cache.markPassFinished(1_000)
+
+    val snapshot = cache.snapshot()
+    assertEquals(1, snapshot.failed)
+    assertEquals(1, snapshot.remaining)
+    assertEquals("degraded", snapshot.state)
   }
 
   /** A reason recorded before the latch closes must not make the key terminal on its own. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -1097,6 +1098,100 @@ class ServeCatalogLiveHostTest {
     hosts.forEach { assertTrue(awaitOptimization(it).fullyOptimized) }
 
     assertEquals(1, peak.get(), "the background lane holds at most one render server-wide")
+  }
+
+  /**
+   * The optimization pass used to run exactly once, from `prewarm` at catalog open. Anything it
+   * could not fill on that single attempt stayed unfilled for the life of the catalog generation —
+   * `startThemeOptimization` clears `optimizationStarted` in its `finally`, but nothing ever called
+   * it again.
+   *
+   * meshcore-mobile sat at `paused 288/372, failed: 0` across two server lifetimes because of it,
+   * stopping at the same 288 both times while the other fourteen catalogs on the box reached
+   * `complete`. The presence heartbeat is the natural re-entry point: it already fires while a
+   * visitor is on the catalog's pages, and the pass holds its own idle gate, so the work it
+   * schedules waits for quiet rather than competing with them.
+   */
+  @Test
+  fun `a presence heartbeat re-enters an optimization pass that ended unfinished`() {
+    val delegate =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    // The plain warm succeeds and only the THEMED render is Busy — the shape observed on the live
+    // server, where these previews' baked pixels and daemon warm were both fine.
+    val busyOnThemes =
+      object : ServeHost by delegate {
+        override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+          if (overrides.themeProvider != null) RenderOutcome.Busy
+          else delegate.render(previewId, overrides)
+      }
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = busyOnThemes,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
+        themeOptimizationIdleMillis = 0,
+      )
+
+    composite.prewarm()
+    awaitPassIdle(composite)
+    // The pass finished without filling its one target, and said nothing about why.
+    assertEquals(1, composite.themeOptimizationSnapshot()?.remaining)
+    assertEquals(0, composite.themeOptimizationSnapshot()?.failed)
+
+    // Heartbeats re-enter it. Each pass records one Busy against the key; at BUSY_LATCH it latches.
+    repeat(CatalogThemeCache.BUSY_LATCH + 2) {
+      composite.keepLiveWarm()
+      awaitPassIdle(composite)
+    }
+
+    val snapshot = composite.themeOptimizationSnapshot()
+    assertEquals(1, snapshot?.failed, "the stuck target is now counted, not silently abandoned")
+    assertEquals("degraded", snapshot?.state, "and no longer reads as ordinary throttling")
+    // ...and the request lane can answer terminally (409) instead of a retry-after it can't honour.
+    assertNotNull(composite.renderFailureLatch(catalogId, themeOverride()))
+  }
+
+  @Test
+  fun `a heartbeat does not restart a pass that already filled everything`() {
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
+        themeOptimizationIdleMillis = 0,
+      )
+
+    composite.prewarm()
+    assertTrue(awaitOptimization(composite).fullyOptimized)
+    val rendersAfterPass = live.renderCalls
+
+    repeat(5) { composite.keepLiveWarm() }
+    Thread.sleep(100)
+
+    assertEquals(rendersAfterPass, live.renderCalls, "a complete cache is not re-rendered")
+  }
+
+  /** Wait for the background pass to go quiet, finished or not (unlike [awaitOptimization]). */
+  private fun awaitPassIdle(host: ServeCatalogLiveHost) {
+    repeat(200) {
+      if (!host.backgroundWorkActive) return
+      Thread.sleep(25)
+    }
+    error("theme optimization pass did not settle: ${host.themeOptimizationSnapshot()}")
   }
 
   private fun awaitOptimization(host: ServeCatalogLiveHost): ThemeOptimizationSnapshot {


### PR DESCRIPTION
## Summary

The theme-optimization pass ran **exactly once**, from `prewarm` at catalog open. `startThemeOptimization` clears `optimizationStarted` in its `finally`, but nothing ever called it again — so whatever the single pass could not fill stayed unfilled for the life of the catalog generation.

This is the last of the four meshcore-mobile render defects, and the one behind the user-reported *"Theme preview unavailable"*.

## The evidence

Read off `preview.coo.ee` running 0.19.39:

```
meshcore-mobile   paused   288/372  rem=84  failed=0     <-- stuck
wear-m3           complete 172/172              jetnews    complete  178/178
jetcaster         complete 642/642              jetchat    complete  440/440
jetsnack          complete 306/306              reply      complete  354/354
confetti-mobile   complete 476/476              pocketcasts complete 1267/1267
...14 of 15 catalogs reach `complete`
```

meshcore-mobile stopped at **the same 288 across two server lifetimes** while every other catalog on the same box finished — pocketcasts does 1267/1267. That is not contention. The missing 84 are **21 previews × 4 declared themes**.

On the request lane those previews answer `503 render busy; retry shortly` — **39 of 39 attempts**, in ~0.5s each, spread over several minutes:

```
chat-channel__…__dark__compact       503/0.73  503/0.47  503/0.50
chat-commands__…__light__compact     503/0.48  503/0.54  503/0.50
device-populated__…__dark__compact   503/0.50  503/0.76  503/0.49
settings-ready__…__light__compact    503/0.60  503/0.49  503/0.49
…6 components, 13 probed ids, 3 passes each
```

A `retry-after: 2` the server can never honour. The grid burns its three `themeRenderRetries` on it and then shows "Theme preview unavailable" — the exact symptom reported.

`failed: 0` is what made this hard to see: the 84 were never *attempted* again, so nothing was ever recorded against them.

## Fix

**1. The presence heartbeat re-enters the pass.** `keepLiveWarm` already fires while a visitor is on the catalog's pages, and the pass holds its own idle gate (`awaitOptimizerTurn`), so the work it schedules waits for quiet rather than competing with them. `startThemeOptimization` is already a CAS and already returns early when the cache is `fullyOptimized`, so re-entry is self-limiting — a test asserts a complete cache is never re-rendered.

**2. `Busy` gets a ceiling.** It genuinely means "ask again" for a warming daemon, which is why the optimizer deliberately left it unmarked. But *"ask again" with no ceiling is indistinguishable from "never"*, and the background lane is the only thing that can tell them apart. After `BUSY_LATCH` consecutive passes the key latches with a reason, so:

| before | after |
|---|---|
| `failed: 0` beside a `remaining` that never moves | `/status` names how many previews are stuck |
| `paused` — reads like ordinary throttling | `degraded` |
| 503 + `retry-after` forever → "Theme preview unavailable" | 409 → the page's existing terminal branch, "This preview can't render live" |

`BUSY_LATCH` (12) is deliberately far looser than `FAILURE_LATCH` (3) — a slow cold start must survive a long run — and a successful render clears the count, so a merely contended preview is never penalised.

## What this does and doesn't claim

It makes the stall **converge and become visible**. For the 21 previews it does not, on its own, make them render: if their live lane is genuinely absent the answer becomes an honest terminal 409 rather than an infinite retry. Whether those six components (`chat-*`, `device-*`, `settings-ready`, all in the folded-in `Screens` section from `:meshcore-components`) *should* have a live lane is a separate question this PR deliberately doesn't guess at — I could not prove from outside the box whether `renderDaemon` returns `Busy` or `NotFound` for them, and the `fontScale` probe I tried doesn't route to the daemon lane so it couldn't discriminate. Once this ships, `/status` will say which, in the latched reason.

## Test plan

`CatalogThemeCacheTest`:
- a run of `BUSY_LATCH` background Busy latches, with a readable reason
- Busy tolerance is strictly looser than the render-failure latch
- a successful render clears the run and restarts it from zero
- a latched key lands in the `failed` count and ends the pass `degraded`

`ServeCatalogLiveHostTest`:
- a presence heartbeat re-enters a pass that ended unfinished; after `BUSY_LATCH` heartbeats the target is counted, the state is `degraded`, and `renderFailureLatch` is non-null (so the request lane 409s). Uses a host that succeeds on the plain warm and is Busy only on themed renders — the shape actually observed, where baked pixels and the daemon warm were both fine.
- a heartbeat does **not** restart a pass that already filled everything

Full `:cli:test` green.

Text-only PR: this changes prefetch scheduling and failure reporting, not rendered pixels.

## Context — the meshcore-mobile chain

| layer | symptom | released |
|---|---|---|
| 1 | `android/os/Parcelable` | #3351 / 0.19.37 ✅ verified |
| 2 | `MeshcoreFonts_androidKt` | #3356 / 0.19.38 ✅ verified by bytecode |
| 3 | `NoSuchMethodError TopAppBar-gNPyAyM` | #3378 / 0.19.39 ✅ verified live (705 renders, 0 failed) |
| — | Themes specimens re-themed | #3369 / 0.19.39 ✅ verified live |
| 4 | prefetch stalls, 503 loop | **this PR** |

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ff3PLh8x3QXsN1mMLn2vG)_