### PR TITLE
feat(deploy): install bubblewrap so the playground jail can actually contain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1158,6 +1158,13 @@ jobs:
       # kept the public host's playground pinned to one catalog with the Android modes off.
       - name: Run deploy compose env-passthrough tests
         run: ./deploy/image/test-compose-env-passthrough.sh
+      # A sandbox profile the docs recommend but the image cannot launch is silent in the posture
+      # this image ships in: a repo-access-gated host admits the playground before it looks at the
+      # jail, so a missing binary logs a preflight warning and serves UNCONTAINED rather than
+      # refusing. That is how preview.coo.ee ran with `active: true` and every containment check
+      # false (issue #3211).
+      - name: Run deploy sandbox tooling tests
+        run: ./deploy/image/test-sandbox-tooling.sh
       # The seed-config reconcile POSTs to a live server's admin API during publish, so its
       # ordering (trust before catalogs) and payload-shape rules are gated rather than eyeballed —
       # a dropped `listed: false` or `group` silently moves a card on the front page.

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -19,6 +19,14 @@ ARG CP_VERSION=0.19.52
 # ---------------------------------------------------------------------------
 # Stage 0: base — JDK + Skiko's native deps (same rationale as the cloudrun image:
 # libGL via libgl1, Mesa software GLX/DRI, fonts; force software GL).
+#
+# `bubblewrap` is here for the playground jail, and only for that. Without it
+# `--playground-sandbox bwrap` cannot launch, so the lane either runs a snippet
+# unconfined (issue #3211) or an operator reaches for a `custom:` argv — which
+# cannot work, because a custom argv is a STATIC prefix (PlaygroundSandbox.command,
+# `Profile.CUSTOM -> customCommand`) and so cannot bind the per-session work dir
+# that only exists at compile time. `Profile.BWRAP` builds its argv from `Paths`
+# and binds it correctly. See deploy/image/README.md § "Containment".
 # ---------------------------------------------------------------------------
 FROM eclipse-temurin:21.0.11_10-jdk AS base
 RUN apt-get update \
@@ -26,6 +34,7 @@ RUN apt-get update \
       libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core \
       libgl1 libglx-mesa0 libgl1-mesa-dri \
       curl ca-certificates git \
