### PR TITLE
refactor(mcp): delete the MCP protocol types the SDK already owns

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/protocol/McpMessages.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/protocol/McpMessages.kt
@@ -1,7 +1,5 @@
 package ee.schimke.composeai.mcp.protocol
 
-import kotlinx.serialization.EncodeDefault
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -16,9 +14,37 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 
 // ---------------------------------------------------------------------------
-// Trimmed daemon-facing MCP message shapes. The SDK owns the wire/session layer;
-// these internal DTOs keep the supervisor/tool catalog code decoupled from SDK
-// types.
+// Internal DTOs for the daemon-facing tool/resource catalog.
+//
+// The MCP Kotlin SDK owns the wire and session layer — transport, JSON-RPC
+// framing, request dispatch, and the `initialize` handshake. These types are
+// deliberately NOT a second implementation of that: they are the boundary
+// between the SDK and the ~5k lines of tool/resource code in `DaemonMcpServer`,
+// so an SDK bump touches one adapter (`McpServer.kt`'s `toSdk*` functions)
+// rather than every tool. That indirection is the reason the file still exists.
+//
+// What it must NOT hold is a parallel copy of a shape the SDK already owns on
+// the wire. It used to: an entire JSON-RPC envelope layer (`McpRequest` /
+// `McpResponse` / `McpNotification` / `McpError` / `McpErrorCodes`), the
+// `initialize` handshake (`InitializeParams` / `InitializeResult` /
+// `Implementation` / `ClientCapabilities` / `ServerCapabilities` /
+// `ToolsCapability` / `ResourcesCapability`), and the request-param types
+// (`CallToolParams` / `ReadResourceParams` / `SubscribeParams` /
+// `UnsubscribeParams` / `ResourceUpdatedParams`). Every one was superseded by
+// the SDK and left behind, referenced by nothing.
+//
+// Several were actively hazardous rather than merely dead, because they shared
+// a simple name with a live type from another package: `InitializeResult`,
+// `ServerCapabilities`, `ClientCapabilities` and `InitializeParams` all also
+// exist in `ee.schimke.composeai.daemon.protocol` (the daemon's own wire
+// contract, which is a different protocol), and `Implementation` /
+// `ServerCapabilities` also exist in the SDK. An IDE auto-import had three
+// candidates for one name, only one of them correct, and picking the dead one
+// compiled clean.
+//
+// Keep that shape: types here exist to decouple the tool catalog, not to
+// restate the SDK. If a new type would just mirror an SDK wire shape, use the
+// SDK's.
 //
 // References:
 // - https://modelcontextprotocol.io/specification/2025-06-18/basic
@@ -27,90 +53,11 @@ import kotlinx.serialization.json.jsonObject
 // ---------------------------------------------------------------------------
 
 // =====================================================================
-// JSON-RPC envelope (id is string | number per spec; we accept both via
-// JsonElement and let the caller round-trip the original on responses).
-// =====================================================================
-
-@OptIn(ExperimentalSerializationApi::class)
-@Serializable
-data class McpRequest(
-  @EncodeDefault val jsonrpc: String = "2.0",
-  val id: JsonElement,
-  val method: String,
-  val params: JsonElement? = null,
-)
-
-@OptIn(ExperimentalSerializationApi::class)
-@Serializable
-data class McpResponse(
-  @EncodeDefault val jsonrpc: String = "2.0",
-  val id: JsonElement,
-  val result: JsonElement? = null,
-  val error: McpError? = null,
-)
-
-@OptIn(ExperimentalSerializationApi::class)
-@Serializable
-data class McpNotification(
-  @EncodeDefault val jsonrpc: String = "2.0",
-  val method: String,
-  val params: JsonElement? = null,
-)
-
-@Serializable data class McpError(val code: Int, val message: String, val data: JsonElement? = null)
-
-object McpErrorCodes {
-  const val PARSE_ERROR: Int = -32700
-  const val INVALID_REQUEST: Int = -32600
-  const val METHOD_NOT_FOUND: Int = -32601
-  const val INVALID_PARAMS: Int = -32602
-  const val INTERNAL_ERROR: Int = -32603
-}
-
-// =====================================================================
-// initialize
-// =====================================================================
-
-@Serializable
-data class InitializeParams(
-  val protocolVersion: String,
-  val capabilities: ClientCapabilities = ClientCapabilities(),
-  val clientInfo: Implementation? = null,
-)
-
-@Serializable
-data class InitializeResult(
-  val protocolVersion: String,
-  val capabilities: ServerCapabilities,
-  val serverInfo: Implementation,
-  val instructions: String? = null,
-)
-
-@Serializable data class Implementation(val name: String, val version: String)
-
-@Serializable data class ClientCapabilities(val experimental: Map<String, JsonElement>? = null)
-
-@Serializable
-data class ServerCapabilities(
-  val tools: ToolsCapability? = null,
-  val resources: ResourcesCapability? = null,
-)
-
-@Serializable data class ToolsCapability(val listChanged: Boolean = false)
-
-@Serializable
-data class ResourcesCapability(val subscribe: Boolean = false, val listChanged: Boolean = false)
-
-// =====================================================================
 // tools/list, tools/call
 // =====================================================================
 
-@Serializable data class ListToolsResult(val tools: List<ToolDef>)
-
 @Serializable
 data class ToolDef(val name: String, val description: String, val inputSchema: JsonElement)
-
-@Serializable data class CallToolParams(val name: String, val arguments: JsonElement? = null)
 
 @Serializable
 data class CallToolResult(val content: List<ContentBlock>, val isError: Boolean? = null)
