### PR TITLE
fix(harness): refresh the viewer.js hash in the serve-viewer-history fixture

### DIFF
--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history.html
@@ -222,7 +222,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/18d3a-5d801c0ca43f333e/viewer.js"></script>
+      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>


### PR DESCRIPTION
## Summary

`main` is red. `ServeWebFixtureTest > serve web fixtures are in sync with ServeWeb()` fails, taking **`Build CLI`** and **`Module Unit Tests`** down with it — on `main` itself and on every open PR. This is one stale line.

A merge race, not a behaviour change:

- `c650aeb` (#3430) added the `serve-viewer-history.html` golden.
- `612b137` (#3435) then edited `viewer.js` and regenerated the **eleven** `serve-viewer-*.html` goldens it knew about — but not the one that had just landed.

The goldens embed a content-addressed asset URL, so that file kept the pre-#3435 hash and drifted out of sync with `ServeWeb`:

```
$ grep -ho 'assets/serve/[^/]*/viewer\.js' vscode-extension/preview-harness/fixtures/pages/*.html | sort | uniq -c
     14 assets/serve/192e2-5b1dc35dd256c015/viewer.js
      1 assets/serve/18d3a-5d801c0ca43f333e/viewer.js     ← serve-viewer-history.html
```

Fourteen siblings agree; this was the only file left behind. Nothing here asserts behaviour — the URL is derived from `viewer.js`'s contents, so there is no "which side is right?" question to get wrong.

**Why one line rather than `UPDATE_SERVE_WEB_FIXTURES=true`.** A full regeneration is equivalent *plus* it rewrites `vscode-extension/preview-harness/fixtures/pages/_render-placeholder.png`. That byte difference is encoder noise the assertion never reads, so it is left out rather than committed as unexplained churn.

## Test plan

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'` — **BUILD SUCCESSFUL** with this one line; fails at `ServeWebFixtureTest.kt:3890` (`assertGolden`) without it.
- Confirmed the same failure reproduces on a clean tree at `29e5ecb` (current `main`), and that #3437 — which touched only `_server.mjs` / `pages-snapshot.spec.mjs` — did not address it.
- No production code touched; the diff is one `<script src>` in a committed test fixture.

Found while driving #3439 to green; that PR is blocked on this and needs no changes of its own.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KchMGSmbx3Rjp6RZdjMyRa)_