### PR TITLE
test(vscode): pair the preview filter with missingRenders=warn, and bound every wait

### DIFF
--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -10,6 +10,11 @@ import type { GradleApi } from "../../gradleService";
  */
 const KILL_GRACE_MS = 5_000;
 
+/** One enqueued-but-not-yet-spawned `gradlew` invocation. */
+interface QueuedInvocation {
+    cancelled: boolean;
+}
+
 /**
  * Real {@link GradleApi} that shells out to the repo's `./gradlew` wrapper.
  * Used by the daily/manual e2e suite to drive the *actual* Gradle plugin
@@ -69,7 +74,95 @@ export class RealGradleApi implements GradleApi {
         return this.cancelledTaskNames;
     }
 
+    /**
+     * Tail of the invocation chain. Every {@link runTask} links onto it, so at
+     * most one `gradlew` process is alive at a time.
+     *
+     * Production reaches Gradle through `vscjava.vscode-gradle`, which talks to
+     * one long-lived daemon, and `gradleService.ts` leans on that: several of
+     * its comments say a second invocation simply "queues behind it on the
+     * daemon's serialised queue". Shelling out to `./gradlew` breaks that
+     * assumption — a client that finds the daemon busy starts *another* one, so
+     * the invocations genuinely run in parallel.
+     *
+     * That is not theoretical. On run 31310881459 the suite's forced
+     * `composePreviewRenderAll` and a save-loop `composePreviewCompile` landed
+     * 0.6s apart on `:samples:cmp`, two daemons started, and the compile
+     * rewrote the module's class output while the other build's
+     * `composePreviewDiscover` was scanning it. Discovery scans `classDirs`, so
+     * the manifest collapsed from 66 previews to the 3 asset-only ones that
+     * come from `resourceDirs`, and every `-PcomposePreview.filter` pattern
+     * then matched nothing:
+     *
+     *     composePreviewRender --preview matched no previews … Available previews:
+     *       lottie/spin.json
+     *       svg/badge.svg
+     *       svg/star.svg
+     *
+     * Scenarios B and E both edit a `.kt` fixture on disk and so both hit it.
+     *
+     * Serialising here restores the one-daemon invariant the extension is
+     * written against. It does **not** fix the underlying product race — two
+     * concurrent Gradle clients against one project can corrupt each other's
+     * task outputs whatever drives them — that belongs in `GradleService`.
+     */
+    private queueTail: Promise<void> = Promise.resolve();
+
+    /**
+     * Invocations that have been enqueued but not yet spawned, by
+     * `cancellationKey`. {@link cancelRunTask} can only kill a live child;
+     * without this, a supersession that arrives while a task is still waiting
+     * its turn would be dropped and the stale build would run anyway — exactly
+     * the "leftover previews from the cancelled refresh" that scenario D pins.
+     */
+    private readonly queued = new Map<string, QueuedInvocation[]>();
+
     runTask(opts: {
+        projectFolder: string;
+        taskName: string;
+        args?: ReadonlyArray<string>;
+        showOutputColors: boolean;
+        onOutput?: (output: {
+            getOutputBytes(): Uint8Array;
+            getOutputType(): number;
+        }) => void;
+        cancellationKey?: string;
+    }): Promise<void> {
+        const key = opts.cancellationKey;
+        const entry: QueuedInvocation = { cancelled: false };
+        if (key) {
+            const waiting = this.queued.get(key);
+            if (waiting) waiting.push(entry);
+            else this.queued.set(key, [entry]);
+        }
+        const run = this.queueTail.then(() => {
+            if (key) {
+                const waiting = this.queued.get(key);
+                if (waiting) {
+                    const at = waiting.indexOf(entry);
+                    if (at >= 0) waiting.splice(at, 1);
+                    if (waiting.length === 0) this.queued.delete(key);
+                }
+            }
+            if (entry.cancelled) {
+                // Worded so `gradleService`'s CANCELLED_RE maps it to a
+                // TaskCancelledError, same as a SIGTERM'd child.
+                throw new Error(
+                    `gradlew ${opts.taskName} cancelled before it started`,
+                );
+            }
+            return this.spawnTask(opts);
+        });
+        // Never let a rejection break the chain — the next invocation still has
+        // to run, and `run` already carries the failure to its own caller.
+        this.queueTail = run.then(
+            () => undefined,
+            () => undefined,
+        );
+        return run;
+    }
+
+    private spawnTask(opts: {
         projectFolder: string;
         taskName: string;
         args?: ReadonlyArray<string>;
@@ -189,6 +282,18 @@ export class RealGradleApi implements GradleApi {
         // keyed by `cancellationKey`. Without a key there's nothing
         // specific to cancel (gradleService always supplies one).
         const key = opts.cancellationKey;
+        // Tasks still waiting their turn have no child to signal — mark them so
+        // they abort when they reach the head of the queue instead of running a
+        // build the caller has already superseded. Not recorded in
+        // `cancelledTaskNames`: nothing was truncated, so a suite reading that
+        // list for partial renders would be misled.
+        const waiting = key ? this.queued.get(key) : undefined;
+        if (waiting?.length) {
+            for (const entry of waiting) entry.cancelled = true;
+            this.onLog(
+                `[realGradleApi] cancel ${opts.taskName} (key=${key}) — ${waiting.length} queued invocation(s) dropped before spawn`,
+            );
+        }
         const child = key ? this.liveChildren.get(key) : undefined;
         if (!child || child.pid === undefined || child.exitCode !== null) {
             return;

--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -10,11 +10,6 @@ import type { GradleApi } from "../../gradleService";
  */
 const KILL_GRACE_MS = 5_000;
 
-/** One enqueued-but-not-yet-spawned `gradlew` invocation. */
-interface QueuedInvocation {
-    cancelled: boolean;
-}
-
 /**
  * Real {@link GradleApi} that shells out to the repo's `./gradlew` wrapper.
  * Used by the daily/manual e2e suite to drive the *actual* Gradle plugin
@@ -74,95 +69,7 @@ export class RealGradleApi implements GradleApi {
         return this.cancelledTaskNames;
     }
 
-    /**
-     * Tail of the invocation chain. Every {@link runTask} links onto it, so at
-     * most one `gradlew` process is alive at a time.
-     *
-     * Production reaches Gradle through `vscjava.vscode-gradle`, which talks to
-     * one long-lived daemon, and `gradleService.ts` leans on that: several of
-     * its comments say a second invocation simply "queues behind it on the
-     * daemon's serialised queue". Shelling out to `./gradlew` breaks that
-     * assumption — a client that finds the daemon busy starts *another* one, so
-     * the invocations genuinely run in parallel.
-     *
-     * That is not theoretical. On run 31310881459 the suite's forced
-     * `composePreviewRenderAll` and a save-loop `composePreviewCompile` landed
-     * 0.6s apart on `:samples:cmp`, two daemons started, and the compile
-     * rewrote the module's class output while the other build's
-     * `composePreviewDiscover` was scanning it. Discovery scans `classDirs`, so
-     * the manifest collapsed from 66 previews to the 3 asset-only ones that
-     * come from `resourceDirs`, and every `-PcomposePreview.filter` pattern
-     * then matched nothing:
-     *
-     *     composePreviewRender --preview matched no previews … Available previews:
-     *       lottie/spin.json
-     *       svg/badge.svg
-     *       svg/star.svg
-     *
-     * Scenarios B and E both edit a `.kt` fixture on disk and so both hit it.
-     *
-     * Serialising here restores the one-daemon invariant the extension is
-     * written against. It does **not** fix the underlying product race — two
-     * concurrent Gradle clients against one project can corrupt each other's
-     * task outputs whatever drives them — that belongs in `GradleService`.
-     */
-    private queueTail: Promise<void> = Promise.resolve();
-
-    /**
-     * Invocations that have been enqueued but not yet spawned, by
-     * `cancellationKey`. {@link cancelRunTask} can only kill a live child;
-     * without this, a supersession that arrives while a task is still waiting
-     * its turn would be dropped and the stale build would run anyway — exactly
-     * the "leftover previews from the cancelled refresh" that scenario D pins.
-     */
-    private readonly queued = new Map<string, QueuedInvocation[]>();
-
     runTask(opts: {
-        projectFolder: string;
-        taskName: string;
-        args?: ReadonlyArray<string>;
-        showOutputColors: boolean;
-        onOutput?: (output: {
-            getOutputBytes(): Uint8Array;
-            getOutputType(): number;
-        }) => void;
-        cancellationKey?: string;
-    }): Promise<void> {
-        const key = opts.cancellationKey;
-        const entry: QueuedInvocation = { cancelled: false };
-        if (key) {
-            const waiting = this.queued.get(key);
-            if (waiting) waiting.push(entry);
-            else this.queued.set(key, [entry]);
-        }
-        const run = this.queueTail.then(() => {
-            if (key) {
-                const waiting = this.queued.get(key);
-                if (waiting) {
-                    const at = waiting.indexOf(entry);
-                    if (at >= 0) waiting.splice(at, 1);
-                    if (waiting.length === 0) this.queued.delete(key);
-                }
-            }
-            if (entry.cancelled) {
-                // Worded so `gradleService`'s CANCELLED_RE maps it to a
-                // TaskCancelledError, same as a SIGTERM'd child.
-                throw new Error(
-                    `gradlew ${opts.taskName} cancelled before it started`,
-                );
-            }
-            return this.spawnTask(opts);
-        });
-        // Never let a rejection break the chain — the next invocation still has
-        // to run, and `run` already carries the failure to its own caller.
-        this.queueTail = run.then(
-            () => undefined,
-            () => undefined,
-        );
-        return run;
-    }
-
-    private spawnTask(opts: {
         projectFolder: string;
         taskName: string;
         args?: ReadonlyArray<string>;
@@ -282,18 +189,6 @@ export class RealGradleApi implements GradleApi {
         // keyed by `cancellationKey`. Without a key there's nothing
         // specific to cancel (gradleService always supplies one).
         const key = opts.cancellationKey;
-        // Tasks still waiting their turn have no child to signal — mark them so
-        // they abort when they reach the head of the queue instead of running a
-        // build the caller has already superseded. Not recorded in
-        // `cancelledTaskNames`: nothing was truncated, so a suite reading that
-        // list for partial renders would be misled.
-        const waiting = key ? this.queued.get(key) : undefined;
-        if (waiting?.length) {
-            for (const entry of waiting) entry.cancelled = true;
-            this.onLog(
-                `[realGradleApi] cancel ${opts.taskName} (key=${key}) — ${waiting.length} queued invocation(s) dropped before spawn`,
-            );
-        }
         const child = key ? this.liveChildren.get(key) : undefined;
         if (!child || child.pid === undefined || child.exitCode !== null) {
             return;

--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -156,11 +156,35 @@ interface SetPreviewsMessage {
     moduleDir: string;
 }
 
+/**
+ * Budget for "the panel should have published this by now" waits.
+ *
+ * Deliberately NOT `this.timeout()`. Passing the Mocha ceiling as a wait
+ * budget means a condition that never becomes true consumes the entire test
+ * and reports a bare `Timeout of 1800000ms exceeded` — no indication of which
+ * invariant failed, and 30 minutes of runner time per occurrence. Scenario E
+ * did exactly that on `main` (run 31306997859): 26 minutes of silence after
+ * `composePreviewDiscover`, then a timeout that named nothing.
+ *
+ * These waits follow an *awaited* `triggerRefresh`, and `refresh` posts
+ * `setPreviews` before it resolves — so in a healthy run the value is already
+ * there on the first poll (measured at 44ms in the cmp-smoke shard). Three
+ * minutes is far past generous; it exists only so a daemon-path repaint that
+ * lands late still counts. The Mocha ceiling stays as the backstop.
+ */
+const PANEL_UPDATE_BUDGET_MS = 3 * 60_000;
+
 async function waitFor<T>(
     description: string,
     timeoutMs: number,
     pollMs: number,
     probe: () => T | undefined,
+    /**
+     * Rendered into the timeout message. A wait that fails should say what it
+     * actually observed — otherwise the next occurrence is as opaque as the
+     * last one.
+     */
+    describeState?: () => string,
 ): Promise<T> {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
@@ -170,8 +194,16 @@ async function waitFor<T>(
         }
         await new Promise((r) => setTimeout(r, pollMs));
     }
+    let state = "";
+    if (describeState) {
+        try {
+            state = `\n  ${describeState()}`;
+        } catch (err) {
+            state = `\n  <describeState threw: ${String(err)}>`;
+        }
+    }
     throw new Error(
-        `Timed out after ${timeoutMs}ms waiting for: ${description}`,
+        `Timed out after ${timeoutMs}ms waiting for: ${description}${state}`,
     );
 }
 
@@ -763,6 +795,36 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         const OLD = /\.RedBoxPreview_/;
         const NEW = /\.RedBoxPreviewRenamed_/;
 
+        // Every wait in this scenario reports through this on timeout. The
+        // three ways the rename flow can stall are indistinguishable from a
+        // bare Mocha timeout but obvious from here: no `setPreviews` posted at
+        // all (the refresh never republished), the new id absent (discovery
+        // did not see the rename), or the old id still present (the module
+        // index was not pruned). The output-channel tail carries the Gradle
+        // lines — `> <task> completed` / `FAILED` / `cancelled` — that the
+        // in-repo e2e otherwise routes to the extension log and discards.
+        const describeCmpPanelState = (): string => {
+            const latest = latestSetPreviewsMatching(
+                api.getPostedMessages(),
+                (m) => m.moduleDir.includes(cmpNeedle),
+            );
+            const ids = latest
+                ? latest.previews.map((p) => p.id).sort()
+                : undefined;
+            const tail = api.getOutputChannelTail(40).join("\n    ");
+            return [
+                `latest cmp setPreviews: ${
+                    ids
+                        ? `${ids.length} preview(s) [${ids.join(", ")}]`
+                        : "<none posted>"
+                }`,
+                `old id present: ${ids ? ids.some((id) => OLD.test(id)) : "n/a"}`,
+                `new id present: ${ids ? ids.some((id) => NEW.test(id)) : "n/a"}`,
+                `lastWarmDaemonError: ${api.getLastWarmDaemonError() ?? "<none>"}`,
+                `Compose Preview output tail:\n    ${tail}`,
+            ].join("\n  ");
+        };
+
         // --- Baseline: the pre-rename manifest must contain RedBoxPreview ---
         assertRefreshRendered(
             api,
@@ -771,7 +833,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         );
         const baseline = await waitFor(
             "cmp baseline setPreviews (with RedBoxPreview)",
-            this.timeout(),
+            PANEL_UPDATE_BUDGET_MS,
             500,
             () => {
                 const msgs = api.getPostedMessages();
@@ -780,6 +842,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                     return m.previews.some((p) => OLD.test(p.id));
                 });
             },
+            describeCmpPanelState,
         );
         const baselineIds = baseline.previews.map((p) => p.id).sort();
         observations.baselineIds = baselineIds;
@@ -820,7 +883,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             );
             const afterRename = await waitFor(
                 "setPreviews after rename (new id present, old id gone)",
-                this.timeout(),
+                PANEL_UPDATE_BUDGET_MS,
                 500,
                 () => {
                     const msgs = api.getPostedMessages();
@@ -833,6 +896,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                         );
                     });
                 },
+                describeCmpPanelState,
             );
             observations.afterRename = {
                 idsSorted: afterRename.previews.map((p) => p.id).sort(),
@@ -873,12 +937,13 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             // written" regression still fails, just via waitFor's timeout.
             await waitFor(
                 `renamed preview render PNG(s) on disk: ${newRenderOutputs.join(", ")}`,
-                this.timeout(),
+                PANEL_UPDATE_BUDGET_MS,
                 500,
                 () =>
                     newRenderOutputs.every((p) => fs.existsSync(p))
                         ? true
                         : undefined,
+                describeCmpPanelState,
             );
 
             // Invariant E3: the stale PNG no longer exists on disk. The
@@ -905,7 +970,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             );
             const reRefreshed = await waitFor(
                 "second post-rename cmp setPreviews",
-                this.timeout(),
+                PANEL_UPDATE_BUDGET_MS,
                 500,
                 () => {
                     const msgs = api.getPostedMessages();
@@ -914,6 +979,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                         nonEmptyForModule(cmpNeedle),
                     );
                 },
+                describeCmpPanelState,
             );
             assert.deepStrictEqual(
                 reRefreshed.previews

--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -174,6 +174,54 @@ interface SetPreviewsMessage {
  */
 const PANEL_UPDATE_BUDGET_MS = 3 * 60_000;
 
+/**
+ * Budget for the awaited `triggerRefresh` itself.
+ *
+ * {@link PANEL_UPDATE_BUDGET_MS} only bounds the *poll after* the refresh
+ * resolves — it does nothing for a refresh that never resolves, because the
+ * timer has not started yet. That is not hypothetical: the first recorded
+ * scenario-E failure (run 31306997859) went silent right after
+ * `composePreviewDiscover` and sat there for 26 minutes with no Gradle
+ * output, no task-cap cancellation, and nothing for the poll to observe.
+ *
+ * Sized above `gradleService`'s 10-minute per-task cap so a genuinely slow
+ * cold render is never cut short — this fires only when something is wedged
+ * past the point the cap itself should have handled.
+ */
+const REFRESH_BUDGET_MS = 12 * 60_000;
+
+/**
+ * Await a refresh under {@link REFRESH_BUDGET_MS}, reporting panel state if it
+ * never resolves. The pending refresh is abandoned rather than cancelled —
+ * the test is failing at that point, and Mocha tears the host down.
+ */
+async function refreshWithinBudget<T>(
+    label: string,
+    refresh: Promise<T>,
+    describeState: () => string,
+): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const budget = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+            () =>
+                reject(
+                    new Error(
+                        `${label}: refresh did not resolve within ${
+                            REFRESH_BUDGET_MS / 1000
+                        }s — it is wedged, not slow.\n  ${describeState()}`,
+                    ),
+                ),
+            REFRESH_BUDGET_MS,
+        );
+    });
+    timer?.unref?.();
+    try {
+        return await Promise.race([refresh, budget]);
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
 async function waitFor<T>(
     description: string,
     timeoutMs: number,
@@ -208,20 +256,32 @@ async function waitFor<T>(
 }
 
 /**
- * Text of the panel's "this file has no previews" empty-state message, if the
- * refresh posted one. `refresh` reaches this branch when the active file
- * resolves to zero visible previews: it posts `clearAll` + this `showMessage`,
- * posts no `setPreviews`, and still returns `'completed'`.
+ * Text of a panel empty-state message, if the refresh posted one. `refresh`
+ * has two such branches, and BOTH are terminal for a test waiting on
+ * `setPreviews`: each posts `clearAll` + a `showMessage`, posts no
+ * `setPreviews`, and still returns `'completed'` — so `assertRefreshRendered`
+ * cannot see them either.
+ *
+ *   * "No @Preview functions in this file (N in other files in this module)."
+ *     — the module has previews, the active file does not.
+ *   * "No @Preview functions found in this module"
+ *     — the whole module came back empty.
+ *
+ * Matching only the first would leave the module-wide case waiting out the
+ * full budget for a `setPreviews` that is never coming.
  */
+const EMPTY_STATE_PREFIXES = [
+    "No @Preview functions in this file",
+    "No @Preview functions found in this module",
+];
+
 function emptyStateText(messages: unknown[]): string | undefined {
     for (let i = messages.length - 1; i >= 0; i--) {
         const m = messages[i] as PostedMessage;
-        if (
-            m.command === "showMessage" &&
-            typeof m.text === "string" &&
-            m.text.startsWith("No @Preview functions in this file")
-        ) {
-            return m.text;
+        if (m.command !== "showMessage" || typeof m.text !== "string") continue;
+        const text = m.text;
+        if (EMPTY_STATE_PREFIXES.some((prefix) => text.startsWith(prefix))) {
+            return text;
         }
     }
     return undefined;
@@ -848,7 +908,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         // --- Baseline: the pre-rename manifest must contain RedBoxPreview ---
         assertRefreshRendered(
             api,
-            await api.triggerRefresh(cmpFile, true, "full"),
+            await refreshWithinBudget(
+                ":samples:cmp render",
+                api.triggerRefresh(cmpFile, true, "full"),
+                describeCmpPanelState,
+            ),
             ":samples:cmp render",
         );
         const baseline = await waitFor(
@@ -898,7 +962,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             api.resetMessages();
             assertRefreshRendered(
                 api,
-                await api.triggerRefresh(cmpFile, true, "full"),
+                await refreshWithinBudget(
+                    ":samples:cmp render",
+                    api.triggerRefresh(cmpFile, true, "full"),
+                    describeCmpPanelState,
+                ),
                 ":samples:cmp render",
             );
             const afterRename = await waitFor(
@@ -1007,7 +1075,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             api.resetMessages();
             assertRefreshRendered(
                 api,
-                await api.triggerRefresh(cmpFile, true, "full"),
+                await refreshWithinBudget(
+                    ":samples:cmp render",
+                    api.triggerRefresh(cmpFile, true, "full"),
+                    describeCmpPanelState,
+                ),
                 ":samples:cmp render",
             );
             const reRefreshed = await waitFor(
@@ -1041,7 +1113,11 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         api.resetMessages();
         assertRefreshRendered(
             api,
-            await api.triggerRefresh(cmpFile, true, "full"),
+            await refreshWithinBudget(
+                ":samples:cmp render",
+                api.triggerRefresh(cmpFile, true, "full"),
+                describeCmpPanelState,
+            ),
             ":samples:cmp render",
         );
         const afterRevert = await waitFor(

--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -207,6 +207,26 @@ async function waitFor<T>(
     );
 }
 
+/**
+ * Text of the panel's "this file has no previews" empty-state message, if the
+ * refresh posted one. `refresh` reaches this branch when the active file
+ * resolves to zero visible previews: it posts `clearAll` + this `showMessage`,
+ * posts no `setPreviews`, and still returns `'completed'`.
+ */
+function emptyStateText(messages: unknown[]): string | undefined {
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const m = messages[i] as PostedMessage;
+        if (
+            m.command === "showMessage" &&
+            typeof m.text === "string" &&
+            m.text.startsWith("No @Preview functions in this file")
+        ) {
+            return m.text;
+        }
+    }
+    return undefined;
+}
+
 function latestSetPreviewsMatching(
     messages: unknown[],
     predicate: (msg: SetPreviewsMessage) => boolean,
@@ -887,6 +907,28 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                 500,
                 () => {
                     const msgs = api.getPostedMessages();
+                    // A refresh that finds nothing to show in the active file
+                    // settles into the panel's empty state — `clearAll` plus
+                    // "No @Preview functions in this file" — and returns
+                    // 'completed' having posted no `setPreviews` at all. That
+                    // slips past `assertRefreshRendered`, which only catches
+                    // 'failed'. It is also terminal: nothing re-triggers a
+                    // refresh afterwards, so waiting out the budget just
+                    // delays the failure and throws away the reason.
+                    //
+                    // Observed on this suite's own PR run (job 93235209013):
+                    // the post-rename `composePreviewRenderAll` died with
+                    // `composePreviewRender --preview matched no previews`
+                    // and the refresh reported "0 visible previews in
+                    // Previews.kt, module has 3".
+                    const emptyState = emptyStateText(msgs);
+                    if (emptyState) {
+                        throw new Error(
+                            "after the rename the panel resolved to its empty " +
+                                `state instead of republishing: "${emptyState}"\n  ` +
+                                describeCmpPanelState(),
+                        );
+                    }
                     return latestSetPreviewsMatching(msgs, (m) => {
                         if (m.previews.length === 0) return false;
                         if (!m.moduleDir.includes(cmpNeedle)) return false;
@@ -1004,7 +1046,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         );
         const afterRevert = await waitFor(
             "setPreviews after reverting the rename",
-            this.timeout(),
+            PANEL_UPDATE_BUDGET_MS,
             500,
             () => {
                 const msgs = api.getPostedMessages();
@@ -1017,6 +1059,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                     );
                 });
             },
+            describeCmpPanelState,
         );
         observations.afterRevertIds = afterRevert.previews
             .map((p) => p.id)

--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -114,6 +114,13 @@ const describeE2E = E2E ? describe : describe.skip;
  * preview elsewhere in the repo. A non-empty filter that matches *nothing*
  * fails the render task outright, so every module this suite renders
  * (`:samples:cmp`, `:samples:android`) must keep at least one entry here.
+ *
+ * **Narrowing the render requires `-PcomposePreview.missingRenders=warn`**
+ * alongside it — see where these patterns are handed to `RealGradleApi`.
+ * `composePreviewRenderAll` finishes with a completeness check across the
+ * whole manifest and the policy defaults to `fail`, so a filtered render
+ * fails the task on every preview the filter excluded. Without the pairing
+ * this suite never once reached the happy path.
  */
 const FIXTURE_PREVIEW_FILTER = [
     // `samples/cmp/.../Previews.kt` — the cmp fixture every scenario
@@ -190,13 +197,41 @@ const PANEL_UPDATE_BUDGET_MS = 3 * 60_000;
  */
 const REFRESH_BUDGET_MS = 12 * 60_000;
 
+/** Head room so a diagnostic always reports before Mocha's own ceiling. */
+const DIAGNOSTIC_SLACK_MS = 30_000;
+
 /**
- * Await a refresh under {@link REFRESH_BUDGET_MS}, reporting panel state if it
- * never resolves. The pending refresh is abandoned rather than cancelled —
- * the test is failing at that point, and Mocha tears the host down.
+ * Clamp a diagnostic budget to what is left of the test's Mocha budget.
+ *
+ * A fixed budget is not enough on its own: scenario E runs four bounded
+ * refreshes inside one 30-minute test, and 4 × {@link REFRESH_BUDGET_MS} is
+ * 48 minutes. A wedge in a *late* refresh would blow the Mocha ceiling before
+ * its own timer fired, reinstating exactly the bare, unattributed timeout
+ * these budgets exist to remove. Deriving each deadline from the remaining
+ * time guarantees the diagnostic wins the race.
+ */
+function budgetWithin(deadlineAt: number, max: number): number {
+    return Math.max(
+        1_000,
+        Math.min(max, deadlineAt - Date.now() - DIAGNOSTIC_SLACK_MS),
+    );
+}
+
+/**
+ * Await a refresh under `budgetMs` — normally
+ * `budgetWithin(deadlineAt, REFRESH_BUDGET_MS)` — reporting panel state if it
+ * never resolves.
+ *
+ * The pending refresh is abandoned, not cancelled: there is no test-API hook
+ * to abort one, and the extension host keeps running after a failed test, so
+ * the abandoned refresh's `pendingRefresh` can still be in flight when the
+ * *next* scenario starts. That is why every scenario downstream of a bounded
+ * refresh bounds its own waits too — an inherited wedge then costs one
+ * `PANEL_UPDATE_BUDGET_MS` per wait instead of a full Mocha ceiling per test.
  */
 async function refreshWithinBudget<T>(
     label: string,
+    budgetMs: number,
     refresh: Promise<T>,
     describeState: () => string,
 ): Promise<T> {
@@ -207,11 +242,11 @@ async function refreshWithinBudget<T>(
                 reject(
                     new Error(
                         `${label}: refresh did not resolve within ${
-                            REFRESH_BUDGET_MS / 1000
+                            budgetMs / 1000
                         }s — it is wedged, not slow.\n  ${describeState()}`,
                     ),
                 ),
-            REFRESH_BUDGET_MS,
+            budgetMs,
         );
     });
     timer?.unref?.();
@@ -312,6 +347,40 @@ function nonEmptyForModule(
         msg.previews.length > 0 && msg.moduleDir.includes(moduleDirNeedle);
 }
 
+/**
+ * Generic timeout diagnostic: what the panel last published for a module,
+ * plus the Gradle tail the extension log would otherwise swallow.
+ *
+ * Scenario E builds a richer one that also reports its old/new rename ids;
+ * this is the version the scenarios with no id-level expectation share.
+ */
+function describeModulePanelState(
+    api: ComposePreviewTestApi,
+    moduleDirNeedle: string,
+): () => string {
+    return () => {
+        const msgs = api.getPostedMessages();
+        const latest = latestSetPreviewsMatching(msgs, (m) =>
+            m.moduleDir.includes(moduleDirNeedle),
+        );
+        const ids = latest
+            ? latest.previews.map((p) => p.id).sort()
+            : undefined;
+        return [
+            `latest ${moduleDirNeedle} setPreviews: ${
+                ids
+                    ? `${ids.length} preview(s) [${ids.join(", ")}]`
+                    : "<none posted>"
+            }`,
+            `empty state: ${emptyStateText(msgs) ?? "<none>"}`,
+            `lastWarmDaemonError: ${api.getLastWarmDaemonError() ?? "<none>"}`,
+            `Compose Preview output tail:\n    ${api
+                .getOutputChannelTail(40)
+                .join("\n    ")}`,
+        ].join("\n  ");
+    };
+}
+
 function fullRenderPath(
     repoRoot: string,
     moduleDir: string,
@@ -399,6 +468,24 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         api.injectGradleApi(
             new RealGradleApi(repoRoot, (line) => console.log(line), [
                 `-PcomposePreview.filter=${FIXTURE_PREVIEW_FILTER.join(",")}`,
+                // Mandatory companion to the filter above, and its absence was
+                // a real bug. `composePreviewRenderAll` ends with a
+                // completeness check over the *whole* manifest, and
+                // `composePreview.missingRenders` defaults to `fail` — so
+                // narrowing the render to 6 of the module's 66 previews made
+                // the task fail every single time:
+                //
+                //   composePreviewRenderAll: render produced no output file
+                //   for 59 of 66 preview(s)
+                //
+                // Every refresh in this suite was therefore landing on
+                // `renderWithDiskFallback` instead of the happy path, so the
+                // scenarios were only ever exercising the degraded route — and
+                // scenario E's post-rename refresh then saw a manifest of 3
+                // resource-only previews and resolved to the panel's empty
+                // state. `ci.yml`'s bundle job pairs a narrowed render with
+                // `missingRenders=warn` for exactly this reason.
+                "-PcomposePreview.missingRenders=warn",
             ]),
         );
 
@@ -864,6 +951,12 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
 
     it("E. rename a @Preview function; old id + PNG drop, new id surfaces, index pruned", async function () {
         api.resetMessages();
+        // Every budget below is clamped against this so the scenario's own
+        // waits can never sum past the Mocha ceiling: four full refreshes at
+        // REFRESH_BUDGET_MS each already exceed it, and a bare Mocha timeout
+        // reports nothing. Clamping means the *last* wait to overrun is the
+        // one that fails, and it fails with `describeCmpPanelState` attached.
+        const deadlineAt = Date.now() + this.timeout();
         const observations: Record<string, unknown> = {};
         const cmpNeedle = path.join("samples", "cmp");
         // The id format is `<class>.<functionName>_<previewName>` (e.g.
@@ -910,6 +1003,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             api,
             await refreshWithinBudget(
                 ":samples:cmp render",
+                budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
                 api.triggerRefresh(cmpFile, true, "full"),
                 describeCmpPanelState,
             ),
@@ -917,7 +1011,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         );
         const baseline = await waitFor(
             "cmp baseline setPreviews (with RedBoxPreview)",
-            PANEL_UPDATE_BUDGET_MS,
+            budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
             500,
             () => {
                 const msgs = api.getPostedMessages();
@@ -964,6 +1058,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                 api,
                 await refreshWithinBudget(
                     ":samples:cmp render",
+                    budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
                     api.triggerRefresh(cmpFile, true, "full"),
                     describeCmpPanelState,
                 ),
@@ -971,7 +1066,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             );
             const afterRename = await waitFor(
                 "setPreviews after rename (new id present, old id gone)",
-                PANEL_UPDATE_BUDGET_MS,
+                budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
                 500,
                 () => {
                     const msgs = api.getPostedMessages();
@@ -1047,7 +1142,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             // written" regression still fails, just via waitFor's timeout.
             await waitFor(
                 `renamed preview render PNG(s) on disk: ${newRenderOutputs.join(", ")}`,
-                PANEL_UPDATE_BUDGET_MS,
+                budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
                 500,
                 () =>
                     newRenderOutputs.every((p) => fs.existsSync(p))
@@ -1077,6 +1172,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                 api,
                 await refreshWithinBudget(
                     ":samples:cmp render",
+                    budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
                     api.triggerRefresh(cmpFile, true, "full"),
                     describeCmpPanelState,
                 ),
@@ -1084,7 +1180,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             );
             const reRefreshed = await waitFor(
                 "second post-rename cmp setPreviews",
-                PANEL_UPDATE_BUDGET_MS,
+                budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
                 500,
                 () => {
                     const msgs = api.getPostedMessages();
@@ -1115,6 +1211,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             api,
             await refreshWithinBudget(
                 ":samples:cmp render",
+                budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
                 api.triggerRefresh(cmpFile, true, "full"),
                 describeCmpPanelState,
             ),
@@ -1122,7 +1219,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         );
         const afterRevert = await waitFor(
             "setPreviews after reverting the rename",
-            PANEL_UPDATE_BUDGET_MS,
+            budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
             500,
             () => {
                 const msgs = api.getPostedMessages();
@@ -1151,8 +1248,17 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
 
     it("F. dropping the editor scope resolves to empty state, not stale cards (#1566)", async function () {
         api.resetMessages();
+        // F and G inherit whatever state a failing E left behind. E abandons
+        // its refresh on timeout rather than cancelling it, so the extension's
+        // `pendingRefresh` can still be in flight when F starts — and F's
+        // waits would then poll a buffer nothing is writing to for the full
+        // Mocha ceiling, turning one wedged render into three 30-minute
+        // timeouts. Bounding these the same way E bounds its own caps the
+        // cascade and makes each failure say what it saw.
+        const deadlineAt = Date.now() + this.timeout();
         const observations: Record<string, unknown> = {};
         const cmpNeedle = path.join("samples", "cmp");
+        const describeState = describeModulePanelState(api, cmpNeedle);
 
         // Unlike the other scenarios, F drives `triggerEditorScopeChange(null)`,
         // which routes through `refresh(false)` with NO caller file — so
@@ -1184,12 +1290,17 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         // visible editor, so the warm stays deterministic without reopening one.
         assertRefreshRendered(
             api,
-            await api.triggerRefresh(cmpFile, true, "full"),
+            await refreshWithinBudget(
+                ":samples:cmp render",
+                budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
+                api.triggerRefresh(cmpFile, true, "full"),
+                describeState,
+            ),
             ":samples:cmp render",
         );
         const loaded = await waitFor(
             "cmp setPreviews before dropping scope",
-            this.timeout(),
+            budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
             500,
             () => {
                 const msgs = api.getPostedMessages();
@@ -1198,6 +1309,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                     nonEmptyForModule(cmpNeedle),
                 );
             },
+            describeState,
         );
         observations.loadedIds = loaded.previews.map((p) => p.id).sort();
         assert.ok(
@@ -1213,7 +1325,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         const EMPTY_TEXT = "Open a Kotlin source file with @Preview functions.";
         await waitFor(
             "empty-state showMessage after dropping scope",
-            this.timeout(),
+            budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
             200,
             () => {
                 const msgs = api.getPostedMessages() as PostedMessage[];
@@ -1221,6 +1333,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                     (m) => m.command === "showMessage" && m.text === EMPTY_TEXT,
                 );
             },
+            describeState,
         );
 
         const post = api.getPostedMessages() as PostedMessage[];
@@ -1258,25 +1371,40 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         // the empty state.
         assertRefreshRendered(
             api,
-            await api.triggerRefresh(cmpFile, true, "full"),
+            await refreshWithinBudget(
+                ":samples:cmp render",
+                budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
+                api.triggerRefresh(cmpFile, true, "full"),
+                describeState,
+            ),
             ":samples:cmp render",
         );
     });
 
     it("G. compile error surfaces a banner without wiping cards; fix clears it", async function () {
         api.resetMessages();
+        // Same reasoning as F: bound every wait against this test's own Mocha
+        // budget so an upstream wedge fails here with a diagnostic instead of
+        // a bare 30-minute timeout.
+        const deadlineAt = Date.now() + this.timeout();
         const observations: Record<string, unknown> = {};
         const cmpNeedle = path.join("samples", "cmp");
+        const describeState = describeModulePanelState(api, cmpNeedle);
 
         // --- Baseline: a clean render so there are cards to keep ---
         assertRefreshRendered(
             api,
-            await api.triggerRefresh(cmpFile, true, "full"),
+            await refreshWithinBudget(
+                ":samples:cmp render",
+                budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
+                api.triggerRefresh(cmpFile, true, "full"),
+                describeState,
+            ),
             ":samples:cmp render",
         );
         const baseline = await waitFor(
             "cmp baseline setPreviews before injecting the error",
-            this.timeout(),
+            budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
             500,
             () => {
                 const msgs = api.getPostedMessages();
@@ -1285,6 +1413,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                     nonEmptyForModule(cmpNeedle),
                 );
             },
+            describeState,
         );
         const baselineIds = baseline.previews.map((p) => p.id).sort();
         observations.baselineIds = baselineIds;
@@ -1304,10 +1433,17 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         let errorPhaseError: Error | null = null;
         try {
             api.resetMessages();
-            await api.triggerRefresh(cmpFile, true, "full");
+            // Not `assertRefreshRendered` — this refresh is *expected* to
+            // report 'failed'; the compile error is the thing under test.
+            await refreshWithinBudget(
+                ":samples:cmp render (with injected syntax error)",
+                budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
+                api.triggerRefresh(cmpFile, true, "full"),
+                describeState,
+            );
             const errBanner = await waitFor(
                 "setCompileErrors after introducing the syntax error",
-                this.timeout(),
+                budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
                 500,
                 () => {
                     const msgs = api.getPostedMessages() as PostedMessage[];
@@ -1317,6 +1453,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                         return Array.isArray(errors) && errors.length > 0;
                     });
                 },
+                describeState,
             );
             const errors = errBanner.errors as Array<Record<string, unknown>>;
             observations.compileErrors = errors.map((e) => ({
@@ -1352,12 +1489,17 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         api.resetMessages();
         assertRefreshRendered(
             api,
-            await api.triggerRefresh(cmpFile, true, "full"),
+            await refreshWithinBudget(
+                ":samples:cmp render",
+                budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
+                api.triggerRefresh(cmpFile, true, "full"),
+                describeState,
+            ),
             ":samples:cmp render",
         );
         const recovered = await waitFor(
             "clean cmp setPreviews after fixing the error",
-            this.timeout(),
+            budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
             500,
             () => {
                 const msgs = api.getPostedMessages();
@@ -1366,6 +1508,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                     nonEmptyForModule(cmpNeedle),
                 );
             },
+            describeState,
         );
         const recoverPhase = api.getPostedMessages() as PostedMessage[];
         observations.recoverPhaseCommands = recoverPhase.map((m) => m.command);


### PR DESCRIPTION
Scenario E ("rename a `@Preview` function") was the residual flake in the `interactive-e-g` shard, and the cause of both post-fix failures on `main` ([31306997859](https://github.com/yschimke/compose-ai-tools/actions/runs/31306997859), [31305131855](https://github.com/yschimke/compose-ai-tools/actions/runs/31305131855)).

This PR does two things, and **does not make scenario E pass** — the remaining failure turned out to be a poisoned build-cache entry, which no change to this file can fix. See "What this does not fix" below.

## Fix 1 — the filter needs `missingRenders=warn`

The suite hands every `gradlew` invocation `-PcomposePreview.filter=…`, narrowing the render to the 6 previews the scenarios assert on. But `composePreviewRenderAll` finishes with a completeness check across the **whole** manifest, and `composePreview.missingRenders` defaults to `fail`:

```
composePreviewRenderAll: render produced no output file for 59 of 66 preview(s)
```

So the render task was failing on **every refresh this suite has ever made**, including the pre-rename baseline. Every scenario only ever exercised `renderWithDiskFallback` — the degraded path that paints the on-disk manifest — never the happy path.

`ci.yml`'s bundle job already pairs a narrowed render with `-PcomposePreview.missingRenders=warn` for exactly this reason. The suite didn't. It does now, and `FIXTURE_PREVIEW_FILTER`'s doc comment states the pairing is mandatory so it can't be dropped again.

Effect, measured: `interactive-e-g` went from a 30-minute bare Mocha timeout to a **2-minute** run, with F and G passing and the baseline refresh reaching the real render path (`Rendered 6 preview(s)`) for the first time.

## Fix 2 — bounded, self-describing waits

A bare `Timeout of 1800000ms exceeded` is not an acceptable failure mode: three quite different bugs collapse into one indistinguishable symptom (`setPreviews` never posted / renamed id never appeared / old id survived), at 30 minutes of runner time each.

- `waitFor` gains an optional `describeState`, rendered into the timeout message: the latest cmp `setPreviews` and its ids, old/new id presence, `getLastWarmDaemonError()`, and 40 lines of the Compose Preview output channel — which carries the `> <task> completed` / `FAILED` / `cancelled` Gradle lines the in-repo e2e otherwise routes to the extension log and discards.
- `refreshWithinBudget` bounds the awaited `triggerRefresh` itself. `PANEL_UPDATE_BUDGET_MS` only bounds the *poll after* the refresh resolves, which does nothing for a refresh that never resolves — and that is precisely what run 31306997859 was.
- The panel's two terminal empty states are matched explicitly and fail immediately with the message text, rather than waiting out a budget for a republish that is never coming.
- Budgets are clamped against the test's remaining Mocha time (`budgetWithin`). A fixed budget isn't enough on its own: E runs four bounded refreshes in one 30-minute test and 4 × `REFRESH_BUDGET_MS` is 48 minutes, so a wedge in a *late* refresh would blow the ceiling before its own timer fired.
- Scenarios F and G are bounded the same way, sharing a generic `describeModulePanelState`.

**Deliberately no retry.** A second forced refresh would very likely make E pass, and "edits not updating" is precisely the failure this suite exists to catch.

## What this does not fix

Scenario E (and scenario B, in `interactive-a-d`, which is red on `main` too) fail on a **poisoned remote build-cache entry**, not on anything in this file. Reproduced with plain Gradle in a clean container — no VS Code, no extension, no daemon:

| same renamed source | `compileKotlin` | `.class` files | `previews.json` |
|---|---|---|---|
| build cache on | `FROM-CACHE` | **0** | **3** |
| `--no-build-cache` | executed | 46 | **66** |

The cache serves an empty `:samples:cmp:compileKotlin` output. Restoring it empties the class directory; `DiscoverPreviewsTask` scans `classDirs`, finds nothing, and writes an asset-only manifest from `resourceDirs`; every filter pattern then matches nothing and `composePreviewRender` fails. That explains the 1-second CI build, why it only bites after a source edit, and why `interactive-a-d` is red on `main` with no PR involved.

Remediation (purging the entries, making the tasks non-cacheable, or narrowing the cache-push policy) is a separate decision and is not attempted here.

## Test plan

- `npm run compile:host` — clean.
- `npm test` — 1674 passing, unchanged (this file is e2e-gated, so the unit suite only proves it still compiles).
- `npm run format:check` — clean.
- `interactive-e-g` on this PR: F and G pass; E fails in ~2 minutes with the manifest state printed, which is how the cache entry was found.

Scenarios A–D still pass `this.timeout()` as a wait budget. Left alone — they run *before* E, and converting latent slow-but-passing waits into failures in the same change would muddy the signal.

No visual surface changes — test harness only, so text-only evidence is the right bar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmbwB3s3xBmk4Q4RWBjpjM)_