### PR TITLE
fix(renderer-desktop): reset override seeds per render, and gate JVM reuse across captures

### DIFF
--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -223,6 +223,15 @@ fun main(args: Array<String>) {
   // not derail the render. Set once here (each subprocess renders one preview);
   // `clearDeclarations()`
   // below leaves seeds intact so the `.overrides.json` declaration drain still works.
+  // Drop any seed a PREVIOUS render left behind before applying this one. In the
+  // one-process-per-capture world this is a no-op (the JVM is fresh every time), which is why the
+  // note above could say "set once here". A pooled renderer worker breaks that assumption: a
+  // seeded `@OverrideVariant` followed by an ordinary preview would leave the variant's values in
+  // the controller — `clearDeclarations()` deliberately keeps seeds — and the ordinary preview
+  // would silently render with someone else's knobs. Resetting per render makes each capture
+  // independent of what the process drew before it, which is exactly what lets the caller stop
+  // paying for a JVM per capture.
+  ee.schimke.composeai.overrides.PreviewOverrideController.resetForNewSession()
   System.getProperty("composeai.overrides.seed")
     ?.takeIf { it.isNotBlank() }
     ?.let { seedJson ->

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererReentrancyTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererReentrancyTest.kt
@@ -1,0 +1,152 @@
+package ee.schimke.composeai.renderer
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The gate on turning `composePreviewRender` from **one JVM per capture** into a pool of long-lived
+ * renderer workers.
+ *
+ * `RenderPreviewsTask.invokeRenderer` calls `execOperations.javaexec` once per capture, so every
+ * preview pays Compose Desktop + Skiko boot. m3-catalog measures that whole path at **2.15
+ * s/preview** (~43 min for its 1095-preview catalog) while the daemon — the same work on an
+ * already-warm JVM — runs at ~0.31 s/preview. The gap is startup, not drawing.
+ *
+ * The obvious fix is the one already shipped for the cmp-jvm lane (`RcJvmWorkerPool`): keep the
+ * renderer exactly as it is and stop paying for its JVM more than once. That is only viable if
+ * [main] can be called repeatedly **in one process** and produce the same pixels each time, which
+ * is what this asserts.
+ *
+ * Why this beats the alternative of routing the task at the preview daemon:
+ * * the daemon renders a `@PreviewParameter` provider's *first value only*, where this path fans
+ *   out one file per value — routing there today would silently drop every fan-out PNG;
+ * * the daemon's render body is a hand-synced *copy* of this one, so the two could drift;
+ * * a worker running this same [main] cannot drift from itself by construction.
+ *
+ * Also measures the amortisation, so the payoff is a number rather than an assumption.
+ *
+ * Needs skiko's natives and skips loudly without them, like the other render tests here.
+ */
+class DesktopRendererReentrancyTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Before
+  fun requireSkikoNatives() {
+    if (!SKIKO_LOADED) {
+      System.err.println(
+        "DesktopRendererReentrancyTest skipped entirely: skiko's native library did not load, so " +
+          "the renderer-reentrancy gate never ran. Cause: $skikoLoadFailure"
+      )
+    }
+    Assume.assumeTrue("skiko natives unavailable: $skikoLoadFailure", SKIKO_LOADED)
+  }
+
+  @Test
+  fun repeatedInProcessRendersMatchTheFirstAndAmortiseStartup() {
+    val outDir = tempFolder.newFolder("renders")
+
+    val timingsNanos = ArrayList<Long>()
+    val renders =
+      (0 until RENDER_COUNT).map { i ->
+        val target = File(outDir, "sticker-$i.png")
+        val start = System.nanoTime()
+        renderOnce(target)
+        timingsNanos += System.nanoTime() - start
+        assertTrue("render $i wrote no file", target.isFile)
+        target.readBytes()
+      }
+
+    val firstMs = timingsNanos.first() / 1_000_000
+    val laterMs = timingsNanos.drop(1).map { it / 1_000_000 }
+    System.err.println(
+      "renderer reentrancy: $RENDER_COUNT renders in one JVM — first ${firstMs}ms, " +
+        "subsequent ${laterMs.joinToString("/")}ms (mean ${laterMs.average().toInt()}ms). " +
+        "Each of these is a whole `javaexec` today."
+    )
+
+    // The property the pool depends on: a render on a warm process is the same picture as the
+    // first one. Compared as decoded pixels — the claim is about what is drawn, and an encoder
+    // change would move bytes without moving a pixel.
+    val first = decode(renders.first())
+    renders.drop(1).forEachIndexed { idx, png ->
+      val later = decode(png)
+      assertEquals(
+        "render ${idx + 1} changed size on a warm JVM",
+        first.width to first.height,
+        later.width to later.height,
+      )
+      val differing = first.argb.indices.count { first.argb[it] != later.argb[it] }
+      assertEquals(
+        "render ${idx + 1} drew different pixels than the first render in the same process — a " +
+          "renderer worker pool would then produce output that depends on how many previews the " +
+          "worker had already drawn ($differing of ${first.argb.size} pixels differ)",
+        0,
+        differing,
+      )
+    }
+  }
+
+  /**
+   * One capture through the real entry point, with the same argument shape
+   * `RenderPreviewsTask.invokeRenderer` passes. Calling [main] rather than a private helper is the
+   * point: a worker would call exactly this, so anything the gate misses the worker would inherit.
+   *
+   * Safe to call in-process because every `exitProcess` in [main] is on the argument-validation
+   * prologue — a *render* failure writes an `.error.json` sidecar and returns normally.
+   */
+  private fun renderOnce(target: File) {
+    main(
+      arrayOf(
+        FIXTURE_CLASS,
+        FIXTURE_FUNCTION,
+        WIDTH.toString(),
+        HEIGHT.toString(),
+        DENSITY.toString(),
+        /* showBackground = */ "true",
+        /* backgroundColor = */ "0",
+        target.absolutePath,
+      )
+    )
+  }
+
+  private class Decoded(val width: Int, val height: Int, val argb: IntArray)
+
+  private fun decode(png: ByteArray): Decoded {
+    val image =
+      requireNotNull(ImageIO.read(ByteArrayInputStream(png))) { "render did not decode as a PNG" }
+    return Decoded(
+      image.width,
+      image.height,
+      image.getRGB(0, 0, image.width, image.height, null, 0, image.width),
+    )
+  }
+
+  private companion object {
+    const val FIXTURE_CLASS = "ee.schimke.composeai.renderer.SizeBoundsRenderTestFixturesKt"
+    const val FIXTURE_FUNCTION = "WrapContentSticker"
+    const val WIDTH = 200
+    const val HEIGHT = 200
+    const val DENSITY = 2.0f
+    const val RENDER_COUNT = 8
+
+    var skikoLoadFailure: String? = null
+
+    val SKIKO_LOADED: Boolean =
+      try {
+        org.jetbrains.skia.FontMgr.default.familiesCount
+        true
+      } catch (t: Throwable) {
+        skikoLoadFailure = "${t::class.java.simpleName}: ${t.message}"
+        false
+      }
+  }
+}

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererReentrancyTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererReentrancyTest.kt
@@ -67,8 +67,14 @@ class DesktopRendererReentrancyTest {
 
     val firstMs = timingsNanos.first() / 1_000_000
     val laterMs = timingsNanos.drop(1).map { it / 1_000_000 }
+    // Deliberately NOT called a JVM/Skiko-boot saving. This JVM is already up, and the companion's
+    // `SKIKO_LOADED` probe has touched `FontMgr` before the first timer starts, so `firstMs` is
+    // in-process Compose warm-up only — it understates a real cold start. The number that bounds
+    // the win is `laterMs` against the *whole* `javaexec` a capture costs today (2.15 s/preview
+    // measured end-to-end by m3-catalog), not against `firstMs`.
     System.err.println(
-      "renderer reentrancy: $RENDER_COUNT renders in one JVM — first ${firstMs}ms, " +
+      "renderer reentrancy: $RENDER_COUNT renders in one JVM — first ${firstMs}ms " +
+        "(in-process warm-up only; JVM + Skiko boot already paid before the timer), " +
         "subsequent ${laterMs.joinToString("/")}ms (mean ${laterMs.average().toInt()}ms). " +
         "Each of these is a whole `javaexec` today."
     )
@@ -96,6 +102,65 @@ class DesktopRendererReentrancyTest {
   }
 
   /**
+   * The other half of worker safety, and the one repetition alone cannot see: a render must not
+   * inherit state from whatever the process drew *before* it.
+   *
+   * `@OverrideVariant` seeds are the sharp edge. `main()` applies a seed only when
+   * `composeai.overrides.seed` is set, and `clearDeclarations()` deliberately keeps seeds alive
+   * across compositions — so before this gate, a seeded variant followed by an ordinary preview
+   * left the ordinary preview rendering with the variant's knobs. A fresh JVM per capture hid it; a
+   * pooled worker would not.
+   */
+  @Test
+  fun aRenderDoesNotInheritTheSeedOfThePreviousOne() {
+    val outDir = tempFolder.newFolder("override-renders")
+
+    // Baseline: the fixture with nothing seeded, drawn before any seed exists in this process.
+    val baseline = File(outDir, "baseline.png").also { renderOnce(it, overrideFixture = true) }
+
+    // A seeded render, which must look different — otherwise the probe proves nothing.
+    val seeded =
+      File(outDir, "seeded.png").also {
+        withSeed(SEED_JSON) { renderOnce(it, overrideFixture = true) }
+      }
+
+    // The same unseeded render again, now *after* a seeded one. This is the contamination case.
+    val afterSeeded =
+      File(outDir, "after-seeded.png").also { renderOnce(it, overrideFixture = true) }
+
+    val baselinePixels = decode(baseline.readBytes())
+    val seededPixels = decode(seeded.readBytes())
+    val afterPixels = decode(afterSeeded.readBytes())
+
+    val seedTook =
+      baselinePixels.argb.indices.count { baselinePixels.argb[it] != seededPixels.argb[it] }
+    assertTrue(
+      "the seed changed nothing, so this test cannot detect a leak — fixture or seed is wrong",
+      seedTook > 0,
+    )
+
+    val leaked =
+      baselinePixels.argb.indices.count { baselinePixels.argb[it] != afterPixels.argb[it] }
+    assertEquals(
+      "an unseeded render inherited the previous render's @OverrideVariant seed " +
+        "($leaked of ${baselinePixels.argb.size} pixels differ from the clean baseline) — a " +
+        "pooled renderer worker would render previews with knobs belonging to whichever variant " +
+        "it happened to draw before them",
+      0,
+      leaked,
+    )
+  }
+
+  private fun <T> withSeed(seedJson: String, block: () -> T): T {
+    System.setProperty(SEED_PROPERTY, seedJson)
+    return try {
+      block()
+    } finally {
+      System.clearProperty(SEED_PROPERTY)
+    }
+  }
+
+  /**
    * One capture through the real entry point, with the same argument shape
    * `RenderPreviewsTask.invokeRenderer` passes. Calling [main] rather than a private helper is the
    * point: a worker would call exactly this, so anything the gate misses the worker would inherit.
@@ -103,11 +168,11 @@ class DesktopRendererReentrancyTest {
    * Safe to call in-process because every `exitProcess` in [main] is on the argument-validation
    * prologue — a *render* failure writes an `.error.json` sidecar and returns normally.
    */
-  private fun renderOnce(target: File) {
+  private fun renderOnce(target: File, overrideFixture: Boolean = false) {
     main(
       arrayOf(
-        FIXTURE_CLASS,
-        FIXTURE_FUNCTION,
+        if (overrideFixture) OVERRIDE_FIXTURE_CLASS else FIXTURE_CLASS,
+        if (overrideFixture) OVERRIDE_FIXTURE_FUNCTION else FIXTURE_FUNCTION,
         WIDTH.toString(),
         HEIGHT.toString(),
         DENSITY.toString(),
@@ -137,6 +202,14 @@ class DesktopRendererReentrancyTest {
     const val HEIGHT = 200
     const val DENSITY = 2.0f
     const val RENDER_COUNT = 8
+
+    const val OVERRIDE_FIXTURE_CLASS = "ee.schimke.composeai.renderer.OverrideLeakTestFixturesKt"
+    const val OVERRIDE_FIXTURE_FUNCTION = "OverrideLeakSticker"
+    const val SEED_PROPERTY = "composeai.overrides.seed"
+
+    /** Seeds [LEAK_KNOB_KEY] to a colour far from the fixture's default green. */
+    const val SEED_JSON =
+      """{"name":"leak","seeds":[{"key":"$LEAK_KNOB_KEY","kind":"COLOR","raw":"#FFB71C1C"}]}"""
 
     var skikoLoadFailure: String? = null
 

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/OverrideLeakTestFixtures.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/OverrideLeakTestFixtures.kt
@@ -1,0 +1,29 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import ee.schimke.composeai.overrides.previewOverrideColor
+
+/**
+ * A preview whose entire appearance is one `@OverrideVariant`-seedable knob, so a seed leaking from
+ * a previous render is visible as a different picture rather than a subtle difference.
+ *
+ * Used by [DesktopRendererReentrancyTest] to prove that a render is independent of what the process
+ * drew before it — the property a pooled renderer worker depends on and a fresh-JVM-per-capture
+ * caller got for free.
+ */
+@Composable
+fun OverrideLeakSticker() {
+  Box(
+    modifier =
+      Modifier.fillMaxSize()
+        .background(previewOverrideColor(key = LEAK_KNOB_KEY, default = Color(0xFF1B5E20)))
+  )
+}
+
+/** Seed key the fixture reads; the test seeds it to a colour far from the default. */
+const val LEAK_KNOB_KEY: String = "leakProbe"


### PR DESCRIPTION
## Summary

The last big fork-per-render cost in the tree is `composePreviewRender`: `RenderPreviewsTask.invokeRenderer` runs `execOperations.javaexec` **once per capture**, so every preview pays a whole JVM. m3-catalog measures that path end-to-end at **2.15 s/preview** — ~43 min for its 1095-preview catalog.

This is the gate on fixing it with a pool of long-lived renderer workers, the way `RcJvmWorkerPool` (#3514) did for the cmp-jvm lane. Review turned it into a bug fix as well.

## The bug review found

`main()` applies `composeai.overrides.seed` only when it is set; `PreviewOverrideController.clearDeclarations()` deliberately **keeps** seeded values; only `resetForNewSession()` drops them, and nothing called it. So a seeded `@OverrideVariant` render followed by an ordinary preview left the ordinary preview drawing with the variant's knobs.

One JVM per capture was hiding it — and the comment above that code stated the assumption out loud: *"Set once here (each subprocess renders one preview)"*. The pool this gate exists to justify would have removed exactly that guarantee.

`main()` now calls `resetForNewSession()` before applying a seed. A no-op today; the precondition for reusing a JVM at all.

## What the measurement does and doesn't say

Eight renders in one process:

```
first 1444 ms (in-process warm-up only), subsequent 43/38/36/35/35/34/33 ms (mean 36 ms)
```

The first figure is **not** a cold start and is not offered as the baseline: this JVM is already up, and the `SKIKO_LOADED` probe touches `FontMgr` during class init before the timer starts. It measures Compose warm-up, not JVM + Skiko boot.

The win is bounded by the **warm render (~36 ms) against the whole `javaexec` a capture costs today (2.15 s/preview)** — measured independently, end-to-end, on real CI hardware over 1095 previews, which is a better cold number than a single subprocess spawn on a warm container would give.

## Why this route rather than routing at the preview daemon

#3526 gated that route and found it blocked: `RenderEngine` renders a `@PreviewParameter` provider's **first value only**, where this path fans out one file per value, so routing there would silently drop every fan-out PNG. It is also a hand-synced *copy* of this render body and can drift.

A worker calling this same `main()` avoids both: no fan-out gap, no protocol change, no cross-backend contract change, and it cannot drift from itself. Two properties make it safe, both now checked rather than assumed — every `exitProcess` in `main()` is on the argument-validation prologue (a render failure writes an `.error.json` sidecar and returns), and only one system property is per-render.

## Tests

- `repeatedInProcessRendersMatchTheFirstAndAmortiseStartup` — eight renders in one process draw identical pixels, and reports the timings above.
- `aRenderDoesNotInheritTheSeedOfThePreviousOne` — clean baseline → seeded render → unseeded render compared back to the baseline, against a fixture whose whole appearance is one seedable colour. It also asserts the *seeded* render actually differs, so it can't pass vacuously.

I verified the leak test bites rather than assuming it: with the production change stashed it **FAILED**; restored, both pass.

```
./gradlew :renderer-desktop:test ktfmtCheck
```

**78 tests, 0 failures, 0 skipped.** Skiko natives loaded, so the gates genuinely rendered.

No visual surface changes: the production change makes each capture start from a clean override state, which is already what a fresh JVM per capture produced.

## Next

Implement the worker + per-module pool and switch `RenderPreviewsTask.invokeRenderer` onto it. The classpath is per-module, but every capture in one task execution shares that module, so a single warm worker serves the whole render. Own PR — substantially bigger than this gate.