### PR TITLE
fix: batch Figma design reference requests

### DIFF
--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -58,6 +58,7 @@ import { fitRgba, isRoundingDelta, resampleRgba } from "./png-resample.mjs";
 import { layoutFromNode } from "@design-parity/adapter-figma";
 import { scaleTree } from "./reference-layout.mjs";
 import { withReferenceAnnotations } from "@design-parity/catalog-export";
+import { FigmaRestRasterizer, parseFigmaRef } from "./figma-rest-raster.mjs";
 
 function arg(name, def = undefined) {
   const i = process.argv.indexOf(`--${name}`);
@@ -191,59 +192,7 @@ async function rasterizeHtml(file, target) {
   }
 }
 
-/** `figma:<fileKey>/<nodeId>` → `{ fileKey, nodeId }`, or null when the ref isn't a Figma handle. */
-function parseFigmaRef(ref) {
-  const m = /^figma:([^/]+)\/(.+)$/.exec(String(ref ?? ""));
-  return m ? { fileKey: m[1], nodeId: m[2] } : null;
-}
-
-/**
- * Render a Figma node to PNG over the REST images endpoint. Asked for at the density that lands on
- * the target sticker's width, so the resample stays a rounding correction — a blind `scale=2` is
- * what made this comparison meaningless before (a frame seeded from a device-pixel export came
- * back at twice the candidate's size).
- */
-async function rasterizeFigma(ref, target) {
-  const parsed = parseFigmaRef(ref);
-  if (!parsed) throw new Error(`not a figma ref: ${ref}`);
-  const headers = { "X-Figma-Token": FIGMA_TOKEN };
-  const nodesUrl =
-    `https://api.figma.com/v1/files/${encodeURIComponent(parsed.fileKey)}/nodes` +
-    `?ids=${encodeURIComponent(parsed.nodeId)}`;
-  const nodes = await fetch(nodesUrl, { headers });
-  if (!nodes.ok) throw new Error(`figma nodes ${nodes.status}`);
-  const nodeJson = await nodes.json();
-  const box =
-    nodeJson?.nodes?.[parsed.nodeId]?.document?.absoluteBoundingBox ??
-    nodeJson?.nodes?.[parsed.nodeId.replace("-", ":")]?.document?.absoluteBoundingBox;
-  // Figma caps `scale` at 4; clamp so an oversized ask doesn't 400 the whole run.
-  const scale = box?.width ? Math.min(4, Math.max(0.01, target.width / box.width)) : 2;
-
-  const imagesUrl =
-    `https://api.figma.com/v1/images/${encodeURIComponent(parsed.fileKey)}` +
-    `?ids=${encodeURIComponent(parsed.nodeId)}&format=png&scale=${scale}`;
-  const images = await fetch(imagesUrl, { headers });
-  if (!images.ok) throw new Error(`figma images ${images.status}`);
-  const url = (await images.json())?.images?.[parsed.nodeId];
-  if (!url) throw new Error("figma images returned no url for the node");
-  const png = await fetch(url);
-  if (!png.ok) throw new Error(`figma image download ${png.status}`);
-  const decoded = PNG.sync.read(Buffer.from(await png.arrayBuffer()));
-  // The node document rides along so the caller can capture layout geometry from the same fetch
-  // that sized the raster — one round trip, and the geometry provably describes these pixels. The
-  // file-level `styles` map rides along with it: a text node references a published style by id,
-  // and only this map turns that id into the name the design itself uses (`Body/Large`), so the
-  // reference column can say `body/large` rather than the anonymous `text`.
-  const entry =
-    nodeJson?.nodes?.[parsed.nodeId] ?? nodeJson?.nodes?.[parsed.nodeId.replace("-", ":")];
-  return {
-    width: decoded.width,
-    height: decoded.height,
-    data: decoded.data,
-    document: entry?.document,
-    styles: entry?.styles,
-  };
-}
+const figmaRasterizer = new FigmaRestRasterizer({ token: FIGMA_TOKEN });
 
 /** A pre-rendered PNG for this ref under `--reference-images`, or null. */
 function suppliedRaster(ref) {
@@ -285,7 +234,7 @@ async function sourceRaster(record) {
       warn(`${record.id}: skipping figma reference ${ref} — no FIGMA_TOKEN in this run`);
       return null;
     }
-    return rasterizeFigma(ref, target);
+    return figmaRasterizer.rasterize(ref, target);
   }
 
   warn(`${record.id}: don't know how to rasterise a '${source}' reference from '${ref}'`);
