### PR TITLE
fix(vscode): give the e2e Gradle render a cold-CI budget, and fail fast when it dies

### DIFF
--- a/.github/workflows/vscode-extension-e2e.yml
+++ b/.github/workflows/vscode-extension-e2e.yml
@@ -95,6 +95,17 @@ jobs:
             grep: ''
     # Per-shard ceiling. The complete suite is deliberately split because
     # its serial worst case exceeds an hour; each shard remains bounded.
+    #
+    # This is also the real backstop against a wedged Gradle build. The
+    # extension's own per-task cap (`TASK_TIMEOUT_MS`) is raised to 10
+    # minutes for e2e by `test/electron/runTest.ts`, because a cold hosted
+    # runner compiles the `includeBuild` plugin plus the sample module
+    # before rendering and routinely runs past the 5-minute interactive
+    # default — which killed every shard mid-render on 2026-08-08. Raising
+    # the cap further (`COMPOSE_PREVIEW_GRADLE_TASK_TIMEOUT_MS`) means
+    # raising this too: the cached-preload suite derives a ~48m worst case
+    # from the cap, and a job that dies here never reaches the suite's
+    # attributable failure.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -597,12 +597,23 @@ function showClassVersionRemediation(err: ClassVersionError): void {
 export interface ComposePreviewTestApi {
     /** Replace the GradleService with one wired to the supplied stub API. */
     injectGradleApi(api: GradleApi): void;
-    /** Drive {@link refresh} synchronously from a test. */
+    /**
+     * Drive {@link refresh} synchronously from a test, resolving with the
+     * outcome it reported.
+     *
+     * The outcome matters to the e2e suites: `refresh` swallows a Gradle
+     * failure (it belongs on the panel, not in a rejected promise), so a
+     * test that only polls `getPostedMessages()` for `setPreviews` cannot
+     * tell "still rendering" from "the render died ten minutes ago" and
+     * burns its whole Mocha budget before failing with a bare timeout. Tests
+     * that expect pixels should assert on `'failed'` immediately — see
+     * `assertRefreshRendered` in `test/electron/suite/refreshOutcome.ts`.
+     */
     triggerRefresh(
         filePath: string,
         force?: boolean,
         tier?: "fast" | "full",
-    ): Promise<void>;
+    ): Promise<RefreshOutcome>;
     /**
      * Drive the production save path for a file — the same `startEditJourney`
      * + `refreshQueue.dispatchSave(..., { allowImmediate: true })` the
@@ -2525,8 +2536,8 @@ export async function activate(
                 filePath: string,
                 force = false,
                 tier: "fast" | "full" = "full",
-            ): Promise<void> {
-                return refresh(force, filePath, tier).then(() => {});
+            ): Promise<RefreshOutcome> {
+                return refresh(force, filePath, tier);
             },
             triggerSave(filePath: string): void {
                 // Mirror the onDidSaveTextDocument handler so tests measure
@@ -4608,7 +4619,7 @@ function sourceLooksLikePreviewDeclaration(
  *   over the previous (now stale) cards; the next save with a clean buffer
  *   will run a real refresh.
  */
