### PR TITLE
refactor: deprecate dead a11y DSL knobs, collapse the onRender fan, dedupe Android publishing

### DIFF
--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.buildlogic
 
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SourcesJar
 import java.io.File
 import javax.inject.Inject
 import org.gradle.api.Plugin
@@ -42,6 +45,8 @@ class ComposeAiMavenPublishingPlugin : Plugin<Project> {
     project.version =
       project.providers.environmentVariable("PLUGIN_VERSION").orNull
         ?: project.nextPatchSnapshotVersion()
+
+    project.configureAndroidLibraryPublication()
 
     project.afterEvaluate {
       val artifactId =
@@ -85,6 +90,36 @@ class ComposeAiMavenPublishingPlugin : Plugin<Project> {
           }
         }
       }
+    }
+  }
+}
+
+/**
+ * Publish an Android library as its single `release` variant, with real sources and an empty
+ * javadoc jar — Maven Central requires *a* javadoc artifact but not a useful one for a Kotlin
+ * library whose docs live in the repo.
+ *
+ * This used to be copy-pasted into all 25 Android modules that publish, each carrying the same
+ * three imports, the same `@file:Suppress("DEPRECATION")` header, and the same nine-line
+ * `mavenPublishing { configure(...) }` block. Twenty-five copies of one decision is twenty-five
+ * places to miss when the plugin's API moves — which the suppression comment itself predicted
+ * ("the replacement types vary between plugin versions"). Now it moves here, once.
+ *
+ * `withPlugin` rather than an `afterEvaluate` check so the JVM modules that share this convention
+ * plugin (65 of the 90) are untouched — vanniktech's own default handles them correctly.
+ */
+@Suppress("DEPRECATION") // AndroidSingleVariantLibrary(Boolean, Boolean); replacement types
+// (SourcesJar / JavadocJar) vary between plugin versions. Re-visit when bumping.
+private fun Project.configureAndroidLibraryPublication() {
+  pluginManager.withPlugin("com.android.library") {
+    extensions.configure<MavenPublishBaseExtension> {
+      configure(
+        AndroidSingleVariantLibrary(
+          javadocJar = JavadocJar.Empty(),
+          sourcesJar = SourcesJar.Sources(),
+          variant = "release",
+        )
+      )
     }
   }
 }

--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -402,20 +402,6 @@ val daemonHarnessClasspathFile by configurations.creating {
   }
 }
 
-// Use the new (non-deprecated) AndroidSingleVariantLibrary constructor — takes typed JavadocJar /
-// SourcesJar instead of booleans. `JavadocJar.Empty()` ships an empty javadoc jar (Maven Central
-// requires the file to exist) without invoking javadoc/Dokka. javadoc 17 fails on AndroidX
-// dependencies' Kotlin metadata version mismatch (`expected version is 1.4.2`); Dokka would work
-// but is heavyweight for an artifact whose value is in KDocs the sources jar carries anyway.
-// `:renderer-android` still uses the deprecated (Boolean, Boolean) overload — fine to migrate
-// independently when its release bumps next.
-val androidSingleVariantLibrary =
-  com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-    javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-    sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-    variant = "release",
-  )
-
 // AGP `testFixtures { enable = true }` ships `daemon-android-<version>-test-fixtures.aar` as
 // part of the published `release` component. The fixture composables (`RedSquare`/`BlueSquare`/
 // etc.) are internal harness aids, not for consumers. Skip the testFixtures publication
@@ -448,8 +434,6 @@ afterEvaluate {
 }
 
 artifacts { add(daemonHarnessClasspathFile.name, writeDaemonClasspath) }
