### PR TITLE
fix(rc-player): replay root layout state operations

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -390,12 +389,10 @@ public fun RcComposePlayer(
     // composition/measurement rather than painting, so action mutations must invalidate this
     // branch as well as the draw layer.
     invalidationVersion
-    SideEffect {
-      state.beginFrame(frameNanos / 1_000_000_000f)
-      // beginFrame resets derived text to the document's literals, so the ids the layout's own
-      // data operations publish have to be recomputed before measurement and drawing read them.
-      state.applyContentStateOperations(contentStateOperations)
-    }
+    state.beginFrame(frameNanos / 1_000_000_000f)
+    // beginFrame resets derived text to the document's literals, so the ids the layout's own data
+    // operations publish must be recomputed before this same composition measures and draws.
+    state.applyContentStateOperations(contentStateOperations)
     LookaheadScope {
       CompositionLocalProvider(
         LocalRcLookaheadScope provides this,

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -211,6 +211,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcPathExpression
 import ee.schimke.composeai.rcplayer.protocol.RcPathTween
 import ee.schimke.composeai.rcplayer.protocol.RcRippleModifier
 import ee.schimke.composeai.rcplayer.protocol.RcRootContentBehavior
+import ee.schimke.composeai.rcplayer.protocol.RcRootLayout
 import ee.schimke.composeai.rcplayer.protocol.RcRoundedClipRectModifier
 import ee.schimke.composeai.rcplayer.protocol.RcScrollModifier
 import ee.schimke.composeai.rcplayer.protocol.RcTextAttribute
@@ -4011,12 +4012,12 @@ private fun blendMode(value: Int): BlendMode =
  * a `COLOR_EXPRESSIONS` feeding a background modifier — have no other execution site in the layout
  * path. Operations nested in a container that owns its own execution (CanvasOperations,
  * LayoutCompute) are left to that owner; only the direct children of a LayoutComponentContent are
- * replayed here.
+ * replayed here. RootLayout also executes direct ComponentData before it paints its children.
  */
 private fun List<RcLinkedNode>.collectContentStateOperations(): List<RcLinkedNode> = buildList {
   this@collectContentStateOperations.filterIsInstance<RcLinkedNode.Container>().forEach { container
     ->
-    if (container.operation is RcLayoutContent) {
+    if (container.operation is RcRootLayout || container.operation is RcLayoutContent) {
       addAll(container.children.filterIsInstance<RcLinkedNode.Operation>())
     }
     addAll(container.children.collectContentStateOperations())

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -20,6 +20,8 @@ import ee.schimke.composeai.rcplayer.protocol.RcCanvasLayout
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsibleColumnLayout
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsiblePriorityModifier
 import ee.schimke.composeai.rcplayer.protocol.RcCollapsibleRowLayout
+import ee.schimke.composeai.rcplayer.protocol.RcColorConstant
+import ee.schimke.composeai.rcplayer.protocol.RcColorExpression
 import ee.schimke.composeai.rcplayer.protocol.RcComponentValue
 import ee.schimke.composeai.rcplayer.protocol.RcCoreText
 import ee.schimke.composeai.rcplayer.protocol.RcDimensionConstraintsModifier
@@ -66,6 +68,65 @@ import kotlin.test.assertTrue
 import org.jetbrains.skia.Bitmap
 
 class RcLayoutRenderTest {
+  @Test
+  fun rootStateOperationsFeedComponentModifiers() {
+    val grey = 0xffb0b0b0.toInt()
+    val blue = 0xff2196f3.toInt()
+    val progressId = 46
+    val colorId = 47
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(1, 0, 0), legacyWidth = 40, legacyHeight = 24, modern = false),
+        listOf(
+          RcRootLayout(1),
+          RcColorConstant(44, grey),
+          RcColorConstant(45, blue),
+          ee.schimke.composeai.rcplayer.protocol.RcFloatExpression(
+            progressId,
+            listOf(RcFloatWord.literal(0f)),
+            animation = listOf(RcFloatWord.literal(0.2f)),
+          ),
+          RcColorExpression(
+            colorId,
+            RcColorExpression.ID_ID_INTERPOLATE,
+            44,
+            45,
+            RcFloatWord(0x7fc00000 or progressId).bits,
+          ),
+          RcBoxLayout(3, 30, 1, 4),
+          width(40f),
+          height(24f),
+          RcBackgroundModifier(
+            flags = RcBackgroundModifier.COLOR_REFERENCE_FLAG,
+            colorId = colorId,
+            reserved1 = 0,
+            reserved2 = 0,
+            red = RcFloatWord.literal(0f),
+            green = RcFloatWord.literal(0f),
+            blue = RcFloatWord.literal(0f),
+            alpha = RcFloatWord.literal(0f),
+            shapeType = RcBackgroundModifier.SHAPE_RECTANGLE,
+          ),
+          RcLayoutContent(4),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+        ),
+      )
+    val scene =
+      ImageComposeScene(width = 40, height = 24, density = Density(1f)) {
+        RcComposePlayer(document)
+      }
+    try {
+      val bitmap = Bitmap().apply { allocN32Pixels(40, 24) }
+      check(scene.render(0L).readPixels(bitmap))
+
+      assertEquals(grey, bitmap.getColor(20, 12))
+    } finally {
+      scene.close()
+    }
+  }
+
   @Test
   fun marqueeClipsOverflowingLayoutContent() {
     val red = 0xffff0000.toInt()


### PR DESCRIPTION
## Summary

- replay direct RootLayout ComponentData alongside LayoutComponentContent state operations
- apply both state scopes synchronously before measurement and drawing, including first-frame capture
- preserve execution ownership for CanvasOperations, LayoutCompute, and action containers
- add a pixel regression where root float/color expressions feed a component background

## Root cause

The Compose layout path rebuilt state derived inside `LayoutComponentContent` from a `SideEffect`, and omitted state operations attached directly to `RootLayout`. That made the first measured frame stale and left root values absent. AndroidX applies both scopes synchronously before measuring and painting a layout component's children.

Home Assistant's boolean/animated Toggle declares an animated `FloatExpression` and interpolated `ColorExpression` directly under RootLayout, then references that color from the track background. The missing replay left the color id unresolved/transparent even though the knob layout was otherwise correct.

## Home Assistant validation

After combining this with #3628, #3629, and #3630, all ten Toggle captures render at **0.00–0.15% CMP-Wasm mismatch**, including literal progress, animated, and boolean initial states.

## Validation

- `./gradlew :rc-player-compose:desktopTest :rc-player-compose:ktfmtCheck`
- complete 106-test Compose desktop suite
- 10-document Toggle artifact rerender at density 2.625
