### PR TITLE
fix(design-artifacts): anchor every generated render exclusion

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -333,17 +333,32 @@ jobs:
           catalog-path: ${{ inputs.catalog-path }}
           github-token: ${{ github.token }}
 
-      - name: Check the CLI can merge shard renders
+      # Two capabilities, one probe, because a CLI can have the first without the second and each
+      # failure mode is silent in its own way:
+      #
+      #  - `bundle merge` reassembles the shard bundles. Without it the fan-out runs to completion
+      #    and dies at the last step, having burned every shard's ~20 minutes.
+      #  - `=<id>` anchored exclusions (#3561) are what make a generated exclusion list safe. Without
+      #    them `--exclude-preview-id` falls back to substring matching, and since ids are
+      #    hierarchical each shard also deletes the variants of every id it excluded — m3-catalog
+      #    captured 267 of 1095 assigned previews that way, on a GREEN run. An old CLI here does not
+      #    fail; it silently publishes a three-quarters-empty catalog, which is strictly worse than
+      #    refusing to start, hence the hard error rather than a warning.
+      - name: Check the CLI can shard and merge
         if: ${{ inputs.cli-source == 'released' }}
         run: |
           set -euo pipefail
           version="$(compose-preview --version | head -1)"
-          if compose-preview bundle help 2>&1 | grep -q 'bundle merge'; then
-            echo "✓ $version supports 'bundle merge'."
-            exit 0
+          help="$(compose-preview bundle help 2>&1 || true)"
+          if ! grep -q 'bundle merge' <<<"$help"; then
+            echo "::error title=CLI too old for render-shards::${version} has no 'compose-preview bundle merge', which the sharded render needs to reassemble the shard bundles. Raise cli-version (or, with cli-version: catalog, the ${{ inputs.catalog-key }} pin in ${{ inputs.catalog-path }}) to a release that carries it, or set render-shards: 1."
+            exit 1
           fi
-          echo "::error title=CLI too old for render-shards::${version} has no 'compose-preview bundle merge', which the sharded render needs to reassemble the shard bundles. Raise cli-version (or, with cli-version: catalog, the ${{ inputs.catalog-key }} pin in ${{ inputs.catalog-path }}) to a release that carries it, or set render-shards: 1."
-          exit 1
+          if ! grep -q '=<id>' <<<"$help"; then
+            echo "::error title=CLI too old for render-shards::${version} has no '=<id>' anchored --exclude-preview-id matching, so each shard's exclusion list would also drop the variants of every id it excludes — the shards would publish a fraction of the catalog without failing. Raise cli-version (or, with cli-version: catalog, the ${{ inputs.catalog-key }} pin in ${{ inputs.catalog-path }}) to a release that carries it, or set render-shards: 1."
+            exit 1
+          fi
+          echo "✓ $version supports 'bundle merge' and anchored '=<id>' exclusions."
 
   render-shard:
     name: ${{ inputs.system }} · shard ${{ matrix.shard }}/${{ inputs.render-shards }}
@@ -725,10 +740,24 @@ jobs:
             --spec "$GITHUB_WORKSPACE/$SPEC" \
             --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
             --out "$GITHUB_WORKSPACE/mode-filter.txt" \
+            --anchored-out "$GITHUB_WORKSPACE/mode-filter-cli.txt" \
             --rows-out "$GITHUB_WORKSPACE/mode-filter-rows.txt"
           # Exclusion polarity: a pattern that matches nothing renders MORE, never less, so a spec
           # that has drifted ahead of the code wastes time instead of dropping a sticker.
