### PR TITLE
fix(design-artifacts): publish design references for annotation-led catalogs

### DIFF
--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -139,6 +139,38 @@ export function imagesByPreviewFunction(spec, catalog) {
 }
 
 /**
+ * Index a catalog's images by the daemon `previewId` that produced them:
+ * `previewId -> [{ componentId, image }]`.
+ *
+ * The fallback join for an **annotation-led catalog**. [imagesByPreviewFunction] walks
+ * `spec.groups` to learn which `@Preview` function produced which sticker — but a catalog whose
+ * inventory lives in `@CatalogComponent` / `@CatalogVariant` annotations has no `groups` at all
+ * (`catalog.spec.json` carries only cover-sheet fields), so that index comes back empty and every
+ * design-map entry warns "matches no published sticker" while the catalog publishes happily around
+ * it. The references simply never appear on the delivery branch, and the server's PNG ↔ Design
+ * reference lane stays dark.
+ *
+ * Reintroducing `groups` purely to satisfy this join would restate the whole inventory in JSON —
+ * the exact duplication the annotations exist to remove, and a second source of truth that can
+ * drift from the first.
+ *
+ * `previewId` is the better key anyway: it is what the export already stamps on every catalog
+ * image, and what a design-map entry already carries to disambiguate light from dark. Joining on it
+ * is exact, where the function-name join needs the spec to say which function owns which sticker.
+ */
+export function imagesByPreviewId(catalog) {
+  const index = new Map();
+  for (const component of catalog?.components ?? []) {
+    for (const image of component?.images ?? []) {
+      if (typeof image?.previewId !== "string" || image.previewId === "") continue;
+      if (!index.has(image.previewId)) index.set(image.previewId, []);
+      index.get(image.previewId).push({ componentId: component.componentId, image });
+    }
+  }
+  return index;
+}
+
+/**
  * The reference id for a serve preview id, disambiguated when one preview carries several
  * references (a Figma node *and* a committed HTML mock, say). Capped at the server's id length —
  * an over-long id is dropped silently on the box, so it must never be emitted.
@@ -214,6 +246,8 @@ export function planDesignReferences({ designMap, spec, catalog }) {
   const warnings = [];
   const records = [];
   const index = imagesByPreviewFunction(spec, catalog);
+  // Only built when the spec-driven index yields nothing for an entry — see [imagesByPreviewId].
+  const byPreviewId = imagesByPreviewId(catalog);
   const ordinals = new Map();
 
   for (const entry of designMap?.components ?? []) {
@@ -222,15 +256,28 @@ export function planDesignReferences({ designMap, spec, catalog }) {
       warnings.push(`design-map entry has no 'path#Member' code handle: ${entry?.code ?? "?"}`);
       continue;
     }
-    const allMatches = index.get(fn);
+    // Function name first — it is the join a spec-led catalog needs, and it stays authoritative
+    // where a spec exists. An annotation-led catalog has no `groups` for that index to walk, so
+    // fall back to the entry's own `previewId`, which the export stamps on every catalog image.
+    let allMatches = index.get(fn);
+    let joinedOnPreviewId = false;
+    if ((!allMatches || allMatches.length === 0) && typeof entry?.previewId === "string") {
+      allMatches = byPreviewId.get(entry.previewId);
+      joinedOnPreviewId = Boolean(allMatches && allMatches.length > 0);
+    }
     if (!allMatches || allMatches.length === 0) {
       warnings.push(
         `design-map '${fn}' matches no published sticker — no catalog.spec.json ` +
-          `preview names that @Preview function, or its component rendered nothing`,
+          `preview names that @Preview function, no published image carries its previewId, ` +
+          `or its component rendered nothing`,
       );
       continue;
     }
-    const matches = narrowToMappedPreviewId(allMatches, entry?.previewId, fn, warnings);
+    // A previewId join has already selected exactly the named sticker, so re-narrowing on the same
+    // field is a no-op at best; skip it so the intent reads once.
+    const matches = joinedOnPreviewId
+      ? allMatches
+      : narrowToMappedPreviewId(allMatches, entry?.previewId, fn, warnings);
     if (matches.length === 0) continue;
     for (const { componentId, image } of matches) {
       const previewId = servePreviewId(image.path);

--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -157,17 +157,65 @@ export function imagesByPreviewFunction(spec, catalog) {
  * `previewId` is the better key anyway: it is what the export already stamps on every catalog
  * image, and what a design-map entry already carries to disambiguate light from dark. Joining on it
  * is exact, where the function-name join needs the spec to say which function owns which sticker.
+ *
+ * ### Two id namespaces
+ *
+ * The two sides are NOT written in the same alphabet, and comparing them verbatim silently drops
+ * references. A design-map entry records the **raw discovery id** — the one the daemon keys renders
+ * on — while a catalog image's `previewId` comes from the bundle manifest, which carries the
+ * **sanitised in-bundle form** (`BundleCommand.kt`: "The manifest's previewIds carry the sanitised
+ * in-bundle form; the daemon keys renders on the RAW discovery id"). Anything outside
+ * `[A-Za-z0-9._-]` becomes `_`, so a `@Preview(name = "Small Round")` is `…_Small Round` in the
+ * design-map and `…_Small_Round` in the catalog.
+ *
+ * So the index is keyed by BOTH forms. An exact hit wins; otherwise the entry's id is sanitised and
+ * matched against the same projection. Catalogs whose preview names need no sanitising (`Light` /
+ * `Dark`) are unaffected either way — which is exactly why this gap survives casual testing.
  */
 export function imagesByPreviewId(catalog) {
-  const index = new Map();
+  const exact = new Map();
+  const sanitised = new Map();
   for (const component of catalog?.components ?? []) {
     for (const image of component?.images ?? []) {
       if (typeof image?.previewId !== "string" || image.previewId === "") continue;
-      if (!index.has(image.previewId)) index.set(image.previewId, []);
-      index.get(image.previewId).push({ componentId: component.componentId, image });
+      const match = { componentId: component.componentId, image };
+      if (!exact.has(image.previewId)) exact.set(image.previewId, []);
+      exact.get(image.previewId).push(match);
+
+      const key = sanitizeBundleEntryId(image.previewId);
+      if (!sanitised.has(key)) sanitised.set(key, []);
+      sanitised.get(key).push(match);
     }
   }
-  return index;
+  return { exact, sanitised };
+}
+
+/**
+ * Mirrors `sanitizeBundleEntryId` in `gradle-plugin/.../BundlePreviewTask.kt`, the transform that
+ * turns a raw discovery id into its in-bundle entry name. Kept character-identical to that regex:
+ * a divergence here reintroduces exactly the silent-drop bug this exists to close.
+ *
+ * Note it is idempotent — sanitising an already-sanitised id is a no-op — which is what lets the
+ * lookup below sanitise both sides without caring which form it started from.
+ */
+export function sanitizeBundleEntryId(id) {
+  return String(id).replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+/**
+ * Resolve a design-map entry's `previewId` against the catalog, across both id namespaces.
+ *
+ * Returns `[]` when nothing matches, and also when the sanitised form matches SEVERAL images. That
+ * second case is `uniqueBundleEntryId`'s collision suffix: two distinct raw ids that sanitise the
+ * same are disambiguated in-bundle (`Foo_A_B`, `Foo_A_B-2`), and the raw id alone can no longer say
+ * which one it meant. Publishing a reference against a coin-flip is worse than publishing none, so
+ * the caller warns instead.
+ */
+function matchesForPreviewId({ exact, sanitised }, previewId) {
+  const direct = exact.get(previewId);
+  if (direct && direct.length > 0) return direct;
+  const viaSanitised = sanitised.get(sanitizeBundleEntryId(previewId)) ?? [];
+  return viaSanitised.length === 1 ? viaSanitised : [];
 }
 
 /**
@@ -262,8 +310,8 @@ export function planDesignReferences({ designMap, spec, catalog }) {
     let allMatches = index.get(fn);
     let joinedOnPreviewId = false;
     if ((!allMatches || allMatches.length === 0) && typeof entry?.previewId === "string") {
-      allMatches = byPreviewId.get(entry.previewId);
-      joinedOnPreviewId = Boolean(allMatches && allMatches.length > 0);
+      allMatches = matchesForPreviewId(byPreviewId, entry.previewId);
+      joinedOnPreviewId = allMatches.length > 0;
     }
     if (!allMatches || allMatches.length === 0) {
       warnings.push(

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -7,6 +7,7 @@ import {
   functionNameOf,
   imagesByPreviewFunction,
   imagesByPreviewId,
+  sanitizeBundleEntryId,
   planDesignReferences,
   referenceId,
   referenceManifest,
@@ -536,9 +537,9 @@ test("planDesignReferences still warns when no published image carries the entry
 });
 
 test("imagesByPreviewId indexes every image that carries a previewId", () => {
-  const index = imagesByPreviewId(ANNOTATION_CATALOG);
+  const { exact } = imagesByPreviewId(ANNOTATION_CATALOG);
   assert.deepEqual(
-    [...index.keys()].sort(),
+    [...exact.keys()].sort(),
     [
       "ee.m3catalog.sections.ButtonsKt.FilledButton_Dark",
       "ee.m3catalog.sections.ButtonsKt.FilledButton_Light",
@@ -546,5 +547,106 @@ test("imagesByPreviewId indexes every image that carries a previewId", () => {
   );
   // Images with no previewId (the `--extra-renders` fold-in) are simply absent rather than keyed
   // under undefined, which would collide every one of them onto a single bucket.
-  assert.equal(imagesByPreviewId({ components: [{ images: [{ path: "a.png" }] }] }).size, 0);
+  assert.equal(imagesByPreviewId({ components: [{ images: [{ path: "a.png" }] }] }).exact.size, 0);
+});
+
+// --- The two id namespaces ---------------------------------------------------------------------
+//
+// A design-map entry records the RAW discovery id; a catalog image's previewId is the SANITISED
+// in-bundle form. Comparing them verbatim drops every entry whose `@Preview(name = …)` contains a
+// space — which is why a catalog using only "Light"/"Dark" never notices.
+
+const SANITISED_CATALOG = {
+  components: [
+    {
+      componentId: "Home/SmallRound",
+      images: [
+        {
+          variant: "ideal",
+          path: "images/home-smallround/ideal__default__light.png",
+          state: "default",
+          width: 192,
+          height: 192,
+          // What the bundle manifest carries: spaces replaced with underscores.
+          previewId: "ee.app.ui.HomeKt.HomeListViewPreview_Devices_-_Small_Round",
+        },
+      ],
+    },
+  ],
+};
+
+test("sanitizeBundleEntryId mirrors the Kotlin transform and is idempotent", () => {
+  assert.equal(sanitizeBundleEntryId("Foo_A B"), "Foo_A_B");
+  assert.equal(sanitizeBundleEntryId("com.example.FooKt.Bar_Font scale 1.5x"),
+    "com.example.FooKt.Bar_Font_scale_1.5x");
+  assert.equal(sanitizeBundleEntryId("Foo_wearos-small-round"), "Foo_wearos-small-round");
+  assert.equal(sanitizeBundleEntryId(sanitizeBundleEntryId("Foo_A B")), sanitizeBundleEntryId("Foo_A B"));
+});
+
+test("planDesignReferences joins a raw previewId to its sanitised catalog twin", () => {
+  const designMap = {
+    components: [
+      {
+        code: "app/src/main/kotlin/ui/Home.kt#HomeListViewPreview",
+        source: "figma",
+        ref: "figma:abc/73:6",
+        // The RAW id, as discovery emits it and design-map records it.
+        previewId: "ee.app.ui.HomeKt.HomeListViewPreview_Devices - Small Round",
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({
+    designMap,
+    spec: ANNOTATION_SPEC,
+    catalog: SANITISED_CATALOG,
+  });
+
+  assert.deepEqual(warnings, []);
+  assert.equal(records.length, 1);
+  assert.match(records[0].label, /^Home\/SmallRound — figma$/);
+});
+
+test("planDesignReferences refuses to guess when a sanitised id matches several stickers", () => {
+  // `uniqueBundleEntryId`'s collision case: two distinct raw ids that sanitise to the same string.
+  // The design-map id below matches NEITHER exactly, and sanitises to a form both share — so the
+  // raw id can no longer say which was meant. A coin-flip reference is worse than none.
+  const collidingCatalog = {
+    components: [
+      {
+        componentId: "Home/Round",
+        images: [
+          { path: "a.png", width: 1, height: 1, previewId: "ee.HomeKt.P_A B" },
+          { path: "b.png", width: 1, height: 1, previewId: "ee.HomeKt.P_A/B" },
+        ],
+      },
+    ],
+  };
+
+  const ambiguous = planDesignReferences({
+    designMap: {
+      components: [
+        { code: "a.kt#P", source: "figma", ref: "figma:abc/1:1", previewId: "ee.HomeKt.P_A+B" },
+      ],
+    },
+    spec: ANNOTATION_SPEC,
+    catalog: collidingCatalog,
+  });
+  assert.deepEqual(ambiguous.records, []);
+  assert.equal(ambiguous.warnings.length, 1);
+  assert.match(ambiguous.warnings[0], /matches no published sticker/);
+
+  // An id that DOES hit one of them exactly still resolves, so the refusal is scoped to genuine
+  // ambiguity rather than to any catalog that happens to contain a collision.
+  const exact = planDesignReferences({
+    designMap: {
+      components: [
+        { code: "a.kt#P", source: "figma", ref: "figma:abc/1:1", previewId: "ee.HomeKt.P_A B" },
+      ],
+    },
+    spec: ANNOTATION_SPEC,
+    catalog: collidingCatalog,
+  });
+  assert.deepEqual(exact.warnings, []);
+  assert.equal(exact.records.length, 1);
 });

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -6,6 +6,7 @@ import {
   derivationMismatches,
   functionNameOf,
   imagesByPreviewFunction,
+  imagesByPreviewId,
   planDesignReferences,
   referenceId,
   referenceManifest,
@@ -442,4 +443,108 @@ test("planDesignReferences warns when the entry's previewId matches no published
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /ContactRowChatPreview_Typo/);
   assert.match(warnings[0], /ContactRowChatPreview_Light/);
+});
+
+// --- Annotation-led catalogs (no `spec.groups`) ------------------------------------------------
+//
+// The inventory lives in `@CatalogComponent` / `@CatalogVariant` annotations and `catalog.spec.json`
+// carries only cover-sheet fields, so the function-name index has nothing to walk. Before the
+// previewId fallback, every entry in such a repo warned "matches no published sticker" and the
+// delivery branch published no `references/` at all — a silent, total loss of the PNG ↔ Design lane.
+
+const ANNOTATION_SPEC = {
+  system: "m3-catalog",
+  title: "Material 3 Design Kit",
+  modes: ["light", "dark"],
+};
+
+const ANNOTATION_CATALOG = {
+  components: [
+    {
+      componentId: "Button/Filled",
+      images: [
+        {
+          variant: "ideal",
+          path: "images/button-filled/ideal__default__light.png",
+          state: "default",
+          theme: "light",
+          width: 300,
+          height: 210,
+          previewId: "ee.m3catalog.sections.ButtonsKt.FilledButton_Light",
+        },
+        {
+          variant: "ideal",
+          path: "images/button-filled/ideal__default__dark.png",
+          state: "default",
+          theme: "dark",
+          width: 300,
+          height: 210,
+          previewId: "ee.m3catalog.sections.ButtonsKt.FilledButton_Dark",
+        },
+      ],
+    },
+  ],
+};
+
+test("planDesignReferences joins on previewId when the spec declares no groups", () => {
+  const designMap = {
+    components: [
+      {
+        code: "catalog/src/main/kotlin/ee/m3catalog/sections/Buttons.kt#FilledButton",
+        source: "figma",
+        ref: "figma:abc/57994:2227",
+        previewId: "ee.m3catalog.sections.ButtonsKt.FilledButton_Light",
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({
+    designMap,
+    spec: ANNOTATION_SPEC,
+    catalog: ANNOTATION_CATALOG,
+  });
+
+  assert.deepEqual(warnings, []);
+  // Exactly the light sticker: the previewId join selects one image, so the dark twin is not
+  // published against a light design.
+  assert.equal(records.length, 1);
+  assert.equal(records[0].raster.width, 300);
+  assert.match(records[0].label, /^Button\/Filled — figma$/);
+});
+
+test("planDesignReferences still warns when no published image carries the entry's previewId", () => {
+  const designMap = {
+    components: [
+      {
+        code: "catalog/src/main/kotlin/ee/m3catalog/sections/Buttons.kt#GhostButton",
+        source: "figma",
+        ref: "figma:abc/1:2",
+        previewId: "ee.m3catalog.sections.ButtonsKt.GhostButton_Light",
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({
+    designMap,
+    spec: ANNOTATION_SPEC,
+    catalog: ANNOTATION_CATALOG,
+  });
+
+  assert.deepEqual(records, []);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /matches no published sticker/);
+});
+
+test("imagesByPreviewId indexes every image that carries a previewId", () => {
+  const index = imagesByPreviewId(ANNOTATION_CATALOG);
+  assert.deepEqual(
+    [...index.keys()].sort(),
+    [
+      "ee.m3catalog.sections.ButtonsKt.FilledButton_Dark",
+      "ee.m3catalog.sections.ButtonsKt.FilledButton_Light",
+    ],
+  );
+  // Images with no previewId (the `--extra-renders` fold-in) are simply absent rather than keyed
+  // under undefined, which would collide every one of them onto a single bucket.
+  assert.equal(imagesByPreviewId({ components: [{ images: [{ path: "a.png" }] }] }).size, 0);
 });


### PR DESCRIPTION
## Summary

**An annotation-led catalog publishes no design references at all, silently.**

`planDesignReferences` joins a design-map entry to its published sticker through `imagesByPreviewFunction`, which walks `spec.groups` to learn which `@Preview` function produced which image. A catalog whose inventory lives in `@CatalogComponent` / `@CatalogVariant` annotations has **no `groups`** — its `catalog.spec.json` carries only cover-sheet fields — so that index comes back empty, every entry warns `matches no published sticker`, and the delivery branch gets no `references/` directory.

Nothing looks broken: the catalog itself publishes fine. The server's PNG ↔ Design reference lane just stays dark.

Observed on [yschimke/m3-catalog](https://github.com/yschimke/m3-catalog) — 37 mapped components, 37 warnings, **zero** references published:

```
##[warning]design-references: design-map 'FilledButton' matches no published sticker — no
catalog.spec.json preview names that @Preview function, or its component rendered nothing
… ×37
```

## Approach

Reintroducing `groups` to satisfy the join would restate the entire inventory in JSON — the duplication the annotations exist to remove, and a second source of truth free to drift from the first.

So join on **`previewId`** instead, as a fallback when the function-name index yields nothing. It is the better key regardless: the export already stamps it on every catalog image, and a design-map entry already carries it to disambiguate light from dark, so the join is *exact* where the function-name one needs the spec to say which function owns which sticker. It also arrives pre-narrowed, so `narrowToMappedPreviewId` is skipped on that path — re-narrowing on the field just joined is a no-op.

Function name stays first and authoritative, so **a spec-led catalog behaves exactly as before**; the fallback only runs where the old path found nothing. An entry naming a `previewId` no published image carries still warns, which is the case the gate exists for.

## Test plan

- [x] `node --test scripts/design-artifacts/design-references.test.mjs` — **18 pass**: 15 pre-existing unchanged, plus 3 new covering the annotation-led join, the still-warns case, and `imagesByPreviewId`'s handling of images with no `previewId` (they must be *absent*, not bucketed under `undefined`, which would collide every `--extra-renders` image into one entry).
- [x] Whole driver suite `node --test scripts/design-artifacts/*.test.mjs` — 443 pass, 2 fail. Both failures (`package-version.test.mjs`, `rc-compare-pixels.test.mjs`) reproduce on a clean `origin/main` worktree and are in files this PR does not touch.
- [ ] After merge: m3-catalog's next Design Artifacts run publishes `references/index.json` and `preview.coo.ee/m3-catalog/` shows the side-by-side.

Driver change with no rendered output, so there is no visual before/after to embed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLc8Vf7Cp97WpjbAdh1AWk)_