### PR TITLE
fix(rc-player): preserve AndroidX weighted row spacing

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -639,10 +639,19 @@ private fun RenderLayoutNode(
           theme = theme,
         )
       } else {
+        val hasWeightedChildren =
+          node.content.children.any { it.modifiers.width?.type == RcDimensionType.WEIGHT }
         Row(
           rowModifier,
           horizontalArrangement =
-            RcHorizontalArrangement(node.operation.horizontalPositioning, spacingDp),
+            RcHorizontalArrangement(
+              node.operation.horizontalPositioning,
+              visualSpacing = spacingDp,
+              // AndroidX measures weighted children from all remaining row space, then adds the
+              // configured gaps while positioning. Compose normally reserves those gaps before
+              // distributing weight, which makes every weighted child too narrow.
+              spacing = if (hasWeightedChildren) 0.dp else spacingDp,
+            ),
           verticalAlignment = rowAlignment(node.operation.verticalPositioning),
         ) {
           node.content.children.forEach { child ->
@@ -1433,8 +1442,11 @@ internal fun columnAlignment(horizontal: Int): Alignment.Horizontal =
     else -> error("Unknown AndroidX column horizontal position $horizontal")
   }
 
-private class RcHorizontalArrangement(private val positioning: Int, override val spacing: Dp) :
-  Arrangement.Horizontal {
+private class RcHorizontalArrangement(
+  private val positioning: Int,
+  private val visualSpacing: Dp,
+  override val spacing: Dp = visualSpacing,
+) : Arrangement.Horizontal {
   override fun Density.arrange(
     totalSize: Int,
     sizes: IntArray,
@@ -1445,7 +1457,7 @@ private class RcHorizontalArrangement(private val positioning: Int, override val
       totalSize,
       sizes,
       positioning,
-      spacing.roundToPx(),
+      visualSpacing.roundToPx(),
       reverse = layoutDirection == LayoutDirection.Rtl,
       outPositions = outPositions,
     )

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -129,6 +129,49 @@ class RcLayoutRenderTest {
   }
 
   @Test
+  fun weightedRowAddsSpacingAfterDistributingTheFullRemainingWidth() {
+    val red = 0xffff0000.toInt()
+    val child = { componentId: Int ->
+      listOf<RcOperation>(
+        RcBoxLayout(componentId, componentId * 10, 1, 4),
+        RcWidthModifier(RcDimensionType.WEIGHT, RcFloatWord.literal(1f)),
+        height(20f),
+        solidBackground(red = 1f, green = 0f, blue = 0f),
+        RcLayoutContent(componentId * 10 + 1),
+        RcNoArg(RcOpcodes.CONTAINER_END),
+        RcNoArg(RcOpcodes.CONTAINER_END),
+      )
+    }
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(1, 0, 0), legacyWidth = 100, legacyHeight = 20, modern = false),
+        listOf(
+          RcRootLayout(1),
+          RcLayoutContent(2),
+          RcRowLayout(3, 30, 1, 4, RcFloatWord.literal(8f)),
+          width(100f),
+          height(20f),
+          RcLayoutContent(4),
+        ) + child(5) + child(6) + child(7) + child(8) + List(4) { RcNoArg(RcOpcodes.CONTAINER_END) },
+      )
+    val scene =
+      ImageComposeScene(width = 100, height = 20, density = Density(1f)) {
+        RcComposePlayer(document)
+      }
+    try {
+      val bitmap = Bitmap().apply { allocN32Pixels(100, 20) }
+      check(scene.render(0L).readPixels(bitmap))
+
+      assertEquals(red, bitmap.getColor(24, 10), "each weight receives 25px")
+      assertEquals(0, bitmap.getColor(25, 10), "the 8px visual gap follows the first weight")
+      assertEquals(0, bitmap.getColor(95, 10), "the fourth child begins only after the third gap")
+      assertEquals(red, bitmap.getColor(99, 10), "the overflowing fourth child remains clipped")
+    } finally {
+      scene.close()
+    }
+  }
+
+  @Test
   fun paddingBeforeExactSizePositionsSubsequentPaint() {
     val document =
       RcDocument(


### PR DESCRIPTION
## Summary

- reproduce AndroidX `RowLayout` weight measurement when `spacedBy` is present
- distribute all remaining width to weighted children before adding visual gaps
- keep ordinary unweighted rows and Flow layouts unchanged
- add a pixel regression proving the final weighted child overflows and is clipped like AndroidX

## Why

AndroidX alpha16 measures weighted row children from the full remaining row width, then adds `spacedBy` during positioning. Compose `Row` normally reserves arrangement spacing before distributing weights, making each weighted child narrower. This is visible in the Home Assistant weather card's four equal-width extra-info panels.

## Test plan

- `./gradlew :rc-player-compose:desktopTest`
- focused Home Assistant Weather rerender: dark **1.98% → 0.95%**, light **6.51% → 1.13%**

## Stack

Merge #3628 first. PR #3630 was merged into #3628, so #3628 now supplies the modifier-order and density behavior this patch builds on. This branch has been rebased onto the repaired #3628 head and passes Compose desktop tests plus Wasm compilation.
