### PR TITLE
feat(design-artifacts): shard the catalog render across parallel jobs

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -283,11 +283,13 @@ jobs:
     name: ${{ inputs.system }} · plan
     if: ${{ inputs.render-shards > 1 }}
     runs-on: ${{ inputs.runs-on }}
-    timeout-minutes: 5
+    timeout-minutes: 10
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
-      # No checkout, no toolchain: this is `[1, 2, …, N]` and nothing else. The real partition is
+      # No checkout, no Gradle: this is `[1, 2, …, N]` and nothing else. The real partition is
       # computed inside each shard from its own discovery, which is what keeps the fan-out free of a
       # serial "discover once, then start the shards" prefix — that prefix would cost a full Gradle
       # configure + compile (~3.7 min) before any shard began, which is the same fixed cost each
@@ -299,6 +301,54 @@ jobs:
         run: |
           set -euo pipefail
           echo "matrix=[$(seq -s, 1 "$SHARDS")]" >> "$GITHUB_OUTPUT"
+
+      # The merge runs LAST, after every shard has spent its ~20 minutes — so a CLI that predates
+      # `bundle merge` would fail with "Unknown bundle subcommand" having burned the whole fan-out.
+      # That is not a hypothetical: the documented default is `cli-source: released`, and
+      # `cli-version: catalog` pins the CLI to the applied plugin version, which for any catalog that
+      # has not bumped its pin is a release older than this feature. So probe it here, once, before
+      # anything expensive starts.
+      #
+      # Only for the released path. `cli-source: build` builds the CLI from the `driver-ref`
+      # checkout, which is the same checkout the merge step builds from, so a probe would mean
+      # building it twice; a `driver-ref` old enough to lack the subcommand is a compose-ai-tools
+      # internal misconfiguration, not a consumer-facing pin.
+      - name: Set up JDK 21
+        if: ${{ inputs.cli-source == 'released' }}
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # `cli-version: catalog` reads the pin out of the caller's version catalog, so the checkout is
+      # needed for the install action to resolve it.
+      - name: Check out the calling repo
+        if: ${{ inputs.cli-source == 'released' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Install compose-preview CLI
+        if: ${{ inputs.cli-source == 'released' }}
+        uses: yschimke/compose-ai-tools/.github/actions/install@main
+        with:
+          version: ${{ inputs.cli-version }}
+          catalog-key: ${{ inputs.catalog-key }}
+          catalog-path: ${{ inputs.catalog-path }}
+          github-token: ${{ github.token }}
+
+      - name: Check the CLI can merge shard renders
+        if: ${{ inputs.cli-source == 'released' }}
+        run: |
+          set -euo pipefail
+          version="$(compose-preview --version | head -1)"
+          if compose-preview bundle help 2>&1 | grep -q 'bundle merge'; then
+            echo "✓ $version supports 'bundle merge'."
+            exit 0
+          fi
+          echo "::error title=CLI too old for render-shards::${version} has no 'compose-preview bundle merge', which the sharded render needs to reassemble the shard bundles. Raise cli-version (or, with cli-version: catalog, the ${{ inputs.catalog-key }} pin in ${{ inputs.catalog-path }}) to a release that carries it, or set render-shards: 1."
+          exit 1
 
   render-shard:
     name: ${{ inputs.system }} · shard ${{ matrix.shard }}/${{ inputs.render-shards }}
@@ -467,11 +517,20 @@ jobs:
           if [ -s "$GITHUB_WORKSPACE/mode-filter.txt" ]; then
             exclude_file=(--exclude-file "$GITHUB_WORKSPACE/mode-filter.txt")
           fi
+          # The render below also applies the pre-flight's positive function-name filter, so the
+          # partition must see the same preview set it will. Partitioning the unfiltered discovery
+          # output would let a shard's whole share be ids of wholly-deferred functions: it would
+          # report work to do, then exclude every id the name filter kept, and the render refuses a
+          # selection that produces nothing.
+          filter_file=()
+          if [ -s "$GITHUB_WORKSPACE/render-filter.txt" ]; then
+            filter_file=(--render-filter-file "$GITHUB_WORKSPACE/render-filter.txt")
+          fi
           previews=$(node compose-ai-tools/scripts/design-artifacts/shard-preview-ids.mjs \
             --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
             --shards "${{ inputs.render-shards }}" \
             --index "${{ matrix.shard }}" \
-            "${exclude_file[@]}" \
+            "${exclude_file[@]}" "${filter_file[@]}" \
             --out "$GITHUB_WORKSPACE/shard-exclude.txt" \
             --plan-out "$GITHUB_WORKSPACE/shard-plan.json")
           echo "previews=$previews" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -217,6 +217,34 @@ on:
         required: false
         type: number
         default: 60
+      render-shards:
+        description: >
+          Split the PRIMARY render across this many parallel jobs. 1 (the default) keeps the
+          single-job pipeline byte for byte — no extra jobs, no artifacts, no merge.
+
+          Above 1, each shard runs the same `bundle pack` with `--exclude-preview-id` naming every
+          preview that is not its share, which leaves the excluded previews listed in the bundle
+          without a baked PNG. The shards therefore emit structurally identical bundles differing
+          only in which `previews/<id>.*` slots are filled, and `compose-preview bundle merge` unions
+          them back into the bundle one serial render would have produced. Every shard derives its
+          own partition from its own `compose-preview list --json` (deterministic: the id list is
+          sorted, then round-robined), so there is no serial discover-then-fan-out prefix — and the
+          merge cross-checks the shards' plans before trusting them.
+
+          What this buys, and what it does not: only the MARGINAL cost divides. Measured on
+          m3-catalog, `render_minutes ≈ 3.7 + 2.15s × previews`, and every shard pays the ~3.7 min of
+          Gradle configure + compile in full. So 4–6 is the useful range and 16 is buying compile
+          time, not throughput. At 1500 previews it takes the render from ~58 min (which blows a
+          40-minute `render-timeout`) to ~23 min end to end.
+
+          Reach for `modePriority` first where a catalog can: deferral makes the work smaller, which
+          sharding then divides. The two compose.
+
+          The extra module (`extra-module`) is NOT sharded — it is a supplement, small by
+          construction, and it renders in the generate job as before.
+        required: false
+        type: number
+        default: 1
       render-timeout:
         description: >
           Seconds `bundle pack` may spend rendering, per module. This is the INNER timeout on the
@@ -246,8 +274,260 @@ on:
 permissions: {}
 
 jobs:
+  # ── Sharded render (render-shards > 1) ──────────────────────────────────────────────────────
+  # Two jobs that do not exist at all in the default single-shard pipeline. `shard-matrix` only
+  # turns the count into a matrix (Actions has no range expression); `render-shard` is the render,
+  # fanned out. Both are skipped when render-shards is 1, and `generate` renders inline exactly as
+  # it always has.
+  shard-matrix:
+    name: ${{ inputs.system }} · plan
+    if: ${{ inputs.render-shards > 1 }}
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      # No checkout, no toolchain: this is `[1, 2, …, N]` and nothing else. The real partition is
+      # computed inside each shard from its own discovery, which is what keeps the fan-out free of a
+      # serial "discover once, then start the shards" prefix — that prefix would cost a full Gradle
+      # configure + compile (~3.7 min) before any shard began, which is the same fixed cost each
+      # shard pays anyway.
+      - name: Build the shard matrix
+        id: plan
+        env:
+          SHARDS: ${{ inputs.render-shards }}
+        run: |
+          set -euo pipefail
+          echo "matrix=[$(seq -s, 1 "$SHARDS")]" >> "$GITHUB_OUTPUT"
+
+  render-shard:
+    name: ${{ inputs.system }} · shard ${{ matrix.shard }}/${{ inputs.render-shards }}
+    if: ${{ inputs.render-shards > 1 }}
+    needs: [shard-matrix]
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    strategy:
+      # A shard that dies takes the run with it: the merge needs every partition, so letting the
+      # siblings burn another 20 minutes to produce an unpublishable bundle helps nobody.
+      fail-fast: true
+      matrix:
+        # The `|| '[1]'` is inert insurance: a skipped `shard-matrix` (render-shards at its default)
+        # leaves the output empty, and `strategy` is expanded early enough that a bare `fromJSON('')`
+        # can fail the workflow rather than skip the job. The fallback is never rendered — the `if`
+        # above is false in exactly the case that produces it.
+        shard: ${{ fromJSON(needs.shard-matrix.outputs.matrix || '[1]') }}
+    env:
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.buildfetch_ro_token }}
+    steps:
+      - name: Check out the calling repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install compose-preview CLI
+        if: ${{ inputs.cli-source == 'released' }}
+        uses: yschimke/compose-ai-tools/.github/actions/install@main
+        with:
+          version: ${{ inputs.cli-version }}
+          catalog-key: ${{ inputs.catalog-key }}
+          catalog-path: ${{ inputs.catalog-path }}
+          github-token: ${{ github.token }}
+
+      - name: Check out compose-ai-tools (export driver)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: yschimke/compose-ai-tools
+          ref: ${{ inputs.driver-ref }}
+          path: compose-ai-tools
+          persist-credentials: false
+
+      - name: Build compose-preview CLI from source
+        if: ${{ inputs.cli-source == 'build' }}
+        working-directory: compose-ai-tools
+        run: |
+          set -euo pipefail
+          ./gradlew :cli:installDist --no-daemon --quiet
+          echo "$GITHUB_WORKSPACE/compose-ai-tools/cli/build/install/compose-preview/bin" >> "$GITHUB_PATH"
+
+      # Node for the driver's partition + spec scripts only. Deliberately NO `npm ci`: the three
+      # scripts this job runs (validate-catalog-spec / deferred-preview-ids / shard-preview-ids) are
+      # dependency-free by design — node built-ins and their own siblings — so a shard skips the
+      # ~1 min install of playwright + the design-parity export engine, which only `generate` needs.
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      # The same build-free pre-flight `generate` runs. Duplicated on purpose rather than passed
+      # down as a job output: it costs seconds, it fails a mistyped spec here instead of after a
+      # 20-minute fan-out, and its `render-filter` output has to reach THIS job's render anyway.
+      - name: Validate catalog spec
+        id: validate-spec
+        env:
+          SPEC: ${{ inputs.spec }}
+          MODULE: ${{ inputs.module }}
+          EXTRA_MODULE: ${{ inputs.extra-module }}
+          PREVIEW_ANNOTATIONS: ${{ inputs.preview-annotations }}
+          WORKDIR: ${{ inputs.working-directory }}
+          LIVE_BUNDLE: ${{ inputs.publish-live-bundle }}
+          LIVE_SOURCE: ${{ inputs.live-rerender-source }}
+        run: |
+          set -euo pipefail
+          to_dir() { printf '%s' "${WORKDIR:+$WORKDIR/}${1#:}" | tr ':' '/'; }
+          args=(--spec "$SPEC" --module-dir "$(to_dir "$MODULE")")
+          if [ -n "$EXTRA_MODULE" ]; then args+=(--src "$(to_dir "$EXTRA_MODULE")"); fi
+          for ann in $PREVIEW_ANNOTATIONS; do args+=(--preview-annotation "$ann"); done
+          if [ "$LIVE_BUNDLE" = "true" ] || [ "$LIVE_SOURCE" = "true" ]; then
+            args+=(--live-bundle)
+          else
+            args+=(--no-live-bundle)
+          fi
+          node compose-ai-tools/scripts/design-artifacts/validate-catalog-spec.mjs "${args[@]}" \
+            --render-filter-out "$GITHUB_WORKSPACE/render-filter.txt" \
+            --deferred-modes-out "$GITHUB_WORKSPACE/deferred-modes.txt"
+          echo "render-filter=$(cat "$GITHUB_WORKSPACE/render-filter.txt")" >> "$GITHUB_OUTPUT"
+          echo "deferred-modes=$(cat "$GITHUB_WORKSPACE/deferred-modes.txt")" >> "$GITHUB_OUTPUT"
+
+      - name: Stage fonts for rendering
+        if: ${{ inputs.stage-font-globs != '' }}
+        env:
+          FONT_GLOBS: ${{ inputs.stage-font-globs }}
+        run: |
+          set -euo pipefail
+          command -v fc-cache >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends fontconfig; }
+          mkdir -p "$HOME/.local/share/fonts"
+          shopt -s nullglob
+          for g in $FONT_GLOBS; do cp $g "$HOME/.local/share/fonts/"; done
+          fc-cache -f "$HOME/.local/share/fonts" >/dev/null
+
+      - name: Install desktop (Skiko) render deps
+        if: ${{ inputs.desktop-render }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig
+
+      # Same font cache as the single-job pipeline. The save key carries the shard index because
+      # Actions caches are immutable: N shards saving one `…-<run_id>` key would have the first win
+      # and the rest log a conflict. The restore-keys are prefixes, so every shard still starts warm
+      # from whatever the last run left — including from a sibling shard's save.
+      - name: Restore downloadable-font cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/composeai/fonts
+          key: composeai-fonts-${{ runner.os }}-${{ inputs.system }}-${{ github.run_id }}-shard-${{ matrix.shard }}
+          restore-keys: |
+            composeai-fonts-${{ runner.os }}-${{ inputs.system }}-
+            composeai-fonts-${{ runner.os }}-
+
+      # Discovery, in this shard, for this shard. `compose-preview list --json` runs
+      # `composePreviewDiscover`; the compile it forces is shared with the render below (same Gradle
+      # build, warm caches), so it costs discovery — the same arrangement the single-job pipeline
+      # already relies on for `modePriority`.
+      - name: Discover previews
+        working-directory: ${{ inputs.working-directory || '.' }}
+        run: |
+          set -euo pipefail
+          compose-preview list --json --module "${{ inputs.module }}" \
+            > "$GITHUB_WORKSPACE/discovered-previews.json"
+
+      - name: Derive per-mode render exclusions
+        id: mode-filter
+        if: ${{ steps.validate-spec.outputs.deferred-modes != '' }}
+        env:
+          SPEC: ${{ inputs.spec }}
+        run: |
+          set -euo pipefail
+          node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/deferred-preview-ids.mjs" \
+            --spec "$GITHUB_WORKSPACE/$SPEC" \
+            --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
+            --out "$GITHUB_WORKSPACE/mode-filter.txt" \
+            --rows-out "$GITHUB_WORKSPACE/mode-filter-rows.txt"
+          echo "exclude-rows=$(cat "$GITHUB_WORKSPACE/mode-filter-rows.txt")" >> "$GITHUB_OUTPUT"
+
+      # This shard's share of the render, as the ids it must NOT render. Deferred ids are dropped
+      # from the partition and re-added to every shard's exclusion list, so a `modePriority` deferral
+      # shrinks the work the shards divide instead of competing with the partition for slots.
+      - name: Plan this shard
+        id: shard-plan
+        run: |
+          set -euo pipefail
+          exclude_file=()
+          if [ -s "$GITHUB_WORKSPACE/mode-filter.txt" ]; then
+            exclude_file=(--exclude-file "$GITHUB_WORKSPACE/mode-filter.txt")
+          fi
+          previews=$(node compose-ai-tools/scripts/design-artifacts/shard-preview-ids.mjs \
+            --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
+            --shards "${{ inputs.render-shards }}" \
+            --index "${{ matrix.shard }}" \
+            "${exclude_file[@]}" \
+            --out "$GITHUB_WORKSPACE/shard-exclude.txt" \
+            --plan-out "$GITHUB_WORKSPACE/shard-plan.json")
+          echo "previews=$previews" >> "$GITHUB_OUTPUT"
+
+      # Skipped when the partition handed this shard nothing — more shards than previews. Its
+      # exclusion list would then name every preview, which `composePreviewRender` refuses outright,
+      # so the right answer is a no-op shard, not a failed one.
+      - name: Render shard ${{ matrix.shard }}
+        if: ${{ steps.shard-plan.outputs.previews != '0' }}
+        working-directory: ${{ inputs.working-directory || '.' }}
+        env:
+          ORG_GRADLE_PROJECT_composePreview.filter: ${{ steps.validate-spec.outputs.render-filter }}
+          EXCLUDE_PREVIEW_ROWS: ${{ steps.mode-filter.outputs.exclude-rows }}
+        run: |
+          set -euo pipefail
+          run() { if [ "${{ inputs.desktop-render }}" = "true" ]; then xvfb-run -a -s "-screen 0 2000x1400x24" "$@"; else "$@"; fi; }
+          embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
+          exclude=()
+          if [ -s "$GITHUB_WORKSPACE/shard-exclude.txt" ]; then
+            exclude=(--exclude-preview-id "$(cat "$GITHUB_WORKSPACE/shard-exclude.txt")")
+          fi
+          if [ -n "${EXCLUDE_PREVIEW_ROWS:-}" ]; then exclude+=(--exclude-preview-row "$EXCLUDE_PREVIEW_ROWS"); fi
+          run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics --progress \
+            "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" \
+            --timeout ${{ inputs.render-timeout }}
+
+      - name: Save downloadable-font cache
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/composeai/fonts
+          key: composeai-fonts-${{ runner.os }}-${{ inputs.system }}-${{ github.run_id }}-shard-${{ matrix.shard }}
+
+      # `compression-level: 0` because a bundle is an already-compressed zip behind a PNG cover —
+      # re-deflating it costs CPU on both ends and saves nothing. `retention-days: 1` because these
+      # are intermediates consumed by the merge minutes later; the published artifact is the
+      # delivery branch.
+      - name: Upload shard ${{ matrix.shard }}
+        if: ${{ steps.shard-plan.outputs.previews != '0' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.system }}-render-shard-${{ matrix.shard }}
+          path: |
+            ${{ github.workspace }}/bundle.png
+            ${{ github.workspace }}/shard-plan.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
   generate:
     name: ${{ inputs.system }}
+    # Skipped needs are the single-shard path, not a failure: with render-shards at its default the
+    # two jobs above never run, and this job must still start. `!cancelled()` plus an explicit
+    # failure check is the pattern that distinguishes "skipped" from "broke".
+    needs: [shard-matrix, render-shard]
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
@@ -373,9 +653,13 @@ jobs:
       # shared with the render below (same Gradle build, warm caches), so the extra invocation costs
       # discovery, not a second compile. Skipped entirely when the spec defers no mode, which is the
       # state of every catalog that hasn't opted in.
+      #
+      # Skipped entirely for a sharded run: the render happens in `render-shard`, which does its own
+      # discovery and its own deferral, so paying for a second Gradle configure + compile here would
+      # add ~4 minutes to produce a filter nothing in this job uses.
       - name: Derive per-mode render exclusions
         id: mode-filter
-        if: ${{ steps.validate-spec.outputs.deferred-modes != '' }}
+        if: ${{ steps.validate-spec.outputs.deferred-modes != '' && inputs.render-shards < 2 }}
         working-directory: ${{ inputs.working-directory || '.' }}
         env:
           SPEC: ${{ inputs.spec }}
@@ -445,6 +729,8 @@ jobs:
             composeai-fonts-${{ runner.os }}-
 
       - name: Render catalog bundle
+        # Sharded runs render in `render-shard` and merge below instead.
+        if: ${{ inputs.render-shards < 2 }}
         # compose-preview finds the Gradle root by walking up for gradlew, so a
         # monorepo of separate builds must render from the build's own dir.
         working-directory: ${{ inputs.working-directory || '.' }}
@@ -475,6 +761,46 @@ jobs:
           run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics --progress \
             "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" \
             --timeout ${{ inputs.render-timeout }}
+
+      - name: Download shard renders
+        if: ${{ inputs.render-shards > 1 }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: ${{ inputs.system }}-render-shard-*
+          path: ${{ github.workspace }}/shards
+
+      # Merge the shard renders into the bundle a single serial render would have produced.
+      #
+      # `bundle merge`, NOT `bundle repack`. Repack swaps re-renders into slots the target already
+      # has, and only for `previews/<id>.png` + `previews/<id>.figma.svg` — so against a shard base
+      # every other shard's previews would report "no matching baked slot" and be skipped entirely,
+      # and any that did land would arrive without their `.semantics.json`, which the completeness
+      # gate fails on. Merge adds the slot and carries every sidecar.
+      #
+      # Shard 1 is the base and contributes the manifests, the cover and the re-render classpath.
+      # That is not an arbitrary pick, it is why `publish-live-bundle` needs no designated shard:
+      # every shard packs the same module at the same commit, so `classes/app.jar` + `libs/` are
+      # identical in all of them and the merge inherits rather than merges them.
+      - name: Merge shard renders
+        if: ${{ inputs.render-shards > 1 }}
+        run: |
+          set -euo pipefail
+          mapfile -t bundles < <(find "$GITHUB_WORKSPACE/shards" -name bundle.png | sort -V)
+          mapfile -t plans < <(find "$GITHUB_WORKSPACE/shards" -name shard-plan.json | sort -V)
+          if [ "${#bundles[@]}" -eq 0 ]; then
+            echo "::error title=No shard renders::render-shards is ${{ inputs.render-shards }} but no shard uploaded a bundle."
+            exit 1
+          fi
+          # Cross-check the partitions BEFORE trusting them. Each shard derived its own from its own
+          # discovery; they agree by construction, and if they ever don't, the symptom downstream is
+          # a completeness-gate failure naming a component, with nothing pointing at the shards.
+          node compose-ai-tools/scripts/design-artifacts/shard-preview-ids.mjs --verify "${plans[@]}"
+          if [ "${#bundles[@]}" -eq 1 ]; then
+            # One shard did all the work (more shards than previews). Nothing to union.
+            cp "${bundles[0]}" "$GITHUB_WORKSPACE/bundle.png"
+          else
+            compose-preview bundle merge "${bundles[@]}" -o "$GITHUB_WORKSPACE/bundle.png"
+          fi
 
       - name: Render extra module
         if: ${{ inputs.extra-module != '' }}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -76,6 +76,7 @@ class BundleCommand(args: List<String>) : Command(args) {
       "externalize" -> ExternalizeSubcommand(subArgs).run()
       "render" -> RenderSubcommand(subArgs).run()
       "repack" -> RepackSubcommand(subArgs).run()
+      "merge" -> MergeSubcommand(subArgs).run()
       "keygen" -> KeygenSubcommand(subArgs).run()
       "sign" -> SignSubcommand(subArgs).run()
       "verify" -> VerifySubcommand(subArgs).run()
@@ -112,6 +113,7 @@ class BundleCommand(args: List<String>) : Command(args) {
         compose-preview bundle externalize <bundle.png | URL> --res-out <dir> [-o <file.png>] [--ext ttf,otf,woff,woff2] [--json]
         compose-preview bundle render  <bundle.png | URL> [-o <dir>] [--knob k=v …] [--res <pool>] [--svg]  (re-render previews; --knob re-themes, --svg also exports vectors)
         compose-preview bundle repack  <bundle.png | URL> --renders <dir> -o <out.png>  (swap baked previews for re-rendered PNGs + figma.svg)
+        compose-preview bundle merge   <base.png | URL> <shard.png | URL>… -o <out.png>  (union the previews of bundles packed from disjoint render selections)
         compose-preview bundle keygen  [-o <key.pem>] [--key-id <id>]  (mint an Ed25519 signing keypair)
         compose-preview bundle sign    <bundle.png> --key <private-key> --key-id <id> [--producer <name>]
         compose-preview bundle verify  <bundle.png | URL> [--trust <store.json>] [--origin <repo@branch>]
@@ -1144,6 +1146,143 @@ internal fun repackRethemedPreviews(source: File, rendersDir: File, outFile: Fil
   source.copyTo(outFile, overwrite = true)
   injectRawZipEntries(outFile, entries)
   return RepackOutcome(png, svg, unmatched)
+}
+
+/**
+ * `bundle merge <base.png> <shard.png>… -o <out.png>` — union the per-preview artifacts of several
+ * bundles that were packed from the SAME module and commit but with disjoint render selections,
+ * into one bundle carrying every shard's pixels.
+ *
+ * This is the merge step of a sharded CI render: N jobs each run `bundle pack --exclude-preview-id
+ * <everything-not-mine>`, so each emits a structurally identical bundle whose `previews.json` lists
+ * every preview and whose `previews/` directory holds only its own partition. Merging them yields
+ * exactly the bundle one serial render would have produced.
+ *
+ * Deliberately NOT `bundle repack`: repack swaps re-renders into slots the target already has and
+ * only handles `previews/<id>.png` + `previews/<id>.figma.svg`, so a shard's previews would every
+ * one of them be "unmatched" (the base has no slot) and its `.semantics.json` sidecar would be
+ * dropped — which the design-catalog completeness gate fails on.
+ */
+private class MergeSubcommand(private val args: List<String>) {
+  private val verbose: Boolean = "--verbose" in args || "-v" in args
+
+  fun run() {
+    val inputs = CliFlags.positionals(args)
+    val out = args.flagValue("--output") ?: args.flagValue("-o")
+    if (inputs.size < 2 || out == null) {
+      System.err.println(
+        "Usage: compose-preview bundle merge <base.png | URL> <shard.png | URL>… -o <out.png>"
+      )
+      exitProcess(64)
+    }
+    val files =
+      try {
+        inputs.map { BundleSource.resolveToFile(it) }
+      } catch (e: IllegalArgumentException) {
+        System.err.println(e.message)
+        exitProcess(1)
+      }
+    val outFile = File(out).absoluteFile
+    val outcome =
+      try {
+        mergeShardBundles(files.first(), files.drop(1), outFile)
+      } catch (e: IllegalArgumentException) {
+        System.err.println("bundle merge: ${e.message}")
+        exitProcess(1)
+      }
+    println(
+      "merged ${outcome.previews} preview(s) from ${files.size - 1} shard(s) " +
+        "(${outcome.entries} entries) → ${outFile.path}"
+    )
+    if (outcome.overlapping.isNotEmpty()) {
+      // Disjoint partitions are the contract; an overlap means the partition and the exclusion list
+      // disagree, which costs render time twice and silently picks a winner. Say so.
+      System.err.println(
+        "  ${outcome.overlapping.size} preview(s) were baked by more than one shard — " +
+          "the base's copy wins; the partition is not disjoint"
+      )
+      if (verbose) outcome.overlapping.forEach { System.err.println("    overlap $it") }
+    }
+  }
+}
+
+/**
+ * Result of [mergeShardBundles]: how many preview ids gained a baked raster from a shard
+ * ([previews]), how many zip [entries] were copied in total (rasters plus every sidecar), and the
+ * ids more than one bundle had baked ([overlapping] — the base's copy wins).
+ */
+internal data class MergeOutcome(val previews: Int, val entries: Int, val overlapping: List<String>)
+
+/**
+ * Zip-entry prefixes that hold PER-PREVIEW render output, and are therefore what a shard
+ * contributes. Everything else — `bundle.json`, `previews.json`, `classes/app.jar`, `libs/`,
+ * `android/`, the leading PNG cover — is identical across shards by construction (same module, same
+ * commit, same classpath; only the render selection differs) and is taken from the base verbatim.
+ * That is also the answer to "does the live classpath survive the merge": it is never merged, it is
+ * inherited, so `publish-live-bundle` needs no designated shard.
+ */
+private val MERGEABLE_SHARD_PREFIXES = listOf("$BUNDLE_PREVIEWS_DIR/", "ir/", "extensions/")
+
+/**
+ * Core of `bundle merge`: write [outFile] as a copy of [base] with every per-preview artifact the
+ * [shards] carry and [base] lacks added to its zip — the baked `previews/<id>.png`, its
+ * `.semantics.json` / `.layout.json` / `.fonts.json` / `.figma.svg` / `.catalog.json` /
+ * `.overrides.json` sidecars, the nested `previews/<id>.figma-raster/…` crops, the `ir/<id>.rc`
+ * documents and the `extensions/<id>.json` data reports.
+ *
+ * Base-wins on collision, and earlier shards win over later ones, so the result is deterministic in
+ * the order the shards are passed. Throws [IllegalArgumentException] if any input is not a bundle.
+ *
+ * Streams each shard's zip and retains only the entries it contributes, so the shared re-render
+ * payload (`classes/app.jar` + `libs/`, hundreds of MB and identical in every shard) is read past
+ * rather than held: peak memory is the base bundle plus the merged preview artifacts, not the sum
+ * of the shards.
+ */
+internal fun mergeShardBundles(base: File, shards: List<File>, outFile: File): MergeOutcome {
+  val baseNames = zipEntryNames(BundleReader.extractZipBytes(base)).toSet()
+  val add = LinkedHashMap<String, ByteArray>()
+  val overlapping = LinkedHashSet<String>()
+  for (shard in shards) {
+    ZipInputStream(ByteArrayInputStream(BundleReader.extractZipBytes(shard))).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val name = entry.name
+        if (entry.isDirectory || MERGEABLE_SHARD_PREFIXES.none { name.startsWith(it) }) {
+          zin.closeEntry()
+          continue
+        }
+        if (name in baseNames || name in add) {
+          bakedPreviewId(name)?.let(overlapping::add)
+        } else {
+          add[name] = zin.readBytes()
+        }
+        zin.closeEntry()
+      }
+    }
+  }
+  outFile.parentFile?.mkdirs()
+  // The base IS the merged bundle plus the other shards' pixels: same manifests, same classpath,
+  // same cover. Copy it whole, then inject what the shards rendered.
+  base.copyTo(outFile, overwrite = true)
+  injectRawZipEntries(outFile, add)
+  return MergeOutcome(
+    previews = add.keys.count { bakedPreviewId(it) != null },
+    entries = add.size,
+    overlapping = overlapping.toList(),
+  )
+}
+
+/**
+ * The preview id [name] is the top-level baked raster of (`previews/<id>.png`), or null for any
+ * other entry — a sidecar, a nested `figma-raster` crop, an `ir/` document. Used to count and to
+ * report overlap in whole previews rather than in zip entries, which is what a partition is
+ * expressed in.
+ */
+private fun bakedPreviewId(name: String): String? {
+  if (!name.startsWith("$BUNDLE_PREVIEWS_DIR/") || !name.endsWith(".png")) return null
+  val rest = name.removePrefix("$BUNDLE_PREVIEWS_DIR/")
+  if ('/' in rest) return null
+  return rest.removeSuffix(".png")
 }
 
 /** The file (non-directory) entry names in [zip], in iteration order. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -33,6 +33,11 @@ internal object CliFlags {
       "--exclude-preview-id",
       "--exclude-preview-row",
       "--output",
+      // The short alias, classified for the same reason as its long form: it consumes the next
+      // token. The registry test's scanner only matches `--` flags, so this one has to be added by
+      // hand — and it has to be, or a variadic positional list (`bundle merge a.png b.png -o
+      // out.png`) reads the output path as another operand.
+      "-o",
       "--timeout",
       "--plugin-version",
       "--fail-on",
@@ -161,6 +166,27 @@ internal object CliFlags {
 
   /** Index of [firstPositional] in [args], or `-1`. */
   fun firstPositionalIndex(args: List<String>): Int = findCommandIndex(args.toTypedArray())
+
+  /**
+   * EVERY bare token in [args] — the positionals, in order, with each [VALUE_FLAGS] flag and the
+   * token it consumes skipped. [firstPositional] answers "which subcommand is this?"; this answers
+   * "which operands did the subcommand get?", for a variadic one like `bundle merge <base>
+   * <shard>…`.
+   */
+  fun positionals(args: List<String>): List<String> = buildList {
+    var i = 0
+    while (i < args.size) {
+      val arg = args[i]
+      when {
+        arg in VALUE_FLAGS -> i += 2
+        arg.startsWith("-") -> i++
+        else -> {
+          add(arg)
+          i++
+        }
+      }
+    }
+  }
 
   /**
    * Index of the subcommand token in [args], or `-1` if argv is entirely flags and their values.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleMergeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleMergeTest.kt
@@ -1,0 +1,226 @@
+package ee.schimke.composeai.cli
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `bundle merge` unions the per-preview artifacts of bundles packed from the same module + commit
+ * but with disjoint render selections — the merge step of a sharded CI render. Pure zip surgery, so
+ * [mergeShardBundles] is exercised directly (no Gradle, no daemon).
+ *
+ * The load-bearing difference from `bundle repack` is asserted here: a shard's preview is ADDED
+ * (the base has no slot for it, because the base's render excluded it) and its `.semantics.json`
+ * sidecar comes with it. Repack does neither, which is why the sharded pipeline cannot be built on
+ * it — the design-catalog completeness gate fails a preview that has pixels but no semantics.
+ */
+class BundleMergeTest {
+
+  private fun tempDir(prefix: String): File =
+    Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
+
+  private fun png(): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB), "png", baos)
+    return baos.toByteArray()
+  }
+
+  /** A minimal PNG+ZIP polyglot: the [cover] PNG followed by a zip of [entries]. */
+  private fun polyglot(cover: ByteArray, entries: Map<String, ByteArray>): File {
+    val zip = ByteArrayOutputStream()
+    ZipOutputStream(zip).use { z ->
+      for ((name, bytes) in entries) {
+        z.putNextEntry(ZipEntry(name))
+        z.write(bytes)
+        z.closeEntry()
+      }
+    }
+    return Files.createTempFile("bundle", ".png").toFile().also {
+      it.deleteOnExit()
+      it.writeBytes(cover + zip.toByteArray())
+    }
+  }
+
+  private fun entryOf(bundle: File, name: String): ByteArray? {
+    ZipInputStream(ByteArrayInputStream(BundleReader.extractZipBytes(bundle))).use { z ->
+      while (true) {
+        val e = z.nextEntry ?: break
+        if (e.name == name) return z.readBytes()
+        z.closeEntry()
+      }
+    }
+    return null
+  }
+
+  /**
+   * A shard as `bundle pack --exclude-preview-id` actually emits one: complete manifests (discovery
+   * is unfiltered, so every shard lists every preview), the shared re-render classpath, and baked
+   * artifacts for [baked] only.
+   */
+  private fun shard(baked: Map<String, String>, classpath: String = "CLASSES"): File =
+    polyglot(
+      png(),
+      buildMap {
+        put("bundle.json", """{"schemaVersion":8,"previewIds":["a","b","c"]}""".toByteArray())
+        put("previews.json", """{"previews":[{"id":"a"},{"id":"b"},{"id":"c"}]}""".toByteArray())
+        put("classes/app.jar", classpath.toByteArray())
+        for ((id, pixels) in baked) {
+          put("previews/$id.png", pixels.toByteArray())
+          put("previews/$id.semantics.json", """{"id":"$id"}""".toByteArray())
+          put("previews/$id.figma.svg", "<svg id='$id'/>".toByteArray())
+        }
+      },
+    )
+
+  @Test
+  fun `adds a shard's previews and their semantics sidecars to the base`() {
+    val base = shard(mapOf("a" to "PIXELS-A"))
+    val second = shard(mapOf("b" to "PIXELS-B"))
+    val out = File(tempDir("out"), "merged.png")
+
+    val outcome = mergeShardBundles(base, listOf(second), out)
+
+    assertEquals(1, outcome.previews, "one preview came from the shard")
+    assertEquals(emptyList(), outcome.overlapping)
+    // The base keeps its own render…
+    assertContentEquals("PIXELS-A".toByteArray(), entryOf(out, "previews/a.png"))
+    // …and the shard's preview is ADDED, slot and all — this is what repack cannot do.
+    assertContentEquals("PIXELS-B".toByteArray(), entryOf(out, "previews/b.png"))
+    // The sidecar the completeness gate checks travels with it.
+    assertContentEquals("""{"id":"b"}""".toByteArray(), entryOf(out, "previews/b.semantics.json"))
+    assertContentEquals("<svg id='b'/>".toByteArray(), entryOf(out, "previews/b.figma.svg"))
+  }
+
+  @Test
+  fun `takes manifests and the re-render classpath from the base, never from a shard`() {
+    // Every shard renders the same module at the same commit, so its classpath is byte-identical by
+    // construction — but the base's is the one that must survive, or `publish-live-bundle` would
+    // depend on which shard happened to be merged last.
+    val base = shard(mapOf("a" to "PIXELS-A"), classpath = "BASE-CLASSES")
+    val second = shard(mapOf("b" to "PIXELS-B"), classpath = "SHARD-CLASSES")
+    val out = File(tempDir("out"), "merged.png")
+
+    mergeShardBundles(base, listOf(second), out)
+
+    assertContentEquals("BASE-CLASSES".toByteArray(), entryOf(out, "classes/app.jar"))
+    assertContentEquals(
+      """{"schemaVersion":8,"previewIds":["a","b","c"]}""".toByteArray(),
+      entryOf(out, "bundle.json"),
+    )
+    assertContentEquals(
+      """{"previews":[{"id":"a"},{"id":"b"},{"id":"c"}]}""".toByteArray(),
+      entryOf(out, "previews.json"),
+    )
+  }
+
+  @Test
+  fun `merges every shard, and a preview no shard rendered simply stays unbaked`() {
+    // `c` is deferred (modePriority) — excluded in every shard. It stays listed in previews.json
+    // and carries no PNG, exactly as an unsharded deferred render leaves it.
+    val base = shard(mapOf("a" to "PIXELS-A"))
+    val out = File(tempDir("out"), "merged.png")
+
+    val outcome =
+      mergeShardBundles(base, listOf(shard(mapOf("b" to "PIXELS-B")), shard(emptyMap())), out)
+
+    assertEquals(1, outcome.previews)
+    assertContentEquals("PIXELS-B".toByteArray(), entryOf(out, "previews/b.png"))
+    assertNull(entryOf(out, "previews/c.png"), "a deferred preview stays unbaked")
+    assertNull(entryOf(out, "previews/c.semantics.json"))
+  }
+
+  @Test
+  fun `reports previews more than one shard baked, and keeps the base's copy`() {
+    val base = shard(mapOf("a" to "BASE-A"))
+    val overlapping = shard(mapOf("a" to "SHARD-A", "b" to "PIXELS-B"))
+    val out = File(tempDir("out"), "merged.png")
+
+    val outcome = mergeShardBundles(base, listOf(overlapping), out)
+
+    assertEquals(listOf("a"), outcome.overlapping, "a non-disjoint partition is reported")
+    assertContentEquals("BASE-A".toByteArray(), entryOf(out, "previews/a.png"))
+    assertEquals(1, outcome.previews, "only b was actually contributed")
+  }
+
+  @Test
+  fun `an earlier shard wins over a later one`() {
+    val base = shard(mapOf("a" to "PIXELS-A"))
+    val first = shard(mapOf("b" to "FIRST-B"))
+    val later = shard(mapOf("b" to "LATER-B"))
+    val out = File(tempDir("out"), "merged.png")
+
+    val outcome = mergeShardBundles(base, listOf(first, later), out)
+
+    assertContentEquals("FIRST-B".toByteArray(), entryOf(out, "previews/b.png"))
+    assertEquals(listOf("b"), outcome.overlapping)
+  }
+
+  @Test
+  fun `carries nested figma-raster crops, ir documents and extension reports`() {
+    val base = polyglot(png(), mapOf("bundle.json" to "{}".toByteArray()))
+    val second =
+      polyglot(
+        png(),
+        mapOf(
+          "bundle.json" to """{"other":true}""".toByteArray(),
+          "previews/b.png" to "PIXELS-B".toByteArray(),
+          "previews/b.figma-raster/0.png" to "CROP".toByteArray(),
+          "ir/b.rc" to "RC".toByteArray(),
+          "extensions/b.json" to "REPORT".toByteArray(),
+          "libs/dep.jar" to "DEP".toByteArray(),
+        ),
+      )
+    val out = File(tempDir("out"), "merged.png")
+
+    val outcome = mergeShardBundles(base, listOf(second), out)
+
+    assertEquals(1, outcome.previews, "the nested crop is not counted as a preview")
+    assertEquals(4, outcome.entries, "png + crop + ir + extension report")
+    assertContentEquals("CROP".toByteArray(), entryOf(out, "previews/b.figma-raster/0.png"))
+    assertContentEquals("RC".toByteArray(), entryOf(out, "ir/b.rc"))
+    assertContentEquals("REPORT".toByteArray(), entryOf(out, "extensions/b.json"))
+    // Shared carriage is inherited from the base, not merged: the shard's libs/ is not copied in.
+    assertNull(entryOf(out, "libs/dep.jar"))
+    assertContentEquals("{}".toByteArray(), entryOf(out, "bundle.json"))
+  }
+
+  @Test
+  fun `rejects an input that is not a bundle`() {
+    val base = shard(mapOf("a" to "PIXELS-A"))
+    val notABundle = Files.createTempFile("junk", ".png").toFile().also { it.writeText("nonsense") }
+    assertFailsWith<IllegalArgumentException> {
+      mergeShardBundles(base, listOf(notABundle), File(tempDir("out"), "merged.png"))
+    }
+  }
+
+  @Test
+  fun `merging no shards is a faithful copy`() {
+    val base = shard(mapOf("a" to "PIXELS-A"))
+    val out = File(tempDir("out"), "merged.png")
+
+    val outcome = mergeShardBundles(base, emptyList(), out)
+
+    assertEquals(0, outcome.previews)
+    assertEquals(0, outcome.entries)
+    assertContentEquals(base.readBytes(), out.readBytes())
+  }
+
+  @Test
+  fun `positionals lists every operand and skips valued flags`() {
+    val args = listOf("base.png", "shard1.png", "-o", "out.png", "--verbose", "shard2.png")
+    assertEquals(listOf("base.png", "shard1.png", "shard2.png"), CliFlags.positionals(args))
+    assertTrue("out.png" !in CliFlags.positionals(args), "-o's value is not an operand")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
@@ -54,6 +54,9 @@ class CliFlagsRegistryTest {
     assertEquals(2, CliFlags.findCommandIndex(arrayOf("--force", "edit didn't reflect", "render")))
     // Attached form is a single argv token, so it's skipped like any other flag.
     assertEquals(1, CliFlags.findCommandIndex(arrayOf("--force=stale", "render")))
+    // The short output alias consumes its value too — the scanner above can't see short flags, so
+    // this is the guard that it stays classified.
+    assertEquals(2, CliFlags.findCommandIndex(arrayOf("-o", "out.png", "render")))
   }
 
   @Test

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -617,14 +617,27 @@ decisions:
   neighbour expands to two, and the slowest shard sets the wall clock;
 - **round-robin over the sorted list, not contiguous blocks** — ids sort by group, so blocks would
   cluster the template-heavy groups into one shard;
-- **deferred ids are removed before partitioning, then re-excluded in every shard** — so a
-  `modePriority` deferral shrinks the work the shards divide instead of competing with the partition
-  for slots. The two levers compose; reach for deferral first, since it makes the work smaller.
+- **whatever the render will not produce is removed before partitioning, then re-applied in every
+  shard** — the ids `modePriority` defers, and the ids the pre-flight's positive function-name filter
+  drops (an entry-level `priority: "deferred"`). Both are exclusions, so the naive union would let
+  them compete with the partition for slots; worse, a shard whose whole share happened to be
+  filtered-out ids would report work to do and then exclude every id the name filter kept, and
+  `composePreviewRender` refuses a selection that renders nothing. The levers compose — reach for
+  deferral first, since it makes the work smaller, and let sharding divide what remains.
 
 Because the shards each plan independently, the merge step cross-checks their uploaded plans
-(`shard-preview-ids.mjs --verify`) before unioning: same discovered set, pairwise disjoint, and a
-complete cover. A disagreement would otherwise surface as a completeness-gate failure naming a
-component, with nothing pointing at the shards.
+(`shard-preview-ids.mjs --verify`) before unioning: same discovered **set** (compared by digest, not
+by count — two runners that saw `["a"]` and `["b"]` are disjoint with a union of the right size),
+pairwise disjoint, and a complete cover. A disagreement would otherwise surface as a
+completeness-gate failure naming a component, with nothing pointing at the shards.
+
+**The CLI has to be new enough.** The merge runs last, after every shard has spent its twenty
+minutes, so a CLI predating `bundle merge` would fail the run having burned the whole fan-out — and
+that is the *default* configuration's failure mode, since `cli-source: released` +
+`cli-version: catalog` pins the CLI to the applied plugin version. So the matrix job probes
+`compose-preview bundle help` for the subcommand before anything expensive starts, and fails with
+the pin to raise. (The probe is skipped for `cli-source: build`, where the CLI is built from the same
+`driver-ref` checkout the merge step builds from.)
 
 Two things it does not shard: the **extra module** (`extra-module`) renders in the generate job as
 before — it is a supplement, small by construction — and a `@PreviewParameter` provider's **rows**,

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -547,8 +547,93 @@ default 600) for exactly that reason.
 It scales with the number of previews, so a catalog that fans one component out over a variant
 matrix outgrows the default well before it outgrows the job — `m3-catalog` crossed it going from 193
 previews to 287, which is one component family gaining its size and shape axes. Raise the input
