### PR TITLE
feat(serve): read per-preview render history off the delivery branches

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistory.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistory.kt
@@ -1,0 +1,302 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+
+/**
+ * Per-preview render history, read off a baseline delivery branch (`compose-preview/main`,
+ * `design-artifacts/<system>`) whose commits are full snapshots of the rendered output.
+ *
+ * The branches carry one commit per publish, so the raw commit list badly overstates how much a
+ * preview actually changed: an unstable preview re-renders differently on every run and therefore
+ * appears in *every* commit. The whole point of this file is the collapse — adjacent commits whose
+ * render bytes are identical are one [Version], and a preview that keeps returning to a render it
+ * had already moved away from is [Timeline.unstable] rather than a preview with hundreds of
+ * changes.
+ *
+ * Measured on `compose-preview/main` at 770 commits — 811 render paths, 1375 observations:
+ * - the run-collapse is a **no-op in practice**, because `git log --raw -- <path>` only reports
+ *   commits in which the file actually changed, so consecutive observations for one path never
+ *   share a blob. It is kept for correctness (a merge or mode-only entry can repeat a blob, and it
+ *   makes [Version.commits] meaningful), not for the reduction;
+ * - trimming the unstable ones ([Timeline.displayVersions]) is where the reduction comes from: 1375
+ *   entries → 826, a 40% cut, from just **5** previews. The worst is 226 runs of 4 renders.
+ *
+ * That concentration is the argument for trimming at all: a handful of non-deterministic previews
+ * would otherwise dominate every timeline in the manifest, and the two wear renders alone account
+ * for over 400 of the entries removed.
+ *
+ * Everything here is pure — [parseGitLog] takes the text of one `git log` invocation and the git
+ * call itself is isolated in [read] — so the collapse rules are unit-testable without a repo.
+ */
+object PreviewHistory {
+
+  /**
+   * The `git log` arguments this parser expects, over [pathspec] on [ref].
+   *
+   * `--raw --no-abbrev` is what makes a whole branch affordable: the raw diff line already carries
+   * the post-image blob sha for every touched file, so the render bytes at each commit are known
+   * without a `rev-parse <commit>:<path>` subprocess per file per commit. One invocation covers the
+   * entire branch — measured at ~1.6s for 770 commits over 537 files.
+   *
+   * `%x01` prefixes a header line and `%x1f` separates its fields, because both are control
+   * characters git will never emit inside a sha, an ISO date, or a path, while a commit *subject*
+   * is free-form and could contain anything more printable.
+   */
+  fun logArgs(ref: String, pathspec: String): List<String> =
+    listOf(
+      "log",
+      "--format=%x01%H%x1f%aI%x1f%s",
+      "--raw",
+      "--no-abbrev",
+      "--no-renames",
+      ref,
+      "--",
+      pathspec,
+    )
+
+  /** One commit on the delivery branch in which a given render had particular bytes. */
+  data class Observation(
+    /** Delivery-branch commit sha. */
+    val commit: String,
+    /** Author date, ISO-8601, as git emitted it. */
+    val date: String,
+    /** The commit subject, kept so [sourceSha] can be re-derived and for display. */
+    val subject: String,
+    /** Content sha of the render *at* this commit — the post-image blob. */
+    val blob: String,
+    /** True when this commit deleted the render (post-image is the all-zero sha). */
+    val deleted: Boolean,
+  ) {
+    /**
+     * The source commit this snapshot was rendered from, recovered from the publish subject.
+     *
+     * Both publishers stamp it, in their own wording — `Update preview baselines from <sha>` and
+     * `chore(design-artifacts): regenerate <system> catalog (<date>, <sha>)` — so the join back to
+     * the change that moved a pixel is a subject parse rather than a second data source. Null when
+     * the subject predates the stamping or doesn't match.
+     */
+    val sourceSha: String?
+      get() = SOURCE_SHA.find(subject)?.groupValues?.get(1)
+  }
+
+  /**
+   * A maximal run of consecutive commits whose render bytes were identical — one *visible* version
+   * of a preview, however many publishes it survived.
+   */
+  data class Version(
+    /** Content sha of the render. */
+    val blob: String,
+    /** Path on the delivery branch, e.g. `renders/samples:wear/Foo.png`. */
+    val path: String,
+    /** The commit that introduced these bytes (oldest in the run). */
+    val since: Observation,
+    /** The newest commit still carrying these bytes. */
+    val until: Observation,
+    /** How many publishes carried them. */
+    val commits: Int,
+    /**
+     * How many separate runs had these bytes. Always 1 for an untrimmed run; on a trimmed unstable
+     * timeline it's how many times the preview came back to this state, which is the honest way to
+     * show a recurring state once without pretending it only happened once.
+     */
+    val occurrences: Int = 1,
+  ) {
+    /** True when these bytes recurred — the state was returned to after changing away. */
+    val recurring: Boolean
+      get() = occurrences > 1
+  }
+
+  /** The full history of one render path, newest version first. */
+  data class Timeline(
+    val path: String,
+    /** Newest first. */
+    val versions: List<Version>,
+    /** Raw commits touching this path, before collapsing. */
+    val observations: Int,
+  ) {
+    /** Distinct render bytes ever seen. */
+    val distinctBlobs: Int
+      get() = versions.map { it.blob }.toSet().size
+
+    /**
+     * How many times the render *returned* to bytes it had already moved away from.
+     *
+     * `runs - distinctBlobs` counts exactly the re-appearances: a preview that changes cleanly N
+     * times has N runs and N distinct blobs and so scores 0, while one alternating A/B/A/B scores
+     * one per flip. A legitimate revert scores 1, which is why [unstable] needs more than one.
+     */
+    val flapCount: Int
+      get() = versions.size - distinctBlobs
+
+    /**
+     * True when the render keeps reverting to earlier bytes — the signature of a non-deterministic
+     * preview (clock, animation frame, randomness), not of a preview that changed a lot.
+     *
+     * Deliberately not a "changed more than N times" threshold: a genuinely churny preview is
+     * usually fine, whereas two returns to a previous render is already something no deterministic
+     * pipeline should produce by accident.
+     */
+    val unstable: Boolean
+      get() = flapCount >= UNSTABLE_FLAP_THRESHOLD
+
+    /**
+     * The states this preview keeps flipping between — bytes that occupy more than one run.
+     *
+     * This is the set a reviewer actually wants named: for the worst offender on
+     * `compose-preview/main` it's 4 renders that 226 commits shuffle between, not 226 changes.
+     */
+    val recurringBlobs: Set<String>
+      get() = versions.groupingBy { it.blob }.eachCount().filterValues { it > 1 }.keys
+
+    /**
+     * The timeline to actually display: unchanged when the preview is stable, and **deduplicated to
+     * one entry per distinct state** when it isn't.
+     *
+     * An unstable preview's run list is almost entirely noise — the same handful of renders
+     * alternating — so showing every run buries the real content under hundreds of identical
+     * thumbnails. Trimming keeps each distinct state once (widest span, summed commits, with
+     * [Version.occurrences] recording how many runs it had) so the timeline shows *what* the
+     * preview flips between instead of *how often* it flipped. [observations], [flapCount] and
+     * [unstable] still carry the raw counts, so nothing is hidden — only collapsed.
+     */
+    val displayVersions: List<Version>
+      get() = if (!unstable) versions else trimRecurring(versions)
+  }
+
+  /**
+   * Collapse an unstable timeline's runs to one [Version] per distinct blob, newest first.
+   *
+   * Ordering follows each state's most recent appearance, so the newest render still leads. `since`
+   * takes the oldest run's introducing commit and `until` the newest run's last one, making the
+   * entry span the whole period the state was in play.
+   */
+  private fun trimRecurring(versions: List<Version>): List<Version> {
+    val byBlob = LinkedHashMap<String, MutableList<Version>>()
+    versions.forEach { byBlob.getOrPut(it.blob) { mutableListOf() }.add(it) }
+    return byBlob.values.map { runs ->
+      // `versions` is newest-first, so runs.first() is the most recent appearance.
+      runs
+        .first()
+        .copy(
+          since = runs.last().since,
+          commits = runs.sumOf { it.commits },
+          occurrences = runs.size,
+        )
+    }
+  }
+
+  /**
+   * Collapse raw newest-first [observations] per path into [Timeline]s.
+   *
+   * Deletions terminate a path's history rather than becoming a version: a preview that was removed
+   * and later re-added should not read as having "returned" to its old bytes and so score a flap.
+   */
+  fun collapse(observations: Map<String, List<Observation>>): Map<String, Timeline> =
+    observations.mapValues { (path, rows) ->
+      collapseOne(path, rows)
+    }
+
+  private fun collapseOne(path: String, rows: List<Observation>): Timeline {
+    val live = rows.takeWhile { !it.deleted }
+    val versions = mutableListOf<Version>()
+    var run = mutableListOf<Observation>()
+    for (row in live) {
+      if (run.isNotEmpty() && run.first().blob != row.blob) {
+        versions += toVersion(path, run)
+        run = mutableListOf()
+      }
+      run += row
+    }
+    if (run.isNotEmpty()) versions += toVersion(path, run)
+    return Timeline(path = path, versions = versions, observations = live.size)
+  }
+
+  /** [run] is newest-first, so its last entry is the commit that introduced the bytes. */
+  private fun toVersion(path: String, run: List<Observation>) =
+    Version(
+      blob = run.first().blob,
+      path = path,
+      since = run.last(),
+      until = run.first(),
+      commits = run.size,
+    )
+
+  /**
+   * Parse the output of a [logArgs] invocation into newest-first observations per path.
+   *
+   * Tolerant by design: this reads a branch that CI writes and that predates the parser, so a line
+   * that doesn't fit the expected shape is skipped rather than failing the whole history. A raw
+   * line arriving before any header (impossible from git, possible from a truncated capture) is
+   * dropped for the same reason.
+   */
+  fun parseGitLog(output: String): Map<String, List<Observation>> {
+    val byPath = LinkedHashMap<String, MutableList<Observation>>()
+    var commit: String? = null
+    var date = ""
+    var subject = ""
+    for (line in output.lineSequence()) {
+      if (line.startsWith(HEADER_MARK)) {
+        val fields = line.substring(1).split(FIELD_SEP)
+        if (fields.size >= 3) {
+          commit = fields[0]
+          date = fields[1]
+          subject = fields[2]
+        } else {
+          commit = null
+        }
+        continue
+      }
+      if (!line.startsWith(':') || commit == null) continue
+      val tab = line.indexOf('\t')
+      if (tab < 0) continue
+      // ":<srcmode> <dstmode> <srcsha> <dstsha> <status>\t<path>" — split() over the whole
+      // whitespace run so a status like "M100" or a mode column width change can't shift indices.
+      val meta = line.substring(1, tab).split(' ').filter { it.isNotEmpty() }
+      if (meta.size < 5) continue
+      val blob = meta[3]
+      val path = line.substring(tab + 1)
+      byPath
+        .getOrPut(path) { mutableListOf() }
+        .add(
+          Observation(
+            commit = commit,
+            date = date,
+            subject = subject,
+            blob = blob,
+            deleted = blob == NULL_SHA,
+          )
+        )
+    }
+    return byPath
+  }
+
+  /**
+   * Read the history of [pathspec] on [ref] from the repo at [repoRoot]. Returns an empty map when
+   * the ref is absent (a clone that never fetched the delivery branch) rather than throwing — the
+   * history surface is additive, and a viewer without it should degrade to no timeline, not fail.
+   */
+  fun read(
+    repoRoot: File,
+    ref: String,
+    pathspec: String = "renders",
+    git: GitRunner = GitWorktrees.RealGitRunner,
+  ): Map<String, Timeline> {
+    val result = git.run(repoRoot, logArgs(ref, pathspec))
+    if (!result.ok) return emptyMap()
+    return collapse(parseGitLog(result.stdout))
+  }
+
+  /** Two returns to previously-seen bytes before a preview is called unstable. See [Timeline]. */
+  const val UNSTABLE_FLAP_THRESHOLD: Int = 2
+
+  private const val HEADER_MARK = "\u0001"
+  private const val FIELD_SEP = "\u001F"
+  private const val NULL_SHA = "0000000000000000000000000000000000000000"
+
+  /**
+   * The source sha in a publish subject: `…baselines from <sha>` (compose-preview) or the `(<date>,
+   * <sha>)` tail (design-artifacts). Both are short shas today; accept 7–40 hex so a future
+   * full-sha stamp still parses.
+   */
+  private val SOURCE_SHA = Regex("(?:from|,)\\s+([0-9a-f]{7,40})\\b")
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistory.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistory.kt
@@ -41,9 +41,18 @@ object PreviewHistory {
    * `%x01` prefixes a header line and `%x1f` separates its fields, because both are control
    * characters git will never emit inside a sha, an ISO date, or a path, while a commit *subject*
    * is free-form and could contain anything more printable.
+   *
+   * `-c core.quotePath=false` matters more than it looks: git's default is to C-quote and
+   * octal-escape any non-ASCII path, so a preview whose name carries an em-dash — which this repo
+   * really does produce, see the UTF-8 note in `design-artifacts-reusable.yml` — would key its
+   * history under `"renders/…Foo\342\200\224dash.png"` and never join back to the preview it
+   * belongs to. Turning quoting off is not sufficient on its own (see [unquotePath]), but it keeps
+   * the common case exact rather than round-tripping every path through an unescaper.
    */
   fun logArgs(ref: String, pathspec: String): List<String> =
     listOf(
+      "-c",
+      "core.quotePath=false",
       "log",
       "--format=%x01%H%x1f%aI%x1f%s",
       "--raw",
@@ -53,6 +62,59 @@ object PreviewHistory {
       "--",
       pathspec,
     )
+
+  /**
+   * Decode a git-quoted pathname back to its real bytes, or return [raw] unchanged when it isn't
+   * quoted.
+   *
+   * [logArgs] already asks git not to quote non-ASCII, but `core.quotePath=false` only covers that
+   * case: a path containing a double quote, a backslash, or a control character is still wrapped
+   * and escaped. Rather than leave a class of paths silently mis-keyed, decode the full C-style
+   * syntax — `\\`, `\"`, the `\a \b \f \n \r \t \v` singles, and `\nnn` octal bytes.
+   *
+   * Octal escapes are per **byte**, so they're accumulated into a byte buffer and decoded as UTF-8
+   * at the end; decoding them one-by-one as characters would mangle every multi-byte codepoint.
+   */
+  internal fun unquotePath(raw: String): String {
+    if (raw.length < 2 || !raw.startsWith('"') || !raw.endsWith('"')) return raw
+    val body = raw.substring(1, raw.length - 1)
+    val bytes = java.io.ByteArrayOutputStream(body.length)
+    var i = 0
+    while (i < body.length) {
+      val ch = body[i]
+      if (ch != '\\') {
+        bytes.write(ch.toString().toByteArray(Charsets.UTF_8))
+        i++
+        continue
+      }
+      i++
+      if (i >= body.length) break
+      when (val esc = body[i]) {
+        'a' -> bytes.write(0x07).also { i++ }
+        'b' -> bytes.write(0x08).also { i++ }
+        'f' -> bytes.write(0x0C).also { i++ }
+        'n' -> bytes.write(0x0A).also { i++ }
+        'r' -> bytes.write(0x0D).also { i++ }
+        't' -> bytes.write(0x09).also { i++ }
+        'v' -> bytes.write(0x0B).also { i++ }
+        '\\',
+        '"' -> bytes.write(esc.code).also { i++ }
+        in '0'..'7' -> {
+          var value = 0
+          var digits = 0
+          while (i < body.length && digits < 3 && body[i] in '0'..'7') {
+            value = value * 8 + (body[i] - '0')
+            i++
+            digits++
+          }
+          bytes.write(value and 0xFF)
+        }
+        // Unknown escape: keep the escaped character verbatim rather than dropping it.
+        else -> bytes.write(esc.toString().toByteArray(Charsets.UTF_8)).also { i++ }
+      }
+    }
+    return String(bytes.toByteArray(), Charsets.UTF_8)
+  }
 
   /** One commit on the delivery branch in which a given render had particular bytes. */
   data class Observation(
@@ -254,7 +316,7 @@ object PreviewHistory {
       val meta = line.substring(1, tab).split(' ').filter { it.isNotEmpty() }
       if (meta.size < 5) continue
       val blob = meta[3]
-      val path = line.substring(tab + 1)
+      val path = unquotePath(line.substring(tab + 1))
       byPath
         .getOrPut(path) { mutableListOf() }
         .add(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryTest.kt
@@ -206,6 +206,50 @@ class PreviewHistoryTest {
   }
 
   @Test
+  fun `git log is asked not to quote non-ASCII paths`() {
+    val args = PreviewHistory.logArgs("compose-preview/main", "renders")
+
+    assertEquals(listOf("-c", "core.quotePath=false"), args.take(2), "must precede the subcommand")
+  }
+
+  /**
+   * The escaped form is exactly what `git log --raw` emitted for `renders/café/Foo—dash.png` with
+   * git's default `core.quotePath`, captured from a real repo — not hand-written.
+   */
+  @Test
+  fun `octal-escaped non-ASCII paths decode back to UTF-8`() {
+    val quoted = """"renders/caf\303\251/Foo\342\200\224dash.png""""
+
+    assertEquals("renders/café/Foo—dash.png", PreviewHistory.unquotePath(quoted))
+  }
+
+  @Test
+  fun `a quoted path still keys history under its real name`() {
+    // core.quotePath=false does not cover a path containing a quote or backslash, so the parser
+    // must decode rather than rely on the config alone.
+    val log = gitLog("publish" to listOf(""""renders/m/Say \"hi\".png"""" to a))
+
+    assertEquals(setOf("""renders/m/Say "hi".png"""), PreviewHistory.parseGitLog(log).keys)
+  }
+
+  @Test
+  fun `control-character and backslash escapes decode`() {
+    assertEquals("renders/m/a\tb.png", PreviewHistory.unquotePath(""""renders/m/a\tb.png""""))
+    assertEquals("""renders/m/a\b.png""", PreviewHistory.unquotePath(""""renders/m/a\\b.png""""))
+  }
+
+  @Test
+  fun `an unquoted path is passed through untouched`() {
+    val plain = "renders/samples:wear/Foo_Devices_-_Large Round.png"
+
+    assertEquals(
+      plain,
+      PreviewHistory.unquotePath(plain),
+      "no round-trip damage in the common case",
+    )
+  }
+
+  @Test
   fun `malformed lines are skipped rather than failing the whole history`() {
     val good = gitLog("publish" to listOf("renders/m/Foo.png" to a))
     val log = good + ":not-a-real-raw-line\n" + "\u0001truncated-header\n" + "stray text\n"

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryTest.kt
@@ -1,0 +1,239 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PreviewHistoryTest {
+
+  private val a = "a".repeat(40)
+  private val b = "b".repeat(40)
+  private val c = "c".repeat(40)
+  private val nullSha = "0".repeat(40)
+
+  /**
+   * Builds the exact bytes `git log --format=%x01%H%x1f%aI%x1f%s --raw --no-abbrev` emits, so the
+   * parser is tested against the real wire shape rather than a convenient approximation. [entries]
+   * is newest-first: each is a commit plus the paths it touched, as `path to newBlob`.
+   */
+  private fun gitLog(vararg entries: Pair<String, List<Pair<String, String>>>): String =
+    buildString {
+      entries.forEach { (subject, files) ->
+        val sha = subject.hashCode().toUInt().toString(16).padStart(40, '0')
+        append("\u0001").append(sha).append("\u001F").append("2026-08-06T10:00:00+00:00")
+        append("\u001F").append(subject).append("\n\n")
+        files.forEach { (path, blob) ->
+          // Real git prints the pre-image too; the parser only reads column 4 (post-image).
+          append(":100644 100644 ").append(c).append(' ').append(blob).append(" M\t").append(path)
+          append('\n')
+        }
+      }
+    }
+
+  private fun timeline(log: String, path: String): PreviewHistory.Timeline =
+    PreviewHistory.collapse(PreviewHistory.parseGitLog(log)).getValue(path)
+
+  @Test
+  fun `adjacent identical renders collapse into one version`() {
+    val log =
+      gitLog(
+        "publish 4" to listOf("renders/m/Foo.png" to a),
+        "publish 3" to listOf("renders/m/Foo.png" to a),
+        "publish 2" to listOf("renders/m/Foo.png" to a),
+        "publish 1" to listOf("renders/m/Foo.png" to b),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(4, t.observations, "raw commit count is preserved")
+    assertEquals(2, t.versions.size, "three identical publishes are one version")
+    assertEquals(3, t.versions.first().commits)
+    assertEquals(0, t.flapCount)
+    assertFalse(t.unstable)
+  }
+
+  @Test
+  fun `a version spans from the commit that introduced it to the newest carrying it`() {
+    val log =
+      gitLog(
+        "newest" to listOf("renders/m/Foo.png" to a),
+        "middle" to listOf("renders/m/Foo.png" to a),
+        "oldest" to listOf("renders/m/Foo.png" to a),
+      )
+    val v = timeline(log, "renders/m/Foo.png").versions.single()
+
+    assertEquals("oldest", v.since.subject, "since is the run's oldest commit")
+    assertEquals("newest", v.until.subject, "until is the run's newest commit")
+  }
+
+  @Test
+  fun `a clean sequence of distinct renders never reads as unstable`() {
+    val log =
+      gitLog(
+        "third" to listOf("renders/m/Foo.png" to c),
+        "second" to listOf("renders/m/Foo.png" to b),
+        "first" to listOf("renders/m/Foo.png" to a),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(3, t.versions.size)
+    assertEquals(0, t.flapCount, "changing a lot is not flapping")
+    assertFalse(t.unstable)
+    assertEquals(t.versions, t.displayVersions, "a stable timeline is shown untrimmed")
+  }
+
+  @Test
+  fun `a single revert is not enough to call a preview unstable`() {
+    val log =
+      gitLog(
+        "reverted back to a" to listOf("renders/m/Foo.png" to a),
+        "changed to b" to listOf("renders/m/Foo.png" to b),
+        "first" to listOf("renders/m/Foo.png" to a),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(1, t.flapCount, "one return to earlier bytes")
+    assertFalse(t.unstable, "a legitimate revert must not be flagged")
+  }
+
+  /** The real shape found on `compose-preview/main`: two renders alternating on every publish. */
+  @Test
+  fun `alternating renders flag as unstable and trim to their distinct states`() {
+    val log =
+      gitLog(
+        *Array(8) { i -> "publish $i" to listOf("renders/m/Flaky.png" to if (i % 2 == 0) a else b) }
+      )
+    val t = timeline(log, "renders/m/Flaky.png")
+
+    assertEquals(8, t.observations)
+    assertEquals(8, t.versions.size, "every publish changed the bytes, so every run is length 1")
+    assertEquals(2, t.distinctBlobs)
+    assertEquals(6, t.flapCount)
+    assertTrue(t.unstable)
+    assertEquals(setOf(a, b), t.recurringBlobs)
+
+    val trimmed = t.displayVersions
+    assertEquals(2, trimmed.size, "225-run reality collapses to the states it flips between")
+    assertEquals(listOf(a, b), trimmed.map { it.blob }, "newest state leads")
+    assertTrue(trimmed.all { it.recurring })
+    assertEquals(4, trimmed.first().occurrences, "four separate runs had these bytes")
+    assertEquals(8, trimmed.sumOf { it.commits }, "trimming loses no commits")
+  }
+
+  @Test
+  fun `a trimmed state spans its whole period in play`() {
+    val log =
+      gitLog(
+        *Array(4) { i -> "publish $i" to listOf("renders/m/Flaky.png" to if (i % 2 == 0) a else b) }
+      )
+    val newest = timeline(log, "renders/m/Flaky.png").displayVersions.first()
+
+    assertEquals("publish 0", newest.until.subject, "until is the most recent appearance")
+    assertEquals("publish 2", newest.since.subject, "since reaches back to the oldest run")
+  }
+
+  @Test
+  fun `history stops at the most recent deletion`() {
+    val log =
+      gitLog(
+        "re-added" to listOf("renders/m/Foo.png" to c),
+        "deleted" to listOf("renders/m/Foo.png" to nullSha),
+        "older a" to listOf("renders/m/Foo.png" to a),
+        "older b" to listOf("renders/m/Foo.png" to b),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(1, t.observations, "history covers only the current incarnation")
+    assertEquals(listOf(c), t.versions.map { it.blob })
+  }
+
+  @Test
+  fun `delete and re-add churn does not read as flapping`() {
+    // Without deletion truncation the null sha alternates with content and scores flaps, which
+    // would mark every renamed or removed-and-restored preview as non-deterministic.
+    val log =
+      gitLog(
+        "re-added" to listOf("renders/m/Foo.png" to a),
+        "deleted" to listOf("renders/m/Foo.png" to nullSha),
+        "added" to listOf("renders/m/Foo.png" to a),
+        "deleted again" to listOf("renders/m/Foo.png" to nullSha),
+        "first" to listOf("renders/m/Foo.png" to a),
+      )
+    val t = timeline(log, "renders/m/Foo.png")
+
+    assertEquals(0, t.flapCount)
+    assertFalse(t.unstable)
+  }
+
+  @Test
+  fun `one commit touching many renders splits per path`() {
+    val log =
+      gitLog(
+        "publish 2" to listOf("renders/m/A.png" to a, "renders/m/B.png" to b),
+        "publish 1" to listOf("renders/m/A.png" to a, "renders/m/B.png" to c),
+      )
+    val all = PreviewHistory.collapse(PreviewHistory.parseGitLog(log))
+
+    assertEquals(setOf("renders/m/A.png", "renders/m/B.png"), all.keys)
+    assertEquals(1, all.getValue("renders/m/A.png").versions.size, "unchanged across both commits")
+    assertEquals(2, all.getValue("renders/m/B.png").versions.size)
+  }
+
+  @Test
+  fun `source sha is recovered from either publisher's subject`() {
+    val log =
+      gitLog(
+        "Update preview baselines from 27ea28c1" to listOf("renders/m/Foo.png" to a),
+        "chore(design-artifacts): regenerate compose-m3 catalog (2026-08-06, 1a2b3c4d)" to
+          listOf("renders/m/Foo.png" to b),
+        "a subject with no sha at all" to listOf("renders/m/Foo.png" to c),
+      )
+    val versions = timeline(log, "renders/m/Foo.png").versions
+
+    assertEquals("27ea28c1", versions[0].until.sourceSha, "compose-preview wording")
+    assertEquals("1a2b3c4d", versions[1].until.sourceSha, "design-artifacts wording")
+    assertEquals(null, versions[2].until.sourceSha, "absent rather than guessed")
+  }
+
+  @Test
+  fun `paths containing spaces and colons survive the parse`() {
+    // Module segments are Gradle paths (`samples:wear`) and preview names can carry spaces.
+    val path = "renders/samples:wear/PreviewsKt.Foo_Devices_-_Large Round.png"
+    val log = gitLog("publish" to listOf(path to a))
+
+    assertEquals(setOf(path), PreviewHistory.parseGitLog(log).keys)
+  }
+
+  @Test
+  fun `malformed lines are skipped rather than failing the whole history`() {
+    val good = gitLog("publish" to listOf("renders/m/Foo.png" to a))
+    val log = good + ":not-a-real-raw-line\n" + "\u0001truncated-header\n" + "stray text\n"
+
+    assertEquals(setOf("renders/m/Foo.png"), PreviewHistory.parseGitLog(log).keys)
+  }
+
+  @Test
+  fun `an unreadable ref yields no history instead of throwing`() {
+    val failing = GitRunner { _, _ -> GitResult(exitCode = 128, stdout = "fatal: bad revision") }
+
+    val history = PreviewHistory.read(File("."), "compose-preview/main", git = failing)
+
+    assertTrue(history.isEmpty(), "a clone without the delivery branch degrades to no timeline")
+  }
+
+  @Test
+  fun `read passes the ref and pathspec through to git`() {
+    var seen: List<String> = emptyList()
+    val recording = GitRunner { _, args ->
+      seen = args
+      GitResult(0, gitLog("publish" to listOf("renders/m/Foo.png" to a)))
+    }
+
+    val history = PreviewHistory.read(File("."), "compose-preview/main", "renders", recording)
+
+    assertEquals(PreviewHistory.logArgs("compose-preview/main", "renders"), seen)
+    assertTrue(seen.contains("--no-abbrev"), "blob shas must not be abbreviated")
+    assertEquals(1, history.size)
+  }
+}


### PR DESCRIPTION
## Summary

First piece of the preview history feature: the shared extractor that turns a delivery branch's commit history into a per-render timeline. Both planned data sources need it, so it lands on its own with tests before any manifest or UI is wired.

Now that `design-artifacts/*` has history (#3387) and `compose-preview/main` always did, the data exists — but a raw `git log` is the wrong thing to show a user, which is what this file is for.

### Why this needs logic, not a `git log`

A non-deterministic preview re-renders differently on every publish, so it appears in *every* commit and reads as hundreds of changes when it really has a handful of states it keeps flipping between. Left alone, those few previews dominate every timeline.

So `Timeline` marks the case — `flapCount`, `unstable`, `recurringBlobs` — and `displayVersions` trims it to one entry per distinct state, keeping `occurrences` so a recurring state is shown once without pretending it only happened once. Raw counts stay on the object, so nothing is hidden, only collapsed.

`unstable` is deliberately *not* a "changed more than N times" threshold — a churny preview is usually fine. It counts **returns to bytes the render had already moved away from**, which is something a deterministic pipeline shouldn't produce. A single revert scores 1 and is not flagged; the threshold is 2.

### Measured on the real `compose-preview/main` (770 commits, 811 render paths, 1375 observations)

| | |
|---|---|
| timeline entries, untrimmed | 1375 |
| **after trimming** | **826** (40% cut) |
| previews needing the trim | **5** |
| worst case | 226 runs → 4 states |

The instability is extremely concentrated: the two `samples:wear/ActivityList*` renders alone account for over 400 of the removed entries. That concentration is the whole argument for trimming.

One thing worth flagging, because it contradicts what I assumed going in: **the run-collapse is a no-op on this data.** `git log --raw -- <path>` only reports commits where the file actually changed, so consecutive observations for a path never share a blob. It's kept for correctness (a merge or mode-only entry can repeat a blob, and it makes `Version.commits` meaningful) and the KDoc says plainly that it isn't where the reduction comes from.

### Extraction cost

One `git log --raw --no-abbrev` for the entire branch. The raw diff line already carries the post-image blob sha, so there's no `rev-parse <commit>:<path>` per file per commit — **~1.6s for 770 commits over 537 files**.

## Test plan

Parsing and collapsing are pure; the git call is isolated behind the existing `GitRunner` seam (the same one `GitWorktrees` uses), so the rules are tested without a repo. 14 tests, all passing:

```
tests=14 failures=0 errors=0 skipped=0 time=0.121s
```

Covering: run collapse and version spans; the A/B/A/B flap shape found in the real data, trimmed to its 2 states with commits conserved; a single revert **not** counting as unstable; deletion truncation, so renamed or removed-and-restored previews don't read as flaky; source-sha recovery from both publishers' subject wordings; paths with spaces and Gradle-style colons; malformed lines skipped rather than failing the whole history; an unreadable ref degrading to no timeline instead of throwing.

The test helper builds the exact `git log --raw` wire bytes rather than a convenient approximation, so the parser is exercised against the real output shape.

Beyond the unit tests, I ran the implementation against the actual `compose-preview/main` to produce the table above — that's where the "collapse is a no-op" finding came from, and the KDoc figures are those measured numbers rather than the prototype's.

`ktfmtCheckAll` and `:cli:test` are green.

No visual surfaces are touched — this is a pure extraction library with no UI yet, so text-only evidence is the right kind here. The timeline UI it feeds will carry before/after renders.

## Follow-up

Not in this PR, in planned order:

1. **`history.json` manifest** emitted by CI alongside the renders — the primary data source, so the hosted viewer works.
2. **Local git override** in project mode, where a repo with the branch is present, for a live timeline. Shares this extractor.
3. **Viewer timeline UI** on the serve preview page.

The manifest-primary/git-override split is deliberate: the serve host only has git in project mode (`--revisions`, rooted at the local project repo), so a direct git walk would never reach `preview.coo.ee`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXp51dArWBD4dWia6GbJkV)_