### PR TITLE
fix(rc-player): evaluate layout modifier colors

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -4004,12 +4004,14 @@ private fun blendMode(value: Int): BlendMode =
   }
 
 /**
- * Collects, in document order, the data operations layout containers carry beside their components.
+ * Collects, in document order, the state operations layout containers carry beside their
+ * components.
  *
- * The layout tree keeps only components, so these — the `TEXT_LOOKUP_INT` publishing a card title,
- * the integer expressions feeding its index — have no other execution site in the layout path.
- * Operations nested in a container that owns its own execution (CanvasOperations, LayoutCompute)
- * are left to that owner; only the direct children of a LayoutComponentContent are replayed here.
+ * The layout tree keeps only components, so these — a `TEXT_LOOKUP_INT` publishing a card title or
+ * a `COLOR_EXPRESSIONS` feeding a background modifier — have no other execution site in the layout
+ * path. Operations nested in a container that owns its own execution (CanvasOperations,
+ * LayoutCompute) are left to that owner; only the direct children of a LayoutComponentContent are
+ * replayed here.
  */
 private fun List<RcLinkedNode>.collectContentStateOperations(): List<RcLinkedNode> = buildList {
   this@collectContentStateOperations.filterIsInstance<RcLinkedNode.Container>().forEach { container

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -539,7 +539,7 @@ public class RcPlayerState(
   }
 
   /**
-   * Applies the data/text operations a layout container carries alongside its child components.
+   * Applies the state operations a layout container carries alongside its child components.
    *
    * AndroidX executes a document's operations in order as it walks the layout, so a `CoreText`
    * reading id 70 sees the `TEXT_LOOKUP_INT` that published it two operations earlier. The layout
@@ -558,6 +558,7 @@ public class RcPlayerState(
         // formats as garbage. Wire order is the document's order, so one pass suffices.
         is RcFloatExpression -> applyFloatExpression(operation)
         is RcIntegerExpression -> applyIntegerExpression(operation)
+        is RcColorExpression -> applyColorExpression(operation)
         is RcIdLookup,
         is RcDataMapLookup -> applyDataOperation(operation)
         is RcTextMerge,

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
@@ -899,6 +899,28 @@ class RcPlayerStateTest {
   }
 
   @Test
+  fun replaysColorExpressionsUsedByLayoutModifiers() {
+    val state =
+      RcPlayerState(
+        RcDocument(
+          RcHeader(RcVersion(0, 1, 0)),
+          listOf(RcColorConstant(7, 0xff000000.toInt()), RcColorConstant(8, 0xffffffff.toInt())),
+        )
+      )
+    val operations =
+      listOf<RcLinkedNode>(
+        RcLinkedNode.Operation(
+          RcColorExpression(30, RcColorExpression.ID_ID_INTERPOLATE, 7, 8, .5f.toRawBits())
+        )
+      )
+
+    assertEquals(0, state.color(30))
+    state.applyContentStateOperations(operations)
+
+    assertEquals(0xffbababa.toInt(), state.color(30))
+  }
+
+  @Test
   fun evaluatesAndroidXCollectionLookupsIntoTypedStores() {
     val state =
       RcPlayerState(


### PR DESCRIPTION
## What changed

- replay `COLOR_EXPRESSIONS` that are direct children of `LayoutComponentContent`
- add a regression test covering a computed color consumed by a layout modifier
- clarify that the layout replay pass handles state operations, not only data/text operations

## Why

Home Assistant toggle tracks use a dynamic color id from a `COLOR_EXPRESSIONS` operation. The CMP/Wasm layout path retained the modifier but dropped the sibling expression from execution, so the modifier resolved the missing id as transparent black.

## Impact

Computed colors used by backgrounds and borders now resolve during the frame before modifier drawing. This restores toggle-track fills and other layout decorations driven by color expressions without changing canvas execution, which already evaluates these operations.

## Root cause

The layout tree keeps components and discards non-component siblings. A replay pass was added previously for float, integer, data, and text producers, but color expressions were omitted even though modifier drawing reads their output ids.

## Checks

- `:rc-player-runtime:desktopTest`
- `:rc-player-runtime:ktfmtCheck`
- `:rc-player-compose:ktfmtCheck`
