### PR TITLE
feat(serve): surface actionable design parity issues

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1768,6 +1768,7 @@ class ServeHttpServer(
           previews = renderHost.previews,
           hasReference = hasReference,
           activity = activity,
+          referenceIdFor = { id -> renderHost.designReferencesFor(id).firstOrNull()?.id },
         )
       if (json) {
         markGeneration("parity", pageCacheControl())

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityDashboard.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityDashboard.kt
@@ -116,12 +116,23 @@ object ServeParityDashboard {
   /** One component with no design reference, and a preview to open it by. */
   data class UnmappedComponent(val name: String, val previewId: String)
 
+  /** One row in the exhaustive code ↔ design inventory shown behind the comparison disclosure. */
+  data class Comparison(
+    val name: String,
+    /** Representative preview for opening the render or its reference comparison. */
+    val previewId: String,
+    val hasReference: Boolean,
+    /** Exact reference asset to score in the browser; null when only mapping presence is known. */
+    val referenceId: String? = null,
+  )
+
   /** Everything [ServeWeb.parityPage] renders. */
   data class Dashboard(
     val coverage: Coverage,
     val feed: List<FeedEntry>,
     val components: List<ComponentActivity>,
     val gaps: List<MappingGap>,
+    val comparisons: List<Comparison> = emptyList(),
     val generatedAt: String? = null,
     val windowDays: Int? = null,
     /** Figma file this catalog is specified by, when the feed named one. */
@@ -156,6 +167,7 @@ object ServeParityDashboard {
     previews: List<ServePreview>,
     hasReference: (String) -> Boolean,
     activity: ParityActivity?,
+    referenceIdFor: (String) -> String? = { null },
   ): Dashboard {
     val components = componentsOf(previews)
     val coverage = coverageOf(components, hasReference)
@@ -226,6 +238,19 @@ object ServeParityDashboard {
       feed = feed,
       components = correlate(feed, components, hasReference),
       gaps = activity?.gaps.orEmpty(),
+      comparisons =
+        components.map { component ->
+          // Score a concrete mapped variant when one exists. A component's default/light card is
+          // usually mapped, but catalogs may intentionally attach the reference to another state.
+          val mappedPreviewId = component.previewIds.firstOrNull(hasReference)
+          val comparisonPreviewId = mappedPreviewId ?: component.representative
+          Comparison(
+            name = component.name,
+            previewId = comparisonPreviewId,
+            hasReference = mappedPreviewId != null,
+            referenceId = mappedPreviewId?.let(referenceIdFor),
+          )
+        },
       generatedAt = activity?.generatedAt,
       windowDays = activity?.windowDays,
       figmaFileName = figmaLane?.fileName,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4937,19 +4937,18 @@ $rows
    * The catalog's **Design parity** view: recent movement on both sides of the code ↔ design pair,
    * how far apart they are, and what isn't mapped yet.
    *
-   * The page is three bands, in the order a reader actually needs them:
+   * The page defaults to the two bands a reader can act on:
    *
    * 1. **Where we stand** — coverage (how many components carry a design reference), open Figma
    *    comments, and how recently each side moved. Computed live for the coverage half, so it is
    *    right even for a catalog that publishes no feed at all.
-   * 2. **Needs a look** — components whose two sides moved *unevenly* inside the window. This is
-   *    the band that justifies putting the feeds together: a component with a commit and no design
-   *    change (or the reverse) is where the render and its reference are drifting apart, and every
-   *    row links straight to that component's reference-vs-render comparison.
-   * 3. **Recent activity** — the merged, reverse-chronological feed itself, filterable by lane.
-   *
-   * Then the gaps: components with no reference (derived here) plus the producer-declared gaps only
-   * the publish job can see.
+   * 2. **Activity and issues** — the merged feed plus components whose two sides moved *unevenly*
+   *    inside the window. This is the band that justifies putting the feeds together: a component
+   *    with a commit and no design change (or the reverse) is where the render and its reference
+   *    are drifting apart, and every row links straight to that component's reference-vs-render
+   *    comparison. The complete component inventory remains available in a collapsed comparison
+   *    table. This keeps the default view useful without turning 78 healthy mappings into the
+   *    page's main subject.
    *
    * Everything textual in [dashboard] is third-party — commit subjects and Figma comment bodies
    * written by other people — so every interpolation goes through [WebEscaping.htmlEscape], and
@@ -5059,7 +5058,7 @@ $rows
               "<td class=\"cp-muted\">${esc(prettyDate(component.lastAt))}</td></tr>"
           }
         """
-        <h2 class="cp-status-sec">Needs a look</h2>
+        <h3 class="cp-parity-sub">Out-of-sync activity</h3>
         <p class="cp-muted">Components that moved on one side only inside this window — where the
           render and its reference are most likely to have drifted apart.</p>
         <div class="cp-status-scroll">
@@ -5077,7 +5076,7 @@ $rows
     val feedBand =
       if (dashboard.feed.isEmpty()) {
         """
-        <h2 class="cp-status-sec">Recent activity</h2>
+          <h2 class="cp-status-sec">Activity</h2>
         <p class="cp-muted">This catalog publishes no activity feed yet. A producer adds one by
           emitting <code>parity/activity.json</code> beside its catalog — see the
           <a href="https://github.com/$SOURCE_REPO/blob/main/docs/public-preview-server.md">server
@@ -5138,7 +5137,7 @@ $rows
                 "${esc(label)}</button>"
             }
         """
-        <h2 class="cp-status-sec">Recent activity</h2>
+        <h2 class="cp-status-sec">Activity</h2>
         <div class="cp-states" role="group" aria-label="Filter activity by lane">
         $filters
         </div>
@@ -5146,7 +5145,6 @@ $rows
         $items
         </ul>
         <p class="cp-muted" id="cp-parity-feed-empty" hidden>No activity in this lane.</p>
-        ${scriptTag("parity.js")}
         """
           .trimIndent()
       }
@@ -5156,7 +5154,6 @@ $rows
         if (coverage.components == 0) ""
         else
           """
-          <h2 class="cp-status-sec">Mapping</h2>
           <p class="cp-muted">Every component in this catalog carries a design reference.</p>
           """
             .trimIndent()
@@ -5216,12 +5213,102 @@ $rows
               .trimIndent()
           }
         """
-        <h2 class="cp-status-sec">Mapping</h2>
         $unmappedList
         $gapRows
         """
           .trimIndent()
       }
