### PR TITLE
docs(design-artifacts): replace the shard cost model with measured numbers

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -226,11 +226,16 @@ on:
           sorted, then round-robined), so there is no serial discover-then-fan-out prefix — and the
           merge cross-checks the shards' plans before trusting them.
 
-          What this buys, and what it does not: only the MARGINAL cost divides. Measured on
-          m3-catalog, `render_minutes ≈ 3.7 + 2.15s × previews`, and every shard pays the ~3.7 min of
-          Gradle configure + compile in full. So 4–6 is the useful range and 16 is buying compile
-          time, not throughput. At 1500 previews it takes the render from ~58 min (which blows a
-          40-minute `render-timeout`) to ~23 min end to end.
+          What this buys, and what it does not: only the MARGINAL cost divides. Re-measured on
+          m3-catalog after #3548 (issue #3559), a single-job render is
+          `render_seconds ≈ 100 + 0.39s × previews`, and a shard's own fixed cost — job prefix, its
+          own discovery, the render step's Gradle prologue — is ~150 s, plus a ~85 s merge tail.
+          The marginal term collapsed 6.5x (2.55s → 0.39s per preview) while the fixed term did not
+          move, so the useful range moved DOWN, not up: at ~1150 previews sharding buys ~3 min of
+          wall clock for three extra runners, and 1 is the right answer. It starts paying again
+          around 3000 previews and is necessary near 6000, where the serial render meets a 2400s
+          `render-timeout`. Measure before raising this; do not budget from the pre-#3548
+          `3.7 + 2.15s × previews` model, which is wrong in both terms.
 
           Reach for `modePriority` first where a catalog can: deferral makes the work smaller, which
           sharding then divides. The two compose.
@@ -287,8 +292,8 @@ jobs:
       # No checkout, no Gradle: this is `[1, 2, …, N]` and nothing else. The real partition is
       # computed inside each shard from its own discovery, which is what keeps the fan-out free of a
       # serial "discover once, then start the shards" prefix — that prefix would cost a full Gradle
-      # configure + compile (~3.7 min) before any shard began, which is the same fixed cost each
-      # shard pays anyway.
+      # configure + compile + discover (~87 s measured) before any shard began, which is the same
+      # fixed cost each shard pays anyway.
       - name: Build the shard matrix
         id: plan
         env:
@@ -297,7 +302,7 @@ jobs:
           set -euo pipefail
           echo "matrix=[$(seq -s, 1 "$SHARDS")]" >> "$GITHUB_OUTPUT"
 
-      # The merge runs LAST, after every shard has spent its ~20 minutes — so a CLI that predates
+      # The merge runs LAST, after every shard has spent its several minutes — so a CLI that predates
       # `bundle merge` would fail with "Unknown bundle subcommand" having burned the whole fan-out.
       # That is not a hypothetical: the documented default is `cli-source: released`, and
       # `cli-version: catalog` pins the CLI to the applied plugin version, which for any catalog that

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -629,19 +629,25 @@ pixels for a live path) and `render-shards` (which divides the work across jobs)
 
 ### Sharding the render across parallel jobs (`render-shards`)
 