-rather than thinning coverage; the other lever is the render priority below, which trades baked
-pixels for a live path.
+rather than thinning coverage; the other levers are the render priority below (which trades baked
+pixels for a live path) and `render-shards` (which divides the work across jobs).
+
+### Sharding the render across parallel jobs (`render-shards`)
+
+Raising `render-timeout` buys one more step and then stops. The render cost is close to linear —
+measured over four `m3-catalog` runs on `main`:
+
+| Commit | Previews | Render step | Job total |
+| --- | --- | --- | --- |
+| `d354560` | 287 | 13.6 min | 17.2 min |
+| `323e4a2` | 519 | 22.5 min | 24.0 min |
+| `5edc70a` | 607 | 26.7 min | 29.6 min |
+| `f35c2e5` | 689 | 27.2 min | 28.9 min |
+
+which fits `render_minutes ≈ 3.7 + 2.15s × previews`. At ~1500 previews that is ~58 min, past a
+40-minute `render-timeout`; at ~2400 it passes the 90-minute job timeout, and no number you can put
+in `render-timeout` helps.
+
+`render-shards: N` splits the primary render across N jobs:
+
+```
+        ┌── shard 1: bundle pack, partition 1 ──┐
+ matrix ┼── shard 2: bundle pack, partition 2 ──┼── merge ── generate ── publish
+        └── shard N: …                          ┘
+```
+
+**Only the marginal 2.15 s divides.** The ~3.7 min of Gradle configure + compile is paid by every
+shard in full, which is what caps the useful count:
+
+| Previews | N=1 | N=4 | N=6 | N=8 |
+| --- | --- | --- | --- | --- |
+| 689 | 29.4 | 15.8 | 13.7 | 12.7 |
+| 1000 | 40.5 | 18.6 | 15.6 | 14.1 |
+| 1500 | 58.4 | 23.0 | 18.6 | 16.3 |
+| 2500 | 94.3 | 32.0 | 24.5 | 20.8 |
+
+(per-shard `1 min setup + 3.7 min compile + ~0.9 min discovery + 2.15s × previews/N`, plus a ~4 min
+merge/generate job). **4–6 is the range.** 6→8 at 1500 previews saves 2.3 min for two more runners;
+anyone reaching for 16 is buying compile time, not throughput. Sharding does not need to be perfect
+— it turns the worst case from impossible into ~25 min.
+
+**How a shard renders only its share.** `bundle pack --exclude-preview-id` leaves the excluded
+previews *listed in the bundle*, just without a baked PNG — the same mechanism render-priority
+deferral relies on. So each shard emits a structurally identical bundle (same `previews.json`, same
+manifest, same re-render classpath) differing only in which `previews/<id>.*` slots are filled.
+
+**How they come back together.** `compose-preview bundle merge <base> <shard>… -o <out>` unions the
+per-preview artifacts: the raster, its `.semantics.json` / `.layout.json` / `.fonts.json` /
+`.figma.svg` / `.catalog.json` sidecars, the nested `figma-raster/` crops, `ir/<id>.rc` and
+`extensions/<id>.json`. Everything else — manifests, cover, `classes/app.jar`, `libs/`, `android/` —
+is inherited from the base shard, which is why **`publish-live-bundle` needs no designated shard**:
+every shard packs the same module at the same commit, so the classpath is identical in all of them.
+
+`bundle repack` is the wrong tool here and it is worth saying why, because it looks right: repack
+swaps re-renders into slots the target *already has*, and only handles `previews/<id>.png` +
+`previews/<id>.figma.svg`. Against a shard base every other shard's previews would report "no
+matching baked slot" and be skipped, and any that did land would arrive without their semantics
+sidecar — which the completeness gate fails.
+
+**Partitioning.** Each shard derives its own partition from its own `compose-preview list --json`,
+so there is no serial discover-then-fan-out prefix (that prefix would cost the same full compile
+each shard pays anyway). It is deterministic — sort the discovered ids, then round-robin — and
+[`shard-preview-ids.mjs`](../../scripts/design-artifacts/shard-preview-ids.mjs) owns the three
+decisions:
+
+- **by preview id, never by function name** — one function expands to a 30-cell matrix while its
+  neighbour expands to two, and the slowest shard sets the wall clock;
+- **round-robin over the sorted list, not contiguous blocks** — ids sort by group, so blocks would
+  cluster the template-heavy groups into one shard;
+- **deferred ids are removed before partitioning, then re-excluded in every shard** — so a
+  `modePriority` deferral shrinks the work the shards divide instead of competing with the partition
+  for slots. The two levers compose; reach for deferral first, since it makes the work smaller.
+
+Because the shards each plan independently, the merge step cross-checks their uploaded plans
+(`shard-preview-ids.mjs --verify`) before unioning: same discovered set, pairwise disjoint, and a
+complete cover. A disagreement would otherwise surface as a completeness-gate failure naming a
+component, with nothing pointing at the shards.
+
+Two things it does not shard: the **extra module** (`extra-module`) renders in the generate job as
+before — it is a supplement, small by construction — and a `@PreviewParameter` provider's **rows**,
+which travel whole with their parent id. The latter is the most likely source of a straggler shard;
+bin-packing from recorded per-preview times is worth building only once one shows up.
+
+The cost is the shard bundles moving through the artifact store — a bundle carrying `classes/` +
+`libs/` is hundreds of MB, uploaded once and downloaded once per shard. They upload with
+`compression-level: 0` (a bundle is already a zip) and `retention-days: 1`.
 
 ### Render priority: deferring the long tail to the live server
 

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -1,0 +1,272 @@
+/**
+ * Partition a catalog's discovered preview ids across N parallel render shards.
+ *
+ * The design-artifacts render is one serial `bundle pack`, and it grows linearly with the preview
+ * count: measured on m3-catalog, `render_minutes ≈ 3.7 + 2.15s × previews`. Past ~1500 previews that
+ * blows `render-timeout`, and past ~2400 the job timeout — so the marginal 2.15s has to be divided
+ * across jobs. This module decides who renders what.
+ *
+ * The mechanism is exclusion, not selection: each shard runs the SAME `bundle pack` with
+ * `--exclude-preview-id <everything that isn't mine>`, which is documented to leave the excluded
+ * previews listed in the bundle (addressable, just without a baked PNG). So every shard emits a
+ * structurally identical bundle — same `previews.json`, same manifest, same re-render classpath —
+ * differing only in which `previews/<id>.*` slots are filled, which is exactly what
+ * `compose-preview bundle merge` unions back together.
+ *
+ * Three decisions worth stating, because each has a wrong-looking-right alternative:
+ *
+ *  - **Partition by preview id, never by `@Preview` function name.** One function expands to a
+ *    30-cell matrix (m3-catalog's icon buttons) while its neighbour expands to two; a name split is
+ *    wildly unbalanced, and the slowest shard sets the wall clock.
+ *  - **Round-robin over the SORTED id list, not contiguous blocks.** Render cost per preview is not
+ *    uniform — a `showSystemUi = true` scaffold costs far more than a 32dp extra-small button — and
+ *    ids sort together by group, so contiguous blocks cluster the template-heavy groups into one
+ *    shard. Round-robin spreads them. It is not bin-packing, and does not try to be: bin-packing
+ *    from recorded per-preview times is only worth it once a straggler actually shows up.
+ *  - **Deferred ids are removed BEFORE partitioning, then re-excluded in every shard.** A
+ *    `modePriority` deferral (issue #2966) and the partition are both expressed as exclusions, so
+ *    the naive union would hand deferred ids a share of the partition and leave one shard rendering
+ *    fewer previews than the others for no reason. Removing them first means the shards balance
+ *    over the set that is actually going to render, and the deferral still applies within each.
+ *
+ * One axis this cannot balance: a `@PreviewParameter` provider's rows. Discovery emits one id for
+ * the parameterized function and the renderer expands the rows later, so such a preview travels
+ * whole — it lands in one shard carrying however many rows it expands to. That is correct (the rows
+ * must not be split across bundles) but it is the most likely source of a straggler shard.
+ *
+ * Pure and dependency-free (node built-ins only) so it unit-tests without an `npm ci`, like its
+ * sibling `deferred-preview-ids.mjs`. The CLI wrapper at the bottom only runs when this file is
+ * executed directly.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { previewsFromJson } from "./deferred-preview-ids.mjs";
+
+/**
+ * Round-robin [ids] (sorted, de-duplicated) into [shards] partitions.
+ *
+ * Returns at most `min(shards, ids.length)` partitions and never an empty one: a shard with nothing
+ * to render would be handed an exclusion list naming every preview, and `composePreviewRender`
+ * rejects that outright ("--exclude-preview-id excluded every one of the N previews"). Clamping is
+ * the right response — a catalog with 3 previews and `render-shards: 6` wants 3 shards, not a
+ * failure.
+ *
+ * @param {string[]} ids every discovered, renderable preview id.
+ * @param {number} shards requested shard count.
+ * @returns {string[][]} one sorted partition per shard.
+ */
+export function partitionPreviewIds(ids, shards) {
+  const sorted = [...new Set((ids ?? []).filter((id) => typeof id === "string" && id.length > 0))]
+    .sort();
+  const count = Math.max(1, Math.min(Math.floor(shards) || 1, sorted.length));
+  if (sorted.length === 0) return [];
+  const out = Array.from({ length: count }, () => []);
+  sorted.forEach((id, i) => out[i % count].push(id));
+  return out;
+}
+
+/**
+ * The full render plan for a sharded run: what each shard renders, and the `--exclude-preview-id`
+ * list that makes it render only that.
+ *
+ * @param {Array<{id: string}>} previews discovered previews (from `compose-preview list --json`).
+ * @param {number} shards requested shard count.
+ * @param {string[]} deferred ids already excluded by `modePriority` — dropped from the partition and
+ *   re-added to every shard's exclusion list.
+ * @returns {{shards: Array<{index: number, previews: string[], exclude: string[]}>, total: number,
+ *   renderable: number, deferred: string[]}} `index` is 1-based (it is what a human reads in the
+ *   Actions matrix); `total` is the effective shard count after clamping.
+ */
+export function shardRenderPlan(previews, shards, deferred = []) {
+  const deferredSet = new Set(deferred ?? []);
+  const all = (previews ?? [])
+    .map((p) => p?.id)
+    .filter((id) => typeof id === "string" && id.length > 0);
+  const renderable = [...new Set(all)].filter((id) => !deferredSet.has(id)).sort();
+  const partitions = partitionPreviewIds(renderable, shards);
+  // Only the ids this shard is NOT rendering, plus the deferred ones. Ids the caller listed as
+  // deferred but discovery never saw are kept in the exclusion list anyway: exclusion polarity means
+  // a pattern matching nothing renders MORE, never less, so a stale entry costs time, not a sticker.
+  return {
+    shards: partitions.map((mine, i) => {
+      const own = new Set(mine);
+      return {
+        index: i + 1,
+        previews: mine,
+        exclude: [...renderable.filter((id) => !own.has(id)), ...deferredSet].sort(),
+      };
+    }),
+    total: partitions.length,
+    renderable: renderable.length,
+    deferred: [...deferredSet].sort(),
+  };
+}
+
+/** Parse a comma/newline-separated id list (a file's contents or a flag value) into ids. */
+export function parseIdList(text) {
+  return String(text ?? "")
+    .split(/[,\n]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Cross-check the per-shard plans a completed matrix uploaded, before their bundles are merged.
+ *
+ * Every shard derives its own partition from its own `compose-preview list --json`, which is what
+ * keeps the pipeline free of a serial discover-then-fan-out prefix — but it also means nothing has
+ * yet checked that the shards agreed. They agree by construction (same commit, same module, and the
+ * partition sorts its input), and a disagreement is not hypothetical enough to leave undiagnosed: it
+ * would surface as an unbaked preview and reach the operator as a completeness-gate failure naming
+ * a component, with no hint that the shards saw different worlds.
+ *
+ * Checks, in the order they'd bite:
+ *  - every shard saw the same renderable set size and planned the same shard count;
+ *  - the partitions are pairwise disjoint (an overlap is wasted render time, and `bundle merge`
+ *    would silently pick a winner);
+ *  - the partitions cover the whole renderable set (a gap is a missing sticker).
+ *
+ * @param {Array<{index: number, total: number, renderable: number, previews: string[]}>} plans
+ * @returns {{ok: boolean, problems: string[]}} `problems` is empty iff the merge is safe.
+ */
+export function verifyShardPlans(plans) {
+  const problems = [];
+  const list = [...(plans ?? [])].sort((a, b) => (a?.index ?? 0) - (b?.index ?? 0));
+  if (list.length === 0) return { ok: false, problems: ["no shard plans were uploaded"] };
+
+  const totals = new Set(list.map((p) => p?.total));
+  if (totals.size > 1) {
+    problems.push(`shards disagree on the shard count: ${[...totals].join(", ")}`);
+  }
+  const renderables = new Set(list.map((p) => p?.renderable));
+  if (renderables.size > 1) {
+    problems.push(
+      `shards discovered different numbers of renderable previews: ${[...renderables].join(", ")}`,
+    );
+  }
+  if (list.length !== (list[0]?.total ?? list.length)) {
+    problems.push(`expected ${list[0]?.total} shard plan(s), got ${list.length}`);
+  }
+
+  const seen = new Map();
+  for (const plan of list) {
+    for (const id of plan?.previews ?? []) {
+      if (seen.has(id)) {
+        problems.push(`preview ${id} was rendered by shards ${seen.get(id)} and ${plan.index}`);
+      } else {
+        seen.set(id, plan.index);
+      }
+    }
+  }
+  const expected = list[0]?.renderable ?? 0;
+  if (seen.size !== expected) {
+    problems.push(
+      `the shards between them rendered ${seen.size} preview(s), but discovery found ${expected}`,
+    );
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+// --- CLI ----------------------------------------------------------------------
+// Two modes, one for each end of the matrix.
+//
+// Plan ONE shard, run inside that shard's own render job:
+//   node shard-preview-ids.mjs --previews discovered.json --shards 6 --index 2 \
+//     [--exclude-file mode-filter.txt] --out exclude.txt --plan-out shard-plan.json
+// Writes the comma-separated `--exclude-preview-id` list this shard passes to `bundle pack`, and a
+// small plan record for the merge-side cross-check. Prints the number of previews this shard renders
+// — 0 means "there was nothing left for you", which a caller should treat as "skip the render", not
+// as an error.
+//
+// VERIFY the plans a finished matrix produced, run before merging its bundles:
+//   node shard-preview-ids.mjs --verify shard-plan-1.json shard-plan-2.json …
+// Exits non-zero, naming the disagreement, if the shards did not between them render exactly the
+// discovered set once each.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: {
+      previews: { type: "string" },
+      shards: { type: "string" },
+      index: { type: "string" },
+      "exclude-file": { type: "string" },
+      out: { type: "string" },
+      "plan-out": { type: "string" },
+      verify: { type: "boolean", default: false },
+    },
+  });
+
+  if (values.verify) {
+    const plans = positionals.map((f) => JSON.parse(readFileSync(f, "utf8")));
+    const { ok, problems } = verifyShardPlans(plans);
+    if (!ok) {
+      for (const problem of problems) {
+        console.error(`shard-preview-ids: ${problem}`);
+      }
+      console.error(
+        "shard-preview-ids: refusing to merge — the shards did not cover the discovered previews " +
+          "exactly once. Re-run the render; if it repeats, discovery is not reproducible across " +
+          "runners and the partition cannot be derived per shard.",
+      );
+      process.exit(1);
+    }
+    console.error(
+      `shard-preview-ids: ${plans.length} shard(s) cover ${plans[0]?.renderable ?? 0} preview(s) ` +
+        `exactly once`,
+    );
+  } else {
+    if (!values.previews || !values.shards || !values.index || !values.out) {
+      console.error(
+        "usage: shard-preview-ids.mjs --previews <list.json> --shards <n> --index <k> " +
+          "--out <exclude.txt> [--plan-out <plan.json>] [--exclude-file <ids.txt>]\n" +
+          "       shard-preview-ids.mjs --verify <plan.json>…",
+      );
+      process.exit(2);
+    }
+    const previews = previewsFromJson(JSON.parse(readFileSync(values.previews, "utf8")));
+    const deferred = values["exclude-file"]
+      ? parseIdList(readFileSync(values["exclude-file"], "utf8"))
+      : [];
+    const requested = Number(values.shards);
+    const index = Number(values.index);
+    const plan = shardRenderPlan(previews, requested, deferred);
+    const mine = plan.shards.find((s) => s.index === index);
+
+    if (plan.total < requested && index === 1) {
+      console.error(
+        `shard-preview-ids: ${requested} shards requested but only ${plan.renderable} renderable ` +
+          `preview(s) — ${plan.total} shard(s) will render, the rest are no-ops.`,
+      );
+    }
+    if (!mine) {
+      // More shards than previews: this one has nothing to do. Its exclusion list would name every
+      // preview, which `composePreviewRender` rejects outright — so say "0" and let the workflow
+      // skip the render rather than fail it.
+      writeFileSync(values.out, "");
+      if (values["plan-out"]) {
+        writeFileSync(
+          values["plan-out"],
+          `${JSON.stringify({ index, total: plan.total, renderable: plan.renderable, previews: [] }, null, 2)}\n`,
+        );
+      }
+      console.error(`shard-preview-ids: shard ${index} of ${plan.total} has no previews to render.`);
+      console.log("0");
+    } else {
+      writeFileSync(values.out, mine.exclude.join(","));
+      if (values["plan-out"]) {
+        writeFileSync(
+          values["plan-out"],
+          `${JSON.stringify({ index, total: plan.total, renderable: plan.renderable, previews: mine.previews }, null, 2)}\n`,
+        );
+      }
+      console.error(
+        `shard-preview-ids: shard ${index}/${plan.total} renders ${mine.previews.length} of ` +
+          `${plan.renderable} preview(s), excluding ${mine.exclude.length}` +
+          (plan.deferred.length > 0 ? ` (${plan.deferred.length} deferred by the spec)` : ""),
+      );
+      console.log(String(mine.previews.length));
+    }
+  }
+}

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -41,8 +41,58 @@
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 import { parseArgs } from "node:util";
 import { previewsFromJson } from "./deferred-preview-ids.mjs";
