### PR TITLE
fix(layout): canonicalize semantics property values

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1516,7 +1516,7 @@ internal object ComposeLayoutInspector {
       // SemanticsConfiguration.toString() delegates to an internal hash-based property map. Its
       // iteration order can change between otherwise identical renderer processes, which made the
       // published layout sidecar (and therefore its containing bundle) differ byte-for-byte. Keep
-      // the established map-like wire shape, but order entries by the stable property-key name.
+      // the established map-like wire shape, but order entries by canonical key/value content.
       is SemanticsConfiguration -> canonicalWireValue(this)
       // Compose's inspector frequently exposes lambdas and runtime objects. Their default
       // `toString()` includes a JVM identity hash (and generated lambdas also carry a VM address),
@@ -1526,9 +1526,10 @@ internal object ComposeLayoutInspector {
 
   internal fun canonicalWireValue(configuration: SemanticsConfiguration): String =
     configuration
-      .map { entry -> entry.key.name to entry.value.wireValue() }
-      .sortedBy { it.first }
+      .map { entry -> entry.key.name to entry.value.wireValue().canonicalizeJvmRuntimeIdentity() }
+      .sortedWith(compareBy<Pair<String, String>>({ it.first }, { it.second }))
       .joinToString(prefix = "{", postfix = "}") { (key, value) -> "$key=$value" }
+      .canonicalizeJvmRuntimeIdentity()
 
   private fun String.canonicalizeJvmRuntimeIdentity(): String =
     replace(

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/SemanticsConfigurationWireValueTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/SemanticsConfigurationWireValueTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -28,5 +29,42 @@ class SemanticsConfigurationWireValueTest {
       "{ContentDescription=[Mail], Role=Image}",
       ComposeLayoutInspector.canonicalWireValue(roleFirst),
     )
+  }
+
+  @Test
+  fun `wire value canonicalizes runtime identities inside string properties`() {
+    val custom = SemanticsPropertyKey<String>("Custom")
+    val first = SemanticsConfiguration().apply { this[custom] = "example.Value@1234abcd" }
+    val second = SemanticsConfiguration().apply { this[custom] = "example.Value@8765dcba" }
+
+    assertEquals(
+      ComposeLayoutInspector.canonicalWireValue(first),
+      ComposeLayoutInspector.canonicalWireValue(second),
+    )
+    assertEquals(
+      "{Custom=example.Value@<identity>}",
+      ComposeLayoutInspector.canonicalWireValue(first),
+    )
+  }
+
+  @Test
+  fun `wire value uses property value to break duplicate name ties`() {
+    val firstKey = SemanticsPropertyKey<String>("Flag")
+    val secondKey = SemanticsPropertyKey<String>("Flag")
+    val configuration =
+      SemanticsConfiguration().apply {
+        this[firstKey] = "initial-a"
+        this[secondKey] = "initial-b"
+      }
+    val firstValueInIterationOrder = configuration.first().value
+    if (firstValueInIterationOrder == "initial-a") {
+      configuration[firstKey] = "b"
+      configuration[secondKey] = "a"
+    } else {
+      configuration[firstKey] = "a"
+      configuration[secondKey] = "b"
+    }
+
+    assertEquals("{Flag=a, Flag=b}", ComposeLayoutInspector.canonicalWireValue(configuration))
   }
 }


### PR DESCRIPTION
## Summary

- canonicalize JVM runtime identities inside emitted semantics property values
- sort semantics entries by key name and canonicalized value, making duplicate key names deterministic
- add focused regressions for both review cases

## Context

Follow-up to the two unresolved review comments on #3637:

1. string-valued semantics properties bypassed producer-level identity canonicalization
2. distinct custom semantics keys with the same name had no deterministic value tie-breaker

The completed representation is canonicalized as a final guard while the canonicalized value participates in sorting.

## Verification

- `./gradlew :data-layoutinspector-connector:test --offline --no-daemon --console=plain`
- `./gradlew :data-layoutinspector-connector:ktfmtCheck --offline --no-daemon --console=plain`
- `git diff --check`
- two sequential M3 bundle captures of `BadgesKt.NumberBadge_Light`, with distinct inspection classloaders (`3b95b809`, `3ae72722`)
  - both bundles: 1,738,028 bytes
  - both SHA-256: `ed06f6e7a91ba5acd50028446d73149d25a45954705654397762012b48397b87`
  - full bundle `cmp`: identical