### PR TITLE
fix(plugin): calibrate the compose link floor, and fail loudly where it cannot be applied

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -386,18 +386,37 @@ internal object AndroidPreviewSupport {
    * (issue #3590 — `yschimke/home-assistant-android` on `compose-bom` 2025.01.00 lost all 13 phone
    * and 22 Wear catalog entries, republishing both design-artifacts branches empty.)
    *
-   * Set to [RENDERER_COMPOSE_CMP_RUNTIME_VERSION] deliberately: that is the version the Rule-3-off
-   * path already renders against, so it is the one Compose line the renderer is known-good on. Keep
-   * the two in lockstep.
+   * **Deliberately NOT [RENDERER_COMPOSE_CMP_RUNTIME_VERSION].** The two answer different questions
+   * — "what does the Rule-3-off path happen to resolve?" versus "what is the lowest version the
+   * renderer can link against?" — and tying them together set the floor too high, raising consumers
+   * that already rendered fine (issue #3603: `yschimke/horologist` on compose-ui 1.11.0 published
+   * 80/80 components, yet sat below a 1.11.2 floor). Over-raising is not free: the main-variant pin
+   * moves with this floor, dragging in newer transitives with their own constraints — that is how a
+   * minSdk-21 consumer's manifest merge broke on `androidx.window:window-core-android:1.5.0`
+   * (issue #3602).
+   *
+   * Bracketed against the published artifacts rather than assumed. Probing
+   * `androidx.compose.ui:ui-android` for the accessor that actually fails:
+   * ```
+   * 1.9.5   ComposeUiNode$Companion — getApplyOnDeactivatedNodeAssertion ABSENT
+   * 1.10.0  ComposeUiNode$Companion — getApplyOnDeactivatedNodeAssertion PRESENT
+   * ```
+   *
+   * so the floor is above 1.9.5 (matching the #3484 report that 1.9.5 is unlinkable) and at most
+   * 1.10.0 for *that* symbol. Set to **1.11.0** — the lowest version with end-to-end evidence, a
+   * real consumer rendering its whole catalog — rather than 1.10.0, because the probe proves one
+   * symbol and not the renderer's whole reference set. Lower it to 1.10.x once a consumer on that
+   * line is verified to render; the cost of the gap is only that a 1.10.x consumer is raised
+   * needlessly, and today no consumer sits there.
    */
-  internal const val RENDERER_COMPOSE_LINK_FLOOR_VERSION: String =
-    RENDERER_COMPOSE_CMP_RUNTIME_VERSION
+  internal const val RENDERER_COMPOSE_LINK_FLOOR_VERSION: String = "1.11.0"
 
   /**
-   * The `androidx.compose.*` groups that share the compose-ui version line (1.7.6 / 1.9.5 / 1.11.2
+   * The `androidx.compose.*` groups that share the compose-ui version line (1.7.6 / 1.9.5 / 1.11.0
    * move together). Deliberately NOT `androidx.compose.material` / `material3`, which version
-   * independently — material3 has no 1.11.2 — nor a bare `androidx.compose.` prefix, which would
-   * sweep them in.
+   * independently — there is no `androidx.compose.material3:material3` on the compose-ui line, so
+   * raising them to the floor would resolve a version that does not exist — nor a bare
+   * `androidx.compose.` prefix, which would sweep them in.
    */
   private val COMPOSE_UI_LINE_GROUPS =
     setOf(
@@ -450,32 +469,45 @@ internal object AndroidPreviewSupport {
 
   /**
    * Version for the main-variant `androidx.compose.ui` / `foundation` pins, which decide the R
-   * class in the merged unit-test resource APK. Always the link floor, because the resource APK has
-   * to sit on whichever Compose actually **runs** — and after [applyRenderGraphResolutionRules]
-   * floors the render graph, that is never below [RENDERER_COMPOSE_LINK_FLOOR_VERSION] in either
-   * case:
+   * class in the merged unit-test resource APK. The resource APK has to sit on whichever Compose
+   * actually **runs**, and the two cases run different ones:
    * * a **Compose-less** consumer renders against OUR compose-ui, which arrives via Compose
-   *   Multiplatform at exactly this version;
-   * * a **Compose** consumer renders against its own, raised to this floor when it resolves below.
+   *   Multiplatform at [RENDERER_COMPOSE_CMP_RUNTIME_VERSION];
+   * * a **Compose** consumer renders against its own, which [applyRenderGraphResolutionRules]
+   *   raises to [RENDERER_COMPOSE_LINK_FLOOR_VERSION] only when it resolves below that — so the
+   *   floor is the lowest version its resource APK can need.
+   *
+   * These were briefly collapsed into one unconditional return, which was only ever correct while
+   * the two constants happened to hold the same value. #3603 gave them different values and the
+   * `main-variant compose pin follows whichever compose actually runs` test caught it at once — a
+   * Compose-less consumer would have been pinned to the floor while rendering against the higher
+   * CMP runtime, which is the resource skew this function exists to prevent.
    *
    * This used to hand a Compose consumer [RENDERER_COMPOSE_FLOOR_VERSION] (1.9.5) on the reasoning
    * that its own BOM wins over ours anyway. That holds only while the consumer is *above* our pin.
    * A consumer below it — `home-assistant-android` on `compose-bom` 2025.01.00 — got the pin
-   * instead, so flooring only the render graph would have left 1.11.2 classes reading a 1.9.5 R
-   * class and traded #3590's `NoSuchMethodError` for the `NoSuchFieldError` of #3484:
+   * instead, so flooring only the render graph would have left floor-version classes reading a
+   * 1.9.5 R class and traded #3590's `NoSuchMethodError` for the `NoSuchFieldError` of #3484:
    * ```
    * NoSuchFieldError: Class androidx.compose.ui.R$id does not have member field
    *   'int androidx_compose_ui_view_compose_view_context'
    * ```
    *
    * (verified against the published artifacts: `ui-android` 1.9.5's `R.txt` has no such id,
-   * 1.11.2's does). Both sides move on one floor or neither does.
+   * 1.11.0's does). Both sides move on one floor or neither does.
    *
    * Consumers already above the floor are unaffected: this is a pin, so Gradle's max-version
    * conflict resolution leaves their own Compose line in place.
    */
-  internal fun mainVariantComposeVersion(project: Project, variantName: String): String =
-    RENDERER_COMPOSE_LINK_FLOOR_VERSION
+  internal fun mainVariantComposeVersion(project: Project, variantName: String): String {
+    val unitTestClasspath =
+      project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
+    return if (consumerBringsOwnCompose(project, unitTestClasspath)) {
+      RENDERER_COMPOSE_LINK_FLOOR_VERSION
+    } else {
+      RENDERER_COMPOSE_CMP_RUNTIME_VERSION
+    }
+  }
 
   /**
    * Compose compiler plugin ids — the Kotlin 2.x plugin every consumer with `@Composable` code

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -10,6 +10,7 @@ import ee.schimke.composeai.daemonlaunch.*
 import ee.schimke.composeai.discovery.*
 import java.util.Collections
 import java.util.IdentityHashMap
+import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -669,6 +670,40 @@ internal object AndroidPreviewSupport {
    * only safe while the main-variant `ui` / `foundation` pins move with it, and the opt-out branch
    * deliberately leaves those to the consumer.
    */
+  /**
+   * The configuration error for a consumer whose Compose is below
+   * [RENDERER_COMPOSE_LINK_FLOOR_VERSION] on a graph we are not allowed to raise.
+   *
+   * Under `composePreview.manageDependencies = false` the main-variant `ui` / `foundation` pins are
+   * the consumer's to declare, so flooring the render graph alone would put floor-version classes
+   * over their older resources — the #3484 `R$id` `NoSuchFieldError`. Leaving the graph alone
+   * instead means the renderer cannot link against it at all — #3590's `NoSuchMethodError`, on
+   * every preview, with nothing explaining why.
+   *
+   * Both silent outcomes are worse than saying so. `validateExternallyManagedDependencies` cannot:
+   * it checks that coordinates are DECLARED, never what they resolve to, and a BOM consumer
+   * declares no version at all. This fires from the resolution rule, which is the first place the
+   * real version exists.
+   */
+  internal fun composeFloorOptOutMessage(module: String, resolved: String): String =
+    """
+    compose-ai-tools cannot render with composePreview.manageDependencies = false.
+
+      Renderer requires  androidx.compose.ui >= $RENDERER_COMPOSE_LINK_FLOOR_VERSION
+      $module resolves to $resolved
+
+    Fix one of:
+      * raise the module's Compose (e.g. a newer androidx.compose:compose-bom) to
+        $RENDERER_COMPOSE_LINK_FLOOR_VERSION or above;
+      * set composePreview.manageDependencies = true, which lets the plugin raise the render
+        classpath and the main-variant pins together.
+
+    Rendering against $resolved fails every preview before user code runs:
+      NoSuchMethodError androidx.compose.ui.node.ComposeUiNode${'$'}Companion
+        .getApplyOnDeactivatedNodeAssertion()
+    """
+      .trimIndent()
+
   internal fun renderGraphTarget(
     group: String,
     name: String,
@@ -697,6 +732,14 @@ internal object AndroidPreviewSupport {
     // exactly the artifact the floor exists to keep off the graph.
     configuration.resolutionStrategy.eachDependency {
       val req = requested
+      // Opt-out: we may not raise this graph, so a below-floor consumer cannot be rendered at all.
+      // Say so here rather than letting every preview die with a Compose-internal stack trace —
+      // resolution is the first point the real version is known (see [composeFloorOptOutMessage]).
+      if (!floorComposeLine && composeLineFloorUpgrade(req.group, req.version) != null) {
+        throw GradleException(
+          composeFloorOptOutMessage("${req.group}:${req.name}", req.version.orEmpty())
+        )
+      }
       val decision = renderGraphTarget(req.group, req.name, req.version, floorComposeLine)
       when {
         decision == null -> Unit

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposeLineFloorTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposeLineFloorTest.kt
@@ -45,7 +45,7 @@ class ComposeLineFloorTest {
 
   @Test
   fun `material and material3 are left alone`() {
-    // They version independently of the ui line — there is no androidx.compose.material3 1.11.2,
+    // They version independently of the ui line — there is no androidx.compose.material3 on it —
     // so raising them to the floor would resolve to a version that does not exist.
     assertThat(upgrade("androidx.compose.material3", "1.3.1")).isNull()
     assertThat(upgrade("androidx.compose.material", "1.7.6")).isNull()
@@ -118,6 +118,10 @@ class ComposeLineFloorTest {
     // opt-out branch deliberately leaves those to the consumer ("consumer must ensure
     // androidx.compose.ui:ui is on the main variant"). Raising the render graph there would put
     // floor-version classes over the consumer's older resources — the #3484 R$id NoSuchFieldError.
+    //
+    // The DECISION is still "do not raise"; the resolution rule additionally throws
+    // composeFloorOptOutMessage for this case, so the consumer gets told rather than silently
+    // rendering nothing. Kept separate so the pure decision stays testable on its own.
     assertThat(
         AndroidPreviewSupport.renderGraphTarget(
           group = "androidx.compose.ui",
@@ -145,6 +149,24 @@ class ComposeLineFloorTest {
   fun `a non-compose module with no sibling is left alone entirely`() {
     assertThat(AndroidPreviewSupport.renderGraphTarget("com.example", "thing", "1.0.0", true))
       .isNull()
+  }
+
+  @Test
+  fun `the opt-out message names the versions and both ways out`() {
+    // The hole this closes: validateExternallyManagedDependencies checks that coordinates are
+    // DECLARED, never what they resolve to, so a below-floor opt-out consumer got #3590's
+    // NoSuchMethodError on every preview with nothing explaining why.
+    val message = AndroidPreviewSupport.composeFloorOptOutMessage("androidx.compose.ui:ui", "1.7.6")
+
+    assertThat(message).contains("manageDependencies = false")
+    // Both numbers a reader needs: what they have, and what is required.
+    assertThat(message).contains("1.7.6")
+    assertThat(message).contains(floor)
+    // Both escape hatches, so the message is actionable rather than merely accurate.
+    assertThat(message).contains("compose-bom")
+    assertThat(message).contains("manageDependencies = true")
+    // …and the symptom, so someone who already hit it can connect the two.
+    assertThat(message).contains("getApplyOnDeactivatedNodeAssertion")
   }
 
   @Test

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposeLineFloorTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposeLineFloorTest.kt
@@ -60,9 +60,23 @@ class ComposeLineFloorTest {
 
   @Test
   fun `an alpha of the floor is still below it`() {
-    assertThat(upgrade("androidx.compose.ui", "1.11.2-alpha01")).isEqualTo(floor)
+    // Derived from the constant rather than hard-coded, so moving the floor cannot leave this
+    // asserting the opposite of its name (issue #3603 moved it from 1.11.2 to 1.11.0).
+    assertThat(upgrade("androidx.compose.ui", "$floor-alpha01")).isEqualTo(floor)
     // …but an alpha of a HIGHER version is not.
     assertThat(upgrade("androidx.compose.ui", "1.12.0-alpha01")).isNull()
+  }
+
+  @Test
+  fun `the floor sits inside the bracket the published artifacts prove`() {
+    // Probing androidx.compose.ui:ui-android for the accessor that actually fails:
+    //   1.9.5  — ComposeUiNode$Companion.getApplyOnDeactivatedNodeAssertion ABSENT
+    //   1.10.0 — PRESENT
+    // and yschimke/horologist renders its full 80-component catalog on 1.11.0. So the floor must
+    // raise 1.9.5 (provably unlinkable) and must NOT raise 1.11.0 (proven to work end to end) —
+    // the second half is what #3603 was: a 1.11.2 floor raised a consumer that was already fine.
+    assertThat(upgrade("androidx.compose.ui", "1.9.5")).isEqualTo(floor)
+    assertThat(upgrade("androidx.compose.ui", "1.11.0")).isNull()
   }
 
   @Test


### PR DESCRIPTION
Fixes #3603. Closes the `manageDependencies=false` gap recorded on #3596.

Two changes to the same contract: get the floor *right*, then stop pretending we can apply it everywhere.

---

## 1. Calibrate the floor — 1.11.2 → 1.11.0

`RENDERER_COMPOSE_LINK_FLOOR_VERSION` was aliased to `RENDERER_COMPOSE_CMP_RUNTIME_VERSION` (1.11.2). Those answer different questions — *what the Rule-3-off path happens to resolve* versus *the lowest version the renderer can link against* — and conflating them set the floor too high.

The result was raising consumers that already worked: `yschimke/horologist` resolves `compose-bom 2026.04.01` → **compose-ui 1.11.0** and publishes **80/80 components**, yet sat below a 1.11.2 floor.

Over-raising is not free. The main-variant pin moves with this floor and drags in newer transitives carrying their own constraints — exactly how a minSdk-21 consumer's manifest merge broke on `androidx.window:window-core-android:1.5.0` (#3602).

### Bracketed against the artifacts, not assumed

Probed the published `androidx.compose.ui:ui-android` AARs:

| version | `getApplyOnDeactivatedNodeAssertion` | `R.txt` has `androidx_compose_ui_view_compose_view_context` |
| --- | --- | --- |
| 1.9.5 | ❌ absent | ❌ absent |
| 1.10.0 | ✅ present | — |
| 1.11.0 | ✅ present | ✅ present |

Both halves of the invariant hold at 1.11.0 — the linkage symbol from #3590 and the R-class field from #3484 — and both are missing at 1.9.5, matching the existing reports.

**1.11.0, not 1.10.0**: the probe proves *one* symbol, not the renderer's whole reference set, and 1.11.0 is the lowest version with end-to-end evidence. The KDoc records the bracket so it can be lowered later with evidence rather than by guess.

### A bug this surfaced

Separating the constants restored the `mainVariantComposeVersion` branch. #3596 collapsed it to an unconditional return, which was only correct *while the two constants held the same value*. With them distinct, a Compose-**less** consumer would have been pinned to the floor while rendering against the higher CMP runtime — the exact resource skew that function exists to prevent. The existing `main-variant compose pin follows whichever compose actually runs` test caught it on the first run.

---

## 2. Fail with a named error where the floor cannot be applied

Under `manageDependencies = false` the main-variant pins are the consumer's to declare, so a below-floor graph has two silent outcomes and no good one — raise only the render classpath and get #3484's `R$id` `NoSuchFieldError`, or leave it and get #3590's `NoSuchMethodError` on every preview. #3596 left this as a `KNOWN GAP` comment; this replaces it with a real error:

```
compose-ai-tools cannot render with composePreview.manageDependencies = false.

  Renderer requires  androidx.compose.ui >= 1.11.0
  androidx.compose.ui:ui resolves to 1.7.6

Fix one of:
  * raise the module's Compose (e.g. a newer androidx.compose:compose-bom) to
    1.11.0 or above;
  * set composePreview.manageDependencies = true, which lets the plugin raise the render
    classpath and the main-variant pins together.

Rendering against 1.7.6 fails every preview before user code runs:
  NoSuchMethodError androidx.compose.ui.node.ComposeUiNode$Companion
    .getApplyOnDeactivatedNodeAssertion()
```

It is raised from the resolution rule because that is the first point the real version exists — `validateExternallyManagedDependencies` cannot do it, as it checks that coordinates are **declared**, never what they resolve to, and a BOM consumer declares no version at all.

The decision function still returns "do not raise" for this case; only the rule throws. Keeping those separate is what lets the behaviour stay unit-testable.

---

## Still open, deliberately

`enforcedPlatform` (#3596) and minSdk (#3602) are **not** covered here. Both need comparing the *resolved* versions of the render graph and the resource-producing graph, which is a different mechanism from a per-dependency rule, and I would rather do that once and properly than add a third detector. This PR covers the two cases where the answer is unambiguous.

## Test plan

- `ComposeLineFloorTest` 10 → **13**: the artifact bracket (1.9.5 raised, 1.11.0 not — the #3603 regression exactly), and the opt-out message asserting it names the resolved version, the required version, both escape hatches, and the symptom.
- The alpha test now derives from the constant instead of hard-coding, so moving the floor cannot leave it asserting the opposite of its name.
- `RenderGraphComposeExclusionTest` 11/11 unchanged.
- Forced re-run: **24 tests, 0 failures.**

Consumer impact: of nine repos checked, only `home-assistant-android` (ui 1.7.6) is below the floor, and it is already fixed and rendering 13 + 22. `horologist` (1.11.0) stops being touched at all.