### PR TITLE
feat(serve): add the history.json manifest for delivery-branch render history

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
@@ -1,0 +1,194 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `history.json` — the precomputed render history that ships alongside the renders on a delivery
+ * branch, so a viewer can show a preview's timeline without a git checkout.
+ *
+ * This exists because the hosted viewer has no repository. `serve` only has git in project mode
+ * (`--revisions`, rooted at the local project repo), so a direct [PreviewHistory] walk can never
+ * reach `preview.coo.ee`. CI already has the branch checked out when it publishes, so it computes
+ * the history once and commits the answer.
+ *
+ * **Keyed by preview id, not render path.** [PreviewHistory] works in branch paths
+ * (`renders/<module>/<basename>`) because that is what git reports, but every consumer — the
+ * viewer, the diff bot, `baselines.json` itself — addresses previews by id
+ * (`<module>/<fqName>_<label>`). The join happens here, once, so no consumer has to reconstruct a
+ * path convention.
+ *
+ * ### Relationship to `daemon.history`
+ *
+ * Not the same feature as the daemon's history archive (`HistorySource`, `GitRefHistorySource`,
+ * `compose-preview history list|read|diff`), despite the shared word. That one reads the daemon's
+ * *reporting branch*, whose layout is one directory per preview with `entry.json` sidecars carrying
+ * semantics / a11y / theme snapshots. This reads the *baseline delivery branches*, written by CI in
+ * a flat `renders/<module>/` layout with no sidecars at all.
+ *
+ * They are kept separate deliberately: a [HistoryEntry][ee.schimke.composeai.daemon.history]-shaped
+ * record would be almost entirely null for delivery-branch data, and this side's job is to be a
+ * small static file a viewer fetches rather than a live source API. If the two ever converge, this
+ * is the file to fold in.
+ */
+object PreviewHistoryManifest {
+
+  /**
+   * Bumped when the shape changes incompatibly, so a viewer can refuse a manifest it can't read.
+   */
+  const val FORMAT_VERSION: String = "compose-preview-history/v1"
+
+  /** The file's name on the delivery branch, beside `baselines.json`. */
+  const val FILE_NAME: String = "history.json"
+
+  @Serializable
+  data class Manifest(
+    @SerialName("formatVersion") val formatVersion: String = FORMAT_VERSION,
+    /**
+     * Delivery-branch commit this was computed from. A viewer can compare it against the branch tip
+     * to tell whether the manifest is current; it is expected to lag by exactly the commit that
+     * carries the manifest itself.
+     */
+    @SerialName("generatedFrom") val generatedFrom: String,
+    /** Keyed by preview id, the same keys `baselines.json` uses. */
+    @SerialName("previews") val previews: Map<String, PreviewTimeline>,
+  )
+
+  @Serializable
+  data class PreviewTimeline(
+    /** Render path on the branch, so a viewer can fetch any version's bytes. */
+    @SerialName("path") val path: String,
+    /** Newest first. Trimmed when [unstable] — see [PreviewHistory.Timeline.displayVersions]. */
+    @SerialName("versions") val versions: List<ManifestVersion>,
+    /** Raw commits touching this render, before any collapsing or trimming. */
+    @SerialName("observations") val observations: Int,
+    /**
+     * True when this render keeps reverting to bytes it had already moved away from. Present so a
+     * viewer can label the timeline as unreliable rather than silently showing a trimmed list that
+     * doesn't add up to [observations].
+     */
+    @SerialName("unstable") val unstable: Boolean,
+    /** Returns to previously-seen bytes. Non-zero with `unstable: false` means a lone revert. */
+    @SerialName("flapCount") val flapCount: Int,
+  )
+
+  @Serializable
+  data class ManifestVersion(
+    /** Content sha of the render — stable across commits, so a viewer can cache by it. */
+    @SerialName("blob") val blob: String,
+    /** Newest delivery-branch commit carrying these bytes. */
+    @SerialName("commit") val commit: String,
+    /** Author date of [commit], ISO-8601. */
+    @SerialName("date") val date: String,
+    /** Source commit these bytes were rendered from, when the publish subject recorded one. */
+    @SerialName("sourceSha") val sourceSha: String? = null,
+    /**
+     * Delivery-branch commit that introduced these bytes. Omitted when it equals [commit], which is
+     * every single-publish version — the common case, and 40 redundant hex characters each. Readers
+     * should fall back to [commit]; [introducedBy] does that.
+     */
+    @SerialName("sinceCommit") val sinceCommit: String? = null,
+    /** Publishes carrying these bytes. */
+    @SerialName("commits") val commits: Int,
+    /**
+     * Separate runs that had these bytes. Omitted when 1 (the overwhelming majority), so the file
+     * doesn't carry a redundant field on every stable entry.
+     */
+    @SerialName("occurrences") val occurrences: Int? = null,
+  ) {
+    /** The commit that introduced these bytes, resolving the omitted-when-equal [sinceCommit]. */
+    val introducedBy: String
+      get() = sinceCommit ?: commit
+  }
+
+  /**
+   * Map render path → preview id, parsed from a `baselines.json` payload.
+   *
+   * The delivery branch stores `renders/<module>/<renderBasename>` and `baselines.json` records
+   * `module` + `renderBasename` per preview, so this reverses that into the lookup [build] needs.
+   * Entries missing either field are skipped rather than guessed at — a preview whose path can't be
+   * reconstructed is better absent from the manifest than present under a wrong key.
+   */
+  fun renderPathsToPreviewIds(baselinesJson: String): Map<String, String> {
+    val root =
+      runCatching { Json.parseToJsonElement(baselinesJson).jsonObject }.getOrNull()
+        ?: return emptyMap()
+    val byPath = LinkedHashMap<String, String>()
+    for ((previewId, entry) in root) {
+      val obj = entry as? JsonObject ?: continue
+      val module = obj["module"]?.jsonPrimitive?.contentOrNullSafe() ?: continue
+      val basename = obj["renderBasename"]?.jsonPrimitive?.contentOrNullSafe() ?: continue
+      if (module.isEmpty() || basename.isEmpty()) continue
+      byPath["renders/$module/$basename"] = previewId
+    }
+    return byPath
+  }
+
+  /**
+   * Build the manifest from extracted [timelines], keyed by preview id via [pathToPreviewId].
+   *
+   * A render path with no matching preview id is dropped. That is the normal fate of history for a
+   * preview that has since been deleted or renamed: it still has commits on the branch, but nothing
+   * in `baselines.json` points at it, so no viewer could address it anyway.
+   *
+   * Previews are emitted in sorted key order so regenerating an unchanged branch produces a
+   * byte-identical file — otherwise every publish would show a spurious `history.json` diff.
+   */
+  fun build(
+    timelines: Map<String, PreviewHistory.Timeline>,
+    pathToPreviewId: Map<String, String>,
+    generatedFrom: String,
+  ): Manifest {
+    val previews = sortedMapOf<String, PreviewTimeline>()
+    for ((path, timeline) in timelines) {
+      val previewId = pathToPreviewId[path] ?: continue
+      if (timeline.versions.isEmpty()) continue
+      previews[previewId] =
+        PreviewTimeline(
+          path = path,
+          versions = timeline.displayVersions.map { it.toManifestVersion() },
+          observations = timeline.observations,
+          unstable = timeline.unstable,
+          flapCount = timeline.flapCount,
+        )
+    }
+    return Manifest(generatedFrom = generatedFrom, previews = previews)
+  }
+
+  private fun PreviewHistory.Version.toManifestVersion() =
+    ManifestVersion(
+      blob = blob,
+      commit = until.commit,
+      date = until.date,
+      sourceSha = until.sourceSha,
+      sinceCommit = since.commit.takeIf { it != until.commit },
+      commits = commits,
+      occurrences = occurrences.takeIf { it > 1 },
+    )
+
+  /**
+   * Serialize for committing. Pretty-printed because this file lands on a branch that humans and
+   * the diff bot read: a one-line JSON blob would make every regeneration an unreviewable diff,
+   * whereas one field per line keeps a changed timeline legible in a PR.
+   */
+  fun encode(manifest: Manifest): String = JSON.encodeToString(manifest) + "\n"
+
+  /** Lenient on read so a manifest written by a newer CLI (extra fields) still loads. */
+  fun decode(text: String): Manifest? =
+    runCatching { JSON.decodeFromString<Manifest>(text) }.getOrNull()
+
+  private val JSON = Json {
+    prettyPrint = true
+    encodeDefaults = false
+    explicitNulls = false
+    ignoreUnknownKeys = true
+  }
+
+  /** `jsonPrimitive.contentOrNull` throws on a non-string primitive; this never does. */
+  private fun kotlinx.serialization.json.JsonPrimitive.contentOrNullSafe(): String? =
+    if (isString) content else null
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -35,6 +37,7 @@ import kotlinx.serialization.json.jsonPrimitive
  * small static file a viewer fetches rather than a live source API. If the two ever converge, this
  * is the file to fold in.
  */
+@OptIn(ExperimentalSerializationApi::class)
 object PreviewHistoryManifest {
 
   /**
@@ -47,7 +50,16 @@ object PreviewHistoryManifest {
 
   @Serializable
   data class Manifest(
-    @SerialName("formatVersion") val formatVersion: String = FORMAT_VERSION,
+    /**
+     * [EncodeDefault] is load-bearing, not decoration: [JSON] sets `encodeDefaults = false` so the
+     * redundant fields below stay off the wire, and without this the version discriminator would be
+     * dropped by exactly the same rule — leaving every published manifest with nothing for a viewer
+     * to version-check against. Kept as a *default* rather than a required parameter so a manifest
+     * that somehow lacks it still decodes.
+     */
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
+    @SerialName("formatVersion")
+    val formatVersion: String = FORMAT_VERSION,
     /**
      * Delivery-branch commit this was computed from. A viewer can compare it against the branch tip
      * to tell whether the manifest is current; it is expected to lag by exactly the commit that

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifestTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifestTest.kt
@@ -1,0 +1,263 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PreviewHistoryManifestTest {
+
+  private val a = "a".repeat(40)
+  private val b = "b".repeat(40)
+
+  private fun gitLog(vararg entries: Pair<String, List<Pair<String, String>>>): String =
+    buildString {
+      entries.forEach { (subject, files) ->
+        val sha = subject.hashCode().toUInt().toString(16).padStart(40, '0')
+        append("\u0001").append(sha).append("\u001F").append("2026-08-06T10:00:00+00:00")
+        append("\u001F").append(subject).append("\n\n")
+        files.forEach { (path, blob) ->
+          append(":100644 100644 ").append(b).append(' ').append(blob).append(" M\t").append(path)
+          append('\n')
+        }
+      }
+    }
+
+  private fun timelines(log: String) = PreviewHistory.collapse(PreviewHistory.parseGitLog(log))
+
+  private val baselines =
+    """
+    {
+      "samples:wear/com.example.PreviewsKt.Foo_Large Round": {
+        "module": "samples:wear",
+        "renderBasename": "Foo_Large_Round.png",
+        "sha256": "irrelevant"
+      }
+    }
+    """
+      .trimIndent()
+
+  @Test
+  fun `baselines entries reverse into a render-path lookup`() {
+    val lookup = PreviewHistoryManifest.renderPathsToPreviewIds(baselines)
+
+    assertEquals(
+      mapOf(
+        "renders/samples:wear/Foo_Large_Round.png" to
+          "samples:wear/com.example.PreviewsKt.Foo_Large Round"
+      ),
+      lookup,
+    )
+  }
+
+  @Test
+  fun `entries missing module or basename are skipped rather than guessed`() {
+    val partial =
+      """
+      {
+        "no-module": { "renderBasename": "Foo.png" },
+        "no-basename": { "module": "samples:wear" },
+        "empty-module": { "module": "", "renderBasename": "Foo.png" },
+        "not-an-object": 7,
+        "good": { "module": "m", "renderBasename": "Foo.png" }
+      }
+      """
+        .trimIndent()
+
+    val lookup = PreviewHistoryManifest.renderPathsToPreviewIds(partial)
+
+    assertEquals(mapOf("renders/m/Foo.png" to "good"), lookup)
+  }
+
+  @Test
+  fun `malformed baselines yield an empty lookup instead of throwing`() {
+    assertEquals(emptyMap(), PreviewHistoryManifest.renderPathsToPreviewIds("{not json"))
+  }
+
+  @Test
+  fun `the manifest is keyed by preview id and carries the render path`() {
+    val log =
+      gitLog(
+        "Update preview baselines from 27ea28c1" to
+          listOf("renders/samples:wear/Foo_Large_Round.png" to a)
+      )
+
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+
+    val entry = manifest.previews.getValue("samples:wear/com.example.PreviewsKt.Foo_Large Round")
+    assertEquals("renders/samples:wear/Foo_Large_Round.png", entry.path)
+    assertEquals("27ea28c1", entry.versions.single().sourceSha, "source commit survives the join")
+    assertEquals(PreviewHistoryManifest.FORMAT_VERSION, manifest.formatVersion)
+    assertEquals("tip", manifest.generatedFrom)
+  }
+
+  @Test
+  fun `a render with no preview id is dropped`() {
+    // The normal fate of a deleted or renamed preview: still has branch commits, but nothing in
+    // baselines.json addresses it, so no viewer could ask for it.
+    val log = gitLog("publish" to listOf("renders/samples:wear/Orphaned.png" to a))
+
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+
+    assertTrue(manifest.previews.isEmpty())
+  }
+
+  @Test
+  fun `an unstable preview is marked and carries its trimmed versions`() {
+    val path = "renders/samples:wear/Foo_Large_Round.png"
+    val log = gitLog(*Array(8) { i -> "publish $i" to listOf(path to if (i % 2 == 0) a else b) })
+
+    val entry =
+      PreviewHistoryManifest.build(
+          timelines(log),
+          PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+          generatedFrom = "tip",
+        )
+        .previews
+        .values
+        .single()
+
+    assertTrue(entry.unstable)
+    assertEquals(6, entry.flapCount)
+    assertEquals(8, entry.observations, "the raw count stays, so the trim is visible not hidden")
+    assertEquals(2, entry.versions.size, "trimmed to the states it flips between")
+    assertEquals(4, entry.versions.first().occurrences)
+  }
+
+  @Test
+  fun `occurrences is omitted for the ordinary single-run version`() {
+    val log = gitLog("publish" to listOf("renders/samples:wear/Foo_Large_Round.png" to a))
+
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+    val encoded = PreviewHistoryManifest.encode(manifest)
+
+    assertNull(manifest.previews.values.single().versions.single().occurrences)
+    assertFalse(encoded.contains("occurrences"), "no redundant field on every stable entry")
+  }
+
+  @Test
+  fun `sinceCommit is omitted when it would repeat commit`() {
+    val log = gitLog("publish" to listOf("renders/samples:wear/Foo_Large_Round.png" to a))
+
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+    val version = manifest.previews.values.single().versions.single()
+
+    assertNull(version.sinceCommit, "single-publish version introduces itself")
+    assertEquals(version.commit, version.introducedBy, "readers still get a commit")
+    assertFalse(PreviewHistoryManifest.encode(manifest).contains("sinceCommit"))
+  }
+
+  @Test
+  fun `sinceCommit is kept when a version spans several publishes`() {
+    val path = "renders/samples:wear/Foo_Large_Round.png"
+    val log = gitLog("newest" to listOf(path to a), "oldest" to listOf(path to a))
+
+    val version =
+      PreviewHistoryManifest.build(
+          timelines(log),
+          PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+          generatedFrom = "tip",
+        )
+        .previews
+        .values
+        .single()
+        .versions
+        .single()
+
+    assertNotNull(version.sinceCommit)
+    assertEquals(version.sinceCommit, version.introducedBy)
+    assertTrue(version.sinceCommit != version.commit, "spans two distinct commits")
+  }
+
+  @Test
+  fun `regenerating an unchanged branch produces a byte-identical file`() {
+    // Otherwise every publish would show a spurious history.json diff on the delivery branch.
+    val log =
+      gitLog(
+        "publish" to listOf("renders/m/B.png" to a, "renders/m/A.png" to b, "renders/m/C.png" to a)
+      )
+    val lookup =
+      mapOf("renders/m/A.png" to "m/A", "renders/m/B.png" to "m/B", "renders/m/C.png" to "m/C")
+
+    val first =
+      PreviewHistoryManifest.encode(PreviewHistoryManifest.build(timelines(log), lookup, "tip"))
+    val again =
+      PreviewHistoryManifest.encode(PreviewHistoryManifest.build(timelines(log), lookup, "tip"))
+
+    assertEquals(first, again)
+    val order = Regex("\"(m/[ABC])\"").findAll(first).map { it.groupValues[1] }.toList()
+    assertEquals(listOf("m/A", "m/B", "m/C"), order, "sorted, not git's discovery order")
+  }
+
+  @Test
+  fun `the encoded manifest round-trips`() {
+    val log =
+      gitLog("publish from 1a2b3c4d" to listOf("renders/samples:wear/Foo_Large_Round.png" to a))
+    val manifest =
+      PreviewHistoryManifest.build(
+        timelines(log),
+        PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+        generatedFrom = "tip",
+      )
+
+    val decoded = PreviewHistoryManifest.decode(PreviewHistoryManifest.encode(manifest))
+
+    assertEquals(manifest, assertNotNull(decoded))
+  }
+
+  @Test
+  fun `a manifest with unknown fields still decodes`() {
+    // Forward-compat: a branch written by a newer CLI must not break an older viewer.
+    val text =
+      """
+      {
+        "formatVersion": "${PreviewHistoryManifest.FORMAT_VERSION}",
+        "generatedFrom": "tip",
+        "somethingNew": {"nested": true},
+        "previews": {
+          "m/A": {
+            "path": "renders/m/A.png",
+            "versions": [
+              {"blob": "$a", "commit": "c1", "date": "d", "commits": 1, "extra": 9}
+            ],
+            "observations": 1,
+            "unstable": false,
+            "flapCount": 0
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val decoded = assertNotNull(PreviewHistoryManifest.decode(text))
+
+    assertEquals("renders/m/A.png", decoded.previews.getValue("m/A").path)
+  }
+
+  @Test
+  fun `undecodable text yields null rather than throwing`() {
+    assertNull(PreviewHistoryManifest.decode("{not json"))
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifestTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifestTest.kt
@@ -212,6 +212,47 @@ class PreviewHistoryManifestTest {
   }
 
   @Test
+  fun `the format version is always written to the wire`() {
+    // Regression: formatVersion is a defaulted field and the encoder sets encodeDefaults = false
+    // to keep redundant fields off the wire, which silently dropped the one discriminator a viewer
+    // needs to reject an incompatible manifest. A round-trip assertion cannot catch this — decode
+    // restores the default — so this asserts on the encoded text.
+    val log = gitLog("publish" to listOf("renders/samples:wear/Foo_Large_Round.png" to a))
+
+    val encoded =
+      PreviewHistoryManifest.encode(
+        PreviewHistoryManifest.build(
+          timelines(log),
+          PreviewHistoryManifest.renderPathsToPreviewIds(baselines),
+          generatedFrom = "tip",
+        )
+      )
+
+    assertTrue(
+      encoded.contains("\"formatVersion\": \"${PreviewHistoryManifest.FORMAT_VERSION}\""),
+      "published manifests must carry the discriminator; got:\n${encoded.take(200)}",
+    )
+  }
+
+  @Test
+  fun `a manifest missing the format version still decodes`() {
+    // It is always written now, but keeping it a defaulted field means an older or hand-edited
+    // file is still readable rather than a hard parse failure.
+    val text =
+      """
+      {
+        "generatedFrom": "tip",
+        "previews": {}
+      }
+      """
+        .trimIndent()
+
+    val decoded = assertNotNull(PreviewHistoryManifest.decode(text))
+
+    assertEquals(PreviewHistoryManifest.FORMAT_VERSION, decoded.formatVersion)
+  }
+
+  @Test
   fun `the encoded manifest round-trips`() {
     val log =
       gitLog("publish from 1a2b3c4d" to listOf("renders/samples:wear/Foo_Large_Round.png" to a))


### PR DESCRIPTION
## Summary

Second piece of the preview history feature, on top of the extractor from #3394. Precomputes `PreviewHistory`'s output into a file that ships beside the renders on a delivery branch, so a viewer can show a preview's timeline without a git checkout.

This is the piece that makes the feature reach the hosted viewer at all: `serve` only has git in project mode (`--revisions`, rooted at the local project repo), so a direct git walk can never reach `preview.coo.ee`. CI already has the branch when it publishes, so it computes the answer once and commits it.

### Keyed by preview id, not render path

`PreviewHistory` works in branch paths because that's what git reports, but every consumer — the viewer, the diff bot, `baselines.json` itself — addresses previews by id. The join (via `module` + `renderBasename`) happens here, once, rather than each consumer reconstructing a path convention.

### Measured against the real `compose-preview/main`

| | |
|---|---|
| `baselines.json` entries joined | **535 / 535** |
| versions emitted | 826 |
| unstable, marked + trimmed | 5 |
| raw / gzipped | 450 KB / **41 KB** |

The 276 render paths that *don't* join are history for previews since deleted or renamed — nothing addresses them, so they're dropped rather than emitted under a guessed key.

Two fields are omitted when redundant, worth 64 KB of raw size on its own: `occurrences` when 1, and `sinceCommit` when it repeats `commit` (every single-publish version). Readers use `introducedBy`, which resolves the fallback.

Output is sorted by preview id so regenerating an unchanged branch is byte-identical — otherwise every publish would show a spurious `history.json` diff on the delivery branch.

### Deliberately separate from `daemon.history`

Worth flagging since the word collides. There's an existing, mature history system — `HistorySource` / `GitRefHistorySource` / `compose-preview history list|read|diff`, documented in HISTORY.md and REPORTING-BRANCH.md. It reads the **daemon's reporting branch**: one directory per preview, `entry.json` sidecars carrying semantics / a11y / theme snapshots.

This reads the **CI baseline delivery branches**: flat `renders/<module>/`, no sidecars, written by a different producer, and never mentioned in those docs.

I kept them separate because a `HistoryEntry`-shaped record would be almost entirely null for delivery-branch data, and this side's job is to be a small static file a viewer fetches rather than a live source API. The KDoc says so explicitly and says this is the file to fold in if they ever converge. **Happy to be overruled** — the alternative (make the delivery branch a third `HistorySource`, so the CLI/JSON-RPC/`HistoryImageDiff` get it free) is defensible, it just needs the sparse-data mapping and the hosted viewer would still want a static manifest.

## Test plan

13 tests, all passing, plus the full `PreviewHistory*` suite green and `ktfmtCheckAll` clean.

Covering: the `baselines.json` join and its skip-rather-than-guess cases (missing `module`, missing `renderBasename`, empty values, non-object entries, malformed JSON); preview-id keying; orphaned paths dropped; the unstable marker and trim surviving into the manifest with raw counts intact; both omitted-field rules in both directions; byte-identical regeneration including sort order; round-trip; and forward-compatible decoding of unknown fields so a branch written by a newer CLI doesn't break an older viewer.

Beyond unit tests I generated the manifest against the actual `compose-preview/main` — that's where the join rate and size figures above come from, and it's what caught the `sinceCommit` redundancy.

No visual surfaces touched; this is data plumbing with no UI yet, so text-only evidence is right. The timeline UI it feeds will carry before/after renders.

## Deliberately not in this PR

**Nothing produces the file yet.** The generator is a library; wiring it needs two decisions I'd rather not make unilaterally at the end of a long session:

1. **How CI invokes it.** `install-cli` already puts the CLI on PATH in the baselines job, so a step there is nearly free — but the CLI's `history` verb is taken by the daemon feature, and `CliRouter`'s command set is pinned by `CliRouterTest`. So this is either a new public verb (name TBD), or a CI-internal entry point that doesn't widen the CLI surface. I lean internal.
2. **Which commit carries it.** Computing from the branch log means the manifest can't describe the commit that carries it. Cleanest is a second commit touching only `history.json` — invisible to the extractor, which filters on the `renders` pathspec, so it can't pollute render history. The alternative (amend into the render commit) leaves the newest entry pointing at a pre-amend sha that no longer exists.

Then: local git override in project mode, and the viewer timeline UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXp51dArWBD4dWia6GbJkV)_