### PR TITLE
fix(rc-compare): render external image placeholders

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupport.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupport.kt
@@ -90,10 +90,17 @@ public data class RcComposeSupportReport(val issues: List<RcComposeSupportIssue>
   }
 }
 
-/** Backend-specific coverage, including nested PaintBundle commands hidden behind one RC opcode. */
+/**
+ * Backend-specific coverage, including nested PaintBundle commands hidden behind one RC opcode.
+ *
+ * [allowExternalImagePlaceholders] treats host-backed bitmap encodings as intentionally blank. It
+ * is useful for offline renderers that need to exercise the rest of a document without claiming
+ * that an unreachable URL image was decoded.
+ */
 public fun RcDocument.composeSupportReport(
   profile: RcOperationProfile? = null,
   availableFontFamilies: Set<String> = emptySet(),
+  allowExternalImagePlaceholders: Boolean = false,
 ): RcComposeSupportReport {
   val issues = mutableListOf<RcComposeSupportIssue>()
   val bitmapIds = operations.filterIsInstance<RcBitmapData>().mapTo(mutableSetOf()) { it.imageId }
@@ -221,7 +228,7 @@ public fun RcDocument.composeSupportReport(
     }
     if (operation is RcBitmapData) {
       when {
-        operation.encoding != RcBitmapData.ENCODING_INLINE ->
+        operation.encoding != RcBitmapData.ENCODING_INLINE && !allowExternalImagePlaceholders ->
           issues +=
             RcComposeSupportIssue(
               index,

--- a/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupportTest.kt
+++ b/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupportTest.kt
@@ -914,13 +914,12 @@ class RcComposeSupportTest {
 
   @Test
   fun rejectsBitmapSourcesThatNeedAnUnconfiguredHost() {
-    val issue =
+    val document =
       RcDocument(header, listOf(RcBitmapData(1, 1, 1, RcBitmapData.TYPE_PNG, 1, byteArrayOf(1))))
-        .composeSupportReport()
-        .issues
-        .single()
+    val issue = document.composeSupportReport().issues.single()
 
     assertEquals("encoding 1 requires an image host", issue.detail)
+    assertTrue(document.composeSupportReport(allowExternalImagePlaceholders = true).fullyRenderable)
   }
 
   @Test

--- a/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
+++ b/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
@@ -107,6 +107,8 @@ public fun main() {
                 .composeSupportReport(
                   RcOperationProfiles.CMP_WASM_ALPHA16,
                   availableFontFamilies = fontFamilies.keys,
+                  allowExternalImagePlaceholders =
+                    queryParameter("allowExternalImagePlaceholders") == "1",
                 )
                 .requireFullyRenderable()
               LoadState.Ready(document, fontFamilies, namedValuesFromLocation())

--- a/scripts/design-artifacts/rc-compare.mjs
+++ b/scripts/design-artifacts/rc-compare.mjs
@@ -454,8 +454,11 @@ async function cmpWasmFor(id, bytes, baked, bakedUnflattened, width, height, ref
     // that reveals it on that signal cannot show a blank surface. This lane is not such a host: the
     // screenshot below goes through CDP, which drives its own compositor frame, and every pixel of
     // the result is then checked against the baked reference. The viewer keeps the default.
+    // External URL images are deliberately transparent in this offline lane. Rendering the rest of
+    // the document is more useful than allowlisting the whole row, and the missing pixels remain in
+    // the parity score rather than being mistaken for a successful image fetch.
     await cmpWasmPage.goto(
-      `${cmpWasmServer.origin}/index.html?src=${encodeURIComponent("/document.rc")}&theme=${encodeURIComponent(THEME)}&handoffDelayMs=0`,
+      `${cmpWasmServer.origin}/index.html?src=${encodeURIComponent("/document.rc")}&theme=${encodeURIComponent(THEME)}&handoffDelayMs=0&allowExternalImagePlaceholders=1`,
     );
     await cmpWasmPage.waitForFunction(
       () => ["ready", "error"].includes(document.documentElement.dataset.rcPlayerState),


### PR DESCRIPTION
## What changed

- add an opt-in support-report mode that treats host-backed images as transparent placeholders
- expose that mode to the Wasm player through a query parameter
- enable it only in the offline rc-compare Wasm lane
- retain missing-image pixels in the parity score

## Why

Two Home Assistant picture-entity documents currently fail the CMP/Wasm readiness gate because their camera frames use `BitmapData` encoding 1 and CI has no image host or Home Assistant egress. The rest of each document is renderable and useful for regression coverage.

## Impact

Offline comparisons render and score the whole reachable document while leaving the external image transparent. Normal Wasm player loads remain strict unless a host explicitly opts in, and the comparison does not claim that the unavailable image decoded successfully.

## Root cause

The CMP renderer already skips non-inline bitmap payloads, but the Wasm support gate rejected the document before composition. The comparison therefore had to allowlist both rows instead of exercising their layouts and overlays.

## Checks

- `:rc-player-compose:desktopTest`
- `:rc-player-compose:ktfmtCheck`
- `:rc-player-wasm:compileKotlinWasmJs`
- `:rc-player-wasm:wasmPlayerDist`
- end-to-end rc-compare Chromium run against both reported `PictureEntity_AppMode` RC documents: 2/2 reached ready and rendered at density 2.625

The broad `npm test` run was stopped after unit tests completed because unrelated long-running browser integration tests did not terminate in this environment; the focused Chromium integration above completed successfully.