-
-mavenPublishing { configure(androidSingleVariantLibrary) }
 
 composeAiMavenPublishing {
   coordinates(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
@@ -35,14 +35,6 @@ class CompositeDataProductRegistry(private val registries: List<DataProductRegis
       else registry.attachmentsFor(previewId, supportedKinds)
     }
 
-  override fun onRender(previewId: String, result: RenderResult) {
-    registries.forEach { it.onRender(previewId, result, overrides = null, result.previewContext) }
-  }
-
-  override fun onRender(previewId: String, result: RenderResult, overrides: PreviewOverrides?) {
-    registries.forEach { it.onRender(previewId, result, overrides, result.previewContext) }
-  }
-
   override fun onRender(
     previewId: String,
     result: RenderResult,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
@@ -60,32 +60,23 @@ interface DataProductRegistry {
    * Render lifecycle hook. Called after a host returns [result] and before `renderFinished`
    * attachments are collected. Producers whose payload is derived from the latest render result can
    * snapshot it here; stateless producers can ignore it.
-   */
-  fun onRender(previewId: String, result: RenderResult) {}
-
-  /**
-   * Render lifecycle hook with the per-call overrides that produced [result], when available.
-   * Producers that need effective render metadata can use [overrides]; older stateless producers
-   * can keep overriding [onRender].
-   */
-  fun onRender(previewId: String, result: RenderResult, overrides: PreviewOverrides?) {
-    onRender(previewId, result)
-  }
-
-  /**
-   * Render lifecycle hook with renderer-collected context. Producers that need slot tables,
-   * composition-local snapshots, frame-clock semantics, or animation sampling metadata should read
-   * them from [previewContext] here. Older producers can keep overriding the two- or three-argument
-   * [onRender] overloads; the default forwards to the existing override chain.
+   *
+   * This is the **only** render hook, and the only one the dispatcher calls (`JsonRpcServer`'s
+   * `renderFinished` path). It used to be a three-overload fan — `(previewId, result)`, `+
+   * overrides`, `+ previewContext` — whose defaults cascaded widest-to-narrowest so a producer
+   * could implement whichever arity it needed. In practice every producer needed the widest, and
+   * the cascade ran the wrong way for them: implementing only the four-argument form left the
+   * narrow ones inert. All thirteen producers worked around that by hand-writing the *reverse*
+   * forwarder, and a new producer that forgot it compiled clean and silently received nothing. One
+   * method removes the trap; [onRender] extension overloads below keep the narrow call shapes
+   * available to callers (tests, mostly) without letting anyone override them.
    */
   fun onRender(
     previewId: String,
     result: RenderResult,
     overrides: PreviewOverrides?,
     previewContext: PreviewContext?,
-  ) {
-    onRender(previewId, result, overrides)
-  }
+  ) {}
 
   /**
    * Render failure lifecycle hook. Called before `renderFailed` is emitted so failure-oriented
@@ -194,4 +185,24 @@ interface DataProductRegistry {
         ): List<DataProductAttachment> = emptyList()
       }
   }
+}
+
+/**
+ * Narrow call shapes for [DataProductRegistry.onRender], as extensions so they resolve statically
+ * and **cannot be overridden** — the whole point of collapsing the old overload fan. Both fill
+ * `previewContext` from `result.previewContext`, which is what all thirteen producers' hand-written
+ * forwarders did before. Kept because most test call sites don't care about overrides or context
+ * and reading `onRender(id, result)` at those sites is clearer than four arguments of nulls.
+ */
+fun DataProductRegistry.onRender(previewId: String, result: RenderResult) {
+  onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+}
+
+/** @see onRender */
+fun DataProductRegistry.onRender(
+  previewId: String,
+  result: RenderResult,
+  overrides: PreviewOverrides?,
+) {
+  onRender(previewId, result, overrides, previewContext = result.previewContext)
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
@@ -247,14 +247,6 @@ class ExtensionRegistry(extensions: List<Extension>) {
         if (supported.isEmpty()) emptyList() else reg.attachmentsFor(previewId, supported)
       }
 
-    override fun onRender(previewId: String, result: RenderResult) {
-      onRender(previewId, result, overrides = null, previewContext = result.previewContext)
-    }
-
-    override fun onRender(previewId: String, result: RenderResult, overrides: PreviewOverrides?) {
-      onRender(previewId, result, overrides, previewContext = result.previewContext)
-    }
-
     override fun onRender(
       previewId: String,
       result: RenderResult,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
@@ -406,15 +406,16 @@ class DataFetchRerenderTest {
 
     @Volatile var lastOnRenderOverrides: PreviewOverrides? = null
 
-    override fun onRender(previewId: String, result: RenderResult) {
+    override fun onRender(
+      previewId: String,
+      result: RenderResult,
+      overrides: PreviewOverrides?,
+      previewContext: ee.schimke.composeai.data.render.PreviewContext?,
+    ) {
       onRenderCalls.incrementAndGet()
       lastOnRenderPreviewId = previewId
       lastOnRenderMetrics = result.metrics
-    }
-
-    override fun onRender(previewId: String, result: RenderResult, overrides: PreviewOverrides?) {
       lastOnRenderOverrides = overrides
-      onRender(previewId, result)
     }
 
     /** Called by [TestRenderHost] when the dispatcher submits a render. */

--- a/data/a11y/connector/build.gradle.kts
+++ b/data/a11y/connector/build.gradle.kts
@@ -32,16 +32,6 @@ dependencies {
   testImplementation(libs.kotlinx.serialization.json)
 }
 
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-a11y-connector",

--- a/data/a11y/core/build.gradle.kts
+++ b/data/a11y/core/build.gradle.kts
@@ -1,11 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-
 // D2.2 — `:data-a11y-core` is the **published** generic-Android piece of the
 // accessibility data product: the ATF wrapper (`AccessibilityChecker`), the
 // Paparazzi-style overlay generator (`AccessibilityOverlay`), and the JSON
@@ -52,18 +44,8 @@ dependencies {
   testImplementation(libs.robolectric)
 }
 
-// Vanniktech's `AndroidSingleVariantLibrary` creates the release publication
+// The `composeai.maven-publishing` convention creates the release publication
 // (with sources + javadoc jar) — do not create one manually; it clashes.
-
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
 
 composeAiMavenPublishing {
   coordinates(

--- a/data/a11y/hierarchy-android/build.gradle.kts
+++ b/data/a11y/hierarchy-android/build.gradle.kts
@@ -1,11 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-
 // `:data-a11y-hierarchy-android` — the Android-platform-specific producer for
 // `a11y/hierarchy` and `a11y/atf`. Wraps `AccessibilityChecker.analyze` (ATF +
 // Robolectric) into a `PostCaptureProcessor` so the typed product graph stays
@@ -29,16 +21,6 @@ dependencies {
 
   testImplementation(libs.junit)
   testImplementation(libs.robolectric)
-}
-
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/data/ambient/connector/build.gradle.kts
+++ b/data/ambient/connector/build.gradle.kts
@@ -78,16 +78,6 @@ dependencies {
   testImplementation(libs.kotlinx.serialization.json)
 }
 
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-ambient-connector",

--- a/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/AmbientDataProduct.kt
+++ b/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/AmbientDataProduct.kt
@@ -162,9 +162,6 @@ class AmbientDataProductRegistry : DataProductRegistry {
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
-    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
-  }
 
   override fun onRender(
     previewId: String,

--- a/data/focus/connector/build.gradle.kts
+++ b/data/focus/connector/build.gradle.kts
@@ -48,16 +48,6 @@ dependencies {
   testImplementation(libs.kotlinx.serialization.json)
 }
 
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-focus-connector",

--- a/data/gestures/connector/build.gradle.kts
+++ b/data/gestures/connector/build.gradle.kts
@@ -83,16 +83,6 @@ dependencies {
   testImplementation(libs.kotlinx.serialization.json)
 }
 
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-gestures-connector",

--- a/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureDataProduct.kt
+++ b/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureDataProduct.kt
@@ -155,9 +155,6 @@ class GestureDataProductRegistry : DataProductRegistry {
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
-    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
-  }
 
   override fun onRender(
     previewId: String,

--- a/data/keyboard/connector/build.gradle.kts
+++ b/data/keyboard/connector/build.gradle.kts
@@ -71,16 +71,6 @@ dependencies {
   testImplementation(libs.robolectric)
 }
 
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-keyboard-connector",

--- a/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProduct.kt
+++ b/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProduct.kt
@@ -263,10 +263,6 @@ class LauncherWidgetDataProductRegistry : DataProductRegistry {
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
-    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
-  }
-
   override fun onRender(
     previewId: String,
     result: RenderResult,

--- a/data/layoutinspector/connector/build.gradle.kts
+++ b/data/layoutinspector/connector/build.gradle.kts
@@ -34,6 +34,10 @@ dependencies {
   // supplies its own at runtime, same shape as the pre-migration `compileOnly(libs.compose.ui)`.
   compileOnly(libs.jetbrains.compose.ui)
   testImplementation(libs.jetbrains.compose.ui)
+  // `ComposeInternalFieldContractTest` builds *real* modifier chains (`Modifier.background(...)`,
+  // `Arrangement.spacedBy(...)`) to check that the private field names `ModifierTokenResolver`
+  // reflects on still exist in the pinned Compose. That needs foundation, not just ui.
+  testImplementation(libs.jetbrains.compose.foundation)
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)
 }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
 import ee.schimke.composeai.data.layoutinspector.FigmaLayeredSvg
@@ -12,6 +13,7 @@ import ee.schimke.composeai.data.layoutinspector.FigmaSvgLayer
 import ee.schimke.composeai.data.layoutinspector.FigmaSvgModel
 import ee.schimke.composeai.data.layoutinspector.FigmaSvgRasterTarget
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorPayload
+import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import ee.schimke.composeai.io.SystemFileSystem
 import java.awt.image.BufferedImage
@@ -639,7 +641,12 @@ class ComposeFigmaSvgDataProductRegistry(
   ) {
   private val latestOutputBaseNameByPreviewId = ConcurrentHashMap<String, String>()
 
-  override fun onRender(previewId: String, result: RenderResult) {
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
     // Mode-specific renders (for example figma-svg-long) do not replace the viewport export, so a
     // result without a concrete output name must leave the latest viewport mapping intact.
     result.outputBaseName?.let { latestOutputBaseNameByPreviewId[previewId] = it }

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeInternalFieldContractTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeInternalFieldContractTest.kt
@@ -1,0 +1,196 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.shape.CutCornerShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Canary for the private Compose internals [ModifierTokenResolver] reads by name.
+ *
+ * The resolver recovers design tokens (background colour, corner radius, elevation, border width,
+ * arrangement gap, …) that Compose's inspector data doesn't expose, by reflecting on the *private
+ * backing fields* of modifier elements — `BackgroundElement.color`, `ShadowGraphicsLayerElement
+ * .elevation`, `Arrangement.spacedBy(...).spacing`, and a dozen more — and by matching some types
+ * on `javaClass.simpleName`. None of that is public API. androidx can rename any of it in a patch
+ * release without breaking our compile.
+ *
+ * Every one of those reads is wrapped in `runCatching { … }.getOrNull()`, so a rename doesn't
+ * throw: the token silently resolves to `null` and the figma-svg / semantics export quietly stops
+ * emitting that property. The resolver's own unit tests can't catch it either — they feed
+ * hand-written fakes (`FakeGraphicsLayer(@JvmField val shadowElevation: Float)`) that mirror the
+ * *assumed* names, so they stay green precisely when the assumption has broken.
+ *
+ * This test closes that gap by asserting the names against **real** modifiers built from the pinned
+ * Compose. It is deliberately about the field's *existence*, not the resolver's arithmetic — the
+ * behavioural tests own that half.
+ *
+ * **When this fails after a Compose bump, that is the test working.** Find what the field or class
+ * was renamed to, update both the resolver and the expectation here, and add a behavioural test if
+ * the shape (not just the name) changed. Do not delete the case.
+ */
+class ComposeInternalFieldContractTest {
+
+  /** Every modifier element in [modifier], innermost first. */
+  private fun elementsOf(modifier: Modifier): List<Any> =
+    modifier.foldIn(mutableListOf<Any>()) { acc, element -> acc.apply { add(element) } }
+
+  /** Walks the class hierarchy the same way [ModifierTokenResolver] does. */
+  private fun hasDeclaredField(target: Any, name: String): Boolean {
+    var cls: Class<*>? = target.javaClass
+    while (cls != null && cls != Any::class.java) {
+      if (cls.declaredFields.any { it.name == name }) return true
+      cls = cls.superclass
+    }
+    return false
+  }
+
+  private fun assertSomeElementHasField(modifier: Modifier, field: String, what: String) {
+    val elements = elementsOf(modifier)
+    assertTrue(
+      "$what: no element in the chain declares a `$field` field. " +
+        "ModifierTokenResolver reflects on that name and will now silently resolve null. " +
+        "Elements present: ${elements.map { it.javaClass.name }}",
+      elements.any { hasDeclaredField(it, field) },
+    )
+  }
+
+  @Test
+  fun `background colour is kept in a color field`() {
+    // ModifierTokenResolver.backgroundColorHex reads the packed ULong out of `color`.
+    assertSomeElementHasField(
+      Modifier.background(Color.Red),
+      field = "color",
+      what = "Modifier.background(Color)",
+    )
+  }
+
+  @Test
+  fun `background brush is kept in a brush field`() {
+    // ModifierTokenResolver's gradient path reads `brush` to recover linear-gradient stops.
+    assertSomeElementHasField(
+      Modifier.background(Brush.horizontalGradient(listOf(Color.Red, Color.Blue))),
+      field = "brush",
+      what = "Modifier.background(Brush)",
+    )
+  }
+
+  @Test
+  fun `background element is still named BackgroundElement`() {
+    // Matched by simpleName in ComposeSemanticsDataProduct and ModifierTokenResolver.
+    val names = elementsOf(Modifier.background(Color.Red)).map { it.javaClass.simpleName }
+    assertTrue(
+      "Modifier.background no longer produces a `BackgroundElement`; " +
+        "simpleName matches in ModifierTokenResolver / ComposeSemanticsDataProduct are now " +
+        "dead. Elements present: $names",
+      names.contains("BackgroundElement"),
+    )
+  }
+
+  @Test
+  fun `Modifier shadow keeps a Dp elevation field`() {
+    // The px `shadowElevation` and the dp `elevation` are different sources with different units
+    // — see ModifierTokenResolverShadowTest. This pins the dp one's name.
+    assertSomeElementHasField(
+      Modifier.shadow(4.dp),
+      field = "elevation",
+      what = "Modifier.shadow(Dp)",
+    )
+  }
+
+  @Test
+  fun `graphicsLayer keeps px shadowElevation alpha and clip fields`() {
+    val modifier =
+      Modifier.graphicsLayer(shadowElevation = 8f, alpha = 0.5f, clip = true, scaleX = 1f)
+    for (field in listOf("shadowElevation", "alpha", "clip")) {
+      assertSomeElementHasField(modifier, field, what = "Modifier.graphicsLayer($field = …)")
+    }
+  }
+
+  @Test
+  fun `clip keeps a shape field`() {
+    assertSomeElementHasField(
+      Modifier.clip(RoundedCornerShape(8.dp)),
+      field = "shape",
+      what = "Modifier.clip(Shape)",
+    )
+  }
+
+  @Test
+  fun `border keeps a width field`() {
+    assertSomeElementHasField(
+      Modifier.border(2.dp, Color.Red),
+      field = "width",
+      what = "Modifier.border(Dp, Color)",
+    )
+  }
+
+  @Test
+  fun `arrangement spacedBy keeps a spacing field`() {
+    // ModifierTokenResolver.arrangementGapWire scans a Row/Column measure policy for an
+    // `Arrangement.*` value and reads `spacing` off it — the value-class getter is name-mangled,
+    // so the field is the only reachable route.
+    val arrangement: Any = Arrangement.spacedBy(8.dp)
+    assertTrue(
+      "Arrangement.spacedBy no longer keeps its gap in a `spacing` field " +
+        "(${arrangement.javaClass.name}); ModifierTokenResolver.arrangementGapWire is now blind.",
+      hasDeclaredField(arrangement, "spacing"),
+    )
+  }
+
+  @Test
+  fun `Dp value class still inlines to a value field`() {
+    // ModifierTokenResolver.floatValue unwraps any value class by reading `value`.
+    val boxed: Any = Dp(4f)
+    assertTrue(
+      "Dp no longer stores its float in a `value` field (${boxed.javaClass.name}); " +
+        "ModifierTokenResolver.floatValue can no longer unwrap Dp/value-class tokens.",
+      hasDeclaredField(boxed, "value"),
+    )
+  }
+
+  @Test
+  fun `ColorPainter is still named ColorPainter and keeps a color field`() {
+    val painter: Any = ColorPainter(Color.Red)
+    assertTrue(
+      "ColorPainter renamed to ${painter.javaClass.simpleName}; the simpleName match in " +
+        "ModifierTokenResolver.unwrapPainter no longer fires.",
+      painter.javaClass.simpleName == "ColorPainter",
+    )
+    assertTrue("ColorPainter no longer keeps a `color` field.", hasDeclaredField(painter, "color"))
+  }
+
+  @Test
+  fun `CutCornerShape is still named CutCornerShape`() {
+    // ModifierTokenResolver maps corner *style* purely off this simpleName.
+    val shape: Any = CutCornerShape(4.dp)
+    assertTrue(
+      "CutCornerShape renamed to ${shape.javaClass.simpleName}; ModifierTokenResolver would " +
+        "now report a cut-corner shape as rounded.",
+      shape.javaClass.simpleName == "CutCornerShape",
+    )
+  }
+
+  @Test
+  fun `corner sizes are still reachable by a size field`() {
+    // ModifierTokenResolver reads `size` off each CornerSize to recover the radius.
+    val corner: Any = RoundedCornerShape(12.dp).topStart
+    assertTrue(
+      "CornerSize no longer keeps its value in a `size` field (${corner.javaClass.name}); " +
+        "corner-radius tokens will resolve null.",
+      hasDeclaredField(corner, "size"),
+    )
+  }
+}

--- a/data/permissions/connector/build.gradle.kts
+++ b/data/permissions/connector/build.gradle.kts
@@ -59,16 +59,6 @@ dependencies {
   testImplementation(libs.kotlinx.serialization.json)
 }
 
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-permissions-connector",

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
@@ -193,9 +193,6 @@ class PermissionsDataProductRegistry : DataProductRegistry {
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
-    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
-  }
 
   override fun onRender(
     previewId: String,

--- a/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
+++ b/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
@@ -160,10 +160,6 @@ class PreviewOverridesDataProductRegistry : DataProductRegistry {
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
-    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
-  }
-
   override fun onRender(
     previewId: String,
     result: RenderResult,

--- a/data/pseudolocale/connector/build.gradle.kts
+++ b/data/pseudolocale/connector/build.gradle.kts
@@ -42,16 +42,6 @@ dependencies {
   testImplementation(libs.robolectric)
 }
 
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-pseudolocale-connector",

--- a/data/remotecompose/connector/build.gradle.kts
+++ b/data/remotecompose/connector/build.gradle.kts
@@ -139,16 +139,6 @@ dependencies {
   testImplementation(libs.kotlinx.serialization.json)
 }
 
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-remotecompose-connector",

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
@@ -441,9 +441,6 @@ class RemoteComposeDataProductRegistry : DataProductRegistry {
     return out
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
-    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
-  }
 
   override fun onRender(
     previewId: String,

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
@@ -9,6 +9,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
@@ -70,7 +71,12 @@ class DeviceBackgroundDataProductRegistry(previewIndex: PreviewIndex) : DataProd
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
     result.previewContext?.let { context ->
       val current = backgrounds[previewId]
       if (current?.previewExplicit == true) return

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
@@ -11,6 +11,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
@@ -84,7 +85,12 @@ class DeviceClipDataProductRegistry(previewIndex: PreviewIndex) : DataProductReg
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
     val context = result.previewContext ?: return
     contexts[previewId] = context
   }

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProduct.kt
@@ -5,6 +5,8 @@ import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.RenderTraceDataProduct
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.util.concurrent.ConcurrentHashMap
@@ -38,7 +40,12 @@ class RenderTraceDataProductRegistry : DataProductRegistry {
       )
     )
 
-  override fun onRender(previewId: String, result: RenderResult) {
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
     val metrics = result.metrics
     if (metrics == null && result.trace == null) {
       latestPayloads.remove(previewId)

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/TestFailureDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/TestFailureDataProduct.kt
@@ -5,6 +5,8 @@ import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.TestFailureDataProduct
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.util.concurrent.ConcurrentHashMap
@@ -30,7 +32,12 @@ class TestFailureDataProductRegistry : DataProductRegistry {
       )
     )
 
-  override fun onRender(previewId: String, result: RenderResult) {
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
     latestFailures.remove(previewId)
   }
 

--- a/data/resources/connector/build.gradle.kts
+++ b/data/resources/connector/build.gradle.kts
@@ -1,7 +1,3 @@
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 plugins {
   id("composeai.base-conventions")
   id("composeai.maven-publishing")
@@ -18,16 +14,6 @@ dependencies {
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)
   testImplementation(libs.robolectric)
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/data/scroll/android/build.gradle.kts
+++ b/data/scroll/android/build.gradle.kts
@@ -1,7 +1,3 @@
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 plugins {
   id("composeai.base-conventions")
   id("composeai.maven-publishing")
@@ -20,16 +16,6 @@ dependencies {
 
   testImplementation(libs.junit)
   testImplementation(libs.robolectric)
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/data/strings/connector/src/main/kotlin/ee/schimke/composeai/daemon/TextStringsDataProduct.kt
+++ b/data/strings/connector/src/main/kotlin/ee/schimke/composeai/daemon/TextStringsDataProduct.kt
@@ -8,6 +8,7 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.strings.TextStringsProduct
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
@@ -75,7 +76,12 @@ class TextStringsDataProductRegistry(
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult, overrides: PreviewOverrides?) {
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
     latestRenderMetadata[previewId] = metadataFor(previewId, overrides)
   }
 

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -172,10 +172,6 @@ class ThemeDataProductRegistry : DataProductRegistry {
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
-    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
-  }
-
   override fun onRender(
     previewId: String,
     result: RenderResult,

--- a/data/uiautomator/connector/build.gradle.kts
+++ b/data/uiautomator/connector/build.gradle.kts
@@ -1,13 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 // `:data-uiautomator-connector` — daemon-side glue for the UIAutomator-shaped script events.
 //
 // Advertises a single `uiautomator` `DataExtensionDescriptor` carrying the `uia.*` script-event
@@ -48,16 +38,6 @@ dependencies {
 
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/data/uiautomator/core/build.gradle.kts
+++ b/data/uiautomator/core/build.gradle.kts
@@ -1,13 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 // `:data-uiautomator-core` — UIAutomator-shaped query/action API for the Compose preview
 // renderer.
 //
@@ -60,16 +50,6 @@ dependencies {
   testImplementation(libs.activity.compose)
   testImplementation("androidx.compose.ui:ui-test-junit4")
   testImplementation("androidx.compose.ui:ui-test-manifest")
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/data/uiautomator/hierarchy-android/build.gradle.kts
+++ b/data/uiautomator/hierarchy-android/build.gradle.kts
@@ -1,11 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-
 // `:data-uiautomator-hierarchy-android` — the Android-platform-specific producer for
 // `uia/hierarchy` (#874). Walks a Compose `SemanticsOwner` tree and emits a typed
 // `UiAutomatorHierarchyPayload` carrying the actionable subset agents need to formulate
@@ -49,16 +41,6 @@ dependencies {
   testImplementation(libs.activity.compose)
   testImplementation("androidx.compose.ui:ui-test-junit4")
   testImplementation("androidx.compose.ui:ui-test-manifest")
-}
-
-mavenPublishing {
-  configure(
-    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
-      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
-      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperDataProduct.kt
+++ b/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperDataProduct.kt
@@ -165,10 +165,6 @@ class WallpaperDataProductRegistry : DataProductRegistry {
     )
   }
 
-  override fun onRender(previewId: String, result: RenderResult) {
-    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
-  }
-
   override fun onRender(
     previewId: String,
     result: RenderResult,

--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -29,9 +29,9 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
    * The Android theme the preview host activity runs under, e.g. `"@style/Theme.Foo"` (also accepts
    * `"com.example:style/Theme.Foo"` or a bare `"Theme.Foo"`).
    *
-   * Leave it unset in an **application** module: the host activity already inherits
-   * `<application android:theme>` from the merged manifest, which is what makes an `AndroidView`
-   * preview resolve app-owned `?attr/…` references.
+   * Leave it unset in an **application** module: the host activity already inherits `<application
+   * android:theme>` from the merged manifest, which is what makes an `AndroidView` preview resolve
+   * app-owned `?attr/…` references.
    *
    * Set it in a **library** module whose previews host platform views. A library's merged manifest
    * has no `<application android:theme>` to inherit, so the host activity falls back to the
@@ -358,28 +358,13 @@ constructor(private val extensionName: String, objects: ObjectFactory) : Named {
   val checks: ListProperty<String> =
     objects.listProperty(String::class.java).convention(emptyList())
 
-  /**
-   * Fail the build if any ERROR-level ATF finding is reported. Default: `false` — findings are
-   * reported (logged, written to the JSON report, surfaced as CLI/VSCode diagnostics) but do not
-   * fail the build unless the consumer explicitly opts in. That way turning on `enabled` is a safe,
-   * purely additive change.
-   */
-  val failOnErrors: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
-
-  /**
-   * Fail the build if any WARNING-level ATF finding is reported. Default: `false` (same rationale
-   * as [failOnErrors]).
-   */
-  val failOnWarnings: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
-
-  /**
-   * Generate an annotated screenshot per preview showing each finding as a numbered badge + legend
-   * panel. Costs ~10ms/preview when there are findings, zero when there aren't. Default: `true` —
-   * if you asked for checks, you probably want to see what they found. Set to `false` for CI jobs
-   * that only care about the JSON / fail-on-errors gate.
-   */
-  val annotateScreenshots: Property<Boolean> =
-    objects.property(Boolean::class.java).convention(true)
+  // No `failOnErrors` / `failOnWarnings` / `annotateScreenshots` here on purpose. They existed
+  // while a11y ran as a *gate* inside the render task; that model is gone (a11y is daemon-only
+  // now, a data producer rather than a build gate — see docs/DATA_PRODUCTS.md). The properties
+  // outlived the gate and were read by nothing, so a consumer setting `failOnErrors = true` got a
+  // silently green build and believed findings were blocking. Removed rather than reimplemented:
+  // if build-failing checks come back, they should be wired to the daemon's producer surface and
+  // named for what they actually gate.
 }
 
 abstract class ComposeAiTracePreviewExtension

--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -358,13 +358,44 @@ constructor(private val extensionName: String, objects: ObjectFactory) : Named {
   val checks: ListProperty<String> =
     objects.listProperty(String::class.java).convention(emptyList())
 
-  // No `failOnErrors` / `failOnWarnings` / `annotateScreenshots` here on purpose. They existed
-  // while a11y ran as a *gate* inside the render task; that model is gone (a11y is daemon-only
-  // now, a data producer rather than a build gate — see docs/DATA_PRODUCTS.md). The properties
-  // outlived the gate and were read by nothing, so a consumer setting `failOnErrors = true` got a
-  // silently green build and believed findings were blocking. Removed rather than reimplemented:
-  // if build-failing checks come back, they should be wired to the daemon's producer surface and
-  // named for what they actually gate.
+  // `failOnErrors` / `failOnWarnings` / `annotateScreenshots` below are **no-ops**, kept only to
+  // honour the binary-stability contract in docs/CONFIG_ONLY_PLUGIN.md § "The binary-stability
+  // contract": this artifact can land on the buildscript classpath at two versions at once (the
+  // one the consumer pinned, and the one the CLI-injected runtime plugin drags in), Gradle
+  // conflict-resolves to a single copy, so deleting a documented DSL property breaks the *other*
+  // version's build script with an unresolved reference — for a consumer who did nothing wrong,
+  // and in a way that stops them rendering at all.
+  //
+  // They existed while a11y ran as a gate inside the render task. That model is gone: a11y is
+  // daemon-only, a data producer rather than a build gate (docs/DATA_PRODUCTS.md), and nothing has
+  // read these since. Deprecating rather than deleting also fixes the actual harm — the old KDoc
+  // promised behaviour that never ran, so `failOnErrors = true` bought a silently green build.
+  // A deprecation warning is visible; a silent no-op is not.
+  //
+  // Remove on the next deliberate binary break of `compose-preview-config`. If build-failing
+  // checks return, wire them to the daemon's producer surface and name them for what they gate.
+
+  @Deprecated(
+    "No-op since a11y became a daemon-side data product rather than a build gate; it never " +
+      "fails the build. Remove it from your composePreview { } block.",
+    level = DeprecationLevel.WARNING,
+  )
+  val failOnErrors: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+
+  @Deprecated(
+    "No-op since a11y became a daemon-side data product rather than a build gate; it never " +
+      "fails the build. Remove it from your composePreview { } block.",
+    level = DeprecationLevel.WARNING,
+  )
+  val failOnWarnings: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+
+  @Deprecated(
+    "No-op. Annotated screenshots are produced by the daemon's a11y data product, not by this " +
+      "flag. Remove it from your composePreview { } block.",
+    level = DeprecationLevel.WARNING,
+  )
+  val annotateScreenshots: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(true)
 }
 
 abstract class ComposeAiTracePreviewExtension

--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
@@ -73,11 +73,11 @@ abstract class DaemonExtension @Inject constructor(objects: ObjectFactory) {
    * rest of the pool on a background thread. Default: `true`.
    *
    * `RobolectricHost.start()` boots the eager slots sequentially and applies the per-slot boot
-   * budget to each, so a [warmSpare] pool (5 sandboxes) would hold `initialize` for roughly
-   * `5 × sandbox boot` — ~58s at the ~11.6s-per-sandbox figure in
-   * `docs/daemon/SANDBOX-POOL.md` — before the client may render anything. With this on, only slot
-   * 0 is on the critical path; dispatch routes across the ready prefix while the remaining slots
-   * boot behind it, and once the pool completes behaviour is bit-identical with the eager path.
+   * budget to each, so a [warmSpare] pool (5 sandboxes) would hold `initialize` for roughly `5 ×
+   * sandbox boot` — ~58s at the ~11.6s-per-sandbox figure in `docs/daemon/SANDBOX-POOL.md` — before
+   * the client may render anything. With this on, only slot 0 is on the critical path; dispatch
+   * routes across the ready prefix while the remaining slots boot behind it, and once the pool
+   * completes behaviour is bit-identical with the eager path.
    *
    * On by default: time-to-first-render is what a human waits on. Nothing can render until
    * `initialize` returns, so the eager path makes every client pay for the whole pool before it may

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -554,9 +554,8 @@ data class PreviewParams(
    */
   val density: Float? = null,
   /**
-   * Bound a **wrapped** width axis is measured against, replacing the renderer's generic
-   * 400×800 dp sandbox ([DeviceDimensions.SANDBOX_WIDTH_DP]). `null` (the default) keeps that
-   * sandbox.
+   * Bound a **wrapped** width axis is measured against, replacing the renderer's generic 400×800 dp
+   * sandbox ([DeviceDimensions.SANDBOX_WIDTH_DP]). `null` (the default) keeps that sandbox.
    *
    * Deliberately not [widthDp]: setting `widthDp` FIXES the axis, so the capture keeps the whole
    * frame and the intrinsic crop never runs. The sandbox bound changes only what
@@ -811,8 +810,9 @@ data class CatalogEntry(
    * COMPONENT only: `@CatalogComponent.perBreakpoint` — split this function's multipreview fan-out
    * into a component per breakpoint rather than folding every render onto one. Which breakpoints
    * those are is NOT recorded here: they come from the renders themselves (each `@Preview`'s device
-   * / width, resolved against the catalog's `breakpoints` table), so the annotation can't contradict
-   * what the function actually rendered. `false` — the default — is the pre-existing behaviour.
+   * / width, resolved against the catalog's `breakpoints` table), so the annotation can't
+   * contradict what the function actually rendered. `false` — the default — is the pre-existing
+   * behaviour.
    */
   val perBreakpoint: Boolean = false,
 )

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -3240,17 +3240,17 @@ object PreviewDiscovery {
    * measured against the Wear screen + density ([DeviceDimensions.DEFAULT_WEAR], 227dp @ 2.0x).
    * Previews that pin their own `device` / `widthDp` / `heightDp` (e.g. the `id:wearos_*_round`
    * breakpoints, or fixed-size specimens) are left untouched, and the preview id — which never
-   * encodes a device for a device-less preview — is unchanged, so `catalog.spec.json` references and
-   * delivery filenames stay stable. A no-op off Wear.
+   * encodes a device for a device-less preview — is unchanged, so `catalog.spec.json` references
+   * and delivery filenames stay stable. A no-op off Wear.
    *
    * The retarget sets [PreviewParams.wrapSandboxWidthDp] / [PreviewParams.wrapSandboxHeightDp], NOT
    * `widthDp` / `heightDp`. Both axes stay wrapped, so every sticker still crops to its measured
-   * bounds; all that changes is the bound `fillMaxWidth`/`fillMaxHeight` resolve against. That's the
-   * distinction #2373 originally missed: it pinned the axes to fix a fill-width `Card` that was
-   * measuring on a 400dp phone sandbox (rendering 1050×210), and in doing so suppressed the crop for
-   * every OTHER device-less preview in the module — a `FilledButton` sticker that used to export
-   * 217×179 became a 454×454 watch canvas with the button adrift in the corner. Sandboxing instead
-   * of pinning fixes the Card (it fills to 227dp) and keeps the Button tight.
+   * bounds; all that changes is the bound `fillMaxWidth`/`fillMaxHeight` resolve against. That's
+   * the distinction #2373 originally missed: it pinned the axes to fix a fill-width `Card` that was
+   * measuring on a 400dp phone sandbox (rendering 1050×210), and in doing so suppressed the crop
+   * for every OTHER device-less preview in the module — a `FilledButton` sticker that used to
+   * export 217×179 became a 454×454 watch canvas with the button adrift in the corner. Sandboxing
+   * instead of pinning fixes the Card (it fills to 227dp) and keeps the Button tight.
    *
    * [pinWearCanvas] (from the `retargetWearPreviews` extension flag, [Input.retargetWearPreviews])
    * selects between two Wear behaviours for those device-less previews; it's a no-op off Wear:
@@ -3263,9 +3263,9 @@ object PreviewDiscovery {
    *
    * **Auto-detected Wear widgets always take the `false` branch, regardless of [pinWearCanvas].** A
    * glance-wear widget preview — one whose `@PreviewParameter` provider comes from
-   * `androidx.glance.wear.*` (the `Squircle`/`RectangularAllWidgetPreviewParams` providers that feed
-   * `WearWidgetParams`) — is exported as a fixed-size drawable asset, so no per-module config is
-   * needed for the common widget case; the flag remains the override for non-glance widget param
+   * `androidx.glance.wear.*` (the `Squircle`/`RectangularAllWidgetPreviewParams` providers that
+   * feed `WearWidgetParams`) — is exported as a fixed-size drawable asset, so no per-module config
+   * is needed for the common widget case; the flag remains the override for non-glance widget param
    * types (#2670). This is per-preview, so one module can mix fill-width catalog components
    * (watch-sandboxed) with widgets (not).
    */
@@ -3285,7 +3285,8 @@ object PreviewDiscovery {
         // the watch screen — `fillMaxWidth` inside a widget means "fill the widget".
         val sandboxToWatch = pinWearCanvas && !isWearWidgetPreview(p)
         if (sandboxToWatch) {
-          // Measure against the wear screen (square 227dp) at wear density, so fill-width components
+          // Measure against the wear screen (square 227dp) at wear density, so fill-width
+          // components
           // (Card) size to the watch and dp→px matches the render. Both axes stay WRAPPED, so the
           // renderer still crops each PNG to its measured bounds — a Card fills the 227dp and keeps
           // it, a Button wraps tight.
@@ -3298,10 +3299,12 @@ object PreviewDiscovery {
               )
           )
         } else {
-          // Opted out (`retargetWearPreviews = false`) or an auto-detected widget: leave the sandbox
+          // Opted out (`retargetWearPreviews = false`) or an auto-detected widget: leave the
+          // sandbox
           // at the renderer's generic default so the composable measures against a widget-sized
           // bound rather than the watch screen (#2670). Still apply the Wear density (2.0x) rather
-          // than the inherited phone default (2.625x), so the cropped dp bounds scale to the correct
+          // than the inherited phone default (2.625x), so the cropped dp bounds scale to the
+          // correct
           // watch-density px, not an oversized phone-scale export.
           info.copy(params = p.copy(density = wear.density))
         }

--- a/renderers/android/build.gradle.kts
+++ b/renderers/android/build.gradle.kts
@@ -1,7 +1,3 @@
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 plugins {
   id("composeai.base-conventions")
   id("composeai.maven-publishing")
@@ -13,8 +9,8 @@ plugins {
 
 android {
   namespace = "ee.schimke.composeai.renderer"
-  // `AndroidSingleVariantLibrary` in `mavenPublishing {}` below wires the
-  // `singleVariant("release")` publication for us — don't declare it twice.
+  // The `composeai.maven-publishing` convention wires the `singleVariant("release")`
+  // publication for us — don't declare it twice.
   // wear-compose 1.7.0-alpha's AARs declare `minCompileSdk = 37`; compile against API 37 so the
   // `compileOnly` `wear.compose.foundation` types resolve. Override the conventions `compileSdk =
   // 36`.
@@ -307,16 +303,6 @@ dependencies {
   // consumer's own protolayout pulls them at runtime under Robolectric. See TilePreviewRenderer.
   compileOnly(libs.wear.protolayout.proto)
   compileOnly(libs.wear.protolayout.external.protobuf)
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/renderers/xr/build.gradle.kts
+++ b/renderers/xr/build.gradle.kts
@@ -1,7 +1,3 @@
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 plugins {
   id("composeai.base-conventions")
   // Published so external consumers can resolve `ee.schimke.composeai:renderer-xr:<version>` —
@@ -116,15 +112,6 @@ dependencies {
 // The heavy XR / compose-test libs are `compileOnly`, so they stay out of the published POM and the
 // plugin supplies the `*-testing` fakes on the render configuration itself (mirrors
 // `:renderer-android`).
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
 
 composeAiMavenPublishing {
   coordinates(

--- a/runtimes/appwidget/build.gradle.kts
+++ b/runtimes/appwidget/build.gradle.kts
@@ -1,13 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 // `:appwidget-preview-runtime` — composable-helper authoring path for legacy `RemoteViews`-backed
 // App Widget previews. Sister to `:notification-preview-runtime` and `:glance-preview-runtime`.
 // `AppWidgetContent { ctx -> RemoteViews(...) }` inflates the consumer's `RemoteViews` factory
@@ -56,16 +46,6 @@ dependencies {
 }
 
 android { testOptions { unitTests { isIncludeAndroidResources = true } } }
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
-}
 
 composeAiMavenPublishing {
   coordinates(

--- a/runtimes/color/build.gradle.kts
+++ b/runtimes/color/build.gradle.kts
@@ -1,13 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 // `:color-preview-runtime` — composable-helper authoring path for colour / design-token specimens.
 // Sister to `:typography-preview-runtime`. `ColorSchemeSpecimen` renders every Material 3
 // `ColorScheme` role as a labelled swatch, and `ColorSpecimen` does the same for an arbitrary list
@@ -58,16 +48,6 @@ dependencies {
   testImplementation(libs.activity.compose)
   testImplementation("androidx.compose.ui:ui-test-junit4")
   testImplementation("androidx.compose.ui:ui-test-manifest")
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/runtimes/glance/build.gradle.kts
+++ b/runtimes/glance/build.gradle.kts
@@ -1,13 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 // `:glance-preview-runtime` — composable-helper authoring path for Glance app-widget
 // previews. Sister to `:notification-preview-runtime`. `GlanceAppWidgetContent(widget = ...)`
 // materialises a `GlanceAppWidget` to `RemoteViews` via the public 1.2.0+
@@ -53,16 +43,6 @@ dependencies {
   // declared supported sizes / resize-axes on the payload. Without this dep the helper still
   // renders the widget; the payload just doesn't carry the size-mode constraints.
   implementation(project(":data-launcher-widget-connector"))
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/runtimes/notification/build.gradle.kts
+++ b/runtimes/notification/build.gradle.kts
@@ -1,13 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 // `:notification-preview-runtime` — the composable-helper authoring path for notification
 // previews. Pairs with the `@NotificationPreview` annotation that ships in `:preview-annotations`:
 // the annotation drives the FQN-discovered NOTIFICATION strategy (renderer-android builds the
@@ -63,16 +53,6 @@ dependencies {
   testImplementation(libs.activity.compose)
   testImplementation("androidx.compose.ui:ui-test-junit4")
   testImplementation("androidx.compose.ui:ui-test-manifest")
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/runtimes/splash/build.gradle.kts
+++ b/runtimes/splash/build.gradle.kts
@@ -1,13 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 // `:splash-preview-runtime` — composable-helper authoring path for the Android 12+
 // SplashScreen window appearance. Sister to `:notification-preview-runtime` and
 // `:glance-preview-runtime`: a tiny JVM-friendly helper consumed inside a regular `@Preview`,
@@ -64,16 +54,6 @@ dependencies {
   testImplementation(libs.activity.compose)
   testImplementation("androidx.compose.ui:ui-test-junit4")
   testImplementation("androidx.compose.ui:ui-test-manifest")
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/runtimes/typography/build.gradle.kts
+++ b/runtimes/typography/build.gradle.kts
@@ -1,13 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 // `:typography-preview-runtime` — composable-helper authoring path for typography / font
 // specimens. Sister to `:notification-preview-runtime` and `:glance-preview-runtime`. The three
 // helpers (`TypographySpecimen`, `FontFamilySpecimen`, `FallbackCoverageSpecimen`) render
@@ -57,16 +47,6 @@ dependencies {
   testImplementation(libs.activity.compose)
   testImplementation("androidx.compose.ui:ui-test-junit4")
   testImplementation("androidx.compose.ui:ui-test-manifest")
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {

--- a/runtimes/wear-preview/build.gradle.kts
+++ b/runtimes/wear-preview/build.gradle.kts
@@ -1,11 +1,3 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; see :splash.
-
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
-
 // `:wear-preview-runtime` — composable-helper authoring path for **Wear TransformingLazyColumn item
 // scaling** in an isolated `@Preview`. Sister to `:splash-preview-runtime` /
 // `:slot-preview-runtime`:
@@ -94,16 +86,6 @@ dependencies {
   compileOnly(libs.glance.wear.core)
   compileOnly(libs.glance.wear.tooling.preview)
   compileOnly(libs.compose.remote.creation.compose)
-}
-
-mavenPublishing {
-  configure(
-    AndroidSingleVariantLibrary(
-      javadocJar = JavadocJar.Empty(),
-      sourcesJar = SourcesJar.Sources(),
-      variant = "release",
-    )
-  )
 }
 
 composeAiMavenPublishing {


### PR DESCRIPTION
Four findings from a design/architecture/code-quality review, each independently revertable. Net **−325 lines** across 47 files.

Text-only evidence is correct here: nothing in this branch is renderable. No `@Preview`, webview, overlay, theme, icon, or fixture is touched — the changes are a Gradle DSL deprecation, a daemon interface signature, build-script consolidation, and a new JVM unit test. Rendered output is byte-identical by construction.

## 1. `fix(gradle-plugin-config)` — three DSL knobs that nothing reads

`failOnErrors`, `failOnWarnings`, `annotateScreenshots` on `PreviewExtensionConfig` have **no readers anywhere in the repo** — not the plugin, renderers, daemon, CLI, or docs. They date from when a11y ran as a build gate inside the render task; that model is gone (a11y is daemon-only, a data producer not a gate — `docs/AGENTS.md`, `DATA_PRODUCTS.md`). The gate was removed, the knobs outlived it.

Worse than dead code, because the KDoc still promised behaviour: a consumer who writes `failOnErrors = true` gets a green build and concludes their previews have no ERROR-level findings.

**They are now `@Deprecated` no-ops, not deleted.** The first cut removed them; Codex correctly caught ([#discussion_r3740888831](https://github.com/yschimke/compose-ai-tools/pull/3522#discussion_r3740888831)) that this violates the binary-stability contract in `docs/CONFIG_ONLY_PLUGIN.md`. That artifact can sit on the buildscript classpath at two versions at once — the consumer's pin, and whatever the CLI-injected runtime drags in — and Gradle resolves to one copy, so deleting a documented DSL property breaks the *other* version's build script for a consumer who did nothing wrong, and stops them rendering entirely. Deprecating also fixes the original harm better: a deprecation warning is visible at the point of use, where a silent no-op is not. Flagged in-code for removal at the next deliberate binary break.

## 2. `refactor(daemon)` — collapse the `DataProductRegistry.onRender` overload fan

`onRender` existed at 2, 3 and 4 args, defaults cascading widest→narrowest. Two problems:

- The dispatcher only ever calls the widest form — **one** production call site, `JsonRpcServer:1226`. The narrow overloads were dead API.
- The cascade ran the wrong way for real producers. All of them need `previewContext`, so implementing the 4-arg form alone left the 2-arg one inert. Thirteen producers papered over it with a byte-identical reverse forwarder. A new producer that forgot it would compile clean and silently receive nothing.

Now one hook. The narrow shapes survive as **extension functions** — statically resolved, non-overridable — so test call sites keep reading as `onRender(id, result)` without reopening the trap.

Five producers had real logic on the 2-arg form and relied on the cascade (`ComposeFigmaSvg`, `DeviceBackground`, `DeviceClip`, `RenderTrace`, `TestFailure`); each is widened to the single hook. The compiler found every one — which is the point.

## 3. `test(layoutinspector)` — canary for the Compose internals the resolver reflects on

`ModifierTokenResolver` reads ~26 private backing fields by name (`BackgroundElement.color`, `ShadowGraphicsLayerElement.elevation`, `Arrangement.spacedBy(...).spacing`, …) plus several `javaClass.simpleName` matches. None of it is public API.

Every read is `runCatching { }.getOrNull()`, so a rename doesn't throw — the token resolves to `null` and the figma-svg / semantics export quietly stops emitting that property. The existing tests **cannot** catch this: they feed hand-written fakes (`FakeGraphicsLayer(@JvmField val shadowElevation: Float)`) that mirror the *assumed* names, so they stay green precisely when the assumption breaks.

This asserts the names against **real** modifiers built from the pinned Compose, so a bump that renames one fails here with old and new names in the message.

## 4. `build` — Android publishing block into the convention plugin

25 modules each carried the same 9-line `mavenPublishing { configure(AndroidSingleVariantLibrary(…)) }`, the same 3 imports, and the same `@file:Suppress("DEPRECATION")` header — ~380 lines of one decision, 25 times. The suppression comment stated the reason to consolidate: *"the replacement types vary between plugin versions."*

`composeai.maven-publishing` already applies `composeai.android-conventions`, so it configures this itself now, gated on `withPlugin("com.android.library")` so the 65 JVM modules sharing the convention keep vanniktech's default. `daemon:android` keeps its testFixtures-skip block — genuinely specific to it.

## Also included

`style:` re-runs ktfmt on three files in the `gradle-plugin` build. This drift **pre-exists on `main`** — verified by stashing this branch and running `ktfmtCheck` on a clean checkout, which reports four files including `PreviewExtension.kt`. Since the `format` job aborts on the first unformatted file, leaving it would mask this branch's own result. Separate commit, safe to drop if you'd rather fix it independently.

## Test plan

Run in-session against a locally provisioned Android SDK (platform 36/37, build-tools 36):

- [x] `ktfmtCheckAll` (root) and `ktfmtCheck` (`gradle-plugin` included build) — both green
- [x] `:daemon:core:test`, `:data-layoutinspector-connector:test`, `:data-render-connector:test`, `:data-strings-connector:test`
- [x] `:data-{permissions,theme,wallpaper,remotecompose,launcher-widget,preview-overrides,ambient,gestures}-connector:test`
- [x] `:daemon:android:assemble`, `:daemon:desktop:assemble`, `:renderer-android:assemble`, and all 10 touched connectors
- [x] `:gradle-plugin-config:build` + `:gradle-plugin:test` (included build), re-run after the deprecation fix
- [x] **Publication unchanged:** `:color-preview-runtime:publishToMavenLocal` still emits release `.aar` + `-sources.jar` + `-javadoc.jar` + `.pom` + `.module`
- [x] **Canary verified in both directions:** all 12 cases pass against the current Compose pin, and mutating one expectation to a bogus field name does fail the suite — a green test that can't go red would be worthless
- [x] Re-verified after rebasing onto `5e80c40`

Not run here: the full `./gradlew check` and the end-to-end catalog renders. No rendering path is touched, so CI covers the remainder.