### PR TITLE
fix: preserve large catalog design coverage

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -98,6 +98,7 @@ internal object CliFlags {
       "--catalog-repo",
       "--catalog-branch-prefix",
       "--catalog-refresh-interval",
+      "--catalog-max-images",
       "--catalog-source-root",
       "--wasm-dir",
       "--rc-player-wasm-dir",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -687,6 +687,9 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val catalogBranchPrefix: String =
     args.flagValue("--catalog-branch-prefix")?.takeIf { it.isNotBlank() }
       ?: ServeCatalogStore.DEFAULT_BRANCH_PREFIX
+  private val catalogMaxImages: Int =
+    args.flagValue("--catalog-max-images")?.toIntOrNull()?.takeIf { it > 0 }
+      ?: ServeCatalogStore.DEFAULT_MAX_IMAGES
 
   /**
    * A parsed `--catalogs` / `--catalogs-unlisted` entry: the [system] id, the [repo] its
@@ -2459,6 +2462,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         trust = { trustStore.get() },
         repo = catalogRepo,
         branchPrefix = catalogBranchPrefix,
+        maxImages = catalogMaxImages,
         serverSideRenderEnabled = allowRenderTrusted,
         registerWasm = { system, wasmDir ->
           // A local `--wasm-dir` is the operator's explicit override, so a published app never
@@ -3183,6 +3187,10 @@ class ServeCommand(args: List<String>) : Command(args) {
                           yschimke/compose-ai-tools); per-entry @<owner>/<repo> overrides it.
         --catalog-branch-prefix <prefix>
                           Branch prefix for --catalogs (default design-artifacts/).
+        --catalog-max-images <count>
+                          Maximum baked previews loaded from one published catalog (default
+                          ${ServeCatalogStore.DEFAULT_MAX_IMAGES}). Images are fetched lazily; this
+                          bounds registered preview metadata and routes, not eager image downloads.
         --catalog-refresh-interval <seconds>
                           Keep a running server fresh: re-check each --catalogs branch's head every
                           <seconds> and re-fetch (catalog.json + renders + web/wasm/ + liveBundle) in

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -1763,7 +1763,14 @@ class ServeCatalogStore(
     fun previewIdFor(imagePath: String): String =
       imagePath.removePrefix("$IMAGES_DIR/").removeSuffix(".png").replace("/", "__")
 
-    private const val DEFAULT_MAX_IMAGES = 1000
+    /**
+     * Maximum baked previews loaded from one published catalog unless the server overrides it.
+     * Images are fetched lazily, so this bounds registered metadata/routes rather than eager
+     * network or bitmap memory. Keep it above the largest first-party catalog (m3-catalog is
+     * currently ~1,150 previews) so the ceiling remains a guard instead of silently truncating a
+     * healthy catalog.
+     */
+    const val DEFAULT_MAX_IMAGES = 2000
     private const val MAX_FETCH_BYTES = 25L * 1024 * 1024 // 25 MB per catalog asset
 
     /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
@@ -46,6 +46,7 @@ class CliFlagsRegistryTest {
   fun `findCommandIndex skips value flags and their values`() {
     assertEquals(0, CliFlags.findCommandIndex(arrayOf("show")))
     assertEquals(2, CliFlags.findCommandIndex(arrayOf("--module", ":app", "show")))
+    assertEquals(2, CliFlags.findCommandIndex(arrayOf("--catalog-max-images", "2500", "serve")))
     // Regression: a global-position value flag that used to be unclassified mis-detected its value
     // as the command.
     assertEquals(2, CliFlags.findCommandIndex(arrayOf("--since", "2024", "history", "list")))

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeCommandTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.cli.serve.ServeCatalogStore
 import ee.schimke.composeai.cli.serve.ServeUrls
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,6 +24,8 @@ class ServeCommandTest {
           "--accept-bundles-from",
           "artifacts.example, cdn.example",
           "--exit-when-idle=45",
+          "--catalog-max-images",
+          "2500",
         )
       )
 
@@ -37,6 +40,7 @@ class ServeCommandTest {
     )
     assertTrue(command.field("exitWhenIdle"))
     assertEquals(45L, command.field<Long>("idleExitSeconds"))
+    assertEquals(2500, command.field<Int>("catalogMaxImages"))
   }
 
   @Test
@@ -48,6 +52,7 @@ class ServeCommandTest {
     assertFalse(command.field("public"))
     assertFalse(command.field("discover"))
     assertFalse(command.field("allowRenderTrusted"))
+    assertEquals(ServeCatalogStore.DEFAULT_MAX_IMAGES, command.field<Int>("catalogMaxImages"))
   }
 
   @Suppress("UNCHECKED_CAST")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -79,8 +79,8 @@ class ServeCatalogStoreTest {
     // ones: whether an image can be had isn't known at load time any more, and finding out would
     // mean fetching everything — the thing lazy loading exists to avoid. So a cap of two publishes
     // the first two declarations, and a card whose image turns out to be missing reports NotFound
-    // on request instead of being silently replaced by a later one. The cap defaults to 1000 while
-    // the largest published catalog declares ~200, so it does not bind in practice.
+    // on request instead of being silently replaced by a later one. The default stays above the
+    // largest published catalog so it remains a guard rather than truncating valid previews.
     val trust =
       TrustStore(
         branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -84,6 +84,8 @@ scaled to zero.
 
 - **`SERVE_IDLE_EXIT`** (default `900`) — the server exits after this many idle
   seconds, letting the instance be reclaimed. Set `0` to disable.
+- **`SERVE_CATALOG_MAX_IMAGES`** (default `2000`) — maximum catalog images registered by the
+  server. Images are fetched lazily, so increasing this does not eagerly load their bitmap bytes.
 - **`timeoutSeconds: 3600`** — hard ceiling on any one request / WebSocket session
   (Cloud Run's max). Lower it to cap session length more aggressively.
 - **`containerConcurrency: 4`** — simultaneous renders per instance.

--- a/deploy/cloudrun/cloudbuild.yaml
+++ b/deploy/cloudrun/cloudbuild.yaml
@@ -57,7 +57,7 @@ steps:
       - --concurrency=4
       - --timeout=3600
       - --port=8080
-      - --set-env-vars=SERVE_MODULE=:samples:cmp,SERVE_IDLE_EXIT=900
+      - --set-env-vars=SERVE_MODULE=:samples:cmp,SERVE_IDLE_EXIT=900,SERVE_CATALOG_MAX_IMAGES=2000
       - --set-secrets=SERVE_TOKEN=compose-preview-token:latest
       # Drop --no-allow-unauthenticated if you front it with IAM instead of the
       # app token. As written the app token is the only gate (public ingress).

--- a/deploy/cloudrun/entrypoint.sh
+++ b/deploy/cloudrun/entrypoint.sh
@@ -19,6 +19,9 @@ args=(
   --port "${PORT}"
 )
 
+[[ -n "${SERVE_CATALOG_MAX_IMAGES:-}" ]] &&
+  args+=(--catalog-max-images "${SERVE_CATALOG_MAX_IMAGES}")
+
 if [[ -f /app/cli/build/install/compose-preview/rc-player-wasm/index.html ]]; then
   args+=(--rc-player-wasm-dir /app/cli/build/install/compose-preview/rc-player-wasm)
 fi

--- a/deploy/cloudrun/service.yaml
+++ b/deploy/cloudrun/service.yaml
@@ -46,6 +46,8 @@ spec:
               value: ":samples:cmp"
             - name: SERVE_IDLE_EXIT
               value: "900"
+            - name: SERVE_CATALOG_MAX_IMAGES
+              value: "2000"
             # The shared auth token, sourced from Secret Manager (see deploy.sh,
             # which creates the `compose-preview-token` secret).
             - name: SERVE_TOKEN

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -475,3 +475,5 @@ should never show two different typefaces.
 - Live bundles resolve coordinate dependencies from the baked Maven tree first,
   then the configured remote repositories. `SERVE_TIMEOUT` (default 1800s)
   guards slow first renders.
+- `SERVE_CATALOG_MAX_IMAGES` forwards to `serve --catalog-max-images`; leave it empty for the CLI
+  default, or raise it when the configured catalogs legitimately contain more images.

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -68,6 +68,9 @@ services:
       # <system>@<owner>/<repo>, comma-separated. Empty (the default) = the file decides.
       SERVE_CATALOGS: "${SERVE_CATALOGS:-}"
       SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-}"
+      # Maximum catalog images registered by the server. Images remain lazily fetched; raise this
+      # when a catalog set legitimately exceeds the CLI default.
+      SERVE_CATALOG_MAX_IMAGES: "${SERVE_CATALOG_MAX_IMAGES:-}"
       # The producer-trust store is config, like catalogs.json: it lives on the
       # `preview_config` volume at /config/producers.json, seeded on first boot from the
       # store baked at /trust/producers.json and never overwritten again — so the published

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -52,6 +52,8 @@ fi
 PORT="${PORT:-8080}"
 
 args=(serve --host 0.0.0.0 --port "${PORT}")
+[[ -n "${SERVE_CATALOG_MAX_IMAGES:-}" ]] &&
+  args+=(--catalog-max-images "${SERVE_CATALOG_MAX_IMAGES}")
 
 # The release tarball carries the matching CMP/Wasm Remote Compose player as a static sidecar.
 # Older releases simply omit it and retain the existing player set.

--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -276,6 +276,44 @@ function narrowToMappedPreviewId(matches, mappedPreviewId, fn, warnings) {
 }
 
 /**
+ * Reduce a variant-aware design-map entry to the untagged binding the catalog overview publishes.
+ *
+ * design-parity accepts `ref` / `previewId` arrays so one code component can bind every authored
+ * state, size and theme. The catalog reference lane currently publishes one inert raster per
+ * component, however, and historically understood only scalar bindings. Treating an array as a
+ * raster handle made the whole entry fail-soft out of the bundle, which made adding exact parity
+ * coverage remove the component's previously published reference.
+ *
+ * The untagged item is the array form's default binding. Publish that one here; the parity workflow
+ * continues to consume the complete arrays directly. Refuse ambiguous or all-tagged arrays instead
+ * of guessing which state represents the component.
+ */
+function primaryDesignBinding(entry, warnings) {
+  const primary = (value, field) => {
+    if (!Array.isArray(value)) return value;
+    const untagged = value.filter(
+      (item) => item && !item.state && !item.theme && !item.size,
+    );
+    if (untagged.length !== 1) {
+      warnings.push(
+        `design-map '${functionNameOf(entry?.code) ?? entry?.code ?? "?"}' has ${untagged.length} ` +
+          `untagged ${field} bindings; exactly one is required for catalog publication`,
+      );
+      return undefined;
+    }
+    return untagged[0]?.[field];
+  };
+
+  const ref = primary(entry?.ref, "ref");
+  const previewId = primary(entry?.previewId, "previewId");
+  if (typeof ref !== "string" || ref === "") return undefined;
+  if (Array.isArray(entry?.previewId) && (typeof previewId !== "string" || previewId === "")) {
+    return undefined;
+  }
+  return { ...entry, ref, previewId };
+}
+
+/**
  * Plan the reference records for a repo: which design-map entries map onto which published
  * stickers, and what each one's raster has to look like.
  *
@@ -298,7 +336,9 @@ export function planDesignReferences({ designMap, spec, catalog }) {
   const byPreviewId = imagesByPreviewId(catalog);
   const ordinals = new Map();
 
-  for (const entry of designMap?.components ?? []) {
+  for (const rawEntry of designMap?.components ?? []) {
+    const entry = primaryDesignBinding(rawEntry, warnings);
+    if (!entry) continue;
     const fn = functionNameOf(entry?.code);
     if (!fn) {
       warnings.push(`design-map entry has no 'path#Member' code handle: ${entry?.code ?? "?"}`);

--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -261,7 +261,18 @@ function narrowToMappedPreviewId(matches, mappedPreviewId, fn, warnings) {
   const labelled = matches.filter(({ image }) => typeof image?.previewId === "string");
   if (labelled.length === 0) return matches;
 
-  const narrowed = labelled.filter(({ image }) => image.previewId === mappedPreviewId);
+  const exact = labelled.filter(({ image }) => image.previewId === mappedPreviewId);
+  const sanitised =
+    exact.length > 0
+      ? []
+      : labelled.filter(
+          ({ image }) =>
+            sanitizeBundleEntryId(image.previewId) === sanitizeBundleEntryId(mappedPreviewId),
+        );
+  // A sanitised collision is ambiguous: the bundle suffixes one of the colliding ids, and the raw
+  // discovery id no longer identifies which sticker owns the reference. Keep exact matches as-is;
+  // accept the sanitised fallback only when it names one sticker.
+  const narrowed = exact.length > 0 ? exact : sanitised.length === 1 ? sanitised : [];
   if (narrowed.length === 0) {
     warnings.push(
       `design-map '${fn}' names previewId '${mappedPreviewId}', which matches none of its ` +
@@ -301,7 +312,7 @@ function primaryDesignBinding(entry, warnings) {
       );
       return undefined;
     }
-    return untagged[0]?.[field];
+    return typeof untagged[0] === "string" ? untagged[0] : untagged[0]?.[field];
   };
 
   const ref = primary(entry?.ref, "ref");

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -259,6 +259,64 @@ test("planDesignReferences maps design-map entries onto serve preview ids", () =
   assert.equal(records[1].origin.ref, "design/ContactChat.dark.html");
 });
 
+test("planDesignReferences publishes the untagged binding from variant arrays", () => {
+  const designMap = {
+    components: [
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatPreview",
+        source: "figma",
+        ref: [
+          { ref: "figma:abc/73:5" },
+          { ref: "figma:abc/73:6", state: "disabled" },
+        ],
+        previewId: [
+          { previewId: "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview" },
+          {
+            previewId: "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview_Disabled",
+            state: "disabled",
+          },
+        ],
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({ designMap, spec: SPEC, catalog: CATALOG });
+
+  assert.deepEqual(warnings, []);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].origin.ref, "figma:abc/73:5");
+  assert.equal(
+    records[0].origin.previewId,
+    "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview",
+  );
+  assert.equal(records[0].source.uri, "figma:abc/73:5");
+});
+
+test("planDesignReferences refuses an array with no untagged catalog binding", () => {
+  const designMap = {
+    components: [
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatPreview",
+        source: "figma",
+        ref: [{ ref: "figma:abc/73:6", state: "disabled" }],
+        previewId: [
+          {
+            previewId: "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview_Disabled",
+            state: "disabled",
+          },
+        ],
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({ designMap, spec: SPEC, catalog: CATALOG });
+
+  assert.deepEqual(records, []);
+  assert.equal(warnings.length, 2);
+  assert.match(warnings[0], /0 untagged ref bindings/);
+  assert.match(warnings[1], /0 untagged previewId bindings/);
+});
+
 test("planDesignReferences carries a declared board density to the driver", () => {
   // Only the design-map author knows a board's scale, and it is what lets the reference column be
   // quoted in dp/sp instead of the board's own pixels (design-parity#279). It is driver input, not

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -292,6 +292,35 @@ test("planDesignReferences publishes the untagged binding from variant arrays", 
   assert.equal(records[0].source.uri, "figma:abc/73:5");
 });
 
+test("planDesignReferences accepts string defaults in variant arrays", () => {
+  const designMap = {
+    components: [
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatPreview",
+        source: "figma",
+        ref: ["figma:abc/73:5", { ref: "figma:abc/73:6", state: "disabled" }],
+        previewId: [
+          "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview",
+          {
+            previewId: "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview_Disabled",
+            state: "disabled",
+          },
+        ],
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({ designMap, spec: SPEC, catalog: CATALOG });
+
+  assert.deepEqual(warnings, []);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].origin.ref, "figma:abc/73:5");
+  assert.equal(
+    records[0].origin.previewId,
+    "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview",
+  );
+});
+
 test("planDesignReferences refuses an array with no untagged catalog binding", () => {
   const designMap = {
     components: [
@@ -659,6 +688,19 @@ const SANITISED_CATALOG = {
   ],
 };
 
+const SANITISED_SPEC = {
+  groups: [
+    {
+      components: [
+        {
+          componentId: "Home/SmallRound",
+          preview: "HomeListViewPreview",
+        },
+      ],
+    },
+  ],
+};
+
 test("sanitizeBundleEntryId mirrors the Kotlin transform and is idempotent", () => {
   assert.equal(sanitizeBundleEntryId("Foo_A B"), "Foo_A_B");
   assert.equal(sanitizeBundleEntryId("com.example.FooKt.Bar_Font scale 1.5x"),
@@ -689,6 +731,31 @@ test("planDesignReferences joins a raw previewId to its sanitised catalog twin",
   assert.deepEqual(warnings, []);
   assert.equal(records.length, 1);
   assert.match(records[0].label, /^Home\/SmallRound — figma$/);
+});
+
+test("planDesignReferences narrows spec matches using a sanitised array primary id", () => {
+  const designMap = {
+    components: [
+      {
+        code: "app/src/main/kotlin/ui/Home.kt#HomeListViewPreview",
+        source: "figma",
+        ref: [{ ref: "figma:abc/73:6" }],
+        previewId: [
+          { previewId: "ee.app.ui.HomeKt.HomeListViewPreview_Devices - Small Round" },
+        ],
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({
+    designMap,
+    spec: SANITISED_SPEC,
+    catalog: SANITISED_CATALOG,
+  });
+
+  assert.deepEqual(warnings, []);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].origin.ref, "figma:abc/73:6");
 });
 
 test("planDesignReferences refuses to guess when a sanitised id matches several stickers", () => {


### PR DESCRIPTION
## Summary

- raise the default published-catalog preview ceiling from 1,000 to 2,000
- add `serve --catalog-max-images <count>` so operators can tune the ceiling
- publish the untagged/default binding from variant-aware design-map arrays
- document that the image limit bounds lazily loaded preview metadata and routes

## Root causes

`ServeCatalogStore` stopped registering previews after 1,000 declared images. The Material 3
catalog currently publishes more than 1,000 images, so later components were silently absent from
the server and its design-reference coverage calculation.

Separately, the design-reference publisher treated array-valued `ref` and `previewId` bindings as
scalar raster handles. Adding exhaustive state and size mappings therefore reduced the published
Material 3 reference manifest from 24 components to 6. The publisher now selects the array's unique
untagged binding for the catalog overview; design-parity still consumes the complete arrays.

Because catalog images are fetched lazily, increasing the ceiling does not eagerly download or
retain all 2,000 bitmaps.

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.ServeCommandTest --tests ee.schimke.composeai.cli.serve.ServeCatalogStoreTest`
- `./gradlew :cli:ktfmtCheck`
- `node --test scripts/design-artifacts/design-references.test.mjs`
- exercised `planDesignReferences` against m3-catalog's current 78 mapped components: 78 records,
  zero warnings
- `git diff --check`
