### PR TITLE
feat(preview): anchored `=&lt;id&gt;` id patterns, so a generated exclusion list is safe

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -130,8 +130,11 @@ class BundleCommand(args: List<String>) : Command(args) {
         --id <preview-id>   Preview to include. Repeatable. First is the cover. Default: all.
         --exclude-preview-id <id|glob>
                             Skip rendering (and semantics-capturing) previews whose discovered id
-                            matches. Repeatable and comma-separated; '*'/'?' globs or a plain
-                            substring, matching composePreviewRender --exclude-preview-id.
+                            matches. Repeatable and comma-separated; '*'/'?' globs, a plain
+                            substring, or '=<id>' for an exact match, matching
+                            composePreviewRender --exclude-preview-id. Prefer '=' for a GENERATED
+                            list (a render sharder's "everything not mine"): ids are hierarchical,
+                            so the plain substring form drops a base id's variants too.
                             Unlike --id (which selects whole previews to PACK) this thins the RENDER
                             of one function's multipreview / multi-annotation fan-out — a design
                             catalog deferring a palette to its live server passes the deferred ids

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
@@ -76,8 +76,17 @@ internal object PackPreviewIdExclusions {
   }
 
   private fun matches(pattern: String, id: String): Boolean =
-    if (pattern.any { it == '*' || it == '?' }) globToRegex(pattern).matches(id)
-    else id == pattern || id.contains(pattern)
+    when {
+      // Exact, deliberately not substring: a base id is a substring of its own fan-out members, so
+      // `FilledButton_Light` would otherwise also drop `FilledButton_Light_VARIANT_off`. See
+      // `PreviewNameFilter.ANCHOR`.
+      pattern.startsWith(ANCHOR) -> id == pattern.substring(ANCHOR.length)
+      pattern.any { it == '*' || it == '?' } -> globToRegex(pattern).matches(id)
+      else -> id == pattern || id.contains(pattern)
+    }
+
+  /** Mirror of `PreviewNameFilter.ANCHOR`. */
+  const val ANCHOR: String = "="
 
   /**
    * Anchored regex for a `*`/`?` glob, escaping every other character so a `.` in a

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
@@ -127,4 +127,21 @@ class PackPreviewIdExclusionsTest {
     // filter gives it. Reach for a glob (`Foo_*`) when that's not what you meant.
     assertEquals(listOf("Bar_Light"), PackPreviewIdExclusions.retain(ids, listOf("Foo")))
   }
+
+  @Test
+  fun `an anchored pattern drops only the id it names, not its fan-out`() {
+    // Issue #3559: ids are hierarchical, so a base id is a substring of its own variants.
+    // Unanchored, excluding a base id also dropped every variant of it — which is what silently
+    // cost a sharded render three quarters of its captures.
+    val ids = listOf("FilledButton_Light", "FilledButton_Light_VARIANT_off", "FilledButton_Dark")
+
+    assertEquals(
+      listOf("FilledButton_Dark"),
+      PackPreviewIdExclusions.retain(ids, listOf("FilledButton_Light")),
+    )
+    assertEquals(
+      listOf("FilledButton_Light_VARIANT_off", "FilledButton_Dark"),
+      PackPreviewIdExclusions.retain(ids, listOf("=FilledButton_Light")),
+    )
+  }
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewFilter.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewFilter.kt
@@ -25,6 +25,14 @@ package ee.schimke.composeai.data.render
  */
 object PreviewFilter {
 
+  /**
+   * Prefix marking a pattern as an **exact** match rather than a substring one — the renderer-side
+   * mirror of `PreviewNameFilter.ANCHOR`, which documents why a generated id list needs it (a base
+   * id is always a substring of its own `_VARIANT_` / row fan-out, so substring exclusion deletes
+   * work a sharder meant to keep).
+   */
+  const val ANCHOR: String = "="
+
   /** System property carrying the comma-separated `--preview` name patterns. */
   const val NAME_FILTER_PROPERTY: String = "composeai.preview.filter"
 
@@ -207,14 +215,20 @@ object PreviewFilter {
     )
 
   private fun matchOne(pattern: String, simpleName: String, fqName: String): Boolean =
-    if (pattern.any { it == '*' || it == '?' }) {
-      val regex = globToRegex(pattern)
-      regex.matches(simpleName) || regex.matches(fqName)
-    } else {
-      simpleName == pattern ||
-        fqName == pattern ||
-        simpleName.contains(pattern) ||
-        fqName.contains(pattern)
+    when {
+      pattern.startsWith(ANCHOR) -> {
+        val exact = pattern.substring(ANCHOR.length)
+        simpleName == exact || fqName == exact
+      }
+      pattern.any { it == '*' || it == '?' } -> {
+        val regex = globToRegex(pattern)
+        regex.matches(simpleName) || regex.matches(fqName)
+      }
+      else ->
+        simpleName == pattern ||
+          fqName == pattern ||
+          simpleName.contains(pattern) ||
+          fqName.contains(pattern)
     }
 
   private fun globToRegex(glob: String): Regex {

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/PreviewFilterTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/PreviewFilterTest.kt
@@ -249,4 +249,14 @@ class PreviewFilterTest {
   fun rowExcludePropertyIsTheWireContractWithThePlugin() {
     assertEquals("composeai.preview.rowExclude", PreviewFilter.ROW_EXCLUDE_PROPERTY)
   }
+
+  @Test
+  fun `an anchored pattern matches the exact id only`() {
+    // Mirrors `SelectPreviewIdsTest` in the plugin — the two matchers must agree, and the anchor is
+    // what makes a generated exclusion list safe (issue #3559).
+    assertTrue(PreviewFilter.matchesId(listOf("=Foo_Light"), "Foo_Light"))
+    assertFalse(PreviewFilter.matchesId(listOf("=Foo_Light"), "Foo_Light_VARIANT_off"))
+    // Unanchored keeps its documented substring behaviour.
+    assertTrue(PreviewFilter.matchesId(listOf("Foo_Light"), "Foo_Light_VARIANT_off"))
+  }
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewNameFilter.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewNameFilter.kt
@@ -12,7 +12,10 @@ package ee.schimke.composeai.discovery
  *   `com.example.preview.ExportHelpDialogPreview`) — the FQN a user reads off the source, derived
  *   from the owning class's package rather than the synthetic `…Kt` holder class.
  *
- * Two matching styles, chosen per pattern:
+ * Three matching styles, chosen per pattern:
+ * - **Anchored** — a pattern prefixed with `=` matches that id or FQN and nothing else:
+ *   `=FilledButton_Light` will not touch `FilledButton_Light_VARIANT_off`. See [ANCHOR] for why
+ *   any generated id list needs this.
  * - **Glob** — a pattern containing `*` (any run) or `?` (one char) is anchored and full-matched
  *   against either candidate: `*ExportHelpDialogPreview`, `Export*Preview`, `com.example.*.Foo`.
  * - **Plain** — a pattern with no glob chars matches on equality *or substring* against either
@@ -24,6 +27,26 @@ package ee.schimke.composeai.discovery
  * "render every preview" behaviour.
  */
 object PreviewNameFilter {
+
+  /**
+   * Prefix that makes a pattern an **exact** match rather than a substring one.
+   *
+   * Plain substring matching is safe on the *include* axis — over-matching only renders more than
+   * asked — and unsafe on the *exclude* axis, where over-matching silently deletes work. Preview
+   * ids are hierarchical (`<base>_<variant>`, `<base>_<row>`), so a base id is **always** a
+   * substring of its own fan-out members: excluding `FilledButton_Light` also excluded
+   * `FilledButton_Light_VARIANT_off`.
+   *
+   * That made substring exclusion unusable with any *generated* id list, which is exactly what a
+   * render sharder produces — a shard excluding the other shards' ids also deleted the variants it
+   * was itself assigned. m3-catalog hit this at scale: 267 captured of 1095 assigned, on a green
+   * run, which is why its `render-shards` has been pinned to 1 (issue #3559).
+   *
+   * `=` is chosen because no discovered id can begin with it (ids derive from Kotlin identifiers
+   * and are path-sanitised), so adding this cannot change the meaning of any existing pattern.
+   */
+  const val ANCHOR: String = "="
+
 
   /**
    * True when [functionName] (owned by [className]) matches at least one of [patterns], or when
@@ -68,14 +91,20 @@ object PreviewNameFilter {
   }
 
   private fun matchOne(pattern: String, simpleName: String, fqName: String): Boolean =
-    if (pattern.any { it == '*' || it == '?' }) {
-      val regex = globToRegex(pattern)
-      regex.matches(simpleName) || regex.matches(fqName)
-    } else {
-      simpleName == pattern ||
-        fqName == pattern ||
-        simpleName.contains(pattern) ||
-        fqName.contains(pattern)
+    when {
+      pattern.startsWith(ANCHOR) -> {
+        val exact = pattern.substring(ANCHOR.length)
+        simpleName == exact || fqName == exact
+      }
+      pattern.any { it == '*' || it == '?' } -> {
+        val regex = globToRegex(pattern)
+        regex.matches(simpleName) || regex.matches(fqName)
+      }
+      else ->
+        simpleName == pattern ||
+          fqName == pattern ||
+          simpleName.contains(pattern) ||
+          fqName.contains(pattern)
     }
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -137,10 +137,11 @@ abstract class RenderPreviewsTask : DefaultTask() {
   @Option(
     option = "exclude-preview-id",
     description =
-      "Skip previews whose discovered id matches this pattern (repeatable; '*'/'?' globs or a " +
-        "plain substring), rendering everything else. The polarity a deferred catalog palette " +
-        "needs. Applied after --preview-id. Excluding every preview fails the task. Overrides " +
-        "-PcomposePreview.idExclude.",
+      "Skip previews whose discovered id matches this pattern (repeatable; '*'/'?' globs, a " +
+        "plain substring, or '=<id>' for an exact match), rendering everything else. Use '=' for " +
+        "a generated list: ids are hierarchical, so a plain base id also drops its variants. The " +
+        "polarity a deferred catalog palette needs. Applied after --preview-id. Excluding every " +
+        "preview fails the task. Overrides -PcomposePreview.idExclude.",
   )
   fun setPreviewIdExcludeOption(values: List<String>) {
     previewIdExcludes.set(values)

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectPreviewIdsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectPreviewIdsTest.kt
@@ -161,4 +161,36 @@ class SelectPreviewIdsTest {
       excludePreviewIds(selectPreviewIds(all, listOf("FilledButton*")), listOf("*_HighContrast"))
     assertThat(kept.map { it.id }).containsExactly("FilledButton_Light", "FilledButton_Dark")
   }
+
+  @Test
+  fun `an anchored exclusion does not take the variants of the id it names`() {
+    // The sharding bug (issue #3559): ids are hierarchical, so a base id is a substring of its own
+    // fan-out members. Unanchored, excluding one shard's `FilledButton_Light` also deleted
+    // `FilledButton_Light_VARIANT_off` — work the excluding shard was itself assigned.
+    val previews =
+      listOf(
+        preview("FilledButton_Light", "FilledButton"),
+        preview("FilledButton_Light_VARIANT_off", "FilledButton"),
+        preview("FilledButton_Dark", "FilledButton"),
+      )
+
+    val unanchored = excludePreviewIds(previews, listOf("FilledButton_Light"))
+    assertThat(unanchored.map { it.id }).containsExactly("FilledButton_Dark")
+
+    val anchored = excludePreviewIds(previews, listOf("=FilledButton_Light"))
+    assertThat(anchored.map { it.id })
+      .containsExactly("FilledButton_Light_VARIANT_off", "FilledButton_Dark")
+      .inOrder()
+  }
+
+  @Test
+  fun `an anchored selection matches only the id it names`() {
+    val previews =
+      listOf(
+        preview("FilledButton_Light", "FilledButton"),
+        preview("FilledButton_Light_VARIANT_off", "FilledButton"),
+      )
+    assertThat(selectPreviewIds(previews, listOf("=FilledButton_Light")).map { it.id })
+      .containsExactly("FilledButton_Light")
+  }
 }


### PR DESCRIPTION
Unblocks #3559.

## The bug

`--exclude-preview-id` matches a plain pattern by equality **or substring**. Preview ids are hierarchical (`<base>_<variant>`, `<base>_<row>`), so a base id is *always* a substring of its own fan-out:

```
exclude "FilledButton_Light"  →  also drops FilledButton_Light_VARIANT_off
```

That makes substring exclusion unusable with any **generated** id list — which is exactly what a render sharder produces. A shard excluding the other shards' ids also deleted the variants it was itself assigned. m3-catalog hit it at scale: **267 captured of 1095 assigned, 235 merged, on a green run**, which is why its `render-shards` has been pinned to 1.

The asymmetry is the whole point, and it's why this wasn't caught by the include axis:

| axis | over-matching means | safe? |
|---|---|---|
| include (`--preview-id`) | renders more than asked | yes |
| exclude (`--exclude-preview-id`) | **silently deletes work** | no |

## The fix

A pattern prefixed with `=` matches that id (or FQN) exactly — no substring, no glob:

```
--exclude-preview-id '=FilledButton_Light'   # leaves FilledButton_Light_VARIANT_off alone
```

Additive, not a behaviour change: plain and glob patterns keep exactly their documented semantics. `=` cannot collide with an existing pattern because no discovered id can begin with it — ids derive from Kotlin identifiers and are path-sanitised.

I chose this over making exclusions exact by default, which would have been a silent breaking change to a documented flag, and over a separate property, which would have needed new plumbing through the CLI flag, the Gradle property and the env var. A prefix rides all three channels for free. It also matches what the m3-catalog comment asked for — *"an exact-id exclusion, or globs the sharder emits"*.

## Applied to all three mirrors

`PreviewNameFilter` (the authority), `PreviewFilter` (renderer-side) and `PackPreviewIdExclusions` (CLI) must agree or the render and the pack disagree about what was skipped. All three changed, each with its own test, plus the two help texts users read.

## Test plan

```
./gradlew :gradle-plugin:test :cli:test :data-render-core:test :gradle-plugin:preview-discovery:test ktfmtCheck
```

**390 + 1763 + 79 + 147 tests, 0 failures, 0 skipped.**

New coverage, one per mirror — each asserts both halves, that `=Foo_Light` spares `Foo_Light_VARIANT_off` *and* that the unanchored form still drops it, so the compatibility claim is pinned rather than asserted:

- `SelectPreviewIdsTest` — anchored exclusion and anchored selection
- `PreviewFilterTest` — `matchesId` anchored vs plain
- `PackPreviewIdExclusionsTest` — `retain` anchored vs plain

No visual surface changes: this changes which previews a filter selects, not how any of them are drawn.

## Not in this PR

Re-enabling sharding, and re-tuning the count. Both belong to #3559 and need the sharder in design-parity to emit `=`-anchored ids first — that repo isn't in scope here. This is the upstream half that makes it possible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk2xtVbDfuqQP2Bkzdndz9)_