+      bubblewrap \
  && rm -rf /var/lib/apt/lists/*
 ENV LIBGL_ALWAYS_SOFTWARE=1 \
     GRADLE_USER_HOME=/root/.gradle

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -208,21 +208,49 @@ before the request body is read, so a throttled caller costs the box nothing. Wa
 > entirely. It assumes exactly one proxy hop. This matters much less than it sounds on this image,
 > where the playground is repo-access-gated and every compile therefore carries a GitHub login.
 
-> **Do not set `SERVE_PLAYGROUND_SANDBOX=bwrap` on a public host and expect it to admit the lane.**
-> Earlier revisions of this file recommended exactly that, and it is refused: `bwrap` contains a
-> snippet but applies no CPU or process-count cap, so the containment posture rejects it and points
-> at `strict`. `strict` in turn needs `systemd-run`, which a Docker container has no systemd to talk
-> to — and neither `bubblewrap` nor `systemd` is installed in this image. **The contained posture is
-> therefore unreachable in the shipped container**; that is tracked in issue #3211, along with the
-> options for changing it. Until it is resolved, a public playground here means the repo-access
-> posture. A sandbox profile may still be set as defence in depth on a host that *does* have the
-> tooling — the lane logs a warning if the configured jail fails its preflight, and serves anyway,
-> because admission never rested on the jail in that posture.
+### Containment
 
-`SERVE_PLAYGROUND_ANDROID_BUNDLE` additionally enables the Android / Remote Compose modes. Those
-need the `lib-daemon-android` sidecar plus `android.jar`, and are **not** recommended on a sandboxed
-host yet — issue #3213 tracks a suspected Robolectric `android-all` lookup failure inside the jail
-that surfaces as a silent "no image" rather than an error.
+`bubblewrap` **is** installed in this image, so `bwrap` is the profile to use here:
+
+```bash
+SERVE_PLAYGROUND_SANDBOX=bwrap
+SERVE_PLAYGROUND_SANDBOX_RO=/root/.m2/repository   # see the Android note below
+```
+
+That gives a snippet no network, no host filesystem beyond the read-only binds, no view of host
+processes, and a cleared environment (so it cannot read `--admin-token` or cloud credentials out of
+`/proc/self/environ`). Exactly one path is writable — the session work dir, which is deleted with
+the snippet's token. Confirm it took on `/status.json` → `playground.sandbox.probe`: all four of
+`egressBlocked`, `filesystemContained`, `processIsolated`, `workDirWritable` should be `true`.
+
+Two things to know about which profile admits the lane, because earlier revisions of this file got
+it wrong in both directions:
+
+- **Repo-access-gated (this image's posture).** `PlaygroundPublicGate.decide` returns `Allow` for a
+  repo-access-gated host *before* it reaches any profile check, so `bwrap` is accepted here with no
+  caveat. Its lack of a cgroup cap is covered by the container's own `--memory` / `--cpus` /
+  `--pids-limit` plus the JVM ceilings the sandbox applies (`-Xmx`, `-XX:ActiveProcessorCount`).
+- **Anonymous (no GitHub auth).** There, and only there, `bwrap` is refused for declaring no CPU or
+  process-count cap, and the gate points at `strict` — which needs `systemd-run` and so remains
+  unreachable in a container. An anonymous public playground on this image is still not a thing;
+  issue #3211 tracks that.
+
+> **Do not reach for `custom:` to work around this.** A `custom:` argv is a **static prefix**
+> (`PlaygroundSandbox.command`, `Profile.CUSTOM -> customCommand`) — it is handed no `Paths`, so it
+> cannot bind the per-session work dir, whose path does not exist until a compile starts. The two
+> reachable outcomes are a jail so tight the render cannot write (preflight fails `workDirWritable`)
+> or one loose enough to contain nothing (preflight fails the other three) — and the second is
+> admitted silently in the repo-access-gated posture, because admission never rested on the jail
+> there. `Profile.BWRAP` builds its argv from `Paths` and binds the work dir correctly. Use it.
+
+`SERVE_PLAYGROUND_ANDROID_BUNDLE` — and `SERVE_PLAYGROUND`'s runtime catalog selector, which offers
+every Android-backed catalog — additionally enable the Android / Remote Compose modes. Those need
+the `lib-daemon-android` sidecar plus `android.jar`; the sidecar lives in `/opt`, which is already
+ro-bound, but Robolectric also resolves an `android-all` jar out of `~/.m2/repository` at run time
+and the jail has no network to fetch it. That is the suspected cause of issue #3213's silent "no
+image" inside a jail, and `SERVE_PLAYGROUND_SANDBOX_RO=/root/.m2/repository` is the remedy —
+**prewarm that cache before going public**, since a cold cache inside `--unshare-net` cannot fill
+itself. Render an Android preview once with the sandbox off, then turn it on.
 
 If the bundle vars are missing, `/playground` returns a styled “Playground unavailable” page instead
 of falling through as a missing design system. If they are set but the gate refuses, you get the

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -134,11 +134,19 @@ services:
       SERVE_PLAYGROUND_CATALOG_LIMIT: "${SERVE_PLAYGROUND_CATALOG_LIMIT:-}"
       SERVE_PLAYGROUND_BUNDLE: "${SERVE_PLAYGROUND_BUNDLE:-}"
       SERVE_PLAYGROUND_ANDROID_BUNDLE: "${SERVE_PLAYGROUND_ANDROID_BUNDLE:-}"
+      # Use `bwrap` here — bubblewrap is installed in this image for exactly this. Do NOT use a
+      # `custom:` argv: it is a static prefix that is handed no per-session paths, so it cannot bind
+      # the work dir a compile needs, and the loose argv people write instead passes for configured
+      # while containing nothing (issue #3211). `bwrap` builds its own argv from those paths.
       SERVE_PLAYGROUND_SANDBOX: "${SERVE_PLAYGROUND_SANDBOX:-}"
       SERVE_PLAYGROUND_SANDBOX_MEMORY_MB: "${SERVE_PLAYGROUND_SANDBOX_MEMORY_MB:-}"
       SERVE_PLAYGROUND_SANDBOX_CPUS: "${SERVE_PLAYGROUND_SANDBOX_CPUS:-}"
       SERVE_PLAYGROUND_SANDBOX_PIDS: "${SERVE_PLAYGROUND_SANDBOX_PIDS:-}"
       SERVE_PLAYGROUND_SANDBOX_TTL: "${SERVE_PLAYGROUND_SANDBOX_TTL:-}"
+      # Extra host paths bound READ-ONLY into the jail. `bwrap` unshares the network, so a cache the
+      # render would otherwise download has to be on this list AND already warm: in practice
+      # /root/.m2/repository, for the Robolectric `android-all` jar the Android modes resolve at run
+      # time (issue #3213 — a cold cache in there is a silent "no image", not an error).
       SERVE_PLAYGROUND_SANDBOX_RO: "${SERVE_PLAYGROUND_SANDBOX_RO:-}"
       SERVE_PLAYGROUND_COMPILE_SLOTS: "${SERVE_PLAYGROUND_COMPILE_SLOTS:-}"
       # PER-CALLER compile budget. Every other playground bound above is a whole-host one, so

--- a/deploy/image/test-sandbox-tooling.sh
+++ b/deploy/image/test-sandbox-tooling.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Guard: any playground sandbox profile the deploy docs tell an operator to set must be one this
+# image can actually launch.
+#
+# Why this needs a test rather than a comment. The docs and the Dockerfile are edited independently,
+# and a mismatch between them is SILENT in the posture this image ships in. A repo-access-gated host
+# admits the playground before it ever looks at the jail (`PlaygroundPublicGate.decide` returns
+# `Allow` for `repoAccessGated` ahead of every profile check), so a profile whose binary is missing
+# does not refuse the lane — it logs a preflight warning and serves anyway, uncontained. That is
+# exactly how preview.coo.ee ran: `bubblewrap` was absent from the image, the README said so and
+# pointed at a `custom:` argv instead, and the resulting jail reported `active: true` with all three
+# containment checks false.
+#
+# `custom:` is rejected outright here, not merely discouraged. A custom argv is a static prefix
+# (`PlaygroundSandbox.command`, `Profile.CUSTOM -> customCommand`) handed no per-session `Paths`, so
+# it cannot bind the work dir that only exists once a compile starts. Both reachable outcomes are
+# wrong: bind nothing and the render cannot write, bind broadly and nothing is contained.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Profiles this image can launch, and the binary each needs. `strict` and `systemd` want
+# `systemd-run`, which a container has no systemd to talk to, so they are absent by design rather
+# than by omission — see README.md § Containment and issue #3211.
+supported_profile() {
+  case "$1" in
+    bwrap) echo "bubblewrap" ;;
+    unshare) echo "util-linux" ;;
+    none) echo "" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Every `SERVE_PLAYGROUND_SANDBOX=<value>` assignment in a docs file. Deliberately anchored to the
+# `=` form so it matches what an operator copies into .env, and not the `SERVE_PLAYGROUND_SANDBOX:
+# "${...}"` passthrough line in docker-compose.yml (which names no profile) nor the `_RO`/`_CPUS`
+# siblings.
+assigned_profiles() {
+  grep -hoE 'SERVE_PLAYGROUND_SANDBOX=[A-Za-z0-9:._/-]+' "$@" 2>/dev/null |
+    sed 's/^SERVE_PLAYGROUND_SANDBOX=//' | sort -u
+}
+
+# The apt package list the Dockerfile installs.
+dockerfile_installs() {
+  local dockerfile="$1" pkg="$2"
+  grep -qE "^[[:space:]]*${pkg}([[:space:]]|\\\\|$)" "${dockerfile}"
+}
+
+check() {
+  local dockerfile="$1"
+  shift
+  local -a docs=("$@")
+  local failed=0 profile pkg
+
+  local -a profiles=()
+  mapfile -t profiles < <(assigned_profiles "${docs[@]}")
+
+  if ((${#profiles[@]} == 0)); then
+    echo "FAIL: no SERVE_PLAYGROUND_SANDBOX=<profile> assignment found in ${docs[*]} —" \
+      "the detector is broken, or the docs stopped recommending a profile." >&2
+    return 1
+  fi
+
+  for profile in "${profiles[@]}"; do
+    if [[ "${profile}" == custom:* || "${profile}" == "custom" ]]; then
+      echo "FAIL: the docs recommend a 'custom:' sandbox argv. A custom argv is a static prefix" \
+        "and cannot bind the per-session work dir; use bwrap." >&2
+      failed=1
+      continue
+    fi
+    if ! pkg="$(supported_profile "${profile}")"; then
+      echo "FAIL: the docs recommend SERVE_PLAYGROUND_SANDBOX=${profile}, which this image cannot" \
+        "launch. Supported here: bwrap, unshare, none." >&2
+      failed=1
+      continue
+    fi
+    if [[ -n "${pkg}" ]] && ! dockerfile_installs "${dockerfile}" "${pkg}"; then
+      echo "FAIL: the docs recommend SERVE_PLAYGROUND_SANDBOX=${profile}, but ${dockerfile}" \
+        "does not install '${pkg}'. The jail would fail its preflight and the lane would serve" \
+        "uncontained (issue #3211)." >&2
+      failed=1
+    fi
+  done
+
+  return "${failed}"
+}
+
+# ---------------------------------------------------------------------------
+# The real check.
+# ---------------------------------------------------------------------------
+real_dockerfile="${DOCKERFILE_UNDER_TEST:-${here}/Dockerfile}"
+real_readme="${README_UNDER_TEST:-${here}/README.md}"
+for f in "${real_dockerfile}" "${real_readme}"; do
+  [[ -f "${f}" ]] || {
+    echo "FAIL: missing ${f}" >&2
+    exit 1
+  }
+done
+
+check "${real_dockerfile}" "${real_readme}" || exit 1
+echo "PASS: every recommended sandbox profile is launchable in this image"
+
+# ---------------------------------------------------------------------------
+# Self-tests: one per failure shape, so a detector that has quietly stopped detecting fails CI
+# rather than passing everything. Each builds a fixture that SHOULD fail and asserts that it does.
+# ---------------------------------------------------------------------------
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+expect_fail() {
+  local label="$1" dockerfile="$2" readme="$3"
+  if check "${dockerfile}" "${readme}" >/dev/null 2>&1; then
+    echo "FAIL: self-test '${label}' passed the check but should have failed." >&2
+    exit 1
+  fi
+  echo "PASS: self-test — ${label}"
+}
+
+# 1. The regression this whole change fixes: docs say bwrap, image lacks bubblewrap.
+printf 'FROM x\nRUN apt-get install -y \\\n      curl \\\n      git\n' >"${tmp}/no-bwrap.Dockerfile"
+printf 'SERVE_PLAYGROUND_SANDBOX=bwrap\n' >"${tmp}/bwrap.md"
+expect_fail "bwrap recommended but bubblewrap not installed" \
+  "${tmp}/no-bwrap.Dockerfile" "${tmp}/bwrap.md"
+
+# 2. A profile this image structurally cannot run.
+printf 'SERVE_PLAYGROUND_SANDBOX=strict\n' >"${tmp}/strict.md"
+expect_fail "strict recommended (needs systemd-run)" "${real_dockerfile}" "${tmp}/strict.md"
+
+# 3. The footgun that produced the uncontained jail in production.
+printf 'SERVE_PLAYGROUND_SANDBOX=custom:bwrap --bind / /\n' >"${tmp}/custom.md"
+expect_fail "custom: argv recommended" "${real_dockerfile}" "${tmp}/custom.md"
+
+# 4. The detector itself going blind — docs that recommend nothing at all.
+printf 'no sandbox guidance here\n' >"${tmp}/empty.md"
+expect_fail "no profile assignment found" "${real_dockerfile}" "${tmp}/empty.md"
+
+echo "PASS: all sandbox tooling checks"


### PR DESCRIPTION
Closes the containment half of #3211 — option 1 from that issue's list, which turned out to be much smaller than the issue assumed.

## What was wrong

`preview.coo.ee` is running the playground with `SERVE_PLAYGROUND_SANDBOX=custom` and reporting a jail that is nominally active and contains nothing:

```json
"sandbox": {
  "profile": "custom", "active": true, "jailDropped": false,
  "probe": { "ran": true, "detail": "probed from pid 67",
    "egressBlocked": false, "filesystemContained": false, "processIsolated": false,
    "workDirWritable": true }
}
```

Three separate things produced that, and this PR fixes all three.

**1. No jail tooling in the image.** `deploy/image/Dockerfile` installed neither `bubblewrap` nor `systemd`, so `bwrap` could never launch and the README told operators to use a `custom:` argv instead.

**2. A `custom:` argv cannot work, at all.** It is a *static prefix* — `PlaygroundSandbox.command` maps `Profile.CUSTOM -> customCommand` and hands it no `Paths`, while `Profile.BWRAP -> bwrapCommand(paths)` receives them. The per-session work dir path does not exist at config time, so a custom argv cannot bind it. Both reachable outcomes are wrong: bind nothing and the render cannot write (`workDirWritable` fails), or bind broadly and nothing is contained (the other three fail). The second is what happened, and in the repo-access-gated posture it is admitted with only a warning, because admission never rested on the jail there.

**3. The README had the gate backwards.** It said the contained posture is unreachable in this image. That is true only for the **anonymous** posture. `PlaygroundPublicGate.decide` returns `Allow` for `repoAccessGated` *before* it reaches the `declaresResourceCaps` refusal that rejects `bwrap` — and repo-access-gated is the posture this image ships in. So `bwrap` was admissible here the whole time; only the binary was missing. The caps it does not declare are covered by the container's own `--memory` / `--cpus` / `--pids-limit` plus the sandbox's own `-Xmx` / `-XX:ActiveProcessorCount`.

`Profile.BWRAP` builds a correct argv: `--unshare-all`, `--unshare-net`, `--clearenv` (so a snippet cannot read `--admin-token` out of `/proc/self/environ`), per-entry `--ro-bind-try` rather than an ancestor bind, and exactly one writable path — the session work dir, deleted with the token.

## Changes

- **`Dockerfile`** — install `bubblewrap`.
- **`README.md`** — new § Containment: recommend `bwrap`, give the copy-pasteable `.env`, explain the two postures, and reject `custom:` with the reason.
- **`docker-compose.yml`** — comments on `SERVE_PLAYGROUND_SANDBOX` and `SERVE_PLAYGROUND_SANDBOX_RO` explaining the trap and the Android cache requirement.
- **`test-sandbox-tooling.sh`** (new, wired into CI) — every profile the docs recommend must be launchable in this image.

## Android interaction (#3213)

`bwrap` unshares the network, so a cache the render would otherwise download must be bound **and already warm**. The `lib-daemon-android` sidecar is fine — it lives in `/opt`, already in `SYSTEM_READ_ONLY_PATHS`. Robolectric's `android-all` jar is not: it resolves out of `~/.m2/repository` at run time. That is the suspected cause of #3213's silent "no image" inside a jail, and `SERVE_PLAYGROUND_SANDBOX_RO=/root/.m2/repository` is the remedy. Documented with the ordering that matters — render an Android preview once with the sandbox off, *then* turn it on, because a cold cache inside `--unshare-net` cannot fill itself.

## Test plan

Measured directly rather than assumed — the issue flagged "whether `bwrap`'s `--unshare-all` even works" as the unverified question blocking options 1–3. On a 6.18 kernel:

| check | no jail | `bwrap --unshare-all` |
|---|---|---|
| visible processes | 77 | **4** |
| `/etc/shadow` readable | yes | **no** |
| network interfaces | present | **none** |

Those are the three checks the preflight reports as failing today.

- `./deploy/image/test-sandbox-tooling.sh` — passes, with 4 self-tests (one per failure shape: bwrap-without-bubblewrap, an unlaunchable profile, a `custom:` recommendation, and the detector going blind).
- Verified the real check is not vacuous: stripping `bubblewrap` from the actual Dockerfile makes it fail with the right message.
- `./deploy/image/test-compose-env-passthrough.sh`, `./deploy/image/test-env-migrations.sh` — still pass.
- `shellcheck` clean; `ci.yml` and `docker-compose.yml` parse.

No visual surfaces touched — deploy wiring, docs, and a shell guard only.

## Not in scope

Options 2–4 from #3211 (cgroup delegation, a docker-socket jail, a systemd VM) stay open. They are only needed for an **anonymous** public playground, which this image still does not support; nothing here changes that. This PR does not flip `preview.coo.ee` over — that is an `.env` edit on the box, and the image needs rebuilding first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqaYLFf7UDZLjkjSpGrmWM)_