### PR TITLE
fix(serve): keep the viewer chrome and fit cap honest after the page moves

### DIFF
--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -30,9 +30,15 @@
     var top = stage.getBoundingClientRect().top + (window.scrollY || 0);
     return Math.max(320, Math.round(window.innerHeight - top - 64)) + "px";
   }
+  // The cap last written to the stage, so a re-measure that lands on the same answer can do
+  // nothing. That is what keeps the observer below off a feedback loop: applying a cap resizes
+  // the image, which resizes the container being observed, which re-measures — and stops there,
+  // because the second measurement matches the first.
+  var appliedFitCap = null;
   function applyZoom(mode) {
     if (mode !== "width") mode = "fit";
     var maxHeight = mode === "fit" ? fitCap() : "";
+    appliedFitCap = mode === "fit" ? maxHeight : null;
     img.style.maxHeight = maxHeight;
     var rcZoomCanvas = document.getElementById("cp-rc-canvas");
     if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
@@ -55,11 +61,37 @@
     });
   }
   applyZoom("fit");
-  // A resize changes the answer fitCap() gave, so re-measure. "Fit width" is an explicit choice to
-  // ignore the viewport's height, so it is left alone.
-  window.addEventListener("resize", function () {
-    if (root.getAttribute("data-zoom") !== "width") applyZoom("fit");
-  });
+  // Re-measure when the answer fitCap() gave could have changed. "Fit width" is an explicit choice
+  // to ignore the viewport's height, so it is left alone.
+  function refit() {
+    if (root.getAttribute("data-zoom") === "width") return;
+    if (fitCap() === appliedFitCap) return;
+    applyZoom("fit");
+  }
+  window.addEventListener("resize", refit);
+  // A resize is not the only thing that invalidates the cap: fitCap() measures from the stage's
+  // TOP, so anything inserted above the stage moves it down and shortens the space it has. The
+  // render-history strip does exactly that — viewer-history.js fetches its manifest and inserts
+  // `.cp-history` between the toolbar and the stage well after this first ran — and a DOM
+  // insertion fires no `resize`, so a delivery-backed viewer kept a cap measured for a stage that
+  // had since moved, pushing a tall history strip's preview back below the fold.
+  //
+  // Observed rather than called back from the history builder: the cap is invalidated by the
+  // stage MOVING, whoever moved it, and an observer catches the next thing to grow above the
+  // stage without that code having to know this cap exists.
+  //
+  // The observed box is the BODY, not the stage or its parent. ResizeObserver reports size, not
+  // position, and the strip is inserted after `.cp-viewer-bar` — a sibling of `.cp-viewer`, so
+  // the stage's own container merely moves down and never changes size. Only an ancestor
+  // containing both the insertion point and the stage grows, and the body is the one element
+  // guaranteed to be that for any future insertion too.
+  if (typeof ResizeObserver === "function" && document.body) {
+    new ResizeObserver(function () {
+      // Coalesce to a frame: an insertion can fire the observer mid-layout, and measuring then
+      // reads geometry the browser is still settling.
+      window.requestAnimationFrame(refit);
+    }).observe(document.body);
+  }
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.
@@ -2254,7 +2286,15 @@
       // the chrome in step when a theme is PICKED — never runs on this path. Without this, going
       // Back from Dark to a Light entry re-rendered the preview light inside a page still pinned
       // dark. The same call the format-comparison pop handler already makes.
-      if (window.cpPageTheme) window.cpPageTheme.follow(themeChoice.value);
+      //
+      // The ACTIVE choice, not the displayed one. A viewer opened with no theme in the URL and
+      // none remembered shows the preview's baked default while `data-theme-active="0"` says
+      // nobody chose it, and the chrome correctly follows the OS. Restoring that entry re-sets
+      // the attribute to "0" above, so passing `.value` here would pin the page to a baked mode
+      // the visitor never picked — the one state Back is supposed to return them to.
+      // `activeThemeChoice()` yields "" for it, which paints neither class and hands the page
+      // back to `prefers-color-scheme`.
+      if (window.cpPageTheme) window.cpPageTheme.follow(activeThemeChoice());
     }
     // The Remote Compose player pick already rode the URL as `rcPlayer=<wire>` (query() emits it,
     // URL_STATE_PARAMS owns it) but nothing ever read it back, so a shared `?rcPlayer=cmp-android`

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -18,7 +18,7 @@
 import { test, expect } from "@playwright/test";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { listThemes } from "./_fixtures.mjs";
 
 const harnessDir = dirname(fileURLToPath(import.meta.url));
