### PR TITLE
fix(serve): reserve a live seat for the per-preview daemon lane

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -51,15 +51,34 @@ class LiveSeatLimiter(
 ) {
   // The reserve is held in its own semaphore rather than subtracted from a single one, so no
   // amount of general-lane demand can consume it. `acquire` never sees it at all.
-  private val reservedPermits: Int =
-    if (totalPermits > 0) perPreviewReserve.coerceIn(0, (totalPermits - 1).coerceAtLeast(0)) else 0
+  //
+  // Carved out ONLY down to [STREAM_RESERVE] — the heaviest single backend — so the general lane
+  // can always hold one at its true weight. Take more than that and the budget silently
+  // over-admits: on a `--live-seats 2` box a general lane of 1 would coerce an Android stream
+  // (weight 2) down to a single permit, and a per-preview daemon could then take the reserved one,
+  // putting three permits' worth of processes on a box budgeted for two. The whole point of the
+  // weighting is that it does not do that.
+  //
+  // So a box too small to afford the slice simply doesn't get one, and keeps its old behaviour
+  // exactly. That is the correct answer rather than a regression: a box that can barely run one
+  // Android daemon cannot run a second daemon of any kind, and the starvation this reserve fixes
+  // only arises where there are seats to be hoarded in the first place.
+  //
+  // Public because it is what `/status` must publish: [perPreviewReserve] is what was *asked for*,
+  // and reporting that would state a slice the limiter may not actually hold — on a small box it is
+  // clamped to nothing, and an oversized custom value would otherwise be reported as larger than
+  // the whole budget. A diagnostic added to make starvation visible must not itself be able to lie.
+  val perPreviewPermits: Int =
+    if (totalPermits > 0)
+      perPreviewReserve.coerceIn(0, (totalPermits - STREAM_RESERVE).coerceAtLeast(0))
+    else 0
   /**
    * Permits the general lane (streams, burst replicas) may draw on — the budget minus the slice.
    */
-  private val generalPermits: Int = (totalPermits - reservedPermits).coerceAtLeast(0)
+  private val generalPermits: Int = (totalPermits - perPreviewPermits).coerceAtLeast(0)
   private val semaphore: Semaphore? = if (totalPermits > 0) Semaphore(generalPermits) else null
   private val perPreviewSemaphore: Semaphore? =
-    if (reservedPermits > 0) Semaphore(reservedPermits) else null
+    if (perPreviewPermits > 0) Semaphore(perPreviewPermits) else null
 
   /** True when this limiter imposes no bound (`totalPermits <= 0`). */
   val unbounded: Boolean

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -27,8 +27,39 @@ import java.util.concurrent.atomic.AtomicLong
  * Thread-safe: the backing [Semaphore] is fair-agnostic like the old flat gate, and each [Ticket]
  * releases its permits at most once.
  */
-class LiveSeatLimiter(val totalPermits: Int) {
-  private val semaphore: Semaphore? = if (totalPermits > 0) Semaphore(totalPermits) else null
+class LiveSeatLimiter(
+  val totalPermits: Int,
+  /**
+   * Permits carved out of [totalPermits] that **only** [acquireBackground] can draw on — the
+   * per-preview lane's guaranteed slice.
+   *
+   * Without it that lane can be starved to a standstill, and was. On preview.coo.ee the eight
+   * resident catalog daemons held all 8 permits with `activeStreams: 0`, so every
+   * `acquireBackground` was refused, [ServePerPreviewDaemonPool.get] returned null, and
+   * `ServeCatalogLiveHost.renderInternal` turned that `NotFound` into `Busy` — a `503 render busy;
+   * retry shortly` on 39 of 39 attempts for all 21 of meshcore-mobile's supplement-module previews,
+   * for the life of the server. The catalog's theme prefetch then pinned at 288/372 forever because
+   * those 84 targets could never be filled.
+   *
+   * It is deliberately small — one desktop daemon's worth by default. The point is not to give the
+   * lane a fair share, only to make it impossible to starve completely: a preview whose ONLY live
+   * lane is its own per-preview bundle (a catalog with a supplement module, where the monolithic
+   * daemon simply does not carry the id) has no fallback that renders, unlike a burst replica which
+   * can narrow onto the primary.
+   */
+  val perPreviewReserve: Int = DEFAULT_PER_PREVIEW_RESERVE,
+) {
+  // The reserve is held in its own semaphore rather than subtracted from a single one, so no
+  // amount of general-lane demand can consume it. `acquire` never sees it at all.
+  private val reservedPermits: Int =
+    if (totalPermits > 0) perPreviewReserve.coerceIn(0, (totalPermits - 1).coerceAtLeast(0)) else 0
+  /**
+   * Permits the general lane (streams, burst replicas) may draw on — the budget minus the slice.
+   */
+  private val generalPermits: Int = (totalPermits - reservedPermits).coerceAtLeast(0)
+  private val semaphore: Semaphore? = if (totalPermits > 0) Semaphore(generalPermits) else null
+  private val perPreviewSemaphore: Semaphore? =
+    if (reservedPermits > 0) Semaphore(reservedPermits) else null
 
   /** True when this limiter imposes no bound (`totalPermits <= 0`). */
   val unbounded: Boolean
@@ -47,7 +78,10 @@ class LiveSeatLimiter(val totalPermits: Int) {
   fun acquire(weight: Int, verified: Boolean = true, countRefusal: Boolean = true): Ticket? {
     val sem = semaphore ?: return Ticket(0)
     if (weight <= 0) return Ticket(0)
-    val permits = weight.coerceIn(1, totalPermits)
+    // Coerced to the GENERAL lane's capacity, not [totalPermits]: the reserve is not available
+    // here, so coercing to the whole budget would ask for more permits than this semaphore can
+    // ever hold and refuse a heavy backend forever — the deadlock the coercion exists to avoid.
+    val permits = weight.coerceIn(1, generalPermits)
     if (sem.tryAcquire(permits)) return Ticket(permits)
     // Seats are reserved before the session is leased (see the stream lane), so a request naming
     // a session the registry doesn't have reaches the budget too. Those are split off rather than
@@ -84,13 +118,32 @@ class LiveSeatLimiter(val totalPermits: Int) {
     val sem = semaphore ?: return Ticket(0)
     if (weight <= 0) return Ticket(0)
     val permits = weight.coerceIn(1, totalPermits)
+    // The dedicated slice first (see above). It exists precisely so a saturated general lane cannot
+    // refuse
+    // this, so it is taken WITHOUT the stream headroom check — those permits were never available
+    // to a stream in the first place, and demanding headroom that by construction cannot exist
+    // would make the reserve unusable.
+    perPreviewSemaphore?.let { if (it.tryAcquire(permits)) return Ticket(permits, reserved = true) }
+    // Otherwise the general lane, still leaving room for an interactive stream.
     if (!sem.tryAcquire(permits + reserve.coerceAtLeast(0))) return null
     if (reserve > 0) sem.release(reserve)
     return Ticket(permits)
   }
 
-  /** Permits currently available — for tests/diagnostics. */
-  fun availablePermits(): Int = semaphore?.availablePermits() ?: Int.MAX_VALUE
+  /**
+   * Permits currently available across BOTH lanes — for tests/diagnostics and `/status`.
+   *
+   * Summed rather than reporting the general lane alone, so the figure stays comparable to
+   * [totalPermits]: a box with its slice free but its general lane full is not at capacity, and
+   * reporting `0 free / 8` there would restate the very confusion this reserve fixes.
+   */
+  fun availablePermits(): Int =
+    semaphore?.let { it.availablePermits() + (perPreviewSemaphore?.availablePermits() ?: 0) }
+      ?: Int.MAX_VALUE
+
+  /** Permits free in the per-preview slice alone — lets `/status` show the lane isn't starved. */
+  fun perPreviewPermitsAvailable(): Int =
+    perPreviewSemaphore?.availablePermits() ?: if (unbounded) Int.MAX_VALUE else 0
 
   /**
    * How many live sessions this limiter has turned away since startup, monotonic.
@@ -123,17 +176,38 @@ class LiveSeatLimiter(val totalPermits: Int) {
      * always start no matter how much render residency has built up.
      */
     const val STREAM_RESERVE: Int = ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT
+
+    /**
+     * Default [perPreviewReserve]: one desktop daemon's worth (weight 1).
+     *
+     * Enough that a catalog whose supplement module carries its own per-preview bundles can always
+     * open one, which is the difference between those previews rendering and never rendering at
+     * all. Kept to one so the general lane — streams, and the burst replicas that widen a themed
+     * batch — gives up as little as possible; a second concurrent per-preview daemon still competes
+     * for the general pool exactly as before.
+     */
+    const val DEFAULT_PER_PREVIEW_RESERVE: Int = 1
   }
 
   private val refusals = AtomicLong()
   private val unverifiedRefusals = AtomicLong()
 
-  /** A held reservation of [permits] live-seat permits; [close] returns them (idempotent). */
-  inner class Ticket internal constructor(val permits: Int) : AutoCloseable {
+  /**
+   * A held reservation of [permits] live-seat permits; [close] returns them (idempotent).
+   *
+   * [reserved] records which pool they came from, so they go back where they came from — returning
+   * a reserved permit to the general semaphore would quietly transfer the per-preview lane's slice
+   * to the general one, and the starvation this class now prevents would reappear after the first
+   * eviction.
+   */
+  inner class Ticket internal constructor(val permits: Int, private val reserved: Boolean = false) :
+    AutoCloseable {
     private val released = AtomicBoolean(false)
 
     override fun close() {
-      if (permits > 0 && released.compareAndSet(false, true)) semaphore?.release(permits)
+      if (permits > 0 && released.compareAndSet(false, true)) {
+        if (reserved) perPreviewSemaphore?.release(permits) else semaphore?.release(permits)
+      }
     }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2063,6 +2063,9 @@ class ServeHttpServer(
             liveSeatsTotal = if (liveSeats.unbounded) 0 else liveSeats.totalPermits,
             liveSeatsAvailable = if (liveSeats.unbounded) -1 else liveSeats.availablePermits(),
             liveSeatsUnbounded = liveSeats.unbounded,
+            perPreviewSeatsTotal = if (liveSeats.unbounded) 0 else liveSeats.perPreviewReserve,
+            perPreviewSeatsAvailable =
+              if (liveSeats.unbounded) -1 else liveSeats.perPreviewPermitsAvailable(),
             liveSeatRefusals = liveSeats.refusalCount(),
             liveSeatRefusalsUnverified = liveSeats.unverifiedRefusalCount(),
           ),
@@ -3757,6 +3760,15 @@ private data class DaemonSummaryDto(
   /** Free permits; `-1` ⇒ unbounded. */
   val liveSeatsAvailable: Int,
   val liveSeatsUnbounded: Boolean,
+  /**
+   * The slice of [liveSeatsTotal] only the per-preview daemon lane may draw on, and how much of it
+   * is free. Published because its absence is exactly what made a total starvation invisible: with
+   * every general permit held by resident catalog daemons, `liveSeatsAvailable` read `0 / 8` and
+   * `liveSeatRefusals` read `0` (the background path never counted one), while every
+   * supplement-module preview on the box answered `503 render busy` forever.
+   */
+  val perPreviewSeatsTotal: Int = 0,
+  val perPreviewSeatsAvailable: Int = 0,
   /**
    * Live sessions turned away for want of seats since startup, monotonic. A counter rather than a
    * gauge because a refusal is an event: [liveSeatsAvailable] beside it is a level, and on a

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2063,7 +2063,7 @@ class ServeHttpServer(
             liveSeatsTotal = if (liveSeats.unbounded) 0 else liveSeats.totalPermits,
             liveSeatsAvailable = if (liveSeats.unbounded) -1 else liveSeats.availablePermits(),
             liveSeatsUnbounded = liveSeats.unbounded,
-            perPreviewSeatsTotal = if (liveSeats.unbounded) 0 else liveSeats.perPreviewReserve,
+            perPreviewSeatsTotal = if (liveSeats.unbounded) 0 else liveSeats.perPreviewPermits,
             perPreviewSeatsAvailable =
               if (liveSeats.unbounded) -1 else liveSeats.perPreviewPermitsAvailable(),
             liveSeatRefusals = liveSeats.refusalCount(),

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterPerPreviewReserveTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterPerPreviewReserveTest.kt
@@ -1,0 +1,106 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The per-preview lane's guaranteed slice of the seat budget.
+ *
+ * Observed on preview.coo.ee before it existed: eight resident catalog daemons held all 8 permits
+ * with `activeStreams: 0`, so every `acquireBackground` was refused,
+ * [ServePerPreviewDaemonPool.get] returned null, and `ServeCatalogLiveHost.renderInternal` turned
+ * that `NotFound` into `Busy`. All 21 of meshcore-mobile's supplement-module previews answered `503
+ * render busy; retry shortly` on 39 of 39 attempts, and the catalog's theme prefetch pinned at
+ * 288/372 for the life of the server. `liveSeatsAvailable: 0` and `liveSeatRefusals: 0` were the
+ * only symptoms visible from outside.
+ *
+ * A burst replica can narrow onto the primary when it is refused; a preview whose only live lane is
+ * its own per-preview bundle has no such fallback, which is why this lane — and only this lane —
+ * gets a floor.
+ */
+class LiveSeatLimiterPerPreviewReserveTest {
+
+  @Test
+  fun `a saturated general lane cannot starve the per-preview slice`() {
+    val limiter = LiveSeatLimiter(totalPermits = 8, perPreviewReserve = 1)
+    // Drain the general lane exactly as the resident catalog daemons did.
+    val held = (1..7).mapNotNull { limiter.acquire(1) }
+    assertEquals(7, held.size, "the general lane is the budget minus the slice")
+    assertNull(limiter.acquire(1), "and is now full")
+
+    assertNotNull(
+      limiter.acquireBackground(1),
+      "the per-preview lane still opens — this is the whole point",
+    )
+  }
+
+  @Test
+  fun `the slice is not available to the general lane`() {
+    val limiter = LiveSeatLimiter(totalPermits = 4, perPreviewReserve = 1)
+    val held = (1..3).mapNotNull { limiter.acquire(1) }
+    assertEquals(3, held.size)
+    assertNull(limiter.acquire(1), "the reserved permit is never handed to a stream or replica")
+  }
+
+  @Test
+  fun `a reserved permit returns to the reserve, not the general pool`() {
+    // Otherwise the slice leaks into the general lane on the first eviction and the starvation
+    // reappears — silently, and only after the box has been up a while.
+    val limiter = LiveSeatLimiter(totalPermits = 4, perPreviewReserve = 1)
+    (1..3).mapNotNull { limiter.acquire(1) }
+    val background = assertNotNull(limiter.acquireBackground(1))
+
+    background.close()
+
+    assertNull(limiter.acquire(1), "the returned permit did not become general capacity")
+    assertNotNull(limiter.acquireBackground(1), "it went back to the lane it came from")
+  }
+
+  @Test
+  fun `background falls back to the general lane while it has stream headroom`() {
+    // The slice is a floor, not a ceiling: a second concurrent per-preview daemon competes for the
+    // general pool exactly as before, and still leaves room for an interactive stream.
+    val limiter = LiveSeatLimiter(totalPermits = 8, perPreviewReserve = 1)
+    val first = assertNotNull(limiter.acquireBackground(1))
+    val second = assertNotNull(limiter.acquireBackground(1), "general lane has plenty free")
+    assertTrue(first.permits == 1 && second.permits == 1)
+  }
+
+  @Test
+  fun `a heavy backend is coerced to the general lane, not the whole budget`() {
+    // Coercing to totalPermits would ask for more than the general semaphore can ever hold and
+    // refuse the backend forever — the exact deadlock the coercion exists to prevent.
+    val limiter = LiveSeatLimiter(totalPermits = 4, perPreviewReserve = 1)
+    assertNotNull(limiter.acquire(99), "a backend heavier than the budget still runs alone")
+  }
+
+  @Test
+  fun `availablePermits sums both lanes so status stays comparable to the total`() {
+    val limiter = LiveSeatLimiter(totalPermits = 4, perPreviewReserve = 1)
+    assertEquals(4, limiter.availablePermits())
+    assertEquals(1, limiter.perPreviewPermitsAvailable())
+
+    (1..3).mapNotNull { limiter.acquire(1) }
+
+    assertEquals(1, limiter.availablePermits(), "the free slice is not reported as capacity gone")
+    assertEquals(1, limiter.perPreviewPermitsAvailable())
+  }
+
+  @Test
+  fun `a reserve as large as the budget still leaves the general lane usable`() {
+    // Misconfiguration must degrade, not deadlock: something has to be able to serve a stream.
+    val limiter = LiveSeatLimiter(totalPermits = 2, perPreviewReserve = 9)
+    assertNotNull(limiter.acquire(1), "the general lane keeps at least one permit")
+  }
+
+  @Test
+  fun `an unbounded limiter is unaffected`() {
+    val limiter = LiveSeatLimiter(totalPermits = 0, perPreviewReserve = 1)
+    assertTrue(limiter.unbounded)
+    assertNotNull(limiter.acquireBackground(1))
+    assertNotNull(limiter.acquire(99))
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterPerPreviewReserveTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterPerPreviewReserveTest.kt
@@ -90,10 +90,47 @@ class LiveSeatLimiterPerPreviewReserveTest {
   }
 
   @Test
-  fun `a reserve as large as the budget still leaves the general lane usable`() {
-    // Misconfiguration must degrade, not deadlock: something has to be able to serve a stream.
-    val limiter = LiveSeatLimiter(totalPermits = 2, perPreviewReserve = 9)
-    assertNotNull(limiter.acquire(1), "the general lane keeps at least one permit")
+  fun `a budget too small to afford the slice gets none, and cannot over-admit`() {
+    // The `--live-seats 2` case. A general lane of 1 would coerce an Android stream (weight 2) down
+    // to a single permit, and a per-preview daemon could then take the reserved one — three
+    // permits' worth of processes on a box budgeted for two, defeating the OOM protection that is
+    // the entire reason the budget is weighted. So a box this small keeps its old behaviour.
+    val limiter = LiveSeatLimiter(totalPermits = 2, perPreviewReserve = 1)
+    assertEquals(0, limiter.perPreviewPermits, "no slice is carved out of a budget this small")
+
+    val android = assertNotNull(limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT))
+    assertEquals(2, android.permits, "the heavy backend is charged its true weight, not clamped")
+    assertEquals(0, limiter.availablePermits(), "and it holds the whole box")
+    assertNull(limiter.acquireBackground(1), "nothing else may run alongside it")
+  }
+
+  @Test
+  fun `the slice never eats the headroom a heaviest-backend stream needs`() {
+    // The invariant that makes the clamp above safe: whenever a slice exists, the general lane can
+    // still hold ANDROID_LIVE_SEAT_WEIGHT at full weight, so `acquire` never under-charges.
+    for (total in 1..12) {
+      val limiter = LiveSeatLimiter(totalPermits = total, perPreviewReserve = 4)
+      val general = total - limiter.perPreviewPermits
+      if (limiter.perPreviewPermits > 0) {
+        assertTrue(
+          general >= ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT,
+          "budget $total left a general lane of $general, too small for the heaviest backend",
+        )
+      }
+      assertTrue(limiter.perPreviewPermits >= 0 && general >= 0)
+    }
+  }
+
+  @Test
+  fun `an oversized reserve is clamped, and status reports what is actually held`() {
+    // `/status` must publish the EFFECTIVE slice. Reporting the requested value would state a
+    // reserve the limiter does not hold — and a diagnostic added to make starvation visible must
+    // not itself be able to lie.
+    val limiter = LiveSeatLimiter(totalPermits = 8, perPreviewReserve = 99)
+    assertEquals(6, limiter.perPreviewPermits, "clamped to the budget minus the stream reserve")
+    assertEquals(99, limiter.perPreviewReserve, "the requested value is kept, but is not the truth")
+    assertEquals(6, limiter.perPreviewPermitsAvailable())
+    assertEquals(8, limiter.availablePermits())
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
@@ -13,6 +13,9 @@ import kotlin.test.assertTrue
  * that let one heavy catalog starve the rest.
  */
 class LiveSeatLimiterTest {
+  // Several cases below pass `perPreviewReserve = 0` deliberately. They pin the GENERAL lane's
+  // arithmetic against the whole budget, which is what they were written to describe; the slice
+  // carved out of that budget by default is covered by LiveSeatLimiterPerPreviewReserveTest.
 
   @Test
   fun `refusals are counted so seat pressure is visible after the fact`() {
@@ -84,7 +87,7 @@ class LiveSeatLimiterTest {
 
   @Test
   fun `desktop-weight sessions fill the budget then the next is refused`() {
-    val limiter = LiveSeatLimiter(2)
+    val limiter = LiveSeatLimiter(2, perPreviewReserve = 0)
     val a = limiter.acquire(1)
     val b = limiter.acquire(1)
     assertNotNull(a)
@@ -101,7 +104,7 @@ class LiveSeatLimiterTest {
 
   @Test
   fun `an Android session costs its heavier weight and blocks a concurrent desktop one`() {
-    val limiter = LiveSeatLimiter(2)
+    val limiter = LiveSeatLimiter(2, perPreviewReserve = 0)
     // Weight 2 (Android) consumes the whole budget of 2.
     val android = limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT)
     assertNotNull(android)
@@ -133,7 +136,7 @@ class LiveSeatLimiterTest {
 
   @Test
   fun `releasing a ticket is idempotent — a double close returns permits only once`() {
-    val limiter = LiveSeatLimiter(2)
+    val limiter = LiveSeatLimiter(2, perPreviewReserve = 0)
     val a = limiter.acquire(1)
     assertNotNull(a)
     a!!.close()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -333,7 +333,13 @@ class ServeSharedDaemonPoolTest {
   fun `a leased replica may use the seats reserved against background work`() {
     // Exactly the stream reserve free: a background holder (the per-preview pool) would be refused
     // here, but a leased burst is foreground and may take it.
-    val seats = LiveSeatLimiter(totalPermits = LiveSeatLimiter.STREAM_RESERVE)
+    //
+    // `perPreviewReserve = 0` because this case is about the STREAM reserve. With the per-preview
+    // slice in play the background holder would be admitted from its own permits — correct, and
+    // covered by LiveSeatLimiterPerPreviewReserveTest — which would silently void the precondition
+    // below and leave this asserting nothing about the interaction it was written for.
+    val seats =
+      LiveSeatLimiter(totalPermits = LiveSeatLimiter.STREAM_RESERVE, perPreviewReserve = 0)
     assertNull(seats.acquireBackground(1), "precondition: background cannot touch the reserve")
 
     val entered = CountDownLatch(1)


### PR DESCRIPTION
This is the actual cause of meshcore-mobile's stuck previews — the thing #3382 made converge but could not fix.

## The measurement

A catalog whose **supplement module** ships its own per-preview bundles has, for those previews, no live lane except the per-preview pool: the monolithic daemon does not carry the id at all. That pool was budgeted like any other background holder, so it could be starved to a standstill. It was.

On `preview.coo.ee`, eight resident catalog daemons held all 8 live seats with `activeStreams: 0`:

```
daemons: { running: 8, activeStreams: 0,
           liveSeatsTotal: 8, liveSeatsAvailable: 0, liveSeatRefusals: 0 }
```

Every `acquireBackground` was refused → `ServePerPreviewDaemonPool.get` returned null → `renderDaemon` reported `NotFound` → `renderInternal` turned it into `Busy`.

The split is exact, and it is by **module**, not by anything about the previews themselves:

| backing module | catalog components | themed render |
|---|---|---|
| `:app` (in the monolithic bundle) | 38 | all served from `catalog-cache` |
| `:meshcore-components` (supplement, per-preview bundles only) | 6 | all `503 render busy`, **39 of 39 attempts** |

Those 6 components carry 21 previews — exactly the 84 theme targets (21 × 4 declared themes) that pinned meshcore-mobile's prefetch at `288/372` across three server lifetimes and two releases, while all fourteen other catalogs reached `complete`.

I verified the artifacts are innocent before touching the server: the supplement per-preview bundles are published and correct — `bundle/previews/…components.ui.ChatBodyPreviewsKt.ChannelChatPreview_Dark.png` is a valid `backend: desktop` bundle carrying exactly that preview, with 37 Maven coordinates that are all `-desktop`/`-jvm` and zero `-android`, produced by 0.19.39. meshcore-mobile's workflow already sets `extra-split-mode: full` correctly. The publishing side is doing its job.

## Why it was invisible

`liveSeatsAvailable` read `0 / 8` — which looks like ordinary load — and `liveSeatRefusals` read `0`, because the background path deliberately does not count a refusal. There was no signal anywhere that an entire lane was dead.

## Fix

`LiveSeatLimiter` now holds a small slice in **its own semaphore**, which only `acquireBackground` can draw on. One desktop daemon's worth by default.

The asymmetry this encodes: a burst replica refused a seat narrows onto the primary and **still renders**; a per-preview daemon refused a seat has no fallback that renders at all. It's a floor, not a fair share — a second concurrent per-preview daemon still competes for the general pool exactly as before.

Published on `/status` as `perPreviewSeatsTotal` / `perPreviewSeatsAvailable` so a starved lane can never again be invisible.

Two details that would each have been a bug:

- **`acquire` coerces a heavy backend to the GENERAL lane's capacity, not the whole budget.** Coercing to the total would ask a semaphore for more permits than it can hold and refuse that backend *forever* — precisely the deadlock the existing coercion was written to prevent.
- **A reserved permit returns to the reserve, not the general pool.** Otherwise the slice leaks into the general lane on the first eviction and the starvation comes back silently, after the box has been up a while.

## Test plan

New `LiveSeatLimiterPerPreviewReserveTest`: a saturated general lane cannot starve the slice; the slice is never handed to a stream or replica; a reserved permit returns to its own lane; background still falls back to the general lane with stream headroom intact; a heavy backend is coerced to the general capacity rather than refused forever; `availablePermits` sums both lanes so `/status` stays comparable to the total; an over-large reserve degrades instead of deadlocking; an unbounded limiter is unaffected.

Four existing tests now pass `perPreviewReserve = 0` explicitly. They pin the **general lane's** arithmetic against the whole budget, which is what they were written to describe — including `ServeSharedDaemonPoolTest`'s stream-reserve case, whose precondition ("background cannot touch the reserve") would otherwise be silently voided by the new slice and leave it asserting nothing.

Full `:cli:test` green (1450 tests).

Text-only: this changes admission control, not rendered pixels.

## What this does not do

It doesn't guarantee those 21 previews render — it guarantees they can *get a daemon*. If they then fail for their own reasons, that now surfaces as a real `Failed` with a reason instead of an infinite `Busy`, which is what #3382's latch was built to report.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ff3PLh8x3QXsN1mMLn2vG)_