### PR TITLE
fix(serve): drop a playground jail that cannot launch, keep the caps

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1085,7 +1085,7 @@ class ServeCommand(args: List<String>) : Command(args) {
     val androidBundle = playgroundAndroidBundlePath
     if (cmpBundle == null && androidBundle == null) return null
 
-    val sandbox = playgroundSandbox.getOrElse { e ->
+    val configuredSandbox = playgroundSandbox.getOrElse { e ->
       System.err.println("serve: ${e.message}. Playground disabled.")
       return null
     }
@@ -1095,11 +1095,16 @@ class ServeCommand(args: List<String>) : Command(args) {
     // only behind a sandbox that has *demonstrated* containment — the preflight runs a throwaway
     // JVM inside the configured jail and reports whether it can still reach the network, the host
     // filesystem, or host processes. A profile's claims are never enough on their own.
+    //
+    // Run for ANY active sandbox, not just a public one. Its containment verdict only *gates* the
+    // anonymous-public posture, but its can-this-jail-even-launch answer matters everywhere: a
+    // token-gated host whose `unshare` is forbidden by the kernel is just as silently broken, and
+    // that is what the fallback below repairs. One throwaway JVM at startup buys it.
     val probe =
-      if (public && sandbox.isActive) {
-        System.err.println("serve: playground sandbox preflight (${sandbox.describe()})…")
+      if (configuredSandbox.isActive) {
+        System.err.println("serve: playground sandbox preflight (${configuredSandbox.describe()})…")
         PlaygroundSandboxProbe.run(
-            sandbox = sandbox,
+            sandbox = configuredSandbox,
             javaHome = java.io.File(System.getProperty("java.home")),
             classpath =
               System.getProperty("java.class.path")
@@ -1114,7 +1119,9 @@ class ServeCommand(args: List<String>) : Command(args) {
     // operator reading it later doesn't have to find the startup log to tell "admitted because
     // collaborators only" from "admitted because contained".
     val admittedBy: String
-    when (val decision = PlaygroundPublicGate.decide(public, repoAccessGated, sandbox, probe)) {
+    when (
+      val decision = PlaygroundPublicGate.decide(public, repoAccessGated, configuredSandbox, probe)
+    ) {
       is PlaygroundPublicGate.Decision.Refuse -> {
         System.err.println("serve: ${decision.reason}")
         workRoot.deleteRecursively()
@@ -1125,6 +1132,25 @@ class ServeCommand(args: List<String>) : Command(args) {
         admittedBy = decision.detail
       }
     }
+    // A configured jail that CANNOT LAUNCH here would otherwise break the lane silently: the gate
+    // already admitted it (on repo access, or because the host is token-gated), `/playground`
+    // answers normally, and then every snippet JVM and every jailed compile fails to spawn behind
+    // an argv that returns EPERM. Drop the jail and keep the caps — `-Xmx`, the CPU cap,
+    // ExitOnOutOfMemoryError, the temp-dir confinement and the hard TTL all still apply, which is
+    // the half that actually protects the box's memory (see PlaygroundSandbox.droppingJail).
+    //
+    // Safe by construction for the contained posture: an anonymous --public host whose probe never
+    // ran is refused above, so this line is unreachable in the one case where the jail is what
+    // admitted the lane.
+    val sandbox =
+      if (probe != null && !probe.ran) {
+        System.err.println(
+          "serve: WARNING playground sandbox '${configuredSandbox.profile.id}' could not launch on this " +
+            "host (${probe.detail}) — dropping the jail and keeping the JVM caps. Snippets run " +
+            "capped but UNCONTAINED; the lane is admitted by ${if (public) "repo-access gating" else "the access token"}, not by containment."
+        )
+        configuredSandbox.droppingJail()
+      } else configuredSandbox
     // A repo-access-gated lane is admitted without consulting the probe, so a broken jail would
     // otherwise pass unremarked — the operator asked for defence in depth and isn't getting it.
     // Say so; the lane still serves, because admission never rested on the jail here.
@@ -1328,6 +1354,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         admittedBy = admittedBy,
         sandboxProfile = sandbox.profile.id,
         sandboxActive = sandbox.isActive,
+        jailDropped = sandbox.jailDropped,
         sandboxMemoryMb = sandbox.memoryMb,
         sandboxCpus = sandbox.cpus,
         sandboxTtlSeconds = sandbox.ttlSeconds,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1142,12 +1142,31 @@ class ServeCommand(args: List<String>) : Command(args) {
     // Safe by construction for the contained posture: an anonymous --public host whose probe never
     // ran is refused above, so this line is unreachable in the one case where the jail is what
     // admitted the lane.
+    // …but NOT for a profile whose caps live in the argv being dropped. `systemd` and `strict`
+    // enforce MemoryMax/CPUQuota/TasksMax through the `systemd-run` prefix, so dropping it leaves
+    // only `-Xmx` (heap, not native memory) and `-XX:ActiveProcessorCount` (pool sizing, not a CPU
+    // quota) — and no pid cap at all. Running an operator who asked for enforceable caps under
+    // caps they cannot enforce is worse than not running: refuse, and say which knob to change.
+    if (probe != null && !probe.ran && configuredSandbox.profile.declaresResourceCaps) {
+      System.err.println(
+        "serve: playground sandbox '${configuredSandbox.profile.id}' could not launch on this " +
+          "host (${probe.detail}), and its CPU/memory/pid caps are enforced BY that command — " +
+          "dropping it would leave the snippet effectively uncapped, so the playground is " +
+          "disabled instead. Fix the jail (a container has no systemd to build a transient scope " +
+          "against), or pick a profile whose caps are JVM-level (bwrap, unshare)."
+      )
+      workRoot.deleteRecursively()
+      return null
+    }
     val sandbox =
       if (probe != null && !probe.ran) {
         System.err.println(
           "serve: WARNING playground sandbox '${configuredSandbox.profile.id}' could not launch on this " +
             "host (${probe.detail}) — dropping the jail and keeping the JVM caps. Snippets run " +
-            "capped but UNCONTAINED; the lane is admitted by ${if (public) "repo-access gating" else "the access token"}, not by containment."
+            "capped but UNCONTAINED; the lane is admitted by ${if (public) "repo-access gating" else "the access token"}, not by containment." +
+            (if (configuredSandbox.profile == PlaygroundSandbox.Profile.CUSTOM)
+              " Any caps that custom argv supplied are gone with it — only the JVM-level ones remain."
+            else "")
         )
         configuredSandbox.droppingJail()
       } else configuredSandbox
@@ -1359,7 +1378,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         sandboxCpus = sandbox.cpus,
         sandboxTtlSeconds = sandbox.ttlSeconds,
         probe = probe,
-        compilerJailed = compiler !== inProcessCompiler,
+        compilerJailed = compiler !== inProcessCompiler && !sandbox.jailDropped,
         compileSlots = playgroundCompileSlots,
         modes = {
           listOfNotNull(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundHealth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundHealth.kt
@@ -28,6 +28,13 @@ data class PlaygroundHealth(
   val sandboxProfile: String,
   /** False for `none`: no jail argv, and **no JVM caps or hard TTL either**. */
   val sandboxActive: Boolean,
+  /**
+   * True when the configured jail could not launch here and was dropped, keeping the JVM caps
+   * (`PlaygroundSandbox.droppingJail`). Snippets are capped but **uncontained** — the operator
+   * asked for a jail and this host cannot give them one, which is worth seeing without reading a
+   * startup log.
+   */
+  val jailDropped: Boolean,
   /** Per-snippet-JVM heap/CPU/pid budget. Only applied when [sandboxActive]. */
   val sandboxMemoryMb: Int,
   val sandboxCpus: Double,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundHealth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundHealth.kt
@@ -46,9 +46,12 @@ data class PlaygroundHealth(
    */
   val probe: PlaygroundSandboxProbe.Report?,
   /**
-   * True when snippet *compiles* run in a disposable jailed child. False means they run in the
-   * serve JVM — which is what an inactive sandbox gets you, and it also makes the compile-slot
-   * budget inert (`PlaygroundJailedCompiler.wrap` hands back the in-process compiler untouched).
+   * True when snippet *compiles* run in a disposable **jailed** child.
+   *
+   * False covers two different states, told apart by [jailDropped]: with it false the compiles run
+   * in the serve JVM (an inactive sandbox, which also makes the compile-slot budget inert, since
+   * `PlaygroundJailedCompiler.wrap` hands back the in-process compiler untouched); with it true
+   * they still run in a disposable, capped, slot-limited child — just not behind a jail.
    */
   val compilerJailed: Boolean,
   /** `--playground-compile-slots`; only meaningful when [compilerJailed]. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
@@ -272,9 +272,16 @@ class PlaygroundJailedCompiler(
         )
         return inProcess
       }
+      // A dropped jail still gets a disposable, capped child — better than the in-process
+      // compiler — but saying it runs "inside the sandbox" would be a lie, and this line is
+      // exactly where an operator looks to confirm the jail took.
       onLog(
-        "playground: compiles run inside the ${sandbox.profile.id} sandbox, " +
-          "$slots at a time (peak ${slots * sandbox.memoryMb}MB)"
+        if (sandbox.jailDropped)
+          "playground: compiles run in a capped child with NO jail (the ${sandbox.profile.id} " +
+            "sandbox could not launch here), $slots at a time (peak ${slots * sandbox.memoryMb}MB)"
+        else
+          "playground: compiles run inside the ${sandbox.profile.id} sandbox, " +
+            "$slots at a time (peak ${slots * sandbox.memoryMb}MB)"
       )
       return PlaygroundJailedCompiler(
         sandbox = sandbox,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
@@ -44,6 +44,12 @@ data class PlaygroundSandbox(
   val extraReadOnlyPaths: List<String> = emptyList(),
   /** Operator-supplied argv for [Profile.CUSTOM]; ignored by every other profile. */
   val customCommand: List<String> = emptyList(),
+  /**
+   * Set by [droppingJail] when the configured jail **cannot launch on this host** and the lane was
+   * admitted on something other than containment. [command] then yields no argv while every other
+   * cap stays on — see that function for why this state exists at all.
+   */
+  val jailDropped: Boolean = false,
 ) {
 
   /**
@@ -112,19 +118,45 @@ data class PlaygroundSandbox(
     get() = profile != Profile.NONE
 
   /**
-   * The argv prefix the snippet JVM launches behind, or empty for [Profile.NONE]. Paths are bound
-   * with the `-try` variants where a host may legitimately lack them, so one missing `/lib64` can't
-   * turn a containment profile into a failed spawn.
+   * Drop the jail argv but keep every other cap — the recovery for a configured jail that cannot
+   * launch on this host (`unshare` under a seccomp/AppArmor policy that forbids user namespaces,
+   * `bwrap` absent from the image).
+   *
+   * Without this, that host is *silently broken*: [PlaygroundPublicGate] admits the lane on the
+   * repo-access posture, `/playground` answers normally, and then every snippet JVM and every
+   * jailed compile fails to spawn because they all launch behind an argv that returns EPERM. The
+   * failure surfaces to a user as a compile that never produces an image, and to an operator as
+   * nothing at all.
+   *
+   * Dropping the jail is strictly better than both alternatives. Against *keeping* it: a jail that
+   * cannot launch contains nothing, so there is no isolation to lose. Against *disabling the
+   * sandbox entirely* ([Profile.NONE]): that would also discard `-Xmx`, the CPU cap,
+   * `ExitOnOutOfMemoryError`, the temp-dir confinement and the hard TTL — and on a host with a
+   * large cgroup limit an uncapped snippet JVM sizes its default heap at a quarter of that limit,
+   * which is the more dangerous failure of the two.
+   *
+   * Deliberately **not** reachable when containment is what admitted the lane: an anonymous
+   * `--public` host whose probe never ran is refused outright by [PlaygroundPublicGate], so the
+   * caller never gets far enough to call this.
+   */
+  fun droppingJail(): PlaygroundSandbox = copy(jailDropped = true)
+
+  /**
+   * The argv prefix the snippet JVM launches behind — empty for [Profile.NONE], and empty when
+   * [jailDropped]. Paths are bound with the `-try` variants where a host may legitimately lack
+   * them, so one missing `/lib64` can't turn a containment profile into a failed spawn.
    */
   fun command(paths: Paths): List<String> =
-    when (profile) {
-      Profile.NONE -> emptyList()
-      Profile.UNSHARE -> unshareCommand()
-      Profile.BWRAP -> bwrapCommand(paths)
-      Profile.SYSTEMD -> systemdCommand()
-      Profile.STRICT -> systemdCommand() + bwrapCommand(paths)
-      Profile.CUSTOM -> customCommand
-    }
+    if (jailDropped) emptyList()
+    else
+      when (profile) {
+        Profile.NONE -> emptyList()
+        Profile.UNSHARE -> unshareCommand()
+        Profile.BWRAP -> bwrapCommand(paths)
+        Profile.SYSTEMD -> systemdCommand()
+        Profile.STRICT -> systemdCommand() + bwrapCommand(paths)
+        Profile.CUSTOM -> customCommand
+      }
 
   /**
    * JVM-level caps applied to **every** active profile, so heap and CPU are bounded even where the
@@ -158,8 +190,8 @@ data class PlaygroundSandbox(
   fun describe(): String =
     if (!isActive) "sandbox=none (playground refused under --public)"
     else
-      "sandbox=${profile.id} mem=${memoryMb}MB heap=${heapMb()}MB cpus=$cpus pids=$pids " +
-        "ttl=${ttlSeconds}s"
+      "sandbox=${profile.id}${if (jailDropped) " (jail dropped — caps only)" else ""} " +
+        "mem=${memoryMb}MB heap=${heapMb()}MB cpus=$cpus pids=$pids ttl=${ttlSeconds}s"
 
   private fun unshareCommand(): List<String> =
     listOf(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
@@ -128,12 +128,20 @@ data class PlaygroundSandbox(
    * failure surfaces to a user as a compile that never produces an image, and to an operator as
    * nothing at all.
    *
-   * Dropping the jail is strictly better than both alternatives. Against *keeping* it: a jail that
-   * cannot launch contains nothing, so there is no isolation to lose. Against *disabling the
-   * sandbox entirely* ([Profile.NONE]): that would also discard `-Xmx`, the CPU cap,
-   * `ExitOnOutOfMemoryError`, the temp-dir confinement and the hard TTL — and on a host with a
-   * large cgroup limit an uncapped snippet JVM sizes its default heap at a quarter of that limit,
-   * which is the more dangerous failure of the two.
+   * Dropping the jail is better than both alternatives *for a profile whose caps are JVM-level*.
+   * Against *keeping* it: a jail that cannot launch contains nothing, so there is no isolation to
+   * lose. Against *disabling the sandbox entirely* ([Profile.NONE]): that would also discard
+   * `-Xmx`, the CPU cap, `ExitOnOutOfMemoryError`, the temp-dir confinement and the hard TTL — and
+   * on a host with a large cgroup limit an uncapped snippet JVM sizes its default heap at a quarter
+   * of that limit, which is the more dangerous failure of the two.
+   *
+   * **Not for [Profile.SYSTEMD] or [Profile.STRICT].** Their `MemoryMax` / `CPUQuota` / `TasksMax`
+   * are enforced by the `systemd-run` prefix that [command] emits, so dropping the argv drops the
+   * enforcement with it, leaving only heap and JVM pool sizing — no native-memory bound, no CPU
+   * quota, no pid cap. `ServeCommand` therefore refuses the lane outright for any profile with
+   * [Profile.declaresResourceCaps] rather than calling this. A [Profile.CUSTOM] argv may also have
+   * supplied caps we cannot see; it is dropped anyway (the alternative is a lane that cannot run at
+   * all) and the startup warning says so.
    *
    * Deliberately **not** reachable when containment is what admitted the lane: an anonymous
    * `--public` host whose probe never ran is refused outright by [PlaygroundPublicGate], so the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2134,6 +2134,7 @@ class ServeHttpServer(
                 SandboxDto(
                   profile = h.sandboxProfile,
                   active = h.sandboxActive,
+                  jailDropped = h.jailDropped,
                   memoryMb = h.sandboxMemoryMb,
                   cpus = h.sandboxCpus,
                   ttlSeconds = h.sandboxTtlSeconds,
@@ -3707,6 +3708,11 @@ private data class SandboxDto(
    * quarter of the limit.
    */
   val active: Boolean,
+  /**
+   * True ⇒ the configured jail could not launch on this host and was dropped; the JVM caps still
+   * apply but the snippet is not contained. Look at `probe.detail` for why it couldn't launch.
+   */
+  val jailDropped: Boolean = false,
   val memoryMb: Int,
   val cpus: Double,
   val ttlSeconds: Long,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxTest.kt
@@ -188,6 +188,28 @@ class PlaygroundSandboxTest {
   }
 
   @Test
+  fun `the profiles excluded from the drop are exactly those whose caps live in the argv`() {
+    // The discriminator ServeCommand refuses on. `systemd`/`strict` enforce MemoryMax, CPUQuota
+    // and TasksMax through the systemd-run prefix that command() emits, so dropping that argv
+    // drops the enforcement — heap and pool sizing are all that would remain. Pinning the set here
+    // means adding a future cgroup-backed profile can't silently inherit the caps-only fallback.
+    val capBacked =
+      PlaygroundSandbox.Profile.entries.filter { it.declaresResourceCaps }.map { it.id }.toSet()
+
+    assertEquals(setOf("systemd", "strict"), capBacked)
+
+    val strict = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.STRICT)
+    assertTrue(
+      strict.command(paths).any { it.startsWith("MemoryMax=") },
+      "the enforceable cap is in the argv, which is what makes dropping it unsafe",
+    )
+    assertTrue(
+      strict.jvmArgs(paths.workDir).none { it.startsWith("MemoryMax") },
+      "and jvmArgs cannot replace it",
+    )
+  }
+
+  @Test
   fun `dropping is inert for every profile that had no argv anyway`() {
     val none = PlaygroundSandbox.NONE.droppingJail()
     assertEquals(emptyList(), none.command(paths))

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxTest.kt
@@ -159,6 +159,40 @@ class PlaygroundSandboxTest {
   fun `the default ttl outlives a preview token so sessions end by expiry, not by the axe`() {
     assertTrue(PlaygroundSandbox.DEFAULT_TTL_SECONDS > PlaygroundTokenStore.DEFAULT_TTL_SECONDS)
   }
+
+  @Test
+  fun `dropping the jail removes the argv and keeps every cap`() {
+    // The recovery for a jail that cannot launch on this host. The argv is what fails to spawn, so
+    // it is the only thing that goes; the caps are the half that actually protects the box.
+    val dropped = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.UNSHARE).droppingJail()
+
+    assertEquals(emptyList(), dropped.command(paths), "no jail argv survives the drop")
+    assertTrue(dropped.isActive, "still active — otherwise the caps would go too")
+    assertTrue("-Xmx1152m" in dropped.jvmArgs(paths.workDir))
+    assertTrue(dropped.jvmArgs(paths.workDir).any { it.startsWith("-XX:ActiveProcessorCount=") })
+    assertTrue("-XX:+ExitOnOutOfMemoryError" in dropped.jvmArgs(paths.workDir))
+    assertEquals(
+      PlaygroundSandbox.DEFAULT_TTL_SECONDS,
+      dropped.ttlSeconds,
+      "the hard kill still arms",
+    )
+  }
+
+  @Test
+  fun `a dropped jail says so, so a log or status is never mistaken for containment`() {
+    val dropped = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP).droppingJail()
+
+    assertTrue("jail dropped" in dropped.describe(), dropped.describe())
+    // The profile id is retained: what the operator ASKED for stays visible next to what happened.
+    assertTrue("bwrap" in dropped.describe(), dropped.describe())
+  }
+
+  @Test
+  fun `dropping is inert for every profile that had no argv anyway`() {
+    val none = PlaygroundSandbox.NONE.droppingJail()
+    assertEquals(emptyList(), none.command(paths))
+    assertFalse(none.isActive, "none stays none — there was nothing to drop")
+  }
 }
 
 /**
@@ -392,6 +426,39 @@ class PlaygroundPublicGateTest {
       )
 
     assertTrue("ANONYMOUS" in allow, allow)
+  }
+
+  @Test
+  fun `a jail that cannot launch is still refused when containment is the admission basis`() {
+    // The safety property the auto-fallback rests on. ServeCommand only drops a jail AFTER the
+    // gate has admitted the lane, so this refusal is what keeps the fallback from ever handing an
+    // anonymous --public host an uncontained playground: it never gets past `decide`.
+    val refusal =
+      assertRefused(
+        PlaygroundPublicGate.decide(
+          isPublic = true,
+          repoAccessGated = false,
+          sandbox = bwrap,
+          probe = PlaygroundSandboxProbe.Report(ran = false, detail = "bwrap: not found"),
+        )
+      )
+
+    assertTrue("bwrap: not found" in refusal, refusal)
+  }
+
+  @Test
+  fun `a repo-access-gated host with an unlaunchable jail is admitted, so it can fall back`() {
+    // The mirror of the case above: here the lane is admitted on WHO can reach it, so the dead
+    // jail is a degradation to report rather than a reason to refuse — which is exactly the state
+    // ServeCommand converts into a caps-only sandbox.
+    assertAllowed(
+      PlaygroundPublicGate.decide(
+        isPublic = true,
+        repoAccessGated = true,
+        sandbox = bwrap,
+        probe = PlaygroundSandboxProbe.Report(ran = false, detail = "bwrap: not found"),
+      )
+    )
   }
 
   private fun assertAllowed(decision: PlaygroundPublicGate.Decision): String {

--- a/docs/design/PLAYGROUND.md
+++ b/docs/design/PLAYGROUND.md
@@ -380,6 +380,39 @@ refused under `--public` and pointed at `strict`; a `custom:` jail is taken at
 its word on caps (they're the operator's to supply, and the startup log says so)
 but must still pass the probe.
 
+#### A jail that cannot launch is dropped, not obeyed
+
+The probe answers a second question the gate does not: **can this jail launch on
+this host at all?** A configured `unshare` under a kernel/AppArmor policy that
+forbids unprivileged user namespaces, or a `bwrap` that isn't installed, does not
+merely fail to contain — it fails to *start*, and every snippet JVM and every
+jailed compile launches behind that same argv.
+
+Left alone, that is a silent breakage of the worst kind. The gate admits the lane
+(on repo access, or because the host is token-gated), `/playground` answers
+normally, `status` reports `ok` — and every compile fails to spawn. It reads to a
+user as a playground that never renders anything, and to an operator as nothing
+at all. It happened on `preview.coo.ee`: `SERVE_PLAYGROUND_SANDBOX=unshare` was
+set, the lane came up looking healthy, and the only evidence was
+`probe.ran: false` in `/status.json`.
+
+So when the preflight reports that the jail could not launch, and the lane was
+admitted on something *other* than containment, `serve` **drops the jail argv and
+keeps every other cap** (`PlaygroundSandbox.droppingJail`). Snippets still run in
+a disposable child under `-Xmx`, the CPU cap, `ExitOnOutOfMemoryError`, the
+temp-dir confinement and the hard TTL — they are simply not contained.
+
+That is strictly better than either alternative. Keeping a jail that cannot
+launch preserves no isolation, because it never ran. Falling back to
+`Profile.NONE` would also discard the caps — and on a host with a large cgroup
+limit an uncapped snippet JVM sizes its default heap at a *quarter of that
+limit*, which is the more dangerous of the two failures.
+
+It cannot rescue the posture where containment *is* the admission basis: an
+anonymous `--public` host whose probe did not run is refused by the gate before
+the fallback is reachable. The drop is reported in the startup log, in
+`describe()`, and as `playground.sandbox.jailDropped` on `/status.json`.
+
 #### The probe answers "is a *stranger's* snippet contained?" — sometimes nobody is asking
 
 That whole chain is the right question only when a stranger can reach the lane.

--- a/docs/design/PLAYGROUND.md
+++ b/docs/design/PLAYGROUND.md
@@ -402,11 +402,20 @@ keeps every other cap** (`PlaygroundSandbox.droppingJail`). Snippets still run i
 a disposable child under `-Xmx`, the CPU cap, `ExitOnOutOfMemoryError`, the
 temp-dir confinement and the hard TTL — they are simply not contained.
 
-That is strictly better than either alternative. Keeping a jail that cannot
-launch preserves no isolation, because it never ran. Falling back to
-`Profile.NONE` would also discard the caps — and on a host with a large cgroup
-limit an uncapped snippet JVM sizes its default heap at a *quarter of that
-limit*, which is the more dangerous of the two failures.
+That is better than either alternative — *for a profile whose caps are
+JVM-level*. Keeping a jail that cannot launch preserves no isolation, because it
+never ran. Falling back to `Profile.NONE` would also discard the caps, and on a
+host with a large cgroup limit an uncapped snippet JVM sizes its default heap at
+a *quarter of that limit*, which is the more dangerous of the two failures.
+
+**`systemd` and `strict` are excluded, and refuse instead.** Their `MemoryMax` /
+`CPUQuota` / `TasksMax` come from the `systemd-run` prefix — the very argv being
+dropped — so degrading them would leave heap and JVM pool sizing with no
+native-memory bound, no CPU quota and no pid cap. An operator who asked for
+enforceable caps should not silently get unenforceable ones, so a cap-declaring
+profile that cannot launch disables the lane with a message naming the choice:
+fix the jail, or pick a profile (`bwrap`, `unshare`) whose caps are JVM-level
+anyway.
 
 It cannot rescue the posture where containment *is* the admission basis: an
 anonymous `--public` host whose probe did not run is refused by the gate before


### PR DESCRIPTION
A configured jail that fails to *start* broke the playground **silently**. Not hypothetical — this is the `preview.coo.ee` incident from earlier today, turned into a fix.

## The failure

`SERVE_PLAYGROUND_SANDBOX=unshare` was set on a host whose kernel policy forbids unprivileged user namespaces. Then:

- the gate admitted the lane on repo access ✅
- `/playground` answered `302 → /auth/github/start` ✅
- `/status.json` reported `status: ok` ✅
- …and **every snippet JVM and every jailed compile would have failed to spawn**, because they all launch behind an argv that returns `EPERM`

To a user that's a playground that never renders anything. To an operator it's nothing at all. The only evidence anywhere was `probe.ran: false` — and that field existed only because it had been added days earlier, for an unrelated reason. The manual escape was `SERVE_PLAYGROUND_SANDBOX=custom:/usr/bin/env`, which nobody should need to know.

## The fix

When the preflight reports the jail could not launch, and the lane was admitted on something *other* than containment, drop the jail argv and keep every other cap — `-Xmx`, the CPU cap, `ExitOnOutOfMemoryError`, the temp-dir confinement, the hard TTL. Snippets still run in a disposable capped child; they are simply not contained.

**Strictly better than both alternatives.** Keeping a jail that cannot launch preserves no isolation, because it never ran. Falling back to `Profile.NONE` would discard the caps as well — and on a host with a large cgroup limit an uncapped JVM sizes its default max heap at **a quarter of that limit** (12 GiB against `preview.coo.ee`'s 48 GiB container). That is the more dangerous of the two failures, and it is exactly what the `custom:/usr/bin/env` workaround was avoiding.

## The safety property

This can never rescue the posture where containment *is* the admission basis. An anonymous `--public` host whose probe didn't run is refused by `PlaygroundPublicGate` **before** the fallback is reachable — pinned by a test, since the whole change would be a hole otherwise:

```kotlin
@Test fun `a jail that cannot launch is still refused when containment is the admission basis`()
@Test fun `a repo-access-gated host with an unlaunchable jail is admitted, so it can fall back`()
```

## One behaviour change worth noting

The preflight now runs for **any** active sandbox, not only under `--public`. Its containment verdict still gates only the anonymous-public posture — but "can this jail launch here?" matters everywhere, and a token-gated host with a forbidden `unshare` was just as broken with no probe at all to notice. Cost: one throwaway JVM at startup, on hosts that configured a sandbox.

## Reported three ways

The failure's entire character was invisibility, so:

- a startup **WARNING** naming what couldn't launch and why
- `describe()` carries `jail dropped — caps only` next to the profile the operator asked for
- **`playground.sandbox.jailDropped`** on `/status.json`
- and the jailed-compiler log no longer claims compiles "run inside the sandbox" when the jail is gone

## Test plan

- [x] `./gradlew :cli:test` — full CLI suite green
- [x] `./gradlew ktfmtCheckAll`
- [x] New unit tests: the drop removes the argv and keeps every cap; a dropped jail says so; dropping is inert for `none`; plus the two gate tests above

**Reproduced the real failure against a live server** with `--playground-sandbox custom:/nonexistent/jail-binary`:

```
serve: sandbox preflight did not run: could not launch '/nonexistent/jail-binary' … error=2
serve: WARNING playground sandbox 'custom' could not launch on this host (…) — dropping the
       jail and keeping the JVM caps. Snippets run capped but UNCONTAINED; the lane is
       admitted by the access token, not by containment.
serve: playground: compiles run in a capped child with NO jail (…)
```

and a compile then **succeeds** where it previously could not:

```
exception : None
previewId : SnippetKt.Hello
previewUrl: /pg/pg_CYj-pacDSvF23SeNdJAV3g
image     : present

status.json -> profile: custom | active: True | jailDropped: True | probe.ran: False
               heap cap still applied from 1536 MB budget; ttl 900 s
```

**And confirmed no regression to the working case** — a launchable jail (`custom:/usr/bin/env`) still reports `jailDropped: False`, `probe.ran: True`, no warning, and `compiles run inside the custom sandbox`.

No visual evidence: server behaviour and one JSON field; no rendered surface is touched.

Refs #3211, #3215

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr)_