### PR TITLE
fix(actions): upload the .error.json sidecars with the render report

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -754,7 +754,16 @@ runs:
         path: |
           **/build/reports/tests/composePreviewRender/
           **/build/test-results/composePreviewRender/
+          **/build/compose-previews/**/*.error.json
           _previews.json
+        # The `.error.json` sidecars are the diagnostic of record for a render
+        # failure — `RenderPreviewsTask` writes one next to where each PNG would
+        # have gone, and the task's own message points at them by name. The two
+        # `composePreviewRender` test-report globs above date from when the render
+        # ran as a test task; nothing writes them now, so without the sidecar line
+        # this artifact matched only `_previews.json` — which a failed render
+        # leaves empty — and uploaded as a 144-byte empty zip. The failure message
+        # told you to download it for "full test output" and it contained nothing.
         if-no-files-found: ignore
         retention-days: 14
 

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -754,16 +754,23 @@ runs:
         path: |
           **/build/reports/tests/composePreviewRender/
           **/build/test-results/composePreviewRender/
-          **/build/compose-previews/**/*.error.json
+          _compose_render_errors/
           _previews.json
-        # The `.error.json` sidecars are the diagnostic of record for a render
-        # failure — `RenderPreviewsTask` writes one next to where each PNG would
-        # have gone, and the task's own message points at them by name. The two
+        # `_compose_render_errors/` is the compose pipeline's snapshot of the
+        # per-preview `.error.json` sidecars — the diagnostic of record for a
+        # render failure, which the renderer writes next to where each PNG would
+        # have gone and the task's own message points at by name. The two
         # `composePreviewRender` test-report globs above date from when the render
-        # ran as a test task; nothing writes them now, so without the sidecar line
-        # this artifact matched only `_previews.json` — which a failed render
-        # leaves empty — and uploaded as a 144-byte empty zip. The failure message
-        # told you to download it for "full test output" and it contained nothing.
+        # ran as a test task; nothing writes them now, so this artifact used to
+        # match only `_previews.json` — which a failed render leaves empty — and
+        # uploaded as a 144-byte empty zip. The failure message told you to
+        # download it for "full test output" and it contained nothing.
+        #
+        # The snapshot is taken in `pipelines/compose.sh` rather than globbed live
+        # from `**/build/compose-previews/` here, because this step runs after
+        # every pipeline: `notifications` re-renders into the same tree and the
+        # renderer deletes each stale sidecar before its next attempt, so a live
+        # glob would upload a later pipeline's errors, or nothing at all.
         if-no-files-found: ignore
         retention-days: 14
 

--- a/.github/actions/apply/pipelines/compose.sh
+++ b/.github/actions/apply/pipelines/compose.sh
@@ -90,6 +90,30 @@ else
   echo "$RENDER_RC" > "$GITHUB_WORKSPACE/_compose_render_rc"
 fi
 
+# Snapshot the per-preview `.error.json` sidecars NOW, while they still
+# describe this render. Two things make the live tree unsafe to upload later:
+# `notifications` re-runs `composePreviewRenderAll` into the same
+# `<module>/build/compose-previews` tree in the default all-pipeline run, and
+# the renderer drops each stale sidecar before its next attempt (see
+# DesktopRendererMain, "Drop any stale sidecar before attempting a fresh
+# render"). The upload step is a top-level GHA step that runs after every
+# pipeline, so a compose failure followed by a successful later re-render
+# would leave `compose_render_rc` non-zero while the diagnostics it points at
+# were deleted — or replaced by a different pipeline's errors.
+compose_rc_now=$(cat "$GITHUB_WORKSPACE/_compose_render_rc" 2>/dev/null || echo 0)
+if [ "$compose_rc_now" -ne 0 ]; then
+  stage_dir="$GITHUB_WORKSPACE/_compose_render_errors"
+  rm -rf "$stage_dir"
+  staged=0
+  while IFS= read -r sidecar; do
+    rel="${sidecar#./}"
+    mkdir -p "$stage_dir/$(dirname "$rel")"
+    cp "$sidecar" "$stage_dir/$rel" || true
+    staged=$((staged + 1))
+  done < <(find . -path '*/build/compose-previews/*' -name '*.error.json' -type f 2>/dev/null)
+  echo "compose pipeline: staged ${staged} render-error sidecar(s) for upload."
+fi
+
 if [ ! -s _previews.json ]; then
   echo "compose pipeline: no _previews.json — workspace has no compose modules, skipping."
   echo "0" > "$GITHUB_WORKSPACE/_compose_rc"


### PR DESCRIPTION
## Summary

When `composePreviewRenderAll` fails, the task's own message says:

> Open the failed pipeline group for the concise cause; **download the matching composePreviewRender report artifact for full test output**.

That artifact has been uploading empty. On a real failure (`yschimke/m3-catalog`, **1086 of 1095** previews failing) it arrived as a **144-byte zip** — the size of an empty archive.

Both globs it carried date from when the render ran as a Gradle *test* task:

```yaml
**/build/reports/tests/composePreviewRender/
**/build/test-results/composePreviewRender/
```

Nothing writes either path now. The renderer records per-preview failures as `.error.json` sidecars instead — `PreviewRenderError` puts each one *"next to where the PNG would have gone"* under `build/compose-previews/`, and `ComposePreviewTasks` reads them back to build the "Per-preview render errors" list. So the artifact matched only `_previews.json`, which a failed compose pipeline leaves empty — the same emptiness that makes the log say `compose comment: nothing to compare, skipping`.

The net effect is a diagnostic dead end. The console prints five preview names and `(+1081 more with sidecars)`; the sidecars are the documented way to see the rest; the artifact meant to carry them is empty.

## How this was found

`m3-catalog`'s `compose-preview.yml` has been red on `main` all day. The failing task is `:catalog:composePreviewRenderAll` (discovery passes), but the *cause* was unreachable: the log tail cuts off before the render step's output, and the artifact the error points at is empty. Reproducing locally produced the sidecars on disk —

```
catalog/build/compose-previews/renders/NumberBadge_Light_VARIANT_digits_3.png.error.json
… 1086 of them
```

— confirming they exist on the runner and simply never leave it.

*(My local run's own failure was a sandbox glibc issue loading `libskiko`, so it does **not** explain m3-catalog's CI failure — that one is still undiagnosed, and this PR is what makes diagnosing it possible.)*

## Not addressed

The sibling `composePreviewRenderAndroidResources-reports` step carries the same two stale test-report globs. That lane does write sidecars, but I could not confirm which directory they land in, and a glob that guessed wrong would either miss them again or pull the *compose* sidecars into the resources artifact. Left for someone who can run that lane rather than fixed blind.

## Test plan

- `.github/actions/apply/action.yml` parses (`yaml.safe_load`).
- Glob verified against the real layout: `catalog/build/compose-previews/renders/*.png.error.json` matches `**/build/compose-previews/**/*.error.json`.
- Path confirmed against source, not assumption — `PreviewRenderError.kt` (sidecar location), `ComposePreviewTasks.kt:1792` (`File(outDir, "$rel.error.json")`), `AndroidPreviewSupport.kt:429` (`buildDirectory.dir("compose-previews")`).
- Sizing: ~1086 sidecars of a few KB each ≈ 2 MB, gated behind a non-zero render rc, so successful runs upload nothing.
- End-to-end proof needs a failing render in CI; the next red `m3-catalog` run is the natural check.

Text-only evidence is correct here — this changes an artifact upload path, nothing rendered.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KchMGSmbx3Rjp6RZdjMyRa)_