### PR TITLE
feat(daemon-desktop): honour @ScrollingPreview(END) in the served render

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -224,9 +224,17 @@ class RenderEngine(
         // so the PNG *and* every tree derived from the same scene (semantics, layout, figma-svg)
         // describe the frame the Gradle render ships. Ahead of `renderOnce`, which is also the
         // interactive session's per-input entry point and must never re-drive under the user.
+        val driveStartNs = System.nanoTime()
         trace.section("render:scrollToEnd") { driveStaticScrollToEnd(state) }
+        val driveNs = System.nanoTime() - driveStartNs
         trace.section("render:once") {
-          renderOnce(state, requestId, sandboxStats = sandboxStats, trace = trace)
+          renderOnce(
+            state,
+            requestId,
+            sandboxStats = sandboxStats,
+            trace = trace,
+            elapsedBeforeNs = driveNs,
+          )
         }
       } finally {
         trace.section("compose:tearDown") { tearDown(state) }
@@ -634,8 +642,16 @@ class RenderEngine(
     trace: PerfettoTraceDataProducer.Recorder =
       PerfettoTraceDataProducer.recorder(state.spec.outputBaseName, backend = "desktop"),
     useWallClockFrameTime: Boolean = false,
+    /**
+     * Wall-clock nanoseconds already spent on this render *before* this call — currently the
+     * `@ScrollingPreview(END)` drive, which runs ahead of `renderOnce` (see [render]) but is part
+     * of the render body by any honest accounting: it can cost tens of scene renders. Folded into
+     * the reported `tookMs` so the daemon's latency and cost-model numbers cover the real work. `0`
+     * for every other caller, including the interactive session.
+     */
+    elapsedBeforeNs: Long = 0L,
   ): RenderResult {
-    val startNs = System.nanoTime()
+    val startNs = System.nanoTime() - elapsedBeforeNs
 
     // Flush snapshot state written out-of-composition since the last render so the held scene
     // observes it before painting. The held-session scrub path mutates `lottieProgressState` from
@@ -1408,36 +1424,58 @@ class RenderEngine(
   internal fun driveStaticScrollToEnd(state: SceneState) {
     val previewId = state.spec.previewId ?: return
     val intent = loadPreviewIndexLazily().staticScrollFor(previewId) ?: return
+    // Under the same JVM-default-`Locale` override `renderOnce` wraps its frames in. The drive
+    // performs the *first* layout and composes every lazy item it scrolls past, and
+    // `rememberResourceEnvironment` caches what it resolves — so without this a localized END
+    // capture would bake default-language `stringResource(...)` text into the items the drive
+    // brought on screen, and re-applying the locale for the final frames alone would not undo it.
+    val previousDefaultLocale = overrideJvmDefaultLocale(effectiveLocaleTag(state.spec.localeTag))
+    try {
+      driveStaticScrollToEndLocalized(state, intent)
+    } finally {
+      restoreJvmDefaultLocale(previousDefaultLocale)
+    }
+  }
+
+  @OptIn(
+    androidx.compose.ui.InternalComposeUiApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+  )
+  private fun driveStaticScrollToEndLocalized(state: SceneState, intent: ScrollCaptureDto) {
     val axisKey =
       if (intent.axis.equals("HORIZONTAL", ignoreCase = true))
         SemanticsProperties.HorizontalScrollAxisRange
       else SemanticsProperties.VerticalScrollAxisRange
 
     // Semantics only exist once the scene has laid out, and `setUp` deliberately doesn't render.
-    state.scene.render(nanoTime = state.nextVirtualFrameNanos())
+    // At timestamp zero, and *without* touching the frame cursor: a preview that turns out to have
+    // nothing scrollable must be captured at the same deterministic frame zero as an ordinary
+    // render, which is what the "capturing the initial frame" message below promises. The cursor
+    // only starts moving once a scrollable is actually found.
+    state.scene.render()
 
     // Re-resolved on each read rather than held: the drive recomposes the scene, and a
     // `SemanticsNode` is a snapshot of one composition pass.
+    //
+    // First in traversal order, *not* the largest — `DesktopScrollRenderer` drives
+    // `nodes.firstOrNull()`, and `PreviewIndex.staticScrollFor` documents the contract as "the
+    // first scrollable on the annotated axis". A screen with two same-axis scrollers must settle
+    // in the same place whether it came from `compose-preview serve` or the Gradle batch render;
+    // agreeing with the other backend matters more than this one picking the scroller it guesses
+    // is the interesting one.
     fun mainScroller(): SemanticsNode? {
       val root = state.scene.semanticsOwners.firstOrNull()?.unmergedRootSemanticsNode ?: return null
-      // The largest node carrying the range is the screen's main scroller; a nested inner one is
-      // smaller. Same choice [measureVerticalScroll] makes, for the same reason.
-      var best: SemanticsNode? = null
-      var largest = -1f
+      var found: SemanticsNode? = null
       fun walk(node: SemanticsNode) {
+        if (found != null) return
         if (node.config.getOrNull(axisKey) != null) {
-          val extent =
-            if (axisKey == SemanticsProperties.HorizontalScrollAxisRange) node.boundsInRoot.width
-            else node.boundsInRoot.height
-          if (extent > largest) {
-            largest = extent
-            best = node
-          }
+          found = node
+          return
         }
         node.children.forEach(::walk)
       }
       walk(root)
-      return best
+      return found
     }
 
     fun axisRange(): ScrollAxisRange? = mainScroller()?.config?.getOrNull(axisKey)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.ScrollAxisRange
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
@@ -218,6 +220,11 @@ class RenderEngine(
       }
     val result =
       try {
+        // `@ScrollingPreview(END)` — settle the scrollable at its content end before the capture,
+        // so the PNG *and* every tree derived from the same scene (semantics, layout, figma-svg)
+        // describe the frame the Gradle render ships. Ahead of `renderOnce`, which is also the
+        // interactive session's per-input entry point and must never re-drive under the user.
+        trace.section("render:scrollToEnd") { driveStaticScrollToEnd(state) }
         trace.section("render:once") {
           renderOnce(state, requestId, sandboxStats = sandboxStats, trace = trace)
         }
@@ -869,10 +876,12 @@ class RenderEngine(
   }
 
   private fun renderFrame(state: SceneState, useWallClockFrameTime: Boolean) =
-    if (useWallClockFrameTime) {
-      state.scene.render(nanoTime = currentFrameNanoTime())
-    } else {
-      state.scene.render()
+    when {
+      useWallClockFrameTime -> state.scene.render(nanoTime = currentFrameNanoTime())
+      // A scroll drive ran and left the frame clock mid-timeline — keep going from there rather
+      // than resetting to zero. See [SceneState.virtualFrameNanos].
+      state.virtualFrameNanos > 0L -> state.scene.render(nanoTime = state.nextVirtualFrameNanos())
+      else -> state.scene.render()
     }
 
   /**
@@ -1033,6 +1042,30 @@ class RenderEngine(
      */
     internal val measuredContent: IntArray = IntArray(2),
   ) {
+    /**
+     * Frame timestamp the next one-shot capture frame renders at, in nanoseconds, or `0` for the
+     * default frozen-at-zero clock.
+     *
+     * [ImageComposeScene.render] takes the frame time `withFrameNanos` and every Compose animation
+     * sees, and the one-shot path deliberately pins it to zero so a preview renders
+     * deterministically — nothing advances, so nothing depends on how long the render took. The
+     * `@ScrollingPreview(END)` drive is the one thing here that *needs* time to pass (an animated
+     * `scrollBy` has to actually run), so it ticks this cursor forward and leaves it where it
+     * finished. The capture frames then continue from there rather than snapping back to zero,
+     * which would hand every in-flight animation a large negative delta on the very frame being
+     * captured.
+     *
+     * Stays `0` for every preview without an END drive, so their frame clock — and their pixels —
+     * are exactly what they were.
+     */
+    internal var virtualFrameNanos: Long = 0L
+
+    /** Advances [virtualFrameNanos] by one 60 Hz frame and returns the new timestamp. */
+    internal fun nextVirtualFrameNanos(): Long {
+      virtualFrameNanos += FRAME_INTERVAL_NANOS
+      return virtualFrameNanos
+    }
+
     @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
     internal fun previewContext(): PreviewContext {
       val slotTables = slotTableCapture?.snapshot().orEmpty()
@@ -1339,6 +1372,125 @@ class RenderEngine(
   )
 
   /**
+   * `@ScrollingPreview(END)` — drive the preview's scrollable to its content end before the frame
+   * is captured, so the daemon's PNG (and the semantics / layout / figma-svg read off the same
+   * scene) show the frame the Gradle render ships, not the resting top.
+   *
+   * The desktop daemon captures through [ImageComposeScene], which has neither a test main-clock
+   * nor `onNode` interactions — the two things `:renderer-desktop`'s `renderScrollPreview` leans on
+   * for the same job. It does expose both halves needed to do it directly, though:
+   * `semanticsOwners` reaches the same `SemanticsActions.ScrollBy` the test harness invokes, and
+   * `render(nanoTime)` is the frame clock an animated scroll advances on. So this drives the scroll
+   * the same way, ticking the scene forward by hand instead of a `MainTestClock`.
+   *
+   * Progress is measured from `ScrollAxisRange.value` for the reason the CMP renderer's END path
+   * measures it: `ScrollBy` animates, and a lazy container's `maxValue` is an estimate that firms
+   * up as items compose, so neither the requested delta nor the remaining distance is a reliable
+   * account of what actually moved. The loop stops on the first step that doesn't move.
+   *
+   * That axis range is also why `maxScrollPx` is a **coarse** bound here. A `LazyColumn` reports
+   * `value` in its own estimated content space (index × average item size), not layout pixels, so
+   * the cap is checked in whatever units the scroller reports and is only enforced between steps —
+   * one step can overshoot it. It does what the annotation needs it for, which is bounding a drive
+   * over a very long list, but it is not a pixel-exact stop position and shouldn't be read as one.
+   *
+   * `reduceMotion` is deliberately not honoured here, unlike the Android daemon: it gates Wear's
+   * `TransformingLazyColumn` edge transforms, and Wear Compose is Android-only, so there is nothing
+   * on this backend for it to flatten.
+   *
+   * No-ops (leaving the frame clock at zero, so the capture is bit-for-bit what it was) when the
+   * preview has no END intent or carries nothing scrollable.
+   */
+  @OptIn(
+    androidx.compose.ui.InternalComposeUiApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+  )
+  internal fun driveStaticScrollToEnd(state: SceneState) {
+    val previewId = state.spec.previewId ?: return
+    val intent = loadPreviewIndexLazily().staticScrollFor(previewId) ?: return
+    val axisKey =
+      if (intent.axis.equals("HORIZONTAL", ignoreCase = true))
+        SemanticsProperties.HorizontalScrollAxisRange
+      else SemanticsProperties.VerticalScrollAxisRange
+
+    // Semantics only exist once the scene has laid out, and `setUp` deliberately doesn't render.
+    state.scene.render(nanoTime = state.nextVirtualFrameNanos())
+
+    // Re-resolved on each read rather than held: the drive recomposes the scene, and a
+    // `SemanticsNode` is a snapshot of one composition pass.
+    fun mainScroller(): SemanticsNode? {
+      val root = state.scene.semanticsOwners.firstOrNull()?.unmergedRootSemanticsNode ?: return null
+      // The largest node carrying the range is the screen's main scroller; a nested inner one is
+      // smaller. Same choice [measureVerticalScroll] makes, for the same reason.
+      var best: SemanticsNode? = null
+      var largest = -1f
+      fun walk(node: SemanticsNode) {
+        if (node.config.getOrNull(axisKey) != null) {
+          val extent =
+            if (axisKey == SemanticsProperties.HorizontalScrollAxisRange) node.boundsInRoot.width
+            else node.boundsInRoot.height
+          if (extent > largest) {
+            largest = extent
+            best = node
+          }
+        }
+        node.children.forEach(::walk)
+      }
+      walk(root)
+      return best
+    }
+
+    fun axisRange(): ScrollAxisRange? = mainScroller()?.config?.getOrNull(axisKey)
+
+    val initial = axisRange()
+    if (initial == null) {
+      System.err.println(
+        "@ScrollingPreview(END) on ${state.spec.outputBaseName}: nothing scrollable on axis " +
+          "${intent.axis} — capturing the initial frame."
+      )
+      return
+    }
+
+    val cap = intent.maxScrollPx?.takeIf { it > 0 }?.toFloat() ?: Float.POSITIVE_INFINITY
+    val startPx = initial.value()
+    var scrolledPx = 0f
+    for (step in 0 until END_DRIVE_MAX_STEPS) {
+      val range = axisRange() ?: break
+      val remaining = (range.maxValue() - range.value()).coerceAtLeast(0f)
+      if (remaining <= SCROLL_SETTLED_EPSILON_PX) break
+      val headroom = (cap - scrolledPx).coerceAtLeast(0f)
+      if (headroom <= SCROLL_SETTLED_EPSILON_PX) break
+
+      val before = range.value()
+      val delta = minOf(remaining, headroom)
+      val action = mainScroller()?.config?.getOrNull(SemanticsActions.ScrollBy)?.action ?: break
+      if (axisKey == SemanticsProperties.HorizontalScrollAxisRange) action(delta, 0f)
+      else action(0f, delta)
+
+      // `ScrollBy` animates; tick the scene until it lands, or the next iteration would measure a
+      // scroll still in flight and the drive would creep instead of converge.
+      repeat(END_STEP_SETTLE_FRAMES) {
+        state.scene.render(nanoTime = state.nextVirtualFrameNanos())
+      }
+
+      val advanced = (axisRange()?.value() ?: before) - before
+      if (advanced <= SCROLL_SETTLED_EPSILON_PX) break
+      scrolledPx = (axisRange()?.value() ?: before) - startPx
+    }
+
+    // Let anything the scroll landing triggers finish before the capture frames.
+    repeat(END_POST_SCROLL_SETTLE_FRAMES) {
+      state.scene.render(nanoTime = state.nextVirtualFrameNanos())
+    }
+    // Reported in the scroller's own axis-range units, not pixels — see the note on `maxScrollPx`
+    // above.
+    System.err.println(
+      "@ScrollingPreview(END) on ${state.spec.outputBaseName}: drove the scrollable " +
+        "${scrolledPx.toInt()} unit(s) to the content end."
+    )
+  }
+
+  /**
    * Measures the tallest vertically-scrollable node in [scene] and how far its composed content
    * reaches, or null when nothing is vertically scrollable. Used by [runScrollSvgScenario] to size
    * the full-page render by *geometry* rather than the LazyList scroll-range estimate (which is
@@ -1469,6 +1621,29 @@ class RenderEngine(
      * side uses; the gradle plugin's daemon launch descriptor sets it once at JVM start.
      */
     const val OUTPUT_DIR_PROP: String = "composeai.render.outputDir"
+
+    /** One 60 Hz frame, in nanoseconds — the tick [SceneState.virtualFrameNanos] advances by. */
+    private const val FRAME_INTERVAL_NANOS: Long = 16_666_667L
+
+    /** Sub-pixel scroll movement that counts as "didn't move". */
+    private const val SCROLL_SETTLED_EPSILON_PX: Float = 0.5f
+
+    /**
+     * Frames [driveStaticScrollToEnd] lets an animated `ScrollBy` run for before re-reading the
+     * axis range. ~0.5 s, comfortably past Compose's default scroll animation.
+     */
+    private const val END_STEP_SETTLE_FRAMES: Int = 32
+
+    /**
+     * Iteration bound for the END drive. A lazy container only firms up its estimated extent as
+     * items compose, so reaching a long list's true end takes several rounds of "jump to the end I
+     * can currently see". The loop exits on the first step that makes no progress, so this is a
+     * runaway guard rather than the usual exit.
+     */
+    private const val END_DRIVE_MAX_STEPS: Int = 60
+
+    /** Frames of settle after the drive, so scroll-triggered chrome isn't caught mid-reveal. */
+    private const val END_POST_SCROLL_SETTLE_FRAMES: Int = 60
 
     /**
      * Issue #1604 — scroll scenarios the daemon's `data/fetch` re-render path can request. The

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineScrollEndTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineScrollEndTest.kt
@@ -1,0 +1,137 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * `@ScrollingPreview(END)` through the **desktop daemon** — the `compose-preview serve` path.
+ *
+ * The daemon captures through `ImageComposeScene`, which has no test main-clock and no `onNode`
+ * interactions, so it never drove a scrollable: an END preview served the resting top while the
+ * Gradle render beside it shipped the settled bottom, and the semantics / layout / figma-svg read
+ * off that same scene disagreed with the PNG too.
+ *
+ * Asserted on the emitted `compose-figma.svg` rather than pixels, deliberately: the SVG is derived
+ * from the scene's semantics + layout trees, so "the SVG carries the bottom rows" proves the whole
+ * derived-artifact family followed the scroll, not just the raster.
+ */
+class RenderEngineScrollEndTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private var previousIndexProp: String? = null
+
+  @After
+  fun restoreIndexProperty() {
+    if (previousIndexProp == null) System.clearProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+    else System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, previousIndexProp!!)
+  }
+
+  /**
+   * A `previews.json` whose single preview carries [scrollJson] as its capture's scroll block — the
+   * shape discovery writes for `@ScrollingPreview`, and the only thing `staticScrollFor` consults.
+   */
+  private fun installPreviewIndex(previewId: String, scrollJson: String?) {
+    val scroll = if (scrollJson == null) "" else ""","scroll":$scrollJson"""
+    val json =
+      """
+      {
+        "previews": [
+          {
+            "id": "$previewId",
+            "className": "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+            "functionName": "LazyColumnListPreview",
+            "sourceFile": "RedFixturePreviews.kt",
+            "captures": [
+              {"renderOutput": "renders/$previewId.png"$scroll}
+            ]
+          }
+        ]
+      }
+      """
+        .trimIndent()
+    val file = tempFolder.newFile("$previewId-previews.json").also { it.writeText(json) }
+    previousIndexProp = System.getProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+    System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, file.absolutePath)
+  }
+
+  /** Renders the 30-row `LazyColumn` fixture through the real daemon and returns its figma-svg. */
+  private fun renderSvg(previewId: String): String {
+    val outputDir = tempFolder.newFolder("renders-$previewId")
+    val dataDir = tempFolder.newFolder("data-$previewId")
+    val engine = RenderEngine(outputDir = outputDir, dataDir = dataDir)
+    val host = DesktopHost(engine = engine)
+    host.start()
+    try {
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=LazyColumnListPreview;" +
+              "widthPx=200;heightPx=520;density=1.0;showBackground=true;" +
+              "previewId=$previewId;outputBaseName=$previewId"
+        ),
+        timeoutMs = 120_000,
+      )
+    } finally {
+      host.shutdown()
+    }
+    val svg = File(File(dataDir, previewId), "compose-figma.svg")
+    assertTrue("figma SVG must be produced: ${svg.absolutePath}", svg.exists())
+    return svg.readText()
+  }
+
+  private fun rowsIn(svg: String): List<Int> =
+    Regex("Row (\\d+)").findAll(svg).map { it.groupValues[1].toInt() }.distinct().sorted().toList()
+
+  @Test
+  fun `an END preview is captured at the bottom of its list`() {
+    installPreviewIndex("EndDriven", """{"mode":"END","axis":"VERTICAL","reduceMotion":true}""")
+    val rows = rowsIn(renderSvg("EndDriven"))
+    assertTrue("the drive must reach the last row (got $rows)", rows.contains(30))
+    assertFalse("the first row must have scrolled out of frame (got $rows)", rows.contains(1))
+  }
+
+  /** The control: the same fixture with no scroll intent keeps the resting top. */
+  @Test
+  fun `a preview with no scroll intent keeps its resting top`() {
+    installPreviewIndex("Undriven", scrollJson = null)
+    val rows = rowsIn(renderSvg("Undriven"))
+    assertTrue("the top row must still be on screen (got $rows)", rows.contains(1))
+    assertFalse("the last row must be far off screen (got $rows)", rows.contains(30))
+  }
+
+  /**
+   * `TOP` *is* the undriven frame, so it must resolve to no drive at all rather than a no-op one —
+   * the same rule [PreviewIndex.staticScrollFor] applies, checked here end-to-end.
+   */
+  @Test
+  fun `a TOP preview is not driven`() {
+    installPreviewIndex("TopOnly", """{"mode":"TOP","axis":"VERTICAL"}""")
+    val rows = rowsIn(renderSvg("TopOnly"))
+    assertTrue("TOP must keep the resting frame (got $rows)", rows.contains(1))
+  }
+
+  /**
+   * `maxScrollPx` bounds the drive, so a small cap lands partway down rather than at the end.
+   *
+   * Asserted as "didn't reach the end" rather than a stop position: a `LazyColumn` reports its
+   * scroll offset in estimated content units rather than layout pixels, and the cap is only checked
+   * between steps, so it bounds the drive without pinning it to an exact pixel.
+   */
+  @Test
+  fun `maxScrollPx bounds the drive`() {
+    installPreviewIndex(
+      "Capped",
+      """{"mode":"END","axis":"VERTICAL","maxScrollPx":60,"reduceMotion":true}""",
+    )
+    val rows = rowsIn(renderSvg("Capped"))
+    assertFalse("a 60px cap must not reach the last row (got $rows)", rows.contains(30))
+    assertTrue("the drive must still have moved off the very top (got $rows)", rows.isNotEmpty())
+  }
+}


### PR DESCRIPTION
## Summary

Completes the `END` story started in #3499 (Android daemon) and #3513 (CMP Desktop renderer). The desktop daemon — the `compose-preview serve` path — was the last backend still serving the resting top for a preview annotated to capture its settled bottom, so the frame the panel showed disagreed with the PNG the Gradle render shipped beside it.

It was skipped in both earlier PRs for a real reason: it captures through `ImageComposeScene`, which has neither a test main-clock nor `onNode` interactions — the two things `renderScrollPreview` leans on. But it does expose both halves needed to drive a scroll directly:

- `scene.semanticsOwners` reaches the same `SemanticsActions.ScrollBy` the test harness invokes, and
- `scene.render(nanoTime)` *is* the frame clock an animated scroll advances on.

So the drive ticks the scene by hand instead of a `MainTestClock`. No move onto `runSkikoComposeUiTest` was needed after all — which also means the semantics / layout / figma-svg products keep coming off the same scene as before.

## Two details worth a reviewer's eye

**Where it runs.** In `render()`, ahead of `renderOnce` — which is also the interactive session's per-input entry point, and must never re-drive under a user who is scrolling the preview themselves.

**The frame clock.** The one-shot path pins `render()`'s `nanoTime` to zero for determinism, and an animated scroll needs time to actually pass. The drive ticks a cursor forward and the capture frames continue from where it stopped, rather than snapping back to zero and handing every in-flight animation a large negative delta on the very frame being captured. Previews without an END drive never touch the cursor, so their frame clock — and their pixels — are exactly what they were.

Because the drive happens before capture, the semantics, layout and figma-svg read off the same scene follow the scroll too. The test asserts on the emitted `compose-figma.svg` for exactly that reason: it proves the whole derived-artifact family moved, not just the raster.

`reduceMotion` is deliberately not honoured here, unlike the Android daemon — it gates Wear's `TransformingLazyColumn` edge transforms, and Wear Compose is Android-only.

## A defect this surfaced (not fixed here)

While testing this I probed what these scrollables actually publish, and the answer explains a lot:

```
[LazyColumnListPreview]  value=0.0  maxValue=100.0   <- item-space, not pixels
[DateRangePicker]        value=0.0  maxValue=0.0     <- not measured yet on the probe frame
```

`ScrollAxisRange` is **not** a pixel budget. The existing `captureLong` driver treats it as one — it sizes each step as `min(stepPx, maxValue - value)` and feeds the result to `ScrollBy`, which *is* in pixels. On a `LazyColumn` that turns a 336 px stride into a ~2 px one, so a `scroll-long` capture of the 30-row fixture stitches 13 slices into a 453 px image instead of a full-page one. The same wrong instrument is why a `DateRangePicker` gets reported as having no scrollable at all.

This PR's drive converges regardless (it measures progress and iterates until nothing moves), so `END` is correct — but `LONG`/`GIF` need the instrument replaced with a geometric one. That's the next change, and it's what "long-scroll screenshots in the preview server" actually depends on.

## Test plan

- [x] New `RenderEngineScrollEndTest`, end-to-end through `DesktopHost`:
  - an `END` preview is captured at the bottom of its list (SVG carries `Row 30`, not `Row 1`)
  - a preview with no scroll intent keeps its resting top
  - a `TOP` preview is not driven
  - `maxScrollPx` bounds the drive
- [x] `:daemon:desktop:test --tests "*RenderEngineTest*" --tests "*RenderEngineWrapContent*" --tests "*RenderEngineFigmaSvgScroll*"` — the neighbouring render-path suites, unchanged
- [x] `ktfmtFormat`

---
_Generated by [Claude Code](https://claude.ai/code/session_01E98YxF6aPxrecEMqV2gWMu)_