### PR TITLE
feat(design-artifacts): resolve each published theme's dark flag

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -148,10 +148,15 @@ Two details are load-bearing:
   showing. A theme whose FQN can't be resolved from `previews.json` is **not published**: an entry
   keyed on anything else is data no consumer can attach to a theme, and the driver warns rather than
   shipping it silently.
-- **`dark` is left unset.** Nothing in the pipeline declares whether a theme is dark — the
-  annotation carries a name and a group — and the field exists as a declaration precisely so it
-  doesn't become a luminance guess made at an arbitrary layer. A consumer needing the mode reads the
-  theme's own `surface` out of its tokens.
+- **`dark` comes from the theme's own resolved surface**, the colour the renderer actually composed
+  that specimen on — `surface`, else `background`, composited over white if it carries alpha. It is
+  decided here rather than left to consumers precisely because the field exists to stop each of them
+  re-deriving it and disagreeing. The rule is *relative luminance < 0.45*, the same one the preview
+  server's `ServeThemeCss` uses to decide which mode a catalog baked, so the published flag and the
+  server's own palette projection can never contradict each other; if one moves, both move. Note
+  that this is a luminance, not a lightness — it crosses at about `#b3b3b3`, so a mid-grey surface
+  counts as dark. A theme that published no surface at all leaves the field absent, since nothing
+  can answer for it.
 
 A folded section does **not** bring its themes with it. `themes/` is catalog-level despite being
 nested, so [`merge-catalog-section.mjs`](../../scripts/design-artifacts/merge-catalog-section.mjs)

--- a/scripts/design-artifacts/catalog-themes.mjs
+++ b/scripts/design-artifacts/catalog-themes.mjs
@@ -26,17 +26,20 @@ import { themeTokensPath } from "@design-parity/catalog-export";
  * worse than the absence a consumer already handles. Skips are reported through [onSkip] so a
  * publishing job can say so rather than silently shipping a thinner catalog.
  *
- * `dark` is deliberately left unset. Nothing in the pipeline *declares* whether a theme is dark —
- * the annotation carries a name and a group — and design-parity#307 made the field a declaration
- * precisely so it wouldn't become a luminance guess made at some arbitrary layer. A consumer that
- * needs the mode can still read the theme's own `surface` out of its published tokens.
+ * `dark` is resolved from the theme's **own resolved `surface`**, the colour the renderer actually
+ * composed that specimen on. It is deliberately decided *here* rather than left to consumers: the
+ * point of the field is that a consumer pinning a page's colour scheme to the selected theme
+ * shouldn't have to re-derive it, and every consumer re-deriving it independently is how two
+ * surfaces end up disagreeing about the same theme. Absent only when a theme published no surface
+ * at all, which is the one case nothing can answer.
  *
  * @param {{previews?: Array<{id?: string, params?: Record<string, unknown>}>}} bundle the packed
  *   bundle, whose `previews.json` entries carry each specimen's provider FQN, name and group.
  * @param {Array<{theme?: string, previewId?: string, providerFqn?: string, tokens?: object}>}
  *   themeTokenSets `themeTokenSetsFromBundle(bundle)`.
  * @param {(previewId: string, theme: string) => void} [onSkip] called for each dropped theme.
