### PR TITLE
fix(bundle): canonicalize inspection sidecars

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -667,12 +667,17 @@ private class PackSubcommand(private val args: List<String>) {
           )
           return null
         }
-        val written = injectSemanticsIntoBundle(bundleFile, outcome.semanticsById.keyedByBundleId())
+        val canonical =
+          InspectionSidecarCanonicalizer.canonicalize(
+            semanticsById = outcome.semanticsById.keyedByBundleId(),
+            layoutById = outcome.layoutById.keyedByBundleId(),
+          )
+        val written = injectSemanticsIntoBundle(bundleFile, canonical.semanticsById)
         val missing = captureCount - written
         // The layout-inspector tree rides alongside the semantics blob (best-effort): a preview
         // that produced a tree gets `previews/<id>.layout.json` so a consumer can build slot-level
         // redlines/wireframes. Injected after semantics so its byte count is reflected too.
-        val layoutWritten = injectLayoutIntoBundle(bundleFile, outcome.layoutById.keyedByBundleId())
+        val layoutWritten = injectLayoutIntoBundle(bundleFile, canonical.layoutById)
         // The fonts/used record rides the same render (best-effort, Android daemon only): carried
         // so the design-catalog export can generate the Wasm tier's fonts.json from actual usage.
         val fontsWritten = injectFontsIntoBundle(bundleFile, outcome.fontsById.keyedByBundleId())
@@ -1576,7 +1581,9 @@ internal const val BUNDLE_PREVIEWS_DIR: String = "previews"
  * payload is the `compose/semantics`
  * [ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload] tree — per-node bounds,
  * label/text, and resolved foreground/background colours — the shape the design-parity static
- * bundle reader consumes as a sibling of the rendered PNG.
+ * bundle reader consumes as a sibling of the rendered PNG. The bundle copy replaces Compose's
+ * per-process node ids with the payload's stable refs; the daemon's live data product keeps its
+ * native ids for same-session joins.
  */
 internal const val BUNDLE_SEMANTICS_SUFFIX: String = ".semantics.json"
 
@@ -1584,7 +1591,9 @@ internal const val BUNDLE_SEMANTICS_SUFFIX: String = ".semantics.json"
  * Suffix for the per-preview layout-inspector blob carried beside `previews/<id>.png`. The payload
  * is the `layout/inspector` [ee.schimke.composeai.data.layoutinspector.LayoutInspectorPayload] tree
  * — the full LayoutNode walk with per-node bounds and resolved design tokens — so a consumer can
