### PR TITLE
fix(catalog): append referenceSet so positional @CatalogComponent calls keep their meaning

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
@@ -18,12 +18,12 @@ package ee.schimke.composeai.preview
  *   the one-line description shown under the sticker.
  * * [reference] defaults to empty. Override with a seed-kit handle (Figma node etc.) for the
  *   one-off import; the render stays authoritative.
- * * [referenceSet] defaults to empty. Override with the handle of the component *family*
- *   [reference] is one variant of — see below.
  * * [parallel] defaults to empty. Override with the component id of the counterpart in the sibling
  *   system named by the catalog's `compareWith` setting.
  * * [perBreakpoint] defaults to false — every render of the function folds onto ONE component. Set
  *   it when the component should be a card *per* breakpoint instead; see below.
+ * * [referenceSet] defaults to empty. Override with the handle of the component *family*
+ *   [reference] is one variant of — see below.
  *
  * ```kotlin
  * @file:CatalogGroup("Buttons")
@@ -99,9 +99,13 @@ annotation class CatalogComponent(
   val group: String = "",
   val caption: String = "",
   val reference: String = "",
-  val referenceSet: String = "",
   val parallel: String = "",
   val perBreakpoint: Boolean = false,
+  // Appended, NOT slotted in beside `reference` where it reads best: a parameter inserted ahead of
+  // an existing one silently re-points a positional call. A five-string `@CatalogComponent(...)`
+  // whose fifth argument meant `parallel` would still compile and quietly mean `referenceSet`.
+  // Declaration order is source API here; the pairing is documented above instead.
+  val referenceSet: String = "",
 )
 
 /**

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -510,9 +510,9 @@ class DiscoveryFunctionalTest {
           val group: String = "",
           val caption: String = "",
           val reference: String = "",
-          val referenceSet: String = "",
           val parallel: String = "",
           val perBreakpoint: Boolean = false,
+          val referenceSet: String = "",
         )
 
         @Retention(AnnotationRetention.BINARY)


### PR DESCRIPTION
## Summary

Follow-up to #3530, which merged while this fix was being verified. Codex flagged it on that PR and it's correct.

`referenceSet` landed slotted in beside `reference`, where it reads best. That position isn't free — a parameter inserted *ahead* of an existing one silently re-points positional calls:

```kotlin
// Written against the old signature, meaning parallel = "FilledButton":
@CatalogComponent("Button/Filled", "Buttons", "Highest emphasis.", "figma:AbCdEf/10:5", "FilledButton")
```

After the insert that fifth argument still compiles — and quietly means `referenceSet`, leaving `parallel` empty. No error, no warning, no diff at the call site.

`preview-annotations` is a published artifact consumed from other repos, so declaration order is source API. This moves the parameter to the end, restoring every existing positional call's meaning. The pairing with `reference` is carried by the KDoc section rather than by adjacency, with a comment at the declaration recording *why* it sits apart from the field it belongs with — otherwise the next person tidies it back.

**Free to do right now:** `v0.19.49` was cut at 14:34, #3530 merged after it. No release has ever carried the field, so no consumer can have written against either order. That window closes at the next release-please cut.

Nothing else moves — named arguments (every usage in this repo, and the form the docs teach) are unaffected, and discovery reads the annotation by parameter *name*, so `previews.json` output is identical.

## Test plan

- `./gradlew :preview-annotations:compileKotlinJvm :preview-annotations:ktfmtCheck` — clean.
- `DiscoveryFunctionalTest`'s locally-declared mirror of the annotation is reordered to match, so the test keeps exercising the real signature rather than drifting from it. The assertions are named-argument based and unchanged.

Non-visual: a parameter reorder in an annotation declaration. No rendered surface is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6ehazFSL6PXLkkv6Q2XuZ)_