### PR TITLE
build(design-artifacts): pin the export engine to 0.1.44

### DIFF
--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -8,9 +8,9 @@
       "name": "design-artifacts-driver",
       "version": "0.0.0",
       "dependencies": {
-        "@design-parity/adapter-figma": "^0.1.38",
+        "@design-parity/adapter-figma": "^0.1.44",
         "@design-parity/candidate": "^0.1.25",
-        "@design-parity/catalog-export": "^0.1.38",
+        "@design-parity/catalog-export": "^0.1.44",
         "pixelmatch": "^7.0.0",
         "playwright": "^1.49.0",
         "pngjs": "^7.0.0"
@@ -20,12 +20,12 @@
       }
     },
     "node_modules/@design-parity/adapter-figma": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.38.tgz",
-      "integrity": "sha512-1IvMjWSWrfNt2yimWsxbtL8MxAhbMmKUXPJBgGfVE8z+PlBjd1vEgqoPqniO+vsVwsPzkIhSIBvWKoPkJVwSag==",
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.44.tgz",
+      "integrity": "sha512-LyhdSKCIXbx831P6XOxEkJhETGoG6gX2I5j96CVl1apRiI5QPNUJvJQIMCfygnxvagEMrXcEWnAKUDYrNtfCCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.38"
+        "@design-parity/core": "^0.1.44"
       }
     },
     "node_modules/@design-parity/candidate": {
@@ -39,18 +39,18 @@
       }
     },
     "node_modules/@design-parity/catalog-export": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.38.tgz",
-      "integrity": "sha512-iVbuHt9vFh0jSoOyM+aOQ+ODt87AKb2jioMiNE8whBrBEh/p4E1dMNF5bnfVepg2JIRu72Id4NPnoQsnRFKccw==",
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.44.tgz",
+      "integrity": "sha512-cBwOAuB+2/JoHcGbQZTpctSaHiinZAF8/nYk/0m0MviQhsfc+AUJdo6Vys4ouSkRS8nG5iOrIv+9ipqnBH6k9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.38"
+        "@design-parity/core": "^0.1.44"
       }
     },
     "node_modules/@design-parity/core": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.38.tgz",
-      "integrity": "sha512-K62ly7ldYzPe4G79JS/rHt3HbL9+T6P7Yq2b2KS6eF/ahSdg0OwiV7OJtPonQGSvQMpoMF14cPJ0iP3JY+aJYQ==",
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.44.tgz",
+      "integrity": "sha512-ZBFRHcnCyUPX3+Wv8JZH15AybTvBbg9KgsY9aemC+Ow2bhQ+ZpQXv0TYhYyhBXeMCrxS0p9BuE/8VUKqwXKlyg==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1"

--- a/scripts/design-artifacts/package-version.test.mjs
+++ b/scripts/design-artifacts/package-version.test.mjs
@@ -6,7 +6,7 @@ import { installedPackageVersion } from "./package-version.mjs";
 test("reads the catalog-export version when package.json is not exported", () => {
   assert.equal(
     installedPackageVersion("@design-parity/catalog-export", import.meta.url),
-    "0.1.38",
+    "0.1.44",
   );
 });
 

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -11,9 +11,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@design-parity/adapter-figma": "^0.1.38",
+    "@design-parity/adapter-figma": "^0.1.44",
     "@design-parity/candidate": "^0.1.25",
-    "@design-parity/catalog-export": "^0.1.38",
+    "@design-parity/catalog-export": "^0.1.44",
     "pixelmatch": "^7.0.0",
     "playwright": "^1.49.0",
     "pngjs": "^7.0.0"


### PR DESCRIPTION
## Summary

The Design Artifacts driver pinned `@design-parity/catalog-export` and `@design-parity/adapter-figma` at `^0.1.38`, so `npm ci` in the workflow resolved an engine predating the reference-column work. The `noReference` / `referenceSet` options the driver already sets reached `buildCatalog` and stopped — the old engine ignored fields it didn't know about, silently.

This bumps both to `^0.1.44`, which carries them onto the published catalog (design-parity #306 and #308). The join in `generate-design-catalog.mjs` now has an engine that understands what it emits.

Closes the last item from the Codex review sweep (#3533): the reference-column options were inert under `npm ci` at the old pin. It also activates the plumbing merged in #3543, which until now terminated at `buildCatalog`.

### Changes

- `scripts/design-artifacts/package.json` — both pins `^0.1.38` → `^0.1.44`
- `scripts/design-artifacts/package-lock.json` — regenerated; `catalog-export`, `adapter-figma` and the transitive `@design-parity/core` all resolve to 0.1.44
- `scripts/design-artifacts/package-version.test.mjs` — asserts catalog-export's exact resolved version, so the literal moves with the pin

`@design-parity/candidate` is left at `^0.1.25`. Its range already floats, but the lockfile keeps it resolved at 0.1.38 while its siblings move to 0.1.44 — the first time this driver has run off-lockstep with a repo that releases all packages at one version. Nothing in the test suite trips on it, so it's noted rather than bundled into this bump.

## Test plan

- `npm ci` in `scripts/design-artifacts/` resolves cleanly against the new pins (14 packages, 0 vulnerabilities)
- `npm test` — 584 tests, 562 pass / 0 fail / 22 skipped. Before the test-literal fix the run was 561/1: `package-version.test.mjs` asserted `'0.1.38'` and got `'0.1.44'`, which is the assertion doing its job
- Confirmed the options are real in the installed engine rather than assumed — `referenceSet` and `noReference` are present in 0.1.44's `spec.d.ts`, `ingest.d.ts`, `manifest.d.ts` and `types.d.ts`, and the field names match what the vendored join at `generate-design-catalog.mjs:643-652` sets

No visual evidence: this is build wiring, with no renderable surface in the diff. Any change to the rendered catalogs shows up where it should — `design-artifacts.yml` triggers on push to `main` for `scripts/design-artifacts/` changes, so merging appends a diffable regeneration commit to each affected `design-artifacts/<system>` delivery branch.

## Note on the upstream release

0.1.43 was tagged and GitHub-released but never reached npm: its release run didn't get a runner until after the tag existed, so release-please reported `release_created=false` and the `publish` job was gated off ([run 31268131569](https://github.com/yschimke/design-parity/actions/runs/31268131569)). design-parity #310 added a `tag` input to `release.yml` as the recovery path; in the event 0.1.44 shipped normally and carried 0.1.43's contents forward, so no dispatch was needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaurAWy7n75Sk3rGhgRpfv)_