### PR TITLE
ci(design-artifacts): default the two embedded rc-compare lanes on

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -128,17 +128,17 @@ on:
         type: boolean
         default: false
       rc-embedded-lane:
-        description: "Add the embedded-player lane to rc-compare.html, making it a three-way page: baked PNG vs the vendored TypeScript RcdPlayer vs AndroidX's Compose-embedded RcPlayer. Off by default because it is the only part of this workflow that needs a Gradle/Android toolchain — it stages the bundle's ir/*.rc, renders them through :third-party-rc-embedded-player (Robolectric), and diffs the result. Requires an Android SDK on the runner; a runner without one (or a harness failure) degrades to the usual two-lane page rather than failing the render. No-op for a catalog that ships no ir/*.rc."
+        description: "Add the embedded-player lane to rc-compare.html, making it a three-way page: baked PNG vs the vendored TypeScript RcdPlayer vs AndroidX's Compose-embedded RcPlayer. ON by default: scoring the same document through two players is what makes a divergence attributable — a row where only the JS player is off is a JS-player bug, one where only the embedded player is off is an embedded-player bug — and a catalog that ships ir/*.rc should get that for free rather than by remembering an input. It stages the bundle's ir/*.rc, renders them through :third-party-rc-embedded-player (Robolectric), and diffs the result; it needs a Gradle/Android toolchain, and a runner without one (or a harness failure) degrades to the usual two-lane page rather than failing the render. Entirely skipped — no Gradle, no Chromium — for a catalog that ships no ir/*.rc. Set false to keep the page two-lane, e.g. on a runner where the extra Gradle build is not worth its minutes."
         required: false
         type: boolean
-        default: false
+        default: true
       rc-embedded-jvm-lane:
-        description: "Add the cmp-jvm desktop-player lane to rc-compare.html — one extra compact column (render + folded diff) rendering the bundle's ir/*.rc through :third-party-rc-embedded-player-jvm (Compose Desktop / Skiko, offscreen). Independent of rc-embedded-lane: either or both can run, and staging happens once for whichever is on. Needs libGL + xvfb (installed by the desktop-render deps step, which also fires on this input). Same tolerance as the Robolectric lane: a harness failure or empty output degrades to a page without the cmp-jvm column rather than failing the render. No-op for a catalog that ships no ir/*.rc."
+        description: "Add the cmp-jvm desktop-player lane to rc-compare.html — one extra compact column (render + folded diff) rendering the bundle's ir/*.rc through :third-party-rc-embedded-player-jvm (Compose Desktop / Skiko, offscreen). ON by default, for the same attribution reason as rc-embedded-lane, and because it exercises the platform-neutral draw path off Android: a jvm-only divergence points at the desktop seam (text/image/skiko) rather than the shared evaluator. Independent of rc-embedded-lane: either or both can run, and staging happens once for whichever is on. Needs libGL + xvfb, installed just-in-time by the rc-compare step once the bundle is known to carry ir/*.rc. Same tolerance as the Robolectric lane: a harness failure or empty output degrades to a page without the cmp-jvm column rather than failing the render. Entirely skipped for a catalog that ships no ir/*.rc."
         required: false
         type: boolean
-        default: false
+        default: true
       rc-cmp-wasm-lane:
-        description: "Add the required CMP/Wasm player lane to rc-compare.html. When enabled, its distribution must build and every ir/*.rc must render unless named in rc-cmp-wasm-allowlist. Evidence is uploaded before a failed gate stops publication. No-op for a catalog that ships no ir/*.rc."
+        description: "Add the required CMP/Wasm player lane to rc-compare.html. When enabled, its distribution must build and every ir/*.rc must render unless named in rc-cmp-wasm-allowlist. Evidence is uploaded before a failed gate stops publication. No-op for a catalog that ships no ir/*.rc. Stays OFF by default — unlike the two embedded lanes, this one is a gate rather than enrichment: a document the Wasm player cannot draw, or one that misses the first-frame budgets, fails the step and the catalog does not publish. Opt in per catalog once you know what its documents do in that player."
         required: false
         type: boolean
         default: false
@@ -783,10 +783,15 @@ jobs:
           fc-cache -f "$HOME/.local/share/fonts" >/dev/null
 
       # CMP desktop (Skiko) links libGL; install Mesa's software GL + a font stack.
