### PR TITLE
test(serve): stop pinning the cache-busting asset hash in the page goldens

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -40,6 +40,11 @@ import kotlinx.serialization.json.buildJsonObject
  *
  * (An env var rather than a `-D` system property, since Gradle forwards the environment to the
  * forked test JVM but not arbitrary system properties.)
+ *
+ * Two fields are deliberately held constant in the goldens so that a diff only ever shows markup:
+ * the server version ([version]) and the cache-busting hash in every asset href (see
+ * [stableAssetHrefs]). Both are volatile, neither is a surface anyone reviews, and left alone they
+ * made this test fail for reasons no reviewer could act on.
  */
 class ServeWebFixtureTest {
 
@@ -1478,7 +1483,7 @@ class ServeWebFixtureTest {
     // The page goldens, named once: the same list backs both the `UPDATE_SERVE_WEB_FIXTURES=true`
     // regeneration below and the sync assertion further down, so a fixture can never be written
     // by one and forgotten by the other.
-    val goldens =
+    val renderedGoldens =
       listOf(
         "serve-landing.html" to landing,
         "serve-landing-public.html" to landingPublic,
@@ -1518,6 +1523,10 @@ class ServeWebFixtureTest {
         "serve-doc-lottie.html" to docLottie,
         "serve-doc-remotecompose.html" to docRemoteCompose,
       )
+
+    // Normalise once, here, so the regeneration below and the sync assertion further down cannot
+    // disagree about what a golden is supposed to contain.
+    val goldens = renderedGoldens.map { (name, html) -> name to stableAssetHrefs(html) }
 
     if (update) {
       pagesDir.mkdirs()
@@ -4059,6 +4068,21 @@ class ServeWebFixtureTest {
    * everything (drift across unrelated pages, on a line nobody on the branch edited).
    */
   private fun assertGoldensInSync(pagesDir: File, goldens: List<Pair<String, String>>) {
+    // Every page loads at least one hashed asset, so a golden without the placeholder means
+    // `stableAssetHrefs` stopped matching what `ServeWeb` emits — the URL shape changed, or the
+    // digest format did. Say so directly instead of letting it surface as 36 files of "drift",
+    // which is the failure this normalisation exists to stop being noise.
+    val unnormalised =
+      goldens.filterNot { (_, html) -> STABLE_ASSET_PREFIX in html }.map { it.first }
+    if (unnormalised.isNotEmpty()) {
+      fail(
+        "no `$STABLE_ASSET_PREFIX` href in: ${unnormalised.joinToString(", ")}.\n" +
+          "ServeWeb's asset URLs no longer match the shape ServeWebFixtureTest normalises " +
+          "(`$ASSET_HREF_PATTERN`). Update stableAssetHrefs to match ServeWebAssets.href, or the " +
+          "goldens will start pinning real content hashes again and every asset edit will drift " +
+          "every page."
+      )
+    }
     val missing = goldens.filterNot { (name, _) -> File(pagesDir, name).isFile }.map { it.first }
     val drifted =
       goldens
@@ -4083,6 +4107,33 @@ class ServeWebFixtureTest {
     }
     fail(report)
   }
+
+  /**
+   * Replace the cache-busting content hash in every asset href with a constant.
+   *
+   * [ServeWebAssets.href] builds `/assets/serve/<size>-<sha256 prefix>/<file>`, so editing any one
+   * of the eleven CSS/JS assets changes a hash that up to **36** goldens embed. That drift is pure
+   * noise: the hash is not a surface anyone reviews, it cannot appear in a screenshot, and the
+   * preview-harness deliberately ignores it — both its static server and the Playwright routes
+   * match these URLs by basename precisely because "the hash is cache-busting and changes whenever
+   * the asset does". What it did instead was fail this test on every branch that touched
+   * `viewer.js`, and twice reach `main` red (#3446, #3456) when a merge landed the asset without
+   * the regeneration. Worse, it trained the reflex the failure message argues against: 36 files of
+   * drift you did not cause looks exactly like the "regenerated before merging main" case, so the
+   * honest response and the lazy one are the same command.
+   *
+   * Pinning it here is the same move this test already makes for the server version ([version] =
+   * `0.0.0-fixture`, so a release does not churn the goldens) and for the fixed provenance date —
+   * hold the volatile-but-uninteresting field constant so the diff only ever shows markup.
+   *
+   * This does not weaken the guard. The regex matches only the versioned form, so if `ServeWeb`
+   * ever stopped emitting one the rendered text would pass through unchanged and
+   * [assertGoldensInSync] would fail on the missing placeholder rather than silently accepting a
+   * broken URL. Production still serves the real hash: [ServeHttpServer] 404s a mismatched version,
+   * and nothing about that path changes here.
+   */
+  private fun stableAssetHrefs(html: String): String =
+    ASSET_HREF_PATTERN.replace(html, STABLE_ASSET_PREFIX)
 
   /** `line N: golden … | rendered …` for the first line where the two texts diverge. */
   private fun firstDifference(golden: String, rendered: String): String {
@@ -4143,4 +4194,17 @@ class ServeWebFixtureTest {
     </svg>
     """
       .trimIndent()
+
+  private companion object {
+    /** What the goldens carry in place of a real content hash. See [stableAssetHrefs]. */
+    const val STABLE_ASSET_PREFIX = "/assets/serve/fixture/"
+
+    /**
+     * `/assets/serve/<size-hex>-<16 hex digits>/` — the exact shape [ServeWebAssets.href] builds
+     * from an asset's byte length and SHA-256 prefix. Deliberately narrow: a looser pattern
+     * (`[^/]+`) would keep matching if that scheme changed, and the goldens would go on looking
+     * normalised while pinning something else.
+     */
+    val ASSET_HREF_PATTERN = Regex("""/assets/serve/[0-9a-f]+-[0-9a-f]{16}/""")
+  }
 }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-lottie.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>loading-spinner.json — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-doc-remotecompose.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>watchface.rc — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-docs-upload.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Share a document — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-format-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-format-compare.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — format comparison</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -59,8 +59,8 @@
         </div>
         <p id="cp-compare-empty" class="cp-empty" hidden>No comparisons match this filter.</p>
         </div>
-        <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-        <script src="/assets/serve/9307-806c15ce8d932fc7/format-compare.js"></script>
+        <script src="/assets/serve/fixture/url-state.js"></script>
+        <script src="/assets/serve/fixture/format-compare.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Design systems — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>wear-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <style>
         :root {
           --cp-bg: #fafafb;
@@ -124,7 +124,7 @@
 </a>
         </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>    (function () {
       var cards = document.querySelectorAll(".cp-card");
       var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -89,7 +89,7 @@
 </a>
         </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>    (function () {
       var cards = document.querySelectorAll(".cp-card");
       var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -171,7 +171,7 @@
 </div>
 </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>    (function () {
       var cards = document.querySelectorAll(".cp-card");
       var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-live.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -86,7 +86,7 @@
 </a>
         </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>    (function () {
       var cards = document.querySelectorAll(".cp-card");
       var input = document.getElementById("cp-search");
@@ -250,7 +250,7 @@ applyThemeChoice();
       apply();
     })();</script>
 <script>window.cpCatalogLive = {base:"",query:"session=compose-m3",signInHref:"",holdMs:500,cards:[{l:"button-filled__ideal__default__light",d:"button-filled__ideal__default__dark"},{l:"switch-on__ideal__default__light",d:"switch-on__ideal__default__dark"},{l:"badge",d:"badge"}]};</script>
-<script src="/assets/serve/4056-e5ab66106be9ac93/catalog-live.js"></script>
+<script src="/assets/serve/fixture/catalog-live.js"></script>
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -100,7 +100,7 @@
 </a>
         </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>(function () {
   var cards = document.querySelectorAll(".cp-card");
   var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -138,7 +138,7 @@
 </a>
         </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>(function () {
   var cards = document.querySelectorAll(".cp-card");
   var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>meshcore-mobile — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -169,7 +169,7 @@
 </section>
 </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>(function () {
   var cards = document.querySelectorAll(".cp-card");
   var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -76,7 +76,7 @@
 </a>
         </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>    (function () {
       var cards = document.querySelectorAll(".cp-card");
       var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -86,7 +86,7 @@
 </a>
         </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>    (function () {
       var cards = document.querySelectorAll(".cp-card");
       var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>compose-m3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -61,7 +61,7 @@
 </a>
         </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>    (function () {
       var cards = document.querySelectorAll(".cp-card");
       var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>:samples:cmp — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -99,7 +99,7 @@
 </a>
         </div>
 <p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
+<script src="/assets/serve/fixture/url-state.js"></script>
 <script>(function () {
   var cards = document.querySelectorAll(".cp-card");
   var input = document.getElementById("cp-search");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-notfound.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Not found — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-parity.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-parity.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Design parity — Compose Material 3 — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -128,7 +128,7 @@
 </li>
         </ul>
         <p class="cp-muted" id="cp-parity-feed-empty" hidden>No activity in this lane.</p>
-        <script src="/assets/serve/50b-356d6d0c4ce18dd5/parity.js"></script>
+        <script src="/assets/serve/fixture/parity.js"></script>
                 <h2 class="cp-status-sec">Mapping</h2>
                     <h3 class="cp-parity-sub">No design reference (2)</h3>
             <p class="cp-muted">These render, but nothing in the design file is mapped to them — so

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Playground — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -22,8 +22,8 @@
   </nav>
 </header>
         <main class="cp-main">
-                <link rel="stylesheet" href="/assets/serve/2210-eb494ea972d2661e/codemirror.css">
-        <link rel="stylesheet" href="/assets/serve/1083-2f91e7afbda68d07/playground.css">
+                <link rel="stylesheet" href="/assets/serve/fixture/codemirror.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/playground.css">
         <h1 class="cp-head">Playground</h1>
         <p class="cp-sub">Write a Compose snippet, compile it against the live catalog, and open a
           preview. This lane runs your code on the server, so it stays behind your token.</p>
@@ -74,7 +74,7 @@ fun Greeting() {
               aria-label="Previews declared by this snippet"></ul>
           </div>
         </div>
-        <script src="/assets/serve/6b581-d6e9c9379c1c3b8b/codemirror.js"></script>
+        <script src="/assets/serve/fixture/codemirror.js"></script>
         <script>(function () {
   var source = document.getElementById("pg-source");
   var mode = document.getElementById("pg-mode");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Figma filled button — design comparison</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -47,8 +47,8 @@
           <label class="cp-overlay-control">Overlay <input class="cp-overlay-range" type="range" min="0" max="100" value="50"><span>50%</span></label>
           <div class="cp-reference-overlay"><img src="/reference/design-button-filled-light.png?session=compose-m3" alt=""><img src="/render/button-filled__ideal__default__light.png?session=compose-m3" alt=""></div>
         </div>
-        <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-        <script src="/assets/serve/9307-806c15ce8d932fc7/format-compare.js"></script>
+        <script src="/assets/serve/fixture/url-state.js"></script>
+        <script src="/assets/serve/fixture/format-compare.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-status.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-status.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Server status — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -275,10 +275,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -337,9 +337,9 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/9307-806c15ce8d932fc7/format-compare.js"></script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/format-compare.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <style>
         :root {
           --cp-bg: #f8f4f8;
@@ -204,10 +204,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -266,8 +266,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Focus ring — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -179,10 +179,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -241,8 +241,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>One-handed — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -178,10 +178,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -240,8 +240,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history-local.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history-local.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -160,10 +160,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -222,8 +222,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -160,10 +160,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -222,8 +222,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -176,10 +176,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -238,8 +238,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -169,10 +169,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -231,8 +231,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -170,10 +170,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -232,8 +232,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Checkbox · Checked (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -173,10 +173,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -235,8 +235,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -166,10 +166,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -228,8 +228,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Button · Filled (light) — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -167,10 +167,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -229,8 +229,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -172,10 +172,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -234,8 +234,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Card — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -162,10 +162,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -224,8 +224,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Settings Complication — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -156,10 +156,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -218,8 +218,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Profile screen — compose-preview</title>
-        <link rel="stylesheet" href="/assets/serve/1049b-fb6c8feac2f8dc97/serve.css">
+        <link rel="stylesheet" href="/assets/serve/fixture/serve.css">
         <!-- Apply the Background/Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
@@ -217,10 +217,10 @@
       <!-- Backdrop shown behind an open drawer on mobile (drawers become bottom sheets there);
            tapping it dismisses the sheet. Inert on desktop. -->
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
-      <script src="/assets/serve/e8c-acead748488355b1/url-state.js"></script>
-      <script src="/assets/serve/22e-68c7d41937f0dccd/viewer-groups.js"></script>
-      <script src="/assets/serve/c0f-86b66f86ed745fcf/viewer-drawers.js"></script>
-      <script src="/assets/serve/2d42-a013f0117b063b17/viewer-history.js"></script>
+      <script src="/assets/serve/fixture/url-state.js"></script>
+      <script src="/assets/serve/fixture/viewer-groups.js"></script>
+      <script src="/assets/serve/fixture/viewer-drawers.js"></script>
+      <script src="/assets/serve/fixture/viewer-history.js"></script>
       <script>(function () {
   var el = document.getElementById("cp-theme");
   if (!el) return;
@@ -279,8 +279,8 @@
   });
   syncBg();
 })();</script>
-      <script src="/assets/serve/1a3bf-5821c98cb28d9399/viewer.js"></script>
-      <script src="/assets/serve/580-33b18e7b310ae1cc/backend-badge.js"></script>
+      <script src="/assets/serve/fixture/viewer.js"></script>
+      <script src="/assets/serve/fixture/backend-badge.js"></script>
         </main>
       </body>
     </html>


### PR DESCRIPTION
`ServeWebFixtureTest` has broken `main` twice now (#3446, #3456) for the same reason, so this removes the cause rather than regenerating again.

## Why it kept breaking

`ServeWebAssets.href` builds `/assets/serve/<size>-<sha256 prefix>/<file>`, and **all 36 page goldens embed one**. Editing any of the eleven CSS/JS assets changes a hash that up to 36 goldens pin — so `viewer.js` and the goldens must move in the same commit, or `main` goes red for everyone.

The hash is worth nothing as a golden:

- it cannot appear in a screenshot — the visual surface these fixtures exist for is unaffected by it;
- the preview-harness **already ignores it**, matching these URLs by basename in both its static server and its Playwright routes, with the comment "the hash is cache-busting and changes whenever the asset does";
- it made this check *harder* to read honestly. 36 files of drift you didn't cause is indistinguishable from the "goldens regenerated before merging main" case the failure message warns about — so the correct response and the lazy one are the same command, which is how it gets regenerated past.

## The change

Hold it constant in the goldens (`/assets/serve/fixture/…`), exactly as this test already holds the server version (`0.0.0-fixture`, so releases don't churn goldens) and the provenance date constant. A golden diff then only ever shows markup.

**This does not weaken the guard**, which is the part worth checking:

- The regex matches *only* the versioned form (`[0-9a-f]+-[0-9a-f]{16}`), deliberately narrow. If `ServeWeb` ever stopped emitting that shape the rendered text would pass through unnormalised, and a new assertion fails naming the cause instead of dumping 36 files of drift. A looser `[^/]+` would have kept "working" while silently pinning something else.
- Production is untouched: `ServeHttpServer` still serves and validates the real content hash, 404ing a mismatched version.

## Test plan

Both directions verified, since a normalisation like this fails silently if it's too broad *or* too narrow:

- **The bug is gone.** Appended a line to `viewer.js` — the exact change that broke `main` twice — and re-ran: **no drift at all**. Before this, that edit drifted every page loading `viewer.js`.
- **Real drift is still caught.** Altered one golden's markup and re-ran; fails as it should:
  `serve-viewer.html: line 6: golden <title>BRITTLENESS-PROBE Profile screen — compose-preview</title> | rendered <title>Profile screen — compose-preview</title>`
- Regeneration touches **only** asset-href lines — `+154/-154`, and grepping the diff for any changed line that isn't an `assets/serve` href returns empty.
- `:cli:test` (1,649 tests) and `:cli:ktfmtCheck` pass.

**Visual evidence:** none applies, and that is checkable rather than asserted — the only changed lines in 36 visual fixtures are asset hrefs whose hash the harness discards when serving, so every rendered screenshot is unchanged by construction.

## Related, not fixed here

`_render-placeholder.png` also churns on regeneration: it's drawn with AWT `drawString` in `Font("SansSerif", …)`, so its bytes depend on the host's installed fonts despite the comment calling it deterministic. Regenerating on this container rewrote it (2730 → 2602 bytes), so I reverted it — it's environment noise, not an improvement. Nothing asserts on it (only that it exists), so it can't fail CI, but it will dirty a visual diff for whoever regenerates on a different machine. Making it font-free would fix that; it changes what the placeholder tile looks like, so it's your call rather than a drive-by.

---
_Generated by [Claude Code](https://claude.ai/code/session_01544ugYx8JzQfQ2iL4ijJKK)_