### PR TITLE
fix(serve): price prefetch replicas as background residency

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -549,12 +549,12 @@ class ServeCatalogLiveHost(
   private fun renderOptimizerBatch(batch: List<ThemeOptimizationJob>): List<RenderOutcome> {
     if (batch.size == 1) {
       val job = batch.single()
-      return listOf(renderLeased(job.previewId, job.overrides))
+      return listOf(renderPrefetch(job.previewId, job.overrides))
     }
     return batch
       .map { job ->
         optimizerBatchExecutor.submit<RenderOutcome> {
-          runCatching { renderLeased(job.previewId, job.overrides) }
+          runCatching { renderPrefetch(job.previewId, job.overrides) }
             .getOrElse { RenderOutcome.Failed("prefetch render threw: ${it.message}") }
         }
       }
@@ -808,10 +808,22 @@ class ServeCatalogLiveHost(
   override fun renderLeased(previewId: String, overrides: PreviewOverrides): RenderOutcome =
     renderInternal(previewId, overrides, leased = true)
 
+  /**
+   * A leased render issued by the idle theme optimizer rather than by a waiting visitor.
+   *
+   * Identical routing to [renderLeased] — it wants the same wide shared-daemon lane — but any
+   * replica it opens is charged to the BACKGROUND seat remainder. The optimizer is background
+   * residency by definition and does not end, so pricing it as foreground let prefetching hold the
+   * stream reserve for hours; see [ServeSharedDaemonPool.render].
+   */
+  private fun renderPrefetch(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+    renderInternal(previewId, overrides, leased = true, background = true)
+
   private fun renderInternal(
     previewId: String,
     overrides: PreviewOverrides,
     leased: Boolean,
+    background: Boolean = false,
   ): RenderOutcome {
     val catalogCacheKey = catalogCacheKey(previewId, overrides)
     val themeCacheKey = themeCacheKey(previewId, overrides)
@@ -837,7 +849,10 @@ class ServeCatalogLiveHost(
       // lane, so it must be awaited even cold and its outcome returned as-is. Everything below is
       // the baked-first routing, which such an id can't use.
       if (previewId in liveOnlyPreviewIds) {
-        return cacheCatalogRender(catalogCacheKey, renderDaemon(daemonId, overrides, leased))
+        return cacheCatalogRender(
+          catalogCacheKey,
+          renderDaemon(daemonId, overrides, leased, background),
+        )
       }
       // Only await the daemon when it's warm and free. A cold Android render can take minutes, and
       // blocking the browse — and the HTTP render slot it holds — on it is what saturates the whole
@@ -861,7 +876,7 @@ class ServeCatalogLiveHost(
       if (
         leased || daemonWarmOrScheduling(daemonId) || awaitForegroundWarm(daemonId, themeCacheKey)
       ) {
-        val live = renderDaemon(daemonId, overrides, leased)
+        val live = renderDaemon(daemonId, overrides, leased, background)
         // Count a real render failure against this theme key so a permanently broken preview stops
         // being re-attempted (see [CatalogThemeCache.recordRenderFailure]). Busy / NotFound are not
         // failures of the render — they are "ask again" and "wrong lane" — and must not latch.
@@ -991,10 +1006,11 @@ class ServeCatalogLiveHost(
     daemonId: String,
     overrides: PreviewOverrides,
     leased: Boolean = false,
+    background: Boolean = false,
   ): RenderOutcome {
     val outcome =
       if (sharedDaemonRenders && leased && sharedDaemonPool != null) {
-        sharedDaemonPool.render(daemonId, overrides)
+        sharedDaemonPool.render(daemonId, overrides, background = background)
       } else {
         renderHostFor(daemonId).render(daemonId, overrides)
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -46,6 +46,20 @@ class ServeSessionRegistry(
    * clock).
    */
   private val suspendedGcTimeoutMillis: Long = DEFAULT_SUSPENDED_GC_TIMEOUT_MILLIS,
+  /**
+   * Idle window for shedding **pooled daemons** ([releaseIdleDaemons]), separate from
+   * [idleTimeoutMillis], which suspends whole sessions.
+   *
+   * They are different questions. Suspending a session throws away a catalog's warm state and the
+   * visitor pays to rebuild it, so ten minutes is a reasonable price of admission. A pool replica
+   * is reopened from the same launch descriptor whenever the next burst needs it, and while it sits
+   * there it holds a live seat weighted 2 — so on an eight-seat box a handful of forgotten replicas
+   * is the whole budget. Reusing the session window meant a replica could hold its seat for the ten
+   * minutes it takes to qualify plus up to another sweep interval before anything looked.
+   *
+   * Non-positive falls back to [idleTimeoutMillis], preserving the old behaviour.
+   */
+  private val daemonIdleMillis: Long = DEFAULT_DAEMON_IDLE_MILLIS,
   private val clock: () -> Long = System::currentTimeMillis,
 ) : AutoCloseable {
 
@@ -160,6 +174,18 @@ class ServeSessionRegistry(
             reaperIntervalMillis,
             TimeUnit.MILLISECONDS,
           )
+          // Pooled daemons are swept on their OWN cadence when it is shorter. A replica holds a
+          // live seat weighted 2 and is cheap to reopen, so waiting a session-suspension interval
+          // to look at it means a handful of forgotten replicas can hold an eight-seat box's whole
+          // budget. Same single thread, so the two sweeps never overlap.
+          if (daemonIdleMillis > 0 && daemonIdleMillis < reaperIntervalMillis) {
+            it.scheduleWithFixedDelay(
+              { runCatching { releaseIdleDaemons() } },
+              daemonIdleMillis,
+              daemonIdleMillis,
+              TimeUnit.MILLISECONDS,
+            )
+          }
         }
     } else {
       null
@@ -348,13 +374,12 @@ class ServeSessionRegistry(
    * unrelated session's acquire. A host closed concurrently by [suspendIdle] just reports zero.
    */
   fun releaseIdleDaemons(): Int {
-    if (idleTimeoutMillis <= 0) return 0
+    val window = if (daemonIdleMillis > 0) daemonIdleMillis else idleTimeoutMillis
+    if (window <= 0) return 0
     val hosts = lock.withLock {
       if (closed) emptyList() else sessions.values.mapNotNull { it.host }
     }
-    return hosts.sumOf { host ->
-      runCatching { host.releaseIdleDaemons(idleTimeoutMillis) }.getOrDefault(0)
-    }
+    return hosts.sumOf { host -> runCatching { host.releaseIdleDaemons(window) }.getOrDefault(0) }
   }
 
   /**
@@ -508,5 +533,13 @@ class ServeSessionRegistry(
      * always suspends first. Pinned/registered sessions are exempt regardless.
      */
     const val DEFAULT_SUSPENDED_GC_TIMEOUT_MILLIS = 60 * 60 * 1000L
+
+    /**
+     * Default idle window before a pooled daemon is closed and its live seat returned — a minute,
+     * against the ten a whole session gets. A replica reopens from its launch descriptor whenever
+     * the next burst needs it; a suspended session costs a visitor a rebuild. Different prices, so
+     * different windows.
+     */
+    const val DEFAULT_DAEMON_IDLE_MILLIS = 60 * 1000L
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -98,7 +98,22 @@ class ServeSharedDaemonPool(
    */
   fun takeColdStartMillis(): Long = peakColdStartMillis.getAndSet(0)
 
-  fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+  /**
+   * [background] prices any replica this render has to open against the BACKGROUND remainder
+   * ([LiveSeatLimiter.acquireBackground]), leaving [LiveSeatLimiter.STREAM_RESERVE] free.
+   *
+   * The default (foreground) is right for a leased browse burst: a visitor is sitting in front of
+   * the grid waiting for those pixels, so it is the same class of demand as a stream. It is wrong
+   * for the idle theme optimizer, which reaches this pool through the same *leased* path but is
+   * background residency by definition — and, unlike a burst, does not end. On the deployed box
+   * that combination held 6-8 of 8 seats for hours with `activeStreams: 0`, against a reserve whose
+   * entire job is to guarantee a visitor can always start a stream.
+   */
+  fun render(
+    previewId: String,
+    overrides: PreviewOverrides,
+    background: Boolean = false,
+  ): RenderOutcome {
     permits.acquire()
     var borrowed: ServeHost? = null
     // An explicit flag, not a `coldStartFrom > 0` sentinel: [clock] is injectable and a test clock
@@ -109,7 +124,7 @@ class ServeSharedDaemonPool(
     try {
       borrowed = lock.withLock {
         check(!closed) { "shared daemon pool is closed" }
-        val host = available.removeFirstOrNull() ?: openSeatedReplica()
+        val host = available.removeFirstOrNull() ?: openSeatedReplica(background)
         // Claimed under the lock so exactly one borrow times the cold start.
         cold = coldReplicas.remove(host)
         if (cold) coldStartFrom = clock()
@@ -149,15 +164,20 @@ class ServeSharedDaemonPool(
    * it waits for one of its own in-flight borrows to come back. That wait is bounded by a render,
    * and the primary is always in circulation, so there is always something to wait for — the batch
    * simply narrows to the width the box can afford instead of adding a JVM it can't.
+   *
+   * [background] takes the seat from the background remainder instead, so prefetch residency can
+   * never occupy the stream reserve — see [render].
    */
-  private fun openSeatedReplica(): ServeHost {
+  private fun openSeatedReplica(background: Boolean): ServeHost {
     var ticket: LiveSeatLimiter.Ticket? = null
     if (liveSeats != null) {
       // countRefusal = false: a miss here does NOT refuse the render. The burst simply narrows
       // onto a host already in circulation (below), so counting it would report throttled widening
       // as visitors turned away — and `liveSeatRefusals` is the evidence any budget change rests
-      // on.
-      ticket = liveSeats.acquire(seatWeight(), countRefusal = false)
+      // on. (`acquireBackground` never counts a refusal for the same reason.)
+      ticket =
+        if (background) liveSeats.acquireBackground(seatWeight())
+        else liveSeats.acquire(seatWeight(), countRefusal = false)
       if (ticket == null) {
         while (available.isEmpty() && !closed) hostReturned.await()
         check(!closed) { "shared daemon pool is closed" }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -266,6 +266,57 @@ class ServeSharedDaemonPoolTest {
     }
   }
 
+  /**
+   * The stream reserve exists so a visitor can always start a stream no matter how much render
+   * residency has built up. A leased *browse* burst is allowed to take it — a visitor is already
+   * waiting on those pixels. The idle theme optimizer reaches this same pool through the same
+   * leased path, but it is background residency and, unlike a burst, it does not end: on the
+   * deployed box that held 6-8 of 8 seats for hours with `activeStreams: 0`.
+   */
+  @Test
+  fun `a background render may not open a replica inside the stream reserve`() {
+    // Exactly the reserve free: foreground may take it, background may not.
+    val seats = LiveSeatLimiter(totalPermits = LiveSeatLimiter.STREAM_RESERVE)
+    val opened = AtomicInteger()
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val primary = BlockingHost("primary", entered, release)
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 2, liveSeats = seats) {
+        opened.incrementAndGet()
+        InstantHost("replica")
+      }
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      val held = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      assertTrue(entered.await(5, TimeUnit.SECONDS), "primary is mid-render")
+
+      // Prefetch overlapping the busy primary: it must NOT spawn into the reserve, so it waits.
+      val prefetch =
+        executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides(), background = true) }
+      assertTrue(
+        runCatching { prefetch.get(1, TimeUnit.SECONDS) }.isFailure,
+        "the prefetch waits for the primary rather than taking the stream reserve",
+      )
+      assertEquals(0, opened.get(), "no replica opened against the reserve")
+
+      release.countDown()
+      assertTrue(held.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok)
+      // It still gets served — narrowing the lane, never failing the render.
+      assertTrue(prefetch.get(10, TimeUnit.SECONDS) is RenderOutcome.Ok)
+      assertEquals(
+        LiveSeatLimiter.STREAM_RESERVE,
+        seats.availablePermits(),
+        "the reserve is intact, so a stream could still start",
+      )
+      assertEquals(0L, seats.refusalCount(), "and narrowing is not a refused visitor")
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+      pool.close()
+    }
+  }
+
   /** The other direction: when replicas ARE affordable, the peak sees them. */
   @Test
   fun `peak in-flight rises with genuinely concurrent renders`() {


### PR DESCRIPTION
Answers "were those 8 seats still needed, or should they have been released earlier?" — asked of the deployed box, where `liveSeatsAvailable` sat at 0–2 of 8 for hours with `activeStreams: 0` and at most 4 daemons running.

They didn't need releasing. They needed pricing.

## The mismatch

The theme optimizer reaches the shared daemon pool through `renderLeased` (`ServeCatalogLiveHost.kt:996`), so every replica it opened was charged as a **foreground** seat. That pricing was chosen for a leased browse burst, and #3326's comment says exactly why:

> A replica opens only when *leased* renders overlap — a visitor is sitting in front of the grid waiting for those pixels — so it is the same class of demand as a stream, not background residency. It is also short-lived: the burst ends, the replica goes idle, and `reapIdle` returns the seat.

Neither premise holds for the optimizer. It is background residency by definition, and its burst doesn't end — it runs for hours. So prefetching was spending the foreground budget and bypassing `STREAM_RESERVE`, whose entire job is to guarantee a visitor can always start a stream.

## The fix

`renderPrefetch` routes identically to `renderLeased` — same wide shared lane, batch throughput unchanged — but any replica it opens takes the **background remainder** via `acquireBackground`. When that isn't available the batch narrows onto a host already in circulation, exactly as it does today when the budget is exhausted, so no render fails and no refusal is counted.

## Pooled daemons get their own idle window

`DEFAULT_DAEMON_IDLE_MILLIS` (1 min), swept on its own cadence, instead of sharing the 10-minute session-suspension window. Suspending a session costs a visitor a rebuild; a pool replica reopens from the same launch descriptor. Sharing the window meant a forgotten replica held a weight-2 seat for the 10 minutes it took to qualify **plus** up to another sweep interval — the reaper's interval defaults to the same 10 minutes.

**This does not reap replicas while the optimizer runs.** Every batch refreshes `replicaLastUsed`, so no idle window of any length will see them. The seat pricing above is what makes that acceptable rather than something to work around.

## What I did not do

I proposed releasing replicas when the optimizer yields its turn, and dropped it on working through the numbers: `OPTIMIZER_RESUME_MILLIS` is 2s and a replica cold start is 34–68s, so a yield/resume cycle would destroy four daemons and pay four cold starts to rebuild them. Strictly worse than today.

## Test plan

- `./gradlew :cli:test` — green (full suite).
- New `a background render may not open a replica inside the stream reserve`: budget = exactly `STREAM_RESERVE`, primary held mid-render so an overlapping request must take the replica path. The prefetch **waits** instead of spawning, no replica opens, the reserve is intact afterwards (a stream could still start), and `refusalCount` stays 0 — narrowing is not a turned-away visitor. It still completes once the primary frees up.
- Pairs with the existing `a leased replica may use the seats reserved against background work`, which asserts the foreground direction is unchanged.

Not visual — seat accounting and reaper cadence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_