@@ -322,6 +271,16 @@ fs.mkdirSync(referencesDir, { recursive: true });
 let written = 0;
 /** Reference id -> a `{ layout }` shim; `referenceAnnotations` reads only that field. */
 const annotatedReferences = {};
+if (FIGMA_TOKEN) {
+  await figmaRasterizer.prepare(
+    records
+      .filter((record) => parseFigmaRef(record.origin.ref) && !suppliedRaster(record.origin.ref))
+      .map((record) => ({
+        ref: record.origin.ref,
+        target: { width: record.raster.width, height: record.raster.height },
+      })),
+  );
+}
 for (const record of records) {
   const target = { width: record.raster.width, height: record.raster.height };
   let raster;

--- a/scripts/design-artifacts/figma-rest-raster.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.mjs
@@ -1,0 +1,196 @@
+import { PNG } from "pngjs";
+
+/** `figma:<fileKey>/<nodeId>` -> `{ fileKey, nodeId }`, or null. */
+export function parseFigmaRef(ref) {
+  const match = /^figma:([^/]+)\/(.+)$/.exec(String(ref ?? ""));
+  return match ? { fileKey: match[1], nodeId: match[2] } : null;
+}
+
+function chunks(values, size) {
+  const out = [];
+  for (let start = 0; start < values.length; start += size) {
+    out.push(values.slice(start, start + size));
+  }
+  return out;
+}
+
+function retryDelay(response, attempt) {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds)) return Math.min(30_000, Math.max(0, seconds * 1_000));
+    const at = Date.parse(retryAfter);
+    if (Number.isFinite(at)) return Math.min(30_000, Math.max(0, at - Date.now()));
+  }
+  return Math.min(8_000, 1_000 * 2 ** attempt);
+}
+
+function entryFor(nodes, nodeId) {
+  return nodes?.[nodeId] ?? nodes?.[nodeId.replace("-", ":")];
+}
+
+function imageFor(images, nodeId) {
+  return images?.[nodeId] ?? images?.[nodeId.replace("-", ":")];
+}
+
+/**
+ * Batched, run-scoped Figma REST rasterizer.
+ *
+ * Node metadata is fetched once per file in chunks, image exports are fetched once per
+ * file/scale in chunks, and downloaded PNGs are memoized by node/scale. A catalog with dozens of
+ * references therefore spends a handful of Figma API requests instead of two requests per node.
+ */
+export class FigmaRestRasterizer {
+  constructor({
+    token,
+    fetchImpl = globalThis.fetch,
+    sleep = (millis) => new Promise((resolve) => setTimeout(resolve, millis)),
+    batchSize = 50,
+    maxAttempts = 5,
+  }) {
+    this.token = token;
+    this.fetchImpl = fetchImpl;
+    this.sleep = sleep;
+    this.batchSize = batchSize;
+    this.maxAttempts = maxAttempts;
+    this.nodes = new Map();
+    this.imageUrls = new Map();
+    this.rasters = new Map();
+  }
+
+  async fetchWithRetry(url, options, label) {
+    let response;
+    for (let attempt = 0; attempt < this.maxAttempts; attempt += 1) {
+      response = await this.fetchImpl(url, options);
+      if (response.ok) return response;
+      const retryable = response.status === 429 || response.status >= 500;
+      if (!retryable || attempt + 1 >= this.maxAttempts) break;
+      await this.sleep(retryDelay(response, attempt));
+    }
+    throw new Error(`${label} ${response?.status ?? "request failed"}`);
+  }
+
+  headers() {
+    return { "X-Figma-Token": this.token };
+  }
+
+  nodeKey({ fileKey, nodeId }) {
+    return `${fileKey}/${nodeId}`;
+  }
+
+  scaleFor(parsed, target) {
+    const entry = this.nodes.get(this.nodeKey(parsed));
+    if (entry instanceof Error) throw entry;
+    const width = entry?.document?.absoluteBoundingBox?.width;
+    const raw = width ? target.width / width : 2;
+    // Four decimals keep requests stable and batch components rendered at the same density while
+    // remaining far below a physical pixel of error at Figma's maximum scale.
+    return Number(Math.min(4, Math.max(0.01, raw)).toFixed(4));
+  }
+
+  imageKey(parsed, target) {
+    return `${this.nodeKey(parsed)}@${this.scaleFor(parsed, target)}`;
+  }
+
+  async prepare(requests) {
+    const parsedRequests = requests
+      .map(({ ref, target }) => ({ parsed: parseFigmaRef(ref), target }))
+      .filter(({ parsed }) => parsed);
+
+    const missingByFile = new Map();
+    for (const { parsed } of parsedRequests) {
+      const key = this.nodeKey(parsed);
+      if (this.nodes.has(key)) continue;
+      const ids = missingByFile.get(parsed.fileKey) ?? new Set();
+      ids.add(parsed.nodeId);
+      missingByFile.set(parsed.fileKey, ids);
+    }
+
+    for (const [fileKey, ids] of missingByFile) {
+      for (const batch of chunks([...ids], this.batchSize)) {
+        try {
+          const url =
+            `https://api.figma.com/v1/files/${encodeURIComponent(fileKey)}/nodes` +
+            `?ids=${encodeURIComponent(batch.join(","))}`;
+          const response = await this.fetchWithRetry(url, { headers: this.headers() }, "figma nodes");
+          const json = await response.json();
+          for (const nodeId of batch) {
+            this.nodes.set(
+              `${fileKey}/${nodeId}`,
+              entryFor(json?.nodes, nodeId) ?? new Error(`figma nodes returned no node ${nodeId}`),
+            );
+          }
+        } catch (error) {
+          for (const nodeId of batch) this.nodes.set(`${fileKey}/${nodeId}`, error);
+        }
+      }
+    }
+
+    const missingImages = new Map();
+    for (const { parsed, target } of parsedRequests) {
+      let scale;
+      try {
+        scale = this.scaleFor(parsed, target);
+      } catch {
+        continue;
+      }
+      const key = `${this.nodeKey(parsed)}@${scale}`;
+      if (this.imageUrls.has(key)) continue;
+      const groupKey = `${parsed.fileKey}\0${scale}`;
+      const group = missingImages.get(groupKey) ?? { fileKey: parsed.fileKey, scale, ids: new Set() };
+      group.ids.add(parsed.nodeId);
+      missingImages.set(groupKey, group);
+    }
+
+    for (const { fileKey, scale, ids } of missingImages.values()) {
+      for (const batch of chunks([...ids], this.batchSize)) {
+        try {
+          const url =
+            `https://api.figma.com/v1/images/${encodeURIComponent(fileKey)}` +
+            `?ids=${encodeURIComponent(batch.join(","))}&format=png&scale=${scale}`;
+          const response = await this.fetchWithRetry(url, { headers: this.headers() }, "figma images");
+          const json = await response.json();
+          for (const nodeId of batch) {
+            this.imageUrls.set(
+              `${fileKey}/${nodeId}@${scale}`,
+              imageFor(json?.images, nodeId) ??
+                new Error(`figma images returned no url for the node ${nodeId}`),
+            );
+          }
+        } catch (error) {
+          for (const nodeId of batch) this.imageUrls.set(`${fileKey}/${nodeId}@${scale}`, error);
+        }
+      }
+    }
+  }
+
+  async rasterize(ref, target) {
+    const parsed = parseFigmaRef(ref);
+    if (!parsed) throw new Error(`not a figma ref: ${ref}`);
+    await this.prepare([{ ref, target }]);
+    const node = this.nodes.get(this.nodeKey(parsed));
+    if (node instanceof Error) throw node;
+    const key = this.imageKey(parsed, target);
+    const url = this.imageUrls.get(key);
+    if (url instanceof Error) throw url;
+    if (!url) throw new Error("figma images returned no url for the node");
+
+    if (!this.rasters.has(key)) {
+      this.rasters.set(
+        key,
+        (async () => {
+          const response = await this.fetchWithRetry(url, {}, "figma image download");
+          const decoded = PNG.sync.read(Buffer.from(await response.arrayBuffer()));
+          return {
+            width: decoded.width,
+            height: decoded.height,
+            data: decoded.data,
+            document: node?.document,
+            styles: node?.styles,
+          };
+        })(),
+      );
+    }
+    return this.rasters.get(key);
+  }
+}

