### PR TITLE
feat(design-artifacts): publish each declared theme's token set

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -153,6 +153,11 @@ Two details are load-bearing:
   doesn't become a luminance guess made at an arbitrary layer. A consumer needing the mode reads the
   theme's own `surface` out of its tokens.
 
+A folded section does **not** bring its themes with it. `themes/` is catalog-level despite being
+nested, so [`merge-catalog-section.mjs`](../../scripts/design-artifacts/merge-catalog-section.mjs)
+skips it the way it skips the top-level `tokens.dtcg.json`: the host's `catalog.json` describes the
+host's themes, and a borrowed system's theme is one the host cannot render.
+
 Until these existed, the theme sheets' tokens were merged into `tokens.dtcg.json` along with the
 system's own. Because M3 role labels repeat across themes, that made a system's published `primary`
 whichever sheet the bundle happened to yield last; splitting them fixed the system set as well as

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -120,6 +120,44 @@ see [the catalog palette](../public-preview-server.md#the-page-wears-the-catalog
 Publishing a catalog with a new brand colour therefore re-themes its pages too,
 with nothing to change on the server.
 
+### Per-theme token sets
+
+`tokens.dtcg.json` is the **system** token set: the one resolved theme the stickers were rendered
+under. A module that declares `@ThemeCatalog` / `@WearThemeCatalog` providers ships more than one,
+and each is published beside it as `themes/<provider-fqn>.dtcg.json`, listed in `catalog.json`:
+
+```jsonc
+"tokensFile": "tokens.dtcg.json",          // the system's own tokens
+"themes": [
+  { "id": "com.example.WearCoralThemeCatalog", "name": "Coral", "group": "Wear",
+    "tokensFile": "themes/com.example.wearcoralthemecatalog.dtcg.json" }
+]
+```
+
+Nothing new is rendered for these. Each theme's specimen sheet already resolved its own
+`MaterialTheme` — colours **and** typeface, since a theme is free to swap the type scale — and the
+renderer writes them into the bundle as a theme-tagged `previews/<id>.catalog.json` sidecar
+(issue #2179). The export driver reads them back per theme
+([`catalog-themes.mjs`](../../scripts/design-artifacts/catalog-themes.mjs) over design-parity's
+`themeTokenSetsFromBundle`) and publishes one file each.
+
+Two details are load-bearing:
+
+- **A theme's id is its provider FQN**, because that is what a preview server addresses it by
+  (`?theme=theme:<providerFqn>`) — so a published token set can be joined to the theme a page is
+  showing. A theme whose FQN can't be resolved from `previews.json` is **not published**: an entry
+  keyed on anything else is data no consumer can attach to a theme, and the driver warns rather than
+  shipping it silently.
+- **`dark` is left unset.** Nothing in the pipeline declares whether a theme is dark — the
+  annotation carries a name and a group — and the field exists as a declaration precisely so it
+  doesn't become a luminance guess made at an arbitrary layer. A consumer needing the mode reads the
+  theme's own `surface` out of its tokens.
+
+Until these existed, the theme sheets' tokens were merged into `tokens.dtcg.json` along with the
+system's own. Because M3 role labels repeat across themes, that made a system's published `primary`
+whichever sheet the bundle happened to yield last; splitting them fixed the system set as well as
+adding the themes.
+
 ### Delivery-branch history
 
 Each publish **appends a commit on top of the branch tip** rather than

--- a/scripts/design-artifacts/catalog-themes.mjs
+++ b/scripts/design-artifacts/catalog-themes.mjs
@@ -1,0 +1,84 @@
+/**
+ * The declared themes a catalog publishes, mapped from a bundle onto the export's
+ * `Catalog.themes` (design-parity#307).
+ *
+ * A system's `tokens.dtcg.json` is the SYSTEM token set — the one resolved theme the stickers were
+ * rendered under. A module that declares `@ThemeCatalog` / `@WearThemeCatalog` providers has more,
+ * and each specimen render already resolved its own: the renderer writes them into the bundle as a
+ * theme-tagged `previews/<id>.catalog.json`, and `@design-parity/candidate`'s
+ * `themeTokenSetsFromBundle` reads them back keyed by theme (design-parity#313).
+ *
+ * This is the last hop — turning those token sets into the shape the export publishes, one
+ * `themes/<slug>.dtcg.json` per theme. What it adds beyond the tokens is *identity*: a theme's
+ * stable id is its **provider FQN**, because that is what a preview server addresses it by
+ * (`?theme=theme:<providerFqn>`), so a consumer can join a published token set to the theme a page
+ * is showing. The name and group come from the same `previews.json` entry the FQN does.
+ */
+
+/**
+ * Build the export's `themes` from a bundle's per-theme token sets.
+ *
+ * A theme with **no resolvable provider FQN** is skipped rather than published under a substitute
+ * id. The id is the whole point of publishing these — a `themes[]` entry keyed on something a
+ * preview server cannot address is data no consumer can attach to the theme it belongs to, which is
+ * worse than the absence a consumer already handles. Skips are reported through [onSkip] so a
+ * publishing job can say so rather than silently shipping a thinner catalog.
+ *
+ * `dark` is deliberately left unset. Nothing in the pipeline *declares* whether a theme is dark —
+ * the annotation carries a name and a group — and design-parity#307 made the field a declaration
+ * precisely so it wouldn't become a luminance guess made at some arbitrary layer. A consumer that
+ * needs the mode can still read the theme's own `surface` out of its published tokens.
+ *
+ * @param {{previews?: Array<{id?: string, params?: Record<string, unknown>}>}} bundle the packed
+ *   bundle, whose `previews.json` entries carry each specimen's provider FQN, name and group.
+ * @param {Array<{theme?: string, previewId?: string, providerFqn?: string, tokens?: object}>}
+ *   themeTokenSets `themeTokenSetsFromBundle(bundle)`.
+ * @param {(previewId: string, theme: string) => void} [onSkip] called for each dropped theme.
+ * @returns {Array<{id: string, name?: string, group?: string, tokens: object}>} in the order given.
+ */
+export function catalogThemesFromBundle(bundle, themeTokenSets, onSkip) {
+  const byId = previewsById(bundle);
+  const out = [];
+  const seen = new Set();
+  for (const set of themeTokenSets ?? []) {
+    const previewId = typeof set?.previewId === "string" ? set.previewId : "";
+    const id = typeof set?.providerFqn === "string" ? set.providerFqn.trim() : "";
+    const theme = typeof set?.theme === "string" ? set.theme : "";
+    if (!id || !set?.tokens) {
+      onSkip?.(previewId, theme);
+      continue;
+    }
+    // One provider is one theme. A repeated FQN would publish two files at the same slug, the
+    // second overwriting the first — so the first wins and the rest are reported like any other
+    // skip rather than silently colliding on disk.
+    if (seen.has(id)) {
+      onSkip?.(previewId, theme);
+      continue;
+    }
+    seen.add(id);
+    const entry = { id, tokens: set.tokens };
+    const params = byId.get(previewId)?.params ?? {};
+    const name = theme || str(params.name);
+    if (name) entry.name = name;
+    const group = str(params.group);
+    if (group) entry.group = group;
+    out.push(entry);
+  }
+  return out;
+}
+
+/** `previews.json` entries keyed by id, so a token set can find the entry it came from. */
+function previewsById(bundle) {
+  const map = new Map();
+  for (const preview of bundle?.previews ?? []) {
+    if (typeof preview?.id === "string") map.set(preview.id, preview);
+  }
+  return map;
+}
+
+/** [value] when it is a non-blank string, else undefined. */
+function str(value) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}

--- a/scripts/design-artifacts/catalog-themes.mjs
+++ b/scripts/design-artifacts/catalog-themes.mjs
@@ -15,6 +15,8 @@
  * is showing. The name and group come from the same `previews.json` entry the FQN does.
  */
 
+import { themeTokensPath } from "@design-parity/catalog-export";
+
 /**
  * Build the export's `themes` from a bundle's per-theme token sets.
  *
@@ -48,14 +50,17 @@ export function catalogThemesFromBundle(bundle, themeTokenSets, onSkip) {
       onSkip?.(previewId, theme);
       continue;
     }
-    // One provider is one theme. A repeated FQN would publish two files at the same slug, the
-    // second overwriting the first — so the first wins and the rest are reported like any other
-    // skip rather than silently colliding on disk.
-    if (seen.has(id)) {
+    // One provider is one theme, and "same theme" means "same FILE": the exporter slugs an FQN
+    // into `themes/<slug>.dtcg.json`, lowercasing it, so two providers differing only in case
+    // collide on disk while comparing as distinct ids. Keying on the emitted path — asked of the
+    // exporter rather than re-derived — makes the check agree with what is actually written. The
+    // first wins and the rest are reported like any other skip.
+    const slot = themeTokensPath(id);
+    if (seen.has(slot)) {
       onSkip?.(previewId, theme);
       continue;
     }
-    seen.add(id);
+    seen.add(slot);
     const entry = { id, tokens: set.tokens };
     const params = byId.get(previewId)?.params ?? {};
     const name = theme || str(params.name);

--- a/scripts/design-artifacts/catalog-themes.test.mjs
+++ b/scripts/design-artifacts/catalog-themes.test.mjs
@@ -1,0 +1,143 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { catalogThemesFromBundle } from "./catalog-themes.mjs";
+
+/** A wear-m3-shaped bundle: three declared themes, one of them typeface-only. */
+const bundle = {
+  previews: [
+    {
+      id: "wearthemecatalog__Coral",
+      params: {
+        wrapperClassName: "com.example.WearCoralThemeCatalog",
+        name: "Coral",
+        group: "Wear",
+      },
+    },
+    {
+      id: "wearthemecatalog__Google Sans Flex",
+      params: {
+        wrapperClassName: "com.example.WearGoogleSansFlexThemeCatalog",
+        name: "Google Sans Flex",
+        group: "Wear",
+      },
+    },
+    { id: "buttons__filled", params: {} },
+  ],
+};
+
+const tokenSets = [
+  {
+    theme: "Coral",
+    previewId: "wearthemecatalog__Coral",
+    providerFqn: "com.example.WearCoralThemeCatalog",
+    tokens: { colors: { primary: "#ff6f61ff" } },
+  },
+  {
+    theme: "Google Sans Flex",
+    previewId: "wearthemecatalog__Google Sans Flex",
+    providerFqn: "com.example.WearGoogleSansFlexThemeCatalog",
+    tokens: { typography: { titleMedium: { fontFamily: "Google Sans Flex" } } },
+  },
+];
+
+test("maps each theme onto the export's shape, keyed by provider FQN", () => {
+  const themes = catalogThemesFromBundle(bundle, tokenSets);
+  assert.deepEqual(themes, [
+    {
+      id: "com.example.WearCoralThemeCatalog",
+      tokens: { colors: { primary: "#ff6f61ff" } },
+      name: "Coral",
+      group: "Wear",
+    },
+    {
+      id: "com.example.WearGoogleSansFlexThemeCatalog",
+      // A theme that swaps only the type scale is a theme: its token set is its
+      // typeface, and that is exactly what makes it distinguishable.
+      tokens: { typography: { titleMedium: { fontFamily: "Google Sans Flex" } } },
+      name: "Google Sans Flex",
+      group: "Wear",
+    },
+  ]);
+});
+
+test("leaves `dark` unset, because nothing declares it", () => {
+  // design-parity#307 made `dark` a declaration so it wouldn't become a luminance
+  // guess at some arbitrary layer. The annotation carries a name and a group and
+  // no mode, so the honest answer here is silence.
+  for (const theme of catalogThemesFromBundle(bundle, tokenSets)) {
+    assert.equal("dark" in theme, false);
+  }
+});
+
+test("skips a theme with no resolvable provider FQN, and says so", () => {
+  // The id is the whole point: a `themes[]` entry keyed on something a preview
+  // server cannot address is data no consumer can attach to a theme.
+  const skipped = [];
+  const themes = catalogThemesFromBundle(
+    bundle,
+    [
+      { theme: "Orphan", previewId: "wearthemecatalog__Orphan", tokens: { colors: {} } },
+      ...tokenSets,
+    ],
+    (previewId, theme) => skipped.push(`${theme}:${previewId}`),
+  );
+  assert.deepEqual(
+    themes.map((t) => t.id),
+    [
+      "com.example.WearCoralThemeCatalog",
+      "com.example.WearGoogleSansFlexThemeCatalog",
+    ],
+  );
+  assert.deepEqual(skipped, ["Orphan:wearthemecatalog__Orphan"]);
+});
+
+test("publishes one theme per provider, keeping the first of a repeat", () => {
+  // Two entries with the same FQN would write two files at one slug, the second
+  // overwriting the first.
+  const skipped = [];
+  const themes = catalogThemesFromBundle(
+    bundle,
+    [
+      tokenSets[0],
+      { ...tokenSets[0], theme: "Coral (again)", tokens: { colors: { primary: "#000000ff" } } },
+    ],
+    (previewId, theme) => skipped.push(theme),
+  );
+  assert.equal(themes.length, 1);
+  assert.deepEqual(themes[0].tokens, { colors: { primary: "#ff6f61ff" } });
+  assert.deepEqual(skipped, ["Coral (again)"]);
+});
+
+test("falls back to the preview entry's name, and copes with no entry at all", () => {
+  const themes = catalogThemesFromBundle(bundle, [
+    {
+      theme: "",
+      previewId: "wearthemecatalog__Coral",
+      providerFqn: "com.example.WearCoralThemeCatalog",
+      tokens: { colors: { primary: "#ff6f61ff" } },
+    },
+    {
+      theme: "Detached",
+      previewId: "not-in-this-bundle",
+      providerFqn: "com.example.Detached",
+      tokens: { colors: { primary: "#123456ff" } },
+    },
+  ]);
+  // A sidecar that declared no display name takes the one on the preview entry…
+  assert.equal(themes[0].name, "Coral");
+  assert.equal(themes[0].group, "Wear");
+  // …and a token set whose specimen isn't in the preview list still publishes,
+  // with no name/group rather than a guess.
+  assert.deepEqual(themes[1], {
+    id: "com.example.Detached",
+    tokens: { colors: { primary: "#123456ff" } },
+    name: "Detached",
+  });
+});
+
+test("an empty or absent input publishes no themes", () => {
+  assert.deepEqual(catalogThemesFromBundle(bundle, []), []);
+  assert.deepEqual(catalogThemesFromBundle(bundle, undefined), []);
+  assert.deepEqual(catalogThemesFromBundle({}, tokenSets).length, 2);
+});

--- a/scripts/design-artifacts/catalog-themes.test.mjs
+++ b/scripts/design-artifacts/catalog-themes.test.mjs
@@ -109,6 +109,24 @@ test("publishes one theme per provider, keeping the first of a repeat", () => {
   assert.deepEqual(skipped, ["Coral (again)"]);
 });
 
+test("treats providers that slug to one file as one theme", () => {
+  // The exporter lowercases an FQN into `themes/<slug>.dtcg.json`, so two ids
+  // differing only in case are distinct strings but the SAME file — the second
+  // would overwrite the first on disk.
+  const skipped = [];
+  const themes = catalogThemesFromBundle(
+    bundle,
+    [
+      { theme: "Coral", previewId: "wearthemecatalog__Coral", providerFqn: "com.example.WearCoral", tokens: { colors: { primary: "#ff6f61ff" } } },
+      { theme: "Coral (cased)", previewId: "wearthemecatalog__Coral", providerFqn: "com.example.wearcoral", tokens: { colors: { primary: "#000000ff" } } },
+    ],
+    (previewId, theme) => skipped.push(theme),
+  );
+  assert.equal(themes.length, 1);
+  assert.equal(themes[0].tokens.colors.primary, "#ff6f61ff");
+  assert.deepEqual(skipped, ["Coral (cased)"]);
+});
+
 test("falls back to the preview entry's name, and copes with no entry at all", () => {
   const themes = catalogThemesFromBundle(bundle, [
     {

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -40,6 +40,7 @@ import {
   readPreviewBundle,
   bundleToCandidates,
   catalogTokensFromBundle,
+  themeTokenSetsFromBundle,
 } from "@design-parity/candidate";
 import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 
@@ -60,6 +61,7 @@ import {
   inventoryFromPreviews,
   mergeCatalogGroups,
 } from "./catalog-inventory.mjs";
+import { catalogThemesFromBundle } from "./catalog-themes.mjs";
 import { variantStateFromId } from "./variant-state.mjs";
 import {
   applyVariantAxisProps,
@@ -952,6 +954,29 @@ const themeTokens = catalogTokens
     )
   : undefined;
 
+// The module's DECLARED themes (`@ThemeCatalog` / `@WearThemeCatalog`), each with the token set its
+// own specimen render resolved — the axis above is the *system*'s one theme, this is every other
+// one it ships. The renderer already wrote them into the bundle (compose-ai-tools#2179); the reader
+// keys them by theme (design-parity#313); this publishes each as `themes/<slug>.dtcg.json` so a
+// consumer can show what a theme IS — a picker chip painted in its own colours and typeface, a
+// per-theme Figma variable mode — instead of only what it is called.
+const declaredThemes = catalogThemesFromBundle(
+  bundle,
+  themeTokenSetsFromBundle(bundle),
+  (previewId, theme) =>
+    console.warn(
+      `[${spec.system}] declared theme ${theme || "(unnamed)"} (${previewId}) resolved no provider ` +
+        `FQN, so it is NOT published: a themes[] entry keyed on anything else cannot be joined to ` +
+        `the theme a preview server is showing.`,
+    ),
+);
+if (declaredThemes.length > 0) {
+  console.log(
+    `[${spec.system}] publishing ${declaredThemes.length} declared theme token set(s): ` +
+      declaredThemes.map((t) => t.name || t.id).join(", "),
+  );
+}
+
 // Resolve the installed `@design-parity/catalog-export` version so the catalog records the export
 // engine that built it (surfaced on the serve host's provenance strip). Best-effort: a resolution
 // failure just omits the field rather than sinking the render.
@@ -994,6 +1019,7 @@ const { catalog, missing, noSticker, withoutSemantics, deferred } =
     ...(values.renderer ? { renderer: values.renderer } : {}),
     ...(designParityVersion() ? { designParity: designParityVersion() } : {}),
     ...(themeTokens ? { themeTokens } : {}),
+    ...(declaredThemes.length > 0 ? { themes: declaredThemes } : {}),
     // Every daemon preview id per function, from the bundles' FULL preview lists — including the
     // deferred palettes whose render was skipped (#2966), which is how their live-only coverage still
     // gets declared even though no image of them exists to fold.

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -675,7 +675,11 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
     ...(spec.display ? { display: spec.display } : {}),
   };
 
-  const catalog = buildCatalog(meta, sources, opts.themeTokens);
+  // `opts.themes` is forwarded explicitly: this join is a VENDORED copy of the published
+  // `catalogFromCandidates` (see the file header), so an option the package's version understands
+  // is silently dropped here unless it is threaded through by hand. Missing it published a catalog
+  // with no `themes[]` while the run logged that it was publishing them.
+  const catalog = buildCatalog(meta, sources, opts.themeTokens, opts.themes);
   return { catalog, missing, noSticker, withoutSemantics, deferred };
 }
 // --- end vendored join --------------------------------------------------------

--- a/scripts/design-artifacts/merge-catalog-section.mjs
+++ b/scripts/design-artifacts/merge-catalog-section.mjs
@@ -114,6 +114,25 @@ async function sameBytes(a, b) {
  */
 const ANNOTATIONS_REL = join("annotations", "index.json");
 
+/**
+ * The one nested directory that is **catalog-level**, not per-component.
+ *
+ * `themes/<provider-fqn>.dtcg.json` is a declared theme's own token set — a sibling of the
+ * top-level `tokens.dtcg.json` that happens to live in a subdirectory because there is one file per
+ * theme. It belongs to the system that declared it: the host's `catalog.json` `themes[]` describes
+ * the HOST's themes, and `mergeManifests` keeps the host's array, so copying a borrowed catalog's
+ * theme files would leave them orphaned in the host — referenced by nothing, and aborting the whole
+ * fold as an asset collision the moment both catalogs declare the same provider with different
+ * tokens.
+ *
+ * This is the exception the "skip every top-level file" rule above was written to avoid needing:
+ * that rule is phrased structurally (top-level ⇒ catalog-level) precisely so a new artifact stays
+ * correct by default, and `themes/` is the first catalog-level artifact that is *nested*. Folding a
+ * borrowed system's themes into a host would be wrong even if the files didn't collide — the host
+ * cannot render them.
+ */
+const THEMES_DIR = "themes";
+
 async function mergeAnnotationManifests(src, dest) {
   const read = async (p) => {
     try {
@@ -144,6 +163,8 @@ async function copyAssets(fromDir, intoDir) {
     // generated pages), not per-component assets — the host keeps its own. Every
     // foldable asset lives in a subdirectory (images/ / wireframes/ / figma/).
     if (!rel.includes(sep)) continue;
+    // …and so is everything under `themes/`, nested though it is — see THEMES_DIR.
+    if (rel.split(sep)[0] === THEMES_DIR) continue;
     const dest = join(intoDir, rel);
     if (rel === ANNOTATIONS_REL) {
       await mergeAnnotationManifests(src, dest);

--- a/scripts/design-artifacts/merge-catalog-section.test.mjs
+++ b/scripts/design-artifacts/merge-catalog-section.test.mjs
@@ -128,6 +128,55 @@ test("mergeCatalogSection folds assets in and rewrites catalog.json", async () =
   assert.equal(await readFile(join(into, "images/Device_Card/x.png"), "utf8"), "HOST-IMG");
 });
 
+test("mergeCatalogSection leaves a borrowed catalog's themes/ behind", async () => {
+  // `themes/<provider-fqn>.dtcg.json` is catalog-level despite being nested: it is
+  // the DECLARING system's theme, `mergeManifests` keeps the host's `themes[]`, and
+  // the host cannot render a borrowed system's theme anyway. Copying it would
+  // orphan the file — and abort the whole fold the moment both catalogs declare the
+  // same provider with different tokens, which is the case this pins.
+  const root = await mkdtemp(join(tmpdir(), "merge-catalog-themes-"));
+  const into = join(root, "into");
+  const from = join(root, "from");
+
+  await mkdir(join(into, "themes"), { recursive: true });
+  await mkdir(join(into, "images/Device_Card"), { recursive: true });
+  await writeFile(
+    join(into, "catalog.json"),
+    JSON.stringify({
+      ...manifest([comp("Device/Card", { section: "Components" })]),
+      themes: [{ id: "com.example.Shared", tokensFile: "themes/com.example.shared.dtcg.json" }],
+    }),
+  );
+  await writeFile(join(into, "images/Device_Card/x.png"), "HOST-IMG");
+  await writeFile(join(into, "themes/com.example.shared.dtcg.json"), '{"host":true}');
+
+  await mkdir(join(from, "themes"), { recursive: true });
+  await mkdir(join(from, "images/Buttons_Filled"), { recursive: true });
+  await writeFile(
+    join(from, "catalog.json"),
+    JSON.stringify({
+      ...manifest([comp("Buttons/Filled")]),
+      themes: [{ id: "com.example.Shared", tokensFile: "themes/com.example.shared.dtcg.json" }],
+    }),
+  );
+  await writeFile(join(from, "images/Buttons_Filled/x.png"), "M3-IMG");
+  // Same slug, DIFFERENT bytes — an asset collision if it were folded as an asset.
+  await writeFile(join(from, "themes/com.example.shared.dtcg.json"), '{"borrowed":true}');
+
+  const res = await mergeCatalogSection({ into, from, section: "Material 3" });
+
+  assert.equal(res.filesCopied, 1); // the image only
+  // The host's own theme file is untouched, not overwritten and not aborted on.
+  assert.equal(
+    await readFile(join(into, "themes/com.example.shared.dtcg.json"), "utf8"),
+    '{"host":true}',
+  );
+  const merged = JSON.parse(await readFile(join(into, "catalog.json"), "utf8"));
+  assert.deepEqual(merged.themes, [
+    { id: "com.example.Shared", tokensFile: "themes/com.example.shared.dtcg.json" },
+  ]);
+});
+
 test("mergeCatalogSection does not abort when both catalogs have differing top-level pages", async () => {
   // The real case: host + borrowed are BOTH generated catalogs, so each carries
   // its own index.html / code-connect.json / README.md with different bytes.

--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -8,9 +8,9 @@
       "name": "design-artifacts-driver",
       "version": "0.0.0",
       "dependencies": {
-        "@design-parity/adapter-figma": "^0.1.44",
-        "@design-parity/candidate": "^0.1.44",
-        "@design-parity/catalog-export": "^0.1.44",
+        "@design-parity/adapter-figma": "^0.1.45",
+        "@design-parity/candidate": "^0.1.45",
+        "@design-parity/catalog-export": "^0.1.45",
         "pixelmatch": "^7.0.0",
         "playwright": "^1.49.0",
         "pngjs": "^7.0.0"
@@ -20,37 +20,37 @@
       }
     },
     "node_modules/@design-parity/adapter-figma": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.44.tgz",
-      "integrity": "sha512-LyhdSKCIXbx831P6XOxEkJhETGoG6gX2I5j96CVl1apRiI5QPNUJvJQIMCfygnxvagEMrXcEWnAKUDYrNtfCCA==",
+      "version": "0.1.45",
+      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.45.tgz",
+      "integrity": "sha512-6fxtslE3VrvBEeXuuDZnahTqhX+VWiO5WUB2Ql6nEZv3wIGZIVculvPw72g+ytxfPMBJj4rJ7Foq3COv5GBW/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.44"
+        "@design-parity/core": "^0.1.45"
       }
     },
     "node_modules/@design-parity/candidate": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.44.tgz",
-      "integrity": "sha512-XZwu9PsGvX/pU4KsQ3MlEXU7BylmssBGzGGCpmBkmD1iDR9k+q1cJ2ie/bwFUed2RcP38x4bXq/krqdf3N4g5w==",
+      "version": "0.1.45",
+      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.45.tgz",
+      "integrity": "sha512-Gym4AIhwdowi4x3Tk4S8WsEp+8xg+RCH6mmadLVGEuQlacP9xakeftZRl0qosEa85+mudygnhRoi4anFt9Qo/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.44",
+        "@design-parity/core": "^0.1.45",
         "fflate": "^0.8.2"
       }
     },
     "node_modules/@design-parity/catalog-export": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.44.tgz",
-      "integrity": "sha512-cBwOAuB+2/JoHcGbQZTpctSaHiinZAF8/nYk/0m0MviQhsfc+AUJdo6Vys4ouSkRS8nG5iOrIv+9ipqnBH6k9g==",
+      "version": "0.1.45",
+      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.45.tgz",
+      "integrity": "sha512-xmIearT53LgR9Q97kr5ZjS5/FYx0Ydmr/b22/jGweG+gApsPmeKCMGn486Y4aPP6QZ8tF5a1V0okBudCHAi8ug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.44"
+        "@design-parity/core": "^0.1.45"
       }
     },
     "node_modules/@design-parity/core": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.44.tgz",
-      "integrity": "sha512-ZBFRHcnCyUPX3+Wv8JZH15AybTvBbg9KgsY9aemC+Ow2bhQ+ZpQXv0TYhYyhBXeMCrxS0p9BuE/8VUKqwXKlyg==",
+      "version": "0.1.45",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.45.tgz",
+      "integrity": "sha512-SDILmXtUvhm2MSBOkm0fLKgZNTdoTS80avHz30JH5kHJtYgiFAozLR+eminn3IL9YkFZveiaK87NtB2niCUjGQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1"

--- a/scripts/design-artifacts/package-version.test.mjs
+++ b/scripts/design-artifacts/package-version.test.mjs
@@ -6,7 +6,7 @@ import { installedPackageVersion } from "./package-version.mjs";
 test("reads the catalog-export version when package.json is not exported", () => {
   assert.equal(
     installedPackageVersion("@design-parity/catalog-export", import.meta.url),
-    "0.1.44",
+    "0.1.45",
   );
 });
 

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -11,9 +11,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@design-parity/adapter-figma": "^0.1.44",
-    "@design-parity/candidate": "^0.1.44",
-    "@design-parity/catalog-export": "^0.1.44",
+    "@design-parity/adapter-figma": "^0.1.45",
+    "@design-parity/candidate": "^0.1.45",
+    "@design-parity/catalog-export": "^0.1.45",
     "pixelmatch": "^7.0.0",
     "playwright": "^1.49.0",
     "pngjs": "^7.0.0"


### PR DESCRIPTION
The producer, now that design-parity 0.1.45 is on the registry with both halves it needs. This is the last hop of per-theme tokens: each declared `@ThemeCatalog` / `@WearThemeCatalog` theme is published as `themes/<provider-fqn>.dtcg.json` beside the system's `tokens.dtcg.json`, listed in `catalog.json`.

**Nothing extra is rendered for it.** Each theme's specimen sheet already resolved its own `MaterialTheme` — colours *and* typeface — and the renderer has been writing that into the bundle as a theme-tagged sidecar since #2179. It was simply never read back per theme.

## Verified end to end against the published packages

Not a unit-test mock — the real `@design-parity/candidate@0.1.45` reader and `catalog-export@0.1.45` writer, over a bundle shaped like `wear-m3`'s, with the output read back off disk:

```
themes → Coral [com.example.WearCoral], KotlinConf [com.example.WearKotlinConf]

catalog.json themes → [
 { "id": "com.example.WearCoral", "name": "Coral", "group": "Wear",
   "tokensFile": "themes/com.example.wearcoral.dtcg.json" },
 { "id": "com.example.WearKotlinConf", "name": "KotlinConf", "group": "Confetti Wear",
   "tokensFile": "themes/com.example.wearkotlinconf.dtcg.json" } ]

themes/ dir → [ 'com.example.wearcoral.dtcg.json', 'com.example.wearkotlinconf.dtcg.json' ]
  Coral:      color.primary=#ff6f61ff
  KotlinConf: color.primary=#7f52ffff  type.titleMedium="JetBrains Mono"

system tokens.dtcg.json primary → #aecbfaff
```

That last line is the other half of design-parity#313 landing: the system's published `primary` is the system's own, not whichever theme sheet the bundle happened to yield last.

## Two decisions worth reviewing

- **A theme's id is its provider FQN.** That is what a preview server addresses it by (`?theme=theme:<providerFqn>`), so a published token set can be joined to the theme a page is showing. A theme whose FQN can't be resolved from `previews.json` is **not published**, and the run warns — an entry keyed on anything else is data no consumer can attach to a theme, which is worse than the absence consumers already handle.
- **`dark` is left unset.** Nothing in the pipeline declares whether a theme is dark; the annotation carries a name and a group. design-parity#307 made the field a declaration precisely so it wouldn't become a luminance guess at an arbitrary layer, so the honest answer here is silence — a consumer needing the mode reads the theme's own `surface` out of its tokens.

## Test plan

- `node --test scripts/design-artifacts/*.test.mjs` — 568 pass, 0 fail. New `catalog-themes.test.mjs` covers the FQN keying, the typeface-only theme, the skip-and-warn path, first-wins on a repeated provider, the name/group fallbacks, and empty input.
- The end-to-end run above, through the published packages.
- `package-version.test.mjs` updated with the pin — it asserts the installed engine version, which is how this repo keeps the pin and the test in step.

## Not in this PR

Serve painting the *declared* chips from these files, and honouring a theme's mode in the page-theme setting. That needs the delivery branches to carry `themes/` first — merging this triggers `design-artifacts.yml` (the driver is a scoped path), so the next publish produces them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZrpC7R6jhZjUghhD17Stm)_