### PR TITLE
fix(rc-player): honor document density behavior

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -182,6 +182,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcGraphicsLayerModifier
 import ee.schimke.composeai.rcplayer.protocol.RcHapticFeedback
 import ee.schimke.composeai.rcplayer.protocol.RcHapticType
+import ee.schimke.composeai.rcplayer.protocol.RcHeader
 import ee.schimke.composeai.rcplayer.protocol.RcHeightInModifier
 import ee.schimke.composeai.rcplayer.protocol.RcIdLookup
 import ee.schimke.composeai.rcplayer.protocol.RcIdOperation
@@ -609,7 +610,7 @@ private fun RenderLayoutNode(
       }
     is RcLayoutNode.Row -> {
       val density = androidx.compose.ui.platform.LocalDensity.current
-      val spacingDp = state.resolve(node.operation.spacedBy).dp
+      val spacingDp = state.dpTypedDp(state.resolve(node.operation.spacedBy), density)
       val spacing = with(density) { spacingDp.roundToPx() }
       val rowModifier =
         effectiveModifier.applyComponentModifiers(
@@ -655,7 +656,8 @@ private fun RenderLayoutNode(
       }
     }
     is RcLayoutNode.Column -> {
-      val spacing = state.resolve(node.operation.spacedBy).dp
+      val density = androidx.compose.ui.platform.LocalDensity.current
+      val spacing = state.dpTypedDp(state.resolve(node.operation.spacedBy), density)
       Column(
         effectiveModifier.applyComponentModifiers(
           node.modifiers,
@@ -683,7 +685,8 @@ private fun RenderLayoutNode(
       }
     }
     is RcLayoutNode.Flow -> {
-      val spacing = state.resolve(node.operation.spacedBy).dp
+      val density = androidx.compose.ui.platform.LocalDensity.current
+      val spacing = state.dpTypedDp(state.resolve(node.operation.spacedBy), density)
       @OptIn(ExperimentalLayoutApi::class)
       FlowRow(
         effectiveModifier.applyComponentModifiers(
@@ -744,7 +747,7 @@ private fun RenderLayoutNode(
         orientation = RcCollapseOrientation.Horizontal,
         mainPositioning = node.operation.horizontalPositioning,
         crossPositioning = node.operation.verticalPositioning,
-        spacing = with(density) { state.resolve(node.operation.spacedBy).dp.roundToPx() },
+        spacing = state.dpTypedPixels(state.resolve(node.operation.spacedBy), density).roundToInt(),
         modifier =
           effectiveModifier.applyComponentModifiers(
             node.modifiers,
@@ -769,7 +772,7 @@ private fun RenderLayoutNode(
         orientation = RcCollapseOrientation.Vertical,
         mainPositioning = node.operation.verticalPositioning,
         crossPositioning = node.operation.horizontalPositioning,
-        spacing = with(density) { state.resolve(node.operation.spacedBy).dp.roundToPx() },
+        spacing = state.dpTypedPixels(state.resolve(node.operation.spacedBy), density).roundToInt(),
         modifier =
           effectiveModifier.applyComponentModifiers(
             node.modifiers,
@@ -1460,6 +1463,20 @@ private class RcVerticalArrangement(private val positioning: Int, override val s
   }
 }
 
+/** AndroidX fields that are pixels in LEGACY/PIXELS documents and dp in DP documents. */
+internal fun rcDpTypedPixels(value: Float, density: Float, densityBehavior: Int): Float =
+  if (densityBehavior == RcHeader.DENSITY_BEHAVIOR_DP) value * density else value
+
+private fun RcPlayerState.dpTypedPixels(value: Float, density: Density): Float =
+  rcDpTypedPixels(value, density.density, document.header.densityBehavior)
+
+private fun RcPlayerState.dpTypedDp(value: Float, density: Density): Dp =
+  with(density) { dpTypedPixels(value, density).toDp() }
+
+/** DimensionIn is the exception: AndroidX treats LEGACY and DP as dp, PIXELS as pixels. */
+internal fun rcDimensionConstraintDp(value: Float, density: Float, densityBehavior: Int): Float =
+  if (densityBehavior == RcHeader.DENSITY_BEHAVIOR_PIXELS) value / density else value
+
 /** AndroidX RowLayout/ColumnLayout positioning, including its additive spacedBy behaviour. */
 internal fun arrangeLinear(
   totalSize: Int,
@@ -1528,7 +1545,7 @@ private fun Modifier.applyComponentModifiers(
       computeBase.applyLayoutComputes(modifiers, state)
     }
   modifiers.dimensionConstraints.forEach { constraint ->
-    result = result.applyDimensionConstraint(constraint, state)
+    result = result.applyDimensionConstraint(constraint, state, density)
   }
   result = result.applyWidth(modifiers, state, density, fillMissingDimensions)
   result = result.applyHeight(modifiers, state, density, fillMissingDimensions)
@@ -1541,8 +1558,8 @@ private fun Modifier.applyComponentModifiers(
         is RcOffsetModifier ->
           result.offset {
             IntOffset(
-              state.resolve(placement.x).roundToInt(),
-              state.resolve(placement.y).roundToInt(),
+              state.dpTypedPixels(state.resolve(placement.x), density).roundToInt(),
+              state.dpTypedPixels(state.resolve(placement.y), density).roundToInt(),
             )
           }
         is RcZIndexModifier -> result.zIndex(state.resolve(placement.value))
@@ -1573,10 +1590,10 @@ private fun Modifier.applyComponentModifiers(
   modifiers.padding.forEach { padding ->
     result =
       result.padding(
-        start = state.resolve(padding.left).dp,
-        top = state.resolve(padding.top).dp,
-        end = state.resolve(padding.right).dp,
-        bottom = state.resolve(padding.bottom).dp,
+        start = state.dpTypedDp(state.resolve(padding.left), density),
+        top = state.dpTypedDp(state.resolve(padding.top), density),
+        end = state.dpTypedDp(state.resolve(padding.right), density),
+        bottom = state.dpTypedDp(state.resolve(padding.bottom), density),
       )
   }
   if (modifiers.clicks.any { it.type != RcClickActionType.CLICK }) {
@@ -2027,7 +2044,8 @@ private fun Modifier.applyAndroidXMarquee(
   operation: RcMarqueeModifier,
   state: RcPlayerState,
 ): Modifier {
-  val density = androidx.compose.ui.platform.LocalDensity.current.density
+  val localDensity = androidx.compose.ui.platform.LocalDensity.current
+  val density = localDensity.density
   val timeSeconds = state.animationTimeSeconds
   return clipToBounds().layout { measurable, constraints ->
     val placeable =
@@ -2039,7 +2057,7 @@ private fun Modifier.applyAndroidXMarquee(
       else constraints.maxWidth
     val width = constraints.constrainWidth(viewportWidth)
     val height = constraints.constrainHeight(placeable.height)
-    val contentWidth = placeable.width + operation.spacing.value
+    val contentWidth = placeable.width + state.dpTypedPixels(operation.spacing.value, localDensity)
     val distance = (contentWidth - width).coerceAtLeast(0f)
     val offset =
       androidXMarqueeOffset(
@@ -2269,34 +2287,51 @@ private fun Modifier.applyGraphicsLayer(
 private fun Modifier.applyDimensionConstraint(
   operation: ee.schimke.composeai.rcplayer.protocol.RcOperation,
   state: RcPlayerState,
+  density: Density,
 ): Modifier =
   when (operation) {
     is RcWidthInModifier ->
-      applyWidthRange(state.resolve(operation.minimum), state.resolve(operation.maximum))
+      applyWidthRange(
+        state.dimensionConstraintDp(state.resolve(operation.minimum), density),
+        state.dimensionConstraintDp(state.resolve(operation.maximum), density),
+      )
     is RcHeightInModifier ->
-      applyHeightRange(state.resolve(operation.minimum), state.resolve(operation.maximum))
+      applyHeightRange(
+        state.dimensionConstraintDp(state.resolve(operation.minimum), density),
+        state.dimensionConstraintDp(state.resolve(operation.maximum), density),
+      )
     is RcDimensionConstraintsModifier ->
       when (operation.type) {
         RcDimensionConstraintsModifier.HORIZONTAL ->
-          applyWidthRange(state.resolve(operation.minimum), state.resolve(operation.maximum))
+          applyWidthRange(
+            state.dimensionConstraintDp(state.resolve(operation.minimum), density),
+            state.dimensionConstraintDp(state.resolve(operation.maximum), density),
+          )
         RcDimensionConstraintsModifier.VERTICAL ->
-          applyHeightRange(state.resolve(operation.minimum), state.resolve(operation.maximum))
+          applyHeightRange(
+            state.dimensionConstraintDp(state.resolve(operation.minimum), density),
+            state.dimensionConstraintDp(state.resolve(operation.maximum), density),
+          )
         RcDimensionConstraintsModifier.REQUIRED_HORIZONTAL ->
           applyWidthRange(
-            state.resolve(operation.minimum),
-            state.resolve(operation.maximum),
+            state.dimensionConstraintDp(state.resolve(operation.minimum), density),
+            state.dimensionConstraintDp(state.resolve(operation.maximum), density),
             required = true,
           )
         RcDimensionConstraintsModifier.REQUIRED_VERTICAL ->
           applyHeightRange(
-            state.resolve(operation.minimum),
-            state.resolve(operation.maximum),
+            state.dimensionConstraintDp(state.resolve(operation.minimum), density),
+            state.dimensionConstraintDp(state.resolve(operation.maximum), density),
             required = true,
           )
         else -> this
       }
     else -> this
   }
+
+private fun RcPlayerState.dimensionConstraintDp(value: Float, density: Density): Float =
+  if (value == -1f) value
+  else rcDimensionConstraintDp(value, density.density, document.header.densityBehavior)
 
 private fun Modifier.applyWidthRange(
   minimum: Float,
@@ -2339,7 +2374,7 @@ private fun Modifier.applyPaintDecorator(
   operation: ee.schimke.composeai.rcplayer.protocol.RcOperation,
   state: RcPlayerState,
 ): Modifier {
-  val density = androidx.compose.ui.platform.LocalDensity.current.density
+  val localDensity = androidx.compose.ui.platform.LocalDensity.current
   return when (operation) {
     is RcBackgroundModifier ->
       drawBehind {
@@ -2373,8 +2408,12 @@ private fun Modifier.applyPaintDecorator(
               alpha = state.resolve(operation.alpha),
             )
           }
-        val borderWidth = state.resolve(operation.borderWidth).coerceAtLeast(0f)
-        val corner = state.resolve(operation.roundedCorner).coerceAtLeast(0f)
+        val borderWidth =
+          state.borderWidthPixels(operation.borderWidth, localDensity).coerceAtLeast(0f)
+        val corner =
+          state
+            .dpTypedPixels(state.resolve(operation.roundedCorner), localDensity)
+            .coerceAtLeast(0f)
         val halfSize = minOf(size.width, size.height) / 2f
         if (operation.wireVersion != 0 && borderWidth >= halfSize) {
           when (operation.shapeType) {
@@ -2414,13 +2453,10 @@ private fun Modifier.applyPaintDecorator(
       }
     is RcRoundedClipRectModifier ->
       drawWithContent {
-        val topStart =
-          rcRoundedClipRadius(operation.topStart, state.resolve(operation.topStart), density)
-        val topEnd = rcRoundedClipRadius(operation.topEnd, state.resolve(operation.topEnd), density)
-        val bottomStart =
-          rcRoundedClipRadius(operation.bottomStart, state.resolve(operation.bottomStart), density)
-        val bottomEnd =
-          rcRoundedClipRadius(operation.bottomEnd, state.resolve(operation.bottomEnd), density)
+        val topStart = state.dpTypedPixels(state.resolve(operation.topStart), localDensity)
+        val topEnd = state.dpTypedPixels(state.resolve(operation.topEnd), localDensity)
+        val bottomStart = state.dpTypedPixels(state.resolve(operation.bottomStart), localDensity)
+        val bottomEnd = state.dpTypedPixels(state.resolve(operation.bottomEnd), localDensity)
         val path =
           Path().apply {
             addRoundRect(
@@ -2443,9 +2479,15 @@ private fun Modifier.applyPaintDecorator(
   }
 }
 
-/** Fixed radii are authored in dp; size-derived references already resolve to physical pixels. */
-internal fun rcRoundedClipRadius(word: RcFloatWord, resolved: Float, density: Float): Float =
-  (resolved * if (word.referencedId == null) density else 1f).coerceAtLeast(0f)
+private fun RcPlayerState.borderWidthPixels(word: RcFloatWord, density: Density): Float {
+  val version = document.header.version
+  val atLeastV7 = version.major > 1 || (version.major == 1 && version.minor >= 1)
+  return if (document.header.densityBehavior == RcHeader.DENSITY_BEHAVIOR_LEGACY && !atLeastV7) {
+    word.value * density.density
+  } else {
+    dpTypedPixels(resolve(word), density)
+  }
+}
 
 @Composable
 private fun Modifier.applyAndroidXRipple(): Modifier {

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -184,6 +184,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcHapticFeedback
 import ee.schimke.composeai.rcplayer.protocol.RcHapticType
 import ee.schimke.composeai.rcplayer.protocol.RcHeader
 import ee.schimke.composeai.rcplayer.protocol.RcHeightInModifier
+import ee.schimke.composeai.rcplayer.protocol.RcHeightModifier
 import ee.schimke.composeai.rcplayer.protocol.RcIdLookup
 import ee.schimke.composeai.rcplayer.protocol.RcIdOperation
 import ee.schimke.composeai.rcplayer.protocol.RcImageAttribute
@@ -201,6 +202,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcMatrixVectorMath
 import ee.schimke.composeai.rcplayer.protocol.RcNoArg
 import ee.schimke.composeai.rcplayer.protocol.RcOffsetModifier
 import ee.schimke.composeai.rcplayer.protocol.RcOpcodes
+import ee.schimke.composeai.rcplayer.protocol.RcPaddingModifier
 import ee.schimke.composeai.rcplayer.protocol.RcPaintData
 import ee.schimke.composeai.rcplayer.protocol.RcPathAppend
 import ee.schimke.composeai.rcplayer.protocol.RcPathCombine
@@ -231,6 +233,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcTransform2
 import ee.schimke.composeai.rcplayer.protocol.RcUpdateDynamicFloatList
 import ee.schimke.composeai.rcplayer.protocol.RcWakeIn
 import ee.schimke.composeai.rcplayer.protocol.RcWidthInModifier
+import ee.schimke.composeai.rcplayer.protocol.RcWidthModifier
 import ee.schimke.composeai.rcplayer.protocol.RcZIndexModifier
 import ee.schimke.composeai.rcplayer.runtime.RcAnimationTimeline
 import ee.schimke.composeai.rcplayer.runtime.RcClickActionBlock
@@ -1547,28 +1550,53 @@ private fun Modifier.applyComponentModifiers(
   modifiers.dimensionConstraints.forEach { constraint ->
     result = result.applyDimensionConstraint(constraint, state, density)
   }
-  result = result.applyWidth(modifiers, state, density, fillMissingDimensions)
-  result = result.applyHeight(modifiers, state, density, fillMissingDimensions)
-  modifiers.marquee?.let { result = result.applyAndroidXMarquee(it, state) }
-  modifiers.scroll?.let { result = result.applyAndroidXScroll(it, state, geometryComponentIds) }
-  modifiers.graphicsLayer?.let { result = result.applyGraphicsLayer(it, state) }
-  modifiers.placementModifiers.forEach { placement ->
+  if (fillMissingDimensions && modifiers.width == null) result = result.fillMaxWidth()
+  if (fillMissingDimensions && modifiers.height == null) result = result.fillMaxHeight()
+  var appliedWidth = false
+  var appliedHeight = false
+  modifiers.ordered.forEach { operation ->
     result =
-      when (placement) {
+      when (operation) {
+        is RcWidthModifier ->
+          if (appliedWidth) result
+          else {
+            appliedWidth = true
+            result.applyWidth(operation, state, density)
+          }
+        is RcHeightModifier ->
+          if (appliedHeight) result
+          else {
+            appliedHeight = true
+            result.applyHeight(operation, state, density)
+          }
+        is RcPaddingModifier ->
+          result.padding(
+            start = state.dpTypedDp(state.resolve(operation.left), density),
+            top = state.dpTypedDp(state.resolve(operation.top), density),
+            end = state.dpTypedDp(state.resolve(operation.right), density),
+            bottom = state.dpTypedDp(state.resolve(operation.bottom), density),
+          )
         is RcOffsetModifier ->
           result.offset {
             IntOffset(
-              state.dpTypedPixels(state.resolve(placement.x), density).roundToInt(),
-              state.dpTypedPixels(state.resolve(placement.y), density).roundToInt(),
+              state.dpTypedPixels(state.resolve(operation.x), density).roundToInt(),
+              state.dpTypedPixels(state.resolve(operation.y), density).roundToInt(),
             )
           }
-        is RcZIndexModifier -> result.zIndex(state.resolve(placement.value))
+        is RcZIndexModifier -> result.zIndex(state.resolve(operation.value))
+        is RcBackgroundModifier,
+        is RcBorderModifier,
+        is RcClipRectModifier,
+        is RcRoundedClipRectModifier,
+        is RcRippleModifier -> result.applyPaintDecorator(operation, state)
+        is RcGraphicsLayerModifier ->
+          if (operation == modifiers.graphicsLayer) result.applyGraphicsLayer(operation, state)
+          else result
         else -> result
       }
   }
-  modifiers.paintDecorators.forEach { decorator ->
-    result = result.applyPaintDecorator(decorator, state)
-  }
+  modifiers.marquee?.let { result = result.applyAndroidXMarquee(it, state) }
+  modifiers.scroll?.let { result = result.applyAndroidXScroll(it, state, geometryComponentIds) }
   if (canvasOperations != null) {
     result = result.drawWithContent {
       rcTrace(RcTraceCategory.FRAME, "rc:drawCanvas") {
@@ -1586,15 +1614,6 @@ private fun Modifier.applyComponentModifiers(
         )
       }
     }
-  }
-  modifiers.padding.forEach { padding ->
-    result =
-      result.padding(
-        start = state.dpTypedDp(state.resolve(padding.left), density),
-        top = state.dpTypedDp(state.resolve(padding.top), density),
-        end = state.dpTypedDp(state.resolve(padding.right), density),
-        bottom = state.dpTypedDp(state.resolve(padding.bottom), density),
-      )
   }
   if (modifiers.clicks.any { it.type != RcClickActionType.CLICK }) {
     result = result.applyAndroidXMultiClick(modifiers.clicks, state)
@@ -2522,21 +2541,16 @@ private fun Modifier.applyAndroidXRipple(): Modifier {
 }
 
 private fun Modifier.applyWidth(
-  modifiers: RcLayoutModifiers,
+  width: RcWidthModifier,
   state: RcPlayerState,
   density: Density,
-  fillMissing: Boolean,
 ): Modifier =
-  when (val width = modifiers.width) {
-    null -> if (fillMissing) fillMaxWidth() else this
-    else ->
-      when (width.type) {
-        RcDimensionType.EXACT -> width(with(density) { state.resolve(width.value).toDp() })
-        RcDimensionType.EXACT_DP -> width(state.resolve(width.value).dp)
-        RcDimensionType.FILL,
-        RcDimensionType.FILL_PARENT_MAX_WIDTH -> fillMaxWidth()
-        else -> this
-      }
+  when (width.type) {
+    RcDimensionType.EXACT -> width(with(density) { state.resolve(width.value).toDp() })
+    RcDimensionType.EXACT_DP -> width(state.resolve(width.value).dp)
+    RcDimensionType.FILL,
+    RcDimensionType.FILL_PARENT_MAX_WIDTH -> fillMaxWidth()
+    else -> this
   }
 
 private fun RowScope.rowWeightModifier(node: RcLayoutNode, state: RcPlayerState): Modifier {
@@ -2558,21 +2572,16 @@ private fun ColumnScope.columnWeightModifier(node: RcLayoutNode, state: RcPlayer
 }
 
 private fun Modifier.applyHeight(
-  modifiers: RcLayoutModifiers,
+  height: RcHeightModifier,
   state: RcPlayerState,
   density: Density,
-  fillMissing: Boolean,
 ): Modifier =
-  when (val height = modifiers.height) {
-    null -> if (fillMissing) fillMaxHeight() else this
-    else ->
-      when (height.type) {
-        RcDimensionType.EXACT -> height(with(density) { state.resolve(height.value).toDp() })
-        RcDimensionType.EXACT_DP -> height(state.resolve(height.value).dp)
-        RcDimensionType.FILL,
-        RcDimensionType.FILL_PARENT_MAX_HEIGHT -> fillMaxHeight()
-        else -> this
-      }
+  when (height.type) {
+    RcDimensionType.EXACT -> height(with(density) { state.resolve(height.value).toDp() })
+    RcDimensionType.EXACT_DP -> height(state.resolve(height.value).dp)
+    RcDimensionType.FILL,
+    RcDimensionType.FILL_PARENT_MAX_HEIGHT -> fillMaxHeight()
+    else -> this
   }
 
 internal data class RcRootTransform(

--- a/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupportTest.kt
+++ b/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeSupportTest.kt
@@ -80,9 +80,17 @@ class RcComposeSupportTest {
   }
 
   @Test
-  fun fixedRoundedClipRadiiScaleButSizeDerivedRadiiDoNot() {
-    assertEquals(104f, rcRoundedClipRadius(RcFloatWord.literal(52f), resolved = 52f, density = 2f))
-    assertEquals(110f, rcRoundedClipRadius(RcFloatWord(0x7fc0002a), resolved = 110f, density = 2f))
+  fun dpTypedOperationValuesFollowDocumentDensityBehavior() {
+    assertEquals(52f, rcDpTypedPixels(52f, 2f, RcHeader.DENSITY_BEHAVIOR_LEGACY))
+    assertEquals(52f, rcDpTypedPixels(52f, 2f, RcHeader.DENSITY_BEHAVIOR_PIXELS))
+    assertEquals(104f, rcDpTypedPixels(52f, 2f, RcHeader.DENSITY_BEHAVIOR_DP))
+  }
+
+  @Test
+  fun dimensionConstraintsRetainTheirAndroidXLegacyException() {
+    assertEquals(52f, rcDimensionConstraintDp(52f, 2f, RcHeader.DENSITY_BEHAVIOR_LEGACY))
+    assertEquals(26f, rcDimensionConstraintDp(52f, 2f, RcHeader.DENSITY_BEHAVIOR_PIXELS))
+    assertEquals(52f, rcDimensionConstraintDp(52f, 2f, RcHeader.DENSITY_BEHAVIOR_DP))
   }
 
   @Test

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -434,6 +434,41 @@ class RcLayoutRenderTest {
   }
 
   @Test
+  fun legacyFlowSpacingRemainsInPhysicalPixelsAtHighDensity() {
+    val green = 0xff00ff00.toInt()
+    val red = 0xffff0000.toInt()
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(1, 1, 0), legacyWidth = 100, legacyHeight = 40, modern = false),
+        listOf<RcOperation>(
+          RcRootLayout(1),
+          RcLayoutContent(2),
+          RcFlowLayout(3, 30, 1, 4, RcFloatWord.literal(20f), Int.MAX_VALUE, Int.MAX_VALUE),
+          width(100f),
+          height(40f),
+          RcLayoutContent(4),
+        ) +
+          canvas(5, 40f, green) +
+          canvas(6, 40f, red) +
+          List(4) { RcNoArg(RcOpcodes.CONTAINER_END) },
+      )
+    val scene =
+      ImageComposeScene(width = 100, height = 40, density = Density(2f)) {
+        RcComposePlayer(document)
+      }
+    try {
+      val bitmap = Bitmap().apply { allocN32Pixels(100, 40) }
+      check(scene.render().readPixels(bitmap))
+
+      assertEquals(green, bitmap.getColor(20, 20))
+      assertEquals(0, bitmap.getColor(50, 20), "20px wire spacing must not become 20dp")
+      assertEquals(red, bitmap.getColor(80, 20), "both children must remain on the first row")
+    } finally {
+      scene.close()
+    }
+  }
+
+  @Test
   fun coreTextRendersInheritedSparseStyle() {
     val document =
       RcDocument(

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -45,6 +45,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcNoArg
 import ee.schimke.composeai.rcplayer.protocol.RcOffsetModifier
 import ee.schimke.composeai.rcplayer.protocol.RcOpcodes
 import ee.schimke.composeai.rcplayer.protocol.RcOperation
+import ee.schimke.composeai.rcplayer.protocol.RcPaddingModifier
 import ee.schimke.composeai.rcplayer.protocol.RcPaintData
 import ee.schimke.composeai.rcplayer.protocol.RcRootLayout
 import ee.schimke.composeai.rcplayer.protocol.RcRoundedClipRectModifier
@@ -122,6 +123,48 @@ class RcLayoutRenderTest {
       check(scene.render(0L).readPixels(bitmap))
 
       assertEquals(grey, bitmap.getColor(20, 12))
+    } finally {
+      scene.close()
+    }
+  }
+
+  @Test
+  fun paddingBeforeExactSizePositionsSubsequentPaint() {
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(1, 0, 0), legacyWidth = 40, legacyHeight = 24, modern = false),
+        listOf(
+          RcRootLayout(1),
+          RcLayoutContent(2),
+          RcBoxLayout(3, 30, 1, 4),
+          width(40f),
+          height(24f),
+          RcLayoutContent(4),
+          RcBoxLayout(5, 50, 1, 4),
+          RcPaddingModifier(
+            RcFloatWord.literal(18f),
+            RcFloatWord.literal(2f),
+            RcFloatWord.literal(0f),
+            RcFloatWord.literal(0f),
+          ),
+          width(16f),
+          height(16f),
+          solidBackground(red = 1f, green = 1f, blue = 1f),
+          RcLayoutContent(6),
+        ) + List(6) { RcNoArg(RcOpcodes.CONTAINER_END) },
+      )
+    val scene =
+      ImageComposeScene(width = 40, height = 24, density = Density(1f)) {
+        RcComposePlayer(document)
+      }
+    try {
+      val bitmap = Bitmap().apply { allocN32Pixels(40, 24) }
+      check(scene.render(0L).readPixels(bitmap))
+
+      assertEquals(0, bitmap.getColor(17, 10))
+      assertEquals(0xffffffff.toInt(), bitmap.getColor(18, 2))
+      assertEquals(0xffffffff.toInt(), bitmap.getColor(33, 17))
+      assertEquals(0, bitmap.getColor(34, 10))
     } finally {
       scene.close()
     }

--- a/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcModel.kt
+++ b/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcModel.kt
@@ -56,6 +56,10 @@ public data class RcHeader(
   public val density: Float
     get() = floatProperty(DOC_DENSITY_AT_GENERATION) ?: 1f
 
+  /** How density-sensitive operation fields are interpreted at playback. */
+  public val densityBehavior: Int
+    get() = intProperty(DOC_DENSITY_BEHAVIOR) ?: DENSITY_BEHAVIOR_LEGACY
+
   public val capabilities: Long
     get() = (property(DOC_CAPABILITIES) as? RcHeaderValue.LongValue)?.value ?: legacyCapabilities
 
@@ -70,6 +74,11 @@ public data class RcHeader(
     public const val DOC_WIDTH: Int = 5
     public const val DOC_HEIGHT: Int = 6
     public const val DOC_DENSITY_AT_GENERATION: Int = 7
+    public const val DOC_DENSITY_BEHAVIOR: Int = 27
+
+    public const val DENSITY_BEHAVIOR_LEGACY: Int = 0
+    public const val DENSITY_BEHAVIOR_PIXELS: Int = 1
+    public const val DENSITY_BEHAVIOR_DP: Int = 2
     // Capabilities are part of the legacy header, not currently a documented map property.
     private const val DOC_CAPABILITIES: Int = -1
   }

--- a/rc-player/protocol/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodecTest.kt
+++ b/rc-player/protocol/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/protocol/RcDocumentCodecTest.kt
@@ -24,6 +24,28 @@ class RcDocumentCodecTest {
   }
 
   @Test
+  fun headerExposesDensityBehaviorWithAndroidXLegacyDefault() {
+    assertEquals(
+      RcHeader.DENSITY_BEHAVIOR_LEGACY,
+      RcHeader(RcVersion(1, 1, 0), modern = false).densityBehavior,
+    )
+    assertEquals(
+      RcHeader.DENSITY_BEHAVIOR_PIXELS,
+      RcHeader(
+          RcVersion(1, 1, 0),
+          properties =
+            listOf(
+              RcHeaderProperty(
+                RcHeader.DOC_DENSITY_BEHAVIOR,
+                RcHeaderValue.IntValue(RcHeader.DENSITY_BEHAVIOR_PIXELS),
+              )
+            ),
+        )
+        .densityBehavior,
+    )
+  }
+
+  @Test
   fun embeddedFontRoundTripsAlpha16PayloadExactly() {
     val font = RcFontData(fontId = 42, type = 7, data = byteArrayOf(0, 1, -1, 127))
     val document = RcDocument(RcHeader(RcVersion(1, 0, 0), modern = false), listOf(font))

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
@@ -52,6 +52,8 @@ import ee.schimke.composeai.rcplayer.trace.RcTraceCategory
 import ee.schimke.composeai.rcplayer.trace.rcTrace
 
 public data class RcLayoutModifiers(
+  /** Direct component operations in wire order. AndroidX modifier semantics are order-sensitive. */
+  val ordered: List<RcOperation> = emptyList(),
   /** Last AndroidX animation policy attached to this component. */
   val animationSpec: RcAnimationSpec? = null,
   val width: RcWidthModifier? = null,
@@ -509,6 +511,7 @@ public object RcLayoutTree {
     val operations =
       container.children.filterIsInstance<RcLinkedNode.Operation>().map { it.operation }
     return RcLayoutModifiers(
+      ordered = operations,
       animationSpec = operations.singleModifier<RcAnimationSpec>(container.operation),
       // AndroidX applies dimension modifiers in wire order. Once the first required dimension
       // fixes the constraints, later width/height modifiers cannot expand past it.


### PR DESCRIPTION
## Summary

- decode the Remote Compose document density-behavior header
- apply AndroidX alpha16 density semantics exhaustively to row, column, flow, collapsible layouts, padding, offset, marquee, rounded clipping, borders, and dimension constraints
- preserve the distinct `DimensionIn` rule and the legacy pre-1.1 border-width behavior
- preserve component modifier wire order (the complete change from merged PR #3630)
- add codec, operation-matrix, and integrated high-density layout coverage

## Merge audit

PR #3630 was merged into this feature branch rather than `main`. Its modifier-order commit is now intentionally included here, rebased with the density work onto current `main`. Merging this PR lands both changes; nothing from #3630 remains stranded.

## Home Assistant validation

Rerendered all 122 captured `homeassistant-remotecompose` documents with the updated Wasm player:

- mean pixel mismatch: **19.14% → 7.23%**
- mean coverage delta: **12.85% → 2.94%**
- Sensor: about **33% → 1%** mismatch
- VerticalStack: **34–36% → 0.8–3.5%**
- Markdown, Calendar, Logbook, Light, Statistics Graph, Area, and responsive Tiles now land around **0.5–2%**

Grid improves substantially but retains a separate content/color issue. Toggle is unchanged and is being investigated separately.

## Validation

- `./gradlew :rc-player-protocol:desktopTest :rc-player-compose:desktopTest --tests '*RcDocumentCodecTest*' --tests '*RcComposeSupportTest*'`
- `./gradlew :rc-player-compose:desktopTest --tests '*RcLayoutRenderTest.legacyFlowSpacingRemainsInPhysicalPixelsAtHighDensity*'`
- `./gradlew :rc-player-compose:ktfmtCheck :rc-player-protocol:ktfmtCheck`
- complete 122-document `rc-compare` rerender
- after rebasing onto current `main`: `./gradlew :rc-player-protocol:desktopTest :rc-player-runtime:desktopTest :rc-player-compose:desktopTest :rc-player-wasm:wasmPlayerDist`