-          echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter.txt")" >> "$GITHUB_OUTPUT"
+          #
+          # The ANCHORED file, not the plain one. `--exclude-preview-id` matches a plain pattern by
+          # equality or substring, and ids are hierarchical, so deferring `Switch_Dark` unanchored
+          # also defers `Switch_Dark_VARIANT_off` — which the spec never deferred, and whose absence
+          # surfaces as a completeness-gate failure naming a component rather than as anything
+          # pointing at the mode filter (#3559).
+          echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter-cli.txt")" >> "$GITHUB_OUTPUT"
+          # A CLI predating anchored matching reads `=Switch_Dark` as a literal substring, matches
+          # nothing, and renders the deferred modes too. That is the safe direction — every sticker
+          # is still baked, the run is just slower — but it is invisible, so say it out loud rather
+          # than let a catalog quietly stop getting the saving it configured.
+          if ! compose-preview bundle help 2>&1 | grep -q '=<id>'; then
+            echo "::warning title=Mode deferral not applied::$(compose-preview --version | head -1) has no '=<id>' anchored --exclude-preview-id matching, so this run renders the deferred modes as well. Every preview is still baked; the render is just as slow as an undeferred one. Raise cli-version to restore the saving."
+          fi
           # A mode that carries no discovered id is a @PreviewParameter row axis: discovery never
           # sees those rows (the renderer expands the provider), so they're skipped by LABEL instead.
           echo "exclude-rows=$(cat "$GITHUB_WORKSPACE/mode-filter-rows.txt")" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -323,8 +323,13 @@ jobs:
             --spec "${{ matrix.spec }}" \
             --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
             --out "$GITHUB_WORKSPACE/mode-filter.txt" \
+            --anchored-out "$GITHUB_WORKSPACE/mode-filter-cli.txt" \
             --rows-out "$GITHUB_WORKSPACE/mode-filter-rows.txt"
-          echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter.txt")" >> "$GITHUB_OUTPUT"
+          # The ANCHORED file. `--exclude-preview-id` matches a plain pattern by equality OR
+          # substring, and ids are hierarchical, so deferring `Switch_Dark` unanchored also defers
+          # `Switch_Dark_VARIANT_off` — never deferred by the spec, and missing from the sheet with
+          # nothing pointing back at this step (#3559).
+          echo "exclude-ids=$(cat "$GITHUB_WORKSPACE/mode-filter-cli.txt")" >> "$GITHUB_OUTPUT"
           # Modes that carry no discovered id are a @PreviewParameter row axis — skipped by label
           # inside the render instead, since discovery never sees those rows.
           echo "exclude-rows=$(cat "$GITHUB_WORKSPACE/mode-filter-rows.txt")" >> "$GITHUB_OUTPUT"

