### PR TITLE
feat(bundle): add opt-in shared classpath hydration

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -103,7 +103,7 @@ on:
         type: boolean
         default: false
       split-mode:
-        description: "Per-preview split mode when split-per-preview is set: 'full' (each bundle carries its re-render classpath from the externalised liveBundle — a desktop/live tier; requires publish-live-bundle) or 'view-only' (baked, no classpath, split from the raw render — an Android/baked tier)."
+        description: "Per-preview split mode when split-per-preview is set: 'full' (self-contained), 'full-shared-classpath' (opt-in: app.jar once in bundle/res and server-hydrated), or 'view-only' (baked, no classpath). Live modes require publish-live-bundle."
         required: false
         type: string
         default: 'full'
@@ -994,6 +994,10 @@ jobs:
           set -euo pipefail
           if [ "${{ inputs.split-mode }}" = "view-only" ]; then
             compose-preview bundle split "$GITHUB_WORKSPACE/bundle.png" --view-only \
+              -o "$GITHUB_WORKSPACE/out/bundle/previews"
+          elif [ "${{ inputs.split-mode }}" = "full-shared-classpath" ]; then
+            compose-preview bundle split "$GITHUB_WORKSPACE/bundle.png" \
+              --shared-classpath-out "$GITHUB_WORKSPACE/out/bundle/res" \
               -o "$GITHUB_WORKSPACE/out/bundle/previews"
           else
             compose-preview bundle split "$GITHUB_WORKSPACE/out/bundle/bundle.png" \

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -514,16 +514,21 @@ jobs:
         env:
           SYSTEM: ${{ matrix.system }}
           EXTRA_RENDERS: ${{ matrix.androidExtraModule }}
-          # FULL for any live-bundle tier (the CMP wasm row + an androidLiveBundle row),
-          # so each per-preview bundle carries its re-render classpath; --view-only for
-          # baked-only tiers.
-          SPLIT_MODE: ${{ (matrix.wasmModule != '' || matrix.androidLiveBundle == '1') && 'full' || 'view-only' }}
+          # The shared-classpath live tier publishes app.jar once under bundle/res/ and lets serve
+          # hydrate executable downloads. Baked-only tiers remain view-only.
+          SPLIT_MODE: ${{ (matrix.wasmModule != '' || matrix.androidLiveBundle == '1') && 'full-shared-classpath' || 'view-only' }}
         run: |
           set -euo pipefail
           view_only_flag=""
           split_source="$GITHUB_WORKSPACE/$SYSTEM-bundle.png"
           if [ "$SPLIT_MODE" = "view-only" ]; then
             view_only_flag="--view-only"
+          elif [ "$SPLIT_MODE" = "full-shared-classpath" ]; then
+            compose-preview bundle split "$GITHUB_WORKSPACE/$SYSTEM-bundle.png" \
+              --shared-classpath-out "$GITHUB_WORKSPACE/out/bundle/res" \
+              -o "$GITHUB_WORKSPACE/out/bundle/previews"
+            # The shared mode is complete; skip the legacy full-mode command below.
+            split_source=""
           else
             # FULL: split the EXTERNALISED live bundle the generate step already produced under
             # out/bundle/ (fonts lifted to bundle/res/<sha>), not the raw sheet. Splitting the raw
@@ -533,8 +538,10 @@ jobs:
             # the shared-pool font references, so `serve` rehydrates fonts from bundle/res once.
             split_source="$GITHUB_WORKSPACE/out/bundle/$SYSTEM-bundle.png"
           fi