- * build slot-level redlines/wireframes the (a11y-shaped) semantics tree can't express.
+ * build slot-level redlines/wireframes the (a11y-shaped) semantics tree can't express. The bundle
+ * copy uses stable structural ids for layout-only nodes and the matching stable semantics ref for
+ * nodes shared with the semantics tree.
  */
 internal const val BUNDLE_LAYOUT_SUFFIX: String = ".layout.json"
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/InspectionSidecarCanonicalizer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/InspectionSidecarCanonicalizer.kt
@@ -1,0 +1,173 @@
+package ee.schimke.composeai.cli
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Removes per-process identities from the inspection sidecars carried by a published bundle.
+ *
+ * The daemon's live data products deliberately expose Compose's runtime `SemanticsNode.id` values:
+ * other products captured in the same session use that id space to join nodes. Those ids are not a
+ * publication identity, however. A fresh renderer assigns a different sequence, and reflected
+ * modifier values can include JVM object hashes and generated-lambda addresses. Carrying those
+ * bytes into every per-preview bundle made an otherwise identical catalog publication replace every
+ * bundle blob.
+ *
+ * Canonicalization happens at the bundle boundary so live-session joins keep their native ids. A
+ * semantics node uses its already-stable `ref` when present, with a structural path fallback. The
+ * matching layout node is rewritten through the old-id mapping; layout-only nodes use their own
+ * structural path. Malformed or future-schema payloads pass through unchanged rather than making
+ * the best-effort `--with-semantics` lane fail.
+ */
+internal object InspectionSidecarCanonicalizer {
+  private val json = Json
+
+  internal data class Result(
+    val semanticsById: Map<String, ByteArray>,
+    val layoutById: Map<String, ByteArray>,
+  )
+
+  fun canonicalize(
+    semanticsById: Map<String, ByteArray>,
+    layoutById: Map<String, ByteArray>,
+  ): Result {
+    val canonicalSemantics = LinkedHashMap<String, ByteArray>(semanticsById.size)
+    val semanticsIds = HashMap<String, Map<String, String>>(semanticsById.size)
+    semanticsById.forEach { (previewId, bytes) ->
+      val canonical = canonicalizeSemantics(bytes)
+      canonicalSemantics[previewId] = canonical?.first ?: bytes
+      semanticsIds[previewId] = canonical?.second.orEmpty()
+    }
+
+    val canonicalLayout = LinkedHashMap<String, ByteArray>(layoutById.size)
+    layoutById.forEach { (previewId, bytes) ->
+      canonicalLayout[previewId] =
+        canonicalizeLayout(bytes, semanticsIds[previewId].orEmpty()) ?: bytes
+    }
+    return Result(canonicalSemantics, canonicalLayout)
+  }
+
+  private fun canonicalizeSemantics(bytes: ByteArray): Pair<ByteArray, Map<String, String>>? =
+    runCatching {
+        val payload =
+          json.parseToJsonElement(bytes.decodeToString()) as? JsonObject ?: return@runCatching null
+        val root = payload["root"] as? JsonObject ?: return@runCatching null
+        val idMapping = LinkedHashMap<String, String>()
+        val canonicalRoot = canonicalizeSemanticsNode(root, "r", idMapping)
+        rewrite(payload, "root", canonicalRoot).toString().encodeToByteArray() to idMapping
+      }
+      .getOrNull()
+
+  private fun canonicalizeSemanticsNode(
+    node: JsonObject,
+    path: String,
+    idMapping: MutableMap<String, String>,
+  ): JsonObject {
+    val oldId = node.string("nodeId")
+    val stableId = node.string("ref") ?: "semantics:$path"
+    if (oldId != null) idMapping[oldId] = stableId
+    return rewrite(
+      source = node,
+      replacements =
+        mapOf(
+          "nodeId" to JsonPrimitive(stableId),
+          "children" to
+            canonicalChildren(node["children"], path, ::canonicalizeSemanticsNode, idMapping),
+        ),
+    )
+  }
+
+  private fun canonicalizeLayout(bytes: ByteArray, semanticsIds: Map<String, String>): ByteArray? =
+    runCatching {
+        val payload =
+          json.parseToJsonElement(bytes.decodeToString()) as? JsonObject ?: return@runCatching null
+        val root = payload["root"] as? JsonObject ?: return@runCatching null
+        val canonicalRoot = canonicalizeLayoutNode(root, "r", semanticsIds)
+        rewrite(payload, "root", canonicalRoot)
+          .canonicalizeRuntimeStrings()
+          .toString()
+          .encodeToByteArray()
+      }
+      .getOrNull()
+
+  private fun canonicalizeLayoutNode(
+    node: JsonObject,
+    path: String,
+    semanticsIds: Map<String, String>,
+  ): JsonObject {
+    val stableId = node.string("nodeId")?.let(semanticsIds::get) ?: "layout:$path"
+    return rewrite(
+      source = node,
+      replacements =
+        mapOf(
+          "nodeId" to JsonPrimitive(stableId),
+          "children" to
+            canonicalChildren(node["children"], path) { child, childPath ->
+              canonicalizeLayoutNode(child, childPath, semanticsIds)
+            },
+        ),
+    )
+  }
+
+  private fun canonicalChildren(
+    children: JsonElement?,
+    path: String,
+    transform: (JsonObject, String) -> JsonObject,
+  ): JsonElement? =
+    (children as? JsonArray)?.let { array ->
+      JsonArray(
+        array.mapIndexed { index, child ->
+          (child as? JsonObject)?.let { transform(it, "$path/$index") } ?: child
+        }
+      )
+    }
+
+  private fun canonicalChildren(
+    children: JsonElement?,
+    path: String,
+    transform: (JsonObject, String, MutableMap<String, String>) -> JsonObject,
+    idMapping: MutableMap<String, String>,
+  ): JsonElement? =
+    canonicalChildren(children, path) { child, childPath -> transform(child, childPath, idMapping) }
+
+  private fun rewrite(source: JsonObject, key: String, value: JsonElement): JsonObject =
+    rewrite(source, mapOf(key to value))
+
+  private fun rewrite(source: JsonObject, replacements: Map<String, JsonElement?>): JsonObject =
+    JsonObject(
+      buildMap {
+        source.forEach { (key, value) ->
+          if (key !in replacements) put(key, value) else replacements[key]?.let { put(key, it) }
+        }
+        replacements.forEach { (key, value) ->
+          if (key !in source && value != null) put(key, value)
+        }
+      }
+    )
+
+  private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.contentOrNull
+
+  private fun JsonElement.canonicalizeRuntimeStrings(): JsonElement =
+    when (this) {
+      is JsonObject -> JsonObject(mapValues { (_, value) -> value.canonicalizeRuntimeStrings() })
+      is JsonArray -> JsonArray(map { it.canonicalizeRuntimeStrings() })
+      is JsonPrimitive ->
+        if (isString) JsonPrimitive(content.canonicalizeJvmRuntimeIdentity()) else this
+    }
+}
+
+private val JVM_OBJECT_IDENTITY =
+  Regex("""([A-Za-z_][\w$]*(?:\.[A-Za-z_][\w$]*)+)@[0-9a-fA-F]{6,16}\b""")
+private val JVM_LAMBDA_IDENTITY =
+  Regex("""(\${'$'}\${'$'}Lambda)/0x[0-9a-fA-F]+@[0-9a-fA-F]{6,16}\b""")
+private val JVM_LAMBDA_ADDRESS = Regex("""(\${'$'}\${'$'}Lambda)/0x[0-9a-fA-F]+""")
+
+internal fun String.canonicalizeJvmRuntimeIdentity(): String =
+  replace(JVM_LAMBDA_IDENTITY, "${'$'}1/<address>@<identity>")
+    .replace(JVM_LAMBDA_ADDRESS, "${'$'}1/<address>")
+    .replace(JVM_OBJECT_IDENTITY, "${'$'}1@<identity>")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/InspectionSidecarCanonicalizerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/InspectionSidecarCanonicalizerTest.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class InspectionSidecarCanonicalizerTest {
+  @Test
+  fun `same inspection tree from different renderer processes has identical bytes`() {
+    val first =
+      InspectionSidecarCanonicalizer.canonicalize(
+        semanticsById = mapOf("preview" to semantics(rootId = "651", buttonId = "655")),
+        layoutById =
+          mapOf(
+            "preview" to
+              layout(
+                rootId = "651",
+                wrapperId = "androidx.compose.ui.node.LayoutNode@1234abcd",
+                buttonId = "655",
+                runtimeHash = "4c3cfed3",
+                lambdaAddress = "00007f6b7824d4b8",
+              )
+          ),
+      )
+    val second =
+      InspectionSidecarCanonicalizer.canonicalize(
+        semanticsById = mapOf("preview" to semantics(rootId = "658", buttonId = "662")),
+        layoutById =
+          mapOf(
+            "preview" to
+              layout(
+                rootId = "658",
+                wrapperId = "androidx.compose.ui.node.LayoutNode@8765dcba",
+                buttonId = "662",
+                runtimeHash = "4fbd2fbd",
+                lambdaAddress = "00007f75302494f8",
+              )
+          ),
+      )
+
+    assertContentEquals(
+      first.semanticsById.getValue("preview"),
+      second.semanticsById.getValue("preview"),
+    )
+    assertContentEquals(first.layoutById.getValue("preview"), second.layoutById.getValue("preview"))
+
+    val semanticsRoot =
+      Json.parseToJsonElement(first.semanticsById.getValue("preview").decodeToString())
+        .jsonObject
+        .getValue("root")
+        .jsonObject
+    assertEquals("r", semanticsRoot.getValue("nodeId").jsonPrimitive.content)
+    val semanticsButton = semanticsRoot.getValue("children").jsonObjectArray().single()
+    assertEquals("r/role:Button", semanticsButton.getValue("nodeId").jsonPrimitive.content)
+
+    val layoutText = first.layoutById.getValue("preview").decodeToString()
+    assertTrue("@<identity>" in layoutText)
+    assertTrue("${'$'}${'$'}Lambda/<address>@<identity>" in layoutText)
+    assertTrue("layout:r/0" in layoutText)
+  }
+
+  @Test
+  fun `malformed future sidecars pass through unchanged`() {
+    val semantics = "not-json".encodeToByteArray()
+    val layout = "[]".encodeToByteArray()
+
+    val result =
+      InspectionSidecarCanonicalizer.canonicalize(
+        semanticsById = mapOf("preview" to semantics),
+        layoutById = mapOf("preview" to layout),
+      )
+
+    assertContentEquals(semantics, result.semanticsById.getValue("preview"))
+    assertContentEquals(layout, result.layoutById.getValue("preview"))
+  }
+
+  private fun semantics(rootId: String, buttonId: String): ByteArray =
+    """
+    {"root":{"nodeId":"$rootId","ref":"r","boundsInRoot":"0,0,100,100","children":[
+      {"nodeId":"$buttonId","ref":"r/role:Button","boundsInRoot":"10,10,90,60","role":"Button"}
+    ]}}
+    """
+      .trimIndent()
+      .encodeToByteArray()
+
+  private fun layout(
+    rootId: String,
+    wrapperId: String,
+    buttonId: String,
+    runtimeHash: String,
+    lambdaAddress: String,
+  ): ByteArray =
+    """
+    {"root":{"nodeId":"$rootId","component":"Root","bounds":{"left":0,"top":0,"right":100,"bottom":100},"modifiers":[
+      {"name":"insets","properties":{"windowInsets":"androidx.compose.ui.platform.EmptyPlatformWindowInsets@$runtimeHash"}}
+    ],"children":[
+      {"nodeId":"$wrapperId","component":"Box","bounds":{"left":0,"top":0,"right":100,"bottom":100},"children":[
+        {"nodeId":"$buttonId","component":"Button","bounds":{"left":10,"top":10,"right":90,"bottom":60},"modifiers":[
+          {"name":"clickable","properties":{"onClick":"example.ButtonKt${'$'}${'$'}Lambda/0x$lambdaAddress@1234abcd"}}
+        ]}
+      ]}
+    ]}}
+    """
+      .trimIndent()
+      .encodeToByteArray()
+
+  private fun kotlinx.serialization.json.JsonElement.jsonObjectArray() =
+    (this as kotlinx.serialization.json.JsonArray).map { it.jsonObject }
+}

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1513,8 +1513,22 @@ internal object ComposeLayoutInspector {
       is String -> this
       is Number,
       is Boolean -> toString()
-      else -> toString()
+      // Compose's inspector frequently exposes lambdas and runtime objects. Their default
+      // `toString()` includes a JVM identity hash (and generated lambdas also carry a VM address),
+      // making an otherwise identical layout-inspector capture differ on every renderer process.
+      else -> toString().canonicalizeJvmRuntimeIdentity()
     }