@@ -1141,4 +1141,134 @@ test("contract · the spec lane compares the frame that was on the stage", async
     await settled();
     await expect.poll(() => requests.length).toBe(beforeLive + 1);
     expect(requests.at(-1).pathname.endsWith(".png")).toBe(true);
+});
+
+test("contract · Back to an unthemed entry hands the chrome back to the OS", async ({
+    page,
+}) => {
+    for (const [name, contentType] of SERVE_ASSETS) {
+        await page.route(`**/assets/serve/**/${name}`, (route) =>
+            route.fulfill({
+                path: resolve(serveAssetsDir, name),
+                contentType,
+            }),
+        );
+    }
+    await page.route("**/render/**", (route) =>
+        route.fulfill({ path: renderPlaceholder, contentType: "image/png" }),
+    );
+    await page.goto("/preview-harness/fixtures/pages/serve-viewer-themes.html");
+
+    const scheme = () =>
+        page.evaluate(() =>
+            (document.documentElement.className.match(/cp-scheme-\w+/) || [""])[0],
+        );
+
+    // The entry this test is about: nothing in the URL, nothing remembered, so `#cp-theme` shows
+    // the preview's BAKED default — `dark`, for this fixture — while `data-theme-active="0"`
+    // records that nobody picked it. The chrome is left to `prefers-color-scheme`, no pinned
+    // class at all.
+    await expect(page.locator("#cp-theme")).toHaveAttribute(
+        "data-theme-active",
+        "0",
+    );
+    await expect(page.locator("#cp-theme")).toHaveJSProperty("value", "dark");
+    expect(await scheme()).toBe("");
+
+    // Pick Light — the chip that is NOT the baked default, so this is a real change rather than a
+    // no-op the handler drops. It pushes a history entry and pins the chrome, the working half.
+    // Driven through the visible chip rather than `#cp-theme`: the select is in the DOM but
+    // visually removed (the bar is its face), so it is the chip a visitor can actually click.
+    await page.click('[data-theme-choice="light"]');
+    await expect.poll(scheme).toBe("cp-scheme-light");
+
+    // Back to the entry that had no choice on it. The select's displayed value returns to the
+    // baked `dark` and `data-theme-active` returns to "0" — so the chrome must return to the OS
+    // too. Passing the DISPLAYED value here instead of the active one pins the page dark: a mode
+    // the visitor never chose, reached by going Back from the one they did.
+    await page.goBack();
+    await expect(page.locator("#cp-theme")).toHaveAttribute(
+        "data-theme-active",
+        "0",
+    );
+    await expect.poll(scheme).toBe("");
+});
+
+test("contract · the fit cap re-measures when the history strip lands", async ({
+    page,
+}) => {
+    for (const [name, contentType] of SERVE_ASSETS) {
+        await page.route(`**/assets/serve/**/${name}`, (route) =>
+            route.fulfill({
+                path: resolve(serveAssetsDir, name),
+                contentType,
+            }),
+        );
+    }
+    await page.route("**/render/**", (route) =>
+        route.fulfill({ path: renderPlaceholder, contentType: "image/png" }),
+    );
+
+    // The fixture carries an INLINE history payload, which viewer-history.js consumes
+    // synchronously — and it is ordered ahead of viewer.js, so the strip is already in the DOM
+    // before the first fit is measured. That is the one arrangement in which this bug cannot
+    // happen. Strip the inline payload so the fetch path runs instead: that is the delivery-backed
+    // shape, where the manifest arrives over the network and the strip lands long after viewer.js
+    // has measured and fitted.
+    await page.route(
+        "**/fixtures/pages/serve-viewer-history.html",
+        async (route) => {
+            const html = await (await route.fetch()).text();
+            await route.fulfill({
+                contentType: "text/html",
+                body: html.replace(
+                    /<script type="application\/json" id="cp-history-data">[\s\S]*?<\/script>/,
+                    "",
+                ),
+            });
+        },
+    );
+    let manifest = null;
+    await page.route("**/history.json", async (route) => {
+        const inline = await (await route.fetch()).text().catch(() => null);
+        await route.fulfill({
+            contentType: "application/json",
+            body: manifest ?? inline ?? "{}",
+        });
+    });
+
+    // Read the payload the fixture ships, and serve it from the manifest URL instead.
+    const raw = readFileSync(
+        resolve(pagesDir, "serve-viewer-history.html"),
+        "utf8",
+    );
+    manifest = raw
+        .match(
+            /<script type="application\/json" id="cp-history-data">([\s\S]*?)<\/script>/,
+        )[1]
+        .trim();
+
+    await page.goto("/preview-harness/fixtures/pages/serve-viewer-history.html");
+    // The strip arrives asynchronously — this is the moment the stage moves down.
+    await page.waitForSelector(".cp-history");
+    await page.waitForTimeout(200);
+
+    const { applied, expected, historyHeight } = await page.evaluate(() => {
+        const stage = document.querySelector(".cp-stage");
+        const top = stage.getBoundingClientRect().top + (window.scrollY || 0);
+        return {
+            applied: parseInt(
+                document.getElementById("cp-img").style.maxHeight,
+                10,
+            ),
+            // fitCap()'s own arithmetic, re-run against the geometry as it stands NOW.
+            expected: Math.max(320, Math.round(window.innerHeight - top - 64)),
+            historyHeight: document.querySelector(".cp-history").offsetHeight,
+        };
+    });
+
+    // Guard the guard: if the strip were too short to move the stage, both numbers would agree no
+    // matter what the code did, and this test would pass against the bug it exists to catch.
+    expect(historyHeight).toBeGreaterThan(0);
+    expect(applied).toBe(expected);
 });

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -322,6 +322,32 @@ const FIXTURE_STATES = [
         },
     },
     {
+        // Going BACK to a history entry on which no theme was ever picked. The viewer opens showing
+        // the preview's baked theme with `data-theme-active="0"` — displayed, not chosen — so the
+        // chrome follows the OS. Picking a theme pins it; returning to that first entry has to
+        // un-pin it again, and nothing else in this spec shoots a popstate, so a regression here
+        // would move no baseline at all.
+        //
+        // Captured under both emulated OS preferences on purpose: "followed the OS" is only
+        // distinguishable from "pinned to the baked default" when the two shots disagree with each
+        // other. On the unfixed code they agree — both pinned dark — which is what the diff shows.
+        fixture: "serve-viewer-themes",
+        suffix: "theme-back-unpinned",
+        apply: async (page) => {
+            // Light, because this fixture's baked default is already dark: picking dark is a no-op
+            // the bar handler drops, and would shoot the page that was there anyway.
+            await page.click('[data-theme-choice="light"]');
+            await page.waitForFunction(() =>
+                document.documentElement.classList.contains("cp-scheme-light"),
+            );
+            await page.goBack();
+            // Settle rather than wait for the un-pinned state. Waiting on the FIXED behaviour would
+            // time out when the bot renders the base branch, turning a visual diff into a harness
+            // error — and the whole point is that both sides capture so the pixels can disagree.
+            await page.waitForTimeout(300);
+        },
+    },
+    {
         // The page theme following the SELECTED PREVIEW THEME (the "Page theme" setting, on by
         // default). Picking Dark repaints the chrome as well as the grid, and the claim is
         // invisible to the two ordinary shots: they are captured under an emulated OS preference,


### PR DESCRIPTION
Follow-ups to two Codex findings that merged unaddressed: [#3539](https://github.com/yschimke/compose-ai-tools/pull/3539#discussion_r3741030680) (commented 4 minutes before the merge) and [#3536](https://github.com/yschimke/compose-ai-tools/pull/3536#discussion_r3740989286).

Same shape in both: state recomputed on one trigger, then left stale when something *else* invalidates it.

## Back to an unthemed entry pinned the chrome

The pop handler restored the Theme select and called `cpPageTheme.follow(themeChoice.value)` — the **displayed** value. On a viewer opened with no theme in the URL and none remembered, the select shows the preview's baked default while `data-theme-active="0"` records that nobody picked it, and the chrome correctly follows the OS. Restoring that entry re-sets the attribute to `"0"` but passed the baked value anyway.

The result is a mode the visitor never chose, reachable *only* by going Back from one they did. Now passes `activeThemeChoice()` — the helper that already encodes this exact rule for rendering, and which yields `""`, handing the page back to `prefers-color-scheme`.

## The fit cap outlived the layout it measured

`fitCap()` measures from the stage's top and was re-run on `resize` alone. The render-history strip arrives over the network and is inserted above the stage long after that, and a DOM insertion fires no `resize` — so a delivery-backed viewer kept a cap measured for a stage that had since moved down, pushing the preview below the fold this cap exists to stay above.

Observed rather than called back from the history builder: the cap is invalidated by the stage *moving*, whoever moved it. The observed box is the **body**, deliberately — the strip lands as a sibling of `.cp-viewer`, so the stage's own container merely moves and never changes size, and `ResizeObserver` reports size, not position. (I got this wrong first time by observing `stage.parentNode`; the test caught it.) A guard comparing against the last applied cap makes an agreeing re-measure a no-op, which is also what stops applying a cap from re-triggering the observer that applied it.

## Visual evidence

The state is now **wired into `pages-snapshot`**, so the visual-diff bot renders and diffs it on this and every future PR — per the repo rule about making coverage automatic rather than one-off. Nothing in the harness shot a popstate before, so this un-pinning would otherwise have moved no baseline at all.

I can render the pixels here but have no way to upload images into a PR body from this environment, so the objective form of the evidence is byte comparison of the harness output, base vs head, for `serve-viewer-themes-theme-back-unpinned`:

| Shot | base (`origin/main`) | head |
|---|---|---|
| `.dark.png` | `445986af…` | `445986af…` — identical |
| `.light.png` | `445986af…` — **byte-identical to the dark shot** | `a3feb804…` |

That middle cell *is* the bug: under a **light** OS, after Back, the base branch renders a page byte-for-byte identical to the dark one. Head renders light. Under a dark OS both agree, which is why the light shot is the whole claim — the same reasoning the existing `theme-sync` state records, inverted.

The new snapshot state settles rather than waiting for the fixed state, so the base branch still captures instead of timing out and turning the diff into a harness error.

## Test plan

Two browser contract tests in `pages-snapshot.spec.mjs`, **both verified failing against the unfixed code with the predicted symptom**:

- *Back to an unthemed entry hands the chrome back to the OS* → base: `Expected: "" / Received: "cp-scheme-dark"`
- *the fit cap re-measures when the history strip lands* → base: `Expected: 334 / Received: 418` — 84px too tall, exactly the height of the strip that moved the stage

The history test rewrites the fixture to drop its inline payload, because that path is synchronous **and** ordered ahead of `viewer.js` — the one arrangement in which this bug cannot occur. It asserts the strip has non-zero height first, so a fixture that stopped moving the stage fails loudly instead of passing for the wrong reason.

Full `pages-snapshot` contract suite: **6 passed**. The 8 failures in `contract.spec.mjs` are pre-existing in this container (`failed to load ../media/webview/preview.js` — the extension bundle isn't built) and fail identically with this change reverted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaurAWy7n75Sk3rGhgRpfv)_