@@ -140,14 +87,8 @@ sealed interface ContentBlock {
 }
 
 // =====================================================================
-// resources/list, resources/read, resources/subscribe, resources/unsubscribe
+// resources/list, resources/read
 // =====================================================================
-
-@Serializable
-data class ListResourcesResult(
-  val resources: List<ResourceDescriptor>,
-  val nextCursor: String? = null,
-)
 
 @Serializable
 data class ResourceDescriptor(
@@ -157,8 +98,6 @@ data class ResourceDescriptor(
   val mimeType: String? = null,
   val size: Long? = null,
 )
-
-@Serializable data class ReadResourceParams(val uri: String)
 
 @Serializable data class ReadResourceResult(val contents: List<ResourceContents>)
 
@@ -203,13 +142,3 @@ object ResourceContentsSerializer : KSerializer<ResourceContents> {
     }
   }
 }
-
-@Serializable data class SubscribeParams(val uri: String)
-
-@Serializable data class UnsubscribeParams(val uri: String)
-
-// =====================================================================
-// notifications: resources/updated, resources/list_changed
-// =====================================================================
-
-@Serializable data class ResourceUpdatedParams(val uri: String)

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -2,10 +2,10 @@ package ee.schimke.composeai.mcp
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
-import ee.schimke.composeai.mcp.protocol.ListToolsResult
 import ee.schimke.composeai.mcp.protocol.ReadResourceResult
 import ee.schimke.composeai.mcp.protocol.ResourceContents
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ListToolsResult
 import java.awt.image.BufferedImage
 import java.io.IOException
 import java.io.InputStream
@@ -3388,7 +3388,7 @@ class DaemonMcpServerTest {
       val listBefore =
         json
           .decodeFromJsonElement(
-            ee.schimke.composeai.mcp.protocol.ListResourcesResult.serializer(),
+            io.modelcontextprotocol.kotlin.sdk.types.ListResourcesResult.serializer(),
             freshClient.request("resources/list"),
           )
           .resources
@@ -3415,7 +3415,7 @@ class DaemonMcpServerTest {
       val listAfter =
         json
           .decodeFromJsonElement(
-            ee.schimke.composeai.mcp.protocol.ListResourcesResult.serializer(),
+            io.modelcontextprotocol.kotlin.sdk.types.ListResourcesResult.serializer(),
             freshClient.request("resources/list"),
           )
           .resources


### PR DESCRIPTION
Follow-up from the code-quality review, independent of #3522. **−106 lines**, two files.

Non-visual: protocol DTOs and a test's deserialization target. No render path touched.

## What was there

`mcp/protocol/McpMessages.kt` held two different kinds of type, and the file didn't distinguish them.

**A deliberate boundary — kept.** `ToolDef`, `CallToolResult`, `ContentBlock`, `ResourceDescriptor`, `ReadResourceResult`, `ResourceContents` decouple the ~5k lines of tool/resource code in `DaemonMcpServer` from the SDK, so an SDK bump touches one adapter (`McpServer.kt`'s `toSdk*` functions) rather than every tool. My review originally called the whole file redundant; that was too broad. These earn their place, and now carry a comment saying so — otherwise the next reader deletes them for the same reason I nearly did.

**A parallel copy of what the SDK owns on the wire — deleted.** Left behind when the SDK was adopted, referenced by nothing:

- JSON-RPC envelope: `McpRequest`, `McpResponse`, `McpNotification`, `McpError`, `McpErrorCodes`
- `initialize` handshake: `InitializeParams`, `InitializeResult`, `Implementation`, `ClientCapabilities`, `ServerCapabilities`, `ToolsCapability`, `ResourcesCapability`
- request params: `CallToolParams`, `ReadResourceParams`, `SubscribeParams`, `UnsubscribeParams`, `ResourceUpdatedParams`

Seventeen types, zero references.

## Why these were worse than ordinary dead code

Several collided on simple name with a *live* type elsewhere. `InitializeResult`, `InitializeParams`, `ClientCapabilities` and `ServerCapabilities` also exist in `ee.schimke.composeai.daemon.protocol` — a different protocol, the daemon's own wire contract — and `Implementation` / `ServerCapabilities` also exist in the SDK.

So an auto-import for `InitializeResult` offered three candidates, one correct, and picking the dead one compiled clean. Every current reference in `mcp/` resolves to the daemon-protocol or SDK version; the local copies had already lost, silently.

## The test-only case

`ListToolsResult` and `ListResourcesResult` were live — but only in tests. Production emits the **SDK's** versions (`McpServer.kt:221,227`); the tests deserialized the same responses into the repo's local re-declaration.

That's the same shape of bug as the Compose fakes in #3522: the test validates against a locally-authored copy of a contract rather than the one the code actually ships, so the two can drift while the suite stays green. They now deserialize into the SDK types — which also confirms the two shapes agree today, since the tests parse real server output.

## Test plan

- [x] `:mcp:test` — **110 tests, 0 failures, 1 skipped**, forced with `--rerun-tasks`. The meaningful coverage is `DaemonMcpServerTest` (74 tests), which drives `tools/list` and `resources/list` end to end through the SDK transport and is what proves the SDK types deserialize the server's real output.
- [x] `:mcp:compileKotlin`, `:mcp:compileTestKotlin`
- [x] `ktfmtCheckAll`
- [x] Verified each deleted type had zero references repo-wide before removal, and that every surviving reference to the collided names (`InitializeResult`, `ServerCapabilities`, `Implementation`, `ClientCapabilities`, `InitializeParams`) resolves to `daemon.protocol` or the SDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2ganhrc41teEErAFsSB8Q)_