### PR TITLE
fix(rc-player): preserve fractional pixel padding totals

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.requiredWidthIn
 import androidx.compose.foundation.layout.width
@@ -141,6 +140,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.offset
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import ee.schimke.composeai.rcplayer.protocol.RcAccessibilitySemantics
@@ -1570,11 +1570,11 @@ private fun Modifier.applyComponentModifiers(
             result.applyHeight(operation, state, density)
           }
         is RcPaddingModifier ->
-          result.padding(
-            start = state.dpTypedDp(state.resolve(operation.left), density),
-            top = state.dpTypedDp(state.resolve(operation.top), density),
-            end = state.dpTypedDp(state.resolve(operation.right), density),
-            bottom = state.dpTypedDp(state.resolve(operation.bottom), density),
+          result.rcPaddingPixels(
+            left = state.dpTypedPixels(state.resolve(operation.left), density),
+            top = state.dpTypedPixels(state.resolve(operation.top), density),
+            right = state.dpTypedPixels(state.resolve(operation.right), density),
+            bottom = state.dpTypedPixels(state.resolve(operation.bottom), density),
           )
         is RcOffsetModifier ->
           result.offset {
@@ -1633,6 +1633,31 @@ private fun Modifier.applyComponentModifiers(
   }
   return result
 }
+
+/**
+ * AndroidX keeps padding in physical pixels until measure, then rounds the combined inset on each
+ * axis. Compose's Dp padding rounds each edge independently, which adds a pixel whenever both wire
+ * edges end in .5 (for example 31.5px + 31.5px must occupy 63px, not 64px).
+ */
+private fun Modifier.rcPaddingPixels(
+  left: Float,
+  top: Float,
+  right: Float,
+  bottom: Float,
+): Modifier = layout { measurable, constraints ->
+  val safeLeft = left.coerceAtLeast(0f)
+  val safeTop = top.coerceAtLeast(0f)
+  val horizontal = rcCombinedPaddingPixels(left, right)
+  val vertical = rcCombinedPaddingPixels(top, bottom)
+  val placeable =
+    measurable.measure(constraints.offset(horizontal = -horizontal, vertical = -vertical))
+  val width = constraints.constrainWidth(placeable.width + horizontal)
+  val height = constraints.constrainHeight(placeable.height + vertical)
+  layout(width, height) { placeable.placeRelative(safeLeft.roundToInt(), safeTop.roundToInt()) }
+}
+
+internal fun rcCombinedPaddingPixels(first: Float, second: Float): Int =
+  (first.coerceAtLeast(0f) + second.coerceAtLeast(0f)).roundToInt()
 
 private fun Modifier.applyAndroidXClickAreas(
   areas: List<RcClickArea>,

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -1285,14 +1285,14 @@ class RcLayoutRenderTest {
   private fun paddedCanvas(componentId: Int, color: Int): List<RcOperation> =
     listOf(
       RcCanvasLayout(componentId, componentId * 10),
-      width(126f),
-      height(126f),
       RcPaddingModifier(
         RcFloatWord.literal(31.5f),
         RcFloatWord.literal(31.5f),
         RcFloatWord.literal(31.5f),
         RcFloatWord.literal(31.5f),
       ),
+      width(126f),
+      height(126f),
       RcNoArg(RcOpcodes.CANVAS_OPERATIONS),
       RcPaintData(listOf(4, color)),
       RcDraw4(

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -512,6 +512,44 @@ class RcLayoutRenderTest {
   }
 
   @Test
+  fun fractionalPixelPaddingDoesNotAccumulateIndependentEdgeRounding() {
+    val red = 0xffff0000.toInt()
+    val green = 0xff00ff00.toInt()
+    val blue = 0xff0000ff.toInt()
+    val yellow = 0xffffff00.toInt()
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(1, 1, 0), legacyWidth = 819, legacyHeight = 247, modern = false),
+        listOf<RcOperation>(
+          RcRootLayout(1),
+          RcLayoutContent(2),
+          RcFlowLayout(3, 30, 1, 4, RcFloatWord.literal(21f), Int.MAX_VALUE, Int.MAX_VALUE),
+          width(819f),
+          height(247f),
+          RcLayoutContent(4),
+        ) +
+          paddedCanvas(5, red) +
+          paddedCanvas(6, green) +
+          paddedCanvas(7, blue) +
+          paddedCanvas(8, yellow) +
+          List(4) { RcNoArg(RcOpcodes.CONTAINER_END) },
+      )
+    val scene =
+      ImageComposeScene(width = 819, height = 247, density = Density(2.625f)) {
+        RcComposePlayer(document)
+      }
+    try {
+      val bitmap = Bitmap().apply { allocN32Pixels(819, 247) }
+      check(scene.render().readPixels(bitmap))
+
+      assertEquals(63, rcCombinedPaddingPixels(31.5f, 31.5f))
+      assertEquals(yellow, bitmap.getColor(670, 50), "the fourth 189px card must not wrap")
+    } finally {
+      scene.close()
+    }
+  }
+
+  @Test
   fun coreTextRendersInheritedSparseStyle() {
     val document =
       RcDocument(
@@ -1239,6 +1277,30 @@ class RcLayoutRenderTest {
         RcFloatWord.literal(0f),
         RcFloatWord.literal(size),
         RcFloatWord.literal(size),
+      ),
+      RcNoArg(RcOpcodes.CONTAINER_END),
+      RcNoArg(RcOpcodes.CONTAINER_END),
+    )
+
+  private fun paddedCanvas(componentId: Int, color: Int): List<RcOperation> =
+    listOf(
+      RcCanvasLayout(componentId, componentId * 10),
+      width(126f),
+      height(126f),
+      RcPaddingModifier(
+        RcFloatWord.literal(31.5f),
+        RcFloatWord.literal(31.5f),
+        RcFloatWord.literal(31.5f),
+        RcFloatWord.literal(31.5f),
+      ),
+      RcNoArg(RcOpcodes.CANVAS_OPERATIONS),
+      RcPaintData(listOf(4, color)),
+      RcDraw4(
+        RcOpcodes.DRAW_RECT,
+        RcFloatWord.literal(0f),
+        RcFloatWord.literal(0f),
+        RcFloatWord.literal(126f),
+        RcFloatWord.literal(126f),
       ),
       RcNoArg(RcOpcodes.CONTAINER_END),
       RcNoArg(RcOpcodes.CONTAINER_END),


### PR DESCRIPTION
## Summary

- retain Remote Compose padding as physical pixels through measurement
- round the combined horizontal and vertical inset once, matching the float-based AndroidX layout model
- add a high-density Flow regression with four exact-fit cards and 31.5px edges

## Why

Home Assistant's Grid is 819px wide and emits four 189px cards separated by three 21px gaps: exactly 819px. Each card is a 126px body with 31.5px padding on both sides. Compose `Dp` padding rounds each edge to 32px, inflating every card to 190px and wrapping the fourth card. AndroidX accumulates the float padding before layout, so the pair remains 63px.

## Validation

- `./gradlew :rc-player-compose:desktopTest :rc-player-compose:ktfmtCheck`
- 108 Compose player tests pass
- focused regression verifies the fourth card stays on the first Flow row at density 2.625

## Stack

Merge #3628 first. PR #3630 was merged into #3628, so #3628 now supplies both the density semantics and modifier wire ordering required here. This branch has been rebased onto the repaired #3628 head and passes Compose desktop tests plus Wasm compilation.
