### PR TITLE
fix(serve): keep prefetch off foreground and per-preview seats

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -133,7 +133,20 @@ class LiveSeatLimiter(
    * can never over-admit under a race — the worst case is a background holder briefly seeing less
    * headroom than really exists and declining, which is the safe direction.
    */
-  fun acquireBackground(weight: Int, reserve: Int = STREAM_RESERVE): Ticket? {
+  fun acquireBackground(
+    weight: Int,
+    reserve: Int = STREAM_RESERVE,
+    /**
+     * Whether this caller may draw on the per-preview slice. True for the per-preview lane the
+     * slice was carved out for; **false** for any other background holder.
+     *
+     * The shared prefetch pool is background work but it is not per-preview work. Letting it take
+     * the slice would hand away the one seat a supplement-only preview is guaranteed — and once the
+     * general lane fills to its stream headroom that preview cannot open its only daemon and falls
+     * back to Busy/503, which is exactly the starvation the slice was added to prevent.
+     */
+    dedicatedSlice: Boolean = true,
+  ): Ticket? {
     val sem = semaphore ?: return Ticket(0)
     if (weight <= 0) return Ticket(0)
     val permits = weight.coerceIn(1, totalPermits)
@@ -142,7 +155,11 @@ class LiveSeatLimiter(
     // this, so it is taken WITHOUT the stream headroom check — those permits were never available
     // to a stream in the first place, and demanding headroom that by construction cannot exist
     // would make the reserve unusable.
-    perPreviewSemaphore?.let { if (it.tryAcquire(permits)) return Ticket(permits, reserved = true) }
+    if (dedicatedSlice) {
+      perPreviewSemaphore?.let {
+        if (it.tryAcquire(permits)) return Ticket(permits, reserved = true)
+      }
+    }
     // Otherwise the general lane, still leaving room for an interactive stream.
     if (!sem.tryAcquire(permits + reserve.coerceAtLeast(0))) return null
     if (reserve > 0) sem.release(reserve)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -26,12 +26,17 @@ class ServeSharedDaemonPool(
    * as it is open, so burst width is bounded by what the box can actually afford and not only by
    * [capacity], which is per catalog. Null keeps the historical unbudgeted behaviour.
    *
-   * Charged as **foreground** ([LiveSeatLimiter.acquire]), unlike the per-preview pool. A replica
-   * opens only when *leased* renders overlap — a visitor is sitting in front of the grid waiting
-   * for those pixels — so it is the same class of demand as a stream, not background residency. It
-   * is also short-lived: the burst ends, the replica goes idle, and [reapIdle] returns the seat.
-   * Making it compete for the background remainder instead capped a visitor's burst at whatever the
-   * prefetcher had left over, which is backwards.
+   * Charged as **foreground** ([LiveSeatLimiter.acquire]) for a visitor's burst: a replica opens
+   * when *leased* renders overlap — someone is sitting in front of the grid waiting for those
+   * pixels — so it is the same class of demand as a stream. It is also short-lived: the burst ends,
+   * the replica goes idle, and [reapIdle] returns the seat. Making it compete for the background
+   * remainder instead capped a visitor's burst at whatever the prefetcher had left over, which is
+   * backwards.
+   *
+   * The idle theme optimizer reaches this pool through the same leased path but satisfies neither
+   * premise — it is background residency and it does not end — so it passes `background = true` to
+   * [render] and its replicas take the background remainder instead. Never the per-preview slice:
+   * that is another lane's guarantee, not spare capacity.
    */
   private val liveSeats: LiveSeatLimiter? = null,
   private val seatWeight: () -> Int = { 1 },
@@ -58,6 +63,9 @@ class ServeSharedDaemonPool(
   // [takeColdStartMillis].
   private val coldReplicas = mutableSetOf<ServeHost>() // guarded by [lock]
   private val peakColdStartMillis = AtomicLong(0)
+  // Replicas whose seat was taken on the FOREGROUND budget, i.e. opened by a visitor's burst. A
+  // prefetch that reuses one must not quietly inherit that pricing — see [render].
+  private val foregroundSeated = mutableSetOf<ServeHost>() // guarded by [lock]
   private var closed = false
 
   init {
@@ -121,6 +129,8 @@ class ServeSharedDaemonPool(
     var cold = false
     var coldStartFrom = 0L
     var startedDaemon = false
+    // Whether this borrow may extend the replica's life — see the repricing block below.
+    var refreshLastUsed = true
     try {
       borrowed = lock.withLock {
         check(!closed) { "shared daemon pool is closed" }
@@ -128,6 +138,24 @@ class ServeSharedDaemonPool(
         // Claimed under the lock so exactly one borrow times the cold start.
         cold = coldReplicas.remove(host)
         if (cold) coldStartFrom = clock()
+        // Reprice a replica a VISITOR opened but a prefetch is now reusing. Opening it background
+        // is only half the job: a foreground burst leaves a foreground-priced replica behind, and
+        // a continuously running optimizer would then keep it alive — refreshing `replicaLastUsed`
+        // every batch so the idle sweep never closes it — while it sits inside the stream reserve.
+        // That is the production state this whole change exists to end, reached by another road.
+        if (background && liveSeats != null && host in foregroundSeated) {
+          val repriced = liveSeats.acquireBackground(seatWeight(), dedicatedSlice = false)
+          if (repriced != null) {
+            seatTickets.put(host, repriced)?.close()
+            foregroundSeated -= host
+          } else {
+            // No background headroom to move it to. Serve the render anyway — narrowing is this
+            // pool's contract and failing prefetch helps nobody — but do NOT extend its life, so
+            // the idle sweep can close it and hand the foreground seat back once the burst is
+            // over. The next batch reopens it priced correctly, or narrows.
+            refreshLastUsed = false
+          }
+        }
         host
       }
       peakInFlight.accumulateAndGet(inFlight.incrementAndGet(), ::maxOf)
@@ -148,7 +176,7 @@ class ServeSharedDaemonPool(
           if (!closed) {
             if (cold && !startedDaemon) coldReplicas += host
             available.addLast(host)
-            replicaLastUsed[host] = clock()
+            if (refreshLastUsed) replicaLastUsed[host] = clock()
             hostReturned.signalAll()
           }
         }
@@ -175,8 +203,10 @@ class ServeSharedDaemonPool(
       // onto a host already in circulation (below), so counting it would report throttled widening
       // as visitors turned away — and `liveSeatRefusals` is the evidence any budget change rests
       // on. (`acquireBackground` never counts a refusal for the same reason.)
+      // `dedicatedSlice = false`: this pool is background work but it is NOT per-preview work, and
+      // that slice is the one seat a supplement-only preview is guaranteed.
       ticket =
-        if (background) liveSeats.acquireBackground(seatWeight())
+        if (background) liveSeats.acquireBackground(seatWeight(), dedicatedSlice = false)
         else liveSeats.acquire(seatWeight(), countRefusal = false)
       if (ticket == null) {
         while (available.isEmpty() && !closed) hostReturned.await()
@@ -198,6 +228,7 @@ class ServeSharedDaemonPool(
     replicas += replica
     // Not warm yet: its daemon session starts on the first render. [takeColdStartMillis].
     coldReplicas += replica
+    if (!background && ticket != null) foregroundSeated += replica
     ticket?.let { seatTickets[replica] = it }
     return replica
   }
@@ -268,6 +299,7 @@ class ServeSharedDaemonPool(
       available.clear()
       replicaLastUsed.clear()
       coldReplicas.clear()
+      foregroundSeated.clear()
       seatTickets.values.forEach { it.close() }
       seatTickets.clear()
       // Wake anyone parked in [openSeatedReplica]; the `closed` check turns their wait into the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -264,9 +264,16 @@ class ServeSharedDaemonPool(
         break
       }
       lock.withLock {
+        // Every per-host collection, or a closed host stays strongly reachable until the whole
+        // pool closes — and a pinned catalog repeats burst-to-idle indefinitely, so that is
+        // unbounded retention rather than a bounded wart. `coldReplicas` is on this list too: a
+        // replica reaped before its first render (opened, answered NotFound, went idle) never
+        // clears itself.
         available.remove(victim)
         replicas.remove(victim)
         replicaLastUsed.remove(victim)
+        coldReplicas.remove(victim)
+        foregroundSeated.remove(victim)
         seatTickets.remove(victim)?.close()
       }
       permits.release()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -310,6 +311,116 @@ class ServeSharedDaemonPoolTest {
         "the reserve is intact, so a stream could still start",
       )
       assertEquals(0L, seats.refusalCount(), "and narrowing is not a refused visitor")
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+      pool.close()
+    }
+  }
+
+  /**
+   * Codex review on #3393. Pricing replicas the optimizer OPENS is only half the job: a visitor's
+   * burst leaves a foreground-priced replica behind, and a continuously running optimizer would
+   * then reuse it and keep it alive — refreshing `replicaLastUsed` every batch so the idle sweep
+   * never closes it — while it occupies the stream reserve. Same production state, another road.
+   */
+  @Test
+  fun `a prefetch cannot extend the life of a replica it could not reprice`() {
+    var now = 0L
+    // One seat above the reserve. A visitor's burst can open a replica on it, but there is then no
+    // background headroom (weight + STREAM_RESERVE) to move that seat onto — so the reprice below
+    // must fail, which is the branch worth pinning: the prefetch keeps rendering, but it must not
+    // buy the replica more time on a foreground seat.
+    val seats = LiveSeatLimiter(totalPermits = 1 + LiveSeatLimiter.STREAM_RESERVE)
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val primary = BlockingHost("primary", entered, release)
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 2, clock = { now }, liveSeats = seats) {
+        InstantHost("replica")
+      }
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      // A visitor's burst opens the replica on the FOREGROUND budget, at t=0.
+      val held = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      assertTrue(entered.await(5, TimeUnit.SECONDS), "primary is mid-render")
+      assertTrue(
+        executor
+          .submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+          .get(10, TimeUnit.SECONDS) is RenderOutcome.Ok
+      )
+      release.countDown()
+      assertTrue(held.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok)
+      assertEquals(1, pool.replicaProcessCount(), "the burst left a replica behind")
+      assertEquals(
+        LiveSeatLimiter.STREAM_RESERVE,
+        seats.availablePermits(),
+        "precondition: only the reserve is left, so there is nowhere to reprice to",
+      )
+
+      // The optimizer reuses it a second later. It still gets its render …
+      now = 1_000
+      assertTrue(pool.render("p", PreviewOverrides(), background = true) is RenderOutcome.Ok)
+
+      // … but the replica's clock still reads from the VISITOR's use, not the prefetch's. Just past
+      // the window measured from t=0 and short of it measured from t=1_000, so this only passes if
+      // the prefetch left `replicaLastUsed` alone.
+      now = 60_500
+      assertEquals(1, pool.reapIdle(idleMillis = 60_000), "the prefetch did not buy it more time")
+      assertEquals(
+        1 + LiveSeatLimiter.STREAM_RESERVE,
+        seats.availablePermits(),
+        "and the foreground seat is back",
+      )
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+      pool.close()
+    }
+  }
+
+  /**
+   * Codex review on #3393. `acquireBackground` tries the per-preview slice FIRST, and that slice is
+   * the one seat a supplement-only preview is guaranteed. A shared prefetch replica taking it
+   * recreates exactly the starvation the slice was carved out to prevent.
+   */
+  @Test
+  fun `a background replica never takes the per-preview slice`() {
+    // A one-seat slice on top of a general lane just wide enough for one background holder
+    // (weight + STREAM_RESERVE = 3). Sized so the two worlds diverge: taking the slice leaves the
+    // general lane wider, taking the general lane leaves the slice intact.
+    val seats = LiveSeatLimiter(totalPermits = 4, perPreviewReserve = 1)
+    assertEquals(1, seats.perPreviewPermits, "precondition: the box affords a one-seat slice")
+
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val primary = BlockingHost("primary", entered, release)
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 2, liveSeats = seats) {
+        InstantHost("replica")
+      }
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      val held = executor.submit<RenderOutcome> { pool.render("p", PreviewOverrides()) }
+      assertTrue(entered.await(5, TimeUnit.SECONDS), "primary is mid-render")
+      // A background replica: the general lane has room, and it must be taken from there.
+      assertTrue(
+        executor
+          .submit<RenderOutcome> { pool.render("p", PreviewOverrides(), background = true) }
+          .get(10, TimeUnit.SECONDS) is RenderOutcome.Ok
+      )
+
+      // Fill the general lane, the state in which the slice is the only thing standing between a
+      // supplement-only preview and a Busy/503. Taking the slice above would leave the general lane
+      // with room to absorb this instead, and the acquire below would then find nothing anywhere.
+      assertNotNull(seats.acquire(2), "the general lane still had room for a stream")
+      assertNotNull(
+        seats.acquireBackground(1),
+        "the per-preview lane still has the seat carved out for it",
+      )
+
+      release.countDown()
+      assertTrue(held.get(5, TimeUnit.SECONDS) is RenderOutcome.Ok)
     } finally {
       release.countDown()
       executor.shutdownNow()


### PR DESCRIPTION
Two P1 review findings on #3393, which merged before they could land on it. Both are ways the prefetcher still ended up holding seats it shouldn't — #3393 priced the replicas the optimizer *opens*, and these are the two paths around that.

## 1. Reprice a replica a visitor opened but a prefetch reuses

A foreground burst leaves a foreground-priced replica behind. A continuously running optimizer then borrows it and refreshes `replicaLastUsed` on every batch, so the idle sweep never closes it — while it sits inside `STREAM_RESERVE`. That is the same production state #3393 set out to end, reached by another road.

A background borrow now moves the seat to the background remainder. When there is no headroom to move it to, the render still runs — narrowing is this pool's contract and failing prefetch helps nobody — but the borrow no longer extends the replica's life, so the sweep reclaims the foreground seat and the next batch reopens it priced correctly, or narrows.

## 2. Keep shared replicas out of the per-preview slice

`acquireBackground` tries the dedicated per-preview semaphore **first**, and that slice is the one seat a supplement-only preview is guaranteed. The shared pool is background work but it is not per-preview work: taking that seat leaves such a preview unable to open its only daemon once the general lane fills to its stream headroom — exactly the starvation the slice was carved out to prevent.

`acquireBackground` grows a `dedicatedSlice: Boolean = true` parameter; the shared pool passes `false`. The per-preview lane is unchanged.

## Test plan

- `./gradlew :cli:test` — green (full suite).
- `a prefetch cannot extend the life of a replica it could not reprice`: budget leaves exactly the reserve free, so repricing must fail. Visitor's burst opens the replica at t=0, prefetch reuses it at t=1,000, `reapIdle(60_000)` at t=60,500 — past the window measured from the visitor's use, short of it measured from the prefetch's. Passes only if the prefetch left `replicaLastUsed` alone.
- `a background replica never takes the per-preview slice`: one-seat slice over a three-permit general lane. Opens a background replica, then fills the general lane, then asserts a per-preview background acquire still succeeds — it can only come from the slice.

**Both were verified in both directions.** Reverting `dedicatedSlice = false` fails the second; reverting `refreshLastUsed = false` fails the first.

Worth recording: my first draft of the repricing test asserted only `availablePermits()`, which reports the general lane and is **identical** whichever budget the seat came from — so it would have passed without the fix. Caught by checking it against a reverted fix rather than by reading it. It now pins the observable branch instead.

Not visual — seat accounting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_