--- a/scripts/design-artifacts/deferred-preview-ids.mjs
+++ b/scripts/design-artifacts/deferred-preview-ids.mjs
@@ -166,6 +166,28 @@ function previewParameterProvider(preview) {
 }
 
 /**
+ * The deferred ids as `--exclude-preview-id` patterns rather than as ids: each `=`-anchored, so it
+ * matches that preview and not the fan-out hanging off it.
+ *
+ * The plain form matches by equality OR substring, and ids are hierarchical, so an unanchored
+ * `Switch_Dark` also defers `Switch_Dark_VARIANT_off` — a preview the spec never deferred, whose
+ * absence surfaces later as a completeness-gate failure rather than as anything pointing back here.
+ * Deferral is an exclusion, and on the exclusion axis over-matching silently deletes work (#3559).
+ *
+ * Kept separate from the `ids` [deferredPreviewIds] returns because the sharder consumes those as
+ * ids — it removes them from the partition by set membership, which an anchored string would miss.
+ * Ids stay plain until the moment they become CLI patterns.
+ *
+ * @param {string[]} ids plain preview ids.
+ * @returns {string[]} the same ids, each `=`-anchored.
+ */
+export function anchoredExclusions(ids) {
+  return (ids ?? [])
+    .filter((id) => typeof id === "string" && id.length > 0)
+    .map((id) => (id.startsWith("=") ? id : `=${id}`));
+}
+
+/**
  * Pull the preview list out of whatever JSON the caller captured: `compose-preview list --json`
  * (`{ previews: [...] }` or a bare array) or a module's discovery manifest (`previews.json`, also
  * `{ previews: [...] }`). Anything else yields an empty list, which means "exclude nothing".
@@ -179,25 +201,31 @@ export function previewsFromJson(parsed) {
 
 // --- CLI ----------------------------------------------------------------------
 // `node deferred-preview-ids.mjs --spec catalog.spec.json --previews previews.json
-//    [--out ids.txt] [--rows-out rows.txt]`
+//    [--out ids.txt] [--anchored-out patterns.txt] [--rows-out rows.txt]`
 // Prints (and optionally writes) the comma-separated exclusion list the render consumes as
 // `compose-preview bundle pack --exclude-preview-id` / `-PcomposePreview.idExclude`, and — for a
 // mode axis that lives in a `@PreviewParameter` provider rather than in ids — the row labels for
 // `--exclude-preview-row` / `-PcomposePreview.rowExclude`. Empty output on either is the normal case
 // for a spec that defers no mode, and means "render everything".
+//
+// Two id shapes, for two consumers: `--out` writes PLAIN ids, which is what `shard-preview-ids.mjs`
+// needs (it removes them from the partition by set membership); `--anchored-out` writes the same ids
+// `=`-anchored, which is what goes to the CLI. Handing the CLI the plain list defers each id's whole
+// fan-out along with it (#3559).
 if (import.meta.url === `file://${process.argv[1]}`) {
   const { values } = parseArgs({
     options: {
       spec: { type: "string" },
       previews: { type: "string" },
       out: { type: "string" },
+      "anchored-out": { type: "string" },
       "rows-out": { type: "string" },
     },
   });
   if (!values.spec || !values.previews) {
     console.error(
       "usage: deferred-preview-ids.mjs --spec <catalog.spec.json> --previews <list.json> " +
-        "[--out <file>] [--rows-out <file>]",
+        "[--out <file>] [--anchored-out <file>] [--rows-out <file>]",
     );
     process.exit(2);
   }
@@ -223,6 +251,9 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   }
   const line = ids.join(",");
   if (values.out) writeFileSync(values.out, line);
+  if (values["anchored-out"]) {
+    writeFileSync(values["anchored-out"], anchoredExclusions(ids).join(","));
+  }
   if (values["rows-out"]) writeFileSync(values["rows-out"], rows.join(","));
   console.log(line);
 }

--- a/scripts/design-artifacts/deferred-preview-ids.test.mjs
+++ b/scripts/design-artifacts/deferred-preview-ids.test.mjs
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  anchoredExclusions,
   deferredPreviewIds,
   previewsFromJson,
   specPreviewFunctions,
@@ -225,4 +226,29 @@ test("previewsFromJson accepts every shape the pipeline produces", () => {
   assert.deepEqual(previewsFromJson({ previews: rows }), rows);
   assert.deepEqual(previewsFromJson({ results: rows }), rows);
   assert.deepEqual(previewsFromJson({ nothing: true }), []);
+});
+
+test("the CLI form of a deferred id is anchored, so its variants are not deferred with it", () => {
+  // Deferral is an exclusion, and on the exclusion axis over-matching silently deletes work: an
+  // unanchored `Switch_Dark` also matches `Switch_Dark_VARIANT_off`, a preview the spec never
+  // deferred. Its absence surfaces as a completeness-gate failure naming a component, with nothing
+  // pointing back at the mode filter (#3559).
+  assert.deepEqual(anchoredExclusions(["Switch_Dark", "Card_Dark"]), ["=Switch_Dark", "=Card_Dark"]);
+  assert.deepEqual(anchoredExclusions(["=Already"]), ["=Already"], "idempotent");
+  assert.deepEqual(anchoredExclusions([]), []);
+  assert.deepEqual(anchoredExclusions(undefined), []);
+});
+
+test("the plain ids stay plain, because the sharder matches them by set membership", () => {
+  // `--out` feeds shard-preview-ids.mjs, which removes deferred ids from the partition with
+  // `Set.has`. Anchoring there would miss every one of them and hand the shards a share of previews
+  // that are then excluded in each — the deferral and the partition competing for slots, which is
+  // the exact arrangement `deferred ids are removed BEFORE partitioning` exists to prevent.
+  const previews = [
+    { id: "FilledButtonPreview_Light", functionName: "FilledButtonPreview" },
+    { id: "FilledButtonPreview_Dark", functionName: "FilledButtonPreview" },
+  ];
+  const { ids } = deferredPreviewIds(spec, previews);
+  assert.deepEqual(ids, ["FilledButtonPreview_Dark"]);
+  assert.ok(ids.every((id) => !id.startsWith("=")));
 });

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -1,10 +1,18 @@
 /**
  * Partition a catalog's discovered preview ids across N parallel render shards.
  *
- * The design-artifacts render is one serial `bundle pack`, and it grows linearly with the preview
- * count: measured on m3-catalog, `render_minutes ≈ 3.7 + 2.15s × previews`. Past ~1500 previews that
- * blows `render-timeout`, and past ~2400 the job timeout — so the marginal 2.15s has to be divided
- * across jobs. This module decides who renders what.
+ * The design-artifacts render is one serial `bundle pack`, and it used to grow linearly with the
+ * preview count: measured on m3-catalog, `render_minutes ≈ 3.7 + 2.15s × previews`. Past ~1500
+ * previews that blew `render-timeout`, and past ~2400 the job timeout — so the marginal 2.15s had to
+ * be divided across jobs. This module decides who renders what.
+ *
+ * **That cost model is superseded and the shard count derived from it is not currently trusted.**
+ * Captures now draw on a warm renderer rather than forking a JVM each time (#3548), which collapsed
+ * the marginal term and left the ~3.7 min fixed configure + compile that every shard pays in full
+ * untouched. Cheaper marginal work with unchanged fixed cost moves the optimum *down*, so the old
+ * "six, not sixteen" conclusion no longer follows from anything measured. #3559 tracks re-measuring
+ * it. Nothing here assumes a particular count — the partition is correct at any N — but do not read
+ * the arithmetic above as current guidance.
  *
  * The mechanism is exclusion, not selection: each shard runs the SAME `bundle pack` with
  * `--exclude-preview-id <everything that isn't mine>`, which is documented to leave the excluded
@@ -13,7 +21,7 @@
  * differing only in which `previews/<id>.*` slots are filled, which is exactly what
  * `compose-preview bundle merge` unions back together.
  *
- * Three decisions worth stating, because each has a wrong-looking-right alternative:
+ * Four decisions worth stating, because each has a wrong-looking-right alternative:
  *
  *  - **Partition by preview id, never by `@Preview` function name.** One function expands to a
  *    30-cell matrix (m3-catalog's icon buttons) while its neighbour expands to two; a name split is
@@ -23,6 +31,16 @@
  *    ids sort together by group, so contiguous blocks cluster the template-heavy groups into one
  *    shard. Round-robin spreads them. It is not bin-packing, and does not try to be: bin-packing
  *    from recorded per-preview times is only worth it once a straggler actually shows up.
+ *  - **Every emitted exclusion is `=`-anchored.** `--exclude-preview-id` matches a plain pattern by
+ *    equality OR substring, and ids are hierarchical (`<base>_<variant>`), so a base id is always a
+ *    substring of its own fan-out: a shard excluding another shard's `SwitchOn_Light` also deleted
+ *    every `SwitchOn_Light_VARIANT_*` it was itself assigned. That cost m3-catalog three quarters of
+ *    its renders — 267 captured of 1095 assigned — silently, on a green run, which is why
+ *    `render-shards` was pinned back to 1. The asymmetry is the point: substring matching
+ *    over-selects harmlessly on the INCLUDE axis and silently deletes work on the EXCLUDE axis, so
+ *    it is unusable with any generated id list, which is exactly what a sharder produces. The `=`
+ *    prefix (#3561) matches the id exactly. It is emitted here, at the boundary where ids become
+ *    CLI patterns, rather than carried through the partition — everything upstream stays plain ids.
  *  - **Deferred ids are removed BEFORE partitioning, then re-excluded in every shard.** A
  *    `modePriority` deferral (issue #2966) and the partition are both expressed as exclusions, so
  *    the naive union would hand deferred ids a share of the partition and leave one shard rendering
@@ -85,6 +103,29 @@ export function previewNameMatches(patterns, functionName, className = "") {
 }
 
 /**
+ * The prefix that makes an `--exclude-preview-id` pattern an exact-id match rather than a substring
+ * one. Mirrors `PreviewNameFilter.ANCHOR` / `PackPreviewIdExclusions.ANCHOR` (#3561); it cannot
+ * collide with a real pattern because no discovered id can begin with it — ids derive from Kotlin
+ * identifiers and are path-sanitised.
+ */
+export const ANCHOR = "=";
+
+/**
+ * Turn plain preview ids into anchored `--exclude-preview-id` patterns.
+ *
+ * Applied at the one boundary where an id becomes a CLI pattern. An id that is already anchored is
+ * left alone, so this is idempotent and a caller that anchored upstream is not double-prefixed.
+ *
+ * @param {string[]} ids plain preview ids.
+ * @returns {string[]} the same ids, each `=`-anchored.
+ */
+export function anchorExclusions(ids) {
+  return (ids ?? [])
+    .filter((id) => typeof id === "string" && id.length > 0)
+    .map((id) => (id.startsWith(ANCHOR) ? id : `${ANCHOR}${id}`));
+}
+
+/**
  * A stable fingerprint of the renderable id set, carried in every shard's plan so the merge can
  * check that the shards discovered the *same* previews rather than merely the same NUMBER of them.
  * Two runners that saw `["a"]` and `["d"]` are disjoint with a union of size two, which a count
@@ -121,6 +162,10 @@ export function partitionPreviewIds(ids, shards) {
  * The full render plan for a sharded run: what each shard renders, and the `--exclude-preview-id`
  * list that makes it render only that.
  *
+ * `previews` are plain ids (they are compared, counted and cross-checked); `exclude` are `=`-anchored
+ * CLI patterns (they are passed to a matcher). Keeping the two shapes distinct is deliberate — see
+ * the anchoring note in the header for what an unanchored exclusion list costs.
+ *
  * Three things are removed from the partition before it is drawn, each for the same reason — a
  * shard must never be handed a share that the render will not actually produce:
  *  - ids of functions the **name filter** drops (an entry-level `priority: "deferred"`);
@@ -149,16 +194,19 @@ export function shardRenderPlan(previews, shards, deferred = [], renderFilter = 
     .filter((id) => typeof id === "string" && id.length > 0);
   const renderable = [...new Set(all)].filter((id) => !deferredSet.has(id)).sort();
   const partitions = partitionPreviewIds(renderable, shards);
-  // Only the ids this shard is NOT rendering, plus the deferred ones. Ids the caller listed as
-  // deferred but discovery never saw are kept in the exclusion list anyway: exclusion polarity means
-  // a pattern matching nothing renders MORE, never less, so a stale entry costs time, not a sticker.
+  // Only the ids this shard is NOT rendering, plus the deferred ones, each `=`-anchored so it
+  // matches that id and not its variants (see the header). Ids the caller listed as deferred but
+  // discovery never saw are kept in the exclusion list anyway: exclusion polarity means a pattern
+  // matching nothing renders MORE, never less, so a stale entry costs time, not a sticker.
   return {
     shards: partitions.map((mine, i) => {
       const own = new Set(mine);
       return {
         index: i + 1,
         previews: mine,
-        exclude: [...renderable.filter((id) => !own.has(id)), ...deferredSet].sort(),
+        exclude: anchorExclusions(
+          [...renderable.filter((id) => !own.has(id)), ...deferredSet].sort(),
+        ),
       };
     }),
     total: partitions.length,

--- a/scripts/design-artifacts/shard-preview-ids.test.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.test.mjs
@@ -2,6 +2,8 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  ANCHOR,
+  anchorExclusions,
   parseIdList,
   partitionPreviewIds,
   previewNameMatches,
@@ -57,9 +59,9 @@ test("each shard excludes exactly the previews the other shards render", () => {
   assert.equal(plan.total, 2);
   assert.equal(plan.renderable, 4);
   assert.deepEqual(plan.shards[0].previews, ["a", "c"]);
-  assert.deepEqual(plan.shards[0].exclude, ["b", "d"]);
+  assert.deepEqual(plan.shards[0].exclude, ["=b", "=d"]);
   assert.deepEqual(plan.shards[1].previews, ["b", "d"]);
-  assert.deepEqual(plan.shards[1].exclude, ["a", "c"]);
+  assert.deepEqual(plan.shards[1].exclude, ["=a", "=c"]);
   // Union of what the shards render is the whole renderable set — nothing is silently dropped.
   assert.deepEqual(plan.shards.flatMap((s) => s.previews).sort(), ["a", "b", "c", "d"]);
 });
@@ -74,17 +76,17 @@ test("deferred ids are excluded in EVERY shard and take no share of the partitio
   assert.deepEqual(plan.shards[0].previews, ["a_Light"]);
   assert.deepEqual(plan.shards[1].previews, ["b_Light"]);
   for (const shard of plan.shards) {
-    assert.ok(shard.exclude.includes("a_Dark"), `shard ${shard.index} defers a_Dark`);
-    assert.ok(shard.exclude.includes("b_Dark"), `shard ${shard.index} defers b_Dark`);
+    assert.ok(shard.exclude.includes("=a_Dark"), `shard ${shard.index} defers a_Dark`);
+    assert.ok(shard.exclude.includes("=b_Dark"), `shard ${shard.index} defers b_Dark`);
   }
-  assert.deepEqual(plan.shards[0].exclude, ["a_Dark", "b_Dark", "b_Light"]);
+  assert.deepEqual(plan.shards[0].exclude, ["=a_Dark", "=b_Dark", "=b_Light"]);
 });
 
 test("a deferred id discovery never saw is still excluded", () => {
   // Exclusion polarity: a pattern matching nothing renders more, never less. A spec that has drifted
   // ahead of the code must not fail the plan.
   const plan = shardRenderPlan(["a", "b"].map(preview), 2, ["ghost"]);
-  assert.ok(plan.shards.every((s) => s.exclude.includes("ghost")));
+  assert.ok(plan.shards.every((s) => s.exclude.includes("=ghost")));
   assert.equal(plan.renderable, 2);
 });
 
@@ -92,7 +94,7 @@ test("one shard means one exclusion list holding only the deferred ids", () => {
   const plan = shardRenderPlan(["a", "b"].map(preview), 1, ["c"]);
   assert.equal(plan.total, 1);
   assert.deepEqual(plan.shards[0].previews, ["a", "b"]);
-  assert.deepEqual(plan.shards[0].exclude, ["c"]);
+  assert.deepEqual(plan.shards[0].exclude, ["=c"]);
 });
 
 test("de-duplicates ids discovery reported twice", () => {
@@ -231,7 +233,7 @@ test("the render filter drops non-required functions BEFORE the partition is dra
   assert.equal(plan.filteredOut, 2);
   assert.deepEqual(plan.shards.flatMap((s) => s.previews).sort(), ["Keep_Dark", "Keep_Light"]);
   for (const shard of plan.shards) {
-    assert.equal(shard.exclude.some((id) => id.startsWith("Drop_")), false,
+    assert.equal(shard.exclude.some((id) => id.startsWith("=Drop_")), false,
       "a filtered-out id needs no exclusion — the name filter already drops it");
   }
 });
@@ -256,7 +258,7 @@ test("the render filter and modePriority deferral compose", () => {
   const plan = shardRenderPlan(previews, 2, ["Keep_Dark"], ["KeepPreview"]);
   assert.equal(plan.renderable, 1);
   assert.deepEqual(plan.shards[0].previews, ["Keep_Light"]);
-  assert.deepEqual(plan.shards[0].exclude, ["Keep_Dark"]);
+  assert.deepEqual(plan.shards[0].exclude, ["=Keep_Dark"]);
 });
 
 // --- discovered-set agreement, not just cardinality -----------------------------------------
@@ -286,4 +288,57 @@ test("verifyShardPlans rejects plans with no digest at all", () => {
   const { ok, problems } = verifyShardPlans(plans);
   assert.equal(ok, false);
   assert.match(problems.join("\n"), /no renderable digest/);
+});
+
+test("every emitted exclusion is anchored, so a shard cannot delete its own variants", () => {
+  // The bug that pinned `render-shards` back to 1. Ids are hierarchical, and
+  // `--exclude-preview-id` matches a plain pattern by equality OR substring — so shard 1 excluding
+  // shard 2's `SwitchOn_Light` also matched `SwitchOn_Light_VARIANT_off`, which shard 1 was itself
+  // assigned. m3-catalog captured 267 of 1095 assigned previews that way, on a green run.
+  const ids = [
+    "SwitchOn_Light",
+    "SwitchOn_Light_VARIANT_off",
+    "SwitchOff_Light",
+    "SwitchOff_Light_VARIANT_on",
+  ];
+  const plan = shardRenderPlan(ids.map(preview), 2);
+
+  const mine = new Set(plan.shards[0].previews);
+  for (const pattern of plan.shards[0].exclude) {
+    assert.ok(pattern.startsWith("="), `${pattern} is not anchored`);
+    // The property that matters, stated as the matcher sees it: an anchored pattern matches the one
+    // id after the `=` and nothing else, so no id this shard renders can be caught by it.
+    assert.equal(mine.has(pattern.slice(1)), false, `${pattern} would delete this shard's own work`);
+  }
+  // Concretely: the ids sort so that shard 1 gets the two `SwitchO*_Light` bases and shard 2 the two
+  // `_VARIANT_` leaves. Unanchored, shard 2's list ("SwitchOff_Light", "SwitchOn_Light") is a
+  // substring of both of its own ids and it would render nothing at all.
+  const shardTwo = plan.shards[1];
+  assert.deepEqual(shardTwo.previews, ["SwitchOff_Light_VARIANT_on", "SwitchOn_Light_VARIANT_off"]);
+  assert.deepEqual(shardTwo.exclude, ["=SwitchOff_Light", "=SwitchOn_Light"]);
+  const unanchored = shardTwo.exclude.map((p) => p.slice(1));
+  assert.ok(
+    shardTwo.previews.every((id) => unanchored.some((p) => id.includes(p))),
+    "the unanchored form really would have matched every id this shard renders",
+  );
+});
+
+test("anchorExclusions is idempotent and drops nothing", () => {
+  assert.deepEqual(anchorExclusions(["a", "=b"]), ["=a", "=b"]);
+  assert.deepEqual(anchorExclusions([]), []);
+  assert.deepEqual(anchorExclusions(undefined), []);
+  assert.equal(ANCHOR, "=");
+});
+
+test("the plan's previews stay PLAIN ids while its exclusions are patterns", () => {
+  // The two shapes are consumed by different things: `previews` is compared and counted by
+  // `verifyShardPlans` (an anchored id would never match a discovered one), `exclude` is handed to a
+  // matcher. Anchoring both would break the merge-side cross-check.
+  const plan = shardRenderPlan(["a", "b"].map(preview), 2);
+  assert.ok(plan.shards.every((s) => s.previews.every((id) => !id.startsWith("="))));
+  assert.ok(plan.shards.every((s) => s.exclude.every((p) => p.startsWith("="))));
+  assert.deepEqual(
+    verifyShardPlans(plan.shards.map((s) => ({ ...s, total: plan.total, renderable: plan.renderable, digest: plan.digest }))),
+    { ok: true, problems: [] },
+  );
 });


### PR DESCRIPTION
Second half of the #3559 blocker. #3561 taught the three matchers to understand `=<id>`; this teaches the pipeline to *emit* it, which is what actually makes sharding safe to re-enable.

## The bug, on the producing side

`--exclude-preview-id` matches a plain pattern by equality **or substring**, and preview ids are hierarchical, so a base id is always a substring of its own fan-out. The sharder expresses each shard's share as "every id that isn't mine", so a shard excluding another shard's `SwitchOn_Light` also deleted `SwitchOn_Light_VARIANT_off` — which it was itself assigned.

m3-catalog: **267 captured of 1095 assigned, 235 merged, on a green run**, hence `render-shards: 1`.

The pathological case is not rare, it is the common one:

```
shard 2 renders  SwitchOff_Light_VARIANT_on, SwitchOn_Light_VARIANT_off
shard 2 excludes SwitchOff_Light,            SwitchOn_Light
```

Every id it excludes is a substring of an id it renders, so unanchored it renders **nothing at all** — and reports success. That case is now a test.

## The fix

Anchor at the one boundary where an id becomes a CLI pattern:

- `shard-preview-ids.mjs` — the `--out` exclusion list (partition + deferred).
- `deferred-preview-ids.mjs` — a new `--anchored-out`, for the unsharded path that passes deferred ids straight to `--exclude-preview-id`.

Ids stay **plain** everywhere else, which is the reason this is two outputs rather than one: the sharder removes deferred ids from the partition by `Set.has`, and `verifyShardPlans` compares `previews` against discovered ids. Anchoring either would silently break the thing it was meant to protect — the deferral would stop competing-for-slots correctly, and the merge-side cross-check would match nothing.

## The unsharded path had it too

Not a sharding-only bug. Mode deferral is also a generated exclusion list, so deferring `Switch_Dark` also deferred `Switch_Dark_VARIANT_off` — a preview the spec never deferred, absent from the sheet, surfacing later as a completeness-gate failure naming a component with nothing pointing back at the mode filter. Fixed in both callers (`design-artifacts.yml` and the reusable workflow).

## Old CLIs

`cli-version: catalog` can pin a release that predates `=`. The two paths differ in what that costs, so they differ in how loud they are:

| path | old CLI does | response |
|---|---|---|
| sharded | anchored pattern matches nothing → each shard renders everything → merge picks winners, catalog is fine but the fan-out bought nothing… **or**, without the fix, silently publishes a quarter of the catalog | **hard error** up front, beside the existing `bundle merge` probe |
| unsharded | deferred modes render too — every sticker still baked, run just slower | `::warning` |

A capability probe beats a version comparison here: `cli-source: build` and `cli-version: catalog` can both land on a CLI whose version string says little about what it supports.

## Also

Corrected the stale cost model in the sharder's header — it still presented `render_minutes ≈ 3.7 + 2.15s × previews` as current guidance, which #3548 invalidated. It now says the marginal term collapsed, the fixed term didn't, the optimum therefore moved *down*, and #3559 is re-measuring. No count is changed here.

## Test plan

```
cd scripts/design-artifacts && node --test
```

**578 tests, 554 pass, 21 skip, 3 fail — all 3 pre-existing** (`package-version`, `rc-compare-pixels`, `rc-size-modifier` need `npm ci`; `Cannot find package 'pngjs'`). Verified identical on a clean `git stash` of this branch.

New coverage:

- *every emitted exclusion is anchored, so a shard cannot delete its own variants* — asserts the property as the matcher sees it (no anchored pattern names an id this shard renders), then pins the concrete shard-2 case above and checks that the **unanchored** form really would have matched all of its own work, so the test fails if the anchoring is removed.
- *the plan's previews stay PLAIN ids while its exclusions are patterns* — plus `verifyShardPlans` still passing on that plan, pinning the two-shapes decision.
- *anchorExclusions is idempotent and drops nothing*.
- deferred: *the CLI form of a deferred id is anchored*, *the plain ids stay plain, because the sharder matches them by set membership*.

Every `run:` block in both workflows bash-syntax-checked with `${{ }}` stubbed out; both files parse as YAML.

No visual surface changes — this decides which previews a filter selects, not how any of them are drawn.

## Not in this PR

Re-enabling sharding or changing the count. That is the rest of #3559 and it wants measurements, not a guess; `render-shards: 1` stays where it is until there are numbers. What changes here is that turning it back up is no longer unsafe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk2xtVbDfuqQP2Bkzdndz9)_