### PR TITLE
feat(deploy): forward the playground selector env into the preview container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1175,6 +1175,12 @@ jobs:
       # are worth a gate rather than a manual check.
       - name: Run deploy .env migration tests
         run: ./deploy/image/test-env-migrations.sh
+      # A SERVE_* knob the entrypoint reads but docker-compose.yml never forwards is silently
+      # inert: the operator sets it in .env exactly as documented and the box comes up ignoring
+      # it, with nothing logged. SERVE_PLAYGROUND sat that way for its whole life, which is what
+      # kept the public host's playground pinned to one catalog with the Android modes off.
+      - name: Run deploy compose env-passthrough tests
+        run: ./deploy/image/test-compose-env-passthrough.sh
       # The seed-config reconcile POSTs to a live server's admin API during publish, so its
       # ordering (trust before catalogs) and payload-shape rules are gated rather than eyeballed —
       # a dropped `listed: false` or `group` silently moves a card on the front page.

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -148,6 +148,31 @@ The selected catalog decides the mode too: its bundle `backend` is what picks th
 Compose. Catalogs whose modes this container can't render — Android ones without the
 `lib-daemon-android` sidecar — are simply not listed.
 
+**This image already carries the Android bits**, so that exclusion does not apply here: the
+Dockerfile's `android-daemon` stage bakes the Robolectric sidecar at `/opt/lib-daemon-android`
+(pointed at by `-Dcomposeai.cli.libDaemonAndroidDir` in `JAVA_TOOL_OPTIONS`) and a minimal Android
+SDK at `/opt/android-sdk` (`ANDROID_HOME`), because the Wear catalog's *live* tier needs exactly the
+same two things. Turning the selector on is therefore all it takes for an Android-backed catalog
+here — `wear-m3`, `remote-m3`, the Wear app catalogs — to be offered and to compile. No image
+change, no extra download, no `SERVE_PLAYGROUND_ANDROID_BUNDLE`.
+
+Remote Compose mode has one extra requirement: it publishes its capture into the `/d/` document
+store, so it needs `SERVE_ACCEPT_DOCS=1`. Without it the Android catalogs still offer Compose
+(Android); only the Remote Compose mode stays absent.
+
+Confirm what actually came up rather than assuming — the startup line
+`serve: playground enabled (POST /api/1/compiler/run) — … android-render✓ catalog-selector✓(≤6)`
+in `docker compose logs preview`, and `/status.json` at `playground.catalogSelector` (null means the
+selector never came on) and `playground.modes`.
+
+> **An existing box needs its `docker-compose.yml` updated too, not just its `.env`.** Compose does
+> not forward the host environment — a variable absent from the `preview` service's `environment:`
+> block never reaches the container, and the entrypoint then skips the flag silently. Every variable
+> on this page is forwarded by the compose file in this directory, but a clone predating that is why
+> `SERVE_PLAYGROUND` could be set in `.env` for months and do nothing. `git pull` the compose file
+> before debugging a knob that appears to be ignored. CI guards the two files against drifting again
+> (`deploy/image/test-compose-env-passthrough.sh`).
+
 Each catalog resolves the first time someone compiles against it and is then held for the life of
 the process (its jars are open in live snippet JVMs, so it can't be evicted). That is what
 `SERVE_PLAYGROUND_CATALOG_LIMIT` bounds: past it, a run naming a *new* catalog is refused with a

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -61,6 +61,9 @@ services:
       SERVE_GITHUB_AUTH_REPO: "${SERVE_GITHUB_AUTH_REPO:-yschimke/compose-ai-tools}"
       SERVE_GITHUB_AUTH_CALLBACK_BASE_URL: "${SERVE_GITHUB_AUTH_CALLBACK_BASE_URL:-}"
       SERVE_GITHUB_AUTH_USERS: "${SERVE_GITHUB_AUTH_USERS:-}"
+      # Empty derives the OAuth scope from the gating repo's visibility (public ⇒ read:user,
+      # private ⇒ read:user repo). Only set this when a GitHub App or org policy demands one.
+      SERVE_GITHUB_AUTH_SCOPE: "${SERVE_GITHUB_AUTH_SCOPE:-}"
       # Optional ADDITIONS to that file, for one extra catalog without editing config:
       # <system>@<owner>/<repo>, comma-separated. Empty (the default) = the file decides.
       SERVE_CATALOGS: "${SERVE_CATALOGS:-}"
@@ -77,6 +80,13 @@ services:
       # Unused in public mode; required only when SERVE_PUBLIC=0.
       SERVE_TOKEN: "${SERVE_TOKEN:-}"
       SERVE_IDLE_EXIT: "0"
+      # Per-render/build budget handed to `serve --timeout`. Empty ⇒ the image's baked 1800s,
+      # generous enough that a cold first render on a slow box doesn't trip the CLI's 300s default.
+      SERVE_TIMEOUT: "${SERVE_TIMEOUT:-}"
+      # Local Wasm build for the in-browser tier. The prebuilt image has no catalog modules to
+      # build one from, so this stays empty here and the tier rides --catalogs instead (serve
+      # fetches each system's web/wasm/ from its trusted design-artifacts branch).
+      SERVE_WASM_DIR: "${SERVE_WASM_DIR:-}"
       # Live (daemon-backed) preview tier — ON by default and build-free. For a Trusted catalog that
       # carries an executable `liveBundle` (the desktop CMP `compose-m3`), serve fetches that bundle
       # from the trusted branch and launches a render daemon straight from it — no checkout, no
@@ -97,10 +107,31 @@ services:
       SERVE_REVISIONS_ALLOW: "${SERVE_REVISIONS_ALLOW:-}"
       SERVE_CATALOG_SOURCE_REPO: "${SERVE_CATALOG_SOURCE_REPO:-}"
       SERVE_CATALOG_SOURCE_REF: "${SERVE_CATALOG_SOURCE_REF:-}"
+      # Where that optional clone lands inside the container. Empty ⇒ /catalog-src.
+      SERVE_CATALOG_SOURCE_ROOT: "${SERVE_CATALOG_SOURCE_ROOT:-}"
       SERVE_LIVE_SEATS: "${SERVE_LIVE_SEATS:-}"
       # Playground compile lane. Off by default: it runs visitor-supplied Kotlin and needs both a
       # catalog liveBundle classpath plus a sandbox profile on public hosts. Set the bundle path(s)
       # to local files available inside the container, for example a bind mount under /config.
+      #
+      # SERVE_PLAYGROUND=1 turns on the RUNTIME CATALOG SELECTOR: instead of compiling every
+      # snippet against one pinned bundle, the editor offers the catalogs this box already serves
+      # and the chosen catalog's own liveBundle picks the renderer, the dependencies and the mode
+      # set. That is what makes the Android / Remote Compose modes reachable here — this image
+      # already bakes the Robolectric sidecar (/opt/lib-daemon-android) and android.jar
+      # (ANDROID_HOME=/opt/android-sdk), so an Android-backed catalog like `wear-m3` compiles and
+      # renders with no extra image content. Without it, `SERVE_PLAYGROUND_BUNDLE` alone pins the
+      # host to that single catalog and the viewer's playground handoff is hidden for every other
+      # one (see PlaygroundCompileService.compilesCatalog).
+      #
+      # It composes with the pin: SERVE_PLAYGROUND_BUNDLE stays the preselected "Server default"
+      # entry. Enabling the selector never widens who may compile — the public-host admission gate
+      # (GitHub repo access, or a sandbox that passes the preflight) is unchanged.
+      SERVE_PLAYGROUND: "${SERVE_PLAYGROUND:-}"
+      # How many DISTINCT catalogs the selector may hold resolved classpaths for at once. Empty ⇒
+      # the CLI default (6); past the bound a run naming a new catalog is refused rather than
+      # evicting a warm one.
+      SERVE_PLAYGROUND_CATALOG_LIMIT: "${SERVE_PLAYGROUND_CATALOG_LIMIT:-}"
       SERVE_PLAYGROUND_BUNDLE: "${SERVE_PLAYGROUND_BUNDLE:-}"
       SERVE_PLAYGROUND_ANDROID_BUNDLE: "${SERVE_PLAYGROUND_ANDROID_BUNDLE:-}"
       SERVE_PLAYGROUND_SANDBOX: "${SERVE_PLAYGROUND_SANDBOX:-}"
@@ -110,10 +141,33 @@ services:
       SERVE_PLAYGROUND_SANDBOX_TTL: "${SERVE_PLAYGROUND_SANDBOX_TTL:-}"
       SERVE_PLAYGROUND_SANDBOX_RO: "${SERVE_PLAYGROUND_SANDBOX_RO:-}"
       SERVE_PLAYGROUND_COMPILE_SLOTS: "${SERVE_PLAYGROUND_COMPILE_SLOTS:-}"
+      # PER-CALLER compile budget. Every other playground bound above is a whole-host one, so
+      # without this one caller can hold every compile slot. Empty ⇒ the CLI defaults (10
+      # compiles/minute, 1 concurrent); set SERVE_PLAYGROUND_RATE_LIMIT=0 to disable the limiter.
+      SERVE_PLAYGROUND_RATE_LIMIT: "${SERVE_PLAYGROUND_RATE_LIMIT:-}"
+      SERVE_PLAYGROUND_CALLER_CONCURRENCY: "${SERVE_PLAYGROUND_CALLER_CONCURRENCY:-}"
+      # Attribute a request to the X-Forwarded-For peer rather than the proxy's own address, so the
+      # per-caller budget above counts real visitors instead of lumping them under Caddy. ONLY safe
+      # behind a proxy that appends the peer address it saw — which the `caddy` service below is.
+      SERVE_TRUST_FORWARDED_FOR: "${SERVE_TRUST_FORWARDED_FOR:-}"
       # Re-check each catalog's design-artifacts branch every N seconds and re-fetch on change, so a
       # regenerated branch reaches this running server without a restart (Watchtower only rolls the
       # image). Empty ⇒ the CLI default (600s); set 0 to disable and serve the boot snapshot only.
       SERVE_CATALOG_REFRESH: "${SERVE_CATALOG_REFRESH:-}"
+      # Bundle-upload lane (POST a locally-built bundle and browse it here). Off unless asked for.
+      SERVE_ACCEPT_BUNDLES: "${SERVE_ACCEPT_BUNDLES:-}"
+      SERVE_ACCEPT_BUNDLES_FROM: "${SERVE_ACCEPT_BUNDLES_FROM:-}"
+      # Document lane (GET/POST /docs, GET /d/<id>) — data only: a Remote Compose / Lottie document
+      # is played back by a player in the visitor's browser, so nothing runs on the box. The
+      # playground's REMOTE_COMPOSE mode publishes its capture into this store, so a box that wants
+      # that mode needs the lane on. Off unless asked for.
+      SERVE_ACCEPT_DOCS: "${SERVE_ACCEPT_DOCS:-}"
+      SERVE_ACCEPT_DOCS_FROM: "${SERVE_ACCEPT_DOCS_FROM:-}"
+      SERVE_DOC_TTL: "${SERVE_DOC_TTL:-}"
+      # Extra Maven repositories the live-daemon classpath resolver may fetch from, beyond Central +
+      # Google. Empty inherits the entrypoint's baked default (jitpack, apollo-snapshots, a8c-libs),
+      # which is what the published catalogs need; `none` sends only Central + Google.
+      SERVE_EXTRA_MAVEN_REPOS: "${SERVE_EXTRA_MAVEN_REPOS:-}"
       PORT: "8080"
     # Persist the RUNTIME download caches across image rolls. A rollout (or Watchtower
     # recreate) replaces the container, discarding its writable layer — so without this the

--- a/deploy/image/test-compose-env-passthrough.sh
+++ b/deploy/image/test-compose-env-passthrough.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Guard: every SERVE_* knob entrypoint.sh reads must be forwarded to the container by
+# docker-compose.yml.
+#
+# Why this needs a test rather than a comment. The two files are edited independently — a new
+# `serve` flag lands in entrypoint.sh (and gets documented in README.md) while docker-compose.yml,
+# the thing that actually decides what reaches the container's environment, is left alone. Compose
+# does NOT pass the host's environment through: an unlisted variable simply isn't there, so the
+# entrypoint's `[[ -n "${VAR:-}" ]]` guard reads empty and skips the flag. Nothing errors, nothing
+# is logged. The operator sets it in .env exactly as documented, restarts, and the box comes up
+# behaving as though they never touched it.
+#
+# That is how `SERVE_PLAYGROUND` — documented in README.md since the runtime catalog selector
+# shipped — spent its whole life unreachable on the prebuilt image, which is why preview.coo.ee ran
+# its playground pinned to a single catalog with the Android modes off, despite the image already
+# baking every Android bit they need.
+#
+# Direction matters: this checks entrypoint ⊆ compose. The reverse is fine and deliberate — compose
+# also carries variables the entrypoint never reads (IMAGE_TAG, PREVIEW_MEM_LIMIT, the rollout and
+# hook services' own), and the image's ENV supplies others directly.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+entrypoint="${ENTRYPOINT_FILE:-${here}/entrypoint.sh}"
+compose="${COMPOSE_FILE_UNDER_TEST:-${here}/docker-compose.yml}"
+
+for f in "${entrypoint}" "${compose}"; do
+  [[ -f "${f}" ]] || {
+    echo "FAIL: missing ${f}" >&2
+    exit 1
+  }
+done
+
+# Variables the entrypoint reads that are deliberately NOT operator-facing compose knobs. Keep this
+# short and justified — it is an exemption from the guard, not a parking space. (Empty today.)
+EXEMPT=()
+
+# Every ${SERVE_...} / ${SERVE_...:-default} / ${SERVE_...:=default} expansion in the entrypoint.
+mapfile -t read_vars < <(
+  grep -oE '\$\{SERVE_[A-Z0-9_]+' "${entrypoint}" | sed 's/^\${//' | sort -u
+)
+((${#read_vars[@]})) || {
+  echo "FAIL: found no SERVE_* reads in ${entrypoint} — the detector is broken." >&2
+  exit 1
+}
+
+# Keys the compose file passes into the `preview` service's environment. Scoped to that service by
+# slicing from its `environment:` block to the next key at the same indent, so the rollout and hook
+# services' own environment blocks can't mask a missing `preview` one.
+mapfile -t passed_vars < <(
+  awk '
+    /^  preview:/                  { in_svc = 1; next }
+    in_svc && /^  [a-z]/           { in_svc = 0 }
+    in_svc && /^    environment:/  { in_env = 1; next }
+    in_env && /^    [a-z]/         { in_env = 0 }
+    in_env && /^      [A-Za-z0-9_]+:/ { key = $1; sub(/:$/, "", key); print key }
+  ' "${compose}" | sort -u
+)
+
+missing=()
+for v in "${read_vars[@]}"; do
+  exempt=0
+  for e in ${EXEMPT[@]+"${EXEMPT[@]}"}; do [[ "${e}" == "${v}" ]] && exempt=1; done
+  ((exempt)) && continue
+  found=0
+  for p in ${passed_vars[@]+"${passed_vars[@]}"}; do [[ "${p}" == "${v}" ]] && found=1; done
+  ((found)) || missing+=("${v}")
+done
+
+if ((${#missing[@]})); then
+  echo "FAIL: entrypoint.sh reads these variables, but docker-compose.yml's \`preview\` service" >&2
+  echo "      does not pass them into the container — so setting them in .env does nothing:" >&2
+  printf '        %s\n' "${missing[@]}" >&2
+  echo >&2
+  echo '  Fix: add `<VAR>: "${<VAR>:-}"` to the preview service'"'"'s environment: block,' >&2
+  echo "  or add it to EXEMPT in $(basename "${BASH_SOURCE[0]}") with a comment saying why." >&2
+  exit 1
+fi
+
+echo "PASS: all ${#read_vars[@]} SERVE_* variables read by entrypoint.sh are passed through"
+
+# Self-test the detector. A guard whose awk or grep silently stops matching would pass for every
+# input — a rubber stamp indistinguishable from a real pass. So prove it still rejects the exact
+# shape of the bug it was written for: a compose file with SERVE_PLAYGROUND removed.
+[[ -n "${PASSTHROUGH_GUARD_SELFTEST:-}" ]] && exit 0
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+grep -v '^      SERVE_PLAYGROUND:' "${compose}" > "${tmp}/docker-compose.yml"
+if PASSTHROUGH_GUARD_SELFTEST=1 \
+  COMPOSE_FILE_UNDER_TEST="${tmp}/docker-compose.yml" \
+  ENTRYPOINT_FILE="${entrypoint}" \
+  bash "${BASH_SOURCE[0]}" >/dev/null 2>&1; then
+  echo "FAIL: self-test — the guard accepted a compose file with SERVE_PLAYGROUND removed." >&2
+  echo "      The detector matches nothing; it would rubber-stamp any input." >&2
+  exit 1
+fi
+echo "PASS: self-test — a compose file missing a read variable is rejected"

--- a/deploy/image/test-compose-env-passthrough.sh
+++ b/deploy/image/test-compose-env-passthrough.sh
@@ -44,27 +44,54 @@ mapfile -t read_vars < <(
   exit 1
 }
 
-# Keys the compose file passes into the `preview` service's environment. Scoped to that service by
-# slicing from its `environment:` block to the next key at the same indent, so the rollout and hook
-# services' own environment blocks can't mask a missing `preview` one.
-mapfile -t passed_vars < <(
+# Mappings the compose file passes into the `preview` service's environment, as `KEY=<value>`.
+# Scoped to that service by slicing from its `environment:` block to the next key at the same
+# indent, so the rollout and hook services' own environment blocks can't mask a missing `preview`
+# one.
+#
+# The VALUE matters as much as the key. A mapping whose value is a constant, or which interpolates
+# the wrong host variable — `SERVE_PLAYGROUND: "${SERVE_PLAYGROUND_BUNDLE:-}"`, one copy-paste away
+# from the line above it — is present in the file and still leaves the knob inert, which is the very
+# failure this guard exists to catch. So each mapping must interpolate the variable of the same
+# name.
+declare -A mapped=()
+while IFS='=' read -r key value; do
+  [[ -n "${key}" ]] && mapped["${key}"]="${value}"
+done < <(
   awk '
     /^  preview:/                  { in_svc = 1; next }
     in_svc && /^  [a-z]/           { in_svc = 0 }
     in_svc && /^    environment:/  { in_env = 1; next }
     in_env && /^    [a-z]/         { in_env = 0 }
-    in_env && /^      [A-Za-z0-9_]+:/ { key = $1; sub(/:$/, "", key); print key }
-  ' "${compose}" | sort -u
+    in_env && /^      [A-Za-z0-9_]+:/ {
+      key = $1; sub(/:$/, "", key)
+      value = $0; sub(/^ *[A-Za-z0-9_]+: */, "", value)
+      print key "=" value
+    }
+  ' "${compose}"
+)
+
+# Values that are deliberately hardcoded rather than sourced from the host environment. Each needs a
+# reason: it is an assertion that the operator is MEANT to be unable to change this on a live box.
+declare -A CONSTANT_OK=(
+  # Pinned on: this box is always-on, so scale-to-zero idle exit must not be switchable per-host.
+  [SERVE_IDLE_EXIT]=1
 )
 
 missing=()
+miswired=()
 for v in "${read_vars[@]}"; do
   exempt=0
   for e in ${EXEMPT[@]+"${EXEMPT[@]}"}; do [[ "${e}" == "${v}" ]] && exempt=1; done
   ((exempt)) && continue
-  found=0
-  for p in ${passed_vars[@]+"${passed_vars[@]}"}; do [[ "${p}" == "${v}" ]] && found=1; done
-  ((found)) || missing+=("${v}")
+  if [[ -z "${mapped[${v}]+set}" ]]; then
+    missing+=("${v}")
+    continue
+  fi
+  [[ -n "${CONSTANT_OK[${v}]:-}" ]] && continue
+  # Accept ${VAR}, ${VAR:-…}, ${VAR:=…}, ${VAR:?…} — anything that reads the same-named host
+  # variable. Reject a bare constant or a reference to a different variable.
+  [[ "${mapped[${v}]}" =~ \$\{${v}[}:] ]] || miswired+=("${v} → ${mapped[${v}]}")
 done
 
 if ((${#missing[@]})); then
@@ -77,21 +104,52 @@ if ((${#missing[@]})); then
   exit 1
 fi
 
-echo "PASS: all ${#read_vars[@]} SERVE_* variables read by entrypoint.sh are passed through"
+if ((${#miswired[@]})); then
+  echo "FAIL: these variables are listed in docker-compose.yml's \`preview\` environment, but their" >&2
+  echo "      values do not read the same-named host variable — so .env still cannot set them:" >&2
+  printf '        %s\n' "${miswired[@]}" >&2
+  echo >&2
+  echo '  Fix: make the value `"${<VAR>:-}"` (matching name), or — if the constant is deliberate —' >&2
+  echo "  add it to CONSTANT_OK in $(basename "${BASH_SOURCE[0]}") with the reason." >&2
+  exit 1
+fi
+
+echo "PASS: all ${#read_vars[@]} SERVE_* variables read by entrypoint.sh are passed through, each" \
+  "reading its own host variable"
 
 # Self-test the detector. A guard whose awk or grep silently stops matching would pass for every
-# input — a rubber stamp indistinguishable from a real pass. So prove it still rejects the exact
-# shape of the bug it was written for: a compose file with SERVE_PLAYGROUND removed.
+# input — a rubber stamp indistinguishable from a real pass. So prove it still rejects each shape of
+# the bug it exists for, one mutation per shape.
 [[ -n "${PASSTHROUGH_GUARD_SELFTEST:-}" ]] && exit 0
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
-grep -v '^      SERVE_PLAYGROUND:' "${compose}" > "${tmp}/docker-compose.yml"
-if PASSTHROUGH_GUARD_SELFTEST=1 \
-  COMPOSE_FILE_UNDER_TEST="${tmp}/docker-compose.yml" \
-  ENTRYPOINT_FILE="${entrypoint}" \
-  bash "${BASH_SOURCE[0]}" >/dev/null 2>&1; then
-  echo "FAIL: self-test — the guard accepted a compose file with SERVE_PLAYGROUND removed." >&2
-  echo "      The detector matches nothing; it would rubber-stamp any input." >&2
-  exit 1
-fi
-echo "PASS: self-test — a compose file missing a read variable is rejected"
+
+# Each case: a description, and a sed/grep program that mutates the real compose file.
+selftest() {
+  local desc="$1" mutated="${tmp}/docker-compose.yml"
+  shift
+  "$@" < "${compose}" > "${mutated}"
+  if cmp -s "${compose}" "${mutated}"; then
+    echo "FAIL: self-test '${desc}' — the mutation changed nothing, so it proves nothing." >&2
+    echo "      (Did the line it targets get renamed?)" >&2
+    exit 1
+  fi
+  if PASSTHROUGH_GUARD_SELFTEST=1 \
+    COMPOSE_FILE_UNDER_TEST="${mutated}" \
+    ENTRYPOINT_FILE="${entrypoint}" \
+    bash "${BASH_SOURCE[0]}" >/dev/null 2>&1; then
+    echo "FAIL: self-test — the guard accepted a compose file where ${desc}." >&2
+    echo "      The detector does not catch that shape; it would rubber-stamp it in review." >&2
+    exit 1
+  fi
+  echo "PASS: self-test — rejected: ${desc}"
+}
+
+# The original bug: the key is absent entirely.
+selftest "SERVE_PLAYGROUND is missing" grep -v '^      SERVE_PLAYGROUND:'
+# The key is present but pinned to a constant, so .env cannot move it.
+selftest "SERVE_PLAYGROUND is hardcoded to a constant" \
+  sed 's|^      SERVE_PLAYGROUND: .*|      SERVE_PLAYGROUND: "0"|'
+# The key is present and interpolated, but from the WRONG host variable — the copy-paste slip.
+selftest "SERVE_PLAYGROUND reads a different host variable" \
+  sed 's|^      SERVE_PLAYGROUND: .*|      SERVE_PLAYGROUND: "${SERVE_PLAYGROUND_BUNDLE:-}"|'

--- a/deploy/image/test-compose-env-passthrough.sh
+++ b/deploy/image/test-compose-env-passthrough.sh
@@ -89,9 +89,17 @@ for v in "${read_vars[@]}"; do
     continue
   fi
   [[ -n "${CONSTANT_OK[${v}]:-}" ]] && continue
-  # Accept ${VAR}, ${VAR:-…}, ${VAR:=…}, ${VAR:?…} — anything that reads the same-named host
-  # variable. Reject a bare constant or a reference to a different variable.
-  [[ "${mapped[${v}]}" =~ \$\{${v}[}:] ]] || miswired+=("${v} → ${mapped[${v}]}")
+  # Accept ${VAR}, ${VAR:-…}, ${VAR:=…}, ${VAR:?…} — but the interpolation must be the WHOLE value,
+  # so the host's setting reaches the container unaltered. Anchoring is what rejects
+  # `"prefix-${SERVE_TIMEOUT:-}"`: a substring match would call that a pass, while `SERVE_TIMEOUT=60`
+  # would arrive as `prefix-60` and go to `--timeout` as garbage. A knob that is forwarded but
+  # mangled is no more usable than one that never arrives, which is the whole subject of this guard.
+  #
+  # The default text itself is unconstrained (`${VAR:-yschimke/compose-ai-tools}` is fine) except
+  # that it may not contain `}` — a nested interpolation is rejected rather than parsed, since it is
+  # both unused here and not something a regex should be trusted to read.
+  [[ "${mapped[${v}]}" =~ ^\"?\$\{${v}(:[-=?][^}]*)?\}\"?$ ]] ||
+    miswired+=("${v} → ${mapped[${v}]}")
 done
 
 if ((${#missing[@]})); then
@@ -153,3 +161,6 @@ selftest "SERVE_PLAYGROUND is hardcoded to a constant" \
 # The key is present and interpolated, but from the WRONG host variable — the copy-paste slip.
 selftest "SERVE_PLAYGROUND reads a different host variable" \
   sed 's|^      SERVE_PLAYGROUND: .*|      SERVE_PLAYGROUND: "${SERVE_PLAYGROUND_BUNDLE:-}"|'
+# The right variable, but wrapped — the host's value would reach the container mangled.
+selftest "SERVE_TIMEOUT interpolates its own variable but wraps it" \
+  sed 's|^      SERVE_TIMEOUT: .*|      SERVE_TIMEOUT: "prefix-${SERVE_TIMEOUT:-}"|'


### PR DESCRIPTION
Follow-up to #3550, which hid the playground handoff for catalogs `preview.coo.ee` can't compile. This is the other half — making it able to compile them.

## What was broken

#3550 concluded that enabling Android for real was "a deployment change, not a code one — the image needs `lib-daemon-android` + `ANDROID_HOME`, and `SERVE_PLAYGROUND=1` for the selector." Checking the image, that turned out to be wrong on both counts, in opposite directions.

**The image already has the Android bits.** The Dockerfile's `android-daemon` stage bakes the Robolectric sidecar at `/opt/lib-daemon-android` (pointed at by `-Dcomposeai.cli.libDaemonAndroidDir` in `JAVA_TOOL_OPTIONS`) and a minimal Android SDK at `/opt/android-sdk` (`ANDROID_HOME`) — because the Wear catalog's *live* tier needs exactly the same two things `buildPlaygroundAndroidDaemonOpener` looks for. Nothing was missing.

**`SERVE_PLAYGROUND=1` never reached the container.** `deploy/image/entrypoint.sh` honours it and `deploy/image/README.md` has documented it since the runtime catalog selector shipped, but `deploy/image/docker-compose.yml` never listed it in the `preview` service's `environment:` block — and Compose does not forward the host environment. An unlisted variable is simply absent, so the entrypoint's `[[ -n "${SERVE_PLAYGROUND:-}" ]]` guard read empty and skipped `--playground`. No error, no log line. An operator could set it in `.env` exactly as documented, restart, and get a box that behaved as though they hadn't touched it.

Current live state — the selector never came on, so one pinned catalog and one mode:

```
$ curl -s https://preview.coo.ee/status.json | jq .playground
  "modes": [ { "mode": "CMP", "source": "served catalog 'compose-m3'", "resolved": true } ],
  "catalogSelector": null,
```

…while that same box is already running Android-backend daemons for the live tier, including the catalog from #3550's bug report:

```
$ curl -s https://preview.coo.ee/status.json | jq '.runningServers[] | {id, backend, seatWeight}'
  { "id": "horologist", "backend": "android", "seatWeight": 2 }
  { "id": "jetchat",    "backend": "android", "seatWeight": 2 }
```

So the Robolectric path demonstrably works on that host today. Only the playground was locked out of it.

## What changed

**Forward the stranded variables.** `SERVE_PLAYGROUND` and `SERVE_PLAYGROUND_CATALOG_LIMIT`, plus the per-caller budget knobs that were stranded the same way (`SERVE_PLAYGROUND_RATE_LIMIT`, `SERVE_PLAYGROUND_CALLER_CONCURRENCY`, `SERVE_TRUST_FORWARDED_FOR`).

Auditing the whole file found ten more documented knobs with the identical defect, so they are forwarded too: the bundle- and document-upload lanes (`SERVE_ACCEPT_BUNDLES`/`_FROM`, `SERVE_ACCEPT_DOCS`/`_FROM`, `SERVE_DOC_TTL` — the document store is what the playground's Remote Compose mode publishes captures into), `SERVE_EXTRA_MAVEN_REPOS`, `SERVE_WASM_DIR`, `SERVE_TIMEOUT`, `SERVE_GITHUB_AUTH_SCOPE`, `SERVE_CATALOG_SOURCE_ROOT`.

Every addition uses the `${VAR:-}` empty default the file already uses throughout, and every consumer in the entrypoint reads it through `:-` or `:=`, so **behaviour is unchanged until an operator sets one**. Verified by parsing the result and checking each new key resolves to an empty default.

**Gate it so it can't drift again.** `deploy/image/test-compose-env-passthrough.sh` fails when `entrypoint.sh` reads a `SERVE_*` variable the `preview` service doesn't forward. Per review it checks the **value** as well as the key: a mapping that is present but inert — `SERVE_PLAYGROUND: "0"`, or the copy-paste slip `SERVE_PLAYGROUND: "${SERVE_PLAYGROUND_BUNDLE:-}"` one line off from its neighbour — leaves the knob just as unsettable, so each value must interpolate the same-named host variable. Deliberate constants are allowed but must be named in `CONSTANT_OK` with a reason, making each one a reviewable assertion rather than a silent hole (`SERVE_IDLE_EXIT: "0"` is the only one today).

It also self-tests its own detector against one mutation per failure shape — absent, constant, wrong variable — since a guard whose awk silently stopped matching would pass for every input, indistinguishable from a real pass. Each mutation asserts it actually changed the file first, so a renamed target line can't quietly degrade a case into a no-op. Wired into CI beside `test-env-migrations.sh`; `deploy/image/**` is already in the `actions_tests` path group, so it runs on this PR.

**Document the actual failure mode**, including the part that bites an existing box: updating `.env` is not enough, the compose file has to be at this revision or later. A stale clone is precisely how the knob stayed inert.

## What this does and doesn't do

It makes the Android playground *reachable* on this image. Turning it on is still an operator step — `SERVE_PLAYGROUND=1` in `.env`, `git pull`, `docker compose up -d` — and the repo has no path to that box's `.env` (`publish-preview-config.yml` reconciles `catalogs.json` / `producers.json` over the admin API, not host config).

Admission is unchanged: the selector decides which classpath a snippet compiles against, never who may compile. `preview.coo.ee` stays repo-access-gated behind GitHub sign-in.

Verify after the roll with the startup line `serve: playground enabled … android-render✓ catalog-selector✓(≤6)` in `docker compose logs preview`, and `playground.catalogSelector` on `/status.json` going non-null. Which catalogs get offered is whatever publishes a verified `liveBundle` with a backend this host renders — `offered` in that same object is the authority, rather than my guess at the list.

## Test plan

- `./deploy/image/test-compose-env-passthrough.sh` — passes: the real check (45 variables, each reading its own host variable) plus all three detector self-tests.
- Mutation-checked beyond the self-tests: removing `SERVE_ACCEPT_DOCS` from the compose file is caught and reported by name, as is pinning `SERVE_PLAYGROUND` to a constant.
- `./deploy/image/test-env-migrations.sh`, `./deploy/image/test-prewarm-fonts.sh` — still green.
- Compose file parses; each of the 15 playground/forwarded keys confirmed to carry the `${VAR:-}` empty default, so a box that sets none of them starts with an identical argv.

No visual surfaces are touched — this is deploy wiring, a shell test and docs.