### PR TITLE
feat(design-artifacts): make the render timeout an input

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -217,6 +217,20 @@ on:
         required: false
         type: number
         default: 60
+      render-timeout:
+        description: >
+          Seconds `bundle pack` may spend rendering, per module. This is the INNER timeout on the
+          render itself, not the job timeout above — a catalog can sit well inside `timeout-minutes`
+          and still be killed here, and the failure reads as a bare "Build timed out after 600s"
+          well before the publish step it never reached.
+
+          Scales with the number of previews, so a catalog that fans a component out over a variant
+          matrix outgrows the default long before it outgrows the job. Raise it rather than thinning
+          coverage; the alternative lever is spec-side render priority (`priority: "deferred"` /
+          `modePriority`), which needs a live path.
+        required: false
+        type: number
+        default: 600
     secrets:
       buildfetch_ro_token:
         description: 'Optional read-only BuildFetch Gradle remote-cache token, to pull cached task outputs instead of building cold.'
@@ -459,7 +473,8 @@ jobs:
           exclude=(); if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS"); fi
           if [ -n "${EXCLUDE_PREVIEW_ROWS:-}" ]; then exclude+=(--exclude-preview-row "$EXCLUDE_PREVIEW_ROWS"); fi
           run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics --progress \
-            "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" --timeout 600
+            "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" \
+            --timeout ${{ inputs.render-timeout }}
 
       - name: Render extra module
         if: ${{ inputs.extra-module != '' }}
@@ -469,7 +484,8 @@ jobs:
           run() { if [ "${{ inputs.desktop-render }}" = "true" ]; then xvfb-run -a -s "-screen 0 2000x1400x24" "$@"; else "$@"; fi; }
           embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
           run compose-preview bundle pack --module "${{ inputs.extra-module }}" --with-semantics --progress \
-            "${embed[@]}" -o "$GITHUB_WORKSPACE/extra-bundle.png" --timeout 600
+            "${embed[@]}" -o "$GITHUB_WORKSPACE/extra-bundle.png" \
+            --timeout ${{ inputs.render-timeout }}
 
       # Save the font cache even when a render step FAILED. A cold-cache run that downloaded
       # some faces before a later one failed to resolve must persist what it got, so the

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -536,6 +536,20 @@ preview server already disambiguates a *colliding* card label on its own
 (`Edgebutton · Small Round`), so the fan-out is for when you want authored ids and
 captions per breakpoint, not merely readable labels.
 
+### The render timeout scales with the sheet, not the job
+
+`bundle pack`'s own `--timeout` is separate from the job's `timeout-minutes`, and it is the one a
+growing catalog hits first: a sheet can sit comfortably inside a 90-minute job and still be killed
+by the inner render timeout, which surfaces as a bare `Build timed out after 600s` long before the
+publish step it never reached. The reusable workflow exposes it as `render-timeout` (seconds,
+default 600) for exactly that reason.
+
+It scales with the number of previews, so a catalog that fans one component out over a variant
+matrix outgrows the default well before it outgrows the job — `m3-catalog` crossed it going from 193
+previews to 287, which is one component family gaining its size and shape axes. Raise the input
+rather than thinning coverage; the other lever is the render priority below, which trades baked
+pixels for a live path.
+
 ### Render priority: deferring the long tail to the live server
 
 A catalog that publishes with a live path — `publish-live-bundle: true` (the bundle


### PR DESCRIPTION
## Summary

`bundle pack`'s `--timeout` was hard-coded at `600` in both render steps of the reusable workflow, so **a catalog that outgrows ten minutes of rendering cannot publish without forking the pipeline** — the thing the reusable workflow exists to prevent.

It's also not the timeout anyone looks at. A sheet can sit comfortably inside a 90-minute `timeout-minutes` and still be killed here, and it surfaces as a bare Gradle message several steps before the publish it never reached:

```
Build timed out after 600s, cancelling...
Gradle bundle task failed. Re-run with --verbose to surface the underlying Gradle error.
```

Nothing in that names the knob, because until now there wasn't one.

The limit scales with **preview count**, not repo size, so the catalogs that hit it are the ones doing the most work per component. [yschimke/m3-catalog](https://github.com/yschimke/m3-catalog) crossed it going from 193 previews to 287 — that's *one* component family (buttons) gaining its expressive size × shape axes, and it's the shape of every remaining family in that sheet.

Default stays `600`, so **every existing caller renders exactly as before.**

Documented next to render priority in `DESIGN_CATALOGS.md`, since the two are alternatives to each other: raise the timeout, or defer the long tail to the live server and pay for a live path.

## Test plan

- [x] YAML parses.
- [x] `render-timeout` reaches both `bundle pack` invocations (primary and `extra-module`); default `600` preserves current behaviour for every caller that doesn't set it.
- [ ] After merge: m3-catalog sets `render-timeout: 1800` and its Design Artifacts run publishes 287 previews instead of dying at 600s.

Workflow input with no rendered output, so there is no visual before/after to embed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLc8Vf7Cp97WpjbAdh1AWk)_