### PR TITLE
feat(serve): split render time and report real batch concurrency

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -33,7 +33,24 @@ data class ThemeOptimizationSnapshot(
    * says whether throughput is render-bound (nothing to fix without a faster renderer) or
    * wait-bound (a scheduling problem), which `cached` alone cannot distinguish.
    */
+  /** [batchMillis] + [warmMillis], kept as the single "rendering" total. */
   val renderMillis: Long = 0,
+  /**
+   * The render bucket, separated — because a cold start and a steady-state render are not the same
+   * cost and the sum reads as though they were.
+   *
+   * [batchMillis] is time inside theme-render batches: the recurring, per-entry cost, and the only
+   * part that scales with how much is left to do. [warmMillis] is time waiting out a cold daemon,
+   * paid once per daemon per pass but running to **34–68s** on an Android/Robolectric lane — so on
+   * a pass that has had only a handful of turns it can be most of [renderMillis] while producing
+   * nothing.
+   *
+   * Reading only the total, a box whose renders are genuinely slow is indistinguishable from one
+   * that is fast but keeps paying for cold starts — and "the renderer is the bottleneck" is the
+   * wrong conclusion to draw from the second. It was very nearly drawn from this catalog.
+   */
+  val batchMillis: Long = 0,
+  val warmMillis: Long = 0,
   /** [gateWaitMillis] + [permitWaitMillis], kept as the single "not rendering" total. */
   val waitingMillis: Long = 0,
   /**
@@ -54,9 +71,14 @@ data class ThemeOptimizationSnapshot(
   val turnsGranted: Int = 0,
   val turnsYielded: Int = 0,
   /**
-   * Renders actually issued concurrently in the last batch, and the widest so far. Makes "five
-   * wide" an observed fact rather than an assumption — a batch that silently collapses to 1 (a
-   * single-daemon lane, or a seat budget that affords no replicas) is otherwise invisible.
+   * Daemons that actually rendered **concurrently** in the last batch, and the most so far.
+   *
+   * Deliberately not the batch's job count. The optimizer submits N jobs to an executor and the
+   * shared pool hands each one a daemon — but when the live-seat budget affords no replica the pool
+   * does not spawn one, it queues the job onto a host already in circulation. So N jobs can be N
+   * threads taking turns on a single daemon, and a count of jobs submitted reports that as "N
+   * wide". This is the peak concurrent borrow observed inside the batch, which is the number that
+   * distinguishes the two.
    */
   val lastBatchWidth: Int = 0,
   val maxBatchWidth: Int = 0,
@@ -105,7 +127,8 @@ class CatalogThemeCache(
   private val state = AtomicReference("waiting")
   private val startedAt = AtomicLong(0)
   private val completedAt = AtomicLong(0)
-  private val renderMillis = AtomicLong(0)
+  private val batchMillis = AtomicLong(0)
+  private val warmMillis = AtomicLong(0)
   private val gateWaitMillis = AtomicLong(0)
   private val permitWaitMillis = AtomicLong(0)
   private val turnsGranted = java.util.concurrent.atomic.AtomicInteger(0)
@@ -137,11 +160,14 @@ class CatalogThemeCache(
     if (millis > 0) permitWaitMillis.addAndGet(millis)
   }
 
-  /** One batch completed: how wide it actually ran, and how long its renders took. */
+  /**
+   * One batch completed. [width] is the peak number of daemons that rendered **concurrently**, not
+   * the job count — see [ThemeOptimizationSnapshot.lastBatchWidth] for why those differ.
+   */
   fun recordBatch(width: Int, millis: Long) {
     lastBatchWidth.set(width)
     maxBatchWidth.accumulateAndGet(width, ::maxOf)
-    if (millis > 0) renderMillis.addAndGet(millis)
+    if (millis > 0) batchMillis.addAndGet(millis)
   }
 
   /** Entries this batch actually produced — the rate's numerator. */
@@ -150,12 +176,13 @@ class CatalogThemeCache(
   }
 
   /**
-   * A cold daemon warm the optimizer waited out. Real render work and often the most expensive part
-   * of the pass, so it belongs in [renderMillis] — leaving it out of both buckets shrank the rate's
-   * denominator and made a cold catalog report a rate it was nowhere near.
+   * A cold daemon warm the optimizer waited out. Real render work, so it counts toward
+   * [ThemeOptimizationSnapshot.renderMillis] and the rate's denominator — leaving it out of every
+   * bucket made a cold catalog report a rate it was nowhere near. But it is kept apart from
+   * [recordBatch] time because it produces no entries and does not recur per entry.
    */
   fun recordWarm(millis: Long) {
-    if (millis > 0) renderMillis.addAndGet(millis)
+    if (millis > 0) warmMillis.addAndGet(millis)
   }
 
   fun configureTargets(keys: Collection<String>) {
@@ -286,9 +313,10 @@ class CatalogThemeCache(
     // Read each counter ONCE and derive everything from those values. Reading them per-field lets a
     // wait that finishes mid-snapshot land in one field and not another, publishing a row where
     // `waitingMillis < gateWaitMillis + permitWaitMillis` — a self-contradicting diagnostic is
-    // worse
-    // than a slightly stale one.
-    val render = renderMillis.get()
+    // worse than a slightly stale one.
+    val batch = batchMillis.get()
+    val warm = warmMillis.get()
+    val render = batch + warm
     val gateWait = gateWaitMillis.get()
     val permitWait = permitWaitMillis.get()
     val waiting = gateWait + permitWait
@@ -316,6 +344,8 @@ class CatalogThemeCache(
           ?.takeIf { it > 0 }
           ?.let { ((total - cachedTargets).coerceAtLeast(0) / it * 60).toLong() },
       renderMillis = render,
+      batchMillis = batch,
+      warmMillis = warm,
       waitingMillis = waiting,
       gateWaitMillis = gateWait,
       permitWaitMillis = permitWait,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -454,11 +454,18 @@ class ServeCatalogLiveHost(
               backgroundWork.withRenderPermit {
                 val renderFrom = clock()
                 catalogThemeCache.recordPermitWait(renderFrom - permitWaitFrom)
+                // Clear the pool's high-water mark so the peak read below belongs to THIS batch.
+                sharedDaemonPool?.takePeakInFlight()
                 renderOptimizerBatch(batch).also {
-                  // Width from the batch actually issued, not the requested ceiling — a batch that
-                  // collapses to 1 (single-daemon lane, or a seat budget with no replicas to spare)
-                  // is exactly the case that is invisible from `cached` alone.
-                  catalogThemeCache.recordBatch(batch.size, clock() - renderFrom)
+                  // Width is the peak number of daemons that ran CONCURRENTLY, not the job count.
+                  // A batch submits N jobs, but when the seat budget affords no replica the pool
+                  // queues them onto a host already in circulation instead of spawning one — so N
+                  // jobs can be N threads taking turns on one daemon. Counting jobs reported that
+                  // as N-wide, which is exactly the collapse this number exists to expose.
+                  catalogThemeCache.recordBatch(
+                    sharedDaemonPool?.takePeakInFlight() ?: 1,
+                    clock() - renderFrom,
+                  )
                 }
               } ?: return@execute
             // Only a FRESH daemon render is optimizer production. The batch is filtered for cache

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -44,11 +45,33 @@ class ServeSharedDaemonPool(
   // Wall-clock of the last render each replica finished, for [reapIdle]. The primary isn't tracked:
   // it belongs to the catalog host and this pool never closes it.
   private val replicaLastUsed = mutableMapOf<ServeHost, Long>()
+  // Concurrent borrows in flight, and the high-water mark since it was last taken. A borrowed host
+  // is out of `available`, so concurrent borrows IS the number of daemons rendering at once — which
+  // is what a caller means by "how wide did that batch actually run", and is not the same as how
+  // many jobs it submitted. See [takePeakInFlight].
+  private val inFlight = AtomicInteger(0)
+  private val peakInFlight = AtomicInteger(0)
   private var closed = false
 
   init {
     require(capacity >= 1) { "capacity must be >= 1, got $capacity" }
   }
+
+  /**
+   * Peak concurrent borrows since the last call, resetting the high-water mark.
+   *
+   * The measurement a batch needs: it submits N jobs, but when the seat budget affords no replica
+   * the pool queues them onto a host already in circulation rather than spawning one. N jobs can
+   * therefore be N threads taking turns on one daemon — indistinguishable from a genuinely N-wide
+   * batch if you count jobs. Read-and-reset rather than a plain gauge because the caller wants the
+   * peak *within its batch*, and sampling the instantaneous value almost never catches it.
+   *
+   * Pool-wide, not per-caller: a foreground leased render borrowing at the same time counts too. In
+   * the optimizer's case that is rare (it runs on an idle box, by construction) and errs toward
+   * reporting the batch as wider than it was — so a NARROW reading is trustworthy, which is the
+   * direction that matters here.
+   */
+  fun takePeakInFlight(): Int = peakInFlight.getAndSet(inFlight.get())
 
   fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
     permits.acquire()
@@ -58,9 +81,11 @@ class ServeSharedDaemonPool(
         check(!closed) { "shared daemon pool is closed" }
         available.removeFirstOrNull() ?: openSeatedReplica()
       }
+      peakInFlight.accumulateAndGet(inFlight.incrementAndGet(), ::maxOf)
       return borrowed.render(previewId, overrides)
     } finally {
       borrowed?.let { host ->
+        inFlight.decrementAndGet()
         lock.withLock {
           if (!closed) {
             available.addLast(host)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
@@ -169,7 +169,8 @@ class CatalogThemeCacheTest {
     cache.recordTurnGranted()
     cache.recordGateWait(20_000) // the gate withheld the turn
     cache.recordPermitWait(10_000) // then it queued behind other catalogs for a permit
-    cache.recordBatch(width = 5, millis = 30_000)
+    cache.recordBatch(width = 5, millis = 24_000)
+    cache.recordWarm(6_000) // a cold daemon, paid once and producing nothing
     cache.recordProduced(5)
     cache.recordTurnYielded()
     repeat(5) { cache.put("k${it + 1}", byteArrayOf(1)) }
@@ -179,16 +180,18 @@ class CatalogThemeCacheTest {
     // 5 entries over 60s of ACTIVE time = 5/min; 5 remaining at that rate = 60s.
     assertEquals(5.0, s.entriesPerMinute)
     assertEquals(60L, s.etaSeconds)
-    // The split is the diagnostic: half the time rendering, half waiting — and the waiting half is
-    // itself split, because "the gate withheld my turn" and "I had my turn and lost the permit
-    // race" have opposite fixes and are indistinguishable in the total.
+    // The split is the diagnostic: half the time rendering, half waiting — and BOTH halves split
+    // again, because within each pair the two causes have opposite fixes and the sum cannot tell
+    // them apart. Cold-start cost vs per-entry render cost; gate withholding vs permit contention.
     assertEquals(30_000L, s.renderMillis)
+    assertEquals(24_000L, s.batchMillis)
+    assertEquals(6_000L, s.warmMillis)
     assertEquals(30_000L, s.waitingMillis)
     assertEquals(20_000L, s.gateWaitMillis)
     assertEquals(10_000L, s.permitWaitMillis)
     assertEquals(1, s.turnsGranted)
     assertEquals(1, s.turnsYielded)
-    // Width is what actually ran, so a batch collapsing to 1 is visible rather than assumed.
+    // Width is daemons that ran concurrently, so a batch collapsing onto one host is visible.
     assertEquals(5, s.lastBatchWidth)
     assertEquals(5, s.maxBatchWidth)
   }
@@ -222,6 +225,36 @@ class CatalogThemeCacheTest {
     assertEquals(0L, gateStarved.permitWaitMillis)
     assertEquals(0L, permitStarved.gateWaitMillis)
     assertEquals(90_000L, permitStarved.permitWaitMillis)
+  }
+
+  /**
+   * The companion to the wait split. Measured on the deployed box, catalogs reported 88–201s of
+   * `renderMillis` against a known warm p50 of 238–1111ms — which reads as a slow renderer until
+   * you notice a cold Android warm is 34–68s and each pass had only 3–4 turns. Back the warm out
+   * and the per-entry cost is sub-second. "Buy a faster renderer" and "stop paying for cold starts"
+   * are not the same project, and the total cannot tell you which one you have.
+   */
+  @Test
+  fun `a cold-start-dominated pass and a render-dominated pass are distinguishable`() {
+    fun snapshotOf(batch: Long, warm: Long) =
+      CatalogThemeCache()
+        .apply {
+          configureTargets(listOf("a"))
+          recordBatch(width = 5, millis = batch)
+          recordWarm(warm)
+        }
+        .snapshot()
+
+    val coldStarts = snapshotOf(batch = 10_000, warm = 110_000)
+    val slowRenders = snapshotOf(batch = 110_000, warm = 10_000)
+
+    // Identical on the old instrumentation …
+    assertEquals(coldStarts.renderMillis, slowRenders.renderMillis)
+    // … and opposite on the new.
+    assertEquals(110_000L, coldStarts.warmMillis)
+    assertEquals(10_000L, coldStarts.batchMillis)
+    assertEquals(10_000L, slowRenders.warmMillis)
+    assertEquals(110_000L, slowRenders.batchMillis)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -112,6 +112,70 @@ class ServeSharedDaemonPoolTest {
     assertEquals(false, primary.closed, "the composite owns the primary daemon")
   }
 
+  /**
+   * The optimizer reports its batch width from this number, and the whole point is that submitting
+   * five jobs does not mean five daemons ran. When the seat budget affords no replica the pool
+   * queues the jobs onto a host already in circulation — five threads taking turns on one daemon,
+   * which a count of jobs submitted would report as five wide. Reading the deployed box's
+   * `maxBatchWidth: 5` as "batching works" was exactly that mistake.
+   */
+  @Test
+  fun `peak in-flight counts daemons that rendered at once, not jobs submitted`() {
+    // Budget fully spent, so every job must share the primary — see the affordability test below.
+    val seats = LiveSeatLimiter(totalPermits = 1)
+    val held = requireNotNull(seats.acquire(1))
+    val opened = AtomicInteger()
+    val primary = InstantHost("primary")
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 5, liveSeats = seats) {
+        opened.incrementAndGet()
+        InstantHost("replica")
+      }
+    val executor = Executors.newFixedThreadPool(5)
+    try {
+      assertEquals(0, pool.takePeakInFlight(), "nothing borrowed yet")
+
+      (1..5)
+        .map { executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) } }
+        .forEach { assertTrue(it.get(10, TimeUnit.SECONDS) is RenderOutcome.Ok) }
+
+      assertEquals(0, opened.get(), "precondition: the budget afforded no replica")
+      // Five jobs, one daemon. The old job-count reading would have said 5.
+      assertEquals(1, pool.takePeakInFlight(), "five jobs served by one daemon is width 1")
+      assertEquals(0, pool.takePeakInFlight(), "and the mark resets, so the next batch is its own")
+    } finally {
+      executor.shutdownNow()
+      pool.close()
+      held.close()
+    }
+  }
+
+  /** The other direction: when replicas ARE affordable, the peak sees them. */
+  @Test
+  fun `peak in-flight rises with genuinely concurrent renders`() {
+    val entered = CountDownLatch(3)
+    val release = CountDownLatch(1)
+    val primary = BlockingHost("primary", entered, release)
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 3) {
+        BlockingHost("replica", entered, release)
+      }
+    val executor = Executors.newFixedThreadPool(3)
+    try {
+      val results =
+        (1..3).map { executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) } }
+      assertTrue(entered.await(5, TimeUnit.SECONDS), "all three should be rendering at once")
+
+      release.countDown()
+      results.forEach { assertTrue(it.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok) }
+      assertEquals(3, pool.takePeakInFlight(), "three daemons really did render concurrently")
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+      pool.close()
+    }
+  }
+
   /** A trivially-completing host, for the tests that don't need to hold a render open. */
   private class InstantHost(private val name: String) : ServeHost {
     override val previews: List<ServePreview> = emptyList()


### PR DESCRIPTION
Steps D and E of the prefetch-throughput plan — the instrumentation that has to be right *before* the scheduler is touched, because the current numbers can't tell you whether a change helped. Follows #3386 (gate vs permit wait).

Both fixes correct a figure that currently reads as good news when it isn't.

## `renderMillis` → `batchMillis` + `warmMillis`

The deployed box reports **88–201s** of render time per catalog against a known warm p50 of **238–1111ms**. That reads as a slow renderer — until you notice a cold Android/Robolectric warm is **34–68s** and each pass has had only 3–4 turns. Back a ~60s warm out of `wear-m3`'s 103.7s and its 48 entries cost ~44s, i.e. **~0.9s each**, which matches the known p50.

"The renderer is slow" and "we keep paying for cold starts" call for completely different work, and the total presents them identically. `recordWarm` still counts toward `renderMillis` and the rate denominator — it is real elapsed time — but it is now its own bucket, because it produces no entries and doesn't recur per entry.

## `lastBatchWidth`/`maxBatchWidth` → daemons that actually ran at once

`recordBatch(batch.size, …)` counted **jobs submitted**. But `renderOptimizerBatch` submits N futures and the shared pool hands each one a daemon *only if the live-seat budget affords a replica* — otherwise `openSeatedReplica` deliberately doesn't spawn, and waits for a host already in circulation. So N jobs can be N threads taking turns on one daemon, reported as width N.

That's exactly the collapse this number exists to expose, which means the box's `maxBatchWidth: 5` is **not** evidence that batching works — and I cited it as such in #3386's body. `ServeSharedDaemonPool` now tracks peak concurrent borrows (a borrowed host is out of `available`, so concurrent borrows *is* daemons rendering at once), and the batch reads-and-resets it. Read-and-reset rather than a gauge because the caller wants the peak *within its batch*; sampling the instantaneous value almost never catches it.

The peak is pool-wide, so a foreground leased render borrowing concurrently would count too. That errs toward reporting a batch as wider than it was, so a **narrow reading is trustworthy** — which is the direction that matters here.

## Measured context

14 catalogs on the live box (0.19.40): **4,268 entries outstanding**, **41.9/min** aggregate, **~85%** of active time spent waiting, `liveSeatsAvailable: 0 of 8`. At the Android seat weight of 2 that's a hard ceiling of 4 concurrent renders box-wide.

## Test plan

- `./gradlew :cli:test` — green.
- `a cold-start-dominated pass and a render-dominated pass are distinguishable`: two snapshots with identical `renderMillis` (120s) and opposite `warmMillis`/`batchMillis`. Indistinguishable before, opposite after.
- `peak in-flight counts daemons that rendered at once, not jobs submitted`: exhausted seat budget, five concurrent jobs, zero replicas spawned → width **1**. The old job-count reading gave 5. Also asserts the mark resets so the next batch is its own.
- `peak in-flight rises with genuinely concurrent renders`: three hosts held mid-render → width **3**, so the narrow reading isn't just a counter stuck at 1.

Not visual — stats plumbing and pool instrumentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_