### PR TITLE
fix(rc-compare): honor document generation density

### DIFF
--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -54,6 +54,7 @@ import {
 } from "./rc-compare-gate.mjs";
 import { BG, flattenOnto, isFullyTransparent, splitCoverage } from "./rc-compare-pixels.mjs";
 import { laneSplit as laneSplitFor } from "./rc-compare-means.mjs";
+import { generationDensity } from "./rc-document-header.mjs";
 import { DEFAULT_FONTS_DIR, fontFaceCss, loadAndVerifyFonts } from "./rc-fonts.mjs";
 
 function arg(name, def = undefined) {
@@ -214,8 +215,9 @@ if (STAGE_EMBEDDED) {
     const pngName = `previews/${id}.png`;
     if (!entries.has(pngName)) continue;
     const { width, height } = pngSize(entries.get(pngName)());
-    fs.writeFileSync(path.join(STAGE_EMBEDDED, `${id}.rc`), entries.get(`ir/${id}.rc`)());
-    staged.push({ id, width, height });
+    const document = entries.get(`ir/${id}.rc`)();
+    fs.writeFileSync(path.join(STAGE_EMBEDDED, `${id}.rc`), document);
+    staged.push({ id, width, height, density: generationDensity(document) });
   }
   fs.writeFileSync(
     path.join(STAGE_EMBEDDED, "manifest.json"),

--- a/scripts/design-artifacts/rc-document-header.mjs
+++ b/scripts/design-artifacts/rc-document-header.mjs
@@ -1,0 +1,35 @@
+/** Header properties used by the rc-compare staging harness. */
+const HEADER_MAGIC = 0x048c0000;
+const DOC_DENSITY_AT_GENERATION = 7;
+const TYPE_FLOAT = 1;
+
+/**
+ * Read DOC_DENSITY_AT_GENERATION from an AndroidX modern Remote Compose header.
+ *
+ * Older documents have no property table, so callers supply the density their lane historically
+ * used. Malformed properties also fall back instead of making an optional comparison lane fail.
+ */
+export function generationDensity(bytes, fallback = 2) {
+  if (!Buffer.isBuffer(bytes) || bytes.length < 17) return fallback;
+  const encodedMajor = bytes.readInt32BE(1);
+  if ((encodedMajor & 0xffff0000) !== HEADER_MAGIC) return fallback;
+  const count = bytes.readInt32BE(13);
+  if (count < 0) return fallback;
+
+  let offset = 17;
+  for (let index = 0; index < count; index++) {
+    if (offset + 4 > bytes.length) return fallback;
+    const tag = bytes.readUInt16BE(offset);
+    const length = bytes.readUInt16BE(offset + 2);
+    offset += 4;
+    if (offset + length > bytes.length) return fallback;
+    const type = tag >>> 10;
+    const key = tag & 0x3f;
+    if (type === TYPE_FLOAT && key === DOC_DENSITY_AT_GENERATION && length === 4) {
+      const density = bytes.readFloatBE(offset);
+      return Number.isFinite(density) && density > 0 ? density : fallback;
+    }
+    offset += length;
+  }
+  return fallback;
+}

--- a/scripts/design-artifacts/rc-document-header.test.mjs
+++ b/scripts/design-artifacts/rc-document-header.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { generationDensity } from "./rc-document-header.mjs";
+
+function modernHeader(properties) {
+  const body = Buffer.concat(
+    properties.map(({ type, key, value }) => {
+      const payload = Buffer.alloc(4);
+      if (type === 1) payload.writeFloatBE(value);
+      else payload.writeInt32BE(value);
+      const item = Buffer.alloc(4);
+      item.writeUInt16BE((type << 10) | key);
+      item.writeUInt16BE(payload.length, 2);
+      return Buffer.concat([item, payload]);
+    }),
+  );
+  const header = Buffer.alloc(17);
+  header.writeInt32BE(0x048c0001, 1);
+  header.writeInt32BE(properties.length, 13);
+  return Buffer.concat([header, body]);
+}
+
+test("reads generation density from a modern Remote Compose header", () => {
+  const bytes = modernHeader([
+    { type: 0, key: 5, value: 840 },
+    { type: 1, key: 7, value: 2.625 },
+  ]);
+  assert.equal(generationDensity(bytes), 2.625);
+});
+
+test("falls back for legacy, absent, invalid, and truncated density properties", () => {
+  assert.equal(generationDensity(Buffer.alloc(32)), 2);
+  assert.equal(generationDensity(modernHeader([{ type: 0, key: 5, value: 840 }])), 2);
+  assert.equal(generationDensity(modernHeader([{ type: 1, key: 7, value: 0 }])), 2);
+  assert.equal(generationDensity(modernHeader([{ type: 1, key: 7, value: 3 }]).subarray(0, 20)), 2);
+});

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderHarness.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderHarness.kt
@@ -18,6 +18,7 @@ package ee.schimke.composeai.rcembedded.jvm
 
 import java.io.File
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.float
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -36,10 +37,9 @@ import org.junit.Test
  * both this and the Android harness read; this fills `rc.jvm.output`, and `rc-compare.mjs
  * --embedded-jvm` reads it back. With nothing staged it skips, so `check` stays green.
  *
- * Density is pinned to 2.0 (the catalogs capture at dpi 320, so documents carry dp→px factors for
- * density 2.0 — a 200dp preview bakes to 400px), matching [renderRemoteDocumentToPng]'s default and
- * the Android harness's `xhdpi`. Rendering at another density would re-lay-out the document and
- * every row would diff on geometry instead of renderer behaviour.
+ * Density comes from each document's `DOC_DENSITY_AT_GENERATION` header property, staged in the
+ * manifest by `rc-compare.mjs`. That keeps dp-denominated modifiers at the same geometry as the
+ * baked reference; legacy manifests retain the historical 2.0 fallback.
  *
  * Like the other skiko tests here it **needs the natives** (`skiko-awt-runtime-*` + a loadable GL
  * lib) and skips loudly where they are absent — a CI check, not a bare-working-tree one.
@@ -87,13 +87,15 @@ class RcJvmRenderHarness {
       png.delete()
       err.delete()
 
-      runCatching { renderRemoteDocumentToPng(rc.readBytes(), entry.width, entry.height) }
+      runCatching {
+          renderRemoteDocumentToPng(rc.readBytes(), entry.width, entry.height, entry.density)
+        }
         .onSuccess { bytes -> png.writeBytes(bytes) }
         .onFailure { t -> err.writeText("${t::class.java.simpleName}: ${t.message?.take(500)}") }
     }
   }
 
-  private data class Entry(val id: String, val width: Int, val height: Int)
+  private data class Entry(val id: String, val width: Int, val height: Int, val density: Float)
 
   private fun parseManifest(manifest: File): List<Entry> =
     Json.parseToJsonElement(manifest.readText()).jsonArray.map { element ->
@@ -102,6 +104,7 @@ class RcJvmRenderHarness {
         id = obj.getValue("id").jsonPrimitive.content,
         width = obj.getValue("width").jsonPrimitive.int,
         height = obj.getValue("height").jsonPrimitive.int,
+        density = obj["density"]?.jsonPrimitive?.float ?: 2f,
       )
     }
 

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcEmbeddedRenderHarness.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcEmbeddedRenderHarness.kt
@@ -27,10 +27,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayer
 import androidx.compose.remote.player.compose.embedded.enableEncodedImageReferences
 import androidx.compose.remote.player.core.RemoteDocument
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.Density
 import java.io.File
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -72,9 +74,10 @@ import org.robolectric.annotation.GraphicsMode
  * When that probe starts failing, Robolectric has grown the draw pass and this can become a
  * `captureToImage()`.
  *
- * Density is pinned: the catalogs capture at dpi 320, so documents carry dp->px factors for density
- * 2.0 (a 200dp preview bakes to 400px). `xhdpi` is that density — rendering at another one
- * re-lays-out the document and every row would diff on geometry instead of renderer behaviour.
+ * Density comes from each document's `DOC_DENSITY_AT_GENERATION` header property, staged in the
+ * manifest by `rc-compare.mjs`. The Robolectric device remains xhdpi for platform resources, while
+ * `LocalDensity` matches the document so dp-denominated modifiers rasterize at the same geometry as
+ * the baked reference. Legacy manifests retain the historical 2.0 fallback.
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
@@ -85,7 +88,7 @@ class RcEmbeddedRenderHarness(private val entry: Entry) {
 
   /** One document to rasterize: `<id>.rc` in the input dir, rendered at the baked PNG's size. */
   @Serializable
-  data class Entry(val id: String, val width: Int, val height: Int) {
+  data class Entry(val id: String, val width: Int, val height: Int, val density: Float = 2f) {
     /** Drives the JUnit case name. */
     override fun toString(): String = id
   }
@@ -124,26 +127,29 @@ class RcEmbeddedRenderHarness(private val entry: Entry) {
 
   private fun renderToBitmap(bytes: ByteArray): Bitmap {
     composeRule.setContent {
-      val density = LocalDensity.current
-      Box(
-        // Sized in px routed through the density rather than in dp, so the capture is exactly the
-        // baked PNG's pixel size — pixelmatch needs both sides equal, and dp rounding drifts.
-        Modifier.size(
-          with(density) { entry.width.toDp() },
-          with(density) { entry.height.toDp() },
-        )
-      ) {
-        // Before the constructor, not after: `RemoteDocument(bytes)` parses inside it, so a
-        // document carrying a URL-encoded bitmap fails here — and takes the whole document with
-        // it — unless the globals are already set. This lane never enters the
-        // `RcPlayer(CapturedDocument)` overload, so it has to opt in for itself.
-        enableEncodedImageReferences()
-        val document = remember { RemoteDocument(bytes) }
-        ExperimentalRemoteDocumentPlayer(
-          document = document,
-          // A still comparison against a still baked PNG.
-          modifier = Modifier.fillMaxSize(),
-        )
+      val hostDensity = LocalDensity.current
+      val documentDensity = Density(entry.density, hostDensity.fontScale)
+      CompositionLocalProvider(LocalDensity provides documentDensity) {
+        Box(
+          // Sized in px routed through the document density, so the capture is exactly the baked
+          // PNG's pixel size — pixelmatch needs both sides equal, and dp rounding drifts.
+          Modifier.size(
+            with(documentDensity) { entry.width.toDp() },
+            with(documentDensity) { entry.height.toDp() },
+          )
+        ) {
+          // Before the constructor, not after: `RemoteDocument(bytes)` parses inside it, so a
+          // document carrying a URL-encoded bitmap fails here — and takes the whole document with
+          // it — unless the globals are already set. This lane never enters the
+          // `RcPlayer(CapturedDocument)` overload, so it has to opt in for itself.
+          enableEncodedImageReferences()
+          val document = remember { RemoteDocument(bytes) }
+          ExperimentalRemoteDocumentPlayer(
+            document = document,
+            // A still comparison against a still baked PNG.
+            modifier = Modifier.fillMaxSize(),
+          )
+        }
       }
     }
 


### PR DESCRIPTION
## What changed

- read `DOC_DENSITY_AT_GENERATION` from modern Remote Compose document headers while staging rc-compare fixtures
- pass the staged density to both embedded renderer harnesses
- provide that density through `LocalDensity` in the Android harness
- retain the historical 2.0 fallback for legacy documents and manifests

## Why

The comparison harness hard-coded density 2.0, but the Home Assistant documents in the reported artifact were generated at density 2.625. The embedded players therefore re-laid out dp-denominated modifiers at the wrong scale, creating widespread geometry diffs that looked like renderer failures.

## Impact

Across all 122 Home Assistant documents, the JVM lane's mean mismatch fell from **16.89%** to **4.57%**, and mean coverage delta fell from **10.49%** to **0.66%**. This isolates remaining player differences instead of scoring harness-density drift.

## Root cause

The document generation density was already encoded in the modern RC header, but `rc-compare --stage-embedded` discarded it and both harnesses assumed xhdpi/2.0.

## Checks

- `node --test scripts/design-artifacts/rc-document-header.test.mjs`
- `:third-party-rc-embedded-player:compileDebugUnitTestKotlin`
- `:third-party-rc-embedded-player-jvm:compileTestKotlin`
- `:third-party-rc-embedded-player:ktfmtCheck`
- `:third-party-rc-embedded-player-jvm:ktfmtCheck`
- full 122-document JVM rerender and rc-compare rescore
