### PR TITLE
fix: bump the build-cache salt to orphan an empty compileKotlin entry

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,11 @@ org.gradle.caching=true
 # server-side: a poisoned entry fails during *load*, so the task never executes and never pushes a
 # replacement, and no amount of re-running clears it. One cold main build reseeds under the new
 # keys. History: 1 = orphan the truncated `:daemon:core:compileKotlin` entry cc7964dd… (2026-07).
-composeai.cacheSalt=1
+# 2 = orphan an EMPTY `:samples:cmp:compileKotlin` entry (2026-08). Unlike a truncated entry this
+# one loads cleanly — it just restores zero `.class` files, so the build stays green while
+# `composePreviewDiscover` scans an empty `classDirs` and writes an asset-only 3-preview manifest
+# instead of 66. Reproduction and follow-ups: issue #3600.
+composeai.cacheSalt=2
 
 # Kill switch for the BuildFetch remote build cache (issue #2824). `off` skips it entirely; the
 # LOCAL cache stays on, including for pushing main runs — see settings.gradle.kts.


### PR DESCRIPTION
A remote build-cache entry for `:samples:cmp:compileKotlin` restores **zero `.class` files**. `composePreviewDiscover` scans `classDirs`, finds nothing, and writes an asset-only 3-preview manifest instead of 66 — after which every `-PcomposePreview.filter` pattern matches nothing and `composePreviewRender` fails:

```
composePreviewRender --preview matched no previews for '…RedBoxPreview*', … Available previews:
  lottie/spin.json
  svg/badge.svg
  svg/star.svg
```

Full investigation and follow-ups: #3600.

## Why the salt is the right lever here

Unlike the truncated entries behind #2824 — which fail during *load* with `Unexpected end of ZLIB input stream` and kill the build outright — this entry loads cleanly. It just contains nothing, so the build stays `BUILD SUCCESSFUL`, `compileKotlin` reports a healthy-looking `FROM-CACHE`, and the first visible symptom appears several tasks downstream in a message that blames the user's filter.

It also can't self-heal: the load succeeds, so the task never executes and never pushes a replacement.

The salt is registered as an input property on `KotlinCompilationTask` in `ComposeAiBaseConventionsPlugin`, and `:samples:cmp:compileKotlin` is one — so unlike #2824's AGP task and artifact transform, the salt does reach this key. That's why this needs a bump rather than the `composeai.remoteCache=off` kill switch.

## Test plan

Reproduced and verified with plain Gradle on a clean checkout — no VS Code, no extension, no daemon. The only edit is renaming one function in `samples/cmp` `Previews.kt` (`fun RedBoxPreview()` → `fun RedBoxPreviewRenamed()`), which is what moves the module onto the poisoned key:

| salt | build cache | `compileKotlin` | `.class` files | `previews.json` |
|---|---|---|---|---|
| 1 | on | `FROM-CACHE` | 0 | **3** |
| 1 | `--no-build-cache` | executed | 46 | 66 |
| **2** | **on** | **executed** | **46** | **66** |

The third row is this change: with the cache still enabled, the new key misses the poisoned entry, the compile runs, and discovery is correct again.

Cost is the documented one — a cold Kotlin recompile across the repo on the next pushing `main` run, which reseeds under the new keys. Measured here at ~2 minutes for the `:samples:cmp` discover path.

## Expected effect on CI

`interactive-a-d` (scenario B) was red on `main` on this alone, and `interactive-e-g` (scenario E) was red on #3593 for the same reason. With #3593's `missingRenders=warn` now merged and this salt bump, both shards should go green — the next post-merge `vscode-extension-e2e` run is the one to read.

No visual surface changes — build configuration only, so text-only evidence is the right bar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmbwB3s3xBmk4Q4RWBjpjM)_