### PR TITLE
fix(layout): stabilize semantics property order

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1513,11 +1513,22 @@ internal object ComposeLayoutInspector {
       is String -> this
       is Number,
       is Boolean -> toString()
+      // SemanticsConfiguration.toString() delegates to an internal hash-based property map. Its
+      // iteration order can change between otherwise identical renderer processes, which made the
+      // published layout sidecar (and therefore its containing bundle) differ byte-for-byte. Keep
+      // the established map-like wire shape, but order entries by the stable property-key name.
+      is SemanticsConfiguration -> canonicalWireValue(this)
       // Compose's inspector frequently exposes lambdas and runtime objects. Their default
       // `toString()` includes a JVM identity hash (and generated lambdas also carry a VM address),
       // making an otherwise identical layout-inspector capture differ on every renderer process.
       else -> toString().canonicalizeJvmRuntimeIdentity()
     }
+
+  internal fun canonicalWireValue(configuration: SemanticsConfiguration): String =
+    configuration
+      .map { entry -> entry.key.name to entry.value.wireValue() }
+      .sortedBy { it.first }
+      .joinToString(prefix = "{", postfix = "}") { (key, value) -> "$key=$value" }
 
   private fun String.canonicalizeJvmRuntimeIdentity(): String =
     replace(

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/SemanticsConfigurationWireValueTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/SemanticsConfigurationWireValueTest.kt
@@ -1,0 +1,32 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsProperties
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SemanticsConfigurationWireValueTest {
+  @Test
+  fun `wire value is independent of semantics property insertion order`() {
+    val roleFirst =
+      SemanticsConfiguration().apply {
+        this[SemanticsProperties.Role] = Role.Image
+        this[SemanticsProperties.ContentDescription] = listOf("Mail")
+      }
+    val descriptionFirst =
+      SemanticsConfiguration().apply {
+        this[SemanticsProperties.ContentDescription] = listOf("Mail")
+        this[SemanticsProperties.Role] = Role.Image
+      }
+
+    assertEquals(
+      ComposeLayoutInspector.canonicalWireValue(roleFirst),
+      ComposeLayoutInspector.canonicalWireValue(descriptionFirst),
+    )
+    assertEquals(
+      "{ContentDescription=[Mail], Role=Image}",
+      ComposeLayoutInspector.canonicalWireValue(roleFirst),
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- serialize `SemanticsConfiguration` properties in stable key-name order
- preserve the existing map-like layout-inspector wire representation
- add a regression test proving insertion order cannot affect output

## Why

The v0.19.56 canonical inspection-sidecar work removed runtime identities, but a two-daemon M3 catalog capture still found one residual difference:

```
{Role=Image, ContentDescription=[Mail]}
{ContentDescription=[Mail], Role=Image}
```

The value came from `SemanticsConfiguration.toString()`, which iterates its internal hash-based property map. This fix canonicalizes the value at the producer boundary instead of heuristically rewriting arbitrary string content downstream.

## Verification

- `./gradlew :data-layoutinspector-connector:test --offline --no-daemon --console=plain`
- `./gradlew :cli:test --tests ee.schimke.composeai.cli.InspectionSidecarCanonicalizerTest --offline --no-daemon --console=plain`
- `./gradlew ktfmtFormatAll --offline --no-daemon --console=plain`
- `git diff --check`
- two sequential M3 bundle captures of `BadgesKt.NumberBadge_Light`, with distinct inspection classloaders (`35627dc0`, `62cdd6e1`)
  - both bundles: 1,738,028 bytes
  - both SHA-256: `ed06f6e7a91ba5acd50028446d73149d25a45954705654397762012b48397b87`
  - full bundle `cmp`: identical
  - extracted bundle diff: no differences

Follow-up to #3622 / #3624 release verification.