### PR TITLE
fix(serve): trip a circuit breaker on fatal render failures instead of retrying forever

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
@@ -1,0 +1,225 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Classifies a render failure reason as **fatal** (a fault no retry of any request can clear) or
+ * transient.
+ *
+ * A daemon that fails to link a native symbol, resolve a class, or find a method is broken at the
+ * classpath/runtime level: the same call will fail identically for every preview, every override,
+ * forever. Retrying is not merely useless, it is actively harmful — see [RenderCircuitBreaker].
+ */
+object RenderFailureClassifier {
+  /**
+   * Substrings of a failure reason that mean "linkage/classpath fault". Matched against the reason
+   * text because that is all the serve host has: the daemon reports its render failure as a message
+   * (`render failed: UnsatisfiedLinkError: 'long org.jetbrains.skia…'`), not a typed throwable
+   * across the RPC boundary.
+   *
+   * Every entry is a [LinkageError] subtype (or [ClassNotFoundException], its checked cousin) —
+   * deliberately narrow. A `NullPointerException` from one preview's composition says nothing about
+   * the next preview; a `NoSuchMethodError` says the two halves of the classpath disagree, which no
+   * input can route around.
+   */
+  private val FATAL_MARKERS =
+    listOf(
+      "UnsatisfiedLinkError",
+      "NoClassDefFoundError",
+      "NoSuchMethodError",
+      "NoSuchFieldError",
+      "ClassNotFoundException",
+      "ExceptionInInitializerError",
+      "IncompatibleClassChangeError",
+      "AbstractMethodError",
+      "UnsupportedClassVersionError",
+      "VerifyError",
+      // The base type, last: a daemon that reports a bare `LinkageError` is in the same bucket.
+      "LinkageError",
+    )
+
+  /** The linkage fault named in [reason], or null when it is an ordinary (retryable) failure. */
+  fun fatalMarker(reason: String): String? = FATAL_MARKERS.firstOrNull { it in reason }
+
+  fun isFatal(reason: String): Boolean = fatalMarker(reason) != null
+}
+
+/**
+ * Per-daemon breaker that stops a [ServeRenderHost] from re-attempting renders it has proved it
+ * cannot serve.
+ *
+ * ## Why
+ *
+ * Issue #3448: an `m3-catalog` daemon hit an `UnsatisfiedLinkError` — a JVM linkage failure that
+ * cannot succeed on retry, ever, for any input — and the host retried it **3794 times in ~14
+ * minutes**, still going. Nothing backed off and nothing gave up, with three separate consequences:
+ * the theme-optimization pass kept feeding a renderer that could not render (275s of gate wait, a
+ * ~7h ETA on work where every item fails); user requests never reached the renderer and timed out
+ * into `503 render busy; retry shortly`, a diagnosis wrong in both directions; and the catalog went
+ * on advertising itself live and healthy at a 95% failure rate.
+ *
+ * ## What
+ *
+ * Two independent trips, because the first is precise and the second is the backstop:
+ * - **Fatal classification.** The first failure [RenderFailureClassifier] calls fatal opens the
+ *   breaker **terminally** — no cooldown, no probe. There is nothing to wait for.
+ * - **Sustained failure rate.** Regardless of class, once [minSamples] outcomes are in the rolling
+ *   window and at least [failureRateThreshold] of them failed, the breaker opens. This catches an
+ *   unclassified fatal error (a message shape nobody anticipated) without needing to name it. A
+ *   rate-tripped breaker is *not* terminal: after [probeCooldownMillis] it lets exactly one render
+ *   through, and a success closes it — a genuine wave of transient failures heals itself.
+ *
+ * While open, [blockedReason] short-circuits renders with the underlying failure text, which is
+ * what turns the useless `503 busy; retry shortly` into an actionable answer naming the linkage
+ * error, and what lets the host drop its `hasLiveStream` / publish a [ServeDegradation] instead of
+ * claiming health.
+ *
+ * Thread-safe; every method takes one short critical section.
+ */
+class RenderCircuitBreaker(
+  /** Outcomes that must be in the window before the rate trip can fire at all. */
+  private val minSamples: Int = MIN_SAMPLES,
+  /** Failure fraction of the window at or above which the rate trip fires. */
+  private val failureRateThreshold: Double = FAILURE_RATE_THRESHOLD,
+  private val windowSize: Int = WINDOW_SIZE,
+  /** How long a rate-tripped breaker stays shut before admitting one probe render. */
+  private val probeCooldownMillis: Long = PROBE_COOLDOWN_MILLIS,
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
+  private val lock = Any()
+
+  // Rolling outcome window: true = failed. Bounded, so the rate reflects recent behaviour rather
+  // than an all-time blur — a daemon that served fine for an hour before breaking must still trip.
+  private val window = ArrayDeque<Boolean>()
+
+  private var openReason: String? = null
+  private var fatal = false
+  private var openedAtEpochMillis: Long? = null
+  private var tripFailureRate: Double? = null
+  // When the next probe may be admitted; only meaningful for a rate trip.
+  private var nextProbeAtMillis: Long = 0
+  private var shortCircuited = 0L
+
+  /**
+   * Why this render must not be attempted, or null to proceed.
+   *
+   * **Mutating**: a rate-tripped breaker past its cooldown returns null here and arms the next
+   * cooldown, admitting exactly one probe render. Use [peekReason] for a read-only look (status
+   * reporting, the HTTP failure latch) so a status poll can't spend the probe.
+   */
+  fun blockedReason(): String? =
+    synchronized(lock) {
+      val reason = openReason ?: return null
+      if (fatal) {
+        shortCircuited++
+        return reason
+      }
+      val now = clock()
+      if (now >= nextProbeAtMillis) {
+        // Half-open: admit this one render and re-arm, so a probe that also fails doesn't open the
+        // floodgates until the next cooldown elapses.
+        nextProbeAtMillis = now + probeCooldownMillis
+        return null
+      }
+      shortCircuited++
+      reason
+    }
+
+  /** Read-only [blockedReason]: never admits a probe, never counts a short-circuit. */
+  fun peekReason(): String? = synchronized(lock) { openReason }
+
+  /** A render succeeded. Closes a rate-tripped breaker; a fatal one stays open. */
+  fun recordOk() =
+    synchronized(lock) {
+      push(false)
+      if (fatal) return
+      openReason = null
+      openedAtEpochMillis = null
+      tripFailureRate = null
+      window.clear()
+    }
+
+  /** A render failed with [reason]; trips the breaker when fatal or when the rate says so. */
+  fun recordFailure(reason: String) =
+    synchronized(lock) {
+      push(true)
+      if (fatal) return
+      val marker = RenderFailureClassifier.fatalMarker(reason)
+      if (marker != null) {
+        fatal = true
+        openReason =
+          "render lane disabled after a non-recoverable $marker — retrying cannot help. " +
+            "Last failure: $reason"
+        openedAtEpochMillis = clock()
+        tripFailureRate = failureRate()
+        return
+      }
+      if (window.size < minSamples) return
+      val rate = failureRate()
+      if (rate < failureRateThreshold) return
+      if (openReason == null) {
+        openedAtEpochMillis = clock()
+        nextProbeAtMillis = clock() + probeCooldownMillis
+      }
+      tripFailureRate = rate
+      openReason =
+        "render lane disabled after ${(rate * 100).toInt()}% of the last ${window.size} renders " +
+          "failed; retrying periodically. Last failure: $reason"
+    }
+
+  /** Point-in-time state for `/status.json`, or null while the breaker has never tripped. */
+  fun snapshot(): RenderBreakerSnapshot? =
+    synchronized(lock) {
+      val reason = openReason ?: return null
+      RenderBreakerSnapshot(
+        open = true,
+        fatal = fatal,
+        reason = reason,
+        openedAtEpochMillis = openedAtEpochMillis,
+        failureRate = tripFailureRate,
+        sampleCount = window.size,
+        shortCircuitedRenders = shortCircuited,
+      )
+    }
+
+  private fun push(failed: Boolean) {
+    window.addLast(failed)
+    while (window.size > windowSize) window.removeFirst()
+  }
+
+  private fun failureRate(): Double =
+    if (window.isEmpty()) 0.0 else window.count { it }.toDouble() / window.size
+
+  companion object {
+    const val MIN_SAMPLES: Int = 20
+    const val FAILURE_RATE_THRESHOLD: Double = 0.9
+    const val WINDOW_SIZE: Int = 50
+
+    /**
+     * Cooldown between probe renders on a rate-tripped breaker. Long enough that a wedged daemon
+     * costs one render a minute instead of thousands (the #3448 behaviour), short enough that a
+     * transient wave — a daemon restart, a burst of cold-start timeouts — heals within a browse.
+     */
+    const val PROBE_COOLDOWN_MILLIS: Long = 60_000L
+  }
+}
+
+/**
+ * Open-breaker state for one daemon's render lane, serialized onto `/status.json` under
+ * `renderStats.breaker`. Present only while the breaker is open — its absence is the healthy case.
+ * Additive on `compose-preview-serve/status/v1`.
+ */
+@Serializable
+data class RenderBreakerSnapshot(
+  val open: Boolean,
+  /** A linkage/classpath fault: terminal, never probed, needs a redeploy rather than a retry. */
+  val fatal: Boolean,
+  /** Human-readable text also returned to callers in place of the render. */
+  val reason: String,
+  val openedAtEpochMillis: Long? = null,
+  /** Failure fraction of the outcome window when the breaker tripped. */
+  val failureRate: Double? = null,
+  val sampleCount: Int = 0,
+  /** Renders refused outright while open — the work this breaker is not doing. */
+  val shortCircuitedRenders: Long = 0,
+)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
@@ -24,6 +24,7 @@ class RenderPerfStats {
   private var failed = 0L
   private var timedOut = 0L
   private var busy = 0L
+  private var shortCircuited = 0L
   private var cacheHits = 0L
   private var coldOk = 0L
   private var firstRenderMs: Long? = null
@@ -44,6 +45,14 @@ class RenderPerfStats {
 
   /** The bounded render-lock acquire backed off ([RenderOutcome.Busy] → caller serves baked). */
   fun recordBusy(): Unit = synchronized(lock) { busy++ }
+
+  /**
+   * A render refused without asking the daemon because this host's [RenderCircuitBreaker] is open.
+   * Its own counter rather than a [recordFailed]: the daemon was never asked, so folding these into
+   * `failed` would inflate the very failure rate that tripped the breaker and hide how much work
+   * the breaker is saving.
+   */
+  fun recordShortCircuit(): Unit = synchronized(lock) { shortCircuited++ }
 
   /**
    * A render that ended in [RenderOutcome.Failed]; [timeout] when it blew its render budget.
@@ -107,6 +116,7 @@ class RenderPerfStats {
         failed = failed,
         timedOut = timedOut,
         busy = busy,
+        shortCircuited = shortCircuited,
         cacheHits = cacheHits,
         coldRenders = coldOk,
         firstRenderMs = firstRenderMs,
@@ -161,6 +171,12 @@ data class RenderPerfSnapshot(
   val timedOut: Long,
   /** Bounded lock acquires that backed off to baked ([RenderOutcome.Busy]). */
   val busy: Long,
+  /**
+   * Renders refused without asking the daemon because the host's [RenderCircuitBreaker] is open —
+   * the retry storm that is no longer happening. Excluded from [renders] and [failed]: the daemon
+   * was never asked.
+   */
+  val shortCircuited: Long = 0,
   /** `/render`s served from the PNG cache without waking the daemon. */
   val cacheHits: Long,
   /** Successful renders issued before the host's first success — the cold-start population. */
@@ -186,6 +202,11 @@ data class RenderPerfSnapshot(
   val lastFailureAtEpochMillis: Long? = null,
   /** Bounded, newest-first failure detail for status diagnostics. */
   val recentFailures: List<RenderFailureSample> = emptyList(),
+  /**
+   * Set while this lane's [RenderCircuitBreaker] is open — the host has stopped attempting renders
+   * and is answering with [RenderBreakerSnapshot.reason] instead. Null is the healthy case.
+   */
+  val breaker: RenderBreakerSnapshot? = null,
 ) {
   companion object {
     /**
@@ -202,6 +223,7 @@ data class RenderPerfSnapshot(
         failed = snapshots.sumOf { it.failed },
         timedOut = snapshots.sumOf { it.timedOut },
         busy = snapshots.sumOf { it.busy },
+        shortCircuited = snapshots.sumOf { it.shortCircuited },
         cacheHits = snapshots.sumOf { it.cacheHits },
         coldRenders = snapshots.sumOf { it.coldRenders },
         firstRenderMs = snapshots.mapNotNull { it.firstRenderMs }.maxOrNull(),
@@ -225,6 +247,17 @@ data class RenderPerfSnapshot(
             .flatMap { it.recentFailures }
             .sortedByDescending { it.atEpochMillis }
             .take(RenderPerfStats.FAILURE_WINDOW_SIZE),
+        // A fatal (linkage) trip wins over a rate trip, then the most recent — the roll-up should
+        // name the breaker that most needs a human, not whichever daemon happens to sort first.
+        breaker =
+          snapshots
+            .mapNotNull { it.breaker }
+            .filter { it.open }
+            .sortedWith(
+              compareByDescending<RenderBreakerSnapshot> { it.fatal }
+                .thenByDescending { it.openedAtEpochMillis ?: 0 }
+            )
+            .firstOrNull(),
       )
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -397,6 +397,12 @@ class ServeCatalogLiveHost(
     }
     catalogThemeCache.configureTargets(jobs.map { it.cacheKey })
     if (jobs.isEmpty() || catalogThemeCache.snapshot().fullyOptimized) return
+    // Never start a pass into a broken renderer. The optimizer is the largest consumer of the
+    // render gate, and every item it queues against an open breaker is pure waste — 4740 remaining
+    // at a ~7h ETA on work where every single render fails (issue #3448). Targets stay configured
+    // so `/status` keeps reporting the shortfall; `keepLiveWarm` re-enters this on every presence
+    // heartbeat, so the pass resumes by itself if the breaker closes.
+    if (renderBreakerStopsBackgroundWork()) return
     if (!optimizationStarted.compareAndSet(false, true)) return
     optimizationActive.set(true)
     optimizationExecutor.execute {
@@ -412,6 +418,10 @@ class ServeCatalogLiveHost(
         val byPreview =
           jobs.filter { catalogThemeCache.get(it.cacheKey) == null }.groupBy { it.previewId }
         for ((previewId, previewJobs) in byPreview) {
+          // Re-checked per preview as well as at entry: a breaker can trip mid-pass (that is the
+          // rate trip's whole job), and the pass must stop feeding the renderer the moment it does
+          // rather than grinding through the remaining thousands of items.
+          if (renderBreakerStopsBackgroundWork()) return@execute
           // Gate BEFORE the warm, not just before the renders. `daemonWarmOrScheduling` starts a
           // cold daemon, which is the single most expensive thing this pass can do to a box that is
           // still loading catalogs or serving traffic — exactly what the idle gate exists to
@@ -520,6 +530,17 @@ class ServeCatalogLiveHost(
         optimizationStarted.set(false)
       }
     }
+  }
+
+  /**
+   * True when the live lane's circuit breaker is open, so background prefetch must stand down.
+   * Marks the cache paused on the way out — the pass is stopping, not finishing, and `/status` must
+   * not read a broken catalog's abandoned targets as a completed optimization.
+   */
+  private fun renderBreakerStopsBackgroundWork(): Boolean {
+    if (renderBreaker()?.open != true) return false
+    catalogThemeCache.markPaused()
+    return true
   }
 
   /**
@@ -756,8 +777,33 @@ class ServeCatalogLiveHost(
   override fun hasSvgExportFor(previewId: String): Boolean =
     (previewId in alias && live.hasSvgExport) || baked.hasSvgExportFor(previewId)
 
-  /** The "Live (stream)" toggle is offered (unlike a plain static catalog). */
-  override val hasLiveStream: Boolean = true
+  /**
+   * The "Live (stream)" toggle is offered (unlike a plain static catalog) — until this catalog's
+   * live lane breaks. An open render breaker means no live render can succeed, so the catalog must
+   * stop advertising `live` on `/status` and stop offering the toggle: reporting a healthy live
+   * lane at a 95% failure rate is issue #3448's third consequence.
+   *
+   * Read off [renderBreaker] rather than `live.hasLiveStream` so a composite whose live host is a
+   * non-daemon stand-in still advertises the stream exactly as before.
+   */
+  override val hasLiveStream: Boolean
+    get() = renderBreaker()?.open != true
+
+  /**
+   * The live lane's open breaker, if any. Only the monolithic daemon is consulted: the per-preview
+   * pool's residents come and go (and a broken *classpath* breaks them all identically, so the
+   * monolith speaks for them), while the pool snapshot would need a live read of hosts this must
+   * never wake.
+   */
+  override fun renderBreaker(): RenderBreakerSnapshot? = live.renderBreaker()
+
+  /**
+   * The baked catalog's own degradations (baked-only, unverified, deferred-not-served — which this
+   * composite previously dropped on the floor, reporting `degradation: null` for every catalog it
+   * fronted), plus the live lane's broken-render-lane degradation when its breaker is open.
+   */
+  override val degradations: List<ServeDegradation>
+    get() = baked.degradations + live.degradations
 
   /**
    * The underlying baked catalog host, so the HTTP layer can read its title / subtitle / trust
@@ -794,8 +840,19 @@ class ServeCatalogLiveHost(
   override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome =
     renderInternal(previewId, overrides, leased = false)
 
+  /**
+   * A broken live lane latches EVERY preview, not just the ones the theme cache has recorded
+   * against: the fault is in the daemon, so the answer is the same for all of them. Checked first
+   * so a `/render` gets the terminal 409 naming the real error before it takes a render slot —
+   * ahead of the per-key theme latch, which only knows about keys the optimizer reached.
+   *
+   * Scoped to daemon-twinned ids ([alias]): an unmapped variant never reaches the live lane — it
+   * replays baked pixels — so a broken daemon must not turn its perfectly serveable request into
+   * a 409.
+   */
   override fun renderFailureLatch(previewId: String, overrides: PreviewOverrides): String? =
-    themeCacheKey(previewId, overrides)?.let(catalogThemeCache::failureReason)
+    (if (previewId in alias) live.renderBreaker()?.takeIf { it.open }?.reason else null)
+      ?: themeCacheKey(previewId, overrides)?.let(catalogThemeCache::failureReason)
 
   /**
    * Shed the pooled daemons — burst replicas and per-preview residents — while keeping the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDegradation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDegradation.kt
@@ -43,6 +43,32 @@ data class ServeDegradation(val code: String, val detail: String) {
     const val DEFERRED_NOT_SERVED = "deferred-not-served"
 
     /**
+     * The session HAD a working live lane and the server has since **switched it off**: its render
+     * circuit breaker tripped (a linkage/classpath fault that can never succeed on retry, or a
+     * sustained failure rate), so live renders are refused with the underlying reason rather than
+     * retried. Distinct from [LIVEBUNDLE_UNAVAILABLE], which is a daemon that never came up.
+     */
+    const val RENDER_LANE_BROKEN = "render-lane-broken"
+
+    /**
+     * The live render lane was disabled by its circuit breaker; [reason] is the breaker's text and
+     * [fatal] marks a linkage fault (needs a fixed bundle, not a retry). See
+     * [RenderCircuitBreaker].
+     */
+    fun renderLaneBroken(reason: String, fatal: Boolean): ServeDegradation =
+      ServeDegradation(
+        RENDER_LANE_BROKEN,
+        if (fatal) {
+          "This catalog's live render lane is disabled: it hit a non-recoverable error that no " +
+            "retry can clear, so device, theme and knob controls serve baked PNG snapshots until " +
+            "the catalog is republished. $reason"
+        } else {
+          "This catalog's live render lane is disabled after a sustained run of render failures — " +
+            "it serves baked PNG snapshots and retries periodically. $reason"
+        },
+      )
+
+    /**
      * [count] live-only previews hidden because this session has no live lane. Paired with
      * whichever reason explains the missing live lane (no live bundle / unverified / bundle
      * unavailable).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -165,6 +165,16 @@ interface ServeHost : AutoCloseable {
   fun renderPerfStats(): RenderPerfSnapshot? = null
 
   /**
+   * This lane's open render breaker, or null while it is rendering normally (the healthy case, and
+   * the default for a host with no live lane to break). A non-null value means the host has
+   * **stopped attempting renders** — a linkage fault it can never recover from, or a sustained
+   * failure rate — and is answering requests with [RenderBreakerSnapshot.reason] instead. Callers
+   * that schedule background render work must consult it and stand down: feeding a broken renderer
+   * is what burned 275s of render gate and a ~7h ETA in issue #3448.
+   */
+  fun renderBreaker(): RenderBreakerSnapshot? = null
+
+  /**
    * Bounded child-daemon pools owned by this host, surfaced on `/status.json` so production
    * monitors can distinguish "one catalog daemon is up" from "a catalog daemon plus N per-preview
    * daemons are resident". Empty for ordinary hosts.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -523,7 +523,48 @@ internal constructor(
   // Serve-side render-latency accounting for `/status` (`renderStats`) — see [RenderPerfStats].
   private val perfStats = RenderPerfStats()
 
-  override fun renderPerfStats(): RenderPerfSnapshot = perfStats.snapshot()
+  /**
+   * Stops this host re-attempting renders it has proved it cannot serve — a linkage fault on the
+   * first occurrence, an unclassified sustained failure rate on the backstop. See
+   * [RenderCircuitBreaker] and issue #3448 (3794 retries of one `UnsatisfiedLinkError` in 14
+   * minutes).
+   */
+  private val breaker = RenderCircuitBreaker()
+
+  override fun renderPerfStats(): RenderPerfSnapshot =
+    perfStats.snapshot().copy(breaker = breaker.snapshot())
+
+  override fun renderBreaker(): RenderBreakerSnapshot? = breaker.snapshot()
+
+  /**
+   * An open breaker is host-wide, so it latches EVERY preview: the fault is in the daemon's
+   * classpath, not in one composition. This is what turns the `503 render busy; retry shortly` into
+   * a terminal 409 naming the linkage error — the HTTP layer consults the latch before it takes a
+   * render slot.
+   */
+  override fun renderFailureLatch(previewId: String, overrides: PreviewOverrides): String? =
+    breaker.peekReason()
+
+  /**
+   * A host whose breaker is open has no working live lane, so it must stop advertising one — the
+   * `/status` `live` / `running` columns and the viewer's stream toggle both read this. Reported
+   * from the breaker alone; no session is touched, so a registered-but-unopened catalog is
+   * unaffected.
+   */
+  override val hasLiveStream: Boolean
+    get() = breaker.peekReason() == null
+
+  /** Publishes the open breaker as a session degradation, so `/status` says WHY it went dark. */
+  override val degradations: List<ServeDegradation>
+    get() =
+      breaker.snapshot()?.let { listOf(ServeDegradation.renderLaneBroken(it.reason, it.fatal)) }
+        ?: emptyList()
+
+  /** Record a failed render against both the perf counters and the breaker. */
+  private fun recordFailure(durationMs: Long, timeout: Boolean, reason: String) {
+    perfStats.recordFailed(durationMs, timeout = timeout, reason = reason)
+    breaker.recordFailure(reason)
+  }
 
   // Set under renderLock immediately before each renderNow; the (single) in-flight render's
   // renderFinished notification fills pngPath and trips the latch. Safe because the lock guarantees
@@ -619,6 +660,16 @@ internal constructor(
       return RenderOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
     }
 
+    // The daemon has already proved it cannot serve this (a linkage fault, or a sustained failure
+    // rate) — answer with that reason instead of asking it again. Ahead of the lock acquire, so a
+    // broken daemon neither holds the render lock nor pushes other callers into a Busy back-off
+    // that reads to the browser as "the server is busy, retry" (issue #3448). A rate-tripped
+    // breaker lets one probe render through per cooldown, so a transient wave still heals.
+    breaker.blockedReason()?.let {
+      perfStats.recordShortCircuit()
+      return RenderOutcome.Failed(it)
+    }
+
     // Perf accounting for `/status` (`renderStats`): the round-trip clock starts at the cache
     // miss, and "cold" is judged before the render — a render issued while this host has never
     // completed one is the cold-start population the boot/warm work targets.
@@ -667,7 +718,7 @@ internal constructor(
           } catch (e: RenderSessionException) {
             val reason = "renderNow failed: ${e.message}"
             onLog(reason)
-            perfStats.recordFailed(perfElapsedMs(), timeout = false, reason = reason)
+            recordFailure(perfElapsedMs(), timeout = false, reason = reason)
             return RenderOutcome.Failed(reason)
           }
 
@@ -679,7 +730,7 @@ internal constructor(
           }
           val reason = "render rejected: ${rejected.reason}"
           onLog(reason)
-          perfStats.recordFailed(perfElapsedMs(), timeout = false, reason = reason)
+          recordFailure(perfElapsedMs(), timeout = false, reason = reason)
           return RenderOutcome.Failed(reason)
         }
 
@@ -697,7 +748,7 @@ internal constructor(
           staleRenders.merge(previewId, 1, Int::plus)
           val reason = "timed out after ${budget}s waiting for render"
           onLog(reason)
-          perfStats.recordFailed(perfElapsedMs(), timeout = true, reason = reason)
+          recordFailure(perfElapsedMs(), timeout = true, reason = reason)
           return RenderOutcome.Failed(reason)
         }
         // The latch also trips on `renderFailed` — the daemon reported the render body threw.
@@ -709,7 +760,7 @@ internal constructor(
         pendingFailure.get()?.let { failure ->
           val reason = "render failed: $failure"
           onLog(reason)
-          perfStats.recordFailed(perfElapsedMs(), timeout = false, reason = reason)
+          recordFailure(perfElapsedMs(), timeout = false, reason = reason)
           return RenderOutcome.Failed(reason)
         }
         warmedUp.set(true)
@@ -726,12 +777,13 @@ internal constructor(
       if (bytes == null) {
         val reason = "render produced no PNG"
         onLog(reason)
-        perfStats.recordFailed(perfElapsedMs(), timeout = false, reason = reason)
+        recordFailure(perfElapsedMs(), timeout = false, reason = reason)
         return RenderOutcome.Failed(reason)
       }
 
       cache.put(key, bytes)
       perfStats.recordOk(perfElapsedMs(), cold = coldAtEntry)
+      breaker.recordOk()
       return RenderOutcome.Ok(bytes)
     } finally {
       renderLock.unlock()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreakerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreakerTest.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Unit coverage for the fatal-vs-transient classifier and the two breaker trips (issue #3448). */
+class RenderCircuitBreakerTest {
+
+  private val linkage =
+    "render failed: UnsatisfiedLinkError: 'long " +
+      "org.jetbrains.skia.PathBuilderKt.PathBuilder_nMakeFromPath(long)'"
+
+  @Test
+  fun `linkage faults classify as fatal, ordinary render errors do not`() {
+    assertEquals("UnsatisfiedLinkError", RenderFailureClassifier.fatalMarker(linkage))
+    assertTrue(RenderFailureClassifier.isFatal("render failed: NoClassDefFoundError: androidx/Foo"))
+    assertTrue(RenderFailureClassifier.isFatal("render failed: NoSuchMethodError: Bar.baz()"))
+    assertFalse(RenderFailureClassifier.isFatal("render failed: java.lang.NullPointerException"))
+    assertFalse(RenderFailureClassifier.isFatal("timed out after 10s waiting for render"))
+  }
+
+  @Test
+  fun `one fatal failure opens the breaker terminally`() {
+    // The #3448 behaviour: 3794 retries of an UnsatisfiedLinkError in ~14 minutes. One is enough.
+    var now = 0L
+    val breaker = RenderCircuitBreaker(clock = { now })
+    assertNull(breaker.blockedReason())
+
+    breaker.recordFailure(linkage)
+
+    val reason = assertNotNull(breaker.blockedReason())
+    assertTrue(reason.contains("UnsatisfiedLinkError"), "reason should name the fault: $reason")
+    val snapshot = assertNotNull(breaker.snapshot())
+    assertTrue(snapshot.open)
+    assertTrue(snapshot.fatal)
+
+    // No cooldown, no probe: a linkage fault cannot succeed later, so time buys nothing.
+    now += 10 * RenderCircuitBreaker.PROBE_COOLDOWN_MILLIS
+    assertNotNull(breaker.blockedReason())
+    // And a stray success cannot re-open the lane — the classpath is still broken.
+    breaker.recordOk()
+    assertNotNull(breaker.blockedReason())
+  }
+
+  @Test
+  fun `a sustained failure rate trips the breaker even for unclassified errors`() {
+    var now = 0L
+    val breaker = RenderCircuitBreaker(clock = { now })
+    // Below the sample floor nothing trips, however bad the rate looks.
+    repeat(RenderCircuitBreaker.MIN_SAMPLES - 1) { breaker.recordFailure("render produced no PNG") }
+    assertNull(breaker.peekReason())
+
+    breaker.recordFailure("render produced no PNG")
+
+    val snapshot = assertNotNull(breaker.snapshot())
+    assertTrue(snapshot.open)
+    assertFalse(snapshot.fatal, "an unclassified error is a rate trip, not a fatal one")
+    assertNotNull(breaker.peekReason())
+  }
+
+  @Test
+  fun `a healthy run keeps the rate breaker closed`() {
+    val breaker = RenderCircuitBreaker(clock = { 0L })
+    repeat(100) {
+      breaker.recordOk()
+      breaker.recordFailure("render produced no PNG")
+    }
+    assertNull(breaker.peekReason(), "a 50% failure rate is not the sustained failure this catches")
+  }
+
+  @Test
+  fun `a rate-tripped breaker probes after the cooldown and closes on success`() {
+    var now = 0L
+    val breaker = RenderCircuitBreaker(clock = { now })
+    repeat(RenderCircuitBreaker.MIN_SAMPLES) { breaker.recordFailure("render produced no PNG") }
+    assertNotNull(breaker.blockedReason())
+
+    // Still shut inside the cooldown: this is what turns a retry storm into one render a minute.
+    now += RenderCircuitBreaker.PROBE_COOLDOWN_MILLIS - 1
+    assertNotNull(breaker.blockedReason())
+
+    // Past it, exactly one render is admitted — the next is shut out until the cooldown re-elapses.
+    now += 1
+    assertNull(breaker.blockedReason())
+    assertNotNull(breaker.blockedReason())
+
+    // The probe succeeded: the lane is healthy again and reports itself so.
+    breaker.recordOk()
+    assertNull(breaker.blockedReason())
+    assertNull(breaker.snapshot())
+  }
+
+  @Test
+  fun `short-circuited renders are counted for status`() {
+    val breaker = RenderCircuitBreaker(clock = { 0L })
+    breaker.recordFailure(linkage)
+    repeat(5) { breaker.blockedReason() }
+    // The first blockedReason above the repeat is the trip check itself; count what we refused.
+    assertEquals(5, assertNotNull(breaker.snapshot()).shortCircuitedRenders)
+    // A status poll must never spend a probe or inflate the count.
+    breaker.peekReason()
+    assertEquals(5, assertNotNull(breaker.snapshot()).shortCircuitedRenders)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -1168,6 +1169,69 @@ class ServeCatalogLiveHostTest {
     assertEquals("degraded", snapshot?.state, "and no longer reads as ordinary throttling")
     // ...and the request lane can answer terminally (409) instead of a retry-after it can't honour.
     assertNotNull(composite.renderFailureLatch(catalogId, themeOverride()))
+  }
+
+  @Test
+  fun `a broken live lane stops theme optimization, live advertising, and busy retries`() {
+    // Issue #3448: the m3-catalog daemon hit an UnsatisfiedLinkError and theme pre-optimization
+    // kept feeding it — 4740 remaining, a ~7h ETA, 275s of gate wait, all on work where every
+    // single render fails — while the catalog went on reporting `live: true, degradation: null`
+    // and visitors got `503 render busy; retry shortly`.
+    val renderRoot = java.nio.file.Files.createTempDirectory("breaker").toFile()
+    renderRoot.deleteOnExit()
+    lateinit var session: FakeRenderSession
+    session =
+      FakeRenderSession(
+        renderRoot,
+        renderHook = { _, _ ->
+          session.emitFailed(daemonId, "UnsatisfiedLinkError: 'long PathBuilder_nMakeFromPath'")
+        },
+      )
+    val live =
+      ServeRenderHost(
+        session = session,
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked =
+          RecordingHost(
+            listOf(ServePreview(catalogId, catalogId), ServePreview(androidOnlyId, androidOnlyId)),
+            "baked",
+          ),
+        serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
+        themeOptimizationIdleMillis = 0,
+      )
+
+    composite.prewarm()
+    awaitPassIdle(composite)
+    assertEquals(1, session.renderCount.get(), "the failing daemon is asked once")
+
+    // Heartbeats re-enter the pass; it must stand down rather than queue more doomed renders.
+    repeat(10) {
+      composite.keepLiveWarm()
+      awaitPassIdle(composite)
+    }
+    assertEquals(1, session.renderCount.get(), "background work must not feed a broken renderer")
+
+    // The catalog stops claiming a healthy live lane and says why.
+    assertFalse(composite.hasLiveStream, "a catalog with no working render lane is not live")
+    val degradation =
+      composite.degradations.single { it.code == ServeDegradation.RENDER_LANE_BROKEN }
+    assertTrue(degradation.detail.contains("UnsatisfiedLinkError"), degradation.detail)
+    assertTrue(assertNotNull(composite.renderBreaker()).fatal)
+
+    // A request for a daemon-twinned preview is answered terminally with the real reason, so the
+    // HTTP layer 409s instead of sending the browser back round the retry-after loop…
+    val latched = assertNotNull(composite.renderFailureLatch(catalogId, themeOverride()))
+    assertTrue(latched.contains("UnsatisfiedLinkError"), latched)
+    // …while a preview that never needed the daemon keeps serving its baked pixels.
+    assertNull(composite.renderFailureLatch(androidOnlyId, PreviewOverrides()))
+    live.close()
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -88,6 +88,54 @@ class ServeRenderHostTest {
   }
 
   @Test
+  fun `a fatal linkage failure trips the breaker instead of being retried forever`() {
+    // Issue #3448: an UnsatisfiedLinkError — a JVM linkage failure that cannot succeed on retry,
+    // ever, for any input — was retried 3794 times in ~14 minutes. The daemon must be asked once.
+    val linkage =
+      "UnsatisfiedLinkError: 'long org.jetbrains.skia.PathBuilderKt.PathBuilder_nMakeFromPath(long)'"
+    lateinit var session: FakeRenderSession
+    session =
+      FakeRenderSession(
+        newRenderRoot(),
+        renderHook = { _, _ -> session.emitFailed(previewId, linkage) },
+      )
+    host(session).use { h ->
+      assertTrue(h.hasLiveStream, "a healthy host advertises its live lane")
+      assertTrue(h.degradations.isEmpty())
+
+      val first = h.render(previewId, PreviewOverrides())
+      assertTrue(first is RenderOutcome.Failed, "expected Failed, got $first")
+
+      // Every subsequent render is answered from the breaker without touching the daemon.
+      repeat(20) { i ->
+        val outcome = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+        assertTrue(outcome is RenderOutcome.Failed, "render $i: expected Failed, got $outcome")
+        assertTrue(
+          outcome.reason.contains("UnsatisfiedLinkError"),
+          "the caller must be told the real fault, not 'busy; retry shortly': ${outcome.reason}",
+        )
+      }
+      assertEquals(1, session.renderCount.get(), "the daemon must be asked exactly once")
+
+      // The lane stops advertising itself as live, publishes why, and latches every preview so the
+      // HTTP layer answers terminally instead of sending the browser round the retry loop.
+      assertFalse(h.hasLiveStream, "a broken lane must stop advertising live")
+      val degradation = h.degradations.single()
+      assertEquals(ServeDegradation.RENDER_LANE_BROKEN, degradation.code)
+      assertTrue(degradation.detail.contains("UnsatisfiedLinkError"))
+      assertNotNull(h.renderFailureLatch(previewId, PreviewOverrides()))
+
+      val breaker = assertNotNull(h.renderBreaker())
+      assertTrue(breaker.fatal)
+      assertEquals(20, breaker.shortCircuitedRenders)
+      val stats = assertNotNull(h.renderPerfStats())
+      assertEquals(20, stats.shortCircuited, "refused renders are counted apart from failures")
+      assertEquals(1, stats.failed, "the short-circuits must not inflate the failure count")
+      assertNotNull(stats.breaker)
+    }
+  }
+
+  @Test
   fun `different overrides each render`() {
     val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -1191,6 +1191,39 @@ backoffs, timeouts) — and the top-level `renderStats` is the roll-up across da
 background-sandbox-boot work drives down). Both are additive on `status/v1` and null/absent until
 something has rendered.
 
+### Render circuit breaker
+
+`renderStats` also carries `shortCircuited` and — only while a lane is broken — a `breaker` object:
+
+```json
+"renderStats": { "renders": 196, "ok": 196, "failed": 21, "shortCircuited": 3773,
+  "breaker": { "open": true, "fatal": true,
+    "reason": "render lane disabled after a non-recoverable UnsatisfiedLinkError — retrying cannot help. …",
+    "openedAtEpochMillis": 1754582400000, "failureRate": 1.0, "sampleCount": 50,
+    "shortCircuitedRenders": 3773 } }
+```
+
+A daemon that fails a render **fatally** — an `UnsatisfiedLinkError`, `NoClassDefFoundError`,
+`NoSuchMethodError` or any other linkage/classpath fault — cannot succeed on retry, ever, for any
+input, so the host stops asking after the first occurrence (`fatal: true`, no cooldown; it takes a
+republished bundle or a restart to clear). Any *other* sustained run of failures — 90% of the last
+50 renders — trips the same breaker without being classified (`fatal: false`); that one probes with
+a single render a minute and closes itself as soon as one succeeds.
+
+While the breaker is open the host:
+
+- answers `/render` with the **underlying failure reason** as a terminal `409`, not
+  `503 render busy; retry shortly` (the daemon isn't busy, and retrying will never help);
+- reports `live: false` for the catalog and publishes a `render-lane-broken` `degradation`, instead
+  of advertising a healthy live lane at a 95% failure rate;
+- **pauses background theme optimization** for that catalog — it is the largest consumer of the
+  render gate and pure waste while every render fails. A presence heartbeat re-enters the pass, so
+  it resumes by itself if the breaker closes.
+
+`shortCircuited` counts the renders refused this way. It is deliberately *not* folded into `failed`
+— the daemon was never asked, so counting it there would inflate the failure rate that tripped the
+breaker and hide how much work the breaker is saving.
+
 A Home Assistant REST sensor reads the top-level `status` (`ok`/`degraded`) as its state and lifts
 the grouped counts + arrays as attributes, e.g.:
 


### PR DESCRIPTION
Fixes #3448.

## Summary

A JVM linkage failure — `UnsatisfiedLinkError`, `NoClassDefFoundError`, `NoSuchMethodError` — cannot succeed on retry, ever, for any input. The serve host retried one 3794 times in ~14 minutes and was still going. This adds a per-daemon circuit breaker and wires its open state through every surface the issue named.

**`RenderCircuitBreaker`** (new) has two independent trips:

- **Fatal classification.** The first failure whose reason names a linkage/classpath fault opens the breaker **terminally** — no cooldown, no probe. There is nothing to wait for; it takes a republished bundle or a restart to clear.
- **Sustained failure rate.** 90% of the last 50 renders, regardless of class — the backstop for an unclassified fatal error. Not terminal: it admits one probe render per minute and closes on the first success, so a genuine wave of transient failures heals itself.

The three consequences from the issue, each addressed:

1. **The render gate.** `ServeCatalogLiveHost` stands its theme-optimization pass down while the breaker is open — checked at pass entry *and* per preview, since a rate trip fires mid-pass. `keepLiveWarm` re-enters it on every presence heartbeat, so it resumes by itself if the breaker closes. Targets stay configured, so `/status` keeps reporting the shortfall rather than reading as complete.
2. **The wrong error.** `ServeRenderHost.renderFailureLatch` now returns the breaker's reason, so the HTTP layer answers a terminal **409 naming the linkage error** before it takes a render slot — instead of the `503 render busy; retry shortly` that was wrong in both directions. On the composite this is scoped to daemon-twinned ids, so an unmapped variant keeps serving its baked pixels.
3. **`degradation: null`.** A broken host drops `hasLiveStream` (so `/status` reports `live: false`) and publishes a `render-lane-broken` `ServeDegradation`. `ServeCatalogLiveHost` also now forwards the baked host's degradations, which it previously dropped on the floor — that composite reported `degradation: null` for every catalog it fronted, including the baked-only / unverified / deferred cases.

`renderStats` gains `shortCircuited` and, while open, a `breaker` object (`open`, `fatal`, `reason`, `openedAtEpochMillis`, `failureRate`, `sampleCount`). Short-circuits are deliberately kept out of `failed`: the daemon was never asked, so counting them there would inflate the very rate that tripped the breaker and hide how much work is being saved. `docs/public-preview-server.md` documents the new fields and the behaviour.

## Test plan

- `RenderCircuitBreakerTest` (new) — classifier fatal/transient split; one fatal failure opens terminally and neither time nor a later success re-opens it; the rate trip needs the sample floor and doesn't fire on a 50% mix; a rate-tripped breaker admits exactly one probe per cooldown and closes on success; short-circuit counting, and `peekReason` never spending a probe.
- `ServeRenderHostTest` — a daemon emitting `UnsatisfiedLinkError` is asked **exactly once** across 21 renders; every later caller gets the real reason; `hasLiveStream` goes false, the degradation carries the fault, the latch is set, and `shortCircuited: 20` / `failed: 1` stay separate.
- `ServeCatalogLiveHostTest` — the composite's optimization pass stops after the first failure and stays stopped across 10 heartbeats (1 daemon render total); `live` drops; the degradation and 409 latch appear for the twinned id but not for the baked-only one.
- `./gradlew :cli:test :cli:ktfmtCheckMain :cli:ktfmtCheckTest` — green.

No visual surface is touched (serve-side render admission, status reporting, docs), so there is no before/after render to embed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pwy9YG95cS1xFhqN4D8QPf)_