### PR TITLE
ci: stop the e2e workflow stacking runs and unblock CI on a cheap scope gate

### DIFF
--- a/.github/ci/test_affected_gradle_tests.py
+++ b/.github/ci/test_affected_gradle_tests.py
@@ -56,7 +56,21 @@ class ModuleUnitTestsGateTest(unittest.TestCase):
 
     def test_ci_gates_module_unit_tests_on_a_non_none_task_list(self):
         ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
-        self.assertIn("needs.changes.outputs.module_test_tasks != 'none'", ci)
+        self.assertIn("needs.module-test-scope.outputs.tasks != 'none'", ci)
+
+    def test_module_unit_tests_consumes_the_resolved_task_list(self):
+        """The gate and the task list must come from the same job.
+
+        `Resolve affected Gradle tests` lives in its own job so it stops blocking the ~11
+        jobs that never read it. That split is only safe while the `if:` gate above and
+        the `TEST_TASKS` the job actually runs both read `module-test-scope` — if one is
+        left pointing at a stale producer, the job passes its gate and then invokes a task
+        list it never resolved.
+        """
+        ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
+        self.assertIn("TEST_TASKS: ${{ needs.module-test-scope.outputs.tasks }}", ci)
+        self.assertIn("needs: [changes, module-test-scope]", ci)
+        self.assertNotIn("module_test_tasks", ci)
 
 
 if __name__ == "__main__":