+
+    val issueBand =
+      if (driftBand.isEmpty() && coverage.unmapped.isEmpty() && dashboard.gaps.isEmpty()) {
+        """
+        <h2 class="cp-status-sec">Issues</h2>
+        <p class="cp-muted">No mapping gaps or one-sided changes were detected.</p>
+        """
+          .trimIndent()
+      } else {
+        """
+        <h2 class="cp-status-sec">Issues</h2>
+        $driftBand
+        $unmappedBand
+        """
+          .trimIndent()
+      }
+
+    val visualIssues =
+      if (dashboard.comparisons.none { it.referenceId != null }) ""
+      else {
+        val count = dashboard.comparisons.count { it.referenceId != null }
+        """
+        <section class="cp-parity-visual-issues" id="cp-parity-visual-issues">
+          <h3 class="cp-parity-sub">Visual differences</h3>
+          <p class="cp-muted" id="cp-parity-score-status">Checking $count mapped comparison(s)…</p>
+          <div class="cp-status-scroll" id="cp-parity-score-results" hidden>
+            <table class="cp-table">
+              <thead><tr><th>Component</th><th>Structural match</th><th>Review</th></tr></thead>
+              <tbody id="cp-parity-score-issues"></tbody>
+            </table>
+          </div>
+        </section>
+        """
+          .trimIndent()
+      }
+
+    val comparisonBand =
+      if (dashboard.comparisons.isEmpty()) ""
+      else {
+        val rows =
+          dashboard.comparisons.joinToString("\n") { component ->
+            val render = previewLink(component.previewId, "Open render")
+            val design =
+              if (component.hasReference) "<span class=\"cp-ok\">Mapped</span>"
+              else "<span class=\"cp-parity-missing\">Missing</span>"
+            val review =
+              if (component.hasReference) previewLink(component.previewId, "Compare") else "—"
+            val scoring =
+              component.referenceId
+                ?.let { referenceId ->
+                  val actualUrl =
+                    "$basePath/render/${WebEscaping.urlEncodeSegment(component.previewId)}.png$q"
+                  val referenceUrl =
+                    "$basePath/reference/${WebEscaping.urlEncodeSegment(referenceId)}.png$q"
+                  " data-parity-comparison data-reference=\"${esc(referenceUrl)}\"" +
+                    " data-actual=\"${esc(actualUrl)}\" data-name=\"${esc(component.name)}\"" +
+                    " data-review=\"${esc(previewHref(component.previewId))}\""
+                }
+                .orEmpty()
+            val score =
+              if (component.referenceId != null)
+                "<span class=\"cp-parity-score cp-muted\">Checking…</span>"
+              else "—"
+            "<tr$scoring><td>${esc(component.name)}</td><td>$render</td><td>$design</td>" +
+              "<td>$score</td><td>$review</td></tr>"
+          }
+        """
+        <details class="cp-parity-comparisons cp-disclosure">
+          <summary>
+            <span class="cp-parity-comparisons-title">All comparisons (${dashboard.comparisons.size})</span>
+            <span class="cp-disclosure-hint">Browse every code component and its design mapping</span>
+          </summary>
+          <div class="cp-disclosure-body cp-status-scroll">
+            <table class="cp-table">
+              <thead><tr><th>Component</th><th>Code</th><th>Design reference</th><th>Structural match</th><th>Review</th></tr></thead>
+              <tbody>
+              $rows
+              </tbody>
+            </table>
+          </div>
+        </details>
+        """
+          .trimIndent()
+      }
+
+    val parityScripts = buildString {
+      if (dashboard.comparisons.any { it.referenceId != null })
+        append(scriptTag("format-compare.js"))
+      if (dashboard.feed.isNotEmpty() || dashboard.comparisons.any { it.referenceId != null })
+        append(scriptTag("parity.js"))
+    }
 
     // Provenance for the page itself: this is snapshotted data, and saying so is the difference
     // between "nothing changed in Figma" and "we last looked a week ago".
