### PR TITLE
fix(ci): stop the baseline push from dropping history.json

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -852,6 +852,21 @@ runs:
           exit 0
         fi
 
+        # The CLI may be absent (`cli-version: none`) or predate this subcommand — `cli-version:
+        # auto`, the default, installs the release matching the consumer's pinned plugin, which
+        # will not know `history-manifest` until one ships. Probe for the capability instead of
+        # parsing versions, and skip rather than fail: the renders are already pushed by this
+        # point, so failing here would break an otherwise good baseline run. The branch keeps the
+        # manifest it already had (carried forward in compose.sh), just not refreshed this run.
+        if ! command -v compose-preview >/dev/null 2>&1; then
+          echo "::notice::history manifest: no compose-preview on PATH (cli-version: none?); skipping history.json."
+          exit 0
+        fi
+        if ! compose-preview inspect history-manifest --help >/dev/null 2>&1; then
+          echo "::notice::history manifest: installed CLI has no 'inspect history-manifest'; skipping history.json. Upgrade the CLI to publish render history."
+          exit 0
+        fi
+
         # The staging repo was fetched --depth=1, and a shallow log would silently truncate every
         # timeline. Fetch the branch's history into a scratch repo instead. --filter=blob:none is
         # exact rather than merely cheap here: the extractor reads blob SHAs out of tree objects

--- a/.github/actions/apply/pipelines/compose.sh
+++ b/.github/actions/apply/pipelines/compose.sh
@@ -139,6 +139,11 @@ if [ "$MODE" = "baseline" ]; then
     git show "FETCH_HEAD:baselines.json" > _prior_baselines/baselines.json 2>/dev/null || true
     git archive FETCH_HEAD renders 2>/dev/null \
       | tar -x -C _prior_baselines/ 2>/dev/null || true
+    # Redirection creates the file even when `git show` fails, so drop it on failure rather than
+    # carrying an empty manifest forward as if it were real.
+    git show "FETCH_HEAD:history.json" > _prior_baselines/history.json 2>/dev/null \
+      || rm -f _prior_baselines/history.json
+    [ -s _prior_baselines/history.json ] || rm -f _prior_baselines/history.json
   fi
 
   python3 "$ACTION_PATH/../lib/compare-previews.py" generate _previews.json \
@@ -148,6 +153,17 @@ if [ "$MODE" = "baseline" ]; then
     --prior-baselines _prior_baselines/baselines.json \
     --prior-renders _prior_baselines/renders \
     "${AB_ARGS[@]}"
+
+  # Carry the published history.json into the staged tree. push-branch.sh commits the staging dir
+  # as the whole tree, so a file absent here is *deleted* from the branch — without this the render
+  # push would drop the manifest every run, leaving a window with no history at all if the
+  # regeneration step later skips. It also keeps SKIP_IF_UNCHANGED meaningful: comparing a tree
+  # that never has history.json against a parent that does would never match, so an unchanged
+  # render set would still push a commit. The manifest is refreshed in a follow-up commit once the
+  # new tip exists (see "Publish compose baseline render history" in action.yml).
+  if [ -f _prior_baselines/history.json ]; then
+    cp _prior_baselines/history.json _baselines/history.json
+  fi
 
   # Stage the push commit MSG into the staging dir for the post-wait step.
   echo "Update preview baselines from ${GITHUB_SHA::8}" > _baselines/_push_msg

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryManifestCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryManifestCommand.kt
@@ -83,6 +83,19 @@ class HistoryManifestCommand(
       exit(1)
     }
 
