### PR TITLE
fix(ci): restore green main — iOS 26 SDK for the player, Rule 3 only where it applies

### DIFF
--- a/.github/ci/summarize-render-errors.py
+++ b/.github/ci/summarize-render-errors.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Summarize `*.png.error.json` render sidecars for a failing CI leg.
+
+When `composePreviewRender` produces no PNGs, the reason is in the per-preview
+sidecars (`PreviewRenderError`, schema `compose-preview-error/v1`) the renderer
+drops next to where each PNG would have gone. The verify steps used to print
+only the sidecar *paths* — on a leg like `wear-os-samples (WearTilesKotlin)`
+that means 188 filenames and not one word about what actually threw, so
+diagnosing it costs a download of the renders artifact (and that artifact is
+not reachable from every environment).
+
+Print the exceptions instead. Failures of this kind are overwhelmingly one root
+cause replicated across every preview, so group by (exception, message) and show
+the full stack trace for the largest group, with a one-line head for the rest.
+
+Usage: summarize-render-errors.py <sidecar> [<sidecar> ...]
+Always exits 0 — this is a diagnostic, the caller owns the failure exit.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+
+# Enough to identify the throw site without burying the log in 188 copies.
+STACK_LINES = 40
+
+
+def main(paths: list[str]) -> int:
+    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    unreadable: list[tuple[str, str]] = []
+
+    for path in paths:
+        try:
+            with open(path) as handle:
+                payload = json.load(handle)
+        except (OSError, ValueError) as error:
+            unreadable.append((path, str(error)))
+            continue
+        payload["_path"] = path
+        groups[(payload.get("exception", "?"), payload.get("message", ""))].append(payload)
+
+    if not groups and not unreadable:
+        return 0
+
+    total = sum(len(items) for items in groups.values())
+    print(f"Render error sidecars: {total} preview(s) failed, {len(groups)} distinct cause(s).")
+
+    # Largest group first: the dominant cause is nearly always the real one.
+    ranked = sorted(groups.items(), key=lambda item: len(item[1]), reverse=True)
+
+    for index, ((exception, message), items) in enumerate(ranked):
+        sample = items[0]
+        print()
+        print(f"[{index + 1}/{len(ranked)}] {len(items)} preview(s): {exception}: {message}")
+        frame = sample.get("topAppFrame")
+        if frame:
+            print(f"  at {frame.get('file', '?')}:{frame.get('line', 0)} ({frame.get('function', '?')})")
+        print(f"  e.g. {sample.get('_path', '?')}")
+
+        # Full trace for the dominant cause only; the rest are identified by
+        # their exception + message + top frame above.
+        if index == 0:
+            trace = (sample.get("stackTrace") or "").splitlines()
+            if trace:
+                print("  stack trace:")
+                for line in trace[:STACK_LINES]:
+                    print(f"    {line}")
+                if len(trace) > STACK_LINES:
+                    print(f"    … {len(trace) - STACK_LINES} more frame(s)")
+
+    if unreadable:
+        print()
+        print(f"{len(unreadable)} sidecar(s) could not be parsed:")
+        for path, error in unreadable[:10]:
+            print(f"  {path}: {error}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,26 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      # Compose Multiplatform 1.11's `ui-uikit` links against iOS 26 SDK symbols — `CMPLayoutRegion`
+      # references `UIViewLayoutRegion`, which does not exist before iOS 26. The `macos-15` image
+      # ships several Xcode 26.x alongside 16.4 but still *defaults* to 16.4 (iOS 18.5 SDK), so
+      # `:rc-player-compose:linkDebugTestIosSimulatorArm64` dies with
+      # `Undefined symbols for architecture arm64: "_OBJC_CLASS_$_UIViewLayoutRegion"` — the whole
+      # job, ~17 min in, on every push since the CMP 1.11.1 bump. Select the newest installed
+      # Xcode 26 rather than pinning one, so an image refresh that retires a point release doesn't
+      # take the job with it.
+      - name: Select an Xcode with the iOS 26 SDK
+        run: |
+          set -euo pipefail
+          xcode="$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -n 1)"
+          if [ -z "$xcode" ]; then
+            echo "No Xcode 26 on this image; Compose Multiplatform's iOS targets need its SDK." >&2
+            ls -d /Applications/Xcode*.app >&2
+            exit 1
+          fi
+          sudo xcode-select --switch "$xcode/Contents/Developer"
+          xcodebuild -version
+          xcodebuild -showsdks | grep -i iphonesimulator
       # `:rc-player-compose` has no `iosX64` compile task: it is the only `:rc-player-*` module that
       # depends on Compose Multiplatform, and CMP 1.11 dropped the Intel-iOS-simulator variant (see
       # that module's build.gradle.kts). Its non-Compose siblings still declare `iosX64()`, so they

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -207,6 +207,9 @@ jobs:
           # reason as the scripts above: the matrix legs that call it have no
           # checkout of this repo, so it has to ride in via the bundle.
           cp .github/ci/android-all-cache-key.py bundle/ci/
+          # Turns a wall of `*.error.json` paths into the actual exceptions when
+          # a render leg produces no PNGs. Same no-checkout reason as above.
+          cp .github/ci/summarize-render-errors.py bundle/ci/
           # Ship consumer patches (e.g. the adaptive-apps-samples XR
           # androidx.xr.compose upgrade) so the integration matrix can apply them to
           # the checked-out external repo before Gradle configures it.
@@ -1073,8 +1076,16 @@ jobs:
             echo "::error::composePreviewRender ran but no PNG files were produced."
             mapfile -t sidecars < <(find . -path '*/build/compose-previews/renders/*.error.json' -not -path '*/external/build/*' 2>/dev/null)
             if [ "${#sidecars[@]}" -gt 0 ]; then
-              echo "Render error sidecars:"
-              printf '  %s\n' "${sidecars[@]}"
+              # Print the exceptions, not just the paths — see the script's
+              # docstring for why the filename-only listing was a dead end.
+              # Ships in the bundle; these legs have no checkout of this repo.
+              summarize="$GITHUB_WORKSPACE/bundle/ci/summarize-render-errors.py"
+              if [ -f "$summarize" ]; then
+                python3 "$summarize" "${sidecars[@]}"
+              else
+                echo "Render error sidecars:"
+                printf '  %s\n' "${sidecars[@]}"
+              fi
             fi
             exit 1
           fi
@@ -1739,8 +1750,13 @@ jobs:
             echo "::error::composePreviewRender ran but no PNG files were produced."
             mapfile -t sidecars < <(find . -path '*/build/compose-previews/renders/*.error.json' 2>/dev/null)
             if [ "${#sidecars[@]}" -gt 0 ]; then
-              echo "Render error sidecars:"
-              printf '  %s\n' "${sidecars[@]}"
+              summarize="$GITHUB_WORKSPACE/bundle/ci/summarize-render-errors.py"
+              if [ -f "$summarize" ]; then
+                python3 "$summarize" "${sidecars[@]}"
+              else
+                echo "Render error sidecars:"
+                printf '  %s\n' "${sidecars[@]}"
+              fi
             fi
             exit 1
           fi

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -245,6 +245,18 @@ class RenderEngine(
     val trace = PerfettoTraceDataProducer.recorder(spec.outputBaseName, backend = "android")
     val slotTableCapture = PreviewSlotTableCapture()
     val themeFallbackCapture = MaterialThemeFallbackCapture()
+    // Material 3 is `compileOnly` here on purpose (mitigation #1 in
+    // `docs/RENDERER_COMPATIBILITY.md`) — the consumer's own copy is what a preview composes
+    // against. A consumer that never uses it does not have one: a Wear app themes with
+    // `androidx.wear.compose.material3`, and `androidx.compose.material3` is nowhere on its unit
+    // test classpath. Rule 3 keeps our own Compose Multiplatform transitives off that graph
+    // (see `AndroidPreviewSupport.applyRenderGraphResolutionRules`), so it is no longer smuggled
+    // in behind the consumer's back either. Probe rather than assume: an unguarded
+    // `CaptureMaterialTheme` fails EVERY preview in such a module with `NoClassDefFoundError:
+    // androidx/compose/material3/ColorScheme` before user code runs. `renderers/android` has
+    // always taken this shape (`WearMaterialTheme` reads Wear's theme reflectively, and the
+    // Material 3 reads sit behind theme-catalog render modes) — this brings the daemon in line.
+    val hasMaterial3 = material3OnClasspath(classLoader)
     // Opt-in (serve / bundle-daemon set it) — see [PLACEHOLDER_MISSING_RESOURCES_PROP]. Off for the
     // pack semantics daemon so a missing resource fails loudly instead of baking a placeholder.
     val placeholderMissingResources =
@@ -439,9 +451,15 @@ class RenderEngine(
                     }
                     .toTypedArray()
                 CompositionLocalProvider(*provided) {
-                  CaptureMaterialTheme { _, typography, shapes, payload ->
-                    themeFallbackCapture.capture(typography, shapes)
-                    themeFallbackCapture.capture(payload)
+                  // Skipped entirely when the consumer has no Material 3 (see
+                  // [material3OnClasspath], probed at the top of `render`); the capture's fields
+                  // are all nullable and the payload below falls back to `null`, which is what a
+                  // Material-3-less preview should report anyway.
+                  if (hasMaterial3) {
+                    CaptureMaterialTheme { _, typography, shapes, payload ->
+                      themeFallbackCapture.capture(typography, shapes)
+                      themeFallbackCapture.capture(payload)
+                    }
                   }
                   val content: @Composable () -> Unit = {
                     ComposeDataExtensionPipeline.Apply(
@@ -1025,12 +1043,16 @@ class RenderEngine(
         .parameterInformationCollected()
         .addSlotTables(slotTables)
         .build()
+    // `themePayloadFromPreviewContext` reads Material 3 objects out of the slot tables, so it is
+    // only callable when the consumer has Material 3 at all — same guard as the capture above.
     val baseThemePayload =
-      themePayloadFromPreviewContext(
-        context = rawPreviewContext,
-        fallbackTypography = themeFallbackCapture.typography,
-        fallbackShapes = themeFallbackCapture.shapes,
-      ) ?: themeFallbackCapture.payload
+      if (!hasMaterial3) null
+      else
+        themePayloadFromPreviewContext(
+          context = rawPreviewContext,
+          fallbackTypography = themeFallbackCapture.typography,
+          fallbackShapes = themeFallbackCapture.shapes,
+        ) ?: themeFallbackCapture.payload
     // Attribute consumers (#1847) against the facts captured while the scene was alive, keyed by
     // SemanticsNode id (matching `compose/semantics`) against the reported tokens.
     val materialThemePayload = baseThemePayload?.let { payload ->
@@ -2472,6 +2494,18 @@ private fun loadWrapperByFqnOrNull(wrapperFqn: String): Pair<ComposableMethod, A
       )
     }
     .getOrNull()
+
+/**
+ * Whether `androidx.compose.material3` is on [loader], i.e. whether the consumer whose classes we
+ * are about to compose has Material 3 at all.
+ *
+ * Not initialised (`false` to `Class.forName`) on purpose: the probe must not run Material 3's
+ * static initialisers, only answer whether the class is resolvable. Everything the daemon reads
+ * from Material 3 — the theme capture and the `compose/theme` payload — is optional metadata, so a
+ * `false` here degrades the render to "no Material 3 theme reported" rather than failing it.
+ */
+internal fun material3OnClasspath(loader: ClassLoader): Boolean =
+  runCatching { Class.forName("androidx.compose.material3.MaterialTheme", false, loader) }.isSuccess
 
 @Composable
 private fun CaptureMaterialTheme(

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/Material3ClasspathProbeTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/Material3ClasspathProbeTest.kt
@@ -1,0 +1,45 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The daemon's Material 3 usage — the theme capture and the `compose/theme` payload — is optional
+ * metadata, and Material 3 is `compileOnly` here so the consumer's own copy wins at runtime (see
+ * `docs/RENDERER_COMPATIBILITY.md`). A consumer may have none at all: a Wear app themes with
+ * `androidx.wear.compose.material3`, and once Rule 3 stopped smuggling our own Compose
+ * Multiplatform transitives onto the render graph
+ * (`AndroidPreviewSupport.applyRenderGraphResolutionRules`) nothing else puts
+ * `androidx.compose.material3` there. Rendering such a module then died in the renderer's own
+ * `CaptureMaterialTheme`, before user code ran:
+ * ```
+ * NoClassDefFoundError: androidx/compose/material3/ColorScheme
+ *     at ee.schimke.composeai.daemon.RenderEngine…evaluate$lambda$1$0$2(RenderEngine.kt:442)
+ * ```
+ *
+ * So `render` probes first. This pins the probe's two answers; the render-path guard it feeds is
+ * covered end-to-end by the `wear-os-samples` legs of the Integration workflow, which are the
+ * Material-3-less consumers that regressed.
+ */
+class Material3ClasspathProbeTest {
+
+  @Test
+  fun `reports material3 present on a loader that has it`() {
+    // This module's own test classpath does carry Material 3.
+    assertTrue(material3OnClasspath(javaClass.classLoader!!))
+  }
+
+  @Test
+  fun `reports material3 absent on a loader that hides it`() {
+    // Stands in for a Wear / foundation-only consumer's render classpath.
+    val hidden =
+      object : ClassLoader(javaClass.classLoader) {
+        override fun loadClass(name: String, resolve: Boolean): Class<*> {
+          if (name.startsWith("androidx.compose.material3.")) throw ClassNotFoundException(name)
+          return super.loadClass(name, resolve)
+        }
+      }
+    assertFalse(material3OnClasspath(hidden))
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -285,6 +285,14 @@ internal object AndroidPreviewSupport {
    * Read eagerly: every caller runs from the Android registration's `afterEvaluate`, so the
    * consumer's build script has already declared its dependencies and applied its plugins. The
    * identity check makes the answer independent of whether our injections have happened yet.
+   *
+   * The compiler-plugin shortcut below is a *positive* signal only, and it is sound in the one
+   * direction it is used: a module that applies the Compose compiler plugin is compiling
+   * `@Composable` code, which cannot compile without a Compose runtime on its graph — so it has
+   * Compose of its own even when the coordinate arrives transitively and the walk below would miss
+   * it. It does not misfire on a tile-only consumer that merely *declares* the plugin: `hasPlugin`
+   * is per-project, so a root-level `alias(...) apply false` (WearTilesKotlin's shape) is false
+   * here, which is what the end-to-end tiles leg exercises.
    */
   internal fun consumerBringsOwnCompose(project: Project, configuration: Configuration?): Boolean {
     if (COMPOSE_COMPILER_PLUGIN_IDS.any(project.plugins::hasPlugin)) return true
@@ -420,9 +428,11 @@ internal object AndroidPreviewSupport {
    * modules (`-desktop` / `-jvmstubs` siblings of the same coordinate) to their `-android` sibling.
    * Kotlin's `org.jetbrains.kotlin.platform.type` attribute (`androidJvm` vs `jvm`) is the official
    * disambiguator, but its compatibility/disambiguation rules are only registered when the Kotlin
-   * plugin is applied — consumers that build Kotlin via AGP alone (e.g. WearTilesKotlin: tile-only
-   * app, only `kotlin.compose` applied through `compose-compiler`, no `kotlin.android` anywhere)
-   * never pick `androidJvm` and Gradle then selects the desktop variant. The desktop
+   * plugin is applied — a consumer that builds Kotlin via AGP alone never picks `androidJvm` and
+   * Gradle then selects the desktop variant. (WearTilesKotlin was that shape when this rule was
+   * written; upstream has since moved its app module to `kotlin.android`, so it no longer is. The
+   * rule stays: it is scoped to coordinates that publish `-android` siblings and is a no-op once
+   * the attribute resolves correctly, and AGP-only consumers still exist.) The desktop
    * `ViewModelProvider` is the KMP rewrite (only `<init>(ViewModelProviderImpl)` survives — the
    * legacy `(ViewModelStoreOwner, Factory)` constructor is gone), while
    * `lifecycle-viewmodel-savedstate-android:2.8.7`'s `getSavedStateHandlesVM` bytecode at line 107
@@ -1373,10 +1383,17 @@ internal object AndroidPreviewSupport {
       //    `R.txt` has no such id; [RENDERER_COMPOSE_CMP_RUNTIME_VERSION]'s
       //    has it.) So a Compose-less consumer gets the CMP runtime version,
       //    keeping its resources and our classes on the same line.
+      //
+      // Resolved once and reused for the `foundation` pin below AND for both
+      // `recordInjectedDependency` entries: `composePreviewDoctor` exists to
+      // explain this exact compatibility scenario, so reporting the floor while
+      // injecting the CMP runtime version would misreport precisely where the
+      // report is load-bearing.
+      val mainComposeVersion = mainVariantComposeVersion(project, variantName)
       addPluginDependency(
         project,
         "${variantName}Implementation",
-        "androidx.compose.ui:ui:${mainVariantComposeVersion(project, variantName)}",
+        "androidx.compose.ui:ui:$mainComposeVersion",
       )
       // Pin `androidx.compose.foundation:foundation` on the main variant for
       // the same reason as compose-ui above — but for class-loading rather
@@ -1396,7 +1413,7 @@ internal object AndroidPreviewSupport {
       addPluginDependency(
         project,
         "${variantName}Implementation",
-        "androidx.compose.foundation:foundation:${mainVariantComposeVersion(project, variantName)}",
+        "androidx.compose.foundation:foundation:$mainComposeVersion",
       )
       recordInjectedDependency(
         project,
@@ -1446,20 +1463,20 @@ internal object AndroidPreviewSupport {
       recordInjectedDependency(
         project,
         injectedDependencies,
-        coordinate = "androidx.compose.ui:ui:$RENDERER_COMPOSE_FLOOR_VERSION",
+        coordinate = "androidx.compose.ui:ui:$mainComposeVersion",
         configuration = "${variantName}Implementation",
         outcome = "APPLIED",
         reason =
-          "compose-ui's AndroidComposeViewAccessibilityDelegateCompat.<clinit> reads androidx.compose.ui.R.id.*; merged test APK needs the compose-ui R class on tile-only consumers without compose-ui in main",
+          "compose-ui's AndroidComposeViewAccessibilityDelegateCompat.<clinit> reads androidx.compose.ui.R.id.*; merged test APK needs the compose-ui R class on tile-only consumers without compose-ui in main. Versioned by whichever Compose actually runs: the renderer's compile floor when the consumer brings its own Compose, the CMP runtime version when ours is the only Compose on the render classpath",
       )
       recordInjectedDependency(
         project,
         injectedDependencies,
-        coordinate = "androidx.compose.foundation:foundation:$RENDERER_COMPOSE_FLOOR_VERSION",
+        coordinate = "androidx.compose.foundation:foundation:$mainComposeVersion",
         configuration = "${variantName}Implementation",
         outcome = "APPLIED",
         reason =
-          "TilePreviewRenderer.TilePreviewComposable calls Modifier.fillMaxSize() from androidx.compose.foundation.layout.SizeKt; tile-only consumers without compose-foundation in main hit NoClassDefFoundError at render time",
+          "TilePreviewRenderer.TilePreviewComposable calls Modifier.fillMaxSize() from androidx.compose.foundation.layout.SizeKt; tile-only consumers without compose-foundation in main hit NoClassDefFoundError at render time. Versioned with compose-ui above — foundation and ui have to stay on one line",
       )
     } else {
       recordInjectedDependency(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -349,6 +349,36 @@ internal object AndroidPreviewSupport {
   private const val PLUGIN_INJECTED_DEPENDENCIES_KEY = "composeai.pluginInjectedDependencies"
 
   /**
+   * The `androidx.compose` version the Compose Multiplatform artifacts on the render classpath
+   * resolve to — `org.jetbrains.compose.ui:ui:1.11.1` declares `androidx.compose.ui:ui:1.11.2`.
+   *
+   * Only reached on consumers that bring no Compose of their own, where those artifacts ARE the
+   * render classpath's Compose (Rule 3 is off, see [consumerBringsOwnCompose]). Bump this in
+   * lockstep with the `compose-multiplatform` catalog entry: read the mapping off the published
+   * `org/jetbrains/compose/ui/ui/<version>/ui-<version>.pom` rather than assuming it tracks the CMP
+   * version, because it does not — 1.11.1 maps to 1.11.2.
+   */
+  internal const val RENDERER_COMPOSE_CMP_RUNTIME_VERSION: String = "1.11.2"
+
+  /**
+   * Version for the main-variant `androidx.compose.ui` / `foundation` pins, which decide the R
+   * class in the merged unit-test resource APK. See the call site for why the two cases differ: a
+   * Compose consumer's own BOM wins over our floor anyway, while a Compose-less consumer runs
+   * against OUR compose-ui and needs its resources on that same line.
+   *
+   * Probes the variant's unit-test runtime classpath — where a consumer's Compose sits, and what
+   * the render configuration is built from. Our own injections into `${variantName}Implementation`
+   * reach it too, but [consumerBringsOwnCompose] skips those by identity, so this does not answer
+   * itself.
+   */
+  internal fun mainVariantComposeVersion(project: Project, variantName: String): String {
+    val unitTestClasspath =
+      project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
+    return if (consumerBringsOwnCompose(project, unitTestClasspath)) RENDERER_COMPOSE_FLOOR_VERSION
+    else RENDERER_COMPOSE_CMP_RUNTIME_VERSION
+  }
+
+  /**
    * Compose compiler plugin ids — the Kotlin 2.x plugin every consumer with `@Composable` code
    * applies, and the legacy AndroidX id for older consumers. Used by [consumerBringsOwnCompose].
    */
@@ -1322,10 +1352,31 @@ internal object AndroidPreviewSupport {
       // with consumer-aligned versions, so this is a no-op for Compose-app
       // consumers that already get a newer ui via their BOM, and a fix for
       // tile-only consumers that don't.
+      //
+      // The VERSION is not the same for both, though. This pin decides the R
+      // class in the merged unit-test resource APK, and that has to agree with
+      // the compose-ui CLASSES on the render classpath:
+      //
+      //  * A Compose consumer keeps Rule 3, so its own Compose is what runs and
+      //    its BOM wins over this floor. Classes and resources are both theirs.
+      //  * A Compose-less consumer has Rule 3 off, so the render classpath's
+      //    compose-ui is OURS — the one Compose Multiplatform brings. Pinning
+      //    the main variant at the 1.9.5 floor there mismatches by two minor
+      //    versions, and the merged APK's R class is missing ids the newer
+      //    classes read:
+      //
+      //      NoSuchFieldError: Class androidx.compose.ui.R$id does not have
+      //        member field 'int androidx_compose_ui_view_compose_view_context'
+      //          at ComposeView_androidKt.getComposeViewContext
+      //
+      //    (Verified against the published artifacts: `ui-android` 1.9.5's
+      //    `R.txt` has no such id; [RENDERER_COMPOSE_CMP_RUNTIME_VERSION]'s
+      //    has it.) So a Compose-less consumer gets the CMP runtime version,
+      //    keeping its resources and our classes on the same line.
       addPluginDependency(
         project,
         "${variantName}Implementation",
-        "androidx.compose.ui:ui:$RENDERER_COMPOSE_FLOOR_VERSION",
+        "androidx.compose.ui:ui:${mainVariantComposeVersion(project, variantName)}",
       )
       // Pin `androidx.compose.foundation:foundation` on the main variant for
       // the same reason as compose-ui above — but for class-loading rather
@@ -1339,14 +1390,13 @@ internal object AndroidPreviewSupport {
       //   `NoClassDefFoundError: androidx/compose/foundation/layout/SizeKt`
       //   at `TilePreviewRendererKt.TilePreviewComposable`
       //
-      // Same `${variantName}Implementation` floor pattern as compose-ui —
-      // Gradle picks the max with consumer-aligned versions, so this is a
-      // no-op for Compose-app consumers that already get foundation via
-      // their BOM, and a fix for tile-only consumers that don't.
+      // Same `${variantName}Implementation` floor pattern as compose-ui, and
+      // versioned by the same rule — foundation and ui have to stay on one
+      // line, so this uses [mainVariantComposeVersion] too.
       addPluginDependency(
         project,
         "${variantName}Implementation",
-        "androidx.compose.foundation:foundation:$RENDERER_COMPOSE_FLOOR_VERSION",
+        "androidx.compose.foundation:foundation:${mainVariantComposeVersion(project, variantName)}",
       )
       recordInjectedDependency(
         project,

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -8,6 +8,8 @@ import com.android.build.api.variant.ScopedArtifacts
 import com.android.build.api.variant.Variant
 import ee.schimke.composeai.daemonlaunch.*
 import ee.schimke.composeai.discovery.*
+import java.util.Collections
+import java.util.IdentityHashMap
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -256,11 +258,37 @@ internal object AndroidPreviewSupport {
    * Compose Multiplatform transitives stay on the graph — they are the render classpath's only
    * Compose, and with nothing to conflict against there is no version pressure to remove.
    *
+   * **Our own injected Compose does not count.** The plugin puts `androidx.compose.ui:ui` and
+   * `androidx.compose.foundation:foundation` (at [RENDERER_COMPOSE_FLOOR_VERSION]) on the main
+   * variant precisely *because* a tile-only consumer has none — the merged unit-test resource APK
+   * needs those R classes. Counting them as "the consumer brings Compose" is circular, and it is
+   * exactly what made the first attempt at this gate a no-op on `wear-os-samples/WearTilesKotlin`:
+   * the probe saw a declared `androidx.compose.ui`, kept Rule 3 on, dropped the Compose
+   * Multiplatform transitives that carry compose-ui 1.11.x, and left the render classpath on the
+   * 1.9.5 floor — against which the renderer's own bytecode does not link:
+   * ```
+   * NoSuchMethodError: 'kotlin.jvm.functions.Function1
+   *   androidx.compose.ui.node.ComposeUiNode$Companion.getApplyOnDeactivatedNodeAssertion()'
+   *     at …renderer.RobolectricRenderTestBase.MeasuredWrapBox(RobolectricRenderTest.kt:2998)
+   * ```
+   *
+   * So the probe skips every dependency the plugin itself contributed, tracked by identity via
+   * [addPluginDependency]. Identity rather than coordinate matching keeps a consumer's own
+   * `androidx.compose.ui:ui` visible even though we inject that same coordinate beside it.
+   *
+   * One deliberate limit: Gradle's `DependencySet` collapses *equal* dependencies, so a consumer
+   * declaring the identical coordinate **and** version we inject leaves one instance — ours — and
+   * reads as Compose-less. That is the safe direction. Such a consumer's only Compose would be the
+   * floor itself, and Rule 3 ON would strip our transitives and leave the renderer unlinkable
+   * against it, exactly as above.
+   *
    * Read eagerly: every caller runs from the Android registration's `afterEvaluate`, so the
-   * consumer's build script has already declared its dependencies and applied its plugins.
+   * consumer's build script has already declared its dependencies and applied its plugins. The
+   * identity check makes the answer independent of whether our injections have happened yet.
    */
   internal fun consumerBringsOwnCompose(project: Project, configuration: Configuration?): Boolean {
     if (COMPOSE_COMPILER_PLUGIN_IDS.any(project.plugins::hasPlugin)) return true
+    val ours = pluginInjectedDependencies(project)
     // Walk `extendsFrom` ourselves rather than calling `Configuration.getHierarchy()`, which is on
     // the Gradle 10 removal list; the closure is tiny and cycles are impossible in Gradle's own
     // model, but `seen` keeps this total either way.
@@ -271,6 +299,7 @@ internal object AndroidPreviewSupport {
       if (!seen.add(candidate)) continue
       val declaresCompose =
         candidate.dependencies.any { dependency ->
+          if (dependency in ours) return@any false
           val group = dependency.group.orEmpty()
           // Bare `androidx.compose` too: that is the BOM's group (`androidx.compose:compose-bom`),
           // which is often the only Compose coordinate a consumer names directly.
@@ -283,6 +312,41 @@ internal object AndroidPreviewSupport {
     }
     return false
   }
+
+  /**
+   * Adds a dependency the PLUGIN contributes (as opposed to one the consumer declared) and records
+   * it so [consumerBringsOwnCompose] can tell the two apart. Use this for every
+   * `androidx.compose.*` / `org.jetbrains.compose.*` coordinate the plugin injects; anything else
+   * is optional, since the probe only ever looks at Compose groups.
+   */
+  internal fun addPluginDependency(
+    project: Project,
+    configurationName: String,
+    notation: Any,
+  ): Dependency {
+    val dependency = project.dependencies.add(configurationName, notation)
+    if (dependency != null) pluginInjectedDependencies(project).add(dependency)
+    return dependency ?: project.dependencies.create(notation)
+  }
+
+  /**
+   * Per-project identity set of the dependencies [addPluginDependency] contributed. Stored on the
+   * project's extra properties so it is scoped to (and collected with) the project rather than held
+   * in a static map. Identity-based, so two equal-but-distinct `Dependency` instances — ours and a
+   * consumer's — never alias.
+   */
+  private fun pluginInjectedDependencies(project: Project): MutableSet<Dependency> {
+    val extra = project.extensions.extraProperties
+    if (extra.has(PLUGIN_INJECTED_DEPENDENCIES_KEY)) {
+      @Suppress("UNCHECKED_CAST")
+      return extra.get(PLUGIN_INJECTED_DEPENDENCIES_KEY) as MutableSet<Dependency>
+    }
+    val set = Collections.newSetFromMap(IdentityHashMap<Dependency, Boolean>())
+    extra.set(PLUGIN_INJECTED_DEPENDENCIES_KEY, set)
+    return set
+  }
+
+  private const val PLUGIN_INJECTED_DEPENDENCIES_KEY = "composeai.pluginInjectedDependencies"
 
   /**
    * Compose compiler plugin ids — the Kotlin 2.x plugin every consumer with `@Composable` code
@@ -1156,11 +1220,13 @@ internal object AndroidPreviewSupport {
     // ui-test entry points are guaranteed to exist. Bumping it later means bumping the renderer's
     // compile floor in lockstep — keep the two in sync.
     if (manageDependencies) {
-      project.dependencies.add(
+      addPluginDependency(
+        project,
         "testImplementation",
         "androidx.compose.ui:ui-test-manifest:$RENDERER_COMPOSE_FLOOR_VERSION",
       )
-      project.dependencies.add(
+      addPluginDependency(
+        project,
         "testImplementation",
         "androidx.compose.ui:ui-test-junit4:$RENDERER_COMPOSE_FLOOR_VERSION",
       )
@@ -1256,7 +1322,8 @@ internal object AndroidPreviewSupport {
       // with consumer-aligned versions, so this is a no-op for Compose-app
       // consumers that already get a newer ui via their BOM, and a fix for
       // tile-only consumers that don't.
-      project.dependencies.add(
+      addPluginDependency(
+        project,
         "${variantName}Implementation",
         "androidx.compose.ui:ui:$RENDERER_COMPOSE_FLOOR_VERSION",
       )
@@ -1276,7 +1343,8 @@ internal object AndroidPreviewSupport {
       // Gradle picks the max with consumer-aligned versions, so this is a
       // no-op for Compose-app consumers that already get foundation via
       // their BOM, and a fix for tile-only consumers that don't.
-      project.dependencies.add(
+      addPluginDependency(
+        project,
         "${variantName}Implementation",
         "androidx.compose.foundation:foundation:$RENDERER_COMPOSE_FLOOR_VERSION",
       )
@@ -1439,7 +1507,8 @@ internal object AndroidPreviewSupport {
           // Pinned to the same renderer-compile-floor as ui-test-manifest above so consumers
           // without a Compose BOM (tile-only / older-Compose) still resolve a version. See the
           // [RENDERER_COMPOSE_FLOOR_VERSION] KDoc for the resolution model.
-          project.dependencies.add(
+          addPluginDependency(
+            project,
             "testImplementation",
             "androidx.compose.runtime:runtime-tracing:$RENDERER_COMPOSE_FLOOR_VERSION",
           )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -217,6 +217,12 @@ internal object AndroidPreviewSupport {
    * Applied to every dependency the plugin contributes, not just the Compose-carrying ones: the
    * excludes are inert on a subtree that has no `org.jetbrains.compose.*` in it, and a uniform rule
    * cannot be defeated by a future connector quietly gaining an `api(…)` edge to one.
+   *
+   * …but only when there IS a consumer Compose to defer to — see [consumerBringsOwnCompose]. Rule 3
+   * is "the consumer's Compose wins", which presumes the consumer has one. Applied to a module that
+   * doesn't, it wins nothing and empties the render classpath instead (issue #3484 —
+   * `wear-os-samples/WearTilesKotlin`, a protolayout-tiles app with no `androidx.compose.*` on its
+   * graph at all, lost all 188 previews once Rule 3 dropped the only Compose there was: ours).
    */
   internal fun addRenderGraphDependency(
     project: Project,
@@ -224,7 +230,8 @@ internal object AndroidPreviewSupport {
     notation: Any,
   ): Dependency {
     val dependency = if (notation is Dependency) notation else project.dependencies.create(notation)
-    if (dependency is ModuleDependency) {
+    val configuration = project.configurations.findByName(configurationName)
+    if (dependency is ModuleDependency && consumerBringsOwnCompose(project, configuration)) {
       COMPOSE_MULTIPLATFORM_ANDROID_ALIAS_GROUPS.forEach { group ->
         dependency.exclude(mapOf("group" to group))
       }
@@ -232,6 +239,66 @@ internal object AndroidPreviewSupport {
     project.dependencies.add(configurationName, dependency)
     return dependency
   }
+
+  /**
+   * Whether the consumer has Compose of its own on [configuration]'s graph — the precondition for
+   * Rule 3 (see [addRenderGraphDependency]).
+   *
+   * Two signals, either sufficient, both readable without resolving anything:
+   * * a declared `androidx.compose.*` / `org.jetbrains.compose.*` dependency anywhere in the
+   *   configuration's `extendsFrom` hierarchy, which is where the consumer's unit-test classpath
+   *   sits — `wear-os-samples/ComposeStarter` declares the Compose BOM plus `ui-tooling`, and a
+   *   Compose Multiplatform consumer declares `implementation(compose.material3)`;
+   * * the Compose compiler plugin, which every module holding a `@Composable @Preview` must apply
+   *   and which a Wear-tiles module (whose previews are protolayout, not Compose) does not.
+   *
+   * A module matching neither has no Compose to defer to. Rule 3 stays off there and our own
+   * Compose Multiplatform transitives stay on the graph — they are the render classpath's only
+   * Compose, and with nothing to conflict against there is no version pressure to remove.
+   *
+   * Read eagerly: every caller runs from the Android registration's `afterEvaluate`, so the
+   * consumer's build script has already declared its dependencies and applied its plugins.
+   */
+  internal fun consumerBringsOwnCompose(project: Project, configuration: Configuration?): Boolean {
+    if (COMPOSE_COMPILER_PLUGIN_IDS.any(project.plugins::hasPlugin)) return true
+    // Walk `extendsFrom` ourselves rather than calling `Configuration.getHierarchy()`, which is on
+    // the Gradle 10 removal list; the closure is tiny and cycles are impossible in Gradle's own
+    // model, but `seen` keeps this total either way.
+    val seen = mutableSetOf<Configuration>()
+    val pending = ArrayDeque(listOfNotNull(configuration))
+    while (pending.isNotEmpty()) {
+      val candidate = pending.removeFirst()
+      if (!seen.add(candidate)) continue
+      val declaresCompose =
+        candidate.dependencies.any { dependency ->
+          val group = dependency.group.orEmpty()
+          // Bare `androidx.compose` too: that is the BOM's group (`androidx.compose:compose-bom`),
+          // which is often the only Compose coordinate a consumer names directly.
+          COMPOSE_CONSUMER_GROUP_PREFIXES.any { prefix ->
+            group == prefix || group.startsWith("$prefix.")
+          }
+        }
+      if (declaresCompose) return true
+      pending.addAll(candidate.extendsFrom)
+    }
+    return false
+  }
+
+  /**
+   * Compose compiler plugin ids — the Kotlin 2.x plugin every consumer with `@Composable` code
+   * applies, and the legacy AndroidX id for older consumers. Used by [consumerBringsOwnCompose].
+   */
+  private val COMPOSE_COMPILER_PLUGIN_IDS =
+    listOf("org.jetbrains.kotlin.plugin.compose", "androidx.compose.compiler")
+
+  /**
+   * Dependency-group roots that mean "this consumer has Compose of its own". Matched exactly or as
+   * a `<prefix>.` parent, so `androidx.compose` (the BOM) counts alongside `androidx.compose.ui`.
+   * Deliberately NOT `androidx.wear.compose`: Wear Compose is additive on top of `androidx.compose`
+   * rather than a substitute for it, so a module that has it also has the real thing and is caught
+   * by these roots anyway.
+   */
+  private val COMPOSE_CONSUMER_GROUP_PREFIXES = listOf("androidx.compose", "org.jetbrains.compose")
 
   internal fun kmpAndroidSiblingName(group: String, name: String): String? {
     if (!group.startsWith("androidx.") && !group.startsWith("org.jetbrains.compose.")) {

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphComposeExclusionTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphComposeExclusionTest.kt
@@ -36,13 +36,27 @@ class RenderGraphComposeExclusionTest {
 
   private fun project() = ProjectBuilder.builder().build()
 
+  /**
+   * A render configuration shaped like a Compose consumer's: it `extendsFrom` the unit-test
+   * classpath, and that classpath carries the consumer's own Compose. Rule 3 only applies to a
+   * consumer that has Compose of its own to defer to.
+   */
+  private fun composeConsumerRenderConfiguration(project: org.gradle.api.Project) =
+    project.configurations.create("composePreviewAndroidRendererDebug").apply {
+      val unitTest =
+        project.configurations.create("debugUnitTestRuntimeClasspath").apply {
+          project.dependencies.add(name, "androidx.compose.ui:ui:1.10.6")
+        }
+      extendsFrom(unitTest)
+    }
+
   @Test
   fun `our own render dependency excludes the compose multiplatform families that alias androidx`() {
     // These six publish Android variants with NO files — they exist only to depend on the matching
     // `androidx.compose.*` artifact, so dropping them from OUR subtree removes version pressure
     // and zero classes.
     val project = project()
-    val configuration = project.configurations.create("composePreviewAndroidRendererDebug")
+    val configuration = composeConsumerRenderConfiguration(project)
 
     val dependency =
       AndroidPreviewSupport.addRenderGraphDependency(
@@ -113,7 +127,7 @@ class RenderGraphComposeExclusionTest {
     // The consumer's own Compose is exactly what the rule exists to preserve. Excluding any
     // `androidx.compose.*` group would empty the render classpath instead of deferring to it.
     val project = project()
-    val configuration = project.configurations.create("composePreviewAndroidRendererDebug")
+    val configuration = composeConsumerRenderConfiguration(project)
 
     val dependency =
       AndroidPreviewSupport.addRenderGraphDependency(
@@ -126,5 +140,45 @@ class RenderGraphComposeExclusionTest {
         dependency.excludeRules.mapNotNull { it.group }.filter { it.startsWith("androidx.") }
       )
       .isEmpty()
+  }
+
+  @Test
+  fun `a consumer with no compose of its own keeps ours on the render graph`() {
+    // Issue #3484. Rule 3 says "the consumer's Compose wins" — a consumer that HAS none wins
+    // nothing, and excluding ours leaves the render classpath with no Compose at all. That is
+    // `wear-os-samples/WearTilesKotlin`: a protolayout-tiles app whose previews are tiles, whose
+    // dependencies are `androidx.wear.tiles` / `androidx.wear.protolayout.*`, and which lost all
+    // 188 renders the moment our own Compose Multiplatform transitives were dropped.
+    val project = project()
+    val configuration =
+      project.configurations.create("composePreviewAndroidRendererDebug").apply {
+        val unitTest =
+          project.configurations.create("debugUnitTestRuntimeClasspath").apply {
+            project.dependencies.add(name, "androidx.wear.protolayout:protolayout-material3:1.4.0")
+          }
+        extendsFrom(unitTest)
+      }
+
+    val dependency =
+      AndroidPreviewSupport.addRenderGraphDependency(
+        project,
+        configuration.name,
+        "ee.schimke.composeai:renderer-android:0.0.0",
+      ) as ModuleDependency
+
+    assertThat(dependency.excludeRules).isEmpty()
+  }
+
+  @Test
+  fun `a consumer's compose reached only through extendsFrom still counts`() {
+    // The consumer's Compose sits on the unit-test classpath the render configuration extends, not
+    // on the render configuration itself, so the probe has to walk `extendsFrom` to see it.
+    // Reading only the render configuration's own dependencies would classify every Compose
+    // consumer as Compose-less and turn Rule 3 off exactly where it is needed.
+    val project = project()
+    val configuration = composeConsumerRenderConfiguration(project)
+
+    assertThat(AndroidPreviewSupport.consumerBringsOwnCompose(project, configuration)).isTrue()
+    assertThat(configuration.dependencies).isEmpty()
   }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphComposeExclusionTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphComposeExclusionTest.kt
@@ -170,6 +170,111 @@ class RenderGraphComposeExclusionTest {
   }
 
   @Test
+  fun `our own injected compose floor does not make a consumer look like a compose consumer`() {
+    // The regression that made the first version of this gate a no-op. The plugin injects
+    // `androidx.compose.ui:ui` / `foundation` at the renderer's floor onto a tile-only consumer's
+    // main variant *because* it has no Compose — the merged unit-test resource APK needs those R
+    // classes. A probe that counts them concludes "this consumer brings its own Compose", keeps
+    // Rule 3 on, and drops the Compose Multiplatform transitives that carry compose-ui 1.11.x —
+    // leaving the render classpath on the 1.9.5 floor, which the renderer's own bytecode does not
+    // link against:
+    //
+    //   NoSuchMethodError: androidx.compose.ui.node.ComposeUiNode$Companion
+    //     .getApplyOnDeactivatedNodeAssertion()
+    //
+    // (issue #3484 — all 188 `wear-os-samples/WearTilesKotlin` previews, unchanged by the gate.)
+    val project = project()
+    val unitTest = project.configurations.create("debugUnitTestRuntimeClasspath")
+    val configuration =
+      project.configurations.create("composePreviewAndroidRendererDebug").apply {
+        extendsFrom(unitTest)
+      }
+    // Exactly what the plugin contributes for a tile-only consumer.
+    AndroidPreviewSupport.addPluginDependency(
+      project,
+      unitTest.name,
+      "androidx.compose.ui:ui:${AndroidPreviewSupport.RENDERER_COMPOSE_FLOOR_VERSION}",
+    )
+    AndroidPreviewSupport.addPluginDependency(
+      project,
+      unitTest.name,
+      "androidx.compose.foundation:foundation:" +
+        AndroidPreviewSupport.RENDERER_COMPOSE_FLOOR_VERSION,
+    )
+
+    assertThat(AndroidPreviewSupport.consumerBringsOwnCompose(project, configuration)).isFalse()
+
+    val dependency =
+      AndroidPreviewSupport.addRenderGraphDependency(
+        project,
+        configuration.name,
+        "ee.schimke.composeai:renderer-android:0.0.0",
+      ) as ModuleDependency
+    assertThat(dependency.excludeRules).isEmpty()
+  }
+
+  @Test
+  fun `a real compose consumer still counts with our floor alongside it`() {
+    // The other side of the skip: our floor pins land on a Compose consumer too, so skipping them
+    // must not blind the probe to the Compose that consumer actually declared. This is the
+    // `ComposeStarter` shape — its own Compose at a different version than our floor — and Rule 3
+    // has to stay on for it, which is what keeps the R$id skew of #3447 fixed.
+    val project = project()
+    val unitTest = project.configurations.create("debugUnitTestRuntimeClasspath")
+    val configuration =
+      project.configurations.create("composePreviewAndroidRendererDebug").apply {
+        extendsFrom(unitTest)
+      }
+    AndroidPreviewSupport.addPluginDependency(
+      project,
+      unitTest.name,
+      "androidx.compose.ui:ui:${AndroidPreviewSupport.RENDERER_COMPOSE_FLOOR_VERSION}",
+    )
+    project.dependencies.add(unitTest.name, "androidx.compose.ui:ui:1.10.6")
+
+    assertThat(AndroidPreviewSupport.consumerBringsOwnCompose(project, configuration)).isTrue()
+
+    val dependency =
+      AndroidPreviewSupport.addRenderGraphDependency(
+        project,
+        configuration.name,
+        "ee.schimke.composeai:renderer-android:0.0.0",
+      ) as ModuleDependency
+    assertThat(dependency.excludeRules.mapNotNull { it.group })
+      .containsAtLeastElementsIn(aliasGroups)
+  }
+
+  @Test
+  fun `a consumer declaring exactly our floor coordinate collapses onto ours`() {
+    // Documents a real limit rather than asserting around it. Gradle's `DependencySet` collapses
+    // equal dependencies, so a consumer declaring the identical coordinate AND version we inject
+    // leaves exactly one instance — the one we registered — and the probe reads it as ours.
+    //
+    // Deliberately left this way: that consumer's only Compose would be the 1.9.5 floor, and Rule 3
+    // ON would strip our Compose Multiplatform transitives and leave the renderer's own bytecode
+    // unlinkable against it (the `getApplyOnDeactivatedNodeAssertion` NoSuchMethodError above).
+    // Answering "no consumer Compose" here keeps the render classpath on a version the renderer can
+    // actually run against, which is the safe direction for the ambiguous case.
+    val project = project()
+    val unitTest = project.configurations.create("debugUnitTestRuntimeClasspath")
+    val configuration =
+      project.configurations.create("composePreviewAndroidRendererDebug").apply {
+        extendsFrom(unitTest)
+      }
+    AndroidPreviewSupport.addPluginDependency(
+      project,
+      unitTest.name,
+      "androidx.compose.ui:ui:${AndroidPreviewSupport.RENDERER_COMPOSE_FLOOR_VERSION}",
+    )
+    project.dependencies.add(
+      unitTest.name,
+      "androidx.compose.ui:ui:${AndroidPreviewSupport.RENDERER_COMPOSE_FLOOR_VERSION}",
+    )
+
+    assertThat(AndroidPreviewSupport.consumerBringsOwnCompose(project, configuration)).isFalse()
+  }
+
+  @Test
   fun `a consumer's compose reached only through extendsFrom still counts`() {
     // The consumer's Compose sits on the unit-test classpath the render configuration extends, not
     // on the render configuration itself, so the probe has to walk `extendsFrom` to see it.

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphComposeExclusionTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphComposeExclusionTest.kt
@@ -286,4 +286,31 @@ class RenderGraphComposeExclusionTest {
     assertThat(AndroidPreviewSupport.consumerBringsOwnCompose(project, configuration)).isTrue()
     assertThat(configuration.dependencies).isEmpty()
   }
+
+  @Test
+  fun `main-variant compose pin follows whichever compose actually runs`() {
+    // The second face of the #3484 failure. With Rule 3 correctly OFF for a tile-only consumer, the
+    // render classpath's compose-ui is OURS (1.11.2, via Compose Multiplatform) — but the merged
+    // unit-test resource APK is built from the consumer's MAIN variant, so pinning that at the
+    // 1.9.5 floor leaves newer classes reading an older R class:
+    //
+    //   NoSuchFieldError: Class androidx.compose.ui.R$id does not have member field
+    //     'int androidx_compose_ui_view_compose_view_context'
+    //       at ComposeView_androidKt.getComposeViewContext
+    //
+    // Verified against the published artifacts: ui-android 1.9.5's R.txt has no such id, 1.11.2's
+    // does. So the pin has to follow whichever Compose actually runs.
+    val tileOnly = project()
+    tileOnly.configurations.create("debugUnitTestRuntimeClasspath")
+    assertThat(AndroidPreviewSupport.mainVariantComposeVersion(tileOnly, "debug"))
+      .isEqualTo(AndroidPreviewSupport.RENDERER_COMPOSE_CMP_RUNTIME_VERSION)
+
+    // A Compose consumer keeps Rule 3, so its own Compose runs and its BOM wins over our floor —
+    // raising the floor there would push it off its own Compose line for no reason.
+    val composeApp = project()
+    val unitTest = composeApp.configurations.create("debugUnitTestRuntimeClasspath")
+    composeApp.dependencies.add(unitTest.name, "androidx.compose.ui:ui:1.10.6")
+    assertThat(AndroidPreviewSupport.mainVariantComposeVersion(composeApp, "debug"))
+      .isEqualTo(AndroidPreviewSupport.RENDERER_COMPOSE_FLOOR_VERSION)
+  }
 }


### PR DESCRIPTION
Three jobs are red on `main` ([CI run 31228260935](https://github.com/yschimke/compose-ai-tools/actions/runs/31228260935), [Integration run 31228260860](https://github.com/yschimke/compose-ai-tools/actions/runs/31228260860)). All three are fallout from the Compose Multiplatform 1.11.1 bump (#3462) — one from the SDK it now needs, two from Rule 3, the render-graph exclusion that PR added to contain it.

## CI / CMP Remote Compose Player

`:rc-player-compose:linkDebugTestIosSimulatorArm64` dies ~17 min in:

```
ld: warning: Could not find or use auto-linked framework 'UIUtilities'
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_UIViewLayoutRegion", referenced from:
       in liborg.jetbrains.compose.ui:ui-uikit-cache.a[20](CMPLayoutRegion.o)
```

`UIViewLayoutRegion` is an iOS 26 API. The `macos-15` image has Xcode 26.0.1 / 26.1.1 / 26.2 / 26.3 installed but still **defaults** to 16.4, whose iOS 18.5 SDK has no such class. Added a step that selects the newest installed `Xcode_26*.app` before the Gradle invocation — newest-installed rather than a pin, so an image refresh retiring a point release doesn't take the job with it, and a hard failure with the available-Xcode listing if none is present.

## Integration / wear-os-samples (ComposeStarter)

Every preview fails in the renderer's own code, before user code runs:

```
RuntimeError: renderFailed: {'kind': 'classpathSkew',
  'message': 'NoClassDefFoundError: androidx/compose/material3/ColorScheme'}
    at ee.schimke.composeai.daemon.RenderEngine…evaluate$lambda$1$0$2(RenderEngine.kt:442)
```

A Wear app themes with `androidx.wear.compose.material3` and has **no** `androidx.compose.material3` anywhere on its graph. Material 3 is `compileOnly` on `:daemon:android` precisely so the consumer's copy wins at runtime, and Rule 3 stopped ours being smuggled in behind its back — so `CaptureMaterialTheme` had nothing to load.

The daemon now probes the classpath and skips both the theme capture and the `compose/theme` payload (which reads Material 3 objects out of the slot tables) when there is none. Everything downstream is already nullable, so such a render degrades to "no Material 3 theme reported" rather than failing. This is the shape `renderers/android` has always had — `WearMaterialTheme` reads Wear's theme reflectively, and its Material 3 reads sit behind theme-catalog render modes, which is why the Gradle render path survived this and the daemon path didn't.

## Integration / wear-os-samples (WearTilesKotlin)

`composePreviewRender` succeeds but every one of the 188 renders writes an `.error.json` sidecar, so `Verify PNGs were produced` fails.

Both of the original hypotheses were wrong, and the diagnostics commit is what settled it. Neither the Rule 3 gate as first written nor `compileSdk = 37` exceeding Robolectric's max SDK was the cause — the `compileSdk 37` warning is real and appears on every run of this leg, but it is a clamp notice, not the failure. The sidecars named the actual cause, twice, and the two exceptions turned out to be two faces of one skew.

**First: the classes were too old.**

```
NoSuchMethodError: 'kotlin.jvm.functions.Function1 androidx.compose.ui.node
  .ComposeUiNode$Companion.getApplyOnDeactivatedNodeAssertion()'
    at …renderer.RobolectricRenderTestBase.MeasuredWrapBox(RobolectricRenderTest.kt:2998)
```

The gate was reading **the plugin's own injection** as the consumer's Compose. For a tile-only consumer the plugin injects `androidx.compose.ui:ui` and `androidx.compose.foundation:foundation` at `RENDERER_COMPOSE_FLOOR_VERSION` (1.9.5) onto the main variant precisely *because* it has none — the merged unit-test resource APK needs those R classes. The probe saw a declared `androidx.compose.ui`, concluded the consumer had Compose, and left Rule 3 on. Rule 3 then dropped the Compose Multiplatform transitives carrying compose-ui 1.11.2, leaving the render classpath on the 1.9.5 floor, which the renderer's own bytecode does not link against. Circular: we injected the Compose that convinced us not to supply Compose.

Fixed by tracking the dependencies the plugin contributes (`addPluginDependency`, an identity set on the project's extra properties) and skipping them in the probe. Identity rather than coordinate, so a consumer's own `androidx.compose.ui:ui` still registers next to our floor pin — `ComposeStarter` still matches, and the R$id skew of #3447 that Rule 3 exists for stays fixed.

One deliberate limit, tested and documented rather than worked around: Gradle's `DependencySet` collapses *equal* dependencies, so a consumer declaring the identical coordinate **and** version we inject reads as Compose-less. That is the safe direction — its only Compose would be the floor, and Rule 3 ON would strip our transitives and leave the renderer unlinkable against it.

**Then: the resources were too old.** With Rule 3 correctly off, the same 188 previews failed on a *different* exception:

```
NoSuchFieldError: Class androidx.compose.ui.R$id does not have member field
  'int androidx_compose_ui_view_compose_view_context'
    at ComposeView_androidKt.getComposeViewContext(ComposeView.android.kt:762)
```

The render classpath's compose-ui was now ours (1.11.2), but the merged unit-test resource APK is built from the consumer's **main variant**, still pinned at the 1.9.5 floor. Newer classes, older R class.

So the main-variant `androidx.compose.ui` / `foundation` pins are now versioned by *which Compose actually runs*, rather than always by the renderer's compile floor:

* **Compose consumer** — Rule 3 on, its own Compose runs and its BOM wins over our floor anyway. Unchanged; raising the floor would push it off its own Compose line for no reason.
* **Compose-less consumer** — Rule 3 off, OUR compose-ui runs, so its resources have to be on that same line.

Both version facts were read off the published artifacts rather than inferred, which is the habit this leg has repeatedly punished skipping: `ui-android` 1.9.5's `R.txt` carries no `androidx_compose_ui_view_compose_view_context` and 1.11.2's does, and the CMP→androidx mapping comes from `org/jetbrains/compose/ui/ui/1.11.1/ui-1.11.1.pom` — it does **not** track the CMP version (1.11.1 maps to 1.11.2), so the constant documents that trap for the next bump.

Two things this exposed that are **not** fixed here, flagged for a decision:

* The `wear-os-samples` cells track `ref: main`, so upstream drift lands in our CI unannounced. WearTilesKotlin has since moved to AGP 9.2.0 / `compileSdk = 37`, which trips our own "exceeds Robolectric's max supported SDK (36); clamping" warning on every run of this leg. Harmless today — it was the runner-up hypothesis and the evidence cleared it — but it is a live source of unrelated red.
* `WearTilesKotlin` is not `pr_blocking`, so on a normal PR every step in it is skipped and the leg reports green regardless. That is what let a broken leg look fixed twice; the runs proving these fixes are manual `workflow_dispatch` runs, where `event_name != 'pull_request'` makes the matrix do real work.

## Diagnostics

`Verify PNGs were produced` used to print the sidecar *paths* and nothing else — 188 filenames and not one word about what threw, with the only route to the exception being a download of the renders artifact (which the network policy blocks from some environments). It now groups sidecars by `(exception, message)` and prints the dominant cause's stack trace, riding in the bundle like `android-all-cache-key.py` since these legs have no checkout. That is what turned this diagnosis from inference into evidence.

## Test plan

- `./gradlew -p gradle-plugin :test --tests '*RenderGraphComposeExclusionTest*'` — ✅ 11 tests. New: our injected floor doesn't make a tile-only consumer look like a Compose consumer (asserted on both the probe and the resulting exclude rules); a real Compose consumer still counts with our floor beside it; the equal-coordinate collapse above; and the main-variant pin following the CMP runtime version on a tile-only consumer while staying on the floor for a Compose consumer.
- `./gradlew -p gradle-plugin :test` — ✅ full plugin unit suite.
- `./gradlew :daemon:android:testDebugUnitTest --tests '*Material3ClasspathProbeTest*'` — ✅ pins both answers of the probe, with a hiding `ClassLoader` standing in for a Wear consumer's render classpath.
- `./gradlew ktfmtFormatAll` — ✅ clean.
- Summarizer exercised over hand-built sidecars: several previews sharing one cause, a second distinct cause, a sidecar with no `topAppFrame`, and an unparseable file.
- End-to-end gate is a manually dispatched Integration run, since the tiles leg does no work on a `pull_request` event.

## Note on evidence

No visual evidence: nothing here changes a rendered surface. The two Integration legs render the same previews they always did — the fix is that they render *at all* again, which the job's own `Verify PNGs were produced` and daemon round-trip steps assert.