### PR TITLE
test(vscode): surface a truncated cmp-smoke render instead of passing on the fallback

### DIFF
--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -47,6 +47,28 @@ export class RealGradleApi implements GradleApi {
      */
     private readonly liveChildren = new Map<string, ChildProcess>();
 
+    /**
+     * Task names this API actually terminated, in order. Populated by
+     * {@link cancelRunTask} only when a live child was killed — a cancel
+     * against an already-exited task is a no-op and is not recorded.
+     *
+     * Exposed because a cancellation is invisible to the tests otherwise.
+     * When `gradleService`'s task cap kills a render mid-flight, the
+     * extension does the production thing — `renderWithDiskFallback` paints
+     * whatever manifest the truncated render left behind — so a suite that
+     * asserts only "≥N previews arrived" passes on a render that never
+     * finished. That is exactly how the 2026-08-08 cold-runner slowdown
+     * stayed hidden in the `cmp-smoke` shard after the task cap was raised:
+     * green, but on the fallback path. Suites where no cancellation is
+     * expected can read this and say so.
+     */
+    private readonly cancelledTaskNames: string[] = [];
+
+    /** @see cancelledTaskNames */
+    get cancelledTasks(): ReadonlyArray<string> {
+        return this.cancelledTaskNames;
+    }
+
     runTask(opts: {
         projectFolder: string;
         taskName: string;
@@ -171,6 +193,7 @@ export class RealGradleApi implements GradleApi {
         if (!child || child.pid === undefined || child.exitCode !== null) {
             return;
         }
+        this.cancelledTaskNames.push(opts.taskName);
         this.onLog(
             `[realGradleApi] cancel ${opts.taskName} (key=${key}) — terminating gradlew pid ${child.pid}`,
         );

--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -193,17 +193,27 @@ export class RealGradleApi implements GradleApi {
         if (!child || child.pid === undefined || child.exitCode !== null) {
             return;
         }
-        this.cancelledTaskNames.push(opts.taskName);
-        this.onLog(
-            `[realGradleApi] cancel ${opts.taskName} (key=${key}) — terminating gradlew pid ${child.pid}`,
-        );
         // SIGTERM first so the Gradle client disconnects gracefully and its
         // daemon cancels the build (releasing the build lock); escalate to
         // SIGKILL if the process is still alive after the grace period.
+        //
+        // `kill` returns false (or throws) when the signal couldn't be
+        // delivered because the process is already gone — which is a real
+        // race here, since the interesting case is a build finishing right
+        // as the task cap fires. Record and log only when the signal
+        // actually went out, so `cancelledTasks` can't attribute a
+        // truncation to a render that completed on its own.
+        let signalSent = false;
         try {
-            child.kill("SIGTERM");
+            signalSent = child.kill("SIGTERM");
         } catch {
-            /* already gone */
+            signalSent = false; /* already gone */
+        }
+        if (signalSent) {
+            this.cancelledTaskNames.push(opts.taskName);
+            this.onLog(
+                `[realGradleApi] cancel ${opts.taskName} (key=${key}) — terminating gradlew pid ${child.pid}`,
+            );
         }
         const killTimer = setTimeout(() => {
             if (child.exitCode === null && child.signalCode === null) {

--- a/vscode-extension/src/test/electron/suite/e2e.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2e.test.ts
@@ -233,16 +233,24 @@ describeE2E("Compose Preview e2e (real Gradle)", function () {
             `webview rendered ${renderedSignal.count} cards but ${previews.length} previews were sent`,
         );
 
-        // This shard drives exactly one refresh, so nothing should ever
-        // supersede it — a cancelled task here can only be `gradleService`'s
-        // task cap killing the render mid-flight. When that happens the
-        // extension does the production thing and paints the truncated
-        // manifest from disk, so every assertion above still passes: the
-        // shard reports green on a render that never finished, and this
-        // shard exists precisely to be the *unfiltered, whole-module* render
-        // coverage (the interactive suite narrows its render with
-        // `-PcomposePreview.filter`). Observed on 2026-08-08, when a
-        // repo-wide cold-cache slowdown pushed the render past the cap.
+        // This shard drives exactly one refresh, so nothing can supersede
+        // the render — a cancelled *render* here can only be
+        // `gradleService`'s task cap killing it mid-flight. When that
+        // happens the extension does the production thing and paints the
+        // truncated manifest from disk, so every assertion above still
+        // passes: the shard reports green on a render that never finished,
+        // and this shard exists precisely to be the *unfiltered,
+        // whole-module* render coverage (the interactive suite narrows its
+        // render with `-PcomposePreview.filter`). Observed on 2026-08-08,
+        // when a repo-wide cold-cache slowdown pushed the render past the
+        // cap.
+        //
+        // Match the render task specifically rather than "anything was
+        // cancelled". `composePreviewApplied` also runs through this
+        // `RealGradleApi` — activation kicks off a fire-and-forget marker
+        // bootstrap — and it can hit the cap on its own without saying
+        // anything about whether the render completed. Warning on that
+        // would claim coverage was lost when it wasn't.
         //
         // Deliberately a warning rather than an assertion: the render being
         // slow is an environment condition, not a defect in the code under
@@ -251,13 +259,26 @@ describeE2E("Compose Preview e2e (real Gradle)", function () {
         // annotation on the run summary so it can't rot unseen. Promote it
         // to a hard assertion once the render reliably finishes inside the
         // cap again.
-        if (gradleApi.cancelledTasks.length > 0) {
+        const cancelledRenders = gradleApi.cancelledTasks.filter((task) =>
+            task.includes("composePreviewRenderAll"),
+        );
+        if (cancelledRenders.length > 0) {
             console.log(
                 `::warning title=Truncated preview render::` +
                     `cmp-smoke asserted against a partial render — the task cap killed ` +
-                    `${gradleApi.cancelledTasks.join(", ")} before it finished, and the ` +
+                    `${cancelledRenders.join(", ")} before it finished, and the ` +
                     `panel fell back to the on-disk manifest. Whole-module render coverage ` +
                     `did NOT run this time.`,
+            );
+        }
+        // Other cancellations don't invalidate the render, but they do mean
+        // something hit the cap — worth a line in the log for triage.
+        const otherCancellations = gradleApi.cancelledTasks.filter(
+            (task) => !task.includes("composePreviewRenderAll"),
+        );
+        if (otherCancellations.length > 0) {
+            console.log(
+                `[e2e] non-render task(s) cancelled at the task cap: ${otherCancellations.join(", ")}`,
             );
         }
     });

--- a/vscode-extension/src/test/electron/suite/e2e.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2e.test.ts
@@ -71,6 +71,7 @@ describeE2E("Compose Preview e2e (real Gradle)", function () {
     this.timeout(15 * 60_000);
 
     let api: ComposePreviewTestApi;
+    let gradleApi: RealGradleApi;
     let kotlinFile: string;
     let repoRoot: string;
     let renderDir: string;
@@ -124,9 +125,8 @@ describeE2E("Compose Preview e2e (real Gradle)", function () {
             "activate() must return ComposePreviewTestApi under COMPOSE_PREVIEW_TEST_MODE=1",
         );
         api = exported;
-        api.injectGradleApi(
-            new RealGradleApi(repoRoot, (line) => console.log(line)),
-        );
+        gradleApi = new RealGradleApi(repoRoot, (line) => console.log(line));
+        api.injectGradleApi(gradleApi);
 
         // Resolve the webview view. Without this, `panel.view` stays
         // undefined, every `panel.postMessage` is silently dropped, and
@@ -232,5 +232,33 @@ describeE2E("Compose Preview e2e (real Gradle)", function () {
             renderedSignal.count >= previews.length,
             `webview rendered ${renderedSignal.count} cards but ${previews.length} previews were sent`,
         );
+
+        // This shard drives exactly one refresh, so nothing should ever
+        // supersede it — a cancelled task here can only be `gradleService`'s
+        // task cap killing the render mid-flight. When that happens the
+        // extension does the production thing and paints the truncated
+        // manifest from disk, so every assertion above still passes: the
+        // shard reports green on a render that never finished, and this
+        // shard exists precisely to be the *unfiltered, whole-module* render
+        // coverage (the interactive suite narrows its render with
+        // `-PcomposePreview.filter`). Observed on 2026-08-08, when a
+        // repo-wide cold-cache slowdown pushed the render past the cap.
+        //
+        // Deliberately a warning rather than an assertion: the render being
+        // slow is an environment condition, not a defect in the code under
+        // test, and failing here would take the shard red for something a
+        // warm build cache fixes on its own. `::warning::` surfaces it as an
+        // annotation on the run summary so it can't rot unseen. Promote it
+        // to a hard assertion once the render reliably finishes inside the
+        // cap again.
+        if (gradleApi.cancelledTasks.length > 0) {
+            console.log(
+                `::warning title=Truncated preview render::` +
+                    `cmp-smoke asserted against a partial render — the task cap killed ` +
+                    `${gradleApi.cancelledTasks.join(", ")} before it finished, and the ` +
+                    `panel fell back to the on-disk manifest. Whole-module render coverage ` +
+                    `did NOT run this time.`,
+            );
+        }
     });
 });


### PR DESCRIPTION
Follow-up to #3568, from investigating why `cmp-smoke` had no headroom under the new cap.

## What the investigation found

**The cmp-smoke "zero headroom" is not a cmp render problem — it is a repo-wide cold-build condition.** Comparing the same five shards on the same workflow, before and after `3fb85d6`:

| Shard | 15:06 (`8400c6d0`) | 22:32 (`5b1df46`) | |
|---|---|---|---|
| wear | 1m41s | 8m32s | **5.1×** |
| interactive-e-g | 2m46s | 6m13s | 2.2× |
| interactive-a-d | 5m03s | 8m52s | 1.8× |
| cmp-smoke | 5m15s | 10m14s | 1.9× |
| cached-preload | 5m48s | 13m00s | 2.2× |

`wear` renders `:samples:wear` through Robolectric and shares no code with the cmp render path, so a 5× slowdown there rules out a regression in cmp rendering. Everything got slower at once, which is what an invalidated build cache looks like — `3fb85d6` touched `build-logic`'s publishing convention plugin plus ~30 `build.gradle.kts` files, changing the build classpath and therefore every cacheable task's key.

So **the 10-minute cap is not too small; the build got slow.** Raising the cap again would just buy time against the wrong problem, and this PR does not do that.

**The separate, real defect is that the shard could not tell.** When the cap kills the render, the extension does the production thing — `renderWithDiskFallback` paints whatever manifest the truncated render left behind. Every assertion in `cmp-smoke` (≥2 previews, ≥2 PNGs, the webview ack) is satisfied by that partial state:

```
22:33:03.784  gradlew :samples:cmp:composePreviewRenderAll …
22:43:03.703  cancel … — terminating gradlew pid 3257
22:43:03.747  [e2e] received 6 previews: …          ← 44ms after the kill: the disk fallback
✔ renders previews for samples/cmp through the real Gradle plugin (600580ms)
```

That matters because this shard is the repo's only **unfiltered, whole-module** render coverage — the interactive suite narrows its render with `-PcomposePreview.filter`, and its own comment points at `cmp-smoke` as the place full-module coverage lives. A silent truncation quietly removes the one thing the shard exists to check.

(For the record, the 6 previews are *not* evidence of truncation on their own: `refresh` scopes the panel strictly to the active file, and `Previews.kt` declares exactly 6. The cancellation is the evidence.)

## The change

`RealGradleApi` records the tasks it actually terminated (a cancel against an already-exited child stays a no-op and is not recorded), and `cmp-smoke` reports them. That shard drives exactly one refresh, so nothing can supersede it — a cancellation there can only be the task cap.

Emitted as a `::warning::` annotation, **not** an assertion. The cause is environmental, not a defect in the code under test, and failing here would take the shard red for something a warm cache fixes on its own. The annotation lands on the run summary so it can't rot unseen. Promote it to a hard assertion once the render reliably finishes inside the cap.

Only `cmp-smoke` gets this. The interactive suite cancels tasks deliberately (scenarios C and D supersede in-flight refreshes), so the same check there would be noise.

## Test plan

- `npm run compile` — clean.
- `npm test` — 1674 passing, unchanged.
- `npm run format:check` — clean.
- This PR touches `vscode-extension/**`, so all five e2e shards run on it. If `cmp-smoke` is still truncating, the annotation will appear on this PR's own run summary — which is the intended demonstration.

No visual surface changes; this is test-harness instrumentation, so text-only evidence is the right bar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmbwB3s3xBmk4Q4RWBjpjM)_