### PR TITLE
test(serve): assert the pop path follows the active theme choice

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
@@ -123,10 +123,17 @@ class ServePageThemeTest {
     // Every pop path restores its theme by ASSIGNING the control's value, which fires no `change`
     // — so each one has to hand the restored choice over itself. Missing this left Back from Dark
     // to a Light entry re-rendering the preview light inside a page still pinned dark.
+    //
+    // It must hand over the ACTIVE choice, not the displayed one: a viewer opened with no theme
+    // anywhere shows its baked default under `data-theme-active="0"`, and passing `.value` there
+    // pins the page to a mode nobody picked. #3544 fixed that in `viewer.js` and left this
+    // assertion on the old spelling, so it has been failing on `main` since.
     val viewerJs = ServeWebAssets.load("viewer.js")!!.bytes.decodeToString()
     assertTrue(
-      viewerJs.contains("window.cpPageTheme.follow(themeChoice.value)"),
-      "the viewer's Back/Forward hydrate must repaint the chrome",
+      viewerJs
+        .substringAfter("function hydrateFromUrl")
+        .contains("window.cpPageTheme.follow(activeThemeChoice())"),
+      "the viewer's Back/Forward hydrate must repaint the chrome, from the active choice",
     )
     val compare = ServeWebAssets.load("format-compare.js")!!.bytes.decodeToString()
     assertTrue(


### PR DESCRIPTION
`ServePageThemeTest > Back and Forward repaint the chrome with the entry they restore` has been **failing on `main`**. Not a flake and not a product bug — a stale assertion.

[#3544](https://github.com/yschimke/compose-ai-tools/pull/3544) changed the viewer's Back/Forward hydrate from `cpPageTheme.follow(themeChoice.value)` to `follow(activeThemeChoice())` — the fix for a viewer with no theme in the URL and none remembered being pinned, on Back, to a baked default the visitor never picked. `viewer.js` moved; this assertion kept looking for the old spelling and started failing on the merge.

So it's re-pointed at the current call. It's also **scoped to the text after `function hydrateFromUrl`**, rather than searching the whole file, so it keeps asserting the *pop* path specifically instead of matching any `follow(…)` that happens to exist — the same shape the format-compare assertion two lines below it already uses (`substringAfter("cpUrlState.onPop")`). Without that scoping the test would pass on a `viewer.js` that repaints on `change` but not on pop, which is the exact regression it was written to catch.

No production code changes — `viewer.js` is untouched.

## Test plan

- `./gradlew :cli:test --tests '*ServePageThemeTest*'` — **green**.
- **Teeth verified**: with `viewer.js` reverted to `follow(themeChoice.value)`, the test fails with `the viewer's Back/Forward hydrate must repaint the chrome, from the active choice`. It rejects the regression rather than passing on anything.
- `./gradlew :cli:test` — **BUILD SUCCESSFUL**, the full module now green. For contrast, the same command on `main` reports `1756 tests completed, 1 failed`, and this was the one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViCDyyNkD8an3J2ZvCFSgs)_