### PR TITLE
fix(serve): treat an empty knob value as a value, not a missing one

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -117,6 +117,12 @@ object ServeOverrides {
    * preview's declared knobs from these, so editing one re-renders the composable (only on a
    * daemon-backed session — a static bundle / the Wasm tier ignore them). Dynamic keys, so not
    * listed in [SUPPORTED_KEYS].
+   *
+   * **`knob.<key>=` with no value is a value, for a string knob.** Clearing a label is an edit a
+   * viewer has to be able to express, and an `@OverrideVariant` can seed one deliberately (`strings
+   * = ["label="]`, which discovery preserves). For any other kind there is nothing to parse out of
+   * it, so it is skipped rather than rejected — the viewer builds these URLs itself and a
+   * half-typed number field must not 400 the page it came from.
    */
   const val KNOB_PREFIX = "knob."
 
@@ -483,7 +489,7 @@ object ServeOverrides {
     for ((rawKey, raw) in params) {
       if (!rawKey.startsWith(KNOB_PREFIX)) continue
       val wireKey = rawKey.removePrefix(KNOB_PREFIX)
-      if (wireKey.isBlank() || raw.isBlank()) continue
+      if (wireKey.isBlank()) continue
       // Type the value. A bare value takes its type from the preview's declaration (default
       // string). A legacy `<kind>:<value>` prefix is honoured ONLY when the knob is undeclared or
       // the prefix matches its declared kind — otherwise a declared *string* knob could never hold
@@ -495,6 +501,16 @@ object ServeOverrides {
       val explicitKind = prefix?.takeIf { declaredKind == null || it == declaredKind }
       val kind = explicitKind ?: declaredKind ?: "string"
       val value = if (explicitKind != null) raw.substring(sep + 1) else raw
+      // `knob.label=` — an EMPTY value. For a string knob that is a real value, not a missing one:
+      // clearing a label is an edit a viewer must be able to express, and an `@OverrideVariant` may
+      // seed one deliberately (`strings = ["label="]`). Dropping it (as a blanket blank-skip did)
+      // silently rendered the author default instead — the seeded variant's whole point inverted.
+      // Whitespace is likewise a real string, so this tests isEmpty rather than isBlank.
+      //
+      // For every other kind there is nothing to parse out of "", and a viewer legitimately
+      // produces it (an emptied number input). That stays a skipped no-op rather than a hard
+      // Invalid, which would 400 a URL the viewer itself built.
+      if (value.isEmpty() && kind != "string") continue
       namedOverrides[wireKey] =
         when (kind) {
           "string" -> PreviewOverrideValue.StringValue(value)

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -181,6 +181,13 @@
     Object.keys(size).forEach(function (k) { o[k] = size[k]; });
     return o;
   }
+  // A knob control's declared kind (`string` / `int` / `float` / `bool` / `color`), from the row
+  // the server rendered. Only the empty-value rules in the collectors below consult it — everything
+  // else sends the control's text verbatim and lets the server type it from the same declaration.
+  // Defaults to `string`, which is what an undeclared knob parses as server-side.
+  function knobKind(el) {
+    return el.getAttribute("data-knob-kind") || "string";
+  }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
   // `knob.<key>=<value>` entries (the daemon's setOverrides parses the same map /render does,
   // typing each from the preview's declaration). Kept separate from overrides() so query() and
@@ -195,7 +202,11 @@
       var key = el.getAttribute("data-knob-key");
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
-      if (val === "") return;
+      // An empty STRING knob is a real value (a cleared label, or a variant seeded to ""), so it
+      // is sent; the server keeps it for a string knob and skips it for a kind that can't parse
+      // it. An emptied number field has nothing to send, and this map REPLACES the daemon's whole
+      // override bag, so sending `knob.count=` would be indistinguishable from clearing it.
+      if (val === "" && knobKind(el) !== "string") return;
       o["knob." + key] = val;
     });
     // Remote Compose knobs carry their own `<kind>:` tag: `rc.<name>=<kind>:<value>`. Sent for
@@ -260,7 +271,8 @@
       var key = el.getAttribute("data-knob-key");
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
-      if (val === "") return;
+      // See liveOverrides(): "" is a value for a string knob and a no-op for every other kind.
+      if (val === "" && knobKind(el) !== "string") return;
       if (val === (el.getAttribute("data-knob-initial") || "")) return;
       parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
@@ -848,7 +860,12 @@
       var key = el.getAttribute("data-knob-key");
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
-      if (val === "") return;
+      // See liveOverrides(): "" is a value for a string knob and a no-op for every other kind.
+      // This one matters most — an @OverrideVariant seeding `label=` opens the control empty, and
+      // wasmAppSrc has already stripped the variant axis off the id, so dropping the seed here
+      // mounts the PRIMARY under a sticker that says otherwise, with no baked artifact to fall
+      // back on.
+      if (val === "" && knobKind(el) !== "string") return;
       // Older pages carry no `data-knob-default`; fall back to the initial so they behave as before
       // rather than sending every knob.
       var authorDefault = el.getAttribute("data-knob-default");

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -352,9 +352,49 @@ class ServeOverridesTest {
   }
 
   @Test
-  fun `blank knob key or value is ignored`() {
-    val o = ok(mapOf("knob." to "string:x", "knob.label" to ""))
-    assertNull(o.namedOverrides)
+  fun `a blank knob key is ignored`() {
+    assertNull(ok(mapOf("knob." to "string:x")).namedOverrides)
+  }
+
+  @Test
+  fun `an empty value is a real seed for a string knob`() {
+    // `knob.label=` is an EDIT, not a missing param: clearing a label is something a viewer must be
+    // able to express, and an `@OverrideVariant` can seed one deliberately (`strings = ["label="]`,
+    // which discovery preserves). Dropping it rendered the author default instead — the seeded
+    // variant's whole point inverted, and on the Wasm tier there is no baked artifact to mask it.
+    assertEquals(
+      PreviewOverrideValue.StringValue(""),
+      ok(mapOf("knob.label" to "")).namedOverrides!!["label"],
+      "an undeclared knob types as a string, so its empty value is kept",
+    )
+    val declared = ServeOverrides.parse(mapOf("knob.label" to ""), mapOf("label" to "string"))
+    assertEquals(
+      PreviewOverrideValue.StringValue(""),
+      (declared as OverrideParse.Ok).overrides.namedOverrides!!["label"],
+    )
+    // Whitespace is a string too — `isBlank` would have swallowed a single-space label.
+    assertEquals(
+      PreviewOverrideValue.StringValue(" "),
+      ok(mapOf("knob.label" to " ")).namedOverrides!!["label"],
+    )
+    // An explicit legacy prefix with nothing after it is the same empty string.
+    assertEquals(
+      PreviewOverrideValue.StringValue(""),
+      ok(mapOf("knob.label" to "string:")).namedOverrides!!["label"],
+    )
+  }
+
+  @Test
+  fun `an empty value is skipped for a knob that cannot parse one`() {
+    // An emptied number/colour field has nothing to seed. Skipped rather than Invalid: the viewer
+    // itself builds these URLs, and a 400 on a half-typed field would break the page it came from.
+    val kinds = mapOf("count" to "int", "weight" to "float", "tint" to "color", "on" to "bool")
+    val parsed =
+      ServeOverrides.parse(
+        mapOf("knob.count" to "", "knob.weight" to "", "knob.tint" to "", "knob.on" to ""),
+        kinds,
+      )
+    assertNull((parsed as OverrideParse.Ok).overrides.namedOverrides)
   }
 
   @Test

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -336,7 +336,7 @@
   syncBg();
 })();</script>
       <script src="/assets/serve/9307-806c15ce8d932fc7/format-compare.js"></script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
