### PR TITLE
fix(catalog): make the sticker helper visible to a playground snippet

### DIFF
--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogStickers.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogStickers.kt
@@ -48,6 +48,12 @@ import ee.schimke.composeai.preview.CatalogComponent
 //     actually mutates state (the segmented toggle flips, the switch/chip toggle).
 // This is the one lever on which the baked and live lanes diverge, exactly as `CatalogComponent`
 // documents.
-internal fun Sticker(id: String) = CatalogSticker {
+// Public, not `internal`: the playground's "open this preview" handoff seeds ONE cluster file and
+// compiles it as its own module against the catalog's `classes/app.jar`. `internal` is
+// name-mangled and invisible across that module boundary, so every sticker in a seeded file would
+// fail to resolve its own helper — a regression the split introduced, since the helper used to be
+// `private` inside the single file the seed carried. `CatalogSticker` / `FullScreenM3` next door in
+// `CatalogTheme.kt` are public for the same reason.
+fun Sticker(id: String) = CatalogSticker {
   CatalogComponent(id, interactive = !LocalInspectionMode.current)
 }


### PR DESCRIPTION
Follow-up to #3425, from its review.

Splitting the sticker sheet moved `Sticker` out of the file that uses it and left it `internal`. The playground's "open this preview" handoff (#3418) seeds **one** cluster file and compiles it as its own module against the catalog's `classes/app.jar` — and `internal` is name-mangled and invisible across that module boundary, so every sticker in a seeded file would fail to resolve its own helper.

It used to be `private` inside the single file the seed carried, so it came along for free. The split silently took that away; this is a regression the split introduced, not a pre-existing gap.

Public, matching `CatalogSticker` / `FullScreenM3` next door in `CatalogTheme.kt` — which are public for exactly this reason and are present in the published bundle (`classes/app.jar` carries `CatalogThemeKt`, verified against `design-artifacts/compose-m3`).

To be clear about what this does and doesn't buy: it removes one *guaranteed* failure from a seeded compile. It doesn't make a seeded catalog file compile clean — a preview file is ordinary module code and still references siblings the minimized bundle doesn't export, which the playground page already says up front.

## Test plan

- `./gradlew :samples:design-catalog-m3:compileKotlin` — clean.
- `./gradlew ktfmtCheckAll` — clean.
- No rendered output change: a visibility modifier on a helper that every preview in the module already called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr)_