- * @returns {Array<{id: string, name?: string, group?: string, tokens: object}>} in the order given.
+ * @returns {Array<{id: string, name?: string, group?: string, dark?: boolean, tokens: object}>} in
+ *   the order given.
  */
 export function catalogThemesFromBundle(bundle, themeTokenSets, onSkip) {
   const byId = previewsById(bundle);
@@ -67,9 +70,61 @@ export function catalogThemesFromBundle(bundle, themeTokenSets, onSkip) {
     if (name) entry.name = name;
     const group = str(params.group);
     if (group) entry.group = group;
+    const dark = themeIsDark(set.tokens);
+    if (dark !== undefined) entry.dark = dark;
     out.push(entry);
   }
   return out;
+}
+
+/**
+ * The luminance below which a surface counts as dark.
+ *
+ * The same 0.45 the preview server's `ServeThemeCss` uses to decide which mode a catalog baked
+ * (`catalogIsDark`), over the same WCAG relative-luminance formula. Deliberately not an independent
+ * judgement: the server is the main consumer of this field, and a theme that this call says is
+ * light while the server's own palette projection treats it as dark would paint a page against
+ * itself. If one moves, both move.
+ */
+const DARK_LUMINANCE = 0.45;
+
+/**
+ * Whether [tokens] describe a dark theme, from the surface the renderer resolved for it — or
+ * undefined when the theme published no surface to judge by.
+ *
+ * `surface` first, then `background`, matching the server's fallback order. A surface carrying
+ * alpha is composited over white before it is measured, for the same reason the server does it: a
+ * translucent colour is not a colour until something is behind it, and white is the only sensible
+ * assumption at this layer.
+ */
+function themeIsDark(tokens) {
+  const colors = tokens?.colors ?? {};
+  const rgb = parseHex(colors.surface) ?? parseHex(colors.background);
+  return rgb === undefined ? undefined : luminance(rgb) < DARK_LUMINANCE;
+}
+
+/**
+ * `#rrggbb` / `#rrggbbaa` (the form `argbToCssHex` emits) → `[r, g, b]`, alpha composited over
+ * white. Undefined for anything else, including a value that isn't a string.
+ */
+function parseHex(value) {
+  if (typeof value !== "string") return undefined;
+  const hex = value.trim().replace(/^#/, "");
+  if (!/^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(hex)) return undefined;
+  const byte = (at) => parseInt(hex.slice(at, at + 2), 16);
+  const rgb = [byte(0), byte(2), byte(4)];
+  if (hex.length === 6) return rgb;
+  const alpha = byte(6) / 255;
+  return rgb.map((c) => Math.round(c * alpha + 255 * (1 - alpha)));
+}
+
+/** WCAG relative luminance of an `[r, g, b]` triple. */
+function luminance([r, g, b]) {
+  const channel = (v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
 }
 
 /** `previews.json` entries keyed by id, so a token set can find the entry it came from. */

--- a/scripts/design-artifacts/catalog-themes.test.mjs
+++ b/scripts/design-artifacts/catalog-themes.test.mjs
@@ -61,10 +61,68 @@ test("maps each theme onto the export's shape, keyed by provider FQN", () => {
   ]);
 });
 
