### PR TITLE
fix(renderer): mirror the capture for real RTL locales, not just ar-XB

### DIFF
--- a/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/LocaleDirection.kt
+++ b/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/LocaleDirection.kt
@@ -7,10 +7,16 @@ package ee.schimke.composeai.data.pseudolocale
  * but leaves the container LTR (start/end padding, row order and chevrons unmirrored), which is not
  * what a real Arabic device shows.
  *
- * Kept as a plain language-code lookup (no `java.util.Locale` / `android.text.TextUtils`) so the
- * exact same decision holds on the Android/Robolectric path and the desktop `ImageComposeScene`
- * path. The set mirrors the RTL languages ICU/`TextUtils.getLayoutDirectionFromLocale` recognise,
- * including the legacy ISO-639 codes (`iw` Hebrew, `ji` Yiddish) alongside their modern spellings.
+ * Kept as a plain subtag lookup (no `java.util.Locale` / `android.text.TextUtils`) so the exact
+ * same decision holds on the Android/Robolectric path and the desktop `ImageComposeScene` path. The
+ * sets mirror what ICU/`TextUtils.getLayoutDirectionFromLocale` recognise, including the legacy
+ * ISO-639 codes (`iw` Hebrew, `ji` Yiddish) alongside their modern spellings.
+ *
+ * **An explicit script subtag wins over the language default**, the way ICU decides it. A language
+ * code only implies a direction because it implies a *script*, so a tag that names the script
+ * outright has already answered the question: `ar-Latn` (Arabic romanised) is LTR despite `ar`, and
+ * `az-Arab` (Azerbaijani in Arabic script) is RTL despite `az`. Language is the fallback for the
+ * common `ar` / `he-IL` shape where no script is written down.
  */
 object LocaleDirection {
   private val RTL_LANGUAGES =
@@ -30,10 +36,35 @@ object LocaleDirection {
       "ji", // Yiddish (legacy)
     )
 
-  /** True when [tag]'s primary language subtag is written right-to-left. */
+  /** ISO 15924 codes for the right-to-left scripts, lowercased for comparison. */
+  private val RTL_SCRIPTS =
+    setOf(
+      "adlm", // Adlam
+      "arab", // Arabic
+      "aran", // Nastaliq (Arabic variant)
+      "hebr", // Hebrew
+      "mand", // Mandaic
+      "nkoo", // N'Ko
+      "rohg", // Hanifi Rohingya
+      "samr", // Samaritan
+      "syrc", // Syriac
+      "thaa", // Thaana
+      "yezi", // Yezidi
+    )
+
+  /**
+   * True when [tag] is written right-to-left — by its explicit script subtag when it carries one,
+   * otherwise by its primary language subtag.
+   */
   fun isRtl(tag: String?): Boolean {
     if (tag.isNullOrBlank()) return false
-    val language = tag.replace('_', '-').substringBefore('-').lowercase()
+    val subtags = tag.replace('_', '-').split('-').filter { it.isNotEmpty() }
+    val language = subtags.firstOrNull()?.lowercase() ?: return false
+    // In BCP-47 the script is the subtag right after the language and is the only 4-alpha one
+    // there: a region is 2 alpha or 3 digits, a variant is 5-8 alphanumeric. Reading strictly by
+    // position keeps a 4-character variant further along the tag from being mistaken for a script.
+    val script = subtags.getOrNull(1)?.takeIf { it.length == 4 && it.all(Char::isLetter) }
+    if (script != null) return script.lowercase() in RTL_SCRIPTS
     return language in RTL_LANGUAGES
   }
 }

