### PR TITLE
ci: reap a closed PR's leftover runs, and dedupe three stacking workflows

### DIFF
--- a/.github/scripts/reap-pr-runs.mjs
+++ b/.github/scripts/reap-pr-runs.mjs
@@ -111,7 +111,12 @@ export async function reapPrRuns({
         head: `${headRepo.split('/')[0]}:${headRef}`,
         per_page: 100,
       })
-      ambiguousHead = openOnSameHead.some((p) => p.number !== prNumber)
+      // ANY open PR here means stop, including this one. A closed PR cannot
+      // appear in a `state: open` listing, so seeing our own number is not a
+      // self-match to filter out — it is this PR having been reopened since the
+      // `pulls.get` above, and its runs are live again. This query is the most
+      // recent word we have on that.
+      ambiguousHead = openOnSameHead.length > 0
     } catch (error) {
       core.warning(`Could not check for other open PRs on ${headRef}: ${error.message}`)
     }
@@ -129,8 +134,19 @@ export async function reapPrRuns({
   // deployment gate after being queued. A single snapshot has no gaps to
   // reason about.
   //
-  // The cost is paging past this branch's completed runs. That is bounded in
-  // practice — one PR head branch, and this job runs once per close.
+  // The cost is paging past this branch's completed runs, and it is not free:
+  // the Actions list endpoint stops at 1000 results however far you page. For a
+  // normal PR branch that is nowhere near binding. For a long-lived branch used
+  // as a PR head — merging the default branch forward into a release branch —
+  // its own push history can fill the window, and a genuinely stuck run older
+  // than that falls outside it and survives.
+  //
+  // Detected rather than silently tolerated: reaping fewer runs than expected
+  // is the safe direction, but it should say so instead of reporting success
+  // over a truncated view. Narrowing the query per status would dodge the cap
+  // at the cost of reintroducing the transition gap above, which is a real
+  // trade rather than a strict improvement — so it is left to a human.
+  const RESULT_WINDOW = 1000
   let runs = []
   try {
     runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
@@ -138,6 +154,12 @@ export async function reapPrRuns({
       branch: headRef,
       per_page: 100,
     })
+    if (runs.length >= RESULT_WINDOW) {
+      core.warning(
+        `Listed ${runs.length} runs for ${headRef}, at or beyond the ${RESULT_WINDOW}-result ` +
+          'API window. Older leftovers may not be visible and will not be reaped.',
+      )
+    }
   } catch (error) {
     // Listing is as fallible as cancelling. Letting this escape would fail
     // the workflow and put a red check on an already-merged PR, which is

--- a/.github/scripts/reap-pr-runs.mjs
+++ b/.github/scripts/reap-pr-runs.mjs
@@ -88,17 +88,33 @@ export async function reapPrRuns({
   //
   // On failure, assume ambiguity. Skipping some fork leftovers costs queue
   // slots; cancelling an open PR's checks costs someone their CI.
+  // Deleting a fork nulls out `head.repo`, so headRepo arrives empty for exactly
+  // the orphaned fork runs most in need of reaping. Without this we would ask
+  // GitHub for head `:branch` and then reject every run, since a run's
+  // `head_repository` is null rather than '' — the guard below would compare
+  // undefined against '' and never match.
+  //
+  // We cannot identify those runs by repo, so we demand the stronger claim
+  // instead: the run must name this PR outright. That is narrower than the
+  // fork fallback, which is the point — with no repo to compare, an unclaimed
+  // run is genuinely unattributable and left alone.
+  const headRepoKnown = Boolean(headRepo)
+
   let ambiguousHead = true
-  try {
-    const openOnSameHead = await github.paginate(github.rest.pulls.list, {
-      ...repo,
-      state: 'open',
-      head: `${headRepo.split('/')[0]}:${headRef}`,
-      per_page: 100,
-    })
-    ambiguousHead = openOnSameHead.some((p) => p.number !== prNumber)
-  } catch (error) {
-    core.warning(`Could not check for other open PRs on ${headRef}: ${error.message}`)
+  if (!headRepoKnown) {
+    core.info('Head repository is gone (deleted fork); only reaping runs that name this PR.')
+  } else {
+    try {
+      const openOnSameHead = await github.paginate(github.rest.pulls.list, {
+        ...repo,
+        state: 'open',
+        head: `${headRepo.split('/')[0]}:${headRef}`,
+        per_page: 100,
+      })
+      ambiguousHead = openOnSameHead.some((p) => p.number !== prNumber)
+    } catch (error) {
+      core.warning(`Could not check for other open PRs on ${headRef}: ${error.message}`)
+    }
   }
 
   // ONE listing, filtered locally — deliberately not a query per status.
@@ -153,7 +169,7 @@ export async function reapPrRuns({
     // PR from a branch named `main` would sweep up our `main` runs. Filtering
     // per run — rather than skipping fork PRs wholesale — means a fork's own
     // leftover runs, which are recorded in this repo, still get reaped.
-    if (run.head_repository?.full_name !== headRepo) continue
+    if (headRepoKnown && run.head_repository?.full_name !== headRepo) continue
 
     // One branch can carry two open PRs at once (different bases), and the
     // other PR's runs can predate this close, so they clear the cutoff. When
@@ -166,7 +182,7 @@ export async function reapPrRuns({
     const associated = run.pull_requests ?? []
     if (associated.length > 0) {
       if (!associated.some((p) => p.number === prNumber)) continue
-    } else if (ambiguousHead) {
+    } else if (!headRepoKnown || ambiguousHead) {
       // Empty association and something else is live on this exact head — we
       // cannot tell whose run this is, so leave it. See `ambiguousHead` above.
       continue

--- a/.github/scripts/reap-pr-runs.mjs
+++ b/.github/scripts/reap-pr-runs.mjs
@@ -1,0 +1,81 @@
+// Cancels the workflow runs left behind when a PR closes.
+//
+// Driven by pr-run-reaper.yml. The logic lives here rather than inline in the
+// workflow because it cancels things unattended: an over-reaching branch match
+// kills CI for work that is still open, and an under-reaching one silently
+// leaves the queue full. Both failure modes are invisible without tests, so
+// reap-pr-runs.test.mjs pins the guards.
+
+/**
+ * @param {object} options
+ * @param {object} options.github        authenticated octokit (github-script's `github`)
+ * @param {object} options.core          github-script's `core`, for logging
+ * @param {{owner: string, repo: string}} options.repo
+ * @param {string} options.headRef       the closed PR's head branch name
+ * @param {string} options.headRepo      `owner/name` of the head repo
+ * @param {string} options.thisRepo      `owner/name` of the repo being reaped
+ * @param {string} options.defaultBranch
+ * @param {number} options.currentRunId  this run, which must not cancel itself
+ * @returns {Promise<{cancelled: string[], failed: string[], skipped: string|null}>}
+ */
+export async function reapPrRuns({
+  github,
+  core,
+  repo,
+  headRef,
+  headRepo,
+  thisRepo,
+  defaultBranch,
+  currentRunId,
+}) {
+  const cancelled = []
+  const failed = []
+
+  // A fork PR's head branch name can collide with one of ours (both sides
+  // routinely have `main`), and the branch filter below matches on name alone,
+  // not on repo. Reaping a fork PR would cancel *our* runs on the same-named
+  // branch. Fork runs are charged to the fork, so skipping costs us nothing.
+  if (headRepo !== thisRepo) {
+    const skipped = `head is ${headRepo}, not ${thisRepo}`
+    core.info(`Skipping: ${skipped}.`)
+    return { cancelled, failed, skipped }
+  }
+
+  // Belt and braces. A PR cannot target its own base, but a mis-triggered run
+  // that reaped the default branch would cancel post-merge CI for every commit
+  // in flight — the single most damaging thing this script could do.
+  if (!headRef || headRef === defaultBranch) {
+    const skipped = `refusing to reap ref ${headRef || '(empty)'}`
+    core.info(`Skipping: ${skipped}.`)
+    return { cancelled, failed, skipped }
+  }
+
+  for (const status of ['queued', 'in_progress']) {
+    const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+      ...repo,
+      branch: headRef,
+      status,
+      per_page: 100,
+    })
+    for (const run of runs) {
+      if (run.id === currentRunId) continue
+      try {
+        await github.rest.actions.cancelWorkflowRun({ ...repo, run_id: run.id })
+        cancelled.push(`${run.name} (${run.id})`)
+      } catch (error) {
+        // A run that finished between the list and the cancel returns 409.
+        // That is the race resolving itself, not a failure worth reporting.
+        if (error.status === 409) continue
+        failed.push(`${run.name} (${run.id}): ${error.message}`)
+      }
+    }
+  }
+
+  core.info(`Cancelled ${cancelled.length} leftover run(s) on ${headRef}.`)
+  for (const entry of cancelled) core.info(`  ${entry}`)
+  // Never fail the workflow over this. The reaper is an optimisation; a
+  // transient API error must not put a red check on an already-merged PR.
+  for (const entry of failed) core.warning(`Could not cancel ${entry}`)
+
+  return { cancelled, failed, skipped: null }
+}

--- a/.github/scripts/reap-pr-runs.mjs
+++ b/.github/scripts/reap-pr-runs.mjs
@@ -77,72 +77,81 @@ export async function reapPrRuns({
   // cancelling live work costs someone their CI.
   const cutoff = closedAt ? Date.parse(closedAt) : NaN
 
-  // Every non-terminal status, not just the two obvious ones. A run sitting in
-  // `waiting` (blocked on a deployment gate) or `requested`/`pending` is not
-  // going to pass through `queued` on its way out — it can sit there
-  // indefinitely, which is exactly the kind of straggler this script exists to
-  // clear. Terminal statuses are not listed: there is nothing to cancel.
-  for (const status of ['queued', 'in_progress', 'requested', 'waiting', 'pending']) {
-    let runs
+  // ONE listing, filtered locally — deliberately not a query per status.
+  //
+  // Per-status queries are separate snapshots taken at different moments, and
+  // runs move between statuses while we work. A run that is `requested` during
+  // a `queued` query and has advanced to `queued` by the time we ask for
+  // `requested` appears in neither, and survives with no later reaper coming
+  // for it. Ordering the queries to chase runs forward would mostly work, but
+  // "mostly" is doing real work there: `requested`/`waiting`/`pending` are not
+  // a clean linear prefix of `queued`, and a run can re-enter `waiting` on a
+  // deployment gate after being queued. A single snapshot has no gaps to
+  // reason about.
+  //
+  // The cost is paging past this branch's completed runs. That is bounded in
+  // practice — one PR head branch, and this job runs once per close.
+  let runs = []
+  try {
+    runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+      ...repo,
+      branch: headRef,
+      per_page: 100,
+    })
+  } catch (error) {
+    // Listing is as fallible as cancelling. Letting this escape would fail
+    // the workflow and put a red check on an already-merged PR, which is
+    // exactly what this script promises not to do.
+    failed.push(`list runs: ${error.message}`)
+  }
+
+  for (const run of runs) {
+    // Terminal runs are the reason the snapshot is cheap to take and the
+    // reason it has to be filtered: there is nothing to cancel on them.
+    if (run.status === 'completed') continue
+
+    if (run.id === currentRunId) continue
+
+    // Only ever cancel PR-triggered runs. Two reasons, and the second is what
+    // makes the rest of this function safe:
+    //
+    // 1. A manual `workflow_dispatch` on a PR branch has no PR association,
+    //    so the empty-association fallback below would otherwise sweep it up.
+    //    vscode-extension-e2e.yml exists partly to be run manually on any
+    //    branch for regression work; killing someone's investigation run
+    //    mid-flight would be a real cost for no queue benefit.
+    // 2. Post-merge CI on the default branch is a `push` run, so this
+    //    excludes it *categorically* rather than by heuristic — which is what
+    //    lets a PR whose head is `main` be reaped at all (see below).
+    if (!PR_EVENTS.has(run.event)) continue
+
+    // The branch filter matches on name alone, not repo. Without this a fork
+    // PR from a branch named `main` would sweep up our `main` runs. Filtering
+    // per run — rather than skipping fork PRs wholesale — means a fork's own
+    // leftover runs, which are recorded in this repo, still get reaped.
+    if (run.head_repository?.full_name !== headRepo) continue
+
+    // One branch can carry two open PRs at once (different bases), and the
+    // other PR's runs can predate this close, so they clear the cutoff. When
+    // GitHub tells us which PRs a run belongs to, believe it.
+    //
+    // Only when it says something, though: `pull_requests` is empty for fork
+    // runs, so *requiring* a match would silently stop reaping exactly the
+    // fork leftovers this script was fixed to catch. Empty means "no claim",
+    // and we fall through to the repo and cutoff checks.
+    const associated = run.pull_requests ?? []
+    if (associated.length > 0 && !associated.some((p) => p.number === prNumber)) continue
+
+    if (!Number.isNaN(cutoff) && Date.parse(run.created_at) >= cutoff) continue
+
     try {
-      runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
-        ...repo,
-        branch: headRef,
-        status,
-        per_page: 100,
-      })
+      await github.rest.actions.cancelWorkflowRun({ ...repo, run_id: run.id })
+      cancelled.push(`${run.name} (${run.id})`)
     } catch (error) {
-      // Listing is as fallible as cancelling. Letting this escape would fail
-      // the workflow and put a red check on an already-merged PR, which is
-      // exactly what this script promises not to do.
-      failed.push(`list ${status} runs: ${error.message}`)
-      continue
-    }
-
-    for (const run of runs) {
-      if (run.id === currentRunId) continue
-
-      // Only ever cancel PR-triggered runs. Two reasons, and the second is what
-      // makes the rest of this function safe:
-      //
-      // 1. A manual `workflow_dispatch` on a PR branch has no PR association,
-      //    so the empty-association fallback below would otherwise sweep it up.
-      //    vscode-extension-e2e.yml exists partly to be run manually on any
-      //    branch for regression work; killing someone's investigation run
-      //    mid-flight would be a real cost for no queue benefit.
-      // 2. Post-merge CI on the default branch is a `push` run, so this
-      //    excludes it *categorically* rather than by heuristic — which is what
-      //    lets a PR whose head is `main` be reaped at all (see below).
-      if (!PR_EVENTS.has(run.event)) continue
-
-      // The branch filter matches on name alone, not repo. Without this a fork
-      // PR from a branch named `main` would sweep up our `main` runs. Filtering
-      // per run — rather than skipping fork PRs wholesale — means a fork's own
-      // leftover runs, which are recorded in this repo, still get reaped.
-      if (run.head_repository?.full_name !== headRepo) continue
-
-      // One branch can carry two open PRs at once (different bases), and the
-      // other PR's runs can predate this close, so they clear the cutoff. When
-      // GitHub tells us which PRs a run belongs to, believe it.
-      //
-      // Only when it says something, though: `pull_requests` is empty for fork
-      // runs, so *requiring* a match would silently stop reaping exactly the
-      // fork leftovers this script was fixed to catch. Empty means "no claim",
-      // and we fall through to the repo and cutoff checks.
-      const associated = run.pull_requests ?? []
-      if (associated.length > 0 && !associated.some((p) => p.number === prNumber)) continue
-
-      if (!Number.isNaN(cutoff) && Date.parse(run.created_at) >= cutoff) continue
-
-      try {
-        await github.rest.actions.cancelWorkflowRun({ ...repo, run_id: run.id })
-        cancelled.push(`${run.name} (${run.id})`)
-      } catch (error) {
-        // A run that finished between the list and the cancel returns 409.
-        // That is the race resolving itself, not a failure worth reporting.
-        if (error.status === 409) continue
-        failed.push(`${run.name} (${run.id}): ${error.message}`)
-      }
+      // A run that finished between the list and the cancel returns 409.
+      // That is the race resolving itself, not a failure worth reporting.
+      if (error.status === 409) continue
+      failed.push(`${run.name} (${run.id}): ${error.message}`)
     }
   }
 

--- a/.github/scripts/reap-pr-runs.mjs
+++ b/.github/scripts/reap-pr-runs.mjs
@@ -63,8 +63,12 @@ export async function reapPrRuns({
   }
   if (pr.state !== 'closed') return skip(`PR #${prNumber} is ${pr.state} again`)
 
-  // Anything created after the PR closed belongs to whatever came next — a
+  // Anything created at or after the close belongs to whatever came next — a
   // reopen, or a fresh PR on the same branch — not to the PR we are cleaning up.
+  // `>=` rather than `>` because GitHub timestamps are second-precision: a run
+  // created in the same second as the close is ambiguous, and the two mistakes
+  // are not equally bad. Skipping a real leftover costs one queue slot;
+  // cancelling live work costs someone their CI.
   const cutoff = closedAt ? Date.parse(closedAt) : NaN
 
   for (const status of ['queued', 'in_progress']) {
@@ -93,7 +97,18 @@ export async function reapPrRuns({
       // leftover runs, which are recorded in this repo, still get reaped.
       if (run.head_repository?.full_name !== headRepo) continue
 
-      if (!Number.isNaN(cutoff) && Date.parse(run.created_at) > cutoff) continue
+      // One branch can carry two open PRs at once (different bases), and the
+      // other PR's runs can predate this close, so they clear the cutoff. When
+      // GitHub tells us which PRs a run belongs to, believe it.
+      //
+      // Only when it says something, though: `pull_requests` is empty for fork
+      // runs, so *requiring* a match would silently stop reaping exactly the
+      // fork leftovers this script was fixed to catch. Empty means "no claim",
+      // and we fall through to the repo and cutoff checks.
+      const associated = run.pull_requests ?? []
+      if (associated.length > 0 && !associated.some((p) => p.number === prNumber)) continue
+
+      if (!Number.isNaN(cutoff) && Date.parse(run.created_at) >= cutoff) continue
 
       try {
         await github.rest.actions.cancelWorkflowRun({ ...repo, run_id: run.id })

--- a/.github/scripts/reap-pr-runs.mjs
+++ b/.github/scripts/reap-pr-runs.mjs
@@ -6,6 +6,11 @@
 // queue full. Both failure modes are invisible without tests, so
 // reap-pr-runs.test.mjs pins every guard below.
 
+// The only run events this script will ever cancel. Everything else on the
+// branch — manual dispatches, pushes, schedules — belongs to someone or
+// something other than the closed PR.
+const PR_EVENTS = new Set(['pull_request', 'pull_request_target'])
+
 /**
  * @param {object} options
  * @param {object} options.github        authenticated octokit (github-script's `github`)
@@ -15,7 +20,6 @@
  * @param {string} options.headRef       its head branch name
  * @param {string} options.headRepo      `owner/name` of the head repo (the fork, for fork PRs)
  * @param {string} options.thisRepo      `owner/name` of the repo being reaped
- * @param {string} options.defaultBranch
  * @param {string} options.closedAt      ISO timestamp the PR closed at
  * @param {number} options.currentRunId  this run, which must not cancel itself
  * @returns {Promise<{cancelled: string[], failed: string[], skipped: string|null}>}
@@ -28,7 +32,6 @@ export async function reapPrRuns({
   headRef,
   headRepo,
   thisRepo,
-  defaultBranch,
   closedAt,
   currentRunId,
 }) {
@@ -39,16 +42,19 @@ export async function reapPrRuns({
     return { cancelled, failed, skipped: reason }
   }
 
-  // Belt and braces. A PR cannot target its own base, so this should be
-  // unreachable — but a mis-triggered run that reaped the default branch would
-  // cancel post-merge CI for every commit in flight, the most damaging thing
-  // this script could do. Only applies to same-repo heads: a fork's `main` is a
-  // different branch that happens to share a name, and the head-repo filter
-  // below is what keeps those apart.
   if (!headRef) return skip('head ref is empty')
-  if (headRepo === thisRepo && headRef === defaultBranch) {
-    return skip(`refusing to reap this repo's ${defaultBranch}`)
-  }
+
+  // A PR whose *head* is the default branch is legitimate — merging `main`
+  // forward into a release branch is the usual case — so this deliberately does
+  // not bail out on `headRef === defaultBranch`. An earlier version did, on the
+  // reasoning that a PR cannot target its own base; that conflated head with
+  // base, and silently stranded every such PR's leftovers.
+  //
+  // What actually protects post-merge CI on the default branch is the run-event
+  // allowlist below: that CI runs on `push`, so it is excluded by kind rather
+  // than by name-matching. That is a stronger guarantee than this check ever
+  // was, and unlike this check it does not depend on guessing which branch
+  // names matter.
 
   // Re-read the PR instead of trusting the event payload. Between the close and
   // this job getting a runner, the PR can be reopened, or a new PR can be
@@ -71,7 +77,12 @@ export async function reapPrRuns({
   // cancelling live work costs someone their CI.
   const cutoff = closedAt ? Date.parse(closedAt) : NaN
 
-  for (const status of ['queued', 'in_progress']) {
+  // Every non-terminal status, not just the two obvious ones. A run sitting in
+  // `waiting` (blocked on a deployment gate) or `requested`/`pending` is not
+  // going to pass through `queued` on its way out — it can sit there
+  // indefinitely, which is exactly the kind of straggler this script exists to
+  // clear. Terminal statuses are not listed: there is nothing to cancel.
+  for (const status of ['queued', 'in_progress', 'requested', 'waiting', 'pending']) {
     let runs
     try {
       runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
@@ -90,6 +101,19 @@ export async function reapPrRuns({
 
     for (const run of runs) {
       if (run.id === currentRunId) continue
+
+      // Only ever cancel PR-triggered runs. Two reasons, and the second is what
+      // makes the rest of this function safe:
+      //
+      // 1. A manual `workflow_dispatch` on a PR branch has no PR association,
+      //    so the empty-association fallback below would otherwise sweep it up.
+      //    vscode-extension-e2e.yml exists partly to be run manually on any
+      //    branch for regression work; killing someone's investigation run
+      //    mid-flight would be a real cost for no queue benefit.
+      // 2. Post-merge CI on the default branch is a `push` run, so this
+      //    excludes it *categorically* rather than by heuristic — which is what
+      //    lets a PR whose head is `main` be reaped at all (see below).
+      if (!PR_EVENTS.has(run.event)) continue
 
       // The branch filter matches on name alone, not repo. Without this a fork
       // PR from a branch named `main` would sweep up our `main` runs. Filtering

--- a/.github/scripts/reap-pr-runs.mjs
+++ b/.github/scripts/reap-pr-runs.mjs
@@ -1,20 +1,22 @@
 // Cancels the workflow runs left behind when a PR closes.
 //
 // Driven by pr-run-reaper.yml. The logic lives here rather than inline in the
-// workflow because it cancels things unattended: an over-reaching branch match
-// kills CI for work that is still open, and an under-reaching one silently
-// leaves the queue full. Both failure modes are invisible without tests, so
-// reap-pr-runs.test.mjs pins the guards.
+// workflow because it cancels things unattended: an over-reaching match kills
+// CI for work that is still open, and an under-reaching one silently leaves the
+// queue full. Both failure modes are invisible without tests, so
+// reap-pr-runs.test.mjs pins every guard below.
 
 /**
  * @param {object} options
  * @param {object} options.github        authenticated octokit (github-script's `github`)
  * @param {object} options.core          github-script's `core`, for logging
  * @param {{owner: string, repo: string}} options.repo
- * @param {string} options.headRef       the closed PR's head branch name
- * @param {string} options.headRepo      `owner/name` of the head repo
+ * @param {number} options.prNumber      the closed PR
+ * @param {string} options.headRef       its head branch name
+ * @param {string} options.headRepo      `owner/name` of the head repo (the fork, for fork PRs)
  * @param {string} options.thisRepo      `owner/name` of the repo being reaped
  * @param {string} options.defaultBranch
+ * @param {string} options.closedAt      ISO timestamp the PR closed at
  * @param {number} options.currentRunId  this run, which must not cancel itself
  * @returns {Promise<{cancelled: string[], failed: string[], skipped: string|null}>}
  */
@@ -22,43 +24,77 @@ export async function reapPrRuns({
   github,
   core,
   repo,
+  prNumber,
   headRef,
   headRepo,
   thisRepo,
   defaultBranch,
+  closedAt,
   currentRunId,
 }) {
   const cancelled = []
   const failed = []
-
-  // A fork PR's head branch name can collide with one of ours (both sides
-  // routinely have `main`), and the branch filter below matches on name alone,
-  // not on repo. Reaping a fork PR would cancel *our* runs on the same-named
-  // branch. Fork runs are charged to the fork, so skipping costs us nothing.
-  if (headRepo !== thisRepo) {
-    const skipped = `head is ${headRepo}, not ${thisRepo}`
-    core.info(`Skipping: ${skipped}.`)
-    return { cancelled, failed, skipped }
+  const skip = (reason) => {
+    core.info(`Skipping: ${reason}.`)
+    return { cancelled, failed, skipped: reason }
   }
 
-  // Belt and braces. A PR cannot target its own base, but a mis-triggered run
-  // that reaped the default branch would cancel post-merge CI for every commit
-  // in flight — the single most damaging thing this script could do.
-  if (!headRef || headRef === defaultBranch) {
-    const skipped = `refusing to reap ref ${headRef || '(empty)'}`
-    core.info(`Skipping: ${skipped}.`)
-    return { cancelled, failed, skipped }
+  // Belt and braces. A PR cannot target its own base, so this should be
+  // unreachable — but a mis-triggered run that reaped the default branch would
+  // cancel post-merge CI for every commit in flight, the most damaging thing
+  // this script could do. Only applies to same-repo heads: a fork's `main` is a
+  // different branch that happens to share a name, and the head-repo filter
+  // below is what keeps those apart.
+  if (!headRef) return skip('head ref is empty')
+  if (headRepo === thisRepo && headRef === defaultBranch) {
+    return skip(`refusing to reap this repo's ${defaultBranch}`)
   }
+
+  // Re-read the PR instead of trusting the event payload. Between the close and
+  // this job getting a runner, the PR can be reopened, or a new PR can be
+  // opened from the same branch — in both cases the branch has live work again
+  // and its runs are not leftovers. If the read fails we skip rather than
+  // guess: not reaping costs a few queue slots, over-reaping costs someone's CI.
+  let pr
+  try {
+    ;({ data: pr } = await github.rest.pulls.get({ ...repo, pull_number: prNumber }))
+  } catch (error) {
+    return skip(`could not re-read PR #${prNumber} (${error.message})`)
+  }
+  if (pr.state !== 'closed') return skip(`PR #${prNumber} is ${pr.state} again`)
+
+  // Anything created after the PR closed belongs to whatever came next — a
+  // reopen, or a fresh PR on the same branch — not to the PR we are cleaning up.
+  const cutoff = closedAt ? Date.parse(closedAt) : NaN
 
   for (const status of ['queued', 'in_progress']) {
-    const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
-      ...repo,
-      branch: headRef,
-      status,
-      per_page: 100,
-    })
+    let runs
+    try {
+      runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+        ...repo,
+        branch: headRef,
+        status,
+        per_page: 100,
+      })
+    } catch (error) {
+      // Listing is as fallible as cancelling. Letting this escape would fail
+      // the workflow and put a red check on an already-merged PR, which is
+      // exactly what this script promises not to do.
+      failed.push(`list ${status} runs: ${error.message}`)
+      continue
+    }
+
     for (const run of runs) {
       if (run.id === currentRunId) continue
+
+      // The branch filter matches on name alone, not repo. Without this a fork
+      // PR from a branch named `main` would sweep up our `main` runs. Filtering
+      // per run — rather than skipping fork PRs wholesale — means a fork's own
+      // leftover runs, which are recorded in this repo, still get reaped.
+      if (run.head_repository?.full_name !== headRepo) continue
+
+      if (!Number.isNaN(cutoff) && Date.parse(run.created_at) > cutoff) continue
+
       try {
         await github.rest.actions.cancelWorkflowRun({ ...repo, run_id: run.id })
         cancelled.push(`${run.name} (${run.id})`)

--- a/.github/scripts/reap-pr-runs.mjs
+++ b/.github/scripts/reap-pr-runs.mjs
@@ -77,6 +77,30 @@ export async function reapPrRuns({
   // cancelling live work costs someone their CI.
   const cutoff = closedAt ? Date.parse(closedAt) : NaN
 
+  // Is anything else still open on this exact head (same fork, same branch)?
+  //
+  // This decides whether the empty-`pull_requests` fallback below is safe. That
+  // fallback exists because fork runs carry no association, so demanding one
+  // would stop us reaping them at all — but "no association" and "belongs to
+  // this PR" are not the same claim. Two PRs can share one fork branch while
+  // targeting different bases, and the still-open one's runs predate this close,
+  // so every other guard passes and we would cancel its live CI.
+  //
+  // On failure, assume ambiguity. Skipping some fork leftovers costs queue
+  // slots; cancelling an open PR's checks costs someone their CI.
+  let ambiguousHead = true
+  try {
+    const openOnSameHead = await github.paginate(github.rest.pulls.list, {
+      ...repo,
+      state: 'open',
+      head: `${headRepo.split('/')[0]}:${headRef}`,
+      per_page: 100,
+    })
+    ambiguousHead = openOnSameHead.some((p) => p.number !== prNumber)
+  } catch (error) {
+    core.warning(`Could not check for other open PRs on ${headRef}: ${error.message}`)
+  }
+
   // ONE listing, filtered locally — deliberately not a query per status.
   //
   // Per-status queries are separate snapshots taken at different moments, and
@@ -140,9 +164,24 @@ export async function reapPrRuns({
     // fork leftovers this script was fixed to catch. Empty means "no claim",
     // and we fall through to the repo and cutoff checks.
     const associated = run.pull_requests ?? []
-    if (associated.length > 0 && !associated.some((p) => p.number === prNumber)) continue
+    if (associated.length > 0) {
+      if (!associated.some((p) => p.number === prNumber)) continue
+    } else if (ambiguousHead) {
+      // Empty association and something else is live on this exact head — we
+      // cannot tell whose run this is, so leave it. See `ambiguousHead` above.
+      continue
+    }
 
-    if (!Number.isNaN(cutoff) && Date.parse(run.created_at) >= cutoff) continue
+    // The *attempt's* start, not the run's creation. Re-running a workflow
+    // reuses the run id and keeps the original `created_at`, bumping
+    // `run_started_at` instead — so a `/rerun` issued on a closed PR (which
+    // pr-commands.yml supports, and which is a deliberate act by a maintainer)
+    // would otherwise look older than the close and get cancelled.
+    const began = Math.max(
+      Date.parse(run.created_at),
+      Date.parse(run.run_started_at ?? run.created_at),
+    )
+    if (!Number.isNaN(cutoff) && began >= cutoff) continue
 
     try {
       await github.rest.actions.cancelWorkflowRun({ ...repo, run_id: run.id })

--- a/.github/scripts/reap-pr-runs.test.mjs
+++ b/.github/scripts/reap-pr-runs.test.mjs
@@ -255,6 +255,30 @@ test('an explicit association still reaps even on an ambiguous head', async () =
   assert.deepEqual(calls.cancelled, [1])
 })
 
+test('a deleted fork still gets its runs reaped via explicit association', async () => {
+  // Deleting a fork nulls `head.repo`, so headRepo arrives empty — for exactly
+  // the orphans most worth reaping. The repo guard cannot apply (a run's
+  // head_repository is null, not ''), so we require the run to name this PR.
+  const { github, core, calls } = harness({
+    runs: [
+      run(1, 'CI', 'queued', { head_repository: null, pull_requests: [{ number: 42 }] }),
+      run(2, 'CI', 'queued', { head_repository: null, pull_requests: [] }),
+    ],
+  })
+  await reapPrRuns({ ...BASE, headRepo: '', github, core })
+  assert.deepEqual(calls.cancelled, [1])
+  // No head query is possible without a repo to name.
+  assert.deepEqual(calls.headQueries, [])
+})
+
+test('a deleted fork never reaps a run claiming a different PR', async () => {
+  const { github, core, calls } = harness({
+    runs: [run(1, 'CI', 'queued', { head_repository: null, pull_requests: [{ number: 77 }] })],
+  })
+  await reapPrRuns({ ...BASE, headRepo: '', github, core })
+  assert.deepEqual(calls.cancelled, [])
+})
+
 test('refuses to reap an empty head ref', async () => {
   const { github, core, calls } = harness({ runs: [run(1, 'CI', 'queued')] })
   const result = await reapPrRuns({ ...BASE, headRef: '', github, core })

--- a/.github/scripts/reap-pr-runs.test.mjs
+++ b/.github/scripts/reap-pr-runs.test.mjs
@@ -154,6 +154,40 @@ test('skips rather than guesses when the PR cannot be re-read', async () => {
   assert.match(result.skipped, /could not re-read/)
 })
 
+test('leaves a concurrent open PR’s runs on the same branch alone', async () => {
+  // One branch, two open PRs against different bases. The other PR's runs
+  // predate this close, so the cutoff alone would not save them.
+  const { github, core, calls } = harness({
+    runs: [
+      run(1, 'CI', 'queued', { pull_requests: [{ number: 42 }] }),
+      run(2, 'CI', 'queued', { pull_requests: [{ number: 77 }] }),
+    ],
+  })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [1])
+})
+
+test('an absent PR association does not stop a fork run being reaped', async () => {
+  // `pull_requests` is empty for fork runs. Requiring a match would re-break
+  // the fork case, so an empty association must fall through to the other guards.
+  const FORK = 'someone-else/compose-ai-tools'
+  const { github, core, calls } = harness({
+    runs: [run(1, 'CI', 'queued', { pull_requests: [], head_repository: { full_name: FORK } })],
+  })
+  await reapPrRuns({ ...BASE, headRepo: FORK, github, core })
+  assert.deepEqual(calls.cancelled, [1])
+})
+
+test('a run created in the same second as the close is left alone', async () => {
+  // GitHub timestamps are second-precision, so this is ambiguous. Prefer
+  // leaving a leftover over cancelling live work.
+  const { github, core, calls } = harness({
+    runs: [run(1, 'CI', 'queued', { created_at: CLOSED_AT })],
+  })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [])
+})
+
 test('leaves runs created after the PR closed alone', async () => {
   // A new PR on the same branch, or a reopen that then re-closed: its checks
   // are live work, not leftovers.

--- a/.github/scripts/reap-pr-runs.test.mjs
+++ b/.github/scripts/reap-pr-runs.test.mjs
@@ -1,0 +1,136 @@
+// Self-test for the PR run reaper. Run: node --test .github/scripts/reap-pr-runs.test.mjs
+//
+// This runs on every PR (the `actions-tests` job in ci.yml) because the reaper
+// cancels workflow runs unattended. The two guards below are the whole safety
+// story: without the fork check it cancels our runs when a fork PR's branch
+// shares a name with ours, and without the default-branch check a mis-trigger
+// wipes post-merge CI for every commit in flight. Neither failure is visible
+// until it has already happened.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { reapPrRuns } from './reap-pr-runs.mjs'
+
+const REPO = { owner: 'yschimke', repo: 'compose-ai-tools' }
+const THIS_REPO = 'yschimke/compose-ai-tools'
+
+function harness({ runs = [], cancelError } = {}) {
+  const calls = { listed: [], cancelled: [] }
+  const github = {
+    paginate: async (_fn, params) => {
+      calls.listed.push({ branch: params.branch, status: params.status })
+      return runs.filter((r) => r.status === params.status)
+    },
+    rest: {
+      actions: {
+        listWorkflowRunsForRepo: 'listWorkflowRunsForRepo',
+        cancelWorkflowRun: async ({ run_id }) => {
+          const error = cancelError?.(run_id)
+          if (error) throw error
+          calls.cancelled.push(run_id)
+        },
+      },
+    },
+  }
+  const core = { info: () => {}, warning: () => {} }
+  return { github, core, calls }
+}
+
+const BASE = {
+  repo: REPO,
+  headRef: 'agent/some-branch',
+  headRepo: THIS_REPO,
+  thisRepo: THIS_REPO,
+  defaultBranch: 'main',
+  currentRunId: 999,
+}
+
+test('cancels queued and in-progress runs on the closed PR branch', async () => {
+  const { github, core, calls } = harness({
+    runs: [
+      { id: 1, name: 'CI', status: 'queued' },
+      { id: 2, name: 'VS Code Extension E2E', status: 'queued' },
+      { id: 3, name: 'Integration', status: 'in_progress' },
+    ],
+  })
+  const result = await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [1, 2, 3])
+  assert.equal(result.cancelled.length, 3)
+  assert.equal(result.skipped, null)
+  assert.deepEqual(
+    calls.listed.map((c) => c.status),
+    ['queued', 'in_progress'],
+  )
+  assert.ok(calls.listed.every((c) => c.branch === 'agent/some-branch'))
+})
+
+test('never cancels itself', async () => {
+  const { github, core, calls } = harness({
+    runs: [
+      { id: 999, name: 'PR Run Reaper', status: 'in_progress' },
+      { id: 7, name: 'CI', status: 'in_progress' },
+    ],
+  })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [7])
+})
+
+test('skips fork PRs so a shared branch name cannot reap our runs', async () => {
+  const { github, core, calls } = harness({
+    runs: [{ id: 1, name: 'CI', status: 'queued' }],
+  })
+  const result = await reapPrRuns({
+    ...BASE,
+    headRef: 'main',
+    headRepo: 'someone-else/compose-ai-tools',
+    github,
+    core,
+  })
+  assert.deepEqual(calls.cancelled, [])
+  assert.deepEqual(calls.listed, [])
+  assert.match(result.skipped, /someone-else/)
+})
+
+test('refuses to reap the default branch', async () => {
+  const { github, core, calls } = harness({
+    runs: [{ id: 1, name: 'CI', status: 'queued' }],
+  })
+  const result = await reapPrRuns({ ...BASE, headRef: 'main', github, core })
+  assert.deepEqual(calls.cancelled, [])
+  assert.deepEqual(calls.listed, [])
+  assert.match(result.skipped, /refusing to reap/)
+})
+
+test('refuses to reap an empty head ref', async () => {
+  const { github, core, calls } = harness({
+    runs: [{ id: 1, name: 'CI', status: 'queued' }],
+  })
+  const result = await reapPrRuns({ ...BASE, headRef: '', github, core })
+  assert.deepEqual(calls.cancelled, [])
+  assert.match(result.skipped, /refusing to reap/)
+})
+
+test('treats a 409 as the finish/cancel race resolving itself', async () => {
+  const { github, core } = harness({
+    runs: [
+      { id: 1, name: 'CI', status: 'queued' },
+      { id: 2, name: 'Format Check', status: 'queued' },
+    ],
+    cancelError: (id) => (id === 1 ? Object.assign(new Error('completed'), { status: 409 }) : null),
+  })
+  const result = await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(result.cancelled, ['Format Check (2)'])
+  assert.deepEqual(result.failed, [])
+})
+
+test('reports a real API error without throwing', async () => {
+  const { github, core } = harness({
+    runs: [{ id: 1, name: 'CI', status: 'queued' }],
+    cancelError: () => Object.assign(new Error('boom'), { status: 500 }),
+  })
+  const result = await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(result.cancelled, [])
+  assert.equal(result.failed.length, 1)
+  assert.match(result.failed[0], /boom/)
+})

--- a/.github/scripts/reap-pr-runs.test.mjs
+++ b/.github/scripts/reap-pr-runs.test.mjs
@@ -1,11 +1,11 @@
 // Self-test for the PR run reaper. Run: node --test .github/scripts/reap-pr-runs.test.mjs
 //
 // This runs on every PR (the `actions-tests` job in ci.yml) because the reaper
-// cancels workflow runs unattended. The two guards below are the whole safety
-// story: without the fork check it cancels our runs when a fork PR's branch
-// shares a name with ours, and without the default-branch check a mis-trigger
-// wipes post-merge CI for every commit in flight. Neither failure is visible
-// until it has already happened.
+// cancels workflow runs unattended, and every guard it has exists because the
+// failure it prevents is invisible until after it has happened: reaping the
+// default branch wipes post-merge CI for commits in flight; matching on branch
+// name alone lets a fork's `main` sweep up ours; and reaping without a
+// close-time cutoff kills the checks of whatever reopened or re-used the branch.
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
@@ -14,15 +14,36 @@ import { reapPrRuns } from './reap-pr-runs.mjs'
 
 const REPO = { owner: 'yschimke', repo: 'compose-ai-tools' }
 const THIS_REPO = 'yschimke/compose-ai-tools'
+const CLOSED_AT = '2026-08-08T12:00:00Z'
+const BEFORE = '2026-08-08T11:00:00Z'
+const AFTER = '2026-08-08T13:00:00Z'
 
-function harness({ runs = [], cancelError } = {}) {
+function run(id, name, status, overrides = {}) {
+  return {
+    id,
+    name,
+    status,
+    created_at: BEFORE,
+    head_repository: { full_name: THIS_REPO },
+    ...overrides,
+  }
+}
+
+function harness({ runs = [], cancelError, listError, prState = 'closed', prError } = {}) {
   const calls = { listed: [], cancelled: [] }
   const github = {
     paginate: async (_fn, params) => {
       calls.listed.push({ branch: params.branch, status: params.status })
+      if (listError) throw listError
       return runs.filter((r) => r.status === params.status)
     },
     rest: {
+      pulls: {
+        get: async () => {
+          if (prError) throw prError
+          return { data: { state: prState } }
+        },
+      },
       actions: {
         listWorkflowRunsForRepo: 'listWorkflowRunsForRepo',
         cancelWorkflowRun: async ({ run_id }) => {
@@ -33,30 +54,32 @@ function harness({ runs = [], cancelError } = {}) {
       },
     },
   }
-  const core = { info: () => {}, warning: () => {} }
-  return { github, core, calls }
+  const warnings = []
+  const core = { info: () => {}, warning: (m) => warnings.push(m) }
+  return { github, core, calls, warnings }
 }
 
 const BASE = {
   repo: REPO,
+  prNumber: 42,
   headRef: 'agent/some-branch',
   headRepo: THIS_REPO,
   thisRepo: THIS_REPO,
   defaultBranch: 'main',
+  closedAt: CLOSED_AT,
   currentRunId: 999,
 }
 
 test('cancels queued and in-progress runs on the closed PR branch', async () => {
   const { github, core, calls } = harness({
     runs: [
-      { id: 1, name: 'CI', status: 'queued' },
-      { id: 2, name: 'VS Code Extension E2E', status: 'queued' },
-      { id: 3, name: 'Integration', status: 'in_progress' },
+      run(1, 'CI', 'queued'),
+      run(2, 'VS Code Extension E2E', 'queued'),
+      run(3, 'Integration', 'in_progress'),
     ],
   })
   const result = await reapPrRuns({ ...BASE, github, core })
   assert.deepEqual(calls.cancelled, [1, 2, 3])
-  assert.equal(result.cancelled.length, 3)
   assert.equal(result.skipped, null)
   assert.deepEqual(
     calls.listed.map((c) => c.status),
@@ -67,35 +90,36 @@ test('cancels queued and in-progress runs on the closed PR branch', async () => 
 
 test('never cancels itself', async () => {
   const { github, core, calls } = harness({
-    runs: [
-      { id: 999, name: 'PR Run Reaper', status: 'in_progress' },
-      { id: 7, name: 'CI', status: 'in_progress' },
-    ],
+    runs: [run(999, 'PR Run Reaper', 'in_progress'), run(7, 'CI', 'in_progress')],
   })
   await reapPrRuns({ ...BASE, github, core })
   assert.deepEqual(calls.cancelled, [7])
 })
 
-test('skips fork PRs so a shared branch name cannot reap our runs', async () => {
+test('reaps a fork PR’s own runs, which are recorded in this repo', async () => {
+  const FORK = 'someone-else/compose-ai-tools'
   const { github, core, calls } = harness({
-    runs: [{ id: 1, name: 'CI', status: 'queued' }],
+    runs: [run(1, 'CI', 'queued', { head_repository: { full_name: FORK } })],
   })
-  const result = await reapPrRuns({
-    ...BASE,
-    headRef: 'main',
-    headRepo: 'someone-else/compose-ai-tools',
-    github,
-    core,
-  })
-  assert.deepEqual(calls.cancelled, [])
-  assert.deepEqual(calls.listed, [])
-  assert.match(result.skipped, /someone-else/)
+  const result = await reapPrRuns({ ...BASE, headRef: 'main', headRepo: FORK, github, core })
+  assert.deepEqual(calls.cancelled, [1])
+  assert.equal(result.skipped, null)
 })
 
-test('refuses to reap the default branch', async () => {
+test('a fork branch named main does not sweep up this repo’s main runs', async () => {
+  const FORK = 'someone-else/compose-ai-tools'
   const { github, core, calls } = harness({
-    runs: [{ id: 1, name: 'CI', status: 'queued' }],
+    runs: [
+      run(1, 'CI', 'queued', { head_repository: { full_name: THIS_REPO } }),
+      run(2, 'CI', 'queued', { head_repository: { full_name: FORK } }),
+    ],
   })
+  await reapPrRuns({ ...BASE, headRef: 'main', headRepo: FORK, github, core })
+  assert.deepEqual(calls.cancelled, [2])
+})
+
+test('refuses to reap this repo’s default branch', async () => {
+  const { github, core, calls } = harness({ runs: [run(1, 'CI', 'queued')] })
   const result = await reapPrRuns({ ...BASE, headRef: 'main', github, core })
   assert.deepEqual(calls.cancelled, [])
   assert.deepEqual(calls.listed, [])
@@ -103,20 +127,49 @@ test('refuses to reap the default branch', async () => {
 })
 
 test('refuses to reap an empty head ref', async () => {
-  const { github, core, calls } = harness({
-    runs: [{ id: 1, name: 'CI', status: 'queued' }],
-  })
+  const { github, core, calls } = harness({ runs: [run(1, 'CI', 'queued')] })
   const result = await reapPrRuns({ ...BASE, headRef: '', github, core })
   assert.deepEqual(calls.cancelled, [])
-  assert.match(result.skipped, /refusing to reap/)
+  assert.match(result.skipped, /empty/)
+})
+
+test('skips entirely if the PR was reopened while this job queued', async () => {
+  const { github, core, calls } = harness({
+    runs: [run(1, 'CI', 'queued')],
+    prState: 'open',
+  })
+  const result = await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [])
+  assert.deepEqual(calls.listed, [])
+  assert.match(result.skipped, /open again/)
+})
+
+test('skips rather than guesses when the PR cannot be re-read', async () => {
+  const { github, core, calls } = harness({
+    runs: [run(1, 'CI', 'queued')],
+    prError: new Error('gateway timeout'),
+  })
+  const result = await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [])
+  assert.match(result.skipped, /could not re-read/)
+})
+
+test('leaves runs created after the PR closed alone', async () => {
+  // A new PR on the same branch, or a reopen that then re-closed: its checks
+  // are live work, not leftovers.
+  const { github, core, calls } = harness({
+    runs: [
+      run(1, 'CI', 'queued', { created_at: BEFORE }),
+      run(2, 'CI', 'queued', { created_at: AFTER }),
+    ],
+  })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [1])
 })
 
 test('treats a 409 as the finish/cancel race resolving itself', async () => {
   const { github, core } = harness({
-    runs: [
-      { id: 1, name: 'CI', status: 'queued' },
-      { id: 2, name: 'Format Check', status: 'queued' },
-    ],
+    runs: [run(1, 'CI', 'queued'), run(2, 'Format Check', 'queued')],
     cancelError: (id) => (id === 1 ? Object.assign(new Error('completed'), { status: 409 }) : null),
   })
   const result = await reapPrRuns({ ...BASE, github, core })
@@ -124,13 +177,28 @@ test('treats a 409 as the finish/cancel race resolving itself', async () => {
   assert.deepEqual(result.failed, [])
 })
 
-test('reports a real API error without throwing', async () => {
-  const { github, core } = harness({
-    runs: [{ id: 1, name: 'CI', status: 'queued' }],
+test('reports a real cancel error without throwing', async () => {
+  const { github, core, warnings } = harness({
+    runs: [run(1, 'CI', 'queued')],
     cancelError: () => Object.assign(new Error('boom'), { status: 500 }),
   })
   const result = await reapPrRuns({ ...BASE, github, core })
   assert.deepEqual(result.cancelled, [])
   assert.equal(result.failed.length, 1)
   assert.match(result.failed[0], /boom/)
+  assert.equal(warnings.length, 1)
+})
+
+test('a listing failure warns instead of failing the workflow', async () => {
+  const { github, core, warnings } = harness({
+    runs: [run(1, 'CI', 'queued')],
+    listError: Object.assign(new Error('rate limited'), { status: 403 }),
+  })
+  const result = await reapPrRuns({ ...BASE, github, core })
+  assert.equal(result.skipped, null)
+  assert.equal(result.cancelled.length, 0)
+  // One per status queried, both surfaced as warnings rather than thrown.
+  assert.equal(result.failed.length, 2)
+  assert.ok(result.failed.every((f) => /rate limited/.test(f)))
+  assert.equal(warnings.length, 2)
 })

--- a/.github/scripts/reap-pr-runs.test.mjs
+++ b/.github/scripts/reap-pr-runs.test.mjs
@@ -222,16 +222,28 @@ test('will not use the fork fallback while another PR shares the head', async ()
   assert.deepEqual(calls.headQueries, ['someone-else:agent/some-branch'])
 })
 
-test('this PR appearing in the head query does not block the fallback', async () => {
-  // The closed PR itself can still come back from the open-PR listing mid-race;
-  // only a *different* PR makes the head ambiguous.
+test('this PR appearing in the head query means it was reopened', async () => {
+  // A closed PR cannot appear in a `state: open` listing, so our own number
+  // coming back is not a self-match to filter out — it is a reopen that landed
+  // after the pulls.get above, and the runs are live again.
   const FORK = 'someone-else/compose-ai-tools'
   const { github, core, calls } = harness({
     runs: [run(1, 'CI', 'queued', { pull_requests: [], head_repository: { full_name: FORK } })],
     openOnSameHead: [{ number: 42 }],
   })
   await reapPrRuns({ ...BASE, headRepo: FORK, github, core })
-  assert.deepEqual(calls.cancelled, [1])
+  assert.deepEqual(calls.cancelled, [])
+})
+
+test('warns when the listing hits the API result window', async () => {
+  // Reaping less than expected is the safe direction, but a truncated view must
+  // not be reported as a clean sweep.
+  const many = Array.from({ length: 1000 }, (_, i) => run(i + 1, 'CI', 'completed'))
+  many.push(run(9999, 'CI', 'queued'))
+  const { github, core, calls, warnings } = harness({ runs: many })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [9999])
+  assert.equal(warnings.filter((w) => w.includes('1000-result')).length, 1)
 })
 
 test('assumes ambiguity when the open-PR check fails', async () => {

--- a/.github/scripts/reap-pr-runs.test.mjs
+++ b/.github/scripts/reap-pr-runs.test.mjs
@@ -31,10 +31,23 @@ function run(id, name, status, overrides = {}) {
   }
 }
 
-function harness({ runs = [], cancelError, listError, prState = 'closed', prError } = {}) {
-  const calls = { listed: [], cancelled: [] }
+function harness({
+  runs = [],
+  cancelError,
+  listError,
+  prState = 'closed',
+  prError,
+  openOnSameHead = [],
+  openOnSameHeadError,
+} = {}) {
+  const calls = { listed: [], cancelled: [], headQueries: [] }
   const github = {
-    paginate: async (_fn, params) => {
+    paginate: async (fn, params) => {
+      if (fn === 'pulls.list') {
+        calls.headQueries.push(params.head)
+        if (openOnSameHeadError) throw openOnSameHeadError
+        return openOnSameHead
+      }
       // One snapshot, no status filter — mirrors the real call.
       calls.listed.push({ branch: params.branch, status: params.status })
       if (listError) throw listError
@@ -42,6 +55,7 @@ function harness({ runs = [], cancelError, listError, prState = 'closed', prErro
     },
     rest: {
       pulls: {
+        list: 'pulls.list',
         get: async () => {
           if (prError) throw prError
           return { data: { state: prState } }
@@ -179,6 +193,66 @@ test('a run advancing between statuses cannot escape the sweep', async () => {
   await reapPrRuns({ ...BASE, github, core })
   assert.deepEqual(calls.cancelled, [1])
   assert.equal(calls.listed.length, 1)
+})
+
+test('leaves a post-close rerun alone', async () => {
+  // `/rerun` (pr-commands.yml) reuses the run id and its original created_at,
+  // bumping run_started_at. Judging by created_at alone would cancel a rerun a
+  // maintainer deliberately started after the close.
+  const { github, core, calls } = harness({
+    runs: [
+      run(1, 'CI', 'in_progress', { created_at: BEFORE, run_started_at: AFTER }),
+      run(2, 'CI', 'queued', { created_at: BEFORE, run_started_at: BEFORE }),
+    ],
+  })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [2])
+})
+
+test('will not use the fork fallback while another PR shares the head', async () => {
+  // Two PRs from one fork branch against different bases. The open one's runs
+  // predate this close and carry no association, so every other guard passes.
+  const FORK = 'someone-else/compose-ai-tools'
+  const { github, core, calls } = harness({
+    runs: [run(1, 'CI', 'queued', { pull_requests: [], head_repository: { full_name: FORK } })],
+    openOnSameHead: [{ number: 77 }],
+  })
+  await reapPrRuns({ ...BASE, headRepo: FORK, github, core })
+  assert.deepEqual(calls.cancelled, [])
+  assert.deepEqual(calls.headQueries, ['someone-else:agent/some-branch'])
+})
+
+test('this PR appearing in the head query does not block the fallback', async () => {
+  // The closed PR itself can still come back from the open-PR listing mid-race;
+  // only a *different* PR makes the head ambiguous.
+  const FORK = 'someone-else/compose-ai-tools'
+  const { github, core, calls } = harness({
+    runs: [run(1, 'CI', 'queued', { pull_requests: [], head_repository: { full_name: FORK } })],
+    openOnSameHead: [{ number: 42 }],
+  })
+  await reapPrRuns({ ...BASE, headRepo: FORK, github, core })
+  assert.deepEqual(calls.cancelled, [1])
+})
+
+test('assumes ambiguity when the open-PR check fails', async () => {
+  const FORK = 'someone-else/compose-ai-tools'
+  const { github, core, calls, warnings } = harness({
+    runs: [run(1, 'CI', 'queued', { pull_requests: [], head_repository: { full_name: FORK } })],
+    openOnSameHeadError: new Error('rate limited'),
+  })
+  await reapPrRuns({ ...BASE, headRepo: FORK, github, core })
+  assert.deepEqual(calls.cancelled, [])
+  assert.equal(warnings.length, 1)
+})
+
+test('an explicit association still reaps even on an ambiguous head', async () => {
+  // Ambiguity only gates the fallback; a run that names this PR is not in doubt.
+  const { github, core, calls } = harness({
+    runs: [run(1, 'CI', 'queued', { pull_requests: [{ number: 42 }] })],
+    openOnSameHead: [{ number: 77 }],
+  })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [1])
 })
 
 test('refuses to reap an empty head ref', async () => {

--- a/.github/scripts/reap-pr-runs.test.mjs
+++ b/.github/scripts/reap-pr-runs.test.mjs
@@ -2,10 +2,11 @@
 //
 // This runs on every PR (the `actions-tests` job in ci.yml) because the reaper
 // cancels workflow runs unattended, and every guard it has exists because the
-// failure it prevents is invisible until after it has happened: reaping the
-// default branch wipes post-merge CI for commits in flight; matching on branch
-// name alone lets a fork's `main` sweep up ours; and reaping without a
-// close-time cutoff kills the checks of whatever reopened or re-used the branch.
+// failure it prevents is invisible until after it has happened: cancelling a
+// `push` run wipes post-merge CI for commits in flight; matching on branch name
+// alone lets a fork's `main` sweep up ours; reaping without a close-time cutoff
+// kills the checks of whatever reopened or re-used the branch; and sweeping up a
+// manual dispatch kills someone's regression investigation.
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
@@ -24,6 +25,7 @@ function run(id, name, status, overrides = {}) {
     name,
     status,
     created_at: BEFORE,
+    event: 'pull_request',
     head_repository: { full_name: THIS_REPO },
     ...overrides,
   }
@@ -65,7 +67,6 @@ const BASE = {
   headRef: 'agent/some-branch',
   headRepo: THIS_REPO,
   thisRepo: THIS_REPO,
-  defaultBranch: 'main',
   closedAt: CLOSED_AT,
   currentRunId: 999,
 }
@@ -83,7 +84,7 @@ test('cancels queued and in-progress runs on the closed PR branch', async () => 
   assert.equal(result.skipped, null)
   assert.deepEqual(
     calls.listed.map((c) => c.status),
-    ['queued', 'in_progress'],
+    ['queued', 'in_progress', 'requested', 'waiting', 'pending'],
   )
   assert.ok(calls.listed.every((c) => c.branch === 'agent/some-branch'))
 })
@@ -118,12 +119,48 @@ test('a fork branch named main does not sweep up this repo’s main runs', async
   assert.deepEqual(calls.cancelled, [2])
 })
 
-test('refuses to reap this repo’s default branch', async () => {
-  const { github, core, calls } = harness({ runs: [run(1, 'CI', 'queued')] })
+test('reaps a PR whose head is the default branch, but never its push runs', async () => {
+  // Merging `main` forward into a release branch is a legitimate PR with
+  // headRef === the default branch. Its leftovers should be reaped; the
+  // default branch's own post-merge CI (a `push` run) must not be touched.
+  const { github, core, calls } = harness({
+    runs: [
+      run(1, 'CI', 'queued', { event: 'pull_request', pull_requests: [{ number: 42 }] }),
+      run(2, 'CI', 'queued', { event: 'push' }),
+    ],
+  })
   const result = await reapPrRuns({ ...BASE, headRef: 'main', github, core })
-  assert.deepEqual(calls.cancelled, [])
-  assert.deepEqual(calls.listed, [])
-  assert.match(result.skipped, /refusing to reap/)
+  assert.deepEqual(calls.cancelled, [1])
+  assert.equal(result.skipped, null)
+})
+
+test('leaves a manual workflow_dispatch run alone', async () => {
+  // A manual one-off has no PR association, so the empty-association fallback
+  // would sweep it up without the event allowlist. vscode-extension-e2e.yml is
+  // run this way for regression work.
+  const { github, core, calls } = harness({
+    runs: [
+      run(1, 'VS Code Extension E2E', 'in_progress', { event: 'workflow_dispatch' }),
+      run(2, 'CI', 'in_progress'),
+    ],
+  })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [2])
+})
+
+test('reaps runs stuck in waiting, requested and pending', async () => {
+  // A run blocked on a deployment gate never passes through queued or
+  // in_progress on its way out — it can sit in `waiting` indefinitely.
+  const { github, core, calls } = harness({
+    runs: [
+      run(1, 'Deploy', 'waiting'),
+      run(2, 'CI', 'requested'),
+      run(3, 'Integration', 'pending'),
+    ],
+  })
+  await reapPrRuns({ ...BASE, github, core })
+  // Ordered by the status loop (requested, then waiting, then pending), not by id.
+  assert.deepEqual(calls.cancelled.sort(), [1, 2, 3])
 })
 
 test('refuses to reap an empty head ref', async () => {
@@ -231,8 +268,8 @@ test('a listing failure warns instead of failing the workflow', async () => {
   const result = await reapPrRuns({ ...BASE, github, core })
   assert.equal(result.skipped, null)
   assert.equal(result.cancelled.length, 0)
-  // One per status queried, both surfaced as warnings rather than thrown.
-  assert.equal(result.failed.length, 2)
+  // One per status queried, all surfaced as warnings rather than thrown.
+  assert.equal(result.failed.length, 5)
   assert.ok(result.failed.every((f) => /rate limited/.test(f)))
-  assert.equal(warnings.length, 2)
+  assert.equal(warnings.length, 5)
 })

--- a/.github/scripts/reap-pr-runs.test.mjs
+++ b/.github/scripts/reap-pr-runs.test.mjs
@@ -35,9 +35,10 @@ function harness({ runs = [], cancelError, listError, prState = 'closed', prErro
   const calls = { listed: [], cancelled: [] }
   const github = {
     paginate: async (_fn, params) => {
+      // One snapshot, no status filter — mirrors the real call.
       calls.listed.push({ branch: params.branch, status: params.status })
       if (listError) throw listError
-      return runs.filter((r) => r.status === params.status)
+      return runs
     },
     rest: {
       pulls: {
@@ -82,11 +83,11 @@ test('cancels queued and in-progress runs on the closed PR branch', async () => 
   const result = await reapPrRuns({ ...BASE, github, core })
   assert.deepEqual(calls.cancelled, [1, 2, 3])
   assert.equal(result.skipped, null)
-  assert.deepEqual(
-    calls.listed.map((c) => c.status),
-    ['queued', 'in_progress', 'requested', 'waiting', 'pending'],
-  )
-  assert.ok(calls.listed.every((c) => c.branch === 'agent/some-branch'))
+  // A single listing with no status filter: per-status queries are separate
+  // snapshots, and a run advancing between them escapes every one.
+  assert.equal(calls.listed.length, 1)
+  assert.equal(calls.listed[0].status, undefined)
+  assert.equal(calls.listed[0].branch, 'agent/some-branch')
 })
 
 test('never cancels itself', async () => {
@@ -159,8 +160,25 @@ test('reaps runs stuck in waiting, requested and pending', async () => {
     ],
   })
   await reapPrRuns({ ...BASE, github, core })
-  // Ordered by the status loop (requested, then waiting, then pending), not by id.
-  assert.deepEqual(calls.cancelled.sort(), [1, 2, 3])
+  assert.deepEqual(calls.cancelled, [1, 2, 3])
+})
+
+test('never cancels an already-completed run', async () => {
+  // The single snapshot includes terminal runs, so they must be rejected here.
+  const { github, core, calls } = harness({
+    runs: [run(1, 'CI', 'completed'), run(2, 'CI', 'queued')],
+  })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [2])
+})
+
+test('a run advancing between statuses cannot escape the sweep', async () => {
+  // The regression that per-status queries caused: `requested` during the
+  // `queued` query, `queued` by the time `requested` was asked for, in neither.
+  const { github, core, calls } = harness({ runs: [run(1, 'CI', 'requested')] })
+  await reapPrRuns({ ...BASE, github, core })
+  assert.deepEqual(calls.cancelled, [1])
+  assert.equal(calls.listed.length, 1)
 })
 
 test('refuses to reap an empty head ref', async () => {
@@ -268,8 +286,8 @@ test('a listing failure warns instead of failing the workflow', async () => {
   const result = await reapPrRuns({ ...BASE, github, core })
   assert.equal(result.skipped, null)
   assert.equal(result.cancelled.length, 0)
-  // One per status queried, all surfaced as warnings rather than thrown.
-  assert.equal(result.failed.length, 5)
+  // The single listing failed, surfaced as a warning rather than thrown.
+  assert.equal(result.failed.length, 1)
   assert.ok(result.failed.every((f) => /rate limited/.test(f)))
-  assert.equal(warnings.length, 5)
+  assert.equal(warnings.length, 1)
 })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1180,6 +1180,8 @@ jobs:
       # a dropped `listed: false` or `group` silently moves a card on the front page.
       - name: Run publish-config reconcile tests
         run: ./.github/scripts/test-publish-config-to-box.sh
+      - name: Run PR run reaper tests
+        run: node --test .github/scripts/reap-pr-runs.test.mjs
 
   # The design-artifacts driver's own `node --test` suite, including the browser tests that drive the
   # built Remote Compose player bundle (`cli/src/main/resources/rc-player/bundle.js`) in headless

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,13 @@ on:
 permissions:
   contents: read
 
+# `pull_request`-only: only the current head's dependency diff is meaningful, so
+# a new push supersedes the review of the head it replaced. 12 runs were still
+# live on merged, deleted branches on 2026-08-08 for want of this.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   review:
     runs-on: ubuntu-latest

--- a/.github/workflows/no-agent-attribution.yml
+++ b/.github/workflows/no-agent-attribution.yml
@@ -58,6 +58,23 @@ on:
 permissions:
   contents: read
 
+# PR runs dedupe; push runs deliberately do NOT.
+#
+# The workflow had no concurrency group at all, so every push stacked another
+# run — 18 were live at once on merged-and-deleted branches (2026-08-08), each
+# holding a queue slot behind the heavy lanes. Grouping PR runs by ref fixes
+# that: a new push to the PR supersedes the run it replaces.
+#
+# Push runs are keyed per-SHA so they never share a group and can never cancel
+# each other. That is load-bearing, not an oversight: `drift` scans only the
+# commits *this push* added to main, so it is not idempotent across commits.
+# Any shared group would let GitHub cancel a pending run — it keeps only the
+# newest pending per group even with `cancel-in-progress: false` — and the
+# commits that run was going to scan would never be checked by anything.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   scan:
     name: Reject agent attribution

--- a/.github/workflows/no-agent-attribution.yml
+++ b/.github/workflows/no-agent-attribution.yml
@@ -65,14 +65,20 @@ permissions:
 # holding a queue slot behind the heavy lanes. Grouping PR runs by ref fixes
 # that: a new push to the PR supersedes the run it replaces.
 #
-# Push runs are keyed per-SHA so they never share a group and can never cancel
+# Push runs are keyed per-RUN so they never share a group and can never cancel
 # each other. That is load-bearing, not an oversight: `drift` scans only the
 # commits *this push* added to main, so it is not idempotent across commits.
 # Any shared group would let GitHub cancel a pending run — it keeps only the
 # newest pending per group even with `cancel-in-progress: false` — and the
 # commits that run was going to scan would never be checked by anything.
+#
+# `github.run_id`, not `github.sha`: a SHA is not unique per push event. A
+# force-push can make an earlier SHA the tip again (X→A, A→B, B→A), which would
+# put two push events in one group and evict the pending run for the first —
+# leaving that event's commit range scanned by nothing. This workflow exists to
+# handle force-pushed history, so it cannot assume tips are never revisited.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/no-agent-attribution.yml
+++ b/.github/workflows/no-agent-attribution.yml
@@ -57,6 +57,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read # `scan` re-reads the PR's current title/body; see below.
 
 # PR runs dedupe; push runs deliberately do NOT.
 #
@@ -64,6 +65,15 @@ permissions:
 # run — 18 were live at once on merged-and-deleted branches (2026-08-08), each
 # holding a queue slot behind the heavy lanes. Grouping PR runs by ref fixes
 # that: a new push to the PR supersedes the run it replaces.
+#
+# Superseding PR runs is only sound because `scan` re-reads the PR's current
+# title and body instead of trusting its own event payload. Group execution
+# order is NOT guaranteed, so an older `edited` run can enter the group after a
+# newer one and cancel it. If each run validated the text frozen into its own
+# payload, the survivor could certify a body that has since gained a prohibited
+# trailer — and because both edits share a head SHA, that stale-clean check
+# would satisfy the required gate. Re-reading makes every run interchangeable,
+# which is the precondition `cancel-in-progress` needs and does not provide.
 #
 # Push runs are keyed per-RUN so they never share a group and can never cancel
 # each other. That is load-bearing, not an oversight: `drift` scans only the
@@ -92,19 +102,35 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Read the PR's title and body from the API, NOT from this run's event
+      # payload. The payload is a snapshot of one `edited` event; a run holding
+      # a stale one can outlive the run holding the current one (see the
+      # concurrency note above), and the gate would then pass on text nobody
+      # will actually merge. The API always answers with what the squash commit
+      # would be built from right now.
+      #
+      # Writing the file here also keeps untrusted text out of the shell
+      # entirely, rather than routing it through env: as before.
+      - name: Read the PR's current title and body
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+            })
+            const fs = require('node:fs')
+            fs.writeFileSync('pr_text.txt', `${pr.title ?? ''}\n${pr.body ?? ''}\n`)
+
       - name: Scan commit identities and Co-authored-by trailers
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
+          # The commit range stays on the payload: this check reports against
+          # the head SHA of the event that started it, and a push produces its
+          # own run. Only the metadata is re-read.
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -uo pipefail
-
-          # The squash commit is built from the PR title + body, so they are
-          # scanned alongside the commit messages. Untrusted — written to a file
-          # rather than interpolated into the shell.
-          { printf '%s\n' "${PR_TITLE:-}"; printf '%s\n' "${PR_BODY:-}"; } > pr_text.txt
 
           .github/scripts/agent-attribution-scan.sh \
             --range "${BASE_SHA}..${HEAD_SHA}" --text-file pr_text.txt

--- a/.github/workflows/pr-run-reaper.yml
+++ b/.github/workflows/pr-run-reaper.yml
@@ -1,0 +1,75 @@
+name: PR Run Reaper
+
+# Cancels the workflow runs left behind when a PR closes.
+#
+# GitHub cancels *in-progress* runs when a ref is deleted, but it does not
+# reliably reap **queued** ones — and when the queue is deep enough that jobs
+# wait 40-70 min for a runner, almost everything is still queued at merge time.
+# Those runs then outlive the branch, the PR, and any check they could report
+# to. Measured on 2026-08-08: 160 of 197 live runs (81%) belonged to branches
+# that no longer existed, crowding out CI for open work.
+#
+# Concurrency groups cannot fix this. They only supersede a run when a *newer*
+# run appears on the same ref, and a merged PR produces no newer run — nothing
+# ever arrives to evict the stragglers. Reaping on close is the missing half.
+#
+# `pull_request_target` is required, not incidental: `pull_request` hands fork
+# PRs a read-only token, which cannot cancel anything. The usual
+# `pull_request_target` hazard is running untrusted head code with a privileged
+# token — this job checks out the BASE ref (the trigger's default) and runs only
+# committed base-branch code, never the PR head.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: pr-run-reaper-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  reap:
+    name: Cancel leftover runs for the closed PR
+    runs-on: ubuntu-latest
+    steps:
+      # No `ref:` — pull_request_target checks out the base branch, which is the
+      # point: the reaper must never execute code from the PR being closed.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        with:
+          script: |
+            const { reapPrRuns } = await import(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/reap-pr-runs.mjs`
+            )
+            const { cancelled, failed, skipped } = await reapPrRuns({
+              github,
+              core,
+              repo: context.repo,
+              headRef: process.env.HEAD_REF,
+              headRepo: process.env.HEAD_REPO,
+              thisRepo: `${context.repo.owner}/${context.repo.repo}`,
+              defaultBranch: context.payload.repository.default_branch,
+              currentRunId: context.runId,
+            })
+            await core.summary
+              .addHeading('PR Run Reaper', 3)
+              .addRaw(
+                skipped
+                  ? `Skipped: ${skipped}.`
+                  : `Closed PR #${context.payload.pull_request.number} on ` +
+                    `\`${process.env.HEAD_REF}\`.`,
+              )
+              .addList([`Cancelled: ${cancelled.length}`, `Could not cancel: ${failed.length}`])
+              .write()

--- a/.github/workflows/pr-run-reaper.yml
+++ b/.github/workflows/pr-run-reaper.yml
@@ -17,13 +17,14 @@ name: PR Run Reaper
 # PRs a read-only token, which cannot cancel anything — and a fork PR's runs are
 # recorded in *this* repo, so they are exactly the leftovers that need reaping.
 # The usual `pull_request_target` hazard is running untrusted head code with a
-# privileged token — this job checks out the BASE ref (the trigger's default)
-# and runs only committed base-branch code, never the PR head.
+# privileged token — this job checks out the default branch explicitly and runs
+# only committed default-branch code, never the PR head.
 #
 # What may and may not be cancelled is decided in reap-pr-runs.mjs, per run:
-# same head repository (branch names alone collide across forks), created no
-# later than the close, never this repo's default branch, and only while the PR
-# is still closed on re-read. See its tests for why each of those exists.
+# same head repository (branch names alone collide across forks), not claimed by
+# a different PR, created before the close, never this repo's default branch,
+# and only while the PR is still closed on re-read. See its tests for why each
+# of those exists.
 
 on:
   pull_request_target:

--- a/.github/workflows/pr-run-reaper.yml
+++ b/.github/workflows/pr-run-reaper.yml
@@ -21,10 +21,10 @@ name: PR Run Reaper
 # only committed default-branch code, never the PR head.
 #
 # What may and may not be cancelled is decided in reap-pr-runs.mjs, per run:
-# same head repository (branch names alone collide across forks), not claimed by
-# a different PR, created before the close, never this repo's default branch,
-# and only while the PR is still closed on re-read. See its tests for why each
-# of those exists.
+# PR-triggered events only (never a push or a manual dispatch), same head
+# repository (branch names alone collide across forks), not claimed by a
+# different PR, created before the close, and only while the PR is still closed
+# on re-read. See its tests for why each of those exists.
 
 on:
   pull_request_target:
@@ -79,7 +79,6 @@ jobs:
               headRef: process.env.HEAD_REF,
               headRepo: process.env.HEAD_REPO,
               thisRepo: `${context.repo.owner}/${context.repo.repo}`,
-              defaultBranch: context.payload.repository.default_branch,
               closedAt: process.env.CLOSED_AT,
               currentRunId: context.runId,
             })

--- a/.github/workflows/pr-run-reaper.yml
+++ b/.github/workflows/pr-run-reaper.yml
@@ -46,17 +46,31 @@ jobs:
     name: Cancel leftover runs for the closed PR
     runs-on: ubuntu-latest
     steps:
-      # Pinned to the default branch, not left to default. `pull_request_target`
-      # takes the workflow *definition* from the default branch but checks out
-      # the PR's *base* ref, so a PR against any other base would pair this
-      # workflow with whatever version of the script that base happens to hold —
-      # missing entirely on a base predating it, so the import fails and nothing
-      # is reaped, or an older, less-guarded copy. Pinning keeps the workflow and
-      # its script version-matched. It also still checks out base-branch code,
-      # never the PR head, which is what makes pull_request_target safe here.
+      # Pinned to the exact commit this workflow definition came from, not left
+      # to default and not the default branch by name.
+      #
+      # `pull_request_target` takes the workflow *definition* from the default
+      # branch but checks out the PR's *base* ref, so an unpinned checkout would
+      # pair this workflow with whatever version of the script that base happens
+      # to hold — missing entirely on a base predating it, so the import fails
+      # and nothing is reaped, or an older, less-guarded copy.
+      #
+      # The branch *name* fixes the wrong-base problem but not the time one: it
+      # is a moving ref, resolved when checkout runs rather than when the event
+      # fired. This job can sit in the very queue it exists to drain, and `main`
+      # moves fast enough here to matter (~19 merges/hour when measured), so a
+      # later commit could rename the module or change its signature and this
+      # run would import code its workflow was never written against.
+      # `github.workflow_sha` is immutable and is precisely the commit the
+      # definition was read from, so the two cannot drift apart. It falls back
+      # to the branch name in case the context is ever unset — that is the old
+      # behaviour, not a new failure mode.
+      #
+      # Either way this checks out default-branch code, never the PR head, which
+      # is what makes pull_request_target safe here.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.workflow_sha || github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false

--- a/.github/workflows/pr-run-reaper.yml
+++ b/.github/workflows/pr-run-reaper.yml
@@ -45,10 +45,17 @@ jobs:
     name: Cancel leftover runs for the closed PR
     runs-on: ubuntu-latest
     steps:
-      # No `ref:` — pull_request_target checks out the base branch, which is the
-      # point: the reaper must never execute code from the PR being closed.
+      # Pinned to the default branch, not left to default. `pull_request_target`
+      # takes the workflow *definition* from the default branch but checks out
+      # the PR's *base* ref, so a PR against any other base would pair this
+      # workflow with whatever version of the script that base happens to hold —
+      # missing entirely on a base predating it, so the import fails and nothing
+      # is reaped, or an older, less-guarded copy. Pinning keeps the workflow and
+      # its script version-matched. It also still checks out base-branch code,
+      # never the PR head, which is what makes pull_request_target safe here.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false

--- a/.github/workflows/pr-run-reaper.yml
+++ b/.github/workflows/pr-run-reaper.yml
@@ -14,10 +14,16 @@ name: PR Run Reaper
 # ever arrives to evict the stragglers. Reaping on close is the missing half.
 #
 # `pull_request_target` is required, not incidental: `pull_request` hands fork
-# PRs a read-only token, which cannot cancel anything. The usual
-# `pull_request_target` hazard is running untrusted head code with a privileged
-# token — this job checks out the BASE ref (the trigger's default) and runs only
-# committed base-branch code, never the PR head.
+# PRs a read-only token, which cannot cancel anything — and a fork PR's runs are
+# recorded in *this* repo, so they are exactly the leftovers that need reaping.
+# The usual `pull_request_target` hazard is running untrusted head code with a
+# privileged token — this job checks out the BASE ref (the trigger's default)
+# and runs only committed base-branch code, never the PR head.
+#
+# What may and may not be cancelled is decided in reap-pr-runs.mjs, per run:
+# same head repository (branch names alone collide across forks), created no
+# later than the close, never this repo's default branch, and only while the PR
+# is still closed on re-read. See its tests for why each of those exists.
 
 on:
   pull_request_target:
@@ -26,6 +32,9 @@ on:
 permissions:
   contents: read
   actions: write
+  # The reaper re-reads the PR before cancelling anything, so a reopen (or a new
+  # PR on the same branch) while this job queued does not get its checks killed.
+  pull-requests: read
 
 concurrency:
   group: pr-run-reaper-${{ github.event.pull_request.number }}
@@ -48,6 +57,7 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          CLOSED_AT: ${{ github.event.pull_request.closed_at }}
         with:
           script: |
             const { reapPrRuns } = await import(
@@ -57,10 +67,12 @@ jobs:
               github,
               core,
               repo: context.repo,
+              prNumber: context.payload.pull_request.number,
               headRef: process.env.HEAD_REF,
               headRepo: process.env.HEAD_REPO,
               thisRepo: `${context.repo.owner}/${context.repo.repo}`,
               defaultBranch: context.payload.repository.default_branch,
+              closedAt: process.env.CLOSED_AT,
               currentRunId: context.runId,
             })
             await core.summary

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,6 +19,14 @@ permissions:
   contents: read
   pull-requests: read
 
+# `pull_request`-only, so grouping by ref is a plain supersede: re-titling or
+# pushing to a PR should replace its title check, not stack another one. Without
+# this the workflow accumulated a run per event — 17 were still live on merged,
+# deleted branches on 2026-08-08, each occupying a queue slot.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Conventional Commit title

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,12 +19,29 @@ permissions:
   contents: read
   pull-requests: read
 
-# `pull_request`-only, so grouping by ref is a plain supersede: re-titling or
-# pushing to a PR should replace its title check, not stack another one. Without
-# this the workflow accumulated a run per event — 17 were still live on merged,
-# deleted branches on 2026-08-08, each occupying a queue slot.
+# Pushes supersede; title edits deliberately do NOT.
+#
+# Without any group the workflow accumulated a run per event — 17 were still
+# live on merged, deleted branches on 2026-08-08, each holding a queue slot.
+# Superseding on push is the plain, safe case: a new head SHA gets its own
+# check, and a run that loses its race reported on a commit that is no longer
+# the head, so nothing is gated on it.
+#
+# `edited` is not that case. Title edits do NOT change the head SHA, so a check
+# from an edit stays attached to the very commit the merge gate reads. Group
+# execution order is not guaranteed, so an older `edited` run can enter after a
+# newer one and cancel it — and `action-semantic-pull-request` validates the
+# title frozen into its own event payload. The survivor would then certify a
+# title that has since been replaced by an invalid one, on the same SHA, and
+# the required check goes green over it.
+#
+# The attribution workflow solves this by re-reading the PR; that is not
+# available here, because the action reads the payload itself rather than
+# taking a title as input. So edits get a group of their own instead and never
+# cancel each other. That costs at most a few seconds per edit — this job runs
+# in about three — and it is the difference between a gate and a suggestion.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.action == 'edited' && github.run_id || 'head' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Follow-up to #3546, which fixed how *fast* CI drains. This fixes what keeps *refilling* it.

## Why

Measured on 2026-08-08, after #3546 merged: **160 of 197 live runs (81%) belonged to branches that no longer existed** — PRs already merged and auto-deleted. Two independent accumulators, neither addressed by #3546:

| Accumulator | Share of live queue |
|---|---|
| Runs outliving their merged PR | **81%** (160/197) |
| Workflows with no concurrency group, stacking a run per event | 47 runs, overlapping the above |

I cancelled the standing backlog manually. Queue **196 → 6**, and job start latency went from 40–70 min to ~2 seconds. This PR stops it rebuilding.

## 1. Runs outlive their PR — new `PR Run Reaper`

GitHub cancels *in-progress* runs when a ref is deleted, but does **not** reliably reap **queued** ones. At 40–70 min queue waits, almost everything is still queued when the PR merges, so the runs outlive the branch, the PR, and any check they could report to.

**Concurrency groups cannot fix this**, which is why #3546 didn't: a group only supersedes a run when a *newer* run appears on the same ref, and a merged PR produces no newer run. Nothing ever arrives to evict the stragglers. Reaping on close is the missing half.

New workflow on `pull_request_target: closed` that cancels whatever is left on the head ref.

**On `pull_request_target`:** required, not incidental — `pull_request` hands fork PRs a read-only token that cannot cancel anything, and a fork PR's runs are recorded in *this* repo, so they are exactly the leftovers needing reaped. The usual hazard is running untrusted head code with a privileged token; this job checks out the **default branch** explicitly and runs only committed default-branch code, never the PR head. The checkout is pinned rather than left to default because `pull_request_target` takes the workflow *definition* from the default branch but the *checkout* from the PR's base — so an unpinned checkout could pair this workflow with a base branch holding an older copy of the script, or none at all.

**Every cancellation decision is per run, not per PR.** Six guards, each covered by tests:

| Guard | Prevents |
|---|---|
| Run event must be `pull_request` / `pull_request_target` | Two things at once: cancelling a manual `workflow_dispatch` someone is using to investigate a regression, and cancelling the default branch's post-merge CI — the latter excluded *by kind* rather than by matching a branch name |
| `head_repository.full_name` must match the PR's head repo | The Actions branch filter matches on *name* alone, so a fork branch named `main` would sweep up this repo's `main` runs |
| Run's `pull_requests` must not claim a *different* PR | One branch can carry two open PRs against different bases; the other PR's runs predate this close and would clear the cutoff |
| Unclaimed runs are only reaped when no *other* open PR shares this head repo **and** ref | The same collision for forks. Fork runs always have an empty `pull_requests`, so the fallback that keeps them reachable would otherwise treat another open PR's live runs as unowned. If that check fails we assume ambiguity — skipping leftovers costs queue slots, cancelling live checks costs someone their CI |
| Attempt must have started **strictly before** `closed_at` | A reopen, a new PR on the same branch, or a deliberate post-close `/rerun` having its fresh checks killed as "leftovers". Uses `max(created_at, run_started_at)`: a rerun reuses the run id and its original `created_at`, so `created_at` alone dates the *run*, not the *attempt*. `>=` because GitHub timestamps are second-precision and the ambiguous case should fall the safe way |
| PR re-read and must still be `closed` | Same race, caught at the top; if the re-read fails we skip rather than guess |

Runs are listed in **one unfiltered snapshot** with terminal statuses rejected locally, rather than one query per non-terminal status. Separate queries are separate snapshots, and a run that advances between them (`requested` when `queued` is asked for, `queued` by the time `requested` is) appears in neither and survives the close with no later reaper guaranteed to run. A single snapshot has no gaps to reason about, and it also catches runs held on a deployment gate, which never pass through `queued` at all.

Listing *and* cancelling errors are both downgraded to `core.warning`. The reaper is an optimisation and must never put a red check on an already-merged PR.

Logic lives in `.github/scripts/reap-pr-runs.mjs`, following the existing `fix-pr-body-markdown.mjs` pattern, because it cancels things unattended and both failure modes — over-reaching and under-reaching — are invisible without tests.

## 2. Three workflows stacked a run per event

No concurrency group at all, so nothing ever superseded anything:

| Workflow | Live zombies | Fix |
|---|---|---|
| `No Agent Attribution` | 18 | PR runs grouped by ref; **push runs keyed per-`run_id`** |
| `PR Title` | 17 | `${{ github.workflow }}-${{ github.ref }}`, cancel-in-progress |
| `dependency-review` | 12 | same |

**`No Agent Attribution` deliberately does not group its push runs.** Its `drift` job scans only *the commits this push added to main* — it is not idempotent across commits. Any shared group would let GitHub cancel a pending run (it keeps only the newest pending per group **even with `cancel-in-progress: false`**), and the commits that run was going to scan would then be checked by nothing. The key is `github.run_id`, not `github.sha`: a SHA identifies a commit, not a push event, and a force-push can make an earlier SHA the tip again (`X→A`, `A→B`, `B→A`), colliding two events in one group. This workflow exists to handle force-pushed history, so it cannot assume tips are never revisited.

Given this is the agent-attribution gate `CLAUDE.md` calls non-negotiable, quietly dropping scans to save queue slots would have been the wrong trade.

**`gitleaks` and `zizmor` were left alone** despite also lacking a group: both are `schedule` + `workflow_dispatch` only, so they never stacked. `pr-body-syntax` was left alone too — #3498 already gave it job-level concurrency.

## Test plan

- [x] `node --test .github/scripts/reap-pr-runs.test.mjs` — **24/24 pass**. Covers every guard above plus its boundaries: cancels queued + in-progress on the head ref; never cancels itself; reaps a fork PR's own runs; a fork branch named `main` does not collide with ours; a `main`-headed PR reaps its own runs while its `push` runs survive; a manual `workflow_dispatch` survives; `waiting`/`requested`/`pending` are reaped; a completed run is never cancelled; a run advancing between statuses cannot escape; refuses an empty ref; skips a reopened PR; skips when the PR cannot be re-read; leaves a concurrent open PR's runs alone; leaves a post-close rerun alone; will not use the fork fallback while another PR shares the head; the closed PR appearing in its own head query does not count as ambiguity; an explicit association still reaps on an ambiguous head; a failed head query suppresses the fallback; leaves runs created at or after the close alone; 409 treated as the finish/cancel race; a real cancel error warns; a listing failure warns instead of throwing.
- [x] Wired into the existing `actions-tests` job in `ci.yml`, so it runs on every PR.
- [x] All five touched workflows parse (`yaml.safe_load`); the inline `github-script` body passes `node --check`.
- [x] `test_affected_gradle_tests.py` still 7/7 — no regression from #3546.
- [x] `scripts/test-agent-attribution.sh` — 44 passed, and `agent-attribution-scan.sh --range origin/main..HEAD` is clean.
- [x] Confirmed `format.yml` is ktfmt-only, so the new `.mjs` files are not subject to a JS formatter gate.
- [ ] Post-merge: confirm the reaper fires on the next merged PR and that live runs on deleted branches stay near zero.

Non-visual (CI wiring only), so text-only evidence is the right bar.

## Review history

Five rounds of automated review found twelve issues, all fixed, and every one was the reaper cancelling something still live rather than missing a leftover. Two were regressions introduced by an earlier round's fix. That pattern is worth a reviewer's attention on its own: the guards are individually justified and tested, but reaping unattended has proven repeatedly harder to bound than it looks. Errors fail toward under-reaping throughout, which is the cheap direction to be wrong in.

The queue this PR was written to fix has since drained on its own (196 → 6, three of the remainder on branches this reaper would clear). So this is no longer urgent — it prevents the backlog rebuilding rather than fixing a live outage, and is worth a careful human read before merging.

## Still not in scope

Unchanged from #3546 — these reduce *demand*, and remain policy calls:

- Debouncing the heavy lanes on `main` (merge queue, or schedule instead of per-commit)
- Gating merges on CI — branches still merge before their checks start, which is *why* runs are orphaned in the first place; the reaper cleans up after that pattern rather than fixing it
- Runner capacity, if ~19 merges/hour is the intended steady state