@@ -5291,9 +5378,11 @@ $rows
         $coverageMeter
         <p class="cp-muted">${coverage.percent}% of ${coverage.components} component(s) carry a
           design reference.</p>
-        $driftBand
         $feedBand
-        $unmappedBand
+        $issueBand
+        $visualIssues
+        $comparisonBand
+        $parityScripts
         """
           .trimIndent(),
     )

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/parity.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/parity.js
@@ -5,14 +5,11 @@
   "use strict";
 
   var feed = document.getElementById("cp-parity-feed");
-  if (!feed) return;
   var empty = document.getElementById("cp-parity-feed-empty");
-  var buttons = Array.prototype.slice.call(
-    document.querySelectorAll("[data-parity-lane]"),
-  );
-  if (!buttons.length) return;
+  var buttons = Array.prototype.slice.call(document.querySelectorAll("[data-parity-lane]"));
 
   function apply(lane) {
+    if (!feed) return;
     var shown = 0;
     var entries = feed.querySelectorAll(".cp-parity-entry");
     for (var i = 0; i < entries.length; i++) {
@@ -34,4 +31,66 @@
       apply(event.currentTarget.dataset.parityLane);
     });
   }
+
+  // Score every published render/reference pair with the same SSIM implementation as the focused
+  // comparison page. Four workers keep a large catalog responsive while still turning the parity
+  // page into an issues view instead of treating "mapped" as "matching".
+  var compare = window.ComposePreviewCompare;
+  var rows = Array.prototype.slice.call(document.querySelectorAll("[data-parity-comparison]"));
+  if (!compare || !rows.length) return;
+  var status = document.getElementById("cp-parity-score-status");
+  var results = document.getElementById("cp-parity-score-results");
+  var issueBody = document.getElementById("cp-parity-score-issues");
+  var next = 0;
+  var completed = 0;
+  var findings = [];
+
+  function esc(value) {
+    var span = document.createElement("span");
+    span.textContent = value;
+    return span.innerHTML;
+  }
+
+  function finish() {
+    findings.sort(function (a, b) { return a.score - b.score; });
+    if (issueBody) {
+      issueBody.innerHTML = findings.map(function (finding) {
+        return "<tr><td>" + esc(finding.name) + "</td><td class=\"cp-parity-missing\">" +
+          finding.score.toFixed(1) + "%</td><td><a href=\"" + esc(finding.review) +
+          "\">Compare</a></td></tr>";
+      }).join("");
+    }
+    if (results) results.hidden = findings.length === 0;
+    if (status) status.textContent = findings.length
+      ? findings.length + " mapped component(s) are below 90% structural match."
+      : "All " + rows.length + " mapped components are at least 90% structural match.";
+  }
+
+  function worker() {
+    var index = next++;
+    if (index >= rows.length) return Promise.resolve();
+    var row = rows[index];
+    return compare.scoreImageUrls(row.dataset.reference, row.dataset.actual).then(function (measured) {
+      var score = measured.percent;
+      var cell = row.querySelector(".cp-parity-score");
+      if (cell) {
+        cell.textContent = score.toFixed(1) + "%";
+        cell.className = "cp-parity-score " + (score < 90 ? "cp-parity-missing" : "cp-ok");
+      }
+      if (score < 90) findings.push({
+        name: row.dataset.name,
+        review: row.dataset.review,
+        score: score,
+      });
+    }, function () {
+      var cell = row.querySelector(".cp-parity-score");
+      if (cell) cell.textContent = "Unavailable";
+    }).then(function () {
+      completed++;
+      if (status) status.textContent = "Checked " + completed + " of " + rows.length + " comparisons…";
+      return worker();
+    });
+  }
+
+  Promise.all([worker(), worker(), worker(), worker()]).then(finish);
 })();

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -684,6 +684,13 @@ html.cp-js .cp-section-head { display: none; }
 .cp-parity-targets { margin-top: 5px; font-size: 0.76rem; }
 .cp-parity-chips { list-style: none; margin: 0 0 8px; padding: 0;
   display: flex; flex-wrap: wrap; gap: 6px; }
+.cp-parity-comparisons { max-width: 860px; margin-top: 30px; padding-top: 18px;
+  border-top: 1px solid var(--md-sys-color-outline-variant); }
+.cp-parity-comparisons-title { font-size: var(--md-sys-typescale-title-medium-size);
+  line-height: var(--md-sys-typescale-title-medium-line); font-weight: 500;
+  color: var(--cp-fg); }
+.cp-parity-comparisons .cp-table { min-width: 620px; }
+.cp-parity-missing { color: var(--md-sys-color-error); font-weight: 500; }
 @media (max-width: 640px) {
   .cp-parity-entry { flex-direction: column; gap: 4px; }
   .cp-parity-when { flex: none; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityDashboardTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityDashboardTest.kt
@@ -29,6 +29,9 @@ class ServeParityDashboardTest {
         previews = previews,
         hasReference = { it == "button-filled__ideal__default__light" },
         activity = null,
+        referenceIdFor = {
+          if (it == "button-filled__ideal__default__light") "figma-button-filled" else null
+        },
       )
 
     assertEquals(2, dashboard.coverage.components, "light+dark are one component, not two")
@@ -37,6 +40,8 @@ class ServeParityDashboardTest {
     assertEquals(listOf("Navigation/Rail"), dashboard.coverage.unmapped.map { it.name })
     // The unmapped chip must open the LIGHT default render — the card the grid shows.
     assertEquals("nav-rail__ideal__default__light", dashboard.coverage.unmapped.single().previewId)
+    assertEquals(listOf("Button/Filled", "Navigation/Rail"), dashboard.comparisons.map { it.name })
+    assertEquals("figma-button-filled", dashboard.comparisons.first().referenceId)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1106,6 +1106,9 @@ class ServeWebFixtureTest {
         previews = themedPreviews,
         // Button is mapped; Switch and Badge are not — a realistic, partly-covered catalog.
         hasReference = { it.startsWith("button-filled") },
+        referenceIdFor = {
+          if (it == "button-filled__ideal__default__light") "design-button-filled-light" else null
+        },
         activity =
           ParityActivity(
             generatedAt = "2026-07-17T09:30:00.000Z",
@@ -1783,14 +1786,23 @@ class ServeWebFixtureTest {
     // it must reach the "needs a look" band; Button moved on both sides and must NOT, because that
     // band exists to be short.
     assertTrue(
-      parity.contains("Needs a look") &&
+      parity.contains("Out-of-sync activity") &&
         parity.contains("Switch on") &&
         parity.contains("design only"),
       "one-sided design movement reaches the drift band",
     )
     assertFalse(
-      parity.substringAfter("Needs a look").substringBefore("Recent activity").contains("Button"),
+      parity
+        .substringAfter("Out-of-sync activity")
+        .substringBefore("Visual differences")
+        .contains("Button"),
       "a component that moved on both sides is not drift",
+    )
+    assertTrue(
+      parity.contains("All comparisons (3)") &&
+        parity.contains("data-parity-comparison") &&
+        parity.contains("Visual differences"),
+      "the secondary inventory includes measured visual parity: $parity",
     )
     // Coverage is derived live from the previews + references, never from the published feed: 3
     // components (light/dark folded), one of them mapped.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-parity.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-parity.html
@@ -77,19 +77,7 @@
 </div>
         <p class="cp-muted">33% of 3 component(s) carry a
           design reference.</p>
-                <h2 class="cp-status-sec">Needs a look</h2>
-        <p class="cp-muted">Components that moved on one side only inside this window — where the
-          render and its reference are most likely to have drifted apart.</p>
-        <div class="cp-status-scroll">
-          <table class="cp-table">
-            <thead><tr><th>Component</th><th>Moved</th><th>Why it's here</th><th>Last change</th></tr></thead>
-            <tbody>
-            <tr><td><a href="/compose-m3/p/switch-on__ideal__default__light">Switch on</a></td><td><span class="cp-parity-lane cp-parity-lane--figma">design only</span></td><td class="cp-muted">the design moved; the code did not</td><td class="cp-muted">2026-07-16 09:02 UTC</td></tr>
-<tr><td><a href="/compose-m3/p/badge">Badge</a></td><td><span class="cp-parity-lane cp-parity-lane--code">code only</span></td><td class="cp-muted">the render moved; its reference did not</td><td class="cp-muted">2026-07-14 08:05 UTC</td></tr>
-            </tbody>
-          </table>
-        </div>
-                <h2 class="cp-status-sec">Recent activity</h2>
+                <h2 class="cp-status-sec">Activity</h2>
         <div class="cp-states" role="group" aria-label="Filter activity by lane">
         <button type="button" class="cp-state-btn" data-parity-lane="all" aria-current="page">All</button>
 <button type="button" class="cp-state-btn" data-parity-lane="code">Code</button>
@@ -154,9 +142,20 @@
 </li>
         </ul>
         <p class="cp-muted" id="cp-parity-feed-empty" hidden>No activity in this lane.</p>
-        <script src="/assets/serve/fixture/parity.js"></script>
-                <h2 class="cp-status-sec">Mapping</h2>
-                    <h3 class="cp-parity-sub">No design reference (2)</h3>
+                <h2 class="cp-status-sec">Issues</h2>
+                <h3 class="cp-parity-sub">Out-of-sync activity</h3>
+        <p class="cp-muted">Components that moved on one side only inside this window — where the
+          render and its reference are most likely to have drifted apart.</p>
+        <div class="cp-status-scroll">
+          <table class="cp-table">
+            <thead><tr><th>Component</th><th>Moved</th><th>Why it's here</th><th>Last change</th></tr></thead>
+            <tbody>
+            <tr><td><a href="/compose-m3/p/switch-on__ideal__default__light">Switch on</a></td><td><span class="cp-parity-lane cp-parity-lane--figma">design only</span></td><td class="cp-muted">the design moved; the code did not</td><td class="cp-muted">2026-07-16 09:02 UTC</td></tr>
+<tr><td><a href="/compose-m3/p/badge">Badge</a></td><td><span class="cp-parity-lane cp-parity-lane--code">code only</span></td><td class="cp-muted">the render moved; its reference did not</td><td class="cp-muted">2026-07-14 08:05 UTC</td></tr>
+            </tbody>
+          </table>
+        </div>
+                            <h3 class="cp-parity-sub">No design reference (2)</h3>
             <p class="cp-muted">These render, but nothing in the design file is mapped to them — so
               nothing can score them against a spec.</p>
             <ul class="cp-parity-chips">
@@ -176,6 +175,33 @@
                 </tbody>
               </table>
             </div>
+        <section class="cp-parity-visual-issues" id="cp-parity-visual-issues">
+  <h3 class="cp-parity-sub">Visual differences</h3>
+  <p class="cp-muted" id="cp-parity-score-status">Checking 1 mapped comparison(s)…</p>
+  <div class="cp-status-scroll" id="cp-parity-score-results" hidden>
+    <table class="cp-table">
+      <thead><tr><th>Component</th><th>Structural match</th><th>Review</th></tr></thead>
+      <tbody id="cp-parity-score-issues"></tbody>
+    </table>
+  </div>
+</section>
+                <details class="cp-parity-comparisons cp-disclosure">
+          <summary>
+            <span class="cp-parity-comparisons-title">All comparisons (3)</span>
+            <span class="cp-disclosure-hint">Browse every code component and its design mapping</span>
+          </summary>
+          <div class="cp-disclosure-body cp-status-scroll">
+            <table class="cp-table">
+              <thead><tr><th>Component</th><th>Code</th><th>Design reference</th><th>Structural match</th><th>Review</th></tr></thead>
+              <tbody>
+              <tr><td>Badge</td><td><a href="/compose-m3/p/badge">Open render</a></td><td><span class="cp-parity-missing">Missing</span></td><td>—</td><td>—</td></tr>
+<tr data-parity-comparison data-reference="/compose-m3/reference/design-button-filled-light.png" data-actual="/compose-m3/render/button-filled__ideal__default__light.png" data-name="Button filled" data-review="/compose-m3/compare/button-filled__ideal__default__light"><td>Button filled</td><td><a href="/compose-m3/compare/button-filled__ideal__default__light">Open render</a></td><td><span class="cp-ok">Mapped</span></td><td><span class="cp-parity-score cp-muted">Checking…</span></td><td><a href="/compose-m3/compare/button-filled__ideal__default__light">Compare</a></td></tr>
+<tr><td>Switch on</td><td><a href="/compose-m3/p/switch-on__ideal__default__light">Open render</a></td><td><span class="cp-parity-missing">Missing</span></td><td>—</td><td>—</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </details>
+        <script src="/assets/serve/fixture/format-compare.js"></script><script src="/assets/serve/fixture/parity.js"></script>
         </main>
         <footer class="cp-site-footer">
           <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·


### PR DESCRIPTION
## What changed

- make activity and issues the primary design-parity content
- add a collapsed, exhaustive comparison table for every catalog component
- score mapped render/reference pairs in the browser using the existing structural comparison implementation
- surface mapped components below the existing 90% good-match threshold as visual issues
- keep unmapped components, producer-declared gaps, and one-sided activity in the Issues section

## Why

The parity page stopped at mapping coverage. A fully mapped catalog therefore looked healthy even when its focused comparison pages showed substantial visual differences, and there was no way to browse all mappings from the parity view.

## User impact

Users now land on actionable activity and issues. They can still expand **All comparisons** to inspect every code/design pair, including its measured structural match and a direct comparison link.

## Validation

- `./gradlew --offline :cli:ktfmtCheck :cli:test --tests '*ServeParityDashboardTest*' --tests '*ServeWebFixtureTest*' --console=plain`
- `node --check cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/parity.js`
- updated `serve-parity.html` preview-harness fixture