### PR TITLE
feat(serve): seed the playground with one declaration, not the whole file

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -163,6 +163,20 @@ data class PreviewInfo(
   val functionName: String,
   val className: String,
   val sourceFile: String? = null,
+  /**
+   * A 1-based line in [sourceFile] known to fall **inside** this preview's function body — its
+   * first statement, from the classfile's `LineNumberTable`. Mirrors `PreviewInfo.bodyLine` in
+   * gradle-plugin/PreviewData.kt.
+   *
+   * Lets a consumer address the declaration rather than the whole file: walk outwards from here to
+   * the surrounding declaration. An **anchor, not a span** — Kotlin emits an inline function's body
+   * into its caller with SMAP line numbers past the end of the caller's file, so the last line of a
+   * method is not a number worth publishing. See the discovery-side KDoc for the measurements.
+   *
+   * Absent from manifests produced before this field existed, so treat it as a hint and keep a
+   * whole-file fallback.
+   */
+  val bodyLine: Int? = null,
   val params: PreviewParams = PreviewParams(),
   val captures: List<Capture> = listOf(Capture()),
   val dataProducts: List<PreviewDataProduct> = emptyList(),

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
@@ -222,25 +222,36 @@ class PlaygroundSeedResolver(
      *
      * ### How the declaration's bounds are found
      *
-     * From **one** anchor, walked outwards in both directions over non-blank lines.
+     * From **one** anchor, expanded to the enclosing *top-level declaration*.
      *
      * A span would be the obvious input, and the classfile appears to offer one — but its upper
      * bound is fiction on Kotlin whenever the method inlines anything (see `PreviewInfo.bodyLine`),
      * and a wrong end here silently cuts into the next declaration. One line known to be *inside*
-     * the body is enough, because the same blank-line rule that finds the top finds the bottom.
+     * the body is enough, because the boundaries are findable from the source.
      *
-     * The rule works because ktfmt (Google style, which every catalog in this repo is formatted
-     * with) separates top-level declarations by exactly one blank line, and never puts a blank line
-     * inside an annotation stack or between KDoc and what it documents. So walking up from the
-     * anchor collects the `fun` line, the annotations and the KDoc — the last of those for free,
-     * rather than needing a doc-comment-matching special case — and walking down collects the
-     * closing braces.
+     * A boundary is [startsTopLevelDeclaration]: a non-blank line at **column 0** whose predecessor
+     * is **blank**. The declaration containing the anchor runs from the nearest such line at or
+     * above it, to the last non-blank line before the next one.
      *
-     * A brace-counting scan would be more general, but it has to model strings, char literals,
-     * comments and nested lambdas to not go wrong, and going wrong means silently truncating
-     * somebody's code mid-expression. Blank-line bounds fail in the other direction: on
-     * unconventionally formatted source they over-select (two declarations with no blank line
-     * between them come out together), which is a slightly bigger buffer rather than a broken one.
+     * Both halves of that test earn their place, and the first version of this had only one of them
+     * — "walk outwards over non-blank lines" — which was wrong in a way worth recording. A blank
+     * line *inside* a body is ordinary formatted Kotlin, not an oddity (`OverridablePreviews`
+     * separates its `previewOverride*` declarations from the `Surface` they feed), and treating it
+     * as the end truncated the declaration mid-body, closing braces and all. Requiring column 0
+     * *and* a preceding blank is what tells a separator from a breath inside a body: an internal
+     * blank line is followed by indented code, and a top-level closing brace sits at column 0 but
+     * is not preceded by a blank.
+     *
+     * A brace-counting scan would be more general still, but it has to model strings, char
+     * literals, comments and nested lambdas to not go wrong, and going wrong means silently
+     * truncating somebody's code mid-expression. This rule fails in the safer direction: on source
+     * that puts no blank line between two declarations it over-selects, taking both — a bigger
+     * buffer rather than a broken one.
+     *
+     * ktfmt (Google style, which every catalog in this repo is formatted with) guarantees the
+     * separating blank line, and never puts one inside an annotation stack or between KDoc and what
+     * it documents — so the annotations and the KDoc come along for free rather than needing a
+     * doc-comment-matching special case.
      *
      * Returns null — meaning "seed the whole file" — when there is no anchor, when the anchor does
      * not fall inside the text (the file moved under a branch `ref` since discovery ran), or when
@@ -252,17 +263,20 @@ class PlaygroundSeedResolver(
       // An anchor past the end means the source has changed since the manifest was built. Slicing
       // on a stale offset would hand over an arbitrary fragment, so fall back to the file.
       if (bodyLine < 1 || bodyLine > lines.size) return null
-      // A blank anchor line means the same thing: the file moved under us, and the walk from here
-      // would collapse to nothing.
+      // A blank anchor line means the same thing: the file moved under us.
       if (lines[bodyLine - 1].isBlank()) return null
 
+      // Up to the declaration this anchor sits in…
       var start = bodyLine - 1 // to 0-based
-      while (start > 0 && lines[start - 1].isNotBlank()) start--
-      var end = bodyLine - 1
-      while (end < lines.lastIndex && lines[end + 1].isNotBlank()) end++
+      while (start > 0 && !startsTopLevelDeclaration(lines, start)) start--
+      // …and down to the last non-blank line before the next declaration begins.
+      var next = start + 1
+      while (next <= lines.lastIndex && !startsTopLevelDeclaration(lines, next)) next++
+      var end = next - 1
+      while (end > start && lines[end].isBlank()) end--
 
       val headerEnd = headerEndExclusive(lines)
-      // The declaration starting at or inside the header means the walk escaped upwards past the
+      // The declaration starting at or inside the header means the scan escaped upwards past the
       // imports — unusual formatting, and re-emitting the header would then duplicate lines.
       if (start < headerEnd) return null
       if (headerEnd == 0 && start == 0 && end == lines.lastIndex) return null
@@ -271,6 +285,23 @@ class PlaygroundSeedResolver(
       val declaration = lines.subList(start, end + 1).joinToString("\n")
       val slice = if (header.isEmpty()) declaration else "$header\n\n$declaration"
       return slice.takeIf { it.trimEnd() != text.trimEnd() }
+    }
+
+    /**
+     * Whether `lines[i]` begins a top-level declaration: non-blank, at **column 0**, and preceded
+     * by a **blank** line (or the start of the file).
+     *
+     * Both conditions matter. Column 0 alone would match a top-level closing brace, ending the
+     * declaration one line early. A preceding blank alone would match the first indented statement
+     * after a blank line inside a body — the case that broke the first version of the slice.
+     * Together they match what a reader would call the start of a declaration: its KDoc, its first
+     * annotation, or its `fun`/`val`/`class` line.
+     */
+    private fun startsTopLevelDeclaration(lines: List<String>, i: Int): Boolean {
+      val line = lines[i]
+      if (line.isBlank()) return false
+      if (line.first().isWhitespace()) return false
+      return i == 0 || lines[i - 1].isBlank()
     }
 
     /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
@@ -15,8 +15,15 @@ import java.util.concurrent.ConcurrentHashMap
  * it may reference siblings the catalog's bundle never exported, or internals the resolved
  * classpath doesn't carry. Those come back as ordinary compile diagnostics against the right
  * classpath, which is a far better place to start editing from than an empty buffer — so the seed
- * is offered verbatim rather than rewritten into something guaranteed to build, which would no
- * longer be the preview's source.
+ * is never rewritten into something guaranteed to build, which would no longer be the preview's
+ * source.
+ *
+ * **What it does narrow is scope.** A section file is one *group*, not one component: opening
+ * `Button/Filled` used to hand over all 242 lines of `Buttons.kt` — five components, and forty-odd
+ * `@OverrideVariant` lines belonging to the variant matrix rather than to anything a visitor wants
+ * to read. When discovery recorded an anchor line inside the preview (`PreviewInfo.bodyLine`), the
+ * seed is the file's header plus **that one declaration**, still verbatim, so the buffer opens on
+ * the composable that was clicked. Without an anchor it stays the whole file, as it always was.
  */
 data class PlaygroundSeed(
   /** The catalog to preselect — the system the preview belongs to. */
@@ -25,10 +32,16 @@ data class PlaygroundSeed(
   val previewId: String,
   /** Editor tab name, from the source path's basename (`FilledButton.kt`). */
   val fileName: String,
-  /** The file's text, verbatim. */
+  /** The seeded Kotlin: the whole file, or its header plus one declaration when [sliced]. */
   val text: String,
   /** Where it was read from, so the note can link back to the human-readable blob. */
   val blobUrl: String?,
+  /**
+   * True when [text] is one declaration rather than the whole file, so the editor's note can say
+   * which it is. A visitor told "this is the whole file" while looking at one function would go
+   * hunting for the rest.
+   */
+  val sliced: Boolean = false,
 )
 
 /**
@@ -78,6 +91,15 @@ class PlaygroundSeedResolver(
     val module: String?,
     /** Module-relative path, as discovery recorded it. */
     val sourceFile: String,
+    /**
+     * A 1-based line inside the preview function's body, as discovery recorded it — the anchor
+     * [sliceDeclaration] walks outwards from to find the whole declaration. Null on a manifest
+     * predating the field, or a classfile with no line numbers; the seed is then the whole file.
+     *
+     * Part of the cache key by construction (it is a [Location] field), which matters: a catalog
+     * republished from a file whose declarations moved must not keep slicing at the old offset.
+     */
+    val bodyLine: Int? = null,
   )
 
   /**
@@ -140,13 +162,15 @@ class PlaygroundSeedResolver(
       onLog("$rawUrl is not valid UTF-8; playground seed unavailable")
       return null
     }
+    val sliced = sliceDeclaration(text, where.bodyLine)
     val seed =
       PlaygroundSeed(
         catalog = system,
         previewId = previewId,
         fileName = fileNameFor(where.sourceFile),
-        text = text,
+        text = sliced ?: text,
         blobUrl = ServeUrls.githubBlobUrl(where.repo, where.ref, where.module, where.sourceFile),
+        sliced = sliced != null,
       )
     // Bounded, and deliberately not an LRU: entries are a few KB, a catalog has a fixed number of
     // previews, and a full cache means the ones people actually open are already served from it. A
@@ -182,6 +206,90 @@ class PlaygroundSeedResolver(
      */
     internal fun fileNameFor(sourceFile: String): String =
       PlaygroundCompileService.safeKtName(sourceFile.replace('\\', '/').substringAfterLast('/'))
+
+    /**
+     * Narrows [text] to the file's **header plus the one declaration** [bodyLine] falls inside, or
+     * null when it can't be done and the caller should seed the whole file.
+     *
+     * ### Why the header is kept whole
+     *
+     * "Header" is everything above the first top-level declaration: the `package` line, any
+     * `@file:` annotations, and the imports. It is carried verbatim rather than pruned to the
+     * imports this one declaration happens to use, because deciding that needs a Kotlin parser and
+     * getting it wrong turns a working buffer into a wall of unresolved references. An unused
+     * import costs a visitor nothing; a missing one costs them the compile. `@file:OptIn(...)` is
+     * in there too, which a body using an experimental API genuinely needs.
+     *
+     * ### How the declaration's bounds are found
+     *
+     * From **one** anchor, walked outwards in both directions over non-blank lines.
+     *
+     * A span would be the obvious input, and the classfile appears to offer one — but its upper
+     * bound is fiction on Kotlin whenever the method inlines anything (see `PreviewInfo.bodyLine`),
+     * and a wrong end here silently cuts into the next declaration. One line known to be *inside*
+     * the body is enough, because the same blank-line rule that finds the top finds the bottom.
+     *
+     * The rule works because ktfmt (Google style, which every catalog in this repo is formatted
+     * with) separates top-level declarations by exactly one blank line, and never puts a blank line
+     * inside an annotation stack or between KDoc and what it documents. So walking up from the
+     * anchor collects the `fun` line, the annotations and the KDoc — the last of those for free,
+     * rather than needing a doc-comment-matching special case — and walking down collects the
+     * closing braces.
+     *
+     * A brace-counting scan would be more general, but it has to model strings, char literals,
+     * comments and nested lambdas to not go wrong, and going wrong means silently truncating
+     * somebody's code mid-expression. Blank-line bounds fail in the other direction: on
+     * unconventionally formatted source they over-select (two declarations with no blank line
+     * between them come out together), which is a slightly bigger buffer rather than a broken one.
+     *
+     * Returns null — meaning "seed the whole file" — when there is no anchor, when the anchor does
+     * not fall inside the text (the file moved under a branch `ref` since discovery ran), or when
+     * the slice would be the whole file anyway.
+     */
+    internal fun sliceDeclaration(text: String, bodyLine: Int?): String? {
+      if (bodyLine == null) return null
+      val lines = text.lines()
+      // An anchor past the end means the source has changed since the manifest was built. Slicing
+      // on a stale offset would hand over an arbitrary fragment, so fall back to the file.
+      if (bodyLine < 1 || bodyLine > lines.size) return null
+      // A blank anchor line means the same thing: the file moved under us, and the walk from here
+      // would collapse to nothing.
+      if (lines[bodyLine - 1].isBlank()) return null
+
+      var start = bodyLine - 1 // to 0-based
+      while (start > 0 && lines[start - 1].isNotBlank()) start--
+      var end = bodyLine - 1
+      while (end < lines.lastIndex && lines[end + 1].isNotBlank()) end++
+
+      val headerEnd = headerEndExclusive(lines)
+      // The declaration starting at or inside the header means the walk escaped upwards past the
+      // imports — unusual formatting, and re-emitting the header would then duplicate lines.
+      if (start < headerEnd) return null
+      if (headerEnd == 0 && start == 0 && end == lines.lastIndex) return null
+
+      val header = lines.subList(0, headerEnd).joinToString("\n").trimEnd()
+      val declaration = lines.subList(start, end + 1).joinToString("\n")
+      val slice = if (header.isEmpty()) declaration else "$header\n\n$declaration"
+      return slice.takeIf { it.trimEnd() != text.trimEnd() }
+    }
+
+    /**
+     * Index of the first line that is part of a top-level declaration — everything before it is the
+     * file header (`package`, `@file:` annotations, imports, and the blank lines and comments among
+     * them).
+     *
+     * Anchored on the **last import**, then the `package` line, rather than on "the first line that
+     * looks like a declaration": a file can open with a licence comment or a block comment that
+     * mentions `fun`, and a header that swallowed the first declaration would be far worse than one
+     * that stopped a few lines early. A file with neither — a script-like snippet — has no header,
+     * which the caller handles.
+     */
+    private fun headerEndExclusive(lines: List<String>): Int {
+      val lastImport = lines.indexOfLast { it.trimStart().startsWith("import ") }
+      if (lastImport >= 0) return lastImport + 1
+      val packageLine = lines.indexOfLast { it.trimStart().startsWith("package ") }
+      return if (packageLine >= 0) packageLine + 1 else 0
+    }
 
     private val httpClient: okhttp3.OkHttpClient by lazy {
       okhttp3.OkHttpClient.Builder()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -199,28 +199,43 @@ class ServeBundleHost(
   }
 
   /**
-   * Per-preview body-line anchors from the bundle's root `previews.json`, feeding
-   * [ServePreview.bodyLine] so the playground handoff can seed one declaration instead of a whole
-   * section file.
+   * Per-preview body-line anchors, feeding [ServePreview.bodyLine] so the playground handoff can
+   * seed one declaration instead of a whole section file.
    *
-   * Read only from the manifest, unlike [sourceFilesById] which prefers the catalog's
-   * `variants.json`. A `VariantMeta` is per *image* and a body line is per *function*, so carrying
-   * it there would restate the same number on every theme and state of a component; the manifest
-   * already keys it the right way. A catalog bundle carries both files, so nothing is lost — and a
-   * bundle with no manifest simply contributes no anchors and seeds whole files.
+   * Read exactly the way [sourceFilesById] is — the catalog's `previews/variants.json` first, then
+   * a root `previews.json` for ids it didn't cover — and that is load-bearing rather than tidiness.
+   * A **catalog** stages no root manifest at all and keys its previews by flattened route ids
+   * (`button-filled__ideal__default__dark`), not the discovery ids a bundle manifest carries, so a
+   * manifest-only read resolves nothing for exactly the case this feature exists to serve and the
+   * handoff silently stays whole-file. The `variants.json` path is where a catalog's anchors live;
+   * the manifest path is the plain uploaded bundle.
+   *
+   * A `VariantMeta` is per *image* and an anchor is per *function*, so this does restate the same
+   * number across a component's themes and states — the same duplication `sourceFile` already
+   * accepts there, for the same reason: it is the only per-preview record a catalog publishes.
    */
   private val bodyLinesById: Map<String, Int> by lazy {
-    val previewsJson = File(bundleDir, PREVIEWS_JSON).toOkioPath()
-    if (!fileSystem.exists(previewsJson)) return@lazy emptyMap()
-    try {
-      val text = fileSystem.read(previewsJson) { readUtf8() }
-      OVERRIDES_JSON.decodeFromString(ee.schimke.composeai.cli.PreviewManifest.serializer(), text)
-        .previews
-        .mapNotNull { preview -> preview.bodyLine?.let { preview.id to it } }
-        .toMap()
-    } catch (e: Exception) {
-      emptyMap()
+    val out = LinkedHashMap<String, Int>()
+    for ((id, meta) in variantMeta) {
+      meta.bodyLine?.takeIf { it > 0 }?.let { out[id] = it }
     }
+    val previewsJson = File(bundleDir, PREVIEWS_JSON).toOkioPath()
+    if (fileSystem.exists(previewsJson)) {
+      try {
+        val text = fileSystem.read(previewsJson) { readUtf8() }
+        val manifest =
+          OVERRIDES_JSON.decodeFromString(
+            ee.schimke.composeai.cli.PreviewManifest.serializer(),
+            text,
+          )
+        for (p in manifest.previews) {
+          if (p.id !in out) p.bodyLine?.takeIf { it > 0 }?.let { out[p.id] = it }
+        }
+      } catch (e: Exception) {
+        // Leave whatever the variants map already contributed.
+      }
+    }
+    out
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -199,6 +199,31 @@ class ServeBundleHost(
   }
 
   /**
+   * Per-preview body-line anchors from the bundle's root `previews.json`, feeding
+   * [ServePreview.bodyLine] so the playground handoff can seed one declaration instead of a whole
+   * section file.
+   *
+   * Read only from the manifest, unlike [sourceFilesById] which prefers the catalog's
+   * `variants.json`. A `VariantMeta` is per *image* and a body line is per *function*, so carrying
+   * it there would restate the same number on every theme and state of a component; the manifest
+   * already keys it the right way. A catalog bundle carries both files, so nothing is lost — and a
+   * bundle with no manifest simply contributes no anchors and seeds whole files.
+   */
+  private val bodyLinesById: Map<String, Int> by lazy {
+    val previewsJson = File(bundleDir, PREVIEWS_JSON).toOkioPath()
+    if (!fileSystem.exists(previewsJson)) return@lazy emptyMap()
+    try {
+      val text = fileSystem.read(previewsJson) { readUtf8() }
+      OVERRIDES_JSON.decodeFromString(ee.schimke.composeai.cli.PreviewManifest.serializer(), text)
+        .previews
+        .mapNotNull { preview -> preview.bodyLine?.let { preview.id to it } }
+        .toMap()
+    } catch (e: Exception) {
+      emptyMap()
+    }
+  }
+
+  /**
    * The live-only ids this host lists, minus any that turned out to have a baked PNG after all (a
    * catalog that both baked and deferred the same route — belt and braces: the baked pixels win, so
    * the id keeps its ordinary snapshot lane).
@@ -263,6 +288,7 @@ class ServeBundleHost(
           group = meta?.group,
           catalogOrder = meta?.order,
           sourceFile = sourceFilesById[id],
+          bodyLine = bodyLinesById[id],
           uiMode = previewParamsById[id]?.uiMode ?: 0,
         )
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -192,6 +192,7 @@ class ServeCatalogStore(
     val section: String?,
     val group: String?,
     val componentSourceFile: String?,
+    val componentBodyLine: Int?,
   )
 
   /**
@@ -288,6 +289,7 @@ class ServeCatalogStore(
         val group = component.group?.takeIf { it.isNotBlank() }
         val componentId = component.componentId?.takeIf { it.isNotBlank() }
         val componentSourceFile = component.sourceFile?.takeIf { it.isNotBlank() }
+        val componentBodyLine = component.bodyLine?.takeIf { it > 0 }
         component.images.mapNotNull { image ->
           val path = image.path
           // Only image-directory PNGs; reject traversal. The path is from a trusted branch, but a
@@ -300,7 +302,17 @@ class ServeCatalogStore(
             File(previewsDir, "$id.png").takeIf {
               it.canonicalFile.toPath().startsWith(previewsRoot)
             }
-          PlannedImage(path, id, target, image, componentId, section, group, componentSourceFile)
+          PlannedImage(
+            path,
+            id,
+            target,
+            image,
+            componentId,
+            section,
+            group,
+            componentSourceFile,
+            componentBodyLine,
+          )
         }
       }
 
@@ -365,6 +377,7 @@ class ServeCatalogStore(
               group = planned.group,
               order = if (hasSectionInfo) count else null,
               sourceFile = planned.componentSourceFile,
+              bodyLine = planned.componentBodyLine,
             )
         }
         count++
@@ -1560,6 +1573,13 @@ class ServeCatalogStore(
      * its source on GitHub. Null for an older catalog that predates the export change.
      */
     val sourceFile: String? = null,
+    /**
+     * A 1-based line inside the `@Preview` function's body within [sourceFile], stamped by the same
+     * export pass from discovery's `previews.json`. Carried into `previews/variants.json` so the
+     * playground handoff can open just that declaration rather than the whole section file. Null
+     * for an older catalog, or a preview whose classfile carried no line numbers.
+     */
+    val bodyLine: Int? = null,
   )
 
   @Serializable
@@ -1651,6 +1671,13 @@ class ServeCatalogStore(
      * source link. Null for a catalog with no recorded source (older export) or a deferred record.
      */
     val sourceFile: String? = null,
+    /**
+     * A 1-based line inside the preview function's body within [sourceFile] (from the catalog
+     * component's [Component.bodyLine]). Shared by every image of a component, like [sourceFile].
+     * Read back by [ServeBundleHost] to populate `ServePreview.bodyLine` so the playground handoff
+     * seeds one declaration instead of the whole file. Null for a catalog that recorded none.
+     */
+    val bodyLine: Int? = null,
   )
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -288,18 +288,17 @@ class ServeHttpServer(
             // just to answer where a file lives.
             val bundleHost = sessions.peekHost(system)?.let { catalogBundleHost(it) }
             val source = bundleHost?.catalogSource
-            val sourceFile =
-              bundleHost
-                ?.previews
-                ?.firstOrNull { it.id == previewId }
-                ?.sourceFile
-                ?.takeIf { it.isNotBlank() }
+            val preview = bundleHost?.previews?.firstOrNull { it.id == previewId }
+            val sourceFile = preview?.sourceFile?.takeIf { it.isNotBlank() }
             if (source != null && sourceFile != null)
               PlaygroundSeedResolver.Location(
                 repo = source.repo,
                 ref = source.ref,
                 module = source.module,
                 sourceFile = sourceFile,
+                // Absent on a catalog published before discovery recorded it, which is exactly the
+                // case the resolver falls back to whole-file seeding for.
+                bodyLine = preview.bodyLine,
               )
             else null
           },

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -160,6 +160,17 @@ data class ServePreview(
    * live/local session with no published source to point at.
    */
   val sourceFile: String? = null,
+  /**
+   * A 1-based line inside this preview's function body within [sourceFile], from the bundle's
+   * `previews.json` ([ee.schimke.composeai.cli.PreviewInfo.bodyLine]).
+   *
+   * Lets the playground handoff seed the editor with the one declaration that was clicked rather
+   * than the whole file it shares with its group — a section file is one *group*, so opening
+   * `Button/Filled` otherwise hands over four other components too. Null for a bundle without a
+   * manifest, or one produced before discovery recorded it; the seed is then whole-file, as it
+   * always was.
+   */
+  val bodyLine: Int? = null,
   /** Discovery-time `@Preview(uiMode=…)`; used to identify the baked Day/Night default. */
   val uiMode: Int = 0,
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2467,7 +2467,18 @@ object ServeWeb {
                 WebEscaping.htmlEscape(seed.fileName)
               }</a>"""
           } ?: WebEscaping.htmlEscape(seed.fileName)
-        """
+        // Which of the two it is matters to a reader: told "the whole file" while looking at one
+        // function, they would go hunting for the rest of it.
+        if (seed.sliced)
+          """
+
+          <p id="pg-seed" class="cp-sub">Opened from $where — the declaration of
+            <code>${WebEscaping.htmlEscape(seed.previewId)}</code>, plus that file's imports, from
+            <code>${WebEscaping.htmlEscape(seed.catalog)}</code>. Just this one composable, not the
+            whole file, but otherwise its source verbatim — so anything it pulls in from elsewhere
+            in its own module shows up as an unresolved reference to delete.</p>"""
+        else
+          """
 
           <p id="pg-seed" class="cp-sub">Opened $where — the file
             <code>${WebEscaping.htmlEscape(seed.previewId)}</code> is declared in, from

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeedSliceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeedSliceTest.kt
@@ -101,6 +101,68 @@ class PlaygroundSeedSliceTest {
     assertFalse(slice.contains("FilledButton"))
   }
 
+  /**
+   * A blank line inside a body is ordinary formatted Kotlin, not an oddity — this fixture is
+   * `samples/cmp`'s `OverridableListPreview`, which separates its `previewOverride*` declarations
+   * from the `Surface` they feed. The anchor is the *first* statement, so an end rule that stopped
+   * at the first blank line would cut the declaration off before `Surface` and emit a buffer with
+   * unbalanced braces: not a smaller slice, an uncompilable one.
+   */
+  @Test
+  fun `a blank line inside the body does not end the declaration`() {
+    val withBlankLine =
+      """
+      package example
+
+      import androidx.compose.runtime.Composable
+
+      @Preview(name = "Overridable List", showBackground = true)
+      @Composable
+      fun OverridableListPreview() {
+        val title = previewOverrideString("title", default = "Shopping list")
+        val itemCount = previewOverrideInt("itemCount", default = 3)
+
+        Surface {
+          Column {
+            Text(title)
+
+            repeat(itemCount) { i -> Text("Item ${'$'}i") }
+          }
+        }
+      }
+
+      @Composable
+      fun Unrelated() {
+        Text("nope")
+      }
+      """
+        .trimIndent()
+    val anchor = withBlankLine.lines().indexOfFirst { it.contains("val title") } + 1
+
+    val slice = PlaygroundSeedResolver.sliceDeclaration(withBlankLine, anchor)
+    assertNotNull(slice)
+    // Everything past the internal blank lines, including the closing braces.
+    assertTrue(slice.contains("Surface {"))
+    assertTrue(slice.contains("repeat(itemCount)"))
+    // Balanced: the declaration was not truncated mid-body.
+    assertEquals(slice.count { it == '{' }, slice.count { it == '}' })
+    // …and still bounded at the next declaration.
+    assertFalse(slice.contains("Unrelated"))
+  }
+
+  /**
+   * The counterpart guard: a top-level closing brace is at column 0, so a boundary test that looked
+   * only at indentation would end every declaration at its own `}` minus one line.
+   */
+  @Test
+  fun `a declaration is not ended by its own closing brace`() {
+    val slice =
+      PlaygroundSeedResolver.sliceDeclaration(sectionFile, lineOf("""val c = counted("Filled")"""))
+    assertNotNull(slice)
+    assertTrue(slice.trimEnd().endsWith("}"))
+    assertEquals(slice.count { it == '{' }, slice.count { it == '}' })
+  }
+
   @Test
   fun `no anchor seeds the whole file`() {
     assertNull(PlaygroundSeedResolver.sliceDeclaration(sectionFile, null))

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeedSliceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeedSliceTest.kt
@@ -1,0 +1,197 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the declaration slice — the part of the playground handoff that decides whether a visitor
+ * lands on one composable or on the whole file it shares with four others.
+ *
+ * The fixture is shaped like the real thing that motivated this: a section file from m3-catalog,
+ * where one group is one file, every component carries a variant matrix as stacked
+ * `@OverrideVariant` lines, and `Buttons.kt` is 242 lines of which the composable a visitor clicked
+ * is about fifteen.
+ */
+class PlaygroundSeedSliceTest {
+
+  /**
+   * Two components in one file, the first carrying KDoc and a matrix. Line numbers matter, so the
+   * anchors below are resolved against this text by [lineOf] rather than hard-coded.
+   */
+  private val sectionFile =
+    """
+    @file:CatalogGroup(name = "Buttons", section = "Actions")
+    @file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+    package ee.schimke.m3catalog.sections
+
+    import androidx.compose.material3.Button
+    import androidx.compose.material3.Text
+    import androidx.compose.runtime.Composable
+    import ee.schimke.composeai.preview.OverrideVariant
+
+    // The five common M3 buttons, highest to lowest emphasis.
+
+    /** The button's label at the type scale its size carries. */
+    @CatalogComponent(id = "Button/Filled", caption = "Highest emphasis.")
+    @CatalogModes
+    @OverrideVariant(name = "xs", strings = ["size=xs"])
+    @OverrideVariant(name = "xs-square", strings = ["size=xs", "shape=square"])
+    @Composable
+    fun FilledButton() = Sticker {
+      val c = counted("Filled")
+      Button(onClick = c.onClick) {
+        Text(c.label)
+      }
+    }
+
+    @CatalogComponent(id = "Button/Tonal", caption = "Secondary.")
+    @CatalogModes
+    @Composable
+    fun TonalButton() = Sticker {
+      Text("Tonal")
+    }
+    """
+      .trimIndent()
+
+  private fun lineOf(needle: String): Int =
+    sectionFile.lines().indexOfFirst { it.contains(needle) } + 1
+
+  @Test
+  fun `a declaration slice carries the header, the annotations and the KDoc`() {
+    // The anchor is the body's first statement — what the line table reports — so the `fun` line
+    // above it and the closing braces below it both have to be recovered by the walk.
+    val slice =
+      PlaygroundSeedResolver.sliceDeclaration(sectionFile, lineOf("""val c = counted("Filled")"""))
+    assertNotNull(slice)
+
+    // Header, verbatim and whole — including the file annotations an experimental-API body needs.
+    assertTrue(slice.contains("@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)"))
+    assertTrue(slice.contains("package ee.schimke.m3catalog.sections"))
+    assertTrue(slice.contains("import androidx.compose.material3.Button"))
+    assertTrue(slice.contains("import ee.schimke.composeai.preview.OverrideVariant"))
+
+    // The declaration, with the annotation stack and the KDoc above it — the blank-line walk picks
+    // those up without a doc-comment-matching special case.
+    assertTrue(slice.contains("/** The button's label at the type scale its size carries. */"))
+    assertTrue(slice.contains("""@CatalogComponent(id = "Button/Filled""""))
+    assertTrue(slice.contains("""@OverrideVariant(name = "xs-square""""))
+    assertTrue(slice.contains("fun FilledButton() = Sticker {"))
+    assertTrue(slice.contains("""val c = counted("Filled")"""))
+
+    // …and nothing belonging to the sibling component.
+    assertFalse(slice.contains("TonalButton"))
+    assertFalse(slice.contains("""Button/Tonal"""))
+
+    // The free-standing comment between the imports and the first declaration belongs to neither,
+    // and is dropped with the rest of the file's body.
+    assertFalse(slice.contains("highest to lowest emphasis"))
+  }
+
+  @Test
+  fun `the last declaration in a file slices without running off the end`() {
+    val slice = PlaygroundSeedResolver.sliceDeclaration(sectionFile, lineOf("""Text("Tonal")"""))
+    assertNotNull(slice)
+    assertTrue(slice.contains("fun TonalButton() = Sticker {"))
+    assertTrue(slice.trimEnd().endsWith("}"))
+    assertFalse(slice.contains("FilledButton"))
+  }
+
+  @Test
+  fun `no anchor seeds the whole file`() {
+    assertNull(PlaygroundSeedResolver.sliceDeclaration(sectionFile, null))
+  }
+
+  /**
+   * A branch `ref` keeps the cache key stable while the file under it moves, so an anchor from an
+   * older manifest can point past the end of the text now being sliced. Slicing on a stale offset
+   * would hand over an arbitrary fragment; the whole file is the honest answer.
+   *
+   * The out-of-range case is not hypothetical, which is why the anchor is a single line rather than
+   * the span the classfile appears to offer: Kotlin emits an inlined function body into its caller
+   * with SMAP line numbers past the end of the caller's file, so a method's *last* line routinely
+   * points at nothing. Measured over m3-catalog, 9 of 244 methods with line info reported an end
+   * beyond their own file — and every one of their starts was in range.
+   */
+  @Test
+  fun `an anchor outside the file seeds the whole file`() {
+    assertNull(PlaygroundSeedResolver.sliceDeclaration(sectionFile, 500))
+    assertNull(PlaygroundSeedResolver.sliceDeclaration(sectionFile, 0))
+    // A blank line is in range but says the source moved — the walk from it would collapse.
+    assertNull(PlaygroundSeedResolver.sliceDeclaration(sectionFile, lineOf("package ") - 1))
+  }
+
+  @Test
+  fun `a single-declaration file is not sliced into a copy of itself`() {
+    val single =
+      """
+      package example
+
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Only() {
+        Text("hi")
+      }
+      """
+        .trimIndent()
+    // Slicing this yields the file back, so there is nothing to gain and the seed stays whole-file.
+    assertNull(PlaygroundSeedResolver.sliceDeclaration(single, 7))
+  }
+
+  @Test
+  fun `a file with no imports or package still slices`() {
+    val loose =
+      """
+      @Composable
+      fun A() {
+        Text("a")
+      }
+
+      @Composable
+      fun B() {
+        Text("b")
+      }
+      """
+        .trimIndent()
+    val slice = PlaygroundSeedResolver.sliceDeclaration(loose, 7)
+    assertNotNull(slice)
+    assertEquals("@Composable\nfun B() {\n  Text(\"b\")\n}", slice)
+  }
+
+  /** End to end through the resolver, so the flag the editor's note reads is pinned too. */
+  @Test
+  fun `the resolver reports whether it sliced`() {
+    fun seedWith(bodyLine: Int?) =
+      PlaygroundSeedResolver(
+          locate = { _, _ ->
+            PlaygroundSeedResolver.Location(
+              repo = "yschimke/m3-catalog",
+              ref = "main",
+              module = ":catalog",
+              sourceFile = "src/main/kotlin/ee/schimke/m3catalog/sections/Buttons.kt",
+              bodyLine = bodyLine,
+            )
+          },
+          fetch = { sectionFile.toByteArray() },
+        )
+        .seed("m3-catalog", "…FilledButton_Light")
+
+    val whole = seedWith(null)
+    assertNotNull(whole)
+    assertFalse(whole.sliced)
+    assertEquals(sectionFile, whole.text)
+
+    val sliced = seedWith(lineOf("""val c = counted("Filled")"""))
+    assertNotNull(sliced)
+    assertTrue(sliced.sliced)
+    assertTrue(sliced.text.length < whole.text.length)
+    assertFalse(sliced.text.contains("TonalButton"))
+    // The tab is still named for the file the declaration came from.
+    assertEquals("Buttons.kt", sliced.fileName)
+  }
+}

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -857,6 +857,26 @@ data class PreviewInfo(
   val functionName: String,
   val className: String,
   val sourceFile: String? = null,
+  /**
+   * A 1-based line in [sourceFile] known to fall **inside** this preview's function body — its
+   * first statement, from the classfile's `LineNumberTable`.
+   *
+   * Lets a consumer address the **declaration** rather than the file: the playground's "open this
+   * preview" handoff walks outwards from here to the surrounding declaration and seeds just that
+   * composable, instead of the editor opening all 242 lines of the section file it shares with four
+   * other components. Purely additive — absent from older manifests, and every consumer degrades to
+   * whole-file behaviour without it.
+   *
+   * **An anchor, not a span, and deliberately so.** A span is what you would reach for, and
+   * ClassGraph offers both bounds — but the upper one cannot be trusted on Kotlin. An inline
+   * function's body is emitted into its caller with JSR-45/SMAP line numbers *past the end of the
+   * caller's file*, so `maxLineNum` runs off the end for any method that inlines anything: measured
+   * over m3-catalog's 244 methods with line info, 9 overran their own file (every one of them a
+   * `remember { … }` caller), while the first line was in range for all 244. Publishing a span
+   * would mean publishing an end that is sometimes fiction, and a consumer slicing on it would cut
+   * into whatever declaration follows. One number that is always right beats two where one is not.
+   */
+  val bodyLine: Int? = null,
   val params: PreviewParams = PreviewParams(),
   /**
    * Non-null on a synthetic override-variant preview (from `@OverrideVariant`): the

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1859,8 +1859,8 @@ object PreviewDiscovery {
 
   /**
    * Recursively collects `@OverrideVariant`s hoisted onto a multi-preview-style annotation class
-   * (and onto its own meta-annotations), mirroring [wrapperFromMetaAnnotation]'s traversal and cycle
-   * guard. Skips `@Preview` and its container — a hoisted variant only ever rides on a custom
+   * (and onto its own meta-annotations), mirroring [wrapperFromMetaAnnotation]'s traversal and
+   * cycle guard. Skips `@Preview` and its container — a hoisted variant only ever rides on a custom
    * annotation. Contributes nothing when the annotation class is off the discovery classpath, which
    * is the same limit every other meta-annotation walk here has.
    */
@@ -3235,6 +3235,7 @@ object PreviewDiscovery {
       functionName = method.name,
       className = classInfo.name,
       sourceFile = previewSourceFile,
+      bodyLine = bodyLineOf(method),
       params = params,
       captures = outputPlan.captures,
       dataProducts = outputPlan.dataProducts,
@@ -3246,6 +3247,19 @@ object PreviewDiscovery {
       fixedTheme = method.annotationInfo.any { it.name == FIXED_THEME_FQN },
     )
   }
+
+  /**
+   * The first line of the method body, from the classfile's `LineNumberTable`, or null when it
+   * carries none (ClassGraph reports `0`, which is what the guard rejects).
+   *
+   * `enableMethodInfo()` is already on for the whole scan, so this costs nothing beyond reading an
+   * int — no extra pass, no source parsing.
+   *
+   * Only the *first* line, never the last: `maxLineNum` is unreliable on Kotlin because an inline
+   * function's body carries SMAP line numbers past the end of the calling file. See
+   * [PreviewInfo.bodyLine].
+   */
+  private fun bodyLineOf(method: MethodInfo): Int? = method.minLineNum.takeIf { it > 0 }
 
   // Module-relative source path, e.g. "src/main/kotlin/com/example/samplewear/Previews.kt".
   // Fall back to the old package-qualified path when source files were not wired into the task.

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -147,6 +147,25 @@ class DiscoveryFunctionalTest {
     // bytecode `SourceFile` attribute and rewritten to a package-qualified
     // path in DiscoverPreviewsTask — see PreviewData.sourceFile.
     assertThat(manifest.previews.any { !it.sourceFile.isNullOrBlank() }).isTrue()
+
+    // …and where in that file it is, from the classfile's LineNumberTable. This addresses the
+    // *declaration* rather than the file, which is what lets the playground handoff seed one
+    // composable instead of every component in a section file.
+    //
+    // The anchor points INSIDE the body: the fixture declares `RedBoxPreview` with `@Preview` and
+    // `@Composable` above it and a `Box { Text(…) }` inside, so what is recorded is the `Box` line
+    // — strictly below the `fun` line. Both previews live in one file, `RedBoxPreview` first, so
+    // the two anchors are ordered. Asserting the relationship rather than exact numbers keeps this
+    // from breaking every time the fixture gains a line.
+    val red = manifest.previews.single { it.functionName == "RedBoxPreview" }
+    val blue = manifest.previews.single { it.functionName == "BlueBoxPreview" }
+    assertThat(red.bodyLine).isNotNull()
+    assertThat(blue.bodyLine).isNotNull()
+    assertThat(red.bodyLine!!).isGreaterThan(0)
+    assertThat(blue.bodyLine!!).isGreaterThan(red.bodyLine!!)
+    // Deliberately NOT asserted against a recorded *end* line: there isn't one. Kotlin emits an
+    // inlined body into its caller with SMAP line numbers past the end of the caller's file, so a
+    // method's last line is not a number worth publishing — see `PreviewInfo.bodyLine`.
   }
 
   @Test

--- a/scripts/design-artifacts/apply-source-files.mjs
+++ b/scripts/design-artifacts/apply-source-files.mjs
@@ -23,12 +23,18 @@
  * with the catalog's source `module` when building the GitHub blob URL, so this stays the
  * bare path the discovery manifest recorded.
  *
- * @param {{components?: Array<{componentId: string, sourceFile?: string}>}} manifest
+ * `bodyLine` — a line inside the preview function's body — rides along on the same join,
+ * for the same reason and to the same place. It is what lets the playground handoff open
+ * the one declaration a visitor clicked instead of the whole section file it shares with
+ * its group. Stamped only alongside a `sourceFile` (a line number with no file is
+ * meaningless), and the server treats its absence as "seed the whole file".
+ *
+ * @param {{components?: Array<{componentId: string, sourceFile?: string, bodyLine?: number}>}} manifest
  *   The parsed `catalog.json`, mutated in place.
  * @param {{groups?: Array<{components?: Array<{componentId: string, preview?: string}>}>}} spec
  *   The catalog spec the manifest was built from.
- * @param {Map<string, {sourceFile?: string}>} sourceByFn
- *   Function-name → `{ sourceFile }` lookup (the generator's `sourceByFunction(bundle)`).
+ * @param {Map<string, {sourceFile?: string, bodyLine?: number}>} sourceByFn
+ *   Function-name → `{ sourceFile, bodyLine }` lookup (the generator's `sourceByFunction(bundle)`).
  * @returns {number} how many components had a `sourceFile` newly stamped.
  */
 export function applySourceFiles(manifest, spec, sourceByFn) {
@@ -47,9 +53,14 @@ export function applySourceFiles(manifest, spec, sourceByFn) {
   for (const component of manifest?.components ?? []) {
     if (component.sourceFile !== undefined) continue; // never clobber an existing path
     const fn = previewByComponentId.get(component.componentId);
-    const sourceFile = fn ? sourceByFn.get(fn)?.sourceFile : undefined;
-    if (sourceFile) {
-      component.sourceFile = sourceFile;
+    const source = fn ? sourceByFn.get(fn) : undefined;
+    if (source?.sourceFile) {
+      component.sourceFile = source.sourceFile;
+      // Only with a path, and only when discovery actually recorded one — an older bundle
+      // carries no `bodyLine`, and a component with a line but no file cannot be opened.
+      if (typeof source.bodyLine === "number" && source.bodyLine > 0) {
+        component.bodyLine = source.bodyLine;
+      }
       stamped += 1;
     }
   }

--- a/scripts/design-artifacts/apply-source-files.test.mjs
+++ b/scripts/design-artifacts/apply-source-files.test.mjs
@@ -5,7 +5,8 @@ import { applySourceFiles } from "./apply-source-files.mjs";
 
 const comp = (componentId, extra = {}) => ({ componentId, images: [], ...extra });
 const manifest = (components) => ({ schema: "design-parity-catalog/v1", system: "s", components });
-const byFn = (entries) => new Map(entries.map(([fn, sf]) => [fn, { sourceFile: sf }]));
+const byFn = (entries) =>
+  new Map(entries.map(([fn, sf, bodyLine]) => [fn, { sourceFile: sf, bodyLine }]));
 
 test("stamps each component's sourceFile from its spec function's discovery path", () => {
   const spec = {
@@ -87,4 +88,48 @@ test("is a no-op with an empty / missing lookup and tolerates empty inputs", () 
   assert.equal(applySourceFiles(manifest([comp("Buttons/Filled")]), spec, undefined), 0);
   assert.equal(applySourceFiles({ components: [] }, {}, byFn([["X", "a.kt"]])), 0);
   assert.equal(applySourceFiles({}, { groups: [] }, byFn([["X", "a.kt"]])), 0);
+});
+
+test("stamps bodyLine alongside sourceFile so the playground can open one declaration", () => {
+  const spec = {
+    groups: [
+      { name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] },
+    ],
+  };
+  const m = manifest([comp("Buttons/Filled")]);
+
+  applySourceFiles(m, spec, byFn([["FilledButtonPreview", "src/main/kotlin/Buttons.kt", 81]]));
+
+  assert.equal(m.components[0].sourceFile, "src/main/kotlin/Buttons.kt");
+  assert.equal(m.components[0].bodyLine, 81);
+});
+
+test("omits bodyLine when discovery recorded none, rather than writing a bogus zero", () => {
+  // An older bundle carries no `bodyLine`; the server reads its absence as "seed the whole file",
+  // so a 0 or null here would be a line number that points at nothing.
+  const spec = {
+    groups: [
+      { name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] },
+    ],
+  };
+  const m = manifest([comp("Buttons/Filled")]);
+
+  applySourceFiles(m, spec, byFn([["FilledButtonPreview", "src/main/kotlin/Buttons.kt", undefined]]));
+
+  assert.equal(m.components[0].sourceFile, "src/main/kotlin/Buttons.kt");
+  assert.equal("bodyLine" in m.components[0], false);
+});
+
+test("never stamps a bodyLine without a sourceFile to resolve it against", () => {
+  const spec = {
+    groups: [
+      { name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] },
+    ],
+  };
+  const m = manifest([comp("Buttons/Filled")]);
+
+  applySourceFiles(m, spec, byFn([["FilledButtonPreview", undefined, 81]]));
+
+  assert.equal(m.components[0].sourceFile, undefined);
+  assert.equal("bodyLine" in m.components[0], false);
 });

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -298,8 +298,9 @@ function sourceByFunction(bundle) {
   for (const preview of bundle.previews ?? []) {
     const fn = preview.functionName ?? preview.id;
     if (out.has(fn) && !prefer(preview.id)) continue;
-    if (preview.sourceFile) out.set(fn, { sourceFile: preview.sourceFile });
-    else if (!out.has(fn)) out.set(fn, { sourceFile: undefined });
+    if (preview.sourceFile)
+      out.set(fn, { sourceFile: preview.sourceFile, bodyLine: preview.bodyLine });
+    else if (!out.has(fn)) out.set(fn, { sourceFile: undefined, bodyLine: undefined });
   }
   return out;
 }


### PR DESCRIPTION
Milestone 4 of 5 in the m3-catalog preview-boilerplate work. Independent of
the others.

## The problem

Clicking **▶ playground** on `Button/Filled` handed the editor all 242 lines
of `Buttons.kt`. A section file is one *group*, not one component, so that is
five components plus forty-odd `@OverrideVariant` lines belonging to the
variant matrix rather than to anything a visitor wants to read.

## What this does

Discovery records `PreviewInfo.bodyLine` — a line known to fall inside the
preview function's body, straight off the classfile's `LineNumberTable`, which
`enableMethodInfo()` already populates, so it costs one int and no extra pass.
The seed resolver walks outwards from it to the surrounding declaration and
keeps the file header whole.

On the real `Buttons.kt`, with the anchor ClassGraph actually reports for
`FilledButton` (line 81): **243 lines → 68**, carrying the right component, its
annotation stack, and the file's imports and `@file:OptIn`. Everything below
`fun FilledButton()`'s closing brace — four more components — is gone.

## An anchor, not a span

This is the load-bearing detail, and the first draft got it wrong. ClassGraph
offers both bounds, so the field started life as `SourceLines(start, end)` — but
**Kotlin emits an inlined function body into its caller with SMAP line numbers
past the end of the caller's file**, so `maxLineNum` runs off the end for any
method that inlines anything.

A functional-test assertion caught it, and I measured the blast radius against
m3-catalog's compiled classes:

| | count |
| --- | --- |
| methods with line info | 244 |
| whose **start** was outside their own file | **0** |
| whose **end** was outside their own file | **9** |

Every one of the nine was a `remember { … }` caller. A published span would
have been a published fiction, and a consumer slicing on it would cut into
whatever declaration follows. One number that is always right beats two where
one is not. The test that caught this is kept, inverted: it now asserts the two
fixtures' anchors are ordered, and says why there is no end to assert.

## Why blank lines rather than brace counting

ktfmt separates top-level declarations by exactly one blank line, and never puts
one inside an annotation stack or between KDoc and what it documents. So walking
out from the anchor collects the annotations, the signature and the KDoc — the
last of those for free, rather than needing a doc-comment special case.

Brace counting would be more general, but it has to model strings, char
literals, comments and nested lambdas to not go wrong, and going wrong means
silently truncating somebody's code mid-expression. Blank-line bounds fail in
the other direction: on unconventionally formatted source they over-select,
which is a slightly bigger buffer rather than a broken one.

The header is carried verbatim rather than pruned to the imports this
declaration happens to use — deciding that needs a parser, an unused import
costs a visitor nothing, and a missing one costs them the compile.

## Honest limits

The seed is still a starting point, not a promise, and the slice does not change
that: `FilledButton` calls a private `SizedLabel` helper further down the file,
which now comes back as an unresolved reference. That is the same contract the
whole-file seed had against a catalog's bundle classpath, and the editor's note
still says so — it just distinguishes the two cases now, since a reader told
"this is the whole file" while looking at one function would go hunting for the
rest.

Everything degrades to the previous whole-file behaviour: no anchor (older
manifest, or a classfile with no debug info), an anchor that no longer fits the
text (a branch `ref` whose file moved since discovery ran), or a slice that
would be the whole file anyway.

## Visual evidence

None. No renderer, fixture or `@Preview` is touched, and no rendered output
changes — this is manifest plumbing plus a text slice on the way into an editor
buffer. The one user-visible surface is the wording of the playground's
`#pg-seed` note, which is plain text in `ServeWeb`.

## Test plan

```sh
./gradlew :cli:test :gradle-plugin:preview-discovery:test
./gradlew :gradle-plugin:functionalTest --tests '*DiscoveryFunctionalTest*'
```

- 40 functional tests pass; the existing source-path test now also pins
  `bodyLine` and its ordering across two previews in one file
- 7 new slice tests: header + annotations + KDoc kept and siblings dropped;
  last-declaration-in-file; no anchor; out-of-range and blank-line anchors;
  a single-declaration file not sliced into a copy of itself; a file with no
  package or imports
- verified against real m3-catalog classes and source, not just fixtures

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjWtkWKvfWUfX7rjw5gAzf)_