### PR TITLE
fix(preview-discovery): reject @PreviewAxis declarations that would bake wrong

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/PreviewAxis.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/PreviewAxis.kt
@@ -67,6 +67,22 @@ package ee.schimke.composeai.preview
  * A product grows fast — five sizes by three widths by two shapes is thirty cells, times every
  * `@Preview` expansion — so discovery warns past [MAX_CELLS_WARN] cells on one function, and
  * refuses past [MAX_CELLS] rather than minting thousands of captures from a typo.
+ *
+ * ## What discovery rejects
+ *
+ * Two rules exist because breaking them produces a catalog entry that is *wrong* rather than
+ * missing, which is the worse failure:
+ *
+ * * **Every value must parse as its [kind].** A `BOOLEAN` axis with a value of `"off"` (or a
+ *   non-numeric `INT` / `FLOAT`) would have its seed silently dropped by the renderer, baking a
+ *   duplicate of the base render while the catalog published props claiming it was that cell. Such
+ *   an axis is ignored with a warning. Write `values = ["true", "false"]` and use [slugs] to name
+ *   them `on` / `off`.
+ * * **Generated names must be distinct.** A name is a render output path, so colliding cells race
+ *   for one file. This needs no mistake to happen — two axes sharing a value name are enough (`a =
+ *   [p, q]` and `b = [p, q]`, both defaulting to `p`, both generate a cell called `q`) — as are
+ *   repeated [slugs]. Colliding cells after the first are dropped with a warning; give the values
+ *   distinct slugs, or set [namesEveryValue] on one axis.
  */
 @Repeatable
 @Retention(AnnotationRetention.BINARY)

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -2006,21 +2006,42 @@ object PreviewDiscovery {
             values.first()
           }
         }
+      val kind = axisSeedKind(pv.getValue("kind"))
+      // Every value has to survive the seed parser, or the cell is a lie. `OverrideSeed
+      // .toValueOrNull` silently drops a seed it cannot parse, so a `kind = BOOLEAN` axis with a
+      // value of `"off"` would render an unmodified copy of the base while the catalog published
+      // props claiming it is the `off` cell — a wrong entry, which is worse than a missing one.
+      val unparseable = values.filterNot { parseableAs(it, kind) }
+      if (unparseable.isNotEmpty()) {
+        warnings.add(
+          "composePreview: '$owner' declares @PreviewAxis(key = \"$key\", kind = $kind) with " +
+            "value(s) ${unparseable.joinToString(", ") { "\"$it\"" }} that are not valid $kind " +
+            "literals — the renderer would drop the seed and bake a duplicate of the base render " +
+            "while the catalog claimed it was that cell. Ignoring the axis."
+        )
+        continue
+      }
       val spec =
         AxisSpec(
           key = key,
           values = values.zip(slugs),
           default = default,
-          kind = axisSeedKind(pv.getValue("kind")),
+          kind = kind,
           namesEveryValue = pv.getValue("namesEveryValue") as? Boolean ?: false,
           order = (pv.getValue("order") as? Int) ?: 0,
         )
       // Two axes on one key would square that key against itself — `size=xs` crossed with
-      // `size=m` is not a cell, it is a contradiction.
-      if (byKey.putIfAbsent(key, spec) != null) {
+      // `size=m` is not a cell, it is a contradiction. Only a *conflicting* duplicate is worth
+      // warning about, though: a hoisted axis is reached twice by design — once flattened into the
+      // method's annotation list by ClassGraph, once by the explicit meta-annotation walk — and
+      // warning on that would fire on the documented hoisting flow itself, for a single source
+      // declaration. Same rule the `@OverrideVariant` path already applies.
+      val existing = byKey.putIfAbsent(key, spec)
+      if (existing != null && existing != spec) {
         warnings.add(
-          "composePreview: '$owner' declares @PreviewAxis(key = \"$key\") more than once — " +
-            "crossing a key with itself produces contradictory cells. Keeping the first."
+          "composePreview: '$owner' declares @PreviewAxis(key = \"$key\") more than once, with " +
+            "different values — crossing a key with itself produces contradictory cells. Keeping " +
+            "the first."
         )
       }
     }