@@ -264,7 +264,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -239,7 +239,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -238,7 +238,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -236,7 +236,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -229,7 +229,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
@@ -230,7 +230,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -233,7 +233,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -226,7 +226,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -227,7 +227,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -232,7 +232,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -222,7 +222,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
@@ -216,7 +216,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -277,7 +277,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -724,3 +724,63 @@ test("contract · snapshot overrides stay composed with a declared theme", async
         { orientation: "landscape" },
     );
 });
+
+// Clearing a string knob is an EDIT, not an absence. The viewer used to drop any empty knob value
+// before it ever reached the URL, so emptying a label silently re-rendered the author default —
+// and an `@OverrideVariant` seeded to "" (`strings = ["label="]`, which discovery preserves) opened
+// its control empty and then mounted the primary. A knob whose kind can't parse "" (this fixture's
+// colour) still has nothing to send, and must stay absent rather than becoming `knob.iconColor=`.
+test("contract · an emptied string knob is sent, an emptied typed knob is not", async ({
+    page,
+}) => {
+    const requests = [];
+    for (const [name, contentType] of SERVE_ASSETS) {
+        await page.route(`**/assets/serve/**/${name}`, (route) =>
+            route.fulfill({
+                path: resolve(serveAssetsDir, name),
+                contentType,
+            }),
+        );
+    }
+    await page.route("**/render/**", async (route) => {
+        requests.push(new URL(route.request().url()));
+        await route.fulfill({
+            path: renderPlaceholder,
+            contentType: "image/png",
+        });
+    });
+    await page.goto(
+        "/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html",
+    );
+    await expect.poll(() => requests.length).toBeGreaterThan(0);
+    // The knob controls live in the collapsed Overrides drawer; open it so they are editable.
+    await page
+        .locator('details[data-cp-group="overrides"]')
+        .evaluate((details) => {
+            details.open = true;
+        });
+
+    const clear = async (key) => {
+        const before = requests.length;
+        const input = page.locator(`.cp-knob[data-knob-key="${key}"]`);
+        await input.fill("");
+        await input.press("Tab");
+        await expect
+            .poll(() => requests.length, { timeout: 5_000 })
+            .toBeGreaterThan(before);
+        await page.waitForTimeout(100);
+        return requests.at(-1).searchParams;
+    };
+
+    // `has` rather than `get(...) === ""`: the distinction under test is present-and-empty versus
+    // absent, and `get` answers null for both an absent param and one this assertion would miss.
+    const afterLabel = await clear("label");
+    expect(afterLabel.has("knob.label")).toBe(true);
+    expect(afterLabel.get("knob.label")).toBe("");
+
+    const afterColor = await clear("iconColor");
+    expect(afterColor.has("knob.iconColor")).toBe(false);
+    // The string knob stays cleared across the second edit — the collector rebuilds the whole
+    // query each time, so a regression that dropped empties would lose it here too.
+    expect(afterColor.get("knob.label")).toBe("");
+});


