### PR TITLE
fix(rc-compare): uncap the compositor frame rate so short viewports are not scored as slow

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -43,6 +43,8 @@
       "cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js",
       "cli/src/test/kotlin/ee/schimke/composeai/cli/serve/**",
       "scripts/design-artifacts/rc-compare*",
+      "scripts/design-artifacts/rc-chromium*",
+      "scripts/design-artifacts/rc-cmp-wasm-*",
       ".github/workflows/design-artifacts-reusable.yml"
     ],
     "module_unit_tests": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,42 @@ jobs:
             rc-player/**/build/test-results/**
           retention-days: 7
 
+  # The CMP/Wasm player's first-frame timing, which is a browser-scheduling property and so cannot be
+  # asserted anywhere the player is not actually loaded in Chromium. Separate from the driver's
+  # `node --test` job because it needs a built `wasmPlayerDist` that job has no Gradle to produce —
+  # left there the test would self-skip forever, which is exactly the "nothing ran them" hole the
+  # driver job comment describes. Ubuntu, not the macOS player job: frame pacing is per-platform, and
+  # ubuntu is where the design-artifacts render lane measures the budgets this guards.
+  rc-cmp-wasm-frame-pacing:
+    name: CMP/Wasm Frame Pacing
+    needs: changes
+    if: ${{ needs.changes.outputs.rc_player_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Build the Wasm player distribution
+        run: ./gradlew :rc-player-wasm:wasmPlayerDist
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Install driver dependencies
+        working-directory: scripts/design-artifacts
+        run: npm ci
+      - name: Install Chromium
+        working-directory: scripts/design-artifacts
+        run: npx playwright install --with-deps chromium
+      # `RC_CMP_WASM_REQUIRE` turns the test's self-skips into failures. Without it a missing
+      # distribution, a missing playwright, or a browser that will not launch all leave this job
+      # green having asserted nothing — which is the hole this job exists to close.
+      - name: Run the frame-pacing guard
+        working-directory: scripts/design-artifacts
+        env:
+          RC_CMP_WASM_REQUIRE: "1"
+        run: node --test rc-cmp-wasm-frame-pacing.test.mjs
+
   functional-tests:
     name: Plugin Functional Tests
     needs: changes

--- a/docs/design/RC_CMP_WASM_PLAYER.md
+++ b/docs/design/RC_CMP_WASM_PLAYER.md
@@ -564,6 +564,22 @@ The remote-m3 replacement corpus is guarded in CI, not recorded as a one-off man
   distribution is 22,756,717 bytes. Source maps and development-only formatters are not shipped.
 - The strict comparison lane caps cold and warm navigation-to-painted-ready time at 10,000 ms and
   5,000 ms respectively. The reviewed 24-document run measured 2,361 ms cold and 2,003 ms warm.
+  Those numbers only hold with the compositor's frame cap lifted (`--disable-frame-rate-limit`, in
+  [`rc-chromium.mjs`](../../scripts/design-artifacts/rc-chromium.mjs)): Chromium paces
+  `requestAnimationFrame` at roughly 1 fps for a page whose CSS viewport is a few dozen pixels
+  tall, and the player waits three frames before posting `ready`. Without the flag the 76 dp-tall
+  `remote-m3` widget previews took ~6,150 ms against the ~2,040 ms of the 124 dp-tall preview
+  beside them — a *warm* row over the warm budget, which read as a startup-cost problem and was
+  not one ([#3445](https://github.com/yschimke/compose-ai-tools/issues/3445)).
+  [`rc-cmp-wasm-frame-pacing.test.mjs`](../../scripts/design-artifacts/rc-cmp-wasm-frame-pacing.test.mjs)
+  holds the short viewport to the tall one; it skips unless `wasmPlayerDist` is built.
+- `cold` and `warm` are properties of a **browser context**, and the lane keys one context per
+  preview density (Playwright binds `deviceScaleFactor` at context creation, and the player reads
+  its density from `devicePixelRatio`). A catalog spanning two densities therefore reports two cold
+  rows, the second partway through the run — measured at ~0.3 s over a warm render, against the
+  ~1.5 s the player itself waits before reporting readiness. Each row records its
+  `cmpWasmDensity`, `cmpWasmViewport`, and `cmpWasmContextRender` in `rc-compare-summary.json`, so
+  a slow row can be attributed rather than guessed at.
 - The live viewer forwards typed named overrides, reloads after knob changes, validates same-origin
   host messages, and surfaces host/named actions as inert `CustomEvent` payloads. Decode, support,
   and resource failures remain bounded inside the iframe instead of replacing the catalog page.

--- a/scripts/design-artifacts/rc-chromium.mjs
+++ b/scripts/design-artifacts/rc-chromium.mjs
@@ -1,0 +1,28 @@
+/**
+ * rc-chromium.mjs — the headless Chromium launch arguments for the lanes that play a Remote Compose
+ * document in a browser (`rc-compare.mjs`, and the tests that measure the same thing).
+ *
+ * They live in one place because a flag that only some of them carry is a flag that silently
+ * changes what a measurement means. In particular `--disable-frame-rate-limit`, which is not a speed knob:
+ * without it Chromium paces `requestAnimationFrame` at roughly **1 fps** for a page whose CSS
+ * viewport is only a few dozen pixels tall, and the CMP/Wasm player waits three frames before it
+ * reports readiness. Measured on the `remote-m3` catalog (Gradient widget document, one context,
+ * warm player, `deviceScaleFactor` 2.625):
+ *
+ *   viewport   without the flag   with the flag
+ *   216×76     6155 ms            1976 ms
+ *   216×120    2044 ms            1986 ms
+ *
+ * The 76 dp-tall widget previews are the whole gap: their frames landed ~950 ms apart instead of
+ * ~70 ms, which is what pushed a *warm* render past the 5,000 ms warm first-frame budget in
+ * https://github.com/yschimke/compose-ai-tools/issues/3445. The flag lifts the compositor's frame
+ * cap; it changes scheduling only, not what is rasterized, and every lane still screenshots after
+ * the player's own readiness marker.
+ */
+export const CHROMIUM_LAUNCH_ARGS = Object.freeze([
+  // Skia's WebGL path in headless containers has no GPU; SwiftShader is the software fallback.
+  "--enable-unsafe-swiftshader",
+  "--no-sandbox",
+  // See above: without this a short viewport is paced at ~1 fps and inflates first-frame timings.
+  "--disable-frame-rate-limit",
+]);

