### PR TITLE
fix(ci): publish history.json on branches that do not have one yet

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -889,21 +889,49 @@ runs:
           --baselines "$stage/baselines.json" \
           --output "$stage/history.json"
 
-        # Second commit, carrying the full tree plus history.json. It has to follow the render push
-        # rather than ride along with it: computed beforehand, the manifest could not describe the
-        # very publish it ships with, so the newest render would be missing from its own timeline.
-        # The extractor filters on the `renders` pathspec, so this commit is invisible to the next
-        # run's history and cannot pollute it.
-        export MSG="Update preview history from ${GITHUB_SHA::8}"
-        export TARGET_BRANCH="$BASELINE_BRANCH"
-        export SKIP_IF_UNCHANGED=1
-        export SHA_OUTPUT_FILE=""
-        # The render push already ran `git init` + `git remote add origin` in here, and
-        # push-branch.sh does both unconditionally — a second run would die on "remote origin
-        # already exists". The staging repo is throwaway, so drop it and let the helper rebuild.
-        rm -rf "$stage/.git"
-        cd "$stage"
-        bash "$ACTION_PATH/lib/push-branch.sh"
+        # Second commit, following the render push rather than riding along with it: computed
+        # beforehand, the manifest could not describe the very publish it ships with, so the newest
+        # render would be missing from its own timeline. The extractor filters on the `renders`
+        # pathspec, so this commit is invisible to the next run's history and cannot pollute it.
+        #
+        # Built as a genuine delta — the tip's tree with one path replaced — NOT via
+        # push-branch.sh. That helper snapshots a directory into a fixed tree and re-parents it onto
+        # whatever the current tip is, so pushing a staging dir that was staged earlier silently
+        # reverts anything published in between: a concurrent baseline run's renders and
+        # baselines.json would be overwritten by this run's older copies. Touching only history.json
+        # makes that impossible regardless of how the runs interleave.
+        #
+        # read-tree/write-tree work in the blob:none clone because they only need tree objects and
+        # the one new blob; the renders' contents are never fetched.
+        MSG="Update preview history from ${GITHUB_SHA::8}"
+        cd _history_repo
+        attempt=1
+        while :; do
+          PARENT=$(git rev-parse FETCH_HEAD)
+          NEW_BLOB=$(git hash-object -w "$GITHUB_WORKSPACE/$stage/history.json")
+          OLD_BLOB=$(git rev-parse --quiet --verify "FETCH_HEAD:history.json" 2>/dev/null || true)
+          if [ "$NEW_BLOB" = "$OLD_BLOB" ]; then
+            echo "history manifest: history.json unchanged on ${BASELINE_BRANCH}; nothing to push."
+            break
+          fi
+          git read-tree "$PARENT"
+          git update-index --add --cacheinfo "100644,${NEW_BLOB},history.json"
+          TREE=$(git write-tree)
+          COMMIT=$(git commit-tree "$TREE" -p "$PARENT" -m "$MSG")
+          if git push --quiet origin "${COMMIT}:refs/heads/${BASELINE_BRANCH}" 2>&1; then
+            echo "history manifest: published ${COMMIT} to ${BASELINE_BRANCH}."
+            break
+          fi
+          if [ "$attempt" -ge 5 ]; then
+            echo "::warning::history manifest: lost the push race ${attempt}x; skipping history.json this run."
+            break
+          fi
+          echo "history manifest: lost the push race; retry ${attempt}/5."
+          attempt=$((attempt + 1))
+          sleep $((attempt * 2))
+          # Re-fetch so the retry re-parents onto (and re-reads) the new tip.
+          git fetch --quiet --filter=blob:none origin "$BASELINE_BRANCH" || true
+        done
 
     - name: Push resource baseline / PR renders
       if: steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.resources == '1'

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -841,12 +841,13 @@ runs:
       run: |
         set -euo pipefail
         stage=_baselines
