### PR TITLE
fix(serve): close three gaps in the playground catalog selector

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1390,7 +1390,9 @@ class ServeCommand(args: List<String>) : Command(args) {
                 androidSupplier?.classpath()?.takeIf { rcCapture != null }
             }
         },
-        catalogTargets = { catalogTargets?.targets().orEmpty() },
+        // Null, not an empty lambda, when the selector is off — the editor tells "no selector here"
+        // from "selector configured, nothing loaded yet" by exactly this.
+        catalogTargets = catalogTargets?.let { targets -> { targets.targets() } },
         compiler = compiler,
         discoverer = PlaygroundPreviewDiscoverer(),
         tokenStore = tokenStore,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogTargets.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogTargets.kt
@@ -126,8 +126,13 @@ class PlaygroundCatalogTargets(
         ?.let {
           return it.classpath()
         }
-      val existing = suppliers[system]
-      if (existing == null && resolvedCount() >= limit) {
+      // Past the check above, this system's supplier is absent or UNRESOLVED either way — so it
+      // holds none of the budget, and a full budget refuses it either way. Deliberately not keyed
+      // on
+      // "have we seen this system before": a supplier whose first resolve failed (a transient Maven
+      // miss, a bundle that hadn't landed) is still in the map, and letting its retry through
+      // because it exists would resolve an N+1st catalog straight past the cap.
+      if (resolvedCount() >= limit) {
         onLog(
           "playground catalog budget spent: $limit catalog(s) already hold a resolved classpath " +
             "and they cannot be evicted while snippet JVMs hold their jars open, so '$system' is " +
@@ -135,7 +140,7 @@ class PlaygroundCatalogTargets(
         )
         return null
       }
-      val supplier = existing ?: newSupplier(system).also { suppliers[system] = it }
+      val supplier = suppliers[system] ?: newSupplier(system).also { suppliers[system] = it }
       return supplier.classpath()
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -73,11 +73,24 @@ class PlaygroundCompileService(
   private val publishRemoteDocument: (String, ByteArray, Boolean) -> String? = { _, _, _ -> null },
   /**
    * The served catalogs a request may name in [PlaygroundRunRequest.catalog]. Read fresh per call —
-   * catalogs load in the background after the lane is wired. Empty ⇒ this host pins its bundles and
-   * offers no runtime choice, which is the pre-selector behaviour.
+   * catalogs load in the background after the lane is wired.
+   *
+   * **Null and "returns empty" are different states**, which is why this is nullable rather than
+   * defaulting to `{ emptyList() }`: null means this host pins its bundles and offers no runtime
+   * choice at all (the pre-selector behaviour), while a non-null seam returning nothing means
+   * `--playground` is on and no catalog has loaded *yet*. The editor renders a selector for the
+   * second and not the first, so collapsing them would leave a host that started before its
+   * catalogs permanently without the control it was configured to have.
    */
-  private val catalogTargets: () -> List<PlaygroundCatalogTarget> = { emptyList() },
+  private val catalogTargets: (() -> List<PlaygroundCatalogTarget>)? = null,
 ) {
+
+  /**
+   * True when `--playground` put a runtime catalog selector on this host, whether or not any
+   * catalog has loaded into it yet. Drives whether the editor renders the Catalog control at all.
+   */
+  val catalogSelectorEnabled: Boolean
+    get() = catalogTargets != null
 
   /**
    * The modes this host can serve **on its pinned default** — the ones whose [catalogClasspath]
@@ -118,7 +131,7 @@ class PlaygroundCompileService(
           resolved = true,
         )
     return listOfNotNull(default) +
-      catalogTargets().map {
+      catalogTargets?.invoke().orEmpty().map {
         PlaygroundCatalogInfo(
           id = it.system,
           label = "${it.system} (${it.backend})",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -996,6 +996,7 @@ class ServeHttpServer(
         token = token,
         isPublic = isPublic,
         catalogs = service.catalogChoices(),
+        catalogSelectorEnabled = service.catalogSelectorEnabled,
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
       ),
       ContentType.Text.Html,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2327,15 +2327,32 @@ object ServeWeb {
      * `/api/1/compiler/catalogs` rather than making the visitor reload.
      */
     catalogs: List<PlaygroundCatalogInfo>,
+    /**
+     * True when `--playground` configured a runtime catalog selector on this host — independent of
+     * whether any catalog has loaded into it yet.
+     *
+     * Kept separate from `catalogs.size` on purpose. A host running `--playground` *plus* a pinned
+     * local bundle renders, during the startup window, a one-entry list holding only that pin — and
+     * deciding on the count alone would omit the control from that page, which the script can then
+     * never build, leaving the visitor pinned until they reload. What the control's presence tracks
+     * is the host's configuration, which does not change under it.
+     */
+    catalogSelectorEnabled: Boolean = false,
     unfurl: UnfurlMetadata? = null,
   ): String {
     val suffix = querySuffix(queryString(token, sessionId = null, isPublic = isPublic))
     val sample = WebEscaping.htmlEscape(PLAYGROUND_SAMPLE)
     // A host that pins its bundles and offers no runtime choice renders exactly the bar it always
-    // did — one Mode select — rather than a one-entry "Catalog" control that decides nothing. An
-    // EMPTY list is not that case: it means nothing has resolved *yet* (catalogs load in the
-    // background), so the control is rendered saying so and the script's refresh fills it in.
-    val showCatalogs = catalogs.isEmpty() || catalogs.size > 1 || catalogs.first().id.isNotEmpty()
+    // did — one Mode select — rather than a one-entry "Catalog" control that decides nothing.
+    // Everything else gets the control, including the two states where the list is momentarily
+    // uninteresting: empty (nothing has loaded yet) and pin-only under [catalogSelectorEnabled].
+    // Both fill in from the script's refresh, and the script can only fill in a control that
+    // exists.
+    val showCatalogs =
+      catalogSelectorEnabled ||
+        catalogs.isEmpty() ||
+        catalogs.size > 1 ||
+        catalogs.first().id.isNotEmpty()
     val catalogOptions =
       if (catalogs.isEmpty())
         """<option value="" disabled selected>No catalogs available yet…</option>"""
@@ -2494,8 +2511,17 @@ object ServeWeb {
         run.disabled = offered.length === 0;
       }
       // Catalogs are fetched in the BACKGROUND after the server starts, so a page opened during
-      // startup legitimately renders a short (or empty) list. Re-ask once on load rather than
-      // making the visitor guess that a reload would help.
+      // startup legitimately renders a short (or empty) list. Re-ask rather than making the visitor
+      // guess that a reload would help.
+      //
+      // ONE fetch is not enough: on a host with nothing pinned the editor commonly loads before the
+      // initial catalog loader has published anything, so the single reply is empty too and nothing
+      // would ever ask again — a permanently disabled Run on a host that came up fine seconds later.
+      // So poll while the answer is still empty, bounded (a host that genuinely serves no compilable
+      // catalog must not poll forever), and stop the moment something is offered.
+      var emptyPolls = 0;
+      var MAX_EMPTY_POLLS = 12;
+      var POLL_MS = 2500;
       function refreshCatalogs() {
         fetch("/api/1/compiler/catalogs" + suffix, { headers: { "Accept": "application/json" } })
           .then(function (r) { return r.ok ? r.json() : null; })
@@ -2527,10 +2553,18 @@ object ServeWeb {
             var empty = document.getElementById("pg-empty");
             if (empty) empty.hidden = catalogs.length > 0;
             syncModes();
+            if (!catalogs.length && ++emptyPolls < MAX_EMPTY_POLLS) {
+              window.setTimeout(refreshCatalogs, POLL_MS);
+            }
           })
           .catch(function () { /* the baked-in list still stands */ });
       }
-      if (catalog) catalog.addEventListener("change", syncModes);
+      if (catalog) {
+        catalog.addEventListener("change", syncModes);
+        // Opening the dropdown is the one moment a stale list actually costs the visitor something,
+        // and it's a cheap place to catch catalogs that finished loading after the poll gave up.
+        catalog.addEventListener("focus", refreshCatalogs);
+      }
       syncModes();
       // Unconditional, not just when there is a selector: a page opened before the host's own pinned
       // bundle finished resolving renders with no modes at all, and the refresh is what recovers it

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogTargetsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogTargetsTest.kt
@@ -169,6 +169,50 @@ class PlaygroundCatalogTargetsTest {
   }
 
   @Test
+  fun `a retry of a previously failed catalog still respects a spent budget`() {
+    // The supplier of a catalog whose FIRST resolve failed stays in the map, unresolved. If the cap
+    // asked "have we seen this system before" rather than "is the budget spent", that retry would
+    // sail past a full budget and resolve an N+1st catalog — a transient Maven miss would be all it
+    // took to break the bound a public host relies on.
+    var brokenResolvable = false
+    val log = mutableListOf<String>()
+    val t =
+      targets(
+        available = listOf("flaky" to "desktop", "a" to "desktop", "b" to "desktop"),
+        limit = 2,
+        suppliers = { system ->
+          // Reads the flag at RESOLVE time, not at construction, so the retry below genuinely could
+          // succeed — otherwise the test would pass with the cap removed.
+          if (system == "flaky")
+            PlaygroundClasspathSupplier(
+              source = PlaygroundBundleSource.ServedCatalog(system),
+              locateServedBundle = {
+                java.io.File(bundles, "$it.png").apply { writeText("bundle") }
+              },
+              resolve = { if (brokenResolvable) classpath(system) else null },
+              onLog = {},
+            )
+          else supplier(system)
+        },
+        log = log,
+      )
+
+    // First attempt fails and leaves an unresolved supplier behind.
+    assertNull(t.classpath("flaky", PlaygroundMode.CMP))
+    assertEquals(0, t.resolvedCount())
+    // Two other catalogs then spend the whole budget.
+    assertNotNull(t.classpath("a", PlaygroundMode.CMP))
+    assertNotNull(t.classpath("b", PlaygroundMode.CMP))
+    assertEquals(2, t.resolvedCount())
+
+    // …and now the retry would succeed on its own terms. It must still be refused.
+    brokenResolvable = true
+    assertNull(t.classpath("flaky", PlaygroundMode.CMP))
+    assertEquals(2, t.resolvedCount())
+    assertTrue(log.any { "budget spent" in it }, "expected a budget refusal: $log")
+  }
+
+  @Test
   fun `catalogs are offered in a stable order`() {
     val t =
       targets(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
@@ -16,8 +16,13 @@ import kotlin.test.assertTrue
  */
 class ServeWebPlaygroundCatalogTest {
 
-  private fun page(catalogs: List<PlaygroundCatalogInfo>) =
-    ServeWeb.playgroundPage(token = "t", isPublic = false, catalogs = catalogs)
+  private fun page(catalogs: List<PlaygroundCatalogInfo>, catalogSelectorEnabled: Boolean = false) =
+    ServeWeb.playgroundPage(
+      token = "t",
+      isPublic = false,
+      catalogs = catalogs,
+      catalogSelectorEnabled = catalogSelectorEnabled,
+    )
 
   private val pinnedDefault =
     PlaygroundCatalogInfo(
@@ -100,6 +105,36 @@ class ServeWebPlaygroundCatalogTest {
     assertTrue(html.contains("""id="pg-empty""""))
     assertTrue(html.contains("fetched in the background"))
     assertTrue(html.contains("<strong>trusted</strong>"))
+  }
+
+  @Test
+  fun `a selector host renders the control even while only the pin has loaded`() {
+    // `--playground` plus a pinned LOCAL bundle: during the startup window the pin is the only
+    // entry
+    // this host can offer, because no served catalog has loaded yet. Deciding on the count alone
+    // would omit the control from this page — and the script can only repopulate a control that
+    // exists, so the visitor would stay pinned until they reloaded by hand.
+    val html = page(listOf(pinnedDefault), catalogSelectorEnabled = true)
+    assertTrue(
+      html.contains("""id="pg-catalog""""),
+      "the control tracks the host's configuration, not how many entries happen to have loaded",
+    )
+    // …and the same list WITHOUT the selector configured still renders the old bar.
+    assertFalse(page(listOf(pinnedDefault)).contains("""id="pg-catalog""""))
+  }
+
+  @Test
+  fun `the catalog list is re-asked until it stops coming back empty`() {
+    // One fetch on load is not enough on a host with nothing pinned: the editor routinely loads
+    // before the initial catalog loader has published anything, so the single reply is empty too
+    // and nothing would ever ask again — a permanently disabled Run on a host that came up fine.
+    val html = page(emptyList(), catalogSelectorEnabled = true)
+    assertTrue(html.contains("setTimeout(refreshCatalogs"), "an empty answer schedules another ask")
+    assertTrue(html.contains("MAX_EMPTY_POLLS"), "…and the polling is bounded, not forever")
+    assertTrue(
+      html.contains("""catalog.addEventListener("focus", refreshCatalogs)"""),
+      "opening the dropdown re-asks, for catalogs that landed after the poll gave up",
+    )
   }
 
   @Test

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -117,8 +117,17 @@ fun Greeting() {
     run.disabled = offered.length === 0;
   }
   // Catalogs are fetched in the BACKGROUND after the server starts, so a page opened during
-  // startup legitimately renders a short (or empty) list. Re-ask once on load rather than
-  // making the visitor guess that a reload would help.
+  // startup legitimately renders a short (or empty) list. Re-ask rather than making the visitor
+  // guess that a reload would help.
+  //
+  // ONE fetch is not enough: on a host with nothing pinned the editor commonly loads before the
+  // initial catalog loader has published anything, so the single reply is empty too and nothing
+  // would ever ask again — a permanently disabled Run on a host that came up fine seconds later.
+  // So poll while the answer is still empty, bounded (a host that genuinely serves no compilable
+  // catalog must not poll forever), and stop the moment something is offered.
+  var emptyPolls = 0;
+  var MAX_EMPTY_POLLS = 12;
+  var POLL_MS = 2500;
   function refreshCatalogs() {
     fetch("/api/1/compiler/catalogs" + suffix, { headers: { "Accept": "application/json" } })
       .then(function (r) { return r.ok ? r.json() : null; })
@@ -150,10 +159,18 @@ fun Greeting() {
         var empty = document.getElementById("pg-empty");
         if (empty) empty.hidden = catalogs.length > 0;
         syncModes();
+        if (!catalogs.length && ++emptyPolls < MAX_EMPTY_POLLS) {
+          window.setTimeout(refreshCatalogs, POLL_MS);
+        }
       })
       .catch(function () { /* the baked-in list still stands */ });
   }
-  if (catalog) catalog.addEventListener("change", syncModes);
+  if (catalog) {
+    catalog.addEventListener("change", syncModes);
+    // Opening the dropdown is the one moment a stale list actually costs the visitor something,
+    // and it's a cheap place to catch catalogs that finished loading after the poll gave up.
+    catalog.addEventListener("focus", refreshCatalogs);
+  }
   syncModes();
   // Unconditional, not just when there is a selector: a page opened before the host's own pinned
   // bundle finished resolving renders with no modes at all, and the refresh is what recovers it


### PR DESCRIPTION
Follow-up to #3397, which merged while these were being fixed. Three findings from its review, each reproduced against the code before fixing.

## 1. The resolved-catalog cap could be walked past (P1)

A catalog whose **first** resolve fails — a transient Maven miss, a bundle that hadn't landed — leaves an *unresolved* supplier in the map. The budget check was keyed on "have we seen this system before":

```kotlin
val existing = suppliers[system]
if (existing == null && resolvedCount() >= limit) { refuse }
```

So once other catalogs had spent the cap, that catalog's retry skipped the check entirely and resolved an N+1st classpath — defeating the bound a public host relies on, triggered by nothing worse than a network blip.

Past the resolved-supplier fast path above it, the entry is absent *or* unresolved either way and therefore holds none of the budget, so the check needs no such qualifier: `if (resolvedCount() >= limit)`.

The new test drives a flaky supplier that fails first and would succeed on retry, spends the budget on two other catalogs, and pins that the retry is still refused. **Verified it discriminates**: with the old guard restored it fails with `expected: <null> but was: <Classpath(moduleName=flaky, …)>`.

## 2. A selector host could render without its selector (P2)

With `--playground` *plus* a pinned local bundle, a page served during the startup window sees exactly one entry (the pin, which resolves immediately) and no loaded catalogs — so deciding on the count alone dropped `#pg-catalog` from that page. The script only repopulates a control that already exists, so that visitor stayed pinned until they reloaded by hand.

The control's presence now tracks the host's *configuration* (`catalogSelectorEnabled`), which doesn't change underneath the page, rather than how many entries happen to have loaded. `PlaygroundCompileService.catalogTargets` became nullable to carry it — "no selector configured" and "selector configured, nothing loaded yet" are genuinely different states and were being collapsed into one.

## 3. One refresh was not enough (P2)

On a host with nothing pinned the editor routinely loads *before* the initial catalog loader has published anything, so the single on-load fetch came back empty too — and nothing ever asked again. Result: a permanently disabled Run on a host that came up fine seconds later.

The page now re-asks while the answer is still empty, bounded (12 tries at 2.5s, stopping the moment something is offered, so a host that genuinely serves no compilable catalog doesn't poll forever), plus one refresh when the dropdown takes focus — the moment a stale list actually costs the visitor something, and a cheap way to catch catalogs that landed after the poll gave up.

## Test plan

- `./gradlew :cli:test` — green. New: `a retry of a previously failed catalog still respects a spent budget`, `a selector host renders the control even while only the pin has loaded`, `the catalog list is re-asked until it stops coming back empty`.
- Mutation-checked the P1 test against the pre-fix guard — it fails, so it is pinning the fix and not the shape.
- `./gradlew ktfmtCheckAll` — clean.
- `pages-snapshot.spec.mjs` (`serve-playground`) — 4 passed; golden fixture regenerated.

No visual change: the rendered bar is identical for every state the previous PR already captured. The one state that changes — `--playground` + a pinned local bundle during startup — now renders the Catalog control where it previously rendered none, and is not separately capturable in the harness (the fixture supplies the catalog list directly rather than booting a host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr)_