### PR TITLE
fix(scroll-android): stride by the viewport, not the axis-range placeholder

### DIFF
--- a/data/scroll/android/src/main/kotlin/ee/schimke/composeai/scroll/ScrollDriver.kt
+++ b/data/scroll/android/src/main/kotlin/ee/schimke/composeai/scroll/ScrollDriver.kt
@@ -122,7 +122,14 @@ fun driveScrollByViewport(
   // First slice captures the initial (unscrolled) frame.
   onSlice(0f)
 
+  // Two totals, deliberately. [scrolledPx] is how far the content is believed to have *moved* —
+  // the stitching hint, and what callers report. [dispatchedPx] is how many pixels were actually
+  // handed to `ScrollBy`, and is the only honest basis for enforcing [maxScrollPx]: `creditedPx`
+  // can credit less than was dispatched (a clamped tail on a container whose `value` is exact),
+  // and deriving headroom from an under-credited total would quietly let a capped drive scroll
+  // past its cap by up to a full stride.
   var scrolledPx = 0f
+  var dispatchedPx = 0f
   repeat(maxIterations) {
     val node = interaction.fetchSemanticsNode()
     val range: ScrollAxisRange =
@@ -131,7 +138,7 @@ fun driveScrollByViewport(
       node.config.getOrNull(SemanticsActions.ScrollBy)?.action
         ?: return ScrollDriveResult.Completed(scrolledPx)
 
-    val headroom = (cap - scrolledPx).coerceAtLeast(0f)
+    val headroom = (cap - dispatchedPx).coerceAtLeast(0f)
     if (headroom <= SETTLED_EPSILON_PX) return ScrollDriveResult.CapReached(scrolledPx)
 
     // Stride by the requested viewport fraction and let the scroller clamp itself at its content
@@ -152,6 +159,7 @@ fun driveScrollByViewport(
         ScrollAxis.HORIZONTAL -> step to 0f
       }
     scrollByAction.invoke(dx, dy)
+    dispatchedPx += step
     rule.mainClock.advanceTimeBy(advanceMsPerStep)
 
     val after = interaction.fetchSemanticsNode().config.getOrNull(axisKey)?.value?.invoke()

--- a/data/scroll/android/src/main/kotlin/ee/schimke/composeai/scroll/ScrollDriver.kt
+++ b/data/scroll/android/src/main/kotlin/ee/schimke/composeai/scroll/ScrollDriver.kt
@@ -53,6 +53,18 @@ fun driveScrollToEnd(
       node.config.getOrNull(SemanticsActions.ScrollBy)?.action
         ?: return ScrollDriveResult.Completed(scrolledPx)
 
+    // Deliberately still sized from the axis range, unlike [driveScrollByViewport].
+    //
+    // The placeholder problem is real here too — a plain `LazyColumn` claims `100.0` before it has
+    // been scrolled — but this drive *self-corrects*: one 100 px step is enough for the container
+    // to publish its true extent, and the next iteration jumps the rest. It reaches the end either
+    // way, in two or three iterations instead of one.
+    //
+    // Enlarging the step anyway is not free: `ScrollBy` animates, so dispatching more than the
+    // remaining distance changes the velocity the animation runs at and shifts where the content
+    // settles by the time the frame is captured. Measured — it re-rendered the Wear `EdgeButton`
+    // sticker to different bytes. A drive that already lands correctly is not worth perturbing for
+    // an iteration or two.
     val remaining = (range.maxValue() - range.value()).coerceAtLeast(0f)
     if (remaining <= SETTLED_EPSILON_PX) return ScrollDriveResult.Completed(scrolledPx)
 
@@ -119,21 +131,35 @@ fun driveScrollByViewport(
       node.config.getOrNull(SemanticsActions.ScrollBy)?.action
         ?: return ScrollDriveResult.Completed(scrolledPx)
 
-    val remaining = (range.maxValue() - range.value()).coerceAtLeast(0f)
-    if (remaining <= SETTLED_EPSILON_PX) return ScrollDriveResult.Completed(scrolledPx)
-
     val headroom = (cap - scrolledPx).coerceAtLeast(0f)
     if (headroom <= SETTLED_EPSILON_PX) return ScrollDriveResult.CapReached(scrolledPx)
 
-    val step = minOf(stepPx, remaining, headroom)
+    // Stride by the requested viewport fraction and let the scroller clamp itself at its content
+    // end.
+    //
+    // Clamping against `maxValue - value` first is what broke this: that is not always a usable
+    // pixel extent. A plain `LazyColumn` publishes a placeholder `100.0` until it has been
+    // scrolled once (measured in the renderer's `WearTlcScrollSemanticsProbeTest`, where it then
+    // jumps to `5010.0`), so a 400 px stride became a 100 px one — four times the slices and four
+    // times the frames, and against [DEFAULT_MAX_ITERATIONS] a quarter of the reach, silently
+    // truncating a long list. Wear's `TransformingLazyColumn` reports a true extent from the first
+    // frame and was never affected; it keeps its exact strides through [creditedPx].
+    val before = range.value()
+    val step = minOf(stepPx, headroom)
     val (dx, dy) =
       when (axis) {
         ScrollAxis.VERTICAL -> 0f to step
         ScrollAxis.HORIZONTAL -> step to 0f
       }
     scrollByAction.invoke(dx, dy)
-    scrolledPx += step
     rule.mainClock.advanceTimeBy(advanceMsPerStep)
+
+    val after = interaction.fetchSemanticsNode().config.getOrNull(axisKey)?.value?.invoke()
+    scrolledPx += creditedPx(before, after, step)
+    // Nothing moved ⇒ the content end, so don't emit another slice of the same frame.
+    if (after != null && kotlin.math.abs(after - before) <= SETTLED_EPSILON_PX) {
+      return ScrollDriveResult.Completed(scrolledPx)
+    }
 
     onSlice(scrolledPx)
   }
@@ -271,6 +297,31 @@ sealed interface ScrollDriveResult {
 
 // 30 iterations × 250ms of virtual time = 7.5s budget, enough for 100-ish
 // LazyColumn items' worth of progressive materialization without runaway.
+/**
+ * How much of a dispatched [requested] stride to count as travelled.
+ *
+ * Prefers the movement the scroller actually reported. `ScrollAxisRange.value` is trustworthy on a
+ * container that knows its extent — Wear's `TransformingLazyColumn` reports the exact clamped tail,
+ * so the final slice is credited 353 px rather than the 400 px asked for — but it is not universally
+ * so: a plain `LazyColumn`'s `value` leaps to its newly-discovered extent (0 → 5010 for a single
+ * 1000 px scroll) the first time it is scrolled. A reported move larger than what was dispatched is
+ * therefore a re-scaling, not travel, and the requested distance is the better estimate.
+ *
+ * Callers treat the total as a hint — the Android stitcher decides placement by pixel matching — so
+ * this only has to be right enough to keep the hint useful.
+ */
+private fun creditedPx(before: Float, after: Float?, requested: Float): Float {
+  if (after == null) return requested
+  val moved = after - before
+  return when {
+    // Didn't move: the content end. Crediting the requested stride here would overstate the total
+    // by a full step on the last, wasted iteration of every drive.
+    kotlin.math.abs(moved) <= SETTLED_EPSILON_PX -> 0f
+    moved > 0f && moved <= requested + 1f -> moved
+    else -> requested
+  }
+}
+
 private const val DEFAULT_MAX_ITERATIONS = 30
 private const val DEFAULT_ADVANCE_MS_PER_STEP = 250L
 

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/AndroidScrollDriverStepTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/AndroidScrollDriverStepTest.kt
@@ -1,0 +1,118 @@
+package ee.schimke.composeai.renderer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import ee.schimke.composeai.scroll.ScrollAxis
+import ee.schimke.composeai.scroll.ScrollDriveResult
+import ee.schimke.composeai.scroll.driveScrollByViewport
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The Android LONG driver has to take **viewport-sized** strides.
+ *
+ * `driveScrollByViewport` sizes each step as `min(stepPx, maxValue - value, headroom)` and reports
+ * the running total to `onSlice`, which is what positions each slice in the stitched image. That
+ * arithmetic assumes `maxValue - value` is a pixel distance. It isn't always: a plain `LazyColumn`
+ * publishes a **placeholder** `maxValue` of `100.0` before its extent is known (measured in
+ * `WearTlcScrollSemanticsProbeTest`, where it jumps to `5010.0` once a real scroll has happened).
+ * Clamping a 400 px stride against that placeholder yields a 100 px step, and the stitched slices
+ * are spaced at a distance the content never actually travelled.
+ *
+ * Wear's `TransformingLazyColumn` publishes a true pixel extent from the first frame, so it is
+ * covered here as the case that must keep working unchanged.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class AndroidScrollDriverStepTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  private val stepPx = 400f
+
+  /** Runs the LONG driver over the composed content and returns the per-slice offsets. */
+  private fun driveAndCollect(): Pair<ScrollDriveResult, List<Float>> {
+    composeRule.mainClock.advanceTimeByFrame()
+    composeRule.mainClock.advanceTimeByFrame()
+    val offsets = mutableListOf<Float>()
+    val result =
+      driveScrollByViewport(
+        rule = composeRule,
+        axis = ScrollAxis.VERTICAL,
+        stepPx = stepPx,
+        maxScrollPx = 0,
+      ) {
+        offsets += it
+      }
+    println("[driver] result=$result offsets=$offsets")
+    return result to offsets
+  }
+
+  /** The gap between consecutive slices — what the stitcher uses to place them. */
+  private fun strides(offsets: List<Float>): List<Float> =
+    offsets.zipWithNext { a, b -> b - a }.filter { it > 0f }
+
+  @Test
+  fun `a plain LazyColumn is driven in viewport-sized strides`() {
+    composeRule.mainClock.autoAdvance = false
+    composeRule.setContent {
+      LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(40) { index ->
+          Text(text = "Row $index", modifier = Modifier.fillMaxWidth().height(60.dp))
+        }
+      }
+    }
+    val (_, offsets) = driveAndCollect()
+    val strides = strides(offsets)
+    assertTrue("the driver must take at least one stride (got $offsets)", strides.isNotEmpty())
+    // The placeholder `maxValue` is 100.0, so a clamped driver's first stride is 100 px. A driver
+    // that steps in real pixels takes the full 400 px.
+    assertTrue(
+      "the first stride must be the requested ${stepPx}px, not a placeholder-clamped one " +
+        "(strides=$strides)",
+      strides.first() >= stepPx - 1f,
+    )
+  }
+
+  /**
+   * Wear's `TransformingLazyColumn` publishes a genuine pixel extent from the first frame, so it
+   * was never affected by the placeholder — this pins that so the fix can't regress it.
+   */
+  @Test
+  fun `a TransformingLazyColumn is driven in viewport-sized strides`() {
+    composeRule.mainClock.autoAdvance = false
+    composeRule.setContent {
+      androidx.wear.compose.material3.MaterialTheme {
+        TransformingLazyColumn(modifier = Modifier.fillMaxSize()) {
+          items(40) { index ->
+            androidx.wear.compose.material3.Text(
+              text = "Row $index",
+              modifier = Modifier.fillMaxWidth().height(60.dp),
+            )
+          }
+        }
+      }
+    }
+    val (_, offsets) = driveAndCollect()
+    val strides = strides(offsets)
+    assertTrue("the driver must take at least one stride (got $offsets)", strides.isNotEmpty())
+    assertTrue(
+      "the first stride must be the requested ${stepPx}px (strides=$strides)",
+      strides.first() >= stepPx - 1f,
+    )
+  }
+}

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/WearTlcScrollSemanticsProbeTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/WearTlcScrollSemanticsProbeTest.kt
@@ -1,0 +1,124 @@
+package ee.schimke.composeai.renderer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * What does a Wear `TransformingLazyColumn` publish as its scroll semantics?
+ *
+ * The Android scroll driver treats `ScrollAxisRange` as a pixel budget — it sizes each step as
+ * `min(stepPx, maxValue - value)` and feeds the result to `SemanticsActions.ScrollBy`, which is in
+ * pixels, and it stops as soon as `maxValue - value` reaches zero. On Compose Desktop that
+ * assumption proved false and broke long captures outright. TLC is the component most likely to
+ * break it here: it is a custom lazy layout that computes its own scroll semantics.
+ *
+ * This test doesn't assert a specific encoding — it asserts the *property the driver depends on*:
+ * that `maxValue - value` is a usable pixel distance. If it isn't, the driver's arithmetic is
+ * wrong regardless of what the numbers happen to mean.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class WearTlcScrollSemanticsProbeTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  private data class Range(val value: Float, val maxValue: Float, val hasScrollBy: Boolean)
+
+  private fun readRange(): Range? {
+    val nodes =
+      composeRule
+        .onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))
+        .fetchSemanticsNodes()
+    val node = nodes.firstOrNull() ?: return null
+    val range = node.config.getOrNull(SemanticsProperties.VerticalScrollAxisRange) ?: return null
+    return Range(
+      value = range.value(),
+      maxValue = range.maxValue(),
+      hasScrollBy = node.config.getOrNull(SemanticsActions.ScrollBy) != null,
+    )
+  }
+
+  @Test
+  fun `report what a plain LazyColumn publishes`() {
+    composeRule.mainClock.autoAdvance = false
+    composeRule.setContent {
+      androidx.compose.foundation.lazy.LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(40) { index ->
+          androidx.compose.material3.Text(text = "Row $index", modifier = Modifier.fillMaxWidth())
+        }
+      }
+    }
+    composeRule.mainClock.advanceTimeByFrame()
+    composeRule.mainClock.advanceTimeByFrame()
+    println("[LC] initial: ${readRange()}")
+    val scrollBy =
+      composeRule
+        .onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))
+        .fetchSemanticsNodes()
+        .firstOrNull()
+        ?.config
+        ?.getOrNull(SemanticsActions.ScrollBy)
+        ?.action
+    scrollBy?.invoke(0f, 1000f)
+    composeRule.mainClock.advanceTimeBy(1000L)
+    println("[LC] after ScrollBy(0, 1000): ${readRange()}")
+  }
+
+  @Test
+  fun `report what a TransformingLazyColumn publishes`() {
+    composeRule.mainClock.autoAdvance = false
+    composeRule.setContent {
+      MaterialTheme {
+        TransformingLazyColumn(modifier = Modifier.fillMaxSize()) {
+          items(40) { index -> Text(text = "Row $index", modifier = Modifier.fillMaxWidth()) }
+        }
+      }
+    }
+    composeRule.mainClock.advanceTimeByFrame()
+    composeRule.mainClock.advanceTimeByFrame()
+
+    val before = readRange()
+    println("[TLC] initial: $before")
+
+    // The distance the driver would compute for its first step, and what actually happens if we
+    // dispatch it.
+    val plannedStep = before?.let { (it.maxValue - it.value).coerceAtLeast(0f) }
+    println("[TLC] driver would step by: $plannedStep px")
+
+    val scrollBy =
+      composeRule
+        .onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))
+        .fetchSemanticsNodes()
+        .firstOrNull()
+        ?.config
+        ?.getOrNull(SemanticsActions.ScrollBy)
+        ?.action
+    println("[TLC] has ScrollBy: ${scrollBy != null}")
+
+    // Dispatch a large, unambiguous pixel scroll and see how the reported range responds.
+    scrollBy?.invoke(0f, 1000f)
+    composeRule.mainClock.advanceTimeBy(1000L)
+    println("[TLC] after ScrollBy(0, 1000): ${readRange()}")
+
+    scrollBy?.invoke(0f, 1000f)
+    composeRule.mainClock.advanceTimeBy(1000L)
+    println("[TLC] after a second ScrollBy(0, 1000): ${readRange()}")
+  }
+}


