### PR TITLE
fix: validate published design references

### DIFF
--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -203,15 +203,38 @@ export function sanitizeBundleEntryId(id) {
 }
 
 /**
+ * The base id of a bundle collision family containing [previewId], or null.
+ *
+ * `assignBundleEntryIds` lets the first sanitised claimant keep `Foo_A_B` and names later
+ * claimants `Foo_A_B_1`, `Foo_A_B_2`, ... . A published catalog retains those bundle ids but not
+ * the manifest's parallel raw-id aliases, so seeing the base plus a numeric suffix is the only
+ * evidence available here that reversing the sanitisation would be unsafe.
+ */
+function collisionFamilyBase(publishedPreviewIds, previewId) {
+  const ids = new Set(publishedPreviewIds);
+  const bases = new Set();
+  for (const id of ids) {
+    const suffix = String(id).match(/^(.*)_([1-9][0-9]*)$/);
+    if (suffix && ids.has(suffix[1])) bases.add(suffix[1]);
+  }
+
+  const mapped = sanitizeBundleEntryId(previewId);
+  if (bases.has(mapped)) return mapped;
+  const mappedSuffix = mapped.match(/^(.*)_([1-9][0-9]*)$/);
+  return mappedSuffix && bases.has(mappedSuffix[1]) ? mappedSuffix[1] : null;
+}
+
+/**
  * Resolve a design-map entry's `previewId` against the catalog, across both id namespaces.
  *
- * Returns `[]` when nothing matches, and also when the sanitised form matches SEVERAL images. That
- * second case is `uniqueBundleEntryId`'s collision suffix: two distinct raw ids that sanitise the
- * same are disambiguated in-bundle (`Foo_A_B`, `Foo_A_B-2`), and the raw id alone can no longer say
- * which one it meant. Publishing a reference against a coin-flip is worse than publishing none, so
- * the caller warns instead.
+ * Returns `[]` when nothing matches, and also when the published ids form a bundle collision family
+ * (`Foo_A_B`, `Foo_A_B_1`, ...). The raw aliases that distinguish those entries are no longer
+ * present in catalog.json, so even an apparent exact hit can belong to the colliding sibling.
+ * Publishing a reference against a coin-flip is worse than publishing none, so the caller warns
+ * instead.
  */
 function matchesForPreviewId({ exact, sanitised }, previewId) {
+  if (collisionFamilyBase(exact.keys(), previewId)) return [];
   const direct = exact.get(previewId);
   if (direct && direct.length > 0) return direct;
   const viaSanitised = sanitised.get(sanitizeBundleEntryId(previewId)) ?? [];
@@ -261,6 +284,18 @@ function narrowToMappedPreviewId(matches, mappedPreviewId, fn, warnings) {
   const labelled = matches.filter(({ image }) => typeof image?.previewId === "string");
   if (labelled.length === 0) return matches;
 
+  const collisionBase = collisionFamilyBase(
+    labelled.map(({ image }) => image.previewId),
+    mappedPreviewId,
+  );
+  if (collisionBase) {
+    warnings.push(
+      `design-map '${fn}' names previewId '${mappedPreviewId}', but published bundle ids in ` +
+        `the '${collisionBase}' collision family cannot be reversed without raw-id aliases`,
+    );
+    return [];
+  }
+
   const exact = labelled.filter(({ image }) => image.previewId === mappedPreviewId);
   const sanitised =
     exact.length > 0
@@ -269,9 +304,9 @@ function narrowToMappedPreviewId(matches, mappedPreviewId, fn, warnings) {
           ({ image }) =>
             sanitizeBundleEntryId(image.previewId) === sanitizeBundleEntryId(mappedPreviewId),
         );
-  // A sanitised collision is ambiguous: the bundle suffixes one of the colliding ids, and the raw
-  // discovery id no longer identifies which sticker owns the reference. Keep exact matches as-is;
-  // accept the sanitised fallback only when it names one sticker.
+  // A sanitised collision without a published suffix is still ambiguous when this match set carries
+  // several unsanitised ids. Keep exact matches as-is; accept the sanitised fallback only when it
+  // names one sticker. Real bundle collision suffixes were rejected above.
   const narrowed = exact.length > 0 ? exact : sanitised.length === 1 ? sanitised : [];
   if (narrowed.length === 0) {
     warnings.push(
@@ -315,9 +350,19 @@ function primaryDesignBinding(entry, warnings) {
     return typeof untagged[0] === "string" ? untagged[0] : untagged[0]?.[field];
   };
 
+  const warningCount = warnings.length;
   const ref = primary(entry?.ref, "ref");
+  const refWarningAdded = warnings.length > warningCount;
   const previewId = primary(entry?.previewId, "previewId");
-  if (typeof ref !== "string" || ref === "") return undefined;
+  if (typeof ref !== "string" || ref === "") {
+    if (!refWarningAdded) {
+      warnings.push(
+        `design-map '${functionNameOf(entry?.code) ?? entry?.code ?? "?"}' has an invalid ref ` +
+          `binding; expected a non-empty string`,
+      );
+    }
+    return undefined;
+  }
   if (Array.isArray(entry?.previewId) && (typeof previewId !== "string" || previewId === "")) {
     return undefined;
   }

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -321,6 +321,30 @@ test("planDesignReferences accepts string defaults in variant arrays", () => {
   );
 });
 
+test("planDesignReferences warns before dropping invalid scalar and array refs", () => {
+  const designMap = {
+    components: [
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatPreview",
+        source: "figma",
+        ref: "",
+      },
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatDarkPreview",
+        source: "figma",
+        ref: [{}],
+      },
+    ],
+  };
+
+  const { records, warnings } = planDesignReferences({ designMap, spec: SPEC, catalog: CATALOG });
+
+  assert.deepEqual(records, []);
+  assert.equal(warnings.length, 2);
+  assert.match(warnings[0], /ContactChatPreview.*invalid ref binding/);
+  assert.match(warnings[1], /ContactChatDarkPreview.*invalid ref binding/);
+});
+
 test("planDesignReferences refuses an array with no untagged catalog binding", () => {
   const designMap = {
     components: [
@@ -758,46 +782,52 @@ test("planDesignReferences narrows spec matches using a sanitised array primary 
   assert.equal(records[0].origin.ref, "figma:abc/73:6");
 });
 
-test("planDesignReferences refuses to guess when a sanitised id matches several stickers", () => {
-  // `uniqueBundleEntryId`'s collision case: two distinct raw ids that sanitise to the same string.
-  // The design-map id below matches NEITHER exactly, and sanitises to a form both share — so the
-  // raw id can no longer say which was meant. A coin-flip reference is worse than none.
+test("planDesignReferences refuses collision-suffixed bundle ids without raw aliases", () => {
+  // What a real bundle-derived catalog carries after raw `P_A B` and `P_A/B` collide: the first
+  // sanitised claimant keeps the base and the second gets `_1`. The raw aliases that identify
+  // which is which are not retained in catalog.json, so neither raw id can be reversed safely.
   const collidingCatalog = {
     components: [
       {
         componentId: "Home/Round",
         images: [
-          { path: "a.png", width: 1, height: 1, previewId: "ee.HomeKt.P_A B" },
-          { path: "b.png", width: 1, height: 1, previewId: "ee.HomeKt.P_A/B" },
+          { path: "a.png", width: 1, height: 1, previewId: "ee.HomeKt.P_A_B" },
+          { path: "b.png", width: 1, height: 1, previewId: "ee.HomeKt.P_A_B_1" },
         ],
       },
     ],
   };
 
-  const ambiguous = planDesignReferences({
-    designMap: {
-      components: [
-        { code: "a.kt#P", source: "figma", ref: "figma:abc/1:1", previewId: "ee.HomeKt.P_A+B" },
-      ],
-    },
-    spec: ANNOTATION_SPEC,
-    catalog: collidingCatalog,
-  });
-  assert.deepEqual(ambiguous.records, []);
-  assert.equal(ambiguous.warnings.length, 1);
-  assert.match(ambiguous.warnings[0], /matches no published sticker/);
+  for (const previewId of ["ee.HomeKt.P_A B", "ee.HomeKt.P_A/B", "ee.HomeKt.P_A_B_1"]) {
+    const result = planDesignReferences({
+      designMap: {
+        components: [{ code: "a.kt#P", source: "figma", ref: "figma:abc/1:1", previewId }],
+      },
+      spec: ANNOTATION_SPEC,
+      catalog: collidingCatalog,
+    });
+    assert.deepEqual(result.records, []);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /matches no published sticker/);
+  }
 
-  // An id that DOES hit one of them exactly still resolves, so the refusal is scoped to genuine
-  // ambiguity rather than to any catalog that happens to contain a collision.
-  const exact = planDesignReferences({
+  const specLed = planDesignReferences({
     designMap: {
       components: [
-        { code: "a.kt#P", source: "figma", ref: "figma:abc/1:1", previewId: "ee.HomeKt.P_A B" },
+        {
+          code: "a.kt#P",
+          source: "figma",
+          ref: "figma:abc/1:1",
+          previewId: "ee.HomeKt.P_A/B",
+        },
       ],
     },
-    spec: ANNOTATION_SPEC,
+    spec: {
+      groups: [{ components: [{ componentId: "Home/Round", preview: "P" }] }],
+    },
     catalog: collidingCatalog,
   });
-  assert.deepEqual(exact.warnings, []);
-  assert.equal(exact.records.length, 1);
+  assert.deepEqual(specLed.records, []);
+  assert.equal(specLed.warnings.length, 1);
+  assert.match(specLed.warnings[0], /collision family cannot be reversed/);
 });


### PR DESCRIPTION
## What changed

- warn before invalid scalar or uniquely untagged array `ref` bindings are dropped
- reject bundle preview-id collision families when `catalog.json` no longer carries enough raw-id information to reverse them safely
- cover scalar, array, annotation-led, and spec-led planner paths

## Why

PR #3612 made variant-aware mappings publish a primary reference, but two post-merge review findings exposed unsafe edge cases. Invalid references could bypass `--strict`, and sanitization collisions could attach a reference to the wrong sticker. This follow-up keeps publication fail-soft by default while ensuring strict mode observes malformed mappings and ambiguous ids are never guessed.

## Validation

- `node --test scripts/design-artifacts/design-references.test.mjs` (27/27 passing)
- `git diff --check`

Follow-up to #3612.