+
+/**
+ * Port of the renderer's `PreviewNameFilter.matches` — the `--preview` / `-PcomposePreview.filter`
+ * selector — so the partition can see the same preview set the render will.
+ *
+ * The pre-flight emits a positive **function-name** filter when a spec defers a whole entry
+ * (`renderFilterPatterns`), and the shard render passes it as `ORG_GRADLE_PROJECT_composePreview.filter`.
+ * Partitioning the *unfiltered* discovery output against that would be a live bug, not a rounding
+ * error: a shard whose share happened to be all deferred-function ids would report work to do, then
+ * exclude every id the name filter kept — and `composePreviewRender` rejects a selection that
+ * renders nothing.
+ *
+ * Semantics, matched deliberately rather than approximated (both directions are wrong: too
+ * permissive re-opens the empty-render bug, too strict silently drops a sticker from every shard):
+ *  - a pattern containing `*` or `?` is anchored and full-matched as a glob;
+ *  - a pattern without them matches on equality **or substring**;
+ *  - either candidate name counts — the simple function name or `<package>.<functionName>`;
+ *  - matching is case-sensitive, any pattern keeps the preview, and an empty list keeps everything.
+ */
+export function previewNameMatches(patterns, functionName, className = "") {
+  const cleaned = (patterns ?? []).map((p) => String(p).trim()).filter((p) => p.length > 0);
+  if (cleaned.length === 0) return true;
+  const simple = String(functionName ?? "");
+  const pkg = String(className ?? "").includes(".")
+    ? String(className).slice(0, String(className).lastIndexOf("."))
+    : "";
+  const fq = pkg.length > 0 ? `${pkg}.${simple}` : simple;
+  return cleaned.some((pattern) => {
+    if (pattern.includes("*") || pattern.includes("?")) {
+      const regex = new RegExp(
+        `^${pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*").replace(/\?/g, ".")}$`,
+      );
+      return regex.test(simple) || regex.test(fq);
+    }
+    return (
+      simple === pattern || fq === pattern || simple.includes(pattern) || fq.includes(pattern)
+    );
+  });
+}
+
+/**
+ * A stable fingerprint of the renderable id set, carried in every shard's plan so the merge can
+ * check that the shards discovered the *same* previews rather than merely the same NUMBER of them.
+ * Two runners that saw `["a"]` and `["d"]` are disjoint with a union of size two, which a count
+ * comparison calls agreement and a digest comparison does not.
+ */
+export function renderableDigest(ids) {
+  return createHash("sha256").update([...(ids ?? [])].sort().join("\n")).digest("hex").slice(0, 16);
+}
 
 /**
  * Round-robin [ids] (sorted, de-duplicated) into [shards] partitions.
@@ -71,17 +121,30 @@ export function partitionPreviewIds(ids, shards) {
  * The full render plan for a sharded run: what each shard renders, and the `--exclude-preview-id`
  * list that makes it render only that.
  *
- * @param {Array<{id: string}>} previews discovered previews (from `compose-preview list --json`).
+ * Three things are removed from the partition before it is drawn, each for the same reason — a
+ * shard must never be handed a share that the render will not actually produce:
+ *  - ids of functions the **name filter** drops (an entry-level `priority: "deferred"`);
+ *  - ids `modePriority` **defers**;
+ * and both are then excluded in *every* shard, so the two levers compose instead of competing.
+ *
+ * @param {Array<{id: string, functionName?: string, className?: string}>} previews discovered
+ *   previews (from `compose-preview list --json`).
  * @param {number} shards requested shard count.
  * @param {string[]} deferred ids already excluded by `modePriority` — dropped from the partition and
  *   re-added to every shard's exclusion list.
+ * @param {string[]} renderFilter the pre-flight's positive function-name patterns
+ *   (`renderFilterPatterns`); empty ⇒ every discovered preview renders.
  * @returns {{shards: Array<{index: number, previews: string[], exclude: string[]}>, total: number,
- *   renderable: number, deferred: string[]}} `index` is 1-based (it is what a human reads in the
- *   Actions matrix); `total` is the effective shard count after clamping.
+ *   renderable: number, digest: string, deferred: string[], filteredOut: number}} `index` is
+ *   1-based (it is what a human reads in the Actions matrix); `total` is the effective shard count
+ *   after clamping.
  */
