### PR TITLE
fix(rc-player): replay layout color attributes

### DIFF
--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -559,6 +559,7 @@ public class RcPlayerState(
         is RcFloatExpression -> applyFloatExpression(operation)
         is RcIntegerExpression -> applyIntegerExpression(operation)
         is RcColorExpression -> applyColorExpression(operation)
+        is RcColorAttribute -> applyColorAttribute(operation)
         is RcIdLookup,
         is RcDataMapLookup -> applyDataOperation(operation)
         is RcTextMerge,

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
@@ -921,6 +921,28 @@ class RcPlayerStateTest {
   }
 
   @Test
+  fun replaysColorAttributesAfterTheColorExpressionsTheyRead() {
+    val state =
+      RcPlayerState(
+        RcDocument(
+          RcHeader(RcVersion(0, 1, 0)),
+          listOf(RcColorConstant(7, 0xff000000.toInt()), RcColorConstant(8, 0xffffffff.toInt())),
+        )
+      )
+    val operations =
+      listOf<RcLinkedNode>(
+        RcLinkedNode.Operation(
+          RcColorExpression(30, RcColorExpression.ID_ID_INTERPOLATE, 7, 8, .5f.toRawBits())
+        ),
+        RcLinkedNode.Operation(RcColorAttribute(31, 30, RcColorAttribute.COLOR_BRIGHTNESS)),
+      )
+
+    state.applyContentStateOperations(operations)
+
+    assertEquals(0.7294118f, state.resolve(RcFloatWord(0x7fc00000 or 31)))
+  }
+
+  @Test
   fun evaluatesAndroidXCollectionLookupsIntoTypedStores() {
     val state =
       RcPlayerState(


### PR DESCRIPTION
## Summary

- replay `RcColorAttribute` operations while applying layout-component content state
- keep color expressions and their subsequent color attributes in the same ordered state update path
- add a regression test that applies brightness after a color expression and verifies the resolved color

## Root cause

The decoder already supported `ColorAttribute`, and component-value attributes are intentionally resolved through measured geometry. However, the layout content-state dispatcher only replayed `ColorExpression`; it silently omitted the following `ColorAttribute`. Home Assistant Grid documents use this operation sequence extensively, leaving derived component colors incomplete.

## Validation

- `./gradlew :rc-player-runtime:desktopTest --tests '*RcPlayerStateTest*' :rc-player-runtime:ktfmtCheck`

This is intentionally separate from the document density-behavior correction in #3628.
