### PR TITLE
fix(rc-compare): serialize the per-lane split and scope its means correctly

### DIFF
--- a/scripts/design-artifacts/rc-compare-means.mjs
+++ b/scripts/design-artifacts/rc-compare-means.mjs
@@ -1,0 +1,33 @@
+/**
+ * Lane-mean aggregation for the `rc-compare` summary.
+ *
+ * Extracted so the one subtlety here is testable: **each lane's means must be scoped to the rows
+ * that lane rendered**, not to the JS player's set. The optional players are independent — an
+ * embedded or CMP/Wasm player routinely renders a document the JS player chokes on (before #3427
+ * the JS lane managed 15 of remote-m3's 27 while the embedded player managed all 27). Averaging an
+ * optional lane over the JS lane's rows silently drops exactly those, leaving the lane's split
+ * disagreeing with the `meanMismatchPct` and `scored` count printed beside it.
+ */
+
+/** Mean of the numeric values [pick] returns over [rows]; null when it never returns one. */
+export function meanOf(rows, pick) {
+  const values = rows.map(pick).filter((v) => typeof v === "number");
+  return values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : null;
+}
+
+/**
+ * The rows an optional lane actually scored: it rendered them, and the baked reference wasn't blank
+ * (a blank reference is unscorable, which is why the lane's own mismatch is null there too).
+ */
+export function laneRows(rows, prefix) {
+  return rows.filter((r) => r[`${prefix}Rendered`] && !r.referenceBlank);
+}
+
+/** `{ meanCoverageDeltaPct, meanContentMismatchPct }` for one optional lane. */
+export function laneSplit(rows, prefix) {
+  const scoped = laneRows(rows, prefix);
+  return {
+    meanCoverageDeltaPct: meanOf(scoped, (r) => r[`${prefix}CoverageDeltaPct`]),
+    meanContentMismatchPct: meanOf(scoped, (r) => r[`${prefix}ContentMismatchPct`]),
+  };
+}

--- a/scripts/design-artifacts/rc-compare-means.test.mjs
+++ b/scripts/design-artifacts/rc-compare-means.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * The bug these pin: scoping an optional lane's means to the *JS* lane's scored rows. The lanes are
+ * independent, so a document the JS player fails and the embedded player renders must still count
+ * toward the embedded lane — otherwise its split disagrees with the `meanMismatchPct` and `scored`
+ * count printed next to it.
+ *
+ * Run with `node --test scripts/design-artifacts/*.test.mjs`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { laneRows, laneSplit, meanOf } from "./rc-compare-means.mjs";
+
+/** Two rows: the JS player only managed the first, the embedded player managed both. */
+const rows = [
+  {
+    rendered: true,
+    referenceBlank: false,
+    embeddedRendered: true,
+    embeddedCoverageDeltaPct: 2,
+    embeddedContentMismatchPct: 10,
+  },
+  {
+    rendered: false, // JS player choked on this document…
+    referenceBlank: false,
+    embeddedRendered: true, // …the embedded player did not.
+    embeddedCoverageDeltaPct: 8,
+    embeddedContentMismatchPct: 30,
+  },
+];
+
+test("a lane's means include rows the JS player failed", () => {
+  assert.equal(laneRows(rows, "embedded").length, 2);
+  const split = laneSplit(rows, "embedded");
+  assert.equal(split.meanCoverageDeltaPct, 5, "mean of 2 and 8, not just the JS-rendered 2");
+  assert.equal(split.meanContentMismatchPct, 20, "mean of 10 and 30");
+});
+
+test("a lane's means exclude rows that lane did not render", () => {
+  const mixed = [...rows, { rendered: true, referenceBlank: false, embeddedRendered: false }];
+  assert.equal(laneRows(mixed, "embedded").length, 2, "the un-rendered row is not scored");
+  assert.equal(laneSplit(mixed, "embedded").meanCoverageDeltaPct, 5);
+});
+
+test("a blank reference is unscorable even when the lane rendered it", () => {
+  const withBlank = [
+    ...rows,
+    {
+      rendered: true,
+      referenceBlank: true,
+      embeddedRendered: true,
+      embeddedCoverageDeltaPct: 99,
+      embeddedContentMismatchPct: 99,
+    },
+  ];
+  assert.equal(laneRows(withBlank, "embedded").length, 2);
+  assert.equal(laneSplit(withBlank, "embedded").meanCoverageDeltaPct, 5, "the blank row is ignored");
+});
+
+test("a lane that rendered nothing scorable reports null, not zero", () => {
+  const none = [{ rendered: true, referenceBlank: false, cmpWasmRendered: false }];
+  assert.deepEqual(laneSplit(none, "cmpWasm"), {
+    meanCoverageDeltaPct: null,
+    meanContentMismatchPct: null,
+  });
+});
+
+test("meanOf ignores nulls rather than counting them as zero", () => {
+  assert.equal(meanOf([{ v: 4 }, { v: null }, { v: 8 }], (r) => r.v), 6);
+  assert.equal(meanOf([{ v: null }], (r) => r.v), null);
+});