-export function shardRenderPlan(previews, shards, deferred = []) {
+export function shardRenderPlan(previews, shards, deferred = [], renderFilter = []) {
   const deferredSet = new Set(deferred ?? []);
-  const all = (previews ?? [])
+  const selected = (previews ?? []).filter((p) =>
+    previewNameMatches(renderFilter, p?.functionName ?? p?.id, p?.className),
+  );
+  const all = selected
     .map((p) => p?.id)
     .filter((id) => typeof id === "string" && id.length > 0);
   const renderable = [...new Set(all)].filter((id) => !deferredSet.has(id)).sort();
@@ -100,6 +163,8 @@ export function shardRenderPlan(previews, shards, deferred = []) {
     }),
     total: partitions.length,
     renderable: renderable.length,
+    digest: renderableDigest(renderable),
+    filteredOut: new Set((previews ?? []).map((p) => p?.id)).size - new Set(all).size,
     deferred: [...deferredSet].sort(),
   };
 }
@@ -123,12 +188,15 @@ export function parseIdList(text) {
  * a component, with no hint that the shards saw different worlds.
  *
  * Checks, in the order they'd bite:
- *  - every shard saw the same renderable set size and planned the same shard count;
+ *  - every shard planned the same shard count, and discovered the **same id set** — compared by
+ *    `digest`, not by count, because two runners that saw `["a"]` and `["b"]` are disjoint with a
+ *    union of the right size, which a count comparison happily calls agreement;
  *  - the partitions are pairwise disjoint (an overlap is wasted render time, and `bundle merge`
  *    would silently pick a winner);
  *  - the partitions cover the whole renderable set (a gap is a missing sticker).
  *
- * @param {Array<{index: number, total: number, renderable: number, previews: string[]}>} plans
+ * @param {Array<{index: number, total: number, renderable: number, digest?: string,
+ *   previews: string[]}>} plans
  * @returns {{ok: boolean, problems: string[]}} `problems` is empty iff the merge is safe.
  */
 export function verifyShardPlans(plans) {
@@ -145,6 +213,17 @@ export function verifyShardPlans(plans) {
     problems.push(
       `shards discovered different numbers of renderable previews: ${[...renderables].join(", ")}`,
     );
+  }
+  // The set, not just its size. Same count with different members is the failure a count check
+  // cannot see, and it is the one that would corrupt the merge quietly: the base's manifest expects
+  // an id nothing baked, while an unrelated artifact rides in from another shard.
+  const digests = new Set(list.map((p) => p?.digest).filter((d) => typeof d === "string"));
+  if (digests.size > 1) {
+    problems.push(
+      `shards discovered different preview SETS (renderable digests ${[...digests].join(", ")})`,
+    );
+  } else if (digests.size === 0) {
+    problems.push("shard plans carry no renderable digest — they predate the set comparison");
   }
   if (list.length !== (list[0]?.total ?? list.length)) {
     problems.push(`expected ${list[0]?.total} shard plan(s), got ${list.length}`);
@@ -174,7 +253,8 @@ export function verifyShardPlans(plans) {
 //
 // Plan ONE shard, run inside that shard's own render job:
 //   node shard-preview-ids.mjs --previews discovered.json --shards 6 --index 2 \
-//     [--exclude-file mode-filter.txt] --out exclude.txt --plan-out shard-plan.json
+//     [--exclude-file mode-filter.txt] [--render-filter-file render-filter.txt] \
+//     --out exclude.txt --plan-out shard-plan.json
 // Writes the comma-separated `--exclude-preview-id` list this shard passes to `bundle pack`, and a
 // small plan record for the merge-side cross-check. Prints the number of previews this shard renders
 // — 0 means "there was nothing left for you", which a caller should treat as "skip the render", not
@@ -192,6 +272,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       shards: { type: "string" },
       index: { type: "string" },
       "exclude-file": { type: "string" },
+      "render-filter-file": { type: "string" },
       out: { type: "string" },
       "plan-out": { type: "string" },
       verify: { type: "boolean", default: false },
@@ -220,7 +301,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     if (!values.previews || !values.shards || !values.index || !values.out) {
       console.error(
         "usage: shard-preview-ids.mjs --previews <list.json> --shards <n> --index <k> " +
-          "--out <exclude.txt> [--plan-out <plan.json>] [--exclude-file <ids.txt>]\n" +
+          "--out <exclude.txt> [--plan-out <plan.json>] [--exclude-file <ids.txt>] " +
+          "[--render-filter-file <patterns.txt>]\n" +
           "       shard-preview-ids.mjs --verify <plan.json>…",
       );
       process.exit(2);
@@ -229,9 +311,21 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     const deferred = values["exclude-file"]
       ? parseIdList(readFileSync(values["exclude-file"], "utf8"))
       : [];
+    // The pre-flight's positive function-name filter, when a spec defers a whole entry. The render
+    // applies it too, so the partition has to see the same set or a shard can end up with a share
+    // the render will not produce.
+    const renderFilter = values["render-filter-file"]
+      ? parseIdList(readFileSync(values["render-filter-file"], "utf8"))
+      : [];
     const requested = Number(values.shards);
     const index = Number(values.index);
-    const plan = shardRenderPlan(previews, requested, deferred);
+    const plan = shardRenderPlan(previews, requested, deferred, renderFilter);
+    if (plan.filteredOut > 0 && index === 1) {
+      console.error(
+        `shard-preview-ids: the render filter drops ${plan.filteredOut} discovered preview(s) ` +
+          `before partitioning (${renderFilter.length} pattern(s)).`,
+      );
+    }
     const mine = plan.shards.find((s) => s.index === index);
 
     if (plan.total < requested && index === 1) {
@@ -248,7 +342,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       if (values["plan-out"]) {
         writeFileSync(
           values["plan-out"],
-          `${JSON.stringify({ index, total: plan.total, renderable: plan.renderable, previews: [] }, null, 2)}\n`,
+          `${JSON.stringify({ index, total: plan.total, renderable: plan.renderable, digest: plan.digest, previews: [] }, null, 2)}\n`,
         );
       }
       console.error(`shard-preview-ids: shard ${index} of ${plan.total} has no previews to render.`);
@@ -258,7 +352,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       if (values["plan-out"]) {
         writeFileSync(
           values["plan-out"],
-          `${JSON.stringify({ index, total: plan.total, renderable: plan.renderable, previews: mine.previews }, null, 2)}\n`,
+          `${JSON.stringify({ index, total: plan.total, renderable: plan.renderable, digest: plan.digest, previews: mine.previews }, null, 2)}\n`,
         );
       }
       console.error(

--- a/scripts/design-artifacts/shard-preview-ids.test.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.test.mjs
@@ -1,0 +1,185 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseIdList,
+  partitionPreviewIds,
+  shardRenderPlan,
+  verifyShardPlans,
+} from "./shard-preview-ids.mjs";
+
+const preview = (id) => ({ id, functionName: id.replace(/_(Light|Dark)$/, "") });
+
+test("round-robins the sorted id list so a heavy group is spread, not clustered", () => {
+  // Ids sort by group, so contiguous blocks would put every Template preview in one shard.
+  const ids = [
+    "ButtonA_Light",
+    "ButtonB_Light",
+    "ButtonC_Light",
+    "TemplateA_Light",
+    "TemplateB_Light",
+    "TemplateC_Light",
+  ];
+  const [first, second, third] = partitionPreviewIds(ids, 3);
+  assert.deepEqual(first, ["ButtonA_Light", "TemplateA_Light"]);
+  assert.deepEqual(second, ["ButtonB_Light", "TemplateB_Light"]);
+  assert.deepEqual(third, ["ButtonC_Light", "TemplateC_Light"]);
+});
+
+test("the partition is a disjoint cover of every id", () => {
+  const ids = Array.from({ length: 47 }, (_, i) => `P${String(i).padStart(2, "0")}`);
+  const partitions = partitionPreviewIds(ids, 6);
+  assert.equal(partitions.length, 6);
+  assert.deepEqual(partitions.flat().sort(), [...ids].sort());
+  assert.equal(new Set(partitions.flat()).size, ids.length, "no id appears twice");
+  const sizes = partitions.map((p) => p.length);
+  assert.ok(Math.max(...sizes) - Math.min(...sizes) <= 1, `balanced within one: ${sizes}`);
+});
+
+test("is deterministic regardless of the order discovery reported ids in", () => {
+  const ids = ["c", "a", "d", "b"];
+  assert.deepEqual(partitionPreviewIds(ids, 2), partitionPreviewIds([...ids].reverse(), 2));
+});
+
+test("clamps the shard count to the preview count rather than planning an empty shard", () => {
+  // An empty shard's exclusion list would name every preview, which composePreviewRender rejects.
+  const partitions = partitionPreviewIds(["a", "b", "c"], 6);
+  assert.equal(partitions.length, 3);
+  assert.ok(partitions.every((p) => p.length > 0));
+});
+
+test("each shard excludes exactly the previews the other shards render", () => {
+  const previews = ["a", "b", "c", "d"].map(preview);
+  const plan = shardRenderPlan(previews, 2);
+
+  assert.equal(plan.total, 2);
+  assert.equal(plan.renderable, 4);
+  assert.deepEqual(plan.shards[0].previews, ["a", "c"]);
+  assert.deepEqual(plan.shards[0].exclude, ["b", "d"]);
+  assert.deepEqual(plan.shards[1].previews, ["b", "d"]);
+  assert.deepEqual(plan.shards[1].exclude, ["a", "c"]);
+  // Union of what the shards render is the whole renderable set — nothing is silently dropped.
+  assert.deepEqual(plan.shards.flatMap((s) => s.previews).sort(), ["a", "b", "c", "d"]);
+});
+
+test("deferred ids are excluded in EVERY shard and take no share of the partition", () => {
+  // The mode deferral and the partition are both exclusions; the deferred ids must not compete for
+  // a slot, or one shard renders fewer previews than the others for no reason.
+  const previews = ["a_Light", "a_Dark", "b_Light", "b_Dark"].map(preview);
+  const plan = shardRenderPlan(previews, 2, ["a_Dark", "b_Dark"]);
+
+  assert.equal(plan.renderable, 2, "only the light previews are rendered at all");
+  assert.deepEqual(plan.shards[0].previews, ["a_Light"]);
+  assert.deepEqual(plan.shards[1].previews, ["b_Light"]);
+  for (const shard of plan.shards) {
+    assert.ok(shard.exclude.includes("a_Dark"), `shard ${shard.index} defers a_Dark`);
+    assert.ok(shard.exclude.includes("b_Dark"), `shard ${shard.index} defers b_Dark`);
+  }
+  assert.deepEqual(plan.shards[0].exclude, ["a_Dark", "b_Dark", "b_Light"]);
+});
+
+test("a deferred id discovery never saw is still excluded", () => {
+  // Exclusion polarity: a pattern matching nothing renders more, never less. A spec that has drifted
+  // ahead of the code must not fail the plan.
+  const plan = shardRenderPlan(["a", "b"].map(preview), 2, ["ghost"]);
+  assert.ok(plan.shards.every((s) => s.exclude.includes("ghost")));
+  assert.equal(plan.renderable, 2);
+});
+
+test("one shard means one exclusion list holding only the deferred ids", () => {
+  const plan = shardRenderPlan(["a", "b"].map(preview), 1, ["c"]);
+  assert.equal(plan.total, 1);
+  assert.deepEqual(plan.shards[0].previews, ["a", "b"]);
+  assert.deepEqual(plan.shards[0].exclude, ["c"]);
+});
+
+test("de-duplicates ids discovery reported twice", () => {
+  const plan = shardRenderPlan([preview("a"), preview("a"), preview("b")], 2);
+  assert.equal(plan.renderable, 2);
+  assert.deepEqual(plan.shards.flatMap((s) => s.previews).sort(), ["a", "b"]);
+});
+
+test("no previews yields no shards, so the caller can refuse instead of rendering nothing", () => {
+  assert.deepEqual(partitionPreviewIds([], 4), []);
+  const plan = shardRenderPlan([], 4);
+  assert.equal(plan.total, 0);
+  assert.deepEqual(plan.shards, []);
+});
+
+test("ignores malformed discovery entries", () => {
+  const plan = shardRenderPlan([{ id: "a" }, {}, { id: "" }, null, { id: "b" }], 2);
+  assert.equal(plan.renderable, 2);
+  assert.deepEqual(plan.shards.flatMap((s) => s.previews).sort(), ["a", "b"]);
+});
+
+test("parseIdList reads both the comma form and a newline-separated file", () => {
+  assert.deepEqual(parseIdList("a,b , c"), ["a", "b", "c"]);
+  assert.deepEqual(parseIdList("a\nb\n\n"), ["a", "b"]);
+  assert.deepEqual(parseIdList(""), []);
+  assert.deepEqual(parseIdList(undefined), []);
+});
+
+/** The plan records the shards upload, as `shardRenderPlan` would have produced them. */
+const plansFor = (previews, shards, deferred = []) =>
+  shardRenderPlan(previews.map(preview), shards, deferred).shards.map((s) => ({
+    index: s.index,
+    total: shards,
+    renderable: previews.length - deferred.length,
+    previews: s.previews,
+  }));
+
+test("verifyShardPlans accepts a disjoint cover of the discovered set", () => {
+  const { ok, problems } = verifyShardPlans(plansFor(["a", "b", "c", "d"], 2));
+  assert.deepEqual(problems, []);
+  assert.ok(ok);
+});
+
+test("verifyShardPlans accepts plans that arrive out of order", () => {
+  const plans = plansFor(["a", "b", "c", "d"], 2).reverse();
+  assert.ok(verifyShardPlans(plans).ok);
+});
+
+test("verifyShardPlans catches a gap — the failure the completeness gate would only hint at", () => {
+  const plans = plansFor(["a", "b", "c", "d"], 2);
+  plans[1].previews = plans[1].previews.slice(1);
+  const { ok, problems } = verifyShardPlans(plans);
+  assert.equal(ok, false);
+  assert.match(problems.join("\n"), /rendered 3 preview\(s\), but discovery found 4/);
+});
+
+test("verifyShardPlans catches an overlap", () => {
+  const plans = plansFor(["a", "b", "c", "d"], 2);
+  plans[1].previews = [...plans[1].previews, "a"];
+  const { ok, problems } = verifyShardPlans(plans);
+  assert.equal(ok, false);
+  assert.match(problems.join("\n"), /preview a was rendered by shards 1 and 2/);
+});
+
+test("verifyShardPlans catches shards that discovered different worlds", () => {
+  const plans = plansFor(["a", "b", "c", "d"], 2);
+  plans[0].renderable = 5;
+  const { ok, problems } = verifyShardPlans(plans);
+  assert.equal(ok, false);
+  assert.match(problems.join("\n"), /different numbers of renderable previews/);
+});
+
+test("verifyShardPlans catches a shard whose bundle never arrived", () => {
+  const plans = plansFor(["a", "b", "c", "d"], 2).slice(0, 1);
+  const { ok, problems } = verifyShardPlans(plans);
+  assert.equal(ok, false);
+  assert.match(problems.join("\n"), /expected 2 shard plan\(s\), got 1/);
+});
+
+test("verifyShardPlans rejects an empty set of plans", () => {
+  assert.deepEqual(verifyShardPlans([]), {
+    ok: false,
+    problems: ["no shard plans were uploaded"],
+  });
+});
+
+test("verifyShardPlans is satisfied by the plans a deferring catalog produces", () => {
+  // Deferred ids are in no shard's partition, and `renderable` counts only what renders — so the
+  // cover check must not expect them back.
+  const plans = plansFor(["a_Light", "a_Dark", "b_Light", "b_Dark"], 2, ["a_Dark", "b_Dark"]);
+  assert.ok(verifyShardPlans(plans).ok, JSON.stringify(plans));
+});

--- a/scripts/design-artifacts/shard-preview-ids.test.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.test.mjs
@@ -4,6 +4,8 @@ import assert from "node:assert/strict";
 import {
   parseIdList,
   partitionPreviewIds,
+  previewNameMatches,
+  renderableDigest,
   shardRenderPlan,
   verifyShardPlans,
 } from "./shard-preview-ids.mjs";
@@ -120,13 +122,16 @@ test("parseIdList reads both the comma form and a newline-separated file", () =>
 });
 
 /** The plan records the shards upload, as `shardRenderPlan` would have produced them. */
-const plansFor = (previews, shards, deferred = []) =>
-  shardRenderPlan(previews.map(preview), shards, deferred).shards.map((s) => ({
+const plansFor = (previews, shards, deferred = []) => {
+  const plan = shardRenderPlan(previews.map(preview), shards, deferred);
+  return plan.shards.map((s) => ({
     index: s.index,
     total: shards,
-    renderable: previews.length - deferred.length,
+    renderable: plan.renderable,
+    digest: plan.digest,
     previews: s.previews,
   }));
+};
 
 test("verifyShardPlans accepts a disjoint cover of the discovered set", () => {
   const { ok, problems } = verifyShardPlans(plansFor(["a", "b", "c", "d"], 2));
@@ -182,4 +187,103 @@ test("verifyShardPlans is satisfied by the plans a deferring catalog produces", 
   // cover check must not expect them back.
   const plans = plansFor(["a_Light", "a_Dark", "b_Light", "b_Dark"], 2, ["a_Dark", "b_Dark"]);
   assert.ok(verifyShardPlans(plans).ok, JSON.stringify(plans));
+});
+
+// --- the pre-flight's positive function-name filter -----------------------------------------
+
+test("previewNameMatches ports the renderer's plain equality-or-substring rule", () => {
+  assert.ok(previewNameMatches([], "Anything"), "an empty filter keeps everything");
+  assert.ok(previewNameMatches(["FilledButtonPreview"], "FilledButtonPreview"));
+  assert.ok(previewNameMatches(["FilledButton"], "FilledButtonPreview"), "substring matches");
+  assert.equal(previewNameMatches(["OutlinedButton"], "FilledButtonPreview"), false);
+  assert.ok(previewNameMatches([" FilledButton ", ""], "FilledButtonPreview"), "trims and skips blanks");
+});
+
+test("previewNameMatches matches the package-qualified name too", () => {
+  const cls = "com.example.ui.ButtonsKt";
+  assert.ok(previewNameMatches(["com.example.ui.FilledButtonPreview"], "FilledButtonPreview", cls));
+  assert.ok(previewNameMatches(["com.example.ui"], "FilledButtonPreview", cls), "package substring");
+  assert.equal(previewNameMatches(["com.other.ui.FilledButtonPreview"], "FilledButtonPreview", cls), false);
+});
+
+test("previewNameMatches anchors a glob instead of substring-matching it", () => {
+  assert.ok(previewNameMatches(["Filled*Preview"], "FilledButtonPreview"));
+  assert.ok(previewNameMatches(["*ButtonPreview"], "FilledButtonPreview"));
+  assert.equal(previewNameMatches(["Filled*"], "OutlinedFilledButtonPreview"), false, "anchored");
+  assert.ok(previewNameMatches(["FilledButtonPreview?"], "FilledButtonPreview2"));
+  // A dot in an FQN glob is a literal, not "any char".
+  assert.equal(previewNameMatches(["com.example.*"], "comXexample.Foo", ""), false);
+});
+
+test("the render filter drops non-required functions BEFORE the partition is drawn", () => {
+  // Without this, a shard could be handed a share made entirely of deferred-function ids: it would
+  // report work to do, exclude every id the name filter kept, and the render would refuse a
+  // selection that produces nothing.
+  const previews = [
+    { id: "Keep_Light", functionName: "KeepPreview" },
+    { id: "Keep_Dark", functionName: "KeepPreview" },
+    { id: "Drop_Light", functionName: "DropPreview" },
+    { id: "Drop_Dark", functionName: "DropPreview" },
+  ];
+  const plan = shardRenderPlan(previews, 2, [], ["KeepPreview"]);
+
+  assert.equal(plan.renderable, 2);
+  assert.equal(plan.filteredOut, 2);
+  assert.deepEqual(plan.shards.flatMap((s) => s.previews).sort(), ["Keep_Dark", "Keep_Light"]);
+  for (const shard of plan.shards) {
+    assert.equal(shard.exclude.some((id) => id.startsWith("Drop_")), false,
+      "a filtered-out id needs no exclusion — the name filter already drops it");
+  }
+});
+
+test("a filter that would leave a shard empty clamps the shard count instead of failing it", () => {
+  const previews = [
+    { id: "Keep_Light", functionName: "KeepPreview" },
+    ...Array.from({ length: 10 }, (_, i) => ({ id: `Drop${i}`, functionName: "DropPreview" })),
+  ];
+  const plan = shardRenderPlan(previews, 6, [], ["KeepPreview"]);
+  assert.equal(plan.total, 1, "one renderable preview means one real shard");
+  assert.deepEqual(plan.shards[0].previews, ["Keep_Light"]);
+  assert.deepEqual(plan.shards[0].exclude, [], "nothing left to exclude");
+});
+
+test("the render filter and modePriority deferral compose", () => {
+  const previews = [
+    { id: "Keep_Light", functionName: "KeepPreview" },
+    { id: "Keep_Dark", functionName: "KeepPreview" },
+    { id: "Drop_Light", functionName: "DropPreview" },
+  ];
+  const plan = shardRenderPlan(previews, 2, ["Keep_Dark"], ["KeepPreview"]);
+  assert.equal(plan.renderable, 1);
+  assert.deepEqual(plan.shards[0].previews, ["Keep_Light"]);
+  assert.deepEqual(plan.shards[0].exclude, ["Keep_Dark"]);
+});
+
+// --- discovered-set agreement, not just cardinality -----------------------------------------
+
+test("renderableDigest is order-independent and set-sensitive", () => {
+  assert.equal(renderableDigest(["a", "b"]), renderableDigest(["b", "a"]));
+  assert.notEqual(renderableDigest(["a", "b"]), renderableDigest(["a", "c"]));
+});
+
+test("verifyShardPlans catches same-sized but DIFFERENT discovered sets", () => {
+  // The count check passes here — two plans, `renderable: 2`, partitions ["a"] and ["d"], disjoint,
+  // union of size two. Only the digest sees that the runners discovered different worlds.
+  const plans = [
+    { index: 1, total: 2, renderable: 2, digest: renderableDigest(["a", "b"]), previews: ["a"] },
+    { index: 2, total: 2, renderable: 2, digest: renderableDigest(["c", "d"]), previews: ["d"] },
+  ];
+  const { ok, problems } = verifyShardPlans(plans);
+  assert.equal(ok, false);
+  assert.match(problems.join("\n"), /different preview SETS/);
+});
+
+test("verifyShardPlans rejects plans with no digest at all", () => {
+  const plans = [
+    { index: 1, total: 2, renderable: 2, previews: ["a"] },
+    { index: 2, total: 2, renderable: 2, previews: ["b"] },
+  ];
+  const { ok, problems } = verifyShardPlans(plans);
+  assert.equal(ok, false);
+  assert.match(problems.join("\n"), /no renderable digest/);
 });


### PR DESCRIPTION
## Summary

The design-artifacts render is one serial `bundle pack`, and it grows close to linearly with the sheet. Measured over four `m3-catalog` runs on `main`:

| Commit | Previews | Render step | Job total |
| --- | --- | --- | --- |
| `d354560` | 287 | 13.6 min | 17.2 min |
| `323e4a2` | 519 | 22.5 min | 24.0 min |
| `5edc70a` | 607 | 26.7 min | 29.6 min |
| `f35c2e5` | 689 | 27.2 min | 28.9 min |

→ `render_minutes ≈ 3.7 + 2.15s × previews`. At ~1500 previews that is ~58 min, past a 40-minute `render-timeout`; at ~2400 it passes the 90-minute job timeout, and **no value of `render-timeout` fixes that**. Only dividing the marginal 2.15 s does.

### `render-shards: N`

New generic input on `design-artifacts-reusable.yml`, **default `1`** — at the default the two new jobs never run and `generate` renders inline exactly as before, byte for byte.

Above 1, each shard runs the same `bundle pack` with `--exclude-preview-id` naming everything that is not its share. Excluded previews stay *listed* in the bundle without a baked PNG (the mechanism render-priority deferral already relies on), so every shard emits a structurally identical bundle — same `previews.json`, same manifest, same re-render classpath — differing only in which `previews/<id>.*` slots are filled.

```
        ┌── shard 1: discover → plan → bundle pack → upload ──┐
 matrix ┼── shard 2: …                                        ┼── merge ── generate ── publish
 [1..N] └── shard N: …                                        ┘
```

### `compose-preview bundle merge` — and why `bundle repack` could not be used

This was the load-bearing open question, and the answer is a **no**:

> `repackRethemedPreviews` swaps re-renders into slots the target **already has**, and only handles `previews/<id>.png` + `previews/<id>.figma.svg`. Against a shard base, every other shard's previews are reported unmatched and dropped — the base's render excluded them, so there is no slot — and the JSON sidecars are explicitly preserved verbatim rather than merged, so any preview that did land would arrive without its `.semantics.json`, which the design-catalog completeness gate fails.

So `bundle merge <base> <shard>… -o <out>` unions the per-preview artifacts: the raster, its `.semantics.json` / `.layout.json` / `.fonts.json` / `.figma.svg` / `.catalog.json` / `.overrides.json` sidecars, the nested `figma-raster/` crops, `ir/<id>.rc` and `extensions/<id>.json`. Base wins on collision, earlier shards over later ones, and it streams each shard's zip so the shared `classes/` + `libs/` payload is read past rather than held.

Manifests, cover and the re-render classpath are **inherited from the base shard, not merged** — every shard packs the same module at the same commit, so they are identical by construction. That is why `publish-live-bundle` + `split-per-preview` need no designated shard.

### Partitioning

Each shard derives its own partition from its own `compose-preview list --json`. A central plan job would have to compile before it could discover, adding its whole ~4.6 min to the critical path instead of ~0.9 min inside each shard's own compile (that compile is shared with the shard's render).

`scripts/design-artifacts/shard-preview-ids.mjs` owns three decisions:

- **by preview id, never by function name** — one function expands to a 30-cell matrix while its neighbour expands to two, and the slowest shard sets wall clock;
- **round-robin over the sorted id list, not contiguous blocks** — ids sort by group, so blocks cluster the template-heavy groups into one shard. Sorting also makes independent shards agree without talking to each other;
- **`modePriority`-deferred ids are removed before partitioning and re-excluded in every shard** — so deferral shrinks the work the shards divide instead of competing with the partition for slots. The two levers compose.

Because the shards plan independently, the merge step cross-checks their uploaded plans (`shard-preview-ids.mjs --verify`: same discovered set, pairwise disjoint, complete cover) before unioning. Without it, a disagreement would surface as a completeness-gate failure naming a component, with nothing pointing at the shards.

### Projection

| Previews | N=1 | N=4 | N=6 | N=8 |
| --- | --- | --- | --- | --- |
| 689 | 29.4 | 15.8 | 13.7 | 12.7 |
| 1000 | 40.5 | 18.6 | 15.6 | 14.1 |
| 1500 | 58.4 | 23.0 | 18.6 | 16.3 |
| 2500 | 94.3 | 32.0 | 24.5 | 20.8 |

Every shard pays the ~3.7 min compile in full, so **4–6 is the useful range**; 6→8 at 1500 previews saves 2.3 min for two more runners, and 16 buys compile time, not throughput.

Not sharded: the **extra module** (a supplement, small by construction) renders in `generate` as before, and a `@PreviewParameter` provider's **rows** travel whole with their parent id — correct, and the most likely source of a straggler shard. Bin-packing from recorded per-preview times is worth building once one shows up.

### Drive-by

`-o` is now classified in `CliFlags.VALUE_FLAGS`. It has always consumed the next token; the registry test's scanner only matches `--` flags, so it was never caught. Without it a variadic positional list (`bundle merge a.png b.png -o out.png`) reads the output path as another operand.

## Test plan

- `./gradlew :cli:test` — 1616/1617 pass. The one failure, `ServeWebFixtureTest > serve web fixtures are in sync with ServeWeb()`, reproduces on a clean tree at this base and is unrelated to this change.
- New `BundleMergeTest` (9 cases) pins the two things repack cannot do — adding a slot, and carrying the semantics sidecar with it — plus base-wins-on-collision, earlier-shard-wins, overlap reporting, inheritance of manifests/classpath, nested crops + `ir/` + `extensions/`, a deferred preview staying unbaked, and rejection of a non-bundle input.
- New `shard-preview-ids.test.mjs` (20 cases), picked up by the existing `design-artifacts-driver-tests` `node --test` job: disjoint cover, balance within one, determinism under reordering, clamping to the preview count, deferral interaction, and every `verifyShardPlans` failure mode (gap, overlap, divergent discovery, missing shard).
- CLI smoke test of `bundle merge` against two hand-built polyglot bundles: shard 2's preview **and** its `.semantics.json` land in the merged bundle; shard 1's `classes/app.jar` and both manifests survive verbatim.
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` clean; both workflow files parse.

Text-only evidence is correct here — nothing rendered changes. The merged bundle is byte-equivalent in content to the unsharded one; that equivalence is what `BundleMergeTest` and the plan cross-check assert.

## Sequencing

`yschimke/m3-catalog` has the matching one-line `render-shards: 6` on a branch. It must not land before this does — the caller pins `@main`, and GitHub rejects an input the called workflow does not declare, failing the run before any job starts.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KchMGSmbx3Rjp6RZdjMyRa)_