-          compose-preview bundle split "$split_source" $view_only_flag \
-            -o "$GITHUB_WORKSPACE/out/bundle/previews"
+          if [ -n "$split_source" ]; then
+            compose-preview bundle split "$split_source" $view_only_flag \
+              -o "$GITHUB_WORKSPACE/out/bundle/previews"
+          fi
           # For compose-m3 the catalog also folds an Android-only supplement (the material3 inset
           # focus ring CMP can't draw), whose renders/semantics override same-named CMP functions in
           # the published catalog. Split it into the same dir so those override renders are published

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleClasspathHydration.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleClasspathHydration.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import java.security.MessageDigest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/** Restore opt-in shared classpath entries into a self-contained executable bundle. */
+internal object BundleClasspathHydration {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /**
+   * Hydrate [source] into [output]. Every declared blob is size/hash verified before it is
+   * injected. The external declaration and any now-stale producer signatures are removed from the
+   * derivative.
+   */
+  fun hydrate(
+    source: File,
+    output: File,
+    fileSystem: FileSystem = SystemFileSystem,
+    resolve: (BundleReader.ExternalClasspath) -> ByteArray?,
+  ): File {
+    val metadata = BundleReader.readMetadata(source)
+    val external = metadata.manifest.externalClasspath
+    output.parentFile?.mkdirs()
+    if (fileSystem.exists(output.path.toPath())) fileSystem.delete(output.path.toPath())
+    fileSystem.copy(source.path.toPath(), output.path.toPath())
+    if (external.isEmpty()) return output
+
+    val additions = LinkedHashMap<String, ByteArray>()
+    for (entry in external) {
+      require(entry.path == "classes/app.jar") {
+        "unsupported external classpath path '${entry.path}'"
+      }
+      require(entry.sha256.length == 64 && entry.sha256.all { it in '0'..'9' || it in 'a'..'f' }) {
+        "external classpath sha256 '${entry.sha256}' is malformed"
+      }
+      val bytes =
+        checkNotNull(resolve(entry)) {
+          "external classpath ${entry.path} (${entry.sha256}) is unavailable"
+        }
+      check(bytes.size.toLong() == entry.size) {
+        "external classpath ${entry.path}: ${bytes.size} bytes != declared ${entry.size}"
+      }
+      check(sha256Hex(bytes) == entry.sha256) {
+        "external classpath ${entry.path}: sha256 mismatch"
+      }
+      additions[entry.path] = bytes
+    }
+
+    val zip = BundleReader.extractZipBytes(source)
+    val manifest =
+      readZipEntry(zip, "bundle.json") ?: error("bundle.json missing in ${source.path}")
+    val root = json.parseToJsonElement(manifest.decodeToString()) as JsonObject
+    additions["bundle.json"] =
+      JsonObject(root.toMutableMap().apply { remove("externalClasspath") })
+        .toString()
+        .encodeToByteArray()
+    rewriteRawZipEntries(
+      output,
+      additions,
+      removals = setOf(BundleSigning.SIGNATURES_PATH),
+      fileSystem = fileSystem,
+    )
+    return output
+  }
+
+  private fun readZipEntry(zip: ByteArray, wanted: String): ByteArray? {
+    java.util.zip.ZipInputStream(java.io.ByteArrayInputStream(zip)).use { input ->
+      while (true) {
+        val entry = input.nextEntry ?: return null
+        if (!entry.isDirectory && entry.name == wanted) return input.readBytes()
+        input.closeEntry()
+      }
+    }
+  }
+
+  private fun sha256Hex(bytes: ByteArray): String =
+    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -106,7 +106,7 @@ class BundleCommand(args: List<String>) : Command(args) {
       Usage:
         compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render] [--with-semantics]
         compose-preview bundle pack --per-preview [--module <name>] [--id <preview>...] [-o <dir>]
-        compose-preview bundle split   <sheet.png | URL> -o <dir> [--view-only]
+        compose-preview bundle split   <sheet.png | URL> -o <dir> [--view-only | --shared-classpath-out <pool>]
         compose-preview bundle inspect <bundle.png | URL>
         compose-preview bundle extract <bundle.png | URL> [-o <dir>]
         compose-preview bundle embed   <bundle.png | URL> [-o <dir|file.png>] [--title T] [--external-images] [--in-bundle]
@@ -191,6 +191,12 @@ class BundleCommand(args: List<String>) : Command(args) {
                             (larger — the shared jars repeat per preview). A sheet packed
                             --with-semantics yields per-preview bundles that carry their semantics,
                             with no daemon or re-render.
+        --shared-classpath-out <pool-dir>
+                            Opt-in live mode: publish classes/app.jar once as <pool>/<sha256> and
+                            record that content-addressed entry in every split bundle. The preview
+                            server hydrates it for daemon execution and executable downloads. The
+                            existing full mode remains self-contained. Cannot combine with
+                            --view-only.
 
       Inspect / extract / render flags:
         -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.
@@ -1772,6 +1778,25 @@ internal fun injectRawZipEntries(
   return entries.size
 }
 
+/** Replace and remove raw zip entries while preserving the bundle's leading PNG cover. */
+internal fun rewriteRawZipEntries(
+  bundleFile: File,
+  entries: Map<String, ByteArray>,
+  removals: Set<String>,
+  fileSystem: FileSystem = SystemFileSystem,
+) {
+  val full = fileSystem.read(bundleFile.path.toPath()) { readByteArray() }
+  val zip = BundleReader.extractZipBytes(bundleFile, fileSystem)
+  val prefix = full.copyOfRange(0, full.size - zip.size)
+  val newZip = addOrReplaceZipEntries(zip, entries, removals)
+  val tmp = File(bundleFile.parentFile, "${bundleFile.name}.rewrite-tmp")
+  fileSystem.write(tmp.path.toPath()) {
+    write(prefix)
+    write(newZip)
+  }
+  fileSystem.atomicMove(tmp.path.toPath(), bundleFile.path.toPath())
+}
+
 /**
  * Return a copy of [existingZip] with [newEntries] (path → bytes) added, replacing any existing
  * entry with the same name (so the operation is idempotent). Every other original entry is
@@ -1781,13 +1806,14 @@ internal fun injectRawZipEntries(
 internal fun addOrReplaceZipEntries(
   existingZip: ByteArray,
   newEntries: Map<String, ByteArray>,
+  removedEntries: Set<String> = emptySet(),
 ): ByteArray {
   val baos = ByteArrayOutputStream()
   ZipOutputStream(baos).use { zout ->
     ZipInputStream(ByteArrayInputStream(existingZip)).use { zin ->
       while (true) {
         val entry = zin.nextEntry ?: break
-        if (!entry.isDirectory && entry.name !in newEntries) {
+        if (!entry.isDirectory && entry.name !in newEntries && entry.name !in removedEntries) {
           zout.putNextEntry(ZipEntry(entry.name).apply { time = ZIP_DOS_EPOCH_MS })
           zin.copyTo(zout)
           zout.closeEntry()
@@ -1943,10 +1969,14 @@ internal object BundleReader {
      * in `PreviewBundleFormat.kt`.
      */
     val externalResources: List<ExternalResource> = emptyList(),
+    /** Whole classpath entries supplied by the sibling content-addressed pool. */
+    val externalClasspath: List<ExternalClasspath> = emptyList(),
   )
 
   /** v8 mirror of `BundleExternalResource` in `PreviewBundleFormat.kt`. */
   @Serializable data class ExternalResource(val path: String, val sha256: String, val size: Long)
+
+  @Serializable data class ExternalClasspath(val path: String, val sha256: String, val size: Long)
 
   /** v7+ mirror of `BundleDataExtension` in `PreviewBundleFormat.kt`. */
   @Serializable data class DataExtension(val extensionId: String, val path: String)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
@@ -9,6 +9,7 @@ import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.security.MessageDigest
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
@@ -44,8 +45,12 @@ import kotlinx.serialization.json.jsonPrimitive
  */
 internal enum class SplitMode {
   FULL,
+  FULL_SHARED_CLASSPATH,
   VIEW_ONLY,
 }
+
+/** One whole bundle entry published once into the split output's content-addressed pool. */
+internal data class SharedClasspathEntry(val path: String, val sha256: String, val size: Long)
 
 /**
  * One split output: the preview id, its cover PNG (polyglot leading bytes), and the appended zip.
@@ -112,6 +117,7 @@ internal fun forEachSplitPreview(
   sheetZip: ByteArray,
   mode: SplitMode,
   crop: Boolean = true,
+  onSharedClasspath: (SharedClasspathEntry, ByteArray) -> Unit = { _, _ -> },
   onPreview: (SplitPreview) -> Unit,
 ): Int {
   val entries = readZipEntries(sheetZip)
@@ -141,13 +147,34 @@ internal fun forEachSplitPreview(
   // renders the `⟦res 0x7f…⟧` placeholder — which only surfaces once an override forces a live
   // per-preview re-render (a plain browse serves the baked PNG/SVG), so a per-variant knob edit
   // on a Wear/Android sticker showed the placeholder instead of the real label.
-  val shared = entries.filterKeys {
-    it == "classes/app.jar" ||
-      it.startsWith("libs/") ||
-      it == "report.json" ||
-      it.startsWith("android/")
-  }
-  val fullMode = mode == SplitMode.FULL
+  val sharedClasspath =
+    if (mode == SplitMode.FULL_SHARED_CLASSPATH) {
+      entries["classes/app.jar"]?.let { bytes ->
+        SharedClasspathEntry(
+            path = "classes/app.jar",
+            sha256 =
+              MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") {
+                "%02x".format(it)
+              },
+            size = bytes.size.toLong(),
+          )
+          .also { onSharedClasspath(it, bytes) }
+      }
+    } else {
+      null
+    }
+  val shared =
+    entries
+      .filterKeys {
+        it == "classes/app.jar" ||
+          it.startsWith("libs/") ||
+          it == "report.json" ||
+          it.startsWith("android/")
+      }
+      .let { carriage ->
+        if (mode == SplitMode.FULL_SHARED_CLASSPATH) carriage - "classes/app.jar" else carriage
+      }
+  val fullMode = mode != SplitMode.VIEW_ONLY
 
   var emitted = 0
   for (id in ids) {
@@ -196,7 +223,10 @@ internal fun forEachSplitPreview(
     }
 
     out["bundle.json"] =
-      SPLIT_JSON.encodeToString(JsonObject.serializer(), perPreviewManifest(manifest, id, fullMode))
+      SPLIT_JSON.encodeToString(
+          JsonObject.serializer(),
+          perPreviewManifest(manifest, id, fullMode, sharedClasspath),
+        )
         .encodeToByteArray()
     out["previews.json"] =
       SPLIT_JSON.encodeToString(
@@ -212,55 +242,73 @@ internal fun forEachSplitPreview(
 }
 
 /** Rewrite the sheet manifest for a single preview: cover + previewIds = [id], IR filtered, etc. */
-private fun perPreviewManifest(manifest: JsonObject, id: String, fullMode: Boolean): JsonObject =
-  buildJsonObject {
-    for ((key, value) in manifest) {
-      when (key) {
-        "previewIds" -> put(key, buildJsonArray { add(JsonPrimitive(id)) })
-        // Keep the raw-id list parallel to previewIds: subset to this preview's raw id (same
-        // index in the source lists), falling back to the bundle id when the source bundle
-        // predates the field or the lists disagree.
-        "rawPreviewIds" -> {
-          val bundleIds =
-            manifest["previewIds"]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
-          val raws = value.jsonArray.map { it.jsonPrimitive.content }
-          val raw = bundleIds.indexOf(id).takeIf { it in raws.indices }?.let { raws[it] } ?: id
-          put(key, buildJsonArray { add(JsonPrimitive(raw)) })
-        }
-        "coverPreviewId" -> put(key, JsonPrimitive(id))
-        // View-only carries no re-render classpath, so record that honestly.
-        "classpath" -> put(key, if (fullMode) value else JsonArray(emptyList()))
-        "resolution" -> put(key, if (fullMode) value else JsonPrimitive("view-only"))
-        // The Android app-resource carriage rides the FULL re-render set (the `android/` entries
-        // copied above); a VIEW_ONLY bundle ships none of it, so drop the manifest pointer too
-        // rather than advertise a `resources.ap_` table the zip doesn't carry (mirrors emptying
-        // `classpath`). A FULL bundle keeps the pointer, now backed by the carried `android/`
-        // files.
-        "androidResources" -> if (fullMode) put(key, value)
-        // Keep only this preview's intermediate representation (empty for classpath-backed
-        // previews).
-        "intermediateRepresentations" ->
-          put(
-            key,
-            buildJsonArray {
-              value.jsonArray
-                .filter { it.jsonObject["previewId"]?.jsonPrimitive?.content == id }
-                .forEach { add(it) }
-            },
-          )
-        // Data-extension reports in a sheet are sliced to the sheet's cover, not this preview —
-        // drop
-        // them rather than carry another preview's data.
-        "dataExtensions" -> {}
-        else -> put(key, value)
+private fun perPreviewManifest(
+  manifest: JsonObject,
+  id: String,
+  fullMode: Boolean,
+  sharedClasspath: SharedClasspathEntry? = null,
+): JsonObject = buildJsonObject {
+  for ((key, value) in manifest) {
+    when (key) {
+      "previewIds" -> put(key, buildJsonArray { add(JsonPrimitive(id)) })
+      // Keep the raw-id list parallel to previewIds: subset to this preview's raw id (same
+      // index in the source lists), falling back to the bundle id when the source bundle
+      // predates the field or the lists disagree.
+      "rawPreviewIds" -> {
+        val bundleIds =
+          manifest["previewIds"]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+        val raws = value.jsonArray.map { it.jsonPrimitive.content }
+        val raw = bundleIds.indexOf(id).takeIf { it in raws.indices }?.let { raws[it] } ?: id
+        put(key, buildJsonArray { add(JsonPrimitive(raw)) })
       }
-    }
-    // Ensure view-only fields exist even if the sheet manifest omitted them.
-    if (!fullMode) {
-      if ("classpath" !in manifest) put("classpath", JsonArray(emptyList()))
-      if ("resolution" !in manifest) put("resolution", JsonPrimitive("view-only"))
+      "coverPreviewId" -> put(key, JsonPrimitive(id))
+      // View-only carries no re-render classpath, so record that honestly.
+      "classpath" -> put(key, if (fullMode) value else JsonArray(emptyList()))
+      "resolution" -> put(key, if (fullMode) value else JsonPrimitive("view-only"))
+      // The Android app-resource carriage rides the FULL re-render set (the `android/` entries
+      // copied above); a VIEW_ONLY bundle ships none of it, so drop the manifest pointer too
+      // rather than advertise a `resources.ap_` table the zip doesn't carry (mirrors emptying
+      // `classpath`). A FULL bundle keeps the pointer, now backed by the carried `android/`
+      // files.
+      "androidResources" -> if (fullMode) put(key, value)
+      // Keep only this preview's intermediate representation (empty for classpath-backed
+      // previews).
+      "intermediateRepresentations" ->
+        put(
+          key,
+          buildJsonArray {
+            value.jsonArray
+              .filter { it.jsonObject["previewId"]?.jsonPrimitive?.content == id }
+              .forEach { add(it) }
+          },
+        )
+      // Data-extension reports in a sheet are sliced to the sheet's cover, not this preview —
+      // drop
+      // them rather than carry another preview's data.
+      "dataExtensions" -> {}
+      else -> put(key, value)
     }
   }
+  // Ensure view-only fields exist even if the sheet manifest omitted them.
+  if (!fullMode) {
+    if ("classpath" !in manifest) put("classpath", JsonArray(emptyList()))
+    if ("resolution" !in manifest) put("resolution", JsonPrimitive("view-only"))
+  }
+  if (sharedClasspath != null) {
+    put(
+      "externalClasspath",
+      buildJsonArray {
+        add(
+          buildJsonObject {
+            put("path", JsonPrimitive(sharedClasspath.path))
+            put("sha256", JsonPrimitive(sharedClasspath.sha256))
+            put("size", JsonPrimitive(sharedClasspath.size))
+          }
+        )
+      },
+    )
+  }
+}
 
 /** Filter `previews.json` down to the single preview [id]. */
 private fun perPreviewPreviews(
@@ -434,13 +482,24 @@ internal class SplitSubcommand(private val args: List<String>) {
   fun run() {
     val path = args.firstOrNull { !it.startsWith("-") }
     val outDirArg = args.flagValue("--output") ?: args.flagValue("-o")
-    val mode = if ("--view-only" in args) SplitMode.VIEW_ONLY else SplitMode.FULL
+    val sharedClasspathOut = args.flagValue("--shared-classpath-out")
+    if ("--view-only" in args && sharedClasspathOut != null) {
+      System.err.println("bundle split: --view-only cannot be combined with --shared-classpath-out")
+      exitProcess(64)
+    }
+    val mode =
+      when {
+        "--view-only" in args -> SplitMode.VIEW_ONLY
+        sharedClasspathOut != null -> SplitMode.FULL_SHARED_CLASSPATH
+        else -> SplitMode.FULL
+      }
     // Content-crop each sticker's PNG to its component box by default (tight importable stickers);
     // `--no-crop` keeps the full render canvas.
     val crop = "--no-crop" !in args
     if (path == null) {
       System.err.println(
-        "Usage: compose-preview bundle split <bundle.png | URL> -o <dir> [--view-only] [--no-crop]"
+        "Usage: compose-preview bundle split <bundle.png | URL> -o <dir> " +
+          "[--view-only | --shared-classpath-out <pool-dir>] [--no-crop]"
       )
       exitProcess(64)
     }
@@ -464,13 +523,30 @@ internal class SplitSubcommand(private val args: List<String>) {
     // collision append -2/-3/… so every preview keeps its own file instead of silently overwriting.
     val usedStems = HashSet<String>()
     val written = ArrayList<File>()
+    val sharedPool = sharedClasspathOut?.let(::File)?.absoluteFile
     // Write each bundle as it is produced and let it go. Collecting them first meant holding every
     // per-preview bundle — each carrying the shared classpath + Android resource table — in memory
     // simultaneously, which OOM'd on a 181-preview catalog. Only the File handles are kept, for the
     // size summary below.
     val emitted =
       try {
-        forEachSplitPreview(zipBytes, mode, crop = crop) { preview ->
+        forEachSplitPreview(
+          zipBytes,
+          mode,
+          crop = crop,
+          onSharedClasspath = { entry, bytes ->
+            val pool = checkNotNull(sharedPool)
+            pool.mkdirs()
+            val target = File(pool, entry.sha256)
+            if (target.isFile) {
+              check(target.length() == entry.size && target.readBytes().contentEquals(bytes)) {
+                "content-addressed pool collision at ${target.path}"
+              }
+            } else {
+              target.writeBytes(bytes)
+            }
+          },
+        ) { preview ->
           val base = sanitizeSplitFileName(preview.id)
           var stem = base
           var n = 1
@@ -497,7 +573,11 @@ internal class SplitSubcommand(private val args: List<String>) {
     val total = sizes.sum()
     println(
       "bundle split — wrote ${written.size} bundle(s) to ${outDir.path} " +
-        "(${if (mode == SplitMode.VIEW_ONLY) "view-only" else "full"})\n" +
+        "(${when (mode) {
+          SplitMode.VIEW_ONLY -> "view-only"
+          SplitMode.FULL -> "full"
+          SplitMode.FULL_SHARED_CLASSPATH -> "full-shared-classpath"
+        }})\n" +
         "  total:   $total bytes\n" +
         "  size:    min ${sizes.minOrNull() ?: 0} / avg ${if (written.isNotEmpty()) total / written.size else 0} / max ${sizes.maxOrNull() ?: 0} bytes"
     )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -143,6 +143,8 @@ internal object CliFlags {
       // bundle externalize
       "--res-out",
       "--ext",
+      // bundle split — content-addressed pool dir for the opt-in shared app classpath
+      "--shared-classpath-out",
       // bundle render — repeatable theme override (theme.colors=scheme:…) applied via the daemon
       "--knob",
       // bundle render — content-addressed pool dir for a published bundle's externalized resources

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1108,6 +1108,7 @@ class ServeCommand(args: List<String>) : Command(args) {
               live = daemon,
               baked = fallback(),
               perPreviewResolve = state.perPreviewResolve,
+              executableBundleProvider = state.executableBundleProvider,
               perPreviewStreamCount = state.perPreviewStreamCount,
               perPreviewRenderStats = state.perPreviewRenderStats,
               perPreviewPoolStats = state.perPreviewPoolStats,
@@ -2698,6 +2699,9 @@ class ServeCommand(args: List<String>) : Command(args) {
           previewAliases = alias,
           bakedFallback = bakedFallback,
           perPreviewResolve = perPreviewPool::get,
+          executableBundleProvider = { daemonId ->
+            fetchPerPreviewBundle(daemonId)?.takeIf(File::isFile)?.readBytes()
+          },
           perPreviewStreamCount = perPreviewPool::activeStreamCount,
           perPreviewRenderStats = perPreviewPool::renderPerfStats,
           perPreviewPoolStats = { listOf(perPreviewPool.snapshot()) },

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -67,6 +67,8 @@ class ServeCatalogLiveHost(
    * per-preview lane, leaving the plain monolithic-only host.
    */
   private val perPreviewResolve: ((daemonId: String) -> ServeHost?)? = null,
+  /** Hydrated per-preview bundle bytes for the viewer's executable download lane. */
+  private val executableBundleProvider: ((daemonId: String) -> ByteArray?)? = null,
   /** Live upstream stream count across the pooled per-preview daemons (supplied by the pool). */
   private val perPreviewStreamCount: () -> Int = { 0 },
   /**
@@ -142,6 +144,11 @@ class ServeCatalogLiveHost(
     System.getProperty("composeai.serve.eagerWarmOnOpen")?.toBooleanStrictOrNull() ?: false,
   private val clock: () -> Long = System::currentTimeMillis,
 ) : ServeHost {
+  override fun canDownloadExecutableBundle(previewId: String): Boolean =
+    executableBundleProvider != null && alias[previewId] != null
+
+  override fun executableBundle(previewId: String): ByteArray? =
+    alias[previewId]?.let { executableBundleProvider?.invoke(it) }
 
   /**
    * Browse + snapshot surface is the baked catalog — its ids are the published catalog ids. The

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.BundleClasspathHydration
 import ee.schimke.composeai.cli.BundleReader
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
@@ -1024,8 +1025,55 @@ class ServeCatalogStore(
       return null
     }
     target.parentFile?.mkdirs()
-    target.writeBytes(bytes)
-    return target
+    val thin = File(previewsDir, "$stem.shared.png")
+    thin.writeBytes(bytes)
+    val hydrated =
+      runCatching {
+          BundleClasspathHydration.hydrate(thin, target) { entry ->
+            fetchExternalClasspathBlob(entry, base, prefix, system)
+          }
+        }
+        .onFailure {
+          System.err.println(
+            "serve: $system per-preview '$stem' classpath hydration failed (${it.message})"
+          )
+        }
+        .getOrNull()
+    thin.delete()
+    return hydrated
+  }
+
+  /** Fetch and verify one whole classpath entry into the shared content-addressed cache. */
+  private fun fetchExternalClasspathBlob(
+    entry: BundleReader.ExternalClasspath,
+    base: String,
+    bundlePathPrefix: String,
+    system: String,
+  ): ByteArray? {
+    val sha = entry.sha256
+    if (
+      entry.path != "classes/app.jar" ||
+        entry.size <= 0 ||
+        entry.size > MAX_LIVE_BUNDLE_FETCH_BYTES ||
+        sha.length != 64 ||
+        sha.any { it !in '0'..'9' && it !in 'a'..'f' }
+    ) {
+      System.err.println("serve: $system external classpath declaration is invalid — skipping")
+      return null
+    }
+    val cached = File(File(root, RES_CACHE_DIR).apply { mkdirs() }, sha)
+    val cachedBytes = cached.takeIf { it.isFile && it.length() == entry.size }?.readBytes()
+    if (cachedBytes != null && sha256Hex(cachedBytes) == sha) return cachedBytes
+
+    val prefix = bundlePathPrefix.trim('/')
+    val url = if (prefix.isEmpty()) "$base$RES_POOL_DIR/$sha" else "$base$prefix/$RES_POOL_DIR/$sha"
+    val bytes = runCatching { fetchExecutableBundle(url) }.getOrNull() ?: return null
+    if (bytes.size.toLong() != entry.size || sha256Hex(bytes) != sha) {
+      System.err.println("serve: $system external classpath verification failed ($url)")
+      return null
+    }
+    cached.writeBytes(bytes)
+    return bytes
   }
 
   /** Filesystem/route-safe stem for a per-preview id (mirrors `bundle split`'s sanitiser). */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -17,6 +17,12 @@ interface ServeHost : AutoCloseable {
   /** The whole servable preview set for this session. */
   val previews: List<ServePreview>
 
+  /** Whether the server can return a self-contained executable bundle for this preview. */
+  fun canDownloadExecutableBundle(previewId: String): Boolean = false
+
+  /** A hydrated, self-contained PNG+ZIP preview bundle, or null when this host has no such lane. */
+  fun executableBundle(previewId: String): ByteArray? = null
+
   /** Independently-authored design references mapped to [previewId], if this host carries any. */
   fun designReferencesFor(previewId: String): List<DesignReference> = emptyList()
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -824,6 +824,8 @@ class ServeHttpServer(
 
         get("/bundle.zip") { handleBundleZip(sessionInPath = false) }
         get("/{system}/bundle.zip") { handleBundleZip(sessionInPath = true) }
+        get("/bundle/{name}") { handleExecutableBundle(sessionInPath = false) }
+        get("/{system}/bundle/{name}") { handleExecutableBundle(sessionInPath = true) }
 
         get("/p/{name}") { handleViewer(sessionInPath = false) }
         get("/{system}/p/{name}") { handleViewer(sessionInPath = true) }
@@ -3150,6 +3152,31 @@ class ServeHttpServer(
     }
   }
 
+  /** Return one server-hydrated, self-contained executable PNG+ZIP preview bundle. */
+  private suspend fun RoutingContext.handleExecutableBundle(sessionInPath: Boolean) {
+    if (rejectBadToken()) return
+    withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
+      val previewId = call.parameters["name"]
+      if (previewId == null || !renderHost.canDownloadExecutableBundle(previewId)) {
+        call.respondText("executable bundle unavailable", status = HttpStatusCode.NotFound)
+        return@withLeasedSession
+      }
+      val bytes = withContext(Dispatchers.IO) { renderHost.executableBundle(previewId) }
+      if (bytes == null) {
+        call.respondText("executable bundle unavailable", status = HttpStatusCode.NotFound)
+        return@withLeasedSession
+      }
+      val filename =
+        previewId.map { if (it.isLetterOrDigit() || it in "._-") it else '_' }.joinToString("") +
+          ".png"
+      call.response.headers.append(
+        HttpHeaders.ContentDisposition,
+        "attachment; filename=\"$filename\"",
+      )
+      call.respondBytes(bytes, ContentType.Image.PNG)
+    }
+  }
+
   /** `GET /p/{name}` (query) and `GET /{system}/p/{name}` (path): one preview's viewer page. */
   private suspend fun RoutingContext.handleViewer(sessionInPath: Boolean) {
     if (rejectBadToken()) return
@@ -3260,6 +3287,10 @@ class ServeHttpServer(
           // flag.
           hasSvgExport = renderHost.hasSvgExportFor(preview.id),
           hasScrollExport = renderHost.hasScrollExportFor(preview.id),
+          executableBundleHref =
+            if (renderHost.canDownloadExecutableBundle(preview.id))
+              "$basePath/bundle/${WebEscaping.urlEncodeSegment(preview.id)}${requestQuerySuffix()}"
+            else null,
           // The inspection layers: the accessibility focus map needs an a11y-capable daemon, the
           // typography / theme layers a semantics-capturing one. Both are session-wide facts (any
           // preview this daemon renders can be inspected), unlike the export gates above.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -56,6 +56,8 @@ data class ServeSessionState(
    * plain sessions and for a branch that ships only the monolithic bundle.
    */
   val perPreviewResolve: ((daemonId: String) -> ServeHost?)? = null,
+  /** Resolve a hydrated, self-contained per-preview bundle for download. */
+  val executableBundleProvider: ((daemonId: String) -> ByteArray?)? = null,
   /** Live upstream stream count across the pooled per-preview daemons (see [perPreviewResolve]). */
   val perPreviewStreamCount: () -> Int = { 0 },
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -461,14 +461,21 @@ object ServeWeb {
     report: ReportIssue?,
     figmaSpec: FigmaSpec?,
     playgroundHref: String?,
+    executableBundleHref: String?,
   ): String {
     val links =
       sourceLinkHtml(sourceHref, sourcePath) +
         playgroundLinkHtml(playgroundHref) +
+        executableBundleLinkHtml(executableBundleHref) +
         reportIssueHtml(report) +
         figmaSpecHtml(figmaSpec)
     if (links.isBlank()) return ""
     return "\n      <div class=\"cp-preview-links\">$links\n      </div>"
+  }
+
+  private fun executableBundleLinkHtml(href: String?): String {
+    val url = href?.takeIf { it.isNotBlank() } ?: return ""
+    return "\n        <a href=\"${WebEscaping.htmlEscape(url)}\" download>download executable bundle</a>"
   }
 
   /**
@@ -5339,6 +5346,8 @@ $rows
     hasSvgExport: Boolean = false,
     /** Whether the full-page raster/vector scroll export is available for this preview. */
     hasScrollExport: Boolean = false,
+    /** Hydrated self-contained per-preview bundle download, when the server can provide one. */
+    executableBundleHref: String? = null,
     /**
      * Whether this session can produce the accessibility data products the viewer's **Accessibility
      * inspection layer** draws from (`a11y/hierarchy`, plus ATF findings / touch targets where the
@@ -6398,7 +6407,14 @@ $rows
     // visitor and the render. It now rides directly above the export bar, where the other
     // "take this away with you" affordances (the PNG and SVG links) already live.
     val previewLinks =
-      previewLinksHtml(sourceHref, preview.sourceFile, reportIssue, figmaSpec, playgroundHref)
+      previewLinksHtml(
+        sourceHref,
+        preview.sourceFile,
+        reportIssue,
+        figmaSpec,
+        playgroundHref,
+        executableBundleHref,
+      )
     // Title, trust badge, id and the view tally on ONE baseline-aligned row. They are all
     // *identity* — three separate blocks said so three times, at the cost of ~90px above the fold.
     val body =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleClasspathHydrationTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleClasspathHydrationTest.kt
@@ -1,0 +1,75 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+
+class BundleClasspathHydrationTest {
+  @Test
+  fun `hydrate restores app jar and removes external declaration and stale signature`() {
+    val dir = kotlin.io.path.createTempDirectory("bundle-hydration-test").toFile()
+    val appJar = "APP-JAR".encodeToByteArray()
+    val sha = sha256(appJar)
+    val source = File(dir, "thin.png")
+    source.writeBytes(
+      zipOf(
+        mapOf(
+          "bundle.json" to
+            """{"schemaVersion":8,"backend":"desktop","previewIds":["A"],"coverPreviewId":"A","classpath":[{"kind":"module","path":"classes/app.jar"}],"modulePath":":app","producedBy":"test","externalClasspath":[{"path":"classes/app.jar","sha256":"$sha","size":${appJar.size}}]}"""
+              .encodeToByteArray(),
+          "previews.json" to """{"previews":[{"id":"A"}]}""".encodeToByteArray(),
+          "previews/A.png" to "PNG".encodeToByteArray(),
+          BundleSigning.SIGNATURES_PATH to "stale".encodeToByteArray(),
+        )
+      )
+    )
+
+    val output = File(dir, "complete.png")
+    BundleClasspathHydration.hydrate(source, output) { appJar }
+    val entries = entries(output)
+    assertContentEquals(appJar, entries.getValue("classes/app.jar"))
+    assertFalse(BundleSigning.SIGNATURES_PATH in entries)
+    val manifest =
+      Json.parseToJsonElement(entries.getValue("bundle.json").decodeToString()).jsonObject
+    assertFalse("externalClasspath" in manifest)
+    assertTrue(manifest["classpath"]!!.jsonArray.isNotEmpty())
+    assertContentEquals("PK".encodeToByteArray(), output.readBytes().copyOfRange(0, 2))
+  }
+
+  private fun zipOf(entries: Map<String, ByteArray>): ByteArray {
+    val out = ByteArrayOutputStream()
+    ZipOutputStream(out).use { zip ->
+      for ((name, bytes) in entries) {
+        zip.putNextEntry(ZipEntry(name))
+        zip.write(bytes)
+        zip.closeEntry()
+      }
+    }
+    return out.toByteArray()
+  }
+
+  private fun entries(file: File): Map<String, ByteArray> {
+    val out = LinkedHashMap<String, ByteArray>()
+    ZipInputStream(ByteArrayInputStream(BundleReader.extractZipBytes(file))).use { zip ->
+      while (true) {
+        val entry = zip.nextEntry ?: break
+        if (!entry.isDirectory) out[entry.name] = zip.readBytes()
+      }
+    }
+    return out
+  }
+
+  private fun sha256(bytes: ByteArray): String =
+    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
@@ -136,6 +136,35 @@ class BundleSplitTest {
   }
 
   @Test
+  fun `shared classpath split publishes app jar once and records its digest`() {
+    val pooled = LinkedHashMap<SharedClasspathEntry, ByteArray>()
+    val split = ArrayList<SplitPreview>()
+    forEachSplitPreview(
+      sheetZip(),
+      SplitMode.FULL_SHARED_CLASSPATH,
+      onSharedClasspath = { entry, bytes -> pooled[entry] = bytes },
+    ) {
+      split += it
+    }
+
+    assertEquals(1, pooled.size)
+    val record = pooled.keys.single()
+    assertEquals("classes/app.jar", record.path)
+    assertEquals(2048L, record.size)
+    assertContentEquals(ByteArray(2048) { 1 }, pooled.values.single())
+
+    val entries = readEntries(split.first { it.id == "A" }.zipBytes)
+    assertFalse("classes/app.jar" in entries)
+    assertTrue("libs/dep.jar" in entries)
+    val manifest =
+      json.parseToJsonElement(entries.getValue("bundle.json").decodeToString()).jsonObject
+    val external = manifest["externalClasspath"]!!.jsonArray.single().jsonObject
+    assertEquals("classes/app.jar", external["path"]!!.jsonPrimitive.content)
+    assertEquals(record.sha256, external["sha256"]!!.jsonPrimitive.content)
+    assertEquals("2048", external["size"]!!.jsonPrimitive.content)
+  }
+
+  @Test
   fun `split is deterministic`() {
     val a1 = splitBundleZip(sheetZip(), SplitMode.VIEW_ONLY).first { it.id == "A" }
     val a2 = splitBundleZip(sheetZip(), SplitMode.VIEW_ONLY).first { it.id == "A" }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -148,6 +148,28 @@ class ServeCatalogLiveHostTest {
   private fun knobOverride() =
     PreviewOverrides(namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("Tap me")))
 
+  @Test
+  fun `executable bundle download maps catalog id to daemon id`() {
+    val (_, live, baked) = host()
+    var requested: String? = null
+    val bytes = byteArrayOf(1, 2, 3)
+    val composite =
+      ServeCatalogLiveHost(
+        mapOf(catalogId to daemonId),
+        live,
+        baked,
+        executableBundleProvider = {
+          requested = it
+          bytes
+        },
+      )
+
+    assertTrue(composite.canDownloadExecutableBundle(catalogId))
+    assertFalse(composite.canDownloadExecutableBundle(androidOnlyId))
+    assertEquals(bytes.toList(), composite.executableBundle(catalogId)?.toList())
+    assertEquals(daemonId, requested)
+  }
+
   private fun themeOverride(provider: String = "com.example.BrandDark") =
     PreviewOverrides(themeProvider = provider)
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1179,7 +1179,10 @@ class ServeCatalogStoreTest {
          {"path":"images/button-filled/ideal__default__dark.png","theme":"dark","previewId":"FilledButton_Dark"}]}]}
       """
         .trimIndent()
-    val perPreviewBytes = byteArrayOf(9, 8, 7)
+    val perPreviewBytes =
+      polyglotBundle(
+        """{"schemaVersion":8,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a","classpath":[{"kind":"module","path":"classes/app.jar"}],"modulePath":":app","producedBy":"test"}"""
+      )
     // Thread-safe: a catalog load also kicks off background fetch lanes (vectors, the published
     // rc-compare), so this recorder is written from those threads while the assertions below read
     // it. A plain ArrayList fails the reads with a ConcurrentModificationException.

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -168,6 +168,30 @@ self-contained (`externalResources` empty), the step doesn't bump
 `schemaVersion`, and a pre-externalize reader just finds fewer resources in the
 jar. Idempotent — re-running finds the fonts already gone and changes nothing.
 
+### Shared per-preview classpath (opt-in)
+
+The ordinary `bundle split` full mode remains self-contained: every per-preview
+bundle carries `classes/app.jar`. For delivery trees where that repetition is
+too expensive, the explicitly opt-in form
+
+```
+compose-preview bundle split sheet.png -o bundle/previews \
+  --shared-classpath-out bundle/res
+```
+
+publishes the sheet's complete `classes/app.jar` once as
+`bundle/res/<sha256>` and records it in each split manifest as
+`externalClasspath: [{path, sha256, size}]`. The split artifacts remain valid
+PNG+ZIP previews, but need their sibling pool to re-render; direct branch
+downloads are therefore not offline-executable.
+
+A trusted preview server fetches and verifies the hash-keyed JAR once, restores
+it into a cached copy of each requested bundle, and uses that self-contained
+copy for both daemon startup and the viewer's “download executable bundle”
+action. Hydration removes `externalClasspath`. It also removes
+`signatures.json`, because adding the restored JAR changes the canonical digest;
+the derivative must be unsigned or signed anew by the hydrating server.
+
 ### Proposed additive schema (v3) for cross-build-system portability
 
 Today `ClasspathEntry` (in both `PreviewBundleFormat.kt` and the viewer's mirror

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -244,7 +244,20 @@ data class BundleManifest(
    * font-parity render needs the rehydration. See [BundleExternalResource].
    */
   val externalResources: List<BundleExternalResource> = emptyList(),
+  /**
+   * (v8, post-split, opt-in) Whole classpath entries omitted from this addressable bundle and
+   * published once in the sibling content-addressed pool. Unlike [externalResources], which are
+   * individual resources materialized onto an extra classpath directory, these bytes restore the
+   * exact zip entry named by [BundleExternalClasspath.path] (currently `classes/app.jar`). A normal
+   * pack and the existing `bundle split` full mode remain self-contained; only the explicit
+   * shared-classpath split mode populates this field.
+   */
+  val externalClasspath: List<BundleExternalClasspath> = emptyList(),
 )
+
+/** One whole bundle classpath entry stored at `bundle/res/<sha256>` instead of inline. */
+@Serializable
+data class BundleExternalClasspath(val path: String, val sha256: String, val size: Long)
 
 /**
  * One resource lifted out of `classes/app.jar` by `bundle externalize` and fetched on demand. See


### PR DESCRIPTION
## Summary

- add an explicit `--shared-classpath-out` split mode while keeping ordinary full splits self-contained by default
- publish `classes/app.jar` once in the content-addressed resource pool and record it as additive `externalClasspath` manifest metadata
- make the preview server verify and restore shared classpath blobs into complete bundles for daemon startup and download
- add a viewer action for downloading the hydrated executable bundle
- opt selected live design-artifact tiers into the new mode and document compatibility/signature behavior

## Why

Per-preview full bundles repeat the same application JAR for every preview. The new mode makes that optimization explicitly opt-in, while allowing the trusted preview server to reconstruct a complete offline-executable bundle before serving it.

Hydration removes the external declaration and stale producer signatures because restoring the JAR changes the canonical bundle digest.

## Validation

- focused CLI/server tests for splitting, hydration, catalog mapping/store, HTTP routing, and viewer fixtures
- `PreviewBundleFormatTest`
- repository-wide `ktfmtCheckAll`
- YAML parsing for both modified workflows
- `git diff --check`
- repository pre-commit and pre-push hooks

Closes #3618