### PR TITLE
fix(rc-player): mirror integer values into float state

### DIFF
--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -154,7 +154,7 @@ public class RcPlayerState(
         is RcFloatConstant -> floats[operation.id] = operation.value.value
         is RcColorConstant -> colors[operation.id] = operation.argb
         is RcTextData -> baseTexts[operation.id] = operation.text
-        is RcIntegerConstant -> integers[operation.id] = operation.value
+        is RcIntegerConstant -> setInteger(operation.id, operation.value)
         is RcBooleanConstant -> booleans[operation.id] = operation.value
         is RcLongConstant -> longs[operation.id] = operation.value
         is RcPathData -> basePaths[operation.id] = operation
@@ -393,8 +393,10 @@ public class RcPlayerState(
   public fun applyDataOperation(operation: RcOperation) {
     when (operation) {
       is RcIdLookup ->
-        integers[operation.outId] =
-          requireNotNull(idLists[operation.listId]).ids[resolve(operation.index).toInt()]
+        setInteger(
+          operation.outId,
+          requireNotNull(idLists[operation.listId]).ids[resolve(operation.index).toInt()],
+        )
       is RcDataMapLookup -> {
         val key = requireNotNull(texts[operation.keyTextId])
         val entry =
@@ -402,11 +404,11 @@ public class RcPlayerState(
             ?: error("Missing AndroidX data-map key '$key'")
         when (entry.type) {
           RcIdMap.TYPE_STRING -> texts[operation.outId] = requireNotNull(texts[entry.id])
-          RcIdMap.TYPE_INT -> integers[operation.outId] = requireNotNull(integers[entry.id])
+          RcIdMap.TYPE_INT -> setInteger(operation.outId, requireNotNull(integers[entry.id]))
           RcIdMap.TYPE_FLOAT -> floats[operation.outId] = requireNotNull(floats[entry.id])
-          RcIdMap.TYPE_LONG -> integers[operation.outId] = requireNotNull(longs[entry.id]).toInt()
+          RcIdMap.TYPE_LONG -> setInteger(operation.outId, requireNotNull(longs[entry.id]).toInt())
           RcIdMap.TYPE_BOOLEAN ->
-            integers[operation.outId] = if (requireNotNull(booleans[entry.id])) 1 else 0
+            setInteger(operation.outId, if (requireNotNull(booleans[entry.id])) 1 else 0)
           else -> error("Unknown AndroidX data-map type ${entry.type}")
         }
       }
@@ -432,8 +434,10 @@ public class RcPlayerState(
   }
 
   public fun applyIntegerExpression(operation: RcIntegerExpression) {
-    integers[operation.outId] =
-      RcIntegerExpressionEvaluator.evaluate(operation) { id -> integers[id] ?: 0 }
+    setInteger(
+      operation.outId,
+      RcIntegerExpressionEvaluator.evaluate(operation) { id -> integers[id] ?: 0 },
+    )
   }
 
   public fun applyImageAttribute(operation: RcImageAttribute) {
@@ -944,6 +948,7 @@ public class RcPlayerState(
 
   public fun setInteger(id: Int, value: Int) {
     integers[id] = value
+    floats[id] = value.toFloat()
   }
 
   public fun setLong(id: Int, value: Long) {
@@ -960,7 +965,7 @@ public class RcPlayerState(
       variable.type == RcNamedVariable.COLOR_TYPE && value is RcNamedValue.Color ->
         colors[variable.id] = value.argb
       variable.type == RcNamedVariable.INT_TYPE && value is RcNamedValue.Integer ->
-        integers[variable.id] = value.value
+        setInteger(variable.id, value.value)
       variable.type == RcNamedVariable.LONG_TYPE && value is RcNamedValue.LongValue ->
         longs[variable.id] = value.value
       else ->

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
@@ -67,6 +67,18 @@ import kotlin.test.assertTrue
 
 class RcPlayerStateTest {
   @Test
+  fun integerValuesAlsoPopulateTheSharedFloatNamespace() {
+    val reference = RcFloatWord(0x7fc00000 or 51)
+    val state =
+      RcPlayerState(RcDocument(RcHeader(RcVersion(1, 0, 0)), listOf(RcIntegerConstant(51, 1))))
+
+    assertEquals(1f, state.resolve(reference))
+
+    state.setInteger(51, 7)
+    assertEquals(7f, state.resolve(reference))
+  }
+
+  @Test
   fun componentGeometryPublishesAllEightKindsAndConverges() {
     var invalidations = 0
     val bindings =


### PR DESCRIPTION
## Summary

- mirror every integer cache write into Remote Compose's shared float namespace
- route integer constants, expressions, ID lookups, data-map lookups, and named integer overrides through the same update path
- cover both document initialization and live integer updates

## Why

AndroidX `RemoteComposeState` stores an integer under both its integer and float maps. Float expressions can therefore reference an ID introduced by an integer operation. The CMP player kept the maps independent, so Home Assistant's Grid preview resolved integer-backed light state as inactive and painted active lights grey.

## Validation

- `./gradlew :rc-player-runtime:desktopTest :rc-player-runtime:ktfmtCheck`
- Home Assistant Grid rerender: Kitchen and Office now use the intended active yellow colors

This is intentionally separate from the Grid wrapping fix, which is caused by fractional physical-pixel padding rounding.
