### PR TITLE
fix(design-artifacts): --allow-incomplete rejects empty catalogs

### DIFF
--- a/scripts/design-artifacts/completeness-gate.mjs
+++ b/scripts/design-artifacts/completeness-gate.mjs
@@ -1,0 +1,24 @@
+/**
+ * Decide whether a catalog render is safe to publish.
+ *
+ * `allowIncomplete` permits a partial catalog, but never a total miss: if at
+ * least one required component is missing and no component resolved, publishing
+ * would replace the delivery branch with an empty catalog.
+ *
+ * A spec made entirely of declared sticker-less or deferred entries has no
+ * `missing` entries, so it is not mistaken for a failed render here.
+ *
+ * @returns {"empty" | "incomplete" | null}
+ */
+export function completenessFailure({
+  allowIncomplete,
+  resolvedCount,
+  missingCount,
+  withoutSemanticsCount,
+}) {
+  if (missingCount > 0 && resolvedCount === 0) return "empty";
+  if (!allowIncomplete && (missingCount > 0 || withoutSemanticsCount > 0)) {
+    return "incomplete";
+  }
+  return null;
+}

--- a/scripts/design-artifacts/completeness-gate.test.mjs
+++ b/scripts/design-artifacts/completeness-gate.test.mjs
@@ -1,0 +1,39 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { completenessFailure } from "./completeness-gate.mjs";
+
+const failure = (overrides = {}) =>
+  completenessFailure({
+    allowIncomplete: false,
+    resolvedCount: 1,
+    missingCount: 0,
+    withoutSemanticsCount: 0,
+    ...overrides,
+  });
+
+test("strict mode rejects an incomplete render", () => {
+  assert.equal(failure({ missingCount: 1 }), "incomplete");
+  assert.equal(failure({ withoutSemanticsCount: 1 }), "incomplete");
+});
+
+test("allow-incomplete permits a partial render", () => {
+  assert.equal(
+    failure({ allowIncomplete: true, resolvedCount: 1, missingCount: 2 }),
+    null,
+  );
+});
+
+test("allow-incomplete still rejects a total render miss", () => {
+  assert.equal(
+    failure({ allowIncomplete: true, resolvedCount: 0, missingCount: 3 }),
+    "empty",
+  );
+});
+
+test("a catalog with only declared non-rendered entries is not a total miss", () => {
+  assert.equal(
+    failure({ allowIncomplete: true, resolvedCount: 0, missingCount: 0 }),
+    null,
+  );
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -125,6 +125,7 @@ import {
 import { applyCatalogPreviewAxes } from "./catalog-preview-axes.mjs";
 import { selectComponentImages, selectOf } from "./catalog-select.mjs";
 import { applyCatalogPreviewDeclarations } from "./catalog-preview-declarations.mjs";
+import { completenessFailure } from "./completeness-gate.mjs";
 
 /**
  * Best-effort fetch + parse of a JSON URL, with a short timeout. Returns null on
@@ -700,9 +701,9 @@ const { values } = parseArgs({
     "source-repo": { type: "string" },
     "source-ref": { type: "string" },
     "source-module": { type: "string" },
-    // Publish even when the render is incomplete (missing previews or absent
-    // semantics). Off by default so a degraded render fails the job rather than
-    // force-pushing a tokens/greenline-less bundle over a good delivery branch.
+    // Publish a partially complete render (missing previews or absent semantics).
+    // A total render miss still fails so it cannot replace a good delivery branch
+    // with an empty catalog.
     "allow-incomplete": { type: "boolean", default: false },
   },
 });
@@ -964,7 +965,8 @@ const { catalog, missing, noSticker, withoutSemantics, deferred } =
 // even when the daemon never started or captured zero semantics. For a scheduled
 // job that force-pushes a delivery branch, refuse to publish an incomplete render
 // (missing previews, or pixels with no semantics → no tokens/contrast/greenlines)
-// so a transient failure can't clobber a good branch. `--allow-incomplete` opts out.
+// so a transient failure can't clobber a good branch. `--allow-incomplete` permits
+// partial output, but a total render miss always fails.
 if (missing.length > 0) {
   console.warn(`[${spec.system}] missing renders for: ${missing.join(", ")}`);
   console.warn(
@@ -1000,10 +1002,20 @@ if (deferred.length > 0) {
   );
 }
 
-if (
-  !values["allow-incomplete"] &&
-  (missing.length > 0 || withoutSemantics.length > 0)
-) {
+const completenessFailureReason = completenessFailure({
+  allowIncomplete: values["allow-incomplete"],
+  resolvedCount: catalog.components.length,
+  missingCount: missing.length,
+  withoutSemanticsCount: withoutSemantics.length,
+});
+if (completenessFailureReason === "empty") {
+  console.error(
+    `[${spec.system}] zero catalog components resolved a render — refusing to publish. ` +
+      `--allow-incomplete permits a partial catalog, not an empty one.`,
+  );
+  process.exit(1);
+}
+if (completenessFailureReason === "incomplete") {
   console.error(
     `[${spec.system}] incomplete render — refusing to publish. ` +
       `Re-run the render, or pass --allow-incomplete to override.`,


### PR DESCRIPTION
## Summary

- keep `--allow-incomplete` working for partially rendered catalogs
- reject a total render miss even when the flag is enabled
- preserve valid catalogs made entirely of deferred or `capture: none` entries

## Root cause

The completeness gate skipped every missing-render failure whenever `--allow-incomplete` was set. It did not distinguish a deliberate partial catalog from a renderer failure that resolved zero catalog components, allowing an empty catalog to replace a previously good delivery branch.

## Impact

A total renderer failure now stops before catalog output is published. Repositories can continue allowing narrow, expected gaps without accepting a completely empty catalog.

## Validation

- `node --test scripts/design-artifacts/completeness-gate.test.mjs`
- 453 non-browser design-artifacts tests passed
- `node --check scripts/design-artifacts/generate-design-catalog.mjs`
- `git diff --check`

Closes #3591