### PR TITLE
fix: lower Compose preview floor to 1.10

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1657,7 +1657,7 @@ jobs:
           # (including the BOM grep against `build.gradle.kts`) and then
           # falls through to the Gradle `composePreviewDoctor` task. The
           # `env.compose-bom-version` check fires when any declared
-          # `compose-bom` is below the renderer floor (2025.01.00) — that's
+          # `compose-bom` is below the renderer floor (2025.12.00) — that's
           # the user-facing diagnostic we want this job to guarantee.
           compose-preview doctor --json --project "$RUNNER_TEMP/fixture" \
             > "$RUNNER_TEMP/doctor.json" || true

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -891,16 +891,18 @@ class DoctorCommand(
    * Grep-based "is your compose-bom recent enough" pre-flight. Runs BEFORE any Gradle call, so it
    * works even outside a Gradle project or before the plugin is applied — complements the
    * plugin-side `CompatRules` findings, which only fire once Gradle has resolved the test
-   * classpath. Renderer-android is compiled with compose- compiler 2.2.21, which emits calls to
-   * `ComposeUiNode.setCompositeKeyHash` — first shipped in compose-ui 1.9 (compose-bom 2025.01.00).
-   * Older consumers hit `NoSuchMethodError` the moment `composePreviewRender` starts.
+   * classpath. The renderer's own `MeasuredWrapBox` links against
+   * `ComposeUiNode.Companion.getApplyOnDeactivatedNodeAssertion`, first shipped in compose-ui
+   * 1.10.0 (compose-bom 2025.12.00). This wrapper is used by the standalone `composePreviewRender`
+   * task as well as daemon-backed rendering, so even a simple preview cannot stay on a 1.9.x render
+   * classpath.
    */
   private fun checkComposeBomVersion() {
     val workspace = File(projectDirArg ?: ".").canonicalFile
     val versions = findComposeBomDeclarations(workspace)
     if (versions.isEmpty()) return // No declarations → nothing to assert on.
 
-    val tooOld = versions.filter { (_, v) -> v.isOlderThan(MIN_BOM_YEAR, MIN_BOM_MONTH) }
+    val tooOld = versions.filter { (_, v) -> isComposeBomBelowRenderFloor(v.raw) == true }
     if (tooOld.isEmpty()) {
       val summary = versions.joinToString(", ") { (_, v) -> v.raw }
       addCheck(
@@ -923,7 +925,7 @@ class DoctorCommand(
           message =
             "compose-bom ${v.raw} declared in ${source.relativeTo(workspace).path} — renderer needs ≥$floor",
           detail =
-            "Older BOMs lack `ComposeUiNode.setCompositeKeyHash`; `composePreviewRender` will fail with NoSuchMethodError.",
+            "Compose UI before 1.10.0 lacks `ComposeUiNode.Companion.getApplyOnDeactivatedNodeAssertion`. The standalone `composePreviewRender` path also uses the renderer-owned `MeasuredWrapBox`, so simple previews are not exempt. With dependency management enabled the plugin raises the render graph and matching resource pins together; with `composePreview.manageDependencies = false`, resolution fails with an actionable error instead.",
           remediation =
             DoctorRemediation(
               summary = "Bump the BOM.",
@@ -1363,12 +1365,15 @@ class DoctorCommand(
 
   companion object {
     /**
-     * Minimum supported Compose BOM — 2025.01.00 → compose-ui 1.9.0. That's the first BOM where
-     * `ComposeUiNode.setCompositeKeyHash` (emitted by compose-compiler 2.2.21) exists on the
-     * runtime side.
+     * Minimum supported Compose BOM — 2025.12.00 → compose-ui 1.10.0. That's the first BOM whose
+     * runtime exposes `ComposeUiNode.Companion.getApplyOnDeactivatedNodeAssertion`, linked by the
+     * renderer's `MeasuredWrapBox` on both standalone and daemon-backed Android renders.
      */
     private const val MIN_BOM_YEAR = 2025
-    private const val MIN_BOM_MONTH = 1
+    private const val MIN_BOM_MONTH = 12
+
+    internal fun isComposeBomBelowRenderFloor(raw: String): Boolean? =
+      ComposeVersion.parse(raw)?.isOlderThan(MIN_BOM_YEAR, MIN_BOM_MONTH)
 
     /** User-Agent for doctor's HEAD probes — matches the string `scripts/install.sh` sends. */
     private const val USER_AGENT = "compose-preview-doctor"
@@ -1479,10 +1484,20 @@ class DoctorCommand(
             ),
         ),
         ErrorSignature(
+          pattern = "getApplyOnDeactivatedNodeAssertion",
+          hint =
+            "compose-ui below 1.10.0 — even standalone simple previews pass through the renderer's MeasuredWrapBox",
+          remediation =
+            DoctorRemediation(
+              summary =
+                "Bump compose-bom to at least 2025.12.00, or enable composePreview.manageDependencies so the plugin raises the render graph and resource pins together."
+            ),
+        ),
+        ErrorSignature(
           pattern = "NoSuchMethodError: androidx.compose.runtime.ComposeUiNode",
           hint =
             "compose-bom too old — renderer-compiled calls postdate the runtime on the consumer's classpath",
-          remediation = DoctorRemediation(summary = "Bump compose-bom to at least 2025.01.00."),
+          remediation = DoctorRemediation(summary = "Bump compose-bom to at least 2025.12.00."),
         ),
       )
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorCommandTest.kt
@@ -6,6 +6,14 @@ import kotlin.test.assertTrue
 
 class DoctorReportSerializationTest {
   @Test
+  fun `compose bom preflight matches the compose 1_10 render floor`() {
+    assertEquals(true, DoctorCommand.isComposeBomBelowRenderFloor("2025.11.01"))
+    assertEquals(false, DoctorCommand.isComposeBomBelowRenderFloor("2025.12.00"))
+    assertEquals(false, DoctorCommand.isComposeBomBelowRenderFloor("2026.01.00"))
+    assertEquals(null, DoctorCommand.isComposeBomBelowRenderFloor("catalog.version"))
+  }
+
+  @Test
   fun `round-trips a report with all fields populated`() {
     val report =
       DoctorReport(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -404,16 +404,14 @@ internal object AndroidPreviewSupport {
    * ```
    *
    * so the floor is above 1.9.5 (matching the #3484 report that 1.9.5 is unlinkable) and at most
-   * 1.10.0 for *that* symbol. Set to **1.11.0** — the lowest version with end-to-end evidence, a
-   * real consumer rendering its whole catalog — rather than 1.10.0, because the probe proves one
-   * symbol and not the renderer's whole reference set. Lower it to 1.10.x once a consumer on that
-   * line is verified to render; the cost of the gap is only that a 1.10.x consumer is raised
-   * needlessly, and today no consumer sits there.
+   * 1.10.0 for that symbol. The repo's Android fixtures also rendered end to end on the Compose
+   * 1.10.x line before the stable BOM moved to 1.11.x. Use **1.10.0**, the first compatible
+   * release, rather than making the current renderer build version the consumer minimum.
    */
-  internal const val RENDERER_COMPOSE_LINK_FLOOR_VERSION: String = "1.11.0"
+  internal const val RENDERER_COMPOSE_LINK_FLOOR_VERSION: String = "1.10.0"
 
   /**
-   * The `androidx.compose.*` groups that share the compose-ui version line (1.7.6 / 1.9.5 / 1.11.0
+   * The `androidx.compose.*` groups that share the compose-ui version line (1.7.6 / 1.9.5 / 1.10.0
    * move together). Deliberately NOT `androidx.compose.material` / `material3`, which version
    * independently — there is no `androidx.compose.material3:material3` on the compose-ui line, so
    * raising them to the floor would resolve a version that does not exist — nor a bare
@@ -495,7 +493,7 @@ internal object AndroidPreviewSupport {
    * ```
    *
    * (verified against the published artifacts: `ui-android` 1.9.5's `R.txt` has no such id,
-   * 1.11.0's does). Both sides move on one floor or neither does.
+   * 1.10.0's does). Both sides move on one floor or neither does.
    *
    * Consumers already above the floor are unaffected: this is a pin, so Gradle's max-version
    * conflict resolution leaves their own Compose line in place.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -54,7 +54,7 @@ internal object CompatRules {
    */
   private val OLD_DEP_MINIMUMS: List<Pair<String, Semver>> =
     listOf(
-      "androidx.compose.ui:ui" to Semver(1, 9, 0),
+      "androidx.compose.ui:ui" to Semver(1, 10, 0),
       "androidx.activity:activity" to Semver(1, 10, 0),
       "androidx.core:core" to Semver(1, 15, 0),
       "androidx.lifecycle:lifecycle-runtime" to Semver(2, 8, 0),

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposeLineFloorTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposeLineFloorTest.kt
@@ -61,7 +61,7 @@ class ComposeLineFloorTest {
   @Test
   fun `an alpha of the floor is still below it`() {
     // Derived from the constant rather than hard-coded, so moving the floor cannot leave this
-    // asserting the opposite of its name (issue #3603 moved it from 1.11.2 to 1.11.0).
+    // asserting the opposite of its name when the floor moves.
     assertThat(upgrade("androidx.compose.ui", "$floor-alpha01")).isEqualTo(floor)
     // …but an alpha of a HIGHER version is not.
     assertThat(upgrade("androidx.compose.ui", "1.12.0-alpha01")).isNull()
@@ -72,10 +72,10 @@ class ComposeLineFloorTest {
     // Probing androidx.compose.ui:ui-android for the accessor that actually fails:
     //   1.9.5  — ComposeUiNode$Companion.getApplyOnDeactivatedNodeAssertion ABSENT
     //   1.10.0 — PRESENT
-    // and yschimke/horologist renders its full 80-component catalog on 1.11.0. So the floor must
-    // raise 1.9.5 (provably unlinkable) and must NOT raise 1.11.0 (proven to work end to end) —
-    // the second half is what #3603 was: a 1.11.2 floor raised a consumer that was already fine.
+    // Android fixtures also rendered end to end on 1.10.x before the stable BOM moved to 1.11.x.
+    // Therefore 1.9.5 remains below the floor, while 1.10.0 is the first accepted release.
     assertThat(upgrade("androidx.compose.ui", "1.9.5")).isEqualTo(floor)
+    assertThat(upgrade("androidx.compose.ui", "1.10.0")).isNull()
     assertThat(upgrade("androidx.compose.ui", "1.11.0")).isNull()
   }
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -126,6 +126,27 @@ class CompatRulesTest {
   }
 
   @Test
+  fun `compose below the render floor fires old-dep warning`() {
+    val main = mainWithBom() + ("androidx.compose.ui:ui" to "1.9.5")
+    val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.9.5")
+    val finding =
+      CompatRules.evaluate(main, test).single { it.id == "old-dep-androidx.compose.ui:ui" }
+
+    assertEquals("warning", finding.severity)
+    assertTrue("recommended >= 1.10.0" in finding.message)
+  }
+
+  @Test
+  fun `compose at the render floor is quiet`() {
+    val main = mainWithBom() + ("androidx.compose.ui:ui" to "1.10.0")
+    val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.0")
+
+    assertNull(
+      CompatRules.evaluate(main, test).firstOrNull { it.id == "old-dep-androidx.compose.ui:ui" }
+    )
+  }
+
+  @Test
   fun `current activity is quiet`() {
     val main = mainWithBom() + ("androidx.activity:activity" to "1.13.0")
     val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")


### PR DESCRIPTION
## Summary

- lower the Android Compose preview render floor from Compose 1.11 to 1.10
- update compatibility rules, dependency management, integration coverage, and floor tests
- teach `doctor` to identify the Compose 1.9 renderer incompatibility and recommend Compose BOM 2025.12 or managed render dependencies

## Why

The previous 1.11.x requirement was more aggressive than necessary. The renderer is compatible with Compose 1.10, but not 1.9: both daemon and standalone preview rendering pass through the renderer-owned `MeasuredWrapBox`, which links against `ComposeUiNode.Companion.getApplyOnDeactivatedNodeAssertion`.

Projects may continue to declare Compose 1.9 when dependency management is enabled, because the plugin raises the render-only graph to the compatible floor. With dependency management disabled, `doctor` now reports the actionable incompatibility.

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.DoctorReportSerializationTest :gradle-plugin:test --tests ee.schimke.composeai.plugin.tooling.CompatRulesTest :cli:ktfmtCheck :gradle-plugin:ktfmtCheck`
- focused Compose floor and render-graph tests
- isolated Android preview render with the full graph resolved at Compose UI 1.10.0
- `git diff --check`