### PR TITLE
build(design-artifacts): pin candidate to 0.1.44 with its siblings

### DIFF
--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@design-parity/adapter-figma": "^0.1.44",
-        "@design-parity/candidate": "^0.1.25",
+        "@design-parity/candidate": "^0.1.44",
         "@design-parity/catalog-export": "^0.1.44",
         "pixelmatch": "^7.0.0",
         "playwright": "^1.49.0",
@@ -29,12 +29,12 @@
       }
     },
     "node_modules/@design-parity/candidate": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.38.tgz",
-      "integrity": "sha512-5Joj+cn7XL1nwnnr3vMd8Wc/Det6AMf7t7zXcrzizSF/XAQdqB0evO2j4NF07LR541i5knsm5GkeOa9hO0zJjw==",
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.44.tgz",
+      "integrity": "sha512-XZwu9PsGvX/pU4KsQ3MlEXU7BylmssBGzGGCpmBkmD1iDR9k+q1cJ2ie/bwFUed2RcP38x4bXq/krqdf3N4g5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.38",
+        "@design-parity/core": "^0.1.44",
         "fflate": "^0.8.2"
       }
     },

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@design-parity/adapter-figma": "^0.1.44",
-    "@design-parity/candidate": "^0.1.25",
+    "@design-parity/candidate": "^0.1.44",
     "@design-parity/catalog-export": "^0.1.44",
     "pixelmatch": "^7.0.0",
     "playwright": "^1.49.0",


### PR DESCRIPTION
## Summary

Follow-up to #3563, which moved `@design-parity/catalog-export` and `@design-parity/adapter-figma` to `^0.1.44` but left `@design-parity/candidate` at `^0.1.25`. Its range floats, so nothing broke — but the lockfile kept it resolved at **0.1.38** while its siblings and the transitive `@design-parity/core` moved to 0.1.44. design-parity releases all 15 packages at a single version, so that was the first time this driver had run off-lockstep with it.

All four `@design-parity/*` packages now resolve to 0.1.44.

## Test plan

`npm test` is **584 tests, 562 pass / 0 fail / 22 skipped** — but that number proves less than it looks, and it's worth being explicit about why. No test in `scripts/design-artifacts/` imports `@design-parity/candidate`, and none imports `generate-design-catalog.mjs`; the suite covers the driver's helper modules only. It would stay green even if candidate's API had broken outright, so it is not evidence for this bump.

What is evidence — exercising the three entry points the driver actually imports (`generate-design-catalog.mjs:39-43`) against 0.1.44:

- `npm ci` resolves clean; `catalog-export`, `adapter-figma`, `candidate` and `core` all report 0.1.44
- all three imports resolve as functions
- `readPreviewBundle` on a non-bundle still rejects with a typed `InvalidBundleError` naming the missing End-Of-Central-Directory record — the documented contract, enforced by the new code
- against a minimal PNG+zip polyglot built to the `bundle.d.ts` format, the full path runs: `readPreviewBundle` parses out `module` / `variant` / 1 preview / 3 zip entries, and `bundleToCandidates` returns a candidate carrying `componentId` and its data-URI `images`
- `catalogTokensFromBundle` returns `undefined`, which is correct rather than a failure — the synthetic bundle carries no token data and the signature is `DesignTokens | undefined`

The real end-to-end check is the Design Artifacts workflow itself, which runs the driver against real bundles and triggers on push to `main` for `scripts/design-artifacts/` changes — so merging exercises this against production input and appends a diffable regeneration commit to each affected `design-artifacts/<system>` branch.

No visual evidence: dependency pin only, no renderable surface in the diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaurAWy7n75Sk3rGhgRpfv)_