### PR TITLE
perf(rc-compare): let the parity lane skip the player's snapshot-handoff tail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,8 +344,8 @@ jobs:
             rc-player/**/build/test-results/**
           retention-days: 7
 
-  # The CMP/Wasm player's first-frame timing, which is a browser-scheduling property and so cannot be
-  # asserted anywhere the player is not actually loaded in Chromium. Separate from the driver's
+  # The CMP/Wasm player's first-frame timing and readiness contract — browser-scheduling properties,
+  # so they cannot be asserted anywhere the player is not actually loaded in Chromium. Separate from the driver's
   # `node --test` job because it needs a built `wasmPlayerDist` that job has no Gradle to produce —
   # left there the test would self-skip forever, which is exactly the "nothing ran them" hole the
   # driver job comment describes. Ubuntu, not the macOS player job: frame pacing is per-platform, and
@@ -374,11 +374,11 @@ jobs:
       # `RC_CMP_WASM_REQUIRE` turns the test's self-skips into failures. Without it a missing
       # distribution, a missing playwright, or a browser that will not launch all leave this job
       # green having asserted nothing — which is the hole this job exists to close.
-      - name: Run the frame-pacing guard
+      - name: Run the browser-level player guards
         working-directory: scripts/design-artifacts
         env:
           RC_CMP_WASM_REQUIRE: "1"
-        run: node --test rc-cmp-wasm-frame-pacing.test.mjs
+        run: node --test rc-cmp-wasm-*.test.mjs
 
   functional-tests:
     name: Plugin Functional Tests

--- a/docs/design/RC_CMP_WASM_PLAYER.md
+++ b/docs/design/RC_CMP_WASM_PLAYER.md
@@ -580,6 +580,20 @@ The remote-m3 replacement corpus is guarded in CI, not recorded as a one-off man
   ~1.5 s the player itself waits before reporting readiness. Each row records its
   `cmpWasmDensity`, `cmpWasmViewport`, and `cmpWasmContextRender` in `rc-compare-summary.json`, so
   a slow row can be attributed rather than guessed at.
+- **The readiness signal is deliberately late, and only for hosts that can flash.** After its three
+  frames the player holds `ready` back for another 1.5 s, so viewer.js's `revealRcWasm` cannot swap
+  the snapshot for a surface the compositor has not presented. `?handoffDelayMs=0` drops that tail
+  and **only a host that composites the result itself may ask for it** — the parity driver does,
+  because its CDP screenshot drives its own frame and every pixel is then checked against the baked
+  reference. Measured across four full `remote-m3` runs, 60 rendered PNGs came back byte-for-byte
+  identical to the tailed baseline while the per-preview cost fell from ~2,000 ms to 453–891 ms
+  (~3 minutes saved on a 122-preview catalog). The viewer keeps the default: its hazard could not be
+  reproduced under any capture available here — `page.screenshot()` and CDP screencasts both drive
+  compositor frames of their own, and a control that revealed the frame 250 ms after load, long
+  before the player could be ready, still captured clean. An unverifiable hazard keeps its guard.
+  [`rc-cmp-wasm-handoff.test.mjs`](../../scripts/design-artifacts/rc-cmp-wasm-handoff.test.mjs)
+  pins both halves: the default still waits, and the tail-free render is byte-identical to a settled
+  one.
 - The live viewer forwards typed named overrides, reloads after knob changes, validates same-origin
   host messages, and surfaces host/named actions as inert `CustomEvent` payloads. Decode, support,
   and resource failures remain bounded inside the iframe instead of replacing the catalog page.

--- a/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
+++ b/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
@@ -109,7 +109,7 @@ public fun main() {
           repeat(3) { withFrameNanos {} }
           // Chromium can acknowledge those frames before the Skiko surface is presented to the
           // compositor. Keep the parent snapshot visible through that short cold-start tail.
-          delay(1_500)
+          delay(handoffDelayMs)
           postReady()
         }
       }
@@ -246,6 +246,28 @@ private suspend fun fetchText(url: String): String = suspendCancellableCoroutine
       null
     }
 }
+
+/** The default cold-start tail. Every render pays it, so a host that cannot flash should not. */
+private const val DEFAULT_HANDOFF_DELAY_MS = 1_500L
+
+/**
+ * How long to keep saying "not ready" after the frames have gone through, so a host that reveals
+ * this player on `ready` cannot swap a snapshot for a surface the compositor has not presented yet.
+ *
+ * `?handoffDelayMs=0` turns the tail off, and **only a host that composites the result itself**
+ * should ask for that. The parity driver is the case that exists: it screenshots through CDP, which
+ * drives its own compositor frame, then verifies the size and every pixel of what came back — so a
+ * surface that was not presented yet cannot slip past it, and the 1.5 s is dead weight repeated
+ * once per preview (~3 minutes across a 122-preview catalog). The viewer's iframe handoff has no
+ * such check and keeps the default: it is the one that would show a blank frame to a human, and
+ * that failure could not be reproduced under CDP capture in the first place — screenshots and
+ * screencasts both drive frames of their own, so neither can observe it. An unverifiable hazard
+ * keeps its guard.
+ */
+private val handoffDelayMs: Long
+  get() =
+    queryParameter("handoffDelayMs")?.toLongOrNull()?.coerceIn(0L, 10_000L)
+      ?: DEFAULT_HANDOFF_DELAY_MS
 
 private fun queryParameter(name: String): String? =
   queryParameterFromLocation(name).toString().takeUnless { it == "null" }

