### PR TITLE
feat(deploy): serve the m3-catalog design system on preview.coo.ee

### DIFF
--- a/deploy/preview.coo.ee/catalogs.json
+++ b/deploy/preview.coo.ee/catalogs.json
@@ -47,6 +47,12 @@
       "group": "design-systems"
     },
     {
+      "system": "m3-catalog",
+      "repo": "yschimke/m3-catalog",
+      "listed": true,
+      "group": "design-systems"
+    },
+    {
       "system": "meshcore-mobile",
       "repo": "yschimke/meshcore-mobile",
       "listed": true

--- a/deploy/preview.coo.ee/producers.json
+++ b/deploy/preview.coo.ee/producers.json
@@ -6,6 +6,10 @@
       "branch": "design-artifacts/*"
     },
     {
+      "repo": "yschimke/m3-catalog",
+      "branch": "design-artifacts/*"
+    },
+    {
       "repo": "yschimke/meshcore-mobile",
       "branch": "design-artifacts/*"
     },


### PR DESCRIPTION
## Summary

Registers [`yschimke/m3-catalog`](https://github.com/yschimke/m3-catalog) — the Material 3 Design Kit rebuilt as code-led `@Preview`s — as a listed catalog on `preview.coo.ee`, in the **Design Systems** group beside `compose-m3` / `wear-m3` / `remote-m3`.

Its first bundle has already published to `design-artifacts/m3-catalog`: **50 components across 8 sections, 188 stickers, 238 layered `figma-svg` vectors, 50 wireframes**, plus six `@ThemeCatalog` modes (baseline light/dark and the kit's four contrast tiers).

Two files, both `deploy/preview.coo.ee/`:

- `catalogs.json` — the catalog entry.
- `producers.json` — trust for `yschimke/m3-catalog`'s `design-artifacts/*`. **Not optional bookkeeping:** a catalog whose repo isn't trusted serves as `unverified`, which on this box means it loses the live lane. m3-catalog publishes with `publish-live-bundle: true` + `split-per-preview: true` precisely so its stickers re-render on demand, so without the trust entry the feature it was built around would be off.

No image rebuild needed — `publish-preview-config.yml` applies both additively over the admin API on merge.

## Test plan

- [x] Both files parse as JSON.
- [x] Every catalog in `catalogs.json` has a matching trusted repo in `producers.json` (checked across all 22 entries, not just the new one).
- [x] `design-artifacts/m3-catalog` exists and carries a complete bundle (`catalog.json` reports 50 components; `images/` 188 files, `figma/` 238 SVGs).
- [ ] After merge: `publish-preview-config.yml` succeeds and `https://preview.coo.ee/m3-catalog/` serves, verified (not `unverified`), with the theme select offering all six modes.

Config-only; no rendered output in this repo changes, so there is no visual before/after to embed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLc8Vf7Cp97WpjbAdh1AWk)_