--- a/scripts/design-artifacts/rc-chromium.test.mjs
+++ b/scripts/design-artifacts/rc-chromium.test.mjs
@@ -1,0 +1,34 @@
+/**
+ * The bug this pins: dropping `--disable-frame-rate-limit` from the render lanes' Chromium launch.
+ *
+ * Without it Chromium paces `requestAnimationFrame` at roughly 1 fps for a page whose CSS viewport
+ * is only a few dozen pixels tall. The CMP/Wasm player waits three frames before reporting
+ * readiness, so the 76 dp-tall widget previews in `remote-m3` took ~6,150 ms instead of ~1,980 ms —
+ * a *warm* render over the lane's 5,000 ms warm first-frame budget (issue #3445). It is a
+ * correctness flag for the measurement, not a speed knob, so it must not be dropped as noise.
+ *
+ * The slow-viewport behaviour itself is exercised end-to-end by rc-cmp-wasm-frame-pacing.test.mjs,
+ * which needs a built player distribution; this one always runs.
+ *
+ * Run with `node --test scripts/design-artifacts/*.test.mjs`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CHROMIUM_LAUNCH_ARGS } from "./rc-chromium.mjs";
+
+test("the shared launch args uncap the compositor frame rate", () => {
+  assert.ok(
+    CHROMIUM_LAUNCH_ARGS.includes("--disable-frame-rate-limit"),
+    "short viewports get ~1 fps frame pacing without it, inflating first-frame measurements",
+  );
+});
+
+test("the shared launch args keep the software GL fallback headless containers need", () => {
+  assert.ok(CHROMIUM_LAUNCH_ARGS.includes("--enable-unsafe-swiftshader"));
+  assert.ok(CHROMIUM_LAUNCH_ARGS.includes("--no-sandbox"));
+});
+
+test("the shared launch args are frozen, so a lane cannot mutate what other lanes measure with", () => {
+  assert.throws(() => CHROMIUM_LAUNCH_ARGS.push("--headless=old"));
+});

--- a/scripts/design-artifacts/rc-cmp-wasm-frame-pacing.test.mjs
+++ b/scripts/design-artifacts/rc-cmp-wasm-frame-pacing.test.mjs
@@ -3,7 +3,10 @@
  * viewport as in a tall one.
  *
  * Run with `node --test scripts/design-artifacts/`. Skipped unless the player distribution is
- * built (`./gradlew :rc-player-wasm:wasmPlayerDist`, or point `RC_CMP_WASM_DIST` at one).
+ * built (`./gradlew :rc-player-wasm:wasmPlayerDist`, or point `RC_CMP_WASM_DIST` at one) — set
+ * `RC_CMP_WASM_REQUIRE=1` to make every one of those skips a failure instead, which is how the
+ * `CMP/Wasm Frame Pacing` CI job runs it. A guard that can silently skip is a guard that stops
+ * guarding the moment its build step moves.
  *
  * The regression this guards (#3445): Chromium paces `requestAnimationFrame` at roughly **1 fps**
  * for a page whose CSS viewport is only a few dozen pixels tall, unless the compositor's frame cap
@@ -39,6 +42,7 @@ const TALL = { width: 216, height: 124 };
 // Throttled pacing put ~950 ms between frames instead of ~70 ms, over three frames. 2× leaves room
 // for a slow machine's noise on a ~2 s render while staying far below the ~3× the bug produced.
 const MAX_RATIO = 2;
+const REQUIRE = process.env.RC_CMP_WASM_REQUIRE === "1";
 
 let chromium;
 let browser;
@@ -117,6 +121,7 @@ async function firstFrameMs(page, viewport) {
 }
 
 test("a short viewport reaches first frame as fast as a tall one", async (t) => {
+  if (skip && REQUIRE) assert.fail(`RC_CMP_WASM_REQUIRE is set but the guard cannot run: ${skip}`);
   if (skip) return t.skip(skip);
   const context = await browser.newContext({ deviceScaleFactor: 2.625 });
   const page = await context.newPage();

--- a/scripts/design-artifacts/rc-cmp-wasm-frame-pacing.test.mjs
+++ b/scripts/design-artifacts/rc-cmp-wasm-frame-pacing.test.mjs
@@ -1,0 +1,137 @@
+/**
+ * rc-cmp-wasm-frame-pacing.test.mjs — the CMP/Wasm player must reach readiness as fast in a short
+ * viewport as in a tall one.
+ *
+ * Run with `node --test scripts/design-artifacts/`. Skipped unless the player distribution is
+ * built (`./gradlew :rc-player-wasm:wasmPlayerDist`, or point `RC_CMP_WASM_DIST` at one).
+ *
+ * The regression this guards (#3445): Chromium paces `requestAnimationFrame` at roughly **1 fps**
+ * for a page whose CSS viewport is only a few dozen pixels tall, unless the compositor's frame cap
+ * is lifted. The player reports readiness after three frames, so on the `remote-m3` catalog the
+ * 216×76 dp widget previews took ~6,150 ms while the 216×124 dp one beside them took ~2,040 ms —
+ * and because only the first render in a browser context is labelled `cold`, that ~6.1 s landed on
+ * a **warm** row and breached the lane's 5,000 ms warm budget. The rc-compare summary reported it
+ * as a startup-cost problem; it was frame pacing, and it reproduces with one document, one context,
+ * and no cold cache at all.
+ *
+ * Asserted as a *ratio* rather than an absolute ceiling: the ~1.5 s the player deliberately waits
+ * before posting `ready` dominates a healthy render, and machine speed moves the rest, but throttled
+ * frames put whole seconds between the two viewports. The unfixed gap is ~3×.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { CHROMIUM_LAUNCH_ARGS } from "./rc-chromium.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(
+  process.env.RC_CMP_WASM_DIST || path.join(HERE, "../../rc-player/wasm/build/wasmDist"),
+);
+const FIXTURE = path.join(HERE, "fixtures", "watch-screen-round-clip.rc");
+// 76 dp is the height of the `remote-m3` widget previews that regressed; 124 dp is the sibling
+// preview that never did. Same document, same context, so the only variable is the viewport.
+const SHORT = { width: 216, height: 76 };
+const TALL = { width: 216, height: 124 };
+// Throttled pacing put ~950 ms between frames instead of ~70 ms, over three frames. 2× leaves room
+// for a slow machine's noise on a ~2 s render while staying far below the ~3× the bug produced.
+const MAX_RATIO = 2;
+
+let chromium;
+let browser;
+let server;
+let origin;
+let skip = false;
+
+function contentType(file) {
+  if (file.endsWith(".html")) return "text/html; charset=utf-8";
+  if (file.endsWith(".mjs") || file.endsWith(".js")) return "text/javascript; charset=utf-8";
+  if (file.endsWith(".wasm")) return "application/wasm";
+  return "application/octet-stream";
+}
+
+before(async () => {
+  try {
+    ({ chromium } = await import("playwright"));
+  } catch {
+    skip = "playwright is not installed";
+    return;
+  }
+  if (!fs.existsSync(path.join(DIST, "index.html"))) {
+    skip = "the CMP/Wasm player distribution is not built";
+    return;
+  }
+  const document = fs.readFileSync(FIXTURE);
+  server = http.createServer((request, response) => {
+    const pathname = decodeURIComponent(new URL(request.url, "http://localhost").pathname);
+    if (pathname === "/document.rc") {
+      response.writeHead(200, { "Content-Type": "application/octet-stream" });
+      response.end(document);
+      return;
+    }
+    const file = path.resolve(DIST, pathname === "/" ? "index.html" : pathname.slice(1));
+    if (!file.startsWith(DIST) || !fs.existsSync(file) || !fs.statSync(file).isFile()) {
+      response.writeHead(404).end();
+      return;
+    }
+    response.writeHead(200, { "Content-Type": contentType(file) });
+    fs.createReadStream(file).pipe(response);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  origin = `http://127.0.0.1:${server.address().port}`;
+  try {
+    browser = await chromium.launch({
+      headless: true,
+      ...(process.env.RC_COMPARE_CHROMIUM ? { executablePath: process.env.RC_COMPARE_CHROMIUM } : {}),
+      args: [...CHROMIUM_LAUNCH_ARGS],
+    });
+  } catch (e) {
+    skip = `chromium unavailable: ${String(e).split("\n")[0]}`;
+  }
+});
+
+after(async () => {
+  await browser?.close();
+  await new Promise((resolve) => (server ? server.close(resolve) : resolve()));
+});
+
+/** Navigation-to-`ready` for one viewport, the same measurement rc-compare's budgets score. */
+async function firstFrameMs(page, viewport) {
+  await page.setViewportSize(viewport);
+  const startedAt = performance.now();
+  await page.goto(`${origin}/index.html?src=${encodeURIComponent("/document.rc")}&theme=light`);
+  await page.waitForFunction(
+    () => ["ready", "error"].includes(document.documentElement.dataset.rcPlayerState),
+    null,
+    { timeout: 60_000 },
+  );
+  const elapsed = performance.now() - startedAt;
+  const state = await page.evaluate(() => document.documentElement.dataset.rcPlayerState);
+  // An `error` render skips the frame wait entirely, so it would pass this test for the wrong
+  // reason. Fail loudly instead.
+  assert.equal(state, "ready", "the fixture must actually render");
+  return elapsed;
+}
+
+test("a short viewport reaches first frame as fast as a tall one", async (t) => {
+  if (skip) return t.skip(skip);
+  const context = await browser.newContext({ deviceScaleFactor: 2.625 });
+  const page = await context.newPage();
+  try {
+    // Warm the context first: the point of comparison is frame pacing, not the player's one-off
+    // load, which would otherwise land entirely on whichever viewport went first.
+    await firstFrameMs(page, TALL);
+    const tall = await firstFrameMs(page, TALL);
+    const short = await firstFrameMs(page, SHORT);
+    assert.ok(
+      short < tall * MAX_RATIO,
+      `short viewport ${short.toFixed(0)} ms vs tall ${tall.toFixed(0)} ms — ` +
+        `frames are being throttled in the short one`,
+    );
+  } finally {
+    await context.close();
+  }
+});

