### PR TITLE
fix(serve): derive the background render lane from the seat budget

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -590,10 +590,14 @@ class ServeCommand(args: List<String>) : Command(args) {
 
   /**
    * Server-wide admission for the catalogs' background theme optimization: it parks while any
-   * catalog is loading, and only one of them renders at a time. Shared by every catalog host this
-   * server opens — see [ServeBackgroundWork] for why both halves matter on a public box.
+   * catalog is loading, and bounds how many of them render at once. Shared by every catalog host
+   * this server opens — see [ServeBackgroundWork] for why both halves matter on a public box.
+   *
+   * The lane is derived from [liveSeatLimiter] because widening it is only safe where something
+   * else bounds daemon count: an unbounded budget (the CLI default) keeps the single lane.
    */
-  private val backgroundWork = ServeBackgroundWork()
+  private val backgroundWork =
+    ServeBackgroundWork(maxConcurrentRenders = ServeBackgroundWork.renderLaneFor(liveSeatLimiter))
 
   /**
    * In-browser CMP tier (`--wasm-dir <system>=<dir>[,<system>=<dir>…]`): map a design system to the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -31,10 +31,10 @@ import java.util.concurrent.atomic.AtomicLong
  */
 class ServeBackgroundWork(
   /**
-   * Background renders admitted at once, server-wide. See [DEFAULT_MAX_CONCURRENT_RENDERS] for why
-   * this is no longer 1.
+   * Background renders admitted at once, server-wide. Defaults to the conservative single lane; a
+   * server that knows its seat budget passes [renderLaneFor] instead.
    */
-  maxConcurrentRenders: Int = DEFAULT_MAX_CONCURRENT_RENDERS,
+  maxConcurrentRenders: Int = CONSERVATIVE_MAX_CONCURRENT_RENDERS,
   private val clock: () -> Long = System::currentTimeMillis,
 ) {
   private val loadsInFlight = AtomicInteger()
@@ -118,30 +118,54 @@ class ServeBackgroundWork(
 
   companion object {
     /**
-     * Background renders admitted at once, server-wide.
+     * The historical lane: one background render server-wide. Still the right answer when nothing
+     * else bounds daemon count — see [renderLaneFor].
+     */
+    const val CONSERVATIVE_MAX_CONCURRENT_RENDERS: Int = 1
+
+    /** Widest lane [renderLaneFor] will derive on its own. Beyond this, ask for it explicitly. */
+    const val MAX_DERIVED_CONCURRENT_RENDERS: Int = 3
+
+    /**
+     * How many background renders this server admits at once, given its live-seat budget.
      *
-     * **This was 1, and one permit for every catalog on the box was the prefetcher's dominant
+     * **The lane was 1, and one permit shared by every catalog was the prefetcher's dominant
      * bottleneck.** Measured on the deployed server (0.19.41, 15 catalogs, no visitors) once the
-     * gate/permit split made it visible: **74.3%** of the optimizer's active time was spent waiting
-     * for this permit, against 10.1% at the idle gate and **6.3%** actually rendering. Fifteen
-     * optimizers queueing on one permit, and every batch collapsing to a single daemon as a result.
+     * gate/permit split made it visible: **74.3%** of the optimizer's active time spent waiting for
+     * this permit, against 10.1% at the idle gate and **6.3%** actually rendering. Every batch
+     * collapsed to a single daemon as a result.
      *
      * The 1 was chosen so "a foreground render is never queued behind more than one background
-     * one". That guarantee is worth less than it sounds and cost more than it saved: a background
-     * batch holds this permit only for its renders — the expensive part, a cold daemon warm of
-     * 34-68s, is awaited *outside* it — and a warm background render is sub-second, so the
-     * foreground now queues behind at most a few seconds instead of one.
+     * one". That is cheaper to relax than it sounds: a background batch holds the permit only for
+     * its renders — the expensive part, a cold daemon warm of 34-68s, is awaited *outside* it — and
+     * a warm background render is sub-second.
      *
-     * Sized to what the box can actually run concurrently rather than to a round number: the live
-     * seat budget is 8 with Android weight 2, and prefetch replicas are charged to the background
-     * remainder (leaving [LiveSeatLimiter.STREAM_RESERVE] for a visitor), so at most three heavy
-     * daemons can be rendering at once anyway. A larger cap would only queue inside the seat budget
-     * instead of here, moving the wait rather than removing it.
+     * **But widening it is only safe because something else bounds daemon count.** Each admitted
+     * catalog submits up to five parallel renders and each one the pool can't serve opens another
+     * daemon, so a lane of 3 is a licence for up to fifteen concurrent daemons. On the deployed box
+     * the seat budget refuses that long before memory does; with [LiveSeatLimiter.unbounded] seats
+     * — the CLI default, `--live-seats 0`, for a local dev box — **nothing does**, and the same
+     * widening that helps a public server would spawn fifteen JVMs on a laptop. So an unbounded
+     * budget keeps [CONSERVATIVE_MAX_CONCURRENT_RENDERS]; only a bounded one derives a wider lane,
+     * from the daemons it could actually afford to run concurrently.
      *
-     * `-Dcomposeai.serve.backgroundRenders=<n>` overrides it; a box with a different seat budget is
-     * the case that wants a different number.
+     * `-Dcomposeai.serve.backgroundRenders=<n>` overrides both, for a deployment that knows better
+     * than either rule.
      */
-    val DEFAULT_MAX_CONCURRENT_RENDERS: Int =
-      System.getProperty("composeai.serve.backgroundRenders")?.toIntOrNull()?.coerceAtLeast(1) ?: 3
+    fun renderLaneFor(seats: LiveSeatLimiter?): Int {
+      System.getProperty("composeai.serve.backgroundRenders")?.toIntOrNull()?.let {
+        return it.coerceAtLeast(1)
+      }
+      if (seats == null || seats.unbounded) return CONSERVATIVE_MAX_CONCURRENT_RENDERS
+      // What the budget can hold beyond the stream reserve, at the heaviest backend's weight —
+      // the same arithmetic the pool does when it decides whether it can afford a replica.
+      val affordable =
+        (seats.totalPermits - LiveSeatLimiter.STREAM_RESERVE) /
+          ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT
+      return affordable.coerceIn(
+        CONSERVATIVE_MAX_CONCURRENT_RENDERS,
+        MAX_DERIVED_CONCURRENT_RENDERS,
+      )
+    }
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
@@ -121,11 +121,29 @@ class ServeBackgroundWorkTest {
     }
   }
 
+  /**
+   * Codex review on #3399. Widening the lane is only safe because the seat budget refuses the
+   * daemons it licenses: a lane of 3, each catalog submitting up to five parallel renders, is up to
+   * fifteen concurrent daemons. On `--live-seats 0` — the CLI default for a local box — nothing
+   * refuses them, so the widening that helps a public server would spawn fifteen JVMs on a laptop.
+   */
   @Test
-  fun `the default admits more than one, since one permit per box starved the prefetcher`() {
-    assertTrue(
-      ServeBackgroundWork.DEFAULT_MAX_CONCURRENT_RENDERS > 1,
-      "15 catalogs queueing on a single permit was 74.3% of the optimizer's active time",
+  fun `the render lane widens only where a seat budget can refuse the daemons it licenses`() {
+    assertEquals(
+      1,
+      ServeBackgroundWork.renderLaneFor(LiveSeatLimiter(totalPermits = 0)),
+      "an unbounded budget bounds nothing, so the lane must stay conservative",
+    )
+    assertEquals(1, ServeBackgroundWork.renderLaneFor(null), "no budget at all is the same case")
+
+    // The deployed box: 8 permits, Android weight 2, stream reserve held back.
+    assertEquals(3, ServeBackgroundWork.renderLaneFor(LiveSeatLimiter(totalPermits = 8)))
+    // A budget that can only afford one heavy daemon beyond the reserve gets one lane, not three.
+    assertEquals(1, ServeBackgroundWork.renderLaneFor(LiveSeatLimiter(totalPermits = 4)))
+    // And the derivation is capped rather than growing without limit on a large box.
+    assertEquals(
+      ServeBackgroundWork.MAX_DERIVED_CONCURRENT_RENDERS,
+      ServeBackgroundWork.renderLaneFor(LiveSeatLimiter(totalPermits = 64)),
     )
   }
 


### PR DESCRIPTION
Review finding on #3399, which merged before it could land there. It invalidates the sizing argument in that PR's own doc comment.

## The gap

#3399 widened the background lane from 1 to 3 and justified the size like this:

> the live seat budget is 8 with Android weight 2 … so at most three heavy daemons can be rendering at once anyway.

That holds only where the budget is **bounded**. The CLI default is `--live-seats 0` — unbounded (`ServeCommand.kt:108`, for a local dev box) — and there nothing refuses what the wider lane licenses:

- 3 catalogs admitted concurrently, each submitting up to **5** parallel renders (`optimizerBatchWidth`)
- each render the pool can't serve opens **another daemon** (`openSeatedReplica`, whose seat check is a no-op when unbounded)
- Android replicas spend 34–68s cold-starting inside those renders

Up to **fifteen concurrent daemons** on a laptop, where the old lane opened one at a time. On the deployed box the seat limiter refuses that long before memory does; locally there is no such guard.

## The fix

The lane is derived rather than constant:

| seat budget | lane |
|---|---|
| unbounded (`--live-seats 0`) or absent | **1** — the safety argument doesn't apply |
| bounded | `(totalPermits − STREAM_RESERVE) / ANDROID_LIVE_SEAT_WEIGHT`, capped at 3 |

That's the same arithmetic the pool does when deciding whether it can afford a replica, so the lane can never license more daemons than the budget will grant. The deployed box (8 permits) still gets 3; a 4-permit box gets 1. `-Dcomposeai.serve.backgroundRenders` still overrides both, for a deployment that knows better than either rule.

## Test plan

- `./gradlew :cli:test` — green (full suite).
- New `the render lane widens only where a seat budget can refuse the daemons it licenses`: unbounded → 1, null → 1, 8 permits → 3, 4 permits → 1, 64 permits → capped at `MAX_DERIVED_CONCURRENT_RENDERS` rather than growing without limit.
- The cap-honoured and cap-reached tests from #3399 are unchanged and still pass, since they pass their cap explicitly.

Not visual — background scheduling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5HmuHiXEbGGHbq3RrWzuV)_