-        # Nothing pushed (no staged renders, or the tree was unchanged) means the branch log is
-        # unchanged too, so any manifest we'd write would be byte-identical to the published one.
-        if [ ! -s "$GITHUB_WORKSPACE/_baseline_pushed_sha" ]; then
-          echo "history manifest: no baseline push this run, skipping."
-          exit 0
-        fi
+        # Deliberately NOT gated on a render push having happened. That gate assumed a current
+        # manifest already exists, so "no push" implies "nothing to regenerate" — which is false on
+        # a branch that has no history.json yet. Since an unchanged render set correctly skips its
+        # push, the manifest could then never be created: the first publish would wait for a render
+        # to change, which is exactly the deadlock the branch was sitting in. Running every baseline
+        # run costs a metadata-only fetch (~1s) and the second push's SKIP_IF_UNCHANGED no-ops when
+        # the regenerated manifest matches what is already published.
         if [ ! -f "$stage/baselines.json" ]; then
           echo "history manifest: no staged baselines.json, skipping."
           exit 0

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryManifestCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryManifestCommand.kt
@@ -87,14 +87,20 @@ class HistoryManifestCommand(
     // so a typo'd or unfetched ref is otherwise indistinguishable from "no history" — and since
     // the publish step overwrites history.json with whatever this writes, that would silently
     // replace a good manifest with an empty one.
-    val generatedFrom =
-      resolveSha(repoDir, branch)
-        ?: run {
-          stderr(
-            "compose-preview history-manifest: '$branch' is not a ref this repository can resolve."
-          )
-          exit(1)
-        }
+    if (resolveSha(repoDir, branch) == null) {
+      stderr(
+        "compose-preview history-manifest: '$branch' is not a ref this repository can resolve."
+      )
+      exit(1)
+    }
+
+    // Anchor to the newest commit that touched renders, NOT the branch tip. The manifest ships in
+    // its own commit, which moves the tip — so a tip-derived value changes on every publish even
+    // when no render did, the regenerated file never matches the published one, and each baseline
+    // run appends another history commit forever. Pinning to the render tip makes a no-op run
+    // regenerate a byte-identical file, which the push then skips. It also describes the manifest
+    // better: this is the render state the timeline covers.
+    val generatedFrom = renderTip(repoDir, branch) ?: resolveSha(repoDir, branch) ?: branch
 
     val timelines =
       try {
@@ -172,6 +178,16 @@ private fun gitShow(repoDir: File, ref: String, path: String): String? =
           .start()
       val out = p.inputStream.bufferedReader().readText()
       if (p.waitFor() == 0 && out.isNotBlank()) out else null
+    }
+    .getOrNull()
+
+/** Newest commit on [ref] that touched the renders tree, ignoring history-only commits. */
+private fun renderTip(repoDir: File, ref: String, pathspec: String = "renders"): String? =
+  runCatching {
+      val p =
+        ProcessBuilder("git", "rev-list", "-1", ref, "--", pathspec).directory(repoDir).start()
+      val out = p.inputStream.bufferedReader().readText().trim()
+      if (p.waitFor() == 0 && out.isNotEmpty()) out else null
     }
     .getOrNull()
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewHistoryManifest.kt
@@ -61,9 +61,14 @@ object PreviewHistoryManifest {
     @SerialName("formatVersion")
     val formatVersion: String = FORMAT_VERSION,
     /**
-     * Delivery-branch commit this was computed from. A viewer can compare it against the branch tip
-     * to tell whether the manifest is current; it is expected to lag by exactly the commit that
-     * carries the manifest itself.
+     * The newest delivery-branch commit **touching renders** that this timeline covers — not the
+     * branch tip.
+     *
+     * The distinction is load-bearing. The manifest ships in its own commit, so a tip-derived value
+     * would change on every publish even when no render did; the regenerated file would never match
+     * the published one and each run would append another history commit forever. Anchoring to the
+     * render tip makes an unchanged branch regenerate byte-identically. A viewer comparing
+     * staleness should compare against the newest render commit, which is exactly this.
      */
     @SerialName("generatedFrom") val generatedFrom: String,
     /** Keyed by preview id, the same keys `baselines.json` uses. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryManifestCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryManifestCommandTest.kt
@@ -78,8 +78,8 @@ class HistoryManifestCommandTest {
 
   @Test
   fun `generatedFrom is the resolved sha, not the ref name`() {
-    // A viewer compares this against the branch tip to tell whether the manifest is stale; a ref
-    // name would always look current.
+    // A viewer compares this against the newest render commit to tell whether the manifest is
+    // stale; a ref name would always look current.
     val repo = deliveryRepo("publish" to "v1")
     val output = File(repo, "history.json")
 
@@ -87,6 +87,55 @@ class HistoryManifestCommandTest {
 
     val manifest = assertNotNull(PreviewHistoryManifest.decode(output.readText()))
     assertTrue(manifest.generatedFrom.matches(Regex("[0-9a-f]{40}")), manifest.generatedFrom)
+  }
+
+  @Test
+  fun `a history-only commit does not change the manifest`() {
+    // The manifest ships in its own commit, which moves the branch tip. Anchoring generatedFrom to
+    // the tip would make every regeneration differ from the published file, so each baseline run
+    // would append another history commit forever. Regenerating after a history-only commit must
+    // be byte-identical so the push can skip.
+    val repo = deliveryRepo("Update preview baselines from aaaaaaaa" to "v1")
+    val first = File(repo, "history.json")
+    run(repo, "--output", first.path)
+    val firstText = first.readText()
+
+    // Commit the manifest, exactly as the publish step does — tip moves, renders do not.
+    ProcessBuilder("git", "add", "-A").directory(repo).start().waitFor()
+    ProcessBuilder("git", "commit", "--quiet", "-m", "Update preview history from aaaaaaaa")
+      .directory(repo)
+      .start()
+      .waitFor()
+
+    val second = File(repo, "regenerated.json")
+    run(repo, "--output", second.path)
+
+    assertEquals(firstText, second.readText(), "regeneration must be byte-identical, or CI churns")
+  }
+
+  @Test
+  fun `generatedFrom tracks the newest render commit, not the branch tip`() {
+    val repo = deliveryRepo("Update preview baselines from aaaaaaaa" to "v1")
+    val renderTip =
+      ProcessBuilder("git", "rev-parse", "HEAD")
+        .directory(repo)
+        .start()
+        .inputStream
+        .bufferedReader()
+        .readText()
+        .trim()
+    File(repo, "unrelated.txt").writeText("not a render")
+    ProcessBuilder("git", "add", "-A").directory(repo).start().waitFor()
+    ProcessBuilder("git", "commit", "--quiet", "-m", "history-only commit")
+      .directory(repo)
+      .start()
+      .waitFor()
+    val output = File(repo, "history.json")
+
+    run(repo, "--output", output.path)
+
+    val manifest = assertNotNull(PreviewHistoryManifest.decode(output.readText()))
+    assertEquals(renderTip, manifest.generatedFrom)
   }
 
   @Test


### PR DESCRIPTION
## Summary

**The manifest was never getting created.** The baseline run for the merge that shipped it (`e5f66959`, 08:44) completed **successfully**, and `compose-preview/main` still contains only `README.md`, `baselines.json`, `renders` — no `history.json`. This isn't a hypothetical: a successful run went by with the feature live and produced nothing.

Two bugs, the second of which only appears once you fix the first.

### 1. Bootstrap deadlock

The step was gated on a render push having happened:

```bash
if [ ! -s "$GITHUB_WORKSPACE/_baseline_pushed_sha" ]; then exit 0
```

on the reasoning that "nothing pushed" ⇒ the branch log is unchanged ⇒ a regenerated manifest would be byte-identical. That holds *only once a current manifest exists*. On a branch without one it's false — and it combines badly with the correct fix from #3417 that lets an unchanged render set skip its push. The first publish then waits for some render to change, which is exactly the state the branch was stuck in.

### 2. Removing the gate alone replaces a deadlock with unbounded churn

`generatedFrom` was the branch tip — and the manifest ships in its **own commit that moves the tip**. So every regeneration differed from the published file, and each run appended another history commit. Simulated, before the second fix:

```
run 2 -> PUSHED 15cf878  generatedFrom=821ede1
run 3 -> PUSHED 92244f0  generatedFrom=15cf878
commits on branch: 4          # from 3 no-op runs
```

`generatedFrom` now anchors to the **newest commit touching `renders/`**, which history-only commits don't move. An unchanged branch regenerates byte-identically and the push skips. It also describes the field better: this is the render state the timeline covers, and it's what a viewer should compare against for staleness.

### After both fixes

Same simulation, seeded to match the branch's real state today (renders present, no manifest, renders unchanged):

```
run 1 -> PUSHED                      # bootstraps, with no render push
run 2 -> SKIPPED (byte-identical)
run 3 -> SKIPPED (byte-identical)

commits on branch: 2
  15f408a Update preview history from run1
  1d05be6 Update preview baselines from 11111111
```

## Test plan

Two new tests pin the properties that would otherwise break silently — both are regressions that produce *wrong output*, not failures:

- regenerating after a history-only commit is **byte-identical** (guards the churn)
- `generatedFrom` tracks the render tip, not the branch tip

Plus: **CLI suite 1584 tests, 0 failures**; `ktfmtCheckAll` clean; `action.yml` parses (31 steps).

Verified by simulation against a bare repo seeded to the branch's actual current state, both before and after, rather than reasoning about the shell.

## Note

This is the third round of fixes on this pipeline (#3415 → #3417 → here). The pattern is consistent: each defect was invisible in review and only showed up by running the thing against realistic state. The two properties above now have tests, so this specific class of silent-wrong can't come back.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXp51dArWBD4dWia6GbJkV)_