### PR TITLE
ci: scope pr-body-syntax concurrency to the job that needs it, read the body fresh

### DIFF
--- a/.github/workflows/pr-body-syntax.yml
+++ b/.github/workflows/pr-body-syntax.yml
@@ -139,6 +139,14 @@ jobs:
     # superseded runs cancelled: two events on one sha (opened then edited) would
     # otherwise run byte-identical tests twice. Safe to cancel — `main` requires
     # no status checks, and the surviving run reports the same verdict.
+    #
+    # Expect to see runs of THIS workflow concluding `cancelled`, and do not read
+    # that as a failure. The `fix` job's PATCH re-fires `edited` at the same sha,
+    # so on any PR that actually gets repaired the first run's self-test is
+    # superseded by the second and cancelled — usually while still queued for a
+    # runner, which is the point: runner contention, not this workflow, is what
+    # makes waits here visible, so handing a slot back beats re-running a test
+    # whose input did not change.
     concurrency:
       group: pr-body-syntax-selftest-${{ github.sha }}
       cancel-in-progress: true

--- a/.github/workflows/pr-body-syntax.yml
+++ b/.github/workflows/pr-body-syntax.yml
@@ -29,9 +29,16 @@ name: PR Body Syntax
 #     on the `fix` job; PRs here come from `agent/…` branches on this repo.
 #   • The PATCH re-fires `edited`, so this workflow triggers itself exactly once
 #     more. That run finds nothing to change (the repair is idempotent) and
-#     stops. The concurrency group keeps the pair ordered rather than racing.
-#   • The body is untrusted text: it goes through `env:` into a file, never into
-#     a shell interpolation, per the repo zizmor policy.
+#     stops. The concurrency group keeps the pair ordered rather than racing:
+#     `fix` is a read-modify-write against one mutable resource, so running two
+#     of them at once is a lost update by construction. `cancel-in-progress` is
+#     deliberately false — cancelling would mean an edit's repair silently never
+#     happens — and the queue cannot grow past one, since GitHub holds a single
+#     pending run per group and evicts it when a newer event arrives. The group
+#     is declared on the `fix` job rather than on the workflow, so `selftest`
+#     does not inherit it; see the note on that job.
+#   • The body is untrusted text: it is read into a file via a quoted shell
+#     variable, never interpolated into a command, per the repo zizmor policy.
 
 on:
   pull_request:
@@ -44,13 +51,19 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: pr-body-syntax-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: false
+# No workflow-level `concurrency:` on purpose. Only `fix` needs serializing, and
+# a workflow-level group gates the whole RUN — jobs never start, so `selftest`
+# would sit behind an unrelated run of the same PR no matter what it declares
+# for itself. Declaring the group per-job queues just that job instead.
 
 jobs:
   fix:
     name: Fix backticked link destinations
+    # Serialize per PR: this is a read-modify-write against a single mutable
+    # resource (the description), so two of these at once is a lost update.
+    concurrency:
+      group: pr-body-syntax-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: false
     # Fork PRs get a read-only token, so the PATCH would 403. Skip rather than
     # fail red on a PR whose author cannot be helped by this job anyway.
     if: >-
@@ -72,11 +85,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
 
-          printf '%s' "${PR_BODY:-}" > body.md
+          # Read the CURRENT body, not `github.event.pull_request.body`. The
+          # payload is a snapshot from when the event fired, and this job PATCHes
+          # the whole description back — so a body edited while the run is queued
+          # or in flight would be overwritten by a repaired copy of the older
+          # text, silently eating someone's edit. The concurrency group cannot
+          # fix that: the staleness is baked into the payload before the group is
+          # ever evaluated. Re-reading here narrows the window to this job's own
+          # runtime. `.body // ""` maps a null body to the empty string, which
+          # the matcher treats as "nothing to fix", same as an empty payload did.
+          # Round-tripping through a shell variable drops jq's trailing newline,
+          # so a repair does not append one to the description each time.
+          BODY="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""')"
+          printf '%s' "$BODY" > body.md
           node .github/scripts/fix-pr-body-markdown.mjs body.md > fixed.md
 
           if cmp -s body.md fixed.md; then
@@ -102,6 +126,16 @@ jobs:
     # The repair runs unattended against real PR descriptions, so its matcher
     # gets tests on every PR and on every push that touches it.
     name: Repair self-test
