### PR TITLE
fix(daemon): let recordings type printable text and mouse-select

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -657,6 +657,13 @@ class AndroidRecordingSession(
             target = target,
             scrollDeltaY = event.scrollDeltaY,
             keyCode = event.keyCode,
+            // #3545 — the character the key typed and the device class the pointer came from. The
+            // sandbox needs both to do more than move a caret: `performKeyInput` inserts from the
+            // code point, and only `performMouseInput` drags out a text selection. Without them a
+            // recorded `TextField` stayed empty and a recorded drag never selected, even though the
+            // very same events dispatched fine outside a recording.
+            text = event.text,
+            pointerType = event.pointerType,
           )
         )
       } catch (t: SemanticsTargetUnresolvedException) {
@@ -1049,9 +1056,11 @@ class AndroidRecordingSession(
    * both modes through one registry. `tMs` is the **frame's** virtual time (live mode stamps the
    * input at the current frame boundary, same convention scripted playback uses).
    *
-   * `RecordingInputParams` doesn't carry `scrollDeltaY` today (the wire shape is set by
-   * `JsonRpcServer.handleRecordingInput`); future rotary-aware live drivers can extend this
-   * synthesisation when the new payload field is wired through.
+   * Every field the wire carries is mapped: anything left off the script event is gone by the time
+   * [scriptHandlers] dispatches. `text` and `pointerType` (issue #3545) are what let a live recording
+   * type printable characters and mouse-select, matching the desktop lane and the ordinary
+   * interactive session; `target` and `scrollDeltaY` were dropped here for the same reason and are
+   * mapped alongside them.
    */
   private fun RecordingInputParams.toScriptEvent(tMs: Long): RecordingScriptEvent =
     RecordingScriptEvent(
@@ -1059,7 +1068,12 @@ class AndroidRecordingSession(
       kind = kind.wireName(),
       pixelX = pixelX,
       pixelY = pixelY,
+      target = target,
+      pointerId = pointerId,
+      scrollDeltaY = scrollDeltaY,
       keyCode = keyCode,
+      text = text,
+      pointerType = pointerType,
     )
 
   override fun encode(format: RecordingFormat): EncodedRecording {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -2223,6 +2223,22 @@ data class RecordingInputParams(
   val scrollDeltaY: Float? = null,
   /** For `keyDown` / `keyUp`. Decimal-string Android `KEYCODE_*`; see `InteractiveKeyCodes`. */
   val keyCode: String? = null,
+  /**
+   * The literal text a `keyDown` produced — see [InteractiveInputParams.text], which this mirrors
+   * field-for-field so a live recording types exactly like an ordinary interactive session does.
+   *
+   * Recording is a second dispatch lane, not a wrapper around the interactive one, so it needs the
+   * field in its own right: without it the live tick loop's `RecordingInputParams` →
+   * `RecordingScriptEvent` → handler-registry hop silently drops the character and a recorded
+   * `TextField` stays empty while the same keystroke typed fine outside a recording (issue #3545).
+   */
+  val text: String? = null,
+  /**
+   * Which pointing device a pointer event came from — see [InteractiveInputParams.pointerType].
+   * Carried here for the same reason as [text]: mouse-drag selection is a device-class behaviour,
+   * and a recording that forwarded every pointer as touch could never select text.
+   */
+  val pointerType: String? = null,
 )
 
 /**
@@ -2278,8 +2294,32 @@ data class RecordingScriptEvent(
    * `rotaryScroll`, `recording.probe`, etc.).
    */
   val pointerId: Int? = null,
-  /** For `keyDown` / `keyUp` (no-op in v1; reserved for v2 key dispatch). */
+  /**
+   * For `input.keyDown` / `input.keyUp`. Decimal-string Android `KEYCODE_*` (see
+   * `InteractiveKeyCodes`), naming the *physical* key. Both backends dispatch it for real — desktop
+   * through `DesktopKeyDispatch`'s Compose `Key` table, Android through the held rule's
+   * `performKeyInput` (issue #1203).
+   */
   val keyCode: String? = null,
+  /**
+   * For `input.keyDown`: the literal character the key produced, mirroring
+   * [InteractiveInputParams.text]. [keyCode] names the key; this names what it typed, and Compose
+   * inserts characters from the code point, so a script carrying only [keyCode] moves the caret but
+   * types nothing (issue #3545).
+   *
+   * A *persisted* field: captured scripts are written out and replayed, so a recording that typed
+   * `"a"` replays as the same `"a"` rather than as a focus-moving `KEYCODE_A`. Distinct from
+   * [inputText], which is the whole-string payload of the UIAutomator `uia.inputText` action.
+   */
+  val text: String? = null,
+  /**
+   * For the pointer events: `"mouse"` / `"touch"` / `"pen"`, mirroring
+   * [InteractiveInputParams.pointerType]. Absent (or unrecognised) means touch — the behaviour
+   * every script had before the field existed, so old captured scripts replay byte-identically.
+   * Only a *mouse* press-drag starts a text selection in Compose, so a script that means to select
+   * has to say so (issue #3545).
+   */
+  val pointerType: String? = null,
   /** Browser wheel delta for `rotaryScroll`; positive means wheel-down. */
   val scrollDeltaY: Float? = null,
   /** Agent-supplied label for probes and state checkpoints. */

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -5,19 +5,8 @@
 
 package ee.schimke.composeai.daemon
 
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.pointer.PointerButton
-import androidx.compose.ui.input.pointer.PointerButtons
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.PointerId
-import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.scene.ComposeScenePointer
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
-import ee.schimke.composeai.daemon.protocol.InteractivePointerType
 import ee.schimke.composeai.data.layoutinspector.SemanticsTarget
 import ee.schimke.composeai.data.layoutinspector.SemanticsTargets
 import ee.schimke.composeai.data.layoutinspector.TargetResolution
@@ -39,10 +28,10 @@ import java.util.concurrent.TimeUnit
  * - `CLICK` → `Press` then `Release` at the same position. Mirrors the Compose-test convention
  *   (`SemanticsNodeInteraction.performClick`) and what a real mouse click materialises into.
  * - `POINTER_DOWN` / `POINTER_UP` → single `Press` / `Release`.
- * - `KEY_DOWN` / `KEY_UP` → Compose `KeyEvent(key, KeyEventType.KeyDown/KeyUp)` via
- *   [androidKeycodeToComposeKey] — wire `keyCode` is the decimal-string Android `KEYCODE_*` value
- *   (issue #1203). Unmapped codes drop silently so a forward-looking client can't crash the
- *   dispatch loop.
+ * - `KEY_DOWN` / `KEY_UP` → [SceneKeyDispatch] — wire `keyCode` is the decimal-string Android
+ *   `KEYCODE_*` value (issue #1203), joined by the `text` the key typed (issue #3491). Unmapped
+ *   codes with nothing typeable drop silently so a forward-looking client can't crash the dispatch
+ *   loop.
  * - `ROTARY_SCROLL` → `Scroll` pointer event at the supplied pixel coords with `scrollDelta.y =
  *   scrollDeltaY`. Reuses the existing pointer pipeline; positive deltaY means wheel-down (same
  *   convention as a browser wheel).
@@ -51,6 +40,10 @@ import java.util.concurrent.TimeUnit
  * the renderer renders to — see `INTERACTIVE.md § 6/§ 7`). `ImageComposeScene.sendPointerEvent`
  * takes scene-px which equals natural pixels at density 1.0; we divide by the held density before
  * dispatch. Null coords (e.g. for keyboard events, which we no-op anyway) skip the dispatch.
+ *
+ * **Shared with the recording lane.** Pointer and key translation live in `DesktopSceneInput.kt`
+ * ([ScenePointerDispatch] / [SceneKeyDispatch]) and are used verbatim by [DesktopRecordingSession],
+ * so the two lanes cannot drift apart the way they did before issue #3545.
  *
  * **Threading.** Every scene touch — `setUp` (run by [DesktopHost] before construction), every
  * `dispatch`, every `render`, the optional [onSceneClose] hook, and the final `tearDown` — is
@@ -94,20 +87,19 @@ class DesktopInteractiveSession(
   @Volatile private var closed: Boolean = false
 
   /**
-   * Per-pointer-id active state — keyed by [InteractiveInputParams.pointerId] (`null` collapses to
-   * `0`). Updated by `POINTER_DOWN` / `POINTER_MOVE` / `POINTER_UP` so the next multi-pointer
-   * dispatch sees every currently-pressed finger in a single `sendPointerEvent` call. Cleared per
-   * id on `POINTER_UP`. Mirrors the same pattern `DesktopRecordingSession` uses for scripted
-   * playback so an external panel sending two simultaneous `pointerDown`s actually gets a
-   * `Modifier.transformable {}` zoom callback (the gating signal is ≥ 2 pointers in one event).
+   * Pointer translation + multi-pointer bookkeeping, shared with [DesktopRecordingSession] so both
+   * lanes synthesise pointers identically (issue #3545). Touched only from [sceneExecutor]'s
+   * thread.
    *
-   * Read and written only from [sceneExecutor]'s thread, so a plain `MutableMap` is safe — no
-   * `ConcurrentHashMap` needed.
+   * Its wall-clock default timestamp reads [RenderEngine.currentFrameNanoTime] so the event
+   * timeline matches what `render(useWallClockFrameTime = true)` exposes to the composition. CLICK
+   * passes explicit values instead, so its synthetic Press and Release land at a predictable Δt.
    */
-  private val activePointers: MutableMap<Int, ActivePointer> = mutableMapOf()
-
-  /** A pressed pointer's scene-space position plus the device class it is being synthesised as. */
-  private data class ActivePointer(val offset: Offset, val type: PointerType)
+  private val pointers: ScenePointerDispatch =
+    ScenePointerDispatch(
+      scene = { state.scene },
+      defaultTimeMillis = { engine.currentFrameNanoTime() / 1_000_000L },
+    )
 
   override val isClosed: Boolean
     get() = closed
@@ -139,88 +131,34 @@ class DesktopInteractiveSession(
         // another pointer is already down still carries the other finger in its event.
         val nowNs = engine.currentFrameNanoTime()
         val nowMs = nowNs / 1_000_000L
-        activePointers[id] = ActivePointer(offset, deviceType)
-        dispatchMultiPointer(eventType = PointerEventType.Press, timeMillis = nowMs)
+        pointers.press(id, offset, deviceType, timeMillis = nowMs)
         state.scene.render(nanoTime = nowNs)
-        activePointers.remove(id)
-        dispatchMultiPointer(
-          eventType = PointerEventType.Release,
-          timeMillis = nowMs + CLICK_HOLD_MS,
-          releasedPointer = ActivePointer(offset, deviceType) to id,
-        )
+        pointers.release(id, offset, deviceType, timeMillis = nowMs + CLICK_HOLD_MS)
       }
       InteractiveInputKind.POINTER_DOWN -> {
         if (px == null || py == null) return
-        val id = input.pointerId ?: 0
-        activePointers[id] = ActivePointer(sceneOffset(px, py), deviceType)
-        dispatchMultiPointer(eventType = PointerEventType.Press)
+        pointers.press(input.pointerId ?: 0, sceneOffset(px, py), deviceType)
       }
       InteractiveInputKind.POINTER_MOVE -> {
         if (px == null || py == null) return
-        val id = input.pointerId ?: 0
-        // Keep the device class the press established: a drag's moves must stay the same pointer
-        // Compose saw go down, or the selection gesture it started is handed a foreign device
-        // mid-stream.
-        val type = activePointers[id]?.type ?: deviceType
-        activePointers[id] = ActivePointer(sceneOffset(px, py), type)
-        dispatchMultiPointer(eventType = PointerEventType.Move)
+        pointers.move(input.pointerId ?: 0, sceneOffset(px, py), deviceType)
       }
       InteractiveInputKind.POINTER_UP -> {
         if (px == null || py == null) return
-        val id = input.pointerId ?: 0
-        // Remove BEFORE dispatch but pass the released id+position into [dispatchMultiPointer] so
-        // Compose sees the up event with `pressed = false` for this pointer alongside any
-        // still-active fingers. Without the explicit released entry, dropping the pointer here and
-        // dispatching only remaining actives would deliver a Move-shaped event and the gesture
-        // detector would never see the "finger lifted" signal.
-        val type = activePointers[id]?.type ?: deviceType
-        activePointers.remove(id)
-        dispatchMultiPointer(
-          eventType = PointerEventType.Release,
-          releasedPointer = ActivePointer(sceneOffset(px, py), type) to id,
-        )
+        pointers.release(input.pointerId ?: 0, sceneOffset(px, py), deviceType)
       }
       InteractiveInputKind.ROTARY_SCROLL -> {
         if (px == null || py == null) return
         val deltaY = input.scrollDeltaY ?: return
-        state.scene.sendPointerEvent(
-          eventType = PointerEventType.Scroll,
-          position = sceneOffset(px, py),
-          scrollDelta = Offset(0f, deltaY),
-        )
+        pointers.scroll(sceneOffset(px, py), deltaY)
       }
-      InteractiveInputKind.KEY_DOWN -> {
-        val key = androidKeycodeToComposeKey(input.keyCode)
-        val typed = printableText(input.text)
-        // A key the table doesn't know AND no printable text is nothing we can dispatch — drop it
-        // silently, same forward-compat contract as before.
-        if (key == null && typed == null) return
-        // Mirror the press into the soft-keyboard band so an agent driving keyboard input through
-        // `interactive/input` sees the matching cap light up. The band's "press implies visible"
-        // rule in `KeyboardController.softInputVisible` also raises the band even if the consumer
-        // hasn't called `keyboardController.show()`.
-        KeyboardBandLabels.fromAndroidKeycode(input.keyCode)?.let(KeyboardController::notifyKeyDown)
-        if (key != null) state.scene.sendKeyEvent(KeyEvent(key, KeyEventType.KeyDown))
-        // Then the *typed character*, as a real AWT `KEY_TYPED` event. This second dispatch is
-        // what makes typing work: Compose desktop's `KeyEvent.isTypedEvent` — the gate on
-        // `KeyCommand.TYPE`, i.e. "insert this character into the text field" — asks the event for
-        // its backing AWT event and requires `id == KEY_TYPED` with a printable `keyChar`. The
-        // synthesised `KeyEvent(key, KeyDown)` above has no AWT event at all, so it can only ever
-        // drive the *command* keys (arrows, Backspace, Delete, Home/End) that map off `Key` alone.
-        // That asymmetry is exactly why caret movement and deletion worked on the live lanes while
-        // typing did nothing (issue #3491).
-        // One event per UTF-16 unit: an AWT `KEY_TYPED` carries a single `char`, so an astral
-        // code point (an emoji) travels as its surrogate pair, which is exactly how AWT delivers
-        // one. Compose appends each unit and the pair lands as the one character it is.
-        typed?.forEach { state.scene.sendKeyEvent(typedKeyEvent(key, it)) }
-      }
-      InteractiveInputKind.KEY_UP -> {
-        val key = androidKeycodeToComposeKey(input.keyCode) ?: return
-        // No typed-character counterpart here: AWT emits `KEY_TYPED` only between press and
-        // release, and Compose only inserts on `KeyDown`.
-        KeyboardBandLabels.fromAndroidKeycode(input.keyCode)?.let(KeyboardController::notifyKeyUp)
-        state.scene.sendKeyEvent(KeyEvent(key, KeyEventType.KeyUp))
-      }
+      // A key the translation table doesn't know AND no printable text is nothing we can dispatch —
+      // dropped silently here (interactive/input is fire-and-forget); the recording lane reports
+      // the
+      // same condition as `unsupported` evidence.
+      InteractiveInputKind.KEY_DOWN ->
+        SceneKeyDispatch.keyDown(state.scene, input.keyCode, input.text)
+      InteractiveInputKind.KEY_UP -> SceneKeyDispatch.keyUp(state.scene, input.keyCode)
     }
   }
 
@@ -372,129 +310,10 @@ class DesktopInteractiveSession(
     return androidx.compose.ui.geometry.Offset(px.toFloat() / d, py.toFloat() / d)
   }
 
-  /**
-   * Dispatch one multi-pointer event carrying every currently-active pointer (and, optionally, a
-   * just-released pointer with `pressed = false`). Mirrors
-   * `DesktopRecordingSession.dispatchMultiPointer` — Skiko's `sendPointerEvent` overload that takes
-   * `List<ComposeScenePointer>` is what gives `Modifier.transformable {}` its rotation / zoom / pan
-   * callbacks: the gesture detector only fires when it sees ≥ 2 pointers in a single event.
-   *
-   * Falls back to a no-op when there are no pointers to dispatch — defensive, the call sites always
-   * provide either an active set, a `releasedPointer`, or both.
-   *
-   * Wall-clock timing: when [timeMillis] is `null` (the default, used by every kind except CLICK)
-   * we read [RenderEngine.currentFrameNanoTime] so the event timeline matches what
-   * `render(useWallClockFrameTime = true)` exposes to the composition. CLICK passes an explicit
-   * value so its synthetic Press and Release land at predictable Δt = `CLICK_HOLD_MS`.
-   */
-  private fun dispatchMultiPointer(
-    eventType: PointerEventType,
-    timeMillis: Long? = null,
-    releasedPointer: Pair<ActivePointer, Int>? = null,
-  ) {
-    val pointers = buildList {
-      for ((pid, pointer) in activePointers) {
-        add(
-          ComposeScenePointer(
-            id = PointerId(pid.toLong()),
-            position = pointer.offset,
-            pressed = true,
-            type = pointer.type,
-          )
-        )
-      }
-      if (releasedPointer != null) {
-        val (pointer, pid) = releasedPointer
-        add(
-          ComposeScenePointer(
-            id = PointerId(pid.toLong()),
-            position = pointer.offset,
-            pressed = false,
-            type = pointer.type,
-          )
-        )
-      }
-    }
-    if (pointers.isEmpty()) return
-    val anyPressed = pointers.any { it.pressed }
-    val effectiveTimeMs = timeMillis ?: (engine.currentFrameNanoTime() / 1_000_000L)
-    state.scene.sendPointerEvent(
-      eventType = eventType,
-      pointers = pointers,
-      buttons = PointerButtons(isPrimaryPressed = anyPressed),
-      timeMillis = effectiveTimeMs,
-      button = if (eventType == PointerEventType.Press) PointerButton.Primary else null,
-    )
-  }
-
   /** For tests that want to peek at the held scene's identity without exposing it permanently. */
   internal fun heldScene(): androidx.compose.ui.ImageComposeScene = state.scene
 
   companion object {
-    /**
-     * The wire's `pointerType` as the Compose device class Skiko dispatches with. Absent /
-     * unrecognised ⇒ [PointerType.Touch], the behaviour every client had before the field existed.
-     */
-    internal fun composePointerType(wire: String?): PointerType =
-      when (InteractivePointerType.parse(wire)) {
-        InteractivePointerType.MOUSE -> PointerType.Mouse
-        InteractivePointerType.PEN -> PointerType.Stylus
-        InteractivePointerType.TOUCH -> PointerType.Touch
-      }
-
-    /**
-     * The text [text] types, or `null` when there is nothing typeable in it — absent, empty, more
-     * than one code point, or a non-printing one (control characters, and the `Shift` / `ArrowLeft`
-     * style key *names* the browser also puts in `KeyboardEvent.key`).
-     *
-     * One *code point*, which is not the same as one `Char`: an emoji is a single character the
-     * client will happily send (its `Array.from(key).length` is 1) but two UTF-16 units, and
-     * measuring in `Char`s would drop it on the floor here while the Android lane inserted it. The
-     * returned string is one code point, so it is either one `Char` or a surrogate pair.
-     */
-    internal fun printableText(text: String?): String? {
-      if (text.isNullOrEmpty()) return null
-      if (text.codePointCount(0, text.length) != 1) return null
-      val codePoint = text.codePointAt(0)
-      if (Character.isISOControl(codePoint)) return null
-      val block = Character.UnicodeBlock.of(codePoint)
-      if (block == null || block == Character.UnicodeBlock.SPECIALS) return null
-      return text
-    }
-
-    /**
-     * A Compose `KeyDown` carrying [ch] as typed text: the code point Compose inserts, plus a
-     * synthetic AWT `KEY_TYPED` as the event's `nativeEvent`. The AWT event is the load-bearing
-     * half — `isTypedEvent` reaches through to it and requires `id == KEY_TYPED` with a printable
-     * `keyChar` before it will map the event to `KeyCommand.TYPE`.
-     *
-     * [key] is the physical key when the wire named one, so a consumer's `Modifier.onKeyEvent`
-     * still sees a coherent event; typing works either way, since the mapping falls through to
-     * `isTypedEvent` for any key that carries no unmodified command of its own.
-     *
-     * The AWT source component is a bare [java.awt.Canvas], never shown or added to a hierarchy —
-     * AWT only refuses a *null* source. `KEY_TYPED` carries no key code by definition
-     * (`VK_UNDEFINED`); the character is the whole payload.
-     */
-    internal fun typedKeyEvent(key: Key?, ch: Char): KeyEvent =
-      KeyEvent(
-        key = key ?: Key.Unknown,
-        type = KeyEventType.KeyDown,
-        codePoint = ch.code,
-        nativeEvent =
-          java.awt.event.KeyEvent(
-            typedEventSource,
-            java.awt.event.KeyEvent.KEY_TYPED,
-            System.currentTimeMillis(),
-            0,
-            java.awt.event.KeyEvent.VK_UNDEFINED,
-            ch,
-          ),
-      )
-
-    /** Lazily built so a session that never types never touches AWT component construction. */
-    private val typedEventSource: java.awt.Component by lazy { java.awt.Canvas() }
-
     /**
      * Synthetic hold time between Press and Release for a CLICK. 100 ms matches what Compose's UI
      * test harness uses by default and is well above `detectTapGestures`'s long-press threshold

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -5,15 +5,7 @@
 
 package ee.schimke.composeai.daemon
 
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.pointer.PointerButton
-import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.PointerId
-import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.scene.ComposeScenePointer
 import ee.schimke.composeai.cli.AccessibilityNode
 import ee.schimke.composeai.cli.TalkBackOverlayFrames
 import ee.schimke.composeai.cli.TalkBackTraversal
@@ -376,10 +368,13 @@ class DesktopRecordingSession(
    *
    * Built-in input kinds (`click`, `pointerDown`, `pointerMove`, `pointerUp`) are registered as
    * real Skiko `sendPointerEvent` calls. `rotaryScroll` reuses the pointer pipeline's
-   * `PointerEventType.Scroll`; `keyDown` / `keyUp` route through `sendKeyEvent` with the desktop
-   * key translation table (`DesktopKeyDispatch.kt`). Issue #1203 closed the no-op gap that lived
-   * here pre-v3. The probe extension handler appears once, here, instead of leaking into the
-   * dispatch loop's special-case branch.
+   * `PointerEventType.Scroll`; `keyDown` / `keyUp` route through the shared [SceneKeyDispatch],
+   * which pairs the desktop key translation table (`DesktopKeyDispatch.kt`) with the
+   * typed-character dispatch a `TextField` actually inserts from. Issue #1203 closed the no-op gap
+   * that lived here pre-v3; issue #3545 replaced the recording lane's private copies of the key and
+   * pointer dispatch with the interactive lane's, so typing and mouse-selection reach recordings
+   * too. The probe extension handler appears once, here, instead of leaking into the dispatch
+   * loop's special-case branch.
    */
   private val scriptHandlers: RecordingScriptHandlerRegistry = buildScriptHandlers()
 
@@ -400,8 +395,8 @@ class DesktopRecordingSession(
           pointerHandler(PointerEventType.Release),
         )
         put("input.rotaryScroll", rotaryScrollHandler())
-        put(InputKeyboardRecordingScriptEvents.KEY_DOWN_EVENT, keyHandler(KeyEventType.KeyDown))
-        put(InputKeyboardRecordingScriptEvents.KEY_UP_EVENT, keyHandler(KeyEventType.KeyUp))
+        put(InputKeyboardRecordingScriptEvents.KEY_DOWN_EVENT, keyDownHandler())
+        put(InputKeyboardRecordingScriptEvents.KEY_UP_EVENT, keyUpHandler())
         put(
           RecordingScriptDataExtensions.ASSERT_VISIBLE_EVENT,
           assertVisibilityHandler(expectVisible = true),
@@ -426,14 +421,17 @@ class DesktopRecordingSession(
     )
 
   /**
-   * Per-pointer-id active state — keyed by [RecordingScriptEvent.pointerId] (`null` collapses to
-   * `0` for backwards compatibility). Updated by [pointerHandler] on every `pointerDown` /
-   * `pointerMove` / `pointerUp` so the next multi-pointer dispatch sees the full set of currently-
-   * pressed fingers. Cleared per id on `pointerUp`. This is what enables real pinch-to-zoom in
-   * scripted recordings — Compose's gesture pipeline needs to see both fingers simultaneously to
-   * fire `Modifier.transformable {}`'s zoom handler.
+   * Pointer translation + per-pointer-id active state, keyed by [RecordingScriptEvent.pointerId]
+   * (`null` collapses to `0` for backwards compatibility). This is what enables real pinch-to-zoom
+   * in recordings — Compose's gesture pipeline needs to see both fingers simultaneously to fire
+   * `Modifier.transformable {}`'s zoom handler.
+   *
+   * The same [ScenePointerDispatch] [DesktopInteractiveSession] uses, so a recording synthesises
+   * mouse / pen / touch pointers exactly like the interactive lane does (issue #3545). Every
+   * dispatch passes the event's virtual `tMs` explicitly, so the wall-clock default is never used.
    */
-  private val activePointers: MutableMap<Int, Offset> = mutableMapOf()
+  private val pointers: ScenePointerDispatch =
+    ScenePointerDispatch(scene = { state.scene }, defaultTimeMillis = { 0L })
 
   private fun pointerIdOrDefault(event: RecordingScriptEvent): Int = event.pointerId ?: 0
 
@@ -646,15 +644,10 @@ class DesktopRecordingSession(
         }
       val id = pointerIdOrDefault(event)
       val offset = sceneOffset(px, py)
-      activePointers[id] = offset
-      dispatchMultiPointer(eventType = PointerEventType.Press, timeMillis = ctx.tMs)
+      val type = composePointerType(event.pointerType)
+      pointers.press(id, offset, type, timeMillis = ctx.tMs)
       state.scene.render(nanoTime = ctx.tNanos)
-      activePointers.remove(id)
-      dispatchMultiPointer(
-        eventType = PointerEventType.Release,
-        timeMillis = ctx.tMs,
-        releasedPointer = id to offset,
-      )
+      pointers.release(id, offset, type, timeMillis = ctx.tMs)
       appliedEvidence(event)
     }
 
@@ -664,11 +657,16 @@ class DesktopRecordingSession(
    * [DesktopInteractiveSession] uses so `Modifier.clickable {}` and other tap-gesture detectors see
    * consistent down→up sequences regardless of mode.
    *
-   * Multi-pointer aware via [RecordingScriptEvent.pointerId]: each event updates [activePointers]
-   * for its own id, then dispatches a single multi-pointer `sendPointerEvent` carrying every
+   * Multi-pointer aware via [RecordingScriptEvent.pointerId]: each event updates [pointers] for its
+   * own id, then dispatches a single multi-pointer `sendPointerEvent` carrying every
    * currently-pressed pointer. That's what pinch-to-zoom needs — without seeing both fingers at the
    * same `tMs`, Compose's `Modifier.transformable` zoom detector treats the two fingers as
    * independent drags and never fires the zoom callback.
+   *
+   * Device-class aware via [RecordingScriptEvent.pointerType] (issue #3545): a script that means to
+   * mouse-drag a text selection says `"mouse"`, and a move / release inherits whatever class its
+   * press established, so a drag can't change device mid-stream. Absent ⇒ touch, so every script
+   * written before the field existed replays exactly as it did.
    */
   private fun pointerHandler(eventType: PointerEventType): RecordingScriptEventHandler =
     RecordingScriptEventHandler { event, ctx ->
@@ -684,82 +682,15 @@ class DesktopRecordingSession(
         }
       val id = pointerIdOrDefault(event)
       val offset = sceneOffset(px, py)
-      val releasedPointer: Pair<Int, Offset>?
+      val type = composePointerType(event.pointerType)
       when (eventType) {
-        PointerEventType.Press -> {
-          activePointers[id] = offset
-          releasedPointer = null
-        }
-        PointerEventType.Move -> {
-          activePointers[id] = offset
-          releasedPointer = null
-        }
-        PointerEventType.Release -> {
-          // Remove BEFORE dispatch but pass the released id+position into [dispatchMultiPointer]
-          // so Compose sees the up event with `pressed = false` for this pointer alongside any
-          // still-active fingers. Without the explicit released entry, dropping the pointer here
-          // and dispatching only remaining actives would deliver a Move-shaped event and the
-          // gesture detector would never see the "finger lifted" signal.
-          activePointers.remove(id)
-          releasedPointer = id to offset
-        }
-        else -> releasedPointer = null
+        PointerEventType.Press -> pointers.press(id, offset, type, timeMillis = ctx.tMs)
+        PointerEventType.Move -> pointers.move(id, offset, type, timeMillis = ctx.tMs)
+        PointerEventType.Release -> pointers.release(id, offset, type, timeMillis = ctx.tMs)
+        else -> Unit
       }
-      dispatchMultiPointer(
-        eventType = eventType,
-        timeMillis = ctx.tMs,
-        releasedPointer = releasedPointer,
-      )
       appliedEvidence(event)
     }
-
-  /**
-   * Dispatch one multi-pointer event carrying every currently-active pointer (and, optionally, a
-   * just-released pointer with `pressed = false`). Skiko's `BaseComposeScene.sendPointerEvent`
-   * overload that takes `List<ComposeScenePointer>` is what makes pinch-to-zoom work — Compose's
-   * pointer pipeline tracks gesture id-by-id and fires `Modifier.transformable {}`'s rotation /
-   * zoom / pan callbacks only when it sees ≥ 2 pointers in a single event.
-   *
-   * Falls back to a no-op when there are no pointers to dispatch (defensive — the handlers always
-   * provide either an active set, a releasedPointer, or both).
-   */
-  private fun dispatchMultiPointer(
-    eventType: PointerEventType,
-    timeMillis: Long,
-    releasedPointer: Pair<Int, Offset>? = null,
-  ) {
-    val pointers = buildList {
-      for ((pid, off) in activePointers) {
-        add(
-          ComposeScenePointer(
-            id = PointerId(pid.toLong()),
-            position = off,
-            pressed = true,
-            type = PointerType.Touch,
-          )
-        )
-      }
-      if (releasedPointer != null) {
-        add(
-          ComposeScenePointer(
-            id = PointerId(releasedPointer.first.toLong()),
-            position = releasedPointer.second,
-            pressed = false,
-            type = PointerType.Touch,
-          )
-        )
-      }
-    }
-    if (pointers.isEmpty()) return
-    val anyPressed = pointers.any { it.pressed }
-    state.scene.sendPointerEvent(
-      eventType = eventType,
-      pointers = pointers,
-      buttons = PointerButtons(isPrimaryPressed = anyPressed),
-      timeMillis = timeMillis,
-      button = if (eventType == PointerEventType.Press) PointerButton.Primary else null,
-    )
-  }
 
   /**
    * Reuses Skiko's pointer-event pipeline for rotary scrolling — the same path a wheel input on a
@@ -786,31 +717,48 @@ class DesktopRecordingSession(
           "${event.kind} requires scrollDeltaY",
         )
       }
-      state.scene.sendPointerEvent(
-        eventType = PointerEventType.Scroll,
-        position = sceneOffset(px, py),
-        timeMillis = ctx.tMs,
-        scrollDelta = Offset(0f, deltaY),
-      )
+      pointers.scroll(sceneOffset(px, py), deltaY, timeMillis = ctx.tMs)
       appliedEvidence(event)
     }
 
   /**
-   * Translate the wire `keyCode` (Android `KEYCODE_*` int as a decimal string — see
-   * `InteractiveKeyCodes`) to a Compose [androidx.compose.ui.input.key.Key] and dispatch via
-   * `BaseComposeScene.sendKeyEvent`. Unmapped codes surface as `unsupported` script evidence so the
-   * agent learns which key didn't make it through.
+   * `input.keyDown` through the shared [SceneKeyDispatch] — the same implementation
+   * [DesktopInteractiveSession] uses, so a recorded keystroke behaves exactly like a live one
+   * (issue #3545).
+   *
+   * Both halves go out: the wire `keyCode` (Android `KEYCODE_*` as a decimal string, see
+   * `InteractiveKeyCodes`) as a Compose `Key`, and the `text` it typed as a `KEY_TYPED`-backed
+   * event — the only half a `TextField` inserts from. Either half alone is enough, so a
+   * non-US-layout character with no `KEYCODE_*` still types.
+   *
+   * An event carrying neither a mapped keycode nor printable text surfaces as `unsupported` script
+   * evidence, so the agent learns which key didn't make it through.
    */
-  private fun keyHandler(type: KeyEventType): RecordingScriptEventHandler =
+  private fun keyDownHandler(): RecordingScriptEventHandler =
     RecordingScriptEventHandler { event, _ ->
-      val key = androidKeycodeToComposeKey(event.keyCode)
-      if (key == null) {
+      if (!SceneKeyDispatch.keyDown(state.scene, event.keyCode, event.text)) {
+        return@RecordingScriptEventHandler unsupportedEvidence(
+          event,
+          "${event.kind} has nothing to dispatch: keyCode '${event.keyCode}' is not in the " +
+            "desktop key translation table and text ${event.text?.let { "'$it'" } ?: "(absent)"} " +
+            "is not a single printable character",
+        )
+      }
+      appliedEvidence(event)
+    }
+
+  /**
+   * `input.keyUp` counterpart. No typed-character half — AWT emits `KEY_TYPED` only between press
+   * and release — so an unmapped keycode is all there is to fail on.
+   */
+  private fun keyUpHandler(): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      if (!SceneKeyDispatch.keyUp(state.scene, event.keyCode)) {
         return@RecordingScriptEventHandler unsupportedEvidence(
           event,
           "${event.kind} keyCode '${event.keyCode}' is not in the desktop key translation table",
         )
       }
-      state.scene.sendKeyEvent(KeyEvent(key, type))
       appliedEvidence(event)
     }
 
@@ -1164,6 +1112,12 @@ class DesktopRecordingSession(
  * zoom / rotate callbacks never fired despite the multi-pointer dispatch the same PR landed. See
  * compose-ai-tools#1360 finding #2.
  *
+ * `text` and `pointerType` are threaded for the same reason (issue #3545): everything not on the
+ * script event is gone by the time [scriptHandlers] dispatches, so a viewer sending the character a
+ * key typed — or saying a drag came from a mouse — used to have both silently discarded the moment
+ * a recording was active. They also ride into [RecordingStopResult.capturedScript], so a captured
+ * session replays as the keystrokes and the selection it actually was.
+ *
  * Top-level (not a member of [DesktopRecordingSession]) so the unit test can exercise the data
  * mapping without standing up an `ImageComposeScene` / `RenderEngine` per assertion.
  */
@@ -1177,6 +1131,8 @@ internal fun RecordingInputParams.toScriptEvent(tMs: Long): RecordingScriptEvent
     pointerId = pointerId,
     scrollDeltaY = scrollDeltaY,
     keyCode = keyCode,
+    text = text,
+    pointerType = pointerType,
   )
 
 /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopSceneInput.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopSceneInput.kt
@@ -1,0 +1,279 @@
+@file:OptIn(
+  androidx.compose.ui.InternalComposeUiApi::class,
+  androidx.compose.ui.ExperimentalComposeUiApi::class,
+)
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.scene.ComposeScenePointer
+import ee.schimke.composeai.daemon.protocol.InteractivePointerType
+
+/**
+ * The one desktop implementation of "turn a wire input into a scene event", shared by
+ * [DesktopInteractiveSession] (the live `interactive/input` lane) and [DesktopRecordingSession]
+ * (the `recording/script` + live-tick lane).
+ *
+ * The two lanes used to carry their own copies. That is how the recording lane ended up unable to
+ * type or mouse-select long after both were fixed for interactive input: the fixes landed in one
+ * copy (issues #3491 / #3504) and the other kept dispatching a code-point-less `KeyEvent` through a
+ * pointer path pinned to [PointerType.Touch] (issue #3545). With one implementation, a fix to key
+ * or pointer translation is a fix to both lanes by construction.
+ *
+ * Everything here is scene-thread confined — the callers already pin their scene touches (the
+ * interactive session to its `sceneExecutor`, the recording session to its playback / tick thread),
+ * so nothing in this file synchronises.
+ */
+
+/** A pointer's scene-space position plus the device class it is being synthesised as. */
+internal data class ScenePointer(val offset: Offset, val type: PointerType)
+
+/**
+ * Multi-pointer dispatch over a held [ImageComposeScene], tracking each pressed pointer by id so
+ * every `sendPointerEvent` carries the full set of currently-down fingers.
+ *
+ * That grouping is the load-bearing part: Skiko's `List<ComposeScenePointer>` overload is what
+ * gives `Modifier.transformable {}` its rotation / zoom / pan callbacks, and the detector only
+ * fires when it sees ≥ 2 pointers *in a single event*. Dispatching each finger separately reads as
+ * two independent drags.
+ *
+ * @param scene the held scene, read lazily so a session can hand over its `state.scene` without
+ *   this class holding the session's `RenderEngine.SceneState`.
+ * @param defaultTimeMillis event timestamp used when a call site passes `timeMillis = null` — the
+ *   interactive lane's wall-clock frame time. Scripted playback always passes its virtual `tMs`.
+ */
+internal class ScenePointerDispatch(
+  private val scene: () -> ImageComposeScene,
+  private val defaultTimeMillis: () -> Long,
+) {
+
+  /**
+   * Per-pointer-id active state. Read and written only from the caller's scene thread, so a plain
+   * [MutableMap] is safe. Cleared per id on release.
+   */
+  private val active: MutableMap<Int, ScenePointer> = mutableMapOf()
+
+  /**
+   * The device class pointer [id] was pressed as, or [fallback] when it isn't currently down.
+   *
+   * A drag's moves and its release must stay the same device Compose saw go down, or the selection
+   * gesture the press started is handed a foreign device mid-stream and drops it.
+   */
+  fun heldTypeOr(id: Int, fallback: PointerType): PointerType = active[id]?.type ?: fallback
+
+  fun press(id: Int, offset: Offset, type: PointerType, timeMillis: Long? = null) {
+    active[id] = ScenePointer(offset, type)
+    send(PointerEventType.Press, timeMillis)
+  }
+
+  fun move(id: Int, offset: Offset, type: PointerType, timeMillis: Long? = null) {
+    active[id] = ScenePointer(offset, heldTypeOr(id, type))
+    send(PointerEventType.Move, timeMillis)
+  }
+
+  /**
+   * Drop pointer [id] and dispatch the release.
+   *
+   * The released pointer is removed from [active] *before* the dispatch but passed in explicitly,
+   * so Compose sees it with `pressed = false` alongside any still-down fingers. Dropping it and
+   * dispatching only the remaining actives would deliver a Move-shaped event and the gesture
+   * detector would never see the "finger lifted" signal.
+   */
+  fun release(id: Int, offset: Offset, type: PointerType, timeMillis: Long? = null) {
+    val held = heldTypeOr(id, type)
+    active.remove(id)
+    send(PointerEventType.Release, timeMillis, ScenePointer(offset, held) to id)
+  }
+
+  /**
+   * Wheel / rotary scroll at [offset]. Positive [deltaY] means wheel-down (the browser convention).
+   *
+   * [timeMillis] is honoured only when non-null: the interactive lane leaves Skiko's own default in
+   * place, which is what it did before this class existed.
+   */
+  fun scroll(offset: Offset, deltaY: Float, timeMillis: Long? = null) {
+    if (timeMillis == null) {
+      scene()
+        .sendPointerEvent(
+          eventType = PointerEventType.Scroll,
+          position = offset,
+          scrollDelta = Offset(0f, deltaY),
+        )
+    } else {
+      scene()
+        .sendPointerEvent(
+          eventType = PointerEventType.Scroll,
+          position = offset,
+          timeMillis = timeMillis,
+          scrollDelta = Offset(0f, deltaY),
+        )
+    }
+  }
+
+  private fun send(
+    eventType: PointerEventType,
+    timeMillis: Long?,
+    releasedPointer: Pair<ScenePointer, Int>? = null,
+  ) {
+    val pointers = buildList {
+      for ((pid, pointer) in active) {
+        add(
+          ComposeScenePointer(
+            id = PointerId(pid.toLong()),
+            position = pointer.offset,
+            pressed = true,
+            type = pointer.type,
+          )
+        )
+      }
+      if (releasedPointer != null) {
+        val (pointer, pid) = releasedPointer
+        add(
+          ComposeScenePointer(
+            id = PointerId(pid.toLong()),
+            position = pointer.offset,
+            pressed = false,
+            type = pointer.type,
+          )
+        )
+      }
+    }
+    // Defensive — every call site provides either an active set, a released pointer, or both.
+    if (pointers.isEmpty()) return
+    val anyPressed = pointers.any { it.pressed }
+    scene()
+      .sendPointerEvent(
+        eventType = eventType,
+        pointers = pointers,
+        buttons = PointerButtons(isPrimaryPressed = anyPressed),
+        timeMillis = timeMillis ?: defaultTimeMillis(),
+        button = if (eventType == PointerEventType.Press) PointerButton.Primary else null,
+      )
+  }
+}
+
+/**
+ * The one desktop key-dispatch implementation, shared by the interactive and recording lanes.
+ *
+ * Both halves of a keystroke go out: the physical [Key] (so a consumer's `Modifier.onKeyEvent` sees
+ * the key it expects, and the command keys — arrows, Backspace, Delete, Home/End — that map off
+ * `Key` alone keep working) and the *typed character*, which is the only half that can actually
+ * insert into a `TextField`.
+ */
+internal object SceneKeyDispatch {
+
+  /**
+   * Dispatch a key-down carrying [keyCode] (decimal-string Android `KEYCODE_*`) and/or the literal
+   * [text] it typed. Returns `false` when neither half is dispatchable — an unmapped keycode with
+   * no printable text — so the interactive lane can drop it silently while the recording lane
+   * reports `unsupported` evidence.
+   */
+  fun keyDown(scene: ImageComposeScene, keyCode: String?, text: String?): Boolean {
+    val key = androidKeycodeToComposeKey(keyCode)
+    val typed = printableText(text)
+    if (key == null && typed == null) return false
+    // Mirror the press into the soft-keyboard band so an agent driving keyboard input sees the
+    // matching cap light up. The band's "press implies visible" rule in
+    // `KeyboardController.softInputVisible` also raises the band even if the consumer never called
+    // `keyboardController.show()`.
+    KeyboardBandLabels.fromAndroidKeycode(keyCode)?.let(KeyboardController::notifyKeyDown)
+    if (key != null) scene.sendKeyEvent(KeyEvent(key, KeyEventType.KeyDown))
+    // Then the typed character, as a real AWT `KEY_TYPED` event. This second dispatch is what makes
+    // typing work: Compose desktop's `KeyEvent.isTypedEvent` — the gate on `KeyCommand.TYPE`, i.e.
+    // "insert this character into the text field" — asks the event for its backing AWT event and
+    // requires `id == KEY_TYPED` with a printable `keyChar`. The synthesised `KeyEvent(key,
+    // KeyDown)` above has no AWT event at all, so it can only ever drive the *command* keys. That
+    // asymmetry is exactly why caret movement and deletion worked while typing did nothing.
+    // One event per UTF-16 unit: an AWT `KEY_TYPED` carries a single `char`, so an astral code
+    // point (an emoji) travels as its surrogate pair, which is exactly how AWT delivers one.
+    // Compose appends each unit and the pair lands as the one character it is.
+    typed?.forEach { scene.sendKeyEvent(typedKeyEvent(key, it)) }
+    return true
+  }
+
+  /**
+   * Dispatch a key-up for [keyCode]. Returns `false` for an unmapped code.
+   *
+   * No typed-character counterpart: AWT emits `KEY_TYPED` only between press and release, and
+   * Compose only inserts on `KeyDown`.
+   */
+  fun keyUp(scene: ImageComposeScene, keyCode: String?): Boolean {
+    val key = androidKeycodeToComposeKey(keyCode) ?: return false
+    KeyboardBandLabels.fromAndroidKeycode(keyCode)?.let(KeyboardController::notifyKeyUp)
+    scene.sendKeyEvent(KeyEvent(key, KeyEventType.KeyUp))
+    return true
+  }
+}
+
+/**
+ * The wire's `pointerType` as the Compose device class Skiko dispatches with. Absent / unrecognised
+ * ⇒ [PointerType.Touch], the behaviour every client had before the field existed.
+ */
+internal fun composePointerType(wire: String?): PointerType =
+  when (InteractivePointerType.parse(wire)) {
+    InteractivePointerType.MOUSE -> PointerType.Mouse
+    InteractivePointerType.PEN -> PointerType.Stylus
+    InteractivePointerType.TOUCH -> PointerType.Touch
+  }
+
+/**
+ * The text [text] types, or `null` when there is nothing typeable in it — absent, empty, more than
+ * one code point, or a non-printing one (control characters, and the `Shift` / `ArrowLeft` style
+ * key *names* the browser also puts in `KeyboardEvent.key`).
+ *
+ * One *code point*, which is not the same as one `Char`: an emoji is a single character the client
+ * will happily send (its `Array.from(key).length` is 1) but two UTF-16 units, and measuring in
+ * `Char`s would drop it on the floor here while the Android lane inserted it. The returned string
+ * is one code point, so it is either one `Char` or a surrogate pair.
+ */
+internal fun printableText(text: String?): String? {
+  if (text.isNullOrEmpty()) return null
+  if (text.codePointCount(0, text.length) != 1) return null
+  val codePoint = text.codePointAt(0)
+  if (Character.isISOControl(codePoint)) return null
+  val block = Character.UnicodeBlock.of(codePoint)
+  if (block == null || block == Character.UnicodeBlock.SPECIALS) return null
+  return text
+}
+
+/**
+ * A Compose `KeyDown` carrying [ch] as typed text: the code point Compose inserts, plus a synthetic
+ * AWT `KEY_TYPED` as the event's `nativeEvent`. The AWT event is the load-bearing half —
+ * `isTypedEvent` reaches through to it and requires `id == KEY_TYPED` with a printable `keyChar`
+ * before it will map the event to `KeyCommand.TYPE`.
+ *
+ * [key] is the physical key when the wire named one, so a consumer's `Modifier.onKeyEvent` still
+ * sees a coherent event; typing works either way, since the mapping falls through to `isTypedEvent`
+ * for any key that carries no unmodified command of its own.
+ *
+ * The AWT source component is a bare [java.awt.Canvas], never shown or added to a hierarchy — AWT
+ * only refuses a *null* source. `KEY_TYPED` carries no key code by definition (`VK_UNDEFINED`); the
+ * character is the whole payload.
+ */
+internal fun typedKeyEvent(key: Key?, ch: Char): KeyEvent =
+  KeyEvent(
+    key = key ?: Key.Unknown,
+    type = KeyEventType.KeyDown,
+    codePoint = ch.code,
+    nativeEvent =
+      java.awt.event.KeyEvent(
+        typedEventSource,
+        java.awt.event.KeyEvent.KEY_TYPED,
+        System.currentTimeMillis(),
+        0,
+        java.awt.event.KeyEvent.VK_UNDEFINED,
+        ch,
+      ),
+  )
+
+/** Lazily built so a process that never types never touches AWT component construction. */
+private val typedEventSource: java.awt.Component by lazy { java.awt.Canvas() }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionLiveInputTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionLiveInputTest.kt
@@ -107,6 +107,54 @@ class DesktopRecordingSessionLiveInputTest {
   }
 
   @Test
+  fun `toScriptEvent threads the typed text and the pointer device through`() {
+    // Issue #3545 — the same drop this file was written about, one field-pair over. Anything not on
+    // the synthesised script event is gone by the time the handler registry dispatches, so a `text`
+    // left off here meant a live recording could never type a character, and a `pointerType` left
+    // off meant every mouse drag reached the composition as touch and never selected.
+    val typed =
+      RecordingInputParams(
+        recordingId = "live-rec",
+        kind = InteractiveInputKind.KEY_DOWN,
+        keyCode = "29", // KEYCODE_A
+        text = "a",
+      )
+    val mouseDown =
+      RecordingInputParams(
+        recordingId = "live-rec",
+        kind = InteractiveInputKind.POINTER_DOWN,
+        pixelX = 10,
+        pixelY = 20,
+        pointerType = "mouse",
+      )
+
+    val typedEvent = typed.toScriptEvent(tMs = 5L)
+    val mouseEvent = mouseDown.toScriptEvent(tMs = 5L)
+
+    assertEquals("a", typedEvent.text)
+    assertEquals("29", typedEvent.keyCode)
+    assertEquals("mouse", mouseEvent.pointerType)
+  }
+
+  @Test
+  fun `toScriptEvent leaves text and pointerType absent for the pre-3545 wire shape`() {
+    // A client that predates the fields sends neither. Both must stay null so the dispatch falls
+    // back to exactly what it did before: no typed character, and a touch pointer.
+    val legacy =
+      RecordingInputParams(
+        recordingId = "live-rec",
+        kind = InteractiveInputKind.POINTER_DOWN,
+        pixelX = 10,
+        pixelY = 20,
+      )
+
+    val event = legacy.toScriptEvent(tMs = 0L)
+
+    assertEquals(null, event.text)
+    assertEquals(null, event.pointerType)
+  }
+
+  @Test
   fun `toScriptEvent threads a semantic target through for agent-driven live recordings`() {
     // The record-live bridge (issue #2047): an agent driving a live recording by handle posts a
     // target on the wire, which must survive into the captured script verbatim (no pixel math).

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingTextInputTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingTextInputTest.kt
@@ -1,0 +1,395 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.RecordingInputParams
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Issue #3545 — typing and mouse-drag selection over the **recording** lane, on desktop.
+ *
+ * [DesktopTextInputSessionTest] pins the same two capabilities for the live *interactive* lane
+ * (issues #3491 / #3504). Recording is a second dispatch implementation, and it got none of that:
+ * `RecordingInputParams` stopped at `keyCode`, `toScriptEvent` mapped neither `text` nor
+ * `pointerType`, and `DesktopRecordingSession` had its own `sendKeyEvent(KeyEvent(key, type))` plus
+ * a multi-pointer dispatch pinned to `PointerType.Touch`. So while a recording was active, a
+ * viewer's keystrokes and its mouse drags were silently downgraded — a recorded `TextField` could
+ * not receive a character and a recorded drag could not select.
+ *
+ * Both lanes now call one implementation (`DesktopSceneInput.kt`), so these assertions and the
+ * interactive ones fail together if either regresses.
+ *
+ * Covered here:
+ * - **scripted** — typing (mapped key, unmapped-key character, astral character), the no-op cases,
+ *   and `unsupported` evidence when an event carries neither half;
+ * - **scripted** — a mouse press-drag selects while a touch press-drag does not;
+ * - **live** — the same over `recording/input`, plus the capture → replay round-trip: the captured
+ *   script carries `text` / `pointerType`, and replaying it types the same characters again.
+ *
+ * Assertions read [TextFieldProbe] rather than pixels: "the value gained an `a`" and "three
+ * characters are selected" are not distinctions a colour match can make. Selection is asserted from
+ * [TextFieldProbe.widestSelection] because releasing a drag collapses the selection to a caret —
+ * real behaviour on both lanes, so the resting state after a completed drag says nothing about
+ * whether the drag selected.
+ */
+class DesktopRecordingTextInputTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private var savedRecordingsDir: String? = null
+
+  @After
+  fun tearDown() {
+    val saved = savedRecordingsDir
+    if (saved == null) System.clearProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    else System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, saved)
+  }
+
+  @Test
+  fun scripted_keyDown_carrying_text_types_into_the_field() {
+    withScriptedRecording("typed") { session ->
+      session.postScript(listOf(keyDown(tMs = FIRST_EVENT_MS, keyCode = KEYCODE_A, text = "a")))
+      val result = session.stop()
+
+      assertEquals(
+        "a scripted keyDown carrying text must insert it — this is the load-bearing #3545 " +
+          "assertion (the recording lane used to dispatch a code-point-less KeyEvent)",
+        TEXT_FIELD_SEED + "a",
+        TextFieldProbe.text,
+      )
+      assertEquals(
+        RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents.single { it.kind == "input.keyDown" }.status,
+      )
+    }
+  }
+
+  @Test
+  fun scripted_keyDown_without_text_still_types_nothing() {
+    withScriptedRecording("keycode-only") { session ->
+      // The pre-#3545 wire shape: the physical key, no typed character. Compose has nothing to
+      // insert, so the value must not move. Pinned so a future default can't silently re-break the
+      // fix by inventing a character from the keycode.
+      session.postScript(listOf(keyDown(tMs = FIRST_EVENT_MS, keyCode = KEYCODE_A, text = null)))
+      val result = session.stop()
+
+      assertEquals("", TextFieldProbe.text)
+      assertEquals(
+        "a mapped keycode still dispatches the physical key, so the event is APPLIED — it just " +
+          "has nothing to type",
+        RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents.single { it.kind == "input.keyDown" }.status,
+      )
+    }
+  }
+
+  @Test
+  fun scripted_keyDown_with_text_but_no_mapped_keycode_still_types() {
+    withScriptedRecording("no-keycode") { session ->
+      // `€` has no Android keycode on the wire's key list at all. The typed half has to stand on
+      // its
+      // own or every non-US-layout key silently drops — and, pre-fix, the recording lane reported
+      // exactly this event as UNSUPPORTED.
+      session.postScript(listOf(keyDown(tMs = FIRST_EVENT_MS, keyCode = null, text = "€")))
+      val result = session.stop()
+
+      assertEquals(TEXT_FIELD_SEED + "€", TextFieldProbe.text)
+      assertEquals(
+        RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents.single { it.kind == "input.keyDown" }.status,
+      )
+    }
+  }
+
+  @Test
+  fun scripted_keyDown_with_an_astral_character_types_it_whole() {
+    withScriptedRecording("astral") { session ->
+      // An emoji is one character to the browser (`Array.from(key).length == 1`, so the viewer
+      // sends
+      // it) and two UTF-16 units to Kotlin. Measuring in `Char`s would drop it here while the
+      // Android lane inserted it — the two backends have to agree, in recordings as in live input.
+      session.postScript(listOf(keyDown(tMs = FIRST_EVENT_MS, keyCode = null, text = ASTRAL)))
+      session.stop()
+
+      assertEquals(TEXT_FIELD_SEED + ASTRAL, TextFieldProbe.text)
+    }
+  }
+
+  @Test
+  fun scripted_keyDown_with_neither_half_emits_unsupported_evidence() {
+    withScriptedRecording("nothing-to-dispatch") { session ->
+      // Neither a keycode the table knows nor a printable character. Interactive input drops this
+      // silently (fire-and-forget); recording owes the agent an explanation.
+      session.postScript(
+        listOf(keyDown(tMs = FIRST_EVENT_MS, keyCode = UNMAPPED_KEYCODE, text = "Shift"))
+      )
+      val result = session.stop()
+
+      val evidence = result.scriptEvents.single { it.kind == "input.keyDown" }
+      assertEquals(RecordingScriptEventStatus.UNSUPPORTED, evidence.status)
+      assertNotNull("unsupported evidence must say why", evidence.message)
+      assertEquals("", TextFieldProbe.text)
+    }
+  }
+
+  @Test
+  fun scripted_mouse_drag_selects_text() {
+    withScriptedRecording("mouse-drag") { session ->
+      session.postScript(dragScript(pointerType = "mouse"))
+      session.stop()
+
+      assertTrue(
+        "a scripted mouse press-drag across the field must select as it drags; widest selection " +
+          "was \"${TextFieldProbe.widestSelection}\" — this is the load-bearing #3545 pointer " +
+          "assertion (recorded pointers used to be pinned to PointerType.Touch, which never selects)",
+        TextFieldProbe.widestSelection.isNotEmpty(),
+      )
+      assertTrue(
+        "the selection must come from the seeded content, not from somewhere else",
+        TEXT_FIELD_SEED.contains(TextFieldProbe.widestSelection),
+      )
+    }
+  }
+
+  @Test
+  fun scripted_touch_drag_does_not_select_text() {
+    withScriptedRecording("touch-drag") { session ->
+      // Absent `pointerType` is the pre-#3545 wire shape *and* what a genuine finger drag should
+      // still do: a touch drag is a gesture, not a selection. Every script written before the field
+      // existed has to keep replaying exactly like this.
+      session.postScript(dragScript(pointerType = null))
+      session.stop()
+
+      assertEquals(
+        "a touch drag must not select — touch selection is driven by long-press + handles",
+        "",
+        TextFieldProbe.widestSelection,
+      )
+    }
+  }
+
+  @Test
+  fun live_input_types_and_the_captured_script_replays_the_same_text() {
+    // Live half: drive `recording/input` the way the viewer does and watch the field fill up.
+    val captured =
+      withLiveRecording("live-typing") { session ->
+        session.postInput(liveKeyDown(keyCode = KEYCODE_A, text = "a"))
+        session.postInput(liveKeyDown(keyCode = null, text = "€"))
+        Thread.sleep(LIVE_SETTLE_MS)
+        val result = session.stop()
+
+        assertEquals(
+          "a live recording must type exactly like an ordinary interactive session does",
+          TEXT_FIELD_SEED + "a€",
+          TextFieldProbe.text,
+        )
+        result.capturedScript
+      }
+
+    // The captured timeline is a persisted artefact — it is written out, handed to
+    // `recording/generateTest`, and replayed. If `text` didn't survive into it, a recorded typing
+    // session would replay as caret movement.
+    val keyEvents = captured.filter { it.kind == "input.keyDown" }
+    assertEquals(2, keyEvents.size)
+    assertEquals(listOf("a", "€"), keyEvents.map { it.text })
+
+    // Replay half: feed the captured script back through the scripted lane and get the same text.
+    withScriptedRecording("live-replay") { session ->
+      // Re-stamp onto the scripted timeline's virtual clock: the live capture's `tMs` are
+      // wall-clock
+      // offsets from `recording/start`, and the field needs a render tick to take focus first.
+      session.postScript(
+        keyEvents.mapIndexed { i, e -> e.copy(tMs = FIRST_EVENT_MS + i * EVENT_GAP_MS) }
+      )
+      session.stop()
+
+      assertEquals(
+        "replaying a captured live recording must reproduce the characters it typed",
+        TEXT_FIELD_SEED + "a€",
+        TextFieldProbe.text,
+      )
+    }
+  }
+
+  @Test
+  fun live_mouse_drag_selects_and_the_captured_script_records_the_device() {
+    val captured =
+      withLiveRecording("live-drag") { session ->
+        for (input in liveDragInputs(pointerType = "mouse")) {
+          session.postInput(input)
+          // One input per tick: the tick loop drains the whole queue into a single virtual instant,
+          // and a press+move+release collapsed into one instant is not a drag.
+          Thread.sleep(LIVE_TICK_MS)
+        }
+        Thread.sleep(LIVE_SETTLE_MS)
+        val result = session.stop()
+
+        assertTrue(
+          "a live mouse press-drag must select as it drags; widest selection was " +
+            "\"${TextFieldProbe.widestSelection}\"",
+          TextFieldProbe.widestSelection.isNotEmpty(),
+        )
+        result.capturedScript
+      }
+
+    val pointerEvents = captured.filter { it.kind.startsWith("input.pointer") }
+    assertEquals(3, pointerEvents.size)
+    assertTrue(
+      "every captured pointer event must record the device it came from, or a replay of the " +
+        "capture silently becomes a touch drag: ${pointerEvents.map { it.kind to it.pointerType }}",
+      pointerEvents.all { it.pointerType == "mouse" },
+    )
+  }
+
+  // --- fixtures -------------------------------------------------------------------------------
+
+  private fun keyDown(tMs: Long, keyCode: String?, text: String?) =
+    RecordingScriptEvent(tMs = tMs, kind = "input.keyDown", keyCode = keyCode, text = text)
+
+  /** Press inside the first glyph, move across the text, release. One pointer, one device class. */
+  private fun dragScript(pointerType: String?): List<RecordingScriptEvent> =
+    listOf(
+      pointerEvent("input.pointerDown", FIRST_EVENT_MS, DRAG_START_X, pointerType),
+      pointerEvent("input.pointerMove", FIRST_EVENT_MS + EVENT_GAP_MS, DRAG_END_X, pointerType),
+      pointerEvent("input.pointerUp", FIRST_EVENT_MS + 2 * EVENT_GAP_MS, DRAG_END_X, pointerType),
+    )
+
+  private fun pointerEvent(kind: String, tMs: Long, x: Int, pointerType: String?) =
+    RecordingScriptEvent(
+      tMs = tMs,
+      kind = kind,
+      pixelX = x,
+      pixelY = TEXT_BASELINE_Y,
+      pointerId = 0,
+      pointerType = pointerType,
+    )
+
+  private fun liveKeyDown(keyCode: String?, text: String?) =
+    RecordingInputParams(
+      recordingId = LIVE_RECORDING_ID,
+      kind = InteractiveInputKind.KEY_DOWN,
+      keyCode = keyCode,
+      text = text,
+    )
+
+  private fun liveDragInputs(pointerType: String?): List<RecordingInputParams> =
+    listOf(
+      livePointer(InteractiveInputKind.POINTER_DOWN, DRAG_START_X, pointerType),
+      livePointer(InteractiveInputKind.POINTER_MOVE, DRAG_END_X, pointerType),
+      livePointer(InteractiveInputKind.POINTER_UP, DRAG_END_X, pointerType),
+    )
+
+  private fun livePointer(kind: InteractiveInputKind, x: Int, pointerType: String?) =
+    RecordingInputParams(
+      recordingId = LIVE_RECORDING_ID,
+      kind = kind,
+      pixelX = x,
+      pixelY = TEXT_BASELINE_Y,
+      pointerId = 0,
+      pointerType = pointerType,
+    )
+
+  private fun <T> withScriptedRecording(slug: String, body: (RecordingSession) -> T): T =
+    withRecording(slug, live = false, recordingId = "rec-$slug", body = body)
+
+  private fun <T> withLiveRecording(slug: String, body: (RecordingSession) -> T): T =
+    withRecording(slug, live = true, recordingId = LIVE_RECORDING_ID, body = body)
+
+  /**
+   * Stand up a host over [EditableTextFieldPreview], hand [body] a recording session, and tear both
+   * down. The probe is reset per test since the fixture's statics outlive the scene.
+   */
+  private fun <T> withRecording(
+    slug: String,
+    live: Boolean,
+    recordingId: String,
+    body: (RecordingSession) -> T,
+  ): T {
+    TextFieldProbe.reset()
+    val outputDir = tempFolder.newFolder("recording-text-renders-$slug")
+    val recordingsRoot = tempFolder.newFolder("recording-text-root-$slug")
+    savedRecordingsDir = savedRecordingsDir ?: System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == TEXT_FIELD_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "EditableTextFieldPreview",
+              widthPx = FIELD_WIDTH_PX,
+              heightPx = FIELD_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "editable-text-field-recording",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = TEXT_FIELD_PREVIEW_ID,
+          recordingId = recordingId,
+          classLoader =
+            DesktopRecordingTextInputTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+          live = live,
+        )
+      try {
+        return body(session)
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private companion object {
+    const val TEXT_FIELD_PREVIEW_ID = "editable-text-field"
+    const val LIVE_RECORDING_ID = "rec-live-text"
+    const val FIELD_WIDTH_PX = 240
+    const val FIELD_HEIGHT_PX = 48
+    const val FPS = 30
+
+    /** `KEYCODE_A`, the wire's decimal-string spelling. */
+    const val KEYCODE_A = "29"
+
+    /** Not in `InteractiveKeyCodes`, so the desktop translation table can't map it. */
+    const val UNMAPPED_KEYCODE = "9999"
+
+    const val ASTRAL = "😀"
+
+    /**
+     * First scripted event's virtual time. Deliberately past frame 0: the fixture takes focus from
+     * a `LaunchedEffect`, and events at `tMs = 0` dispatch before the first render tick runs it.
+     */
+    const val FIRST_EVENT_MS = 100L
+
+    /** Comfortably more than one 30 fps frame, so consecutive events land in different buckets. */
+    const val EVENT_GAP_MS = 100L
+
+    /** Inside the first glyph, and inside the field's single line of text at density 1. */
+    const val DRAG_START_X = 2
+    const val DRAG_END_X = 40
+    const val TEXT_BASELINE_Y = 12
+
+    /** Live mode runs on wall-clock: one tick between inputs, and a settle before `stop()`. */
+    const val LIVE_TICK_MS = 80L
+    const val LIVE_SETTLE_MS = 150L
+  }
+}

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -1098,9 +1098,27 @@ object TextFieldProbe {
 
   @Volatile var selected: String = ""
 
+  /**
+   * The widest selection seen across every value change, rather than whatever is selected right
+   * now.
+   *
+   * Releasing a mouse drag collapses the selection back to a caret — real Compose behaviour, and
+   * what a user sees when they let go — so [selected] read after a completed drag is legitimately
+   * empty. A test that drives a whole press → drag → release and wants to assert "this drag
+   * selected" has to look at what the drag produced, not at the resting state after it.
+   */
+  @Volatile var widestSelection: String = ""
+
+  fun record(value: TextFieldValue) {
+    text = value.text
+    selected = value.text.substring(value.selection.min, value.selection.max)
+    if (selected.length > widestSelection.length) widestSelection = selected
+  }
+
   fun reset() {
     text = ""
     selected = ""
+    widestSelection = ""
   }
 }
 
@@ -1126,8 +1144,7 @@ fun EditableTextFieldPreview() {
       value = value,
       onValueChange = {
         value = it
-        TextFieldProbe.text = it.text
-        TextFieldProbe.selected = it.text.substring(it.selection.min, it.selection.max)
+        TextFieldProbe.record(it)
       },
       textStyle = TextStyle(color = Color.Black, fontSize = 20.sp),
       modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -191,6 +191,14 @@ no-op.
   pixelY?: number;
   // For 'keyDown'/'keyUp' only.
   keyCode?: string;
+  // The literal character a printable 'keyDown' produced (the browser's
+  // KeyboardEvent.key). `keyCode` names the physical key; this names what it
+  // typed, and a TextField inserts from the code point — so caret movement and
+  // deletion work from `keyCode` alone while typing needs this (#3491).
+  text?: string;
+  // DOM PointerEvent.pointerType — 'mouse' | 'touch' | 'pen'. Absent means
+  // touch. Load-bearing for text selection: only a mouse press-drag starts one.
+  pointerType?: string;
   // Semantic target (#1784) — set instead of pixelX/pixelY to act by stable
   // handle. The daemon resolves it against the held session's *live* semantics
   // tree and dispatches at the matched node's centre. Explicit pixels win when
@@ -198,6 +206,11 @@ no-op.
   target?: { ref?: string; testTag?: string; role?: string; text?: string };
 }
 ```
+
+`recording/input` carries the same field set (plus `recordingId` in place of
+`frameStreamId`), and both lanes share one dispatch implementation per backend —
+so a live recording types and mouse-selects exactly like an ordinary interactive
+session (#3545).
 
 Notification not request: input fires-and-forgets. The daemon
 dispatches the input into the active composition and emits a fresh

--- a/vscode-extension/src/bundleViewerPanel.ts
+++ b/vscode-extension/src/bundleViewerPanel.ts
@@ -100,6 +100,17 @@ type WebviewMessage =
           imageHeight: number;
           scrollDeltaY?: number;
           keyCode?: string;
+          /**
+           * The character a printable `keyDown` produced. `keyCode` names the
+           * physical key and cannot type — the caret and Backspace work from
+           * it, a character does not (issue #3491).
+           */
+          text?: string;
+          /**
+           * DOM `PointerEvent.pointerType`; absent means touch. Mouse is what
+           * drags out a text selection.
+           */
+          pointerType?: string;
       }
     | {
           command: "setRecording";
@@ -744,6 +755,8 @@ export class BundleViewerPanel {
                 pixelY: msg.pixelY,
                 scrollDeltaY: msg.scrollDeltaY,
                 keyCode: msg.keyCode,
+                text: msg.text,
+                pointerType: msg.pointerType,
             });
         } catch (err) {
             this.deps.logLine(
@@ -771,6 +784,8 @@ export class BundleViewerPanel {
                 pixelY: msg.pixelY,
                 scrollDeltaY: msg.scrollDeltaY,
                 keyCode: msg.keyCode,
+                text: msg.text,
+                pointerType: msg.pointerType,
             });
         } catch (err) {
             this.deps.logLine(

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -1221,6 +1221,13 @@ export interface RecordingScriptEvent {
     pointerId?: number;
     scrollDeltaY?: number;
     keyCode?: string;
+    /**
+     * See `InteractiveInputParams.text` — the character a `input.keyDown` typed. Persisted in
+     * captured scripts, so a replayed recording types what it originally typed (issue #3545).
+     */
+    text?: string;
+    /** See `InteractiveInputParams.pointerType`. Absent means touch. */
+    pointerType?: string;
     label?: string;
     checkpointId?: string;
     lifecycleEvent?: string;


### PR DESCRIPTION
Closes #3545.

## What was broken

#3524 / #3519 fixed printable-key typing and mouse-selection for the **live interactive** lane. The **recording** lane is a second, parallel dispatch implementation and got none of it:

- Kotlin `RecordingInputParams` ended at `keyCode` — no `text`, no `pointerType`
- `RecordingInputParams.toScriptEvent()` mapped neither field (desktop *and* Android)
- the live tick loop goes `RecordingInputParams` → `toScriptEvent` → `scriptHandlers.dispatch`, so anything not on the script event is gone by dispatch time
- `DesktopRecordingSession` had its own `keyHandler` calling `sendKeyEvent(KeyEvent(key, type))` — the code-point-less event that couldn't type — and its own multi-pointer dispatch pinned to `PointerType.Touch`

So the viewer sent `text` and `pointerType` and, while a recording was active, both were silently discarded: a recorded `TextField` couldn't receive a character, a recorded mouse drag couldn't select, and the captured script omitted both.

Not a regression — the recording lane could never do either. This is the unfinished half.

## What this does

**Extracts the shared seam instead of copy-pasting the fixes.** Desktop key and pointer translation now live in one place, `daemon/desktop/.../DesktopSceneInput.kt`:

- `ScenePointerDispatch` — per-pointer-id active set, device-class-aware multi-pointer `sendPointerEvent`, and scroll
- `SceneKeyDispatch` — physical `Key` + the `KEY_TYPED`-backed typed-character event, plus the soft-keyboard band notification
- `composePointerType` / `printableText` / `typedKeyEvent`, moved off `DesktopInteractiveSession`'s companion

`DesktopInteractiveSession` and `DesktopRecordingSession` both call it, so a fix to key or pointer translation is a fix to both lanes by construction. `DesktopRecordingSession` lost ~90 lines of duplicate dispatch in the process.

**Carries the fields through the wire.** `text` + `pointerType` added to `RecordingInputParams` and `RecordingScriptEvent`, and mapped in `toScriptEvent()` on desktop and Android. Android's mapping was also silently dropping `target`, `pointerId` and `scrollDeltaY` (its KDoc claimed `scrollDeltaY` wasn't on the wire, which stopped being true a while ago) — mapped alongside them.

**Evidence.** A `keyDown` that carries a mapped keycode *or* printable text is `APPLIED`; only one carrying neither is `UNSUPPORTED`, with a reason naming both halves. Previously `€` — a character with no `KEYCODE_*` at all — came back `UNSUPPORTED` from a recording while typing fine live.

**Astral characters and non-US layouts reach this lane for free**, since it is now literally the same code path (covered by the tests below).

**VS Code**: `bundleViewerPanel.ts` was dropping `text` / `pointerType` on *both* lanes (`extension.ts` already forwarded them); both are now forwarded, and `RecordingScriptEvent` in `daemonProtocol.ts` gained the fields.

## Compatibility

`RecordingScriptEvent` is persisted — captured scripts get written out and replayed. Absent `pointerType` still means touch and absent `text` still types nothing, so every script written before these fields replays byte-identically. Both fields ride into `RecordingStopResult.capturedScript`, so a captured live session now replays as the keystrokes and the device class it actually was.

## Test plan

New `DesktopRecordingTextInputTest` — the recording-lane mirror of `DesktopTextInputSessionTest`, reading `TextFieldProbe` rather than pixels (a colour match can't tell "the value gained an `a`" from "three characters are selected"):

- scripted `input.keyDown` with `text` types; keycode-only still types nothing; `€` (no keycode) types; an emoji types whole; `keyCode`-unmapped + non-printable `text` is `UNSUPPORTED` with a reason
- scripted mouse press-drag selects; touch press-drag does not
- **round-trip**: a live recording types `a` then `€` over `recording/input`, the captured script carries both `text` values, and replaying that captured script through the scripted lane types the same characters again
- a live mouse drag selects, and every captured pointer event records `pointerType: "mouse"`

`DesktopRecordingSessionLiveInputTest` gained mapping assertions for both fields, including the pre-#3545 wire shape staying null.

`TextFieldProbe` gained `widestSelection`. Releasing a drag collapses the selection to a caret — real Compose behaviour on *both* lanes — so the resting state after a completed drag says nothing about whether the drag selected. The existing interactive test only passes because it asserts before the collapsing recomposition flushes; the new tests don't depend on that timing.

Run locally:

```
./gradlew :daemon:desktop:test :daemon:core:test     # BUILD SUCCESSFUL
./gradlew :daemon:android:testDebugUnitTest          # BUILD SUCCESSFUL
./gradlew ktfmtCheckAll                              # BUILD SUCCESSFUL
npm --prefix vscode-extension test                   # 1670 passing
npx tsc --noEmit                                     # clean (bar the pre-existing version.generated stub)
```

## Visual evidence

Not applicable — no rendered surface changes. This is input-dispatch plumbing plus wire fields; the observable effect is *what a recorded composition does with the input*, which the tests above assert on the composition's `TextFieldValue` (text content and selection range) rather than on pixels. There is deliberately no new `@Preview` to register with the preview harness.

---
_Generated by [Claude Code](https://claude.ai/code/session_013DmCjuKUKgb2C1xbeNBwkp)_