### PR DESCRIPTION
`knob.<key>=` was dropped on the floor by every layer that handles it on the way in: all three viewer collectors (`liveOverrides()`, `query()`, `wasmOverridePatch()`) returned early on `val === ""`, and `ServeOverrides.parse` skipped any `raw.isBlank()`. An empty string was simply unreachable as an override value.

## Two real cases

**Clearing a text knob.** The viewer sent nothing, the server re-rendered the author default, and the control snapped back. It's the one edit a string knob can't express.

**An `@OverrideVariant` seeded to empty** — `strings = ["label="]`, which `readOverrideSeeds` preserves (`OverrideSeed(key="label", raw="")`). Its control opens empty, so `val === ""` held and the seed never left the page. On the Wasm tier that's worst: `wasmAppSrc` has already stripped the variant axis off the id, so the app mounts the **primary** under a sticker captioned as the variant — and unlike the PNG lane there's no baked artifact to mask it.

## The rule

The knob's kind decides.

- `string` keeps an empty value — including whitespace, which `isBlank` also swallowed and which is a perfectly good label. `data-knob-kind` on the row is what the viewer consults; the server uses the same declaration via `knobKinds`.
- Every other kind has nothing to parse out of `""`, so it stays a **skipped no-op** rather than becoming a hard `Invalid`. The viewer builds these URLs itself, and a half-typed number field must not 400 the page it came from.

The runtime layers were already correct — `ControllerPreviewOverrideHost.string` and the Wasm `catalogOverrideString` both honour `StringValue("")` — so this only touches the two layers that were discarding it.

## Visual evidence

None, deliberately: this changes no pixels for anything committed. No catalog in the repo seeds a knob to `""` today, and "user clears a text field" is an interaction rather than a baked state, so there is no fixture whose render moves. What the change actually alters is the render URL and the Wasm patch, which is pinned behaviourally instead:

**New** `contract · an emptied string knob is sent, an emptied typed knob is not` in `pages-snapshot.spec.mjs`. It drives the committed `serve-viewer-catalog-knobs` fixture with the real `viewer.js` routed in, clears the `label` (string) knob and asserts the render request carries `knob.label=` **present and empty**, then clears `iconColor` (colour) and asserts `knob.iconColor` is **absent** — and that `label` is still empty after the second edit, since the collector rebuilds the whole query each time. I verified it fails against the pre-fix `query()` guard (`Expected: true, Received: false`) before keeping it.

## Provenance

Raised by the Codex review on #3428, which flagged it at a line that PR touched. Worth being precise: the `if (val === "") return;` guard **predates** #3428 and was present in all three collectors, so this is a standing limitation across every lane, not a regression that PR introduced. #3428 had already merged by the time the comment landed, hence a separate branch.

## Test plan

- `./gradlew :cli:test` — green.
- `ServeOverridesTest`: `an empty value is a real seed for a string knob` (bare, declared-string, whitespace, and the legacy `string:` prefix with nothing after it) and `an empty value is skipped for a knob that cannot parse one` (int/float/colour/bool). The old `blank knob key or value is ignored` split into a key-only case, since the value half is now the opposite contract.
- `pages-snapshot` — 73 passed, including the new contract test.
- `ServeWebFixtureTest` golden HTML regenerated (viewer.js is content-hash-addressed, so its `<script src>` moves in every viewer fixture — that's the whole diff there).
- `./gradlew ktfmtCheckAll` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhvrrdcDXZjHeHEpqpgNtr)_