-Raising `render-timeout` buys one more step and then stops. The render cost is close to linear —
-measured over four `m3-catalog` runs on `main`:
+Raising `render-timeout` buys one more step and then stops. The render cost is close to linear, and
+the coefficients were re-measured on CI after [#3548](https://github.com/yschimke/compose-ai-tools/pull/3548)
+made captures draw on a warm renderer instead of forking a JVM per preview (issue #3559). Both rows
+below are the same `m3-catalog` render step on `ubuntu-latest`, decomposed from the task timings the
+step prints:
 
-| Commit | Previews | Render step | Job total |
-| --- | --- | --- | --- |
-| `d354560` | 287 | 13.6 min | 17.2 min |
-| `323e4a2` | 519 | 22.5 min | 24.0 min |
-| `5edc70a` | 607 | 26.7 min | 29.6 min |
-| `f35c2e5` | 689 | 27.2 min | 28.9 min |
+| | fixed (configure + compile + discover + pack) | `composePreviewRender` | semantics capture | full sheet |
+| --- | --- | --- | --- | --- |
+| before #3548 (1095 previews) | 104 s | 2.38 s/preview | 0.17 s/preview | 2893 s |
+| after #3548 (1147 previews) | 100 s | 0.202 s/preview | 0.185 s/preview | 543 s |
 
-which fits `render_minutes ≈ 3.7 + 2.15s × previews`. At ~1500 previews that is ~58 min, past a
-40-minute `render-timeout`; at ~2400 it passes the 90-minute job timeout, and no number you can put
-in `render-timeout` helps.
+```
+render_seconds ≈ 100 + 0.39s × previews      (was ≈ 104 + 2.55s × previews)
+```
+
+Two things to read off that. The **fixed term did not move, and was never 3.7 min** — the older
+figure in this document conflated the whole render step with its prologue. And the surviving
+marginal cost is now roughly half semantics capture, which is daemon-driven and was never part of
+what #3548 addressed; there is no second 6x waiting in the render.
 
 `render-shards: N` splits the primary render across N jobs:
 
@@ -651,20 +657,30 @@ in `render-timeout` helps.
         └── shard N: …                          ┘
 ```
 
-**Only the marginal 2.15 s divides.** The ~3.7 min of Gradle configure + compile is paid by every
-shard in full, which is what caps the useful count:
+**Only the marginal 0.39 s divides**, and a shard's own fixed cost is ~150 s — job prefix ~25 s, its
+own `compose-preview list --json` discovery ~87 s (measured), the render step's Gradle prologue
+~20 s, upload and font-cache tail ~15 s — plus a ~85 s merge/generate/publish job. So
+`T ≈ 150 + 0.39 × previews/N + 85`, in minutes:
 
-| Previews | N=1 | N=4 | N=6 | N=8 |
-| --- | --- | --- | --- | --- |
-| 689 | 29.4 | 15.8 | 13.7 | 12.7 |
-| 1000 | 40.5 | 18.6 | 15.6 | 14.1 |
-| 1500 | 58.4 | 23.0 | 18.6 | 16.3 |
-| 2500 | 94.3 | 32.0 | 24.5 | 20.8 |
+| Previews | N=1 | N=2 | N=4 | N=6 | N=8 |
+| --- | --- | --- | --- | --- | --- |
+| 1147 (m3-catalog today) | **9.1** | 7.6 | 5.8 | 5.2 | 4.9 |
+| 2500 | 17.9 | 12.1 | 8.0 | 6.6 | 6.0 |
+| 5000 | 34.2 | 20.2 | 12.0 | 9.3 | 8.0 |
 
-(per-shard `1 min setup + 3.7 min compile + ~0.9 min discovery + 2.15s × previews/N`, plus a ~4 min
-merge/generate job). **4–6 is the range.** 6→8 at 1500 previews saves 2.3 min for two more runners;
-anyone reaching for 16 is buying compile time, not throughput. Sharding does not need to be perfect
-— it turns the worst case from impossible into ~25 min.
+**At today's size the answer is 1.** Sharding 1147 previews four ways buys ~3 min of wall clock for
+three extra runners and ~8 extra runner-minutes, while the serial render sits at under a quarter of
+its `render-timeout` — that is not a trade worth making, and it is the *opposite* of what the
+superseded model said (it recommended 4–6). Cheaper marginal work against an unchanged fixed cost
+moves the optimum down, not up. Sharding starts paying again around 3000 previews and becomes
+necessary near 6000, where a serial render meets a 2400 s `render-timeout`; the machinery stays
+wired and tested for that, because the pressure returns with the sheet.
+
+One caveat on the table: the ~85 s merge tail was measured on a run whose shards uploaded only a
+fraction of their renders (the pre-anchoring bug in
+[#3570](https://github.com/yschimke/compose-ai-tools/pull/3570)), so downloading and merging N full
+shard bundles will cost somewhat more. It makes sharding look slightly better than it is, which does
+not change the conclusion at 1147 previews.
 
 **How a shard renders only its share.** `bundle pack --exclude-preview-id` leaves the excluded
 previews *listed in the bundle*, just without a baked PNG — the same mechanism render-priority

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -1,18 +1,41 @@
 /**
  * Partition a catalog's discovered preview ids across N parallel render shards.
  *
- * The design-artifacts render is one serial `bundle pack`, and it used to grow linearly with the
- * preview count: measured on m3-catalog, `render_minutes ≈ 3.7 + 2.15s × previews`. Past ~1500
- * previews that blew `render-timeout`, and past ~2400 the job timeout — so the marginal 2.15s had to
- * be divided across jobs. This module decides who renders what.
+ * The design-artifacts render is one serial `bundle pack`, and it grows linearly with the preview
+ * count. This module decides who renders what when that is split across jobs.
  *
- * **That cost model is superseded and the shard count derived from it is not currently trusted.**
- * Captures now draw on a warm renderer rather than forking a JVM each time (#3548), which collapsed
- * the marginal term and left the ~3.7 min fixed configure + compile that every shard pays in full
- * untouched. Cheaper marginal work with unchanged fixed cost moves the optimum *down*, so the old
- * "six, not sixteen" conclusion no longer follows from anything measured. #3559 tracks re-measuring
- * it. Nothing here assumes a particular count — the partition is correct at any N — but do not read
- * the arithmetic above as current guidance.
+ * **The cost model, re-measured on CI after #3548 (issue #3559).** Both terms come from the same
+ * m3-catalog job on `ubuntu-latest`, read off the render step's own task timings:
+ *
+ *   render_seconds ≈ 100 + 0.39 × previews          (one job, no sharding)
+ *
+ * against `≈ 104 + 2.55 × previews` before #3548 — same catalog, same runner, four weeks of growth
+ * apart. What moved is only the marginal term, and only part of it:
+ *
+ *   term                     before #3548        after #3548
+ *   fixed (configure+compile   104 s               100 s        ← unchanged, and never was 3.7 min
+ *     + discover + pack)
+ *   composePreviewRender       2.38 s/preview      0.202 s/preview   ← the warm renderer, 12x
+ *   semantics capture          0.17 s/preview      0.185 s/preview   ← daemon-driven, untouched
+ *
+ * so m3-catalog's full sheet went from 2893 s to 543 s (1095 → 1147 previews). The marginal term is
+ * now barely twice the semantics pass that #3548 never touched, which is the real ceiling on any
+ * further win here.
+ *
+ * **What that means for the shard count.** A shard's fixed cost is its own job prefix (~25 s) plus
+ * its own `compose-preview list --json` discovery (~87 s: configure + compile + discover) plus the
+ * render step's Gradle prologue (~20 s) and its upload/cache tail (~15 s) — about **150 s**, again
+ * not 3.7 min. So `T_shard ≈ 150 s + 0.39 s × previews/N`, plus a ~85 s merge/generate/publish tail.
+ * At m3-catalog's 1147 previews that is 9.1 min serial against 5.8 min at N=4 — three minutes of
+ * wall clock for three extra runners, with the serial render sitting at a fifth of its
+ * `render-timeout`. **The optimum moved down, exactly as cheaper marginal work with an unchanged
+ * fixed cost predicts, and at this size it moved below 2: the catalog ships `render-shards: 1`.**
+ * Sharding starts paying again around 3000 previews, and becomes necessary near 6000, where the
+ * serial render meets a 2400 s `render-timeout`.
+ *
+ * Nothing here assumes a particular count — the partition is correct at any N — and the machinery
+ * stays because the pressure that motivated it returns with the sheet, not because it is switched
+ * on today.
  *
  * The mechanism is exclusion, not selection: each shard runs the SAME `bundle pack` with
  * `--exclude-preview-id <everything that isn't mine>`, which is documented to leave the excluded


### PR DESCRIPTION
Closes #3559. #3570 made sharding safe; this says what it is now worth.

## The measurement

`render_minutes ≈ 3.7 + 2.15s × previews` was fitted when every capture forked a JVM. #3548 ended that, so both terms were re-measured on CI — same catalog (m3-catalog), same runner, decomposed from the task timings the render step itself prints:

| | fixed (configure + compile + discover + pack) | `composePreviewRender` | semantics capture | full sheet |
|---|---|---|---|---|
| before #3548 — 1095 previews, [run 31192651935](https://github.com/yschimke/m3-catalog/actions/runs/31192651935) | 104 s | 2603 s → **2.38 s/preview** | 186 s → 0.17 s/preview | **2893 s** |
| after #3548 — 1147 previews, [run 31282283505](https://github.com/yschimke/m3-catalog/actions/runs/31282283505) | 100 s | 232 s → **0.202 s/preview** | 211 s → 0.185 s/preview | **543 s** |

```
render_seconds ≈ 100 + 0.39s × previews        (was ≈ 104 + 2.55s × previews)
```

Two sibling runs agree with the second row (568 s, 548 s for the same step).

**Both terms of the old model were wrong.** The marginal cost fell 6.5×. The fixed cost never moved — and was never 3.7 min: the old fit read the whole render step as if it were prologue. What survives of the marginal term is now roughly half semantics capture, which is daemon-driven and was never what #3548 addressed, so there is no second 6× waiting in the render.

## What it means for the count

A shard's own fixed cost, measured on the six-shard run [31245536104](https://github.com/yschimke/m3-catalog/actions/runs/31245536104) — its *render* durations are meaningless (that run is the bug #3570 fixed) but its fixed steps are real: job prefix ~25 s + its own `Discover previews` step **87 s** + the render step's Gradle prologue ~20 s + upload/cache ~15 s ≈ **150 s**, plus a ~85 s merge/generate/publish job.

`T ≈ 150s + 0.39s × previews/N + 85s`, in minutes:

| Previews | N=1 | N=2 | N=4 | N=6 | N=8 |
|---|---|---|---|---|---|
| 1147 (m3-catalog today) | **9.1** | 7.6 | 5.8 | 5.2 | 4.9 |
| 2500 | 17.9 | 12.1 | 8.0 | 6.6 | 6.0 |
| 5000 | 34.2 | 20.2 | 12.0 | 9.3 | 8.0 |

**The optimum moved down, and at today's size below 2** — which is what cheaper marginal work against an unchanged fixed cost always does. Sharding 1147 previews four ways buys ~3 min of wall clock for three extra runners and ~8 extra runner-minutes, while the serial render sits at under a quarter of its `render-timeout`. The old model's "4–6 is the range" is the opposite of the answer.

Thresholds to raise it again: sharding starts paying around **3000** previews, and is necessary near **6000**, where a serial render meets a 2400 s `render-timeout`. The machinery stays wired and tested for that.

## Changed

Three places quoted the superseded model; all three now carry the measured one:

- `scripts/design-artifacts/shard-preview-ids.mjs` — the header block #3570 marked "superseded, #3559 tracks re-measuring it" now has the numbers.
- `.github/workflows/design-artifacts-reusable.yml` — the `render-shards` input description, plus two stale asides (`~3.7 min` for a central plan job → the measured ~87 s discovery; "every shard has spent its ~20 minutes").
- `docs/design/DESIGN_CATALOGS.md` — the sharding section's fit, projection table and range guidance.

The companion change to the catalog that actually sets the count is yschimke/m3-catalog#36.

## Caveat, stated in the docs too

The ~85 s merge tail was measured on a run whose shards uploaded only a fraction of their renders, so merging N *full* bundles costs more. That biases the table in sharding's favour, which does not change the conclusion at 1147 previews. Shard balance on a real sheet has still never been measured — the only sharded run this catalog took was the buggy one.

## Test plan

```
cd scripts/design-artifacts && node --test
```

**580 tests, 555 pass, 21 skip, 4 fail — all 4 pre-existing** (`catalog-themes`, `package-version`, `rc-compare-pixels`, `rc-size-modifier`: `Cannot find package '@design-parity/catalog-export'` / `'pngjs'`, i.e. they need `npm ci`). No logic changed here — the `.mjs` diff is its header comment.

Both workflow files parse as YAML.

No visual surface changes: comments, docs and one workflow input description.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk2xtVbDfuqQP2Bkzdndz9)_