### PR TITLE
feat(serve): apply a declared theme to a replayed preview as named colour seeds

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -137,8 +137,16 @@ interface ServeHost : AutoCloseable {
    */
   fun themeReplayColors(providerFqn: String): Map<String, String> = emptyMap()
 
-  /** Whether any declared theme can be applied by replay ([themeReplayColors]). */
-  fun canThemeByReplay(): Boolean = declaredThemes.any {
+  /**
+   * The declared themes a **replayed** preview can actually be rendered under — those this host
+   * publishes a [themeReplayColors] mapping for.
+   *
+   * Per theme, not per host: a catalog may publish mappings for some of its themes and not others,
+   * and a theme that moves only typography legitimately has no colours to seed at all. Offering the
+   * whole declared set because *one* of them is mapped puts the unmapped ones back on the terminal
+   * 409 the gate exists to prevent.
+   */
+  fun replayableThemes(): List<ServeTheme> = declaredThemes.filter {
     themeReplayColors(it.providerFqn).isNotEmpty()
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -116,6 +116,33 @@ interface ServeHost : AutoCloseable {
   fun canRenderOverridesFor(previewId: String): Boolean = canRenderOverrides
 
   /**
+   * The **named-value overrides that apply a declared theme to an already-recorded document** —
+   * `<name>` to a colour literal (`#RRGGBB`), keyed by the document's own state names.
+   *
+   * This is what lets a theme reach a preview whose composable is gone. A Remote Compose document
+   * emits the roles it draws through as named state (`USER:WearM3.primary` and friends) rather than
+   * folding them into constants, so the player's `setNamedColorOverride` can re-theme a *replayed*
+   * document with no recomposition. Seeding these is that operation, and it is the only route a
+   * theme has on a session that cannot recompose — a published catalog whose module bytecode was
+   * dropped at pack time.
+   *
+   * Empty (the default) means this host publishes no such mapping for [providerFqn], and a
+   * `themeProvider` render of a replayed preview stays the terminal refusal it is today. That is
+   * deliberate: applying nothing and answering `200` would be the #3449 failure — a render that
+   * claims a theme it never applied, indistinguishable from one where the theme changed nothing.
+   *
+   * Only consulted for previews that replay. A session that can recompose applies the provider by
+   * re-running the composable, which reaches everything a theme does — including the typeface,
+   * which has no named value to carry it.
+   */
+  fun themeReplayColors(providerFqn: String): Map<String, String> = emptyMap()
+
+  /** Whether any declared theme can be applied by replay ([themeReplayColors]). */
+  fun canThemeByReplay(): Boolean = declaredThemes.any {
+    themeReplayColors(it.providerFqn).isNotEmpty()
+  }
+
+  /**
    * Maximum browser-side concurrency a short-lived themed-thumbnail burst may request. A plain
    * daemon has one render lock, so the default remains serial. A composite backed by independent
    * per-preview daemons may opt into a larger temporary burst; the HTTP server still clamps it to

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1565,7 +1565,9 @@ class ServeHttpServer(
           // 409. Same predicate that refusal is derived from, deliberately read here rather than
           // re-derived — the viewer greys the identical choice off `irReplay`, and a grid that
           // disagreed with either would offer chips that turn every card into an error.
-          irReplayFor = { id -> droppedOverridesAreTerminal(renderHost, id) },
+          irReplayFor = { id ->
+            droppedOverridesAreTerminal(renderHost, id) && !renderHost.canThemeByReplay()
+          },
           // Long-press a card to open a live daemon session inside it. Same two conditions the
           // viewer's Live toggle answers to — the session offers the stream lane, and this preview
           // has a daemon twin to stream — so a card only takes the gesture when the socket behind
@@ -2954,7 +2956,10 @@ class ServeHttpServer(
           }
           .toMap()
       val normalizedOverrideParams =
-        ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, overrideParams)
+        ServeWeb.SystemDisplay.normalizeOverrideParams(
+          sessionId,
+          expandThemeProvider(renderHost, previewId, overrideParams),
+        )
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
       // Reject a themeProvider this catalog never declared instead of quietly rendering the
@@ -3442,7 +3447,10 @@ class ServeHttpServer(
           }
           .toMap()
       val normalizedOverrideParams =
-        ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, overrideParams)
+        ServeWeb.SystemDisplay.normalizeOverrideParams(
+          sessionId,
+          expandThemeProvider(renderHost, previewId, overrideParams),
+        )
       // Type a bare `knob.<key>=<value>` from the preview's declared knobs (an explicit
       // `<kind>:<value>` still wins) so the viewer never has to spell the type in the URL.
       val knobKinds =
@@ -3663,6 +3671,41 @@ class ServeHttpServer(
     renderHost.hasRemoteComposeDoc(previewId)
 
   /**
+   * [params] with a `themeProvider` **expanded into the named-value seeds that apply it to a
+   * replayed document** ([ServeHost.themeReplayColors]) — or unchanged, when that can't be done.
+   *
+   * Expanding rather than passing the provider through is the whole trick. A replayed preview has
+   * no composition for a `PreviewWrapperProvider` to wrap, so `themeProvider` reaches the render
+   * lane as an override nothing can honour and is refused. Its *colours*, though, are named state
+   * the player can rewrite, so the same request expressed as `rc.<role>=color:…` seeds succeeds.
+   * The `themeProvider` key is dropped from the result once expanded: it has been satisfied, and
+   * leaving it would have [droppedOverridesFor] report an un-applied override on a render that
+   * applied it.
+   *
+   * Only for previews that **replay**. A preview whose lane can recompose keeps its `themeProvider`
+   * untouched, because re-running the composable applies the whole theme — the typeface included,
+   * which no named value can carry. Seeding colours there would silently narrow what a theme means.
+   */
+  private fun expandThemeProvider(
+    renderHost: ServeHost,
+    previewId: String,
+    params: Map<String, String>,
+  ): Map<String, String> {
+    val provider = params["themeProvider"]?.takeIf { it.isNotBlank() } ?: return params
+    if (!droppedOverridesAreTerminal(renderHost, previewId)) return params
+    val colors = renderHost.themeReplayColors(provider)
+    if (colors.isEmpty()) return params
+    val seeded = params.toMutableMap()
+    seeded.remove("themeProvider")
+    for ((name, value) in colors) {
+      // An explicit `rc.` seed on the URL is the caller being more specific than the theme, so it
+      // wins — same precedence a per-role override has over a scheme anywhere else.
+      seeded.putIfAbsent("${ServeOverrides.RC_NAMED_PREFIX}$name", "color:$value")
+    }
+    return seeded
+  }
+
+  /**
    * Answer a render whose **validated overrides were not applied** — [bytes] are the preview's
    * baked artifact, produced without a renderer, while the request asked for [dropped]. Shared by
    * the PNG and SVG lanes so the two can't drift: a vector read off the delivery branch ignores a
@@ -3781,9 +3824,13 @@ class ServeHttpServer(
     // the JS lane's in-browser knob application.
     val seeds =
       ServeOverrides.rcNamedValueSeeds(
-        call.request.queryParameters.entries().associate { (key, values) ->
-          key to (values.firstOrNull() ?: "")
-        }
+        expandThemeProvider(
+          renderHost,
+          previewId,
+          call.request.queryParameters.entries().associate { (key, values) ->
+            key to (values.firstOrNull() ?: "")
+          },
+        )
       )
     val result =
       withContext(Dispatchers.IO) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1558,15 +1558,18 @@ class ServeHttpServer(
           // The module's declared @ThemeCatalog themes join the header's Theme control, so the grid
           // can be redrawn under any theme the catalog configures — not just baked Light/Dark. Only
           // a daemon-twinned card can actually re-render one, hence the per-preview predicate.
-          declaredThemes = renderHost.declaredThemes,
+          declaredThemes = applicableThemes(renderHost),
           canRenderThemeFor = { id -> renderHost.canRenderOverridesFor(id) },
           // …and a twin that REPLAYS a captured document rather than recomposing can't honour a
           // theme provider either, however live it is: the render below refuses it with a terminal
           // 409. Same predicate that refusal is derived from, deliberately read here rather than
           // re-derived — the viewer greys the identical choice off `irReplay`, and a grid that
           // disagreed with either would offer chips that turn every card into an error.
+          // A replayed card is theme-overridable exactly when the session publishes a mapping for
+          // something — the chips themselves are narrowed to those themes just below, so a card
+          // passing this gate can apply every theme it is offered.
           irReplayFor = { id ->
-            droppedOverridesAreTerminal(renderHost, id) && !renderHost.canThemeByReplay()
+            droppedOverridesAreTerminal(renderHost, id) && renderHost.replayableThemes().isEmpty()
           },
           // Long-press a card to open a live daemon session inside it. Same two conditions the
           // viewer's Live toggle answers to — the session offers the stream lane, and this preview
@@ -2955,11 +2958,9 @@ class ServeHttpServer(
             if (ServeOverrides.isOverrideParam(key)) key to value else null
           }
           .toMap()
+      val themeSeeding = expandThemeProvider(renderHost, previewId, overrideParams)
       val normalizedOverrideParams =
-        ServeWeb.SystemDisplay.normalizeOverrideParams(
-          sessionId,
-          expandThemeProvider(renderHost, previewId, overrideParams),
-        )
+        ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, themeSeeding.params)
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
       // Reject a themeProvider this catalog never declared instead of quietly rendering the
@@ -3241,6 +3242,9 @@ class ServeHttpServer(
           // question that predicate asks, deliberately read here rather than derived from
           // `hasRemoteComposeDoc` on the client — the two must not drift apart.
           irReplay = droppedOverridesAreTerminal(renderHost, preview.id),
+          // …but a replayed preview can still take a declared theme when the session publishes its
+          // colours, so the viewer greys the recomposition-only controls without greying this one.
+          replayThemes = renderHost.replayableThemes().isNotEmpty(),
           // Per-preview: the Remote Compose backend selector's enabled lanes. The host advertises
           // its server/client lanes; the opt-in CMP/Wasm distribution contributes the browser
           // lane when this preview has an RC document. Empty for a non-RC preview ⇒ no selector.
@@ -3255,7 +3259,7 @@ class ServeHttpServer(
           wasmSameOrigin = wasmSameOrigin,
           basePath = basePath,
           isPublic = isPublic,
-          declaredThemes = renderHost.declaredThemes,
+          declaredThemes = applicableThemes(renderHost),
           // Android-daemon-only: gates the "Show gesture hints" row so a `@GestureHintPreview`
           // doesn't show a toggle that would do nothing on a desktop-backed session.
           gesturesRenderable = renderHost.gesturesRenderable,
@@ -3446,11 +3450,9 @@ class ServeHttpServer(
             if (ServeOverrides.isOverrideParam(key)) key to value else null
           }
           .toMap()
+      val themeSeeding = expandThemeProvider(renderHost, previewId, overrideParams)
       val normalizedOverrideParams =
-        ServeWeb.SystemDisplay.normalizeOverrideParams(
-          sessionId,
-          expandThemeProvider(renderHost, previewId, overrideParams),
-        )
+        ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, themeSeeding.params)
       // Type a bare `knob.<key>=<value>` from the preview's declared knobs (an explicit
       // `<kind>:<value>` still wins) so the viewer never has to spell the type in the URL.
       val knobKinds =
@@ -3515,11 +3517,19 @@ class ServeHttpServer(
             else
               renderHost.cachedRender(previewId, overrides)
                 ?: renderHost.bakedRender(previewId, overrides)
+          // A "pure declared-theme render" — the classification the burst lease admits on. Read
+          // from the request rather than the parsed overrides, because an expanded provider is no
+          // longer in them: `themeSeeding.provider` is what the expansion consumed, and the request
+          // was still *only* a theme selection when `themeProvider` was its sole override param.
           val pureThemeProvider =
             overrides.themeProvider?.takeIf {
               overrides == PreviewOverrides(themeProvider = it) &&
                 renderHost.declaredThemes.any { theme -> theme.providerFqn == it }
             }
+              ?: themeSeeding.provider?.takeIf {
+                overrideParams.keys.all { key -> key == "themeProvider" } &&
+                  renderHost.declaredThemes.any { theme -> theme.providerFqn == it }
+              }
           // A preview this catalog has permanently failed to render is answered here, before any
           // lease or render slot is taken. 409 rather than 503/500: the request will never succeed,
           // so the page must stop retrying it. Retrying a latched preview is exactly what kept the
@@ -3667,6 +3677,21 @@ class ServeHttpServer(
    * "retry shortly". [refuseDroppedOverrides] answers 409 instead, which the viewer already treats
    * as final.
    */
+  /**
+   * The declared themes this session can actually render something under — all of them once any
+   * preview can recompose, else only those with a published replay mapping.
+   *
+   * Offering a theme no lane can apply is the failure this filter exists for: the control looks
+   * live, the click 409s, and the visitor is told the preview "can't render live" for a theme the
+   * catalog advertised.
+   */
+  private fun applicableThemes(renderHost: ServeHost): List<ServeTheme> =
+    if (renderHost.previews.any { !droppedOverridesAreTerminal(renderHost, it.id) }) {
+      renderHost.declaredThemes
+    } else {
+      renderHost.replayableThemes()
+    }
+
   private fun droppedOverridesAreTerminal(renderHost: ServeHost, previewId: String): Boolean =
     renderHost.hasRemoteComposeDoc(previewId)
 
@@ -3690,20 +3715,41 @@ class ServeHttpServer(
     renderHost: ServeHost,
     previewId: String,
     params: Map<String, String>,
-  ): Map<String, String> {
-    val provider = params["themeProvider"]?.takeIf { it.isNotBlank() } ?: return params
-    if (!droppedOverridesAreTerminal(renderHost, previewId)) return params
+  ): ThemeSeeding {
+    val provider =
+      params["themeProvider"]?.takeIf { it.isNotBlank() } ?: return ThemeSeeding(params)
+    if (!droppedOverridesAreTerminal(renderHost, previewId)) return ThemeSeeding(params)
     val colors = renderHost.themeReplayColors(provider)
-    if (colors.isEmpty()) return params
+    if (colors.isEmpty()) return ThemeSeeding(params)
     val seeded = params.toMutableMap()
     seeded.remove("themeProvider")
     for ((name, value) in colors) {
       // An explicit `rc.` seed on the URL is the caller being more specific than the theme, so it
       // wins — same precedence a per-role override has over a scheme anywhere else.
-      seeded.putIfAbsent("${ServeOverrides.RC_NAMED_PREFIX}$name", "color:$value")
+      //
+      // A **blank** one is not that. `ServeOverrides.parse` skips an empty `rc.` value outright, so
+      // honouring the bare key here would drop the theme's seed for that role and leave the
+      // document
+      // on its authored colour — a theme applied in part, reported as applied in full. Blank means
+      // absent for this merge, and the theme fills the role.
+      val key = "${ServeOverrides.RC_NAMED_PREFIX}$name"
+      if (seeded[key].isNullOrBlank()) seeded[key] = "color:$value"
     }
-    return seeded
+    return ThemeSeeding(seeded, provider)
   }
+
+  /**
+   * [params] after [expandThemeProvider], plus the provider it consumed (null when it expanded
+   * nothing).
+   *
+   * The provider is carried out rather than inferred later because expansion *removes* it from the
+   * params: every downstream classification that keys off `themeProvider` — the theme-render lease
+   * admission most of all — would otherwise read a plain seeded render and silently skip. A themed
+   * thumbnail burst that stops being admitted doesn't fail; it just stops sharing the catalog's
+   * allocation, so every page runs the full advertised concurrency straight at the global render
+   * semaphore.
+   */
+  private data class ThemeSeeding(val params: Map<String, String>, val provider: String? = null)
 
   /**
    * Answer a render whose **validated overrides were not applied** — [bytes] are the preview's
@@ -3825,12 +3871,13 @@ class ServeHttpServer(
     val seeds =
       ServeOverrides.rcNamedValueSeeds(
         expandThemeProvider(
-          renderHost,
-          previewId,
-          call.request.queryParameters.entries().associate { (key, values) ->
-            key to (values.firstOrNull() ?: "")
-          },
-        )
+            renderHost,
+            previewId,
+            call.request.queryParameters.entries().associate { (key, values) ->
+              key to (values.firstOrNull() ?: "")
+            },
+          )
+          .params
       )
     val result =
       withContext(Dispatchers.IO) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -5306,6 +5306,17 @@ $rows
      */
     irReplay: Boolean = false,
     /**
+     * Whether a declared theme can still be applied to this preview **despite** [irReplay] — the
+     * session publishes the theme's colours as named values (`ServeHost.themeReplayColors`), which
+     * the player rewrites on a replayed document with no recomposition.
+     *
+     * Its own flag rather than a softening of [irReplay], because the two say different things and
+     * only one of them moves: everything else [irReplay] greys out — locale, author knobs, string
+     * `rc.` seeds — still cannot be honoured by a replay. Emitted as `data-replay-themes` so
+     * `viewer.js` re-enables exactly the provider-theme options and nothing beside them.
+     */
+    replayThemes: Boolean = false,
+    /**
      * The Remote Compose render backends the viewer may offer for this preview as a per-preview
      * **backend selector** — the [RcPlayerBackend.wire] ids the host reports via
      * [ServeHost.enabledRcPlayersFor]. Non-empty for a Remote Compose preview: the viewer renders
@@ -5497,6 +5508,7 @@ $rows
     val wearAlwaysDark = SystemDisplay.isDarkFirst(basePath.trim('/').ifBlank { sessionId ?: "" })
     val alwaysDarkAttr = if (wearAlwaysDark) " data-always-dark=\"1\"" else ""
     val irReplayAttr = if (irReplay) " data-ir-replay=\"1\"" else ""
+    val replayThemesAttr = if (replayThemes) " data-replay-themes=\"1\"" else ""
     // The baked fallback shown before any override is chosen. The unified Theme selector displays
     // this choice without sending a redundant uiMode override on first load.
     val viewerTheme = previewTheme(preview, isDarkFirstSystem(basePath, sessionId, declaredSurface))
@@ -6336,7 +6348,7 @@ $rows
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       $historyInlineHtml
-      <div class="cp-viewer cp-controls-open"$bgThemeAttr$alwaysDarkAttr$irReplayAttr data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-can-render-overrides="$canRenderOverrides" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel" data-render-density="$RENDER_DENSITY"$wasmAttr$rcAttr$historyAttrs>
+      <div class="cp-viewer cp-controls-open"$bgThemeAttr$alwaysDarkAttr$irReplayAttr$replayThemesAttr data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-can-render-overrides="$canRenderOverrides" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel" data-render-density="$RENDER_DENSITY"$wasmAttr$rcAttr$historyAttrs>
         $navDrawer
         <div class="cp-stage"><span class="cp-backend" id="cp-backend" role="status" aria-live="polite"></span><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas>$rcCanvas$wasmFrame$rcWasmFrame$specImg$specCompare$inspectLayerHtml<div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         $inspectLegendHtml

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -1693,6 +1693,10 @@
   //  * Remote Compose knobs stay live except the string-valued ones, and only in the server lane —
   //    see the `.cp-rc-knob` pass below.
   var irReplay = root.getAttribute("data-ir-replay") === "1";
+  // A replayed preview whose session publishes its declared themes as named colour values. The
+  // server rewrites `?themeProvider=` into those seeds, so the provider options work here even
+  // though nothing else `irReplay` disables does — those still need a composition.
+  var replayThemes = root.getAttribute("data-replay-themes") === "1";
   // Force [el] off for the IR-replay reason, tagging it so the visitor gets the "why" on hover
   // rather than a control that is merely dead. Only ever *adds* the disable — every call site
   // assigns `el.disabled` from its own lane logic immediately before, so the not-dead branch just
@@ -1765,7 +1769,7 @@
       // which needs a composition to wrap. Day/Night is NOT gated the same way — the player can
       // derive its paint theme from the host at draw time, so that axis stays offered.
       var canProviderTheme = !fixedTheme && hasDeclaredThemes && !onWasm && !onRc && !onSpec &&
-        !irReplay && (!staticSnapshot || canRenderOverrides);
+        (!irReplay || replayThemes) && (!staticSnapshot || canRenderOverrides);
       // Wear has no day/night axis, but Night (Default) must remain selectable when provider
       // themes are offered so the visitor can clear a chosen provider and return to the app.
       var canDefaultTheme = !fixedTheme && !onRc && !onSpec &&

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeThemeReplaySeedTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeThemeReplaySeedTest.kt
@@ -160,4 +160,65 @@ class ServeThemeReplaySeedTest {
   fun `a replayed preview with no published mapping still refuses`() {
     assertEquals(409, render("unmapped", "unmapped-one"), "terminal, as before")
   }
+
+  /**
+   * A blank explicit seed is not the caller overriding a role — `ServeOverrides.parse` skips an
+   * empty `rc.` value outright, so honouring the bare key would drop the theme's colour for that
+   * role and leave the document on its authored one. The response would still report a themed
+   * render: a theme applied in part, claimed in full.
+   */
+  @Test
+  fun `a blank explicit seed does not suppress the theme's colour`() {
+    val url =
+      "http://127.0.0.1:${server.port}/replayed/render/replayed-one.png" +
+        "?themeProvider=${theme.providerFqn}&rc.WearM3.primary="
+    assertEquals(200, client.newCall(Request.Builder().url(url).build()).execute().use { it.code })
+
+    assertEquals(
+      RemoteNamedValue.ColorValue("#FF6F61"),
+      replayed.seen.single().remoteCompose?.namedValues?.get("WearM3.primary"),
+      "the theme fills a role the request left blank",
+    )
+  }
+
+  /**
+   * The declared set is narrowed to what the session can apply. A catalog publishing a mapping for
+   * one theme and not another must not offer the unmapped one — selecting it would reach the
+   * terminal 409 the gate exists to prevent.
+   */
+  @Test
+  fun `only themes with a published mapping are replayable`() {
+    // A real host, not a delegate: `replayableThemes()` is an interface default, so `by` would
+    // forward it to the delegate and run it against the delegate's themes rather than these.
+    val partial =
+      object : ServeHost {
+        override val previews = emptyList<ServePreview>()
+        override val label = "partial"
+        override val declaredThemes = listOf(theme, ServeTheme("Teal", "com.example.TealTheme"))
+
+        override fun themeReplayColors(providerFqn: String): Map<String, String> =
+          if (providerFqn == theme.providerFqn) coral else emptyMap()
+
+        override fun render(previewId: String, overrides: PreviewOverrides) = RenderOutcome.NotFound
+
+        override fun subscribeStream(
+          previewId: String,
+          overrides: PreviewOverrides,
+          codec: StreamCodec?,
+          maxFps: Int?,
+          onUnavailable: ((String) -> Unit)?,
+          onFrame: (StreamFrameParams) -> Unit,
+        ): StreamHandle? = null
+
+        override fun activeStreamCount(): Int = 0
+
+        override fun close() {}
+      }
+
+    assertEquals(
+      listOf(theme.providerFqn),
+      partial.replayableThemes().map { it.providerFqn },
+      "the unmapped theme is not offered",
+    )
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeThemeReplaySeedTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeThemeReplaySeedTest.kt
@@ -1,0 +1,163 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.ConcurrentHashMap
+import javax.imageio.ImageIO
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * A declared theme reaching a preview whose composable is gone.
+ *
+ * A Remote Compose document emits the roles it draws through as **named state**
+ * (`USER:WearM3.primary` and friends) rather than folding them into constants, so the player can
+ * re-theme a *replayed* document with no recomposition. `themeProvider` can't ride that lane —
+ * there is no composition for a `PreviewWrapperProvider` to wrap, which is why the render lane
+ * refuses it — but the colours it stands for can, expressed as `rc.<role>=color:…` seeds.
+ *
+ * So the server expands one into the other. These pin the expansion's three load-bearing
+ * properties: it happens for a replayed preview when the host publishes a mapping, it does **not**
+ * happen where recomposition would apply the theme more completely, and the request stops being
+ * reported as an un-applied override once satisfied — a render that applied a theme must not also
+ * claim it dropped it (#3449).
+ */
+class ServeThemeReplaySeedTest {
+
+  private val theme = ServeTheme("Coral", "com.example.CoralTheme")
+  private val coral = mapOf("WearM3.primary" to "#FF6F61", "WearM3.secondary" to "#FFB4A9")
+
+  private fun png(): ByteArray =
+    ByteArrayOutputStream()
+      .also { ImageIO.write(BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB), "png", it) }
+      .toByteArray()
+
+  /**
+   * [rcDoc] non-null makes the preview replayed — the axis the expansion turns on. [replayColors]
+   * empty models a catalog that declares themes but publishes no replay mapping, which must keep
+   * refusing rather than rendering an unthemed image under a theme's name.
+   */
+  private inner class ThemedHost(
+    private val name: String,
+    private val rcDoc: ByteArray?,
+    private val replayColors: Map<String, String>,
+  ) : ServeHost {
+    /** Every override set the render lane was actually asked for, in arrival order. */
+    val seen = ConcurrentHashMap.newKeySet<PreviewOverrides>()
+
+    override val previews = listOf(ServePreview("$name-one", "One"))
+    override val label = name
+    override val declaredThemes = listOf(theme)
+    override val canRenderOverrides = true
+
+    override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+      seen.add(overrides)
+      return RenderOutcome.Ok(png())
+    }
+
+    override fun remoteComposeDoc(previewId: String): ByteArray? = rcDoc
+
+    override fun themeReplayColors(providerFqn: String): Map<String, String> =
+      if (providerFqn == theme.providerFqn) replayColors else emptyMap()
+
+    override fun subscribeStream(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
+      onFrame: (StreamFrameParams) -> Unit,
+    ): StreamHandle? = null
+
+    override fun activeStreamCount(): Int = 0
+
+    override fun close() {}
+  }
+
+  private val replayed = ThemedHost("replayed", byteArrayOf(1, 2, 3), coral)
+  private val unmapped = ThemedHost("unmapped", byteArrayOf(1, 2, 3), emptyMap())
+  private val recomposing = ThemedHost("recomposing", null, coral)
+
+  private val registry = ServeSessionRegistry(open = { null })
+  private val client = OkHttpClient()
+
+  private val server: ServeHttpServer by lazy {
+    registry.register("replayed", host = replayed, pinned = true)
+    registry.register("unmapped", host = unmapped, pinned = true)
+    registry.register("recomposing", host = recomposing, pinned = true)
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "unused-in-public",
+        sessions = registry,
+        defaultSessionId = "replayed",
+        isPublic = true,
+      )
+      .also { it.start() }
+  }
+
+  @AfterTest
+  fun tearDown() {
+    server.stop()
+  }
+
+  private fun render(system: String, preview: String): Int {
+    val url =
+      "http://127.0.0.1:${server.port}/$system/render/$preview.png" +
+        "?themeProvider=${theme.providerFqn}"
+    return client.newCall(Request.Builder().url(url).build()).execute().use { it.code }
+  }
+
+  @Test
+  fun `a replayed preview renders the theme as named colour seeds`() {
+    assertEquals(200, render("replayed", "replayed-one"), "the seeded render succeeds")
+
+    val overrides = replayed.seen.single()
+    assertEquals(
+      mapOf(
+        "WearM3.primary" to RemoteNamedValue.ColorValue("#FF6F61"),
+        "WearM3.secondary" to RemoteNamedValue.ColorValue("#FFB4A9"),
+      ),
+      overrides.remoteCompose?.namedValues,
+      "the theme's roles reach the lane as named values",
+    )
+    // …and the provider itself does NOT, or `droppedOverridesFor` would report an un-applied
+    // override on the very render that applied it, and refuse a 200 it already earned.
+    assertNull(overrides.themeProvider, "the provider is satisfied, not forwarded")
+  }
+
+  /**
+   * Recomposition applies the whole theme — the typeface included, which no named value can carry.
+   * Seeding colours there would silently narrow what selecting a theme means.
+   */
+  @Test
+  fun `a recomposing preview keeps the provider untouched`() {
+    assertEquals(200, render("recomposing", "recomposing-one"))
+
+    val overrides = recomposing.seen.single()
+    assertEquals(theme.providerFqn, overrides.themeProvider, "the lane applies it by recomposing")
+    assertTrue(
+      overrides.remoteCompose?.namedValues.isNullOrEmpty(),
+      "no colours are seeded behind its back",
+    )
+  }
+
+  /**
+   * A catalog can declare themes and publish no replay mapping. Rendering the default pixels under
+   * the theme's name would be the #3449 failure — bytes indistinguishable from a theme that changed
+   * nothing — so the refusal has to stand.
+   */
+  @Test
+  fun `a replayed preview with no published mapping still refuses`() {
+    assertEquals(409, render("unmapped", "unmapped-one"), "terminal, as before")
+  }
+}


### PR DESCRIPTION
A theme could not reach a preview whose composable was dropped at pack time. `themeProvider` substitutes a `PreviewWrapperProvider` around a composition; a replayed document has none, so the render lane refused it — correctly, but that left a published catalog's Theme select with nothing it could do.

The colours it stands for *can* reach it, so the server expands the request instead of refusing it.

## Why this works

`RemoteMaterialTheme`'s scheme is **not** constant-folded into the document. Every role it draws through is emitted as named state — `USER:WearM3.primary`, `USER:WearM3.surfaceContainer`, `USER:WearM3.onSurface` — and the player's `setNamedColorOverride` rewrites exactly those, on a replayed document, with no recomposition.

So a `themeProvider` on a replayed preview becomes the `rc.<role>=color:…` seeds that mean the same thing, carried by machinery that already exists. Both replay lanes — the daemon and the isolated cmp-jvm player — go through one expansion, so they can't disagree about what a theme is.

Already demonstrable against production, which is what this generalises:

```
curl "https://preview.coo.ee/remote-m3/render/button-filled__ideal__default__compact.png\
?rcPlayer=cmp-jvm&rc.WearM3.primary=color:%23FF6F61&rc.WearM3.secondary=color:%23FFB4A9"
```

returns a coral button from bytes whose module bytecode was dropped at pack time. This PR is what lets `?theme=` do that for you.

## Three properties, each pinned by a test

- **The provider key is consumed, not forwarded.** Leaving it would have `droppedOverridesFor` report an un-applied override on the very render that applied it — refusing a `200` it had earned (#3449).
- **A preview whose lane can recompose keeps its provider untouched.** Re-running the composable applies the whole theme, typeface included, which no named value can carry. Seeding colours there would silently narrow what selecting a theme means.
- **A catalog that declares themes but publishes no mapping keeps refusing.** Rendering default pixels under a theme's name is precisely the failure #3449 exists to prevent; an empty map must not become a silent success.

## Scope, and what it does not do yet

`ServeHost.themeReplayColors` defaults to empty, so **every host behaves exactly as it does today** until one publishes a mapping. Nothing in this PR changes a live deployment's behaviour.

Populating it from the delivery branch is the next change, and it's the interesting one. The obvious route — teach the theme-catalog render strategy to read the Remote theme — turns out to be impossible, which is worth recording because I told Codex the opposite on #3604:

```
public final RemoteColorScheme getColorScheme(Composer, int);
  RuntimeVisibleAnnotations:
    androidx.compose.remote.creation.compose.layout.RemoteComposable
```

`RemoteMaterialTheme`'s accessors are all `@RemoteComposable` — readable only inside remote scope. `WearThemeSpecimen` is a plain `@Composable` sheet outside any document, so no reflection reaches the value; it doesn't exist there. The per-theme token set has to come from the **document** instead: render a sticker under the provider, read the named colour state, diff against the unthemed capture. That same artifact is what feeds `themeReplayColors`, so the token-set fix and this data source are one piece of work rather than two.

Also still open, and unchanged here: the typeface half. It's resolved host-side from the built-in default family id, so it needs the resolver override rather than a named value.

## Test plan

- `ServeThemeReplaySeedTest` (new) — three fake hosts over real HTTP, differing only in whether the preview replays and whether a mapping is published. Asserts the seeds that reach the render lane, that the provider is consumed, that a recomposing lane is untouched, and that an unmapped catalog still gets its terminal 409.
- Full `:cli:test` and `ktfmtCheckAll` green — including the existing IR-replay and landing-gate tests, which this had to keep honest.

Text-only PR: no rendered surface changes, since no host publishes a mapping yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLCewobB9n1dLSjoaiQwfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLCewobB9n1dLSjoaiQwfE)_