### PR DESCRIPTION
Follow-up to #3520, which fixed this class of bug on Compose Desktop. The open question was whether Wear's `TransformingLazyColumn` — the component most likely to publish unusual scroll semantics — was exposed to the same thing on Android.

**It isn't. A plain `LazyColumn` is.**

## Measured, not assumed

New `WearTlcScrollSemanticsProbeTest` asks the components directly:

```
TransformingLazyColumn        value=0.0     maxValue=916.0     <- true pixels from frame one
  after ScrollBy(0, 1000):    value=916.0   maxValue=916.0     <- clamps correctly at the end

LazyColumn                    value=0.0     maxValue=100.0     <- placeholder
  after ScrollBy(0, 1000):    value=5010.0  maxValue=5010.0    <- real extent, once scrolled
```

TLC reports a genuine pixel extent from its first frame, so the driver's `maxValue - value` arithmetic has always been right for it. A plain `LazyColumn` publishes a placeholder `100.0` until it has been scrolled once.

**This also corrects something I got wrong in #3520.** That PR called the desktop `maxValue=100.0` "item space". It isn't — it's an unknown-extent placeholder, as the second row above shows. The conclusion there was right (it is not a usable pixel distance), the explanation wasn't.

## What was broken

`driveScrollByViewport` — the LONG/GIF driver — sizes each stride as `min(stepPx, maxValue - value, headroom)`. On a plain list that clamps a 400 px viewport stride to 100 px. Measured on a 40-row list:

