### PR TITLE
fix(rc-player): preserve component modifier order

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -185,6 +185,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcHapticFeedback
 import ee.schimke.composeai.rcplayer.protocol.RcHapticType
 import ee.schimke.composeai.rcplayer.protocol.RcHeader
 import ee.schimke.composeai.rcplayer.protocol.RcHeightInModifier
+import ee.schimke.composeai.rcplayer.protocol.RcHeightModifier
 import ee.schimke.composeai.rcplayer.protocol.RcIdLookup
 import ee.schimke.composeai.rcplayer.protocol.RcIdOperation
 import ee.schimke.composeai.rcplayer.protocol.RcImageAttribute
@@ -202,6 +203,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcMatrixVectorMath
 import ee.schimke.composeai.rcplayer.protocol.RcNoArg
 import ee.schimke.composeai.rcplayer.protocol.RcOffsetModifier
 import ee.schimke.composeai.rcplayer.protocol.RcOpcodes
+import ee.schimke.composeai.rcplayer.protocol.RcPaddingModifier
 import ee.schimke.composeai.rcplayer.protocol.RcPaintData
 import ee.schimke.composeai.rcplayer.protocol.RcPathAppend
 import ee.schimke.composeai.rcplayer.protocol.RcPathCombine
@@ -231,6 +233,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcTransform2
 import ee.schimke.composeai.rcplayer.protocol.RcUpdateDynamicFloatList
 import ee.schimke.composeai.rcplayer.protocol.RcWakeIn
 import ee.schimke.composeai.rcplayer.protocol.RcWidthInModifier
+import ee.schimke.composeai.rcplayer.protocol.RcWidthModifier
 import ee.schimke.composeai.rcplayer.protocol.RcZIndexModifier
 import ee.schimke.composeai.rcplayer.runtime.RcAnimationTimeline
 import ee.schimke.composeai.rcplayer.runtime.RcClickActionBlock
