### PR TITLE
perf(plugin): draw captures on a warm renderer instead of forking a JVM each time

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2904,6 +2904,7 @@ internal object AndroidPreviewSupport {
         group = "compose preview"
         description = "Render kind=LOTTIE previews via the desktop Compottie renderer"
         onlyIf { extension.enabled.get() }
+        projectDirectory.set(project.layout.projectDirectory)
         previewsJson.set(previewOutputDir.map { it.file("previews.json") })
         renderBackend.set("desktop")
         tier.set(resolveTier(project))
@@ -2951,6 +2952,7 @@ internal object AndroidPreviewSupport {
         group = "compose preview"
         description = "Render kind=SVG previews via the desktop Skia renderer"
         onlyIf { extension.enabled.get() }
+        projectDirectory.set(project.layout.projectDirectory)
         previewsJson.set(previewOutputDir.map { it.file("previews.json") })
         renderBackend.set("desktop")
         tier.set(resolveTier(project))

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -370,6 +370,7 @@ internal object ComposePreviewTasks {
       )
     val renderTask =
       project.tasks.register("composePreviewRender", RenderPreviewsTask::class.java) {
+        projectDirectory.set(project.layout.projectDirectory)
         onlyIf { extension.enabled.get() }
         previewsJson.set(previewOutputDir.map { it.file("previews.json") })
         outputDir.set(previewOutputDir.map { it.dir("renders") })

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
@@ -49,6 +49,17 @@ import java.util.concurrent.atomic.AtomicInteger
  * makes safe: repeated in-process renders draw identical pixels, and a capture does not inherit the
  * `@OverrideVariant` seed of the one before it.
  *
+ * **What reuse gives up.** A fork gave each capture a fresh JVM, so a preview that mutates
+ * top-level or `object` state during composition could not affect any other. A warm worker loads
+ * consumer classes once, so that isolation is gone: an order-dependent preview can now influence a
+ * later capture. This is the trade the preview daemon has always made — it renders many previews
+ * per JVM behind a persistent classloader — so the batch lane is not held to a stricter standard
+ * than the interactive one. Bounded rather than defended against: [maxRendersPerWorker] recycles
+ * workers, the default of one worker keeps ordering deterministic rather than racy, and
+ * [SYS_PROP_ENABLED]`=off` restores per-capture forks exactly. A preview whose pixels depend on
+ * what rendered before it is not reproducible for the catalogs either, so the fix in that case is
+ * the preview, not the pool.
+ *
  * **Failure posture**, mirroring the cmp-jvm pool and the two defects review found there:
  * * anything the pool cannot serve reports [WorkerResult.Unusable] and the caller forks that
  *   capture instead, so the worst case is the cost that was already being paid;
@@ -110,10 +121,9 @@ internal class DesktopRenderWorkerPool(
   /** Captures served warm, for the task's one-line summary. */
   val servedWarm = AtomicInteger(0)
 
-  private val watchdog =
-    Executors.newSingleThreadScheduledExecutor { r ->
-      Thread(r, "compose-preview-render-worker-watchdog").apply { isDaemon = true }
-    }
+  private val watchdog = Executors.newSingleThreadScheduledExecutor { r ->
+    Thread(r, "compose-preview-render-worker-watchdog").apply { isDaemon = true }
+  }
 
   fun render(args: List<String>, overridesSeed: String?): WorkerResult {
     synchronized(lock) {
@@ -133,8 +143,7 @@ internal class DesktopRenderWorkerPool(
             is StartOutcome.Failed -> return WorkerResult.Unusable(started.reason)
           }
 
-      val result =
-        worker.render(args, overridesSeed.orEmpty(), requestIds.incrementAndGet())
+      val result = worker.render(args, overridesSeed.orEmpty(), requestIds.incrementAndGet())
       if (result is WorkerResult.Unusable) {
         discard(worker)
         worker = null
@@ -158,7 +167,8 @@ internal class DesktopRenderWorkerPool(
         var picked: Worker? = null
         while (picked == null) {
           val candidate = idle.pollFirst() ?: break
-          if (candidate.isAlive() && !candidate.shouldRetire(maxRendersPerWorker)) picked = candidate
+          if (candidate.isAlive() && !candidate.shouldRetire(maxRendersPerWorker))
+            picked = candidate
           else doomed += candidate
         }
         picked
@@ -209,8 +219,7 @@ internal class DesktopRenderWorkerPool(
       // blocked forever with the JVM still up. Registering first means `close()` can always reap
       // it, and a pool that closed underneath us is detected right after.
       val worker = Worker(command, watchdog, workingDir, stderrSink)
-      val tracked =
-        synchronized(lock) { if (closed) false else liveWorkers.add(worker) }
+      val tracked = synchronized(lock) { if (closed) false else liveWorkers.add(worker) }
       if (!tracked) {
         worker.close()
         return StartOutcome.Failed("render worker pool is closed")
@@ -336,8 +345,7 @@ internal class DesktopRenderWorkerPool(
         val message = String(ByteArray(len).also { fromWorker.readFully(it) }, Charsets.UTF_8)
 
         renders++
-        return if (status == STATUS_OK) WorkerResult.Ok
-        else WorkerResult.Failed(message.take(300))
+        return if (status == STATUS_OK) WorkerResult.Ok else WorkerResult.Failed(message.take(300))
       } catch (e: Exception) {
         val timedOut = guard.fired()
         close()

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
@@ -67,6 +67,22 @@ internal class DesktopRenderWorkerPool(
   private val maxWorkers: Int,
   private val maxRendersPerWorker: Int,
   private val renderTimeoutSeconds: Long,
+  /**
+   * Working directory for every worker, which must be the **task project's** directory:
+   * `ExecOperations.javaexec` defaulted to it, so a preview reading a relative path resolved it
+   * against the subproject. A bare `ProcessBuilder` would inherit the Gradle daemon's directory
+   * instead and quietly resolve the same path somewhere else — a difference between the warm and
+   * forked lanes, which is exactly what this pool must never introduce.
+   */
+  private val workingDir: File,
+  /**
+   * Where a worker's stderr goes. The forked lane let the renderer's own diagnostics through to the
+   * build log — missing `@PreviewParameter` providers, device-frame and display-filter failures,
+   * the `Render failed …` line that accompanies an error sidecar. Those arrive on *successful*
+   * requests (the renderer handles them and returns normally), so a pool that only kept stderr for
+   * its own failure messages would silently swallow them.
+   */
+  private val stderrSink: (String) -> Unit,
   private val workerMainClass: String = WORKER_MAIN_CLASS,
 ) : AutoCloseable {
 
@@ -187,17 +203,22 @@ internal class DesktopRenderWorkerPool(
       add(workerMainClass)
     }
     return try {
-      val worker = Worker(command, watchdog)
-      worker.handshake(HANDSHAKE_TIMEOUT_SECONDS)
-      val registered =
-        synchronized(lock) {
-          startFailures = 0
-          // `close()` may have run while this worker was booting; registering it now would leak a
-          // process nothing will reap.
-          if (closed) false else liveWorkers.add(worker)
-        }
-      if (!registered) {
+      // Registered BEFORE the handshake, not after. A worker waiting for its hello frame is a live
+      // child process; if `close()` ran while it booted it would be invisible to shutdown, and
+      // `watchdog.shutdownNow()` would then drop the handshake kill-switch — leaving the read
+      // blocked forever with the JVM still up. Registering first means `close()` can always reap
+      // it, and a pool that closed underneath us is detected right after.
+      val worker = Worker(command, watchdog, workingDir, stderrSink)
+      val tracked =
+        synchronized(lock) { if (closed) false else liveWorkers.add(worker) }
+      if (!tracked) {
         worker.close()
+        return StartOutcome.Failed("render worker pool is closed")
+      }
+      worker.handshake(HANDSHAKE_TIMEOUT_SECONDS)
+      synchronized(lock) { startFailures = 0 }
+      if (synchronized(lock) { closed }) {
+        discard(worker)
         StartOutcome.Failed("render worker pool is closed")
       } else {
         StartOutcome.Started(worker)
@@ -230,8 +251,14 @@ internal class DesktopRenderWorkerPool(
     watchdog.shutdownNow()
   }
 
-  private class Worker(command: List<String>, private val watchdog: ScheduledExecutorService) {
-    private val process = ProcessBuilder(command).redirectErrorStream(false).start()
+  private class Worker(
+    command: List<String>,
+    private val watchdog: ScheduledExecutorService,
+    workingDir: File,
+    private val stderrSink: (String) -> Unit,
+  ) {
+    private val process =
+      ProcessBuilder(command).directory(workingDir).redirectErrorStream(false).start()
     private val toWorker = DataOutputStream(process.outputStream.buffered())
     private val fromWorker = DataInputStream(process.inputStream.buffered())
     private val stderrTail = ArrayDeque<String>()
@@ -245,6 +272,10 @@ internal class DesktopRenderWorkerPool(
                 stderrTail.addLast(line)
                 while (stderrTail.size > STDERR_TAIL_LINES) stderrTail.pollFirst()
               }
+              // Forwarded as well as buffered: the tail exists for the pool's own failure
+              // messages, but most renderer diagnostics ride a *successful* request and would
+              // otherwise never be seen.
+              stderrSink(line)
             }
           } catch (_: IOException) {
             // Process went away; nothing to drain.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.plugin
+
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.IOException
+import java.util.ArrayDeque
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A pool of long-lived `DesktopRendererWorkerMain` processes for one module's render, so a capture
+ * costs a frame on a warm JVM instead of a whole fork.
+ *
+ * `RenderPreviewsTask` forked `:renderer-desktop` once per capture, paying JVM + Compose Desktop +
+ * Skiko boot every time — 2.15 s/preview measured end-to-end on m3-catalog (~43 min for its 1095
+ * previews) against ~36 ms warm.
+ *
+ * **Per module, and per task execution.** Unlike `RcJvmWorkerPool` — whose workers take a
+ * self-describing `.rc` document from any project — a renderer worker is bound to the consumer's
+ * classpath, so it can only serve the module that spawned it. That costs nothing here: every
+ * capture in one `composePreviewRender` execution shares that module, which is exactly the run the
+ * amortisation applies to. The pool is created and closed inside the task action, so no process
+ * outlives the build and nothing process-shaped is held on a task field (configuration cache).
+ *
+ * **Why this is sound.** The worker calls the renderer's own `main()`, so a pooled capture runs the
+ * identical code a forked one did. `DesktopRendererReentrancyTest` pins the two properties that
+ * makes safe: repeated in-process renders draw identical pixels, and a capture does not inherit the
+ * `@OverrideVariant` seed of the one before it.
+ *
+ * **Failure posture**, mirroring the cmp-jvm pool and the two defects review found there:
+ * * anything the pool cannot serve reports [WorkerResult.Unusable] and the caller forks that
+ *   capture instead, so the worst case is the cost that was already being paid;
+ * * a render the *renderer* rejects reports [WorkerResult.Failed] — a real answer about that
+ *   capture, not retried on a fork, which would double the cost of every broken preview;
+ * * [close] destroys **checked-out** workers too, before stopping the watchdog: a worker mid-render
+ *   is absent from [idle], and `shutdownNow()` drops the scheduled kill that is the only other way
+ *   out of a blocked pipe read;
+ * * after [MAX_START_FAILURES] consecutive spawn failures the pool disables itself for the rest of
+ *   the run, so a systematically broken pool costs one failed spawn rather than one per capture.
+ */
+internal class DesktopRenderWorkerPool(
+  private val classpath: List<File>,
+  private val javaExecutable: String,
+  private val jvmArgs: List<String>,
+  private val maxWorkers: Int,
+  private val maxRendersPerWorker: Int,
+  private val renderTimeoutSeconds: Long,
+  private val workerMainClass: String = WORKER_MAIN_CLASS,
+) : AutoCloseable {
+
+  sealed interface WorkerResult {
+    object Ok : WorkerResult
+
+    /** The renderer answered "I could not draw this". Do not fork a retry. */
+    data class Failed(val reason: String) : WorkerResult
+
+    /** The pool could not serve this at all; the caller should fork this capture. */
+    data class Unusable(val reason: String) : WorkerResult
+  }
+
+  private val permits = Semaphore(maxWorkers, /* fair= */ true)
+  private val idle = ArrayDeque<Worker>()
+
+  /** Every live worker, **including** checked-out ones — see [close]. */
+  private val liveWorkers = LinkedHashSet<Worker>()
+  private val lock = Any()
+  private val requestIds = AtomicInteger(0)
+  private var startFailures = 0
+  private var disabledReason: String? = null
+  private var closed = false
+
+  /** Captures served warm, for the task's one-line summary. */
+  val servedWarm = AtomicInteger(0)
+
+  private val watchdog =
+    Executors.newSingleThreadScheduledExecutor { r ->
+      Thread(r, "compose-preview-render-worker-watchdog").apply { isDaemon = true }
+    }
+
+  fun render(args: List<String>, overridesSeed: String?): WorkerResult {
+    synchronized(lock) {
+      disabledReason?.let {
+        return WorkerResult.Unusable(it)
+      }
+      if (closed) return WorkerResult.Unusable("render worker pool is closed")
+    }
+
+    permits.acquire()
+    var worker: Worker? = null
+    try {
+      worker =
+        takeIdle()
+          ?: when (val started = startWorker()) {
+            is StartOutcome.Started -> started.worker
+            is StartOutcome.Failed -> return WorkerResult.Unusable(started.reason)
+          }
+
+      val result =
+        worker.render(args, overridesSeed.orEmpty(), requestIds.incrementAndGet())
+      if (result is WorkerResult.Unusable) {
+        discard(worker)
+        worker = null
+      } else {
+        servedWarm.incrementAndGet()
+      }
+      return result
+    } finally {
+      val finished = worker
+      if (finished != null) {
+        if (finished.shouldRetire(maxRendersPerWorker)) discard(finished) else returnIdle(finished)
+      }
+      permits.release()
+    }
+  }
+
+  private fun takeIdle(): Worker? {
+    val doomed = ArrayList<Worker>()
+    val chosen =
+      synchronized(lock) {
+        var picked: Worker? = null
+        while (picked == null) {
+          val candidate = idle.pollFirst() ?: break
+          if (candidate.isAlive() && !candidate.shouldRetire(maxRendersPerWorker)) picked = candidate
+          else doomed += candidate
+        }
+        picked
+      }
+    doomed.forEach { discard(it) }
+    return chosen
+  }
+
+  private fun returnIdle(worker: Worker) {
+    val parked =
+      synchronized(lock) {
+        if (closed || !worker.isAlive()) false
+        else {
+          idle.addLast(worker)
+          true
+        }
+      }
+    if (!parked) discard(worker)
+  }
+
+  /** Forget a worker and destroy its process. Idempotent, so a double-discard on a race is safe. */
+  private fun discard(worker: Worker) {
+    synchronized(lock) {
+      liveWorkers.remove(worker)
+      idle.remove(worker)
+    }
+    worker.close()
+  }
+
+  private sealed interface StartOutcome {
+    class Started(val worker: Worker) : StartOutcome
+
+    class Failed(val reason: String) : StartOutcome
+  }
+
+  private fun startWorker(): StartOutcome {
+    val command = buildList {
+      add(javaExecutable)
+      addAll(jvmArgs)
+      add("-cp")
+      add(classpath.joinToString(File.pathSeparator) { it.absolutePath })
+      add(workerMainClass)
+    }
+    return try {
+      val worker = Worker(command, watchdog)
+      worker.handshake(HANDSHAKE_TIMEOUT_SECONDS)
+      val registered =
+        synchronized(lock) {
+          startFailures = 0
+          // `close()` may have run while this worker was booting; registering it now would leak a
+          // process nothing will reap.
+          if (closed) false else liveWorkers.add(worker)
+        }
+      if (!registered) {
+        worker.close()
+        StartOutcome.Failed("render worker pool is closed")
+      } else {
+        StartOutcome.Started(worker)
+      }
+    } catch (e: Exception) {
+      val reason = "could not start a render worker: ${e.message}"
+      synchronized(lock) {
+        startFailures++
+        if (startFailures >= MAX_START_FAILURES) {
+          disabledReason =
+            "$reason (disabled after $startFailures consecutive failures; " +
+              "forking each capture instead)"
+        }
+      }
+      StartOutcome.Failed(reason)
+    }
+  }
+
+  override fun close() {
+    val doomed =
+      synchronized(lock) {
+        closed = true
+        idle.clear()
+        liveWorkers.toList().also { liveWorkers.clear() }
+      }
+    // Every worker, not just the parked ones, and before the watchdog stops: destroying a
+    // checked-out worker's process is what unblocks the thread waiting on its pipe, and
+    // `shutdownNow()` would otherwise drop the scheduled kill that is the only other way out.
+    doomed.forEach { it.close() }
+    watchdog.shutdownNow()
+  }
+
+  private class Worker(command: List<String>, private val watchdog: ScheduledExecutorService) {
+    private val process = ProcessBuilder(command).redirectErrorStream(false).start()
+    private val toWorker = DataOutputStream(process.outputStream.buffered())
+    private val fromWorker = DataInputStream(process.inputStream.buffered())
+    private val stderrTail = ArrayDeque<String>()
+    private var renders = 0
+
+    init {
+      Thread {
+          try {
+            process.errorStream.bufferedReader().forEachLine { line ->
+              synchronized(stderrTail) {
+                stderrTail.addLast(line)
+                while (stderrTail.size > STDERR_TAIL_LINES) stderrTail.pollFirst()
+              }
+            }
+          } catch (_: IOException) {
+            // Process went away; nothing to drain.
+          }
+        }
+        .apply {
+          name = "compose-preview-render-worker-stderr"
+          isDaemon = true
+          start()
+        }
+    }
+
+    fun isAlive(): Boolean = process.isAlive
+
+    fun shouldRetire(maxRenders: Int): Boolean = renders >= maxRenders
+
+    fun handshake(timeoutSeconds: Long) {
+      val guard = armWatchdog(timeoutSeconds)
+      try {
+        val magic = fromWorker.readInt()
+        if (magic != MAGIC_HELLO) throw IOException("unexpected hello magic $magic")
+        val version = fromWorker.readInt()
+        if (version != WORKER_PROTOCOL_VERSION) {
+          throw IOException(
+            "worker speaks protocol $version, this plugin speaks $WORKER_PROTOCOL_VERSION"
+          )
+        }
+      } catch (e: Exception) {
+        close()
+        throw IOException("${e.message.orEmpty()}${stderrSuffix()}", e)
+      } finally {
+        guard.disarm()
+      }
+    }
+
+    fun render(args: List<String>, seed: String, requestId: Int): WorkerResult {
+      val guard = armWatchdog(RENDER_GUARD_SECONDS)
+      try {
+        val seedBytes = seed.toByteArray(Charsets.UTF_8)
+        toWorker.writeInt(MAGIC_REQUEST)
+        toWorker.writeInt(requestId)
+        toWorker.writeInt(seedBytes.size)
+        toWorker.write(seedBytes)
+        toWorker.writeInt(args.size)
+        args.forEach {
+          val b = it.toByteArray(Charsets.UTF_8)
+          toWorker.writeInt(b.size)
+          toWorker.write(b)
+        }
+        toWorker.flush()
+
+        val magic = fromWorker.readInt()
+        if (magic != MAGIC_RESPONSE) throw IOException("unexpected response magic $magic")
+        fromWorker.readInt() // requestId — one in-flight request per worker, so informational.
+        val status = fromWorker.readInt()
+        val len = fromWorker.readInt()
+        if (len < 0) throw IOException("negative message length $len")
+        val message = String(ByteArray(len).also { fromWorker.readFully(it) }, Charsets.UTF_8)
+
+        renders++
+        return if (status == STATUS_OK) WorkerResult.Ok
+        else WorkerResult.Failed(message.take(300))
+      } catch (e: Exception) {
+        val timedOut = guard.fired()
+        close()
+        // Unusable rather than Failed: the *worker* broke, so nothing was learned about this
+        // capture and the caller is entitled to fork it.
+        return WorkerResult.Unusable(
+          if (timedOut) "render worker timed out after ${RENDER_GUARD_SECONDS}s"
+          else "render worker failed: ${e.message}${stderrSuffix()}"
+        )
+      } finally {
+        guard.disarm()
+      }
+    }
+
+    private fun armWatchdog(timeoutSeconds: Long): Guard {
+      val fired = AtomicBoolean(false)
+      val future =
+        watchdog.schedule(
+          {
+            fired.set(true)
+            // A pipe read has no timeout; destroying the process is the only way to unblock it.
+            process.destroyForcibly()
+          },
+          timeoutSeconds,
+          TimeUnit.SECONDS,
+        )
+      return Guard(fired, future)
+    }
+
+    class Guard(private val fired: AtomicBoolean, private val future: ScheduledFuture<*>) {
+      /** Whether the kill actually ran — inferring it from process liveness would race. */
+      fun fired(): Boolean = fired.get()
+
+      fun disarm() {
+        future.cancel(false)
+      }
+    }
+
+    private fun stderrSuffix(): String =
+      synchronized(stderrTail) { stderrTail.lastOrNull() }
+        ?.takeIf { it.isNotBlank() }
+        ?.let { ": ${it.take(300)}" }
+        .orEmpty()
+
+    fun close() {
+      runCatching { toWorker.close() }
+      runCatching { fromWorker.close() }
+      runCatching { process.destroyForcibly() }
+    }
+  }
+
+  internal companion object {
+    const val WORKER_MAIN_CLASS = "ee.schimke.composeai.renderer.DesktopRendererWorkerMainKt"
+
+    // Mirrors `DesktopRendererWorkerMain.kt`. The plugin cannot depend on the renderer module (it
+    // is resolved into the consumer's dependency graph), so the wire constants are duplicated on
+    // purpose; the version check in [Worker.handshake] is what keeps that honest.
+    const val MAGIC_HELLO = 0x43505731
+    const val MAGIC_REQUEST = 0x43505131
+    const val MAGIC_RESPONSE = 0x43505231
+    const val WORKER_PROTOCOL_VERSION = 1
+    const val STATUS_OK = 0
+
+    const val HANDSHAKE_TIMEOUT_SECONDS = 120L
+    const val MAX_START_FAILURES = 3
+    const val STDERR_TAIL_LINES = 40
+
+    /**
+     * Per-capture kill-switch. Generous because a single heavy capture (a long scroll, a GIF
+     * window) legitimately takes a while, and killing a worker mid-render costs the whole warm JVM.
+     */
+    const val RENDER_GUARD_SECONDS = 600L
+
+    const val SYS_PROP_ENABLED = "composeai.render.workerPool"
+    const val SYS_PROP_WORKERS = "composeai.render.workerPool.workers"
+    const val SYS_PROP_MAX_RENDERS = "composeai.render.workerPool.maxRenders"
+
+    fun isEnabled(): Boolean =
+      !System.getProperty(SYS_PROP_ENABLED).equals("off", ignoreCase = true)
+
+    /**
+     * One worker by default. Captures are already driven serially by the task, and the render
+     * itself is Skiko-bound; extra workers buy resident memory rather than throughput. Sharding
+     * across Gradle workers remains the way to use more cores.
+     */
+    fun configuredWorkers(): Int =
+      System.getProperty(SYS_PROP_WORKERS)?.toIntOrNull()?.coerceIn(1, 8) ?: 1
+
+    fun configuredMaxRenders(): Int =
+      System.getProperty(SYS_PROP_MAX_RENDERS)?.toIntOrNull()?.coerceAtLeast(1) ?: 500
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -410,6 +410,34 @@ abstract class RenderPreviewsTask : DefaultTask() {
       )
     }
 
+    // One warm renderer for this whole task execution, closed before the action returns so no
+    // process outlives the build. Created here rather than held on the task so nothing
+    // process-shaped is on a field the configuration cache would try to store.
+    val lane = RenderLane(openWorkerPool())
+    try {
+      renderCaptures(manifest, manifestOutputFiles, previewsRoot, outDir, mainClass, lane)
+    } finally {
+      lane.pool?.let { pool ->
+        pool.close()
+        val warm = pool.servedWarm.get()
+        if (warm > 0) {
+          logger.lifecycle(
+            "composePreviewRender: $warm capture(s) drawn on a warm renderer " +
+              "(no per-capture JVM fork)."
+          )
+        }
+      }
+    }
+  }
+
+  private fun renderCaptures(
+    manifest: PreviewManifest,
+    manifestOutputFiles: List<java.io.File>,
+    previewsRoot: java.io.File,
+    outDir: java.io.File,
+    mainClass: String,
+    lane: RenderLane,
+  ) {
     for (preview in manifest.previews) {
       val spec =
         DeviceDimensions.resolveForRender(
@@ -468,6 +496,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
           scroll = capture.scroll,
           animation = capture.animation,
           fanoutSiblingStems = fanoutSiblingStems(manifestOutputFiles, outputFile),
+          lane = lane,
         )
       }
 
@@ -490,6 +519,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
           outputFile = outputFile,
           scroll = product.scroll,
           fanoutSiblingStems = fanoutSiblingStems(manifestOutputFiles, outputFile),
+          lane = lane,
         )
       }
     }
@@ -506,7 +536,46 @@ abstract class RenderPreviewsTask : DefaultTask() {
     scroll: ScrollCapture?,
     animation: AnimationCapture? = null,
     fanoutSiblingStems: List<String> = emptyList(),
+    lane: RenderLane,
   ) {
+    val rendererArgs =
+      rendererArgs(
+        preview = preview,
+        spec = spec,
+        density = density,
+        widthPx = widthPx,
+        heightPx = heightPx,
+        outputFile = outputFile,
+        scroll = scroll,
+        animation = animation,
+        fanoutSiblingStems = fanoutSiblingStems,
+      )
+    val overridesSeed =
+      preview.overrides?.let { OVERRIDES_JSON.encodeToString(OverrideVariantSpec.serializer(), it) }
+
+    // Warm path: a pooled worker draws this on an already-booted JVM instead of paying JVM +
+    // Compose Desktop + Skiko startup again for one capture. It calls the renderer's own `main()`,
+    // so a pooled capture runs identical code to a forked one. Only `Unusable` falls through to the
+    // fork below — a `Failed` is the renderer's real answer about this capture, and re-running it
+    // cold would double the cost of every capture that cannot be drawn.
+    lane.pool?.let { pool ->
+      when (val pooled = pool.render(rendererArgs, overridesSeed)) {
+        is DesktopRenderWorkerPool.WorkerResult.Ok -> return
+        is DesktopRenderWorkerPool.WorkerResult.Failed ->
+          throw GradleException(
+            "composePreviewRender: ${preview.className}#${preview.functionName} — ${pooled.reason}"
+          )
+        is DesktopRenderWorkerPool.WorkerResult.Unusable -> {
+          if (lane.fallbackNoticePrinted.compareAndSet(false, true)) {
+            logger.info(
+              "composePreviewRender: render worker unavailable (${pooled.reason}); " +
+                "forking per capture as before."
+            )
+          }
+        }
+      }
+    }
+
     execOperations.javaexec {
       // Fork on a JDK new enough for the consumer's bytecode when the plugin raised it (see
       // [RenderJvmSelection]); otherwise leave the default (Gradle daemon JVM).
@@ -563,8 +632,90 @@ abstract class RenderPreviewsTask : DefaultTask() {
           OVERRIDES_JSON.encodeToString(OverrideVariantSpec.serializer(), it),
         )
       }
-      args =
-        listOf(
+      args = rendererArgs
+    }
+  }
+
+  /**
+   * The warm renderer for one task execution, plus the one-shot notice flag so a pool that cannot
+   * serve says so once rather than per capture. Passed down the render loop rather than held on the
+   * task: a live pool on a task field is exactly the kind of state the configuration cache cannot
+   * store.
+   */
+  private class RenderLane(val pool: DesktopRenderWorkerPool?) {
+    val fallbackNoticePrinted = java.util.concurrent.atomic.AtomicBoolean(false)
+  }
+
+  /**
+   * Spin up the render worker pool for this execution, or null to keep forking per capture.
+   *
+   * Null whenever the pool cannot be trusted to behave exactly like the fork it replaces: switched
+   * off explicitly, or a renderer classpath that could not be resolved. Everything else — a worker
+   * that fails to start or speaks the wrong protocol — is handled per capture inside the pool,
+   * which reports `Unusable` and lets the caller fork that one.
+   */
+  private fun openWorkerPool(): DesktopRenderWorkerPool? {
+    if (!DesktopRenderWorkerPool.isEnabled()) return null
+    val cp = renderClasspath.files.toList()
+    if (cp.isEmpty()) return null
+    return DesktopRenderWorkerPool(
+      classpath = cp,
+      javaExecutable = renderJavaExecutable.orNull ?: defaultJavaExecutable(),
+      jvmArgs = workerJvmArgs(),
+      maxWorkers = DesktopRenderWorkerPool.configuredWorkers(),
+      maxRendersPerWorker = DesktopRenderWorkerPool.configuredMaxRenders(),
+      renderTimeoutSeconds = DesktopRenderWorkerPool.RENDER_GUARD_SECONDS,
+    )
+  }
+
+  private fun defaultJavaExecutable(): String {
+    val candidate = java.io.File(System.getProperty("java.home"), "bin/java")
+    return if (candidate.canExecute()) candidate.absolutePath else "java"
+  }
+
+  /**
+   * The `-D` flags a worker boots under — the per-execution half of what the per-capture
+   * `javaexec` sets inline.
+   *
+   * Deliberately the same set, and deliberately *only* the constant ones: every property here is
+   * fixed for the whole task, so it can live on the worker's command line. The one genuinely
+   * per-capture property (`composeai.overrides.seed`) rides the request frame instead, because a
+   * worker that inherited one preview's variant seed would draw the next preview with it.
+   */
+  private fun workerJvmArgs(): List<String> = buildList {
+    add("-Dapple.awt.UIElement=true")
+    add("-Dcomposeai.displayfilter.filters=${displayFilterFilters.get()}")
+    add("-Dcomposeai.deviceframe.device=${deviceFrameDevice.get()}")
+    if (deviceFrameDevice.get().isNotBlank()) {
+      add("-Dcomposeai.deviceframe.cacheDir=${DeviceArtPrefetch.defaultCacheDir().absolutePath}")
+    }
+    previewRowExcludes
+      .getOrElse(emptyList())
+      .filter { it.isNotBlank() }
+      .let { rows ->
+        if (rows.isNotEmpty()) {
+          add("-Dcomposeai.preview.rowExclude=${rows.joinToString(",")}")
+        }
+      }
+  }
+
+  /**
+   * The renderer's positional argv for one capture — the single source of truth for both the pooled
+   * worker and the per-capture fork, so the two lanes can never drift into passing different
+   * arguments for the same preview.
+   */
+  private fun rendererArgs(
+    preview: PreviewInfo,
+    spec: DeviceDimensions.SizeSpec,
+    density: Float,
+    widthPx: Int,
+    heightPx: Int,
+    outputFile: java.io.File,
+    scroll: ScrollCapture?,
+    animation: AnimationCapture?,
+    fanoutSiblingStems: List<String>,
+  ): List<String> =
+    listOf(
           preview.className,
           preview.functionName,
           widthPx.toString(),
@@ -647,8 +798,6 @@ abstract class RenderPreviewsTask : DefaultTask() {
           // own fan-out and deletes the sibling's renders. Empty string signals "no siblings".
           fanoutSiblingStems.joinToString("|"),
         )
-    }
-  }
 }
 
 private fun Float.roundHalfUpPx(): Int = kotlin.math.floor(this + 0.5f).toInt().coerceAtLeast(1)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -697,8 +697,8 @@ abstract class RenderPreviewsTask : DefaultTask() {
   }
 
   /**
-   * The `-D` flags a worker boots under — the per-execution half of what the per-capture
-   * `javaexec` sets inline.
+   * The `-D` flags a worker boots under — the per-execution half of what the per-capture `javaexec`
+   * sets inline.
    *
    * Deliberately the same set, and deliberately *only* the constant ones: every property here is
    * fixed for the whole task, so it can live on the worker's command line. The one genuinely
@@ -739,88 +739,88 @@ abstract class RenderPreviewsTask : DefaultTask() {
     fanoutSiblingStems: List<String>,
   ): List<String> =
     listOf(
-          preview.className,
-          preview.functionName,
-          widthPx.toString(),
-          heightPx.toString(),
-          density.toString(),
-          preview.params.showBackground.toString(),
-          preview.params.backgroundColor.toString(),
-          outputFile.absolutePath,
-          // 9th arg — empty string signals "no wrapper" (keeps arg positions stable).
-          preview.params.wrapperClassName.orEmpty(),
-          // 10th/11th — AS-parity wrap flags. When set, the renderer
-          // wraps the composable, measures it, and crops the PNG to
-          // the intrinsic bounds on that axis.
-          spec.wrapWidth.toString(),
-          spec.wrapHeight.toString(),
-          // 12th/13th — @PreviewParameter spec. Empty string signals
-          // "no provider"; otherwise the renderer enumerates the
-          // provider's values.take(limit) in-process and writes one
-          // `<id>_PARAM_<idx>.png` per value. Plugin-side can't know
-          // the count (consumer's classpath isn't loaded here), so
-          // fan-out is delegated to the renderer process that already
-          // has everything on its classpath.
-          preview.params.previewParameterProviderClassName.orEmpty(),
-          preview.params.previewParameterLimit.toString(),
-          // 14th — `@Preview(locale = ...)`. Empty string signals "no override". The renderer
-          // detects `en-XA` / `ar-XB` and applies the runtime pseudolocale wrap (currently
-          // LayoutDirection.Rtl for ar-XB on desktop; Android additionally pseudolocalises
-          // string resources via the `:data-pseudolocale-connector` Resources subclass).
-          preview.params.locale.orEmpty(),
-          // 15th–18th — @ScrollingPreview intent forwarded per capture / data product. Empty
-          // 15th signals "no scroll intent". Renderer dispatches LONG / GIF to
-          // `renderScrollPreview` (`runComposeUiTest`-driven scroll + slice or frame encode);
-          // TOP / END fall through to the default single-frame path.
-          scroll?.mode?.name.orEmpty(),
-          scroll?.axis?.name.orEmpty(),
-          (scroll?.maxScrollPx ?: 0).toString(),
-          (scroll?.frameIntervalMs ?: 0).toString(),
-          // 19th/20th — preview kind + (for kind=LOTTIE) the resource-relative asset path. Empty
-          // 19th defaults to COMPOSE on the renderer side. A LOTTIE entry has no class/function to
-          // reflect; the renderer inflates the asset at arg 20 via Compottie instead.
-          preview.params.kind.name,
-          preview.params.assetPath.orEmpty(),
-          // 21st — `@Preview(fontScale = ...)`. Compose Desktop has no resource-qualifier system,
-          // so the renderer threads this through `Density(density, fontScale)` (and re-provides it
-          // as `LocalDensity`) the same way the daemon's desktop RenderEngine does. `1.0` is the
-          // annotation default / no-op; omitting it keeps older callers at 1.0 on the renderer
-          // side.
-          preview.params.fontScale.toString(),
-          // 22nd–24th — `@Preview(showSystemUi = ...)` (issue #1930). When set on a phone-shape
-          // capture, DesktopRendererMain wraps the composition in the synthetic `SystemBarsFrame`
-          // (status bar + gesture-nav pill) so the desktop capture matches the Android renderer
-          // instead of coming back chrome-less. uiMode carries the night bit for dark chrome;
-          // device is forwarded only so the renderer can skip round/Wear surfaces.
-          preview.params.showSystemUi.toString(),
-          preview.params.uiMode.toString(),
-          preview.params.device.orEmpty(),
-          // 25th–27th — `@AnimatedPreview` window. `-1` durationMs signals "no animation intent"
-          // (the renderer falls through to scroll / single-frame). `>= 0` means the annotation is
-          // present and dispatches to `renderAnimatedPreview` (a `runSkikoComposeUiTest`
-          // paused-clock loop that advances `mainClock` by frameIntervalMs across the window and
-          // encodes the frames as a GIF) — the desktop counterpart of the Android renderer's
-          // `@AnimatedPreview` path. `0` is the annotation's auto-detect sentinel and must NOT be
-          // collapsed into "no animation": a default-args `@AnimatedPreview` still needs the
-          // animated path or the `.gif` renderOutput gets a single PNG frame (issue #2190). An
-          // older renderer that predates the `-1` protocol parses it via `takeIf { it > 0 } ?: 0`,
-          // so the sentinel degrades to the old "no animation" behaviour rather than breaking. The
-          // reverse skew (an older plugin driving a newer renderer pinned on the
-          // `composePreviewRenderer` configuration) is guarded renderer-side: a bare `0` is only
-          // read as auto-detect when the capture is animation-shaped (a `.gif` output with no
-          // scroll intent).
-          // `showCurves` is forwarded for parity; the desktop path emits a screenshot-only GIF (no
-          // curve strip).
-          (animation?.durationMs ?: -1).toString(),
-          (animation?.frameIntervalMs ?: 0).toString(),
-          (animation?.showCurves ?: false).toString(),
-          // 28th — sibling stems the renderer's `@PreviewParameter` stale fan-out cleanup must
-          // leave alone (issue #2193): manifest outputs in the same directory whose stem extends
-          // this capture's (`Foo` vs the `@Preview(name = "Dark")` sibling's `Foo_Dark`). The
-          // subprocess has no manifest, so without this it treats every `<stem>_*` file as its
-          // own fan-out and deletes the sibling's renders. Empty string signals "no siblings".
-          fanoutSiblingStems.joinToString("|"),
-        )
+      preview.className,
+      preview.functionName,
+      widthPx.toString(),
+      heightPx.toString(),
+      density.toString(),
+      preview.params.showBackground.toString(),
+      preview.params.backgroundColor.toString(),
+      outputFile.absolutePath,
+      // 9th arg — empty string signals "no wrapper" (keeps arg positions stable).
+      preview.params.wrapperClassName.orEmpty(),
+      // 10th/11th — AS-parity wrap flags. When set, the renderer
+      // wraps the composable, measures it, and crops the PNG to
+      // the intrinsic bounds on that axis.
+      spec.wrapWidth.toString(),
+      spec.wrapHeight.toString(),
+      // 12th/13th — @PreviewParameter spec. Empty string signals
+      // "no provider"; otherwise the renderer enumerates the
+      // provider's values.take(limit) in-process and writes one
+      // `<id>_PARAM_<idx>.png` per value. Plugin-side can't know
+      // the count (consumer's classpath isn't loaded here), so
+      // fan-out is delegated to the renderer process that already
+      // has everything on its classpath.
+      preview.params.previewParameterProviderClassName.orEmpty(),
+      preview.params.previewParameterLimit.toString(),
+      // 14th — `@Preview(locale = ...)`. Empty string signals "no override". The renderer
+      // detects `en-XA` / `ar-XB` and applies the runtime pseudolocale wrap (currently
+      // LayoutDirection.Rtl for ar-XB on desktop; Android additionally pseudolocalises
+      // string resources via the `:data-pseudolocale-connector` Resources subclass).
+      preview.params.locale.orEmpty(),
+      // 15th–18th — @ScrollingPreview intent forwarded per capture / data product. Empty
+      // 15th signals "no scroll intent". Renderer dispatches LONG / GIF to
+      // `renderScrollPreview` (`runComposeUiTest`-driven scroll + slice or frame encode);
+      // TOP / END fall through to the default single-frame path.
+      scroll?.mode?.name.orEmpty(),
+      scroll?.axis?.name.orEmpty(),
+      (scroll?.maxScrollPx ?: 0).toString(),
+      (scroll?.frameIntervalMs ?: 0).toString(),
+      // 19th/20th — preview kind + (for kind=LOTTIE) the resource-relative asset path. Empty
+      // 19th defaults to COMPOSE on the renderer side. A LOTTIE entry has no class/function to
+      // reflect; the renderer inflates the asset at arg 20 via Compottie instead.
+      preview.params.kind.name,
+      preview.params.assetPath.orEmpty(),
+      // 21st — `@Preview(fontScale = ...)`. Compose Desktop has no resource-qualifier system,
+      // so the renderer threads this through `Density(density, fontScale)` (and re-provides it
+      // as `LocalDensity`) the same way the daemon's desktop RenderEngine does. `1.0` is the
+      // annotation default / no-op; omitting it keeps older callers at 1.0 on the renderer
+      // side.
+      preview.params.fontScale.toString(),
+      // 22nd–24th — `@Preview(showSystemUi = ...)` (issue #1930). When set on a phone-shape
+      // capture, DesktopRendererMain wraps the composition in the synthetic `SystemBarsFrame`
+      // (status bar + gesture-nav pill) so the desktop capture matches the Android renderer
+      // instead of coming back chrome-less. uiMode carries the night bit for dark chrome;
+      // device is forwarded only so the renderer can skip round/Wear surfaces.
+      preview.params.showSystemUi.toString(),
+      preview.params.uiMode.toString(),
+      preview.params.device.orEmpty(),
+      // 25th–27th — `@AnimatedPreview` window. `-1` durationMs signals "no animation intent"
+      // (the renderer falls through to scroll / single-frame). `>= 0` means the annotation is
+      // present and dispatches to `renderAnimatedPreview` (a `runSkikoComposeUiTest`
+      // paused-clock loop that advances `mainClock` by frameIntervalMs across the window and
+      // encodes the frames as a GIF) — the desktop counterpart of the Android renderer's
+      // `@AnimatedPreview` path. `0` is the annotation's auto-detect sentinel and must NOT be
+      // collapsed into "no animation": a default-args `@AnimatedPreview` still needs the
+      // animated path or the `.gif` renderOutput gets a single PNG frame (issue #2190). An
+      // older renderer that predates the `-1` protocol parses it via `takeIf { it > 0 } ?: 0`,
+      // so the sentinel degrades to the old "no animation" behaviour rather than breaking. The
+      // reverse skew (an older plugin driving a newer renderer pinned on the
+      // `composePreviewRenderer` configuration) is guarded renderer-side: a bare `0` is only
+      // read as auto-detect when the capture is animation-shaped (a `.gif` output with no
+      // scroll intent).
+      // `showCurves` is forwarded for parity; the desktop path emits a screenshot-only GIF (no
+      // curve strip).
+      (animation?.durationMs ?: -1).toString(),
+      (animation?.frameIntervalMs ?: 0).toString(),
+      (animation?.showCurves ?: false).toString(),
+      // 28th — sibling stems the renderer's `@PreviewParameter` stale fan-out cleanup must
+      // leave alone (issue #2193): manifest outputs in the same directory whose stem extends
+      // this capture's (`Foo` vs the `@Preview(name = "Dark")` sibling's `Foo_Dark`). The
+      // subprocess has no manifest, so without this it treats every `<stem>_*` file as its
+      // own fan-out and deletes the sibling's renders. Empty string signals "no siblings".
+      fanoutSiblingStems.joinToString("|"),
+    )
 }
 
 private fun Float.roundHalfUpPx(): Int = kotlin.math.floor(this + 0.5f).toInt().coerceAtLeast(1)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -24,6 +24,16 @@ import org.gradle.process.ExecOperations
 @CacheableTask
 abstract class RenderPreviewsTask : DefaultTask() {
 
+  /**
+   * The task's project directory — the working directory a render runs in.
+   *
+   * `ExecOperations.javaexec` defaults to it, so a preview reading a relative path has always
+   * resolved it against its own subproject. The worker pool starts its processes here for the same
+   * reason; `@Internal` because it affects where a render *runs*, not what it produces, and making
+   * it an input would key every module's cache on its own absolute path.
+   */
+  @get:org.gradle.api.tasks.Internal abstract val projectDirectory: DirectoryProperty
+
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NONE)
   abstract val previewsJson: RegularFileProperty
@@ -658,6 +668,10 @@ abstract class RenderPreviewsTask : DefaultTask() {
     if (!DesktopRenderWorkerPool.isEnabled()) return null
     val cp = renderClasspath.files.toList()
     if (cp.isEmpty()) return null
+    // A registration that never wired the project directory forks rather than guessing one: a
+    // worker started in the wrong directory would resolve a preview's relative paths differently
+    // from the lane it replaces, which is worse than not pooling.
+    val workingDir = projectDirectory.orNull?.asFile ?: return null
     return DesktopRenderWorkerPool(
       classpath = cp,
       javaExecutable = renderJavaExecutable.orNull ?: defaultJavaExecutable(),
@@ -665,6 +679,15 @@ abstract class RenderPreviewsTask : DefaultTask() {
       maxWorkers = DesktopRenderWorkerPool.configuredWorkers(),
       maxRendersPerWorker = DesktopRenderWorkerPool.configuredMaxRenders(),
       renderTimeoutSeconds = DesktopRenderWorkerPool.RENDER_GUARD_SECONDS,
+      // `javaexec` defaulted the working directory to the task's project, so a preview reading a
+      // relative path resolved it against that subproject. A worker must start there too, or the
+      // warm and forked lanes would disagree about what `File("src/main/resources/…")` means.
+      workingDir = workingDir,
+      // The forked lane let the renderer's diagnostics through to the build log. Most of them ride
+      // a *successful* request — a missing `@PreviewParameter` provider, a device-frame failure,
+      // the `Render failed …` line beside an error sidecar — so without this they would vanish the
+      // moment a capture went warm.
+      stderrSink = { line -> logger.lifecycle("composePreviewRender: $line") },
     )
   }
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolStub.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolStub.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.plugin
+
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.EOFException
+import java.io.File
+import java.io.FileDescriptor
+import java.io.FileOutputStream
+import java.io.PrintStream
+import kotlin.system.exitProcess
+
+/**
+ * A stand-in for `DesktopRendererWorkerMain` that speaks the same frames without Compose or Skiko,
+ * so [DesktopRenderWorkerPoolTest] can exercise the pool's protocol, recycling and failure handling
+ * on any machine — including CI images with no native render stack, where the real worker cannot
+ * start at all.
+ *
+ * `stub.mode` selects the behaviour: `ok` (default) writes the file named by the last argv entry
+ * and reports success, `failed` reports a render failure, `hang` never answers, `crash` exits
+ * mid-request, and `badVersion` sends an unrecognised protocol version.
+ *
+ * On success it writes `"<argc>:<seed>#<n>"` into the output file, where `n` counts the requests
+ * this process has served — which is how a test tells a reused warm worker from a fresh one.
+ */
+object DesktopRenderWorkerPoolStub {
+
+  @JvmStatic
+  fun main(args: Array<String>) {
+    val mode = System.getProperty("stub.mode", "ok")
+    val frames = DataOutputStream(BufferedOutputStream(FileOutputStream(FileDescriptor.out)))
+    System.setOut(PrintStream(FileOutputStream(FileDescriptor.err), true))
+    val input = DataInputStream(System.`in`.buffered())
+
+    frames.writeInt(DesktopRenderWorkerPool.MAGIC_HELLO)
+    frames.writeInt(
+      if (mode == "badVersion") 99 else DesktopRenderWorkerPool.WORKER_PROTOCOL_VERSION
+    )
+    frames.flush()
+
+    var served = 0
+    while (true) {
+      val magic =
+        try {
+          input.readInt()
+        } catch (_: EOFException) {
+          exitProcess(0)
+        }
+      if (magic != DesktopRenderWorkerPool.MAGIC_REQUEST) exitProcess(4)
+
+      val requestId = input.readInt()
+      val seed = String(input.readPayload(), Charsets.UTF_8)
+      val argc = input.readInt()
+      val argv = List(argc) { String(input.readPayload(), Charsets.UTF_8) }
+
+      when (mode) {
+        "hang" -> Thread.sleep(Long.MAX_VALUE)
+        "crash" -> exitProcess(9)
+      }
+
+      served++
+      var status = DesktopRenderWorkerPool.STATUS_OK
+      var message = ""
+      if (mode == "failed") {
+        status = 1
+        message = "stub refused request $requestId"
+      } else {
+        // Last argv entry is the renderer's output path in the real protocol.
+        argv.lastOrNull()?.let { File(it).writeText("$argc:$seed#$served") }
+      }
+
+      val payload = message.toByteArray(Charsets.UTF_8)
+      frames.writeInt(DesktopRenderWorkerPool.MAGIC_RESPONSE)
+      frames.writeInt(requestId)
+      frames.writeInt(status)
+      frames.writeInt(payload.size)
+      frames.write(payload)
+      frames.flush()
+    }
+  }
+
+  private fun DataInputStream.readPayload(): ByteArray {
+    val len = readInt()
+    return ByteArray(len).also { readFully(it) }
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolStub.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolStub.kt
@@ -17,8 +17,9 @@ import kotlin.system.exitProcess
  * start at all.
  *
  * `stub.mode` selects the behaviour: `ok` (default) writes the file named by the last argv entry
- * and reports success, `failed` reports a render failure, `hang` never answers, `crash` exits
- * mid-request, and `badVersion` sends an unrecognised protocol version.
+ * and reports success, `chatty` also writes a line to stderr on a *successful* request (the case
+ * real renderer diagnostics arrive in), `failed` reports a render failure, `hang` never answers,
+ * `crash` exits mid-request, and `badVersion` sends an unrecognised protocol version.
  *
  * On success it writes `"<argc>:<seed>#<n>"` into the output file, where `n` counts the requests
  * this process has served — which is how a test tells a reused warm worker from a fresh one.
@@ -57,6 +58,8 @@ object DesktopRenderWorkerPoolStub {
         "hang" -> Thread.sleep(Long.MAX_VALUE)
         "crash" -> exitProcess(9)
       }
+
+      if (mode == "chatty") System.err.println("stub diagnostic for request $requestId")
 
       served++
       var status = DesktopRenderWorkerPool.STATUS_OK

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolTest.kt
@@ -56,6 +56,41 @@ class DesktopRenderWorkerPoolTest {
   }
 
   @Test
+  fun workersStartInTheTaskProjectDirectory() {
+    // `javaexec` defaulted its working directory to the task's project, so a preview reading a
+    // relative path resolved it there. A worker inheriting the Gradle daemon's directory instead
+    // would resolve the same path somewhere else — a difference between the warm and forked lanes.
+    val projectDir = tempFolder.newFolder("subproject")
+    pool(workingDir = projectDir).use { pool ->
+      val marker = File(projectDir, "cwd.txt")
+      // A *relative* output path: it can only land in `projectDir` if the worker started there.
+      assertOk(pool.render(listOf("ignored.ClassKt", "cwd.txt"), null))
+      assertTrue("worker did not run in the task project directory", marker.isFile)
+    }
+  }
+
+  @Test
+  fun rendererDiagnosticsFromASuccessfulCaptureReachTheSink() {
+    // Most renderer diagnostics ride a *successful* request — the renderer handles the problem and
+    // returns normally — so a pool that kept stderr only for its own failure messages would drop
+    // exactly the output the forked lane used to surface.
+    val seen = java.util.Collections.synchronizedList(mutableListOf<String>())
+    pool(mode = "chatty", stderrSink = { seen.add(it) }).use { pool ->
+      assertOk(pool.render(argsFor(tempFolder.newFile("x.txt")), null))
+      val deadline = System.currentTimeMillis() + 10_000
+      while (
+        seen.none { it.contains("stub diagnostic") } && System.currentTimeMillis() < deadline
+      ) {
+        Thread.sleep(20)
+      }
+      assertTrue(
+        "renderer stderr never reached the sink: $seen",
+        seen.any { it.contains("stub diagnostic") },
+      )
+    }
+  }
+
+  @Test
   fun aCaptureTheRendererRejectsIsFailedNotUnusable() {
     pool(mode = "failed").use { pool ->
       val result = pool.render(argsFor(tempFolder.newFile("x.txt")), null)
@@ -151,6 +186,8 @@ class DesktopRenderWorkerPoolTest {
     mode: String = "ok",
     maxRendersPerWorker: Int = 100,
     workerMainClass: String = STUB_MAIN_CLASS,
+    workingDir: File = tempFolder.root,
+    stderrSink: (String) -> Unit = {},
   ) =
     DesktopRenderWorkerPool(
       classpath = System.getProperty("java.class.path").split(File.pathSeparator).map(::File),
@@ -162,6 +199,8 @@ class DesktopRenderWorkerPoolTest {
       maxWorkers = 1,
       maxRendersPerWorker = maxRendersPerWorker,
       renderTimeoutSeconds = 60,
+      workingDir = workingDir,
+      stderrSink = stderrSink,
       workerMainClass = workerMainClass,
     )
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolTest.kt
@@ -1,0 +1,171 @@
+package ee.schimke.composeai.plugin
+
+import java.io.File
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Covers [DesktopRenderWorkerPool] against [DesktopRenderWorkerPoolStub] — a worker speaking the
+ * real frames without Compose or Skiko, so the protocol, warm reuse and every failure path are
+ * asserted on machines with no native render stack.
+ *
+ * The distinction these are built around is the pool's whole failure posture: `Failed` means the
+ * *renderer* answered "I cannot draw this capture" and the caller must not fork a retry (that would
+ * double the cost of every broken preview), while `Unusable` means the *pool* could not serve and
+ * forking that capture is correct.
+ */
+class DesktopRenderWorkerPoolTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun aWarmWorkerServesSuccessiveCapturesAndCarriesTheRequest() {
+    pool().use { pool ->
+      val first = tempFolder.newFile("first.txt")
+      val second = tempFolder.newFile("second.txt")
+
+      assertOk(pool.render(argsFor(first), null))
+      assertOk(pool.render(argsFor(second), null))
+
+      // `#2` is the point of the pool: the second capture was drawn by the same process, so it
+      // paid no JVM boot. A fresh worker would report `#1` again.
+      assertEquals("2:#1", first.readText())
+      assertEquals("2:#2", second.readText())
+      assertEquals(2, pool.servedWarm.get())
+    }
+  }
+
+  @Test
+  fun theOverrideSeedRidesTheRequestRatherThanTheWorkerEnvironment() {
+    pool().use { pool ->
+      val seeded = tempFolder.newFile("seeded.txt")
+      val plain = tempFolder.newFile("plain.txt")
+      pool.render(argsFor(seeded), """{"name":"v"}""")
+      pool.render(argsFor(plain), null)
+
+      // Same worker, different seeds — the per-capture seed must not stick to the process, or a
+      // preview would render with the variant knobs of whatever ran before it.
+      assertTrue(seeded.readText(), seeded.readText().contains("""{"name":"v"}"""))
+      assertEquals("2:#2", plain.readText())
+    }
+  }
+
+  @Test
+  fun aCaptureTheRendererRejectsIsFailedNotUnusable() {
+    pool(mode = "failed").use { pool ->
+      val result = pool.render(argsFor(tempFolder.newFile("x.txt")), null)
+      assertTrue(
+        "expected Failed, got $result",
+        result is DesktopRenderWorkerPool.WorkerResult.Failed,
+      )
+      val failed = result as DesktopRenderWorkerPool.WorkerResult.Failed
+      assertTrue(failed.reason, failed.reason.contains("stub refused"))
+    }
+  }
+
+  @Test
+  fun aWorkerThatDiesMidCaptureIsUnusableSoTheCallerForks() {
+    pool(mode = "crash").use { pool ->
+      assertUnusable(pool.render(argsFor(tempFolder.newFile("x.txt")), null))
+    }
+  }
+
+  @Test
+  fun aRendererSpeakingAnotherProtocolVersionIsRefused() {
+    pool(mode = "badVersion").use { pool ->
+      val result = pool.render(argsFor(tempFolder.newFile("x.txt")), null)
+      val unusable = assertUnusable(result)
+      assertTrue(unusable.reason, unusable.reason.contains("protocol"))
+    }
+  }
+
+  @Test
+  fun aWorkerIsRetiredAfterItsCaptureBudget() {
+    pool(maxRendersPerWorker = 1).use { pool ->
+      val first = tempFolder.newFile("a.txt")
+      val second = tempFolder.newFile("b.txt")
+      pool.render(argsFor(first), null)
+      pool.render(argsFor(second), null)
+      // Both `#1`: the budget of one retired the first worker, bounding any native leak.
+      assertEquals("2:#1", first.readText())
+      assertEquals("2:#1", second.readText())
+    }
+  }
+
+  @Test
+  fun closingThePoolReleasesAWorkerThatIsMidCapture() {
+    // A checked-out worker is absent from the idle set, so a shutdown that drains only `idle`
+    // leaves its JVM alive and its caller blocked on a pipe read forever — and stopping the
+    // watchdog removes the scheduled kill that was the only other way out.
+    val pool = pool(mode = "hang")
+    val outcome = ArrayBlockingQueue<DesktopRenderWorkerPool.WorkerResult>(1)
+    val thread = Thread { outcome.add(pool.render(argsFor(tempFolder.newFile("x.txt")), null)) }
+    thread.start()
+    Thread.sleep(2_000)
+
+    pool.close()
+
+    val result =
+      outcome.poll(60, TimeUnit.SECONDS)
+        ?: error("closing the pool left a mid-capture caller blocked — it never returned")
+    assertUnusable(result)
+    thread.join(10_000)
+    assertTrue("render thread did not finish after shutdown", !thread.isAlive)
+  }
+
+  @Test
+  fun repeatedStartFailuresDisableThePoolSoTheCostIsPaidOnce() {
+    pool(workerMainClass = "ee.schimke.composeai.plugin.NoSuchWorkerMain").use { pool ->
+      val reasons =
+        (1..DesktopRenderWorkerPool.MAX_START_FAILURES + 1).map {
+          assertUnusable(pool.render(argsFor(tempFolder.newFile("x$it.txt")), null)).reason
+        }
+      // Every attempt is unusable, so every capture still gets rendered by a fork; once the pool
+      // has given up it says so rather than spawning a doomed JVM per capture.
+      assertTrue(reasons.last(), reasons.last().contains("disabled after"))
+    }
+  }
+
+  private fun assertOk(result: DesktopRenderWorkerPool.WorkerResult) {
+    assertTrue("expected Ok, got $result", result is DesktopRenderWorkerPool.WorkerResult.Ok)
+  }
+
+  private fun assertUnusable(
+    result: DesktopRenderWorkerPool.WorkerResult
+  ): DesktopRenderWorkerPool.WorkerResult.Unusable {
+    assertTrue(
+      "expected Unusable, got $result",
+      result is DesktopRenderWorkerPool.WorkerResult.Unusable,
+    )
+    return result as DesktopRenderWorkerPool.WorkerResult.Unusable
+  }
+
+  private fun argsFor(target: File) = listOf("ignored.ClassKt", target.absolutePath)
+
+  private fun pool(
+    mode: String = "ok",
+    maxRendersPerWorker: Int = 100,
+    workerMainClass: String = STUB_MAIN_CLASS,
+  ) =
+    DesktopRenderWorkerPool(
+      classpath = System.getProperty("java.class.path").split(File.pathSeparator).map(::File),
+      javaExecutable =
+        File(System.getProperty("java.home"), "bin/java").let {
+          if (it.canExecute()) it.absolutePath else "java"
+        },
+      jvmArgs = listOf("-Dstub.mode=$mode"),
+      maxWorkers = 1,
+      maxRendersPerWorker = maxRendersPerWorker,
+      renderTimeoutSeconds = 60,
+      workerMainClass = workerMainClass,
+    )
+
+  private companion object {
+    const val STUB_MAIN_CLASS = "ee.schimke.composeai.plugin.DesktopRenderWorkerPoolStub"
+  }
+}

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -916,6 +916,12 @@ internal fun renderPreview(
   // in-process render in the functional tests) never inherits the switch. See
   // [overrideJvmDefaultLocale].
   val previousDefaultLocale = overrideJvmDefaultLocale(localeTag)
+  // Held outside the try so the `finally` below can always release it. The scene owns a Skia
+  // `Surface`; closing it only on the success path leaked one per *handled* render failure — the
+  // sidecar path returns normally rather than throwing — which a fresh JVM per capture disposed of
+  // for free and a reused renderer worker does not. `RenderEngine` states the same invariant for
+  // the daemon's copy of this body; this is the standalone renderer catching up to it.
+  var sceneToRelease: ImageComposeScene? = null
   try {
 
     // `@Preview(fontScale = ...)` rides on `Density.fontScale`. Threading it through the scene's
@@ -940,7 +946,9 @@ internal fun renderPreview(
     val sceneWidthPx = sceneSize.width
     val sceneHeightPx = sceneSize.height
     val scene =
-      ImageComposeScene(width = sceneWidthPx, height = sceneHeightPx, density = sceneDensity)
+      ImageComposeScene(width = sceneWidthPx, height = sceneHeightPx, density = sceneDensity).also {
+        sceneToRelease = it
+      }
 
     // Measured content size in pixels, captured from the wrapping Box via
     // onGloballyPositioned. Only read when at least one axis wraps.
@@ -1080,13 +1088,15 @@ internal fun renderPreview(
       fileSystem.write(outputFile.path.toPath()) { write(pngData.bytes) }
     }
 
-    scene.close()
+    // Released in the `finally` below rather than here, so a throw between the scene's
+    // construction and this point cannot strand its Skia surface.
 
     // After a successful render, write the editable knobs this preview declared via
     // `previewOverride*`
     // as the `renders/<stem>.overrides.json` sidecar `BundlePreviewTask` packs into the bundle.
     writePreviewOverridesSidecar(outputFile, fileSystem)
   } finally {
+    runCatching { sceneToRelease?.close() }
     restoreJvmDefaultLocale(previousDefaultLocale)
   }
 }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerMain.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.renderer
+
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.EOFException
+import java.io.FileDescriptor
+import java.io.FileOutputStream
+import java.io.PrintStream
+import kotlin.system.exitProcess
+
+/**
+ * The **pooled** counterpart of [main]: a long-lived renderer that draws one capture per request
+ * frame instead of one per process.
+ *
+ * `RenderPreviewsTask` used to `javaexec` this module once per capture, so every preview paid a
+ * whole JVM plus Compose Desktop and Skiko boot — 2.15 s/preview measured end-to-end on m3-catalog,
+ * ~43 min for its 1095-preview catalog, against ~36 ms for a render on an already-warm process.
+ *
+ * The body here is deliberately thin: it decodes a frame and calls [main] with exactly the argv the
+ * per-capture `javaexec` would have passed. Nothing about *how* a preview is drawn lives in this
+ * file, so a pooled capture cannot draw differently from a forked one — the property
+ * `DesktopRendererReentrancyTest` pins, and the reason this is a transport change rather than a
+ * rendering one.
+ *
+ * Two things make calling [main] repeatedly in one process safe, both of them checked rather than
+ * assumed:
+ * * every `exitProcess` in [main] is on the argument-validation prologue — a *render* failure
+ *   writes an `.error.json` sidecar and returns normally, so a broken preview costs a request
+ *   rather than a worker;
+ * * `@OverrideVariant` seeds are reset per render (see [main]'s `resetForNewSession()` call), so a
+ *   capture never inherits the knobs of whatever the worker drew before it.
+ *
+ * ## Wire protocol
+ *
+ * Binary frames over stdin/stdout, big-endian, no external dependency — the same shape as
+ * `RcJvmRenderWorkerMain`, whose pool this one's mirrors. The plugin side is
+ * `DesktopRenderWorkerPool`, which refuses to use a worker whose [WORKER_PROTOCOL_VERSION] it does
+ * not recognise, so a renderer resolved from an older `composePreviewRenderer` configuration falls
+ * back to per-capture forks instead of hanging on a handshake that never comes.
+ *
+ * ```
+ * worker -> pool, once at startup:
+ *   int32 MAGIC_HELLO, int32 WORKER_PROTOCOL_VERSION
+ * pool -> worker, per request:
+ *   int32 MAGIC_REQUEST, int32 requestId,
+ *   int32 seedLen, <seedLen bytes UTF-8>,     // `composeai.overrides.seed`, empty for none
+ *   int32 argc, argc x (int32 len, <len bytes UTF-8>)
+ * worker -> pool, per response:
+ *   int32 MAGIC_RESPONSE, int32 requestId, int32 status (0=ok, 1=failed),
+ *   int32 messageLen, <messageLen bytes UTF-8>   // empty on success
+ * ```
+ *
+ * The rendered artifact is **not** returned over the wire: [main] writes it to the output path in
+ * the argv, exactly as the forked renderer did, so the pool changes nothing about where files land.
+ *
+ * Closing the worker's stdin ends it cleanly (the next frame read hits EOF and it exits 0).
+ */
+fun desktopRendererWorkerMain() {
+  // Claim the real stdout for protocol frames BEFORE anything else can print to it. Skiko, AWT,
+  // Compottie and the renderer itself all write to `System.out`; one stray line would be read as a
+  // frame header and desynchronise the stream permanently. Everything that keeps writing to
+  // `System.out` lands on stderr, which the pool drains into its failure tail.
+  val frames = DataOutputStream(BufferedOutputStream(FileOutputStream(FileDescriptor.out)))
+  System.setOut(PrintStream(FileOutputStream(FileDescriptor.err), true))
+
+  val input = DataInputStream(System.`in`.buffered())
+
+  frames.writeInt(MAGIC_HELLO)
+  frames.writeInt(WORKER_PROTOCOL_VERSION)
+  frames.flush()
+
+  while (true) {
+    val magic =
+      try {
+        input.readInt()
+      } catch (_: EOFException) {
+        // The pool closed our stdin: an ordinary shutdown, not a failure.
+        frames.flush()
+        exitProcess(0)
+      }
+    if (magic != MAGIC_REQUEST) {
+      System.err.println("compose-preview renderer worker: unexpected frame magic $magic; exiting")
+      exitProcess(4)
+    }
+
+    val requestId = input.readInt()
+    val seed = String(input.readPayload(), Charsets.UTF_8)
+    val argc = input.readInt()
+    if (argc < 0 || argc > MAX_ARGC) {
+      System.err.println("compose-preview renderer worker: implausible argc $argc; exiting")
+      exitProcess(4)
+    }
+    val args = Array(argc) { String(input.readPayload(), Charsets.UTF_8) }
+
+    var fatal: Throwable? = null
+    var status = STATUS_OK
+    var message = ""
+    try {
+      // Per-render, so it rides the request rather than the worker's environment. Cleared
+      // afterwards as well as set: `main()` resets the controller per render, but leaving a stale
+      // property set would make the *next* request look seeded to anything else reading it.
+      if (seed.isEmpty()) System.clearProperty(OVERRIDES_SEED_PROPERTY)
+      else System.setProperty(OVERRIDES_SEED_PROPERTY, seed)
+      main(args)
+    } catch (e: Exception) {
+      // A capture the renderer cannot draw is an ordinary per-request failure. `main()` already
+      // writes an `.error.json` sidecar for render failures it handles; this covers the rest
+      // without taking the worker down, matching the forked path's non-zero exit for one capture.
+      status = STATUS_FAILED
+      message = "${e::class.java.simpleName}: ${e.message}"
+    } catch (t: Throwable) {
+      // An Error (OOM, a native link failure) means the process is no longer trustworthy. Answer
+      // first so the caller gets a reason rather than a timeout, then exit so the pool discards it.
+      fatal = t
+      status = STATUS_FAILED
+      message = "${t::class.java.simpleName}: ${t.message}"
+    } finally {
+      System.clearProperty(OVERRIDES_SEED_PROPERTY)
+    }
+
+    val payload = message.toByteArray(Charsets.UTF_8)
+    frames.writeInt(MAGIC_RESPONSE)
+    frames.writeInt(requestId)
+    frames.writeInt(status)
+    frames.writeInt(payload.size)
+    frames.write(payload)
+    frames.flush()
+
+    fatal?.let {
+      System.err.println(
+        "compose-preview renderer worker: fatal ${it::class.java.simpleName}; exiting"
+      )
+      exitProcess(5)
+    }
+  }
+}
+
+/** Entry point for `java -cp … ee.schimke.composeai.renderer.DesktopRendererWorkerMainKt`. */
+fun main() {
+  desktopRendererWorkerMain()
+}
+
+/**
+ * Read a length-prefixed payload, rejecting a length that could only come from a desynchronised
+ * stream — without this a corrupt length allocates an arbitrary array and the worker dies on OOM
+ * rather than on the protocol error that actually happened.
+ */
+private fun DataInputStream.readPayload(): ByteArray {
+  val len = readInt()
+  if (len < 0 || len > MAX_PAYLOAD_BYTES) {
+    System.err.println("compose-preview renderer worker: implausible payload length $len; exiting")
+    exitProcess(4)
+  }
+  return ByteArray(len).also { readFully(it) }
+}
+
+// Mirrored by `DesktopRenderWorkerPool` in the gradle plugin, which cannot depend on this module
+// (the renderer is resolved into the consumer's graph). The version check on the hello frame is
+// what keeps the duplication honest: a mismatch is refused and the caller forks instead.
+internal const val MAGIC_HELLO = 0x43505731 // 'CPW1'
+internal const val MAGIC_REQUEST = 0x43505131 // 'CPQ1'
+internal const val MAGIC_RESPONSE = 0x43505231 // 'CPR1'
+internal const val WORKER_PROTOCOL_VERSION = 1
+internal const val STATUS_OK = 0
+internal const val STATUS_FAILED = 1
+internal const val OVERRIDES_SEED_PROPERTY = "composeai.overrides.seed"
+
+/** Far above any real argv or seed, far below "allocate until OOM". */
+private const val MAX_PAYLOAD_BYTES = 64 * 1024 * 1024
+private const val MAX_ARGC = 1024

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerProtocolTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerProtocolTest.kt
@@ -1,0 +1,216 @@
+package ee.schimke.composeai.renderer
+
+import java.io.ByteArrayInputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.util.concurrent.TimeUnit
+import javax.imageio.ImageIO
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end check that a **pooled capture is indistinguishable from a forked one**.
+ *
+ * `DesktopRendererReentrancyTest` proves the renderer is safe to call repeatedly in one process;
+ * this proves the *transport* around it adds nothing — that a worker driven over its frame protocol
+ * writes the same pixels to the same place as the per-capture `javaexec` it replaces, keeps serving
+ * after a capture it cannot draw, and exits cleanly when its stdin closes.
+ *
+ * The plugin-side pool (`DesktopRenderWorkerPool`) is covered separately against a stub; this one
+ * runs the real renderer, so it needs skiko's natives and skips loudly without them.
+ */
+class DesktopRendererWorkerProtocolTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private var worker: Process? = null
+
+  @Before
+  fun requireSkikoNatives() {
+    if (!SKIKO_LOADED) {
+      System.err.println(
+        "DesktopRendererWorkerProtocolTest skipped entirely: skiko's native library did not load, " +
+          "so the pooled-capture transport was never exercised. Cause: $skikoLoadFailure"
+      )
+    }
+    Assume.assumeTrue("skiko natives unavailable: $skikoLoadFailure", SKIKO_LOADED)
+  }
+
+  @After
+  fun stopWorker() {
+    worker?.destroyForcibly()
+  }
+
+  @Test
+  fun aWorkerDrawsWhatTheForkedRendererDrawsAndStaysWarmAcrossCaptures() {
+    // Reference: the renderer invoked exactly as `invokeRenderer` forks it today.
+    val forked = File(tempFolder.newFolder("forked"), "sticker.png")
+    renderForked(forked)
+    assertTrue("forked render wrote no file", forked.isFile)
+
+    val process = startWorker().also { worker = it }
+    val toWorker = DataOutputStream(process.outputStream.buffered())
+    val fromWorker = DataInputStream(process.inputStream.buffered())
+
+    assertEquals("hello magic", MAGIC_HELLO, fromWorker.readInt())
+    assertEquals("protocol version", WORKER_PROTOCOL_VERSION, fromWorker.readInt())
+
+    val pooledDir = tempFolder.newFolder("pooled")
+    val first = File(pooledDir, "sticker-1.png")
+    assertEquals(STATUS_OK, fromWorker.exchange(toWorker, argsFor(first), requestId = 1))
+    assertPixelsEqual(forked, first, "a pooled capture must draw what the forked renderer drew")
+
+    // Second capture on the SAME process — the amortisation the pool exists for, which must not
+    // change the picture either.
+    val second = File(pooledDir, "sticker-2.png")
+    assertEquals(STATUS_OK, fromWorker.exchange(toWorker, argsFor(second), requestId = 2))
+    assertPixelsEqual(forked, second, "a warm capture drifted from the first")
+
+    // Closing stdin is the shutdown contract; the worker must exit 0, not be killed.
+    toWorker.close()
+    assertTrue("worker did not exit after stdin closed", process.waitFor(120, TimeUnit.SECONDS))
+    assertEquals("clean shutdown exit code", 0, process.exitValue())
+  }
+
+  @Test
+  fun aCaptureTheRendererCannotDrawDoesNotCostTheWorker() {
+    val process = startWorker().also { worker = it }
+    val toWorker = DataOutputStream(process.outputStream.buffered())
+    val fromWorker = DataInputStream(process.inputStream.buffered())
+    fromWorker.readInt()
+    fromWorker.readInt()
+
+    // A class that isn't there. The renderer records this per capture rather than dying, exactly
+    // as the forked path reported it via one non-zero exit.
+    val doomed = File(tempFolder.newFolder("doomed"), "missing.png")
+    val bad =
+      argsFor(doomed).toMutableList().also { it[0] = "ee.schimke.composeai.renderer.NoSuchClassKt" }
+    fromWorker.exchange(toWorker, bad, requestId = 1)
+
+    // The point: the worker is still serving. A pool that lost a warm JVM to every bad preview
+    // would give most of the amortisation back on a module with one broken capture.
+    val good = File(tempFolder.newFolder("after"), "sticker.png")
+    assertEquals(
+      "worker did not survive a capture it could not draw",
+      STATUS_OK,
+      fromWorker.exchange(toWorker, argsFor(good), requestId = 2),
+    )
+    assertTrue("recovered capture wrote no file", good.isFile)
+  }
+
+  private fun assertPixelsEqual(expected: File, actual: File, message: String) {
+    val a = decode(expected.readBytes())
+    val b = decode(actual.readBytes())
+    assertEquals("$message (size)", a.width to a.height, b.width to b.height)
+    val differing = a.argb.indices.count { a.argb[it] != b.argb[it] }
+    assertEquals("$message ($differing of ${a.argb.size} pixels differ)", 0, differing)
+  }
+
+  private fun DataInputStream.exchange(
+    toWorker: DataOutputStream,
+    args: List<String>,
+    requestId: Int,
+    seed: String = "",
+  ): Int {
+    val seedBytes = seed.toByteArray(Charsets.UTF_8)
+    toWorker.writeInt(MAGIC_REQUEST)
+    toWorker.writeInt(requestId)
+    toWorker.writeInt(seedBytes.size)
+    toWorker.write(seedBytes)
+    toWorker.writeInt(args.size)
+    args.forEach {
+      val b = it.toByteArray(Charsets.UTF_8)
+      toWorker.writeInt(b.size)
+      toWorker.write(b)
+    }
+    toWorker.flush()
+
+    assertEquals("response magic", MAGIC_RESPONSE, readInt())
+    assertEquals("response is for the request we sent", requestId, readInt())
+    val status = readInt()
+    val len = readInt()
+    ByteArray(len).also { readFully(it) }
+    return status
+  }
+
+  private fun argsFor(target: File) =
+    listOf(
+      FIXTURE_CLASS,
+      FIXTURE_FUNCTION,
+      WIDTH.toString(),
+      HEIGHT.toString(),
+      DENSITY.toString(),
+      "true",
+      "0",
+      target.absolutePath,
+    )
+
+  private fun renderForked(target: File) {
+    val process =
+      ProcessBuilder(
+          jvmCommand("ee.schimke.composeai.renderer.DesktopRendererMainKt") + argsFor(target)
+        )
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
+    assertTrue("forked render did not finish", process.waitFor(180, TimeUnit.SECONDS))
+    assertEquals("forked render exit code", 0, process.exitValue())
+  }
+
+  private fun startWorker(): Process =
+    ProcessBuilder(jvmCommand("ee.schimke.composeai.renderer.DesktopRendererWorkerMainKt"))
+      .redirectError(ProcessBuilder.Redirect.INHERIT)
+      .start()
+
+  /**
+   * Identical flags for both lanes — differing ones would make them draw differently for reasons
+   * that have nothing to do with pooling.
+   */
+  private fun jvmCommand(mainClass: String): List<String> {
+    val java = File(System.getProperty("java.home"), "bin/java")
+    return listOf(
+      if (java.canExecute()) java.absolutePath else "java",
+      "-Dapple.awt.UIElement=true",
+      "-cp",
+      System.getProperty("java.class.path"),
+      mainClass,
+    )
+  }
+
+  private class Decoded(val width: Int, val height: Int, val argb: IntArray)
+
+  private fun decode(png: ByteArray): Decoded {
+    val image =
+      requireNotNull(ImageIO.read(ByteArrayInputStream(png))) { "render did not decode as a PNG" }
+    return Decoded(
+      image.width,
+      image.height,
+      image.getRGB(0, 0, image.width, image.height, null, 0, image.width),
+    )
+  }
+
+  private companion object {
+    const val FIXTURE_CLASS = "ee.schimke.composeai.renderer.SizeBoundsRenderTestFixturesKt"
+    const val FIXTURE_FUNCTION = "WrapContentSticker"
+    const val WIDTH = 200
+    const val HEIGHT = 200
+    const val DENSITY = 2.0f
+
+    var skikoLoadFailure: String? = null
+
+    val SKIKO_LOADED: Boolean =
+      try {
+        org.jetbrains.skia.FontMgr.default.familiesCount
+        true
+      } catch (t: Throwable) {
+        skikoLoadFailure = "${t::class.java.simpleName}: ${t.message}"
+        false
+      }
+  }
+}


### PR DESCRIPTION
Closes #3542.

## Summary

`RenderPreviewsTask.invokeRenderer` ran `execOperations.javaexec` **once per capture**, so every preview paid a whole JVM plus Compose Desktop and Skiko boot — **2.15 s/preview** measured end-to-end on m3-catalog, ~43 min for its 1095-preview catalog, against ~36 ms warm (#3540).

`composePreviewRender` now opens one `DesktopRenderWorkerPool` per execution and sends each capture to a long-lived `DesktopRendererWorkerMain` over a small binary frame protocol — the same shape shipped for the cmp-jvm lane in #3514.

## Evidence

Real task, `:samples:cmp`, 64 captures:

```
composePreviewRender: 64 capture(s) drawn on a warm renderer (no per-capture JVM fork).
Rendered 61 preview(s)
BUILD SUCCESSFUL in 5m 38s
```

versus `-Dcomposeai.render.workerPool=off`: **7 m 13 s**. (Both include shared build work, so the per-capture delta — ~1.5 s — is the meaningful figure, not the ratio.)

**The whole render was run both ways and all 66 output files are byte-identical.** That is the claim that matters: this is a transport change, not a rendering one.

## Why it can't change pixels

The worker calls the renderer's **own `main()`** with exactly the argv the fork passed. Nothing about how a preview is drawn lives in the new code. Three properties make reuse safe, each already gated:

- repeated in-process renders draw identical pixels (#3540);
- a capture does not inherit the previous one's `@OverrideVariant` seed — #3540 fixed that leak, and the one genuinely per-capture property (`composeai.overrides.seed`) rides the **request frame** rather than the worker environment, since a worker that inherited it would draw the next preview with the wrong knobs;
- every `exitProcess` in `main()` is on the argument prologue, so a capture the renderer cannot draw costs a request, not a worker — asserted directly.

## Scope and lifecycle

Per module *and* per task execution. The renderer is bound to the consumer's classpath so a worker cannot be shared across modules — but every capture in one execution shares that module, which is exactly the run the amortisation applies to.

The pool is created and closed **inside the task action**, so nothing process-shaped sits on a task field for the configuration cache to store, and no worker outlives the build.

## Failure posture

Carries both defects review found on the cmp-jvm pool:

- anything the pool cannot serve reports `Unusable` and **that capture forks exactly as before**, so the worst case is the cost already being paid;
- a capture the renderer rejects reports `Failed` and is not re-run cold, so a broken preview costs one render rather than two;
- `close()` destroys **checked-out** workers before stopping the watchdog — a mid-render worker is absent from the idle set, and `shutdownNow()` would drop the scheduled kill that is the only other way out of a blocked pipe read;
- repeated spawn failures disable the pool for the rest of the run rather than costing a doomed JVM per capture.

Off switch: `-Dcomposeai.render.workerPool=off`, plus `.workers` / `.maxRenders`.

## Test plan

```
./gradlew :gradle-plugin:test :renderer-desktop:test ktfmtCheck
```

**384 + 80 tests, 0 failures, 0 skipped**, plus the two-way `:samples:cmp` render comparison above.

New coverage:
- `DesktopRendererWorkerProtocolTest` (real renderer) — a pooled capture is pixel-identical to a forked one, a warm capture does not drift, a capture that cannot be drawn does not cost the worker, and closing stdin exits 0.
- `DesktopRenderWorkerPoolTest` (stub worker, no Skiko) — warm reuse, per-request seed isolation, `Failed` vs `Unusable`, protocol-version mismatch, retire-by-budget, close-while-mid-capture, and self-disable after repeated spawn failures.

No visual surface changes — the byte-identical two-way render is the evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk2xtVbDfuqQP2Bkzdndz9)_