### PR TITLE
fix(figma-svg): tighten the paint-box capture and the raster-text rule

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1248,12 +1248,19 @@ internal object ComposeLayoutInspector {
           )
           // The box the fill/ring modifier drew into, measured off its own coordinator in the same
           // root space as `placedBounds` — the direct answer to the question `paintInset` and the
-          // measured-size growth heuristic can only estimate (issue #3572). Taken from the FIRST
-          // such modifier: the resolver reads its colour/shape the same way, so shape and box come
-          // from one modifier rather than two.
+          // measured-size growth heuristic can only estimate (issue #3572).
+          //
+          // The FILL's modifier is preferred over a ring's, matching the precedence the resolver
+          // itself uses: one box cannot describe both when a chain pads between them, and the fill
+          // is the layer's dominant paint (a ring that resolves fully transparent is dropped by the
+          // renderer outright, so taking its outer box would stretch a visible background over a
+          // region nothing painted). A ring-only node — an `OutlinedCard`, a divider — still gets
+          // its own box from the `border`.
           ?.let { resolved ->
-            modifiers
-              .firstOrNull { ModifierTokenResolver.paintsContainer(it.modifier) }
+            val paint =
+              modifiers.firstOrNull { ModifierTokenResolver.fillsContainer(it.modifier) }
+                ?: modifiers.firstOrNull { ModifierTokenResolver.ringsContainer(it.modifier) }
+            paint
               ?.coordinates
               ?.boundsIn(rootCoords)
               ?.takeIf { it.right > it.left && it.bottom > it.top }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -167,7 +167,16 @@ internal object ModifierTokenResolver {
           }
         }
       }
-      if (name == "padding" || simpleName.startsWith("PaddingElement")) {
+      // `PaddingValuesElement` is the `Modifier.padding(PaddingValues)` overload — a different
+      // class
+      // from the per-edge `PaddingElement`, so the class arm has to name it too or the reflection
+      // fallback in [paddingInsets] is unreachable on any build that leaves `nameFallback` null
+      // (desktop/skiko), which is exactly where the fallback matters (issue #3573).
+      if (
+        name == "padding" ||
+          simpleName.startsWith("PaddingElement") ||
+          simpleName.startsWith("PaddingValuesElement")
+      ) {
         val insets = paddingInsets(mod, elements, inspectable?.valueOverride)
         if (padding == null) padding = insets
         // Leading padding (before any paint modifier) insets the drawn shape; record the first one
@@ -355,15 +364,22 @@ internal object ModifierTokenResolver {
    * Matched on both the inspector name and the element class, like every other lookup here — the
    * desktop/skiko build doesn't always populate inspector info.
    */
-  fun paintsContainer(modifier: Any): Boolean {
+  fun paintsContainer(modifier: Any): Boolean = fillsContainer(modifier) || ringsContainer(modifier)
+
+  /** The fill half of [paintsContainer] — `Modifier.background` / `Modifier.paint`. */
+  fun fillsContainer(modifier: Any): Boolean {
     val name = (modifier as? InspectableValue)?.nameFallback
     val simpleName = modifier.javaClass.simpleName
     return name == "background" ||
       simpleName == "BackgroundElement" ||
       name == "paint" ||
-      simpleName == "PainterElement" ||
-      name == "border" ||
-      simpleName.startsWith("BorderModifier")
+      simpleName == "PainterElement"
+  }
+
+  /** The ring half of [paintsContainer] — `Modifier.border`. */
+  fun ringsContainer(modifier: Any): Boolean {
+    val name = (modifier as? InspectableValue)?.nameFallback
+    return name == "border" || modifier.javaClass.simpleName.startsWith("BorderModifier")
   }
 
   internal fun appliedClipsContent(coordinates: Any): Boolean =

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -1542,10 +1542,26 @@ data class FigmaSvgModel(
      */
     private fun FigmaSvgLayer.rasterCovers(left: Int, top: Int, right: Int, bottom: Int): Boolean =
       (raster != null &&
+        // A raster the emitter then hides or trims does not stand in for the text it baked in.
+        // Faded to nothing, or masked to less than the box, it must leave the live text alone —
+        // otherwise the glyphs end up in neither the pixels nor the `<text>`.
+        opacity > 0.0 &&
+        contentOpacity > 0.0 &&
+        clipBox.covers(left, top, right, bottom) &&
         this.left <= left &&
         this.top <= top &&
         this.right >= right &&
         this.bottom >= bottom) || children.any { it.rasterCovers(left, top, right, bottom) }
+
+    /** Whether this mask (null = unmasked) leaves the given box entirely visible. */
+    private fun LayoutInspectorBounds?.covers(
+      left: Int,
+      top: Int,
+      right: Int,
+      bottom: Int,
+    ): Boolean =
+      this == null ||
+        (this.left <= left && this.top <= top && this.right >= right && this.bottom >= bottom)
 
     /**
      * Editable-text fallback for a Compose Text whose semantics were intentionally cleared.


### PR DESCRIPTION
Follow-up to #3580. Codex left three P2s on it and the PR merged before they landed, so they come as a fresh branch off `main` rather than commits on merged history. All three are real; each is a few lines.

## 1. `PaddingValuesElement` was unreachable without inspector metadata

#3580 taught `paddingInsets` to read a `PaddingValues`, but the caller gates on `name == "padding" || simpleName.startsWith("PaddingElement")`. `Modifier.padding(PaddingValues)` lowers to `PaddingValuesElement` — a different class — so on any build that leaves `nameFallback` null the reflection was never reached. That is precisely the desktop/skiko case the reflection fallback exists for; Robolectric populates the name, which is why the Wear tests passed either way. The class arm now names it.

## 2. `paintBox` could take a ring's box for a fill's token

The capture took the first `background`/`paint`/`border` entry. One box cannot describe both when a chain pads between them, and a fully transparent ring is dropped by the renderer outright (`takeIf { it.opacity > 0.0 }`) — so `border(transparent).padding(…).background(visible)` attached the border's outer box to a background that never painted there, and `paintBox` being authoritative made that stretch stick.

The fill's modifier now wins, matching the precedence the resolver itself uses when it reads the colour. A ring-only node — an `OutlinedCard`, a divider — still gets its box from the `border`.

## 3. The descendant-raster text rule ignored visibility

`rasterCovers` was pure geometry, so a raster faded to nothing (`opacity`/`contentOpacity` at 0) or masked by a `clipBox` smaller than the box it claims to cover still suppressed the ancestor's live text — leaving those glyphs in neither the pixels nor the `<text>`. It now requires the raster to actually be visible and unmasked over that box.

## Test plan

- `./gradlew :renderer-android:testDebugUnitTest :data-layoutinspector-core:test :data-layoutinspector-connector:test ktfmtCheckAll` — green on top of merged `main`.
- The three behaviour tests from #3580 (`FigmaSvgWearCompactButtonRenderTest`, `FigmaSvgRasterizedTextFieldRenderTest`, `FigmaSvgGradientPaintGrowthRenderTest`) still pass, so the paint-box results they pin are unchanged.

No visual evidence: none of the three changes the output of any preview the catalogs currently contain — that is what makes them hardening rather than fixes. #1 only fires on a backend Robolectric doesn't exercise, and #2 and #3 both narrow conditions that no current catalog node meets (the transparent-ring-then-padding chain and a zero-opacity covering raster). The catalog before/after for the behaviour this builds on is in `renders/figma-svg-fidelity/`, landed with #3580.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XrscSvCccWovuNg44XxmRm)_