### PR TITLE
feat(serve): split optimizer wait time into gate wait and permit wait

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -29,12 +29,27 @@ data class ThemeOptimizationSnapshot(
   val entriesPerMinute: Double? = null,
   val etaSeconds: Long? = null,
   /**
-   * Where the pass's wall-clock actually goes: inside renders vs. waiting for its turn at the idle
-   * gate. This is the split that says whether throughput is render-bound (nothing to fix without a
-   * faster renderer) or gate-bound (a scheduling problem), which `cached` alone cannot distinguish.
+   * Where the pass's wall-clock actually goes: inside renders vs. waiting. This is the split that
+   * says whether throughput is render-bound (nothing to fix without a faster renderer) or
+   * wait-bound (a scheduling problem), which `cached` alone cannot distinguish.
    */
   val renderMillis: Long = 0,
+  /** [gateWaitMillis] + [permitWaitMillis], kept as the single "not rendering" total. */
   val waitingMillis: Long = 0,
+  /**
+   * The two waits, separated — because they have opposite fixes and the sum cannot tell them apart.
+   *
+   * [gateWaitMillis] is time the idle gate withheld a turn: the box looked busy, so the pass is
+   * being deliberately polite and the lever is the quiet window. [permitWaitMillis] is time the
+   * pass HAD its turn and queued behind other catalogs for a server-wide render permit: the box was
+   * idle and the pass was merely outnumbered, and the lever is how many catalogs prefetch at once.
+   *
+   * Reading only the total, a deployment where every catalog optimizes simultaneously and starves
+   * on permits is indistinguishable from one where a trickle of traffic keeps the gate shut — and
+   * loosening the quiet window, the obvious response to the latter, does nothing for the former.
+   */
+  val gateWaitMillis: Long = 0,
+  val permitWaitMillis: Long = 0,
   /** How often the idle gate granted the pass its turn, and how often traffic took it back. */
   val turnsGranted: Int = 0,
   val turnsYielded: Int = 0,
@@ -91,7 +106,8 @@ class CatalogThemeCache(
   private val startedAt = AtomicLong(0)
   private val completedAt = AtomicLong(0)
   private val renderMillis = AtomicLong(0)
-  private val waitingMillis = AtomicLong(0)
+  private val gateWaitMillis = AtomicLong(0)
+  private val permitWaitMillis = AtomicLong(0)
   private val turnsGranted = java.util.concurrent.atomic.AtomicInteger(0)
   private val turnsYielded = java.util.concurrent.atomic.AtomicInteger(0)
   private val lastBatchWidth = java.util.concurrent.atomic.AtomicInteger(0)
@@ -111,10 +127,17 @@ class CatalogThemeCache(
     turnsYielded.incrementAndGet()
   }
 
-  /** Wall-clock spent waiting at the idle gate rather than rendering. */
-  fun recordWaiting(millis: Long) {
-    if (millis > 0) waitingMillis.addAndGet(millis)
+  /** Wall-clock the idle gate withheld a turn because the box looked busy. */
+  fun recordGateWait(millis: Long) {
+    if (millis > 0) gateWaitMillis.addAndGet(millis)
   }
+
+  /** Wall-clock spent holding a turn but queued behind other catalogs for a render permit. */
+  fun recordPermitWait(millis: Long) {
+    if (millis > 0) permitWaitMillis.addAndGet(millis)
+  }
+
+  private fun waitingMillis(): Long = gateWaitMillis.get() + permitWaitMillis.get()
 
   /** One batch completed: how wide it actually ran, and how long its renders took. */
   fun recordBatch(width: Int, millis: Long) {
@@ -285,7 +308,9 @@ class CatalogThemeCache(
           ?.takeIf { it > 0 }
           ?.let { ((total - cachedTargets).coerceAtLeast(0) / it * 60).toLong() },
       renderMillis = renderMillis.get(),
-      waitingMillis = waitingMillis.get(),
+      waitingMillis = waitingMillis(),
+      gateWaitMillis = gateWaitMillis.get(),
+      permitWaitMillis = permitWaitMillis.get(),
       turnsGranted = turnsGranted.get(),
       turnsYielded = turnsYielded.get(),
       lastBatchWidth = lastBatchWidth.get(),
@@ -305,7 +330,7 @@ class CatalogThemeCache(
 
   private fun ratePerMinute(): Double? {
     val produced = optimizerProduced.get()
-    val activeMillis = renderMillis.get() + waitingMillis.get()
+    val activeMillis = renderMillis.get() + waitingMillis()
     if (produced <= 0 || activeMillis <= 0) return null
     return produced / (activeMillis / 60_000.0)
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -137,8 +137,6 @@ class CatalogThemeCache(
     if (millis > 0) permitWaitMillis.addAndGet(millis)
   }
 
-  private fun waitingMillis(): Long = gateWaitMillis.get() + permitWaitMillis.get()
-
   /** One batch completed: how wide it actually ran, and how long its renders took. */
   fun recordBatch(width: Int, millis: Long) {
     lastBatchWidth.set(width)
@@ -285,6 +283,16 @@ class CatalogThemeCache(
     val cachedTargets = synchronized(renderLock) { targetKeys.count(renders::containsKey) }
     val total = targetKeys.size
     val complete = total > 0 && cachedTargets == total
+    // Read each counter ONCE and derive everything from those values. Reading them per-field lets a
+    // wait that finishes mid-snapshot land in one field and not another, publishing a row where
+    // `waitingMillis < gateWaitMillis + permitWaitMillis` — a self-contradicting diagnostic is
+    // worse
+    // than a slightly stale one.
+    val render = renderMillis.get()
+    val gateWait = gateWaitMillis.get()
+    val permitWait = permitWaitMillis.get()
+    val waiting = gateWait + permitWait
+    val rate = ratePerMinute(render + waiting)
     return ThemeOptimizationSnapshot(
       state =
         if (complete) "complete" else state.get().let { if (it == "complete") "paused" else it },
@@ -302,15 +310,15 @@ class CatalogThemeCache(
       // Rate over the pass's ACTIVE time (render + gate wait), not wall-clock since it started:
       // wall-clock includes stretches where the pass held no turn at all, which drags the figure
       // toward zero and hides whether it is keeping up while it runs.
-      entriesPerMinute = ratePerMinute(),
+      entriesPerMinute = rate,
       etaSeconds =
-        ratePerMinute()
+        rate
           ?.takeIf { it > 0 }
           ?.let { ((total - cachedTargets).coerceAtLeast(0) / it * 60).toLong() },
-      renderMillis = renderMillis.get(),
-      waitingMillis = waitingMillis(),
-      gateWaitMillis = gateWaitMillis.get(),
-      permitWaitMillis = permitWaitMillis.get(),
+      renderMillis = render,
+      waitingMillis = waiting,
+      gateWaitMillis = gateWait,
+      permitWaitMillis = permitWait,
       turnsGranted = turnsGranted.get(),
       turnsYielded = turnsYielded.get(),
       lastBatchWidth = lastBatchWidth.get(),
@@ -328,9 +336,9 @@ class CatalogThemeCache(
       )
     }
 
-  private fun ratePerMinute(): Double? {
+  /** [activeMillis] is passed in so the rate divides by the same numbers the snapshot publishes. */
+  private fun ratePerMinute(activeMillis: Long): Double? {
     val produced = optimizerProduced.get()
-    val activeMillis = renderMillis.get() + waitingMillis()
     if (produced <= 0 || activeMillis <= 0) return null
     return produced / (activeMillis / 60_000.0)
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -447,11 +447,13 @@ class ServeCatalogLiveHost(
             // Time the RENDER inside the permit. Starting the clock before `withRenderPermit`
             // charged the server-wide queue to renderMillis, which would make a permit-bound
             // deployment read as render-bound — defeating the one diagnostic this exists for.
+            // The queue time is its own bucket: this pass HAS its turn and is merely outnumbered by
+            // other catalogs, which is a different problem from the gate withholding the turn.
             val permitWaitFrom = clock()
             val outcomes =
               backgroundWork.withRenderPermit {
                 val renderFrom = clock()
-                catalogThemeCache.recordWaiting(renderFrom - permitWaitFrom)
+                catalogThemeCache.recordPermitWait(renderFrom - permitWaitFrom)
                 renderOptimizerBatch(batch).also {
                   // Width from the batch actually issued, not the requested ceiling — a batch that
                   // collapses to 1 (single-daemon lane, or a seat budget with no replicas to spare)
@@ -563,7 +565,7 @@ class ServeCatalogLiveHost(
     if (!optimizerHasTurn.get()) {
       val waitedFrom = clock()
       val granted = awaitServerIdle()
-      catalogThemeCache.recordWaiting(clock() - waitedFrom)
+      catalogThemeCache.recordGateWait(clock() - waitedFrom)
       if (!granted) return false
       catalogThemeCache.recordTurnGranted()
       optimizerHasTurn.set(true)
@@ -596,7 +598,7 @@ class ServeCatalogLiveHost(
     // per interruption is what capped throughput: at a ~50% yield rate a 60s re-entry averages
     // ~30s/entry against a sub-second render, i.e. ~97% waiting.
     return awaitQuiet(OPTIMIZER_RESUME_MILLIS).also {
-      catalogThemeCache.recordWaiting(clock() - resumeFrom)
+      catalogThemeCache.recordGateWait(clock() - resumeFrom)
       if (it) {
         // A resume IS a grant. Counting only cold entries made yields exceed grants after any
         // interrupted pass, which reads as the gate losing turns it never handed out.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
@@ -167,7 +167,8 @@ class CatalogThemeCacheTest {
     cache.configureTargets((1..10).map { "k$it" })
 
     cache.recordTurnGranted()
-    cache.recordWaiting(30_000) // half the active time spent waiting for a turn
+    cache.recordGateWait(20_000) // the gate withheld the turn
+    cache.recordPermitWait(10_000) // then it queued behind other catalogs for a permit
     cache.recordBatch(width = 5, millis = 30_000)
     cache.recordProduced(5)
     cache.recordTurnYielded()
@@ -178,14 +179,49 @@ class CatalogThemeCacheTest {
     // 5 entries over 60s of ACTIVE time = 5/min; 5 remaining at that rate = 60s.
     assertEquals(5.0, s.entriesPerMinute)
     assertEquals(60L, s.etaSeconds)
-    // The split is the diagnostic: half the time rendering, half waiting at the gate.
+    // The split is the diagnostic: half the time rendering, half waiting — and the waiting half is
+    // itself split, because "the gate withheld my turn" and "I had my turn and lost the permit
+    // race" have opposite fixes and are indistinguishable in the total.
     assertEquals(30_000L, s.renderMillis)
     assertEquals(30_000L, s.waitingMillis)
+    assertEquals(20_000L, s.gateWaitMillis)
+    assertEquals(10_000L, s.permitWaitMillis)
     assertEquals(1, s.turnsGranted)
     assertEquals(1, s.turnsYielded)
     // Width is what actually ran, so a batch collapsing to 1 is visible rather than assumed.
     assertEquals(5, s.lastBatchWidth)
     assertEquals(5, s.maxBatchWidth)
+  }
+
+  /**
+   * Measured on the deployed box: 14 catalogs all optimizing at once, every one reporting waiting
+   * at 3–6× its render time. The total said "not render-bound" and stopped there — it could not say
+   * whether the gate was withholding turns (loosen the quiet window) or the catalogs were starving
+   * each other for render permits (prefetch fewer at once). Those two shapes must read differently.
+   */
+  @Test
+  fun `a permit-starved pass and a gate-starved pass are distinguishable`() {
+    fun snapshotOf(gate: Long, permit: Long) =
+      CatalogThemeCache()
+        .apply {
+          configureTargets(listOf("a"))
+          recordGateWait(gate)
+          recordPermitWait(permit)
+          recordBatch(width = 1, millis = 10_000)
+        }
+        .snapshot()
+
+    val gateStarved = snapshotOf(gate = 90_000, permit = 0)
+    val permitStarved = snapshotOf(gate = 0, permit = 90_000)
+
+    // Identical on the old instrumentation …
+    assertEquals(gateStarved.waitingMillis, permitStarved.waitingMillis)
+    assertEquals(gateStarved.renderMillis, permitStarved.renderMillis)
+    // … and opposite on the new.
+    assertEquals(90_000L, gateStarved.gateWaitMillis)
+    assertEquals(0L, gateStarved.permitWaitMillis)
+    assertEquals(0L, permitStarved.gateWaitMillis)
+    assertEquals(90_000L, permitStarved.permitWaitMillis)
   }
 
   @Test
@@ -207,7 +243,7 @@ class CatalogThemeCacheTest {
   fun `foreground-filled entries do not inflate the prefetch rate`() {
     val cache = CatalogThemeCache()
     cache.configureTargets((1..10).map { "k$it" })
-    cache.recordWaiting(60_000)
+    cache.recordGateWait(60_000)
 
     // Five entries arrive from foreground requests; the optimizer produced none of them.
     repeat(5) { cache.put("k${it + 1}", byteArrayOf(1)) }


### PR DESCRIPTION
The stats from #3373 are now readable on the deployed box (0.19.40), and they answer the render-bound-vs-not question immediately — then stop one step short of being actionable.

## What the live numbers say

All 14 running catalogs, sampled from `/status.json`:

| catalog | entries/min | renderMillis | waitingMillis | turns G/Y | batch width |
|---|---|---|---|---|---|
| confetti-mobile | 6.19 | 201198 | 525668 | 4/3 | 5 |
| confetti-wear | 4.92 | 134151 | 597192 | 4/3 | 5 |
| pocketcasts | 4.06 | 121820 | 573559 | 3/2 | 5 |
| wear-m3 | 3.86 | 103746 | 642704 | 3/2 | 4 |
| jetchat | 3.54 | 157973 | 587955 | 4/3 | 4 |
| jetcaster | 3.28 | 123656 | 626872 | 4/3 | 5 |
| meshcore-mobile | 3.14 | 125964 | 637825 | 4/3 | 4 |
| horologist | 3.04 | 107377 | 604125 | 3/2 | 3 |
| reply | 2.98 | 169380 | 534632 | 3/2 | 5 |
| jetnews | 1.95 | 118367 | 618978 | 3/2 | 2 |
| jetsnack | 1.66 | 108255 | 613209 | 3/2 | 2 |
| jetlagged | 1.30 | 97788 | 642600 | 3/2 | 2 |
| pocketcasts-wear | 1.02 | 98970 | 606751 | 4/3 | 1 |
| jetcaster-wear | 0.98 | 104217 | 628001 | 3/2 | 1 |

Waiting runs **3–6×** render time everywhere, each catalog has had **3–4 turns** in ~11 minutes, and batching *is* running wide (4–5 against a pool capacity of 5) where the daemon lane allows. The renderer is fine: confetti-mobile produced 75 entries in 201s of render time, ~22/min **while it holds a turn**, against a published 6.19/min.

## Why the total isn't enough

`waitingMillis` cannot say *why* the pass isn't rendering, and the two causes have opposite fixes:

- **Gate wait** — the idle gate withheld the turn. The box looked busy, the pass is being deliberately polite, and the lever is the quiet window.
- **Permit wait** — the pass *had* its turn and queued behind the other catalogs for a server-wide render permit. The box was idle and the pass was merely outnumbered; the lever is how many catalogs prefetch at once.

Fourteen catalogs optimizing simultaneously against `maxConcurrentRenders: 8` looks identical, in the total, to a trickle of traffic holding the gate shut — and loosening the quiet window, the obvious response to the latter, does nothing for the former. Since these all started within ~40s of each other and each has taken only 3–4 turns, permit contention is the likelier story, but the current instrumentation can't establish that.

`waitingMillis` is now the sum of two reported counters, `gateWaitMillis` and `permitWaitMillis`, so the next deploy answers it.

## Test plan

- `./gradlew :cli:test` — green.
- New test `a permit-starved pass and a gate-starved pass are distinguishable`: builds two snapshots with identical `waitingMillis` and `renderMillis`, asserts they are identical on the old fields and opposite on the new — i.e. that the split adds information the total didn't carry.
- Existing stats test updated to record both waits (20s gate + 10s permit) and assert each bucket plus the unchanged 30s total.

Not visual — `/status.json` fields only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_