### PR TITLE
feat(preview-annotations): @PreviewAxis, a variant matrix as its axes

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/PreviewAxis.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/PreviewAxis.kt
@@ -1,0 +1,151 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Declares **one dimension** a preview varies along, so discovery can expand the cross product of
+ * every declared axis into one seeded capture per cell — the declarative form of a stack of
+ * [OverrideVariant]s.
+ *
+ * ## Why
+ *
+ * A variant matrix is a cross product, and writing it out cell by cell scales badly in the two ways
+ * that matter. m3-catalog's buttons are five sizes by two shapes, its icon buttons add a third
+ * width axis, and its toggle buttons a selected axis: 237 `@OverrideVariant` annotations across
+ * thirteen blocks, each cell spelled twice — once as a seed (`strings =
+ * ["size=xs", "shape=square"]`) and once as a name (`"xs-square"`) — with nothing checking that the
+ * two agree. They had already drifted. [OverrideVariant] hoisted onto an annotation class fixes the
+ * *repetition* across components, but a hoisted matrix is still a hand-enumerated product, and
+ * stacking two hoisted annotations is a union rather than a product.
+ *
+ * ```
+ * @PreviewAxis(key = "size",  values = ["xs", "s", "m", "l", "xl"], default = "s")
+ * @PreviewAxis(key = "shape", values = ["round", "square"])
+ * @CatalogModes
+ * @Composable
+ * fun FilledButton() = Sticker { … }   // 9 cells, none of them typed out
+ * ```
+ *
+ * The sticker reads its knobs exactly as before (`previewOverrideString("size", "s")`), and each
+ * cell is rendered with that cell's values seeded.
+ *
+ * ## What it emits that a hand-written variant cannot
+ *
+ * **Typed props.** An `@OverrideVariant` contributes one opaque string to the published catalog —
+ * `state: "xs-square"` — because the name is all the export has to go on. An axis cell knows what
+ * it *is*, so it publishes `props: {size: "xs", shape: "square"}`. That matters beyond tidiness:
+ * design-parity pairs a rendered candidate against a reference by its variant properties, and a
+ * design kit's component set carries exactly these as named properties. A hand-typed name has to
+ * coincidentally match the kit's naming for a cell to pair; a prop map matches by construction.
+ *
+ * Every cell carries its **full** assignment, defaults included — `s` and `round` are as much part
+ * of what a cell is as `xs` and `square` — even though only the non-default values are seeded,
+ * since seeding a knob with the value it already resolves to is a no-op.
+ *
+ * ## Naming
+ *
+ * A cell is named by its non-default values, in axis-declaration order, joined by `-`: `xs-square`,
+ * `xs`, `square`. Set [namesEveryValue] on an axis that should appear in every name even at its
+ * default — m3-catalog does this for `size`, where a cell called `square` with no size in it reads
+ * as a shape variant of nothing, giving `s-square` instead.
+ *
+ * The all-defaults cell is **not** a variant: it is the base render the `@Preview` already
+ * produces, so it is skipped and an unseeded sticker stays byte-identical to what it published
+ * before its axes were declared.
+ *
+ * ## Combining
+ *
+ * Axes stacked on one function **multiply**, which is the whole point and the opposite of how
+ * stacked [OverrideVariant]s combine. Axes may also be hoisted onto an annotation class (same
+ * `ANNOTATION_CLASS` target, same meta-annotation walk), and a function's direct axes multiply with
+ * every hoisted one — so a shared `@SizeAndShape` can be combined with a per-component extra axis
+ * without either knowing about the other. Two axes with the same [key] would square that key
+ * against itself, so the later one is dropped with a warning.
+ *
+ * Mixing `@PreviewAxis` with `@OverrideVariant` on one function is allowed: the axis cells and the
+ * hand-written variants are unioned, which is how a component that is a clean product *except* for
+ * one odd extra state stays expressible. Names must not collide across the two.
+ *
+ * A product grows fast — five sizes by three widths by two shapes is thirty cells, times every
+ * `@Preview` expansion — so discovery warns past [MAX_CELLS_WARN] cells on one function, and
+ * refuses past [MAX_CELLS] rather than minting thousands of captures from a typo.
+ */
+@Repeatable
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@MustBeDocumented
+annotation class PreviewAxis(
+  /**
+   * The `previewOverride*` knob this axis seeds, and the prop name each cell publishes — `"size"`,
+   * `"shape"`, `"width"`.
+   */
+  val key: String,
+  /**
+   * The values this axis takes, in the order their cells should be emitted. At least two; a
+   * one-value axis multiplies nothing and is dropped with a warning.
+   */
+  val values: Array<String>,
+  /**
+   * The value an **unseeded** render resolves to — the author default the composable passes to
+   * `previewOverrideString(key, default)`. Cells never seed it, and by default never name it.
+   *
+   * Empty means `values[0]`. A default that is not in [values] is a mistake discovery warns about
+   * and treats as `values[0]`, since it would otherwise make every cell non-default and emit a
+   * duplicate of the base render.
+   */
+  val default: String = "",
+  /**
+   * Which typed array an [OverrideVariant] would have put these values in — the knob's Kotlin type.
+   *
+   * A `previewOverrideBoolean` knob only honours a boolean seed, so an axis over a boolean knob has
+   * to say so. Its [values] are still written as strings (`["true", "false"]`); this decides how
+   * they are seeded.
+   */
+  val kind: PreviewAxisKind = PreviewAxisKind.STRING,
+  /**
+   * Per-value name fragments, when a value's own spelling is not what a cell should be called — a
+   * `selected` axis over `["true", "false"]` naming itself `["on", "off"]`.
+   *
+   * Positional against [values]. Empty (the default) means each value names itself; a non-empty
+   * array of the wrong length is ignored with a warning rather than silently misnaming half the
+   * cells.
+   */
+  val slugs: Array<String> = [],
+  /**
+   * Whether every cell's name carries this axis, or only the cells that are off [default].
+   *
+   * False everywhere by default. True is for the axis a reader needs in order to make sense of the
+   * others: m3-catalog sets it on `size`, so the shape variant of the default size is `s-square`
+   * rather than a bare `square`. It affects the name only — a default value is still never seeded.
+   */
+  val namesEveryValue: Boolean = false,
+  /**
+   * Where this axis sits in a cell's name and props, low to high — `size` at 1 and `shape` at 2
+   * give `xs-square`, not `square-xs`.
+   *
+   * Explicit because **the order repeated annotations are emitted in is not a contract**. It is a
+   * detail of the compiler, and Kotlin's does not match the order they were written in: a
+   * cross-check against ClassGraph (which preserves whatever it is handed, verified on
+   * javac-produced classes) showed a two-axis function coming back with its axes swapped, which
+   * silently renames every cell. Sorting on a declared number makes the naming a property of the
+   * source rather than of the toolchain.
+   *
+   * Axes that share an order keep their emitted order relative to each other, so a single-axis
+   * function — and any matrix whose naming you don't care about — needs nothing here.
+   */
+  val order: Int = 0,
+) {
+  companion object {
+    /** Past this many cells on one function, discovery warns; the render bill is real. */
+    const val MAX_CELLS_WARN = 64
+
+    /** Past this many, discovery refuses the expansion — a product this size is a typo. */
+    const val MAX_CELLS = 512
+  }
+}
+
+/** The Kotlin type of the knob a [PreviewAxis] seeds — which typed seed array its values go in. */
+enum class PreviewAxisKind {
+  STRING,
+  BOOLEAN,
+  INT,
+  FLOAT,
+}

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -858,7 +858,26 @@ data class OverrideSeed(
  * composing, so the same preview function renders once more with the knob(s) flipped. [name] is the
  * `_VARIANT_<name>` render-output tag and the variant's catalog `state`.
  */
-@Serializable data class OverrideVariantSpec(val name: String, val seeds: List<OverrideSeed>)
+@Serializable
+data class OverrideVariantSpec(
+  val name: String,
+  val seeds: List<OverrideSeed>,
+  /**
+   * The **full axis assignment** this variant represents, when it came from a `@PreviewAxis` cross
+   * product rather than a hand-written `@OverrideVariant` — `[size=xs, shape=square]`.
+   *
+   * Empty for a hand-written variant, which has only a [name] to describe itself. That difference
+   * is the point of declaring axes: the export publishes a named variant as an opaque `state`
+   * string, so pairing it against a design kit's component set means hoping the hand-typed name
+   * matches the kit's property naming. A cell that knows its own properties publishes them as
+   * `props`, and pairs by construction.
+   *
+   * Carries **every** axis, defaults included — `size=s` is as much part of what a cell is as
+   * `shape=square` — even though [seeds] holds only the non-default values, since seeding a knob
+   * with the value it already resolves to is a no-op.
+   */
+  val props: List<CatalogVariantProp> = emptyList(),
+)
 
 @Serializable
 data class PreviewInfo(

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -231,6 +231,29 @@ object PreviewDiscovery {
   private const val OVERRIDE_VARIANT_FQN = "ee.schimke.composeai.preview.OverrideVariant"
   private const val OVERRIDE_VARIANT_CONTAINER_FQN =
     "ee.schimke.composeai.preview.OverrideVariant.Container"
+  // `@PreviewAxis` — repeatable; declares ONE dimension, and discovery expands the cross product of
+  // every axis on a function into one seeded variant per cell. Unlike stacked `@OverrideVariant`s
+  // (which union), axes multiply. See `PreviewAxis.kt`.
+  private const val PREVIEW_AXIS_FQN = "ee.schimke.composeai.preview.PreviewAxis"
+  private const val PREVIEW_AXIS_CONTAINER_FQN =
+    "ee.schimke.composeai.preview.PreviewAxis.Container"
+
+  /**
+   * Annotations the meta-annotation walk treats as leaves — the hoistable ones themselves. Their
+   * own meta-annotations are `@Retention` / `@Target`, never more of the same, so descending into
+   * them only costs a scan.
+   */
+  /** Mirrors `PreviewAxis.MAX_CELLS_WARN` / `MAX_CELLS`; see that annotation's KDoc. */
+  private const val PREVIEW_AXIS_MAX_CELLS_WARN = 64L
+  private const val PREVIEW_AXIS_MAX_CELLS = 512L
+
+  private val HOISTABLE_LEAF_FQNS =
+    setOf(
+      OVERRIDE_VARIANT_FQN,
+      OVERRIDE_VARIANT_CONTAINER_FQN,
+      PREVIEW_AXIS_FQN,
+      PREVIEW_AXIS_CONTAINER_FQN,
+    )
   // The stable FQN is shared by both Android's ui-tooling-preview and CMP's
   // `org.jetbrains.compose.components:components-ui-tooling-preview` — Kotlin
   // `expect`/`actual` collapses onto the same `androidx...` class name on
@@ -1579,12 +1602,23 @@ object PreviewDiscovery {
     // `@OverrideVariant` (repeatable) — each spec yields one extra synthetic preview per @Preview
     // expansion below, rendered with its `previewOverride*` seeds applied. Applies to every
     // expansion, the same "one annotation, applies to every preview" policy as the capture specs.
+    //
+    // `@PreviewAxis` (also repeatable) produces the same kind of spec, but by expanding the CROSS
+    // PRODUCT of the declared axes rather than by being written out per cell — and each of its
+    // cells carries its full axis assignment as typed props, which a hand-written variant has no
+    // way to say. The two are unioned: a component that is a clean product except for one odd extra
+    // state stays expressible. Axes go first so their cells win a name collision, which is the
+    // useful precedence — a hand-written variant that shadows a generated cell is the mistake, and
+    // `mergeVariantSpecs` warns about it either way.
+    val owner = "${classInfo.name}.${method.name}"
+    val axisSpecs =
+      expandAxes(extractPreviewAxes(annotations, scanResult, owner, warnings), owner, warnings)
     val overrideVariantSpecs =
-      extractOverrideVariantSpecs(
-        annotations,
-        scanResult,
-        owner = "${classInfo.name}.${method.name}",
-        warnings = warnings,
+      mergeVariantSpecs(
+        axisSpecs,
+        extractOverrideVariantSpecs(annotations, scanResult, owner, warnings),
+        owner,
+        warnings,
       )
     // @RoboComposePreviewOptions, similarly, applies to the function as a
     // whole — each timing fans out into its own manifest entry, orthogonal
@@ -1870,16 +1904,265 @@ object PreviewDiscovery {
     scanResult: ScanResult,
     visited: MutableSet<String>,
     into: MutableList<AnnotationInfo>,
+  ) = walkMetaAnnotations(ann, scanResult, visited) { collectOverrideVariants(it, into) }
+
+  /**
+   * The shared meta-annotation traversal: visit [ann]'s annotation class, hand every annotation on
+   * it to [collect], and recurse into those in turn.
+   *
+   * One walk for both hoistable annotation families (`@OverrideVariant`, `@PreviewAxis`) so they
+   * cannot disagree about what "hoisted" reaches — which they would, being two copies of a
+   * traversal with a cycle guard. [visited] is shared per call site, so a diamond of annotation
+   * classes is visited once.
+   */
+  private fun walkMetaAnnotations(
+    ann: AnnotationInfo,
+    scanResult: ScanResult,
+    visited: MutableSet<String>,
+    collect: (AnnotationInfo) -> Unit,
   ) {
     if (ann.name in visited) return
     if (isDirectPreview(ann) || isPreviewContainer(ann)) return
-    if (ann.name == OVERRIDE_VARIANT_FQN || ann.name == OVERRIDE_VARIANT_CONTAINER_FQN) return
+    // The hoistable annotations themselves are leaves: their own meta-annotations are
+    // `@Retention` / `@Target`, never more variants, and descending into them wastes a scan.
+    if (ann.name in HOISTABLE_LEAF_FQNS) return
     visited.add(ann.name)
     val annClassInfo = scanResult.getClassInfo(ann.name) ?: return
     for (metaAnn in annClassInfo.annotationInfo.toList()) {
-      collectOverrideVariants(metaAnn, into)
-      overrideVariantsFromMetaAnnotation(metaAnn, scanResult, visited, into)
+      collect(metaAnn)
+      walkMetaAnnotations(metaAnn, scanResult, visited, collect)
     }
+  }
+
+  /** One resolved `@PreviewAxis`: its knob, its values (with name slugs), and its default. */
+  private data class AxisSpec(
+    val key: String,
+    val values: List<Pair<String, String>>, // value → name slug
+    val default: String,
+    val kind: OverrideSeedKind,
+    val namesEveryValue: Boolean,
+    val order: Int,
+  )
+
+  /**
+   * Reads every `@PreviewAxis` on a function — direct or hoisted onto an annotation class — into an
+   * [AxisSpec], in declaration order.
+   *
+   * Malformed axes are dropped with a warning rather than failing the build, matching how the rest
+   * of discovery treats an annotation it cannot use: a broken axis costs the cells it would have
+   * added, and saying so beats failing every other preview in the module.
+   */
+  private fun extractPreviewAxes(
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+    owner: String,
+    warnings: MutableList<String>,
+  ): List<AxisSpec> {
+    val infos = mutableListOf<AnnotationInfo>()
+    val visited = mutableSetOf<String>()
+    for (ann in annotations) {
+      collectPreviewAxes(ann, infos)
+      walkMetaAnnotations(ann, scanResult, visited) { collectPreviewAxes(it, infos) }
+    }
+    val byKey = LinkedHashMap<String, AxisSpec>()
+    for (info in infos) {
+      val pv = info.parameterValues
+      val key = (pv.getValue("key") as? String)?.takeIf { it.isNotBlank() } ?: continue
+      val values = readStringArray(pv.getValue("values")).distinct()
+      if (values.size < 2) {
+        warnings.add(
+          "composePreview: '$owner' declares @PreviewAxis(key = \"$key\") with " +
+            "${values.size} distinct value(s) — an axis with fewer than two multiplies nothing. " +
+            "Ignoring it."
+        )
+        continue
+      }
+      val slugsRaw = readStringArray(pv.getValue("slugs"))
+      val slugs =
+        when {
+          slugsRaw.isEmpty() -> values
+          slugsRaw.size == values.size -> slugsRaw
+          else -> {
+            warnings.add(
+              "composePreview: '$owner' declares @PreviewAxis(key = \"$key\") with " +
+                "${slugsRaw.size} slugs for ${values.size} values — positional, so a mismatch " +
+                "would misname cells. Using the values as their own slugs."
+            )
+            values
+          }
+        }
+      val declaredDefault = (pv.getValue("default") as? String).orEmpty()
+      val default =
+        when {
+          declaredDefault.isEmpty() -> values.first()
+          declaredDefault in values -> declaredDefault
+          else -> {
+            warnings.add(
+              "composePreview: '$owner' declares @PreviewAxis(key = \"$key\", default = " +
+                "\"$declaredDefault\") but that is not one of its values — every cell would then " +
+                "count as non-default and one would duplicate the base render. Using " +
+                "\"${values.first()}\"."
+            )
+            values.first()
+          }
+        }
+      val spec =
+        AxisSpec(
+          key = key,
+          values = values.zip(slugs),
+          default = default,
+          kind = axisSeedKind(pv.getValue("kind")),
+          namesEveryValue = pv.getValue("namesEveryValue") as? Boolean ?: false,
+          order = (pv.getValue("order") as? Int) ?: 0,
+        )
+      // Two axes on one key would square that key against itself — `size=xs` crossed with
+      // `size=m` is not a cell, it is a contradiction.
+      if (byKey.putIfAbsent(key, spec) != null) {
+        warnings.add(
+          "composePreview: '$owner' declares @PreviewAxis(key = \"$key\") more than once — " +
+            "crossing a key with itself produces contradictory cells. Keeping the first."
+        )
+      }
+    }
+    // Stable sort on the declared order: the order repeated annotations are EMITTED in is a
+    // compiler detail, not a contract, and Kotlin's does not match the order they were written in
+    // — a two-axis function came back swapped, which silently renames every cell. Axes sharing an
+    // order keep their emitted order relative to each other, so a single-axis function needs
+    // nothing. See `PreviewAxis.order`.
+    return byKey.values.sortedBy { it.order }
+  }
+
+  /** Adds [ann] to [into] when it is a `@PreviewAxis`, unwrapping the repeatable container. */
+  private fun collectPreviewAxes(ann: AnnotationInfo, into: MutableList<AnnotationInfo>) {
+    when (ann.name) {
+      PREVIEW_AXIS_FQN -> into.add(ann)
+      PREVIEW_AXIS_CONTAINER_FQN -> {
+        when (val value = ann.parameterValues.getValue("value")) {
+          is Array<*> -> value.filterIsInstance<AnnotationInfo>().forEach { into.add(it) }
+          is AnnotationInfo -> into.add(value)
+          else -> {
+            val len = runCatching { java.lang.reflect.Array.getLength(value) }.getOrNull() ?: 0
+            for (i in 0 until len) {
+              (java.lang.reflect.Array.get(value, i) as? AnnotationInfo)?.let { into.add(it) }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * `PreviewAxisKind` → [OverrideSeedKind]. ClassGraph surfaces an enum-valued annotation parameter
+   * as an `AnnotationEnumValue`, so the name is read off it rather than the class being loaded.
+   */
+  private fun axisSeedKind(raw: Any?): OverrideSeedKind {
+    val name =
+      when (raw) {
+        is AnnotationEnumValue -> raw.valueName
+        is String -> raw
+        else -> null
+      }
+    return when (name) {
+      "BOOLEAN" -> OverrideSeedKind.BOOLEAN
+      "INT" -> OverrideSeedKind.INT
+      "FLOAT" -> OverrideSeedKind.FLOAT
+      else -> OverrideSeedKind.STRING
+    }
+  }
+
+  /**
+   * Expands [axes] into one [OverrideVariantSpec] per cell of their cross product, skipping the
+   * all-defaults cell.
+   *
+   * Cells come out in axis-major order (the first axis varies slowest), so the emitted order tracks
+   * the declaration order a reader sees. A cell:
+   * * **seeds** only its non-default values — seeding a knob with the value it already resolves to
+   *   is a no-op, and leaving it out keeps the seed list saying exactly what moved;
+   * * is **named** by its non-default slugs joined by `-`, plus any axis marked
+   *   [AxisSpec.namesEveryValue];
+   * * publishes its **full** assignment as props, defaults included, because that is what the cell
+   *   *is* and what a design kit's component set carries on the other side of a parity pairing.
+   *
+   * The all-defaults cell is detected on having no seeds rather than an empty name, since
+   * `namesEveryValue` leaves it named (`s`) even though it moves nothing. Emitting it would bake a
+   * second capture identical to the base render.
+   */
+  private fun expandAxes(
+    axes: List<AxisSpec>,
+    owner: String,
+    warnings: MutableList<String>,
+  ): List<OverrideVariantSpec> {
+    if (axes.isEmpty()) return emptyList()
+    val total = axes.fold(1L) { acc, axis -> acc * axis.values.size }
+    if (total > PREVIEW_AXIS_MAX_CELLS) {
+      warnings.add(
+        "composePreview: '$owner' declares @PreviewAxis axes whose cross product is $total cells " +
+          "(${axes.joinToString(" x ") { "${it.key}(${it.values.size})" }}), over the " +
+          "$PREVIEW_AXIS_MAX_CELLS cap — that is a render bill, not a matrix. Ignoring the axes; " +
+          "split the component or drop an axis."
+      )
+      return emptyList()
+    }
+    if (total > PREVIEW_AXIS_MAX_CELLS_WARN) {
+      warnings.add(
+        "composePreview: '$owner' expands to $total @PreviewAxis cells " +
+          "(${axes.joinToString(" x ") { "${it.key}(${it.values.size})" }}), each rendered for " +
+          "every @Preview on the function. Intentional?"
+      )
+    }
+
+    var combinations: List<List<Pair<String, String>>> = listOf(emptyList())
+    for (axis in axes) {
+      combinations = combinations.flatMap { prefix -> axis.values.map { prefix + it } }
+    }
+    return combinations.mapNotNull { combination ->
+      val slugs = mutableListOf<String>()
+      val seeds = mutableListOf<OverrideSeed>()
+      val props = mutableListOf<CatalogVariantProp>()
+      for ((axis, valueAndSlug) in axes.zip(combination)) {
+        val (value, slug) = valueAndSlug
+        val isDefault = value == axis.default
+        if (axis.namesEveryValue || !isDefault) slugs.add(slug)
+        props.add(CatalogVariantProp(key = axis.key, value = value))
+        if (!isDefault) {
+          seeds.add(OverrideSeed(key = axis.key, index = null, kind = axis.kind, raw = value))
+        }
+      }
+      if (seeds.isEmpty()) null
+      else
+        OverrideVariantSpec(name = slugs.joinToString("-"), seeds = seeds, props = props.toList())
+    }
+  }
+
+  /**
+   * Unions the `@PreviewAxis` cells with the hand-written `@OverrideVariant`s, first wins on a name
+   * collision.
+   *
+   * Both produce the same kind of spec and both are keyed by name — the `_VARIANT_<name>` render
+   * output's identity — so a name carried by both would have the second overwrite the first's file.
+   * [axisCells] goes first because a generated cell is the one whose name is derived rather than
+   * typed: if a hand-written variant shadows it, the hand-written one is the mistake.
+   */
+  private fun mergeVariantSpecs(
+    axisCells: List<OverrideVariantSpec>,
+    handWritten: List<OverrideVariantSpec>,
+    owner: String,
+    warnings: MutableList<String>,
+  ): List<OverrideVariantSpec> {
+    if (axisCells.isEmpty()) return handWritten
+    if (handWritten.isEmpty()) return axisCells
+    val merged = LinkedHashMap<String, OverrideVariantSpec>()
+    axisCells.forEach { merged[it.name] = it }
+    val shadowed = handWritten.filter { it.name in merged }.map { it.name }
+    handWritten.forEach { merged.putIfAbsent(it.name, it) }
+    if (shadowed.isNotEmpty()) {
+      warnings.add(
+        "composePreview: '$owner' has @OverrideVariant(s) named ${shadowed.joinToString(", ")} " +
+          "that a @PreviewAxis cell already produces — one render output per name, so the " +
+          "hand-written one is ignored. Rename it, or drop it if the axes already cover the cell."
+      )
+    }
+    return merged.values.toList()
   }
 
   /** Parses `"key=value"` / `"key#index=value"` string-array entries into typed [OverrideSeed]s. */

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -441,6 +441,210 @@ class DiscoveryFunctionalTest {
       )
   }
 
+  /**
+   * `@PreviewAxis`: the declarative form of a variant matrix. Two axes on one function multiply
+   * into their cross product minus the base cell, each carrying its full assignment as props.
+   *
+   * The assertions are exactly the properties a naive expansion gets wrong: axes multiply (rather
+   * than unioning, which is how stacked `@OverrideVariant`s combine); the all-defaults cell is
+   * skipped rather than emitted as a duplicate of the base render; a default value is never seeded
+   * but IS part of the cell's props; and `namesEveryValue` puts an axis in every name.
+   */
+  @Test
+  fun `composePreviewDiscover expands @PreviewAxis into the cross product`() {
+    val projectDir = createCmpTestProject()
+
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    annDir.mkdirs()
+    File(annDir, "PreviewAxis.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Repeatable
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+        annotation class PreviewAxis(
+            val key: String,
+            val values: Array<String>,
+            val default: String = "",
+            val kind: PreviewAxisKind = PreviewAxisKind.STRING,
+            val slugs: Array<String> = [],
+            val namesEveryValue: Boolean = false,
+            val order: Int = 0,
+        )
+
+        enum class PreviewAxisKind { STRING, BOOLEAN, INT, FLOAT }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "src/main/kotlin/test/Matrix.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
+        import ee.schimke.composeai.preview.PreviewAxis
+
+        @Preview
+        @PreviewAxis(
+            key = "size",
+            values = ["xs", "s", "m"],
+            default = "s",
+            namesEveryValue = true,
+            order = 1,
+        )
+        @PreviewAxis(key = "shape", values = ["round", "square"], order = 2)
+        @Composable
+        fun MatrixPreview() {
+            Box(modifier = Modifier.size(50.dp)) { Text("Matrix") }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val matrix = manifest.previews.filter { it.functionName == "MatrixPreview" }
+    // 3 sizes x 2 shapes = 6 cells, minus the all-defaults one, plus the base preview.
+    assertThat(matrix).hasSize(6)
+    assertThat(matrix.mapNotNull { it.overrides?.name })
+      .containsExactly("xs", "xs-square", "s-square", "m", "m-square")
+
+    // `size` names every cell (`s-square`, not `square`); `shape` only when off its default.
+    val sSquare = matrix.single { it.overrides?.name == "s-square" }
+    // A default value is never seeded — an unseeded knob already resolves to it…
+    assertThat(sSquare.overrides!!.seeds)
+      .containsExactly(
+        OverrideSeed(key = "shape", index = null, kind = OverrideSeedKind.STRING, raw = "square")
+      )
+    // …but it IS part of what the cell is, so it rides on the props.
+    assertThat(sSquare.overrides!!.props.map { it.key to it.value })
+      .containsExactly("size" to "s", "shape" to "square")
+
+    val xsSquare = matrix.single { it.overrides?.name == "xs-square" }
+    assertThat(xsSquare.overrides!!.seeds).hasSize(2)
+    assertThat(xsSquare.overrides!!.props.map { it.key to it.value })
+      .containsExactly("size" to "xs", "shape" to "square")
+
+    // The base render is untouched: no seeds, no props, no `_VARIANT_` tag.
+    val base = matrix.single { it.overrides == null }
+    assertThat(base.captures.single().renderOutput).doesNotContain("_VARIANT_")
+  }
+
+  /** Axes hoisted onto an annotation class multiply with a function's own — the composable case. */
+  @Test
+  fun `composePreviewDiscover multiplies hoisted @PreviewAxis with a direct one`() {
+    val projectDir = createCmpTestProject()
+
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    annDir.mkdirs()
+    File(annDir, "PreviewAxis.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Repeatable
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+        annotation class PreviewAxis(
+            val key: String,
+            val values: Array<String>,
+            val default: String = "",
+            val kind: PreviewAxisKind = PreviewAxisKind.STRING,
+            val slugs: Array<String> = [],
+            val namesEveryValue: Boolean = false,
+            val order: Int = 0,
+        )
+
+        enum class PreviewAxisKind { STRING, BOOLEAN, INT, FLOAT }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "src/main/kotlin/test/Hoisted.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
+        import ee.schimke.composeai.preview.PreviewAxis
+        import ee.schimke.composeai.preview.PreviewAxisKind
+
+        @PreviewAxis(key = "shape", values = ["round", "square"], order = 1)
+        annotation class ShapeAxis
+
+        @Preview
+        @ShapeAxis
+        @PreviewAxis(
+            key = "selected",
+            values = ["true", "false"],
+            default = "true",
+            kind = PreviewAxisKind.BOOLEAN,
+            slugs = ["on", "off"],
+            order = 2,
+        )
+        @Composable
+        fun HoistedPreview() {
+            Box(modifier = Modifier.size(50.dp)) { Text("Hoisted") }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val hoisted = manifest.previews.filter { it.functionName == "HoistedPreview" }
+    // 2 shapes x 2 selected = 4 cells, minus the all-defaults one, plus the base. A hoisted axis
+    // MULTIPLIES with a direct one — a union would have given 2 variants, not 3.
+    assertThat(hoisted).hasSize(4)
+    assertThat(hoisted.mapNotNull { it.overrides?.name })
+      .containsExactly("square", "off", "square-off")
+
+    // `slugs` renames the values for the name only; the seed still carries the value, typed
+    // BOOLEAN so a `previewOverrideBoolean` read honours it.
+    val off = hoisted.single { it.overrides?.name == "off" }
+    assertThat(off.overrides!!.seeds)
+      .containsExactly(
+        OverrideSeed(key = "selected", index = null, kind = OverrideSeedKind.BOOLEAN, raw = "false")
+      )
+    assertThat(off.overrides!!.props.map { it.key to it.value })
+      .containsExactly("shape" to "round", "selected" to "false")
+  }
+
   @Test
   fun `composePreviewDiscover aggregates @ColorCatalog tokens into catalog sheets`() {
     val projectDir = createCmpTestProject()

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -61,6 +61,10 @@ import {
   mergeCatalogGroups,
 } from "./catalog-inventory.mjs";
 import { variantStateFromId } from "./variant-state.mjs";
+import {
+  applyVariantAxisProps,
+  overridesByPreviewId,
+} from "./variant-axis-props.mjs";
 import { renderIndexHtml } from "./render-index-html.mjs";
 import { renderCompareHtml } from "./render-compare-html.mjs";
 import { renderCrossSystemHtml } from "./render-cross-system-html.mjs";
@@ -212,9 +216,23 @@ async function loadCandidates(path, breakpoints) {
   // live catalog server (`ServeCatalogStore` → `variants.json` → `ServeWeb`) both fold off, so no
   // downstream change is needed. Mirrors the spec-driven `foldVariants` state tag for the
   // hand-written pressed/disabled state variants.
+  //
+  // A `@PreviewAxis` cell is the exception: its spec carries the full axis assignment, so it
+  // publishes structured `props` instead of an opaque `state` — matching a reference by property
+  // rather than by whether a hand-typed name coincides with the kit's naming. Props win over state
+  // for such a cell (stamping both would double-count one render), so the axis pass runs first and
+  // the state pass skips any image it claimed.
+  const axisProps = applyVariantAxisProps(candidates, overridesByPreviewId(candidateBundle));
+  if (axisProps.stamped > 0) {
+    console.log(`[${basename(path)}] stamped @PreviewAxis props on ${axisProps.stamped} image(s)`);
+  }
   for (const candidate of candidates) {
     const state = variantStateFromId(candidate.previewId ?? candidate.id);
-    if (state) for (const image of candidate.images ?? []) image.state = state;
+    if (state) {
+      for (const image of candidate.images ?? []) {
+        if (!axisProps.claimed.has(image)) image.state = state;
+      }
+    }
   }
   // Candidate images retain width-derived size but not `PreviewParams.fontScale`. Promote a
   // non-default scale to a props axis before candidates sharing one function are folded, and remove

--- a/scripts/design-artifacts/variant-axis-props.mjs
+++ b/scripts/design-artifacts/variant-axis-props.mjs
@@ -1,0 +1,67 @@
+/**
+ * Turn a `@PreviewAxis` cell's recorded axis assignment into catalog `props`.
+ *
+ * A hand-written `@OverrideVariant` has only a name, so the export can say no more about it than
+ * `state: "xs-square"` — one opaque string. That string is what design-parity then pairs against a
+ * reference's variant properties, so a cell matches the kit only if the name someone typed happens
+ * to coincide with the kit's own naming.
+ *
+ * An axis cell knows what it *is*. Discovery records the full assignment on the variant spec
+ * (`OverrideVariantSpec.props`), and this projects it onto the image as
+ * `props: {size: "xs", shape: "square"}` — the same shape `@CatalogVariant(props = […])` already
+ * produces, so everything downstream (the fold, the viewer's variant switcher, parity's pairing)
+ * reads it without further change.
+ *
+ * **`state` is left alone when props are present.** The two describe the same cell, and stamping
+ * both would double-count it: the fold would surface `state:xs-square` *and* a props axis for one
+ * render. Props are the better of the two — structured, and matching by property rather than by
+ * spelling — so they win, and `state` stays at its default. A cell whose spec carries no props
+ * (every pre-existing `@OverrideVariant`) is untouched and keeps its `state` exactly as before.
+ *
+ * @param {Array<{previewId?: string, id?: string, images?: Array<object>}>} candidates
+ *   Candidate renders, mutated in place.
+ * @param {Map<string, {props?: Array<{key: string, value: string}>}>} overridesByPreviewId
+ *   Preview id → its `overrides` spec from the discovery manifest.
+ * @returns {{stamped: number, claimed: Set<object>}} how many images were stamped, and which —
+ *   the caller uses `claimed` to leave exactly those images' `state` alone, rather than inferring
+ *   it from whether an image happens to carry props from some other source.
+ */
+export function applyVariantAxisProps(candidates, overridesByPreviewId) {
+  const claimed = new Set();
+  if (!overridesByPreviewId || overridesByPreviewId.size === 0) return { stamped: 0, claimed };
+  let stamped = 0;
+  for (const candidate of candidates) {
+    const id = candidate.previewId ?? candidate.id;
+    const props = overridesByPreviewId.get(id)?.props;
+    if (!Array.isArray(props) || props.length === 0) continue;
+    const asObject = {};
+    for (const { key, value } of props) {
+      if (typeof key === "string" && key && typeof value === "string") asObject[key] = value;
+    }
+    if (Object.keys(asObject).length === 0) continue;
+    for (const image of candidate.images ?? []) {
+      // Merge under anything already there: a `fontScale` promoted from preview params, or a
+      // spec-authored prop, is about a different axis than the knobs and must not be dropped.
+      image.props = { ...asObject, ...(image.props ?? {}) };
+      claimed.add(image);
+      stamped += 1;
+    }
+  }
+  return { stamped, claimed };
+}
+
+/**
+ * `previewId → overrides spec` for every preview in the bundle that carries one.
+ *
+ * Keyed by the raw discovery id, which is what the candidate reader hands back — the same key
+ * `variantStateFromId` parses its `_VARIANT_` suffix out of.
+ *
+ * @param {{previews?: Array<{id: string, overrides?: object}>}} bundle
+ */
+export function overridesByPreviewId(bundle) {
+  const out = new Map();
+  for (const preview of bundle?.previews ?? []) {
+    if (preview?.id && preview.overrides) out.set(preview.id, preview.overrides);
+  }
+  return out;
+}

--- a/scripts/design-artifacts/variant-axis-props.test.mjs
+++ b/scripts/design-artifacts/variant-axis-props.test.mjs
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyVariantAxisProps, overridesByPreviewId } from "./variant-axis-props.mjs";
+
+const axisSpec = (name, props) => ({
+  name,
+  seeds: [],
+  props: Object.entries(props).map(([key, value]) => ({ key, value })),
+});
+
+test("an axis cell publishes its assignment as props", () => {
+  const candidates = [
+    { previewId: "pkg.Kt.FilledButton_Light_VARIANT_xs-square", images: [{ theme: "light" }] },
+  ];
+  const overrides = new Map([
+    [
+      "pkg.Kt.FilledButton_Light_VARIANT_xs-square",
+      axisSpec("xs-square", { size: "xs", shape: "square" }),
+    ],
+  ]);
+
+  const { stamped, claimed } = applyVariantAxisProps(candidates, overrides);
+
+  assert.equal(stamped, 1);
+  assert.deepEqual(candidates[0].images[0].props, { size: "xs", shape: "square" });
+  assert.equal(claimed.has(candidates[0].images[0]), true);
+});
+
+test("a hand-written variant carries no props and is left for the state pass", () => {
+  // Every pre-existing `@OverrideVariant` looks like this: a spec with seeds but no axis
+  // assignment. It must come out of here untouched so its `_VARIANT_<name>` still becomes a state.
+  const candidates = [{ previewId: "pkg.Kt.SwitchOn_VARIANT_off", images: [{}] }];
+  const overrides = new Map([
+    ["pkg.Kt.SwitchOn_VARIANT_off", { name: "off", seeds: [{ key: "checked" }] }],
+  ]);
+
+  const { stamped, claimed } = applyVariantAxisProps(candidates, overrides);
+
+  assert.equal(stamped, 0);
+  assert.equal(claimed.size, 0);
+  assert.equal(candidates[0].images[0].props, undefined);
+});
+
+test("existing props win over the axis assignment rather than being clobbered", () => {
+  // A `fontScale` promoted from preview params, or a spec-authored prop, is a different axis.
+  const candidates = [
+    { previewId: "p_VARIANT_xs", images: [{ props: { fontScale: "2.0", size: "kept" } }] },
+  ];
+  const overrides = new Map([["p_VARIANT_xs", axisSpec("xs", { size: "xs", shape: "round" })]]);
+
+  applyVariantAxisProps(candidates, overrides);
+
+  assert.deepEqual(candidates[0].images[0].props, {
+    shape: "round",
+    fontScale: "2.0",
+    size: "kept",
+  });
+});
+
+test("every image of a multi-theme cell is stamped", () => {
+  const candidates = [
+    { previewId: "p_VARIANT_xs", images: [{ theme: "light" }, { theme: "dark" }] },
+  ];
+  const overrides = new Map([["p_VARIANT_xs", axisSpec("xs", { size: "xs" })]]);
+
+  const { stamped } = applyVariantAxisProps(candidates, overrides);
+
+  assert.equal(stamped, 2);
+  assert.deepEqual(candidates[0].images[1].props, { size: "xs" });
+});
+
+test("no overrides at all is a no-op", () => {
+  const candidates = [{ previewId: "p", images: [{}] }];
+  const { stamped, claimed } = applyVariantAxisProps(candidates, new Map());
+  assert.equal(stamped, 0);
+  assert.equal(claimed.size, 0);
+  assert.equal(candidates[0].images[0].props, undefined);
+});
+
+test("overridesByPreviewId indexes only previews that carry a spec", () => {
+  const bundle = {
+    previews: [
+      { id: "a", overrides: { name: "x", seeds: [] } },
+      { id: "b" },
+      { id: "c", overrides: { name: "y", seeds: [] } },
+    ],
+  };
+  const map = overridesByPreviewId(bundle);
+  assert.deepEqual([...map.keys()], ["a", "c"]);
+});


### PR DESCRIPTION
Milestone 5 of 5 in the m3-catalog preview-boilerplate work, and the one the
earlier ones were building toward. Builds on #3523 (hoisting) but is
independent of it.

## Why, given #3523 already exists

A variant matrix is a cross product, and until now it had to be **enumerated** —
cell by cell on every function, or, since #3523, cell by cell once and applied
everywhere. Either way somebody types out the product, and stacking two hoisted
annotations *unions* rather than multiplies. m3-catalog's icon buttons are
5 sizes × 3 widths × 2 shapes: twenty-nine hand-written cells, four times over.

`@PreviewAxis` declares one dimension and lets discovery do the multiplying:

```kotlin
@PreviewAxis(key = "size",  values = ["xs", "s", "m", "l", "xl"], default = "s",
             namesEveryValue = true, order = 1)
@PreviewAxis(key = "shape", values = ["round", "square"], order = 2)
@CatalogModes
@Composable
fun FilledButton() = Sticker { … }   // nine cells, none of them typed out
```

Adding a size becomes one value rather than a row per component.

## The part that isn't just less typing

An axis cell knows what it **is**, so it publishes
`props: {size: "xs", shape: "square"}` where a hand-written variant can only
publish `state: "xs-square"` — one opaque string, because the name is all the
export has to go on.

That matters beyond tidiness. design-parity pairs a rendered candidate against a
reference by its variant properties, and a design kit's component set carries
exactly these as named properties. A hand-typed name pairs only if it happens to
coincide with the kit's naming; a prop map pairs by construction.

Every cell carries its **full** assignment, defaults included — `size=s` is as
much part of what a cell is as `shape=square` — while only the non-default
values are *seeded*, since seeding a knob with the value it already resolves to
is a no-op.

`state` is left alone for such a cell rather than stamped alongside: the two
describe the same render, and stamping both would double-count it in the fold.
Every pre-existing `@OverrideVariant` carries no props and keeps its `state`
exactly as before.

## Axis order is declared, not inferred

Worth calling out, because the first draft of the functional test caught it. The
order repeated annotations are **emitted** in is a compiler detail, not a
contract, and Kotlin's does not match the order they were written in — a
size-then-shape matrix came back naming its cells `square-xs`, silently renaming
every cell in the catalog. ClassGraph preserves whatever it is handed (verified
against javac-produced classes, where `@Meta("a") @Meta("b")` comes back in that
order), so the swap is upstream of it.

Sorting on a declared `order` makes naming a property of the source rather than
of the toolchain. Axes sharing an order keep their emitted order relative to each
other, so a single-axis function needs nothing.

## Guard rails

- Axes and hand-written `@OverrideVariant`s are **unioned**, so a component
  that is a clean product except for one odd extra state stays expressible. Axis
  cells win a name collision — a generated name is derived, so a hand-written one
  shadowing it is the mistake — and the run warns either way.
- A product grows fast, so discovery warns past 64 cells and **refuses** past
  512 rather than minting thousands of captures from a typo.
- Malformed axes — one value, a default that is not one of the values,
  mismatched `slugs`, a duplicated key — are dropped with a warning naming the
  problem, rather than failing every other preview in the module.

## Visual evidence

None. No renderer, fixture or `@Preview` is touched, and nothing existing renders
differently: this adds a new way to *declare* variants, and no catalog in this
repo uses it yet. The captures it mints go through the same
`overrideVariantPreview` path `@OverrideVariant` already used, and the existing
`@OverrideVariant` functional tests are untouched and pass. m3-catalog adopting
it is a separate PR in its own repo, where the render diff will show up.

## Test plan

```sh
./gradlew :gradle-plugin:functionalTest --tests '*DiscoveryFunctionalTest*'
./gradlew :gradle-plugin:preview-discovery:test :preview-annotations:build
node --test scripts/design-artifacts/variant-axis-props.test.mjs
```

- 42 functional tests pass, 2 of them new
- new: two direct axes multiply; the all-defaults cell is skipped rather than
  duplicating the base render; a default is named but not seeded; props carry
  the full assignment
- new: a hoisted axis multiplies with a direct one (a union would have given 2
  variants, not 3); `slugs` rename for the name only; `BOOLEAN` seeds stay typed
- 6 new `variant-axis-props` tests: props stamped per image, hand-written
  variants left for the state pass, existing props not clobbered

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjWtkWKvfWUfX7rjw5gAzf)_