### PR TITLE
feat(design-artifacts): publish a reference column that reads against the render

### DIFF
--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -604,6 +604,22 @@ a catalog must never lose its render to a reference lane. Pass `--strict` to gat
 A repo with no `design-map.json` is a clean no-op, so the step runs unconditionally for every
 catalog.
 
+The same step also writes the **reference side of the annotation layers** — the numbered spec boxes
+the compare page draws over each column. Two things decide whether those numbers can be read against
+the render's:
+
+- **`density` on the design-map entry** — the reference board's scale, in source pixels per dp. A
+  Figma file reports its own pixels and nothing in it says what they are pixels *of*, so only the
+  map's author knows. Declared, the reference column is quoted in the same `dp`/`sp` the render
+  resolved (`text 17.5sp` for a 3× board's 52.5px), with the factor and the source unit recorded in
+  the annotation's `detail` so the original number stays recoverable. Undeclared, the column names
+  the board's own unit (`text 52.5px`) rather than guessing — a wrong factor silently rescales every
+  spec, which is worse than an honest `px`. Omit it unless you know it.
+- **`≈` in a label** — the spacing was measured off the frame's child geometry, not declared. Only an
+  auto-layout frame carries Figma's `padding` / `itemSpacing`, so a hand-placed mock would otherwise
+  publish a type layer and no layout layer at all. The measurement fills that gap; the mark keeps it
+  from reading as a number the design file actually asserts.
+
 The lane only appears once a catalog actually publishes references — before the producer existed
 every catalog served the format controls on the left:
 

--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -345,8 +345,17 @@ export function planDesignReferences({ designMap, spec, catalog }) {
           provider: providerFor(entry.source),
           attributes: { code: entry.code, preview: fn, componentId },
         },
-        // How the driver is to obtain the pixels. Not part of the served manifest.
-        origin: { source: entry.source, ref: entry.ref, previewId: entry.previewId },
+        // How the driver is to obtain the pixels, plus what it needs to describe them. Not part of
+        // the served manifest. `density` is the design-map author's statement of the reference
+        // board's scale (source px per dp); it is what lets the annotation layer quote the design's
+        // spacing and type in the same dp/sp the render resolved instead of the board's own pixels
+        // (design-parity#279). Absent when the entry doesn't declare it, and never guessed.
+        origin: {
+          source: entry.source,
+          ref: entry.ref,
+          previewId: entry.previewId,
+          density: entry.density,
+        },
       };
       if (entry.ref) record.source.uri = entry.ref;
       records.push(record);

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -259,6 +259,32 @@ test("planDesignReferences maps design-map entries onto serve preview ids", () =
   assert.equal(records[1].origin.ref, "design/ContactChat.dark.html");
 });
 