-      # Also needed by the rc-compare cmp-jvm lane, whose player is the same Skiko stack
-      # even when the primary render is Android/Robolectric (remote-m3: desktop-render=false).
+      # The rc-compare cmp-jvm lane needs the same stack — its player IS this Skiko stack
+      # even when the primary render is Android/Robolectric (remote-m3: desktop-render=false)
+      # — but it installs its own copy just-in-time instead of firing this step, because
+      # `rc-embedded-jvm-lane` now defaults to true and this step runs before the render:
+      # gating on the input here would charge an apt round-trip to every caller, including
+      # the catalogs (compose-m3, wear-m3) whose bundles carry no ir/*.rc and skip the lane
+      # entirely. By the time rc-compare runs, the bundle is built and the answer is known.
       - name: Install desktop (Skiko) render deps
-        if: ${{ inputs.desktop-render || inputs.rc-embedded-jvm-lane }}
+        if: ${{ inputs.desktop-render }}
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq --no-install-recommends \
@@ -1226,9 +1231,18 @@ jobs:
           fi
 
           # cmp-jvm (Compose Desktop / Skiko) embedded lane. Same three moves, different harness:
-          # the jvm player links libGL and draws offscreen, so its Gradle test runs under xvfb-run
-          # (libGL + xvfb come from the desktop-render deps step, which fires on this input too).
+          # the jvm player links libGL and draws offscreen, so its Gradle test runs under xvfb-run.
+          # The deps are installed here rather than by the desktop-render step above: that step runs
+          # long before the bundle exists, so with this lane defaulting to true it would charge an
+          # apt round-trip to every caller, including the ones whose bundles carry no ir/*.rc and
+          # exit this step at its first check. Guarded on xvfb-run, so a desktop-render caller --
+          # which already installed the same stack -- doesn't pay for it twice.
           if [ "${{ inputs.rc-embedded-jvm-lane }}" = "true" ]; then
+            if ! command -v xvfb-run >/dev/null 2>&1; then
+              sudo apt-get update -qq
+              sudo apt-get install -y -qq --no-install-recommends \
+                xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig
+            fi
             RC_JVM_OUT="$RUNNER_TEMP/rc-embedded-jvm-out"
             rm -rf "$RC_JVM_OUT"
             if (cd "$GITHUB_WORKSPACE/compose-ai-tools" && \

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1238,10 +1238,18 @@ jobs:
           # exit this step at its first check. Guarded on xvfb-run, so a desktop-render caller --
           # which already installed the same stack -- doesn't pay for it twice.
           if [ "${{ inputs.rc-embedded-jvm-lane }}" = "true" ]; then
-            if ! command -v xvfb-run >/dev/null 2>&1; then
-              sudo apt-get update -qq
-              sudo apt-get install -y -qq --no-install-recommends \
-                xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig
+            # Fail-soft, and it has to be spelled this way. The step runs under `set -e` and is only
+            # `continue-on-error` in the cmp-wasm configuration, so a bare `apt-get` here would take
+            # the whole step down — skipping the publish — on a runner where the install can't work:
+            # a non-Debian `runs-on` (a caller input), or a transient apt outage. Both are exactly
+            # the "runner can't host this lane" case the harness below already degrades on, so they
+            # degrade the same way. Wrapped in the `if` condition, where `set -e` does not fire; if
+            # xvfb-run is still missing afterwards the Gradle invocation fails and the else branch
+            # drops the column, which is the intended end state either way.
+            if ! command -v xvfb-run >/dev/null 2>&1 \
+               && ! (sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends \
+                       xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig); then
+              echo "::warning::could not install libGL/xvfb; the cmp-jvm lane will degrade to a missing column"
             fi
             RC_JVM_OUT="$RUNNER_TEMP/rc-embedded-jvm-out"
             rm -rf "$RC_JVM_OUT"

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -628,20 +628,16 @@ jobs:
       publish-live-bundle: true
       split-per-preview: true
       split-mode: full
-      # The only catalog here that ships `ir/<id>.rc`, and it already builds Android — so this is
-      # where the third rc-compare lane costs least and says most. Scoring the same document
-      # through both players is what makes a divergence attributable: a row where only the JS
-      # player is off is a JS-player bug, one where only the embedded player is off is an
-      # embedded-player bug. This catalog currently contains both kinds.
-      rc-embedded-lane: true
-      # And the cmp-jvm (Compose Desktop / Skiko) player, as one extra compact column: the desktop
-      # half of the embedded player rasterizing the same staged documents. Same attribution win as
-      # the Robolectric lane, and it exercises the platform-neutral draw path off Android — a jvm-only
-      # divergence points at the desktop seam (text/image/skiko) rather than the shared evaluator.
-      rc-embedded-jvm-lane: true
+      # The embedded (Robolectric) and cmp-jvm (Compose Desktop / Skiko) rc-compare lanes used to be
+      # spelled out here; they now default to true in the reusable workflow, so every catalog that
+      # ships `ir/<id>.rc` gets them — the rationale (a divergence is only attributable when the same
+      # document is scored through more than one player) never was remote-m3-specific.
+      #
       # The CMP/Wasm implementation under development in #3201, rendered in the same browser
       # environment visitors use. This gives it an immediate per-document parity signal beside
-      # the established JS, Android embedded, and cmp-jvm lanes.
+      # the established JS, Android embedded, and cmp-jvm lanes. Still opt-in, and deliberately so:
+      # it is a gate, not enrichment — a document it cannot draw fails the render rather than
+      # dropping a column — so it stays where someone is watching the result.
       rc-cmp-wasm-lane: true
     secrets:
       buildfetch_ro_token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}