--- a/data/pseudolocale/core/src/test/kotlin/ee/schimke/composeai/data/pseudolocale/LocaleDirectionTest.kt
+++ b/data/pseudolocale/core/src/test/kotlin/ee/schimke/composeai/data/pseudolocale/LocaleDirectionTest.kt
@@ -1,0 +1,82 @@
+package ee.schimke.composeai.data.pseudolocale
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [LocaleDirection] is the single source of truth for "does this tag mirror?" across all four
+ * render paths — daemon desktop, daemon Android, the Robolectric plugin path and the desktop batch
+ * renderers — so its answers are pinned here rather than re-derived per renderer.
+ */
+class LocaleDirectionTest {
+
+  @Test
+  fun rtlLanguagesMirror() {
+    assertTrue(LocaleDirection.isRtl("ar"))
+    assertTrue(LocaleDirection.isRtl("he"))
+    assertTrue(LocaleDirection.isRtl("fa"))
+    assertTrue(LocaleDirection.isRtl("ur"))
+    assertTrue(LocaleDirection.isRtl("ps"))
+    assertTrue(LocaleDirection.isRtl("dv"))
+    assertTrue(LocaleDirection.isRtl("ckb"))
+  }
+
+  @Test
+  fun legacyIso639CodesMirrorLikeTheirModernSpellings() {
+    assertTrue(LocaleDirection.isRtl("iw")) // Hebrew
+    assertTrue(LocaleDirection.isRtl("ji")) // Yiddish
+    assertTrue(LocaleDirection.isRtl("yi"))
+  }
+
+  @Test
+  fun ltrLanguagesDoNotMirror() {
+    assertFalse(LocaleDirection.isRtl("en"))
+    assertFalse(LocaleDirection.isRtl("de"))
+    assertFalse(LocaleDirection.isRtl("ja"))
+    assertFalse(LocaleDirection.isRtl("az")) // Latin by default; see the Arab-script case below
+  }
+
+  @Test
+  fun regionAndVariantSubtagsAreIgnored() {
+    assertTrue(LocaleDirection.isRtl("ar-EG"))
+    assertTrue(LocaleDirection.isRtl("he-IL"))
+    assertFalse(LocaleDirection.isRtl("en-GB"))
+    // Underscore form, as a `java.util.Locale.toString()` would spell it.
+    assertTrue(LocaleDirection.isRtl("ar_EG"))
+    // A 4-character *variant* (5-8 alphanumeric is the real rule, but be defensive) must not be
+    // read as a script: `de` stays LTR whatever trails it.
+    assertFalse(LocaleDirection.isRtl("de-DE-1901"))
+  }
+
+  /**
+   * The script subtag is the direct answer where the language code is only a proxy for one. A
+   * language-only lookup gets both of these backwards.
+   */
+  @Test
+  fun explicitScriptBeatsTheLanguageDefault() {
+    // RTL language, LTR script → LTR.
+    assertFalse(LocaleDirection.isRtl("ar-Latn"))
+    assertFalse(LocaleDirection.isRtl("sd-Deva")) // Sindhi in Devanagari
+    assertFalse(LocaleDirection.isRtl("ug-Cyrl")) // Uyghur in Cyrillic
+    assertFalse(LocaleDirection.isRtl("ar-Latn-EG")) // …with a region after the script
+
+    // LTR language, RTL script → RTL.
+    assertTrue(LocaleDirection.isRtl("az-Arab")) // Azerbaijani in Arabic script
+    assertTrue(LocaleDirection.isRtl("pa-Arab")) // Shahmukhi Punjabi
+    assertTrue(LocaleDirection.isRtl("ks-Arab"))
+    assertTrue(LocaleDirection.isRtl("ff-Adlm")) // Fula in Adlam
+    assertTrue(LocaleDirection.isRtl("ar-Arab-EG")) // agreeing script is still RTL
+
+    // Case-insensitive, as BCP-47 tags are.
+    assertTrue(LocaleDirection.isRtl("AZ-ARAB"))
+    assertFalse(LocaleDirection.isRtl("AR-LATN"))
+  }
+
+  @Test
+  fun blankAndNullTagsDoNotMirror() {
+    assertFalse(LocaleDirection.isRtl(null))
+    assertFalse(LocaleDirection.isRtl(""))
+    assertFalse(LocaleDirection.isRtl("   "))
+  }
+}

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRenderer.kt
@@ -127,7 +127,9 @@ fun renderAnimatedPreview(
   val totalDuration = requestedDuration.coerceIn(frameInterval, MAX_ANIMATION_DURATION_MS)
   val frameCount = (totalDuration / frameInterval).coerceAtLeast(1)
 
-  val pseudolocale = ee.schimke.composeai.data.pseudolocale.Pseudolocale.fromTag(localeTag)
+  // `ar-XB` and every real RTL locale (`ar`, `he`, `fa`, …) mirror the captured frames — see
+  // [rendersRightToLeft].
+  val rtl = rendersRightToLeft(localeTag)
   val sceneDensity = Density(density, fontScale)
 
   val frames = mutableListOf<BufferedImage>()
@@ -147,7 +149,7 @@ fun renderAnimatedPreview(
           else -> Color.Transparent
         }
       val baseProviders: @Composable (@Composable () -> Unit) -> Unit = { inner ->
-        if (pseudolocale?.isRtl == true) {
+        if (rtl) {
           CompositionLocalProvider(
             LocalInspectionMode provides false,
             LocalDensity provides sceneDensity,

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -830,6 +830,29 @@ internal fun restoreJvmDefaultLocale(previous: java.util.Locale?) {
   if (previous != null) java.util.Locale.setDefault(previous)
 }
 
+/**
+ * Whether a `localeTag` render should compose with `LayoutDirection.Rtl` — true for the `ar-XB`
+ * bidi pseudolocale **and** for a real RTL locale (`ar`, `he`, `fa`, `ur`, …).
+ *
+ * The real-locale half is the part that was missing on this batch path. [overrideJvmDefaultLocale]
+ * gives `stringResource(...)` the translated copy, so a `@Preview(locale = "ar")` came back with
+ * correctly shaped Arabic — inside a container that was still laid out left-to-right: navigation
+ * icon on the left, FAB bottom-right, start/end padding unmirrored. That is not what an Arabic
+ * device shows, and it made the capture read as "RTL is fine" when the layout had never been
+ * exercised. The daemon desktop `RenderEngine.localeProviders`, the daemon Android `RenderEngine`
+ * and `RobolectricRenderTest` all already consult [LocaleDirection]; the three desktop batch
+ * renderers keyed off `Pseudolocale.isRtl` alone, so `ar-XB` mirrored and `ar` did not.
+ *
+ * Takes the raw tag rather than the effective one: [effectiveLocaleTag] folds `ar-XB` to `en`, and
+ * asking "is `en` RTL?" would lose the pseudolocale's flip. Pseudolocale first, real locale second,
+ * so the two can never double-count.
+ */
+internal fun rendersRightToLeft(localeTag: String?): Boolean {
+  val pseudolocale = ee.schimke.composeai.data.pseudolocale.Pseudolocale.fromTag(localeTag)
+  if (pseudolocale != null) return pseudolocale.isRtl
+  return ee.schimke.composeai.data.pseudolocale.LocaleDirection.isRtl(effectiveLocaleTag(localeTag))
+}
+
 @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
 internal fun renderPreview(
   className: String,
@@ -909,12 +932,13 @@ internal fun renderPreview(
     // onGloballyPositioned. Only read when at least one axis wraps.
     var measured: IntSize? = null
 
-    // Pseudolocale (`en-XA`, `ar-XB`): ar-XB flips `LocalLayoutDirection` to RTL so the captured
-    // PNG mirrors layout. en-XA is a no-op visually on desktop — CMP's
+    // RTL: `ar-XB` (bidi pseudolocale) and every real RTL locale (`ar`, `he`, `fa`, …) flip
+    // `LocalLayoutDirection` so the captured PNG mirrors layout — see [rendersRightToLeft].
+    // en-XA is a no-op visually on desktop — CMP's
     // `org.jetbrains.compose.resources.stringResource` doesn't go through `LocalContext.resources`,
     // so the Resources-subclass trick the Android connector uses doesn't apply here. See the
     // platform-support note in `site/reference/pseudolocale.md`.
-    val pseudolocale = ee.schimke.composeai.data.pseudolocale.Pseudolocale.fromTag(localeTag)
+    val rtl = rendersRightToLeft(localeTag)
     // `@Preview(uiMode = 32)` (`UI_MODE_NIGHT_YES`) must flip the composition to dark, not just
     // tint
     // the system-bar chrome below. Compose Desktop's `isSystemInDarkTheme()` reads
@@ -925,7 +949,7 @@ internal fun renderPreview(
     val systemTheme = systemThemeFromUiMode(uiMode)
     scene.setContent {
       val baseProviders: @Composable (@Composable () -> Unit) -> Unit = { inner ->
-        if (pseudolocale?.isRtl == true) {
+        if (rtl) {
           CompositionLocalProvider(
             LocalInspectionMode provides true,
             LocalDensity provides sceneDensity,

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
@@ -115,7 +115,9 @@ fun renderScrollPreview(
     if (previewArgs.isEmpty()) clazz.getDeclaredComposableMethod(functionName)
     else findComposableMethodForScroll(clazz, functionName, previewArgs)
 
-  val pseudolocale = ee.schimke.composeai.data.pseudolocale.Pseudolocale.fromTag(localeTag)
+  // `ar-XB` and every real RTL locale (`ar`, `he`, `fa`, …) mirror the captured slices — see
+  // [rendersRightToLeft].
+  val rtl = rendersRightToLeft(localeTag)
   var captured = false
 
   val sceneDensity = Density(density, fontScale)
@@ -141,7 +143,7 @@ fun renderScrollPreview(
           else -> Color.Transparent
         }
       val baseProviders: @Composable (@Composable () -> Unit) -> Unit = { inner ->
-        if (pseudolocale?.isRtl == true) {
+        if (rtl) {
           CompositionLocalProvider(
             LocalInspectionMode provides true,
             LocalDensity provides sceneDensity,

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/RendererLocaleTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/RendererLocaleTest.kt
@@ -2,8 +2,10 @@ package ee.schimke.composeai.renderer
 
 import java.util.Locale
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -64,6 +66,38 @@ class RendererLocaleTest {
     } finally {
       Locale.setDefault(original)
     }
+  }
+
+  /**
+   * The direction half of the override, and the one this path was missing: a **real** RTL locale
+   * has to mirror the capture, not just translate it. `@Preview(locale = "ar")` used to render
+   * correctly shaped Arabic inside a left-to-right container — navigation icon left, FAB
+   * bottom-right, start/end padding unmirrored — because only `Pseudolocale.isRtl` was consulted.
+   *
+   * The other three render paths (daemon desktop, daemon Android, `RobolectricRenderTest`) already
+   * ask [ee.schimke.composeai.data.pseudolocale.LocaleDirection], so this pins the batch renderer
+   * to the same answer rather than to its own list.
+   */
+  @Test
+  fun realRtlLocalesMirrorNotJustTheBidiPseudolocale() {
+    // Real RTL locales, bare and region-qualified.
+    assertTrue(rendersRightToLeft("ar"))
+    assertTrue(rendersRightToLeft("ar-EG"))
+    assertTrue(rendersRightToLeft("he"))
+    assertTrue(rendersRightToLeft("iw")) // legacy Hebrew code
+    assertTrue(rendersRightToLeft("fa"))
+    assertTrue(rendersRightToLeft("ur-PK"))
+
+    // The bidi pseudolocale keeps flipping — its base tag is `en`, so this only holds because
+    // `rendersRightToLeft` asks the pseudolocale before folding the tag.
+    assertTrue(rendersRightToLeft("ar-XB"))
+
+    // LTR locales, the accent pseudolocale (English copy, LTR) and "no override" must not flip.
+    assertFalse(rendersRightToLeft("de"))
+    assertFalse(rendersRightToLeft("ja"))
+    assertFalse(rendersRightToLeft("en-XA"))
+    assertFalse(rendersRightToLeft(null))
+    assertFalse(rendersRightToLeft(""))
   }
 
   /**

--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogI18n.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogI18n.kt
@@ -81,3 +81,26 @@ fun SwitchOnRtl() =
 @Preview(name = "Dark", fontScale = 2f, uiMode = 32, group = "modes")
 @Composable
 fun SwitchOnLargeFont() = Sticker("switch-on")
+
+// A REAL RTL locale, as opposed to the `ar-XB` pseudolocale above. This is the regression guard for
+// the bug where the desktop batch renderers keyed their `LayoutDirection` flip off
+// `Pseudolocale.isRtl` alone: `ar-XB` mirrored, `ar` did not, so a catalog with real Arabic
+// translations rendered correctly shaped Arabic inside a left-to-right container — the leading
+// swatch still on the left, the text column still starting at the left edge. It read as "RTL is
+// fine" precisely where RTL had never been exercised.
+//
+// The slotted card is the sticker that shows it: it has BOTH a leading region and a text column, so
+// a mirror is unmistakable, and its headline/supporting copy comes from `strings.xml` — so this one
+// capture proves the two halves of a locale override together (translated copy AND mirrored
+// layout), which no `ar-XB` capture can (desktop CMP pseudolocalises direction, not text).
+@CatalogVariant(
+  of = "Card/Slots",
+  props = ["locale=ar"],
+  caption =
+    "i18n axis: a real RTL locale (ar) — Arabic copy from values-ar AND mirrored layout, the two " +
+      "halves a locale override applies together.",
+)
+@Preview(name = "Light", locale = "ar", group = "modes")
+@Preview(name = "Dark", locale = "ar", uiMode = 32, group = "modes")
+@Composable
+fun SlottedCardArabic() = Sticker("card-slots")

--- a/site/reference/pseudolocale.md
+++ b/site/reference/pseudolocale.md
@@ -115,6 +115,15 @@ Android, one piece on Desktop:
    - **Desktop** — emits the rewritten tag through the `LocaleList`
      `CompositionLocal`. Lives in `RenderEngine.localeProviders`
      (daemon) and `DesktopRendererMain` (plugin path).
+
+   **RTL is not pseudolocale-only.** A *real* RTL locale (`ar`, `he`,
+   `fa`, `ur`, …) flips layout direction on every path too — `ldrtl` on
+   Android, `LocalLayoutDirection = Rtl` on Desktop — decided by
+   [`LocaleDirection.isRtl`](https://github.com/yschimke/compose-ai-tools/blob/main/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/LocaleDirection.kt)
+   from the tag's language subtag. `ar-XB` is the *translation-free* way
+   to test RTL, not the only way to get it. Without this a
+   `@Preview(locale = "ar")` renders shaped Arabic inside an unmirrored
+   container, which looks like passing RTL and isn't.
 2. **Around-composable wrap.** Each platform has a
    `PreviewOverrideExtension` planner that maps `localeTag` to an
    around-composable:


### PR DESCRIPTION
## The bug

The three desktop **batch** renderers decided layout direction from `Pseudolocale.isRtl` alone, so `ar-XB` mirrored and `ar` did not. `overrideJvmDefaultLocale` already gives `stringResource(...)` the translated copy, so a `@Preview(locale = "ar")` came back as correctly shaped Arabic **inside a left-to-right container** — leading region still on the left, start/end padding unmirrored. That is the worst kind of wrong: it reads as "RTL is fine" in exactly the capture where RTL was never exercised.

Found it in the wild — [`m3-catalog#23`](https://github.com/yschimke/m3-catalog/pull/23) translated that catalog into 17 locales and baked an `ar` capture of its app-scaffold template; the copy came back Arabic and the layout came back LTR.

Every other render path already asks `LocaleDirection.isRtl`: daemon desktop (`RenderEngine.localeProviders`), daemon Android (`RenderEngine`), and `RobolectricRenderTest`. Only the batch path was left keyed to the pseudolocale.

## The fix

`rendersRightToLeft(localeTag)` next to the other locale helpers in `DesktopRendererMain`, used by all three batch renderers (`DesktopRendererMain`, `DesktopAnimatedRenderer`, `DesktopScrollRenderer`). Pseudolocale is consulted **before** the tag is folded to its base, so `ar-XB` keeps flipping (its base tag is `en`) and the two sources can never double-count.

No new list of RTL languages — it defers to the existing `LocaleDirection`, so all four paths now give the same answer for the same tag.

## Visual evidence

`Card/Slots` from `:samples:design-catalog-m3` at `locale = "ar"`, rendered locally on this branch. Same preview, same command, renderer fix the only difference.

| Before (main) | After (this PR) |
| --- | --- |
| ![Card/Slots at locale=ar before the fix: swatch on the left, Arabic text left-aligned](https://raw.githubusercontent.com/yschimke/compose-ai-tools/fe6ef9b016fb9ef42978089491b2a730658ba57b/renders/desktop-rtl/ar-before.png) | ![Card/Slots at locale=ar after the fix: swatch on the right, Arabic text right-aligned](https://raw.githubusercontent.com/yschimke/compose-ai-tools/fe6ef9b016fb9ef42978089491b2a730658ba57b/renders/desktop-rtl/ar-after.png) |

Arabic copy resolves in both — that half already worked. What changes is the container: the leading swatch moves to the trailing edge and the text column right-aligns.

The English baseline for the same sticker, unchanged by this PR:

![Card/Slots in English: swatch left, Headline / Supporting text](https://raw.githubusercontent.com/yschimke/compose-ai-tools/fe6ef9b016fb9ef42978089491b2a730658ba57b/renders/desktop-rtl/en-baseline.png)

(The clipped descender on the supporting line is pre-existing in that sample — `PreviewSlot("supporting", …)` pins a 16dp slot height — and shows identically in the English baseline. Not touched here.)

Those three PNGs live on the `evidence-rtl` branch so this diff carries no binaries; the images are commit-pinned, so they stay viewable.

## Coverage from here

`:samples:design-catalog-m3` gains a `Card/Slots` variant at `locale = "ar"` — a sticker with both a leading region and a text column, so a mirror is unmistakable, and its copy comes from `values-ar/strings.xml`, so one capture proves translation and direction together (an `ar-XB` capture cannot: desktop CMP pseudolocalises direction, not text). The CI diff bot renders it on every PR from now on, which is what would have caught this.

**No existing desktop capture moves.** No desktop sample used a real RTL locale before — that is precisely why this survived. The only new renders are the two `SlottedCardArabic` captures.

## Test plan

```
./gradlew :renderer-desktop:ktfmtFormat :renderer-desktop:test          # BUILD SUCCESSFUL
./gradlew :samples:design-catalog-m3:composePreviewRender --preview=SlottedCard   # 6 rendered
```

`RendererLocaleTest.realRtlLocalesMirrorNotJustTheBidiPseudolocale` covers `ar` / `ar-EG` / `he` / `iw` / `fa` / `ur-PK` and `ar-XB` as flipping, and `de` / `ja` / `en-XA` / null / blank as not.

Docs: `site/reference/pseudolocale.md` gains a note that RTL is not pseudolocale-only, so the next reader does not infer that `ar-XB` is the only way to get a mirrored capture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7Ppa4bDfaqpdGvnmbYF6P)_