### PR TITLE
fix(ci): give the history commit a committer identity

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -874,6 +874,12 @@ runs:
         # via `git log --raw` and never opens a render, so no PNG content is needed.
         rm -rf _history_repo
         git init -q _history_repo
+        # commit-tree refuses to run without a committer identity, and a freshly `git init`ed repo
+        # has none — the render push never hit this because push-branch.sh sets its own. Without it
+        # the manifest generates fine and then the commit dies with exit 128, so the branch still
+        # advances with renders and only history.json is silently lost.
+        git -C _history_repo config user.name "github-actions[bot]"
+        git -C _history_repo config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git -C _history_repo remote add origin \
           "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git"
         if ! git -C _history_repo fetch --quiet --filter=blob:none origin "$BASELINE_BRANCH"; then


### PR DESCRIPTION
## Summary

**This is why `history.json` has never appeared on `compose-preview/main`**, through five merged PRs.

I finally pulled the job log for the baseline run on `5ae59ef2`. The step works perfectly right up to the last call:

```
compose-preview history-manifest: wrote _baselines/history.json: 531 previews,
822 versions, 5 unstable, 284 unmatched render paths dropped.
##[error]Process completed with exit code 128.
```

128 is git. The delta push (added in #3424) builds its commit in a scratch repo created by `git init`, which has **no committer identity**, and `commit-tree` refuses to run without one. `push-branch.sh` sets its own — which is exactly why the render push was never affected, and why replacing that helper with a direct `commit-tree` introduced this.

## Why it hid for three rounds of fixes

The failure happens *after* the renders are pushed. So the delivery branch still advances, the manifest is silently absent, and the branch looks indistinguishable from a run that skipped. That's the shape I kept diagnosing — bootstrap gate, then `generatedFrom` churn — and both of those were real bugs, but neither was *this* one. The `Apply compose-preview` job was red the whole time and I was reading the branch state instead of the run.

## Verified by reproduction, not reasoning

My first attempt to reproduce it **passed**, because this machine has a global git identity. That made the repro worthless, so I re-ran it with `GIT_CONFIG_GLOBAL=/dev/null` to match a runner:

```
without identity:  fatal: unable to auto-detect email address   (exit 128)
with identity:     commit-tree OK: fbb06761
```

## Test plan

- Reproduced the exact failure under runner-like conditions, and confirmed the fix resolves it (above).
- `action.yml` parses.
- No Kotlin changed; the generator itself was already working — the log line above shows it producing a complete 531-preview manifest.

Renders were pushed on that run (`c0f7152aa`), so once this lands the next baseline run should publish the manifest rather than dropping it.

I'd like to see the file actually appear on the branch before anyone calls this feature done — that judgement has been wrong five times now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXp51dArWBD4dWia6GbJkV)_