### PR TITLE
fix(figma-svg): evaluate a layer block against the node's real density

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -331,7 +331,7 @@ internal object ModifierTokenResolver {
           ?.firstOrNull { it.name == "alpha" }
           ?.value
           ?.let(::floatValue)
-        ?: evaluateLayerBlockAlpha(info.modifier, nodeSize(info))
+        ?: evaluateLayerBlockAlpha(info.modifier, nodeSize(info), nodeDensity(info))
         ?: appliedGraphicsLayerAlpha(info.coordinates)
     return effective?.coerceIn(0f, 1f)?.toDouble()
   }
@@ -480,7 +480,11 @@ internal object ModifierTokenResolver {
    * a series of property assignments, and reading the animation state it closes over gives exactly
    * the alpha the frame was drawn with.
    */
-  internal fun evaluateLayerBlockAlpha(modifier: Any, nodeSize: Long? = null): Float? {
+  internal fun evaluateLayerBlockAlpha(
+    modifier: Any,
+    nodeSize: Long? = null,
+    density: Density? = null,
+  ): Float? {
     val block = layerBlock(modifier) ?: return null
     val recorded = HashMap<String, Any?>()
     // The node's own placed size, so a block that *derives* alpha from geometry evaluates against
@@ -488,8 +492,24 @@ internal object ModifierTokenResolver {
     // `SurfaceTransformation` does exactly that — its alpha is a function of where the item sits in
     // its scaled slot — and answering `size` with the type's zero handed it a 0×0 box, which
     // collapsed to `opacity="0.0"`/`0.04` on groups the PNG paints fully opaque.
-    val geometry: Map<String, Any> =
-      nodeSize?.let { mapOf("size" to it, "center" to centerOf(it)) } ?: emptyMap()
+    //
+    // The node's real `density`/`fontScale` for the same reason: `GraphicsLayerScope` *is* a
+    // `Density`, so a block may convert dp inside itself (`alpha = if (size.height < 40.dp.toPx())
+    // …`) — and since this evaluator is now preferred over the coordinator's applied value, an
+    // assumed `1f` would quietly outrank the alpha the frame really used on any non-mdpi device.
+    //
+    // `size`/`center` are seeded even when the node has none: `GraphicsLayerScope.size` *defaults*
+    // to `Size.Unspecified`, so letting the interface body answer would hand the block a `NaN` box
+    // and a `NaN` alpha behind it. A zero box keeps the documented no-coordinates fallback.
+    val geometry: Map<String, Any> = buildMap {
+      val size = nodeSize ?: 0L
+      put("size", size)
+      put("center", centerOf(size))
+      density?.let {
+        put("density", it.density)
+        put("fontScale", it.fontScale)
+      }
+    }
     // The scope interface by name, not from the lambda's generic signature: a Kotlin lambda erases
     // to a raw `Function1`, so there is no type argument to read back off it.
     val iface =
@@ -504,24 +524,44 @@ internal object ModifierTokenResolver {
         ?.takeIf { it.isInterface } ?: return null
     val scope =
       runCatching {
-          java.lang.reflect.Proxy.newProxyInstance(iface.classLoader, arrayOf(iface)) { _, m, args
-            ->
+          java.lang.reflect.Proxy.newProxyInstance(iface.classLoader, arrayOf(iface)) {
+            proxy,
+            m,
+            args ->
             val name = m.name
-            when {
-              name.startsWith("set") && args != null && args.size == 1 -> {
-                recorded[propertyName(name, "set")] = args[0]
-                null
-              }
-              // Getters (and anything else) answer with a harmless default so a block that reads
-              // back a property it just set, or consults `density`, doesn't blow up mid-evaluation.
-              else -> defaultFor(m.returnType, name, recorded, geometry)
+            if (name.startsWith("set") && args != null && args.size == 1) {
+              recorded[propertyName(name, "set")] = args[0]
+              return@newProxyInstance null
             }
+            // A property the scope already knows: what the block just assigned, this node's real
+            // geometry/density, or Compose's own identity.
+            knownProperty(name, recorded, geometry)?.let {
+              return@newProxyInstance it
+            }
+            // `Density`'s dp/sp conversions are real method bodies on the interface, and a Proxy
+            // intercepts those as well as the abstract accessors. Stubbing them handed a block
+            // that writes `alpha = if (size.height < 40.dp.toPx()) …` a zero threshold, which is
+            // the same class of wrong answer as an assumed density — and now that this evaluator
+            // outranks the coordinator's applied alpha, a wrong answer here is worse than none.
+            // Run the real body: it reads `density` back off this same proxy, so it converts
+            // against the node's value.
+            if (m.isDefault) {
+              val invoked = runCatching {
+                java.lang.reflect.InvocationHandler.invokeDefault(proxy, m, *(args ?: emptyArray()))
+              }
+              if (invoked.isSuccess) return@newProxyInstance invoked.getOrNull()
+            }
+            // Anything else answers with a harmless zero so the block doesn't blow up mid-run.
+            zeroFor(m.returnType)
           }
         }
         .getOrNull() ?: return null
     @Suppress("UNCHECKED_CAST") val invoke = block as? Function1<Any?, Any?> ?: return null
     runCatching { invoke(scope) }.getOrNull() ?: return null
-    return recorded["alpha"] as? Float
+    // A block can still compute its way to a non-finite alpha — dividing by a dimension this scope
+    // could not supply, say. Decline instead of exporting it: `opacity="NaN"` is not a colour any
+    // consumer can read, and returning null lets the coordinator's applied value answer instead.
+    return (recorded["alpha"] as? Float)?.takeIf { it.isFinite() }
   }
 
   /**
@@ -538,6 +578,16 @@ internal object ModifierTokenResolver {
         else packFloats(size.width.toFloat(), size.height.toFloat())
       }
       .getOrNull()
+
+  /**
+   * This modifier's own `Density`, or null when the coordinates can't supply one.
+   *
+   * A `NodeCoordinator` reaches `Density` through `MeasureScope`, so the placed coordinates carry
+   * the device's real `density`/`fontScale` — no reflection needed, and no need to thread the
+   * renderer's density down here. Null leaves [evaluateLayerBlockAlpha] on the identity defaults,
+   * the same degradation as a detached node's missing size.
+   */
+  private fun nodeDensity(info: ModifierInfo): Density? = info.coordinates as? Density
 
   /** The centre of a packed `Size`, as a packed `Offset` — the same packing layout. */
   private fun centerOf(packedSize: Long): Long =
@@ -571,8 +621,7 @@ internal object ModifierTokenResolver {
    * reads a property back, else the type's zero. `density`/`fontScale` answer 1 so a block that
    * converts dp inside itself divides by something sane rather than zero.
    */
-  private fun defaultFor(
-    type: Class<*>,
+  private fun knownProperty(
     name: String,
     recorded: Map<String, Any?>,
     geometry: Map<String, Any> = emptyMap(),
@@ -581,22 +630,23 @@ internal object ModifierTokenResolver {
     recorded[property]?.let {
       return it
     }
-    // Before the static identities: a real `size`/`center` for this node beats `Size.Zero`, which
-    // is what a geometry-derived block would otherwise divide into (issue #2615).
+    // Before the static identities: a real `size`/`center`/`density` for this node beats the
+    // assumed value, which is what a geometry- or density-derived block would otherwise divide
+    // into (issues #2615, #3579).
     geometry[property]?.let {
       return it
     }
-    GRAPHICS_LAYER_DEFAULTS[property]?.let {
-      return it
-    }
-    return when (type) {
+    return GRAPHICS_LAYER_DEFAULTS[property]
+  }
+
+  private fun zeroFor(type: Class<*>): Any? =
+    when (type) {
       java.lang.Float.TYPE -> 0f
       java.lang.Boolean.TYPE -> false
       java.lang.Integer.TYPE -> 0
       java.lang.Long.TYPE -> 0L
       else -> null
     }
-  }
 
   /**
    * The property a proxied accessor belongs to: `getAlpha` → `alpha`.

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/GraphicsLayerBlockGeometryTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/GraphicsLayerBlockGeometryTest.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.daemon
 
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -71,8 +73,75 @@ class GraphicsLayerBlockGeometryTest {
   }
 
   @Test
+  fun aNonFiniteAlphaIsDeclinedRatherThanExported() {
+    // `GraphicsLayerScope.size` defaults to `Size.Unspecified`, so a block dividing into a
+    // dimension can reach NaN. `opacity="NaN"` is not a value any consumer can read — decline so
+    // the coordinator's applied alpha answers instead.
+    val element = LayerElement { alpha = size.height / (size.height - size.height) }
+
+    assertNull(ModifierTokenResolver.evaluateLayerBlockAlpha(element, packedSize(200f, 80f)))
+  }
+
+  @Test
   fun aModifierWithNoBlockDeclinesInsteadOfGuessing() {
     assertNull(ModifierTokenResolver.evaluateLayerBlockAlpha(Any(), packedSize(48f, 48f)))
+  }
+
+  @Test
+  fun aBlockDerivingAlphaFromDensitySeesTheNodesRealDensity() {
+    // `GraphicsLayerScope` is a `Density`, so a block may convert dp inside itself. The evaluator
+    // is preferred over the coordinator's applied alpha, so assuming mdpi here would quietly
+    // outrank the alpha the frame really used on every non-mdpi device (#3589 review).
+    val element = LayerElement { alpha = if (size.height < 40.dp.toPx()) 0.5f else 1f }
+
+    // 80px tall at density 3 is 26.7dp — under the 40dp threshold, so it fades.
+    assertEquals(
+      0.5f,
+      ModifierTokenResolver.evaluateLayerBlockAlpha(
+        element,
+        packedSize(200f, 80f),
+        Density(density = 3f),
+      )!!,
+      0.001f,
+    )
+    // The same box at mdpi is 80dp — over the threshold, so it does not.
+    assertEquals(
+      1f,
+      ModifierTokenResolver.evaluateLayerBlockAlpha(
+        element,
+        packedSize(200f, 80f),
+        Density(density = 1f),
+      )!!,
+      0.001f,
+    )
+  }
+
+  @Test
+  fun aFontScaleDerivedBlockSeesTheNodesRealFontScale() {
+    val element = LayerElement { alpha = if (fontScale > 1.2f) 0.25f else 1f }
+
+    assertEquals(
+      0.25f,
+      ModifierTokenResolver.evaluateLayerBlockAlpha(
+        element,
+        packedSize(48f, 48f),
+        Density(density = 1f, fontScale = 1.5f),
+      )!!,
+      0.001f,
+    )
+  }
+
+  @Test
+  fun withoutADensityTheBlockFallsBackToTheIdentityScale() {
+    // No coordinates to read a density off: the evaluator keeps the `1f` identity rather than
+    // inventing one, which is the pre-existing behaviour for every caller that has none.
+    val element = LayerElement { alpha = if (density > 1f) 0.5f else 1f }
+
+    assertEquals(
+      1f,
+      ModifierTokenResolver.evaluateLayerBlockAlpha(element, packedSize(48f, 48f))!!,
+      0.001f,
+    )
   }
 
   @Test

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgLayerBlockDensityTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgLayerBlockDensityTest.kt
@@ -1,0 +1,142 @@
+package ee.schimke.composeai.renderer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.LocalInspectionTables
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.captureRoboImage
+import ee.schimke.composeai.daemon.ComposeFigmaSvgDataProducer
+import ee.schimke.composeai.daemon.ComposeSemanticsDataProducer
+import ee.schimke.composeai.daemon.LayoutInspectorDataProducer
+import ee.schimke.composeai.data.render.PreviewContext
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * A lambda-form `graphicsLayer { … }` is evaluated against a recording proxy, and that evaluation
+ * now outranks the coordinator's applied alpha. So the proxy has to answer `density` with the
+ * node's real value: a block converting dp inside itself would otherwise resolve against an assumed
+ * mdpi and publish an alpha the frame never used, on every other device (issue #3579, and the
+ * review on #3589).
+ *
+ * The density reaches the proxy through `ModifierInfo.coordinates`, which is a `NodeCoordinator` —
+ * a `MeasureScope`, hence a `Density`. This test exists because that is a *cast*, and a cast that
+ * silently starts returning null would restore the old wrong answer with nothing else failing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class FigmaSvgLayerBlockDensityTest {
+
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("figma-svg-layer-density").toFile()
+    System.setProperty("roborazzi.test.record", "true")
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+    System.clearProperty("roborazzi.test.record")
+  }
+
+  @Test
+  fun `a dp-derived layer alpha resolves against the node's real density`() {
+    // xhdpi, so density is 2. The box is 25dp = 50px tall and the block's threshold is 40dp.
+    //   real density (2):    50px < 80px  -> the block assigns 0.5
+    //   assumed mdpi (1):    50px < 40px  -> the block assigns 1.0 and the fade is lost
+    // The two disagree only because the size is in px while the threshold is in dp, which is
+    // exactly the shape that made an assumed density invisible in every other test.
+    val svg = renderSvg("layer-block-density")
+    File("build/figma-svg-layer-density").mkdirs()
+    File("build/figma-svg-layer-density/layer-block-density.svg").writeText(svg)
+
+    assertTrue(
+      "the dp-derived alpha must resolve against density 2 and emit opacity 0.5; " +
+        "an assumed mdpi drops the fade entirely:\n$svg",
+      Regex("<g[^>]*\\bopacity=\"0\\.5\"").containsMatchIn(svg),
+    )
+  }
+
+  private fun renderSvg(previewId: String): String {
+    RuntimeEnvironment.setQualifiers("w400dp-h400dp-xhdpi")
+    @Suppress("DEPRECATION") val rule = createAndroidComposeRule<ComponentActivity>()
+    var svg = ""
+    val statement =
+      object : Statement() {
+        override fun evaluate() {
+          val slots = mutableSetOf<CompositionData>()
+          rule.setContent {
+            InspectableDensityContent(slots) {
+              Box(
+                Modifier.size(25.dp)
+                  .graphicsLayer { alpha = if (size.height < 40.dp.toPx()) 0.5f else 1f }
+                  .background(Color.Red)
+              )
+            }
+          }
+          rule.waitForIdle()
+          val frame = File(rootDir, "$previewId-frame.png")
+          frame.parentFile?.mkdirs()
+          rule.onRoot().captureRoboImage(file = frame)
+          val semRoot = rule.onRoot(useUnmergedTree = true).fetchSemanticsNode()
+          val ctx =
+            PreviewContext.Builder(previewId, null, null, previewId)
+              .rootForTest(semRoot.root as RootForTest)
+              .addSlotTables(slots.toList())
+              .parameterInformationCollected()
+              .build()
+          val layout = LayoutInspectorDataProducer.buildPayload(ctx, density = 2f)!!
+          val sem = ComposeSemanticsDataProducer.buildPayload(semRoot, density = 2f)
+          ComposeFigmaSvgDataProducer.writeSvg(
+            rootDir = rootDir,
+            previewId = previewId,
+            layout = layout,
+            semantics = sem,
+            density = 2f,
+            frameImage = frame,
+          )
+          svg = File(rootDir, "$previewId/compose-figma.svg").readText()
+        }
+      }
+    rule.apply(statement, Description.createTestDescription(javaClass, previewId)).evaluate()
+    return svg
+  }
+}
+
+@OptIn(InternalComposeApi::class)
+@Composable
+private fun InspectableDensityContent(
+  capture: MutableSet<CompositionData>,
+  content: @Composable () -> Unit,
+) {
+  currentComposer.collectParameterInformation()
+  capture.add(currentComposer.compositionData)
+  CompositionLocalProvider(LocalInspectionTables provides capture, content = content)
+}


### PR DESCRIPTION
Follow-up to #3589, addressing the Codex P2 review left on it — the review landed while auto-merge was completing, so this is a separate change rather than a push onto the merged branch.

#3589 made `evaluateLayerBlockAlpha` authoritative over the coordinator's `lastLayerAlpha`, which is right for a block whose alpha depends on draw-time state. But the recording proxy answers `density` and `fontScale` with a hard-coded `1f`, so a block deriving alpha from the scope's density would export the assumed value and now *outrank* the alpha the frame actually used, on any non-mdpi device. The review is correct.

`GraphicsLayerScope` is a `Density`, and so is the `NodeCoordinator` behind `ModifierInfo.coordinates` (via `MeasureScope`), so the node's real `density`/`fontScale` can be fed in alongside the size the evaluator already supplies — no reflection, and no threading the renderer's density down. That makes the evaluator faithful rather than trading one wrong answer for another.

## Two things that surfaced while pinning it down

**`Density`'s conversions were returning zero.** `toPx`/`toDp` are method *bodies* on the interface, and a `Proxy` intercepts those as well as the abstract accessors — so `40.dp.toPx()` answered `0`, handing a block like `alpha = if (size.height < 40.dp.toPx()) …` a zero threshold. Same class of wrong answer as an assumed density, and newly harmful for the same reason. The handler now runs the real body via `InvocationHandler.invokeDefault` (Java 16+; this repo targets 17), which reads `density` back off the same proxy and converts against the node's value.

**That exposed a `NaN` path.** With interface bodies live, `GraphicsLayerScope.size` answers with its real `Size.Unspecified` default when the node has no coordinates — and the `NaN` propagates into the alpha, which would have reached the SVG as `opacity="NaN"`. Two guards: seed the zero box the no-coordinates fallback has always documented, and decline a non-finite alpha outright so the coordinator's applied value answers instead.

## Test plan

- `GraphicsLayerBlockGeometryTest` gains four cases: a dp-threshold block resolving differently at density 3 vs 1, a `fontScale`-derived block, the no-density fallback holding the `1f` identity, and a non-finite alpha being declined rather than exported.
- `./gradlew :data-layoutinspector-connector:test :data-layoutinspector-core:test :renderer-android:testDebugUnitTest` — all green, including `AppliedGraphicsLayerAlphaTest` (#2615), the #2853 animated-lambda case, and `FigmaSvgWearScalingAlphaTest` from #3589.

## Visual evidence

None embedded, deliberately: this change alters no existing preview. Verified rather than assumed — re-exporting the Wear scaling sticker from #3589 gives a file byte-identical to the committed `renders/figma-svg-wear-scaling-alpha/after.svg` apart from the Wear `TimeText` wall clock. The change only moves output for blocks that read `density`/`fontScale`/dp-conversions, or that would otherwise have produced `NaN`; the catalogs contain none today, which is precisely why this needed tests rather than a screenshot.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrscSvCccWovuNg44XxmRm)_