### PR TITLE
fix(history): move the render-history archive out of the working tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ site/Gemfile.lock
 site/vendor/
 
 # Daemon preview-history archive — written by the daemon's `HistoryManager` when running
-# (sysprop `composeai.daemon.historyDir`). Each module gets its own archive at
-# `<moduleDir>/.compose-preview-history/`. Ignore at any depth.
+# (sysprop `composeai.daemon.historyDir`). Since #3407 the default lives OUTSIDE the working
+# tree, under `$XDG_CACHE_HOME/composeai/history/` — nothing new lands here. The pattern stays
+# for checkouts that still carry a pre-#3407 `<moduleDir>/.compose-preview-history/`, which the
+# daemon keeps using when present. Ignore at any depth.
 .compose-preview-history/

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
@@ -12,7 +12,10 @@ import ee.schimke.composeai.daemon.history.LocalFsHistorySource
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
 import ee.schimke.composeai.data.layoutinspector.SemanticsDelta
 import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
+import ee.schimke.composeai.io.LEGACY_HISTORY_DIRNAME
+import ee.schimke.composeai.io.composeAiHistoryDir
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Base64
 import kotlin.system.exitProcess
@@ -390,8 +393,8 @@ class HistoryCommand(private val args: List<String>) {
 
   /**
    * Opens the history source: `--ref <fullRef>` reads the reporting branch (git), else the local
-   * `.compose-preview-history/`. Returns null (after reporting "no history") only for the local
-   * case when the dir is absent, so callers can short-circuit.
+   * archive under the user cache (see [defaultHistoryDir]). Returns null (after reporting "no
+   * history") only for the local case when the dir is absent, so callers can short-circuit.
    */
   private fun openSource(json: Boolean): HistorySource? {
     val ref = args.flagValue("--ref")
@@ -399,7 +402,7 @@ class HistoryCommand(private val args: List<String>) {
     if (ref != null) {
       return GitRefHistorySource(repoRoot = cwd, ref = ref)
     }
-    val dir = args.flagValue("--history-dir")?.let { Paths.get(it) } ?: cwd.resolve(HISTORY_DIRNAME)
+    val dir = args.flagValue("--history-dir")?.let { Paths.get(it) } ?: defaultHistoryDir(cwd)
     if (!Files.isDirectory(dir)) {
       if (json) {
         println(
@@ -476,7 +479,8 @@ class HistoryCommand(private val args: List<String>) {
         help                 Show this help message
 
       Source:
-        --history-dir <dir>  History dir (default: <cwd>/$HISTORY_DIRNAME)
+        --history-dir <dir>  History dir (default: the cwd module's archive under the user cache,
+                             or ./$HISTORY_DIRNAME when that legacy directory still exists)
         --ref <fullRef>      Read the reporting branch instead, e.g. refs/heads/preview/main
 
       list options:
@@ -504,7 +508,36 @@ class HistoryCommand(private val args: List<String>) {
 
   internal companion object {
     const val HISTORY_SCHEMA = "compose-preview-history/v1"
-    const val HISTORY_DIRNAME = ".compose-preview-history"
+    const val HISTORY_DIRNAME = LEGACY_HISTORY_DIRNAME
+
+    /**
+     * The history archive for the module rooted at [cwd], matching what the daemon writes:
+     * `<cache>/history/<workspaceSlug>/<moduleRel>` (see `common/io`'s `composeAiHistoryDir`), or
+     * the legacy `<cwd>/.compose-preview-history` when that directory still exists.
+     *
+     * The workspace root is found by walking up for a `settings.gradle[.kts]` — the same anchor
+     * Gradle uses for `project.rootDir`, which is what the plugin hands the daemon. A cwd with no
+     * settings file above it (running outside a Gradle build) is treated as its own root, which
+     * matches the single-module case and keeps the command usable standalone.
+     */
+    internal fun defaultHistoryDir(cwd: Path): Path =
+      composeAiHistoryDir(workspaceRootOf(cwd).toFile(), cwd.toFile()).toPath()
+
+    /** Nearest ancestor of [start] (inclusive) holding a `settings.gradle[.kts]`, else [start]. */
+    internal fun workspaceRootOf(start: Path): Path {
+      var dir: Path? = start.toAbsolutePath().normalize()
+      while (dir != null) {
+        if (
+          Files.isRegularFile(dir.resolve("settings.gradle.kts")) ||
+            Files.isRegularFile(dir.resolve("settings.gradle"))
+        ) {
+          return dir
+        }
+        dir = dir.parent
+      }
+      return start.toAbsolutePath().normalize()
+    }
+
     private const val DEFAULT_LIMIT = 50
 
     /** Flags that take a value, so a space-separated value isn't mistaken for an operand. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -171,7 +171,7 @@ private fun printFullUsage() {
                        changed semantically — a cheap, pixel-free regression signal:
                        `compose-preview diff-semantics <base> <head> [--json] [--fail-on-change]`
       history          Inspect archived render history: `history list|read|diff` over the
-                       local `.compose-preview-history/` archive or a `--ref` reporting branch
+                       local filesystem archive or a `--ref` reporting branch
       extensions       Introspect registered data extensions (`extensions list`)
       profile          Run a saved JSON profile: `compose-preview profile <path.json>`. A
                        profile bundles `extensions`, `filter`, `failOn`, and a chosen `report`

--- a/common/io/src/main/kotlin/ee/schimke/composeai/io/FileSystems.kt
+++ b/common/io/src/main/kotlin/ee/schimke/composeai/io/FileSystems.kt
@@ -123,9 +123,15 @@ fun composeAiHistoryWorkspaceSlug(workspaceRoot: File): String {
 
 /**
  * The module's path relative to [workspaceRoot], `/`-joined and sanitised per segment — e.g.
- * `auth/composables`. The root project maps to `_root`, as does any module that doesn't sit under
- * the workspace root (a `projectDir` reassigned outside the tree by `settings.gradle.kts`), which
- * falls back to a hash of its own path so two such modules can't collide.
+ * `auth/composables`. The root project maps to `_root`. A module that doesn't sit under the
+ * workspace root (a `projectDir` reassigned outside the tree by `settings.gradle.kts`) falls back
+ * to a hash of its own path so two such modules can't collide.
+ *
+ * Sanitisation is lossy — `ui components` and `ui-components` both flatten to `ui-components` — so
+ * a segment that had to be rewritten carries a digest of its original text
+ * ([sanitiseHistorySegmentInjectively]). Two distinct modules in one workspace sharing a history
+ * directory would mix their entries and prune state, and let matching preview ids overwrite each
+ * other. Segments that need no rewriting (the overwhelming majority) stay plain and readable.
  */
 fun composeAiHistoryModuleSegment(workspaceRoot: File, projectDir: File): String {
   val root = workspaceRoot.absolutePath.replace('\\', '/').trimEnd('/')
@@ -139,8 +145,30 @@ fun composeAiHistoryModuleSegment(workspaceRoot: File, projectDir: File): String
     .removePrefix("$root/")
     .split('/')
     .filter { it.isNotEmpty() }
-    .joinToString("/") { sanitiseHistorySegment(it) }
+    .joinToString("/") { sanitiseHistorySegmentInjectively(it) }
     .ifEmpty { "_root" }
+}
+
+/**
+ * [sanitiseHistorySegment], plus an 8-hex digest of the original text when sanitising changed it.
+ *
+ * Distinct directory names must not land on the same segment: `ui components` and `ui-components`
+ * are different modules, and two non-ASCII names can flatten to the same run of hyphens. Only
+ * rewritten segments pay the suffix, so ordinary paths stay readable.
+ *
+ * Residual caveat: a segment literally named `ui-components-<those 8 hex chars>` would still
+ * collide with the suffixed form of `ui components`. That needs a deliberately crafted directory
+ * name and is not worth making every path unreadable to prevent.
+ */
+private fun sanitiseHistorySegmentInjectively(segment: String): String {
+  val sanitised = sanitiseHistorySegment(segment)
+  if (sanitised == segment) return sanitised
+  val digest =
+    java.security.MessageDigest.getInstance("SHA-256")
+      .digest(segment.toByteArray(Charsets.UTF_8))
+      .joinToString("") { "%02x".format(it) }
+      .take(8)
+  return "$sanitised-$digest"
 }
 
 /**

--- a/common/io/src/main/kotlin/ee/schimke/composeai/io/FileSystems.kt
+++ b/common/io/src/main/kotlin/ee/schimke/composeai/io/FileSystems.kt
@@ -47,3 +47,111 @@ fun composeAiCacheDir(subdir: String): File {
     else File(System.getProperty("user.home") ?: ".", ".cache/composeai")
   return File(base, subdir)
 }
+
+/** Directory name of the legacy in-tree history archive, kept for backwards compatibility. */
+const val LEGACY_HISTORY_DIRNAME: String = ".compose-preview-history"
+
+/**
+ * Where a module's render history lives:
+ * `composeAiCacheDir("history")/<workspaceSlug>/<moduleRel>`.
+ *
+ * History is a semi-persistent timeline of local edits — regenerable enough to be a cache, and
+ * never something the user authored. It used to live at `<projectDir>/.compose-preview-history`,
+ * which meant every previewed module grew an untracked directory next to its sources (and, on
+ * projects that never opted in, one that appeared without the user asking). Relocating it under the
+ * user-level cache root puts it alongside the font cache and bundle deps, which are the same
+ * category of data.
+ *
+ * The reporting-branch flow is unaffected: that publishes to a git ref (see
+ * `docs/daemon/REPORTING-BRANCH.md`), and the in-tree directory was only ever its local staging
+ * area.
+ *
+ * **Legacy directories win.** When `<projectDir>/.compose-preview-history` already exists, it is
+ * returned unchanged so an existing timeline isn't stranded by an upgrade. Delete it (or move it
+ * under the cache root) to migrate; nothing recreates it.
+ *
+ * The layout must be reproduced byte-for-byte by two other implementations that can't call this one
+ * — the Gradle plugin (no dependency on this module) and the VS Code extension (TypeScript).
+ * [composeAiHistoryWorkspaceSlug] documents the slug contract those mirror; `HistoryPathsTest` and
+ * its TS counterpart pin the same vectors on both sides.
+ */
+fun composeAiHistoryDir(workspaceRoot: File, projectDir: File): File {
+  val legacy = File(projectDir, LEGACY_HISTORY_DIRNAME)
+  if (legacy.isDirectory) return legacy
+  return File(
+    File(composeAiCacheDir("history"), composeAiHistoryWorkspaceSlug(workspaceRoot)),
+    composeAiHistoryModuleSegment(workspaceRoot, projectDir),
+  )
+}
+
+/**
+ * Where the reporting-branch (`GitRefHistorySource`) working cache lives when no module history
+ * directory is configured: `<cache>/history/<workspaceSlug>/.git-ref-cache`.
+ *
+ * The cache is keyed by repo rather than by module — it's a bare git working area for reading and
+ * writing the `refs/heads/preview/…` reporting branches, and one per checkout is enough. When a
+ * module history directory *is* configured, `GitRefHistorySource.defaultCacheDir` nests the cache
+ * inside it instead; this is only the standalone fallback, which previously landed in the repo
+ * working tree.
+ */
+fun composeAiGitRefCacheDir(repoRoot: File): File =
+  File(
+    File(composeAiCacheDir("history"), composeAiHistoryWorkspaceSlug(repoRoot)),
+    ".git-ref-cache",
+  )
+
+/**
+ * Stable per-workspace directory name: `<sanitised basename>-<sha256(path) truncated to 12 hex>`.
+ *
+ * The readable prefix keeps `~/.cache/composeai/history/` browsable; the hash keeps two checkouts
+ * of the same repo (`~/src/app` and `~/src/app-worktree`, or the same name under different parents)
+ * from colliding. The hash is taken over the absolute path with separators normalised to `/` —
+ * deliberately NOT the real (symlink-resolved) path, because Gradle, the daemon and the VS Code
+ * extension each learn the workspace root by a different route and only the unresolved form is
+ * reliably identical across all three.
+ */
+fun composeAiHistoryWorkspaceSlug(workspaceRoot: File): String {
+  val normalised = workspaceRoot.absolutePath.replace('\\', '/').trimEnd('/')
+  val digest =
+    java.security.MessageDigest.getInstance("SHA-256")
+      .digest(normalised.toByteArray(Charsets.UTF_8))
+      .joinToString("") { "%02x".format(it) }
+      .take(12)
+  val name = sanitiseHistorySegment(normalised.substringAfterLast('/'))
+  return if (name.isEmpty()) digest else "$name-$digest"
+}
+
+/**
+ * The module's path relative to [workspaceRoot], `/`-joined and sanitised per segment — e.g.
+ * `auth/composables`. The root project maps to `_root`, as does any module that doesn't sit under
+ * the workspace root (a `projectDir` reassigned outside the tree by `settings.gradle.kts`), which
+ * falls back to a hash of its own path so two such modules can't collide.
+ */
+fun composeAiHistoryModuleSegment(workspaceRoot: File, projectDir: File): String {
+  val root = workspaceRoot.absolutePath.replace('\\', '/').trimEnd('/')
+  val module = projectDir.absolutePath.replace('\\', '/').trimEnd('/')
+  if (module == root) return "_root"
+  if (!module.startsWith("$root/")) {
+    // Outside the workspace tree — no meaningful relative path, so key it by its own identity.
+    return "_external-" + composeAiHistoryWorkspaceSlug(projectDir)
+  }
+  return module
+    .removePrefix("$root/")
+    .split('/')
+    .filter { it.isNotEmpty() }
+    .joinToString("/") { sanitiseHistorySegment(it) }
+    .ifEmpty { "_root" }
+}
+
+/**
+ * Replaces anything outside `[A-Za-z0-9._-]` with `-` so a segment is safe on every filesystem.
+ *
+ * Deliberately ASCII-only — `Char.isLetterOrDigit()` would accept Unicode letters, and the mirrored
+ * TypeScript implementation uses a plain `[^A-Za-z0-9._-]` character class. A module directory with
+ * non-ASCII characters must slugify identically on both sides or the two would read different
+ * directories.
+ */
+private fun sanitiseHistorySegment(segment: String): String =
+  segment
+    .map { if (it in 'A'..'Z' || it in 'a'..'z' || it in '0'..'9' || it in ".-_") it else '-' }
+    .joinToString("")

--- a/common/io/src/test/kotlin/ee/schimke/composeai/io/HistoryPathsTest.kt
+++ b/common/io/src/test/kotlin/ee/schimke/composeai/io/HistoryPathsTest.kt
@@ -66,7 +66,29 @@ class HistoryPathsTest {
 
   @Test
   fun `module segment sanitises characters outside the safe set`() {
-    assertEquals("a-b/c-d", composeAiHistoryModuleSegment(File("/w"), File("/w/a b/c:d")))
+    // Each rewritten segment carries an 8-hex digest of its original text.
+    assertEquals(
+      "a-b-c8687a08/c-d-66c7bbe2",
+      composeAiHistoryModuleSegment(File("/w"), File("/w/a b/c:d")),
+    )
+  }
+
+  @Test
+  fun `module names that sanitise identically stay distinct`() {
+    // `ui components` and `ui-components` are different modules; without the digest suffix both
+    // flatten to `ui-components` and would share one history dir, mixing entries and prune state.
+    val spaced = composeAiHistoryModuleSegment(File("/w"), File("/w/ui components"))
+    val hyphenated = composeAiHistoryModuleSegment(File("/w"), File("/w/ui-components"))
+    assertEquals("ui-components-50bae342", spaced)
+    assertEquals("ui-components", hyphenated)
+    assertNotEquals(spaced, hyphenated)
+  }
+
+  @Test
+  fun `an already-safe segment is left plain`() {
+    // The digest is only paid by segments sanitising had to rewrite, so ordinary paths stay
+    // readable in `~/.cache/composeai/history/`.
+    assertEquals("auth", composeAiHistoryModuleSegment(File("/w"), File("/w/auth")))
   }
 
   @Test

--- a/common/io/src/test/kotlin/ee/schimke/composeai/io/HistoryPathsTest.kt
+++ b/common/io/src/test/kotlin/ee/schimke/composeai/io/HistoryPathsTest.kt
@@ -1,0 +1,146 @@
+package ee.schimke.composeai.io
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the history-path layout.
+ *
+ * Three implementations must agree byte-for-byte: this one, the Gradle plugin's inlined copy
+ * (`AndroidPreviewClasspath.composeAiHistoryDir` — the plugin can't depend on `:common-io`), and
+ * the VS Code extension's TypeScript copy (`vscode-extension/src/historyPaths.ts`). The `GOLDEN_*`
+ * vectors below are duplicated verbatim in `historyPaths.test.ts`; changing either side alone makes
+ * the daemon write to one directory and the panel read from another, which surfaces as a silently
+ * empty history drawer rather than a crash. Change the layout only with both suites updated
+ * together.
+ */
+class HistoryPathsTest {
+
+  @get:Rule val tmp: TemporaryFolder = TemporaryFolder()
+
+  // ---- Golden vectors (mirrored in vscode-extension/src/test/historyPaths.test.ts) ----
+
+  @Test
+  fun `workspace slug is a readable prefix plus a 12-hex digest`() {
+    assertEquals("app-671822104ddc", composeAiHistoryWorkspaceSlug(File("/home/dev/src/app")))
+    assertEquals(
+      "my-project-75d59f8a453b",
+      composeAiHistoryWorkspaceSlug(File("/home/dev/src/my project")),
+    )
+  }
+
+  @Test
+  fun `workspace slug ignores a trailing separator`() {
+    assertEquals(
+      composeAiHistoryWorkspaceSlug(File("/home/dev/src/app")),
+      composeAiHistoryWorkspaceSlug(File("/home/dev/src/app/")),
+    )
+  }
+
+  @Test
+  fun `same basename under different parents does not collide`() {
+    assertNotEquals(
+      composeAiHistoryWorkspaceSlug(File("/home/dev/a/app")),
+      composeAiHistoryWorkspaceSlug(File("/home/dev/b/app")),
+    )
+  }
+
+  @Test
+  fun `module segment is the workspace-relative path`() {
+    assertEquals(
+      "auth/composables",
+      composeAiHistoryModuleSegment(File("/w"), File("/w/auth/composables")),
+    )
+  }
+
+  @Test
+  fun `module segment for the root project is _root`() {
+    assertEquals("_root", composeAiHistoryModuleSegment(File("/w"), File("/w")))
+    assertEquals("_root", composeAiHistoryModuleSegment(File("/w"), File("/w/")))
+  }
+
+  @Test
+  fun `module segment sanitises characters outside the safe set`() {
+    assertEquals("a-b/c-d", composeAiHistoryModuleSegment(File("/w"), File("/w/a b/c:d")))
+  }
+
+  @Test
+  fun `module segment keeps dots underscores and hyphens`() {
+    assertEquals("my_mod.x-1", composeAiHistoryModuleSegment(File("/w"), File("/w/my_mod.x-1")))
+  }
+
+  @Test
+  fun `module outside the workspace tree gets its own identity`() {
+    // `settings.gradle.kts` may reassign a projectDir outside the root. No relative path exists,
+    // so the segment keys on the module's own absolute path instead of silently colliding.
+    val a = composeAiHistoryModuleSegment(File("/w"), File("/elsewhere/mod"))
+    val b = composeAiHistoryModuleSegment(File("/w"), File("/other/mod"))
+    assertTrue(a.startsWith("_external-"), "expected an _external- segment, got '$a'")
+    assertNotEquals(a, b)
+  }
+
+  @Test
+  fun `a workspace-root prefix match must be a real path boundary`() {
+    // "/w-other" starts with "/w" as a string but is not inside it.
+    val segment = composeAiHistoryModuleSegment(File("/w"), File("/w-other/mod"))
+    assertTrue(segment.startsWith("_external-"), "expected an _external- segment, got '$segment'")
+  }
+
+  // ---- Resolution against the cache root + the legacy fallback ----
+
+  @Test
+  fun `history dir lands under the cache root`() {
+    val workspace = tmp.newFolder("ws")
+    val module = File(workspace, "auth/composables").apply { mkdirs() }
+
+    val dir = composeAiHistoryDir(workspace, module)
+
+    val expected =
+      File(
+        File(composeAiCacheDir("history"), composeAiHistoryWorkspaceSlug(workspace)),
+        "auth/composables",
+      )
+    assertEquals(expected.absolutePath, dir.absolutePath)
+  }
+
+  @Test
+  fun `history dir is not inside the workspace`() {
+    val workspace = tmp.newFolder("ws")
+    val module = File(workspace, "app").apply { mkdirs() }
+
+    val dir = composeAiHistoryDir(workspace, module)
+
+    assertTrue(
+      !dir.absolutePath.startsWith(workspace.absolutePath + File.separator),
+      "history must not be written inside the workspace, got ${dir.absolutePath}",
+    )
+  }
+
+  @Test
+  fun `an existing legacy directory wins so upgrades do not strand a timeline`() {
+    val workspace = tmp.newFolder("ws")
+    val module = File(workspace, "app").apply { mkdirs() }
+    val legacy = File(module, LEGACY_HISTORY_DIRNAME).apply { mkdirs() }
+
+    assertEquals(legacy.absolutePath, composeAiHistoryDir(workspace, module).absolutePath)
+  }
+
+  @Test
+  fun `a legacy path that is a file not a directory is ignored`() {
+    val workspace = tmp.newFolder("ws")
+    val module = File(workspace, "app").apply { mkdirs() }
+    File(module, LEGACY_HISTORY_DIRNAME).writeText("not a directory")
+
+    val dir = composeAiHistoryDir(workspace, module)
+
+    assertTrue(
+      !dir.absolutePath.startsWith(module.absolutePath + File.separator),
+      "a stray file must not divert history back into the workspace, got ${dir.absolutePath}",
+    )
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -53,6 +53,7 @@ import ee.schimke.composeai.data.render.extensions.provides
 import ee.schimke.composeai.data.theme.NodeThemeFacts
 import ee.schimke.composeai.data.theme.ThemeConsumerAttribution
 import ee.schimke.composeai.data.theme.ThemePayload
+import ee.schimke.composeai.io.composeAiCacheDir
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.CoilLoadDiagnostics
 import ee.schimke.composeai.renderer.CoilPreviewSupport
@@ -126,13 +127,14 @@ class RenderEngine(
   /**
    * Directory under which PNG files are written. Defaults to the `composeai.render.outputDir`
    * system property (mirrors `:renderer-android`'s contract); falls back to
-   * `${user.dir}/.compose-preview-history/daemon-renders/` so unit tests don't need to set the
-   * property.
+   * `<userCache>/composeai/history/daemon-renders/` so unit tests don't need to set the property.
+   * Deliberately NOT under `user.dir` — an unset property must not scatter PNGs through whatever
+   * directory the daemon happened to be launched from.
    */
   private val outputDir: File =
     File(
       System.getProperty(OUTPUT_DIR_PROP)
-        ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
+        ?: composeAiCacheDir("history").resolve("daemon-renders").absolutePath
     ),
   /**
    * D2 — root of the per-preview data-product output tree

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -38,6 +38,7 @@ import ee.schimke.composeai.data.theme.ResolvedThemeTokens
 import ee.schimke.composeai.data.theme.ThemeConsumer
 import ee.schimke.composeai.data.theme.ThemePayload
 import ee.schimke.composeai.data.theme.TypographyToken
+import ee.schimke.composeai.io.composeAiCacheDir
 import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
@@ -1776,7 +1777,8 @@ open class RobolectricHost(
   /**
    * Resolve the directory recordings live under. Mirrors [DesktopHost.recordingsRootDir]: defers to
    * `composeai.daemon.recordingsDir` when set; falls back to a sibling of the engine's output dir;
-   * final fallback to `${user.dir}/.compose-preview-history/daemon-recordings`.
+   * final fallback to `<userCache>/composeai/history/daemon-recordings` (never `user.dir` — an
+   * unconfigured daemon must not write into whatever directory it was launched from).
    */
   private fun recordingsRootDir(): File {
     val sysprop = System.getProperty(RECORDINGS_DIR_PROP)
@@ -1786,7 +1788,7 @@ open class RobolectricHost(
       if (engineOut != null && engineOut.isNotBlank()) {
         File(engineOut).parentFile ?: File(System.getProperty("user.dir") ?: ".")
       } else {
-        File("${System.getProperty("user.dir")}/.compose-preview-history")
+        composeAiCacheDir("history")
       }
     return File(parent, "daemon-recordings")
   }
@@ -2626,7 +2628,7 @@ open class RobolectricHost(
       val outputDir =
         java.io.File(
           System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
-            ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
+            ?: composeAiCacheDir("history").resolve("daemon-renders").absolutePath
         )
       outputDir.mkdirs()
       val outputFile = java.io.File(outputDir, "${start.outputBaseName}.png")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.daemon.history
 
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
 import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
+import ee.schimke.composeai.io.LEGACY_HISTORY_DIRNAME
+import ee.schimke.composeai.io.composeAiGitRefCacheDir
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -72,8 +74,7 @@ class GitRefHistorySource(
   private val ref: String,
   private val syncMode: SyncMode = SyncMode.READ_ONLY,
   displayId: String = "git:$ref",
-  private val cacheDir: Path =
-    repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),
+  private val cacheDir: Path = defaultRepoCacheDir(repoRoot),
   private val gitExecutable: String = "git",
   private val warnEmitter: (String) -> Unit = { System.err.println(it) },
   /** Git remote pushed to under [SyncMode.WRITE_PUSH]. Defaults to `origin`. */
@@ -150,11 +151,10 @@ class GitRefHistorySource(
   }
 
   /**
-   * Fresh working-tree dirtiness, **ignoring the history system's own artifacts** — the local FS
-   * archive and the git-ref cache both live under the history dir ([cacheDir]'s parent), and
-   * `HistoryManager` writes the FS source before this one, so if that dir isn't gitignored its
-   * just-written files would make every render look dirty and self-block curation (#1923 review). A
-   * change anywhere else marks the tree dirty. Null when git can't be run.
+   * Fresh working-tree dirtiness, **ignoring the history system's own artifacts** —
+   * `HistoryManager` writes the FS source before this one, so if a history directory isn't
+   * gitignored its just-written files would make every render look dirty and self-block curation
+   * (#1923 review). A change anywhere else marks the tree dirty. Null when git can't be run.
    */
   private fun currentDirty(): Boolean? {
     val out = runGit("-c", "core.quotePath=false", "status", "--porcelain") ?: return null
@@ -164,12 +164,30 @@ class GitRefHistorySource(
       // Porcelain v1 line: two status chars + a space + the path (from index 3).
       if (line.length < 4) return@any false
       val path = line.substring(3)
-      historyDir == null || !(path == historyDir || path.startsWith("$historyDir/"))
+      !isHistoryArtifact(path, historyDir)
     }
   }
 
   /**
-   * The history dir (FS archive + git-ref cache) relative to [repoRoot]; null when not under it.
+   * Whether a `git status` path is history churn rather than a real source edit.
+   *
+   * Two independent checks, because since #3407 the archive normally lives *outside* the working
+   * tree (under the user cache) and [relativeHistoryDir] is then null:
+   * 1. under the configured history dir, when that happens to sit inside the repo — the case a
+   *    consumer creates by passing an in-repo `composeai.daemon.historyDir` explicitly;
+   * 2. any path with a `.compose-preview-history` segment — the pre-#3407 in-tree layout, which the
+   *    daemon still uses when such a directory already exists. Matching by name rather than by
+   *    configured path matters because the *other* modules' legacy archives are equally not the
+   *    user's edits, and only one module's history dir is configured on any given source.
+   */
+  private fun isHistoryArtifact(path: String, historyDir: String?): Boolean {
+    if (historyDir != null && (path == historyDir || path.startsWith("$historyDir/"))) return true
+    return path.split('/').any { it == LEGACY_HISTORY_DIRNAME }
+  }
+
+  /**
+   * The configured history dir (FS archive + git-ref cache) relative to [repoRoot]; null when it
+   * isn't under it — which is the normal case now that the archive defaults to the user cache.
    */
   private fun relativeHistoryDir(): String? {
     val historyRoot = cacheDir.parent ?: return null
@@ -1010,6 +1028,14 @@ class GitRefHistorySource(
       }
 
     fun defaultCacheDir(historyDir: Path): Path = historyDir.resolve(".git-ref-cache")
+
+    /**
+     * Cache location when no module history directory is configured. Keyed by repo under the
+     * user-level cache root — this used to be `<repoRoot>/.compose-preview-history/.git-ref-cache`,
+     * i.e. a bare git working area planted in the user's working tree.
+     */
+    fun defaultRepoCacheDir(repoRoot: Path): Path =
+      composeAiGitRefCacheDir(repoRoot.toFile()).toPath()
   }
 }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -529,7 +529,7 @@ class HistoryManager(
                 syncMode = gitRefSyncMode,
                 cacheDir =
                   historyDir?.let(GitRefHistorySource::defaultCacheDir)
-                    ?: repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),
+                    ?: GitRefHistorySource.defaultRepoCacheDir(repoRoot),
                 warnEmitter = warnEmitter,
                 debounceMs = gitRefDebounceMs,
                 publishPolicy = gitRefPublishPolicy,
@@ -550,7 +550,7 @@ class HistoryManager(
               syncMode = gitRefSyncMode,
               cacheDir =
                 historyDir?.let(GitRefHistorySource::defaultCacheDir)
-                  ?: repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),
+                  ?: GitRefHistorySource.defaultRepoCacheDir(repoRoot),
               warnEmitter = warnEmitter,
             )
           }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -710,6 +710,32 @@ class GitRefHistorySourceTest {
   }
 
   @Test
+  fun clean_on_branch_ignores_a_legacy_history_dir_in_another_module() {
+    // #3407: the archive now defaults to the user cache, so `cacheDir.parent` is outside the repo
+    // and the relative-path check can't help. A pre-#3407 in-tree archive under ANOTHER module is
+    // still not the user's edit — only the name check keeps it from self-blocking curation.
+    onBranch("main")
+    // The module dir must be tracked, else `git status --porcelain` collapses the whole untracked
+    // subtree to `?? feature/` and never mentions the archive at all.
+    val moduleDir = repoRoot.resolve("feature/ui")
+    Files.createDirectories(moduleDir)
+    Files.writeString(moduleDir.resolve("Screen.kt"), "// source")
+    runOk("git", "-C", repoRoot.toString(), "add", "feature/ui/Screen.kt")
+    runOk("git", "-C", repoRoot.toString(), "commit", "-m", "add module")
+    val legacy = moduleDir.resolve(".compose-preview-history")
+    Files.createDirectories(legacy)
+    Files.writeString(legacy.resolve("20260430-100000-aaaaaaaa.png"), "fs-archive-render")
+    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
+    val e = entry("20260430-100000-aaaaaaaa", "com.example.A", "a".toByteArray())
+    assertEquals(WriteResult.WRITTEN, src.write(e, "a".toByteArray()))
+    assertEquals(
+      "a sibling module's history churn isn't dirty",
+      1,
+      src.list(HistoryFilter()).totalCount,
+    )
+  }
+
+  @Test
   fun clean_on_branch_skips_when_real_content_dirty_despite_history_artifacts() {
     // The flip side: history artifacts are ignored, but a real source edit alongside them still
     // marks the tree dirty and keeps the render off the branch.

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
+import ee.schimke.composeai.io.composeAiCacheDir
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutionException
@@ -502,8 +503,8 @@ open class DesktopHost(
     val engineOut = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
     val parent =
       if (engineOut != null && engineOut.isNotBlank()) File(engineOut).parentFile
-      else File("${System.getProperty("user.dir")}/.compose-preview-history")
-    return File(parent ?: File(System.getProperty("user.dir")), "daemon-recordings")
+      else composeAiCacheDir("history")
+    return File(parent ?: composeAiCacheDir("history"), "daemon-recordings")
   }
 
   /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -50,6 +50,7 @@ import ee.schimke.composeai.data.render.extensions.loadPreviewWrapperClass
 import ee.schimke.composeai.data.render.extensions.provides
 import ee.schimke.composeai.data.theme.ThemePayload
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.io.composeAiCacheDir
 import ee.schimke.composeai.preview.lottie.LottiePreview
 import java.io.File
 import java.util.Base64
@@ -105,13 +106,14 @@ class RenderEngine(
   /**
    * Directory under which PNG files are written. Defaults to the `composeai.render.outputDir`
    * system property (mirrors the Android side's contract); falls back to
-   * `${user.dir}/.compose-preview-history/daemon-renders/` so unit tests don't need to set the
-   * property.
+   * `<userCache>/composeai/history/daemon-renders/` so unit tests don't need to set the property.
+   * Deliberately NOT under `user.dir` — an unset property must not scatter PNGs through whatever
+   * directory the daemon happened to be launched from.
    */
   private val outputDir: File =
     File(
       System.getProperty(OUTPUT_DIR_PROP)
-        ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
+        ?: composeAiCacheDir("history").resolve("daemon-renders").absolutePath
     ),
   private val dataDir: File = (outputDir.parentFile ?: outputDir).resolve("data"),
   private val previewContextCapture: PreviewContextCapture? = null,

--- a/docs/NON_GRADLE_INTEGRATION.md
+++ b/docs/NON_GRADLE_INTEGRATION.md
@@ -97,7 +97,7 @@ for the classpath but not the rest):
     "composeai.daemon.previewsJsonPath": "/abs/path/to/previews.json",
     "composeai.harness.previewsManifest": "/abs/path/to/previews.json",
     "composeai.render.outputDir": "/abs/path/to/build/compose-previews/renders",
-    "composeai.daemon.historyDir": "/abs/path/to/.compose-preview-history",
+    "composeai.daemon.historyDir": "/abs/path/to/history-archive",
     "composeai.daemon.userClassDirs": "/abs/path/to/<your-module-classes/>",
     "composeai.daemon.idleTimeoutMs": "5000"
   },
@@ -161,7 +161,7 @@ The minimum set the daemon reads at boot:
 | `composeai.daemon.previewsJsonPath` | Path to `previews.json`. The daemon seeds its preview index from this on startup. |
 | `composeai.harness.previewsManifest` | Same path. Legacy alias still read by the harness path. |
 | `composeai.render.outputDir` | Where rendered PNGs land. The daemon writes here; you read from here. |
-| `composeai.daemon.historyDir` | Where per-render archives go. Pick any dir; defaults under `.compose-preview-history/`. |
+| `composeai.daemon.historyDir` | Where per-render archives go. Pick any dir; defaults under `$XDG_CACHE_HOME/composeai/history/`, never inside the project tree ([HISTORY.md](daemon/HISTORY.md)). |
 | `composeai.daemon.userClassDirs` | `:`-separated list of directories holding user `.class` files. Used by classloader hot-swap on `fileChanged` notifications. |
 | `composeai.daemon.idleTimeoutMs` | Idle exit timeout. `5000` is the gradle plugin's default. |
 

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -8,10 +8,48 @@ an hour ago?", "did the bytes change?", and "diff against `main`."
 The legacy Gradle-side `HistorizePreviewsTask` was removed in PR #311.
 The daemon is now the only writer.
 
+## Where the archive lives
+
+Since #3407 the archive is **outside the working tree**, under the
+user-level cache root:
+
+```
+$XDG_CACHE_HOME/composeai/history/<workspaceSlug>/<moduleRel>/
+  workspaceSlug = <sanitised basename>-<sha256(abs workspace path)[0..12]>
+  moduleRel     = the module's path relative to the workspace root
+                  (`auth/composables`; the root project maps to `_root`)
+```
+
+History is a semi-persistent timeline of local edits — cache-shaped
+data, never user-authored — so it belongs beside the font cache rather
+than next to someone's sources. Previously each previewed module grew an
+untracked `<moduleDir>/.compose-preview-history/`, which showed up in
+`git status` and (before the lazy-bootstrap fix in #3406) appeared even
+in projects that had never opted into Compose Preview.
+
+**A pre-existing `<moduleDir>/.compose-preview-history/` still wins**, so
+upgrading doesn't strand a timeline anyone already has. Nothing recreates
+it once removed; delete it to migrate to the cache location.
+
+The reporting-branch flow is unaffected — it publishes to a git ref (see
+[REPORTING-BRANCH.md](REPORTING-BRANCH.md)), and the in-tree directory was
+only ever its local staging area. `GitRefHistorySource`'s working cache
+moves with it: `<historyDir>/.git-ref-cache`, or
+`<cache>/history/<workspaceSlug>/.git-ref-cache` when no module history
+directory is configured.
+
+Three implementations compute this layout and must agree byte-for-byte:
+`common/io`'s `composeAiHistoryDir` (what the daemon writes through), an
+inlined copy in the Gradle plugin (which passes
+`-Dcomposeai.daemon.historyDir`), and `vscode-extension/src/historyPaths.ts`
+(which reads it back for the panel's FS fallback). Drift doesn't crash —
+it silently empties the history drawer. Shared golden vectors live in
+`HistoryPathsTest.kt` and `historyPaths.test.ts`.
+
 ## On-disk schema
 
 ```
-<historyDir>/                                 # default $projectDir/.compose-preview-history
+<historyDir>/                                 # see "Where the archive lives" below
 ├── index.jsonl                               # append-only log of every entry
 ├── <sanitised-preview-id>/
 │   ├── 20260430-101234-a1b2c3d4.png
@@ -253,9 +291,10 @@ See `HistoryPruneConfig`. Only writable sources participate.
 
 The daemon mains (`daemon-android`, `daemon-desktop`) accept
 `composeai.daemon.historyDir` as a system property; null disables
-history entirely. When unset, they default to
-`<repoRoot>/.compose-preview-history` (CWD as the fallback when the
-daemon can't resolve a repo root).
+history entirely. The Gradle plugin always sets it (see "Where the
+archive lives"); an unset value only happens for a standalone daemon,
+which falls back to the same user-cache root rather than writing into
+whatever directory it was launched from.
 
 ## Concurrency model
 
@@ -338,7 +377,7 @@ sources; writes go to the first writable source.
 
 ### `LocalFsHistorySource`
 
-The default `.compose-preview-history/` directory. Read-write.
+The local filesystem archive (see "Where the archive lives"). Read-write.
 `watch()` is `WatchService` with a polling fallback.
 
 ### `GitRefHistorySource`

--- a/docs/daemon/REPORTING-BRANCH.md
+++ b/docs/daemon/REPORTING-BRANCH.md
@@ -4,7 +4,7 @@ A long-lived git ref (default `refs/heads/preview/main`) that accumulates
 render **history** — images *and* data products — so users and agents can ask
 "what did this preview look like, and what were its a11y findings, an hour /
 a commit / a release ago?" It is the durable, pushable counterpart to the
-local [`.compose-preview-history/`](HISTORY.md) archive.
+local [filesystem history](HISTORY.md) archive.
 
 Part of the report-history epic (#1866); this document is sub-issue #1868. The
 writer that produces the branch is #1870; the per-file formats are the

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
@@ -540,8 +540,24 @@ internal fun composeAiHistoryModuleSegment(workspaceRoot: File, projectDir: File
     .removePrefix("$root/")
     .split('/')
     .filter { it.isNotEmpty() }
-    .joinToString("/") { sanitiseHistorySegment(it) }
+    .joinToString("/") { sanitiseHistorySegmentInjectively(it) }
     .ifEmpty { "_root" }
+}
+
+/**
+ * See `common/io`'s `sanitiseHistorySegmentInjectively`. Kept byte-identical to it: a segment that
+ * sanitising had to rewrite carries an 8-hex digest of its original text, so `ui components` and
+ * `ui-components` stay distinct modules.
+ */
+private fun sanitiseHistorySegmentInjectively(segment: String): String {
+  val sanitised = sanitiseHistorySegment(segment)
+  if (sanitised == segment) return sanitised
+  val digest =
+    java.security.MessageDigest.getInstance("SHA-256")
+      .digest(segment.toByteArray(Charsets.UTF_8))
+      .joinToString("") { "%02x".format(it) }
+      .take(8)
+  return "$sanitised-$digest"
 }
 
 /** ASCII-only on purpose — see `common/io`'s counterpart for why. */

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
@@ -465,14 +465,90 @@ internal object AndroidPreviewClasspath {
  * configuration cache records `XDG_CACHE_HOME` / `user.home` as inputs instead of flagging a raw
  * `System.getenv` read.
  */
-internal fun composeAiFontsCacheDir(project: Project): String {
+internal fun composeAiFontsCacheDir(project: Project): String =
+  File(composeAiCacheRoot(project), "fonts").absolutePath
+
+/**
+ * Root of the user-level cache — `$XDG_CACHE_HOME/composeai` when `XDG_CACHE_HOME` is set and
+ * non-blank, else `~/.cache/composeai`. Resolved through [org.gradle.api.provider.ProviderFactory]
+ * so the configuration cache records `XDG_CACHE_HOME` / `user.home` as inputs instead of flagging a
+ * raw `System.getenv` read.
+ */
+private fun composeAiCacheRoot(project: Project): File {
   val xdg =
     project.providers.environmentVariable("XDG_CACHE_HOME").orNull?.takeIf { it.isNotBlank() }
-  val base =
-    if (xdg != null) File(xdg, "composeai")
-    else File(project.providers.systemProperty("user.home").get(), ".cache/composeai")
-  return File(base, "fonts").absolutePath
+  return if (xdg != null) File(xdg, "composeai")
+  else File(project.providers.systemProperty("user.home").get(), ".cache/composeai")
 }
+
+/** Directory name of the legacy in-tree history archive, kept for backwards compatibility. */
+internal const val LEGACY_HISTORY_DIRNAME: String = ".compose-preview-history"
+
+/**
+ * Absolute path of this module's render-history archive:
+ * `$XDG_CACHE_HOME/composeai/history/<workspaceSlug>/<moduleRel>`.
+ *
+ * **Mirror of `common/io`'s `composeAiHistoryDir` — the plugin can't depend on that module, so the
+ * layout is inlined here.** A third implementation lives in the VS Code extension
+ * (`vscode-extension/src/historyPaths.ts`), which reads the archive the daemon writes. All three
+ * must agree byte-for-byte; they're pinned by `HistoryPathsTest` (`:common-io`),
+ * `AndroidPreviewClasspathTest` (here) and `historyPaths.test.ts` sharing the same golden vectors.
+ * A drift between them doesn't crash — it silently gives the reader an empty history drawer.
+ *
+ * History used to live at `<projectDir>/.compose-preview-history`, which grew an untracked
+ * directory next to every previewed module's sources. It's a semi-persistent timeline of local
+ * edits — cache-shaped data, never user-authored — so it belongs beside the font cache rather than
+ * in the working tree. The reporting-branch flow is unaffected: that publishes to a git ref, and
+ * the in-tree directory was only its local staging area.
+ *
+ * An existing `<projectDir>/.compose-preview-history` wins, so upgrading doesn't strand a timeline
+ * someone already has. Nothing recreates it once removed.
+ */
+internal fun composeAiHistoryDir(project: Project): String {
+  val projectDir = project.layout.projectDirectory.asFile
+  val legacy = File(projectDir, LEGACY_HISTORY_DIRNAME)
+  if (legacy.isDirectory) return legacy.absolutePath
+  val historyRoot = File(composeAiCacheRoot(project), "history")
+  return File(
+      File(historyRoot, composeAiHistoryWorkspaceSlug(project.rootDir)),
+      composeAiHistoryModuleSegment(project.rootDir, projectDir),
+    )
+    .absolutePath
+}
+
+/** See `common/io`'s `composeAiHistoryWorkspaceSlug`. Kept byte-identical to it. */
+internal fun composeAiHistoryWorkspaceSlug(workspaceRoot: File): String {
+  val normalised = workspaceRoot.absolutePath.replace('\\', '/').trimEnd('/')
+  val digest =
+    java.security.MessageDigest.getInstance("SHA-256")
+      .digest(normalised.toByteArray(Charsets.UTF_8))
+      .joinToString("") { "%02x".format(it) }
+      .take(12)
+  val name = sanitiseHistorySegment(normalised.substringAfterLast('/'))
+  return if (name.isEmpty()) digest else "$name-$digest"
+}
+
+/** See `common/io`'s `composeAiHistoryModuleSegment`. Kept byte-identical to it. */
+internal fun composeAiHistoryModuleSegment(workspaceRoot: File, projectDir: File): String {
+  val root = workspaceRoot.absolutePath.replace('\\', '/').trimEnd('/')
+  val module = projectDir.absolutePath.replace('\\', '/').trimEnd('/')
+  if (module == root) return "_root"
+  if (!module.startsWith("$root/")) {
+    return "_external-" + composeAiHistoryWorkspaceSlug(projectDir)
+  }
+  return module
+    .removePrefix("$root/")
+    .split('/')
+    .filter { it.isNotEmpty() }
+    .joinToString("/") { sanitiseHistorySegment(it) }
+    .ifEmpty { "_root" }
+}
+
+/** ASCII-only on purpose — see `common/io`'s counterpart for why. */
+private fun sanitiseHistorySegment(segment: String): String =
+  segment
+    .map { if (it in 'A'..'Z' || it in 'a'..'z' || it in '0'..'9' || it in ".-_") it else '-' }
+    .joinToString("")
 
 /**
  * The resolved value to forward as the daemon JVM's `composeai.svg.embedFonts`, so a

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2754,6 +2754,7 @@ internal object AndroidPreviewSupport {
     // Built lazily via providers so the AGP unit-test task's javaLauncher
     // resolves at execution time (same reason composePreviewRender above defers it).
     val daemonFontsCacheDir = composeAiFontsCacheDir(project)
+    val daemonHistoryDir = composeAiHistoryDir(project)
     val daemonFontsOffline =
       project.providers.gradleProperty("composePreview.fontsOffline").orElse("false")
     val daemonSvgEmbedFonts = composeAiSvgEmbedFonts(project)
@@ -2997,13 +2998,10 @@ internal object AndroidPreviewSupport {
       // launchers used to set this); now any production-mode launcher needs it.
       this.systemProperties.put("composeai.harness.previewsManifest", manifestFile)
       // H1+H2 — `composeai.daemon.historyDir` flips daemon-side history recording on. Default
-      // location is `<projectDir>/.compose-preview-history` (matches the legacy convention;
-      // user-visible `.gitignore` pattern). Without this sysprop the daemon's `HistoryManager`
-      // stays null and the VS Code history view shows an empty drawer.
-      this.systemProperties.put(
-        "composeai.daemon.historyDir",
-        project.layout.projectDirectory.dir(".compose-preview-history").asFile.absolutePath,
-      )
+      // location is under the user-level cache root, NOT the project tree — see
+      // [composeAiHistoryDir]. Without this sysprop the daemon's `HistoryManager` stays null and
+      // the VS Code history view shows an empty drawer.
+      this.systemProperties.put("composeai.daemon.historyDir", daemonHistoryDir)
       this.systemProperties.put("composeai.daemon.workspaceRoot", project.rootDir.absolutePath)
       this.workingDirectory.set(project.projectDir.absolutePath)
       this.manifestPath.set(manifestFile)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -726,6 +726,7 @@ internal object ComposePreviewTasks {
     val rendersDirProvider = previewOutputDir.map { it.dir("renders").asFile.absolutePath }
     val outputFileProvider = previewOutputDir.map { it.file("daemon-launch.json") }
     val daemonFontsCacheDir = composeAiFontsCacheDir(project)
+    val daemonHistoryDir = composeAiHistoryDir(project)
     val daemonFontsOffline =
       project.providers.gradleProperty("composePreview.fontsOffline").orElse("false")
     val daemonSvgEmbedFonts = composeAiSvgEmbedFonts(project)
@@ -883,13 +884,10 @@ internal object ComposePreviewTasks {
       // launchers used to set this); now any production-mode launcher needs it.
       systemProperties.put("composeai.harness.previewsManifest", previewsJsonProvider)
       // H1+H2 — `composeai.daemon.historyDir` is what flips daemon-side history recording from
-      // off to on. Default location is `<projectDir>/.compose-preview-history` (matches the
-      // legacy convention; user-visible `.gitignore` pattern). Without this sysprop the daemon's
-      // `HistoryManager` stays null and the VS Code history view shows an empty drawer.
-      systemProperties.put(
-        "composeai.daemon.historyDir",
-        project.layout.projectDirectory.dir(".compose-preview-history").asFile.absolutePath,
-      )
+      // off to on. Default location is under the user-level cache root, NOT the project tree —
+      // see [composeAiHistoryDir]. Without this sysprop the daemon's `HistoryManager` stays null
+      // and the VS Code history view shows an empty drawer.
+      systemProperties.put("composeai.daemon.historyDir", daemonHistoryDir)
       systemProperties.put("composeai.daemon.workspaceRoot", project.rootDir.absolutePath)
 
       workingDirectory.set(project.projectDir.absolutePath)

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5066,8 +5066,13 @@ async function refresh(
               // Keep the chosen reporting branch across same-module refreshes
               // (mirrors the previewId narrow); a module switch resets to local.
               gitRef: prior!.gitRef,
+              workspaceRoot: gradleService.workspaceRoot,
           }
-        : { moduleId: module.modulePath, projectDir };
+        : {
+              moduleId: module.modulePath,
+              projectDir,
+              workspaceRoot: gradleService.workspaceRoot,
+          };
     applyHistoryScope(newScope);
     const modules: ModuleInfo[] = [module];
     const modulePathList = modules.map((m) => m.modulePath);
@@ -6754,6 +6759,7 @@ async function runLivePreviewDiff(
     const scope: HistoryScope = {
         moduleId: module.modulePath,
         projectDir,
+        workspaceRoot: gradleService.workspaceRoot,
         previewId,
     };
     let entries: unknown[];
@@ -7165,6 +7171,7 @@ async function diffAllVsMain(): Promise<void> {
                     const list = await historySource!.list({
                         moduleId,
                         projectDir,
+                        workspaceRoot: gradleService!.workspaceRoot,
                         previewId: preview.id,
                     });
                     for (const e of list.entries) {

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -13,6 +13,7 @@ import {
     readGitRefEntryField,
     reportingBranchLabel,
 } from "./reportingBranches";
+import { historyDirFor as resolveHistoryDir } from "./historyPaths";
 
 /**
  * Read-only Preview History panel — HISTORY.md § "VS Code integration".
@@ -532,6 +533,11 @@ export interface HistoryScope {
     /** Module project directory; the panel needs this to resolve the
      *  fallback `historyDir` when the daemon is down. */
     projectDir: string;
+    /** Workspace root the module sits under. Paired with `projectDir` to
+     *  locate the module's history archive under the user cache — the
+     *  archive is keyed by (workspace, module-relative path), so the panel
+     *  can't resolve it from `projectDir` alone. See `historyPaths.ts`. */
+    workspaceRoot: string;
     /** Optional preview filter; when null, the panel shows every preview
      *  in the module's history. */
     previewId?: string;
@@ -652,7 +658,7 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
 }
 
 function historyDirFor(scope: HistoryScope): string {
-    return `${scope.projectDir}/.compose-preview-history`;
+    return resolveHistoryDir(scope.workspaceRoot, scope.projectDir);
 }
 
 /**

--- a/vscode-extension/src/historyPaths.ts
+++ b/vscode-extension/src/historyPaths.ts
@@ -42,6 +42,26 @@ function sanitiseSegment(segment: string): string {
     return segment.replace(/[^A-Za-z0-9._-]/g, "-");
 }
 
+/**
+ * `sanitiseSegment`, plus an 8-hex digest of the original text when sanitising changed it.
+ *
+ * Distinct directory names must not land on the same segment: `ui components` and `ui-components`
+ * are different modules, and two non-ASCII names can flatten to the same run of hyphens. Sharing a
+ * history directory would mix their entries and prune state. Only rewritten segments pay the
+ * suffix, so ordinary paths stay readable.
+ */
+function sanitiseSegmentInjectively(segment: string): string {
+    const sanitised = sanitiseSegment(segment);
+    if (sanitised === segment) {
+        return sanitised;
+    }
+    const digest = createHash("sha256")
+        .update(segment, "utf8")
+        .digest("hex")
+        .slice(0, 8);
+    return `${sanitised}-${digest}`;
+}
+
 /** Absolute path with separators normalised to `/` and any trailing separator dropped. */
 function normalise(p: string): string {
     const abs = path.resolve(p).replace(/\\/g, "/");
@@ -87,7 +107,7 @@ export function historyModuleSegment(
         .slice(root.length + 1)
         .split("/")
         .filter((s) => s.length > 0)
-        .map(sanitiseSegment)
+        .map(sanitiseSegmentInjectively)
         .join("/");
     return segment.length === 0 ? "_root" : segment;
 }

--- a/vscode-extension/src/historyPaths.ts
+++ b/vscode-extension/src/historyPaths.ts
@@ -1,0 +1,118 @@
+// Where a module's render history lives on disk.
+//
+// This is the THIRD implementation of one layout. The daemon writes the archive via `common/io`'s
+// `composeAiHistoryDir` (Kotlin), the Gradle plugin computes the same path to hand the daemon as
+// `-Dcomposeai.daemon.historyDir` (a separate inlined copy — the plugin can't depend on
+// `:common-io`), and this one reads it back for the panel's FS fallback when the daemon isn't up.
+//
+// All three must agree byte-for-byte. A drift doesn't crash: the daemon writes one directory, the
+// panel reads another, and the history drawer is silently empty. The golden vectors in
+// `test/historyPaths.test.ts` are duplicated verbatim from `HistoryPathsTest.kt`; change the layout
+// only with both suites updated together.
+//
+// History used to live at `<projectDir>/.compose-preview-history`, which grew an untracked
+// directory next to every previewed module's sources. It's a semi-persistent timeline of local
+// edits — cache-shaped data, never user-authored — so it belongs beside the font cache. The
+// reporting-branch flow is unaffected: that publishes to a git ref, and the in-tree directory was
+// only its local staging area.
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { createHash } from "crypto";
+
+/** Directory name of the legacy in-tree history archive, kept for backwards compatibility. */
+export const LEGACY_HISTORY_DIRNAME = ".compose-preview-history";
+
+/**
+ * Root of the user-level cache: `$XDG_CACHE_HOME/composeai` when set and non-blank, else
+ * `~/.cache/composeai`. Mirrors `common/io`'s `composeAiCacheDir`.
+ */
+export function composeAiCacheDir(subdir: string): string {
+    const xdg = process.env.XDG_CACHE_HOME;
+    const base =
+        xdg && xdg.trim().length > 0
+            ? path.join(xdg, "composeai")
+            : path.join(os.homedir() || ".", ".cache", "composeai");
+    return path.join(base, subdir);
+}
+
+/** Replaces anything outside `[A-Za-z0-9._-]` with `-`. ASCII-only, matching the Kotlin side. */
+function sanitiseSegment(segment: string): string {
+    return segment.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+/** Absolute path with separators normalised to `/` and any trailing separator dropped. */
+function normalise(p: string): string {
+    const abs = path.resolve(p).replace(/\\/g, "/");
+    return abs.length > 1 ? abs.replace(/\/+$/, "") : abs;
+}
+
+/**
+ * Stable per-workspace directory name: `<sanitised basename>-<sha256(path) truncated to 12 hex>`.
+ *
+ * The readable prefix keeps the cache browsable; the hash keeps two checkouts of the same repo from
+ * colliding. Hashed over the absolute path with `/` separators — deliberately NOT the real
+ * (symlink-resolved) path, because Gradle, the daemon and this extension each learn the workspace
+ * root by a different route and only the unresolved form is reliably identical across all three.
+ */
+export function historyWorkspaceSlug(workspaceRoot: string): string {
+    const normalised = normalise(workspaceRoot);
+    const digest = createHash("sha256")
+        .update(normalised, "utf8")
+        .digest("hex")
+        .slice(0, 12);
+    const name = sanitiseSegment(normalised.split("/").pop() ?? "");
+    return name.length === 0 ? digest : `${name}-${digest}`;
+}
+
+/**
+ * The module's path relative to `workspaceRoot`, `/`-joined and sanitised per segment. The root
+ * project maps to `_root`; a module outside the workspace tree (a `projectDir` reassigned by
+ * `settings.gradle.kts`) keys on its own identity so two such modules can't collide.
+ */
+export function historyModuleSegment(
+    workspaceRoot: string,
+    projectDir: string,
+): string {
+    const root = normalise(workspaceRoot);
+    const module = normalise(projectDir);
+    if (module === root) {
+        return "_root";
+    }
+    if (!module.startsWith(`${root}/`)) {
+        return `_external-${historyWorkspaceSlug(projectDir)}`;
+    }
+    const segment = module
+        .slice(root.length + 1)
+        .split("/")
+        .filter((s) => s.length > 0)
+        .map(sanitiseSegment)
+        .join("/");
+    return segment.length === 0 ? "_root" : segment;
+}
+
+/**
+ * Absolute path of a module's history archive.
+ *
+ * An existing `<projectDir>/.compose-preview-history` wins so an upgrade doesn't strand a timeline
+ * someone already has; nothing recreates it once removed.
+ */
+export function historyDirFor(
+    workspaceRoot: string,
+    projectDir: string,
+): string {
+    const legacy = path.join(projectDir, LEGACY_HISTORY_DIRNAME);
+    try {
+        if (fs.statSync(legacy).isDirectory()) {
+            return legacy;
+        }
+    } catch {
+        /* absent — fall through to the cache location */
+    }
+    return path.join(
+        composeAiCacheDir("history"),
+        historyWorkspaceSlug(workspaceRoot),
+        historyModuleSegment(workspaceRoot, projectDir),
+    );
+}

--- a/vscode-extension/src/test/historyPaths.test.ts
+++ b/vscode-extension/src/test/historyPaths.test.ts
@@ -62,10 +62,25 @@ describe("historyPaths", () => {
         });
 
         it("sanitises characters outside the safe set", () => {
+            // Each rewritten segment carries an 8-hex digest of its original text.
             assert.strictEqual(
                 historyModuleSegment("/w", "/w/a b/c:d"),
-                "a-b/c-d",
+                "a-b-c8687a08/c-d-66c7bbe2",
             );
+        });
+
+        it("keeps module names that sanitise identically distinct", () => {
+            // `ui components` and `ui-components` are different modules; without the digest
+            // suffix both flatten to `ui-components` and would share one history dir.
+            const spaced = historyModuleSegment("/w", "/w/ui components");
+            const hyphenated = historyModuleSegment("/w", "/w/ui-components");
+            assert.strictEqual(spaced, "ui-components-50bae342");
+            assert.strictEqual(hyphenated, "ui-components");
+            assert.notStrictEqual(spaced, hyphenated);
+        });
+
+        it("leaves an already-safe segment plain", () => {
+            assert.strictEqual(historyModuleSegment("/w", "/w/auth"), "auth");
         });
 
         it("keeps dots, underscores and hyphens", () => {

--- a/vscode-extension/src/test/historyPaths.test.ts
+++ b/vscode-extension/src/test/historyPaths.test.ts
@@ -1,0 +1,163 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+    LEGACY_HISTORY_DIRNAME,
+    composeAiCacheDir,
+    historyDirFor,
+    historyModuleSegment,
+    historyWorkspaceSlug,
+} from "../historyPaths";
+
+/**
+ * Mirror of `common/io`'s `HistoryPathsTest.kt`.
+ *
+ * The GOLDEN vectors below are duplicated verbatim from that suite. Three implementations compute
+ * this layout — Kotlin in `:common-io` (what the daemon writes through), an inlined copy in the
+ * Gradle plugin (which hands the daemon `-Dcomposeai.daemon.historyDir`), and this TypeScript one
+ * (which reads the archive back for the panel's FS fallback). If they drift, the daemon writes one
+ * directory and the panel reads another: no crash, just a silently empty history drawer. Change
+ * the layout only with both suites updated together.
+ */
+describe("historyPaths", () => {
+    describe("workspace slug", () => {
+        it("is a readable prefix plus a 12-hex digest", () => {
+            assert.strictEqual(
+                historyWorkspaceSlug("/home/dev/src/app"),
+                "app-671822104ddc",
+            );
+            assert.strictEqual(
+                historyWorkspaceSlug("/home/dev/src/my project"),
+                "my-project-75d59f8a453b",
+            );
+        });
+
+        it("ignores a trailing separator", () => {
+            assert.strictEqual(
+                historyWorkspaceSlug("/home/dev/src/app/"),
+                historyWorkspaceSlug("/home/dev/src/app"),
+            );
+        });
+
+        it("does not collide for the same basename under different parents", () => {
+            assert.notStrictEqual(
+                historyWorkspaceSlug("/home/dev/a/app"),
+                historyWorkspaceSlug("/home/dev/b/app"),
+            );
+        });
+    });
+
+    describe("module segment", () => {
+        it("is the workspace-relative path", () => {
+            assert.strictEqual(
+                historyModuleSegment("/w", "/w/auth/composables"),
+                "auth/composables",
+            );
+        });
+
+        it("maps the root project to _root", () => {
+            assert.strictEqual(historyModuleSegment("/w", "/w"), "_root");
+            assert.strictEqual(historyModuleSegment("/w", "/w/"), "_root");
+        });
+
+        it("sanitises characters outside the safe set", () => {
+            assert.strictEqual(
+                historyModuleSegment("/w", "/w/a b/c:d"),
+                "a-b/c-d",
+            );
+        });
+
+        it("keeps dots, underscores and hyphens", () => {
+            assert.strictEqual(
+                historyModuleSegment("/w", "/w/my_mod.x-1"),
+                "my_mod.x-1",
+            );
+        });
+
+        it("gives a module outside the workspace tree its own identity", () => {
+            const a = historyModuleSegment("/w", "/elsewhere/mod");
+            const b = historyModuleSegment("/w", "/other/mod");
+            assert.ok(
+                a.startsWith("_external-"),
+                `expected an _external- segment, got '${a}'`,
+            );
+            assert.notStrictEqual(a, b);
+        });
+
+        it("requires a real path boundary, not a string prefix", () => {
+            // "/w-other" starts with "/w" as a string but is not inside it.
+            const segment = historyModuleSegment("/w", "/w-other/mod");
+            assert.ok(
+                segment.startsWith("_external-"),
+                `expected an _external- segment, got '${segment}'`,
+            );
+        });
+    });
+
+    describe("historyDirFor", () => {
+        let tmp: string;
+
+        beforeEach(() => {
+            tmp = fs.mkdtempSync(path.join(os.tmpdir(), "history-paths-"));
+        });
+
+        afterEach(() => {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        });
+
+        it("lands under the cache root", () => {
+            const workspace = path.join(tmp, "ws");
+            const module = path.join(workspace, "auth", "composables");
+            fs.mkdirSync(module, { recursive: true });
+
+            assert.strictEqual(
+                historyDirFor(workspace, module),
+                path.join(
+                    composeAiCacheDir("history"),
+                    historyWorkspaceSlug(workspace),
+                    "auth/composables",
+                ),
+            );
+        });
+
+        it("never resolves inside the workspace", () => {
+            const workspace = path.join(tmp, "ws");
+            const module = path.join(workspace, "app");
+            fs.mkdirSync(module, { recursive: true });
+
+            const dir = historyDirFor(workspace, module);
+
+            assert.ok(
+                !dir.startsWith(workspace + path.sep),
+                `history must not be written inside the workspace, got ${dir}`,
+            );
+        });
+
+        it("prefers an existing legacy directory so upgrades do not strand a timeline", () => {
+            const workspace = path.join(tmp, "ws");
+            const module = path.join(workspace, "app");
+            const legacy = path.join(module, LEGACY_HISTORY_DIRNAME);
+            fs.mkdirSync(legacy, { recursive: true });
+
+            assert.strictEqual(historyDirFor(workspace, module), legacy);
+        });
+
+        it("ignores a legacy path that is a file rather than a directory", () => {
+            const workspace = path.join(tmp, "ws");
+            const module = path.join(workspace, "app");
+            fs.mkdirSync(module, { recursive: true });
+            fs.writeFileSync(
+                path.join(module, LEGACY_HISTORY_DIRNAME),
+                "not a directory",
+            );
+
+            const dir = historyDirFor(workspace, module);
+
+            assert.ok(
+                !dir.startsWith(module + path.sep),
+                `a stray file must not divert history back into the workspace, got ${dir}`,
+            );
+        });
+    });
+});


### PR DESCRIPTION
Follow-up to #3406. That PR stopped unconfigured projects from being pulled into the pipeline at all; this one stops the pipeline from writing into the working tree even when you *do* use it.

## Problem

Every previewed module grew an untracked `<moduleDir>/.compose-preview-history/` next to its sources. History is a semi-persistent timeline of local edits — cache-shaped data, never user-authored, and it doesn't need to survive `rm -rf ~/.cache`. It belongs beside the font cache (`composeAiCacheDir("fonts")`) and bundle deps, not in the working copy.

## Layout

```
$XDG_CACHE_HOME/composeai/history/<workspaceSlug>/<moduleRel>/
  workspaceSlug = <sanitised basename>-<sha256(abs workspace path)[0..12]>
  moduleRel     = module path relative to the workspace root, `_root` for the root project
```

The readable prefix keeps the cache browsable; the digest keeps two checkouts of the same repo from colliding. It hashes the **unresolved** absolute path rather than the realpath — Gradle, the daemon and the extension each learn the workspace root by a different route, and only the unresolved form is reliably identical across all three. Cost: a symlinked second path to the same checkout gets its own history.

**An existing `<moduleDir>/.compose-preview-history/` still wins**, so upgrading doesn't strand a timeline anyone already has. Nothing recreates it once removed.

The reporting-branch flow is unaffected — it publishes to a git ref, and the in-tree directory was only ever its local staging area. `GitRefHistorySource`'s working cache moves with it, and its standalone fallback no longer plants a bare git working area in the user's repo.

Also fixes the daemon's unconfigured-fallback paths for renders and recordings, which resolved against `user.dir` — writing into whatever directory the daemon happened to be launched from.

## The triple implementation is the risk here

Three implementations compute this layout and must agree byte-for-byte:

| Where | Why it can't share code |
| --- | --- |
| `common/io`'s `composeAiHistoryDir` | canonical; what the daemon writes through |
| `AndroidPreviewClasspath` (inlined copy) | the Gradle plugin can't depend on `:common-io` |
| `vscode-extension/src/historyPaths.ts` | TypeScript; reads the archive for the panel's FS fallback |

Drift doesn't crash — the daemon writes one directory, the panel reads another, and the history drawer is silently empty. `HistoryPathsTest.kt` and `historyPaths.test.ts` therefore share the same golden vectors, and both files say so.

## Behavioural repair that fell out of the move

`GitRefHistorySource` decided which `git status` entries were "history churn rather than a real edit" (#1923) by relativising the cache dir against the repo root. With the cache outside the repo that check yields nothing, so a legacy in-tree archive would count as dirty and self-block curation. Dirtiness now also ignores any path with a `.compose-preview-history` segment, which covers sibling modules' legacy archives too — only one module's history dir is ever configured on a given source.

Writing the regression test for that surfaced a subtlety worth recording: `git status --porcelain` collapses a fully-untracked subtree to its shallowest directory, so a nested legacy archive is only reported by name when its module directory is tracked. The test commits a source file first to reflect the real shape.

## Test plan

- `:common-io:test` — 13 new golden-vector tests (slug, module segment, cache resolution, legacy fallback, stray-file-not-a-directory).
- `:daemon:core:test` — passing, including the new `clean_on_branch_ignores_a_legacy_history_dir_in_another_module`.
- `:gradle-plugin:test`, `:cli:test` — passing.
- `vscode-extension` — 1639 passing (13 new, mirroring the Kotlin vectors).
- `ktfmtCheckAll` and `prettier --check` clean.

Non-visual change (path plumbing), so no render evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV6CXoK9tzPaWQ1RpXR3M7)_