--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -53,6 +53,7 @@ import {
   readCmpWasmPixelTolerances,
 } from "./rc-compare-gate.mjs";
 import { BG, flattenOnto, isFullyTransparent, splitCoverage } from "./rc-compare-pixels.mjs";
+import { laneSplit as laneSplitFor } from "./rc-compare-means.mjs";
 import { DEFAULT_FONTS_DIR, fontFaceCss, loadAndVerifyFonts } from "./rc-fonts.mjs";
 
 function arg(name, def = undefined) {
@@ -698,11 +699,6 @@ const meanOf = (pick) => {
 };
 const meanCoverageDeltaPct = meanOf((r) => r.coverageDeltaPct);
 const meanContentMismatchPct = meanOf((r) => r.contentMismatchPct);
-/** Same split for the other player lanes, so every lane is judged on the same two axes. */
-const laneSplit = (prefix) => ({
-  meanCoverageDeltaPct: meanOf((r) => r[`${prefix}CoverageDeltaPct`]),
-  meanContentMismatchPct: meanOf((r) => r[`${prefix}ContentMismatchPct`]),
-});
 let cmpWasmGate = null;
 if (REQUIRE_CMP_WASM) {
   try {
@@ -751,7 +747,7 @@ fs.writeFileSync(
               const ok = rows.filter((r) => r.embeddedRendered && !r.referenceBlank);
               return ok.length ? ok.reduce((s, r) => s + r.embeddedMismatchPct, 0) / ok.length : null;
             })(),
-            ...laneSplit("embedded"),
+            ...laneSplitFor(rows, "embedded"),
           }
         : null,
       embeddedJvm: EMBEDDED_JVM
@@ -764,7 +760,7 @@ fs.writeFileSync(
                 ? ok.reduce((s, r) => s + r.embeddedJvmMismatchPct, 0) / ok.length
                 : null;
             })(),
-            ...laneSplit("embeddedJvm"),
+            ...laneSplitFor(rows, "embeddedJvm"),
           }
         : null,
       cmpWasm: CMP_WASM
@@ -777,7 +773,7 @@ fs.writeFileSync(
                 ? ok.reduce((s, r) => s + r.cmpWasmMismatchPct, 0) / ok.length
                 : null;
             })(),
