### PR TITLE
fix(serve): make the parity feed actually reach a published catalog

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -463,6 +463,7 @@ class ServeCatalogStore(
     val manifestReferences = fetchDesignReferences(base)
     writeDesignReferences(manifestReferences + catalog.references, base, staging)
     writeAnnotations(base, staging)
+    writeParityActivity(base, staging)
 
     // The staged catalog is usable — atomically replace the live dir with it. The delete + rename
     // is near-instant (same filesystem), so the window where `dir` is absent is microseconds, not
@@ -1231,6 +1232,36 @@ class ServeCatalogStore(
     dir.mkdirs()
     File(dir, ServeAnnotationStore.INDEX_FILE)
       .writeText(json.encodeToString(AnnotationManifest.serializer(), manifest))
+  }
+
+  /**
+   * Stage the published design-parity activity feed, if the catalog has one.
+   *
+   * Same reason [writeAnnotations] exists, and the same shape: a served catalog is a fresh staging
+   * directory assembled from explicitly fetched parts, so a file nobody copies is invisible to
+   * [ServeBundleHost] however faithfully the producer published it. Without this the `/parity` view
+   * would fall back to coverage-only on every *published* catalog — which is every catalog the
+   * feature is actually for — and the code/Figma feed would only ever appear for a local bundle.
+   *
+   * No assets to fetch: the feed is one self-contained JSON document, so staging is a straight copy
+   * of the manifest. It is validated here before it is written rather than only on read, so a
+   * malformed feed never reaches the staging tree at all.
+   *
+   * Fail-soft like the rest of the staging path: no feed, an unfetchable one, or one that doesn't
+   * survive validation simply serves the catalog without the activity lane.
+   */
+  private fun writeParityActivity(base: String, staging: File) {
+    val bytes =
+      runCatching { fetchCatalogAsset("$base${ParityActivity.DIRECTORY}/${ParityActivity.FILE}") }
+        .getOrNull() ?: return
+    val activity =
+      runCatching { json.decodeFromString(ParityActivity.serializer(), bytes.decodeToString()) }
+        .getOrNull()
+        ?.let { ServeParityActivityStore.sanitize(it) } ?: return
+    val dir = File(staging, ParityActivity.DIRECTORY)
+    dir.mkdirs()
+    File(dir, ParityActivity.FILE)
+      .writeText(json.encodeToString(ParityActivity.serializer(), activity))
   }
 
   private fun writeDesignReferences(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
@@ -342,6 +343,123 @@ class ServeCatalogStoreTest {
     assertTrue(requested.any { it.endsWith("/references/index.json") })
     assertFalse(requested.any { it.startsWith("https://api.figma.com") })
     assertFalse(requested.any { it.endsWith("mocks/button.html") })
+  }
+
+  /**
+   * A served catalog is a fresh staging tree assembled from explicitly fetched parts, so a
+   * published file nobody copies is invisible to the host no matter what the producer wrote. The
+   * parity feed is exactly that kind of file, and getting this wrong is silent: the `/parity` view
+   * still renders, just coverage-only, on every *published* catalog — which is every catalog the
+   * feature exists for.
+   */
+  @Test
+  fun `catalog stages the published parity activity feed`() {
+    val root = tempRoot()
+    val requested = mutableListOf<String>()
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[
+         {"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val activity =
+      """
+      {"schema":"compose-preview-activity/v1","generatedAt":"2026-08-06T09:12:00Z",
+       "windowDays":30,
+       "code":{"repo":"yschimke/m3-catalog","ref":"main","events":[
+         {"sha":"4e73ec2b9f0a1c3d5e7f9a1b3c5d7e9f0a1b3c5d","subject":"fix: padding",
+          "at":"2026-08-05T10:00:00Z","previewIds":["button"],"components":["Button/Filled"]}]},
+       "figma":{"fileKey":"abc123","comments":[
+         {"id":"c1","at":"2026-08-04T08:00:00Z","message":"2dp short","nodeId":"51592:4768"}]},
+       "gaps":[{"kind":"unmapped-design-node","detail":"nothing maps to it"}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      requested += url
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.encodeToByteArray()
+        url.endsWith("/parity/activity.json") -> activity.encodeToByteArray()
+        url.endsWith("/images/button.png") -> png()
+        else -> null
+      }
+    }
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = fetch,
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    assertTrue(requested.any { it.endsWith("/parity/activity.json") }, "the feed is fetched")
+    val loaded = registered.getValue("compose-m3").parityActivity()
+    assertNotNull(loaded, "the feed reached the host through the staging tree")
+    assertEquals("yschimke/m3-catalog", loaded.code?.repo)
+    assertEquals(1, loaded.code?.events?.size)
+    assertEquals("51592:4768", loaded.figma?.comments?.single()?.nodeId)
+    assertEquals(1, loaded.gaps.size)
+  }
+
+  @Test
+  fun `a catalog publishing no parity feed serves without one`() {
+    val root = tempRoot()
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = { url ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.encodeToByteArray()
+            url.endsWith("/images/button.png") -> png()
+            else -> null
+          }
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertNull(registered.getValue("compose-m3").parityActivity())
+  }
+
+  /** A malformed feed must not reach the staging tree, let alone the page. */
+  @Test
+  fun `a parity feed that fails validation is not staged`() {
+    val root = tempRoot()
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = { url ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.encodeToByteArray()
+            // Right filename, wrong schema token — the reader would discard it anyway; this
+            // asserts it never lands.
+            url.endsWith("/parity/activity.json") ->
+              """{"schema":"something-else/v9","gaps":[]}""".encodeToByteArray()
+            url.endsWith("/images/button.png") -> png()
+            else -> null
+          }
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertNull(registered.getValue("compose-m3").parityActivity())
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityActivityStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityActivityStoreTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import java.io.File
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -255,10 +256,38 @@ class ServeParityActivityStoreTest {
     assertEquals(1, loaded.figma?.versions?.size)
     // The comment resolved to the preview it specifies, which is what makes the page a parity view.
     assertEquals(
-      listOf("sections.SwitchesKt.SwitchOn_Light"),
+      listOf("switch-on__ideal__default__light"),
       loaded.figma?.comments?.single()?.previewIds,
     )
     assertEquals(MappingGap.Kind.UNMAPPED_DESIGN_NODE, loaded.gaps.single().kind)
+
+    // **The namespace check.** The emitter and the server key previews in two different alphabets:
+    // a design map names the raw *discovery* id (`sections.ButtonsKt.FilledButton_Light`) while the
+    // serve host keys a preview by the route-safe id derived from its image path. The feed must
+    // carry the latter — emitting the former loses every inbound link on the page silently, since
+    // `ServeParityDashboard` just filters unknown ids out and renders a row with no target. So
+    // assert the *shape*, not only the value: a discovery id here is a bug even if it parses.
+    val eventPreviewIds =
+      loaded.code!!.events.flatMap { it.previewIds } +
+        loaded.figma!!.comments.flatMap { it.previewIds }
+    assertTrue(eventPreviewIds.isNotEmpty(), "the fixture must exercise the join")
+    for (id in eventPreviewIds) {
+      assertFalse(
+        id.contains('.'),
+        "expected a route-safe serve id, got what looks like a discovery id: $id",
+      )
+    }
+    // …and they are ids a dashboard built over that catalog would actually match.
+    val dashboard =
+      ServeParityDashboard.build(
+        previews = eventPreviewIds.distinct().map { ServePreview(it, it) },
+        hasReference = { false },
+        activity = loaded,
+      )
+    assertTrue(
+      dashboard.feed.any { it.previewIds.isNotEmpty() },
+      "the published feed must produce inbound links against a catalog serving those ids",
+    )
     // …and every outbound link the page will build from it resolves.
     assertNotNull(
       ServeParityActivityStore.commitUrl(loaded.code?.repo, loaded.code!!.events.single().sha)

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -587,6 +587,16 @@ doesn't recognize. Publishing the discovery id would therefore be *silent*: the 
 every row just loses its link to the comparison, and the feed degrades into the pair of unrelated
 changelogs it exists not to be.
 
+That translation is deliberately **incomplete rather than approximate**. A catalog image carries the
+*sanitized* in-bundle id (`sanitizeBundleEntryId`), so an exact match is tried first and a sanitized
+one second — but sanitizing is lossy, and `assignBundleEntryIds` in the plugin resolves collisions by
+letting the first claimant keep the base form and suffixing the rest. Where two previews share a
+sanitized key the raw→route direction genuinely isn't invertible from the catalog, so that key
+resolves to *nothing*. Reproducing the plugin's suffix assignment in JavaScript would be a third
+restatement of a Kotlin derivation with nothing checking it, and its failure mode is a link that
+quietly points at the wrong component — worse than no link, because a reader who lands on the wrong
+comparison has no way to tell.
+
 `gaps[].kind` is one of `dangling-mapping` (the map names a preview the catalog no longer
 publishes), `unrendered-reference` (a mapped node whose raster couldn't be published), or
 `unmapped-design-node` (a component in the design file nothing maps to). An unknown kind is dropped

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -550,7 +550,7 @@ produced nothing is omitted rather than published empty.
       "subject": "fix(button): tighten the filled button's label padding",
       "at": "2026-08-05T10:00:00+00:00",
       "author": "yschimke",
-      "previewIds": ["sections.ButtonsKt.FilledButton_Light"],
+      "previewIds": ["button-filled__ideal__default__light"],
       "components": ["Button/Filled"]
     }]
   },
@@ -565,7 +565,7 @@ produced nothing is omitted rather than published empty.
       "author": "Dana",
       "resolved": false,
       "nodeId": "51592:4768",
-      "previewIds": ["sections.SwitchesKt.SwitchOn_Light"],
+      "previewIds": ["switch-on__ideal__default__light"],
       "components": ["Switch/On"]
     }]
   },
@@ -577,6 +577,15 @@ produced nothing is omitted rather than published empty.
   }]
 }
 ```
+
+**`previewIds` are route-safe serve ids, not discovery ids.** A design map names the raw discovery
+id the daemon keys renders on (`sections.ButtonsKt.FilledButton_Light`), while the server keys a
+preview by the id derived from its image path (`ServeCatalogStore.previewIdFor`). The emitter
+translates through the published `catalog.json` — which carries both — before writing an event,
+because the server filters every event's ids against the live catalog and simply drops the ones it
+doesn't recognize. Publishing the discovery id would therefore be *silent*: the page still renders,
+every row just loses its link to the comparison, and the feed degrades into the pair of unrelated
+changelogs it exists not to be.
 
 `gaps[].kind` is one of `dangling-mapping` (the map names a preview the catalog no longer
 publishes), `unrendered-reference` (a mapped node whose raster couldn't be published), or
@@ -610,7 +619,17 @@ after the references step so the catalog is final. It reads:
   that join is what turns "a designer commented" into a link to a comparison. Replies are dropped
   (a thread's openers are the signal) and only a display name is published, never an email.
 - **gaps** — computed against the published `catalog.json` and, with a token, the file's component
-  list.
+  list. `unrendered-reference` is *derived* rather than reported: the reference step's warnings are
+  gone by the time this runs, so the emitter instead reads the `references/index.json` it just
+  wrote — which records each reference's design-map `code` handle — and reports a mapped entry
+  missing from it. Only with a token, since without one that step skips `figma:` entries by design
+  and "missing" would mean "never tried".
+
+The staging side matters as much as the producing side: a served catalog is a fresh tree assembled
+from explicitly fetched parts, so `ServeCatalogStore` copies `parity/activity.json` into it
+(validating first) exactly as it does the reference and annotation manifests. A file nobody stages
+is invisible to the host however faithfully it was published — and the failure is silent, because
+the page falls back to coverage-only rather than erroring.
 
 Fail-soft throughout, like the reference step: no token ⇒ the code lane and the gaps still publish,
 which is the normal state for a fork or a PR run. A repo with no history, no design map and no token

--- a/scripts/design-artifacts/emit-parity-activity.mjs
+++ b/scripts/design-artifacts/emit-parity-activity.mjs
@@ -49,7 +49,9 @@ import {
   indexDesignMap,
   mappingGaps,
   parseGitLog,
+  routeIdResolver,
 } from "./parity-activity.mjs";
+import { REFERENCES_DIR, derivationMismatches } from "./design-references.mjs";
 
 function arg(name, def = undefined) {
   const i = process.argv.indexOf(`--${name}`);
@@ -119,7 +121,21 @@ for (const component of catalog?.components ?? []) {
   }
 }
 
-const index = indexDesignMap(designMap, (id) => componentIdByPreviewId.get(id) ?? null);
+// The derivation `routeIdResolver` depends on is a restatement of a Kotlin function, and the
+// catalog export records enough to check it. The reference step already hard-fails on a mismatch;
+// warn here rather than failing twice, since a wrong derivation costs this feed its links but not
+// the catalog its render.
+const drift = derivationMismatches(catalog);
+if (drift.length > 0) {
+  warn(`serve preview-id derivation no longer matches the catalog export. First: ${drift[0]}`);
+}
+
+const index = indexDesignMap(designMap, {
+  componentIdFor: (id) => componentIdByPreviewId.get(id) ?? null,
+  // Events must carry ROUTE ids: `ServeParityDashboard` filters them against the live catalog's
+  // `ServePreview.id`, so a discovery id would drop every inbound link on the page.
+  routeIdFor: routeIdResolver(catalog),
+});
 
 // ---------------------------------------------------------------------------- code lane
 
@@ -247,10 +263,34 @@ figmaVersions = figmaVersions.filter((v) => withinWindow(v.at));
 
 // ---------------------------------------------------------------------------- gaps + write
 
+/**
+ * The reference manifest the step before this one just wrote, or null when it wrote none.
+ *
+ * Only consulted when a token was available: without one, `emit-design-references.mjs` skips every
+ * `figma:` entry by design, so "missing from the manifest" would mean "we never tried" rather than
+ * "the render failed" — and reporting a gap per mapped component on every fork/PR run would bury
+ * the real findings under noise.
+ */
+const referenceManifest = (() => {
+  if (!FIGMA_TOKEN) return null;
+  const manifestPath = path.join(OUT, REFERENCES_DIR, "index.json");
+  if (!fs.existsSync(manifestPath)) return null;
+  return runCatchingJson(manifestPath);
+})();
+
+function runCatchingJson(file) {
+  try {
+    return readJson(file);
+  } catch {
+    return null;
+  }
+}
+
 const gaps = mappingGaps({
   designMap,
   catalogPreviewIds: [...publishedPreviewIds],
   figmaComponents,
+  referenceManifest,
 });
 
 const activity = buildActivity({

--- a/scripts/design-artifacts/fixtures/parity-activity.json
+++ b/scripts/design-artifacts/fixtures/parity-activity.json
@@ -12,7 +12,7 @@
         "at": "2026-08-05T10:00:00+00:00",
         "author": "yschimke",
         "previewIds": [
-          "sections.ButtonsKt.FilledButton_Light"
+          "button-filled__ideal__default__light"
         ],
         "components": [
           "Button/Filled"
@@ -41,7 +41,7 @@
         "resolved": false,
         "nodeId": "51592:4768",
         "previewIds": [
-          "sections.SwitchesKt.SwitchOn_Light"
+          "switch-on__ideal__default__light"
         ],
         "components": [
           "Switch/On"

--- a/scripts/design-artifacts/parity-activity.mjs
+++ b/scripts/design-artifacts/parity-activity.mjs
@@ -96,10 +96,28 @@ function figmaRefsOf(entry) {
  * the sanitised in-bundle form, so a `@Preview(name = "Small Round")` is `…_Small Round` on one
  * side and `…_Small_Round` on the other. Catalogs whose names need no sanitising match either way,
  * which is exactly why this gap survives casual testing.
+ *
+ * ## Ambiguous sanitised keys are dropped, not guessed
+ *
+ * Sanitising is lossy, so two distinct previews can land on one key (`"A B"` and `"A/B"` both
+ * become `A_B`). `assignBundleEntryIds` in the plugin resolves that by letting the first claimant
+ * keep the base form and suffixing the rest `_1`, `_2`, … — meaning the raw→sanitised direction is
+ * genuinely *not* invertible from the catalog alone.
+ *
+ * Two ways out, and the cheap-looking one is wrong: reproducing the plugin's suffix assignment here
+ * would restate a *third* Kotlin derivation in JavaScript, with nothing checking the restatement —
+ * and if it drifted, the failure would be a link that quietly points at the wrong component. A
+ * misdirected link is worse than an absent one: absent, the reader knows to go look; misdirected,
+ * they compare the wrong pair and trust the answer.
+ *
+ * So an ambiguous key resolves to **nothing**. The affected rows keep their text and lose only
+ * their inbound link, exactly as they do for a preview the catalog dropped.
  */
 export function catalogRouteIds(catalog) {
   const exact = new Map();
   const sanitised = new Map();
+  /** Sanitised keys claimed by more than one image — see the ambiguity note above. */
+  const ambiguous = new Set();
   for (const component of catalog?.components ?? []) {
     for (const image of component?.images ?? []) {
       if (typeof image?.previewId !== "string" || image.previewId === "") continue;
@@ -107,21 +125,32 @@ export function catalogRouteIds(catalog) {
       const routeId = servePreviewId(image.path);
       if (!exact.has(image.previewId)) exact.set(image.previewId, routeId);
       const key = sanitizeBundleEntryId(image.previewId);
-      if (!sanitised.has(key)) sanitised.set(key, routeId);
+      const claimed = sanitised.get(key);
+      // Only a *different* route is a collision: one preview rendered into several catalog images
+      // legitimately repeats its own id, and that is not ambiguity.
+      if (claimed !== undefined && claimed !== routeId) ambiguous.add(key);
+      else if (claimed === undefined) sanitised.set(key, routeId);
     }
   }
-  return { exact, sanitised };
+  for (const key of ambiguous) sanitised.delete(key);
+  return { exact, sanitised, ambiguous };
 }
 
 /**
  * A `discoveryId -> routeId` resolver over [catalogRouteIds], returning null for an id the catalog
- * doesn't publish. Null rather than the input: emitting an unresolved id would put a preview id the
- * server cannot match into the feed, which is the bug this exists to prevent.
+ * doesn't publish — or one whose sanitised form is ambiguous. Null rather than the input, and null
+ * rather than a guess: emitting an id the server can't match loses a link, while emitting the wrong
+ * one sends the reader to the wrong comparison. Both are bugs; only the second is silent.
+ *
+ * The exact map is consulted first, so an id needing no sanitising is never affected by a collision
+ * elsewhere in the catalog.
  */
 export function routeIdResolver(catalog) {
   const { exact, sanitised } = catalogRouteIds(catalog);
   return (discoveryId) =>
-    exact.get(discoveryId) ?? sanitised.get(sanitizeBundleEntryId(String(discoveryId ?? ""))) ?? null;
+    exact.get(discoveryId) ??
+    sanitised.get(sanitizeBundleEntryId(String(discoveryId ?? ""))) ??
+    null;
 }
 
 /**
@@ -275,6 +304,14 @@ export function figmaVersionEventsFrom(payload) {
  * - a design-map entry naming a preview id the published catalog doesn't contain (**dangling**);
  * - a mapped Figma node whose reference raster failed to publish (**unrendered**);
  * - a component published in the Figma file that nothing maps to (**unmapped design node**).
+ *
+ * **`catalogPreviewIds` and the design map's ids are compared through [sanitizeBundleEntryId], not
+ * verbatim.** A design map carries the RAW discovery id while a catalog image carries the sanitised
+ * in-bundle form, so `pkg.FooKt.Bar_Small Round` and `pkg.FooKt.Bar_Small_Round` are the same
+ * preview written two ways. Comparing them literally reports a perfectly healthy mapping as
+ * dangling *and* suppresses the unrendered-reference check for it — one false finding and one
+ * missed one, from the same mismatch. Sanitising is idempotent, so normalising both sides is safe
+ * whichever form a caller happens to pass.
  */
 export function mappingGaps({
   designMap,
@@ -285,11 +322,14 @@ export function mappingGaps({
   referenceManifest = null,
 } = {}) {
   const gaps = [];
-  const live = new Set(catalogPreviewIds);
+  const live = new Set(catalogPreviewIds.map((id) => sanitizeBundleEntryId(String(id ?? ""))));
+  const isPublished = (id) => live.has(sanitizeBundleEntryId(String(id ?? "")));
 
   for (const entry of designMap?.components ?? []) {
     const previewIds = previewIdsOf(entry);
-    const missing = previewIds.filter((id) => !live.has(id));
+    // Reported verbatim as the design map spells it — the normalisation is for *comparison*; a
+    // reader fixing the map needs to see the id they actually wrote.
+    const missing = previewIds.filter((id) => !isPublished(id));
     if (missing.length > 0 && previewIds.length > 0) {
       gaps.push({
         kind: GAP_KINDS.DANGLING_MAPPING,
@@ -332,7 +372,7 @@ export function mappingGaps({
       if (typeof entry?.code !== "string" || published.has(entry.code)) continue;
       if (figmaRefsOf(entry).length === 0) continue;
       const previewIds = previewIdsOf(entry);
-      if (previewIds.length === 0 || previewIds.some((id) => !live.has(id))) continue;
+      if (previewIds.length === 0 || previewIds.some((id) => !isPublished(id))) continue;
       gaps.push({
         kind: GAP_KINDS.UNRENDERED_REFERENCE,
         detail:

--- a/scripts/design-artifacts/parity-activity.mjs
+++ b/scripts/design-artifacts/parity-activity.mjs
@@ -32,6 +32,8 @@
  * `emit-parity-activity.mjs`, which drives this.
  */
 
+import { sanitizeBundleEntryId, servePreviewId } from "./design-references.mjs";
+
 /** The `schema` token `ServeParityActivityStore` requires; anything else is ignored wholesale. */
 export const ACTIVITY_SCHEMA = "compose-preview-activity/v1";
 
@@ -78,16 +80,71 @@ function figmaRefsOf(entry) {
 }
 
 /**
+ * `discovery previewId -> route-safe serve id`, for every image the catalog published.
+ *
+ * **This is the join the feed's inbound links live or die on, and the two sides are written in
+ * different alphabets.** A design map names the *discovery* id the daemon keys renders on
+ * (`sections.ButtonsKt.FilledButton_Light`); the serve host keys a preview by the *route-safe* id
+ * derived from the image path (`button-filled__ideal__default__light` — `ServeCatalogStore
+ * .previewIdFor`, restated as [servePreviewId]). `ServeParityDashboard` filters every event's
+ * preview ids against the live route ids, so emitting discovery ids means every row silently loses
+ * its link to the comparison — the page degrades to two changelogs, which is the one thing it
+ * exists not to be.
+ *
+ * Keyed by both the exact and the [sanitizeBundleEntryId] projection for the same reason
+ * `imagesByPreviewId` is: the design map carries the RAW discovery id while a catalog image carries
+ * the sanitised in-bundle form, so a `@Preview(name = "Small Round")` is `…_Small Round` on one
+ * side and `…_Small_Round` on the other. Catalogs whose names need no sanitising match either way,
+ * which is exactly why this gap survives casual testing.
+ */
+export function catalogRouteIds(catalog) {
+  const exact = new Map();
+  const sanitised = new Map();
+  for (const component of catalog?.components ?? []) {
+    for (const image of component?.images ?? []) {
+      if (typeof image?.previewId !== "string" || image.previewId === "") continue;
+      if (typeof image?.path !== "string" || image.path === "") continue;
+      const routeId = servePreviewId(image.path);
+      if (!exact.has(image.previewId)) exact.set(image.previewId, routeId);
+      const key = sanitizeBundleEntryId(image.previewId);
+      if (!sanitised.has(key)) sanitised.set(key, routeId);
+    }
+  }
+  return { exact, sanitised };
+}
+
+/**
+ * A `discoveryId -> routeId` resolver over [catalogRouteIds], returning null for an id the catalog
+ * doesn't publish. Null rather than the input: emitting an unresolved id would put a preview id the
+ * server cannot match into the feed, which is the bug this exists to prevent.
+ */
+export function routeIdResolver(catalog) {
+  const { exact, sanitised } = catalogRouteIds(catalog);
+  return (discoveryId) =>
+    exact.get(discoveryId) ?? sanitised.get(sanitizeBundleEntryId(String(discoveryId ?? ""))) ?? null;
+}
+
+/**
  * Index a design map for both join directions:
  *
  * - `byPath`: source file path → `{ previewIds, components }` — for the code lane.
  * - `byNode`: Figma node id (in BOTH `73:6` and `73-6` spellings, because the API returns one and
  *   the design map writes the other) → `{ previewIds, components }` — for the design lane.
  *
- * `components` are catalog component ids when [componentIdFor] can resolve one for a preview id,
- * else the design-map handle's `#Member`. Display-only; the server prefers its own live spelling.
+ * The recorded `previewIds` are **route ids** once [routeIdFor] is supplied — the namespace the
+ * serve host keys previews by, and the only one its inbound links resolve in (see
+ * [catalogRouteIds]). An entry [routeIdFor] cannot resolve contributes no preview id rather than an
+ * unmatchable one. The default identity resolver is for tests that work in one namespace; the
+ * driver always passes a real one.
+ *
+ * `components` are catalog component ids when [componentIdFor] can resolve one for a *discovery*
+ * id, else the design-map handle's `#Member`. Display-only; the server prefers its own live
+ * spelling.
  */
-export function indexDesignMap(designMap, componentIdFor = () => null) {
+export function indexDesignMap(
+  designMap,
+  { componentIdFor = () => null, routeIdFor = (id) => id } = {},
+) {
   const byPath = new Map();
   const byNode = new Map();
 
@@ -100,9 +157,10 @@ export function indexDesignMap(designMap, componentIdFor = () => null) {
   };
 
   for (const entry of designMap?.components ?? []) {
-    const previewIds = previewIdsOf(entry);
+    const discoveryIds = previewIdsOf(entry);
     const member = String(entry?.code ?? "").split("#")[1] ?? null;
-    const component = previewIds.map((id) => componentIdFor(id)).find(Boolean) ?? member;
+    const component = discoveryIds.map((id) => componentIdFor(id)).find(Boolean) ?? member;
+    const previewIds = discoveryIds.map((id) => routeIdFor(id)).filter(Boolean);
     record(byPath, pathOf(entry?.code), previewIds, component);
     for (const { nodeId } of figmaRefsOf(entry)) {
       record(byNode, nodeId, previewIds, component);
@@ -224,6 +282,7 @@ export function mappingGaps({
   publishedReferenceNodeIds = [],
   droppedReferences = [],
   figmaComponents = [],
+  referenceManifest = null,
 } = {}) {
   const gaps = [];
   const live = new Set(catalogPreviewIds);
@@ -249,6 +308,41 @@ export function mappingGaps({
       ...(dropped?.ref ? { ref: dropped.ref } : {}),
       ...(dropped?.previewId ? { previewId: dropped.previewId } : {}),
     });
+  }
+
+  // The same gap, *derived* rather than reported. The reference step drops an entry it can't
+  // rasterize with a `::warning::` and moves on, and those warnings are gone by the time this runs
+  // — so relying on a caller to hand them over would leave `unrendered-reference` a documented kind
+  // nothing ever emits. The published manifest is the durable evidence: it records the design-map
+  // `code` handle of every reference that made it (`emit-design-references.mjs` puts it in
+  // `source.attributes.code`), so a mapped entry that is missing from it is precisely one that
+  // didn't rasterize.
+  //
+  // Scoped to entries whose preview the catalog DOES publish — an entry mapping to nothing at all
+  // is a different finding, and one the dangling-mapping check above already reports. Skipped
+  // entirely when no manifest was passed, because "no manifest" and "an empty manifest" are
+  // different claims and only the second means every reference failed.
+  if (referenceManifest) {
+    const published = new Set(
+      (referenceManifest.references ?? [])
+        .map((r) => r?.source?.attributes?.code)
+        .filter((code) => typeof code === "string"),
+    );
+    for (const entry of designMap?.components ?? []) {
+      if (typeof entry?.code !== "string" || published.has(entry.code)) continue;
+      if (figmaRefsOf(entry).length === 0) continue;
+      const previewIds = previewIdsOf(entry);
+      if (previewIds.length === 0 || previewIds.some((id) => !live.has(id))) continue;
+      gaps.push({
+        kind: GAP_KINDS.UNRENDERED_REFERENCE,
+        detail:
+          "Mapped to a Figma node, but no reference raster was published for it — the render " +
+          "step could not produce one, so nothing can score this preview against its spec.",
+        code: entry.code,
+        ...(typeof entry.ref === "string" ? { ref: entry.ref } : {}),
+        previewId: previewIds[0],
+      });
+    }
   }
 
   // A published component the map never names. Compared in both node-id spellings for the same

--- a/scripts/design-artifacts/parity-activity.test.mjs
+++ b/scripts/design-artifacts/parity-activity.test.mjs
@@ -6,12 +6,14 @@ import {
   GAP_KINDS,
   GIT_LOG_FORMAT,
   buildActivity,
+  catalogRouteIds,
   codeEventsFrom,
   figmaCommentEventsFrom,
   figmaVersionEventsFrom,
   indexDesignMap,
   mappingGaps,
   parseGitLog,
+  routeIdResolver,
 } from "./parity-activity.mjs";
 
 /** A design map in the shape m3-catalog publishes: repo-relative code handles + figma refs. */
@@ -49,9 +51,9 @@ test("indexDesignMap joins by source path and by node id in both spellings", () 
 });
 
 test("indexDesignMap prefers a catalog component id over the code handle's member", () => {
-  const index = indexDesignMap(designMap, (previewId) =>
-    previewId.includes("FilledButton") ? "Button/Filled" : null,
-  );
+  const index = indexDesignMap(designMap, {
+    componentIdFor: (previewId) => (previewId.includes("FilledButton") ? "Button/Filled" : null),
+  });
 
   assert.deepEqual(index.byPath.get("catalog/src/main/kotlin/sections/Buttons.kt").components, [
     "Button/Filled",
@@ -80,6 +82,108 @@ test("indexDesignMap handles the per-axis array form of previewId and ref", () =
     "app.DeviceKt.Dark",
   ]);
   assert.deepEqual(index.byNode.get("10:9").previewIds, ["app.DeviceKt.Light", "app.DeviceKt.Dark"]);
+});
+
+/**
+ * A published catalog, in the shape the export writes it: every image carries BOTH the discovery
+ * `previewId` a design map names and the `path` the serve route id is derived from.
+ */
+const catalog = {
+  components: [
+    {
+      componentId: "Button/Filled",
+      images: [
+        {
+          path: "images/button-filled/ideal__default__light.png",
+          previewId: "sections.ButtonsKt.FilledButton_Light",
+        },
+      ],
+    },
+    {
+      componentId: "Switch/On",
+      images: [
+        {
+          path: "images/switch-on/ideal__default__light.png",
+          // Sanitised in-bundle form: the design map writes the RAW id with a space.
+          previewId: "sections.SwitchesKt.SwitchOn_Small_Round",
+        },
+      ],
+    },
+  ],
+};
+
+test("catalogRouteIds maps a discovery id onto the route id the server keys previews by", () => {
+  const { exact, sanitised } = catalogRouteIds(catalog);
+
+  assert.equal(
+    exact.get("sections.ButtonsKt.FilledButton_Light"),
+    "button-filled__ideal__default__light",
+  );
+  // A design map carries the raw id; the catalog carries the sanitised one. Both must resolve, or
+  // a `@Preview(name = "Small Round")` silently loses its links.
+  assert.equal(
+    sanitised.get("sections.SwitchesKt.SwitchOn_Small_Round"),
+    "switch-on__ideal__default__light",
+  );
+  const resolve = routeIdResolver(catalog);
+  assert.equal(
+    resolve("sections.SwitchesKt.SwitchOn_Small Round"),
+    "switch-on__ideal__default__light",
+  );
+  // An id the catalog doesn't publish resolves to null, never to itself: emitting an unmatchable
+  // id is exactly the bug this exists to prevent.
+  assert.equal(resolve("sections.GoneKt.Removed"), null);
+});
+
+test("events carry ROUTE ids, not the discovery ids the design map names", () => {
+  const index = indexDesignMap(designMap, { routeIdFor: routeIdResolver(catalog) });
+  const events = codeEventsFrom(
+    [
+      {
+        sha: "a".repeat(40),
+        at: "2026-08-05T10:00:00+00:00",
+        subject: "fix(button): padding",
+        files: ["catalog/src/main/kotlin/sections/Buttons.kt"],
+      },
+    ],
+    index,
+  );
+
+  // `ServeParityDashboard` filters these against the live `ServePreview.id`. A discovery id would
+  // match nothing and every inbound link on the page would silently disappear.
+  assert.deepEqual(events[0].previewIds, ["button-filled__ideal__default__light"]);
+});
+
+test("a comment's pinned node resolves to a route id too", () => {
+  const index = indexDesignMap(designMap, { routeIdFor: routeIdResolver(catalog) });
+  const events = figmaCommentEventsFrom(
+    {
+      comments: [
+        {
+          id: "1",
+          created_at: "2026-08-04T08:00:00Z",
+          message: "2dp short",
+          client_meta: { node_id: "57994:2227" },
+        },
+      ],
+    },
+    index,
+  );
+
+  assert.deepEqual(events[0].previewIds, ["button-filled__ideal__default__light"]);
+});
+
+test("a mapping the catalog no longer publishes contributes no preview id to an event", () => {
+  const index = indexDesignMap(
+    { components: [{ code: "ui/Gone.kt#Gone", previewId: "app.GoneKt.Gone" }] },
+    { routeIdFor: routeIdResolver(catalog) },
+  );
+  const events = codeEventsFrom(
+    [{ sha: "a".repeat(40), at: "2026-08-05T10:00:00+00:00", subject: "x", files: ["ui/Gone.kt"] }],
+    index,
+  );
+
+  assert.equal(events.length, 0, "no resolvable preview ⇒ the commit is not a mapped-file commit");
 });
 
 test("codeEventsFrom keeps commits that touch mapped files and drops the rest", () => {
@@ -228,6 +332,70 @@ test("mappingGaps reports a published Figma component nothing maps to", () => {
     [[GAP_KINDS.UNMAPPED_DESIGN_NODE, "Bottom sheet"]],
   );
   assert.equal(gaps[0].ref, "figma:ocdac/51827:5859");
+});
+
+test("mappingGaps derives an unrendered reference from the published manifest", () => {
+  // Both entries are mapped and both previews are published, but only Buttons made it into
+  // `references/index.json` — so the Switches raster failed to render. Without this derivation the
+  // `unrendered-reference` kind would be documented and unreachable, because the reference step's
+  // warnings are gone by the time this runs.
+  const gaps = mappingGaps({
+    designMap,
+    catalogPreviewIds: [
+      "sections.ButtonsKt.FilledButton_Light",
+      "sections.SwitchesKt.SwitchOn_Light",
+    ],
+    referenceManifest: {
+      schema: "compose-preview-references/v1",
+      references: [
+        {
+          id: "button",
+          source: {
+            attributes: { code: "catalog/src/main/kotlin/sections/Buttons.kt#FilledButton" },
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(
+    gaps.map((g) => [g.kind, g.code]),
+    [
+      [
+        GAP_KINDS.UNRENDERED_REFERENCE,
+        "catalog/src/main/kotlin/sections/Switches.kt#SwitchOn",
+      ],
+    ],
+  );
+});
+
+test("no reference manifest means no derived gaps — absent is not the same as empty", () => {
+  const gaps = mappingGaps({
+    designMap,
+    catalogPreviewIds: [
+      "sections.ButtonsKt.FilledButton_Light",
+      "sections.SwitchesKt.SwitchOn_Light",
+    ],
+  });
+
+  assert.deepEqual(gaps, [], "a tokenless run must not report every mapping as unrendered");
+});
+
+test("a dangling entry is reported as dangling, not as unrendered", () => {
+  // Its preview isn't published at all, so its missing reference is a symptom, not the finding.
+  const gaps = mappingGaps({
+    designMap,
+    catalogPreviewIds: ["sections.ButtonsKt.FilledButton_Light"],
+    referenceManifest: { references: [] },
+  });
+
+  assert.deepEqual(
+    gaps.map((g) => g.kind),
+    [GAP_KINDS.DANGLING_MAPPING, GAP_KINDS.UNRENDERED_REFERENCE],
+    "Buttons is published but unrendered; Switches is dangling and reported only as such",
+  );
+  assert.equal(gaps[0].previewId, "sections.SwitchesKt.SwitchOn_Light");
+  assert.equal(gaps[1].code, "catalog/src/main/kotlin/sections/Buttons.kt#FilledButton");
 });
 
 test("mappingGaps passes through references the raster step dropped", () => {

--- a/scripts/design-artifacts/parity-activity.test.mjs
+++ b/scripts/design-artifacts/parity-activity.test.mjs
@@ -135,6 +135,61 @@ test("catalogRouteIds maps a discovery id onto the route id the server keys prev
   assert.equal(resolve("sections.GoneKt.Removed"), null);
 });
 
+test("an ambiguous sanitised key resolves to nothing rather than the wrong preview", () => {
+  // `"A B"` and `"A/B"` both sanitise to `A_B`; the plugin's `assignBundleEntryIds` keeps the base
+  // for the first claimant and suffixes the rest, so raw→sanitised is not invertible here. Guessing
+  // would point a commit at the wrong component's comparison — silently, and confidently.
+  const collided = {
+    components: [
+      {
+        componentId: "Foo",
+        images: [
+          { path: "images/foo-a/ideal__default__light.png", previewId: "pkg.FooKt.Bar_A_B" },
+          { path: "images/foo-b/ideal__default__light.png", previewId: "pkg.FooKt.Bar_A_B_1" },
+        ],
+      },
+    ],
+  };
+  const { ambiguous } = catalogRouteIds(collided);
+  assert.deepEqual([...ambiguous], []);
+
+  // The real collision: two images whose previewIds sanitise to one key.
+  const real = {
+    components: [
+      {
+        componentId: "Foo",
+        images: [
+          { path: "images/foo-a/ideal__default__light.png", previewId: "pkg.FooKt.Bar_A B" },
+          { path: "images/foo-b/ideal__default__light.png", previewId: "pkg.FooKt.Bar_A/B" },
+        ],
+      },
+    ],
+  };
+  const resolve = routeIdResolver(real);
+  // Each id still resolves EXACTLY — the exact map is consulted first, so a collision elsewhere
+  // never degrades an id that needs no sanitising.
+  assert.equal(resolve("pkg.FooKt.Bar_A B"), "foo-a__ideal__default__light");
+  assert.equal(resolve("pkg.FooKt.Bar_A/B"), "foo-b__ideal__default__light");
+  // …but a third spelling that only reaches them through the lossy key gets nothing, not a guess.
+  assert.equal(resolve("pkg.FooKt.Bar_A\tB"), null);
+  assert.deepEqual([...catalogRouteIds(real).ambiguous], ["pkg.FooKt.Bar_A_B"]);
+});
+
+test("one preview rendered into several images is not a collision", () => {
+  const resolve = routeIdResolver({
+    components: [
+      {
+        componentId: "Foo",
+        images: [
+          { path: "images/foo/ideal__default__light.png", previewId: "pkg.FooKt.Bar" },
+          { path: "images/foo/ideal__default__light.png", previewId: "pkg.FooKt.Bar" },
+        ],
+      },
+    ],
+  });
+  assert.equal(resolve("pkg.FooKt.Bar"), "foo__ideal__default__light");
+});
+
 test("events carry ROUTE ids, not the discovery ids the design map names", () => {
   const index = indexDesignMap(designMap, { routeIdFor: routeIdResolver(catalog) });
   const events = codeEventsFrom(
@@ -366,6 +421,38 @@ test("mappingGaps derives an unrendered reference from the published manifest", 
         "catalog/src/main/kotlin/sections/Switches.kt#SwitchOn",
       ],
     ],
+  );
+});
+
+test("a sanitised catalog id is not mistaken for a dangling mapping", () => {
+  // The design map writes the RAW discovery id; the catalog carries the sanitised in-bundle form.
+  // Comparing them literally reports a healthy mapping as dangling AND suppresses the
+  // unrendered-reference check for it — one false finding and one missed one, same mismatch.
+  const spaced = {
+    components: [
+      {
+        code: "ui/Foo.kt#Bar",
+        ref: "figma:abc/1:2",
+        previewId: "pkg.FooKt.Bar_Small Round",
+      },
+    ],
+  };
+
+  assert.deepEqual(
+    mappingGaps({ designMap: spaced, catalogPreviewIds: ["pkg.FooKt.Bar_Small_Round"] }),
+    [],
+    "the same preview written two ways is not a dangling mapping",
+  );
+
+  // …and with the reference manifest proving the raster failed, the RIGHT finding now surfaces.
+  const gaps = mappingGaps({
+    designMap: spaced,
+    catalogPreviewIds: ["pkg.FooKt.Bar_Small_Round"],
+    referenceManifest: { references: [] },
+  });
+  assert.deepEqual(
+    gaps.map((g) => g.kind),
+    [GAP_KINDS.UNRENDERED_REFERENCE],
   );
 });
 


### PR DESCRIPTION
Follow-up to #3470 (which auto-merged before these landed). Three defects, all found by the Codex reviewer on that PR, and all of which fail **silently** — the page still renders, just degraded, so none surfaces as an error.

### 1. The feed never reached a published catalog (P1)

A served catalog is a fresh staging tree assembled from explicitly fetched parts, and nothing copied `parity/activity.json` into it. So `/parity` fell back to coverage-only on every *published* catalog — which is every catalog the view is actually for — and the code/Figma feed and producer gaps were reachable only from a local bundle. `ServeCatalogStore` now stages it beside the reference and annotation manifests, validating before writing so a malformed feed never lands in the tree at all.

### 2. Events carried the wrong preview-id namespace (P1)

A design map names the raw **discovery** id (`sections.ButtonsKt.FilledButton_Light`); the serve host keys a preview by the **route-safe** id derived from its image path (`button-filled__ideal__default__light`). `ServeParityDashboard` filters event ids against the live catalog and drops what it doesn't recognise — so emitting discovery ids meant *every* inbound link disappeared and the page became the two unrelated changelogs it exists not to be.

The emitter now translates through the published `catalog.json`, which carries both, keyed by the sanitised projection as well: the map holds the raw id and the catalog the in-bundle one, so a `@Preview(name = "Small Round")` differs by a character on each side. An id the catalog doesn't publish resolves to null rather than passing through unmatchable. Discovery ids remain what the dangling-mapping check compares against — the two namespaces are now separate on purpose rather than by accident.

Verified end to end against a real repo: the emitter now writes `bottomappbarsticker-light__ideal__default__light`, the id `ServeCatalogStore.previewIdFor` produces.

### 3. `unrendered-reference` was documented but unreachable (P2)

Nothing populated `droppedReferences`, and the reference step's `::warning::`s are gone by the time this runs. It's now derived from durable evidence instead: `references/index.json` records each reference's design-map `code` handle, so a mapped entry missing from it is precisely one that failed to rasterize. Consulted **only when a token was present** — without one that step skips `figma:` entries by design, so "missing" would mean "never tried", and reporting a gap per mapped component on every fork/PR run would bury the real findings.

## Test plan

- `./gradlew :cli:test` — green (full suite).
- New staging coverage in `ServeCatalogStoreTest`: fetched-and-staged, absent, and validation-rejected.
- The cross-language fixture test now asserts the **shape** of the ids the feed carries (a discovery id fails even though it parses) and round-trips them through `ServeParityDashboard` to prove they produce inbound links — the regression that let #2 through was that the fixture was self-consistent in the wrong namespace.
- `node --test` in `scripts/design-artifacts` — 24 pass, covering the route-id join including the sanitised spelling, an unresolvable mapping contributing no id, and the derived gap across absent-vs-empty manifests.
- `./gradlew ktfmtCheck` — green.
- No visual change: this is data plumbing behind a page that already has committed fixtures, and `serve-parity.html` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqLRhzcwojve5zxW16jxYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqLRhzcwojve5zxW16jxYt)_