| | strides | reach |
| --- | --- | --- |
| before | 20 × 100 px | 2000 px |
| after | 5 × 400 px | 2400 px |

Four times the slices and four times the frames — and against `DEFAULT_MAX_ITERATIONS = 30`, only a quarter of the reach, so a long list truncates silently.

**Output was not corrupted**, which is why this stayed invisible: the Android stitcher places slices by pixel matching and treats the reported offset as a hint. That's the difference from desktop, where the offset positions slices directly and the same bug collapsed the image.

## The fix, and what it deliberately leaves alone

The stride is now the requested viewport fraction, with the scroller left to clamp itself at the content end, and the drive stops when the content stops moving rather than when the range claims zero. `creditedPx` keeps the reported total honest — it prefers the movement the scroller actually reported, so TLC's clamped 353 px tail is still credited as 353, and falls back to the requested distance when the report is implausible (a `LazyColumn`'s `value` leaping to its newly discovered extent).

`driveScrollToEnd` is **untouched**, on purpose. It has the same clamp but self-corrects — one 100 px step is enough for the container to publish its true extent, and the next iteration jumps the rest. Enlarging its step is not free: `ScrollBy` animates, so dispatching more than the remaining distance changes the animation velocity and shifts where the content settles by capture time. An earlier version of this change did exactly that and **re-rendered the Wear `EdgeButton` sticker to different bytes**. Reverted; the sticker hashes `ee352ab3b6aa7ca0e97a5247abfc5f76` on this branch, identical to `main`.

## Test plan

- [x] New `WearTlcScrollSemanticsProbeTest` — records what TLC and a plain `LazyColumn` publish, so the assumption underlying the driver is written down rather than folklore
- [x] New `AndroidScrollDriverStepTest` — drives both through `driveScrollByViewport` and asserts the first stride is the requested 400 px. **Verified to discriminate**: it fails on the unfixed driver (100 px strides) and passes after
- [x] `:renderer-android:testDebugUnitTest` — full suite
- [x] `:data-scroll-android:testDebugUnitTest`, `:data-scroll-core:test`
- [x] `:samples:design-catalog-wear-m3:composePreviewRenderAll` — Wear catalog renders, with `EdgeButtonSticker_Small_Round` byte-compared against `main`
- [x] `ktfmtFormat`

No visual evidence embedded because there is deliberately nothing to show: the Wear renders are byte-identical, and the plain-`LazyColumn` improvement is fewer slices and greater reach rather than different pixels — both asserted numerically above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E98YxF6aPxrecEMqV2gWMu)_