### PR TITLE
fix(serve): refuse a dropped override on the vector and Storybook lanes too

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -551,7 +551,10 @@ class ServeBundleHost(
     // Crops resolve relative to the SVG's own dir: `<slug>.figma-raster/` next to the slug vector,
     // `<variant>.figma-raster/` next to a per-variant one.
     val dir = svgFile.parent ?: return SvgOutcome.NotFound
-    return SvgOutcome.Ok(inlineFigmaRasters(fileSystem, dir, svg).encodeToByteArray())
+    return SvgOutcome.Ok(
+      inlineFigmaRasters(fileSystem, dir, svg).encodeToByteArray(),
+      RenderOutcome.Generation.BAKED,
+    )
   }
 
   /**
@@ -574,7 +577,10 @@ class ServeBundleHost(
       svgFile.parent?.toFile()?.relativeToOrNull(catalogRoot)?.invariantSeparatorsPath
         ?: return renderSvg(previewId, overrides)
     val base = "https://raw.githubusercontent.com/${prov.repo}/${prov.branch}/$relDir"
-    return SvgOutcome.Ok(linkFigmaRasters(svg, base).encodeToByteArray())
+    return SvgOutcome.Ok(
+      linkFigmaRasters(svg, base).encodeToByteArray(),
+      RenderOutcome.Generation.BAKED,
+    )
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2821,8 +2821,18 @@ class ServeHttpServer(
         call.response.headers.append(HttpHeaders.RetryAfter, "2")
         call.respondText("render busy; retry shortly", status = HttpStatusCode.ServiceUnavailable)
       }
-      is RenderOutcome.Ok ->
-        call.respondText(StorybookCompat.iframePage(storyId, outcome.png), ContentType.Text.Html)
+      is RenderOutcome.Ok -> {
+        // A story's args ride the same override params, and this lane is consumed by exactly the
+        // tools #3449 is about — BackstopJS / reg-suit style PNG-diffing across arg values. Baked
+        // pixels here would read as "this arg changes nothing".
+        val dropped = droppedOverridesFor(outcome.generation, previewId, overrides)
+        if (dropped.isNotEmpty() && !acceptsBakedFallback()) {
+          refuseDroppedOverrides(renderHost, previewId, dropped)
+        } else {
+          markDroppedOverrides(dropped)
+          call.respondText(StorybookCompat.iframePage(storyId, outcome.png), ContentType.Text.Html)
+        }
+      }
       RenderOutcome.NotFound -> call.respondText("no such story", status = HttpStatusCode.NotFound)
       is RenderOutcome.Failed ->
         call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
@@ -2861,8 +2871,18 @@ class ServeHttpServer(
           status = HttpStatusCode.ServiceUnavailable,
         )
       }
-      is SvgOutcome.Ok ->
-        call.respondText(StorybookCompat.iframeSvgPage(storyId, outcome.svg), ContentType.Text.Html)
+      is SvgOutcome.Ok -> {
+        val dropped = droppedOverridesFor(outcome.generation, previewId, overrides)
+        if (dropped.isNotEmpty() && !acceptsBakedFallback()) {
+          refuseDroppedOverrides(renderHost, previewId, dropped)
+        } else {
+          markDroppedOverrides(dropped)
+          call.respondText(
+            StorybookCompat.iframeSvgPage(storyId, outcome.svg),
+            ContentType.Text.Html,
+          )
+        }
+      }
       SvgOutcome.NotFound ->
         call.respondText(
           "svg unavailable for this story (no daemon-backed SVG export)",
@@ -3336,14 +3356,16 @@ class ServeHttpServer(
               // Baked pixels answering an override-bearing request are pixels that do NOT reflect
               // the override — byte-identical to the un-overridden snapshot, under a 200 (#3449).
               // Every other generation is a real render keyed by these overrides.
-              val dropped =
-                if (outcome.generation == RenderOutcome.Generation.BAKED) {
-                  CatalogLiveRouting.droppedOverrideNames(previewId, overrides)
-                } else {
-                  emptyList()
-                }
+              val dropped = droppedOverridesFor(outcome.generation, previewId, overrides)
               if (dropped.isNotEmpty()) {
-                respondDroppedOverrides(renderHost, previewId, outcome, dropped)
+                respondDroppedOverrides(
+                  renderHost,
+                  previewId,
+                  dropped,
+                  outcome.png,
+                  ContentType.Image.PNG,
+                  outcome.generation,
+                )
               } else {
                 markGeneration(
                   outcome.generation.wire,
@@ -3371,22 +3393,40 @@ class ServeHttpServer(
   }
 
   /**
-   * Answer a render whose **validated overrides were not applied** — the pixels in [outcome] are
-   * the preview's baked snapshot, produced without a renderer, while the request asked for
-   * [dropped].
+   * The validated overrides a [generation] artifact for [previewId] does **not** reflect — empty
+   * unless the bytes came straight off a published bundle ([RenderOutcome.Generation.BAKED] — no
+   * renderer was involved in this request). Every other generation is a real render keyed by these
+   * overrides, cache hit or not.
+   */
+  private fun droppedOverridesFor(
+    generation: RenderOutcome.Generation,
+    previewId: String,
+    overrides: PreviewOverrides,
+  ): List<String> =
+    if (generation == RenderOutcome.Generation.BAKED) {
+      CatalogLiveRouting.droppedOverrideNames(previewId, overrides)
+    } else {
+      emptyList()
+    }
+
+  /**
+   * Answer a render whose **validated overrides were not applied** — [bytes] are the preview's
+   * baked artifact, produced without a renderer, while the request asked for [dropped]. Shared by
+   * the PNG and SVG lanes so the two can't drift: a vector read off the delivery branch ignores a
+   * `fontScale` exactly as thoroughly as a baked PNG does.
    *
-   * The old behaviour was `200 image/png` with those bytes, which is a wrong answer delivered
-   * confidently: the response is indistinguishable from a render where the override genuinely
-   * changed nothing, so a diff bot, a parity check, or an agent iterating on a theme concludes "no
-   * visual difference" for pixels that were never rendered (#3449). Every override kind now agrees
-   * here — `fontScale`, `uiMode`, and `themeProvider` alike — rather than one path 503ing while the
+   * The old behaviour was `200` with those bytes, which is a wrong answer delivered confidently:
+   * the response is indistinguishable from a render where the override genuinely changed nothing,
+   * so a diff bot, a parity check, or an agent iterating on a theme concludes "no visual
+   * difference" for an artifact that was never rendered (#3449). Every override kind agrees here —
+   * `fontScale`, `uiMode`, and `themeProvider` alike — rather than one path 503ing while the
    * commoner ones quietly returned the snapshot.
    *
    * Three outcomes, all naming the dropped params in [DROPPED_OVERRIDES_HEADER] so even a `curl -I`
    * can tell:
    * - `?fallback=baked` — the caller explicitly accepted the snapshot (the viewer asks for this
    *   when it would rather show published pixels than a broken image). 200, plus
-   *   `X-Compose-Preview-Render: baked-fallback`, since the pixels carry no signal of their own.
+   *   `X-Compose-Preview-Render: baked-fallback`, since the bytes carry no signal of their own.
    * - the preview HAS a live lane, just not right now (daemon down, cold, no free seat) — 503 +
    *   `Retry-After`, matching what a pure `themeProvider` request already returned in this state.
    * - the preview has NO live lane at all (a static/untrusted catalog, an unmapped Android-only
@@ -3395,16 +3435,43 @@ class ServeHttpServer(
   private suspend fun RoutingContext.respondDroppedOverrides(
     renderHost: ServeHost,
     previewId: String,
-    outcome: RenderOutcome.Ok,
+    dropped: List<String>,
+    bytes: ByteArray,
+    contentType: ContentType,
+    generation: RenderOutcome.Generation,
+  ) {
+    if (acceptsBakedFallback()) {
+      markDroppedOverrides(dropped)
+      markGeneration(generation.wire, DYNAMIC_RESOURCE_CACHE_CONTROL)
+      call.respondBytes(bytes, contentType)
+      return
+    }
+    refuseDroppedOverrides(renderHost, previewId, dropped)
+  }
+
+  /** Whether the caller passed `?fallback=baked` — an explicit "serve the snapshot anyway". */
+  private fun RoutingContext.acceptsBakedFallback(): Boolean =
+    call.request.queryParameters[FALLBACK_PARAM]?.lowercase() == FALLBACK_BAKED
+
+  /**
+   * Name the un-applied overrides on a response that carries the baked artifact regardless — the
+   * accepted `?fallback=baked`, and the Storybook isolation pages, whose consumers asked for an
+   * HTML wrapper this server has no refusal shape for beyond a status. A no-op when nothing was
+   * dropped, so an honest render carries no stray header.
+   */
+  private fun RoutingContext.markDroppedOverrides(dropped: List<String>) {
+    if (dropped.isEmpty()) return
+    call.response.headers.append(DROPPED_OVERRIDES_HEADER, dropped.joinToString(","))
+    call.response.headers.append(RENDER_HEADER, RENDER_BAKED_FALLBACK)
+  }
+
+  /** The refusal half of [respondDroppedOverrides]: 503 when a live lane exists, else 409. */
+  private suspend fun RoutingContext.refuseDroppedOverrides(
+    renderHost: ServeHost,
+    previewId: String,
     dropped: List<String>,
   ) {
     call.response.headers.append(DROPPED_OVERRIDES_HEADER, dropped.joinToString(","))
-    if (call.request.queryParameters[FALLBACK_PARAM]?.lowercase() == FALLBACK_BAKED) {
-      call.response.headers.append(RENDER_HEADER, RENDER_BAKED_FALLBACK)
-      markGeneration(outcome.generation.wire, DYNAMIC_RESOURCE_CACHE_CONTROL)
-      call.respondBytes(outcome.png, ContentType.Image.PNG)
-      return
-    }
     val params = dropped.joinToString(", ")
     if (renderHost.canRenderOverridesFor(previewId)) {
       call.response.headers.append(HttpHeaders.RetryAfter, "2")
@@ -3551,7 +3618,25 @@ class ServeHttpServer(
         val svg =
           if (webMode) webModeSvg(outcome.svg.toString(Charsets.UTF_8)).toByteArray(Charsets.UTF_8)
           else outcome.svg
-        call.respondBytes(svg, ContentType.parse(ComposeFigmaSvgProduct.MEDIA_TYPE_SVG))
+        val contentType = ContentType.parse(ComposeFigmaSvgProduct.MEDIA_TYPE_SVG)
+        // The vector lane drops overrides exactly like the PNG one: a `figma/<slug>.svg` read off
+        // the delivery branch was drawn at the preview's discovery-time axes, so serving it for a
+        // `?fontScale=2.0` export is the same silent wrong answer (#3449). `?scroll=long` is
+        // daemon-only (a bundle has no full-page vector), so it never lands here baked.
+        val dropped = droppedOverridesFor(outcome.generation, previewId, overrides)
+        if (dropped.isNotEmpty()) {
+          respondDroppedOverrides(
+            renderHost,
+            previewId,
+            dropped,
+            svg,
+            contentType,
+            outcome.generation,
+          )
+        } else {
+          markGeneration(outcome.generation.wire)
+          call.respondBytes(svg, contentType)
+        }
       }
       SvgOutcome.NotFound -> call.respondText("no such preview", status = HttpStatusCode.NotFound)
       is SvgOutcome.Failed ->

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -247,7 +247,16 @@ sealed interface RenderOutcome {
 
 /** Result of a figma-svg render request — the SVG counterpart of [RenderOutcome]. */
 sealed interface SvgOutcome {
-  data class Ok(val svg: ByteArray) : SvgOutcome
+  data class Ok(
+    val svg: ByteArray,
+    /**
+     * How these bytes were produced, exposed on HTTP responses for remote diagnosis — the same
+     * ladder [RenderOutcome.Ok] reports. [RenderOutcome.Generation.BAKED] means the vector was read
+     * from a published bundle with no renderer involved, which is what lets the HTTP layer notice
+     * that an override-bearing request was answered with pixels (well, paths) that ignore it.
+     */
+    val generation: RenderOutcome.Generation = RenderOutcome.Generation.DAEMON,
+  ) : SvgOutcome
 
   /** No such preview id, or this host can't produce SVG (a static bundle has no daemon). */
   data object NotFound : SvgOutcome

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -820,12 +820,12 @@ internal constructor(
 
     val key = ServeOverrides.cacheKey(previewId, overrides)
     svgCache.get(key)?.let {
-      return SvgOutcome.Ok(it)
+      return SvgOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
     }
 
     return renderLock.withLock {
       svgCache.get(key)?.let {
-        return@withLock SvgOutcome.Ok(it)
+        return@withLock SvgOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
       }
 
       // Force a fresh render of these overrides so the shared per-preview SVG file on disk is
@@ -894,12 +894,12 @@ internal constructor(
 
     val key = ServeOverrides.cacheKey(previewId, overrides)
     scrollSvgCache.get(key)?.let {
-      return SvgOutcome.Ok(it)
+      return SvgOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
     }
 
     return renderLock.withLock {
       scrollSvgCache.get(key)?.let {
-        return@withLock SvgOutcome.Ok(it)
+        return@withLock SvgOutcome.Ok(it, RenderOutcome.Generation.DAEMON_CACHE)
       }
 
       // Force a fresh full-page render at these overrides (the shared per-preview file may hold a

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -197,6 +197,23 @@ class ServeHttpRoutingTest {
     return ServeBundleHost(dir, label = label, title = title, degradations = degradations)
   }
 
+  /**
+   * A baked catalog that also carries the published `figma/<slug>.svg` vector, so the `.svg` lane
+   * serves something instead of 404ing. The vector is as static as the PNG — it was exported at the
+   * preview's discovery-time axes — which is what makes an override on this lane a silent drop
+   * (#3449).
+   */
+  private fun svgBundle(label: String): ServeBundleHost {
+    val dir = Files.createTempDirectory("routing-$label").toFile().also { it.deleteOnExit() }
+    File(dir, "index.html").writeText("<html></html>")
+    File(dir, "previews").apply { mkdirs() }
+    File(dir, "previews/$previewId.png").writeBytes(png())
+    val figma = File(dir, "figma").apply { mkdirs() }
+    File(figma, "$previewId.svg")
+      .writeText("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"2\" height=\"2\"></svg>")
+    return ServeBundleHost(dir, label = label, figmaDir = figma)
+  }
+
   private val registry = ServeSessionRegistry(open = { null })
   private val rcWasmDir =
     Files.createTempDirectory("routing-rc-wasm").toFile().also { dir ->
@@ -228,6 +245,7 @@ class ServeHttpRoutingTest {
     )
     registry.register("burst", host = burstHost, pinned = true)
     registry.register("live-down", host = liveDownHost, pinned = true)
+    registry.register("svg-catalog", host = svgBundle("svg-catalog"), pinned = true)
     ServeHttpServer(
         host = "127.0.0.1",
         requestedPort = 0,
@@ -357,6 +375,61 @@ class ServeHttpRoutingTest {
     assertEquals("fontScale,knob.label", knobHeaders[ServeHttpServer.DROPPED_OVERRIDES_HEADER])
     // An unrecognised param is not an override, so it still serves the snapshot (unchanged).
     assertEquals(200, get("/default-mod/render/$previewId.png?zzzBogusParam=1").first)
+  }
+
+  /**
+   * The vector lane drops overrides exactly like the raster one — a `figma/<slug>.svg` read off the
+   * delivery branch was exported at the preview's discovery-time axes — so it must refuse too, and
+   * with the same shape.
+   */
+  @Test
+  fun `the svg lane refuses an override it cannot apply, and marks an accepted fallback`() {
+    val (plainCode, plainBody, plainHeaders) = getFull("/svg-catalog/render/$previewId.svg")
+    assertEquals(200, plainCode)
+    assertTrue(plainBody.contains("<svg"), "the un-overridden request serves the baked vector")
+    assertEquals("baked", plainHeaders[ServeHttpServer.GENERATION_HEADER])
+    assertEquals(null, plainHeaders[ServeHttpServer.DROPPED_OVERRIDES_HEADER])
+
+    val (code, body, headers) = getFull("/svg-catalog/render/$previewId.svg?fontScale=2.0")
+    assertEquals(409, code)
+    assertEquals("fontScale", headers[ServeHttpServer.DROPPED_OVERRIDES_HEADER])
+    assertTrue(body.contains("override not applied: fontScale"), "body names the param: $body")
+
+    val (okCode, okBody, okHeaders) =
+      getFull("/svg-catalog/render/$previewId.svg?fontScale=2.0&fallback=baked")
+    assertEquals(200, okCode)
+    assertEquals(plainBody, okBody, "the opted-in fallback is the baked vector")
+    assertEquals(
+      ServeHttpServer.RENDER_BAKED_FALLBACK,
+      okHeaders[ServeHttpServer.RENDER_HEADER],
+      "the fallback vector says it is one",
+    )
+    assertEquals("fontScale", okHeaders[ServeHttpServer.DROPPED_OVERRIDES_HEADER])
+  }
+
+  /**
+   * The Storybook isolation pages are consumed by PNG-diffing visual tools — precisely the
+   * caller #3449 describes — and a story's args ride the same override params, so they refuse too.
+   * The page shape has no room for a signal of its own, hence the status.
+   */
+  @Test
+  fun `the storybook iframe lanes refuse a dropped override`() {
+    assertEquals(200, get("/compose-m3/iframe.html?id=$previewId").first)
+    val (code, _, headers) = getFull("/compose-m3/iframe.html?id=$previewId&fontScale=2.0")
+    assertEquals(409, code)
+    assertEquals("fontScale", headers[ServeHttpServer.DROPPED_OVERRIDES_HEADER])
+
+    assertEquals(200, get("/svg-catalog/iframe.html?id=$previewId&format=svg").first)
+    val (svgCode, _, svgHeaders) =
+      getFull("/svg-catalog/iframe.html?id=$previewId&format=svg&fontScale=2.0")
+    assertEquals(409, svgCode)
+    assertEquals("fontScale", svgHeaders[ServeHttpServer.DROPPED_OVERRIDES_HEADER])
+
+    // The opt-in still works here: the page is served, marked as carrying baked bytes.
+    val (okCode, _, okHeaders) =
+      getFull("/compose-m3/iframe.html?id=$previewId&fontScale=2.0&fallback=baked")
+    assertEquals(200, okCode)
+    assertEquals(ServeHttpServer.RENDER_BAKED_FALLBACK, okHeaders[ServeHttpServer.RENDER_HEADER])
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -393,9 +393,21 @@ class ServeRenderHostTest {
   fun `renderSvg serves identical requests from cache`() {
     val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->
-      h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
-      h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      val first = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      val second = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
       assertEquals(1, session.renderCount.get(), "second identical SVG request must hit the cache")
+      // The vector lane reports the same generation ladder as the raster one — it rides the
+      // `X-Compose-Preview-Generation` header, so a cache hit must not claim to be a fresh render.
+      assertEquals(
+        RenderOutcome.Generation.DAEMON,
+        (first as SvgOutcome.Ok).generation,
+        "the first SVG export really was rendered",
+      )
+      assertEquals(
+        RenderOutcome.Generation.DAEMON_CACHE,
+        (second as SvgOutcome.Ok).generation,
+        "the second came from the SVG cache",
+      )
     }
   }
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -1108,25 +1108,34 @@ un-overridden snapshot**, so a `200 image/png` there is a wrong answer delivered
 bot, a parity check, or an agent iterating on a theme reads "no visual difference" and concludes the
 override had no effect on the UI, when in fact it was never rendered ([#3449]).
 
-So `GET /render/{id}.png` refuses instead, and every override kind agrees — `fontScale`, `uiMode`,
-`themeProvider`, `device`, `knob.<key>`, `rc.<name>`:
+So the render refuses instead, and every override kind agrees — `fontScale`, `uiMode`,
+`themeProvider`, `device`, `knob.<key>`, `rc.<name>` — as does every lane that can answer with
+published bytes: the raster `GET /render/{id}.png`, the vector `GET /render/{id}.svg` (a
+`figma/<slug>.svg` off the delivery branch was exported at the preview's discovery-time axes, so it
+drops an override exactly as thoroughly), and the Storybook isolation pages `GET /iframe.html?id=…`
+(a story's args ride the same params, and PNG-diffing visual tools are precisely the caller this is
+for):
 
 | state | response |
 |---|---|
-| no override, or one the baked variant already satisfies (`uiMode=light` on a `…__light` id) | `200 image/png`, `X-Compose-Preview-Generation: baked` |
-| the override was applied | `200 image/png`, `X-Compose-Preview-Generation: daemon` (or `daemon-cache` / `catalog-cache`) |
+| no override, or one the baked variant already satisfies (`uiMode=light` on a `…__light` id, `background=default`) | `200`, `X-Compose-Preview-Generation: baked` |
+| the override was applied | `200`, `X-Compose-Preview-Generation: daemon` (or `daemon-cache` / `catalog-cache`) |
 | the preview **has** a live lane, but it can't serve right now (daemon down/cold, no free seat) | `503` + `Retry-After: 2` |
 | the preview has **no** live lane at all (static or untrusted catalog, unmapped variant) | `409` — retrying can't help |
-| `&fallback=baked` on the request | `200 image/png` + `X-Compose-Preview-Render: baked-fallback` |
+| `&fallback=baked` on the request | `200` + `X-Compose-Preview-Render: baked-fallback` |
 
 All four override-carrying responses carry **`X-Compose-Preview-Dropped-Overrides`** — a
-comma-separated list of exactly the params the returned pixels do not reflect (`fontScale,uiMode`,
+comma-separated list of exactly the params the returned bytes do not reflect (`fontScale,uiMode`,
 `knob.label`, …), so even a `curl -I` can tell. An unrecognised param is not an override and is
 still ignored silently (a cache-buster must not 409 a page).
 
 `&fallback=baked` is the opt-in for callers that would rather show the published snapshot than
-nothing — but it is marked unmissably in the headers, because the pixels themselves carry no signal.
+nothing — but it is marked unmissably in the headers, because the bytes themselves carry no signal.
 A malformed override value is still a `400` at parse time, as before; this is about *valid* ones.
+
+Not affected: `?scroll=long` (the full-page raster/vector export is daemon-only, so it 404s rather
+than falling back), and the `.rc` document lane (the browser player applies `rc.<name>` seeds
+client-side, so nothing is dropped server-side).
 
 [#3449]: https://github.com/yschimke/compose-ai-tools/issues/3449
 

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history-local.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history-local.html
@@ -222,7 +222,7 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/192e2-5b1dc35dd256c015/viewer.js"></script>
+      <script src="/assets/serve/19b85-e499ea55e964b438/viewer.js"></script>
       <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
         </main>
       </body>

--- a/vscode-extension/preview-harness/serve-lanes.spec.mjs
+++ b/vscode-extension/preview-harness/serve-lanes.spec.mjs
@@ -107,6 +107,13 @@ test("SVG lane bakes the override text into the vector", async ({
   // The overridden label must appear as text in the SVG body — this is the lane
   // that regressed when the bundle daemon didn't register compose/figma-svg.
   expect(svg, "SVG body should contain the override text").toContain(OVERRIDE);
+  // #3449: this vector was really rendered with the override, so the response must
+  // carry no dropped-override signal. A refusal here would mean the lane had
+  // silently dropped back to the catalog's baked `figma/<slug>.svg`.
+  expect(
+    res.headers()["x-compose-preview-dropped-overrides"],
+    "a real override SVG export drops nothing",
+  ).toBeUndefined();
 });
 
 test("Live WebSocket lane upgrades and pushes a frame", async ({ page }) => {


### PR DESCRIPTION
Follow-up to #3460 (issue #3449), closing the gap that PR called out: `/render/<id>.png` refuses an override it can't apply, but the sibling lanes that can also answer with **published bytes** still returned them under a `200`.

## What was still silent

- **`GET /render/<id>.svg`** — a `figma/<slug>.svg` read off the delivery branch was exported at the preview's discovery-time axes, so it ignores a `fontScale` exactly as thoroughly as a baked PNG does. There was no way to tell a published vector from a rendered one, so `SvgOutcome.Ok` now carries the same `generation` ladder as `RenderOutcome.Ok` (`ServeBundleHost` stamps `BAKED`; every daemon path keeps the `DAEMON` default). `.svg` responses now also carry `X-Compose-Preview-Generation`, like the raster ones.
- **`GET /iframe.html?id=…`** (both `format=png` and `format=svg`) — a story's args ride the same override params, and the PNG-diffing visual tools this Storybook-compat surface exists for (BackstopJS, reg-suit, `@storybook/test-runner`) are precisely the caller #3449 describes. The isolation page has no room for a signal of its own, so a dropped override is a status; `&fallback=baked` serves the page marked with the header.

All lanes now share one `droppedOverridesFor` / `respondDroppedOverrides` pair, so they can't drift on what counts as dropped or on what a refusal looks like.

**Not affected**, and now documented as such: `?scroll=long` (the full-page export is daemon-only — it 404s rather than falling back) and the `.rc` document lane (the browser player applies `rc.<name>` seeds client-side, so nothing is dropped server-side).

## Also here: a stale fixture on `main`

`serve-viewer-history-local.html` arrived on main via #3456 carrying the **pre-#3460** viewer.js asset hash — that PR generated its fixture before #3460 landed and merged after it, so `ServeWebFixtureTest` is red on `main` itself right now (every other page fixture has the current hash). Regenerated here, in its own commit; it is not a consequence of this change.

## Test plan

- `./gradlew :cli:test` green (1651 tests) with new `ServeHttpRoutingTest` coverage against a real embedded server:
  - a baked-catalog session that carries `figma/<slug>.svg` — `.svg` serves `200` + `generation: baked` un-overridden, `409` + `X-Compose-Preview-Dropped-Overrides: fontScale` with the override, and `&fallback=baked` returns the identical vector marked `X-Compose-Preview-Render: baked-fallback`;
  - both Storybook iframe lanes — `200` plain, `409` + dropped header with an override, `200` + marked page with `fallback=baked`.
- `serve-lanes` e2e gains the honest-side guard for the vector lane (a real daemon SVG export must carry **no** dropped-override header), mirroring the PNG one — so an accidental drop back to the baked vector fails CI.
- Verified against a locally built CLI serving a static bundle:

```
--- storybook isolation page (PNG lane) ---
iframe.html?id=<id>                    200
iframe.html?id=<id>&fontScale=2.0      409 | X-Compose-Preview-Dropped-Overrides: fontScale
…&fontScale=2.0&fallback=baked         200 | Dropped-Overrides: fontScale | Render: baked-fallback

--- png lane (regression check, unchanged from #3460) ---
render/<id>.png                        200 | X-Compose-Preview-Generation: baked
render/<id>.png?fontScale=2.0          409 | X-Compose-Preview-Dropped-Overrides: fontScale
render/<id>.png?background=default     200 | X-Compose-Preview-Generation: baked
```

  (The baked-`.svg` case needs a catalog-registered `figmaDir`, which the `--bundle` path never sets — that one is covered by the HTTP routing test above, which drives the same code over a real socket.)
- Docs: the *"When an override can't be applied"* section in `docs/public-preview-server.md` now names all three lanes and the two that are deliberately exempt.

No visual evidence: this changes HTTP status/headers only. The viewer is untouched (no `viewer.js` diff, no page-fixture regeneration beyond the stale-hash fix above), so nothing rendered changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SzM3BTqbHwsNaPa1Nd1Fb

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzM3BTqbHwsNaPa1Nd1Fb)_