@@ -2030,6 +2051,28 @@ object PreviewDiscovery {
     // order keep their emitted order relative to each other, so a single-axis function needs
     // nothing. See `PreviewAxis.order`.
     return byKey.values.sortedBy { it.order }
+  }
+
+  /**
+   * Whether [value] is a literal the seed parser will accept for [kind].
+   *
+   * Deliberately the same predicates `OverrideSeed.toValueOrNull` applies — `toBooleanStrictOrNull`
+   * / `toIntOrNull` / `toFloatOrNull` on the trimmed text — so an axis is rejected here exactly
+   * when the renderer would have silently dropped its seed. A looser check would let a bad cell
+   * through to bake wrong; a stricter one would reject an axis that renders fine.
+   *
+   * `COLOR` is not reachable from `@PreviewAxis` (the annotation's `kind` has no colour member), so
+   * it is treated as unvalidated rather than given a hex parser that nothing can call.
+   */
+  private fun parseableAs(value: String, kind: OverrideSeedKind): Boolean {
+    val text = value.trim()
+    return when (kind) {
+      OverrideSeedKind.STRING -> true
+      OverrideSeedKind.BOOLEAN -> text.toBooleanStrictOrNull() != null
+      OverrideSeedKind.INT -> text.toIntOrNull() != null
+      OverrideSeedKind.FLOAT -> text.toFloatOrNull() != null
+      OverrideSeedKind.COLOR -> true
+    }
   }
 
   /** Adds [ann] to [into] when it is a `@PreviewAxis`, unwrapping the repeatable container. */