--- a/scripts/design-artifacts/figma-rest-raster.test.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.test.mjs
@@ -1,0 +1,93 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PNG } from "pngjs";
+
+import { FigmaRestRasterizer, parseFigmaRef } from "./figma-rest-raster.mjs";
+
+function json(value, init) {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function onePixelPng() {
+  const png = new PNG({ width: 1, height: 1 });
+  png.data.set([1, 2, 3, 255]);
+  return PNG.sync.write(png);
+}
+
+test("parseFigmaRef preserves node ids containing colons", () => {
+  assert.deepEqual(parseFigmaRef("figma:file/57994:2227"), {
+    fileKey: "file",
+    nodeId: "57994:2227",
+  });
+  assert.equal(parseFigmaRef("design/button.png"), null);
+});
+
+test("batches nodes and equal-scale image exports, then caches duplicate rasters", async () => {
+  const calls = [];
+  const png = onePixelPng();
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url.includes("/nodes?")) {
+      const ids = new URL(url).searchParams.get("ids").split(",");
+      return json({
+        nodes: Object.fromEntries(
+          ids.map((id, index) => [
+            id,
+            { document: { absoluteBoundingBox: { width: index === 0 ? 10 : 20 } }, styles: {} },
+          ]),
+        ),
+      });
+    }
+    if (url.includes("/images/")) {
+      const ids = new URL(url).searchParams.get("ids").split(",");
+      return json({ images: Object.fromEntries(ids.map((id) => [id, `https://cdn.test/${id}`])) });
+    }
+    return new Response(png, { status: 200, headers: { "content-type": "image/png" } });
+  };
+  const rasterizer = new FigmaRestRasterizer({ token: "token", fetchImpl });
+  const requests = [
+    { ref: "figma:file/1:1", target: { width: 20, height: 20 } },
+    { ref: "figma:file/2:2", target: { width: 40, height: 40 } },
+    { ref: "figma:file/1:1", target: { width: 20, height: 20 } },
+  ];
+
+  await rasterizer.prepare(requests);
+  await Promise.all(requests.map(({ ref, target }) => rasterizer.rasterize(ref, target)));
+  await rasterizer.rasterize(requests[0].ref, requests[0].target);
+
+  assert.equal(calls.filter((url) => url.includes("/nodes?")).length, 1);
+  assert.equal(calls.filter((url) => url.includes("/images/")).length, 1);
+  assert.equal(calls.filter((url) => url.includes("cdn.test")).length, 2);
+  assert.match(calls.find((url) => url.includes("/nodes?")), /ids=1%3A1%2C2%3A2/);
+  assert.match(calls.find((url) => url.includes("/images/")), /scale=2/);
+});
+
+test("retries a rate-limited batch once and respects Retry-After", async () => {
+  const sleeps = [];
+  let nodeAttempts = 0;
+  const png = onePixelPng();
+  const fetchImpl = async (url) => {
+    if (url.includes("/nodes?")) {
+      nodeAttempts += 1;
+      if (nodeAttempts === 1) return new Response("limited", { status: 429, headers: { "retry-after": "0" } });
+      return json({ nodes: { "1:1": { document: { absoluteBoundingBox: { width: 10 } } } } });
+    }
+    if (url.includes("/images/")) return json({ images: { "1:1": "https://cdn.test/1:1" } });
+    return new Response(png, { status: 200 });
+  };
+  const rasterizer = new FigmaRestRasterizer({
+    token: "token",
+    fetchImpl,
+    sleep: async (millis) => sleeps.push(millis),
+  });
+
+  const raster = await rasterizer.rasterize("figma:file/1:1", { width: 20, height: 20 });
+
+  assert.equal(nodeAttempts, 2);
+  assert.deepEqual(sleeps, [0]);
+  assert.equal(raster.width, 1);
+});


### PR DESCRIPTION
## What changed

- batch Figma node metadata requests by file
- batch image-export requests by file and effective render scale
- memoize node metadata, export URLs, and downloaded PNGs for the duration of the publish job
- retry HTTP 429 and 5xx responses with bounded exponential backoff while respecting `Retry-After`

## Why

The m3-catalog design-artifacts run attempted one nodes request and one image-export request per mapped component. Figma began returning HTTP 429 responses after six successful exports, so a green publish produced only 6/93 mapped components on the public parity page.

At the common catalog density, dozens of mapped nodes now require one batched metadata request and one batched export request instead of two API requests per component. Duplicate node/scale exports also reuse the downloaded raster.

## Validation

- `node --test figma-rest-raster.test.mjs design-references.test.mjs` — 30 passed
- full `npm test` advanced through the relevant design-artifacts and fixture suites without a failure; it was stopped after optional Chromium-backed workers did not exit in the sparse checkout
- `git diff --check`
