### PR TITLE
feat(serve): give the playground compile lane a per-caller budget

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -74,6 +74,8 @@ internal object CliFlags {
       "--playground-sandbox-ro",
       "--playground-compile-slots",
       "--playground-catalog-limit",
+      "--playground-rate-limit",
+      "--playground-caller-concurrency",
       "--extra-maven-repos",
       "--trust-store",
       "--catalogs",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -50,6 +50,7 @@ import ee.schimke.composeai.cli.serve.ServeMdnsAdvertiser
 import ee.schimke.composeai.cli.serve.ServeModuleRef
 import ee.schimke.composeai.cli.serve.ServePerPreviewDaemonPool
 import ee.schimke.composeai.cli.serve.ServePreview
+import ee.schimke.composeai.cli.serve.ServeRateLimiter
 import ee.schimke.composeai.cli.serve.ServeRenderHost
 import ee.schimke.composeai.cli.serve.ServeRevisionFactory
 import ee.schimke.composeai.cli.serve.ServeSessionFactory
@@ -335,6 +336,38 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val playgroundCatalogLimit: Int =
     args.flagValue("--playground-catalog-limit")?.toIntOrNull()?.takeIf { it > 0 }
       ?: PlaygroundCatalogTargets.DEFAULT_LIMIT
+
+  /**
+   * `--playground-rate-limit <n>`: compiles per minute **per caller** (0 disables the limiter).
+   *
+   * Every other playground bound — compile slots, the compile timeout, the body cap, live seats,
+   * the token store — is a whole-host one (issue #3214). None of them stops two callers from
+   * holding every slot with back-to-back 180-second compiles while everyone else is told the
+   * playground is busy. This is the fair-sharing half.
+   */
+  private val playgroundRateLimit: Int =
+    args.flagValue("--playground-rate-limit")?.toIntOrNull()?.takeIf { it >= 0 }
+      ?: DEFAULT_PLAYGROUND_RATE_LIMIT
+
+  /**
+   * `--playground-caller-concurrency <n>`: compiles one caller may hold at once. Default 1, which
+   * is the knob that answers the complaint directly — with the host's `--playground-compile-slots`
+   * at its default 2, one caller cannot hold both.
+   */
+  private val playgroundCallerConcurrency: Int =
+    args.flagValue("--playground-caller-concurrency")?.toIntOrNull()?.takeIf { it > 0 } ?: 1
+
+  /**
+   * `--trust-forwarded-for`: rate-limit an anonymous caller by the **last** `X-Forwarded-For` entry
+   * rather than the socket peer.
+   *
+   * Opt-in, because the header is client-supplied: on a directly-exposed host trusting it would let
+   * a caller mint a fresh identity per request and walk straight past the limit. Set it only when
+   * this server sits behind a reverse proxy you control that *appends* the peer address it saw
+   * (nginx's `$proxy_add_x_forwarded_for`) — that appended last entry is the one a client can't
+   * forge. Without it, every caller behind the proxy shares one bucket.
+   */
+  private val trustForwardedFor: Boolean = "--trust-forwarded-for" in args
 
   /**
    * `--playground-sandbox <profile>`: the **per-session sandbox** every playground snippet JVM runs
@@ -1536,6 +1569,34 @@ class ServeCommand(args: List<String>) : Command(args) {
     return PlaygroundLane(compile = service, redeem = redeem, health = health)
   }
 
+  /**
+   * The per-caller compile budget, or null when `--playground-rate-limit 0` turned it off.
+   *
+   * Only the **compile** lane is metered, not `/pg/` redemption: a redemption is only reachable
+   * with a token a compile just minted, so limiting compiles transitively limits it — and
+   * redemption already answers to the live-seat budget, the token store's cap, and the token TTL.
+   * Metering it twice would refuse a caller the preview they already paid for.
+   */
+  private fun buildPlaygroundRateLimiter(): ServeRateLimiter? {
+    if (playgroundRateLimit <= 0) {
+      System.err.println(
+        "serve: WARNING playground compile lane is UNMETERED (--playground-rate-limit 0). Its " +
+          "remaining bounds are all whole-host ones, so one caller can hold every compile slot."
+      )
+      return null
+    }
+    System.err.println(
+      "serve: playground compile budget — $playgroundRateLimit/min per caller, " +
+        "$playgroundCallerConcurrency concurrent" +
+        (if (trustForwardedFor) ", keyed by the last X-Forwarded-For entry when anonymous" else "")
+    )
+    return ServeRateLimiter(
+      permitsPerWindow = playgroundRateLimit,
+      windowSeconds = 60,
+      maxConcurrent = playgroundCallerConcurrency,
+    )
+  }
+
   /** The playground's Stage-1 compile lane + Stage-2 redeem lane, sharing one token store. */
   private class PlaygroundLane(
     val compile: PlaygroundCompileService,
@@ -1951,6 +2012,8 @@ class ServeCommand(args: List<String>) : Command(args) {
         playgroundHealth = playgroundLane?.health,
         playgroundRedeem = playgroundLane?.redeem,
         githubAuth = githubAuth,
+        playgroundRateLimiter = playgroundLane?.let { buildPlaygroundRateLimiter() },
+        trustForwardedFor = trustForwardedFor,
         engagementStore = ServeEngagementStore(engagementFile),
       )
     if (trustAdmin != null) {
@@ -3098,5 +3161,13 @@ class ServeCommand(args: List<String>) : Command(args) {
      * — cheap enough to poll every watched catalog at this cadence indefinitely.
      */
     const val DEFAULT_CATALOG_REFRESH_SECONDS = 600L
+
+    /**
+     * Compiles per minute per caller. Sized for a person using the editor, not for a script: a
+     * deliberate Run every six seconds sustained is already brisk, and the bucket lets a burst of
+     * ten through back-to-back before it starts pacing. Raise it for a busy shared host; 0 turns
+     * the limiter off entirely.
+     */
+    const val DEFAULT_PLAYGROUND_RATE_LIMIT = 10
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -237,6 +237,23 @@ class ServeHttpServer(
    * has resolved. Null when the lane isn't wired at all. See [PlaygroundHealth].
    */
   private val playgroundHealth: (() -> PlaygroundHealth)? = null,
+  /**
+   * Per-caller budget on the compile lane (issue #3214), or null to leave it unmetered. Every other
+   * playground bound is a whole-host one, so without this two callers issuing back-to-back compiles
+   * hold every slot and everyone else is told the playground is busy.
+   */
+  private val playgroundRateLimiter: ServeRateLimiter? = null,
+  /**
+   * Trust the **last** entry of `X-Forwarded-For` as the client address when rate-limiting an
+   * anonymous caller, instead of the socket peer.
+   *
+   * Off by default and opt-in for a reason: the header is client-supplied, so trusting it on a
+   * directly-exposed host lets a caller forge a fresh identity per request and bypass the limit
+   * entirely. The *last* entry — not the first — is the one a single reverse proxy appended from
+   * the peer address it actually saw (nginx's `$proxy_add_x_forwarded_for`), which a client cannot
+   * forge. That is exactly one hop's worth of trust; behind two proxies this names the inner one.
+   */
+  private val trustForwardedFor: Boolean = false,
   /** Aggregate view counts; pass a file-backed store to keep them across server restarts. */
   private val engagementStore: ServeEngagementStore = ServeEngagementStore(),
 ) {
@@ -1069,10 +1086,73 @@ class ServeHttpServer(
     }
   }
 
+  /**
+   * Who to charge for a request, for rate-limiting purposes.
+   *
+   * The **authenticated GitHub login** where there is one: it survives a changed address, it is the
+   * identity the repo-access gate already admitted on, and on a repo-access-gated host it is what
+   * every compile carries. Otherwise the client address, which is all a token-gated or local host
+   * has. Prefixed so the two spaces can never collide — a login is not an address, and a caller who
+   * signs in should not inherit the budget an anonymous neighbour behind the same NAT just spent.
+   */
+  private fun RoutingContext.rateLimitKey(): String {
+    githubAuth
+      ?.currentLogin(call)
+      ?.takeIf { it.isNotBlank() }
+      ?.let {
+        return "gh:$it"
+      }
+    val forwarded =
+      if (!trustForwardedFor) null
+      else
+        call.request.headers["X-Forwarded-For"]
+          ?.split(',')
+          ?.map { it.trim() }
+          ?.lastOrNull { it.isNotEmpty() }
+    return "ip:" + (forwarded ?: call.request.origin.remoteHost)
+  }
+
+  /**
+   * Charge this request against its caller's budget, responding `429` + `Retry-After` and returning
+   * null when they are over it. A non-null result MUST be released when the work finishes.
+   */
+  private suspend fun RoutingContext.acquirePlaygroundPermit():
+    ServeRateLimiter.Decision.Admitted? {
+    val limiter = playgroundRateLimiter ?: return ServeRateLimiter.Decision.Admitted {}
+    return when (val decision = limiter.tryAcquire(rateLimitKey())) {
+      is ServeRateLimiter.Decision.Admitted -> decision
+      is ServeRateLimiter.Decision.Throttled -> {
+        call.response.headers.append(HttpHeaders.RetryAfter, decision.retryAfterSeconds.toString())
+        call.respondText(
+          JSON.encodeToString(
+            PlaygroundRunResponse.serializer(),
+            PlaygroundRunResponse(exception = "Too many requests — ${decision.reason}."),
+          ),
+          ContentType.Application.Json,
+          HttpStatusCode.TooManyRequests,
+        )
+        null
+      }
+    }
+  }
+
   private suspend fun RoutingContext.handlePlaygroundRun(service: PlaygroundCompileService) {
     if (rejectBadToken()) return
     if (rejectMissingGithubAuth(api = true)) return
     if (rejectMissingGithubRepoAccess(api = true)) return
+    // After the gates, before the body read: a throttled caller should cost this host a 429 and
+    // nothing else — not 256 KB of buffered upload, and certainly not a compile slot.
+    val permit = acquirePlaygroundPermit() ?: return
+    try {
+      handlePlaygroundRunAdmitted(service)
+    } finally {
+      permit.release()
+    }
+  }
+
+  private suspend fun RoutingContext.handlePlaygroundRunAdmitted(
+    service: PlaygroundCompileService
+  ) {
     val body =
       withContext(Dispatchers.IO) {
         call.receiveStream().use { readCapped(it, MAX_PLAYGROUND_BYTES) }
@@ -2191,6 +2271,13 @@ class ServeHttpServer(
               catalogSelector =
                 h.catalogSelector?.invoke()?.let {
                   CatalogSelectorDto(offered = it.offered, resolved = it.resolved, limit = it.limit)
+                },
+              rateLimit =
+                playgroundRateLimiter?.let {
+                  RateLimitDto(
+                    activeCallers = it.activeCallers(),
+                    trackedCallers = it.trackedCallers(),
+                  )
                 },
             )
           },
@@ -3734,6 +3821,19 @@ private data class PlaygroundDto(
   val modes: List<ModeDto>,
   /** The runtime catalog selector (`--playground`), or null when this host pins its bundles. */
   val catalogSelector: CatalogSelectorDto? = null,
+  /** The per-caller compile budget, or null when the lane is unmetered. */
+  val rateLimit: RateLimitDto? = null,
+)
+
+@Serializable
+private data class RateLimitDto(
+  /** Callers holding a compile permit right now. */
+  val activeCallers: Int,
+  /**
+   * Distinct callers the limiter is tracking. A number pinned near its cap on a public host is the
+   * signature of a key-space spray, not of an audience.
+   */
+  val trackedCallers: Int,
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRateLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRateLimiter.kt
@@ -1,0 +1,186 @@
+package ee.schimke.composeai.cli.serve
+
+/**
+ * A **per-caller** budget for an expensive serve lane: a token bucket for the request *rate* plus a
+ * counter for *concurrent* work, keyed by whoever is asking (issue #3214).
+ *
+ * Everything the playground already bounds — compile slots, the compile timeout, the request-body
+ * cap, live seats, the token store's size and TTL — bounds *simultaneous resource use across the
+ * whole host*. None of it is a per-caller budget, so two clients issuing back-to-back 180-second
+ * compiles hold every slot indefinitely and everyone else gets "the playground is busy compiling".
+ * That is the gap this closes: not lifetime (the sandbox TTL already reclaims a wedged JVM) and not
+ * total capacity, but **fair sharing**.
+ *
+ * Deliberately its own type rather than a `PlaygroundRateLimiter`: `/docs` uploads have capacity
+ * caps and likewise no rate limit, and the shape needed there is the same one.
+ *
+ * ## The bucket
+ *
+ * [permitsPerWindow] tokens refilling continuously over [windowSeconds], capacity equal to the same
+ * number — so a caller may burst their whole minute's budget at once and then waits, which is what
+ * an editor's Run button actually looks like. The refill is computed from elapsed time on read
+ * rather than by a timer, so an idle host does no work and a caller who steps away is fully
+ * refilled when they return.
+ *
+ * ## The concurrency counter
+ *
+ * [maxConcurrent] bounds what one caller may hold *at once*, and it is the half that answers the
+ * issue's complaint directly: with the host's compile slots at 2 and this at 1, one caller cannot
+ * hold both. It is acquired and released around the work, so it is only ever released by the caller
+ * that took it — see [Decision.Admitted.release], which is idempotent.
+ *
+ * ## Key-space growth
+ *
+ * A public host is keyed partly by client address, which an attacker chooses. The map is therefore
+ * bounded at [maxKeys]: admitting a new key first sweeps every entry that is **indistinguishable
+ * from a fresh one** (nothing in flight and a fully refilled bucket), which costs a caller nothing
+ * to lose. If that frees nothing, the host has [maxKeys] callers actively spending budget right now
+ * and a new key is refused rather than growing the map — under a key-space spray that is the honest
+ * answer, and the alternative is unbounded memory chosen by the attacker.
+ */
+class ServeRateLimiter(
+  /**
+   * Tokens per caller per [windowSeconds], and the bucket's capacity (so a full burst is allowed).
+   */
+  private val permitsPerWindow: Int,
+  private val windowSeconds: Long = 60,
+  /** How much work one caller may hold at once. */
+  private val maxConcurrent: Int = 1,
+  /** Distinct callers tracked before new ones are refused; see the class KDoc. */
+  private val maxKeys: Int = DEFAULT_MAX_KEYS,
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
+
+  /** The outcome of asking for permission to start one unit of work. */
+  sealed interface Decision {
+    /**
+     * Go ahead. [release] MUST be called when the work finishes (including on failure); it is
+     * idempotent, so a `finally` that runs twice cannot hand the caller back a permit they no
+     * longer hold.
+     */
+    class Admitted(private val onRelease: () -> Unit) : Decision {
+      private var released = false
+
+      fun release() {
+        synchronized(this) {
+          if (released) return
+          released = true
+        }
+        onRelease()
+      }
+    }
+
+    /**
+     * Refused. [retryAfterSeconds] is what the caller should be told to wait — a real number for
+     * the rate bound (when the next token lands) and a short nudge for the concurrency bound (which
+     * clears when their own in-flight work does, at a time nobody here can predict).
+     */
+    data class Throttled(val retryAfterSeconds: Long, val reason: String) : Decision
+  }
+
+  private class Bucket(var tokens: Double, var lastRefillMillis: Long, var inFlight: Int)
+
+  private val buckets = HashMap<String, Bucket>()
+
+  private val refillPerMilli: Double = permitsPerWindow.toDouble() / (windowSeconds * 1000.0)
+
+  /**
+   * Take one permit for [key], or say why not. Cheap and non-blocking — a refused caller is told to
+   * come back rather than parked, because parking is what turns a rate problem into a thread
+   * problem.
+   */
+  fun tryAcquire(key: String): Decision {
+    synchronized(this) {
+      val now = clock()
+      val bucket =
+        buckets[key]
+          ?: run {
+            if (buckets.size >= maxKeys) {
+              sweepIdle(now)
+              if (buckets.size >= maxKeys) {
+                return Decision.Throttled(
+                  retryAfterSeconds = windowSeconds,
+                  reason =
+                    "the server is tracking $maxKeys active callers already; try again shortly",
+                )
+              }
+            }
+            Bucket(tokens = permitsPerWindow.toDouble(), lastRefillMillis = now, inFlight = 0)
+              .also { buckets[key] = it }
+          }
+
+      refill(bucket, now)
+
+      if (bucket.inFlight >= maxConcurrent) {
+        return Decision.Throttled(
+          retryAfterSeconds = CONCURRENCY_RETRY_AFTER_SECONDS,
+          reason =
+            "you already have ${bucket.inFlight} request(s) in flight (limit $maxConcurrent); " +
+              "wait for one to finish",
+        )
+      }
+      if (bucket.tokens < 1.0) {
+        // When the next whole token lands, rounded up so a "retry after 0" can never bounce.
+        val waitMillis = ((1.0 - bucket.tokens) / refillPerMilli).toLong()
+        return Decision.Throttled(
+          retryAfterSeconds = ((waitMillis + 999) / 1000).coerceAtLeast(1),
+          reason = "rate limit: $permitsPerWindow request(s) per ${windowSeconds}s per caller",
+        )
+      }
+
+      bucket.tokens -= 1.0
+      bucket.inFlight++
+      return Decision.Admitted { release(key) }
+    }
+  }
+
+  /** Callers currently holding at least one permit — for `/status.json`. */
+  fun activeCallers(): Int = synchronized(this) { buckets.count { it.value.inFlight > 0 } }
+
+  /** Distinct callers tracked right now, against [maxKeys]. */
+  fun trackedCallers(): Int = synchronized(this) { buckets.size }
+
+  private fun release(key: String) {
+    synchronized(this) {
+      val bucket = buckets[key] ?: return
+      if (bucket.inFlight > 0) bucket.inFlight--
+    }
+  }
+
+  private fun refill(bucket: Bucket, now: Long) {
+    val elapsed = now - bucket.lastRefillMillis
+    if (elapsed <= 0) return
+    bucket.lastRefillMillis = now
+    bucket.tokens =
+      (bucket.tokens + elapsed * refillPerMilli).coerceAtMost(permitsPerWindow.toDouble())
+  }
+
+  /**
+   * Drop every entry that carries no state a fresh one wouldn't: nothing in flight, bucket full.
+   * Recreating such an entry gives its caller exactly what they had, so this is free to do.
+   */
+  private fun sweepIdle(now: Long) {
+    val iterator = buckets.entries.iterator()
+    while (iterator.hasNext()) {
+      val bucket = iterator.next().value
+      refill(bucket, now)
+      if (bucket.inFlight == 0 && bucket.tokens >= permitsPerWindow) iterator.remove()
+    }
+  }
+
+  companion object {
+    /**
+     * Distinct callers tracked. Comfortably above any real audience for a repo-access-gated
+     * playground, and small enough that a spray of forged keys costs the host kilobytes rather than
+     * memory pressure.
+     */
+    const val DEFAULT_MAX_KEYS = 4096
+
+    /**
+     * What a concurrency refusal advises. Unlike the rate bound there is no computable answer — the
+     * caller's own in-flight work clears when it clears — so this is a nudge sized to "a compile is
+     * running", not a promise.
+     */
+    const val CONCURRENCY_RETRY_AFTER_SECONDS = 5L
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.MediaType.Companion.toMediaType
@@ -151,6 +152,7 @@ class PlaygroundRoutingTest {
     runCatching { gatedServer.stop() }
     runCatching { githubNoRepoServer.stop() }
     runCatching { githubRepoServer.stop() }
+    runCatching { limitedServer.stop() }
     runCatching { registry.close() }
   }
 
@@ -179,6 +181,65 @@ class PlaygroundRoutingTest {
         "/pg/${json["previewToken"]!!.jsonPrimitive.content}",
         json["previewUrl"]!!.jsonPrimitive.content,
       )
+    }
+  }
+
+  /**
+   * A host whose compile lane carries a per-caller budget of two per window (issue #3214). Two is
+   * the smallest number that still shows the *bucket* rather than only its floor.
+   */
+  private val limitedServer: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "unused-in-public",
+        sessions = registry,
+        defaultSessionId = "none",
+        isPublic = true,
+        playgroundService = playground,
+        playgroundRateLimiter =
+          ServeRateLimiter(permitsPerWindow = 2, windowSeconds = 600, maxConcurrent = 2),
+      )
+      .also { it.start() }
+  }
+
+  @Test
+  fun `a caller over their compile budget gets 429 with Retry-After`() {
+    val body =
+      """{"files":[{"name":"Snippet.kt","text":"@Preview @Composable fun P(){}"}],"confType":"compose-cmp"}"""
+    repeat(2) { i ->
+      postRun(body, limitedServer.port).use { resp ->
+        assertEquals(200, resp.code, "budgeted request ${i + 1} should be admitted")
+      }
+    }
+    postRun(body, limitedServer.port).use { resp ->
+      assertEquals(429, resp.code)
+      val retryAfter = resp.header("Retry-After")?.toLongOrNull()
+      assertTrue(retryAfter != null && retryAfter >= 1, "Retry-After should be set: $retryAfter")
+      // Answered in the run route's own JSON shape, so the editor surfaces it as a status line
+      // rather than as an unparseable body.
+      val json = Json.parseToJsonElement(resp.body!!.string()).jsonObject
+      assertTrue(
+        json["exception"]?.jsonPrimitive?.content?.contains("Too many requests") == true,
+        "the refusal rides the run response contract: $json",
+      )
+      // …and it costs the caller nothing: a throttled request never reaches the compiler, so no
+      // token is minted and no work dir is allocated for it.
+      assertTrue(
+        json["previewToken"]?.jsonPrimitive?.contentOrNull?.startsWith("pg_") != true,
+        "a throttled request must not mint a token: $json",
+      )
+    }
+  }
+
+  @Test
+  fun `an unmetered host still admits every compile`() {
+    // The default `server` has no limiter wired — the pre-#3214 behaviour, which must be exactly
+    // what a host that opts out of the budget still gets.
+    val body =
+      """{"files":[{"name":"Snippet.kt","text":"@Preview @Composable fun P(){}"}],"confType":"compose-cmp"}"""
+    repeat(4) { i ->
+      postRun(body, server.port).use { resp -> assertEquals(200, resp.code, "request ${i + 1}") }
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRateLimiterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRateLimiterTest.kt
@@ -1,0 +1,160 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Pins the per-caller budget from issue #3214 — the bound the playground was missing, where every
+ * other bound it has is a whole-host one.
+ */
+class ServeRateLimiterTest {
+
+  private var now = 0L
+
+  private fun limiter(
+    permits: Int = 3,
+    windowSeconds: Long = 60,
+    maxConcurrent: Int = 1,
+    maxKeys: Int = ServeRateLimiter.DEFAULT_MAX_KEYS,
+  ) =
+    ServeRateLimiter(
+      permitsPerWindow = permits,
+      windowSeconds = windowSeconds,
+      maxConcurrent = maxConcurrent,
+      maxKeys = maxKeys,
+      clock = { now },
+    )
+
+  private fun ServeRateLimiter.take(key: String): ServeRateLimiter.Decision.Admitted? =
+    (tryAcquire(key) as? ServeRateLimiter.Decision.Admitted)
+
+  /** Take a permit and give it straight back — one completed unit of work. */
+  private fun ServeRateLimiter.cycle(key: String): Boolean {
+    val permit = take(key) ?: return false
+    permit.release()
+    return true
+  }
+
+  @Test
+  fun `a caller may burst the whole window, then is paced`() {
+    val l = limiter(permits = 3)
+    repeat(3) { assertTrue(l.cycle("gh:alice"), "burst request ${it + 1} should be admitted") }
+    val refused = l.tryAcquire("gh:alice")
+    assertIs<ServeRateLimiter.Decision.Throttled>(refused)
+    assertTrue(refused.reason.contains("rate limit"), refused.reason)
+    // A Retry-After of 0 would have the client bounce straight back; the wait is always ≥ 1s.
+    assertTrue(refused.retryAfterSeconds >= 1, "retryAfter=${refused.retryAfterSeconds}")
+    assertTrue(refused.retryAfterSeconds <= 60, "retryAfter=${refused.retryAfterSeconds}")
+  }
+
+  @Test
+  fun `the bucket refills continuously, not on a window boundary`() {
+    val l = limiter(permits = 3, windowSeconds = 60)
+    repeat(3) { l.cycle("gh:alice") }
+    // A third of the window buys back exactly one of three permits.
+    now += 20_000
+    assertTrue(l.cycle("gh:alice"), "one token should have refilled after a third of the window")
+    assertTrue(l.tryAcquire("gh:alice") is ServeRateLimiter.Decision.Throttled, "…but only one")
+  }
+
+  @Test
+  fun `refill never exceeds the bucket's capacity`() {
+    val l = limiter(permits = 3)
+    l.cycle("gh:alice")
+    // Away for an hour — a caller must come back with a full bucket, not an hour's worth of credit.
+    now += 3_600_000
+    repeat(3) { assertTrue(l.cycle("gh:alice"), "request ${it + 1} after idling") }
+    assertTrue(l.tryAcquire("gh:alice") is ServeRateLimiter.Decision.Throttled)
+  }
+
+  @Test
+  fun `one caller cannot hold every compile slot`() {
+    // The issue's actual complaint: two clients issuing back-to-back long compiles hold both host
+    // slots indefinitely. A per-caller concurrency of 1 is what stops one of them doing it alone.
+    val l = limiter(permits = 100, maxConcurrent = 1)
+    val held = l.take("gh:alice")
+    assertTrue(held != null)
+    val second = l.tryAcquire("gh:alice")
+    assertIs<ServeRateLimiter.Decision.Throttled>(second)
+    assertTrue(second.reason.contains("in flight"), second.reason)
+    // …while a different caller is unaffected — this bounds one caller, not the host.
+    assertTrue(l.cycle("gh:bob"))
+    held!!.release()
+    assertTrue(l.cycle("gh:alice"), "the slot frees when their own work finishes")
+  }
+
+  @Test
+  fun `releasing twice does not hand back a permit the caller no longer holds`() {
+    val l = limiter(permits = 100, maxConcurrent = 1)
+    val permit = l.take("gh:alice")!!
+    permit.release()
+    permit.release()
+    // If the double release had decremented twice, inFlight would have gone negative and this
+    // caller would silently be allowed two concurrent compiles from then on.
+    val first = l.take("gh:alice")
+    assertTrue(first != null)
+    assertTrue(
+      l.tryAcquire("gh:alice") is ServeRateLimiter.Decision.Throttled,
+      "concurrency must still be 1 after a double release",
+    )
+  }
+
+  @Test
+  fun `callers are budgeted independently and logins never collide with addresses`() {
+    val l = limiter(permits = 1)
+    assertTrue(l.cycle("gh:alice"))
+    assertTrue(l.tryAcquire("gh:alice") is ServeRateLimiter.Decision.Throttled)
+    // A different login, and an address, each get their own budget. The prefixes are what stop a
+    // signed-in user inheriting what an anonymous neighbour behind the same NAT just spent.
+    assertTrue(l.cycle("gh:bob"))
+    assertTrue(l.cycle("ip:10.0.0.1"))
+    assertTrue(l.cycle("ip:alice"))
+  }
+
+  @Test
+  fun `idle callers are swept so a key spray costs bounded memory`() {
+    val l = limiter(permits = 2, maxKeys = 4)
+    // Four one-shot callers: each spends a token, so none is immediately sweepable.
+    (1..4).forEach { assertTrue(l.cycle("ip:10.0.0.$it")) }
+    assertEquals(4, l.trackedCallers())
+    // Once their buckets have refilled they are indistinguishable from fresh keys, so a new caller
+    // reclaims the space instead of being refused.
+    now += 60_000
+    assertTrue(l.cycle("ip:10.0.0.5"))
+    assertTrue(l.trackedCallers() <= 4, "tracked=${l.trackedCallers()}")
+  }
+
+  @Test
+  fun `a new caller is refused rather than growing the map past its cap`() {
+    val l = limiter(permits = 2, maxKeys = 2)
+    // Both slots held by callers with work in flight — nothing is sweepable, by construction.
+    val a = l.take("ip:10.0.0.1")
+    val b = l.take("ip:10.0.0.2")
+    assertTrue(a != null && b != null)
+    val refused = l.tryAcquire("ip:10.0.0.3")
+    assertIs<ServeRateLimiter.Decision.Throttled>(refused)
+    assertTrue(refused.reason.contains("active callers"), refused.reason)
+    assertEquals(2, l.trackedCallers())
+    // …and the space is reclaimable once those callers go quiet.
+    a!!.release()
+    b!!.release()
+    now += 60_000
+    assertTrue(l.cycle("ip:10.0.0.3"))
+  }
+
+  @Test
+  fun `activeCallers counts only callers holding a permit right now`() {
+    val l = limiter(permits = 10, maxConcurrent = 2)
+    assertEquals(0, l.activeCallers())
+    val a = l.take("gh:alice")!!
+    l.take("gh:alice")
+    val b = l.take("gh:bob")!!
+    assertEquals(2, l.activeCallers())
+    a.release()
+    b.release()
+    // alice's second permit is still out — she is still active, bob is not.
+    assertEquals(1, l.activeCallers())
+  }
+}

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -158,6 +158,31 @@ Peak compile memory is `SERVE_PLAYGROUND_COMPILE_SLOTS × SERVE_PLAYGROUND_SANDB
 (≈3 GB at defaults) on top of the catalogs already loaded, so review `SERVE_LIVE_SEATS` in the same
 change on a small box.
 
+### Fair sharing between callers
+
+Compile slots, the compile timeout, the body cap, live seats and the token store are all
+**whole-host** bounds — none of them stops one caller from holding every slot with back-to-back
+compiles while everyone else is told the playground is busy. A per-caller budget is on by default
+and needs no configuration:
+
+```bash
+SERVE_PLAYGROUND_RATE_LIMIT=10           # compiles per minute per caller (0 disables)
+SERVE_PLAYGROUND_CALLER_CONCURRENCY=1    # compiles one caller may hold at once
+```
+
+The caller is the **signed-in GitHub login** where there is one — which on a repo-access-gated host
+is every compile — and the client address otherwise. Over budget answers `429` with `Retry-After`,
+before the request body is read, so a throttled caller costs the box nothing. Watch it on
+`/status.json` at `playground.rateLimit` (`activeCallers`, `trackedCallers`).
+
+> **Behind a reverse proxy, anonymous callers share one bucket** unless you opt in with
+> `SERVE_TRUST_FORWARDED_FOR=1`. That makes the limiter key on the **last** `X-Forwarded-For` entry
+> — the one nginx's `$proxy_add_x_forwarded_for` appended from the peer address it actually saw,
+> which a client cannot forge. Do **not** set it on a directly-exposed host: the header is
+> client-supplied there, so a caller could mint a fresh identity per request and bypass the limit
+> entirely. It assumes exactly one proxy hop. This matters much less than it sounds on this image,
+> where the playground is repo-access-gated and every compile therefore carries a GitHub login.
+
 > **Do not set `SERVE_PLAYGROUND_SANDBOX=bwrap` on a public host and expect it to admit the lane.**
 > Earlier revisions of this file recommended exactly that, and it is refused: `bwrap` contains a
 > snippet but applies no CPU or process-count cap, so the containment posture rejects it and points

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -237,6 +237,16 @@ fi
   args+=(--playground-sandbox-ro "${SERVE_PLAYGROUND_SANDBOX_RO}")
 [[ -n "${SERVE_PLAYGROUND_COMPILE_SLOTS:-}" ]] &&
   args+=(--playground-compile-slots "${SERVE_PLAYGROUND_COMPILE_SLOTS}")
+# Per-caller compile budget (issue #3214). Every other playground bound is a whole-host one, so
+# without this one caller can hold every compile slot. Default 10/min, 1 concurrent; set
+# SERVE_PLAYGROUND_RATE_LIMIT=0 to turn the limiter off. SERVE_TRUST_FORWARDED_FOR is only safe
+# behind a reverse proxy that APPENDS the peer address it saw — see the CLI flag's docs.
+[[ -n "${SERVE_PLAYGROUND_RATE_LIMIT:-}" ]] &&
+  args+=(--playground-rate-limit "${SERVE_PLAYGROUND_RATE_LIMIT}")
+[[ -n "${SERVE_PLAYGROUND_CALLER_CONCURRENCY:-}" ]] &&
+  args+=(--playground-caller-concurrency "${SERVE_PLAYGROUND_CALLER_CONCURRENCY}")
+[[ -n "${SERVE_TRUST_FORWARDED_FOR:-}" && "${SERVE_TRUST_FORWARDED_FOR}" != "0" ]] &&
+  args+=(--trust-forwarded-for)
 
 # Bound concurrent live (daemon-backed) stream sessions by a PERMIT BUDGET — each live session
 # charges permits by backend weight (a desktop CMP daemon = 1, a heavier Robolectric Android one = 2,

--- a/docs/design/PLAYGROUND.md
+++ b/docs/design/PLAYGROUND.md
@@ -704,3 +704,60 @@ live snippet JVMs and swapping them mid-flight needs generation-scoped unpack
 dirs and a retirement policy. A long-running host keeps compiling against the ABI
 it first resolved; restart to pick up a newer one. Issue #3212 splits that half
 out explicitly.
+
+### 8.5 Sharing the compile lane — **a per-caller budget, not just capacity**
+
+Everything above bounds *simultaneous resource use across the host*: compile
+slots, the 180 s compile timeout, the 256 KB body cap, live seats, the token
+store's size and TTL. None of it is a per-caller budget, so two clients issuing
+back-to-back long compiles hold every slot indefinitely and everyone else is told
+the playground is busy (issue #3214).
+
+`ServeRateLimiter` adds the missing half: a token bucket for the request *rate*
+plus a counter for *concurrent* work, keyed per caller.
+
+| Bound | Default | Flag |
+|---|---|---|
+| Compiles per minute, per caller | 10 | `--playground-rate-limit` (0 = off) |
+| Concurrent compiles, per caller | 1 | `--playground-caller-concurrency` |
+
+Four decisions worth recording:
+
+**The key is the GitHub login where there is one**, the client address otherwise,
+and the two spaces are prefixed (`gh:` / `ip:`) so they can never collide. A login
+survives a changed address and is the identity the repo-access gate already
+admitted on; on a repo-access-gated host it is what *every* compile carries, which
+is why the address path matters mainly for token-gated and local hosts.
+
+**Anonymous callers behind a proxy share one bucket** unless `--trust-forwarded-for`
+is set, and that flag is opt-in on purpose: `X-Forwarded-For` is client-supplied,
+so trusting it on a directly-exposed host would let a caller mint a fresh identity
+per request. When it *is* set the limiter reads the **last** entry — the one a
+single reverse proxy appended from the peer address it saw — not the first, which
+the client controls. Exactly one hop's worth of trust.
+
+**The check runs after the gates and before the body read.** A throttled caller
+costs the host a 429 and nothing else: no 256 KB of buffered upload, no compile
+slot, no work dir, no token. The refusal rides the ordinary run-response shape
+(`exception`) with a `Retry-After`, so the editor surfaces it as a status line
+rather than an unparseable body.
+
+**Only the compile lane is metered, not `/pg/` redemption.** A redemption is
+reachable only with a token a compile just minted, so limiting compiles limits it
+transitively — and it already answers to the live-seat budget, the token store's
+cap, and the token TTL. Metering it again would refuse a caller the preview they
+already paid for.
+
+The key space is bounded (`DEFAULT_MAX_KEYS`, 4096) because a public host is keyed
+partly by an address the attacker chooses. Admitting a new key first sweeps every
+entry indistinguishable from a fresh one — nothing in flight, bucket fully
+refilled — which costs its caller nothing to lose; only if that frees nothing is
+the new key refused, which under a key-space spray is the honest answer and the
+alternative is memory growth the attacker picks. `/status.json` reports
+`playground.rateLimit.{activeCallers,trackedCallers}`; the latter pinned near its
+cap is the signature of a spray rather than of an audience.
+
+Item 1 of #3214 — auth as a hard prerequisite on a public box — is already
+satisfied by §6.2's gate, which refuses an anonymous *and* uncontained lane
+outright. The `/docs` upload lane has the same shape of gap and can reuse
+`ServeRateLimiter` as-is.


### PR DESCRIPTION
Closes item 2 of #3214.

Every bound the playground had was a **whole-host** one — compile slots, the 180 s compile timeout, the 256 KB body cap, live seats, the token store's size and TTL. None of them is a per-caller budget, so two clients issuing back-to-back long compiles hold every slot indefinitely and everyone else is told the playground is busy compiling.

`ServeRateLimiter` adds the missing half: a token bucket for the request *rate* plus a counter for *concurrent* work, keyed per caller.

| Bound | Default | Flag / env |
|---|---|---|
| Compiles per minute, per caller | 10 | `--playground-rate-limit` / `SERVE_PLAYGROUND_RATE_LIMIT` (0 = off, with a warning) |
| Concurrent compiles, per caller | 1 | `--playground-caller-concurrency` / `SERVE_PLAYGROUND_CALLER_CONCURRENCY` |

With the host's compile slots at their default 2, a per-caller concurrency of 1 is what answers the issue's complaint directly: one caller can no longer hold both.

## Decisions worth reviewing

**The key is the GitHub login where there is one**, the client address otherwise, prefixed (`gh:` / `ip:`) so the two spaces cannot collide. A login survives a changed address and is the identity the repo-access gate already admitted on; on a repo-access-gated host it is what *every* compile carries, so the address path matters mainly for token-gated and local hosts.

**Anonymous callers behind a proxy share one bucket** unless `--trust-forwarded-for` is set, and that is opt-in on purpose: `X-Forwarded-For` is client-supplied, so trusting it on a directly-exposed host would let a caller mint a fresh identity per request and walk straight past the limit. When it *is* set the limiter reads the **last** entry — the one a single reverse proxy appended from the peer address it actually saw (nginx's `$proxy_add_x_forwarded_for`) — not the first, which the client controls. Exactly one hop's worth of trust, documented as such.

**The check runs after the gates and before the body read.** A throttled caller costs the host a 429 and nothing else: no 256 KB of buffered upload, no compile slot, no work dir, no token. The refusal rides the ordinary run-response shape (`exception`) with a `Retry-After`, so the editor surfaces it as a status line rather than an unparseable body.

**Only the compile lane is metered, not `/pg/` redemption** (the issue's item 3, deliberately declined). A redemption is reachable only with a token a compile just minted, so limiting compiles limits it transitively — and it already answers to the live-seat budget, the token store's cap and the token TTL. Metering it again would refuse a caller the preview they already paid for.

**The key space is bounded** (4096) because a public host is keyed partly by an address the attacker chooses. Admitting a new key first sweeps every entry indistinguishable from a fresh one — nothing in flight, bucket fully refilled — which costs its caller nothing to lose; only if that frees nothing is the new key refused. Under a key-space spray that is the honest answer, and the alternative is memory growth the attacker picks.

Kept as `ServeRateLimiter` rather than a playground-specific type because, as the issue notes, the `/docs` upload lane has the same gap and the same shape.

**Item 1 of the issue** (auth as a hard prerequisite on a public box) is already satisfied by `PlaygroundPublicGate`, which refuses an anonymous *and* uncontained lane outright — so it is not re-litigated here.

Observability: `/status.json` gains `playground.rateLimit.{activeCallers,trackedCallers}`. The latter pinned near its cap is the signature of a spray rather than of an audience.

## Test plan

- `./gradlew :cli:test` — green. New `ServeRateLimiterTest` (9 cases: burst-then-pace, continuous refill, refill capped at capacity, the one-caller-can't-hold-every-slot case, idempotent release, independent caller budgets, idle sweep, the refusal at the key cap, `activeCallers` accounting) and two route-level cases in `PlaygroundRoutingTest` (429 + `Retry-After` + no token minted; an unmetered host still admits everything).
- `./gradlew ktfmtCheckAll` — clean.
- **Verified against a running server** (`--catalogs compose-m3 --playground`, real compiles against the resolved catalog classpath):
  - `--playground-rate-limit 2`: requests 1–2 → `200` with `previewId: SnippetKt.Greeting`; requests 3–4 → `429`, `Retry-After: 16`, `"Too many requests — rate limit: 2 request(s) per 60s per caller."`, no token minted.
  - `--playground-caller-concurrency 1`: two simultaneous compiles from one caller → one `200`, one `429` with `Retry-After: 5` and `"you already have 1 request(s) in flight (limit 1)"`.
  - `/status.json` → `playground.rateLimit: {"activeCallers": 0, "trackedCallers": 1}`.
  - startup log: `serve: playground compile budget — 2/min per caller, 1 concurrent`.

No visual evidence: this is server behaviour, two startup log lines and one `/status.json` object. No rendered surface changes — the editor's only new behaviour is showing the 429's message in the status line it already uses for `exception`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr)_