-test("leaves `dark` unset, because nothing declares it", () => {
-  // design-parity#307 made `dark` a declaration so it wouldn't become a luminance
-  // guess at some arbitrary layer. The annotation carries a name and a group and
-  // no mode, so the honest answer here is silence.
+test("resolves `dark` from the theme's own resolved surface", () => {
+  const themes = catalogThemesFromBundle(bundle, [
+    {
+      theme: "Night",
+      previewId: "wearthemecatalog__Coral",
+      providerFqn: "com.example.Night",
+      // wear-m3's real surface: a near-black watch face.
+      tokens: { colors: { surface: "#202124ff", primary: "#4dd0e1ff" } },
+    },
+    {
+      theme: "Day",
+      previewId: "wearthemecatalog__Coral",
+      providerFqn: "com.example.Day",
+      tokens: { colors: { surface: "#fffbffff" } },
+    },
+  ]);
+  assert.equal(themes[0].dark, true);
+  assert.equal(themes[1].dark, false);
+});
+
+test("uses the server's threshold, which is a luminance and not a lightness", () => {
+  // The rule is `relative luminance < 0.45`, the same one `ServeThemeCss` decides a
+  // catalog's baked mode with. That crosses at about #b3b3b3, NOT at 50% grey — so
+  // a mid-grey surface counts as dark. Pinned because it reads as surprising, and
+  // because the value that matters is agreement with the server rather than the
+  // number itself: if one moves, both move.
+  const at = (surface) =>
+    catalogThemesFromBundle({}, [
+      { theme: "t", previewId: "p", providerFqn: "com.example.T", tokens: { colors: { surface } } },
+    ])[0].dark;
+  assert.equal(at("#808080ff"), true, "mid grey is dark by luminance");
+  assert.equal(at("#b3b3b3ff"), false, "…and #b3b3b3 is where it turns over");
+  assert.equal(at("#b2b2b2ff"), true);
+  // The real published surfaces, either side of the line.
+  assert.equal(at("#202124ff"), true, "wear-m3's watch face");
+  assert.equal(at("#fffbffff"), false, "jetnews");
+});
+
+test("falls back to `background`, and composites a translucent surface over white", () => {
+  const [onBackground, translucent] = catalogThemesFromBundle(bundle, [
+    {
+      theme: "NoSurface",
+      previewId: "x",
+      providerFqn: "com.example.NoSurface",
+      tokens: { colors: { background: "#000000ff", primary: "#ffffffff" } },
+    },
+    {
+      theme: "Translucent",
+      previewId: "y",
+      providerFqn: "com.example.Translucent",
+      // Black at 10% over white is a pale grey — a light theme, not a dark one.
+      tokens: { colors: { surface: "#0000001a" } },
+    },
+  ]);
+  assert.equal(onBackground.dark, true);
+  assert.equal(translucent.dark, false);
+});
+
+test("leaves `dark` unset when a theme published no surface at all", () => {
+  // Neither fixture theme carries a surface — one has only a `primary`, the other
+  // only a typeface. A brand colour says nothing about the mode it is painted on,
+  // so the field stays absent rather than being inferred from the wrong role.
   for (const theme of catalogThemesFromBundle(bundle, tokenSets)) {
     assert.equal("dark" in theme, false);
   }


### PR DESCRIPTION
`themes[].dark` was going out unset on every published theme (#3573), so the consumer the field exists for — a page pinning its colour scheme to the selected theme — still had nothing to read.

## Where it comes from

The theme's own **resolved `surface`** (else `background`, composited over white if it carries alpha): the colour the renderer actually composed that specimen on. That is the most authoritative signal available short of an annotation nobody writes, and deciding it *here* is the point of the field — every consumer re-deriving it independently is how two surfaces end up disagreeing about the same theme.

The rule is `relative luminance < 0.45`, **lifted from the preview server's `ServeThemeCss.catalogIsDark` rather than invented**, so the published flag and the server's own palette projection can't contradict each other. If one moves, both move.

## Checked against real palettes, not just fixtures

```
ok   wear-m3 (dark-first watch face)  #202124ff → dark=true
ok   jetnews (light)                  #fffbffff → dark=false
ok   jetsnack (pure white)            #ffffffff → dark=false
ok   M3 baseline light                #fef7ffff → dark=false
ok   M3 baseline dark                 #141218ff → dark=true
```

That run also corrected me: I'd expected `#808080` to come out light, and it doesn't. 0.45 is a *luminance*, not a lightness — it crosses at about `#b3b3b3`, so a mid-grey surface counts as dark. Surprising enough that there's now a test pinning both the crossover and the fact that matching the server matters more than the number.

## What stays absent

A theme that published no surface at all — `wear-m3`'s typeface-only theme is a real example, and another carries just a `primary`. A brand colour says nothing about the mode it's painted on, so the field is omitted rather than inferred from the wrong role.

## Test plan

- `node --test scripts/design-artifacts/*.test.mjs` — 578 pass, 0 fail. New cases: dark and light surfaces resolved; `background` fallback; a translucent surface composited over white (black at 10% is a *light* theme); the luminance-vs-lightness crossover; and the no-surface case left unset.
- The real-palette run above.
- The previous "leaves `dark` unset" test is replaced rather than deleted — its subject is now the narrower no-surface case.

## Follow-up

design-parity's `CatalogTheme.dark` doc still says "declared rather than derived", which was written before there was a producer that could answer. Now that one can, the wording and this behaviour should agree — I'll send a doc amendment there rather than leave the contract reading against its only producer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZrpC7R6jhZjUghhD17Stm)_