-type RefreshOutcome =
+export type RefreshOutcome =
     "completed" | "cancelled" | "no-module" | "failed" | "gated";
 
 /**

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -114,7 +114,61 @@ function expandParamCaptures(
     return expanded;
 }
 
-const TASK_TIMEOUT_MS = 5 * 60 * 1000;
+/**
+ * Wall-clock ceiling for a single `gradlew` invocation, when nothing
+ * overrides it. Five minutes is sized for the interactive case this cap
+ * exists to serve: an editor user staring at a wedged build wants it
+ * abandoned and the build lock freed, not nursed indefinitely.
+ */
+const DEFAULT_TASK_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Env override for {@link TASK_TIMEOUT_MS}, in milliseconds. Only the e2e
+ * harness sets it (`test/electron/runTest.ts`); production reads no env and
+ * keeps {@link DEFAULT_TASK_TIMEOUT_MS}.
+ */
+const TASK_TIMEOUT_ENV = "COMPOSE_PREVIEW_GRADLE_TASK_TIMEOUT_MS";
+
+/**
+ * Effective per-task ceiling. On expiry `runTask` fires `cancelRunTask`
+ * (which kills the gradlew client and releases the build lock) and rejects
+ * with a `timed out after Ns` error.
+ *
+ * Overridable because the interactive budget is wrong for CI e2e, which
+ * runs the opposite workload: a cold hosted runner pays `includeBuild`
+ * plugin compilation *plus* a cold Kotlin/Compose module compile before the
+ * first pixel, and that regularly runs past five minutes. When it does, the
+ * cap kills the render mid-flight and every `vscode-extension-e2e` shard
+ * fails — observed on 2026-08-08, where the cold `:samples:cmp` render was
+ * cancelled at exactly 5m00s while the very next render on the same runner,
+ * against the build outputs the killed one had produced, finished in 64s.
+ * The e2e harness therefore raises the cap for its own run; the workflow's
+ * per-shard `timeout-minutes` remains the real backstop against a wedge.
+ */
+export const TASK_TIMEOUT_MS = resolveTaskTimeoutMs(
+    process.env[TASK_TIMEOUT_ENV],
+);
+
+/**
+ * Parse the {@link TASK_TIMEOUT_ENV} override, falling back to
+ * {@link DEFAULT_TASK_TIMEOUT_MS} for anything that isn't a positive finite
+ * number. A malformed value must not degrade into `NaN` or `0` — either
+ * would make `setTimeout` fire immediately and cancel every build the
+ * instant it started.
+ *
+ * Exported for tests; production reads {@link TASK_TIMEOUT_MS}.
+ */
+export function resolveTaskTimeoutMs(raw: string | undefined): number {
+    if (!raw) {
+        return DEFAULT_TASK_TIMEOUT_MS;
+    }
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return DEFAULT_TASK_TIMEOUT_MS;
+    }
+    return Math.floor(parsed);
+}
+
 const MANIFEST_CACHE_TTL_MS = 30_000;
 /**
  * How long after a successful `composePreviewApplied` invocation we treat

--- a/vscode-extension/src/test/electron/runTest.ts
+++ b/vscode-extension/src/test/electron/runTest.ts
@@ -2,6 +2,24 @@ import * as path from "path";
 import { downloadAndUnzipVSCode, runTests } from "@vscode/test-electron";
 
 /**
+ * Per-Gradle-task ceiling handed to the extension host for e2e runs, via
+ * `COMPOSE_PREVIEW_GRADLE_TASK_TIMEOUT_MS` (see `gradleService.ts`).
+ *
+ * The production default is 5 minutes, tuned for an interactive user who
+ * wants a wedged build abandoned quickly. E2E is a different workload: a
+ * cold hosted runner compiles the `includeBuild` plugin and the sample
+ * module before rendering anything, which routinely takes longer than that
+ * — and when it does, the cap cancels the render and the suite fails with
+ * no useful signal. Ten minutes clears the observed cold cost with room to
+ * spare while staying well inside every suite's Mocha timeout and the
+ * workflow's 60-minute per-shard cap, which remain the wedge backstops.
+ *
+ * Set `COMPOSE_PREVIEW_GRADLE_TASK_TIMEOUT_MS` in the environment to
+ * override (e.g. to reproduce the production cap locally).
+ */
+const E2E_GRADLE_TASK_TIMEOUT_MS = 10 * 60_000;
+
+/**
  * Entry point for `npm run test:electron`.
  *
  * Downloads a stable VS Code if needed, installs the test-only fake
@@ -132,6 +150,16 @@ async function main(): Promise<void> {
             ELECTRON_RUN_AS_NODE: undefined,
             COMPOSE_PREVIEW_TEST_MODE: "1",
             ...(e2eMode ? { COMPOSE_PREVIEW_E2E: "1" } : {}),
+            // Both e2e modes drive real cold Gradle builds, so both need the
+            // longer per-task ceiling. The fast suite keeps the production
+            // default — its Gradle API is a stub and never blocks.
+            ...(e2eMode || e2eExternal
+                ? {
+                      COMPOSE_PREVIEW_GRADLE_TASK_TIMEOUT_MS:
+                          process.env.COMPOSE_PREVIEW_GRADLE_TASK_TIMEOUT_MS ??
+                          String(E2E_GRADLE_TASK_TIMEOUT_MS),
+                  }
+                : {}),
             ...(process.env.COMPOSE_PREVIEW_E2E_FILES
                 ? {
                       COMPOSE_PREVIEW_E2E_FILES:

--- a/vscode-extension/src/test/electron/suite/e2e.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2e.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import type { ComposePreviewTestApi } from "../../../extension";
 import { RealGradleApi } from "../realGradleApi";
+import { assertRefreshRendered } from "./refreshOutcome";
 
 /**
  * End-to-end test. Drives the extension against a real Gradle build of
@@ -158,7 +159,11 @@ describeE2E("Compose Preview e2e (real Gradle)", function () {
 
     it("renders previews for samples/cmp through the real Gradle plugin", async () => {
         api.resetMessages();
-        await api.triggerRefresh(kotlinFile, /* force */ true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(kotlinFile, /* force */ true, "full"),
+            "cold :samples:cmp render",
+        );
 
         // The panel may emit several setPreviews on its way through the
         // refresh flow; the last one is the one carrying the rendered

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import type { ComposePreviewTestApi } from "../../../extension";
 import { RealGradleApi } from "../realGradleApi";