--- a/docs/design/evidence/rc-compare-cmp-jvm-lane/README.md
+++ b/docs/design/evidence/rc-compare-cmp-jvm-lane/README.md
@@ -1,6 +1,6 @@
 # rc-compare — the cmp-jvm desktop-player lane in CI
 
-Evidence for `rc-embedded-jvm-lane`, the opt-in input that adds a **fourth** lane to the published
+Evidence for `rc-embedded-jvm-lane`, the input that adds a **fourth** lane to the published
 `rc-compare.html`: the same captured `ir/*.rc` document rendered through the Compose Desktop / Skiko
 embedded player (`:third-party-rc-embedded-player-jvm`), beside the baked PNG, the vendored
 TypeScript `RcdPlayer`, and AndroidX's Compose-embedded `RcPlayer`.
@@ -8,8 +8,14 @@ TypeScript `RcdPlayer`, and AndroidX's Compose-embedded `RcPlayer`.
 It rides on the machinery the Robolectric lane already introduced. `--stage-embedded` now runs once
 if *either* lane is on and writes the `<id>.rc` + `manifest.json` both harnesses read; the jvm
 harness fills `rc.jvm.output`, and `rc-compare.mjs --embedded-jvm` reads it back. The jvm player
-links libGL and draws offscreen, so its Gradle test runs under `xvfb-run` with the libGL the
-`desktop-render` deps step installs (that step now also fires on this input).
+links libGL and draws offscreen, so its Gradle test runs under `xvfb-run`.
+
+> Two things changed after this evidence was captured. The input now defaults to **true**, so a
+> catalog shipping `ir/*.rc` gets the cmp-jvm column without opting in. And libGL/xvfb are no longer
+> installed by the `desktop-render` deps step: that step runs long before the bundle exists, so
+> firing it on a default-true input would charge an apt round-trip to every caller, including the
+> catalogs that carry no `ir/*.rc` and skip the lane. The `rc-compare` step installs them itself,
+> just-in-time, guarded on `command -v xvfb-run` so a `desktop-render` caller doesn't pay twice.
 
 ## Produced by running exactly what the workflow runs — against the real remote-m3 bundle
 

--- a/docs/design/evidence/rc-compare-embedded-lane/README.md
+++ b/docs/design/evidence/rc-compare-embedded-lane/README.md
@@ -1,8 +1,13 @@
 # rc-compare — the embedded-player lane in CI
 
-Evidence for `rc-embedded-lane`, the opt-in input that turns the published `rc-compare.html` into a
+Evidence for `rc-embedded-lane`, the input that turns the published `rc-compare.html` into a
 three-way page: baked PNG vs the vendored TypeScript `RcdPlayer` vs AndroidX's Compose-embedded
 `RcPlayer`.
+
+> The lane landed opt-in (`default: false`) and was enabled per catalog. It now defaults to **true**,
+> so any catalog whose bundle carries `ir/*.rc` gets the third lane without asking — the attribution
+> argument below is a property of the page, not of `remote-m3`. Catalogs with no `ir/*.rc` still skip
+> the whole step, and a runner without an Android toolchain still degrades to the two-lane page.
 
 The driver has supported `--stage-embedded` / `--embedded` since the lane was vendored, but nothing
 ran them — `design-artifacts-reusable.yml` invoked `rc-compare.mjs` with neither, so every published


### PR DESCRIPTION
## Summary

`/homeassistant-remotecompose/compare?format=rc` serves **one** player; `/remote-m3/compare?format=rc` serves **four**. That is not a bug in the page or the catalog — it is an unset input.

`rc-compare.html` always renders two lanes: the baked PNG and the vendored TypeScript `RcdPlayer`. The other two — embedded (Robolectric) and cmp-jvm (Compose Desktop / Skiko) — were `workflow_call` inputs defaulting to `false`, and `remote-m3` was the only caller that ever set them. Every other catalog shipping `ir/*.rc` silently got the two-lane page.

