### PR TITLE
feat(serve): widen the background render lane from 1 to 3

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -24,14 +24,17 @@ import java.util.concurrent.atomic.AtomicLong
  *   whole startup pass read as *busy* so the optimizer stays parked until the catalogs are up.
  * - **Each other.** Once loading finishes, every catalog's optimizer becomes runnable at the same
  *   instant. [withRenderPermit] caps the background lane at [maxConcurrentRenders] renders
- *   server-wide (one by default), so the optimizers take turns instead of holding every live seat —
- *   and a foreground render is never queued behind more than one background one.
+ *   server-wide, so the optimizers take turns instead of holding every live seat.
  *
  * Both knobs are process-wide: one instance is built per `serve` run and shared by every catalog
  * host it opens.
  */
 class ServeBackgroundWork(
-  maxConcurrentRenders: Int = 1,
+  /**
+   * Background renders admitted at once, server-wide. See [DEFAULT_MAX_CONCURRENT_RENDERS] for why
+   * this is no longer 1.
+   */
+  maxConcurrentRenders: Int = DEFAULT_MAX_CONCURRENT_RENDERS,
   private val clock: () -> Long = System::currentTimeMillis,
 ) {
   private val loadsInFlight = AtomicInteger()
@@ -111,5 +114,34 @@ class ServeBackgroundWork(
     } finally {
       renderPermits.release()
     }
+  }
+
+  companion object {
+    /**
+     * Background renders admitted at once, server-wide.
+     *
+     * **This was 1, and one permit for every catalog on the box was the prefetcher's dominant
+     * bottleneck.** Measured on the deployed server (0.19.41, 15 catalogs, no visitors) once the
+     * gate/permit split made it visible: **74.3%** of the optimizer's active time was spent waiting
+     * for this permit, against 10.1% at the idle gate and **6.3%** actually rendering. Fifteen
+     * optimizers queueing on one permit, and every batch collapsing to a single daemon as a result.
+     *
+     * The 1 was chosen so "a foreground render is never queued behind more than one background
+     * one". That guarantee is worth less than it sounds and cost more than it saved: a background
+     * batch holds this permit only for its renders — the expensive part, a cold daemon warm of
+     * 34-68s, is awaited *outside* it — and a warm background render is sub-second, so the
+     * foreground now queues behind at most a few seconds instead of one.
+     *
+     * Sized to what the box can actually run concurrently rather than to a round number: the live
+     * seat budget is 8 with Android weight 2, and prefetch replicas are charged to the background
+     * remainder (leaving [LiveSeatLimiter.STREAM_RESERVE] for a visitor), so at most three heavy
+     * daemons can be rendering at once anyway. A larger cap would only queue inside the seat budget
+     * instead of here, moving the wait rather than removing it.
+     *
+     * `-Dcomposeai.serve.backgroundRenders=<n>` overrides it; a box with a different seat budget is
+     * the case that wants a different number.
+     */
+    val DEFAULT_MAX_CONCURRENT_RENDERS: Int =
+      System.getProperty("composeai.serve.backgroundRenders")?.toIntOrNull()?.coerceAtLeast(1) ?: 3
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
@@ -82,35 +82,58 @@ class ServeBackgroundWorkTest {
     assertEquals(60_000L, clock())
   }
 
+  /**
+   * The cap is what matters, not any particular value — so this asserts the permit admits exactly
+   * as many as it was built for, at 1 (the old default, still the right shape for a small box) and
+   * at a wider setting. The default itself moved from 1 to 3 because one permit shared by every
+   * catalog was measured as 74.3% of the prefetcher's active time on the deployed server.
+   */
   @Test
-  fun `the render permit admits one background render at a time`() {
-    val work = ServeBackgroundWork()
-    val inFlight = AtomicInteger()
-    val peak = AtomicInteger()
-    val done = CountDownLatch(4)
-    val pool = Executors.newFixedThreadPool(4)
-    try {
-      repeat(4) {
-        pool.execute {
-          work.withRenderPermit {
-            peak.accumulateAndGet(inFlight.incrementAndGet()) { a, b -> maxOf(a, b) }
-            Thread.sleep(25)
-            inFlight.decrementAndGet()
+  fun `the render permit admits exactly as many background renders as it was built for`() {
+    for (cap in listOf(1, 3)) {
+      val work = ServeBackgroundWork(maxConcurrentRenders = cap)
+      val inFlight = AtomicInteger()
+      val peak = AtomicInteger()
+      val started = CountDownLatch(cap)
+      val done = CountDownLatch(6)
+      val pool = Executors.newFixedThreadPool(6)
+      try {
+        repeat(6) {
+          pool.execute {
+            work.withRenderPermit {
+              peak.accumulateAndGet(inFlight.incrementAndGet()) { a, b -> maxOf(a, b) }
+              started.countDown()
+              Thread.sleep(25)
+              inFlight.decrementAndGet()
+            }
+            done.countDown()
           }
-          done.countDown()
         }
+        // Reaching the cap is asserted, not just staying under it: a permit stuck at 1 would keep
+        // `peak` low and pass a ceiling-only check while starving exactly as it did in production.
+        assertTrue(started.await(10, TimeUnit.SECONDS), "cap $cap was never reached")
+        assertTrue(done.await(10, TimeUnit.SECONDS), "background renders did not drain")
+      } finally {
+        pool.shutdownNow()
       }
-      assertTrue(done.await(10, TimeUnit.SECONDS), "background renders did not drain")
-    } finally {
-      pool.shutdownNow()
-    }
 
-    assertEquals(1, peak.get())
+      assertEquals(cap, peak.get(), "cap $cap admitted the wrong number")
+    }
+  }
+
+  @Test
+  fun `the default admits more than one, since one permit per box starved the prefetcher`() {
+    assertTrue(
+      ServeBackgroundWork.DEFAULT_MAX_CONCURRENT_RENDERS > 1,
+      "15 catalogs queueing on a single permit was 74.3% of the optimizer's active time",
+    )
   }
 
   @Test
   fun `an interrupted wait for the permit reports stop rather than rendering anyway`() {
-    val work = ServeBackgroundWork()
+    // Cap of 1 so the second caller is guaranteed to be *waiting* when it is interrupted — that is
+    // this test's subject. With the wider default it would sail through without ever blocking.
+    val work = ServeBackgroundWork(maxConcurrentRenders = 1)
     val held = CountDownLatch(1)
     val release = CountDownLatch(1)
     val holder = Thread {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1058,11 +1058,21 @@ class ServeCatalogLiveHostTest {
     assertEquals(1, live.renderCalls)
   }
 
+  /**
+   * The shared lane bounds the optimizers — it no longer serialises them.
+   *
+   * This asserted a peak of exactly 1 while the background cap was 1. That cap was measured on the
+   * deployed server as the prefetcher's dominant bottleneck: 15 catalogs queueing on one permit,
+   * 74.3% of the pass's active time spent waiting for it against 6.3% rendering. The invariant
+   * worth keeping is the ceiling, not the serialisation, so the cap is now passed explicitly and
+   * the assertion follows it.
+   */
   @Test
-  fun `catalog optimizers sharing one server render one at a time`() {
+  fun `catalog optimizers sharing one server never exceed the background lane`() {
     val inFlight = AtomicInteger()
     val peak = AtomicInteger()
-    val backgroundWork = ServeBackgroundWork()
+    val cap = 2
+    val backgroundWork = ServeBackgroundWork(maxConcurrentRenders = cap)
     fun host(tag: String): ServeCatalogLiveHost {
       val delegate =
         RecordingHost(
@@ -1097,7 +1107,10 @@ class ServeCatalogLiveHostTest {
     hosts.forEach { it.prewarm() }
     hosts.forEach { assertTrue(awaitOptimization(it).fullyOptimized) }
 
-    assertEquals(1, peak.get(), "the background lane holds at most one render server-wide")
+    assertTrue(
+      peak.get() in 1..cap,
+      "the background lane holds at most $cap renders server-wide, saw ${peak.get()}",
+    )
   }
 
   /**


### PR DESCRIPTION
The theme optimizer's dominant bottleneck, now that the gate/permit split (#3386) and the corrected batch width (#3389) can actually see it.

## What the deployed box says

Server 0.19.41, 15 catalogs prefetching, `activeStreams: 0`:

| bucket | share of active time |
|---|---|
| **permit wait** | **74.3%** |
| gate wait | 10.1% |
| warm (cold starts) | 9.4% |
| **batch (actual render)** | **6.3%** |

15,024s of permit wait against 2,035s of gate wait — **7.4 : 1**. And `ServeBackgroundWork` admits **one** background render server-wide, so every catalog on the box was queueing on a single permit. The corrected batch width confirms the mechanism: real concurrency is **1** on 13 of 15 catalogs, 3 at the highest.

This is why the split was worth building. Left to intuition, "the prefetcher spends its life waiting" points at the idle quiet window — which is the smaller tenth of the problem. (I initially proposed the opposite change, *capping* concurrent catalogs at 2–3, on the assumption that the 8 in `config.maxConcurrentRenders` was this lane. It's the HTTP render cap; a different semaphore.)

## The change

`DEFAULT_MAX_CONCURRENT_RENDERS = 3`, overridable with `-Dcomposeai.serve.backgroundRenders`.

The `1` existed so "a foreground render is never queued behind more than one background one". That guarantee is cheaper to relax than it looks: a background batch holds this permit only for its **renders** — the expensive part, a 34–68s cold daemon warm, is awaited *outside* it — and a warm background render is sub-second. Foreground now queues behind a few seconds at worst.

**3, not a round number.** The seat budget is 8 at Android weight 2, and prefetch replicas draw on the background remainder (leaving `STREAM_RESERVE` free, per #3393/#3396), so at most three heavy daemons can render concurrently regardless. A larger cap would queue inside the seat budget instead of here — moving the wait, not removing it.

## Tests that pinned the old cap

Both failures on the first run were tests encoding the behaviour this deliberately changes:

- `an interrupted wait for the permit reports stop rather than rendering anyway` now builds a single-permit lane explicitly. Its subject is the interrupt, and it needs a caller that genuinely blocks.
- `catalog optimizers sharing one server render one at a time` asserted a peak of exactly 1. Renamed to `... never exceed the background lane`, passes its cap explicitly, asserts `peak in 1..cap`. The ceiling is the invariant worth keeping; the serialisation was the bug.

The permit test also grew an assertion that the cap is **reached**, via a latch — the old shape asserted only `peak == 1`, which a permit stuck at 1 would pass while starving exactly as production did.

## Test plan

- `./gradlew :cli:test` — green, 1487 tests.
- Cap honoured at both 1 and 3, and reached at both.
- `DEFAULT_MAX_CONCURRENT_RENDERS > 1` pinned so a future edit back to 1 fails loudly.

Effect is measurable after deploy: `permitWaitMillis` should fall sharply against `batchMillis`, and `maxBatchWidth` should rise above 1. If permit wait simply becomes seat contention, that shows up as widths still pinned at 1, and the next lever is the seat budget rather than this one.

Not visual — background scheduling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_