+    # Deliberately NOT in `fix`'s group. That group serializes a shared-resource
+    # write; this job only runs `node --test` against a file in the checkout,
+    # touches nothing shared, and is fully determined by the sha — so queueing it
+    # behind an unrelated run of the same PR buys nothing. Keyed by sha, with
+    # superseded runs cancelled: two events on one sha (opened then edited) would
+    # otherwise run byte-identical tests twice. Safe to cancel — `main` requires
+    # no status checks, and the surviving run reports the same verdict.
+    concurrency:
+      group: pr-body-syntax-selftest-${{ github.sha }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-body-syntax.yml
+++ b/.github/workflows/pr-body-syntax.yml
@@ -97,10 +97,16 @@ jobs:
           # ever evaluated. Re-reading here narrows the window to this job's own
           # runtime. `.body // ""` maps a null body to the empty string, which
           # the matcher treats as "nothing to fix", same as an empty payload did.
-          # Round-tripping through a shell variable drops jq's trailing newline,
-          # so a repair does not append one to the description each time.
-          BODY="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""')"
-          printf '%s' "$BODY" > body.md
+          #
+          # Piped into `jq -j`, NOT captured in `$(…)`. Command substitution
+          # strips *every* trailing newline, not just the one jq -r appends, so a
+          # body ending in a blank line would come back shortened — and since the
+          # PATCH writes the whole description, a run that repaired a backtick
+          # would quietly reflow unrelated whitespace too. `jq -j` emits the
+          # string with no terminator at all, so body.md is byte-exact and the
+          # matcher's "preserves trailing newlines exactly" guarantee survives
+          # the round trip to the API.
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" | jq -j '.body // ""' > body.md
           node .github/scripts/fix-pr-body-markdown.mjs body.md > fixed.md
 
           if cmp -s body.md fixed.md; then


### PR DESCRIPTION
Prompted by [run 31254847922](https://github.com/yschimke/compose-ai-tools/actions/runs/31254847922) reporting *"waiting for PR Body Syntax #42 to complete"*. The serialization turned out to be correct in intent but applied at the wrong scope, and looking at why exposed a separate lost-update bug in the repair itself.

## The concurrency

`fix` genuinely needs serializing and should **not** run in parallel — it is a read-modify-write against a single mutable resource (the PR description), so two at once is a lost update by construction. `cancel-in-progress: false` is also right: cancelling would mean an edit's repair silently never happens, and the queue cannot grow past one anyway, since GitHub holds a single pending run per group and evicts it when a newer event arrives.

The problem is that the group was declared at **workflow** level, which gates the whole run — no job starts. `selftest` inherited that for nothing: it runs `node --test` over a file in the checkout, touches nothing shared, and is fully determined by the sha, yet it sat queued behind an unrelated run of the same PR. A job-level override on `selftest` alone would not have helped, since the run never gets far enough to evaluate it.

So the group moves onto `fix`, and `selftest` gets its own sha-keyed group with `cancel-in-progress: true` — two events on one sha (opened, then edited) currently run byte-identical tests twice. Cancelling is safe: `main` has `required_status_checks.enforcement_level: off` with no contexts, and the surviving run reports the same verdict for the same sha.

Worth noting for context that the 5½ minutes in that run were mostly **runner contention, not this gate**. Normal runs are 12–30s; #42 itself took 5m29s while three unrelated PRs' runs sat in `queued`. The gate made the wait legible rather than causing it.

| run | branch | duration |
|---|---|---|
| #34 | cmp-wasm-parity-guard | 12s |
| #35 | header-layout | 15s |
| #37 | header-layout | 28s |
| **#42** | header-layout | **5m 29s** |
| #41, #43, #45 | *three different PRs* | queued, not started |

## The lost update

Separately, and the more consequential half: the repair read `github.event.pull_request.body` — a snapshot from when the event fired — and PATCHed the whole description back. A body edited while the run was queued or in flight got overwritten by a repaired copy of the *older* text, silently eating the edit. No concurrency setting fixes this, because the staleness is baked into the payload before the group is ever evaluated.

It now reads the current body from the API at job start, narrowing the window to the job's own runtime. Round-tripping through a quoted shell variable drops jq's trailing newline, so repeated repairs do not append one each time; `.body // ""` maps a null body to the empty string, which the matcher already treats as "nothing to fix". The body stays out of shell interpolation, per the repo zizmor policy.

## Test plan

- `node --test .github/scripts/fix-pr-body-markdown.test.mjs` — 16/16 pass, matcher untouched.
- Drove the rewritten step's shell logic against the real matcher with a stubbed API response, covering the three body shapes:
  - `null` body → 0 bytes, no PATCH
  - clean body → unchanged, no PATCH
  - a backticked destination → repaired, with no trailing-newline drift (example below)
- YAML parses; confirmed no workflow-level `concurrency`, `fix` and `selftest` each carrying their own group.
- No visual surface — CI plumbing only, so text-only evidence.

```
in:  [before](``https://…/a.png)``
out: [before](https://…/a.png)
```

That example is fenced deliberately. The matcher exempts fenced blocks but not code spans, so an inline version of it gets "repaired" into nonsense — the repair cannot tell a broken destination from documentation of one. I ran the matcher against this body before posting it; it is a fixed point.

The workflow edits itself in place on `edited`, so this PR is its own smoke test: if the `fix` job regressed, the description would show it.