--- a/scripts/design-artifacts/rc-cmp-wasm-handoff.test.mjs
+++ b/scripts/design-artifacts/rc-cmp-wasm-handoff.test.mjs
@@ -34,10 +34,15 @@ const DIST = path.resolve(
 const FIXTURE = path.join(HERE, "fixtures", "watch-screen-round-clip.rc");
 const VIEWPORT = { width: 227, height: 227 };
 const DENSITY = 2;
-// The default tail is 1,500 ms. Assert well under it so a slow machine cannot fail the test, but
-// far enough above the ~600 ms a tail-free render takes that the two cannot be confused.
+// The default tail is 1,500 ms. A *lower* bound on the default render is safe on any machine — a
+// slow one only overshoots it, and nothing but a missing tail can undershoot.
 const MIN_DEFAULT_MS = 1_200;
-const MAX_TAIL_FREE_MS = 1_000;
+// The tail-free render is checked against a default one from the same context rather than against a
+// wall-clock ceiling. Its elapsed time is a whole navigation, Wasm startup, font load and three
+// frames — all machine-speed — so an absolute deadline would fail a slow-but-correct runner while
+// the production lane happily allows 5,000 ms. The *difference* between the two is the tail and
+// nothing else, so it survives a runner that runs everything at half speed.
+const MIN_TAIL_SAVING_MS = 1_000;
 const REQUIRE = process.env.RC_CMP_WASM_REQUIRE === "1";
 
 let chromium;
@@ -151,9 +156,11 @@ test("handoffDelayMs=0 drops the tail without changing a pixel", async (t) => {
     const settled = await render(page, "");
     return { fast, settled };
   });
+  const saved = settled.elapsed - fast.elapsed;
   assert.ok(
-    fast.elapsed < MAX_TAIL_FREE_MS,
-    `handoffDelayMs=0 still took ${fast.elapsed.toFixed(0)} ms — the parameter is not applied`,
+    saved > MIN_TAIL_SAVING_MS,
+    `handoffDelayMs=0 took ${fast.elapsed.toFixed(0)} ms against ${settled.elapsed.toFixed(0)} ms ` +
+      `with the tail — only ${saved.toFixed(0)} ms apart, so the parameter is not being applied`,
   );
   assert.ok(
     fast.png.equals(settled.png),

--- a/scripts/design-artifacts/rc-cmp-wasm-handoff.test.mjs
+++ b/scripts/design-artifacts/rc-cmp-wasm-handoff.test.mjs
@@ -1,0 +1,162 @@
+/**
+ * rc-cmp-wasm-handoff.test.mjs — the player's `?handoffDelayMs` contract, from both sides.
+ *
+ * Run with `node --test scripts/design-artifacts/`. Skipped unless the player distribution is
+ * built (`./gradlew :rc-player-wasm:wasmPlayerDist`, or point `RC_CMP_WASM_DIST` at one); set
+ * `RC_CMP_WASM_REQUIRE=1` to turn those skips into failures, as the CI job does.
+ *
+ * The player holds back `ready` for 1.5 s after its frames have gone through, so a host that
+ * reveals it on that signal — viewer.js's `revealRcWasm` swaps the snapshot for the iframe — cannot
+ * show a surface the compositor has not presented. That tail is also ~1.5 s of every parity render,
+ * around three minutes across a 122-preview catalog, and the parity driver cannot flash: it
+ * screenshots through CDP, which drives its own compositor frame, then checks every pixel against
+ * the baked reference. So the driver passes `handoffDelayMs=0` and the viewer keeps the default.
+ *
+ * Both halves are pinned here because each fails silently on its own. Drop the default and the
+ * viewer regains a blank-frame flash that no capture in this repo can observe — screenshots and CDP
+ * screencasts both drive frames of their own, so the hazard survives only as a guard, not a test.
+ * Ignore the parameter and the driver quietly pays the tail again, which is how it went unnoticed
+ * for as long as it did.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { CHROMIUM_LAUNCH_ARGS } from "./rc-chromium.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(
+  process.env.RC_CMP_WASM_DIST || path.join(HERE, "../../rc-player/wasm/build/wasmDist"),
+);
+const FIXTURE = path.join(HERE, "fixtures", "watch-screen-round-clip.rc");
+const VIEWPORT = { width: 227, height: 227 };
+const DENSITY = 2;
+// The default tail is 1,500 ms. Assert well under it so a slow machine cannot fail the test, but
+// far enough above the ~600 ms a tail-free render takes that the two cannot be confused.
+const MIN_DEFAULT_MS = 1_200;
+const MAX_TAIL_FREE_MS = 1_000;
+const REQUIRE = process.env.RC_CMP_WASM_REQUIRE === "1";
+
+let chromium;
+let browser;
+let server;
+let origin;
+let skip = false;
+
+function contentType(file) {
+  if (file.endsWith(".html")) return "text/html; charset=utf-8";
+  if (file.endsWith(".mjs") || file.endsWith(".js")) return "text/javascript; charset=utf-8";
+  if (file.endsWith(".wasm")) return "application/wasm";
+  return "application/octet-stream";
+}
+
+before(async () => {
+  try {
+    ({ chromium } = await import("playwright"));
+  } catch {
+    skip = "playwright is not installed";
+    return;
+  }
+  if (!fs.existsSync(path.join(DIST, "index.html"))) {
+    skip = "the CMP/Wasm player distribution is not built";
+    return;
+  }
+  const document = fs.readFileSync(FIXTURE);
+  server = http.createServer((request, response) => {
+    const pathname = decodeURIComponent(new URL(request.url, "http://localhost").pathname);
+    if (pathname === "/document.rc") {
+      response.writeHead(200, { "Content-Type": "application/octet-stream" });
+      response.end(document);
+      return;
+    }
+    const file = path.resolve(DIST, pathname === "/" ? "index.html" : pathname.slice(1));
+    if (!file.startsWith(DIST) || !fs.existsSync(file) || !fs.statSync(file).isFile()) {
+      response.writeHead(404).end();
+      return;
+    }
+    response.writeHead(200, { "Content-Type": contentType(file) });
+    fs.createReadStream(file).pipe(response);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  origin = `http://127.0.0.1:${server.address().port}`;
+  try {
+    browser = await chromium.launch({
+      headless: true,
+      ...(process.env.RC_COMPARE_CHROMIUM ? { executablePath: process.env.RC_COMPARE_CHROMIUM } : {}),
+      args: [...CHROMIUM_LAUNCH_ARGS],
+    });
+  } catch (e) {
+    skip = `chromium unavailable: ${String(e).split("\n")[0]}`;
+  }
+});
+
+after(async () => {
+  await browser?.close();
+  await new Promise((resolve) => (server ? server.close(resolve) : resolve()));
+});
+
+/** Render once the way rc-compare does, returning navigation-to-`ready` and the screenshot. */
+async function render(page, query) {
+  const startedAt = performance.now();
+  await page.goto(
+    `${origin}/index.html?src=${encodeURIComponent("/document.rc")}&theme=light${query}`,
+  );
+  await page.waitForFunction(
+    () => ["ready", "error"].includes(document.documentElement.dataset.rcPlayerState),
+    null,
+    { timeout: 60_000 },
+  );
+  const elapsed = performance.now() - startedAt;
+  const state = await page.evaluate(() => document.documentElement.dataset.rcPlayerState);
+  assert.equal(state, "ready", "the fixture must actually render");
+  return { elapsed, png: await page.screenshot({ omitBackground: true }) };
+}
+
+async function withPage(run) {
+  const context = await browser.newContext({ deviceScaleFactor: DENSITY });
+  const page = await context.newPage();
+  await page.setViewportSize(VIEWPORT);
+  try {
+    return await run(page);
+  } finally {
+    await context.close();
+  }
+}
+
+test("the default keeps the cold-start tail the viewer's reveal depends on", async (t) => {
+  if (skip && REQUIRE) assert.fail(`RC_CMP_WASM_REQUIRE is set but the guard cannot run: ${skip}`);
+  if (skip) return t.skip(skip);
+  const elapsed = await withPage(async (page) => {
+    await render(page, ""); // warm the context so this measures the tail, not the player's load
+    return (await render(page, "")).elapsed;
+  });
+  assert.ok(
+    elapsed >= MIN_DEFAULT_MS,
+    `default render reported ready in ${elapsed.toFixed(0)} ms — the tail a host reveal ` +
+      `depends on is gone`,
+  );
+});
+
+test("handoffDelayMs=0 drops the tail without changing a pixel", async (t) => {
+  if (skip && REQUIRE) assert.fail(`RC_CMP_WASM_REQUIRE is set but the guard cannot run: ${skip}`);
+  if (skip) return t.skip(skip);
+  const { fast, settled } = await withPage(async (page) => {
+    await render(page, "&handoffDelayMs=0");
+    const fast = await render(page, "&handoffDelayMs=0");
+    // The same document with the full tail is the reference: whatever the driver screenshots
+    // without waiting must equal what a fully settled render produces.
+    const settled = await render(page, "");
+    return { fast, settled };
+  });
+  assert.ok(
+    fast.elapsed < MAX_TAIL_FREE_MS,
+    `handoffDelayMs=0 still took ${fast.elapsed.toFixed(0)} ms — the parameter is not applied`,
+  );
+  assert.ok(
+    fast.png.equals(settled.png),
+    "a tail-free render must be byte-identical to a settled one",
+  );
+});

--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -436,8 +436,14 @@ async function cmpWasmFor(id, bytes, baked, bakedUnflattened, width, height, ref
     cmpWasmServer.setDocument(bytes);
     await cmpWasmPage.setViewportSize({ width: viewportWidth, height: viewportHeight });
     const startedAt = performance.now();
+    // `handoffDelayMs=0` drops the player's cold-start tail — 1.5 s it holds back `ready` so a host
+    // that reveals it on that signal cannot show a blank surface. This lane is not such a host: the
+    // screenshot below goes through CDP, which drives its own compositor frame, and every pixel of
+    // the result is then checked against the baked reference. Measured over a full 27-preview
+    // remote-m3 run, dropping it leaves every rendered PNG byte-for-byte identical and takes the
+    // per-preview cost from ~2.0 s to ~0.5 s. The viewer keeps the default.
     await cmpWasmPage.goto(
-      `${cmpWasmServer.origin}/index.html?src=${encodeURIComponent("/document.rc")}&theme=${encodeURIComponent(THEME)}`,
+      `${cmpWasmServer.origin}/index.html?src=${encodeURIComponent("/document.rc")}&theme=${encodeURIComponent(THEME)}&handoffDelayMs=0`,
     );
     await cmpWasmPage.waitForFunction(
       () => ["ready", "error"].includes(document.documentElement.dataset.rcPlayerState),


### PR DESCRIPTION
The follow-up flagged in #3459 — the ~2 s per-preview floor in the CMP/Wasm lane. It is almost entirely the player's `delay(1_500)` before `postReady`, not navigation: `page.goto` returns in ~60 ms and decode/link/layout are ~0 ms.

## What the delay is for

After its three frames the player holds `ready` back another 1.5 s so a host that reveals it on that signal cannot swap a snapshot for a surface the compositor has not presented. viewer.js's `revealRcWasm` does exactly that — hides the `<img>` snapshot and shows the iframe the moment `cp-rc-wasm-ready` arrives. That guard is real and stays.

The parity driver is not such a host. It screenshots through CDP — which drives its own compositor frame — then checks the size and every pixel of the result against the baked reference. A surface that had not been presented could not slip past it. So the tail is dead weight there, paid once per preview.

## The change

`?handoffDelayMs=` on the player, defaulting to the current 1,500 ms and clamped to [0, 10,000]. `rc-compare.mjs` passes `0`. Nothing else changes.

| | before | after |
|---|---|---|
| warm render (spread over 3 runs) | ~2,000 ms | 453–891 ms |
| cold render | 2,360 ms | ~840 ms |
| rendered PNGs identical to the tailed baseline | — | **60/60** |

That is ~1.4 s per preview, so roughly **three minutes off a 122-preview catalog** in this lane alone.

## Why the viewer keeps the default

I tried to measure the flash and could not, and that is the reason the default is untouched rather than lowered for everyone:

- `page.screenshot()` cannot see it — it drives a fresh compositor frame, so the surface is always painted by the time the capture lands.
- CDP screencast cannot see it either, at the frame rates it delivers here.
- **Control run:** revealing the iframe 250 ms after load — long before the player could possibly be ready — still captured perfectly clean under both methods. A measurement that cannot detect a deliberately broken reveal cannot certify a working one.

So the evidence supports the claim I am making (the driver's pixels are unchanged) and does not support the claim I am *not* making (that the viewer would be fine without the tail). An unverifiable hazard keeps its guard.

Readback was the other option and is unavailable: the Skiko canvas lives in `#rcPlayer`'s shadow root with `preserveDrawingBuffer: false`, so `readPixels` returns zeros and `toDataURL` returns a blank image outside the drawing frame. There is no in-page way to ask "is this painted?".

## Test plan

- **4 full `remote-m3` runs** (27 previews, real `wasmPlayerDist`, freshly packed bundle): 15 rendered PNGs each, **60/60 byte-for-byte identical** to the merged baseline from #3459; mean mismatch 1.32% in every run; gate passes at the documented budgets.
- **New `rc-cmp-wasm-handoff.test.mjs`** pins both halves, because each fails silently alone: the default still waits ≥1,200 ms (so nobody can quietly drop the viewer's guard), and a `handoffDelayMs=0` render is byte-identical to a settled one (so nobody can quietly stop applying it). Both verified passing against a real distribution.
- The `CMP/Wasm Frame Pacing` job now runs `rc-cmp-wasm-*.test.mjs`, so the new guard is covered by the same `RC_CMP_WASM_REQUIRE=1` that turns skips into failures.
- `node --test scripts/design-artifacts/`: 507 passing, 0 failures. `ktfmtCheck` clean.

**Visual evidence:** as in #3459, the assertion is that nothing moved — 60/60 renders byte-identical across four runs is the stronger form of a before/after gallery that would show two identical images.

## Note

With warm renders now ~0.5 s, the 5,000 ms warm and 10,000 ms cold budgets have a lot of headroom. Still not touching them here — that is a policy call about CI runner variance, and this PR is already changing what the numbers mean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01544ugYx8JzQfQ2iL4ijJKK)_