### PR TITLE
fix(serve): charge replica cold starts to the warm bucket

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -454,9 +454,20 @@ class ServeCatalogLiveHost(
               backgroundWork.withRenderPermit {
                 val renderFrom = clock()
                 catalogThemeCache.recordPermitWait(renderFrom - permitWaitFrom)
-                // Clear the pool's high-water mark so the peak read below belongs to THIS batch.
+                // Clear the pool's high-water marks so the reads below belong to THIS batch.
                 sharedDaemonPool?.takePeakInFlight()
+                sharedDaemonPool?.takeColdStartMillis()
                 renderOptimizerBatch(batch).also {
+                  val elapsed = clock() - renderFrom
+                  // A replica's daemon starts on its FIRST render, so that render carries a full
+                  // cold start. Only the primary's warm is visible above (`awaitWarmCompletion`),
+                  // and a five-wide batch can be opening four cold replicas underneath it — which
+                  // would land 34-68s each in the per-entry bucket, exactly the conflation the
+                  // warm/batch split exists to remove. Capped at the interval it is taken from:
+                  // the pool reports the longest overlapping cold start, but a foreground borrow
+                  // could have started one before this batch began.
+                  val cold = (sharedDaemonPool?.takeColdStartMillis() ?: 0L).coerceIn(0L, elapsed)
+                  catalogThemeCache.recordWarm(cold)
                   // Width is the peak number of daemons that ran CONCURRENTLY, not the job count.
                   // A batch submits N jobs, but when the seat budget affords no replica the pool
                   // queues them onto a host already in circulation instead of spawning one — so N
@@ -464,7 +475,7 @@ class ServeCatalogLiveHost(
                   // as N-wide, which is exactly the collapse this number exists to expose.
                   catalogThemeCache.recordBatch(
                     sharedDaemonPool?.takePeakInFlight() ?: 1,
-                    clock() - renderFrom,
+                    elapsed - cold,
                   )
                 }
               } ?: return@execute

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -91,6 +91,10 @@ class ServeSharedDaemonPool(
    *
    * The **longest**, not the sum: the cold starts overlap inside one batch, whose wall-clock is
    * bounded by its slowest lane. Summing them would exceed the interval being attributed.
+   *
+   * A replica stays cold until a render actually enters its session — a `NotFound` (answered from
+   * the id set first) or a throw leaves it cold, so the cold start is still reported when whichever
+   * later render does start the daemon pays it.
    */
   fun takeColdStartMillis(): Long = peakColdStartMillis.getAndSet(0)
 
@@ -101,6 +105,7 @@ class ServeSharedDaemonPool(
     // legitimately starts at 0, which would silently disable the measurement.
     var cold = false
     var coldStartFrom = 0L
+    var startedDaemon = false
     try {
       borrowed = lock.withLock {
         check(!closed) { "shared daemon pool is closed" }
@@ -111,15 +116,22 @@ class ServeSharedDaemonPool(
         host
       }
       peakInFlight.accumulateAndGet(inFlight.incrementAndGet(), ::maxOf)
-      return borrowed.render(previewId, overrides)
+      return borrowed.render(previewId, overrides).also {
+        // `ServeRenderHost.render` answers NotFound from its id set BEFORE touching its lazy
+        // session, so an id this replica doesn't carry leaves the daemon just as cold as it was.
+        // Consuming the marker there would hand the real cold start — paid by whichever later
+        // render does start the session — straight to `batchMillis`. A throw is the same case.
+        startedDaemon = it !is RenderOutcome.NotFound
+      }
     } finally {
-      if (cold) {
+      if (cold && startedDaemon) {
         peakColdStartMillis.accumulateAndGet(clock() - coldStartFrom, ::maxOf)
       }
       borrowed?.let { host ->
         inFlight.decrementAndGet()
         lock.withLock {
           if (!closed) {
+            if (cold && !startedDaemon) coldReplicas += host
             available.addLast(host)
             replicaLastUsed[host] = clock()
             hostReturned.signalAll()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -51,6 +52,12 @@ class ServeSharedDaemonPool(
   // many jobs it submitted. See [takePeakInFlight].
   private val inFlight = AtomicInteger(0)
   private val peakInFlight = AtomicInteger(0)
+  // Replicas opened but not yet rendered, and the longest first-render seen since it was last
+  // taken. A replica is opened lazily and its daemon session does not start until that first
+  // render, so the render carries a 34-68s cold start on an Android lane. See
+  // [takeColdStartMillis].
+  private val coldReplicas = mutableSetOf<ServeHost>() // guarded by [lock]
+  private val peakColdStartMillis = AtomicLong(0)
   private var closed = false
 
   init {
@@ -73,17 +80,42 @@ class ServeSharedDaemonPool(
    */
   fun takePeakInFlight(): Int = peakInFlight.getAndSet(inFlight.get())
 
+  /**
+   * The longest replica cold start since the last call, resetting the mark.
+   *
+   * A replica is opened lazily and its daemon session does not start until its first render, so
+   * that render carries the full cold start — 34-68s on an Android/Robolectric lane. Without this
+   * the caller charges it to per-entry render cost, which is precisely the conflation the
+   * warm/batch split exists to remove: only the PRIMARY's warm is visible to the caller, and a
+   * five-wide batch can be opening four cold replicas underneath it.
+   *
+   * The **longest**, not the sum: the cold starts overlap inside one batch, whose wall-clock is
+   * bounded by its slowest lane. Summing them would exceed the interval being attributed.
+   */
+  fun takeColdStartMillis(): Long = peakColdStartMillis.getAndSet(0)
+
   fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
     permits.acquire()
     var borrowed: ServeHost? = null
+    // An explicit flag, not a `coldStartFrom > 0` sentinel: [clock] is injectable and a test clock
+    // legitimately starts at 0, which would silently disable the measurement.
+    var cold = false
+    var coldStartFrom = 0L
     try {
       borrowed = lock.withLock {
         check(!closed) { "shared daemon pool is closed" }
-        available.removeFirstOrNull() ?: openSeatedReplica()
+        val host = available.removeFirstOrNull() ?: openSeatedReplica()
+        // Claimed under the lock so exactly one borrow times the cold start.
+        cold = coldReplicas.remove(host)
+        if (cold) coldStartFrom = clock()
+        host
       }
       peakInFlight.accumulateAndGet(inFlight.incrementAndGet(), ::maxOf)
       return borrowed.render(previewId, overrides)
     } finally {
+      if (cold) {
+        peakColdStartMillis.accumulateAndGet(clock() - coldStartFrom, ::maxOf)
+      }
       borrowed?.let { host ->
         inFlight.decrementAndGet()
         lock.withLock {
@@ -132,6 +164,8 @@ class ServeSharedDaemonPool(
         throw e
       }
     replicas += replica
+    // Not warm yet: its daemon session starts on the first render. [takeColdStartMillis].
+    coldReplicas += replica
     ticket?.let { seatTickets[replica] = it }
     return replica
   }
@@ -201,6 +235,7 @@ class ServeSharedDaemonPool(
       closed = true
       available.clear()
       replicaLastUsed.clear()
+      coldReplicas.clear()
       seatTickets.values.forEach { it.close() }
       seatTickets.clear()
       // Wake anyone parked in [openSeatedReplica]; the `closed` check turns their wait into the

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -203,6 +203,69 @@ class ServeSharedDaemonPoolTest {
     }
   }
 
+  /**
+   * Codex review on #3390. `ServeRenderHost.render` answers `NotFound` from its id set BEFORE it
+   * touches its lazy session — `ServeCatalogLiveHost.renderDaemon` reaches that path whenever the
+   * shared descriptor lacks an id. Consuming the cold marker there would mark a daemon warm that
+   * has never started, so the real cold start, paid by whichever later render does start it, would
+   * land back in `batchMillis` unreported.
+   */
+  @Test
+  fun `a NotFound leaves the replica cold, so the real cold start is still reported`() {
+    var now = 0L
+    var started = false
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val primary = BlockingHost("primary", entered, release)
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 2, clock = { now }) {
+        object : ServeHost by InstantHost("replica") {
+          override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+            // An id this host doesn't carry never reaches the session — no cold start is paid.
+            if (previewId == "absent") return RenderOutcome.NotFound
+            if (!started) {
+              started = true
+              now += 40_000
+            }
+            return RenderOutcome.Ok("replica".encodeToByteArray())
+          }
+        }
+      }
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      val held = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      assertTrue(entered.await(5, TimeUnit.SECONDS), "primary is mid-render")
+
+      // Opens the replica, but asks for an id it doesn't have.
+      assertEquals(
+        RenderOutcome.NotFound,
+        executor
+          .submit<RenderOutcome> { pool.render("absent", PreviewOverrides()) }
+          .get(10, TimeUnit.SECONDS),
+      )
+      assertEquals(0L, pool.takeColdStartMillis(), "no session was entered, so no cold start yet")
+
+      // The next render on that same replica is the one that actually starts the daemon.
+      assertTrue(
+        executor
+          .submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+          .get(10, TimeUnit.SECONDS) is RenderOutcome.Ok
+      )
+      assertEquals(
+        40_000L,
+        pool.takeColdStartMillis(),
+        "and it is reported, not lost to batch time",
+      )
+
+      release.countDown()
+      assertTrue(held.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok)
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+      pool.close()
+    }
+  }
+
   /** The other direction: when replicas ARE affordable, the peak sees them. */
   @Test
   fun `peak in-flight rises with genuinely concurrent renders`() {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -150,6 +150,59 @@ class ServeSharedDaemonPoolTest {
     }
   }
 
+  /**
+   * Codex review on #3389. A replica's daemon session starts on its FIRST render, so that render
+   * carries the full cold start — 34-68s on an Android lane. Only the primary's warm is visible to
+   * the optimizer (via `awaitWarmCompletion`), so without this the replicas' cold starts land in
+   * the per-entry render bucket: the exact conflation the warm/batch split exists to remove, in the
+   * exact scenario it was built to diagnose.
+   */
+  @Test
+  fun `a replica's first render is reported as cold-start time, and only the first`() {
+    var now = 0L
+    val slowFirstRender = mutableSetOf<String>()
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    // Primary held mid-render, so the second request must open a replica.
+    val primary = BlockingHost("primary", entered, release)
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 2, clock = { now }) {
+        object : ServeHost by InstantHost("replica") {
+          override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+            // A cold start on the first render only, exactly as a real daemon session behaves.
+            if (slowFirstRender.add("replica")) now += 40_000
+            return RenderOutcome.Ok("replica".encodeToByteArray())
+          }
+        }
+      }
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      assertEquals(0L, pool.takeColdStartMillis(), "nothing opened yet")
+
+      val held = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      assertTrue(entered.await(5, TimeUnit.SECONDS), "primary is mid-render")
+      assertTrue(
+        executor
+          .submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+          .get(10, TimeUnit.SECONDS) is RenderOutcome.Ok
+      )
+
+      assertEquals(40_000L, pool.takeColdStartMillis(), "the replica's first render was a cold one")
+      assertEquals(0L, pool.takeColdStartMillis(), "and the mark resets")
+
+      // Reuse: the daemon is warm now, so nothing more is charged to cold start.
+      assertTrue(pool.render("p", PreviewOverrides()) is RenderOutcome.Ok)
+      assertEquals(0L, pool.takeColdStartMillis(), "a warm reuse is not a cold start")
+
+      release.countDown()
+      assertTrue(held.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok)
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+      pool.close()
+    }
+  }
+
   /** The other direction: when replicas ARE affordable, the peak sees them. */
   @Test
   fun `peak in-flight rises with genuinely concurrent renders`() {


### PR DESCRIPTION
Review findings on #3389, which merged before the fix could land on it.

## 1. Replica cold starts were counted as per-entry render cost

The warm/batch split assumed the only cold start was the primary's, which `awaitWarmCompletion` already charges to `warmMillis`. It isn't. A shared-pool replica is opened **lazily** (`openSeatedReplica`) and `ServeRenderHost` doesn't start its daemon session until the first `render` call — so that render carries the full 34–68s Android/Robolectric cold start, and it happens *inside* the batch, landing in `batchMillis`.

A five-wide batch opens up to four of them. So the split still reported startup as recurring per-entry cost in exactly the scenario it was built to diagnose — the one where a cold catalog looks render-bound and isn't.

`ServeSharedDaemonPool` now marks a replica cold until its first render and reports the longest such render via `takeColdStartMillis()` (read-and-reset, same shape as `takePeakInFlight`). The batch subtracts it from its own elapsed interval and charges it to `recordWarm`.

**The longest, not the sum**: cold starts overlap within one batch, whose wall-clock is bounded by its slowest lane — summing would attribute more time than the interval contains. It's capped at that interval regardless, since a foreground borrow could have started a replica before the batch began.

## 2. `NotFound` marked a replica warm that had never started

Second review finding, on the first commit here. `ServeRenderHost.render` answers `NotFound` from its id set *before* touching its lazy session — a path `ServeCatalogLiveHost.renderDaemon` reaches whenever the shared descriptor lacks an id. Consuming the cold marker there marked a daemon warm that had never started, so the real cold start, paid by whichever later render did start it, went back to `batchMillis` unreported. A throw has the same shape.

The marker is now consumed only when the call actually entered the daemon, and restored to the pool otherwise.

## A defect the tests caught

The first draft used `coldStartFrom > 0` as the "this borrow was cold" sentinel. `clock` is injectable and a test clock legitimately starts at 0, so the measurement silently disabled itself — the new test failed with `expected: <40000> but was: <0>`. Now an explicit flag. Worth noting because that sentinel would have failed open in production on any clock that can return 0.

## Test plan

- `./gradlew :cli:test` — green (full suite), on both commits.
- `a replica's first render is reported as cold-start time, and only the first`: injected clock, primary held mid-render so the second request must open a replica, replica's first render advances the clock 40s. Asserts 40,000 on the first read, 0 on the second (mark resets), and 0 after a warm reuse of the same replica.
- `a NotFound leaves the replica cold, so the real cold start is still reported`: opens a replica with an id it doesn't carry → 0 reported; the next render on that same replica is the one that starts the daemon → 40,000 reported.

Not visual — pool instrumentation and stats attribution.