### PR TITLE
fix(serve): resolve Robolectric dependencies in sandbox

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1463,7 +1463,7 @@ class ServeCommand(args: List<String>) : Command(args) {
     val launch = AndroidBundleLaunch()
     val daemonClasspath = (daemonJars + listOf(androidJar)).map { it.absolutePath }
     val jvmArgs = launch.jvmArgs()
-    val sysprops = launch.robolectricSystemProperties()
+    val sysprops = sandbox.robolectricSystemProperties(launch.robolectricSystemProperties())
     return { classesDir, previewsJson, workspaceRoot, userClasspath ->
       openPlaygroundFirstFrameDaemon(
         daemonClasspath,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandbox.kt
@@ -146,6 +146,29 @@ data class PlaygroundSandbox(
   }
 
   /**
+   * Add the host Maven repository to a jailed Robolectric launch explicitly. Bwrap replaces `HOME`
+   * with [Paths.workDir], so Robolectric's default `user.home/.m2/repository` lookup points at an
+   * empty ephemeral directory even when the operator exposed the real cache with
+   * `--playground-sandbox-ro`. `maven.repo.local` is Robolectric's supported override and remains
+   * readable through that read-only bind.
+   *
+   * Inactive sandboxes return [base] unchanged, preserving the pre-sandbox launch byte-for-byte.
+   * Relative `maven.repo.local` overrides are made absolute before the jail changes directory.
+   */
+  fun robolectricSystemProperties(
+    base: Map<String, String>,
+    mavenRepoLocal: String? = System.getProperty("maven.repo.local"),
+    userHome: String? = System.getProperty("user.home"),
+  ): Map<String, String> {
+    if (!isActive) return base
+    val repository =
+      mavenRepoLocal?.takeIf { it.isNotBlank() }?.let(::File)
+        ?: userHome?.takeIf { it.isNotBlank() }?.let { File(it, ".m2/repository") }
+        ?: return base
+    return base + ("maven.repo.local" to repository.absolutePath)
+  }
+
+  /**
    * Heap ceiling: three quarters of the memory budget, leaving room for the JVM's own non-heap
    * footprint (metaspace, code cache, Skiko/Robolectric native allocations) under a cgroup that
    * would otherwise OOM-kill the process before the heap limit ever bit.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -410,7 +410,10 @@ internal object ServeBundleDaemon {
             put("composeai.daemon.previewsJsonPath", previewsJson.absolutePath)
             put("composeai.render.outputDir", File(workDir, "renders").absolutePath)
             put("composeai.render.placeholderMissingResources", "true")
-            putAll(backendLaunch.extraSystemProperties)
+            putAll(
+              if (android) sandbox.robolectricSystemProperties(backendLaunch.extraSystemProperties)
+              else backendLaunch.extraSystemProperties
+            )
           },
         workingDirectory = workDir.absolutePath,
         manifestPath = previewsJson.absolutePath,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSandboxTest.kt
@@ -124,6 +124,38 @@ class PlaygroundSandboxTest {
   }
 
   @Test
+  fun `jailed robolectric launch resolves dependencies from the host maven repository`() {
+    val sandbox = PlaygroundSandbox(profile = PlaygroundSandbox.Profile.BWRAP)
+    val base = linkedMapOf("robolectric.graphicsMode" to "NATIVE")
+
+    val fromHome =
+      sandbox.robolectricSystemProperties(base = base, mavenRepoLocal = null, userHome = "/root")
+    assertEquals("NATIVE", fromHome["robolectric.graphicsMode"])
+    assertEquals("/root/.m2/repository", fromHome["maven.repo.local"])
+
+    val overridden =
+      sandbox.robolectricSystemProperties(
+        base = base,
+        mavenRepoLocal = "/cache/maven",
+        userHome = "/ignored",
+      )
+    assertEquals("/cache/maven", overridden["maven.repo.local"])
+  }
+
+  @Test
+  fun `unsandboxed robolectric launch stays unchanged`() {
+    val base = linkedMapOf("robolectric.graphicsMode" to "NATIVE")
+
+    assertTrue(
+      PlaygroundSandbox.NONE.robolectricSystemProperties(
+        base = base,
+        mavenRepoLocal = "/cache/maven",
+        userHome = "/root",
+      ) === base
+    )
+  }
+
+  @Test
   fun `custom carries the operator argv verbatim and claims nothing`() {
     val sandbox = PlaygroundSandbox.parseProfile("custom:firejail --net=none").getOrThrow()
 


### PR DESCRIPTION
## Summary

- pass the host Maven repository to Robolectric through `maven.repo.local` when a playground sandbox is active
- apply the override to Android first-frame, Remote Compose capture, and redeemed Android sessions
- preserve unsandboxed launch properties exactly

## Root cause

Bubblewrap clears the environment and changes `HOME` to the snippet's ephemeral work directory. Robolectric consequently looked for `android-all-instrumented` under the empty jailed home even when the real Maven cache was exposed read-only with `--playground-sandbox-ro`.

## Impact

Sandboxed Android and Remote Compose playground modes can resolve the prewarmed Robolectric runtime without network access. Operators must still expose the Maven cache through `--playground-sandbox-ro`.

## Validation

- `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.PlaygroundSandboxTest'`
- `./gradlew :cli:ktfmtCheck`
- `git diff --check`
- repository pre-commit and pre-push hooks

Fixes #3213