### PR TITLE
fix(vscode): defer the applied-marker bootstrap to first view open

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -63,6 +63,12 @@ already applies `com.android.application`, `com.android.library`, or
 script is passed to every Gradle invocation via `--init-script` and pulls
 the plugin from Maven Central.
 
+Nothing runs until you open the **Compose Preview** view. Activation alone
+never invokes Gradle, so a workspace you never preview is left untouched —
+no `build/compose-previews/` markers, no `.compose-preview-history/`. The
+first time the view opens, the extension runs `composePreviewApplied` once to
+map out which modules apply the plugin, and takes it from there.
+
 To opt in manually instead, add
 [`ee.schimke.composeai.preview`](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin)
 to the module whose previews you want to render:

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -529,15 +529,26 @@ function inMinimalMode(): boolean {
  * unrelated Android project in VS Code left untracked directories behind
  * (issue: "creates bin directories on unconfigured projects").
  *
- * Deferring to the first time the Compose Preview view actually resolves makes
- * the whole pipeline opt-in by use: a workspace where the user never opens the
- * view is never touched. For anyone who does open it, behaviour is unchanged —
- * the markers land before the panel's first discover round-trip, exactly as
- * they did when activation kicked this off.
+ * Deferring this to an explicit opt-in — the Compose Preview view resolving, or
+ * a `Refresh Previews` / `Render All Previews` command — makes the pipeline
+ * opt-in by use. For anyone who does open the view, behaviour is unchanged: the
+ * markers land before the panel's first discover round-trip, exactly as they
+ * did when activation kicked this off.
+ *
+ * **Scope of the guarantee.** This makes an *unconfigured* workspace inert, not
+ * every workspace. `runActivationRefresh` still fires on the activation timer,
+ * and it renders whenever `resolveModule` succeeds — which it does for a module
+ * that literally declares the plugin, or one carrying `applied.json` markers
+ * from a previous session. That's intended: both are workspaces the user has
+ * already configured or already previewed, and pre-warming them is the point of
+ * the activation refresh. What changed is that a workspace which has done
+ * neither can no longer be pulled into that state by activation alone, because
+ * nothing writes the markers that would make `resolveModule` start succeeding.
  *
  * Idempotent and concurrency-safe: the in-flight promise is memoised, so
- * repeated `webviewReady` messages (hide/show, webview reload) await the first
- * run rather than starting a second. Resolves `true` when markers were actually
+ * repeated `webviewReady` messages (hide/show, webview reload) and a
+ * palette-driven refresh racing the first view open all await the same run
+ * rather than starting a second. Resolves `true` when markers were actually
  * (re)written — the caller's cue to re-send the module list — and `false` when
  * the run was skipped or failed.
  */
@@ -1882,11 +1893,23 @@ export async function activate(
         ),
     );
     context.subscriptions.push(
-        vscode.commands.registerCommand("composePreview.refresh", () =>
-            refresh(true, editorScope.file ?? undefined),
-        ),
-        vscode.commands.registerCommand("composePreview.renderAll", () =>
-            refresh(true, editorScope.file ?? undefined),
+        // Both commands await the marker bootstrap first. Running one from the
+        // palette is an explicit opt-in just like opening the view, and on a
+        // cold project that applies the plugin via a version-catalog alias or a
+        // convention plugin the build-script text scan can't see it — so
+        // without the markers `refresh` resolves no module and silently does
+        // nothing. Awaiting also serialises against an in-flight view-open
+        // bootstrap (the promise is memoised) rather than racing it.
+        vscode.commands.registerCommand("composePreview.refresh", async () => {
+            await ensureAppliedMarkersBootstrapped();
+            return refresh(true, editorScope.file ?? undefined);
+        }),
+        vscode.commands.registerCommand(
+            "composePreview.renderAll",
+            async () => {
+                await ensureAppliedMarkersBootstrapped();
+                return refresh(true, editorScope.file ?? undefined);
+            },
         ),
         // Dev affordance: load a committed SpatialScene fixture into the
         // panel's 3D view, standing in for the (not-yet-built) `:renderer-xr`

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -164,6 +164,13 @@ const DAEMON_BOOTSTRAP_PROGRESS_MS = 18_000;
 const DAEMON_SPAWN_PROGRESS_MS = 7_000;
 
 let gradleService: GradleService | null = null;
+/**
+ * Set once {@link ensureAppliedMarkersBootstrapped} has kicked off (or
+ * deliberately skipped) the one-shot `composePreviewApplied` run for this
+ * session. Guards the lazy bootstrap so a visibility cycle — hide/show the
+ * view, reload the webview — doesn't re-enter it.
+ */
+let appliedMarkersBootstrap: Promise<boolean> | null = null;
 let daemonGate: DaemonGate | null = null;
 let daemonScheduler: DaemonScheduler | null = null;
 /** Non-null only when `composePreview.daemon.continuousCompile` is set. */
@@ -501,6 +508,72 @@ export function resolveMode(gradleService: {
  */
 function inMinimalMode(): boolean {
     return daemonGate?.spawnsDaemons === false;
+}
+
+/**
+ * One-shot, lazy `composePreviewApplied` bootstrap — writes the authoritative
+ * `<module>/build/compose-previews/applied.json` markers that
+ * [GradleService.findPreviewModules] / [GradleService.resolveModule] prefer over
+ * the build-script text scan (which misses version-catalog aliases and
+ * convention plugins).
+ *
+ * **Why this is lazy.** It used to run unconditionally at activation, gated only
+ * by [GradleService.hasPotentialComposePreviewHost] — which is true for any
+ * workspace applying AGP or `org.jetbrains.compose`, i.e. essentially every
+ * Android project. Because the bundled auto-inject init script applies the
+ * preview plugin to every such module, that single activation-time run wrote
+ * `build/compose-previews/` into every module of a workspace that had never
+ * opted into Compose Preview at all — and once markers exist, `resolveModule`
+ * starts resolving, editor focus starts driving renders, and the daemon starts
+ * writing `.compose-preview-history/` next to the user's sources. Opening an
+ * unrelated Android project in VS Code left untracked directories behind
+ * (issue: "creates bin directories on unconfigured projects").
+ *
+ * Deferring to the first time the Compose Preview view actually resolves makes
+ * the whole pipeline opt-in by use: a workspace where the user never opens the
+ * view is never touched. For anyone who does open it, behaviour is unchanged —
+ * the markers land before the panel's first discover round-trip, exactly as
+ * they did when activation kicked this off.
+ *
+ * Idempotent and concurrency-safe: the in-flight promise is memoised, so
+ * repeated `webviewReady` messages (hide/show, webview reload) await the first
+ * run rather than starting a second. Resolves `true` when markers were actually
+ * (re)written — the caller's cue to re-send the module list — and `false` when
+ * the run was skipped or failed.
+ */
+async function ensureAppliedMarkersBootstrapped(): Promise<boolean> {
+    if (appliedMarkersBootstrap) {
+        return appliedMarkersBootstrap;
+    }
+    const service = gradleService;
+    if (!service) {
+        return false;
+    }
+    if (!service.hasPotentialComposePreviewHost()) {
+        logLine(
+            "[startup] no Android/Compose Gradle host detected; skipping composePreviewApplied bootstrap",
+        );
+        appliedMarkersBootstrap = Promise.resolve(false);
+        return false;
+    }
+    appliedMarkersBootstrap = (async () => {
+        logLine(
+            "[startup] preview view opened; running composePreviewApplied marker bootstrap",
+        );
+        // `bootstrapAppliedMarkers` swallows Gradle failures itself (the
+        // build-script scan is a usable fallback); only the typed JDK
+        // misconfigurations come back through the callback, and those get the
+        // same remediation notifications activation used to show.
+        await service.bootstrapAppliedMarkers((err) => {
+            if (err instanceof ClassVersionError) {
+                showClassVersionRemediation(err);
+            } else if (err instanceof JdkImageError) {
+                showJdkImageRemediation(err);
+            }
+        });
+        return true;
+    })();
+    return appliedMarkersBootstrap;
 }
 
 /**
@@ -2177,40 +2250,9 @@ export async function activate(
             },
         ),
     );
-    // Refresh applied-markers in the background so future module resolution can
-    // use the authoritative `applied.json` path. Doctor stays explicit via
-    // `composePreview.runDoctor`.
-    //
-    // The same bootstrap is the trigger for the post-sync mode re-evaluation:
-    // text-scan fallbacks miss version-catalog aliases / convention-plugin
-    // setups, AND the bundled auto-inject init script applies the plugin to
-    // Android/Compose hosts that never literally `id(...)` it themselves. In
-    // both cases the workspace can boot into minimal mode and only learn that
-    // the plugin *is* applied once Gradle writes its `applied.json` markers.
-    // When that happens (and the user hasn't pinned the setting), swap the
-    // backend in place — the daemon is spawned lazily, so re-wiring the gate
-    // and scheduler is enough; no window reload is needed. Re-wiring happens
-    // before the panel sees its first preview request, which keeps the swap
-    // invisible to the user in the typical case.
-    // `bootstrapAppliedMarkers` still runs so other parts of the system
-    // (panel chrome, plugin-detection caches) see the authoritative marker
-    // JSON Gradle writes. The post-sync mode re-evaluation that used to
-    // upgrade `"auto"` from `"minimal"` to `"full"` is gone: `composePreview.mode`
-    // is now a binary user pin (`"minimal"` | `"full"`), so the mode never
-    // changes mid-session except via a settings change + window reload.
-    if (gradleService.hasPotentialComposePreviewHost()) {
-        void gradleService.bootstrapAppliedMarkers((err) => {
-            if (err instanceof ClassVersionError) {
-                showClassVersionRemediation(err);
-            } else if (err instanceof JdkImageError) {
-                showJdkImageRemediation(err);
-            }
-        });
-    } else {
-        outputChannel.appendLine(
-            "[startup] no Android/Compose Gradle host detected; skipping composePreviewApplied bootstrap",
-        );
-    }
+    // NOTE: the `composePreviewApplied` marker bootstrap deliberately does NOT
+    // run here. See [ensureAppliedMarkersBootstrapped] — it is deferred to the
+    // first time the user actually opens the Compose Preview view.
 
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((event) => {
@@ -5711,6 +5753,46 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             // cache only — if there's nothing cached the panel stays empty
             // until the user clicks Refresh.
             sendModuleList();
+            // The view is open, so the user has opted into the pipeline for
+            // this workspace — this is the trigger for the one-shot
+            // `composePreviewApplied` marker bootstrap that used to fire at
+            // activation. Fire-and-forget: it resolves module paths for
+            // layouts the build-script scan can't see (catalog aliases,
+            // convention plugins, auto-inject), and re-sends the module list
+            // once Gradle has written the markers. The refresh sequence below
+            // is unaffected — it runs against whatever the scan already knows,
+            // and the post-bootstrap `refresh` re-runs it with the full set.
+            {
+                // Snapshot resolvability *before* the bootstrap so we can tell
+                // whether the markers taught us something the scan didn't know.
+                const preBootstrapScope = editorScope.file;
+                const resolvedBefore = Boolean(
+                    preBootstrapScope &&
+                    gradleService?.resolveModule(preBootstrapScope),
+                );
+                void ensureAppliedMarkersBootstrapped().then((bootstrapped) => {
+                    if (!bootstrapped) {
+                        return;
+                    }
+                    sendModuleList();
+                    // A re-render is only warranted when the scoped file
+                    // went from unresolvable to resolvable — the refresh
+                    // scheduled below bailed with "no-module" in that case
+                    // and nothing else will retry it. Minimal mode is
+                    // manual-only, so it never auto-renders here.
+                    const scopeFile = editorScope.file;
+                    if (
+                        resolvedBefore ||
+                        inMinimalMode() ||
+                        !scopeFile ||
+                        scopeFile !== preBootstrapScope ||
+                        !gradleService?.resolveModule(scopeFile)
+                    ) {
+                        return;
+                    }
+                    void refresh(false, scopeFile, "full");
+                });
+            }
             if (editorScope.file) {
                 if (inMinimalMode()) {
                     void preloadCachedPreviews(editorScope.file);

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -350,7 +350,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
             },
         );
 
-        // Mirror the e2eExternal sequencing: run the activation-time
+        // Mirror the e2eExternal sequencing: run the (lazy, view-open-driven)
         // `composePreviewApplied` marker bootstrap explicitly before warming
         // the daemon. `:samples:wear` is detected via literal-id text-scan
         // even without markers, so this isn't strictly required for

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -227,11 +227,11 @@ describeExternal(
             // via `alias(libs.plugins.composeai.preview)` — the literal
             // `id(...)` text-scan in `appliesPlugin` doesn't match catalog
             // aliases, so `resolveModule` stays null until Gradle writes
-            // `applied.json` for the module. The activation-time
-            // `bootstrapAppliedMarkers` call is fire-and-forget AND
-            // targets the original GradleService (the one `injectGradleApi`
-            // above replaced), so without an explicit await the warm below
-            // races the marker write and intermittently fails on cold
+            // `applied.json` for the module. The production bootstrap is
+            // lazy (it fires on first Compose Preview view open, not at
+            // activation) and is fire-and-forget when it does fire, so the
+            // test drives it explicitly and awaits it — otherwise the warm
+            // below races the marker write and intermittently fails on cold
             // workspaces. Regression for #1362.
             const tBootstrap = phaseStart();
             await api.triggerBootstrapAppliedMarkers();


### PR DESCRIPTION
## Problem

Opening an unrelated Android project in VS Code left untracked directories behind — `build/compose-previews/` in every module, and `.compose-preview-history/` next to sources.

The cause was activation-time eagerness:

1. `activate()` ran `bootstrapAppliedMarkers()` unconditionally, gated only by `hasPotentialComposePreviewHost()` (`gradleService.ts:1239`) — which returns true for any workspace applying `com.android.application`, `com.android.library`, or `org.jetbrains.compose`, i.e. essentially every Android project.
2. The bundled auto-inject init script applies the preview plugin to exactly those modules, so `composePreviewApplied` fanned out and wrote `applied.json` into all of them.
3. Once markers exist, `resolveModule` starts resolving → editor focus drives renders → the daemon spawns with `composeai.daemon.historyDir = <projectDir>/.compose-preview-history`.

Step 1 was the only thing that ran without an opt-in signal. Every other entry point (`transitionToFile`, `warmDaemonForFile`, `refresh`) already bails when `resolveModule` returns null.

## Change

Defer the bootstrap to an explicit opt-in: the Compose Preview view resolving (first `webviewReady`), or a `Refresh Previews` / `Render All Previews` command.

- New `ensureAppliedMarkersBootstrapped()` memoises an in-flight promise, so a visibility cycle, a webview reload, or a palette refresh racing the first view open all await the same run.
- The `hasPotentialComposePreviewHost()` cheap skip and the `ClassVersionError` / `JdkImageError` remediation notifications are preserved, just moved.
- After the markers land, the module list is re-sent, plus a `refresh` when the scoped file went from unresolvable to resolvable — the case where the earlier refresh bailed with `no-module` and nothing else would retry. Minimal mode stays manual-only.
- The manual refresh commands await the bootstrap before refreshing, so a cold catalog-alias / convention-plugin project doesn't resolve no module and silently do nothing when driven from the palette.

## Scope of the guarantee

This makes an **unconfigured** workspace inert — not every workspace. `runActivationRefresh` still fires on the activation timer and renders whenever `resolveModule` succeeds, which it does for a module that literally declares the plugin or carries `applied.json` markers from a previous session. That's intended: both are workspaces the user has already configured or already previewed, and pre-warming them is what the activation refresh is for.

What changed is that a workspace which has done neither can no longer be pulled into that state by activation alone, because nothing writes the markers that would make `resolveModule` start succeeding.

## Test plan

- `npm test` — 1626 passing.
- `npx tsc --noEmit -p .` clean; `npm run format:check` clean.
- Both e2e suites (`e2eExternal`, `e2eA11y`) already call `triggerBootstrapAppliedMarkers()` explicitly rather than relying on activation, which matches the new lazy contract; their comments are updated to stop describing it as activation-time.

Non-visual change (activation plumbing), so no render evidence applies.

**Coverage gap, called out deliberately:** there is no new automated test asserting "activation touches no files". The electron harness injects its recording `GradleApi` in `beforeEach`, i.e. *after* activation, so the activation-time invocation was never observable there in the first place. Adding that would mean reworking the harness to inject before activate.