### PR TITLE
fix(serve): seed a variant's knob into the Wasm tier

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -5514,9 +5514,19 @@ object ServeWeb {
         val bool = kind == "bool"
         val initial =
           if (bool) (if (value == "true" || value == "1") "true" else "false") else value
+        // …and `data-knob-default` is the AUTHOR default, which for a seeded variant is not the
+        // same thing. A `@OverrideVariant` preview opens on `current` (`enabled=false`) while its
+        // author default is `true`, and the Wasm tier — unlike the PNG lane — has no baked artifact
+        // carrying that seed: it mounts the live component and has to be told. So the Wasm patch
+        // compares against this rather than against `initial`, or a variant would mount as its
+        // primary (see `wasmOverridePatch`).
+        val authorDefault = WebEscaping.htmlEscape(overrideValueText(d.default))
+        val defaultAttr =
+          if (bool) (if (authorDefault == "true" || authorDefault == "1") "true" else "false")
+          else authorDefault
         val attrs =
           "class=\"cp-knob\" data-knob-key=\"$wireKey\" data-knob-kind=\"$kind\" " +
-            "data-knob-initial=\"$initial\""
+            "data-knob-initial=\"$initial\" data-knob-default=\"$defaultAttr\""
         if (bool) {
           val checked = if (value == "true" || value == "1") " checked" else ""
           "<label class=\"cp-live-row\"><input type=\"checkbox\" $attrs$checked$dis> $label</label>"

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -832,15 +832,28 @@
     parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
     parts.push("stageBg=" + encodeURIComponent(wasmStageBg()));
     // Author-declared knobs also apply in the browser: the wasm catalog seeds its
-    // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
-    // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+    // `catalogOverride*` from these `knob.<key>` params.
+    //
+    // Compared against the AUTHOR DEFAULT, not against `data-knob-initial` as query() does — and
+    // that difference is the whole point. A `@OverrideVariant` sticker (the unchecked checkbox, the
+    // disabled button) opens with its knob already seeded away from the author default, so
+    // `val === initial` holds and an initial-based filter would send nothing. The PNG lane can
+    // afford that because the baked capture already carries the seed; the Wasm tier has no baked
+    // artifact — it mounts the live component from `?id=<slug>`, and `wasmAppSrc` strips the
+    // variant axis off the id — so an unsent seed silently mounts the PRIMARY (a checked checkbox,
+    // an enabled button) under a sticker that says otherwise. A knob genuinely at its author
+    // default is still omitted, so an ordinary sticker is unchanged.
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      // Older pages carry no `data-knob-default`; fall back to the initial so they behave as before
+      // rather than sending every knob.
+      var authorDefault = el.getAttribute("data-knob-default");
+      if (authorDefault === null) authorDefault = el.getAttribute("data-knob-initial") || "";
+      if (val === authorDefault) return;
       parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
     return parts.join("&");

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -3351,6 +3351,7 @@ class ServeWebFixtureTest {
     assertTrue(
       catalogKnobs.contains(
         "data-knob-key=\"label\" data-knob-kind=\"string\" data-knob-initial=\"Filled\" " +
+          "data-knob-default=\"Filled\" " +
           "value=\"Filled\">"
       ),
       "declared knobs are enabled on an override-renderable session",
@@ -3427,6 +3428,7 @@ class ServeWebFixtureTest {
     assertTrue(
       staticKnobs.contains(
         "data-knob-key=\"label\" data-knob-kind=\"string\" data-knob-initial=\"Filled\" " +
+          "data-knob-default=\"Filled\" " +
           "value=\"Filled\" disabled"
       ),
       "a plain static bundle leaves declared knobs disabled",
@@ -3456,6 +3458,7 @@ class ServeWebFixtureTest {
     assertTrue(
       wasmKnobs.contains(
         "data-knob-key=\"label\" data-knob-kind=\"string\" data-knob-initial=\"Filled\" " +
+          "data-knob-default=\"Filled\" " +
           "value=\"Filled\">"
       ),
       "a wasm-backed published catalog enables the declared knob controls (no trailing disabled)",

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebKnobSeedTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebKnobSeedTest.kt
@@ -1,0 +1,56 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Pins the knob attributes the viewer's Wasm patch reads.
+ *
+ * A `@OverrideVariant` sticker (the unchecked checkbox, the disabled button) opens with its knob
+ * already seeded away from the author default. The PNG lane can ignore that — the baked capture
+ * carries the seed — but the Wasm tier mounts the live component from `?id=<slug>` with the variant
+ * axis stripped off the id, so it has to be *told*. That means the page must publish both numbers:
+ * what the control opens on, and what the author declared.
+ */
+class ServeWebKnobSeedTest {
+
+  private fun declaration(key: String, default: Boolean, current: Boolean) =
+    PreviewOverrideDeclaration(
+      key = key,
+      type = "bool",
+      label = key,
+      default = PreviewOverrideValue.BooleanValue(default),
+      current = PreviewOverrideValue.BooleanValue(current),
+    )
+
+  private fun viewer(vararg declarations: PreviewOverrideDeclaration): String {
+    val preview =
+      ServePreview(id = "button-filled", label = "Filled", overrides = declarations.toList())
+    return ServeWeb.viewerPage(
+      preview,
+      token = "t",
+      basePath = "/compose-m3",
+      siblings = listOf(preview),
+      wasmSrc = "/wasm/compose-m3/?id=button-filled",
+    )
+  }
+
+  @Test
+  fun `a seeded variant publishes both the opening value and the author default`() {
+    val html = viewer(declaration("enabled", default = true, current = false))
+    // The control opens on the seed…
+    assertTrue(html.contains("""data-knob-initial="false""""), html.substringAfter("cp-knob"))
+    // …and still says what the author declared, which is the only way the Wasm patch can tell that
+    // this sticker is a variant rather than an untouched primary.
+    assertTrue(html.contains("""data-knob-default="true""""))
+  }
+
+  @Test
+  fun `an ordinary sticker opens on its author default, and says so`() {
+    val html = viewer(declaration("enabled", default = true, current = true))
+    assertTrue(html.contains("""data-knob-initial="true""""))
+    assertTrue(html.contains("""data-knob-default="true""""))
+  }
+}

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -211,13 +211,13 @@
           <div class="cp-knobs">
             <div class="cp-knobs-head">Declared overrides — edit a value to re-render.</div>
             <label>label
-  <input type="text" class="cp-knob" data-knob-key="label" data-knob-kind="string" data-knob-initial="Filled" value="Filled">
+  <input type="text" class="cp-knob" data-knob-key="label" data-knob-kind="string" data-knob-initial="Filled" data-knob-default="Filled" value="Filled">
 </label>
 <label>iconColor
-  <input type="text" class="cp-knob" data-knob-key="iconColor" data-knob-kind="color" data-knob-initial="#FF6750A4" value="#FF6750A4">
+  <input type="text" class="cp-knob" data-knob-key="iconColor" data-knob-kind="color" data-knob-initial="#FF6750A4" data-knob-default="#FF6750A4" value="#FF6750A4">
 </label>
             <label>theme.font
-              <input type="text" class="cp-knob" data-knob-key="theme.font" data-knob-kind="string" data-knob-initial="Roboto Flex" value="Roboto Flex" list="cp-dl-theme-font">
+              <input type="text" class="cp-knob" data-knob-key="theme.font" data-knob-kind="string" data-knob-initial="Roboto Flex" data-knob-default="Roboto Flex" value="Roboto Flex" list="cp-dl-theme-font">
               <datalist id="cp-dl-theme-font">
             <option value="Roboto Flex"></option>
 <option value="Google Sans Flex"></option>
@@ -336,7 +336,7 @@
   syncBg();
 })();</script>
       <script src="/assets/serve/9307-806c15ce8d932fc7/format-compare.js"></script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
@@ -264,7 +264,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -239,7 +239,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -238,7 +238,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -236,7 +236,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -229,7 +229,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
@@ -230,7 +230,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -233,7 +233,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -226,7 +226,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -227,7 +227,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -232,7 +232,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -222,7 +222,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
@@ -216,7 +216,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -277,7 +277,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1895a-d159ad5dce9d4442/viewer.js"></script>
+      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>


### PR DESCRIPTION
Found by the review of #3423, verified against the published catalog.

## The bug

Open the unchecked checkbox — or, since #3423, the disabled button — and switch the viewer to **Wasm**. You get the *checked* checkbox: the primary, under a sticker that says otherwise.

`ServeUrls.wasmAppSrc` mounts `?id=<previewId.substringBefore("__")>`, so the variant axis is stripped off the id. From the published `design-artifacts/compose-m3`:

```
images/checkbox-checked/ideal__unchecked.png     →  id=checkbox-checked  ← mounts CHECKED
images/button-filled/ideal__disabled__light.png  →  id=button-filled     ← mounts ENABLED
```

The component then reads its knob, finds no seed, and falls back to the author default.

## Why the seed was dropped

It was there to send — the viewer filtered it out. A `@OverrideVariant` sticker opens with its knob *already* at the seeded value, so `val === data-knob-initial` holds and the Wasm patch's "omit a knob still at its initial, so an unedited knob reverts to the author default" rule dropped it.

That rule is correct for `query()`: the PNG lane's baked capture already carries the seed, and sending a `knob.*` there would route a published catalog to the daemon for a slower, subtly different re-render. The Wasm tier has no baked artifact — it mounts the live component — so it has to be told.

## The fix

The page now publishes **`data-knob-default`** (the author default) alongside `data-knob-initial` (what the control opens on), and the Wasm patch compares against the former.

- A knob genuinely at its author default is still omitted → an ordinary sticker sends nothing new, and the PNG lane is untouched.
- A seeded variant now sends its seed → Wasm mounts what the sticker shows.
- Pages without the new attribute fall back to the old behaviour rather than sending every knob.

## Scope

**Pre-existing, not introduced by #3423.** The four selection-control variants (`unchecked`, `off`, `unselected` ×2) have mounted as their primaries in Wasm since they were folded onto `@OverrideVariant`. #3423 extended it to the two disabled buttons, which is how it surfaced. This fixes all six.

## Test plan

- `./gradlew :cli:test` — green. New `ServeWebKnobSeedTest` pins both numbers on the page: a seeded variant renders `data-knob-initial="false"` with `data-knob-default="true"`, and an ordinary sticker renders both as the default. Three exact-attribute assertions in `ServeWebFixtureTest` updated for the added attribute.
- `./gradlew ktfmtCheckAll` — clean.
- Golden fixtures regenerated (every viewer fixture gains the attribute on its knob rows).

No visual evidence: the change is one HTML data attribute and a JS comparison. The pixels it fixes are in the Wasm iframe, which the harness doesn't boot — the incorrect mount is the *live in-browser* component, not a baked capture, so there is no baseline that moves. The `serve-viewer-catalog-knobs` fixture covers the attribute's presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr)_