### PR TITLE
fix(preview-data-api): tolerate a page-backdrop manifest without ref

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designparity/PageBackdrop.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designparity/PageBackdrop.kt
@@ -107,10 +107,16 @@ public data class Placement(
   /** Nesting depth below the page frame; `0` for a top-level instance. */
   val depth: Int = 0,
   /**
-   * The instance's own design ref, `"figma:<fileKey>/<nodeId>"`. Always present, linked or not, so
-   * a hotspot can deep-link into the design tool even where no code implements it.
+   * The instance's own design ref, `"figma:<fileKey>/<nodeId>"` — what lets a hotspot deep-link
+   * into the design tool even where no code implements it.
+   *
+   * **Nullable on purpose.** The producer emits it for every placement, linked or not, but only
+   * since the release that introduced it; manifests written by an earlier producer have no `ref` at
+   * all, and a required field here would make those a hard parse failure rather than a degraded
+   * read. Prefer [PageBackdropManifest.refFor], which fills the gap from the manifest's `fileKey` —
+   * the same string the producer would have written.
    */
-  val ref: String,
+  val ref: String? = null,
   /**
    * Code handle, e.g. `"ui/Button.kt#PrimaryButton"`. Null when [link] is [PlacementLink.UNLINKED].
    */
@@ -179,4 +185,18 @@ public data class PageBackdropManifest(
   /** Whether this build understands the manifest's version. */
   public val isSupported: Boolean
     get() = supportsPageBackdropVersion(version)
+
+  /**
+   * The design ref for [placement], deriving it when the producer didn't write one.
+   *
+   * Use this rather than [Placement.ref] directly. A ref is `"figma:<fileKey>/<nodeId>"`, and both
+   * halves are already here — so a manifest from a producer predating the field loses nothing but
+   * the literal string, and reconstructing it is exact rather than a guess.
+   *
+   * This is the tolerance a consumer owes a contract whose producer releases separately. The
+   * version-range check covers *breaking* changes; this covers the ordinary case of running against
+   * an older producer, which no version bump announces.
+   */
+  public fun refFor(placement: Placement): String =
+    placement.ref ?: "figma:$fileKey/${placement.nodeId}"
 }

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designparity/PageBackdropParseTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designparity/PageBackdropParseTest.kt
@@ -53,11 +53,40 @@ class PageBackdropParseTest {
 
   @Test
   fun `every placement carries a ref, linked or not`() {
-    val page = parse(fixture()).pages.single()
+    val manifest = parse(fixture())
+    val page = manifest.pages.single()
     assertTrue(
-      page.placements.all { it.ref.startsWith("figma:") },
+      page.placements.all { it.ref?.startsWith("figma:") == true },
       "a bare ref is what makes an unlinked hotspot still clickable",
     )
+  }
+
+  @Test
+  fun `a manifest from a producer predating ref still parses, and the ref is reconstructed`() {
+    // The field was added without a version bump, so an older producer's output is still a v1
+    // manifest -- just without `ref`. Requiring it would turn every pre-existing artifact into a
+    // hard parse failure instead of a degraded read.
+    val original = parse(fixture())
+    val stripped = parse(fixture().replace(Regex("\\s*\"ref\": \"[^\"]*\",\n"), "\n"))
+
+    val page = stripped.pages.single()
+    assertEquals(9, page.placements.size, "dropping ref must not drop placements")
+    assertTrue(
+      page.placements.all { it.ref == null },
+      "the fixture under test must actually lack refs",
+    )
+
+    // Reconstruction is exact, not approximate: it rebuilds the very string the producer wrote.
+    val expected = original.pages.single().placements.map { it.ref }
+    val derived = page.placements.map { stripped.refFor(it) }
+    assertEquals(expected, derived)
+  }
+
+  @Test
+  fun `refFor passes through a ref the producer did write`() {
+    val manifest = parse(fixture())
+    val placement = manifest.pages.single().placements.first()
+    assertEquals(placement.ref, manifest.refFor(placement))
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #3500, fixing a compatibility hole I left in it.

## The bug

`Placement.ref` was non-optional, so kotlinx throws `MissingFieldException` on any manifest written before the producer gained the field — which is **every manifest that exists today**, since the design-parity release carrying `ref` hasn't shipped yet. A workflow artifact already on disk would have been a hard parse failure rather than a degraded read.

## The reasoning error behind it

The stated compatibility rule covers *an old consumer reading a new producer*: unknown fields are ignored, so additive changes need no version bump. It does **not** cover *a new consumer reading an old producer* — which is the direction that actually bites, and which no version bump announces, because from the producer's side nothing broke.

## The fix

`ref` becomes nullable, and `PageBackdropManifest.refFor(placement)` fills the gap. A ref is `"figma:<fileKey>/<nodeId>"` and both halves are already in the manifest, so the reconstruction is **exact, not a guess**.

## Test plan

- `./gradlew :preview-data-api:test --tests "*PageBackdropParseTest*"` — **BUILD SUCCESSFUL**, 10 tests (2 new).
- The key new test strips **every** `ref` from the producer's own committed fixture, parses it, and asserts the derived strings equal the originals one-for-one — so "exact reconstruction" is verified rather than asserted.
- A second test checks `refFor` passes through a ref the producer *did* write.
- `ktfmtCheckMain` / `ktfmtCheckTest` clean.
- Non-visual change (wire-format DTO + tests), so no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6ehazFSL6PXLkkv6Q2XuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6ehazFSL6PXLkkv6Q2XuZ)_