--- a/.github/ci/test_affected_gradle_tests.py
+++ b/.github/ci/test_affected_gradle_tests.py
@@ -68,9 +68,34 @@ class ModuleUnitTestsGateTest(unittest.TestCase):
         list it never resolved.
         """
         ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
-        self.assertIn("TEST_TASKS: ${{ needs.module-test-scope.outputs.tasks }}", ci)
+        self.assertIn(
+            "TEST_TASKS: ${{ github.event_name == 'pull_request' "
+            "&& needs.module-test-scope.outputs.tasks || 'full' }}",
+            ci,
+        )
         self.assertIn("needs: [changes, module-test-scope]", ci)
         self.assertNotIn("module_test_tasks", ci)
+
+    def test_non_pr_events_keep_module_coverage_without_a_resolver_hop(self):
+        """`main` and the nightly cron must not queue a job just to be told `full`.
+
+        On non-PR events `path-scope.py` enables every group, so gating the resolver on
+        `module_unit_tests` alone would schedule it on every push — and since Module Unit
+        Tests `needs:` it, post-merge coverage would sit behind a second runner queue to
+        compute a constant. The resolver is therefore `pull_request`-only, which makes
+        `!cancelled()` load-bearing on the consumer: without it, the skipped resolver
+        would skip post-merge and nightly module tests outright.
+        """
+        ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
+        scope_gate = "if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.module_unit_tests == 'true'"
+        self.assertIn(scope_gate, ci)
+        self.assertIn("!cancelled()", ci)
+        self.assertIn("needs.changes.result == 'success'", ci)
+        self.assertIn("needs.module-test-scope.result != 'failure'", ci)
+        self.assertIn(
+            "(github.event_name != 'pull_request' || needs.module-test-scope.outputs.tasks != 'none')",
+            ci,
+        )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,16 @@ concurrency:
 # `github.event.pull_request` is null, so pushes to main always run the full
 # suite.
 jobs:
+  # Deliberately the cheapest job in the workflow: checkout + a path classifier,
+  # a few seconds. Every other job is `needs: changes`, and GitHub does not even
+  # create — let alone queue — a dependent job until its dependency finishes, so
+  # whatever runs here is paid twice: once as runner time, and again as queue
+  # time added to all ~12 downstream jobs. Resolving the affected Gradle tests
+  # (a full `./.github/actions/setup` + a Gradle model query, ~4 min) used to sit
+  # in this job and blocked all of them, though only Module Unit Tests consumes
+  # the result. It now lives in `module-test-scope` below, which runs alongside
+  # the other jobs instead of in front of them. Keep this job cheap: anything
+  # added here delays the entire workflow.
   changes:
     name: Determine CI scope
     runs-on: ubuntu-latest
@@ -55,7 +65,6 @@ jobs:
       renderer_android_tests: ${{ steps.scope.outputs.renderer_android_tests }}
       rc_player_tests: ${{ steps.scope.outputs.rc_player_tests }}
       module_unit_tests: ${{ steps.scope.outputs.module_unit_tests }}
-      module_test_tasks: ${{ steps.test-scope.outputs.tasks }}
       functional_tests: ${{ steps.scope.outputs.functional_tests }}
       build_samples: ${{ steps.scope.outputs.build_samples }}
       build_cli: ${{ steps.scope.outputs.build_cli }}
@@ -76,20 +85,44 @@ jobs:
           git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
           python3 .github/ci/path-scope.py \
             --config .github/ci/ci-paths.json >> "$GITHUB_OUTPUT"
+
+  # Split out of `changes` so its ~4 min of Gradle model resolution stops
+  # sitting on the critical path of every other job (see the note on `changes`).
+  # Only Module Unit Tests reads `tasks`, and that job runs `needs:` on both, so
+  # the chain is one job deeper for it alone while the other ~11 start as soon
+  # as the cheap classifier lands.
+  #
+  # Skipped entirely when Module Unit Tests is out of scope: its sole consumer
+  # is gated on the same condition, and a skipped `needs:` skips the dependent,
+  # which is the intended outcome there.
+  module-test-scope:
+    name: Resolve affected module tests
+    needs: changes
+    if: ${{ needs.changes.outputs.module_unit_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    runs-on: ubuntu-latest
+    outputs:
+      tasks: ${{ steps.test-scope.outputs.tasks }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch the PR base commit
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
+      # Only a PR narrows the suite, and only then is the Gradle model needed.
       - uses: ./.github/actions/setup
-        if: github.event_name == 'pull_request' && steps.scope.outputs.module_unit_tests == 'true'
+        if: github.event_name == 'pull_request'
       - name: Resolve affected Gradle tests
         id: test-scope
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.sha }}
-          RUN_MODULE_TESTS: ${{ steps.scope.outputs.module_unit_tests }}
         run: |
           if [ "$EVENT_NAME" != "pull_request" ]; then
             tasks=full
-          elif [ "$RUN_MODULE_TESTS" != "true" ]; then
-            tasks=none
           else
             tasks=$(python3 .github/ci/affected-gradle-tests.py)
           fi
@@ -254,14 +287,14 @@ jobs:
   # of masking them — the point of the job is to know the true state, not to stop at the first red.
   module-unit-tests:
     name: Module Unit Tests
-    needs: changes
-    # `module_test_tasks != 'none'` is load-bearing, not belt-and-braces: the two scopes are
+    needs: [changes, module-test-scope]
+    # `tasks != 'none'` is load-bearing, not belt-and-braces: the two scopes are
     # resolved from different configs and can disagree. `path-scope.py` fails OPEN on a path it
     # doesn't recognise (turning every group on, this job included), while
     # `affected-gradle-tests.py` reads `gradle-test-scope.json`, where e.g. `.github/**` is
     # ignored — so a PR touching only such a path enabled the job with `tasks=none` and it died
     # on `gradlew none` ("Task 'none' not found"). `none` means there is nothing to run: skip.
-    if: ${{ needs.changes.outputs.module_unit_tests == 'true' && needs.changes.outputs.module_test_tasks != 'none' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    if: ${{ needs.changes.outputs.module_unit_tests == 'true' && needs.module-test-scope.outputs.tasks != 'none' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -274,7 +307,7 @@ jobs:
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       - name: Run affected module tests (full suite off PRs)
         env:
-          TEST_TASKS: ${{ needs.changes.outputs.module_test_tasks }}
+          TEST_TASKS: ${{ needs.module-test-scope.outputs.tasks }}
         run: |
           if [ "$TEST_TASKS" = full ]; then
             ./gradlew test --continue \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,13 +92,19 @@ jobs:
   # the chain is one job deeper for it alone while the other ~11 start as soon
   # as the cheap classifier lands.
   #
-  # Skipped entirely when Module Unit Tests is out of scope: its sole consumer
-  # is gated on the same condition, and a skipped `needs:` skips the dependent,
-  # which is the intended outcome there.
+  # PRs only, and that restriction is the whole point. Only a PR narrows the
+  # suite; on push and schedule the answer is unconditionally `full`. Since
+  # `path-scope.py` enables every group on non-PR events, gating this job on
+  # `module_unit_tests` alone would schedule it on EVERY push to `main` purely
+  # to echo a constant — and because Module Unit Tests `needs:` it, that job
+  # could not enter the runner queue until this one had queued and finished
+  # too. On a saturated queue that is another 40-70 min in front of post-merge
+  # module coverage: the exact cost this split exists to remove. Non-PR events
+  # skip the job and the consumer defaults to `full` directly.
   module-test-scope:
     name: Resolve affected module tests
     needs: changes
-    if: ${{ needs.changes.outputs.module_unit_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.module_unit_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
     outputs:
       tasks: ${{ steps.test-scope.outputs.tasks }}
@@ -106,26 +112,20 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # `changes` fetched this into its own checkout; the split means this job
+      # has to fetch it again for `affected-gradle-tests.py` to diff against.
       - name: Fetch the PR base commit
-        if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
-      # Only a PR narrows the suite, and only then is the Gradle model needed.
       - uses: ./.github/actions/setup
-        if: github.event_name == 'pull_request'
       - name: Resolve affected Gradle tests
         id: test-scope
         env:
-          EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.sha }}
         run: |
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            tasks=full
-          else
-            tasks=$(python3 .github/ci/affected-gradle-tests.py)
-          fi
+          tasks=$(python3 .github/ci/affected-gradle-tests.py)
           echo "tasks=$tasks" >> "$GITHUB_OUTPUT"
 
   plugin-tests:
@@ -294,7 +294,21 @@ jobs:
     # `affected-gradle-tests.py` reads `gradle-test-scope.json`, where e.g. `.github/**` is
     # ignored — so a PR touching only such a path enabled the job with `tasks=none` and it died
     # on `gradlew none` ("Task 'none' not found"). `none` means there is nothing to run: skip.
-    if: ${{ needs.changes.outputs.module_unit_tests == 'true' && needs.module-test-scope.outputs.tasks != 'none' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    # It is scoped to `pull_request` because that is the only event that produces it.
+    #
+    # `!cancelled()` is required, not decoration: `module-test-scope` deliberately does not run
+    # on push/schedule, and a skipped `needs:` skips the dependent by default — which would
+    # silently delete post-merge and nightly module coverage. The explicit
+    # `needs.changes.result == 'success'` and `module-test-scope.result != 'failure'` restore
+    # the propagation that `!cancelled()` switches off, so a broken scope job still stops this
+    # one rather than running it against an empty task list.
+    if: >-
+      ${{ !cancelled()
+          && needs.changes.result == 'success'
+          && needs.changes.outputs.module_unit_tests == 'true'
+          && needs.module-test-scope.result != 'failure'
+          && (github.event_name != 'pull_request' || needs.module-test-scope.outputs.tasks != 'none')
+          && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -307,7 +321,8 @@ jobs:
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       - name: Run affected module tests (full suite off PRs)
         env:
-          TEST_TASKS: ${{ needs.module-test-scope.outputs.tasks }}
+          # Non-PR events skip the resolver job, so default to the full suite here.
+          TEST_TASKS: ${{ github.event_name == 'pull_request' && needs.module-test-scope.outputs.tasks || 'full' }}
         run: |
           if [ "$TEST_TASKS" = full ]; then
             ./gradlew test --continue \

--- a/.github/workflows/vscode-extension-e2e.yml
+++ b/.github/workflows/vscode-extension-e2e.yml
@@ -54,10 +54,19 @@ permissions:
   contents: read
 
 concurrency:
-  # One in-flight e2e per commit; manual dispatches get their own slot
-  # via run_id.
-  group: vscode-extension-e2e-${{ github.sha }}-${{ github.run_id }}
-  cancel-in-progress: false
+  # One in-flight e2e per ref, NOT per run. The group used to include
+  # `github.run_id`, which is unique per run — so the group was unique per run
+  # and nothing was ever deduplicated. At a high merge rate that stacked
+  # several full five-shard runs on `main` at once (four concurrently, aged
+  # 80+ min, observed 2026-08-08), each holding five runner slots to verify a
+  # commit already superseded by the time a runner freed up. Keying on the ref
+  # lets a newer commit cancel the run it replaces.
+  #
+  # `workflow_dispatch` keeps a per-run slot and stays uncancellable: a manual
+  # one-off (reproducing a regression on a branch) is deliberate work that
+  # ordinary push/PR traffic on the same ref must not kill.
+  group: vscode-extension-e2e-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   e2e:


### PR DESCRIPTION
## Why

Investigating a 170-run deep Actions queue on 2026-08-08. Snapshot at ~17:00 UTC: **170 runs `queued`, 18 `in_progress`**, jobs waiting **41–70 min** for a runner, and of the last 60 completed runs **39 `cancelled` / 21 `skipped` — zero successes or failures**. Runner capacity was going almost entirely to work that got thrown away.

Measured job-level waits (`created_at` → `started_at`):

| Run | Job | Waited |
|---|---|---|
| VS Code E2E (main, 15:39) | `interactive-a-d` | 70 min |
| Compose Preview (main, 15:59) | `Apply compose-preview` | 55 min |
| Design Artifacts (main, 15:53) | `remote-m3` | 51 min |
| CI (PR, 15:52) | `Module Unit Tests` | 41 min |

This PR fixes the two capacity bugs behind that. It does **not** address the underlying driver — ~19 merges/hour into `main`, each firing ~10 workflows — which is a policy call, not a code fix. See *Not in scope* below.

## What

**1. `vscode-extension-e2e.yml` — a concurrency group that could never match itself**

```yaml
group: vscode-extension-e2e-${{ github.sha }}-${{ github.run_id }}
cancel-in-progress: false
```

`github.run_id` is unique per run, so the group was unique per run and **nothing was ever deduplicated**. It triggers on every push to `main` with a 5-shard matrix at ~10 min/shard. Four of these were live concurrently on `main`, aged 81–87 min — roughly 20 runner slots verifying commits already superseded before a runner freed up, while the trivial `No Agent Attribution` check sat queued for 63 min.

Now keyed on `github.ref` with `cancel-in-progress: true`, so a newer commit supersedes the run it replaces. `workflow_dispatch` keeps a per-run slot and stays uncancellable, so a deliberate manual reproduction on a branch is not killed by ordinary push/PR traffic on the same ref.

**2. `ci.yml` — the scope gate charged every PR job for work only one job reads**

On a **pull request**, `Determine CI scope` did two things: a cheap path classification (~5 s), and `Resolve affected Gradle tests` — a full `./.github/actions/setup` plus a Gradle model query, **~4 min** (measured 15:49:18→15:52:50). GitHub does not create, let alone queue, a dependent job until its dependency finishes, so that 4 min was paid twice: once as runner time, and again as queue time in front of **all ~12 downstream jobs** — even though only `Module Unit Tests` consumes the result. Under saturation this is what turned a 40-minute wait into a ~90-minute one.

Moved to its own `module-test-scope` job so it runs *beside* the other jobs instead of ahead of them. `changes` is now checkout + classifier only, and 11 of 12 jobs enter the queue ~4 min earlier.

The resolver is **`pull_request`-only**, which matters as much as the split itself — see below.

## Correctness notes

- **The resolver must not run on push or schedule.** Only a PR narrows the suite; on other events the answer is unconditionally `full`, and the old code short-circuited to it without touching Gradle. Since `path-scope.py` enables *every* group on non-PR events, gating the new job on `module_unit_tests` alone would have scheduled it on **every push to `main`** purely to echo a constant — and because `Module Unit Tests` `needs:` it, post-merge coverage could not enter the runner queue until that job had itself queued and finished. On a saturated queue that is another 40–70 min in front of the coverage this PR exists to speed up. Caught in review by Codex; fixed in `1786444`.
- **`!cancelled()` on `Module Unit Tests` is load-bearing, not decoration.** A skipped `needs:` skips the dependent by default, so a `pull_request`-only resolver would otherwise have deleted post-merge and nightly module coverage outright. The explicit `needs.changes.result == 'success'` and `needs.module-test-scope.result != 'failure'` restore the propagation `!cancelled()` switches off, so a failed scope job still stops the consumer rather than letting it run against an empty task list.
- **Base commit is fetched in the new job.** The classifier and the resolver no longer share a checkout, and `affected-gradle-tests.py` diffs `BASE_SHA..HEAD_SHA`. `actions/checkout` defaults to depth 1, so the fetch is re-added. It also fails open to `full` if the base is unreachable, unchanged from before.
- **The release-please bypass guard is carried over verbatim** onto the new job (`release-please--` head branch **and** `github-actions[bot]` author).
- The `RUN_MODULE_TESTS`/`tasks=none` branch is dropped because the job `if` now guarantees it; `module-unit-tests` still defends against `none` and empty from config skew.

Resulting behaviour, all events:

| Event | `module-test-scope` | `Module Unit Tests` | `TEST_TASKS` |
|---|---|---|---|
| push to `main` | skipped | runs | `full` |
| schedule (nightly) | skipped | runs | `full` |
| PR, group out of scope | skipped | skipped | — |
| PR, `tasks=none` | success | skipped | — |
| PR, tasks resolved | success | runs | resolved list |
| PR, resolver failed | failure | skipped | — |
| `changes` failed | skipped | skipped | — |
| release-please PR | skipped | skipped | — |

## Test plan

- [x] `python3 .github/ci/test_affected_gradle_tests.py` — 7/7 pass (3 new).
- [x] Both workflows parse (`yaml.safe_load`); `ci.yml` 20 jobs.
- [x] Every `needs.<job>.outputs.<name>` in `ci.yml` still resolves to a declared producer — no dangling refs after removing `module_test_tasks`.
- [x] Confirmed `path-scope.py` enables all groups on non-`pull_request` events, and walked the event matrix above to confirm `main` and nightly coverage survives the PR-only resolver.
- [ ] Post-merge: confirm only one `VS Code Extension E2E` run is live on `main` at a time, that `Module Unit Tests` still runs post-merge with `full`, and that queue depth falls.

The existing `ci.yml` guard test pinned the old `needs.changes.outputs.module_test_tasks != 'none'` string. It now also pins the `TEST_TASKS` expression, the `needs:` list, the resolver's PR-only gate, and the `!cancelled()` chain — so a future edit can neither leave the gate reading one job and the task list another, nor silently drop non-PR module coverage.

No visual surfaces are touched — this is CI wiring only, so text-only evidence is the right bar here.

## Not in scope

Deliberately left out, since they change CI policy rather than fix a bug:

- **Debouncing the heavy lanes on `main`.** At ~19 merges/hour with `cancel-in-progress: true` on `${{ github.workflow }}-${{ github.ref }}`, runs on `main` are structurally incapable of completing — eight were killed after 31 min of real execution. Running E2E / Compose Preview / Design Artifacts on a schedule or merge queue rather than per-commit is the real fix.
- **Gating merges on CI.** There were **0 open PRs** during the investigation: agent branches merge before their CI can start, so those runs get cancelled on branch deletion. The PR gate is currently paying full runner cost for no signal.
- **Runner capacity.** If the merge rate is intended to stay this high, the account's concurrent-job ceiling is simply too low for the workload.