-            ...laneSplit("cmpWasm"),
+            ...laneSplitFor(rows, "cmpWasm"),
             firstFrame: (() => {
               const summarize = (kind) => {
                 const values = rows
@@ -805,6 +801,9 @@ fs.writeFileSync(
         mismatchPct: r.mismatchPct,
         coverageDeltaPct: r.coverageDeltaPct,
         contentMismatchPct: r.contentMismatchPct,
+        // The share of the canvas the content verdict is computed over. Without it a content
+        // number read alone can't be told apart from one drawn from a sliver of overlap.
+        bothPaintedPct: r.bothPaintedPct ?? null,
         mismatchPx: r.mismatchPx,
         width: r.width,
         height: r.height,
@@ -812,14 +811,20 @@ fs.writeFileSync(
         referenceBlank: r.referenceBlank ?? false,
         embeddedRendered: r.embeddedRendered ?? null,
         embeddedMismatchPct: r.embeddedMismatchPct ?? null,
+        embeddedCoverageDeltaPct: r.embeddedCoverageDeltaPct ?? null,
+        embeddedContentMismatchPct: r.embeddedContentMismatchPct ?? null,
         embeddedMismatchPx: r.embeddedMismatchPx ?? null,
         embeddedNote: r.embeddedNote ?? null,
         embeddedJvmRendered: r.embeddedJvmRendered ?? null,
         embeddedJvmMismatchPct: r.embeddedJvmMismatchPct ?? null,
+        embeddedJvmCoverageDeltaPct: r.embeddedJvmCoverageDeltaPct ?? null,
+        embeddedJvmContentMismatchPct: r.embeddedJvmContentMismatchPct ?? null,
         embeddedJvmMismatchPx: r.embeddedJvmMismatchPx ?? null,
         embeddedJvmNote: r.embeddedJvmNote ?? null,
         cmpWasmRendered: r.cmpWasmRendered ?? null,
         cmpWasmMismatchPct: r.cmpWasmMismatchPct ?? null,
+        cmpWasmCoverageDeltaPct: r.cmpWasmCoverageDeltaPct ?? null,
+        cmpWasmContentMismatchPct: r.cmpWasmContentMismatchPct ?? null,
         cmpWasmMismatchPx: r.cmpWasmMismatchPx ?? null,
         cmpWasmFirstFrameMs: r.cmpWasmFirstFrameMs ?? null,
         cmpWasmStartup: r.cmpWasmStartup ?? null,


### PR DESCRIPTION
Two defects from #3438, both raised in review after it had already merged — so they are live on `main`. I verified each against the code before fixing; both are real.

## The per-preview split never reached the JSON

The summary's row mapper copies each optional lane's fields explicitly, so `embeddedCoverageDeltaPct` / `embeddedContentMismatchPct` and their cmp-jvm and cmp-wasm counterparts were dropped on the way out. Consumers got lane means and nothing per preview — the opposite of what #3438's description promised.

`bothPaintedPct` was missing for the JS lane too, dating back to #3434. That one matters more than it looks: a content mismatch of 0.4% means nothing without knowing whether it was computed over 90% of the canvas or 2% of it.

## Each lane's split means were scoped to the JS lane's rows

`scored` is built from `r.rendered` — the **JS** player's flag. So any document the JS player failed was excluded from *every other lane's* means, while those lanes' own `meanMismatchPct` correctly filters on their own rendered flag. The two numbers sat in the same object disagreeing about which rows they covered.

Not hypothetical: on remote-m3 before #3427 the JS lane rendered 15 of 27 while the embedded player rendered all 27, so the embedded split would have averaged 15 rows next to a `scored: 27` printed beside it.

## Why this needed a unit test

remote-m3's means are **unchanged** by this fix, because its JS lane now renders 27/27 and the two scopings coincide. Re-running the catalog would have shown nothing. The aggregation therefore moves into `rc-compare-means.mjs`, where the scoping can be exercised directly instead of living inline in a top-level script.

Five cases pin it: rows the JS lane failed still count toward another lane, rows the lane itself failed do not, a blank reference stays unscorable even when the lane rendered it, an empty lane reports `null` rather than a flattering zero, and nulls don't average as zeros.

## Test plan

- [x] `rc-compare-means.test.mjs` — 5 new cases, all pass
- [x] `rc-compare-pixels.test.mjs` + `rc-compare-gate.test.mjs` — 19 pass, 0 fail
- [x] End-to-end on remote-m3 with js + embedded + cmp-jvm + cmp-wasm: every serialized row now carries all nine split fields, verified by reading them back out of `rc-compare-summary.json`
- [x] Behaviour preserved by the extraction — `embedded` and `embeddedJvm` summary objects are byte-identical to the pre-extraction run

---
_Generated by [Claude Code](https://claude.ai/code/session_012kyj89JWsfoQxSzL1YWRGS)_