@@ -1524,28 +1527,53 @@ private fun Modifier.applyComponentModifiers(
   modifiers.dimensionConstraints.forEach { constraint ->
     result = result.applyDimensionConstraint(constraint, state, density)
   }
-  result = result.applyWidth(modifiers, state, density, fillMissingDimensions)
-  result = result.applyHeight(modifiers, state, density, fillMissingDimensions)
-  modifiers.marquee?.let { result = result.applyAndroidXMarquee(it, state) }
-  modifiers.scroll?.let { result = result.applyAndroidXScroll(it, state, geometryComponentIds) }
-  modifiers.graphicsLayer?.let { result = result.applyGraphicsLayer(it, state) }
-  modifiers.placementModifiers.forEach { placement ->
+  if (fillMissingDimensions && modifiers.width == null) result = result.fillMaxWidth()
+  if (fillMissingDimensions && modifiers.height == null) result = result.fillMaxHeight()
+  var appliedWidth = false
+  var appliedHeight = false
+  modifiers.ordered.forEach { operation ->
     result =
-      when (placement) {
+      when (operation) {
+        is RcWidthModifier ->
+          if (appliedWidth) result
+          else {
+            appliedWidth = true
+            result.applyWidth(operation, state, density)
+          }
+        is RcHeightModifier ->
+          if (appliedHeight) result
+          else {
+            appliedHeight = true
+            result.applyHeight(operation, state, density)
+          }
+        is RcPaddingModifier ->
+          result.padding(
+            start = state.dpTypedDp(state.resolve(operation.left), density),
+            top = state.dpTypedDp(state.resolve(operation.top), density),
+            end = state.dpTypedDp(state.resolve(operation.right), density),
+            bottom = state.dpTypedDp(state.resolve(operation.bottom), density),
+          )
         is RcOffsetModifier ->
           result.offset {
             IntOffset(
-              state.dpTypedPixels(state.resolve(placement.x), density).roundToInt(),
-              state.dpTypedPixels(state.resolve(placement.y), density).roundToInt(),
+              state.dpTypedPixels(state.resolve(operation.x), density).roundToInt(),
+              state.dpTypedPixels(state.resolve(operation.y), density).roundToInt(),
             )
           }
-        is RcZIndexModifier -> result.zIndex(state.resolve(placement.value))
+        is RcZIndexModifier -> result.zIndex(state.resolve(operation.value))
+        is RcBackgroundModifier,
+        is RcBorderModifier,
+        is RcClipRectModifier,
+        is RcRoundedClipRectModifier,
+        is RcRippleModifier -> result.applyPaintDecorator(operation, state)
+        is RcGraphicsLayerModifier ->
+          if (operation == modifiers.graphicsLayer) result.applyGraphicsLayer(operation, state)
+          else result
         else -> result
       }
   }
-  modifiers.paintDecorators.forEach { decorator ->
-    result = result.applyPaintDecorator(decorator, state)
-  }
+  modifiers.marquee?.let { result = result.applyAndroidXMarquee(it, state) }
+  modifiers.scroll?.let { result = result.applyAndroidXScroll(it, state, geometryComponentIds) }
   if (canvasOperations != null) {
     result = result.drawWithContent {
       rcTrace(RcTraceCategory.FRAME, "rc:drawCanvas") {
@@ -1563,15 +1591,6 @@ private fun Modifier.applyComponentModifiers(
         )
       }
     }
-  }
-  modifiers.padding.forEach { padding ->
-    result =
-      result.padding(
-        start = state.dpTypedDp(state.resolve(padding.left), density),
-        top = state.dpTypedDp(state.resolve(padding.top), density),
-        end = state.dpTypedDp(state.resolve(padding.right), density),
-        bottom = state.dpTypedDp(state.resolve(padding.bottom), density),
-      )
   }
   if (modifiers.clicks.any { it.type != RcClickActionType.CLICK }) {
     result = result.applyAndroidXMultiClick(modifiers.clicks, state)
@@ -2498,21 +2517,16 @@ private fun Modifier.applyAndroidXRipple(): Modifier {
 }
 
 private fun Modifier.applyWidth(
-  modifiers: RcLayoutModifiers,
+  width: RcWidthModifier,
   state: RcPlayerState,
   density: Density,
-  fillMissing: Boolean,
 ): Modifier =
-  when (val width = modifiers.width) {
-    null -> if (fillMissing) fillMaxWidth() else this
-    else ->
-      when (width.type) {
-        RcDimensionType.EXACT -> width(with(density) { state.resolve(width.value).toDp() })
-        RcDimensionType.EXACT_DP -> width(state.resolve(width.value).dp)
-        RcDimensionType.FILL,
-        RcDimensionType.FILL_PARENT_MAX_WIDTH -> fillMaxWidth()
-        else -> this
-      }
+  when (width.type) {
+    RcDimensionType.EXACT -> width(with(density) { state.resolve(width.value).toDp() })
+    RcDimensionType.EXACT_DP -> width(state.resolve(width.value).dp)
+    RcDimensionType.FILL,
+    RcDimensionType.FILL_PARENT_MAX_WIDTH -> fillMaxWidth()
+    else -> this
   }
 
 private fun RowScope.rowWeightModifier(node: RcLayoutNode, state: RcPlayerState): Modifier {
@@ -2534,21 +2548,16 @@ private fun ColumnScope.columnWeightModifier(node: RcLayoutNode, state: RcPlayer
 }
 
 private fun Modifier.applyHeight(
-  modifiers: RcLayoutModifiers,
+  height: RcHeightModifier,
   state: RcPlayerState,
   density: Density,
-  fillMissing: Boolean,
 ): Modifier =
-  when (val height = modifiers.height) {
-    null -> if (fillMissing) fillMaxHeight() else this
-    else ->
-      when (height.type) {
-        RcDimensionType.EXACT -> height(with(density) { state.resolve(height.value).toDp() })
-        RcDimensionType.EXACT_DP -> height(state.resolve(height.value).dp)
-        RcDimensionType.FILL,
-        RcDimensionType.FILL_PARENT_MAX_HEIGHT -> fillMaxHeight()
-        else -> this
-      }
+  when (height.type) {
+    RcDimensionType.EXACT -> height(with(density) { state.resolve(height.value).toDp() })
+    RcDimensionType.EXACT_DP -> height(state.resolve(height.value).dp)
+    RcDimensionType.FILL,
+    RcDimensionType.FILL_PARENT_MAX_HEIGHT -> fillMaxHeight()
+    else -> this
   }
 
 internal data class RcRootTransform(

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -43,6 +43,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcNoArg
 import ee.schimke.composeai.rcplayer.protocol.RcOffsetModifier
 import ee.schimke.composeai.rcplayer.protocol.RcOpcodes
 import ee.schimke.composeai.rcplayer.protocol.RcOperation
+import ee.schimke.composeai.rcplayer.protocol.RcPaddingModifier
 import ee.schimke.composeai.rcplayer.protocol.RcPaintData
 import ee.schimke.composeai.rcplayer.protocol.RcRootLayout
 import ee.schimke.composeai.rcplayer.protocol.RcRoundedClipRectModifier
@@ -66,6 +67,48 @@ import kotlin.test.assertTrue
 import org.jetbrains.skia.Bitmap
 
 class RcLayoutRenderTest {
+  @Test
+  fun paddingBeforeExactSizePositionsSubsequentPaint() {
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(1, 0, 0), legacyWidth = 40, legacyHeight = 24, modern = false),
+        listOf(
+          RcRootLayout(1),
+          RcLayoutContent(2),
+          RcBoxLayout(3, 30, 1, 4),
+          width(40f),
+          height(24f),
+          RcLayoutContent(4),
+          RcBoxLayout(5, 50, 1, 4),
+          RcPaddingModifier(
+            RcFloatWord.literal(18f),
+            RcFloatWord.literal(2f),
+            RcFloatWord.literal(0f),
+            RcFloatWord.literal(0f),
+          ),
+          width(16f),
+          height(16f),
+          solidBackground(red = 1f, green = 1f, blue = 1f),
+          RcLayoutContent(6),
+        ) + List(6) { RcNoArg(RcOpcodes.CONTAINER_END) },
+      )
+    val scene =
+      ImageComposeScene(width = 40, height = 24, density = Density(1f)) {
+        RcComposePlayer(document)
+      }
+    try {
+      val bitmap = Bitmap().apply { allocN32Pixels(40, 24) }
+      check(scene.render(0L).readPixels(bitmap))
+
+      assertEquals(0, bitmap.getColor(17, 10))
+      assertEquals(0xffffffff.toInt(), bitmap.getColor(18, 2))
+      assertEquals(0xffffffff.toInt(), bitmap.getColor(33, 17))
+      assertEquals(0, bitmap.getColor(34, 10))
+    } finally {
+      scene.close()
+    }
+  }
+
   @Test
   fun marqueeClipsOverflowingLayoutContent() {
     val red = 0xffff0000.toInt()

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcLayoutTree.kt
@@ -51,6 +51,8 @@ import ee.schimke.composeai.rcplayer.trace.RcTraceCategory
 import ee.schimke.composeai.rcplayer.trace.rcTrace
 
 public data class RcLayoutModifiers(
+  /** Direct component operations in wire order. AndroidX modifier semantics are order-sensitive. */
+  val ordered: List<RcOperation> = emptyList(),
   /** Last AndroidX animation policy attached to this component. */
   val animationSpec: RcAnimationSpec? = null,
   val width: RcWidthModifier? = null,
@@ -497,6 +499,7 @@ public object RcLayoutTree {
     val operations =
       container.children.filterIsInstance<RcLinkedNode.Operation>().map { it.operation }
     return RcLayoutModifiers(
+      ordered = operations,
       animationSpec = operations.singleModifier<RcAnimationSpec>(container.operation),
       // AndroidX applies dimension modifiers in wire order. Once the first required dimension
       // fixes the constraints, later width/height modifiers cannot expand past it.


### PR DESCRIPTION
## Summary

- retain direct component operations in their original Remote Compose wire order
- replay width, height, padding, offset, z-index, graphics-layer, and paint modifiers in that order
- continue honoring AndroidX's first width/height modifier rule and existing dimension constraints
- add a pixel regression for `padding → exact size → background`

## Root cause

The layout tree grouped modifier kinds before rendering: dimensions and paint were always applied before padding. AndroidX instead walks `ComponentModifiers` in wire order. Padding before an exact dimension contributes outer space and translates subsequent paint; padding after paint only insets component content.

Home Assistant's toggle knob emits `padding(start, top)`, then a 16×16 exact size, clip, and white background. Grouping padding last constrained it inside the exact size, so every progress value painted the knob at the left edge. Ordered replay restores the intended off/mid/on travel without a Toggle-specific path.

## Validation

- `./gradlew :rc-player-runtime:desktopTest :rc-player-compose:desktopTest`
- `./gradlew :rc-player-runtime:ktfmtCheck :rc-player-compose:ktfmtCheck`
- all 105 Compose desktop tests pass, including existing marquee and scroll cases

This is intentionally separate from density behavior (#3628) and layout ColorAttribute replay (#3629).
