### PR TITLE
perf(serve): pool the cmp-jvm render workers instead of a JVM per document

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
@@ -78,6 +78,34 @@ internal object RcJvmServerRenderer {
     val cp = classpath()
     if (cp.isEmpty()) return RenderResult.Unavailable(unavailableReason())
 
+    // Warm path: a pooled worker draws this on an already-booted JVM (~85 ms) instead of paying
+    // Compose Desktop + Skiko startup again (~2.3 s). Only `Unusable` falls through to the one-shot
+    // path below — a `Failed` is the player's real answer about this document, and re-rendering it
+    // cold would double the cost of every document that cannot be drawn.
+    pool(cp)?.let { pool ->
+      when (val pooled = pool.render(docBytes, spec, seedLines(seeds).joinToString("\n"), format)) {
+        is RcJvmWorkerPool.PoolResult.Ok -> return RenderResult.Ok(pooled.bytes)
+        is RcJvmWorkerPool.PoolResult.Failed -> return RenderResult.Failed(pooled.reason)
+        is RcJvmWorkerPool.PoolResult.Unusable -> Unit
+      }
+    }
+
+    return renderOneShot(cp, docBytes, spec, seeds, format)
+  }
+
+  /**
+   * The original process-per-document path, kept as the fallback for every way the pool can decline
+   * to serve: pooling switched off, a `lib-rcjvm/` too old to speak the worker protocol, a worker
+   * that could not be spawned, or one that broke mid-request. Behaviour here is unchanged, so the
+   * worst case of the pool existing is the cost that was already being paid.
+   */
+  private fun renderOneShot(
+    cp: List<File>,
+    docBytes: ByteArray,
+    spec: RcJvmRenderSpec,
+    seeds: Map<String, RemoteNamedValue>,
+    format: Format,
+  ): RenderResult {
     val input = File.createTempFile("rcjvm-in-", ".rc")
     val output = File.createTempFile("rcjvm-out-", ".${format.wire}")
     val seedsFile = writeSeedsFile(seeds)
@@ -87,18 +115,7 @@ internal object RcJvmServerRenderer {
 
       val command = buildList {
         add(javaBin())
-        add("--enable-native-access=ALL-UNNAMED")
-        // Skiko draws offscreen; keep the JVM out of the macOS Dock / app-switcher when spawned
-        // on a developer's Mac, matching BundleRenderer's desktop renderer launch.
-        add("-Dapple.awt.UIElement=true")
-        // The player's `GoogleFontTypefaceResolver` downloads a `google:`-named family into the
-        // shared font cache — the same directory the Android and desktop daemons are pointed at,
-        // so a family already fetched for another lane is reused rather than re-downloaded. With
-        // no cache directory the resolver stays off and the lane substitutes a local face, so this
-        // is what makes the cmp-jvm chip show a branded typeface at all. The offline switch is
-        // forwarded when this process carries one.
-        add("-Dcomposeai.fonts.cacheDir=${composeAiCacheDir("fonts").absolutePath}")
-        System.getProperty("composeai.fonts.offline")?.let { add("-Dcomposeai.fonts.offline=$it") }
+        addAll(renderJvmArgs())
         add("-cp")
         add(cp.joinToString(File.pathSeparator) { it.absolutePath })
         add(MAIN_CLASS)
@@ -163,17 +180,85 @@ internal object RcJvmServerRenderer {
   }
 
   /**
-   * Serialize [seeds] to the line-based file `RcJvmRenderMain` reads (`<kind> <base64Name>
-   * <value>`, kind ∈ str/float/int/color), or null when there is nothing to seed. Normalizes the
-   * wire types the jvm player does not need to distinguish — `dp` collapses to float and `bool` to
-   * int, matching the daemon's `applyConnectorOverrides` — and drops a colour whose `#AARRGGBB`
-   * string won't parse.
+   * The JVM flags every cmp-jvm render runs under, shared by the pooled worker and the one-shot
+   * subprocess.
+   *
+   * Shared deliberately, not by coincidence: the font cache directory below decides which typeface
+   * a `google:`-named family resolves to, so a pooled worker started without it would draw text
+   * differently from the one-shot fallback. Two lanes that are supposed to be interchangeable must
+   * boot identically, or "did the pool serve this?" becomes visible in the pixels — exactly the
+   * property `RcJvmHotWorkerDeterminismTest` exists to protect.
    */
-  private fun writeSeedsFile(seeds: Map<String, RemoteNamedValue>): File? {
-    if (seeds.isEmpty()) return null
+  private fun renderJvmArgs(): List<String> = buildList {
+    add("--enable-native-access=ALL-UNNAMED")
+    // Skiko draws offscreen; keep the JVM out of the macOS Dock / app-switcher when spawned
+    // on a developer's Mac, matching BundleRenderer's desktop renderer launch.
+    add("-Dapple.awt.UIElement=true")
+    // The player's `GoogleFontTypefaceResolver` downloads a `google:`-named family into the
+    // shared font cache — the same directory the Android and desktop daemons are pointed at,
+    // so a family already fetched for another lane is reused rather than re-downloaded. With
+    // no cache directory the resolver stays off and the lane substitutes a local face, so this
+    // is what makes the cmp-jvm chip show a branded typeface at all. The offline switch is
+    // forwarded when this process carries one.
+    add("-Dcomposeai.fonts.cacheDir=${composeAiCacheDir("fonts").absolutePath}")
+    System.getProperty("composeai.fonts.offline")?.let { add("-Dcomposeai.fonts.offline=$it") }
+  }
+
+  /**
+   * The process-wide worker pool, created on first use so a cli invocation that never renders a
+   * cmp-jvm document never spawns a JVM. Null when pooling is switched off
+   * ([RcJvmWorkerPool.SYS_PROP_ENABLED]`=off`), which forces every render down the one-shot path.
+   */
+  @Volatile private var poolInstance: RcJvmWorkerPool? = null
+
+  private fun pool(cp: List<File>): RcJvmWorkerPool? {
+    if (!RcJvmWorkerPool.isEnabled()) return null
+    poolInstance?.let {
+      return it
+    }
+    return synchronized(this) {
+      poolInstance
+        ?: RcJvmWorkerPool(
+            classpath = cp,
+            javaBin = javaBin(),
+            extraJvmArgs = renderJvmArgs(),
+            maxWorkers = RcJvmWorkerPool.configuredWorkers(),
+            maxRendersPerWorker = RcJvmWorkerPool.configuredMaxRenders(),
+            maxWorkerAgeMillis = RcJvmWorkerPool.configuredMaxAgeMillis(),
+            renderTimeoutSeconds = RENDER_TIMEOUT_SECONDS,
+          )
+          .also { created ->
+            poolInstance = created
+            // Workers outlive any single render, so nothing else would reap them if the cli exits
+            // while some are parked.
+            Runtime.getRuntime().addShutdownHook(Thread({ created.close() }, "rcjvm-pool-shutdown"))
+          }
+    }
+  }
+
+  /** Releases every pooled worker. Exposed for tests and for an explicit serve shutdown. */
+  fun shutdownPool() {
+    synchronized(this) {
+      poolInstance?.close()
+      poolInstance = null
+    }
+  }
+
+  /**
+   * Serialize [seeds] to the line-based format the player reads (`<kind> <base64Name> <value>`,
+   * kind ∈ str/float/int/color). Normalizes the wire types the jvm player does not need to
+   * distinguish — `dp` collapses to float and `bool` to int, matching the daemon's
+   * `applyConnectorOverrides` — and drops a colour whose `#AARRGGBB` string won't parse.
+   *
+   * One producer for both lanes: the pooled worker receives these lines inline in its request
+   * frame, the one-shot subprocess reads them from the file [writeSeedsFile] writes. The parser is
+   * `parseSeedText` in the player module.
+   */
+  internal fun seedLines(seeds: Map<String, RemoteNamedValue>): List<String> {
+    if (seeds.isEmpty()) return emptyList()
     val b64 = Base64.getEncoder()
     fun enc(s: String) = b64.encodeToString(s.toByteArray(Charsets.UTF_8))
-    val lines = seeds.mapNotNull { (name, value) ->
+    return seeds.mapNotNull { (name, value) ->
       val n = enc(name)
       when (value) {
         is RemoteNamedValue.StringValue -> "str $n ${enc(value.value)}"
@@ -184,6 +269,11 @@ internal object RcJvmServerRenderer {
         is RemoteNamedValue.ColorValue -> rcColorToArgb(value.argb)?.let { "color $n $it" }
       }
     }
+  }
+
+  /** [seedLines] as the temp file the one-shot `--seeds` flag points at, or null when empty. */
+  private fun writeSeedsFile(seeds: Map<String, RemoteNamedValue>): File? {
+    val lines = seedLines(seeds)
     if (lines.isEmpty()) return null
     return File.createTempFile("rcjvm-seeds-", ".txt").also {
       it.writeText(lines.joinToString("\n"))

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
@@ -42,6 +42,13 @@ internal object RcJvmServerRenderer {
 
   private const val MAIN_CLASS = "ee.schimke.composeai.rcembedded.jvm.RcJvmRenderMainKt"
   private const val RENDER_TIMEOUT_SECONDS = 120L
+
+  /**
+   * Least budget worth starting a cold one-shot render with. Below this the retry cannot finish (a
+   * fresh JVM needs ~2.3s just to boot Compose + Skiko before it draws anything), so spending the
+   * remainder on a render that is going to be killed anyway only delays the failure.
+   */
+  private const val MIN_FALLBACK_SECONDS = 10L
   private const val DRAIN_FLUSH_MILLIS = 1000L
 
   /**
@@ -78,19 +85,40 @@ internal object RcJvmServerRenderer {
     val cp = classpath()
     if (cp.isEmpty()) return RenderResult.Unavailable(unavailableReason())
 
+    // One budget for the whole request, spent across both lanes. Without this a pooled worker could
+    // burn its full watchdog and *then* hand a fresh one-shot render another full timeout, so a
+    // request that used to fail at 120s would hold its caller's render-semaphore slot for ~240s and
+    // starve unrelated renders.
+    val startNanos = System.nanoTime()
+    fun secondsLeft(): Long =
+      RENDER_TIMEOUT_SECONDS - (System.nanoTime() - startNanos) / 1_000_000_000L
+
     // Warm path: a pooled worker draws this on an already-booted JVM (~85 ms) instead of paying
     // Compose Desktop + Skiko startup again (~2.3 s). Only `Unusable` falls through to the one-shot
     // path below — a `Failed` is the player's real answer about this document, and re-rendering it
     // cold would double the cost of every document that cannot be drawn.
     pool(cp)?.let { pool ->
-      when (val pooled = pool.render(docBytes, spec, seedLines(seeds).joinToString("\n"), format)) {
+      val pooled =
+        pool.render(docBytes, spec, seedLines(seeds).joinToString("\n"), format, secondsLeft())
+      when (pooled) {
         is RcJvmWorkerPool.PoolResult.Ok -> return RenderResult.Ok(pooled.bytes)
         is RcJvmWorkerPool.PoolResult.Failed -> return RenderResult.Failed(pooled.reason)
-        is RcJvmWorkerPool.PoolResult.Unusable -> Unit
+        is RcJvmWorkerPool.PoolResult.Unusable -> {
+          // A pool that declined instantly (disabled, stale sidecar, spawn refused) leaves the
+          // budget intact and the cold retry is free to use it. A pool that declined by *timing
+          // out* has already spent it — retrying cold would only blow through the deadline the
+          // caller is holding a semaphore permit against, so report the failure instead.
+          if (secondsLeft() < MIN_FALLBACK_SECONDS) {
+            return RenderResult.Failed(
+              "${pooled.reason}; no time left in the ${RENDER_TIMEOUT_SECONDS}s render budget " +
+                "for a one-shot retry"
+            )
+          }
+        }
       }
     }
 
-    return renderOneShot(cp, docBytes, spec, seeds, format)
+    return renderOneShot(cp, docBytes, spec, seeds, format, secondsLeft())
   }
 
   /**
@@ -105,6 +133,7 @@ internal object RcJvmServerRenderer {
     spec: RcJvmRenderSpec,
     seeds: Map<String, RemoteNamedValue>,
     format: Format,
+    timeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
   ): RenderResult {
     val input = File.createTempFile("rcjvm-in-", ".rc")
     val output = File.createTempFile("rcjvm-out-", ".${format.wire}")
@@ -152,11 +181,11 @@ internal object RcJvmServerRenderer {
             isDaemon = true
             start()
           }
-      val finished = process.waitFor(RENDER_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+      val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
       if (!finished) {
         process.destroyForcibly()
         drain.join(DRAIN_FLUSH_MILLIS)
-        return RenderResult.Failed("cmp-jvm render timed out after ${RENDER_TIMEOUT_SECONDS}s")
+        return RenderResult.Failed("cmp-jvm render timed out after ${timeoutSeconds}s")
       }
       // The process exited, so the reader has hit EOF; this join just flushes the last lines.
       drain.join(DRAIN_FLUSH_MILLIS)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
@@ -93,6 +93,17 @@ internal class RcJvmWorkerPool(
 
   private val permits = Semaphore(maxWorkers, /* fair= */ true)
   private val idle = ArrayDeque<Worker>()
+
+  /**
+   * Every worker this pool has started and not yet discarded — **including** the ones currently
+   * checked out to a render thread.
+   *
+   * [idle] alone is not enough to shut down: a worker that is mid-render is absent from it, so
+   * closing only the parked ones would leave its child JVM alive and its caller blocked on a pipe
+   * read that nothing will ever complete (shutting the watchdog down drops the scheduled kill that
+   * would otherwise free it).
+   */
+  private val liveWorkers = LinkedHashSet<Worker>()
   private val lock = Any()
   private val requestIds = AtomicInteger(0)
   private var startFailures = 0
@@ -108,6 +119,11 @@ internal class RcJvmWorkerPool(
     spec: RcJvmRenderSpec,
     seedsText: String,
     format: RcJvmServerRenderer.Format,
+    /**
+     * Budget for this render, so the caller can bound pool-attempt + fallback together rather than
+     * letting each lane spend the full timeout in turn. Defaults to the pool's own timeout.
+     */
+    timeoutSeconds: Long = renderTimeoutSeconds,
   ): PoolResult {
     synchronized(lock) {
       disabledReason?.let {
@@ -121,15 +137,24 @@ internal class RcJvmWorkerPool(
     try {
       worker =
         takeIdle()
-          ?: when (val started = startWorker()) {
+          ?: when (val started = startWorker(timeoutSeconds)) {
             is StartOutcome.Started -> started.worker
             is StartOutcome.Failed -> return PoolResult.Unusable(started.reason)
           }
 
-      val result = worker.render(docBytes, spec, seedsText, format, requestIds.incrementAndGet())
+      val result =
+        worker.render(
+          docBytes,
+          spec,
+          seedsText,
+          format,
+          requestIds.incrementAndGet(),
+          timeoutSeconds,
+        )
       if (result is PoolResult.Unusable) {
         // The worker broke mid-request (wedged, died, desynchronised). It is already destroyed;
         // dropping it here means the next caller spawns a fresh one.
+        discard(worker)
         worker = null
       }
       return result
@@ -137,7 +162,7 @@ internal class RcJvmWorkerPool(
       val finished = worker
       if (finished != null) {
         if (finished.shouldRetire(clock(), maxRendersPerWorker, maxWorkerAgeMillis)) {
-          finished.close()
+          discard(finished)
         } else {
           returnIdle(finished)
         }
@@ -169,12 +194,33 @@ internal class RcJvmWorkerPool(
         }
         picked
       }
-    doomed.forEach { it.close() }
+    doomed.forEach { discard(it) }
     return chosen
   }
 
-  private fun returnIdle(worker: Worker) =
-    synchronized(lock) { if (closed || !worker.isAlive()) worker.close() else idle.addLast(worker) }
+  private fun returnIdle(worker: Worker) {
+    val parked =
+      synchronized(lock) {
+        if (closed || !worker.isAlive()) false
+        else {
+          idle.addLast(worker)
+          true
+        }
+      }
+    if (!parked) discard(worker)
+  }
+
+  /**
+   * Forget a worker and destroy its process. Idempotent, so the races that can double-discard one —
+   * [close] running while a render thread is finishing with it, say — are harmless.
+   */
+  private fun discard(worker: Worker) {
+    synchronized(lock) {
+      liveWorkers.remove(worker)
+      idle.remove(worker)
+    }
+    worker.close()
+  }
 
   private sealed interface StartOutcome {
     class Started(val worker: Worker) : StartOutcome
@@ -182,7 +228,7 @@ internal class RcJvmWorkerPool(
     class Failed(val reason: String) : StartOutcome
   }
 
-  private fun startWorker(): StartOutcome {
+  private fun startWorker(timeoutSeconds: Long): StartOutcome {
     val command = buildList {
       add(javaBin)
       addAll(extraJvmArgs)
@@ -191,10 +237,21 @@ internal class RcJvmWorkerPool(
       add(workerMainClass)
     }
     return try {
-      val worker = Worker(command, watchdog, renderTimeoutSeconds, clock())
-      worker.handshake(HANDSHAKE_TIMEOUT_SECONDS)
-      synchronized(lock) { startFailures = 0 }
-      StartOutcome.Started(worker)
+      val worker = Worker(command, watchdog, clock())
+      worker.handshake(minOf(HANDSHAKE_TIMEOUT_SECONDS, timeoutSeconds.coerceAtLeast(1)))
+      val registered =
+        synchronized(lock) {
+          startFailures = 0
+          // `close()` may have run while this worker was booting. Registering it now would leak a
+          // child JVM that nothing will ever reap.
+          if (closed) false else liveWorkers.add(worker)
+        }
+      if (!registered) {
+        worker.close()
+        StartOutcome.Failed("cmp-jvm worker pool is closed")
+      } else {
+        StartOutcome.Started(worker)
+      }
     } catch (e: Exception) {
       val reason = "cmp-jvm worker pool could not start a worker: ${e.message}"
       synchronized(lock) {
@@ -213,8 +270,13 @@ internal class RcJvmWorkerPool(
     val doomed =
       synchronized(lock) {
         closed = true
-        idle.toList().also { idle.clear() }
+        idle.clear()
+        liveWorkers.toList().also { liveWorkers.clear() }
       }
+    // Every worker, not just the parked ones. Destroying a checked-out worker's process is what
+    // unblocks the render thread waiting on its pipe — and it has to happen *before* the watchdog
+    // stops, because `shutdownNow()` drops the scheduled kill that is the only other way out of
+    // that read.
     doomed.forEach { it.close() }
     watchdog.shutdownNow()
   }
@@ -225,7 +287,6 @@ internal class RcJvmWorkerPool(
   private class Worker(
     command: List<String>,
     private val watchdog: java.util.concurrent.ScheduledExecutorService,
-    private val renderTimeoutSeconds: Long,
     private val bornAtMillis: Long,
   ) {
     private val process = ProcessBuilder(command).redirectErrorStream(false).start()
@@ -292,6 +353,7 @@ internal class RcJvmWorkerPool(
       seedsText: String,
       format: RcJvmServerRenderer.Format,
       requestId: Int = 0,
+      renderTimeoutSeconds: Long,
     ): PoolResult {
       val guard = armWatchdog(renderTimeoutSeconds)
       var timedOut = false

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
@@ -1,0 +1,438 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.cli.serve
+
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.IOException
+import java.util.ArrayDeque
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A pool of long-lived `RcJvmRenderWorkerMain` processes, so a cmp-jvm render costs a frame on a
+ * warm JVM (~85 ms) instead of a fresh Compose Desktop + Skiko boot (~2.3 s).
+ *
+ * A worker holds nothing project-derived — a `.rc` document is self-describing, which is why the
+ * browser's JS player draws the same bytes with no knowledge of any catalog — so **any** worker can
+ * serve **any** document, from any module or repository, in any order. There is deliberately no
+ * affinity, no per-catalog warmup and no keying: that is the whole difference from the `@Preview`
+ * daemon, which must stay per-module because it holds the consumer's classloader.
+ *
+ * ## Why this is allowed to exist
+ *
+ * `rc-compare` gates the PR on pixel parity, so a render that depended on how many documents a
+ * worker had already drawn would convert a correctness gate into a flake source.
+ * `RcJvmHotWorkerDeterminismTest` is the standing proof that it does not: it renders a corpus cold,
+ * churns the process with dozens of renders at varied sizes, densities, seeds and formats, then
+ * re-renders and asserts byte identity. If that test ever fails, the correct response is to disable
+ * this pool ([SYS_PROP_ENABLED]`=off`), not to relax the assertion.
+ *
+ * ## Failure posture
+ *
+ * Every failure mode degrades to the pre-existing one-shot subprocess rather than to a broken
+ * render:
+ * * a sidecar too old to speak the protocol, or a worker that cannot be spawned, reports
+ *   [PoolResult.Unusable] and the caller falls back;
+ * * after [MAX_START_FAILURES] consecutive spawn/handshake failures the pool disables itself for
+ *   the life of the process, so a systematically broken pool costs one failed spawn, not one per
+ *   render;
+ * * a worker that wedges is destroyed by the watchdog and never returned to the idle set;
+ * * a document the player genuinely cannot draw reports [PoolResult.Failed] — that is a real answer
+ *   and is **not** retried on the one-shot path, which would double the cost of every bad document.
+ *
+ * Workers are recycled after [maxRendersPerWorker] renders or [maxWorkerAgeMillis], bounding any
+ * native leak without giving up the amortisation.
+ *
+ * Thread-safe: [maxWorkers] permits gate admission, and a worker is only ever checked out to one
+ * thread at a time, so a worker's streams are never touched concurrently.
+ */
+internal class RcJvmWorkerPool(
+  private val classpath: List<File>,
+  private val javaBin: String,
+  private val extraJvmArgs: List<String>,
+  private val maxWorkers: Int,
+  private val maxRendersPerWorker: Int,
+  private val maxWorkerAgeMillis: Long,
+  private val renderTimeoutSeconds: Long,
+  private val clock: () -> Long = System::currentTimeMillis,
+  /**
+   * The worker entry point to spawn. Overridden only by tests, which point it at a stub that speaks
+   * the same frames without Compose or Skiko — so the protocol, the retire policy and every failure
+   * path are covered on a machine with no native render stack.
+   */
+  private val workerMainClass: String = WORKER_MAIN_CLASS,
+) : AutoCloseable {
+
+  sealed interface PoolResult {
+    data class Ok(val bytes: ByteArray) : PoolResult
+
+    /** The player answered, and the answer is "I cannot draw this". Do not fall back. */
+    data class Failed(val reason: String) : PoolResult
+
+    /** The pool could not serve this at all. The caller should use the one-shot path. */
+    data class Unusable(val reason: String) : PoolResult
+  }
+
+  private val permits = Semaphore(maxWorkers, /* fair= */ true)
+  private val idle = ArrayDeque<Worker>()
+  private val lock = Any()
+  private val requestIds = AtomicInteger(0)
+  private var startFailures = 0
+  private var disabledReason: String? = null
+  private var closed = false
+
+  private val watchdog = Executors.newSingleThreadScheduledExecutor { r ->
+    Thread(r, "rcjvm-pool-watchdog").apply { isDaemon = true }
+  }
+
+  fun render(
+    docBytes: ByteArray,
+    spec: RcJvmRenderSpec,
+    seedsText: String,
+    format: RcJvmServerRenderer.Format,
+  ): PoolResult {
+    synchronized(lock) {
+      disabledReason?.let {
+        return PoolResult.Unusable(it)
+      }
+      if (closed) return PoolResult.Unusable("cmp-jvm worker pool is closed")
+    }
+
+    permits.acquire()
+    var worker: Worker? = null
+    try {
+      worker =
+        takeIdle()
+          ?: when (val started = startWorker()) {
+            is StartOutcome.Started -> started.worker
+            is StartOutcome.Failed -> return PoolResult.Unusable(started.reason)
+          }
+
+      val result = worker.render(docBytes, spec, seedsText, format, requestIds.incrementAndGet())
+      if (result is PoolResult.Unusable) {
+        // The worker broke mid-request (wedged, died, desynchronised). It is already destroyed;
+        // dropping it here means the next caller spawns a fresh one.
+        worker = null
+      }
+      return result
+    } finally {
+      val finished = worker
+      if (finished != null) {
+        if (finished.shouldRetire(clock(), maxRendersPerWorker, maxWorkerAgeMillis)) {
+          finished.close()
+        } else {
+          returnIdle(finished)
+        }
+      }
+      permits.release()
+    }
+  }
+
+  /**
+   * Hand out a parked worker, discarding any that died while idle (an OOM-killer, a stray `pkill
+   * java`) or that aged out while parked — handing back a corpse would surface its EOF as a render
+   * failure on a document that is perfectly fine.
+   */
+  private fun takeIdle(): Worker? {
+    val doomed = ArrayList<Worker>()
+    val chosen =
+      synchronized(lock) {
+        var picked: Worker? = null
+        while (picked == null) {
+          val candidate = idle.pollFirst() ?: break
+          if (
+            candidate.isAlive() &&
+              !candidate.shouldRetire(clock(), maxRendersPerWorker, maxWorkerAgeMillis)
+          ) {
+            picked = candidate
+          } else {
+            doomed += candidate
+          }
+        }
+        picked
+      }
+    doomed.forEach { it.close() }
+    return chosen
+  }
+
+  private fun returnIdle(worker: Worker) =
+    synchronized(lock) { if (closed || !worker.isAlive()) worker.close() else idle.addLast(worker) }
+
+  private sealed interface StartOutcome {
+    class Started(val worker: Worker) : StartOutcome
+
+    class Failed(val reason: String) : StartOutcome
+  }
+
+  private fun startWorker(): StartOutcome {
+    val command = buildList {
+      add(javaBin)
+      addAll(extraJvmArgs)
+      add("-cp")
+      add(classpath.joinToString(File.pathSeparator) { it.absolutePath })
+      add(workerMainClass)
+    }
+    return try {
+      val worker = Worker(command, watchdog, renderTimeoutSeconds, clock())
+      worker.handshake(HANDSHAKE_TIMEOUT_SECONDS)
+      synchronized(lock) { startFailures = 0 }
+      StartOutcome.Started(worker)
+    } catch (e: Exception) {
+      val reason = "cmp-jvm worker pool could not start a worker: ${e.message}"
+      synchronized(lock) {
+        startFailures++
+        if (startFailures >= MAX_START_FAILURES) {
+          disabledReason =
+            "$reason (disabled after $startFailures consecutive failures; " +
+              "falling back to one-shot renders)"
+        }
+      }
+      StartOutcome.Failed(reason)
+    }
+  }
+
+  override fun close() {
+    val doomed =
+      synchronized(lock) {
+        closed = true
+        idle.toList().also { idle.clear() }
+      }
+    doomed.forEach { it.close() }
+    watchdog.shutdownNow()
+  }
+
+  /**
+   * One worker process plus the frame streams and the bookkeeping that decides when to retire it.
+   */
+  private class Worker(
+    command: List<String>,
+    private val watchdog: java.util.concurrent.ScheduledExecutorService,
+    private val renderTimeoutSeconds: Long,
+    private val bornAtMillis: Long,
+  ) {
+    private val process = ProcessBuilder(command).redirectErrorStream(false).start()
+    private val toWorker = DataOutputStream(process.outputStream.buffered())
+    private val fromWorker = DataInputStream(process.inputStream.buffered())
+    private val stderrTail = ArrayDeque<String>()
+    private var renders = 0
+
+    init {
+      Thread {
+          try {
+            process.errorStream.bufferedReader().forEachLine { line ->
+              synchronized(stderrTail) {
+                stderrTail.addLast(line)
+                while (stderrTail.size > STDERR_TAIL_LINES) stderrTail.pollFirst()
+              }
+            }
+          } catch (_: IOException) {
+            // The process went away; nothing to drain.
+          }
+        }
+        .apply {
+          name = "rcjvm-worker-stderr"
+          isDaemon = true
+          start()
+        }
+    }
+
+    fun isAlive(): Boolean = process.isAlive
+
+    fun shouldRetire(now: Long, maxRenders: Int, maxAgeMillis: Long): Boolean =
+      renders >= maxRenders || (now - bornAtMillis) >= maxAgeMillis
+
+    /**
+     * Read the worker's hello frame, under a watchdog: a JVM that starts but never speaks (a broken
+     * classpath that hangs, a native loader stuck on a lock) must not block a render thread
+     * forever.
+     */
+    fun handshake(timeoutSeconds: Long) {
+      val guard = armWatchdog(timeoutSeconds)
+      try {
+        val magic = fromWorker.readInt()
+        if (magic != MAGIC_HELLO) {
+          throw IOException("unexpected hello magic $magic (is lib-rcjvm stale?)")
+        }
+        val version = fromWorker.readInt()
+        if (version != PROTOCOL_VERSION) {
+          throw IOException(
+            "worker speaks protocol $version, this cli speaks $PROTOCOL_VERSION " +
+              "(is lib-rcjvm stale?)"
+          )
+        }
+      } catch (e: Exception) {
+        close()
+        throw IOException("${e.message.orEmpty()}${stderrSuffix()}", e)
+      } finally {
+        guard.disarm()
+      }
+    }
+
+    fun render(
+      docBytes: ByteArray,
+      spec: RcJvmRenderSpec,
+      seedsText: String,
+      format: RcJvmServerRenderer.Format,
+      requestId: Int = 0,
+    ): PoolResult {
+      val guard = armWatchdog(renderTimeoutSeconds)
+      var timedOut = false
+      try {
+        val seeds = seedsText.toByteArray(Charsets.UTF_8)
+        toWorker.writeInt(MAGIC_REQUEST)
+        toWorker.writeInt(requestId)
+        toWorker.writeInt(spec.widthPx)
+        toWorker.writeInt(spec.heightPx)
+        toWorker.writeInt(spec.density.toRawBits())
+        toWorker.writeInt(
+          if (format == RcJvmServerRenderer.Format.SVG) WIRE_FORMAT_SVG else WIRE_FORMAT_PNG
+        )
+        toWorker.writeInt(seeds.size)
+        toWorker.write(seeds)
+        toWorker.writeInt(docBytes.size)
+        toWorker.write(docBytes)
+        toWorker.flush()
+
+        val magic = fromWorker.readInt()
+        if (magic != MAGIC_RESPONSE) {
+          throw IOException("unexpected response magic $magic")
+        }
+        fromWorker.readInt() // requestId — single in-flight request per worker, so informational.
+        val status = fromWorker.readInt()
+        val payloadLen = fromWorker.readInt()
+        if (payloadLen < 0) throw IOException("negative payload length $payloadLen")
+        val payload = ByteArray(payloadLen).also { fromWorker.readFully(it) }
+
+        renders++
+        return if (status == STATUS_OK) {
+          PoolResult.Ok(payload)
+        } else {
+          PoolResult.Failed("cmp-jvm render failed: ${String(payload, Charsets.UTF_8).take(300)}")
+        }
+      } catch (e: Exception) {
+        timedOut = guard.fired()
+        close()
+        val reason =
+          if (timedOut) {
+            "cmp-jvm render timed out after ${renderTimeoutSeconds}s"
+          } else {
+            "cmp-jvm pooled worker failed: ${e.message}${stderrSuffix()}"
+          }
+        // Unusable, not Failed: the *worker* broke, so nothing was learned about the document and
+        // the caller is entitled to try the one-shot path.
+        return PoolResult.Unusable(reason)
+      } finally {
+        guard.disarm()
+      }
+    }
+
+    /**
+     * Arm the kill-switch that bounds a blocking frame read.
+     *
+     * A pipe read has no timeout, so destroying the process is the only thing that can unblock the
+     * render thread. The returned guard records whether it actually *fired*: inferring that from
+     * `!process.isAlive` instead would race, because `destroyForcibly` returns before the OS has
+     * reaped the process, and a timeout would then be reported as a generic worker failure.
+     */
+    private fun armWatchdog(timeoutSeconds: Long): Guard {
+      val fired = java.util.concurrent.atomic.AtomicBoolean(false)
+      val future =
+        watchdog.schedule(
+          {
+            fired.set(true)
+            process.destroyForcibly()
+          },
+          timeoutSeconds,
+          TimeUnit.SECONDS,
+        )
+      return Guard(fired, future)
+    }
+
+    class Guard(
+      private val fired: java.util.concurrent.atomic.AtomicBoolean,
+      private val future: java.util.concurrent.ScheduledFuture<*>,
+    ) {
+      fun fired(): Boolean = fired.get()
+
+      fun disarm() {
+        future.cancel(false)
+      }
+    }
+
+    private fun stderrSuffix(): String {
+      val tail = synchronized(stderrTail) { stderrTail.lastOrNull() }
+      return tail?.takeIf { it.isNotBlank() }?.let { ": ${it.take(300)}" }.orEmpty()
+    }
+
+    fun close() {
+      runCatching { toWorker.close() }
+      runCatching { fromWorker.close() }
+      runCatching { process.destroyForcibly() }
+    }
+  }
+
+  internal companion object {
+    const val WORKER_MAIN_CLASS = "ee.schimke.composeai.rcembedded.jvm.RcJvmRenderWorkerMainKt"
+
+    // Mirrors `RcJvmRenderWorkerMain.kt`. The cli cannot depend on the player module (its Skiko
+    // natives are deliberately kept off the cli classpath — that is why the render is a subprocess
+    // at all), so the wire constants are duplicated here on purpose. The version check in
+    // [Worker.handshake] is what keeps the duplication honest: a sidecar that disagrees is refused
+    // and the caller falls back, rather than the two sides silently misreading each other.
+    const val MAGIC_HELLO = 0x52435731
+    const val MAGIC_REQUEST = 0x52435131
+    const val MAGIC_RESPONSE = 0x52435231
+    const val PROTOCOL_VERSION = 1
+    const val STATUS_OK = 0
+    const val STATUS_FAILED = 1
+    const val WIRE_FORMAT_PNG = 0
+    const val WIRE_FORMAT_SVG = 1
+
+    const val HANDSHAKE_TIMEOUT_SECONDS = 60L
+    const val MAX_START_FAILURES = 3
+    const val STDERR_TAIL_LINES = 40
+
+    const val SYS_PROP_ENABLED = "composeai.rcjvm.pool"
+    const val SYS_PROP_WORKERS = "composeai.rcjvm.pool.workers"
+    const val SYS_PROP_MAX_RENDERS = "composeai.rcjvm.pool.maxRenders"
+    const val SYS_PROP_MAX_AGE_MINUTES = "composeai.rcjvm.pool.maxAgeMinutes"
+
+    /**
+     * Default worker count. Each worker is a full Compose Desktop JVM, so this is deliberately
+     * small and independent of core count past a point — serve's own render semaphore already
+     * bounds concurrency, and more workers buy resident memory rather than throughput.
+     */
+    fun defaultWorkers(): Int = (Runtime.getRuntime().availableProcessors() / 2).coerceIn(1, 3)
+
+    fun isEnabled(): Boolean =
+      !System.getProperty(SYS_PROP_ENABLED).equals("off", ignoreCase = true)
+
+    fun configuredWorkers(): Int =
+      System.getProperty(SYS_PROP_WORKERS)?.toIntOrNull()?.coerceIn(1, 16) ?: defaultWorkers()
+
+    fun configuredMaxRenders(): Int =
+      System.getProperty(SYS_PROP_MAX_RENDERS)?.toIntOrNull()?.coerceAtLeast(1) ?: 200
+
+    fun configuredMaxAgeMillis(): Long =
+      (System.getProperty(SYS_PROP_MAX_AGE_MINUTES)?.toLongOrNull()?.coerceAtLeast(1) ?: 30L) *
+        60_000L
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolStub.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolStub.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.cli.serve
+
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.EOFException
+import java.io.FileDescriptor
+import java.io.FileOutputStream
+import java.io.PrintStream
+import kotlin.system.exitProcess
+
+/**
+ * A stand-in for `RcJvmRenderWorkerMain` that speaks the same frames without Compose or Skiko, so
+ * [RcJvmWorkerPoolTest] can exercise the pool's protocol, recycling and failure handling on any
+ * machine — including one with no native render stack, where the real worker cannot start at all.
+ *
+ * Behaviour is selected by system properties on the spawned JVM, so one stub covers every case the
+ * pool has to survive:
+ * * `stub.mode=ok` (default) — echo a deterministic artifact derived from the request.
+ * * `stub.mode=failed` — answer `STATUS_FAILED`, the "player cannot draw this document" case.
+ * * `stub.mode=hang` — accept the request and never answer, so the watchdog has to fire.
+ * * `stub.mode=badVersion` — hello with an unrecognised protocol version.
+ * * `stub.mode=crash` — exit before answering, the "worker died mid-request" case.
+ * * `stub.mode=chatty` — write to `System.out` before the hello frame. The real worker reroutes
+ *   `System.out` to stderr for exactly this reason; the stub proves the pool would notice if it
+ *   ever stopped.
+ *
+ * The artifact for `ok` is `"<width>x<height>@<density>:<format>:<seeds>:<docLen>#<n>"`, where `n`
+ * counts the requests **this process** has served. That lets a test assert the whole request
+ * survived the wire, and — via `n` — distinguish a reused warm worker from a freshly spawned one,
+ * which is the entire property the pool exists to provide.
+ */
+object RcJvmWorkerPoolStub {
+
+  @JvmStatic
+  fun main(args: Array<String>) {
+    val mode = System.getProperty("stub.mode", "ok")
+
+    if (mode == "chatty") {
+      // Deliberately NOT rerouted: this is the mistake the real worker guards against.
+      println("stub: a stray line on stdout")
+      System.out.flush()
+    }
+
+    val frames = DataOutputStream(BufferedOutputStream(FileOutputStream(FileDescriptor.out)))
+    System.setOut(PrintStream(FileOutputStream(FileDescriptor.err), true))
+    val input = DataInputStream(System.`in`.buffered())
+
+    frames.writeInt(RcJvmWorkerPool.MAGIC_HELLO)
+    frames.writeInt(if (mode == "badVersion") 99 else RcJvmWorkerPool.PROTOCOL_VERSION)
+    frames.flush()
+
+    var served = 0
+    while (true) {
+      val magic =
+        try {
+          input.readInt()
+        } catch (_: EOFException) {
+          exitProcess(0)
+        }
+      if (magic != RcJvmWorkerPool.MAGIC_REQUEST) exitProcess(4)
+
+      val requestId = input.readInt()
+      val width = input.readInt()
+      val height = input.readInt()
+      val density = Float.fromBits(input.readInt())
+      val format = input.readInt()
+      val seeds = String(input.readPayload(), Charsets.UTF_8)
+      val doc = input.readPayload()
+
+      when (mode) {
+        "hang" -> {
+          System.err.println("stub: hanging on request $requestId")
+          Thread.sleep(Long.MAX_VALUE)
+        }
+        "crash" -> {
+          System.err.println("stub: dying on request $requestId")
+          exitProcess(9)
+        }
+      }
+
+      served++
+      val formatName = if (format == RcJvmWorkerPool.WIRE_FORMAT_SVG) "svg" else "png"
+      val payload = "${width}x$height@$density:$formatName:$seeds:${doc.size}#$served".toByteArray()
+      val status =
+        if (mode == "failed") RcJvmWorkerPool.STATUS_FAILED else RcJvmWorkerPool.STATUS_OK
+
+      frames.writeInt(RcJvmWorkerPool.MAGIC_RESPONSE)
+      frames.writeInt(requestId)
+      frames.writeInt(status)
+      frames.writeInt(payload.size)
+      frames.write(payload)
+      frames.flush()
+    }
+  }
+
+  private fun DataInputStream.readPayload(): ByteArray {
+    val len = readInt()
+    return ByteArray(len).also { readFully(it) }
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Covers [RcJvmWorkerPool] against [RcJvmWorkerPoolStub] — a worker that speaks the real frames
+ * without Compose or Skiko, so the protocol, the warm-reuse property and every failure path are
+ * asserted on any machine, including CI images with no native render stack.
+ *
+ * The distinction these tests are built around is the one the pool's whole failure posture rests
+ * on: `Failed` means the *player* answered "I cannot draw this document" and the caller must
+ * **not** retry the one-shot path (that would double the cost of every bad document), while
+ * `Unusable` means the *pool* could not serve at all and falling back is correct.
+ */
+class RcJvmWorkerPoolTest {
+
+  @Test
+  fun aWarmWorkerIsReusedAcrossDocumentsAndCarriesTheWholeRequest() {
+    pool().use { pool ->
+      val first = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      val second = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+
+      // The spec, format and document length all survived the wire.
+      assertEquals("640x480@2.0:png::${DOC.size}#1", first.text())
+      // `#2` is the point of the pool: the second document was drawn by the same process, so it
+      // paid no JVM boot. A fresh worker would report `#1` again.
+      assertEquals("640x480@2.0:png::${DOC.size}#2", second.text())
+    }
+  }
+
+  @Test
+  fun seedsAndFormatReachTheWorker() {
+    pool().use { pool ->
+      val result = pool.render(DOC, SPEC, "float bmFtZQ== 1.5", RcJvmServerRenderer.Format.SVG)
+      assertEquals("640x480@2.0:svg:float bmFtZQ== 1.5:${DOC.size}#1", result.text())
+    }
+  }
+
+  @Test
+  fun aDocumentThePlayerCannotDrawIsFailedNotUnusable() {
+    pool(mode = "failed").use { pool ->
+      val result = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      // Failed, so `RcJvmServerRenderer` returns it as-is instead of re-rendering cold.
+      val failed = assertIs<RcJvmWorkerPool.PoolResult.Failed>(result)
+      assertContains(failed.reason, "cmp-jvm render failed")
+    }
+  }
+
+  @Test
+  fun aHangingWorkerIsKilledByTheWatchdogAndReportedAsUnusable() {
+    pool(mode = "hang", renderTimeoutSeconds = 2).use { pool ->
+      val result = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      val unusable = assertIs<RcJvmWorkerPool.PoolResult.Unusable>(result)
+      assertContains(unusable.reason, "timed out")
+    }
+  }
+
+  @Test
+  fun aWorkerThatDiesMidRequestIsUnusableSoTheCallerFallsBack() {
+    pool(mode = "crash").use { pool ->
+      val result = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      assertIs<RcJvmWorkerPool.PoolResult.Unusable>(result)
+    }
+  }
+
+  @Test
+  fun aSidecarSpeakingAnotherProtocolVersionIsRefused() {
+    pool(mode = "badVersion").use { pool ->
+      val result = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      val unusable = assertIs<RcJvmWorkerPool.PoolResult.Unusable>(result)
+      assertContains(unusable.reason, "protocol")
+    }
+  }
+
+  @Test
+  fun strayStdoutFromAWorkerIsRefusedRatherThanReadAsAFrame() {
+    // Why the real worker reroutes `System.out` to stderr before anything else runs: one stray
+    // line is read as a frame header and the stream never resynchronises. Refusing beats
+    // misreading — the caller falls back and still gets a picture.
+    pool(mode = "chatty").use { pool ->
+      val result = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      assertIs<RcJvmWorkerPool.PoolResult.Unusable>(result)
+    }
+  }
+
+  @Test
+  fun aWorkerIsRetiredAfterItsRenderBudget() {
+    pool(maxRendersPerWorker = 1).use { pool ->
+      val first = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      val second = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      // Both report `#1`: the budget of one retired the first worker, so the second render was
+      // served by a fresh process. This is what bounds a native leak.
+      assertEquals("640x480@2.0:png::${DOC.size}#1", first.text())
+      assertEquals("640x480@2.0:png::${DOC.size}#1", second.text())
+    }
+  }
+
+  @Test
+  fun anAgedOutWorkerIsRetiredEvenWithBudgetLeft() {
+    var now = 0L
+    pool(maxWorkerAgeMillis = 1_000, clock = { now }).use { pool ->
+      val first = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      now += 5_000
+      val second = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+      assertEquals("640x480@2.0:png::${DOC.size}#1", first.text())
+      assertEquals("640x480@2.0:png::${DOC.size}#1", second.text())
+    }
+  }
+
+  @Test
+  fun repeatedStartFailuresDisableThePoolSoTheCostIsPaidOnce() {
+    pool(workerMainClass = "ee.schimke.composeai.cli.serve.NoSuchWorkerMain").use { pool ->
+      val reasons =
+        (1..RcJvmWorkerPool.MAX_START_FAILURES + 1).map {
+          assertIs<RcJvmWorkerPool.PoolResult.Unusable>(
+              pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
+            )
+            .reason
+        }
+      // Every attempt is unusable (so every render still gets a picture from the one-shot path),
+      // and once the pool has given up it says so rather than spawning a doomed JVM per render.
+      assertTrue(reasons.all { it.isNotBlank() })
+      assertContains(reasons.last(), "disabled after")
+    }
+  }
+
+  @Test
+  fun concurrentRendersAreServedWithoutCrossingStreams() {
+    pool(maxWorkers = 3).use { pool ->
+      val results = java.util.concurrent.ConcurrentHashMap<Int, String>()
+      val threads =
+        (1..12).map { i ->
+          Thread {
+            // A document of a distinct length per caller, so a crossed stream is detectable.
+            val doc = ByteArray(i) { it.toByte() }
+            results[i] = pool.render(doc, SPEC, "", RcJvmServerRenderer.Format.PNG).text()
+          }
+        }
+      threads.forEach { it.start() }
+      threads.forEach { it.join(60_000) }
+
+      assertEquals(12, results.size)
+      // Each caller must get the answer to *its own* document. A shared or interleaved stream
+      // would surface here as a mismatched length.
+      (1..12).forEach { i -> assertContains(results.getValue(i), ":$i#") }
+    }
+  }
+
+  private fun RcJvmWorkerPool.PoolResult.text(): String =
+    String(assertIs<RcJvmWorkerPool.PoolResult.Ok>(this).bytes, Charsets.UTF_8)
+
+  private fun pool(
+    mode: String = "ok",
+    maxWorkers: Int = 1,
+    maxRendersPerWorker: Int = 100,
+    maxWorkerAgeMillis: Long = 10 * 60_000L,
+    renderTimeoutSeconds: Long = 60,
+    clock: () -> Long = System::currentTimeMillis,
+    workerMainClass: String = STUB_MAIN_CLASS,
+  ) =
+    RcJvmWorkerPool(
+      classpath = testClasspath(),
+      javaBin = javaBin(),
+      extraJvmArgs = listOf("-Dstub.mode=$mode"),
+      maxWorkers = maxWorkers,
+      maxRendersPerWorker = maxRendersPerWorker,
+      maxWorkerAgeMillis = maxWorkerAgeMillis,
+      renderTimeoutSeconds = renderTimeoutSeconds,
+      clock = clock,
+      workerMainClass = workerMainClass,
+    )
+
+  /** This JVM's own classpath, which carries the stub — no staged sidecar needed. */
+  private fun testClasspath(): List<File> =
+    System.getProperty("java.class.path").split(File.pathSeparator).map(::File)
+
+  private fun javaBin(): String {
+    val candidate = File(System.getProperty("java.home"), "bin/java")
+    return if (candidate.canExecute()) candidate.absolutePath else "java"
+  }
+
+  private companion object {
+    const val STUB_MAIN_CLASS = "ee.schimke.composeai.cli.serve.RcJvmWorkerPoolStub"
+    val SPEC = RcJvmRenderSpec(widthPx = 640, heightPx = 480, density = 2f)
+    val DOC = ByteArray(37) { it.toByte() }
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolTest.kt
@@ -129,6 +129,39 @@ class RcJvmWorkerPoolTest {
   }
 
   @Test
+  fun closingThePoolReleasesAWorkerThatIsMidRender() {
+    // A checked-out worker is absent from the idle set, so a shutdown that only drains `idle`
+    // leaves its child JVM alive and its caller blocked on a pipe read forever — and stopping the
+    // watchdog removes the scheduled kill that was the only other way out. Destroying every live
+    // worker, before the watchdog stops, is what makes shutdown terminate.
+    val pool = pool(mode = "hang", renderTimeoutSeconds = 600)
+    val outcome = java.util.concurrent.ArrayBlockingQueue<RcJvmWorkerPool.PoolResult>(1)
+    val renderThread = Thread {
+      outcome.add(pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG))
+    }
+    renderThread.start()
+
+    // Wait until the worker is genuinely mid-render rather than still booting, so the test covers
+    // the checked-out case instead of accidentally closing an empty pool.
+    val spawned = System.currentTimeMillis()
+    while (
+      renderThread.state == Thread.State.NEW && System.currentTimeMillis() - spawned < 30_000
+    ) {
+      Thread.sleep(20)
+    }
+    Thread.sleep(2_000)
+
+    pool.close()
+
+    val result =
+      outcome.poll(60, java.util.concurrent.TimeUnit.SECONDS)
+        ?: error("closing the pool left a mid-render caller blocked — it never returned")
+    assertIs<RcJvmWorkerPool.PoolResult.Unusable>(result)
+    renderThread.join(10_000)
+    assertTrue(!renderThread.isAlive, "render thread did not finish after shutdown")
+  }
+
+  @Test
   fun repeatedStartFailuresDisableThePoolSoTheCostIsPaidOnce() {
     pool(workerMainClass = "ee.schimke.composeai.cli.serve.NoSuchWorkerMain").use { pool ->
       val reasons =

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderMain.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderMain.kt
@@ -119,33 +119,10 @@ private const val FORMAT_SVG = "svg"
 private const val DEFAULT_DENSITY = 2f
 
 /**
- * Read the knob-seed file the serve side wrote: one seed per line, space-separated `<kind>
- * <base64Name> <value>`, where `kind` is `str` / `float` / `int` / `color`. The name is base64 (it
- * may contain any character); for `str` the value is base64 too, for the numeric kinds it is a
- * plain decimal (`color` is a decimal ARGB int). Unknown kinds / malformed lines are skipped.
+ * Read the knob-seed file the serve side wrote. The format — and the skip-don't-fail posture for
+ * malformed lines — is documented on [parseSeedText], which the pooled worker shares.
  */
-private fun readSeeds(file: File): Map<String, RcSeed> {
-  val decoder = java.util.Base64.getDecoder()
-  fun decode(s: String) = String(decoder.decode(s), Charsets.UTF_8)
-  val seeds = LinkedHashMap<String, RcSeed>()
-  file.readLines().forEach { line ->
-    if (line.isBlank()) return@forEach
-    val parts = line.split(' ')
-    if (parts.size < 3) return@forEach
-    val (kind, nameB64, rawValue) = Triple(parts[0], parts[1], parts[2])
-    val name = decode(nameB64)
-    val seed =
-      when (kind) {
-        "str" -> RcSeed.StringValue(decode(rawValue))
-        "float" -> rawValue.toFloatOrNull()?.let { RcSeed.FloatValue(it) }
-        "int" -> rawValue.toIntOrNull()?.let { RcSeed.IntValue(it) }
-        "color" -> rawValue.toIntOrNull()?.let { RcSeed.ColorValue(it) }
-        else -> null
-      }
-    if (seed != null) seeds[name] = seed
-  }
-  return seeds
-}
+private fun readSeeds(file: File): Map<String, RcSeed> = parseSeedText(file.readText())
 
 /**
  * Parse `--flag value` pairs; unknown or dangling flags are ignored (the caller controls the argv).

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderWorkerMain.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderWorkerMain.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded.jvm
+
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.EOFException
+import java.io.FileDescriptor
+import java.io.FileOutputStream
+import java.io.PrintStream
+import kotlin.system.exitProcess
+
+/**
+ * The **pooled** counterpart of [main]: a long-lived worker that renders one captured Remote
+ * Compose document per request frame, instead of one per process.
+ *
+ * The one-shot entry point pays Compose Desktop + Skiko boot on every document — measured at ~2.3
+ * s, against ~85 ms for a render on an already-warm JVM. Since a `.rc` document is self-describing
+ * (it is the same byte stream the in-browser JS player draws with no knowledge of any project), a
+ * worker needs nothing project-derived and can therefore take a document from any catalog, in any
+ * order. That is what makes a shared pool possible here and not for the `@Preview` lane, whose
+ * daemon must hold the consumer module's classloader.
+ *
+ * Reusing a process across documents is only sound because it is observably identical to a fresh
+ * one: `RcJvmHotWorkerDeterminismTest` renders a corpus cold, churns the process, and asserts the
+ * re-render is byte-identical. That test is the gate on this file existing — if it ever fails, the
+ * pool must be disabled rather than the assertion relaxed, because `rc-compare` gates the PR on
+ * pixel parity and a worker-age-dependent render would make that gate flaky.
+ *
+ * ## Wire protocol
+ *
+ * Binary frames over stdin/stdout, big-endian, no external dependency. The cli side is
+ * `RcJvmWorkerPool`, which mirrors these constants and refuses to use a worker whose
+ * [PROTOCOL_VERSION] it does not recognise — so an install whose `lib-rcjvm/` sidecar predates this
+ * file falls back to the one-shot path instead of hanging on a handshake that never comes.
+ *
+ * ```
+ * worker -> pool, once at startup:
+ *   int32 MAGIC_HELLO, int32 PROTOCOL_VERSION
+ * pool -> worker, per request:
+ *   int32 MAGIC_REQUEST, int32 requestId, int32 width, int32 height,
+ *   int32 densityBits (Float.floatToIntBits), int32 format (0=png, 1=svg),
+ *   int32 seedsLen, <seedsLen bytes UTF-8>, int32 docLen, <docLen bytes>
+ * worker -> pool, per response:
+ *   int32 MAGIC_RESPONSE, int32 requestId, int32 status (0=ok, 1=failed),
+ *   int32 payloadLen, <payloadLen bytes>   // artifact bytes on ok, UTF-8 reason on failure
+ * ```
+ *
+ * Closing the worker's stdin ends it cleanly (the next frame read hits EOF and it exits 0).
+ */
+fun rcJvmRenderWorkerMain() {
+  // Claim the real stdout for protocol frames BEFORE anything else can print to it. Skiko, AWT,
+  // the font resolver and any transitive library are all free to write to `System.out`; a single
+  // stray line would be read as a frame header and desynchronise the stream for good. Everything
+  // that goes on writing to `System.out` lands on stderr instead, where the pool drains it into
+  // the failure tail.
+  val frames = DataOutputStream(BufferedOutputStream(FileOutputStream(FileDescriptor.out)))
+  System.setOut(PrintStream(FileOutputStream(FileDescriptor.err), true))
+
+  val input = DataInputStream(System.`in`.buffered())
+
+  frames.writeInt(MAGIC_HELLO)
+  frames.writeInt(PROTOCOL_VERSION)
+  frames.flush()
+
+  while (true) {
+    val magic =
+      try {
+        input.readInt()
+      } catch (_: EOFException) {
+        // The pool closed our stdin: an ordinary shutdown, not a failure.
+        frames.flush()
+        exitProcess(0)
+      }
+    if (magic != MAGIC_REQUEST) {
+      // The stream is desynchronised and there is no safe way to resynchronise mid-frame. Die so
+      // the pool replaces this worker rather than serving it garbage forever.
+      System.err.println("rcjvm worker: unexpected frame magic $magic; exiting")
+      exitProcess(4)
+    }
+
+    val requestId = input.readInt()
+    val width = input.readInt()
+    val height = input.readInt()
+    val density = Float.fromBits(input.readInt())
+    val format = input.readInt()
+    val seedsText = String(input.readPayload(), Charsets.UTF_8)
+    val doc = input.readPayload()
+
+    var fatal: Throwable? = null
+    val response =
+      try {
+        val seeds = parseSeedText(seedsText)
+        val artifact =
+          when (format) {
+            WIRE_FORMAT_SVG -> renderRemoteDocumentToSvg(doc, width, height, density, seeds)
+            else -> renderRemoteDocumentToPng(doc, width, height, density, seeds)
+          }
+        Response(STATUS_OK, artifact)
+      } catch (e: Exception) {
+        // A document this player cannot draw is an ordinary per-request failure: report it and stay
+        // alive, exactly as the one-shot path reports it as a non-zero exit without implying the
+        // renderer itself is broken.
+        Response(STATUS_FAILED, "${e::class.java.simpleName}: ${e.message}".toByteArray())
+      } catch (t: Throwable) {
+        // An Error (OOM, a native link failure, a StackOverflow) says the *process* is no longer
+        // trustworthy. Answer the caller so it gets a reason rather than a timeout, then exit so
+        // the pool discards this worker instead of reusing a damaged JVM.
+        fatal = t
+        Response(STATUS_FAILED, "${t::class.java.simpleName}: ${t.message}".toByteArray())
+      }
+
+    frames.writeInt(MAGIC_RESPONSE)
+    frames.writeInt(requestId)
+    frames.writeInt(response.status)
+    frames.writeInt(response.payload.size)
+    frames.write(response.payload)
+    frames.flush()
+
+    fatal?.let {
+      System.err.println("rcjvm worker: fatal ${it::class.java.simpleName}; exiting")
+      exitProcess(5)
+    }
+  }
+}
+
+/** Entry point for `java -cp … ee.schimke.composeai.rcembedded.jvm.RcJvmRenderWorkerMainKt`. */
+fun main() {
+  rcJvmRenderWorkerMain()
+}
+
+private class Response(val status: Int, val payload: ByteArray)
+
+/**
+ * Read a length-prefixed payload, rejecting a length that could only come from a desynchronised
+ * stream — without this a corrupt length allocates an arbitrary array and the worker dies on OOM
+ * instead of on the protocol error that actually happened.
+ */
+private fun DataInputStream.readPayload(): ByteArray {
+  val len = readInt()
+  if (len < 0 || len > MAX_PAYLOAD_BYTES) {
+    System.err.println("rcjvm worker: implausible payload length $len; exiting")
+    exitProcess(4)
+  }
+  return ByteArray(len).also { readFully(it) }
+}
+
+// Mirrored by `RcJvmWorkerPool` on the cli side. 'RCW1' / 'RCQ1' / 'RCR1' as big-endian ASCII.
+internal const val MAGIC_HELLO = 0x52435731
+internal const val MAGIC_REQUEST = 0x52435131
+internal const val MAGIC_RESPONSE = 0x52435231
+internal const val PROTOCOL_VERSION = 1
+internal const val STATUS_OK = 0
+internal const val STATUS_FAILED = 1
+internal const val WIRE_FORMAT_PNG = 0
+internal const val WIRE_FORMAT_SVG = 1
+
+/** 256 MB — far above any real document or rendered artifact, far below "allocate until OOM". */
+private const val MAX_PAYLOAD_BYTES = 256 * 1024 * 1024

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcSeedFormat.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcSeedFormat.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded.jvm
+
+/**
+ * The knob-seed wire format shared by both entry points into this player — the one-shot [main]
+ * (which reads it from a `--seeds` file) and the pooled [rcJvmRenderWorkerMain] (which receives it
+ * inline in a request frame).
+ *
+ * One seed per line, space-separated `<kind> <base64Name> <value>`, where `kind` is `str` / `float`
+ * / `int` / `color`. The name is base64 (it may contain any character); for `str` the value is
+ * base64 too, for the numeric kinds it is a plain decimal (`color` is a decimal ARGB int). Unknown
+ * kinds and malformed lines are skipped rather than failing the render — a seed the caller could
+ * not express must degrade to the document's authored default, never to no picture at all.
+ *
+ * The producer is `RcJvmServerRenderer.seedLines` on the cli side; this is the only parser, so the
+ * two lanes can never disagree about what a seed file means.
+ */
+internal fun parseSeedText(text: String): Map<String, RcSeed> {
+  val decoder = java.util.Base64.getDecoder()
+  fun decode(s: String) = String(decoder.decode(s), Charsets.UTF_8)
+  val seeds = LinkedHashMap<String, RcSeed>()
+  text.lineSequence().forEach { line ->
+    if (line.isBlank()) return@forEach
+    val parts = line.split(' ')
+    if (parts.size < 3) return@forEach
+    val (kind, nameB64, rawValue) = Triple(parts[0], parts[1], parts[2])
+    val name =
+      try {
+        decode(nameB64)
+      } catch (_: IllegalArgumentException) {
+        return@forEach
+      }
+    val seed =
+      when (kind) {
+        "str" ->
+          try {
+            RcSeed.StringValue(decode(rawValue))
+          } catch (_: IllegalArgumentException) {
+            null
+          }
+        "float" -> rawValue.toFloatOrNull()?.let { RcSeed.FloatValue(it) }
+        "int" -> rawValue.toIntOrNull()?.let { RcSeed.IntValue(it) }
+        "color" -> rawValue.toIntOrNull()?.let { RcSeed.ColorValue(it) }
+        else -> null
+      }
+    if (seed != null) seeds[name] = seed
+  }
+  return seeds
+}

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmHotWorkerDeterminismTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmHotWorkerDeterminismTest.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded.jvm
+
+import java.io.File
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The gate on reusing a **long-lived** jvm render worker instead of spawning one JVM per document.
+ *
+ * `RcJvmServerRenderer` currently forks a fresh JVM for every `.rc` it draws, so every render pays
+ * Compose Desktop + Skiko boot. A pooled worker amortises that across documents — but only if a
+ * worker that has already drawn many documents still produces **byte-identical** output to a worker
+ * that has drawn none. That is not free: `ImageComposeScene`, Skia, the AWT/font stack and the
+ * `GoogleFontTypefaceResolver` cache all hold process-global state, and `rc-compare` gates the PR
+ * on pixel parity — so hot-worker drift would turn a correctness gate into a flake source.
+ *
+ * This test is that check, and it is the reason the pool is allowed to exist. It renders a corpus
+ * cold (first touch in a fresh JVM — exactly what the one-shot subprocess produces today), churns
+ * the process with many renders at varied sizes, densities, seeds and formats, then re-renders the
+ * corpus at the original spec and asserts the bytes are identical.
+ *
+ * Deliberately compares **encoded PNG bytes**, not a pixel tolerance: the pool's promise is that
+ * pooling is unobservable, and anything short of byte identity means a cached render could differ
+ * from a freshly-computed one depending only on worker age — which is precisely the
+ * non-reproducibility this repo's diffing exists to catch.
+ *
+ * Like the other skiko tests here it needs the natives and skips loudly where they are absent.
+ */
+class RcJvmHotWorkerDeterminismTest {
+
+  @Before
+  fun requireSkikoNatives() {
+    if (!SKIKO_LOADED) {
+      System.err.println(
+        "RcJvmHotWorkerDeterminismTest skipped entirely: skiko's native library did not load, so " +
+          "the hot-worker determinism gate never ran. Cause: $skikoLoadFailure"
+      )
+    }
+    Assume.assumeTrue("skiko natives unavailable: $skikoLoadFailure", SKIKO_LOADED)
+  }
+
+  @Test
+  fun aHotWorkerRendersByteIdenticallyToAColdOne() {
+    val corpus = corpus()
+    check(corpus.isNotEmpty()) { "no .rc fixtures found — the determinism gate would be vacuous" }
+
+    // Cold: the first touch of each document in this JVM. This is what the one-shot subprocess
+    // produces today, so it is the reference the pool must reproduce.
+    val coldNanos = ArrayList<Long>()
+    val cold = corpus.map { doc ->
+      val start = System.nanoTime()
+      val png = renderRemoteDocumentToPng(doc.bytes, WIDTH, HEIGHT, DENSITY)
+      coldNanos += System.nanoTime() - start
+      doc.name to png
+    }
+
+    // Churn: age the process the way a pooled worker would be aged — many documents, varied specs,
+    // seeds applied, and the SVG lane interleaved (it allocates temp dirs and a second scene type).
+    var churned = 0
+    repeat(CHURN_ROUNDS) { round ->
+      corpus.forEach { doc ->
+        val width = WIDTH + ((round * 37) % 240)
+        val height = HEIGHT + ((round * 53) % 180)
+        val density = DENSITIES[(round + churned) % DENSITIES.size]
+        val seeds =
+          if (round % 3 == 0) emptyMap()
+          else mapOf("prototype.churn" to RcSeed.FloatValue(round.toFloat()))
+        renderRemoteDocumentToPng(doc.bytes, width, height, density, seeds)
+        churned++
+        if (round % 4 == 0) {
+          runCatching { renderRemoteDocumentToSvg(doc.bytes, width, height, density) }
+        }
+      }
+    }
+
+    // Hot: the same documents at the same spec, on a worker that has now drawn `churned` others.
+    val hotNanos = ArrayList<Long>()
+    val hot = corpus.map { doc ->
+      val start = System.nanoTime()
+      val png = renderRemoteDocumentToPng(doc.bytes, WIDTH, HEIGHT, DENSITY)
+      hotNanos += System.nanoTime() - start
+      doc.name to png
+    }
+
+    System.err.println(
+      "hot-worker determinism: ${corpus.size} document(s), $churned churn render(s); " +
+        "cold ${coldNanos.sum() / 1_000_000}ms total (first ${coldNanos.first() / 1_000_000}ms), " +
+        "hot ${hotNanos.sum() / 1_000_000}ms total"
+    )
+
+    cold.zip(hot).forEach { (coldEntry, hotEntry) ->
+      val (name, coldPng) = coldEntry
+      val (_, hotPng) = hotEntry
+      if (!coldPng.contentEquals(hotPng)) {
+        System.err.println(
+          "DRIFT on $name: cold ${coldPng.size} bytes vs hot ${hotPng.size} bytes; " +
+            "first difference at byte ${firstDifference(coldPng, hotPng)}"
+        )
+      }
+      assertArrayEquals(
+        "a worker that has drawn $churned document(s) must render '$name' byte-identically to a " +
+          "cold one — otherwise pooling is observable and rc-compare's pixel gate becomes flaky",
+        coldPng,
+        hotPng,
+      )
+    }
+  }
+
+  private data class Doc(val name: String, val bytes: ByteArray)
+
+  /**
+   * Every `.rc` fixture in the repository, not just this module's own: the pool's premise is that a
+   * worker takes a document from anywhere, so the gate should see documents captured by different
+   * lanes (the shared title-card fixture plus the design-artifacts export fixtures).
+   */
+  private fun corpus(): List<Doc> {
+    val bundled = javaClass.getResourceAsStream("/$FIXTURE")?.use { Doc(FIXTURE, it.readBytes()) }
+    val fromRepo =
+      repoRoot()
+        ?.resolve("scripts/design-artifacts/fixtures")
+        ?.listFiles { f: File -> f.extension == "rc" }
+        ?.sortedBy { it.name }
+        ?.map { Doc(it.name, it.readBytes()) }
+        .orEmpty()
+    return listOfNotNull(bundled) + fromRepo
+  }
+
+  /** Walk up from the module dir until the repo root (the one with `settings.gradle.kts`). */
+  private fun repoRoot(): File? {
+    var dir: File? = File(System.getProperty("user.dir")).absoluteFile
+    while (dir != null) {
+      if (File(dir, "settings.gradle.kts").isFile) return dir
+      dir = dir.parentFile
+    }
+    return null
+  }
+
+  private fun firstDifference(a: ByteArray, b: ByteArray): Int {
+    val n = minOf(a.size, b.size)
+    for (i in 0 until n) if (a[i] != b[i]) return i
+    return n
+  }
+
+  private companion object {
+    const val FIXTURE = "rc-fixtures/TitleCardRemote-640x480.rc"
+    const val WIDTH = 640
+    const val HEIGHT = 480
+    const val DENSITY = 2f
+    const val CHURN_ROUNDS = 24
+    val DENSITIES = floatArrayOf(1f, 1.5f, 2f, 3f).toTypedArray()
+
+    var skikoLoadFailure: String? = null
+
+    /** Whether Skia is callable at all — decided once by touching a class that loads the native. */
+    val SKIKO_LOADED: Boolean =
+      try {
+        org.jetbrains.skia.FontMgr.default.familiesCount
+        true
+      } catch (t: Throwable) {
+        skikoLoadFailure = "${t::class.java.simpleName}: ${t.message}"
+        false
+      }
+  }
+}

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderWorkerProtocolTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderWorkerProtocolTest.kt
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded.jvm
+
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * End-to-end check that a **pooled worker is unobservable**: a document drawn by
+ * [rcJvmRenderWorkerMain] over the wire must be byte-identical to the same document drawn by the
+ * one-shot `RcJvmRenderMain` subprocess it replaces.
+ *
+ * `RcJvmHotWorkerDeterminismTest` proves a warm process does not drift from a cold one; this proves
+ * the *transport* adds nothing either — that framing, the inline seed text and the stdout hygiene
+ * all preserve the artifact exactly. Together they are what let `RcJvmServerRenderer` route a
+ * render through the pool or the one-shot path interchangeably without the choice showing up in
+ * `rc-compare`'s pixel gate.
+ *
+ * The cli-side counterpart (`RcJvmWorkerPoolTest`) covers the pool's failure and recycling paths
+ * against a stub; this one covers the real player, so it needs skiko's natives and skips loudly
+ * where they are absent.
+ */
+class RcJvmRenderWorkerProtocolTest {
+
+  private var worker: Process? = null
+
+  @Before
+  fun requireSkikoNatives() {
+    if (!SKIKO_LOADED) {
+      System.err.println(
+        "RcJvmRenderWorkerProtocolTest skipped entirely: skiko's native library did not load, so " +
+          "the pooled-worker transport was never exercised. Cause: $skikoLoadFailure"
+      )
+    }
+    Assume.assumeTrue("skiko natives unavailable: $skikoLoadFailure", SKIKO_LOADED)
+  }
+
+  @After
+  fun stopWorker() {
+    worker?.destroyForcibly()
+  }
+
+  @Test
+  fun aWorkerRendersByteIdenticallyToTheOneShotLaneAndStaysWarmAcrossDocuments() {
+    val doc = fixtureBytes()
+    // The reference is the *one-shot subprocess*, not an in-process call. Those are not the same
+    // picture: a JVM's graphics configuration (headless mode above all, which Gradle sets on its
+    // test workers) reaches text metrics, so an in-process render here differs from any spawned
+    // render by ~1 KB of PNG. That is not drift the pool introduces — it is why `renderJvmArgs` is
+    // shared, and why the only meaningful question is whether the two *spawned* lanes agree.
+    val oneShot = renderOneShot(doc)
+
+    val process = startWorker().also { worker = it }
+    val toWorker = DataOutputStream(process.outputStream.buffered())
+    val fromWorker = DataInputStream(process.inputStream.buffered())
+
+    assertEquals("hello magic", MAGIC_HELLO, fromWorker.readInt())
+    assertEquals("protocol version", PROTOCOL_VERSION, fromWorker.readInt())
+
+    val first = fromWorker.exchange(toWorker, doc, requestId = 1)
+    assertEquals("status", STATUS_OK, first.status)
+    assertArrayEquals(
+      "a pooled render must be byte-identical to the one-shot lane — otherwise which lane served " +
+        "a request would be visible in the pixels, and rc-compare's parity gate becomes flaky",
+      oneShot,
+      first.payload,
+    )
+
+    // Second document on the SAME process: this is the amortisation the pool exists for, and it
+    // must not change the answer either.
+    val second = fromWorker.exchange(toWorker, doc, requestId = 2)
+    assertEquals("status", STATUS_OK, second.status)
+    assertArrayEquals("warm render drifted from the cold one", oneShot, second.payload)
+
+    // Closing stdin is the shutdown contract; the worker must exit 0 rather than be killed.
+    toWorker.close()
+    assertTrue("worker did not exit after stdin closed", process.waitFor(60, TimeUnit.SECONDS))
+    assertEquals("clean shutdown exit code", 0, process.exitValue())
+  }
+
+  @Test
+  fun anUndrawableDocumentIsReportedWithoutKillingTheWorker() {
+    val process = startWorker().also { worker = it }
+    val toWorker = DataOutputStream(process.outputStream.buffered())
+    val fromWorker = DataInputStream(process.inputStream.buffered())
+    fromWorker.readInt()
+    fromWorker.readInt()
+
+    val garbage = fromWorker.exchange(toWorker, ByteArray(64) { 0xEF.toByte() }, requestId = 1)
+    assertEquals("garbage should fail, not crash", STATUS_FAILED, garbage.status)
+    assertTrue("a failure must carry a reason", garbage.payload.isNotEmpty())
+
+    // The point: one bad document does not cost the pool a worker. The next render still works.
+    val good = fromWorker.exchange(toWorker, fixtureBytes(), requestId = 2)
+    assertEquals("worker survived a bad document", STATUS_OK, good.status)
+    assertArrayEquals(renderOneShot(fixtureBytes()), good.payload)
+  }
+
+  private class Frame(val status: Int, val payload: ByteArray)
+
+  private fun DataInputStream.exchange(
+    toWorker: DataOutputStream,
+    doc: ByteArray,
+    requestId: Int,
+    seedsText: String = "",
+  ): Frame {
+    val seeds = seedsText.toByteArray(Charsets.UTF_8)
+    toWorker.writeInt(MAGIC_REQUEST)
+    toWorker.writeInt(requestId)
+    toWorker.writeInt(WIDTH)
+    toWorker.writeInt(HEIGHT)
+    toWorker.writeInt(DENSITY.toRawBits())
+    toWorker.writeInt(WIRE_FORMAT_PNG)
+    toWorker.writeInt(seeds.size)
+    toWorker.write(seeds)
+    toWorker.writeInt(doc.size)
+    toWorker.write(doc)
+    toWorker.flush()
+
+    assertEquals("response magic", MAGIC_RESPONSE, readInt())
+    assertEquals("response is for the request we sent", requestId, readInt())
+    val status = readInt()
+    val payload = ByteArray(readInt()).also { readFully(it) }
+    return Frame(status, payload)
+  }
+
+  /**
+   * Render through the existing one-shot entry point, spawned exactly the way
+   * `RcJvmServerRenderer.renderOneShot` spawns it. This is the lane the pool must be
+   * indistinguishable from.
+   */
+  private fun renderOneShot(doc: ByteArray): ByteArray {
+    val input = File.createTempFile("rcjvm-proto-in-", ".rc").apply { writeBytes(doc) }
+    val output = File.createTempFile("rcjvm-proto-out-", ".png").apply { delete() }
+    try {
+      val process =
+        ProcessBuilder(
+            jvmCommand("ee.schimke.composeai.rcembedded.jvm.RcJvmRenderMainKt") +
+              listOf(
+                "--input",
+                input.absolutePath,
+                "--output",
+                output.absolutePath,
+                "--width",
+                WIDTH.toString(),
+                "--height",
+                HEIGHT.toString(),
+                "--density",
+                DENSITY.toString(),
+                "--format",
+                "png",
+              )
+          )
+          .redirectError(ProcessBuilder.Redirect.INHERIT)
+          .start()
+      assertTrue("one-shot render did not finish", process.waitFor(120, TimeUnit.SECONDS))
+      assertEquals("one-shot render exit code", 0, process.exitValue())
+      return output.readBytes()
+    } finally {
+      input.delete()
+      output.delete()
+    }
+  }
+
+  /**
+   * The JVM flags both lanes boot under, mirroring `RcJvmServerRenderer.renderJvmArgs`. Identical
+   * on purpose: differing flags would make the two lanes draw differently for reasons that have
+   * nothing to do with pooling.
+   */
+  private fun jvmCommand(mainClass: String): List<String> {
+    val java = File(System.getProperty("java.home"), "bin/java")
+    return listOf(
+      if (java.canExecute()) java.absolutePath else "java",
+      "--enable-native-access=ALL-UNNAMED",
+      "-Dapple.awt.UIElement=true",
+      "-cp",
+      System.getProperty("java.class.path"),
+      mainClass,
+    )
+  }
+
+  /**
+   * Spawn the worker on this test JVM's own classpath — it already carries the player and skiko's
+   * natives, so no staged `lib-rcjvm/` sidecar is needed to exercise the real entry point.
+   */
+  private fun startWorker(): Process =
+    ProcessBuilder(jvmCommand("ee.schimke.composeai.rcembedded.jvm.RcJvmRenderWorkerMainKt"))
+      .redirectError(ProcessBuilder.Redirect.INHERIT)
+      .start()
+
+  private fun fixtureBytes(): ByteArray =
+    checkNotNull(javaClass.getResourceAsStream("/$FIXTURE")) { "missing test fixture $FIXTURE" }
+      .use { it.readBytes() }
+
+  private companion object {
+    const val FIXTURE = "rc-fixtures/TitleCardRemote-640x480.rc"
+    const val WIDTH = 640
+    const val HEIGHT = 480
+    const val DENSITY = 2f
+
+    var skikoLoadFailure: String? = null
+
+    val SKIKO_LOADED: Boolean =
+      try {
+        org.jetbrains.skia.FontMgr.default.familiesCount
+        true
+      } catch (t: Throwable) {
+        skikoLoadFailure = "${t::class.java.simpleName}: ${t.message}"
+        false
+      }
+  }
+}


### PR DESCRIPTION
## Summary

`RcJvmServerRenderer` spawned a fresh JVM for every `.rc` document, so every cmp-jvm render paid Compose Desktop + Skiko boot. This replaces that with a pool of long-lived workers.

Measured on the shared fixtures, in one process:

| | time |
|---|---|
| first render (JVM + Skiko boot) | **2310 ms** |
| each render after | **~85 ms** |

A **27×** amortisation that was being left on the table on every render.

### Why a pool works here and not for `@Preview`

A `.rc` document is self-describing — it is the same byte stream the in-browser JS player draws with no knowledge of any project. A worker therefore holds nothing project-derived and can take a document from **any** catalog, in any order: no affinity, no per-catalog warmup, no keying. The `@Preview` daemon cannot do this, because it holds the consumer module's classloader (`UserClassLoaderHolder`, a 129-entry classpath fingerprint) — the classpath *is* its identity.

### What's here

- `RcJvmRenderWorkerMain` — long-lived entry point speaking a small binary frame protocol over stdin/stdout. Claims the real stdout for frames and reroutes `System.out` to stderr before anything else runs, since one stray library line would be read as a frame header.
- `RcJvmWorkerPool` — borrow/return, watchdog kill, recycling after a render budget or max age, and self-disable after repeated spawn failures.
- `RcJvmServerRenderer.render` is unchanged for callers; `ServeHttpServer` is untouched.

## Correctness

`rc-compare` gates the PR on pixel parity, so a render that varied with worker age would convert a correctness gate into a flake source. That risk is the gate on this change, not an afterthought:

- **`RcJvmHotWorkerDeterminismTest`** — renders a corpus cold, churns the process with 72 renders at varied sizes, densities, seeds and formats (SVG lane interleaved), then re-renders and asserts **byte identity**. If this ever fails the answer is to switch pooling off, not to relax the assertion.
- **`RcJvmRenderWorkerProtocolTest`** — a pooled render is byte-identical to the one-shot subprocess it replaces; a warm worker does not drift; an undrawable document does not cost a worker; closing stdin exits 0.
- **`RcJvmWorkerPoolTest`** — reuse, recycling by budget and by age, watchdog timeout, mid-request crash, protocol-version mismatch, stray stdout, and 12 concurrent renders across 3 workers without crossing streams. Runs against a stub worker, so the pool's failure paths are covered on machines with no native render stack.

Worth recording: an **in-process** render differs from any *spawned* render by ~1 KB of PNG, because a JVM's graphics configuration (headless above all, which Gradle sets on its test workers) reaches text metrics. That is not drift the pool introduces, but it is why both lanes now boot under one shared `renderJvmArgs` — the font cache directory decides which typeface a `google:` family resolves to, so differing flags would make the two lanes draw differently for reasons unrelated to pooling.

## Failure posture

Every failure degrades to the pre-existing one-shot path, so the worst case is the cost already being paid: pooling off, a `lib-rcjvm/` sidecar too old to speak the protocol (refused by version handshake rather than hanging), a worker that cannot spawn, or one that breaks mid-request.

A `Failed` — the player's real answer about a document — deliberately does **not** fall back, so a document that cannot be drawn costs one render rather than two. After three consecutive spawn failures the pool disables itself for the process lifetime, so a systematically broken pool costs one failed spawn, not one per render.

Off switch: `-Dcomposeai.rcjvm.pool=off`. Size, render budget and max age via `composeai.rcjvm.pool.{workers,maxRenders,maxAgeMinutes}`.

## Test plan

```
./gradlew :third-party-rc-embedded-player-jvm:test :cli:test ktfmtCheck
```

**1769 tests, 0 failures, 1 skipped** (the skip is a pre-existing rc-compare staging harness with nothing staged). Skiko natives loaded in this container, so the determinism and protocol tests genuinely ran rather than skipping.

No visual surface changes — this is render-transport plumbing, and the tests assert the pixels are byte-identical to what the previous path produced.

## Follow-ups, not in scope

- Route `rc-compare`'s offline batch through the pool. It renders N previews × 4–5 backends with no latency SLO, so it is where the multiplier is largest.
- A Robolectric worker pool. Bigger prize (the Android sandbox boot dwarfs Skiko's) but a bigger job: Robolectric's per-test lifecycle assumes teardown between runs, so "stateless worker takes any document" needs proving there separately — the determinism harness added here is the tool for that.
- `composePreviewRender`'s 2.15 s/preview (the real finding behind #3487) is untouched: it needs the module classpath, so its fix is the per-module daemon, not this pool.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk2xtVbDfuqQP2Bkzdndz9)_