+    // Resolve the ref up front. PreviewHistory.read returns an empty map when git exits non-zero,
+    // so a typo'd or unfetched ref is otherwise indistinguishable from "no history" — and since
+    // the publish step overwrites history.json with whatever this writes, that would silently
+    // replace a good manifest with an empty one.
+    val generatedFrom =
+      resolveSha(repoDir, branch)
+        ?: run {
+          stderr(
+            "compose-preview history-manifest: '$branch' is not a ref this repository can resolve."
+          )
+          exit(1)
+        }
+
     val timelines =
       try {
         PreviewHistory.read(repoDir, branch, RENDERS_DIR)
@@ -93,7 +106,17 @@ class HistoryManifestCommand(
         exit(1)
       }
 
-    val generatedFrom = resolveSha(repoDir, branch) ?: branch
+    // A resolvable ref with baselines entries but no render history means the log read failed or
+    // the pathspec matched nothing — never a legitimately empty branch. Refuse rather than publish
+    // a manifest asserting this branch has no history.
+    if (timelines.isEmpty()) {
+      stderr(
+        "compose-preview history-manifest: '$branch' resolved but yielded no render history " +
+          "under '$RENDERS_DIR/', while baselines.json lists ${pathToPreviewId.size} previews; " +
+          "refusing to write an empty manifest."
+      )
+      exit(1)
+    }
     val manifest = PreviewHistoryManifest.build(timelines, pathToPreviewId, generatedFrom)
 
     output.absoluteFile.parentFile?.mkdirs()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryManifestCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryManifestCommandTest.kt
@@ -162,6 +162,67 @@ class HistoryManifestCommandTest {
   }
 
   @Test
+  fun `an unresolvable ref is an error, not an empty manifest`() {
+    // PreviewHistory.read returns an empty map when git exits non-zero, so without an up-front ref
+    // check a typo'd or unfetched ref looks exactly like "this branch has no history" — and the
+    // publish step would then overwrite a good history.json with an empty one.
+    val repo = deliveryRepo("publish" to "v1")
+    val output = File(repo, "history.json")
+
+    val error =
+      runCatching {
+          HistoryManifestCommand(
+              args =
+                listOf("--repo", repo.path, "--branch", "no-such-ref", "--output", output.path),
+              workingDir = repo,
+              stdout = {},
+              stderr = {},
+              exit = { throw CommandExit(it) },
+            )
+            .run()
+        }
+        .exceptionOrNull()
+
+    assertEquals(1, assertIs<CommandExit>(error).code)
+    assertFalse(output.exists(), "must not overwrite a published manifest with an empty one")
+  }
+
+  @Test
+  fun `a resolvable ref with no render history refuses rather than emptying the manifest`() {
+    // Baselines list previews but the log shows no renders: the read failed or the pathspec found
+    // nothing. Either way it is never a legitimately empty branch.
+    val repo = createTempDirectory("history-manifest-empty").toFile()
+    fun git(vararg a: String) {
+      ProcessBuilder(listOf("git") + a).directory(repo).redirectErrorStream(true).start().waitFor()
+    }
+    git("init", "--quiet", "--initial-branch", "main")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    File(repo, "baselines.json").writeText(baselines)
+    git("add", "-A")
+    git("commit", "--quiet", "-m", "baselines only, no renders")
+    val output = File(repo, "history.json")
+
+    val err = mutableListOf<String>()
+    val error =
+      runCatching {
+          HistoryManifestCommand(
+              args = listOf("--repo", repo.path, "--branch", "main", "--output", output.path),
+              workingDir = repo,
+              stdout = {},
+              stderr = { err += it },
+              exit = { throw CommandExit(it) },
+            )
+            .run()
+        }
+        .exceptionOrNull()
+
+    assertEquals(1, assertIs<CommandExit>(error).code)
+    assertFalse(output.exists())
+    assertContains(err.joinToString("\n"), "refusing to write an empty manifest")
+  }
+
+  @Test
   fun `--help prints usage and names the sibling command it is not`() {
     val out = mutableListOf<String>()
     HistoryManifestCommand(


### PR DESCRIPTION
## Summary

Follow-up to #3415. Codex left three findings on it (two P1) that were correct, but the PR merged before I could push the fixes — so these defects are currently live on `main`. New branch off `main` since #3415 is finished.

All three were reproduced before fixing, not just reasoned about.

### P1 — the render push deleted the manifest

`push-branch.sh` commits the staging dir as the **entire tree**, and `compare-previews.py generate` rebuilds that dir each run with only `baselines.json`, `renders/`, `README.md`. So the render push deleted `history.json` and the follow-up commit put it back. Two consequences:

- **`SKIP_IF_UNCHANGED` could never match** — the new tree always lacked a file the parent had — so every baseline run pushed a commit even with zero render changes, churning a branch whose whole point is being diffable.
- If the regeneration step took its skip path, the branch was left with **no manifest at all**.

`compose.sh` now carries the published manifest into the staged tree. Demonstrated on a simulated branch, both cases against the same clean parent:

```
parent tip: baselines.json  history.json  renders/m/A.png

A) staging WITHOUT history.json (the bug), renders unchanged:
   -> PUSHED 6346fcb        # manifest-deleting commit, for no change
B) staging WITH carried history.json, renders unchanged:
   -> SKIPPED (no new commit)
```

### P1 — unconditional CLI invocation broke consumers

This one hurts downstream repos more than this one. `cli-version: none` installs no CLI at all, and `auto` — **the default** — installs the release matching the consumer's pinned plugin, which won't know `history-manifest` until one ships. Either way the step failed *after* the renders were pushed, turning an otherwise good baseline run red.

It now probes for the subcommand (`inspect history-manifest --help`) rather than parsing versions, and skips with a notice. An older or absent CLI keeps the manifest it already has instead of failing the run.

### P2 — git failure was indistinguishable from empty history

`PreviewHistory.read` returns an empty map when git exits non-zero:

```kotlin
val result = git.run(repoRoot, logArgs(ref, pathspec))
if (!result.ok) return emptyMap()
```

So an unresolvable ref produced an empty manifest with exit 0 — and since the publish step overwrites `history.json` with whatever is produced, that would **silently replace a good manifest with an empty one**. The command now resolves the ref up front, and refuses when a resolvable ref yields no render history while `baselines.json` lists previews — never a legitimately empty branch. I fixed it in the command rather than changing `PreviewHistory.read`'s signature, since that API has other callers.

## Test plan

- 2 new tests for the refusal paths (unresolvable ref; resolvable ref with no render history), both asserting the output file is **not** written.
- **CLI suite: 1557 tests, 0 failures**; `ktfmtCheckAll` clean.
- `action.yml` parses (31 steps); `compose.sh` passes `bash -n`.
- Carry-forward behaviour verified by simulation above, against a clean parent both times — my first attempt at that comparison was contaminated by the preceding case having already mutated the branch, so I re-ran it properly.

CI plumbing only, no visual surfaces.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXp51dArWBD4dWia6GbJkV)_