+test("planDesignReferences carries a declared board density to the driver", () => {
+  // Only the design-map author knows a board's scale, and it is what lets the reference column be
+  // quoted in dp/sp instead of the board's own pixels (design-parity#279). It is driver input, not
+  // part of the served manifest, so it rides on `origin` — and is absent, never guessed, when the
+  // entry says nothing.
+  const designMap = {
+    components: [
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatPreview",
+        source: "figma",
+        ref: "figma:abc/73:5",
+        density: 3,
+      },
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatDarkPreview",
+        source: "claude-design",
+        ref: "design/ContactChat.dark.html",
+      },
+    ],
+  };
+
+  const { records } = planDesignReferences({ designMap, spec: SPEC, catalog: CATALOG });
+  assert.equal(records[0].origin.density, 3);
+  assert.equal(records[1].origin.density, undefined);
+});
+
 test("planDesignReferences warns rather than throwing when a handle maps to nothing", () => {
   const designMap = {
     components: [{ code: "ui/Other.kt#NotInTheSpec", source: "claude-design", ref: "x.html" }],

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -230,11 +230,19 @@ async function rasterizeFigma(ref, target) {
   if (!png.ok) throw new Error(`figma image download ${png.status}`);
   const decoded = PNG.sync.read(Buffer.from(await png.arrayBuffer()));
   // The node document rides along so the caller can capture layout geometry from the same fetch
-  // that sized the raster — one round trip, and the geometry provably describes these pixels.
-  const document =
-    nodeJson?.nodes?.[parsed.nodeId]?.document ??
-    nodeJson?.nodes?.[parsed.nodeId.replace("-", ":")]?.document;
-  return { width: decoded.width, height: decoded.height, data: decoded.data, document };
+  // that sized the raster — one round trip, and the geometry provably describes these pixels. The
+  // file-level `styles` map rides along with it: a text node references a published style by id,
+  // and only this map turns that id into the name the design itself uses (`Body/Large`), so the
+  // reference column can say `body/large` rather than the anonymous `text`.
+  const entry =
+    nodeJson?.nodes?.[parsed.nodeId] ?? nodeJson?.nodes?.[parsed.nodeId.replace("-", ":")];
+  return {
+    width: decoded.width,
+    height: decoded.height,
+    data: decoded.data,
+    document: entry?.document,
+    styles: entry?.styles,
+  };
 }
 
 /** A pre-rendered PNG for this ref under `--reference-images`, or null. */
@@ -284,6 +292,30 @@ async function sourceRaster(record) {
   return null;
 }
 
+/**
+ * The reference board's scale for one record — source pixels per dp — from the design-map entry
+ * that planned it, or `undefined`.
+ *
+ * Only the design-map author knows this: a Figma file reports its own pixels and nothing in it says
+ * what they are pixels *of*. Declared, the annotation layer quotes the design's spacing and type in
+ * the same dp/sp the render resolved, and the two columns of the compare page can finally be read
+ * against each other. Undeclared, the layer names the board's unit (`text 52.5px`) and leaves the
+ * number checkable — which is where design-parity#277 left it.
+ *
+ * A non-positive or non-finite value is dropped with a warning rather than applied: it would divide
+ * every spec on the reference side by nonsense, silently, and a wrong number that looks like dp is
+ * worse than an honest px.
+ */
+function referenceDensity(record) {
+  const density = record.origin?.density;
+  if (density === undefined) return undefined;
+  if (typeof density !== "number" || !Number.isFinite(density) || density <= 0) {
+    warn(`${record.id}: ignoring density '${density}' — it must be a positive number`);
+    return undefined;
+  }
+  return density;
+}
+
 const referencesDir = path.join(OUT, REFERENCES_DIR);
 fs.mkdirSync(referencesDir, { recursive: true });
 
@@ -305,7 +337,12 @@ for (const record of records) {
   }
 
   // Captured before the fit rewrites `raster`, then moved onto the published raster below.
-  const capturedLayout = raster.document ? layoutFromNode(raster.document) : undefined;
+  const capturedLayout = raster.document
+    ? layoutFromNode(raster.document, {
+        styles: raster.styles,
+        density: referenceDensity(record),
+      })
+    : undefined;
 
   // Where the artwork ends up inside the published raster. Full-bleed unless a fit letterboxes it.
   let placement = { width: target.width, height: target.height, x: 0, y: 0 };

--- a/scripts/design-artifacts/reference-layout.mjs
+++ b/scripts/design-artifacts/reference-layout.mjs
@@ -17,6 +17,11 @@
  * are where it starts. Those default to a raster the artwork fills edge to edge; they carry real
  * values when the reference was letterboxed to keep its proportions, since the annotations then
  * have to move with the artwork rather than with the canvas.
+ *
+ * Only `bounds` move. `tokens` (the padding / gap / type sizes the annotations quote) stay in the
+ * design's own pixels, and the tree's `density` describes exactly those — a spec is not relocated
+ * by where its box was drawn, and rescaling it here would leave `density` describing a unit that no
+ * longer exists.
  */
 export function scaleTree(tree, targetWidth, offsetX = 0, offsetY = 0) {
   const frame = tree?.root?.bounds;

--- a/scripts/design-artifacts/reference-layout.test.mjs
+++ b/scripts/design-artifacts/reference-layout.test.mjs
@@ -45,6 +45,13 @@ test("preserves non-geometry fields so labels and roles survive", () => {
   assert.equal(scaled.root.children[0].label, "Send");
 });
 
+test("keeps the tree's density, which describes tokens rather than boxes", () => {
+  // Only bounds are relocated into the raster; the specs the annotations quote stay in the
+  // design's own pixels, so the factor that converts them must survive unchanged.
+  const scaled = scaleTree({ ...tree, density: 3 }, 400);
+  assert.equal(scaled.density, 3);
+});
+
 test("returns undefined when there is no frame to scale against", () => {
   // Nothing to anchor a ratio to; annotating with an assumed scale would be worse than not at all.
   assert.equal(scaleTree(undefined, 400), undefined);


### PR DESCRIPTION
Publisher half of design-parity#279 / yschimke/design-parity#304.

meshcore-mobile's published `annotations/index.json` carries 19 annotated references with **zero** layout annotations, and 118 typography annotations quoted in the Figma board's own pixels. The page works; the column can be looked at but not compared. The export engine gains the capabilities in the paired PR — this is the three lines of plumbing that feed them.

## What changes

**The Figma `styles` map is passed through.** `rasterizeFigma` already had it in hand: `GET /v1/files/:key/nodes` returns the file-level published-style metadata beside the document, and only that map turns a text node's style *id* into the name the design itself uses. It was being dropped on the floor. Now the reference column can say `body/large` instead of the anonymous `text`.

**A design-map entry may declare `density`** — the board's scale in source pixels per dp — which rides on the plan record's driver-only `origin` (not the served manifest) and reaches `layoutFromNode`. Declared, the reference column is quoted in the same `dp`/`sp` the render resolved: a 3× board's `text 52.5px` becomes `text 17.5sp`, with the factor and source unit recorded in the annotation's `detail` so the original number stays recoverable. Undeclared, it keeps naming the board's own unit rather than guessing — a wrong factor silently rescales every spec, which is worse than an honest `px`. A non-positive or non-finite value is `::warning::`-ed and dropped rather than applied.

**`scaleTree` documents what it does and does not move.** It relocates `bounds` into the published raster and leaves `tokens` alone — a spec is not relocated by where its box was drawn — so the `density` it now carries keeps describing the unit those specs are actually in. Rescaling them there would leave `density` describing a unit that no longer exists.

Hand-placed reference frames additionally gain a layout layer for free: the export engine measures the inset and gap off child geometry when the frame declares no auto-layout, and marks every such phrase `≈` so it never reads as a spec the file asserts. No driver change needed for that — it arrives with the dependency.

The driver's `@design-parity/*` deps are `^0.1.38`, so all of this activates on design-parity's next release; until then the extra option argument is inert and the manifest is byte-identical.

## Test plan

- `node --test` in `scripts/design-artifacts/` — 538 pass, 21 skipped, same 3 pre-existing environment failures as on a clean `main` (`rc-compare-pixels`, `rc-size-modifier`, and the catalog-export-version test, all needing installed deps this container lacks). Verified by stashing and re-running.
- New coverage: `planDesignReferences` carries a declared `density` onto `origin` and leaves it absent when the entry says nothing; `scaleTree` preserves a tree's `density` across the rescale.

Documented in [`docs/public-preview-server.md`](docs/public-preview-server.md) beside the reference-manifest producer, covering both what `density` buys an adopter and what a `≈` in a label means.

Text-only change to a publish-time script and its docs — no `@Preview`, webview, or overlay is touched, so there is no rendered surface to diff. The visible effect is in a *published catalog's* annotation manifest, which regenerates on merge via `design-artifacts.yml` (this touches `scripts/design-artifacts/`, so the push trigger scopes and runs it) and shows up on the compare page for meshcore-mobile's mapped screens once design-parity ships the engine side.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFVhfYJVuZWhs1paGBhb8L)_