### PR TITLE
feat(preview-annotations): let @OverrideVariant sit on an annotation class

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
@@ -46,10 +46,40 @@ package ee.schimke.composeai.preview
  * `SwitchOn_*_VARIANT_off` and the rest from these annotations, with matching `figma/…` vectors —
  * so a desktop catalog has no reason to keep a hand-written wrapper for a variant that differs only
  * by a knob.
+ *
+ * ## Hoisting a whole matrix onto one annotation
+ *
+ * `@Target` includes `ANNOTATION_CLASS`, so a set of variants that several components share can be
+ * declared **once** on an annotation class and applied with one line each — the same "declare the
+ * fan-out once, tag the functions" move a multi-preview annotation makes for `@Preview`:
+ * ```
+ * @OverrideVariant(name = "xs", strings = ["size=xs"])
+ * @OverrideVariant(name = "xs-square", strings = ["size=xs", "shape=square"])
+ * // … one per cell …
+ * annotation class SizeShapeMatrix
+ *
+ * @CatalogModes @SizeShapeMatrix @Composable fun FilledButton() = …
+ * ```
+ *
+ * That is what the M3 catalogs need: five sizes by two shapes is nine cells, and writing them out
+ * per component put 237 near-identical annotations across thirteen blocks, which drifted.
+ *
+ * Two properties worth knowing before reaching for it:
+ * * **Stacking is a union, not a product.** A function tagged with a five-cell size annotation and
+ *   a two-cell shape annotation gets **seven** variants, not ten — each annotation contributes its
+ *   own cells, and nothing crosses them. Declare the cross product on one annotation if that is
+ *   what you want.
+ * * **Names must be unique across everything the function ends up carrying**, direct and hoisted
+ *   alike, because the name is what distinguishes the rendered `_VARIANT_<name>` output. Discovery
+ *   keeps the first of a repeated name and warns, rather than emitting two captures that overwrite
+ *   each other's file.
+ *
+ * Resolution walks the whole meta-annotation closure, so an annotation class that is itself tagged
+ * with another one contributes both sets.
  */
 @Repeatable
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @MustBeDocumented
 annotation class OverrideVariant(
   /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1578,7 +1578,13 @@ object PreviewDiscovery {
     // `@OverrideVariant` (repeatable) — each spec yields one extra synthetic preview per @Preview
     // expansion below, rendered with its `previewOverride*` seeds applied. Applies to every
     // expansion, the same "one annotation, applies to every preview" policy as the capture specs.
-    val overrideVariantSpecs = extractOverrideVariantSpecs(annotations)
+    val overrideVariantSpecs =
+      extractOverrideVariantSpecs(
+        annotations,
+        scanResult,
+        owner = "${classInfo.name}.${method.name}",
+        warnings = warnings,
+      )
     // @RoboComposePreviewOptions, similarly, applies to the function as a
     // whole — each timing fans out into its own manifest entry, orthogonal
     // to any multi-preview expansion.
@@ -1770,39 +1776,108 @@ object PreviewDiscovery {
    * each. Each per-type array entry is `"key=value"` / `"key#index=value"`; the array it lives in
    * fixes its [OverrideSeedKind]. A variant that names no parseable seed is dropped (it would
    * render identically to the base).
+   *
+   * Variants may be **hoisted onto a multi-preview-style annotation class** so a matrix several
+   * components share is declared once (`@Target` includes `ANNOTATION_CLASS`; see `OverrideVariant`
+   * for the semantics). Two things make that work here. ClassGraph already flattens a method's
+   * meta-annotation closure into `method.annotationInfo`, unwrapping the repeatable container as it
+   * goes, so hoisted variants arrive in [annotations] alongside the direct ones; and
+   * [overrideVariantsFromMetaAnnotation] walks the closure explicitly as well, so resolution does
+   * not silently depend on that flattening staying true of a future ClassGraph. Both paths feed the
+   * same de-duplication below, so an annotation reachable twice contributes once.
+   *
+   * **Names are de-duplicated, first wins.** A variant's name is what distinguishes its rendered
+   * `_VARIANT_<name>` output, so two variants sharing one would write to the same file — the second
+   * overwriting the first, silently, with whichever seeds it happened to carry. That was
+   * unreachable while variants could only sit directly on a function (Kotlin rejects two identical
+   * repeated annotations at the same site only when their arguments match, but a catalog author
+   * writing them by hand sees them adjacent). Hoisting makes it easy: stack two matrices that
+   * overlap on one cell and nothing in the compile objects. Keeping the first and warning names the
+   * collision at discovery time, where the fix is obvious.
    */
   private fun extractOverrideVariantSpecs(
-    annotations: List<AnnotationInfo>
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+    owner: String,
+    warnings: MutableList<String>,
   ): List<OverrideVariantSpec> {
     val infos = mutableListOf<AnnotationInfo>()
+    val visited = mutableSetOf<String>()
     for (ann in annotations) {
-      when (ann.name) {
-        OVERRIDE_VARIANT_FQN -> infos.add(ann)
-        OVERRIDE_VARIANT_CONTAINER_FQN -> {
-          when (val value = ann.parameterValues.getValue("value")) {
-            is Array<*> -> value.filterIsInstance<AnnotationInfo>().forEach { infos.add(it) }
-            is AnnotationInfo -> infos.add(value)
-            else -> {
-              val len = runCatching { java.lang.reflect.Array.getLength(value) }.getOrNull() ?: 0
-              for (i in 0 until len) {
-                (java.lang.reflect.Array.get(value, i) as? AnnotationInfo)?.let { infos.add(it) }
-              }
-            }
-          }
-        }
-      }
+      collectOverrideVariants(ann, infos)
+      overrideVariantsFromMetaAnnotation(ann, scanResult, visited, infos)
     }
-    return infos.mapNotNull { info ->
+    val specs = LinkedHashMap<String, OverrideVariantSpec>()
+    val collisions = LinkedHashSet<String>()
+    for (info in infos) {
       val pv = info.parameterValues
-      val name =
-        (pv.getValue("name") as? String)?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+      val name = (pv.getValue("name") as? String)?.takeIf { it.isNotBlank() } ?: continue
       val seeds =
         readOverrideSeeds(pv.getValue("booleans"), OverrideSeedKind.BOOLEAN) +
           readOverrideSeeds(pv.getValue("strings"), OverrideSeedKind.STRING) +
           readOverrideSeeds(pv.getValue("ints"), OverrideSeedKind.INT) +
           readOverrideSeeds(pv.getValue("floats"), OverrideSeedKind.FLOAT) +
           readOverrideSeeds(pv.getValue("colors"), OverrideSeedKind.COLOR)
-      if (seeds.isEmpty()) null else OverrideVariantSpec(name = name, seeds = seeds)
+      if (seeds.isEmpty()) continue
+      val spec = OverrideVariantSpec(name = name, seeds = seeds)
+      val existing = specs.putIfAbsent(name, spec)
+      // Only a *conflicting* duplicate is worth a warning. The same annotation reached twice — once
+      // flattened by ClassGraph and once by the explicit meta-annotation walk — is the common case
+      // and produces an identical spec, which is exactly the de-duplication working.
+      if (existing != null && existing != spec) collisions.add(name)
+    }
+    for (name in collisions) {
+      warnings.add(
+        "composePreview: '$owner' carries more than one @OverrideVariant named '$name' with " +
+          "different seeds — most likely two hoisted variant annotations that overlap on a cell. " +
+          "Variant names are the `_VARIANT_$name` render output's identity, so the second would " +
+          "overwrite the first; keeping the first and ignoring the rest. Rename the cell, or drop " +
+          "the overlapping annotation."
+      )
+    }
+    return specs.values.toList()
+  }
+
+  /** Adds [ann] to [into] when it is an `@OverrideVariant`, unwrapping the repeatable container. */
+  private fun collectOverrideVariants(ann: AnnotationInfo, into: MutableList<AnnotationInfo>) {
+    when (ann.name) {
+      OVERRIDE_VARIANT_FQN -> into.add(ann)
+      OVERRIDE_VARIANT_CONTAINER_FQN -> {
+        when (val value = ann.parameterValues.getValue("value")) {
+          is Array<*> -> value.filterIsInstance<AnnotationInfo>().forEach { into.add(it) }
+          is AnnotationInfo -> into.add(value)
+          else -> {
+            val len = runCatching { java.lang.reflect.Array.getLength(value) }.getOrNull() ?: 0
+            for (i in 0 until len) {
+              (java.lang.reflect.Array.get(value, i) as? AnnotationInfo)?.let { into.add(it) }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Recursively collects `@OverrideVariant`s hoisted onto a multi-preview-style annotation class
+   * (and onto its own meta-annotations), mirroring [wrapperFromMetaAnnotation]'s traversal and cycle
+   * guard. Skips `@Preview` and its container — a hoisted variant only ever rides on a custom
+   * annotation. Contributes nothing when the annotation class is off the discovery classpath, which
+   * is the same limit every other meta-annotation walk here has.
+   */
+  private fun overrideVariantsFromMetaAnnotation(
+    ann: AnnotationInfo,
+    scanResult: ScanResult,
+    visited: MutableSet<String>,
+    into: MutableList<AnnotationInfo>,
+  ) {
+    if (ann.name in visited) return
+    if (isDirectPreview(ann) || isPreviewContainer(ann)) return
+    if (ann.name == OVERRIDE_VARIANT_FQN || ann.name == OVERRIDE_VARIANT_CONTAINER_FQN) return
+    visited.add(ann.name)
+    val annClassInfo = scanResult.getClassInfo(ann.name) ?: return
+    for (metaAnn in annClassInfo.annotationInfo.toList()) {
+      collectOverrideVariants(metaAnn, into)
+      overrideVariantsFromMetaAnnotation(metaAnn, scanResult, visited, into)
     }
   }
 

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -239,6 +239,189 @@ class DiscoveryFunctionalTest {
       )
   }
 
+  /**
+   * The hoisted form: a matrix declared once on an annotation class and applied with one line.
+   *
+   * This is what stops a catalog retyping a cross product per component — five sizes by two shapes
+   * is nine cells, and m3-catalog had 237 near-identical annotations across thirteen blocks before
+   * `@OverrideVariant` could sit on an annotation class.
+   *
+   * Three properties are asserted together because they are the ones a naive implementation gets
+   * wrong: hoisted variants are found at all; stacking two annotations is a **union** (2 + 1 = 3
+   * variants, not 2 x 1 = 2 or some product); and a name carried by both is de-duplicated rather
+   * than emitted twice onto the same `_VARIANT_` output path.
+   */
+  @Test
+  fun `composePreviewDiscover expands @OverrideVariant hoisted onto an annotation class`() {
+    val projectDir = createCmpTestProject()
+
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    annDir.mkdirs()
+    File(annDir, "OverrideVariant.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Repeatable
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+        annotation class OverrideVariant(
+            val name: String,
+            val booleans: Array<String> = [],
+            val strings: Array<String> = [],
+            val ints: Array<String> = [],
+            val floats: Array<String> = [],
+            val colors: Array<String> = [],
+        )
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "src/main/kotlin/test/Sized.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
+        import ee.schimke.composeai.preview.OverrideVariant
+
+        @OverrideVariant(name = "xs", strings = ["size=xs"])
+        @OverrideVariant(name = "l", strings = ["size=l"])
+        annotation class SizeMatrix
+
+        @OverrideVariant(name = "square", strings = ["shape=square"])
+        annotation class ShapeMatrix
+
+        @Preview
+        @SizeMatrix
+        @ShapeMatrix
+        @Composable
+        fun SizedPreview() {
+            Box(modifier = Modifier.size(50.dp)) { Text("Sized") }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val sized = manifest.previews.filter { it.functionName == "SizedPreview" }
+    // Base + three variants. Union, not product: two annotations carrying 2 and 1 cells give 3.
+    assertThat(sized).hasSize(4)
+    assertThat(sized.mapNotNull { it.overrides?.name }).containsExactly("xs", "l", "square")
+
+    val xs = sized.single { it.overrides?.name == "xs" }
+    assertThat(xs.id).endsWith("_VARIANT_xs")
+    assertThat(xs.captures.single().renderOutput).contains("_VARIANT_xs")
+    assertThat(xs.overrides!!.seeds)
+      .containsExactly(
+        OverrideSeed(key = "size", index = null, kind = OverrideSeedKind.STRING, raw = "xs")
+      )
+
+    // The annotation is reachable both through ClassGraph's meta-annotation flattening and through
+    // the explicit closure walk. Reaching it twice must still produce one variant, not two.
+    assertThat(sized.count { it.overrides?.name == "square" }).isEqualTo(1)
+  }
+
+  /**
+   * Two hoisted matrices that disagree about one cell. The name is the rendered output's identity,
+   * so emitting both would have the second silently overwrite the first's PNG.
+   */
+  @Test
+  fun `composePreviewDiscover keeps the first of a colliding @OverrideVariant name and warns`() {
+    val projectDir = createCmpTestProject()
+
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    annDir.mkdirs()
+    File(annDir, "OverrideVariant.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Repeatable
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+        annotation class OverrideVariant(
+            val name: String,
+            val booleans: Array<String> = [],
+            val strings: Array<String> = [],
+            val ints: Array<String> = [],
+            val floats: Array<String> = [],
+            val colors: Array<String> = [],
+        )
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "src/main/kotlin/test/Clash.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
+        import ee.schimke.composeai.preview.OverrideVariant
+
+        @OverrideVariant(name = "wide", strings = ["size=xl"])
+        annotation class FirstMatrix
+
+        @OverrideVariant(name = "wide", strings = ["width=wide"])
+        annotation class SecondMatrix
+
+        @Preview
+        @FirstMatrix
+        @SecondMatrix
+        @Composable
+        fun ClashPreview() {
+            Box(modifier = Modifier.size(50.dp)) { Text("Clash") }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.output).contains("more than one @OverrideVariant named 'wide'")
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val clash = manifest.previews.filter { it.functionName == "ClashPreview" }
+    // Base + exactly one `wide`, seeded from the annotation that won.
+    assertThat(clash).hasSize(2)
+    assertThat(clash.single { it.overrides != null }.overrides!!.seeds)
+      .containsExactly(
+        OverrideSeed(key = "size", index = null, kind = OverrideSeedKind.STRING, raw = "xl")
+      )
+  }
+
   @Test
   fun `composePreviewDiscover aggregates @ColorCatalog tokens into catalog sheets`() {
     val projectDir = createCmpTestProject()


### PR DESCRIPTION
Milestone 2 of 5 in the m3-catalog preview-boilerplate work, and the one piece
that has to ship from here.

## Why

A variant matrix is a cross product, and until now it had to be written out cell
by cell on every function that wanted it, because `@OverrideVariant` was
`@Target(FUNCTION)`. m3-catalog is what that costs:

| File | `@OverrideVariant` | Components | Matrix |
| --- | --- | --- | --- |
| `IconButtons.kt` | 116 | 4 | size(5) x width(3) x shape(2) |
| `ToggleButtons.kt` | 76 | 4 | size(5) x shape(2) x selected(2) |
| `Buttons.kt` | 45 | 5 | size(5) x shape(2) |

237 near-identical annotations across thirteen blocks, maintained
independently and already drifted — `IconButtons.kt` spells the default size
explicitly in `s-narrow` (`["size=s", "width=narrow"]`) and implicitly in
`s-square` (`["shape=square"]`).

Widening the target lets a matrix be declared once and applied with one line —
the same "declare the fan-out once, tag the functions" move a multi-preview
annotation already makes for `@Preview`:

```kotlin
@OverrideVariant(name = "xs", strings = ["size=xs"])
@OverrideVariant(name = "xs-square", strings = ["size=xs", "shape=square"])
// … one per cell …
annotation class SizeShapeMatrix

@CatalogModes @SizeShapeMatrix @Composable fun FilledButton() = …
```

## What discovery needed

Less than expected. ClassGraph already flattens a method's meta-annotation
closure into `method.annotationInfo`, unwrapping the repeatable container as it
goes — verified against the pinned 4.8.186 — so hoisted variants arrive
alongside the direct ones with no change at all.

`overrideVariantsFromMetaAnnotation` walks the closure explicitly as well,
mirroring the existing `@PreviewWrapperClass` traversal with the same cycle
guard, so resolution does not silently depend on that flattening staying true of
a future ClassGraph. That means an annotation is now routinely reachable
**twice**, which forces the de-duplication below to be right rather than
incidental.

**Specs are de-duplicated by name, first wins.** A variant's name is its
rendered `_VARIANT_<name>` output path, so two variants sharing one would have
the second silently overwrite the first's PNG. That was hard to hit while
variants could only sit directly on a function; stacking two hoisted matrices
that overlap on one cell makes it easy, and nothing in the compile objects. A
warning names the collision at discovery time — but only when the duplicates
actually *disagree*, so the doubly-reached-but-identical case stays quiet
instead of warning on every hoisted annotation.

**Stacking is a union, not a product.** A two-cell annotation plus a one-cell
annotation gives three variants, not two or six. Documented on the annotation,
because it is precisely what an author reaching for "one annotation per
dimension" will assume otherwise — and it is why the follow-up in m3-catalog
declares one annotation per *matrix* rather than per axis. A first-class
cross-product axis annotation is milestone 5 and a separate PR.

## Visual evidence

None, and deliberately: no renderer, fixture or `@Preview` is touched. This
changes which annotations discovery *finds*; the captures it mints from them,
their ids, output paths and seeding are all unchanged, and existing
`@OverrideVariant` usage discovers byte-identically (the pre-existing functional
test is untouched and passes).

## Test plan

```sh
./gradlew :gradle-plugin:functionalTest --tests '*DiscoveryFunctionalTest*'
./gradlew :gradle-plugin:preview-discovery:test :preview-annotations:build
```

- 40 functional tests pass, 2 of them new
- new: hoisted variants are discovered; stacking two annotations is a union;
  an annotation reachable through both paths contributes exactly one variant
- new: two matrices colliding on a name keep the first, emit one variant, and
  the run warns with the offending name

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjWtkWKvfWUfX7rjw5gAzf)_