The argument for those lanes is a property of the page, not of `remote-m3`: **a divergence is only attributable when the same document is scored through more than one player.** A row where only the JS player is off is a JS-player bug; one where only the embedded player is off is an embedded-player bug. Any catalog carrying `ir/*.rc` wants that, so:

- `rc-embedded-lane` → `default: true`
- `rc-embedded-jvm-lane` → `default: true`
- `remote-m3` stops restating what is now the default (its rationale moved into the input descriptions)

`rc-cmp-wasm-lane` **deliberately stays off**. Unlike the two above it is a gate, not enrichment: a document it cannot draw, or one that misses the cold/warm first-frame budgets, fails the step and the catalog does not publish. That belongs where someone is watching the result.

### The one cost this had to fix first

The lanes are free where they do not apply — the `rc-compare` step inspects `bundle.png` and exits before Gradle or Chromium when there is no `ir/*.rc`. One thing sat outside that check: the libGL/xvfb apt install fired on `inputs.rc-embedded-jvm-lane`, from a step that runs *long before the bundle exists*. Flipping the default would have charged that round-trip to every caller, including `compose-m3` and `wear-m3`, which never reach the lane.

It now installs just-in-time inside `rc-compare` — past the `ir/*.rc` check, guarded on `command -v xvfb-run` so a `desktop-render` caller (which already has the same stack) doesn't pay twice. The standalone step keeps firing on `inputs.desktop-render` alone, where it is still needed before the render.

## Blast radius

| caller | ships `ir/*.rc`? | effect |
|---|---|---|
| `remote-m3` (this repo) | yes | none — already ran all four lanes |
| `wear-m3` (this repo) | no | none — step exits at the bundle check |
| `compose-m3` (this repo) | n/a | none — inline job, does not use the reusable workflow |
| `homeassistant-remotecompose` | **yes** | gains the embedded + cmp-jvm columns ([companion PR](https://github.com/yschimke/homeassistant-remotecompose/pull/547) raises its job timeout) |

## Visual evidence

This changes which columns a CI-produced page carries. The page is rendered by the workflow against a real catalog bundle — it cannot be produced in this container (no Android/Skiko toolchain, and Chromium's egress to `preview.coo.ee` is reset by this session's proxy, so the live pages can't be screenshotted here either). What the diff makes default is exactly the output already captured in this repo's evidence dirs, so those are the pixels:

**Before — two lanes** is what every non-`remote-m3` catalog gets today: baked PNG + `RC · JS player`, which is the one-player page reported on `/homeassistant-remotecompose/compare`.

**After — `rc-embedded-lane` adds the third lane** (baked PNG · JS player · embedded `RcPlayer`):

![rc-compare with the embedded lane](https://raw.githubusercontent.com/yschimke/compose-ai-tools/588439ce134963ce05d81c74ad009ed929071156/docs/design/evidence/rc-compare-embedded-lane/rc-compare-three-lane.png)

**After — `rc-embedded-jvm-lane` adds the fourth**, as one extra compact column (render + folded diff):

![rc-compare four-lane, compact](https://raw.githubusercontent.com/yschimke/compose-ai-tools/588439ce134963ce05d81c74ad009ed929071156/docs/design/evidence/rc-compare-cmp-jvm-lane/rc-compare-four-lane-compact.png)

Expanded, the same page with each lane's diff open:

![rc-compare four-lane, expanded](https://raw.githubusercontent.com/yschimke/compose-ai-tools/588439ce134963ce05d81c74ad009ed929071156/docs/design/evidence/rc-compare-cmp-jvm-lane/rc-compare-four-lane-expanded.png)

The end-to-end confirmation is the next published `/homeassistant-remotecompose/compare?format=rc`, which should go from one player to three.

## Test plan

- `.github/workflows/design-artifacts-reusable.yml` and `design-artifacts.yml` parse as YAML; the `rc-compare` step's `run:` script passes `bash -n`.
- Input defaults assert as expected: `rc-embedded-lane=true`, `rc-embedded-jvm-lane=true`, `rc-cmp-wasm-lane=false`, `desktop-render=false`.
- No `.mjs` under `scripts/design-artifacts/` changed, so the driver's own suites (`rc-compare-*.test.mjs`, `render-rc-compare-html.test.mjs`) are untouched — CI runs them regardless.
- Real check is the next `design-artifacts` run: `remote-m3` must still publish a four-lane page (proving the moved apt install feeds `xvfb-run`), and `wear-m3` must be unchanged.
- Docs updated: both evidence READMEs now say the lanes are default-on, and the cmp-jvm one records where its libGL/xvfb comes from.