+import { assertRefreshRendered } from "./refreshOutcome";
 
 /**
  * End-to-end test for the subscription-driven accessibility chain
@@ -431,7 +432,11 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
         timeoutMs: number,
     ): Promise<PreviewSummary[]> {
         api.resetMessages();
-        await api.triggerRefresh(wearKotlinFile, /* force */ true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(wearKotlinFile, /* force */ true, "full"),
+            "samples/wear render",
+        );
         const setPreviews = await waitFor(
             "non-empty setPreviews for samples/wear",
             timeoutMs,

--- a/vscode-extension/src/test/electron/suite/e2eBundleChain.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eBundleChain.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import type { ComposePreviewTestApi } from "../../../extension";
 import { RealGradleApi } from "../realGradleApi";
+import { assertRefreshRendered } from "./refreshOutcome";
 
 /**
  * Electron-driven e2e for the bundle chip ↔ tab ↔ overlay chain
@@ -190,7 +191,11 @@ describeE2E("Compose Preview bundle chip↔tab↔overlay e2e (wear)", function (
         // the first visible card, which is the previewId the chip's
         // outbound subscribe targets.
         api.resetMessages();
-        await api.triggerRefresh(wearKotlinFile, /* force */ true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(wearKotlinFile, /* force */ true, "full"),
+            "samples/wear render",
+        );
         const setPreviews = await waitFor(
             "non-empty setPreviews for samples/wear",
             this.timeout(),

--- a/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
@@ -4,6 +4,8 @@ import * as path from "path";
 import * as vscode from "vscode";
 import type { ComposePreviewTestApi } from "../../../extension";
 import { RealGradleApi } from "../realGradleApi";
+import { TASK_TIMEOUT_MS } from "../../../gradleService";
+import { assertRefreshRendered } from "./refreshOutcome";
 
 /**
  * End-to-end coverage for the "switching modules shows cached PNGs
@@ -98,13 +100,18 @@ function firstNonEmptySetPreviews(
  * Wall-clock ceiling for one whole prime attempt — the awaited Gradle
  * render *and* the subsequent wait for its `setPreviews`, together (see
  * `primeModule`). A render runs through `gradleService`, which caps each
- * Gradle task at 5 minutes (`TASK_TIMEOUT_MS`) and fires `cancelRunTask`
- * on expiry; budget just past that cap so a render completing near it
- * still posts its `setPreviews`, while a wedged one is abandoned shortly
- * after the cap kills it. Because this bounds the *entire* attempt (not
- * just the wait), `SUITE_TIMEOUT_MS` below can be derived from it directly.
+ * Gradle task at `TASK_TIMEOUT_MS` and fires `cancelRunTask` on expiry;
+ * budget just past that cap so a render completing near it still posts its
+ * `setPreviews`, while a wedged one is abandoned shortly after the cap
+ * kills it. Because this bounds the *entire* attempt (not just the wait),
+ * `SUITE_TIMEOUT_MS` below can be derived from it directly.
+ *
+ * Derived from the cap rather than hardcoded so the two can't drift: the
+ * e2e harness raises `TASK_TIMEOUT_MS` above the interactive default (see
+ * `runTest.ts`), and a budget stuck at the old value would abandon a
+ * healthy-but-slow cold render before the cap ever fired.
  */
-const PRIME_ATTEMPT_BUDGET_MS = 6 * 60_000;
+const PRIME_ATTEMPT_BUDGET_MS = TASK_TIMEOUT_MS + 60_000;
 /** Prime attempts per module (one retry on a freed build lock). */
 const PRIME_MAX_ATTEMPTS = 2;
 /** Modules primed by the before-hook: `:samples:cmp` + `:samples:wear`. */
@@ -120,8 +127,10 @@ const PRIME_OVERHEAD_MS = 4 * 60_000;
  * the worst case — every attempt for both modules exhausting its budget —
  * and `primeModule` reaches its attributable `throw lastErr` instead of
  * degrading into a bare Mocha "hook timeout" with no Gradle context. With
- * the values above this is 28 minutes, comfortably under the workflow's
- * 60m job cap.
+ * the e2e task cap of 10 minutes this is 48 minutes, still under the
+ * workflow's 60m job cap; raising the cap further via
+ * `COMPOSE_PREVIEW_GRADLE_TASK_TIMEOUT_MS` needs that job cap raised to
+ * match, or the job dies before the suite reaches its diagnostic throw.
  */
 const SUITE_TIMEOUT_MS =
     PRIME_MODULE_COUNT * PRIME_MAX_ATTEMPTS * PRIME_ATTEMPT_BUDGET_MS +
@@ -133,7 +142,7 @@ const SUITE_TIMEOUT_MS =
  * to preload.
  *
  * Bounded + retried on purpose. `triggerRefresh` *awaits* the Gradle
- * render (gradleService caps it at the 5-minute `TASK_TIMEOUT_MS` and, via
+ * render (gradleService caps it at `TASK_TIMEOUT_MS` and, via
  * `RealGradleApi`, kills the gradlew client + releases its build lock on
  * expiry); on a render that times out without producing a manifest the
  * refresh resolves *without* posting `setPreviews`. So the render's
@@ -145,7 +154,7 @@ const SUITE_TIMEOUT_MS =
  * `PRIME_ATTEMPT_BUDGET_MS` deadline, then retry once on the freed lock
  * (the retry's refresh cancels any render still in flight from the
  * abandoned attempt). A healthy render always completes inside the
- * 5-minute task cap and posts `setPreviews` before the refresh resolves,
+ * task cap and posts `setPreviews` before the refresh resolves,
  * so the budget never truncates a healthy-but-slow cold render. On failure
  * we dump the Compose Preview output channel — the underlying render
  * rejection is otherwise swallowed by the refresh scheduler, leaving only
@@ -181,7 +190,11 @@ async function primeModule(
             );
         });
         const work = (async () => {
-            await api.triggerRefresh(file, /* force */ true, "full");
+            assertRefreshRendered(
+                api,
+                await api.triggerRefresh(file, /* force */ true, "full"),
+                `${label} prime`,
+            );
             await waitFor(
                 `non-empty setPreviews for ${label} prime`,
                 PRIME_ATTEMPT_BUDGET_MS,

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import type { ComposePreviewTestApi } from "../../../extension";
 import { RealGradleApi } from "../realGradleApi";
+import { assertRefreshRendered } from "./refreshOutcome";
 
 /**
  * External-consumer end-to-end test. Drives the VS Code extension against a
@@ -342,7 +343,11 @@ describeExternal(
             );
 
             const tRefresh = phaseStart();
-            await api.triggerRefresh(kotlinFile, /* force */ true, "full");
+            assertRefreshRendered(
+                api,
+                await api.triggerRefresh(kotlinFile, /* force */ true, "full"),
+                "external consumer render",
+            );
 
             const previewsMessage = await waitFor(
                 "non-empty setPreviews from external composePreviewRenderAll",

--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import type { ComposePreviewTestApi } from "../../../extension";
 import { RealGradleApi } from "../realGradleApi";
+import { assertRefreshRendered } from "./refreshOutcome";
 
 /**
  * Exploratory scenario driver targeting the failure modes reported as
@@ -91,7 +92,7 @@ const describeE2E = E2E ? describe : describe.skip;
  * Without it the disk assertions can't hold on CI hardware. `triggerRefresh`
  * runs the production `composePreviewRenderAll`, which renders the *whole*
  * module, and `gradleService` caps every Gradle task at `TASK_TIMEOUT_MS`
- * (5 minutes) — `:samples:android` alone carries 160+ `@Preview`s behind
+ * — `:samples:android` alone carries 160+ `@Preview`s behind
  * Robolectric, so a cold full-module render is killed at the cap long before
  * it reaches `TypographyGallery.kt`. The extension then behaves exactly as
  * designed (`renderWithDiskFallback` paints the on-disk manifest and records
@@ -312,7 +313,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
 
         // --- Cmp cold ---
         const cmpStart = Date.now();
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
         const cmpFirst = await waitFor(
             "first cmp setPreviews",
             this.timeout(),
@@ -360,7 +365,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         // --- Switch to android ---
         api.resetMessages();
         const androidStart = Date.now();
-        await api.triggerRefresh(androidFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(androidFile, true, "full"),
+            ":samples:android render",
+        );
         const androidFirst = await waitFor(
             "first android setPreviews",
             this.timeout(),
@@ -440,7 +449,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         // --- Switch back to cmp ---
         api.resetMessages();
         const cmpReStart = Date.now();
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
         const cmpSecond = await waitFor(
             "second cmp setPreviews",
             this.timeout(),
@@ -482,7 +495,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         const observations: Record<string, unknown> = {};
         const cmpNeedle = path.join("samples", "cmp");
 
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
         const baseline = await waitFor(
             "cmp baseline setPreviews",
             this.timeout(),
@@ -515,7 +532,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         let editPhaseError: Error | null = null;
         try {
             api.resetMessages();
-            await api.triggerRefresh(cmpFile, true, "full");
+            assertRefreshRendered(
+                api,
+                await api.triggerRefresh(cmpFile, true, "full"),
+                ":samples:cmp render",
+            );
             const afterAdd = await waitFor(
                 `setPreviews after adding ${tag}`,
                 this.timeout(),
@@ -570,7 +591,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         if (editPhaseError) throw editPhaseError;
 
         api.resetMessages();
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
         const afterRevert = await waitFor(
             `setPreviews after reverting ${tag}`,
             this.timeout(),
@@ -667,7 +692,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         const racing = api.triggerRefresh(cmpFile, true, "full");
         // Give the cmp refresh enough wall time to enter Gradle.
         await new Promise((r) => setTimeout(r, 250));
-        await api.triggerRefresh(androidFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(androidFile, true, "full"),
+            ":samples:android render",
+        );
         await racing.catch(() => {
             /* cancellation expected */
         });
@@ -735,7 +764,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         const NEW = /\.RedBoxPreviewRenamed_/;
 
         // --- Baseline: the pre-rename manifest must contain RedBoxPreview ---
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
         const baseline = await waitFor(
             "cmp baseline setPreviews (with RedBoxPreview)",
             this.timeout(),
@@ -780,7 +813,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         let renamePhaseError: Error | null = null;
         try {
             api.resetMessages();
-            await api.triggerRefresh(cmpFile, true, "full");
+            assertRefreshRendered(
+                api,
+                await api.triggerRefresh(cmpFile, true, "full"),
+                ":samples:cmp render",
+            );
             const afterRename = await waitFor(
                 "setPreviews after rename (new id present, old id gone)",
                 this.timeout(),
@@ -861,7 +898,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             // module round-trip must not resurrect RedBoxPreview from a stale
             // `previewModuleIndex` entry.
             api.resetMessages();
-            await api.triggerRefresh(cmpFile, true, "full");
+            assertRefreshRendered(
+                api,
+                await api.triggerRefresh(cmpFile, true, "full"),
+                ":samples:cmp render",
+            );
             const reRefreshed = await waitFor(
                 "second post-rename cmp setPreviews",
                 this.timeout(),
@@ -890,7 +931,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
 
         // --- Revert: the original RedBoxPreview must come back, renamed gone ---
         api.resetMessages();
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
         const afterRevert = await waitFor(
             "setPreviews after reverting the rename",
             this.timeout(),
@@ -952,7 +997,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         // from a loaded panel for the assertion to mean anything. The caller
         // path (`triggerRefresh(cmpFile, …)`) scopes by argument, not by a
         // visible editor, so the warm stays deterministic without reopening one.
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
         const loaded = await waitFor(
             "cmp setPreviews before dropping scope",
             this.timeout(),
@@ -1022,7 +1071,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
 
         // Restore a real scope so a later test in the suite doesn't inherit
         // the empty state.
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
     });
 
     it("G. compile error surfaces a banner without wiping cards; fix clears it", async function () {
@@ -1031,7 +1084,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         const cmpNeedle = path.join("samples", "cmp");
 
         // --- Baseline: a clean render so there are cards to keep ---
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
         const baseline = await waitFor(
             "cmp baseline setPreviews before injecting the error",
             this.timeout(),
@@ -1108,7 +1165,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
 
         // --- Fix: the banner clears and a clean manifest returns ---
         api.resetMessages();
-        await api.triggerRefresh(cmpFile, true, "full");
+        assertRefreshRendered(
+            api,
+            await api.triggerRefresh(cmpFile, true, "full"),
+            ":samples:cmp render",
+        );
         const recovered = await waitFor(
             "clean cmp setPreviews after fixing the error",
             this.timeout(),

--- a/vscode-extension/src/test/electron/suite/refreshOutcome.ts
+++ b/vscode-extension/src/test/electron/suite/refreshOutcome.ts
@@ -1,0 +1,55 @@
+import type { ComposePreviewTestApi, RefreshOutcome } from "../../../extension";
+
+/**
+ * Fail-fast guard for e2e refreshes that are supposed to produce pixels.
+ *
+ * `refresh` reports a build failure by returning `'failed'` and posting a
+ * `showMessage` at the panel — it never rejects, because in production the
+ * error belongs on the panel rather than in an unhandled promise. That
+ * makes a dead render indistinguishable from a slow one to a test that only
+ * polls `getPostedMessages()` for `setPreviews`, so the poll runs to the
+ * Mocha ceiling and the suite reports a bare "Timeout of 1800000ms
+ * exceeded" with no Gradle context.
+ *
+ * That is exactly how the 2026-08-08 breakage presented: the cold
+ * `:samples:cmp` render was cancelled at the Gradle task cap five minutes
+ * in, and the shard then sat idle for another 10-25 minutes before failing
+ * on a timeout that named neither the task nor the cap. Asserting the
+ * outcome turns that into an immediate, attributable failure and gives the
+ * runner its slot back.
+ *
+ * Only call this where the refresh is *expected* to render. Scenarios that
+ * deliberately provoke a failure (e.g. the injected Kotlin syntax error in
+ * interactive scenario G) must read the outcome themselves.
+ */
+export function assertRefreshRendered(
+    api: ComposePreviewTestApi,
+    outcome: RefreshOutcome,
+    label: string,
+): void {
+    if (outcome !== "failed") {
+        return;
+    }
+    throw new Error(
+        `${label}: refresh reported '${outcome}' — ${lastPanelMessage(api) ?? "no showMessage was posted"}`,
+    );
+}
+
+/**
+ * Text of the most recent `showMessage` post, which is where the generic
+ * build-failure branch of `refresh` puts the underlying error (including
+ * the `Gradle task <task> timed out after <n>s` the task cap raises).
+ */
+function lastPanelMessage(api: ComposePreviewTestApi): string | undefined {
+    const messages = api.getPostedMessages() as Array<{
+        command?: string;
+        text?: unknown;
+    }>;
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i];
+        if (message?.command === "showMessage" && message.text) {
+            return String(message.text);
+        }
+    }
+    return undefined;
+}

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -8,6 +8,7 @@ import {
     TaskCancelledError,
     encodeBundlePreviewId,
     isModulePreviewSchedulable,
+    resolveTaskTimeoutMs,
 } from "../gradleService";
 import { JdkImageError } from "../jdkImageErrorDetector";
 
@@ -1827,5 +1828,34 @@ describe("isModulePreviewSchedulable", () => {
 
     it("treats a missing enabled (legacy / scan-detected) as enabled", () => {
         assert.strictEqual(isModulePreviewSchedulable(base), true);
+    });
+});
+
+describe("resolveTaskTimeoutMs", () => {
+    const DEFAULT_MS = 5 * 60 * 1000;
+
+    it("falls back to the interactive default when unset", () => {
+        assert.strictEqual(resolveTaskTimeoutMs(undefined), DEFAULT_MS);
+        assert.strictEqual(resolveTaskTimeoutMs(""), DEFAULT_MS);
+    });
+
+    it("accepts a positive override — the e2e harness raises the cap", () => {
+        assert.strictEqual(resolveTaskTimeoutMs("600000"), 600_000);
+    });
+
+    it("truncates a fractional override to whole milliseconds", () => {
+        assert.strictEqual(resolveTaskTimeoutMs("600000.7"), 600_000);
+    });
+
+    it("ignores values that would cancel every build immediately", () => {
+        // NaN / 0 / negative all make setTimeout fire on the next tick, which
+        // would kill each gradlew client the instant it spawned.
+        for (const raw of ["banana", "0", "-1", "Infinity"]) {
+            assert.strictEqual(
+                resolveTaskTimeoutMs(raw),
+                DEFAULT_MS,
+                `expected ${raw} to fall back to the default`,
+            );
+        }
     });
 });


### PR DESCRIPTION
## Summary

`VS Code Extension E2E` has been red on **every** concluded run since 3fb85d6 landed at 2026-08-08 15:07 UTC — 21 of 21 across `main` and PR branches (the rest of the recent history is `cancelled` by the ref-keyed concurrency group, not passing). Two independent defects, both visible in [run 31272469433](https://github.com/yschimke/compose-ai-tools/actions/runs/31272469433):

**1. The 5-minute Gradle task cap is the wrong budget for a cold CI render.**

`gradleService`'s `TASK_TIMEOUT_MS` is sized for an interactive editor user who wants a wedged build abandoned and the lock freed. CI e2e is the opposite workload — a cold hosted runner compiles the `includeBuild` plugin *and* the sample module before rendering anything. The `cmp-smoke` log shows the render was killed at exactly 5m00s and was never wedged:

```
19:40:39.912  [realGradleApi] gradlew :samples:cmp:composePreviewRenderAll …
19:45:39.913  [realGradleApi] cancel :samples:cmp:composePreviewRenderAll — terminating gradlew pid 3265
```

In `interactive-a-d`, the very next render on that same runner — against the build outputs the killed one had already produced — finished in **64s** (`✔ B. edit a @Preview source… (63680ms)`). The work was essentially done; the cap just fired first. The margin had been razor-thin for a while: the last green run's whole `cmp-smoke` step, VS Code boot included, was 5m15s.

The cap is now overridable via `COMPOSE_PREVIEW_GRADLE_TASK_TIMEOUT_MS`, and the e2e harness sets it to 10 minutes. Production reads no env and keeps the 5-minute default; the workflow's per-shard `timeout-minutes: 60` stays the real wedge backstop.

**2. A dead render was indistinguishable from a slow one, so shards hung instead of failing.**

`refresh` reports a build failure by returning `'failed'` and posting a panel message — it never rejects, because in production the error belongs on the panel. The suites only polled `getPostedMessages()` for `setPreviews`, so after the 5-minute kill `interactive-a-d` sat **completely idle for another 25 minutes** (no Gradle output between 19:46:38 and 20:11:38) before failing on a bare `Timeout of 1800000ms exceeded` that named neither the task nor the cap. That is 15–33 min of runner time per red shard, and a log with no diagnosis.

`triggerRefresh` now resolves with the refresh outcome, and the e2e suites assert it through a new shared `assertRefreshRendered`, which surfaces the underlying panel message (e.g. `Gradle task :samples:cmp:composePreviewRenderAll timed out after 600s`). Scenario G reads the outcome itself — its injected Kotlin syntax error is *supposed* to fail — as do the deliberately-superseded racing refreshes in C and D.

`e2eCachedPreloadOnSwitch` now derives `PRIME_ATTEMPT_BUDGET_MS` from the cap instead of hardcoding 6 minutes, so the two can't drift; at a 10-minute cap its worst case is 48m, still inside the 60m job cap. Stale "5 minutes" comments elsewhere were corrected.

## Test plan

- `npm run compile` — clean (host + webview).
- `npm test` — 1674 passing, including 4 new cases pinning `resolveTaskTimeoutMs`: unset/empty falls back to the 5-minute default, a positive override is honoured, a fractional value truncates, and `banana` / `0` / `-1` / `Infinity` fall back rather than degrading into a `setTimeout` that cancels every build on the next tick.
- `npm run format:check` — clean (also enforced by the `pre-commit` hook, which ran on this commit).
- The real proof is this PR's own `VS Code Extension E2E` run: it touches `vscode-extension/**` and `.github/workflows/vscode-extension-e2e.yml`, so all five shards run on the PR.

No visual surface changes — this is CI/test-harness plumbing, so text-only evidence is the right bar here.

## Note, not addressed here

25 of the 30 most recent runs are `cancelled`, not failed: the ref-keyed concurrency group means a burst of merges to `main` leaves only the last commit verified. That is the documented intent of #3546 and I have left it alone, but it is worth a look if `main` coverage matters more than runner cost.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmbwB3s3xBmk4Q4RWBjpjM)_