### PR TITLE
fix(serve): stop reporting overrides an IR replay never applied as applied

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLiveRouting.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLiveRouting.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.daemon.protocol.UiMode
 
 /**
@@ -116,6 +117,57 @@ internal object CatalogLiveRouting {
       rc.namedValues.keys.sorted().forEach { names += "${ServeOverrides.RC_NAMED_PREFIX}$it" }
     }
     return names.ifEmpty { listOf("overrides") }
+  }
+
+  /**
+   * The overrides an **IR replay** of [previewId] cannot honour, named as the caller spelled them —
+   * the daemon-lane counterpart of [droppedOverrideNames].
+   *
+   * A schema-v5 IR-backed preview is redrawn by replaying a captured document, never by re-running
+   * the composable that authored it (`BundleIrReplayStore` / `RemoteComposeIrReplay`). So every
+   * axis whose *only* route to the pixels is a fresh composition is inert: the daemon renders,
+   * answers `200`, and hands back bytes byte-identical to the baked snapshot. That is the #3449
+   * failure mode wearing a successful render's clothes — worse than the baked case it was written
+   * for, because `generation=daemon` reads as proof the override was applied.
+   *
+   * Deliberately a **narrow allow-list of the inert axes** rather than the inverse of what replay
+   * honours. Getting this set too wide turns working renders into refusals, so an axis earns its
+   * place here only by being recomposition-only by construction:
+   * - `fontScale`, `localeTag`, `uiMode` — Robolectric `Configuration` qualifiers the composable
+   *   reads during composition. Verified inert against the published `remote-m3` catalog: each
+   *   returns the baked bytes under `generation=daemon`.
+   * - `themeProvider` and the `knob.` named overrides — both are seeded *into* a composition
+   *   (`PreviewWrapperProvider` substitution, the named-override planner). There is no composition.
+   * - **string** `rc.` named values. The rest of the Remote Compose facet does reach the replayed
+   *   document through the player's `StateUpdater` — `rc.shaderColor` and `rc.progress` both move
+   *   pixels on `remote-m3` — but a string seed does not land in the alpha player
+   *   (`RemoteContext.setNamedStringOverride` → `overrideText` → `RemoteComposeState.overrideData`
+   *   is structurally identical to the float path that works, so the divergence is downstream of
+   *   anything this repo controls). Reported as un-applied until the player honours it; the day it
+   *   does, this entry comes out and `IrReplayDroppedOverridesTest` is what notices.
+   *
+   * The size / density / device family is **not** listed: those reach the player through the
+   * capture's `displayMetrics`, so a replay can answer them.
+   *
+   * Runs [withoutBakedNoOps] first for the same reason [droppedOverrideNames] does — a `uiMode`
+   * restating the variant's own baked theme is satisfied, not dropped, so naming it would refuse a
+   * request the replay answers truly.
+   */
+  fun irReplayDroppedOverrideNames(previewId: String, o: PreviewOverrides): List<String> {
+    val dropped = withoutBakedNoOps(previewId, o)
+    val names = mutableListOf<String>()
+    if (dropped.fontScale != null) names += "fontScale"
+    if (dropped.localeTag != null) names += "localeTag"
+    if (dropped.uiMode != null) names += "uiMode"
+    if (dropped.themeProvider != null) names += "themeProvider"
+    dropped.namedOverrides?.keys?.sorted()?.forEach { names += "${ServeOverrides.KNOB_PREFIX}$it" }
+    dropped.remoteCompose
+      ?.namedValues
+      ?.filterValues { it is RemoteNamedValue.StringValue }
+      ?.keys
+      ?.sorted()
+      ?.forEach { names += "${ServeOverrides.RC_NAMED_PREFIX}$it" }
+    return names
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2998,7 +2998,7 @@ class ServeHttpServer(
         // A story's args ride the same override params, and this lane is consumed by exactly the
         // tools #3449 is about — BackstopJS / reg-suit style PNG-diffing across arg values. Baked
         // pixels here would read as "this arg changes nothing".
-        val dropped = droppedOverridesFor(outcome.generation, previewId, overrides)
+        val dropped = droppedOverridesFor(renderHost, outcome.generation, previewId, overrides)
         if (dropped.isNotEmpty() && !acceptsBakedFallback()) {
           refuseDroppedOverrides(renderHost, previewId, dropped)
         } else {
@@ -3045,7 +3045,7 @@ class ServeHttpServer(
         )
       }
       is SvgOutcome.Ok -> {
-        val dropped = droppedOverridesFor(outcome.generation, previewId, overrides)
+        val dropped = droppedOverridesFor(renderHost, outcome.generation, previewId, overrides)
         if (dropped.isNotEmpty() && !acceptsBakedFallback()) {
           refuseDroppedOverrides(renderHost, previewId, dropped)
         } else {
@@ -3567,7 +3567,8 @@ class ServeHttpServer(
               // Baked pixels answering an override-bearing request are pixels that do NOT reflect
               // the override — byte-identical to the un-overridden snapshot, under a 200 (#3449).
               // Every other generation is a real render keyed by these overrides.
-              val dropped = droppedOverridesFor(outcome.generation, previewId, overrides)
+              val dropped =
+                droppedOverridesFor(renderHost, outcome.generation, previewId, overrides)
               if (dropped.isNotEmpty()) {
                 respondDroppedOverrides(
                   renderHost,
@@ -3610,15 +3611,32 @@ class ServeHttpServer(
    * overrides, cache hit or not.
    */
   private fun droppedOverridesFor(
+    renderHost: ServeHost,
     generation: RenderOutcome.Generation,
     previewId: String,
     overrides: PreviewOverrides,
   ): List<String> =
     if (generation == RenderOutcome.Generation.BAKED) {
       CatalogLiveRouting.droppedOverrideNames(previewId, overrides)
+    } else if (renderHost.hasRemoteComposeDoc(previewId)) {
+      // A real render happened — and still could not apply everything, because this preview is
+      // replayed from its captured document rather than recomposed. See
+      // [CatalogLiveRouting.irReplayDroppedOverrideNames] for which axes that costs and why the
+      // list is narrow.
+      CatalogLiveRouting.irReplayDroppedOverrideNames(previewId, overrides)
     } else {
       emptyList()
     }
+
+  /**
+   * Whether a refusal for [previewId] is **terminal** — retrying can never apply the override. True
+   * for an IR-replayed preview: there is no composition to re-run, today or in a minute, so the
+   * 503-with-`Retry-After` a live-lane-exists preview gets would be a lie the viewer turns into
+   * "retry shortly". [refuseDroppedOverrides] answers 409 instead, which the viewer already treats
+   * as final.
+   */
+  private fun droppedOverridesAreTerminal(renderHost: ServeHost, previewId: String): Boolean =
+    renderHost.hasRemoteComposeDoc(previewId)
 
   /**
    * Answer a render whose **validated overrides were not applied** — [bytes] are the preview's
@@ -3676,7 +3694,12 @@ class ServeHttpServer(
     call.response.headers.append(RENDER_HEADER, RENDER_BAKED_FALLBACK)
   }
 
-  /** The refusal half of [respondDroppedOverrides]: 503 when a live lane exists, else 409. */
+  /**
+   * The refusal half of [respondDroppedOverrides]: 503 when a live lane exists, else 409. An
+   * IR-replayed preview takes the 409 branch even though it *has* a live lane
+   * ([droppedOverridesAreTerminal]) — the lane works, it just can't recompose, so "retry shortly"
+   * would send the viewer round a loop that never converges.
+   */
   private suspend fun RoutingContext.refuseDroppedOverrides(
     renderHost: ServeHost,
     previewId: String,
@@ -3684,7 +3707,14 @@ class ServeHttpServer(
   ) {
     call.response.headers.append(DROPPED_OVERRIDES_HEADER, dropped.joinToString(","))
     val params = dropped.joinToString(", ")
-    if (renderHost.canRenderOverridesFor(previewId)) {
+    if (droppedOverridesAreTerminal(renderHost, previewId)) {
+      call.respondText(
+        "override not applied: $params — this preview is replayed from its captured document, " +
+          "which cannot be recomposed, so the override can never apply; add " +
+          "&$FALLBACK_PARAM=$FALLBACK_BAKED to accept the published snapshot (which ignores it)",
+        status = HttpStatusCode.Conflict,
+      )
+    } else if (renderHost.canRenderOverridesFor(previewId)) {
       call.response.headers.append(HttpHeaders.RetryAfter, "2")
       call.respondText(
         "override not applied: $params — this preview's live render lane is unavailable; " +
@@ -3834,7 +3864,7 @@ class ServeHttpServer(
         // the delivery branch was drawn at the preview's discovery-time axes, so serving it for a
         // `?fontScale=2.0` export is the same silent wrong answer (#3449). `?scroll=long` is
         // daemon-only (a bundle has no full-page vector), so it never lands here baked.
-        val dropped = droppedOverridesFor(outcome.generation, previewId, overrides)
+        val dropped = droppedOverridesFor(renderHost, outcome.generation, previewId, overrides)
         if (dropped.isNotEmpty()) {
           respondDroppedOverrides(
             renderHost,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/IrReplayDroppedOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/IrReplayDroppedOverridesTest.kt
@@ -1,0 +1,178 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
+import ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * [CatalogLiveRouting.irReplayDroppedOverrideNames] — the daemon-lane counterpart of
+ * [CatalogLiveRouting.droppedOverrideNames].
+ *
+ * A schema-v5 IR-backed preview is redrawn by replaying its captured document, never by re-running
+ * the composable. Overrides that only reach the pixels through a fresh composition are therefore
+ * inert — and, before this predicate existed, invisibly so: the daemon rendered, answered `200`
+ * with `generation=daemon`, and handed back bytes byte-identical to the baked snapshot. A caller
+ * diffing renders across override values reads that as "the override had no visual effect".
+ *
+ * The expectations below are pinned against the published `remote-m3` catalog, where each of these
+ * was observed returning the baked bytes under a successful daemon render.
+ */
+class IrReplayDroppedOverridesTest {
+
+  private val lightId = "button-namedlabel__ideal__default__light"
+
+  @Test
+  fun `an override-free request drops nothing`() {
+    assertEquals(
+      emptyList(),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(lightId, PreviewOverrides()),
+    )
+  }
+
+  @Test
+  fun `configuration qualifiers a replay cannot recompose are named`() {
+    assertEquals(
+      listOf("fontScale"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(lightId, PreviewOverrides(fontScale = 2.0f)),
+    )
+    assertEquals(
+      listOf("localeTag"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(lightId, PreviewOverrides(localeTag = "ar")),
+    )
+  }
+
+  /**
+   * Same baked-theme no-op rule [CatalogLiveRouting.droppedOverrideNames] applies: a `uiMode`
+   * restating the variant's own theme is *satisfied* by the replay, so naming it would refuse a
+   * request that was answered truly.
+   */
+  @Test
+  fun `a uiMode matching the variant's own theme is satisfied, a differing one is not`() {
+    assertEquals(
+      emptyList(),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        PreviewOverrides(uiMode = UiMode.LIGHT),
+      ),
+    )
+    assertEquals(
+      listOf("uiMode"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        PreviewOverrides(uiMode = UiMode.DARK),
+      ),
+    )
+  }
+
+  /** Both seed a composition that never runs on the replay path. */
+  @Test
+  fun `theme providers and knobs are named`() {
+    assertEquals(
+      listOf("themeProvider"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        PreviewOverrides(themeProvider = "com.example.BrandTheme"),
+      ),
+    )
+    assertEquals(
+      listOf("knob.label"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        PreviewOverrides(
+          namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("Tap me"))
+        ),
+      ),
+    )
+  }
+
+  /**
+   * The heart of it: the Remote Compose facet is **not** wholesale inert. Colour and float seeds
+   * reach the replayed document through the player's `StateUpdater` and genuinely move pixels
+   * (`rc.shaderColor` / `rc.progress` on `remote-m3` both do). A *string* seed does not land in the
+   * alpha player, so only that kind is reported.
+   *
+   * When the player starts honouring string seeds, this is the assertion that fails — which is the
+   * point: the entry comes out of the predicate at the same time, rather than the server quietly
+   * refusing an override that had begun working.
+   */
+  @Test
+  fun `only string rc seeds are named — colour and float seeds reach the replay`() {
+    val mixed =
+      PreviewOverrides(
+        remoteCompose =
+          RemoteComposeOverride(
+            namedValues =
+              mapOf(
+                "label" to RemoteNamedValue.StringValue("HELLO"),
+                "shaderColor" to RemoteNamedValue.ColorValue("#FF00FF00"),
+                "progress" to RemoteNamedValue.FloatValue(0.95f),
+                "iconSize" to RemoteNamedValue.DpValue(64f),
+              )
+          )
+      )
+    assertEquals(
+      listOf("rc.label"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(lightId, mixed),
+    )
+  }
+
+  /** Picking the player that draws the replay is exactly what the replay path reads. */
+  @Test
+  fun `the player selection is honoured by the replay`() {
+    assertEquals(
+      emptyList(),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        PreviewOverrides(
+          remoteCompose = RemoteComposeOverride(player = RemoteComposePlayerKind.EMBEDDED)
+        ),
+      ),
+    )
+  }
+
+  /**
+   * The size / density family reaches the player through the capture's `displayMetrics`, so a
+   * replay can answer it. Listing it would turn working renders into refusals — the failure mode
+   * this predicate's narrowness exists to avoid.
+   */
+  @Test
+  fun `size overrides are not named`() {
+    assertEquals(
+      emptyList(),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        PreviewOverrides(widthPx = 640, heightPx = 480, density = 2.0f),
+      ),
+    )
+  }
+
+  @Test
+  fun `every named axis reports together, sorted within a family`() {
+    assertEquals(
+      listOf("fontScale", "localeTag", "uiMode", "themeProvider", "knob.a", "knob.b", "rc.text"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        PreviewOverrides(
+          fontScale = 1.5f,
+          localeTag = "fr",
+          uiMode = UiMode.DARK,
+          themeProvider = "com.example.BrandTheme",
+          namedOverrides =
+            mapOf(
+              "b" to PreviewOverrideValue.StringValue("second"),
+              "a" to PreviewOverrideValue.StringValue("first"),
+            ),
+          remoteCompose =
+            RemoteComposeOverride(
+              namedValues = mapOf("text" to RemoteNamedValue.StringValue("body"))
+            ),
+        ),
+      ),
+    )
+  }
+}

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
@@ -296,6 +296,20 @@ internal fun stampGenerationDensity(bytes: ByteArray, density: Float): ByteArray
  * Pushes every entry of [overrides] through [updater] using the matching `setUserLocal*` setter for
  * the `RemoteNamedValue` variant. Internal but visible for tests; ordinary callers reach this via
  * [RemoteOverridablePreview] / [RemoteOverridablePreviewWrapper].
+ *
+ * **A string seed does not currently reach a replayed document.** Colour, float, dp and int seeds
+ * all move pixels on the published `remote-m3` catalog (`rc.shaderColor`, `rc.progress`); a string
+ * seed (`rc.label`, `rc.text`) comes back byte-identical to the un-overridden render. The
+ * divergence is not in this function or its callers — every branch below is covered by
+ * `ApplyConnectorOverridesTest`, and in the alpha player (1.0.0-alpha16) `setUserLocalString` →
+ * `RemoteContext.setNamedStringOverride` → `overrideText` → `RemoteComposeState.overrideData` is
+ * structurally identical to the float path that works, down to the same bounds guard and the same
+ * `updateListeners` call. Whatever swallows it sits below that, in how the player re-resolves text
+ * it has already laid out.
+ *
+ * Until it lands, the serve layer reports a string seed as un-applied rather than answering `200`
+ * with unchanged pixels — see `CatalogLiveRouting.irReplayDroppedOverrideNames`, whose
+ * `IrReplayDroppedOverridesTest` is what will fail (deliberately) on the day the player honours it.
  */
 internal fun applyConnectorOverrides(
   updater: StateUpdater,


### PR DESCRIPTION
Follow-up to #3510, covering the two things that PR flagged and deliberately left out.

## The bug

A schema-v5 IR-backed preview is redrawn by replaying its captured document, never by re-running the composable that authored it. Overrides whose only route to the pixels is a fresh composition are therefore inert — and were **invisibly** so. Against the published catalog:

```
GET /remote-m3/render/button-namedlabel__ideal__default__compact.png?fontScale=2.0
200   x-compose-preview-generation: daemon   md5=13c974b8d2

GET /remote-m3/render/button-namedlabel__ideal__default__compact.png?rc.label=HELLO
200   x-compose-preview-generation: daemon   md5=13c974b8d2

GET /remote-m3/render/button-namedlabel__ideal__default__compact.png      (no override)
200   x-compose-preview-generation: baked    md5=13c974b8d2
```

Same bytes, three ways. That is the #3449 failure mode wearing a successful render's clothes, and worse than the baked case it was written for: `generation=daemon` reads as proof the override *was* applied, so a diff bot, a parity check, or an agent iterating on a knob concludes "no visual difference" for an axis that was never honoured.

## Change

`droppedOverridesFor` now asks a second question past "were these baked pixels": for a preview the host carries an `ir/<id>.rc` for, it reports the axes a replay cannot honour. `refuseDroppedOverrides` answers **409** for those rather than 503 — the lane works, it just can't recompose, so `Retry-After` would send the viewer round a loop that never converges. The viewer already treats 409 as terminal, so it renders "this preview can only be served as its published snapshot" instead of "retry shortly". `?fallback=baked` still opts into the snapshot, now with the header naming what was dropped.

The predicate is a **narrow allow-list of inert axes**, not the inverse of what replay honours — too wide turns working renders into refusals:

| named | why |
|---|---|
| `fontScale`, `localeTag`, `uiMode` | Robolectric `Configuration` qualifiers read during composition; each verified inert against the published catalog |
| `themeProvider`, `knob.*` | both seed a composition that never runs |
| **string** `rc.*` seeds | see below |

Deliberately **not** named: the size / density / device family, which reaches the player through the capture's `displayMetrics` and so *is* answerable by a replay. `uiMode` runs through the existing `withoutBakedNoOps`, so a `uiMode` restating a variant's own baked theme stays satisfied rather than refused.

`hasRemoteComposeDoc` can't false-positive here: only `ServeBundleHost` and `ServeCatalogLiveHost` supply docs, both from the bundle's `ir/` entries, which `bundle pack` writes only for previews listed in `intermediateRepresentations`. A live project daemon (`ServeRenderHost`) returns null, so a class-backed preview that merely renders Remote Compose content is untouched.

## On `rc.label` — investigated, not fixable here

The rest of the Remote Compose facet genuinely works: `rc.shaderColor=%2300FF00` and `rc.progress=0.95` both move pixels on `remote-m3`. Only string seeds don't land.

It is not for want of wiring in this repo. Every branch of `applyConnectorOverrides` is covered by `ApplyConnectorOverridesTest`, and disassembling the alpha player (1.0.0-alpha16) shows the string path is structurally identical to the float path that works:

```
setUserLocalString → RemoteContext.setNamedStringOverride → overrideText → RemoteComposeState.overrideData
setUserLocalFloat  → RemoteContext.setNamedFloatOverride  → overrideFloat → RemoteComposeState.overrideFloat
```

Same `mVarNameHashMap` lookup, same `id < 10000` bounds guard, same `updateListeners(id)` call at the end. Whatever swallows it sits below that — most likely in how the player re-resolves text it has already laid out, which a colour or float change doesn't need. That's recorded on `applyConnectorOverrides` so the next reader doesn't re-derive it.

So this PR makes the failure **honest** rather than silent. If you'd rather I keep digging for a workaround (forcing a re-layout after seeding, or applying string seeds before the document is applied), that's a separate piece of work against the alpha player and I'd want a Robolectric reproduction in `:data-remotecompose-connector` first.

## Visual evidence

Not applicable — no rendered surface changes. This alters HTTP status and headers on requests that previously returned unchanged pixels; the pixels themselves are identical either way, which is precisely the problem being reported rather than fixed. The observable change is the status line, shown in the reproduction above and asserted in the tests.

## Test plan

New `IrReplayDroppedOverridesTest` pins each family. The assertion that matters most is the negative one — colour / float / dp seeds are **not** reported — so the predicate can't quietly grow into refusing overrides that work. It's also the test that fails, deliberately, on the day the player starts honouring string seeds, at which point `rc.` strings come out of the list.

Green locally:

- `:cli:test --tests 'ee.schimke.composeai.cli.serve.*'` — full serve suite, no regressions from the 409 branch
- `:data-remotecompose-connector:testDebugUnitTest`
- `:cli:ktfmtFormat`, `:data-remotecompose-connector:ktfmtFormat` — no changes

## Follow-up not in this PR

The viewer still *offers* the inert controls on an IR-backed preview — you can drag the font-scale slider and get a legible 409 instead of a silent lie, which is the improvement, but greying them out (the way `rcActive()` already does for the JS canvas lane) needs an `ir-replay` flag threaded from `ServeWeb` into `viewer.js`. Worth doing; separable.

The cold-start 503 on the first override request after the daemon idles is also still there — unrelated to this path, wants a warm-up or client-side retry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEY7UkZYZXHGs9zYsMCiJs)_