@@ -2115,23 +2158,60 @@ object PreviewDiscovery {
     for (axis in axes) {
       combinations = combinations.flatMap { prefix -> axis.values.map { prefix + it } }
     }
-    return combinations.mapNotNull { combination ->
-      val slugs = mutableListOf<String>()
-      val seeds = mutableListOf<OverrideSeed>()
-      val props = mutableListOf<CatalogVariantProp>()
-      for ((axis, valueAndSlug) in axes.zip(combination)) {
-        val (value, slug) = valueAndSlug
-        val isDefault = value == axis.default
-        if (axis.namesEveryValue || !isDefault) slugs.add(slug)
-        props.add(CatalogVariantProp(key = axis.key, value = value))
-        if (!isDefault) {
-          seeds.add(OverrideSeed(key = axis.key, index = null, kind = axis.kind, raw = value))
+    return combinations
+      .mapNotNull { combination ->
+        val slugs = mutableListOf<String>()
+        val seeds = mutableListOf<OverrideSeed>()
+        val props = mutableListOf<CatalogVariantProp>()
+        for ((axis, valueAndSlug) in axes.zip(combination)) {
+          val (value, slug) = valueAndSlug
+          val isDefault = value == axis.default
+          if (axis.namesEveryValue || !isDefault) slugs.add(slug)
+          props.add(CatalogVariantProp(key = axis.key, value = value))
+          if (!isDefault) {
+            seeds.add(OverrideSeed(key = axis.key, index = null, kind = axis.kind, raw = value))
+          }
         }
+        if (seeds.isEmpty()) null
+        else
+          OverrideVariantSpec(name = slugs.joinToString("-"), seeds = seeds, props = props.toList())
       }
-      if (seeds.isEmpty()) null
-      else
-        OverrideVariantSpec(name = slugs.joinToString("-"), seeds = seeds, props = props.toList())
+      .let { cells -> dedupeCellNames(cells, owner, warnings) }
+  }
+
+  /**
+   * Drops cells whose generated name collides with an earlier one, warning about each.
+   *
+   * A name is a render output path, so two cells sharing one race for the same file — and unlike
+   * the hand-written case this needs no authoring mistake to happen. Two axes that share a value
+   * name are enough: `a = [p, q]` and `b = [p, q]`, both defaulting to `p`, generate `q` for `(q,
+   * p)` and `q` again for `(p, q)`. Repeated `slugs` on one axis do it too.
+   *
+   * Dropped rather than renamed: a generated name is what the published sticker is addressed by, so
+   * inventing a disambiguating suffix would silently mint a URL nobody declared. Naming the
+   * collision and losing the cell is the honest failure — the fix (distinct slugs, or an axis that
+   * names every value) is then obvious.
+   */
+  private fun dedupeCellNames(
+    cells: List<OverrideVariantSpec>,
+    owner: String,
+    warnings: MutableList<String>,
+  ): List<OverrideVariantSpec> {
+    val byName = LinkedHashMap<String, OverrideVariantSpec>()
+    val collided = LinkedHashSet<String>()
+    for (cell in cells) {
+      if (byName.putIfAbsent(cell.name, cell) != null) collided.add(cell.name)
     }
+    if (collided.isNotEmpty()) {
+      warnings.add(
+        "composePreview: '$owner' expands @PreviewAxis to cells that collide on the name(s) " +
+          "${collided.joinToString(", ")} — a name is a render output path, so only the first of " +
+          "each is kept. Two axes sharing a value name, or repeated `slugs`, produce this; give " +
+          "the values distinct slugs, or set `namesEveryValue` on one axis so its cells stay " +
+          "distinguishable."
+      )
+    }
+    return byName.values.toList()
   }
 
   /**

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -645,6 +645,127 @@ class DiscoveryFunctionalTest {
       .containsExactly("shape" to "round", "selected" to "false")
   }
 
+  /**
+   * The three ways an axis expansion can go wrong quietly, all in one project so the warnings are
+   * asserted against a single run.
+   *
+   * `Untyped` — a `BOOLEAN` axis whose values are not boolean literals. The renderer's seed parser
+   * drops what it cannot parse, so the cell would bake as a duplicate of the base render while the
+   * catalog published props claiming it was that cell: a wrong entry, not a missing one.
+   *
+   * `Colliding` — two axes sharing a value name. No authoring mistake required, and a name is a
+   * render output path, so the two cells would race for one file.
+   *
+   * `Hoisted` — the documented hoisting flow, which must NOT warn. A hoisted axis is reached twice
+   * by design (ClassGraph flattens it into the method's annotation list, and the meta-annotation
+   * walk finds it again), and warning on that would fire on every correct use.
+   */
+  @Test
+  fun `composePreviewDiscover rejects unusable @PreviewAxis declarations and warns`() {
+    val projectDir = createCmpTestProject()
+
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    annDir.mkdirs()
+    File(annDir, "PreviewAxis.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Repeatable
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+        annotation class PreviewAxis(
+            val key: String,
+            val values: Array<String>,
+            val default: String = "",
+            val kind: PreviewAxisKind = PreviewAxisKind.STRING,
+            val slugs: Array<String> = [],
+            val namesEveryValue: Boolean = false,
+            val order: Int = 0,
+        )
+
+        enum class PreviewAxisKind { STRING, BOOLEAN, INT, FLOAT }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "src/main/kotlin/test/Bad.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
+        import ee.schimke.composeai.preview.PreviewAxis
+        import ee.schimke.composeai.preview.PreviewAxisKind
+
+        @Preview
+        @PreviewAxis(
+            key = "selected",
+            values = ["on", "off"],
+            kind = PreviewAxisKind.BOOLEAN,
+        )
+        @Composable
+        fun UntypedPreview() {
+            Box(modifier = Modifier.size(50.dp)) { Text("Untyped") }
+        }
+
+        @Preview
+        @PreviewAxis(key = "a", values = ["p", "q"], order = 1)
+        @PreviewAxis(key = "b", values = ["p", "q"], order = 2)
+        @Composable
+        fun CollidingPreview() {
+            Box(modifier = Modifier.size(50.dp)) { Text("Colliding") }
+        }
+
+        @PreviewAxis(key = "shape", values = ["round", "square"])
+        annotation class ShapeOnly
+
+        @Preview
+        @ShapeOnly
+        @Composable
+        fun HoistedOkPreview() {
+            Box(modifier = Modifier.size(50.dp)) { Text("Hoisted") }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+
+    // The BOOLEAN axis is ignored outright, so the function keeps only its base preview — rather
+    // than gaining a cell that bakes identically to it under a props claim.
+    assertThat(result.output).contains("are not valid BOOLEAN literals")
+    assertThat(manifest.previews.filter { it.functionName == "UntypedPreview" }).hasSize(1)
+
+    // `a=q,b=p` and `a=p,b=q` both name themselves `q`; the second is dropped, `q-q` survives.
+    assertThat(result.output).contains("collide on the name(s) q")
+    val colliding = manifest.previews.filter { it.functionName == "CollidingPreview" }
+    assertThat(colliding.mapNotNull { it.overrides?.name }).containsExactly("q", "q-q")
+
+    // …and the correct hoisted case is silent about duplicates while still producing its cell.
+    assertThat(result.output)
+      .doesNotContain("declares @PreviewAxis(key = \"shape\") more than once")
+    val hoisted = manifest.previews.filter { it.functionName == "HoistedOkPreview" }
+    assertThat(hoisted.mapNotNull { it.overrides?.name }).containsExactly("square")
+  }
+
   @Test
   fun `composePreviewDiscover aggregates @ColorCatalog tokens into catalog sheets`() {
     val projectDir = createCmpTestProject()


### PR DESCRIPTION
Follow-up to #3537, which merged before these could be pushed. Three review
findings, all real, all the same shape: they produce a catalog entry that is
**wrong** rather than missing, which is the worse failure.

## 1. Values are checked against `kind`

A `BOOLEAN` axis written `values = ["on", "off"]` passed discovery, but
`OverrideSeed.toValueOrNull` silently drops a seed it cannot parse. The cell
therefore baked as an unmodified duplicate of the base render **while the
catalog published props claiming it was the `off` cell**. Same for a
non-numeric `INT` / `FLOAT`.

Such an axis is now ignored with a warning naming the offending values. The
check applies the same predicates the seed parser does — `toBooleanStrictOrNull`
/ `toIntOrNull` / `toFloatOrNull` on the trimmed text — so an axis is rejected
exactly when the renderer would have dropped it. Looser would let a bad cell
bake; stricter would reject an axis that renders fine. (`COLOR` is unreachable
from `@PreviewAxis` — its `kind` has no colour member — so it is left
unvalidated rather than given a parser nothing can call.)

The right way to write that axis is `values = ["true", "false"]` with
`slugs = ["on", "off"]`, which the annotation KDoc now says.

## 2. Generated names are de-duplicated

A name is a render output path, so colliding cells race for one file — and this
needs **no authoring mistake**. Two axes sharing a value name are enough:

```kotlin
@PreviewAxis(key = "a", values = ["p", "q"], order = 1)
@PreviewAxis(key = "b", values = ["p", "q"], order = 2)
```

`(q, p)` names itself `q`, and so does `(p, q)`. Repeated `slugs` on one axis do
it too.

Colliding cells after the first are now dropped with a warning, rather than
renamed: a generated name is what the published sticker is addressed by, so
inventing a disambiguating suffix would silently mint a URL nobody declared.
Naming the collision and losing the cell is the honest failure, and the fix
(distinct slugs, or `namesEveryValue` on one axis) is then obvious.

## 3. A hoisted axis no longer warns about itself

The duplicate-key warning fired on the **documented hoisting flow**, for a
single source declaration. A hoisted axis is reached twice by design —
ClassGraph flattens it into the method's annotation list, and the
meta-annotation walk finds it again — so `putIfAbsent` returning non-null is the
normal case, not a conflict.

Only a *conflicting* duplicate warns now. That is the rule
`extractOverrideVariantSpecs` already applied for exactly this reason, and this
path should have mirrored it.

## Visual evidence

None. No renderer, fixture or `@Preview` is touched. This narrows which
`@PreviewAxis` declarations discovery accepts; the captures it mints from valid
ones are unchanged, and no catalog in this repo uses the annotation yet.

## Test plan

```sh
./gradlew :gradle-plugin:functionalTest --tests '*DiscoveryFunctionalTest*'
./gradlew :gradle-plugin:preview-discovery:test :preview-annotations:build
```

- 43 functional tests pass, 1 new
- the new test carries all three cases in one project, so the warnings are
  asserted against a single run: the `BOOLEAN` axis with non-boolean values
  keeps only its base preview; the two colliding axes yield `q` and `q-q`; and
  the correctly hoisted axis produces its cell with no duplicate warning
- each assertion discriminates — before the fixes they read 2 previews, a third
  `q`, and a spurious warning respectively

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjWtkWKvfWUfX7rjw5gAzf)_