### PR TITLE
fix(daemon): replay IR-backed previews in live interactive sessions

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -2463,7 +2463,7 @@ internal fun InvokeWithOptionalWrapper(
  * Remote Compose, whose player lives in the alpha connector the daemon can't compile against.
  */
 @Composable
-private fun InvokeIrReplay(replayClass: Class<*>, bytes: ByteArray) {
+internal fun InvokeIrReplay(replayClass: Class<*>, bytes: ByteArray) {
   val (method, instance) =
     remember(replayClass) {
       val inst = replayClass.getDeclaredConstructor().apply { isAccessible = true }.newInstance()

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -36,6 +36,7 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
 import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
+import ee.schimke.composeai.data.render.extensions.loadIrReplayClass
 import ee.schimke.composeai.data.theme.ResolvedThemeTokens
 import ee.schimke.composeai.data.theme.ThemeConsumer
 import ee.schimke.composeai.data.theme.ThemePayload
@@ -1521,6 +1522,11 @@ open class RobolectricHost(
         // measured size, not at the sandbox window's. See `InteractiveCommand.Start.wrapWidth`.
         wrapWidth = spec.wrapWidth,
         wrapHeight = spec.wrapHeight,
+        // IR replay key — an IR-backed preview has no consumer class to reflect (pack-time
+        // minimisation drops it), so the held loop replays its carried bytes instead. Prefer the
+        // spec's own id and fall back to the acquire argument: both name the same preview, but a
+        // resolver-built spec is the authority on the form `BundleIrReplayStore` is keyed by.
+        previewId = spec.previewId ?: previewId,
       )
     )
     if (!replyLatch.await(INTERACTIVE_START_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
@@ -2555,7 +2561,26 @@ open class RobolectricHost(
       val isNotification = start.kind.equals(RenderEngine.NOTIFICATION_KIND, ignoreCase = true)
       val isGlanceAppWidget =
         start.kind.equals(RenderEngine.GLANCE_APPWIDGET_KIND, ignoreCase = true)
-      val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget
+      // v5 IR replay — the same dispatch `RenderEngine.render` performs, which the held loop was
+      // missing. A bundle may carry this preview's intermediate representation, in which case its
+      // consumer class was dropped at pack time and `Class.forName` below can only ever throw
+      // `ClassNotFoundException`. That throw is what a fully IR-backed catalog hit on every
+      // `interactive/start`: the render lane replayed the carried document happily while live mode
+      // reported "input requires a live stream — unavailable".
+      //
+      // Resolved through the same `IrReplayComposableProvider` SPI the one-shot path uses: the
+      // protolayout branch inflates directly, Remote Compose goes through the connector's replay
+      // composable (the daemon can't compile against the alpha player SDK). A null replay class
+      // means the connector isn't on the classpath — then we fall through to reflection, which
+      // fails exactly as it did before rather than blanking the preview silently.
+      val irReplay = BundleIrReplayStore.lookup(start.previewId)
+      val isProtolayoutIr = irReplay?.format == BundleIrReplayStore.FORMAT_PROTOLAYOUT
+      val rcReplayClass: Class<*>? =
+        if (irReplay?.format == BundleIrReplayStore.FORMAT_REMOTECOMPOSE)
+          runCatching { loadIrReplayClass(BundleIrReplayStore.FORMAT_REMOTECOMPOSE) }.getOrNull()
+        else null
+      val isIrReplay = isProtolayoutIr || rcReplayClass != null
+      val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget || isIrReplay
       // `@PreviewParameter` previews resolve to the `(<T>, Composer, int)` overload and are invoked
       // with the provider's first value — same contract as the one-shot render (issue #3027).
       // `resolve` also opens the method for reflective invocation, so a `private fun` preview
@@ -2862,7 +2887,25 @@ open class RobolectricHost(
                               },
                             propagateMinConstraints = true,
                           ) {
-                          if (isTile) {
+                          if (isProtolayoutIr) {
+                            // v5 IR replay, protolayout — inflate the captured `Layout` +
+                            // `Resources` protos through `TileRenderer`, with no reference to the
+                            // tile function that produced them. Same AndroidView-hosted shape as
+                            // `RenderEngine.render`'s branch, so a held frame and a one-shot
+                            // capture walk an identical Compose tree.
+                            ee.schimke.composeai.renderer.TileIrReplayComposable(
+                              layoutBytes = irReplay!!.bytes,
+                              resourcesBytes = irReplay.resourcesBytes ?: ByteArray(0),
+                              label = "IR replay ${start.previewId ?: start.outputBaseName}",
+                            )
+                          } else if (rcReplayClass != null) {
+                            // v5 IR replay, Remote Compose — paint the captured RemoteDocument
+                            // through the connector's player, reached reflectively. The view
+                            // player owns the document's own state, so the held composition stays
+                            // interactive: a tap dispatched by `interactive/input` lands on the
+                            // document exactly as it would on-device.
+                            InvokeIrReplay(rcReplayClass, irReplay!!.bytes)
+                          } else if (isTile) {
                             ee.schimke.composeai.renderer.TilePreviewComposable(
                               className = start.previewClassName,
                               functionName = start.previewFunctionName,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -462,6 +462,21 @@ sealed interface InteractiveCommand {
      */
     val wrapWidth: Boolean = false,
     val wrapHeight: Boolean = false,
+    /**
+     * `RenderSpec.previewId` — the key `BundleIrReplayStore` files a bundle's captured
+     * intermediate representations under. The held-rule loop looks it up exactly like
+     * `RenderEngine.render` does, so an IR-backed preview (a Remote Compose doc, a Wear
+     * protolayout tile) replays from its carried bytes instead of reflecting a consumer class that
+     * pack-time minimisation deliberately dropped. Without it every preview in a fully IR-backed
+     * catalog — `samples/design-catalog-remote-m3`, whose `classes/app.jar` is empty by design —
+     * failed `interactive/start` with `ClassNotFoundException` and the viewer reported "input
+     * requires a live stream — unavailable".
+     *
+     * Threaded as the raw `java.lang.String` for the same do-not-acquire bridge reason as [kind]
+     * and the other `spec.*` fields above. `null` on a caller that predates this field, which just
+     * restores the old reflect-the-class behaviour.
+     */
+    val previewId: String? = null,
   ) : InteractiveCommand
 
   /**

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveIrReplayTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveIrReplayTest.kt
@@ -1,0 +1,237 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Regression coverage for live mode on an **IR-backed** preview — a preview whose consumer bytecode
+ * pack-time minimisation deliberately dropped (`PreviewBundleFormat`: "the enclosing class is
+ * dropped from the minimisation closure seed"), leaving the bundle's `classes/app.jar` without it.
+ *
+ * `RenderEngine.render` has replayed those previews from their carried IR since schema v5, but
+ * `RobolectricHost`'s held-rule loop did not — it went straight to `Class.forName`, so every
+ * `interactive/start` against a fully IR-backed catalog failed with
+ * `ClassNotFoundException` and the viewer reported "input requires a live stream — unavailable".
+ * The published `remote-m3` catalog is exactly that shape: all 28 previews carry an `ir/<id>.rc`
+ * document and its `classes/app.jar` is an empty 22-byte jar, so live mode could never work there.
+ *
+ * [replaysIrBackedPreviewAndStillFailsWithoutIr] pins the fix in both directions: the IR-backed id
+ * now composes its replay, while an identically-shaped id the bundle carries no IR for still fails
+ * resolution — so the pass can't be a false positive from some other fallback quietly rendering a
+ * frame.
+ *
+ * The replay composable is a fake registered through the same `ServiceLoader` SPI
+ * `:data-remotecompose-connector` uses in production (see the `META-INF/services` resource beside
+ * this source set). `:daemon:android` has no Remote Compose connector on its own classpath — the
+ * real player is supplied by the consumer app — so the fake is the only provider for the
+ * `remotecompose` format here and can't shadow a real one.
+ */
+class AndroidInteractiveIrReplayTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @After
+  fun clearIrProperties() {
+    System.clearProperty(BundleIrReplayStore.BUNDLE_MANIFEST_PATH_PROP)
+    System.clearProperty(BundleIrReplayStore.IR_DIR_PROP)
+    BundleIrReplayStore.resetForTest()
+  }
+
+  /**
+   * Both directions in one host. They share a `RobolectricHost` because booting two sandboxes is
+   * the expensive part of this test (see `AndroidInteractiveSessionTest`'s note on cold-boot cost)
+   * and because the two acquires are the *same* preview shape differing only in whether the bundle
+   * carries IR for that id — which is precisely the fix's decision point.
+   */
+  @Test
+  fun replaysIrBackedPreviewAndStillFailsWithoutIr() {
+    val outputDir = tempFolder.newFolder("ir-interactive-renders")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    seedIrBundle(IR_PREVIEW_ID)
+
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = ::specForAbsentClass)
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = IR_PREVIEW_ID,
+          classLoader = AndroidInteractiveIrReplayTest::class.java.classLoader!!,
+        )
+      try {
+        val result = session.render(requestId = RenderHost.nextRequestId())
+        assertNotNull("held IR replay must produce a PNG path", result.pngPath)
+        // The fake replay composable paints solid green. Any other outcome — a blank frame, the
+        // activity background — means the held loop did not route through IR replay.
+        val greenPct = greenPct(File(result.pngPath!!))
+        assertTrue(
+          "expected the held frame to be ≥95% the replay composable's green " +
+            "(got ${"%.2f".format(greenPct * 100)}%)",
+          greenPct >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+
+      // Negative control, so the pass above can't be a false positive from some other fallback
+      // quietly painting a frame: an identically-shaped preview whose id the bundle carries NO IR
+      // for still reflects its class, and still fails the way the bug report did. Expressed as a
+      // second id rather than by clearing the store's system properties — the held loop reads
+      // `BundleIrReplayStore` from inside the Robolectric sandbox, whose statics outlive a
+      // host, so a cleared-and-reloaded store is not observable from here.
+      try {
+        host
+          .acquireInteractiveSession(
+            previewId = NO_IR_PREVIEW_ID,
+            classLoader = AndroidInteractiveIrReplayTest::class.java.classLoader!!,
+          )
+          .close()
+        fail("acquire must fail when the preview's class is absent and no IR is carried")
+      } catch (e: UnsupportedOperationException) {
+        assertTrue(
+          "expected the start error to name the missing class, got: ${e.message}",
+          e.message.orEmpty().contains("ClassNotFoundException"),
+        )
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * A spec naming a class that genuinely isn't on any classloader here — standing in for the
+   * consumer bytecode a v5 bundle drops. [RenderSpec.previewId] is left null on purpose so the test
+   * also covers `acquireInteractiveSession`'s fallback to the acquire argument for the IR key,
+   * which is the shape every `previewSpecResolver` in this module builds.
+   */
+  private fun specForAbsentClass(previewId: String): RenderSpec? =
+    if (previewId != IR_PREVIEW_ID && previewId != NO_IR_PREVIEW_ID) null
+    else
+      RenderSpec(
+        className = ABSENT_CLASS_FQN,
+        functionName = "ButtonGroupRemote",
+        widthPx = IR_WIDTH_PX,
+        heightPx = IR_HEIGHT_PX,
+        density = 1.0f,
+        showBackground = true,
+        outputBaseName = "interactive-ir-replay",
+      )
+
+  /**
+   * Write the two artefacts [BundleIrReplayStore] reads — a `bundle.json` carrying one
+   * `intermediateRepresentations` descriptor and the IR bytes beside it — and point the store's
+   * system properties at them, exactly as `ServeBundleDaemon.materialize` does for a live catalog.
+   * The bytes are opaque here: the fake replay composable ignores them, so this test stays about
+   * the dispatch decision rather than the Remote Compose wire format.
+   */
+  private fun seedIrBundle(previewId: String) {
+    val irDir = tempFolder.newFolder("ir")
+    File(irDir, "$previewId.rc").writeBytes(byteArrayOf(1, 2, 3, 4))
+    val manifest = tempFolder.newFile("bundle.json")
+    manifest.writeText(
+      """
+      {
+        "intermediateRepresentations": [
+          {
+            "previewId": "$previewId",
+            "format": "${BundleIrReplayStore.FORMAT_REMOTECOMPOSE}",
+            "path": "ir/$previewId.rc"
+          }
+        ]
+      }
+      """
+        .trimIndent()
+    )
+    System.setProperty(BundleIrReplayStore.BUNDLE_MANIFEST_PATH_PROP, manifest.absolutePath)
+    System.setProperty(BundleIrReplayStore.IR_DIR_PROP, irDir.absolutePath)
+    BundleIrReplayStore.resetForTest()
+  }
+
+  /**
+   * Fraction of pixels within tolerance of [REPLAY_GREEN]. Inlined for the same reason
+   * `AndroidInteractiveSessionTest` inlines its own pixel helper — pulling `:daemon:harness`'s
+   * `PixelDiff` would invert the dependency graph.
+   */
+  private fun greenPct(png: File): Double {
+    val img = ImageIO.read(png) ?: error("could not decode $png")
+    var hits = 0
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          kotlin.math.abs(r - ((REPLAY_GREEN shr 16) and 0xFF)) <= 8 &&
+            kotlin.math.abs(g - ((REPLAY_GREEN shr 8) and 0xFF)) <= 8 &&
+            kotlin.math.abs(b - (REPLAY_GREEN and 0xFF)) <= 8
+        ) {
+          hits++
+        }
+      }
+    }
+    return hits.toDouble() / (img.width * img.height)
+  }
+
+  private companion object {
+    /**
+     * Shaped like the id that reported the bug — `remote-m3`'s `ButtonGroupRemote` sticker, whose
+     * `interactive/start` failed with `ClassNotFoundException:
+     * com.example.designcatalogremotem3.CatalogPreviewsKt`.
+     */
+    const val IR_PREVIEW_ID: String =
+      "com.example.designcatalogremotem3.CatalogPreviewsKt." +
+        "ButtonGroupRemote_width_320dp_height_240dp_dpi_320"
+
+    /** Same absent class, but an id the seeded bundle carries no `intermediateRepresentation` for. */
+    const val NO_IR_PREVIEW_ID: String =
+      "com.example.designcatalogremotem3.CatalogPreviewsKt." +
+        "CardRemote_width_320dp_height_240dp_dpi_320"
+
+    const val ABSENT_CLASS_FQN: String = "com.example.designcatalogremotem3.CatalogPreviewsKt"
+
+    const val IR_WIDTH_PX: Int = 120
+
+    const val IR_HEIGHT_PX: Int = 120
+
+    const val REPLAY_GREEN: Int = 0x2E7D32
+  }
+}
+
+/**
+ * Registered via `src/test/resources/META-INF/services/...IrReplayComposableProvider`, mirroring how
+ * `:data-remotecompose-connector` registers `RemoteComposeIrReplay`.
+ */
+class FakeRemoteComposeIrReplayProvider : IrReplayComposableProvider {
+  override val format: String = BundleIrReplayStore.FORMAT_REMOTECOMPOSE
+
+  override fun replayClass(): Class<*> = FakeRemoteComposeIrReplay::class.java
+}
+
+/**
+ * Stand-in for the connector's replay composable: the `@Composable Replay(bytes: ByteArray)` shape
+ * plus a no-arg constructor the renderer resolves through `getDeclaredComposableMethod`. Paints a
+ * flat colour so a captured frame proves which branch composed it, and ignores the bytes — the real
+ * player's document decoding is the connector's business, not this dispatch test's.
+ */
+class FakeRemoteComposeIrReplay {
+  @Composable
+  @Suppress("UNUSED_PARAMETER")
+  fun Replay(bytes: ByteArray) {
+    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF2E7D32)))
+  }
+}

--- a/daemon/android/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider
+++ b/daemon/android/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider
@@ -1,0 +1,1 @@
+ee.schimke.composeai.daemon.FakeRemoteComposeIrReplayProvider

--- a/docs/daemon/INTERACTIVE-ANDROID.md
+++ b/docs/daemon/INTERACTIVE-ANDROID.md
@@ -349,6 +349,50 @@ override val supportsInteractive: Boolean
 `INTERACTIVE_SLOT_INDEX = 1` for v3. Slot 0 stays the always-on
 normal-render slot.
 
+## 7.1 IR-backed previews have no class to reflect
+
+`runHeldInteractiveSession` branches on preview flavour exactly like
+`RenderEngine.render`, and that includes the schema-v5 **intermediate
+representation** check — not just the tile / notification / Glance kinds.
+
+A preview whose flavour emitted a serialisable IR (a Remote Compose
+`RemoteDocument`, a Wear protolayout `Layout` proto) is replayed from the bytes
+the bundle carries under `ir/<id>.<ext>`. Its consumer bytecode is
+**deliberately absent**: `BundlePreviewTask` seeds the pack closure only from
+non-IR previews, so an IR preview contributes no module classes and a catalog
+where *every* preview is IR-backed ships an empty `classes/app.jar`. Reflecting
+`start.previewClassName` there can only ever throw `ClassNotFoundException`.
+
+So the held loop resolves the IR first, keyed by `InteractiveCommand.Start`'s
+`previewId` through `BundleIrReplayStore`:
+
+```kotlin
+val irReplay = BundleIrReplayStore.lookup(start.previewId)
+val isProtolayoutIr = irReplay?.format == BundleIrReplayStore.FORMAT_PROTOLAYOUT
+val rcReplayClass =
+    if (irReplay?.format == BundleIrReplayStore.FORMAT_REMOTECOMPOSE)
+        runCatching { loadIrReplayClass(BundleIrReplayStore.FORMAT_REMOTECOMPOSE) }.getOrNull()
+    else null
+val isIrReplay = isProtolayoutIr || rcReplayClass != null
+// isIrReplay joins isTile / isNotification / isGlanceAppWidget in
+// `nonComposableInvocation`, so Class.forName is skipped entirely.
+```
+
+and composes the matching branch inside the held `setContent`:
+`TileIrReplayComposable` for protolayout, the connector's replay composable
+(reached reflectively — the daemon can't compile against the alpha Remote
+Compose player) for `remotecompose`.
+
+The interactive contract survives the indirection: the Remote Compose view
+player owns the replayed document's own state, so a tap delivered by
+`interactive/input` lands on the document exactly as it would on-device.
+
+Without this branch, `interactive/start` against a fully IR-backed catalog
+failed on every preview and the viewer reported "input requires a live stream —
+unavailable: … ClassNotFoundException", while the *stateless* render lane on the
+same daemon replayed the same preview happily — the asymmetry that made the bug
+confusing to read. `AndroidInteractiveIrReplayTest` pins both directions.
+
 ## 10.3 RenderSpec qualifier set / PR C
 
 PR C threads dimensions through `previewSpecResolver` from


### PR DESCRIPTION
Live mode failed on every `remote-m3` preview:

```
input requires a live stream — unavailable: UnsupportedOperationException:
RobolectricHost.acquireInteractiveSession failed for previewId=
'com.example.designcatalogremotem3.CatalogPreviewsKt.ButtonGroupRemote_width_320dp_height_240dp_dpi_320':
ClassNotFoundException: com.example.designcatalogremotem3.CatalogPreviewsKt
```

## Root cause

`RenderEngine.render` has dispatched schema-v5 **intermediate representations** since they landed — a Remote Compose document or a Wear protolayout proto is replayed from the bytes the bundle carries, because `BundlePreviewTask` seeds the pack closure only from *non*-IR previews and so deliberately drops the composable that produced it.

`RobolectricHost`'s held-rule loop never learned that branch. It went straight to `Class.forName(start.previewClassName)`.

For a catalog where **every** preview is IR-backed, that class is never there. Confirmed against the published bundle on `design-artifacts/remote-m3`:

```
$ python3 -c "import zipfile; z=zipfile.ZipFile('bundle.png'); \
    print([(n, z.getinfo(n).file_size) for n in z.namelist() if n.startswith('classes/')])"
[('classes/app.jar', 22)]        # 22 bytes = an empty jar
```

28 `ir/<id>.rc` documents, zero `com/example/designcatalogremotem3/*` classes anywhere in the bundle (checked `classes/app.jar` and all three `libs/full*.jar`). So `interactive/start` could only ever throw — while the *stateless* render lane on the same daemon served the same preview happily. That asymmetry is what made the failure confusing to read.

## Change

The held loop now resolves the IR first and composes the matching branch:

- `previewId` threaded through `InteractiveCommand.Start` as a plain `String?`, the same primitive-threading pattern `kind` / `wrapWidth` / the qualifier fields already use for the do-not-acquire sandbox boundary.
- `BundleIrReplayStore.lookup(start.previewId)` → `TileIrReplayComposable` for protolayout, the connector's reflectively-reached replay composable (`IrReplayComposableProvider` SPI) for Remote Compose.
- `isIrReplay` joins the tile / notification / Glance kinds in `nonComposableInvocation`, so reflection is **skipped** rather than attempted-and-caught.
- A null replay class (connector absent) falls through to reflection and fails exactly as before, rather than blanking the preview silently.

The interactive contract survives the indirection: the Remote Compose view player owns the replayed document's own state, so a tap delivered by `interactive/input` lands on the document as it would on-device.

`docs/daemon/INTERACTIVE-ANDROID.md` gains §7.1 covering the dispatch.

## Visual evidence

Not applicable — this changes daemon dispatch, not rendered output. No `@Preview`, overlay, theme, or webview surface is touched; the replayed frame is the same `RemoteDocument` the render lane already paints, and the render lane's pixels are unchanged (`RenderEngine`'s only edit is a `private` → `internal` visibility widening on `InvokeIrReplay`, no behaviour).

The surface that *did* change — a live-mode frame for an IR-backed preview — has no capture path today: it needs a held interactive session, which the `@Preview` PNG pipeline doesn't reach. It's covered instead by a pixel assertion inside the new test (the frame must be ≥95% the replay composable's green), which is the same evidence a screenshot would carry, asserted every run rather than eyeballed once.

## Test plan

New `AndroidInteractiveIrReplayTest` boots a two-sandbox `RobolectricHost` against a preview class that genuinely isn't on any classloader, and pins **both** directions in one host:

- an id the seeded bundle carries IR for → acquire succeeds and the held frame is ≥95% the replay composable's colour;
- an identically-shaped id with no IR → still fails with `ClassNotFoundException`.

The negative control is what stops the pass being a false positive from some other fallback quietly painting a frame. It's expressed as a second id rather than by clearing the store's system properties, because the held loop reads `BundleIrReplayStore` from inside the Robolectric sandbox, whose statics outlive a host.

Green locally:

- `:daemon:android:testDebugUnitTest --tests AndroidInteractiveIrReplayTest`
- `:daemon:android:testDebugUnitTest --tests 'AndroidInteractive*' --tests 'RobolectricHost*' --tests AndroidRecordingSessionTest` — no regressions in the neighbouring interactive suites
- `:daemon:android:ktfmtFormat` — no changes

## Not in this PR

Two adjacent things surfaced while reproducing, both separate from the live-stream failure:

1. **Overrides needing recomposition are silent no-ops on an IR catalog.** `?fontScale=2.0` and `?localeTag=ar` return `200` with `x-compose-preview-generation: daemon` and bytes byte-identical to the baked snapshot — IR replay can't apply them, but the server counts a daemon answer as a real render and emits no `X-Compose-Preview-Dropped-Overrides`. That's the #3449 failure mode reappearing behind a successful render. (Named-value overrides do work — `?rc.shaderColor=%2300FF00` and `?rc.progress=0.95` both change pixels.)
2. **Cold-start 503s read as permanent errors.** The first override request after the daemon goes idle returns `503 … retry shortly`; dragging the font-scale slider hits it immediately. Legible, but worth a warm-up or a client-side retry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEY7UkZYZXHGs9zYsMCiJs)_