+
+  private fun String.canonicalizeJvmRuntimeIdentity(): String =
+    replace(
+        Regex("""(\${'$'}\${'$'}Lambda)/0x[0-9a-fA-F]+@[0-9a-fA-F]{6,16}\b"""),
+        "${'$'}1/<address>@<identity>",
+      )
+      .replace(Regex("""(\${'$'}\${'$'}Lambda)/0x[0-9a-fA-F]+"""), "${'$'}1/<address>")
+      .replace(
+        Regex("""([A-Za-z_][\w$]*(?:\.[A-Za-z_][\w$]*)+)@[0-9a-fA-F]{6,16}\b"""),
+        "${'$'}1@<identity>",
+      )
 
   /**
    * Extracts Wear curved text (a `CurvedLayout`/`TimeText` clock) from a layout node. Curved text


### PR DESCRIPTION
## Summary

Canonicalize the semantics and layout inspection sidecars embedded in published preview bundles.

A same-source M3 catalog republish rewrote all 1,139 bundle files and added about 59.4 MiB to the Git pack even though the rendered PNGs and application JARs were unchanged. The differences came from ephemeral Compose node IDs, JVM identity hashes, and generated lambda addresses in the inspection JSON.

This change:

- assigns stable semantics IDs from existing refs, with structural-path fallbacks
- assigns stable layout-only IDs from structural paths and preserves semantics/layout joins
- normalizes JVM object identities and generated lambda addresses
- performs bundle-only ID canonicalization, retaining native IDs in the live daemon data products
- sanitizes non-user JVM identity strings at the producer boundary
- passes malformed or future-schema JSON through unchanged

## Validation

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.InspectionSidecarCanonicalizerTest :data-layoutinspector-connector:compileKotlin --offline --no-daemon --console=plain`
- `./gradlew ktfmtCheckAll --offline --no-daemon --console=plain`
- `git diff --check origin/main...HEAD`

## Separate follow-up

#3618 tracks investigation of externalizing the shared classpath. This PR intentionally does not change the self-contained per-preview bundle design.