### PR TITLE
fix(plugin): resolve the render worker launcher from the running JVM

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -691,9 +691,26 @@ abstract class RenderPreviewsTask : DefaultTask() {
     )
   }
 
+  /**
+   * The launcher a worker is spawned with, when the plugin has not raised the render JDK.
+   *
+   * Taken from the **running process** rather than assembled from `java.home`: the file is
+   * `bin/java` on Linux and macOS but `bin\java.exe` on Windows, so a hand-built `bin/java` path
+   * fails `canExecute()` there and falls back to searching `PATH` — which a Gradle launched via
+   * `JAVA_HOME` need not be on. Every spawn would then fail and the task would quietly revert to
+   * per-capture forks after three attempts, losing the whole point of the pool on that platform.
+   * `ExecOperations.javaexec` never had this problem because Gradle resolves the launcher itself.
+   */
   private fun defaultJavaExecutable(): String {
-    val candidate = java.io.File(System.getProperty("java.home"), "bin/java")
-    return if (candidate.canExecute()) candidate.absolutePath else "java"
+    ProcessHandle.current().info().command().orElse(null)?.let { running ->
+      if (java.io.File(running).canExecute()) return running
+    }
+    // Fallbacks for a JVM that hides its command line, still platform-correct.
+    val home = java.io.File(System.getProperty("java.home"), "bin")
+    return listOf("java", "java.exe")
+      .map { java.io.File(home, it) }
+      .firstOrNull { it.canExecute() }
+      ?.absolutePath ?: "java"
   }
 
   /**

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerProtocolTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopRendererWorkerProtocolTest.kt
@@ -173,9 +173,16 @@ class DesktopRendererWorkerProtocolTest {
    * that have nothing to do with pooling.
    */
   private fun jvmCommand(mainClass: String): List<String> {
-    val java = File(System.getProperty("java.home"), "bin/java")
+    // The running launcher, not a hand-built `bin/java` — that name is `java.exe` on Windows.
+    val launcher =
+      ProcessHandle.current().info().command().orElse(null)?.takeIf { File(it).canExecute() }
+        ?: listOf("java", "java.exe")
+          .map { File(System.getProperty("java.home"), "bin/$it") }
+          .firstOrNull { it.canExecute() }
+          ?.absolutePath
+        ?: "java"
     return listOf(
-      if (java.canExecute()) java.absolutePath else "java",
+      launcher,
       "-Dapple.awt.UIElement=true",
       "-cp",
       System.getProperty("java.class.path"),


### PR DESCRIPTION
Follow-up to #3548. Review raised this on that PR, but it merged before the fix landed, so it comes as its own change rather than a stacked commit.

## The problem

`DesktopRenderWorkerPool`'s default launcher was assembled as `java.home/bin/java`. On Windows that file is `bin\java.exe`, so `canExecute()` fails and the code fell back to searching `java` on `PATH` — which a Gradle launched via `JAVA_HOME` need not be on.

Two consequences, the second worse than the first:

- **Silent loss of the optimisation.** Every worker spawn fails, the pool disables itself after three attempts, and the task reverts to per-capture forks. Correct output, none of the speedup, no obvious signal.
- **Lane divergence.** The fork lane resolves its launcher through Gradle's own `javaexec`, so the two lanes could disagree about *which JVM runs a capture*. Keeping them identical is the property the whole pool rests on — that was the point of sharing `renderJvmArgs` and the working directory, and this quietly undercut it.

## The fix

Take the launcher from `ProcessHandle.current().info().command()` — the JVM actually running the build, correct on every platform without guessing at a filename. Falls back to a platform-complete `bin/java` **or** `bin/java.exe` probe for a JVM that hides its command line, then bare `java`.

`renderJavaExecutable` still wins when the plugin has raised the render JDK; this only changes the default.

The renderer's protocol test built the same path by hand, so it is fixed there too — otherwise the test would fail on a Windows checkout for the same reason.

## Test plan

```
./gradlew :gradle-plugin:test :renderer-desktop:test ktfmtCheck
```

Green. No new test: the defect is a platform-specific filename, and asserting it would mean either faking `os.name` or a Windows runner — neither of which this repo's CI has. `ProcessHandle`-based resolution is exercised on every existing pool test that spawns a worker, since it is now the path they all take.

No visual surface changes — this selects which `java` binary starts a worker, not what it draws.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk2xtVbDfuqQP2Bkzdndz9)_