### PR TITLE
fix(rc-embedded): let both embedded lanes parse URL-encoded bitmaps

### DIFF
--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
@@ -22,6 +22,7 @@ package ee.schimke.composeai.rcembedded.jvm
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.remote.core.CoreDocument
+import androidx.compose.remote.core.Limits
 import androidx.compose.remote.core.Operation
 import androidx.compose.remote.core.RemoteClock
 import androidx.compose.remote.core.RemoteComposeBuffer
@@ -147,9 +148,38 @@ internal const val RC_EMBEDDED_TRACE_DOCUMENT: String = "rc-embedded.document"
 
 internal const val RC_EMBEDDED_TRACE_FRAME: String = "rc-embedded.frame"
 
+/**
+ * Let the AndroidX parser accept URL- and file-encoded bitmaps.
+ *
+ * `Limits.ENABLE_IMAGE_URLS` / `ENABLE_IMAGE_FILES` are mutable globals that ship `false`. With
+ * them off, `BitmapData.read` throws `URL image not supported [<id>]` the moment a document carries
+ * a `BitmapData` with `ENCODING_URL` — and because that throw happens during `inflateFromBuffer`,
+ * it takes down the *whole* parse. The document then produces no render at all, so this lane drops
+ * its column for it rather than drawing the 95% of the document that has nothing to do with the
+ * image.
+ *
+ * Enabling the parse is not enabling a fetch. The reference is only resolved if the host supplies a
+ * loader, and this renderer supplies none — the image slot stays empty and the rest of the document
+ * draws. That is exactly what the JS and CMP players already do with the same bytes, which is what
+ * makes the comparison a comparison: before this, a URL-image document was the one case where the
+ * embedded lanes were blank for a reason that had nothing to do with the renderer under test.
+ *
+ * Both flags, not just the URL one, because a document authored against both assumes both: the Home
+ * Assistant catalog that surfaced this calls its own `enableRemoteImageUrls()` — setting the
+ * identical pair — from every player entry point it owns. This lane is an entry point it doesn't.
+ *
+ * Set on every parse rather than once in an initializer: the flags are process-global and public,
+ * so anything else on the classpath can flip them back, and re-asserting costs two field writes.
+ */
+private fun enableEncodedImageReferences() {
+  Limits.ENABLE_IMAGE_URLS = true
+  Limits.ENABLE_IMAGE_FILES = true
+}
+
 /** Parse `.rc` bytes into a [CoreDocument]. Mirrors `RcPlayer(capturedDocument)`'s buffer load. */
 internal fun parseDocument(bytes: ByteArray): CoreDocument =
   Tracer.global.trace(category = RC_EMBEDDED_TRACE_DOCUMENT, name = "rcEmbedded:parseDocument") {
+    enableEncodedImageReferences()
     CoreDocument(RemoteClock.SYSTEM).apply {
       ByteArrayInputStream(bytes).use { stream ->
         initFromBuffer(RemoteComposeBuffer.fromInputStream(stream))

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmUrlBitmapParseTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmUrlBitmapParseTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded.jvm
+
+import androidx.compose.remote.core.CoreDocument
+import androidx.compose.remote.core.Limits
+import androidx.compose.remote.core.RemoteComposeBuffer
+import androidx.compose.remote.core.operations.BitmapData
+import java.io.ByteArrayInputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * A document carrying a URL-encoded bitmap must parse.
+ *
+ * `Limits.ENABLE_IMAGE_URLS` is a public mutable global in `remote-core` that ships `false`. While
+ * it is off, `BitmapData.read` throws `URL image not supported [<id>]` for any `BitmapData` with
+ * `ENCODING_URL`, and because that read happens inside `inflateFromBuffer` the throw fails the
+ * *whole* document, not just the image. [parseDocument] opts in, so the document parses and the
+ * image slot is simply left unresolved — nothing here supplies a loader, and parsing a URL is not
+ * fetching one.
+ *
+ * A real regression, not a hypothetical: two Home Assistant picture-entity previews
+ * (`PictureEntity_AppMode_{Dark,Light}`, whose app-mode strategy references the camera frame by URL
+ * instead of baking it) were the only 2 of that catalog's 122 documents this lane could not render,
+ * while the JS and CMP players drew both. It was easy to misread as a missing operation, because
+ * the parse died reporting an opcode — yet 106 documents carrying that same opcode parsed fine, and
+ * the real trigger was the image encoding. Hence [urlBitmapIsRejectedWhenTheGlobalIsOff]: it pins
+ * the actual failure mode so the two are told apart next time.
+ */
+class RcJvmUrlBitmapParseTest {
+
+  /**
+   * Smallest document that reaches the branch: a header plus one URL-form `BitmapData`. Written
+   * through upstream's own `BitmapData.apply` overload — the one that packs `type` and `encoding`
+   * into the high halves of the width/height fields — so the test exercises the real wire layout
+   * instead of a local re-implementation of it that could drift.
+   */
+  private fun urlBitmapDocument(imageId: Int): ByteArray {
+    val buffer = RemoteComposeBuffer()
+    buffer.header(WIDTH, HEIGHT, DENSITY, /* capabilities= */ 0L)
+    val wire = buffer.buffer
+    BitmapData.apply(
+      wire,
+      imageId,
+      BitmapData.TYPE_PNG,
+      WIDTH.toShort(),
+      BitmapData.ENCODING_URL,
+      HEIGHT.toShort(),
+      URL.toByteArray(),
+    )
+    return wire.buffer.copyOf(wire.size())
+  }
+
+  @Test
+  fun urlBitmapDocumentParses() {
+    val document = parseDocument(urlBitmapDocument(imageId = 42))
+
+    val bitmap = document.operations.filterIsInstance<BitmapData>().singleOrNull()
+    assertNotNull("the URL bitmap should survive the parse", bitmap)
+    assertEquals(42, bitmap!!.id)
+    assertEquals(WIDTH, bitmap.width)
+    assertEquals(HEIGHT, bitmap.height)
+  }
+
+  /**
+   * The failure being guarded against, asserted against the shipped default so this still means
+   * something if AndroidX ever flips it: with the global off the parse dies, and it dies naming the
+   * *image*, never an operation code.
+   */
+  @Test
+  fun urlBitmapIsRejectedWhenTheGlobalIsOff() {
+    val document = urlBitmapDocument(imageId = 7)
+    val restore = Limits.ENABLE_IMAGE_URLS
+    val failure =
+      try {
+        Limits.ENABLE_IMAGE_URLS = false
+        runCatching {
+            ByteArrayInputStream(document).use {
+              CoreDocument().initFromBuffer(RemoteComposeBuffer.fromInputStream(it))
+            }
+          }
+          .exceptionOrNull()
+      } finally {
+        Limits.ENABLE_IMAGE_URLS = restore
+      }
+
+    assertNotNull("expected the parse to fail while URL images are disabled", failure)
+    assertEquals("URL image not supported [7]", failure!!.message)
+  }
+
+  private companion object {
+    const val WIDTH = 64
+    const val HEIGHT = 64
+    const val DENSITY = 1f
+    const val URL = "https://example.invalid/camera.png"
+  }
+}

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -464,21 +464,11 @@ public fun RcPlayer(
 ) {
     val coreDoc =
         remember(capturedDocument) {
-            // `Limits.ENABLE_IMAGE_URLS` / `ENABLE_IMAGE_FILES` are mutable globals that ship
-            // `false`, and with them off `BitmapData.read` throws `URL image not supported [<id>]`
-            // as soon as a document carries a `BitmapData` with `ENCODING_URL`. That throw lands
-            // inside `inflateFromBuffer`, so it fails the entire parse and the document renders as
-            // nothing — not "the image is missing", but no player output at all.
-            //
-            // Parsing an encoded reference is not fetching one: resolution needs an `imageLoader`,
-            // and a caller that passes none (every render harness here) simply leaves the slot
-            // empty and draws the rest of the document. That matches what the JS and CMP players do
-            // with the same bytes, so enabling this removes a difference between the players that
-            // was never about the players. Both flags because a document authored against both
-            // assumes both — see the sibling `enableRemoteImageUrls()` in the Home Assistant
-            // catalog, which sets the identical pair at every player entry point it owns.
-            Limits.ENABLE_IMAGE_URLS = true
-            Limits.ENABLE_IMAGE_FILES = true
+            // Ahead of the parse below, which fails the whole document on a URL-encoded bitmap
+            // unless the globals are set. This overload is only one of the byte-level entry
+            // points — `RemoteDocument(bytes)` parses in its own constructor, so callers taking
+            // that route enable it themselves.
+            enableEncodedImageReferences()
             CoreDocument(RemoteClock.SYSTEM).apply {
                 ByteArrayInputStream(capturedDocument.bytes).use {
                     initFromBuffer(RemoteComposeBuffer.fromInputStream(it))

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -464,6 +464,21 @@ public fun RcPlayer(
 ) {
     val coreDoc =
         remember(capturedDocument) {
+            // `Limits.ENABLE_IMAGE_URLS` / `ENABLE_IMAGE_FILES` are mutable globals that ship
+            // `false`, and with them off `BitmapData.read` throws `URL image not supported [<id>]`
+            // as soon as a document carries a `BitmapData` with `ENCODING_URL`. That throw lands
+            // inside `inflateFromBuffer`, so it fails the entire parse and the document renders as
+            // nothing — not "the image is missing", but no player output at all.
+            //
+            // Parsing an encoded reference is not fetching one: resolution needs an `imageLoader`,
+            // and a caller that passes none (every render harness here) simply leaves the slot
+            // empty and draws the rest of the document. That matches what the JS and CMP players do
+            // with the same bytes, so enabling this removes a difference between the players that
+            // was never about the players. Both flags because a document authored against both
+            // assumes both — see the sibling `enableRemoteImageUrls()` in the Home Assistant
+            // catalog, which sets the identical pair at every player entry point it owns.
+            Limits.ENABLE_IMAGE_URLS = true
+            Limits.ENABLE_IMAGE_FILES = true
             CoreDocument(RemoteClock.SYSTEM).apply {
                 ByteArrayInputStream(capturedDocument.bytes).use {
                     initFromBuffer(RemoteComposeBuffer.fromInputStream(it))

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RemoteImageSupport.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RemoteImageSupport.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("RestrictedApiAndroidX")
+
+package androidx.compose.remote.player.compose.embedded
+
+import androidx.compose.remote.core.Limits
+
+/**
+ * Let the AndroidX parser accept URL- and file-encoded bitmaps.
+ *
+ * `Limits.ENABLE_IMAGE_URLS` / `ENABLE_IMAGE_FILES` are public mutable globals in `remote-core`
+ * that ship `false`. While they are off, `BitmapData.read` throws `URL image not supported [<id>]`
+ * for any `BitmapData` carrying `ENCODING_URL`, and because that read happens inside
+ * `inflateFromBuffer` the throw fails the **whole document** rather than just the image. A player
+ * or harness handed such a document then produces nothing at all.
+ *
+ * Enabling the parse is not enabling a fetch: the reference is only resolved if the host supplies a
+ * loader, so a caller that passes none simply leaves the image slot empty and draws the rest of the
+ * document — which is what the JS and CMP players already do with the same bytes.
+ *
+ * **Call this before the bytes are parsed, not before they are drawn.** Parsing happens in more
+ * than one place, and two of them are constructors: `RemoteDocument(bytes)` decodes inside its own
+ * constructor, so a call sited after it has already missed. Every entry point that turns bytes into
+ * a `CoreDocument` needs this ahead of it. That is the same rule the Home Assistant catalog follows
+ * with its own `enableRemoteImageUrls()`, which it calls from each of its player entry points.
+ *
+ * Idempotent and cheap — two field writes — so re-asserting per parse is deliberate: the flags are
+ * process-global and public, and anything else on the classpath can flip them back.
+ */
+public fun enableEncodedImageReferences() {
+    Limits.ENABLE_IMAGE_URLS = true
+    Limits.ENABLE_IMAGE_FILES = true
+}

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcEmbeddedRenderHarness.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcEmbeddedRenderHarness.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayer
+import androidx.compose.remote.player.compose.embedded.enableEncodedImageReferences
 import androidx.compose.remote.player.core.RemoteDocument
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -132,6 +133,11 @@ class RcEmbeddedRenderHarness(private val entry: Entry) {
           with(density) { entry.height.toDp() },
         )
       ) {
+        // Before the constructor, not after: `RemoteDocument(bytes)` parses inside it, so a
+        // document carrying a URL-encoded bitmap fails here — and takes the whole document with
+        // it — unless the globals are already set. This lane never enters the
+        // `RcPlayer(CapturedDocument)` overload, so it has to opt in for itself.
+        enableEncodedImageReferences()
         val document = remember { RemoteDocument(bytes) }
         ExperimentalRemoteDocumentPlayer(
           document = document,

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcViewPlayerRenderHarness.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcViewPlayerRenderHarness.kt
@@ -24,6 +24,7 @@ import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.remote.player.compose.RemoteDocumentPlayer
+import androidx.compose.remote.player.compose.embedded.enableEncodedImageReferences
 import androidx.compose.remote.player.core.RemoteDocument
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -102,6 +103,9 @@ class RcViewPlayerRenderHarness(private val entry: RcEmbeddedRenderHarness.Entry
           with(density) { entry.height.toDp() },
         )
       ) {
+        // As in `RcEmbeddedRenderHarness`: `RemoteDocument(bytes)` parses in its constructor, so
+        // the globals have to be set before it or a URL-encoded bitmap fails the whole document.
+        enableEncodedImageReferences()
         val document = remember { RemoteDocument(bytes) }
         // The View player takes the document's pixel size directly rather than filling its parent.
         RemoteDocumentPlayer(


### PR DESCRIPTION
## Summary

The first three-lane run of the `homeassistant-remotecompose` catalog ([run #58](https://github.com/yschimke/homeassistant-remotecompose/actions/runs/31309320287)) rendered 120 of 122 documents in both embedded lanes. The two it missed rendered fine in the JS and CMP players:

```
PictureEntity_AppMode_Dark:  JS 80.05%  |  embedded NOT RENDERED  |  cmp-jvm NOT RENDERED
PictureEntity_AppMode_Light: JS 81.24%  |  embedded NOT RENDERED  |  cmp-jvm NOT RENDERED
```

`Limits.ENABLE_IMAGE_URLS` and `ENABLE_IMAGE_FILES` are public mutable globals in `remote-core` that ship `false`. While they are off, `BitmapData.read` throws `URL image not supported [<id>]` for any `BitmapData` carrying `ENCODING_URL` — and because that read happens inside `inflateFromBuffer`, the throw fails the **whole document**, not just the image. The lane then has nothing to publish and drops its column for that row.

Both embedded lanes now opt in at their parse sites. This is not a new idea: the Home Assistant catalog already calls its own `enableRemoteImageUrls()` — setting the identical pair — from every player entry point it owns (`TerrazzoApplication`, `HaEmbeddedPlayer`, `WrapAdaptiveRemoteDocumentPlayer`, `CardCapture`). These lanes are entry points it does not own.

**Parsing an encoded reference is not fetching one.** Resolution needs a loader; these harnesses supply none, so the image slot stays empty and the rest of the document draws — exactly what the JS and CMP players already do with the same bytes. No new egress.

## It was not a missing operation

Worth recording, because the failure reported an opcode and that is a trap:

| | evidence |
|---|---|
| documents in the catalog | 122 |
| carrying `CORE_TEXT` (239) | **108** |
| of those, rendering fine in both embedded lanes | **106** |
| carrying a URL-encoded bitmap (`encoding=1`) | **2** |
| failing | **the same 2** |

The correlation is with the image encoding, not the opcode. Confirmed by running the two documents through the real `remote-core` `1.0.0-alpha16` parser directly — 2/122 fail as shipped, **0/122** with the flags on, and the exception names the image:

```
Limits.ENABLE_IMAGE_URLS = false -> RuntimeException: URL image not supported [46]
Limits.ENABLE_IMAGE_URLS = true  -> parses
```

## Visual evidence

The affected surface is the CI-published compare page, which cannot be rendered in this container (no Android/Skiko toolchain). The pixels below are the ones the pipeline actually produced, from the published catalog at `design-artifacts/homeassistant-remotecompose@1aa7a45`.

**`PictureEntity_AppMode_Light` — the failing document.** Baked reference and the JS player's render both exist; the image itself is absent in both because the camera URL is unreachable in CI, which is expected and is the same in every player:

| baked PNG | RC · JS player |
|---|---|
| !``[AppMode baked](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/1aa7a45/rc-baked/ee.schimke.ha.previews.PictureEntityStrategyPreviewsKt.PictureEntity_AppMode_Light_picture-entity_app-mode__light_.png)`` | !``[AppMode JS player](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/1aa7a45/rc/ee.schimke.ha.previews.PictureEntityStrategyPreviewsKt.PictureEntity_AppMode_Light_picture-entity_app-mode__light_.png)`` |

There is no third or fourth image to show for that row, and that is the bug: the published tree has **no** `rc-embedded/` or `rc-embedded-jvm/` entry for it at all.

**`PictureEntity_WidgetMode_Light` — the control.** Same card, same layout, same two `CORE_TEXT` ops; the only difference is that widget mode bakes the frame instead of referencing it by URL. It renders in every lane:

| baked PNG | RC · JS player | RC · embedded player | RC · cmp-jvm player |
|---|---|---|---|
| !``[WidgetMode baked](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/1aa7a45/rc-baked/ee.schimke.ha.previews.PictureEntityStrategyPreviewsKt.PictureEntity_WidgetMode_Light_picture-entity_widget-mode__light_.png)`` | !``[WidgetMode JS player](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/1aa7a45/rc/ee.schimke.ha.previews.PictureEntityStrategyPreviewsKt.PictureEntity_WidgetMode_Light_picture-entity_widget-mode__light_.png)`` | !``[WidgetMode embedded](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/1aa7a45/rc-embedded/ee.schimke.ha.previews.PictureEntityStrategyPreviewsKt.PictureEntity_WidgetMode_Light_picture-entity_widget-mode__light_.png)`` | !``[WidgetMode cmp-jvm](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/1aa7a45/rc-embedded-jvm/ee.schimke.ha.previews.PictureEntityStrategyPreviewsKt.PictureEntity_WidgetMode_Light_picture-entity_widget-mode__light_.png)`` |

After this change the AppMode row gets the same four columns as the WidgetMode row. The end-to-end confirmation is the next `design-artifacts` run, where the page should report `122/122 rendered` in the embedded lanes rather than 120.

## Test plan

- New `RcJvmUrlBitmapParseTest` in the cmp-jvm lane, both directions:
  - a document with a URL-form `BitmapData` parses through `parseDocument`, and the op survives with its id and dimensions;
  - with `Limits.ENABLE_IMAGE_URLS` forced off it fails with exactly `URL image not supported [7]` — pinning the real failure mode so it is not misread as an opcode problem again.
- The fixture is synthesised in the test through upstream's own `BitmapData.apply` overload (the one packing `type`/`encoding` into the high halves of width/height), so the wire layout under test is upstream's rather than a local re-implementation, and no binary blob is checked in.
- Both assertions were verified against the real `remote-core-1.0.0-alpha16.jar` before being written as Kotlin.
- `ktfmtCheck` passes for both touched modules.
- **Not run locally:** `:third-party-rc-embedded-player-jvm:test`. `compileKotlin` fails in this container on `RcJvmFigmaSvgRenderer.kt` with unresolved `ComposeFigmaSvgDataProducer` / `ComposeSemanticsDataProducer` / `LayoutInspectorDataProducer`. This is pre-existing and unrelated — it reproduces identically on a clean tree with these changes stashed, in a file this PR does not touch. CI compiles and runs it.

## Not addressed here

The two AppMode documents render without their camera image in every lane, because CI cannot reach the Home Assistant URL. That is correct behaviour for a headless render and is unchanged by this PR; it is why those rows show a high JS mismatch (~80%) against the baked reference. Making URL-backed images resolvable in the render harness would be a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Jp77i7Ce63KoJeQkew2uQ)_