--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -44,6 +44,7 @@ import pixelmatch from "pixelmatch";
 import { chromium } from "playwright";
 
 import { renderRcCompareHtml } from "./render-rc-compare-html.mjs";
+import { CHROMIUM_LAUNCH_ARGS } from "./rc-chromium.mjs";
 import {
   applyCmpWasmPerformanceBudgets,
   applyCmpWasmPixelTolerances,
@@ -425,7 +426,12 @@ async function cmpWasmFor(id, bytes, baked, bakedUnflattened, width, height, ref
     const viewportHeight = previewParams?.heightDp ?? Math.round(height / density);
     const pageState = await cmpWasmPageFor(density);
     const { page: cmpWasmPage, consoleErrors: cmpWasmConsoleErrors } = pageState;
-    const startup = pageState.renders++ === 0 ? "cold" : "warm";
+    // `cold`/`warm` describes *this browser context*, and contexts are keyed by density (see
+    // `cmpWasmPageFor`) — so a catalog whose previews span two densities legitimately reports two
+    // cold rows, the second of them partway through the run. Both are recorded with their density
+    // so a slow row can be attributed instead of guessed at.
+    const contextRender = pageState.renders++;
+    const startup = contextRender === 0 ? "cold" : "warm";
     cmpWasmConsoleErrors.length = 0;
     cmpWasmServer.setDocument(bytes);
     await cmpWasmPage.setViewportSize({ width: viewportWidth, height: viewportHeight });
@@ -468,6 +474,9 @@ async function cmpWasmFor(id, bytes, baked, bakedUnflattened, width, height, ref
       cmpWasmMismatchPx: referenceBlank ? null : px,
       cmpWasmFirstFrameMs: firstFrameMs,
       cmpWasmStartup: startup,
+      cmpWasmDensity: density,
+      cmpWasmContextRender: contextRender,
+      cmpWasmViewport: `${viewportWidth}×${viewportHeight}`,
       cmpWasm: `rc-cmp-wasm/${id}.png`,
       cmpWasmDiff: `rc-cmp-wasm-diff/${id}.png`,
     };
@@ -492,11 +501,18 @@ const bundleJs = fs.readFileSync(PLAYER, "utf8");
 const browser = await chromium.launch({
   headless: true,
   ...(EXEC ? { executablePath: EXEC } : {}),
-  args: ["--enable-unsafe-swiftshader", "--no-sandbox"],
+  args: [...CHROMIUM_LAUNCH_ARGS],
 });
 const page = await browser.newContext({ deviceScaleFactor: 1 }).then((c) => c.newPage());
 const cmpWasmServer = CMP_WASM ? await startCmpWasmServer(CMP_WASM) : null;
 const cmpWasmPages = new Map();
+/**
+ * One browser context per preview density, because Playwright binds `deviceScaleFactor` at context
+ * creation — there is no per-render way to change it, and the player takes its density from the
+ * page's `devicePixelRatio`. Contexts do not share a cache, so the first render in each pays a
+ * fresh player load; that render is the one labelled `cold` (measured at ~0.3 s over a warm one
+ * here, small next to the ~2 s every render costs). Everything after it in that context is `warm`.
+ */
 async function cmpWasmPageFor(density) {
   if (cmpWasmPages.has(density)) return cmpWasmPages.get(density);
   const context = await browser.newContext({ deviceScaleFactor: density });
@@ -669,7 +685,8 @@ for (const id of rcIds) {
       ? ""
       : cmpWasm.cmpWasmRendered
         ? `  |  cmp-wasm ${cmpWasm.cmpWasmMismatchPct.toFixed(2)}% ` +
-          `(${cmpWasm.cmpWasmStartup} ${cmpWasm.cmpWasmFirstFrameMs.toFixed(0)} ms)`
+          `(${cmpWasm.cmpWasmStartup} ${cmpWasm.cmpWasmFirstFrameMs.toFixed(0)} ms, ` +
+          `${cmpWasm.cmpWasmViewport}@${cmpWasm.cmpWasmDensity})`
         : `  |  cmp-wasm NOT RENDERED`;
   console.log(
     `  ${name}: ${mismatchPct.toFixed(2)}% (${mismatchPx} px, ${width}×${height})${embNote}${embJvmNote}${cmpWasmNote}`,
@@ -828,6 +845,9 @@ fs.writeFileSync(
         cmpWasmMismatchPx: r.cmpWasmMismatchPx ?? null,
         cmpWasmFirstFrameMs: r.cmpWasmFirstFrameMs ?? null,
         cmpWasmStartup: r.cmpWasmStartup ?? null,
+        cmpWasmDensity: r.cmpWasmDensity ?? null,
+        cmpWasmContextRender: r.cmpWasmContextRender ?? null,
+        cmpWasmViewport: r.cmpWasmViewport ?? null,
         cmpWasmNote: r.cmpWasmNote ?? null,
         cmpWasmError: r.cmpWasmError ?? null,
       })),


### PR DESCRIPTION
Fixes the budget breach reported in #3445 — but not through the mechanism the issue proposed, and the difference matters, so the measurements are below.

## What was actually wrong

Chromium paces `requestAnimationFrame` at roughly **1 fps** for a page whose CSS viewport is only a few dozen pixels tall. The CMP/Wasm player waits three frames before posting `ready`, so the two 76 dp-tall `remote-m3` widget previews took ~6.1 s while the 124 dp-tall one beside them took ~2.0 s. Only the first render in a browser context is labelled `cold`, so one of those ~6.1 s renders landed on a **warm** row and blew the 5,000 ms warm budget.

The player's own User Timing marks (`?rcTrace=1`) show it directly — same document, same context, warm player:

| viewport | frame gaps | navigation → ready |
|---|---|---|
| 216×76 | 800 ms, 950 ms | 6,529 ms |
| 216×120 | 5 ms, 72 ms | 2,070 ms |

Decode, link, and layout are ~0 ms in both. The time is spent waiting for frames.

## Why it is not the second cold start

The issue's mechanism (a second density creating a second, empty-cache context mid-run) is not what breached the budget:

- The widget previews are at density **2.625**, not 1 — they carry `previewParams`, and their `216×76` dp viewport is what they have in common, not their density.
- The stall reproduces with **one context, one document, no cold cache**, at density 1, 2 and 2.625 alike: `216×76` is ~6.1 s and `216×124` is ~2.0 s in the same warm page. `567×200` at density 1 — the same device pixels — is ~2.0 s, so it is the CSS viewport, not the surface size.
- A freshly created context costs ~0.3 s over a warm render here, against the ~1.5 s the player itself waits before reporting readiness.

So the per-density page cache and the `cold`/`warm` split are both innocent; option 1 and option 2 in the issue would each have left the 6.4 s warm render in place. (Option 1 is also not directly available: Playwright binds `deviceScaleFactor` at context creation, and a per-render `Emulation.setDeviceMetricsOverride` on a second CDP session is overwritten by Playwright's own emulation — verified.)

## The fix

`--disable-frame-rate-limit` on the lane's Chromium launch. It lifts the compositor's frame cap; it changes scheduling only, and the lane still screenshots after the player's readiness marker. Launch arguments move into `rc-chromium.mjs` so the reasoning travels with them and a future cleanup does not drop the flag as noise.

Rows now also carry `cmpWasmDensity`, `cmpWasmViewport`, and `cmpWasmContextRender` in `rc-compare-summary.json` (and in the console line), so the next anomaly here is attributable from the summary instead of taking a catalog run to reproduce.

## Test plan

Full `rc-compare` runs over a freshly packed `samples/design-catalog-remote-m3` bundle (27 previews, real `wasmPlayerDist`), before and after:

| | before | after |
|---|---|---|
| cold first frame | 6,474 ms | 2,360 ms |
| slowest warm first frame | **6,365 ms** (over the 5,000 ms budget) | 2,148 ms |
| mean warm first frame | ~2,030 ms | 2,024 ms |
| gate with `--cmp-wasm-max-cold-first-frame-ms 10000 --cmp-wasm-max-warm-first-frame-ms 5000` | breached | passes |

**Visual evidence — nothing changed, and that is the assertion.** This PR alters frame *scheduling*, not rasterization, so the check that matters is that no pixel moved: every rendered PNG from the two runs is byte-for-byte identical, `0/15` differing in the `rc-cmp-wasm` lane and `0/27` in the untouched `rc` lane, with all 27 rows' `mismatchPx` unchanged (mean mismatch 1.32% both runs). Rendering a before/after gallery would print two identical images; the byte comparison is the stronger form of the same claim.

New tests:

- `rc-cmp-wasm-frame-pacing.test.mjs` — end-to-end guard holding a short viewport to within 2× of a tall one in the same warm context. Verified it fails without the flag (`short viewport 4545 ms vs tall 2062 ms`) and passes with it. Skips unless `:rc-player-wasm:wasmPlayerDist` is built (or `RC_CMP_WASM_DIST` points at one).
- `rc-chromium.test.mjs` — always-runs pin on the flag itself.

`node --test scripts/design-artifacts/`: 521 tests, 0 failures.

## Left alone, deliberately

The issue's third point — the ~2 s per-preview floor — is mostly **not** navigation. `page.goto` returns in ~60 ms and decode/layout are ~0 ms; ~1.5 s of every render is the player's own deliberate `delay(1_500)` before `postReady`, which guards the live viewer's no-flash handoff. Handing the player a new document in place would save the ~0.5 s of real work, not the sleep. Worth its own issue against the readiness contract rather than a change smuggled into this one.

Budget values are unchanged. With the slowest warm render now at 2.1 s there is room to tighten 5,000 ms considerably, but that is a policy call about CI runner variance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01544ugYx8JzQfQ2iL4ijJKK)_