### PR TITLE
Fix declared theme chrome and card backgrounds

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -226,7 +226,29 @@ fun detectedFeaturesOf(preview: ee.schimke.composeai.cli.PreviewInfo): Pair<Bool
  * [ServePreview]. [providerFqn] is the `PreviewWrapperProvider` FQN sent verbatim as the
  * `themeProvider` override; [name] is the human label; [group] buckets related themes (a brand).
  */
-data class ServeTheme(val name: String, val providerFqn: String, val group: String? = null)
+data class ServeTheme(
+  val name: String,
+  val providerFqn: String,
+  val group: String? = null,
+  /** Light/dark mode implied by this theme, when its name or provider is unambiguous. */
+  val mode: String? = inferredThemeMode(name, providerFqn),
+)
+
+internal fun inferredThemeMode(name: String, providerFqn: String): String? {
+  val words =
+    "$name $providerFqn"
+      .replace(Regex("([a-z])([A-Z])"), "$1 $2")
+      .split(Regex("[^A-Za-z]+"))
+      .map { it.lowercase() }
+      .toSet()
+  val light = "light" in words
+  val dark = "dark" in words
+  return when {
+    light && !dark -> "light"
+    dark && !light -> "dark"
+    else -> null
+  }
+}
 
 /**
  * Extract the module's declared `@ThemeCatalog` / `@WearThemeCatalog` themes from a discovery

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1259,7 +1259,10 @@ object ServeWeb {
             ?.takeIf { !qualified }
             ?.let { " title=\"${WebEscaping.htmlEscape(it)} · $label\"" } ?: ""
         append("\n$indent<button type=\"button\" class=\"cp-theme-btn\"")
-        append(" data-theme-choice=\"theme:${WebEscaping.htmlEscape(t.providerFqn)}\"$title>")
+        val modeAttr = t.mode?.let { " data-theme-mode=\"${WebEscaping.htmlEscape(it)}\"" } ?: ""
+        append(
+          " data-theme-choice=\"theme:${WebEscaping.htmlEscape(t.providerFqn)}\"$modeAttr$title>"
+        )
         append("$label</button>")
       }
     }
@@ -1624,6 +1627,7 @@ object ServeWeb {
             var img = c.querySelector("img");
             var base = themeBase[i];
             if (!img || !base) return;
+            if (selectedThemeMode) c.setAttribute("data-bg-theme", selectedThemeMode);
             var themedSrc = base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider);
             var job = {
               card: c,
@@ -1695,6 +1699,12 @@ object ServeWeb {
         themeBtns.forEach(function (b) {
           b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
         });
+        var selectedThemeButton = null;
+        themeBtns.forEach(function (b) {
+          if (b.getAttribute("data-theme-choice") === theme) selectedThemeButton = b;
+        });
+        var selectedThemeMode = selectedThemeButton
+          ? selectedThemeButton.getAttribute("data-theme-mode") || "" : "";
         // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
         // supplying themed ones), alt text, label, id, viewer link and stage backing.
         // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.
@@ -2060,8 +2070,10 @@ object ServeWeb {
         // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
         // have copied a remembered localStorage value into el.value — honoring it would tint the
         // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-        var chosen =
-          !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+        var selectedOption = el.options[el.selectedIndex];
+        var chosen = !el.disabled && selectedOption
+          ? selectedOption.getAttribute("data-theme-mode") ||
+            (el.value === "light" || el.value === "dark" ? el.value : "") : "";
         var m = chosen || bgDefault;
         if (m) root.setAttribute("data-bg-theme", m);
         else root.removeAttribute("data-bg-theme");
@@ -4407,6 +4419,7 @@ object ServeWeb {
       version = version,
       themeCss = themeCss,
       themeStorageKey = themeStorageKey(sessionId, basePath),
+      declaredThemes = declaredThemeChips,
       body =
         """
         <h1 class="cp-head cp-catalog-head">${WebEscaping.htmlEscape(heading)}${compactTrustBadge(trust)}</h1>
@@ -6047,7 +6060,8 @@ $rows
       val grouped = declaredThemes.groupBy { it.group }
       val optionsOf: (List<ServeTheme>) -> String = { list ->
         list.joinToString("\n") { t ->
-          "<option value=\"theme:${WebEscaping.htmlEscape(t.providerFqn)}\"$providerDis>" +
+          val modeAttr = t.mode?.let { " data-theme-mode=\"${WebEscaping.htmlEscape(it)}\"" } ?: ""
+          "<option value=\"theme:${WebEscaping.htmlEscape(t.providerFqn)}\"$modeAttr$providerDis>" +
             "${WebEscaping.htmlEscape(t.name)}</option>"
         }
       }
@@ -6529,6 +6543,7 @@ $rows
         ),
       themeCss = themeCss,
       themeStorageKey = themeStorageKey(sessionId, basePath),
+      declaredThemes = viewerDeclaredThemes,
       // Only the `js` chip paints in this document's canvas, and it only exists when the preview
       // carries a captured document.
       rcFonts = hasRemoteComposeDoc,
@@ -6648,6 +6663,10 @@ $rows
      */
     themeStorageKey: String = "",
     /**
+     * Declared themes whose resolved mode lets the head script paint correctly before first draw.
+     */
+    declaredThemes: List<ServeTheme> = emptyList(),
+    /**
      * Register the vendored Remote Compose typefaces ([ServeRcFonts]) on this page. True for the
      * pages that play a `.rc` document **client-side** — without the faces the player's `Roboto,
      * sans-serif` request falls through to whatever the *viewer's* machine calls `sans-serif`, so
@@ -6720,7 +6739,7 @@ $rows
         <!-- Apply the Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
-        ${pageThemeScript(themeStorageKey)}
+        ${pageThemeScript(themeStorageKey, declaredThemes)}
       </head>
       <body>
         ${siteHeader(navSuffix, headerAction, headerBreadcrumb)}
@@ -6745,18 +6764,26 @@ $rows
    *
    * The order is the same one the grid and the viewer use for the theme itself: the URL wins
    * (`?theme=` on a catalog landing, `?uiMode=` in the viewer — someone picked that chip or was
-   * handed the link), then the choice this catalog remembers. Only an explicit `light` / `dark`
-   * moves the chrome; `default` and an app-declared `theme:<providerFqn>` carry no light/dark axis,
-   * so they leave the page on the visitor's OS preference rather than guessing a mode for it.
+   * handed the link), then the choice this catalog remembers. A declared theme moves the chrome
+   * when [ServeTheme.mode] is unambiguous; unqualified themes still follow the visitor's OS.
    */
-  private fun pageThemeScript(themeStorageKey: String): String {
+  private fun pageThemeScript(themeStorageKey: String, declaredThemes: List<ServeTheme>): String {
     val storedTheme =
       themeStorageKey
         .takeIf { it.isNotBlank() }
         ?.let { "||localStorage.getItem(${WebEscaping.jsString(it)})" } ?: ""
-    return "<script>try{var p=new URLSearchParams(location.search)," +
+    val modeEntries = declaredThemes.mapNotNull { theme ->
+      theme.mode?.let { mode ->
+        WebEscaping.jsString("theme:${theme.providerFqn}") + ":" + WebEscaping.jsString(mode)
+      }
+    }
+    val modeInit =
+      modeEntries.takeIf { it.isNotEmpty() }?.let { "m={${it.joinToString(",")}}," } ?: ""
+    val modeResolve = if (modeEntries.isEmpty()) "" else "t=m[t]||t;"
+    return "<script>try{var p=new URLSearchParams(location.search),$modeInit" +
       "t=localStorage.getItem(\"cp-page-theme\")===\"system\"?\"\"" +
       ":(p.get(\"theme\")||p.get(\"uiMode\")$storedTheme);" +
+      modeResolve +
       "if(t===\"light\"||t===\"dark\")document.documentElement.classList.add(\"cp-scheme-\"+t);" +
       "}catch(e){}</script>"
   }

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/page-theme.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/page-theme.js
@@ -21,9 +21,8 @@
 // a page served under `?theme=dark` never flashes light; this file keeps it in step afterwards and
 // owns the Settings menu.
 //
-// Only an EXPLICIT light/dark choice moves the chrome. `default` and an app-declared
-// `theme:<providerFqn>` say nothing about the page's mode — a declared theme is a palette, not a
-// light/dark axis — so those leave it to the OS rather than guessing.
+// An explicit light/dark choice moves the chrome. A declared theme does too when its catalog
+// metadata resolves an unambiguous mode; an unqualified declared theme still follows the OS.
 (function () {
     "use strict";
 
@@ -49,7 +48,12 @@
 
     /** The page mode a theme choice implies, or "" when it implies nothing. */
     function modeOf(choice) {
-        return choice === "light" || choice === "dark" ? choice : "";
+        if (choice === "light" || choice === "dark") return choice;
+        var button = null;
+        document.querySelectorAll(".cp-theme-btn").forEach(function (candidate) {
+            if (candidate.getAttribute("data-theme-choice") === choice) button = candidate;
+        });
+        return button ? button.getAttribute("data-theme-mode") || "" : "";
     }
 
     /**

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -551,18 +551,19 @@ html.cp-js .cp-section-head { display: none; }
    is painted in wear-m3's own near-black-and-cyan and the Light chip in its light projection,
    whichever way round the page itself is; the pair reads as two swatches of one system rather than
    two labels. Costs nothing: no extra data, no render, one property per chip.
-   Only the baked light/dark axis is tasted. `Default` and an app-declared `theme:<providerFqn>`
-   chip keep the plain outlined pill, because the page has no token set for either — a declared
-   theme's palette isn't published yet (design-parity#307 adds the export side), and inventing a
-   swatch for it would be a guess at the one thing the chip claims to show. */
-.cp-theme-btn:is([data-theme-choice="light"], [data-compare-theme="light"]) { color-scheme: light; }
-.cp-theme-btn:is([data-theme-choice="dark"], [data-compare-theme="dark"]) { color-scheme: dark; }
-.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"],
+   The baked axis and any declared theme with an unambiguous light/dark mode are tasted. `Default`
+   and an unqualified `theme:<providerFqn>` keep the plain outlined pill: the page cannot resolve a
+   mode for those without guessing. */
+.cp-theme-btn:is([data-theme-choice="light"], [data-theme-mode="light"],
+    [data-compare-theme="light"]) { color-scheme: light; }
+.cp-theme-btn:is([data-theme-choice="dark"], [data-theme-mode="dark"],
+    [data-compare-theme="dark"]) { color-scheme: dark; }
+.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"], [data-theme-mode],
     [data-compare-theme="light"], [data-compare-theme="dark"]) {
   background: var(--md-sys-color-surface-container-low);
   color: var(--md-sys-color-on-surface);
   border-color: var(--md-sys-color-outline-variant); }
-.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"],
+.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"], [data-theme-mode],
     [data-compare-theme="light"], [data-compare-theme="dark"]):hover:not(:disabled) {
   background: color-mix(in srgb, var(--md-sys-color-on-surface) 8%,
     var(--md-sys-color-surface-container-low)); }
@@ -575,7 +576,7 @@ html.cp-js .cp-section-head { display: none; }
    against the surface it is actually painted on. Everything here therefore stays inside one
    `color-scheme`, which is also why the pin above is unconditional: a rule that dropped the pin on
    a state change would leave the chip's colours resolved in one mode and its label in another. */
-.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"],
+.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"], [data-theme-mode],
     [data-compare-theme="light"], [data-compare-theme="dark"]):disabled {
   background: var(--md-sys-color-surface-container-low);
   color: color-mix(in srgb, var(--md-sys-color-on-surface) 38%, transparent);
@@ -590,13 +591,13 @@ html.cp-js .cp-section-head { display: none; }
    only, so an outward ring is clipped flat along the top — and along the outer edge of the first
    and last chip — leaving a "selected" marker with two sides missing. An inset ring is clip-proof
    in any container, and on a filled swatch it reads as the chip's own keyline anyway. */
-.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"],
+.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"], [data-theme-mode],
     [data-compare-theme="light"], [data-compare-theme="dark"])[aria-pressed="true"] {
   background: var(--md-sys-color-surface-container-low);
   color: var(--md-sys-color-on-surface);
   border-color: transparent; font-weight: 600;
   box-shadow: inset 0 0 0 2px var(--md-sys-color-primary); }
-.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"],
+.cp-theme-btn:is([data-theme-choice="light"], [data-theme-choice="dark"], [data-theme-mode],
     [data-compare-theme="light"], [data-compare-theme="dark"])[aria-pressed="true"]:disabled {
   color: color-mix(in srgb, var(--md-sys-color-on-surface) 38%, transparent);
   box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--md-sys-color-primary) 38%, transparent); }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
@@ -143,22 +143,17 @@ class ServePageThemeTest {
   }
 
   @Test
-  fun `the baked Light and Dark chips are painted in their own theme`() {
+  fun `theme chips with a resolved mode are painted in their own theme`() {
     // The chips are a taster, not two labels: each pins its own `color-scheme`, which re-resolves
     // every `light-dark()` pair — including a served catalog's palette — in THAT chip's mode. The
     // same property the page-theme setting uses, applied one level down.
     val sheet = ServeWebAssets.load("serve.css")!!.bytes.decodeToString()
     assertTrue(
-      sheet.contains(
-        """[data-theme-choice="light"], [data-compare-theme="light"]) """ +
-          "{ color-scheme: light; }"
-      ),
+      sheet.contains("""[data-compare-theme="light"]) { color-scheme: light; }"""),
       "the Light chip must resolve the token layer in light",
     )
     assertTrue(
-      sheet.contains(
-        """[data-theme-choice="dark"], [data-compare-theme="dark"]) """ + "{ color-scheme: dark; }"
-      ),
+      sheet.contains("""[data-compare-theme="dark"]) { color-scheme: dark; }"""),
       "the Dark chip must resolve it in dark",
     )
     // Selection is a ring rather than a fill swap: the fill IS the swatch, so replacing it would
@@ -171,6 +166,34 @@ class ServePageThemeTest {
         .substringBefore("}")
     assertTrue(pressed.contains("box-shadow: inset 0 0 0 2px"), pressed)
     assertTrue(pressed.contains("--md-sys-color-surface-container-low"), pressed)
+  }
+
+  @Test
+  fun `a named declared theme paints the page and card stage in its mode`() {
+    val darkTheme = ServeTheme("Dark Medium Contrast", "com.example.DarkMediumContrastTheme")
+    val html =
+      ServeWeb.landingPage(
+        "compose-m3",
+        previews,
+        token = "t",
+        declaredThemes = listOf(darkTheme),
+        canRenderThemeFor = { true },
+      )
+
+    assertTrue(
+      html.contains(
+        "data-theme-choice=\"theme:${darkTheme.providerFqn}\" data-theme-mode=\"dark\""
+      ),
+      "the declared-theme chip must carry its resolved mode",
+    )
+    assertTrue(
+      html.contains("\"theme:${darkTheme.providerFqn}\":\"dark\""),
+      "the pre-paint script must resolve a shared declared-theme URL before first paint",
+    )
+    assertTrue(
+      html.contains("if (selectedThemeMode) c.setAttribute(\"data-bg-theme\", selectedThemeMode)"),
+      "a themed render's card stage must follow that theme's mode",
+    )
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeViewerThemeBarTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeViewerThemeBarTest.kt
@@ -68,7 +68,7 @@ class ServeViewerThemeBarTest {
         "no chip for ${theme.name}: $html",
       )
       assertTrue(
-        html.contains("<option value=\"theme:${theme.providerFqn}\">"),
+        html.contains("<option value=\"theme:${theme.providerFqn}\""),
         "the chip's value must be an option the select actually offers: $html",
       )
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -4300,7 +4300,7 @@ class ServeWebFixtureTest {
     )
     assertTrue(
       view.contains(
-        "<option value=\"theme:com.example.BrandLightThemeCatalog\">Brand Light</option>"
+        "<option value=\"theme:com.example.BrandLightThemeCatalog\" data-theme-mode=\"light\">Brand Light</option>"
       ),
       "each declared theme is an option keyed by its provider FQN",
     )
@@ -4348,7 +4348,9 @@ class ServeWebFixtureTest {
     assertTrue(
       Regex("<select id=\"cp-theme\"[^>]*data-has-declared-themes=\"true\"[^>]* disabled>")
         .containsMatchIn(staticThemed) &&
-        staticThemed.contains("value=\"theme:com.example.BrandLightThemeCatalog\" disabled"),
+        staticThemed.contains(
+          "value=\"theme:com.example.BrandLightThemeCatalog\" data-theme-mode=\"light\" disabled"
+        ),
       "the theme selector is disabled on a static bundle (no daemon to apply it)",
     )
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
@@ -130,10 +130,14 @@ class ServeWebGridThumbnailTest {
     assertTrue(html.contains("data-theme-choice=\"light\">Light</button>"))
     assertTrue(html.contains("data-theme-choice=\"dark\">Dark</button>"))
     assertTrue(
-      html.contains("data-theme-choice=\"theme:com.example.LightTheme\">Example · Light</button>")
+      html.contains(
+        "data-theme-choice=\"theme:com.example.LightTheme\" data-theme-mode=\"light\">Example · Light</button>"
+      )
     )
     assertTrue(
-      html.contains("data-theme-choice=\"theme:com.example.DarkTheme\">Example · Dark</button>")
+      html.contains(
+        "data-theme-choice=\"theme:com.example.DarkTheme\" data-theme-mode=\"dark\">Example · Dark</button>"
+      )
     )
   }
 

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
@@ -217,6 +217,12 @@ var appliedTheme = null;
         themeBtns.forEach(function (b) {
   b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
 });
+var selectedThemeButton = null;
+themeBtns.forEach(function (b) {
+  if (b.getAttribute("data-theme-choice") === theme) selectedThemeButton = b;
+});
+var selectedThemeMode = selectedThemeButton
+  ? selectedThemeButton.getAttribute("data-theme-mode") || "" : "";
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
 // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -8,7 +8,7 @@
         <!-- Apply the Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
-        <script>try{var p=new URLSearchParams(location.search),t=localStorage.getItem("cp-page-theme")==="system"?"":(p.get("theme")||p.get("uiMode")||localStorage.getItem("cp-theme:compose-m3"));if(t==="light"||t==="dark")document.documentElement.classList.add("cp-scheme-"+t);}catch(e){}</script>
+        <script>try{var p=new URLSearchParams(location.search),m={"theme:com.example.BrandLightThemeCatalog":"light","theme:com.example.BrandDarkThemeCatalog":"dark"},t=localStorage.getItem("cp-page-theme")==="system"?"":(p.get("theme")||p.get("uiMode")||localStorage.getItem("cp-theme:compose-m3"));t=m[t]||t;if(t==="light"||t==="dark")document.documentElement.classList.add("cp-scheme-"+t);}catch(e){}</script>
       </head>
       <body>
         <header class="cp-site-header">
@@ -57,8 +57,8 @@
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
-    <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandLightThemeCatalog" title="Brand · Brand Light">Brand Light</button>
-    <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandDarkThemeCatalog" title="Brand · Brand Dark">Brand Dark</button>
+    <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandLightThemeCatalog" data-theme-mode="light" title="Brand · Brand Light">Brand Light</button>
+    <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandDarkThemeCatalog" data-theme-mode="dark" title="Brand · Brand Dark">Brand Dark</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.HighContrastThemeCatalog">High Contrast</button>
   </span>
 </div>
@@ -348,6 +348,12 @@ window.addEventListener("pagehide", function () { releaseThemeLease(themeLease, 
         themeBtns.forEach(function (b) {
   b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
 });
+var selectedThemeButton = null;
+themeBtns.forEach(function (b) {
+  if (b.getAttribute("data-theme-choice") === theme) selectedThemeButton = b;
+});
+var selectedThemeMode = selectedThemeButton
+  ? selectedThemeButton.getAttribute("data-theme-mode") || "" : "";
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
 // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.
@@ -403,6 +409,7 @@ function applyThemeChoice() {
       var img = c.querySelector("img");
       var base = themeBase[i];
       if (!img || !base) return;
+      if (selectedThemeMode) c.setAttribute("data-bg-theme", selectedThemeMode);
       var themedSrc = base + (base.indexOf("?") === -1 ? "?" : "&") + "themeProvider=" + encodeURIComponent(provider);
       var job = {
         card: c,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -252,6 +252,12 @@ var appliedTheme = null;
         themeBtns.forEach(function (b) {
   b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
 });
+var selectedThemeButton = null;
+themeBtns.forEach(function (b) {
+  if (b.getAttribute("data-theme-choice") === theme) selectedThemeButton = b;
+});
+var selectedThemeMode = selectedThemeButton
+  ? selectedThemeButton.getAttribute("data-theme-mode") || "" : "";
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
 // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-ir-replay-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-ir-replay-themes.html
@@ -166,6 +166,12 @@ var appliedTheme = null;
         themeBtns.forEach(function (b) {
   b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
 });
+var selectedThemeButton = null;
+themeBtns.forEach(function (b) {
+  if (b.getAttribute("data-theme-choice") === theme) selectedThemeButton = b;
+});
+var selectedThemeMode = selectedThemeButton
+  ? selectedThemeButton.getAttribute("data-theme-mode") || "" : "";
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
 // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-live.html
@@ -166,6 +166,12 @@ var appliedTheme = null;
         themeBtns.forEach(function (b) {
   b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
 });
+var selectedThemeButton = null;
+themeBtns.forEach(function (b) {
+  if (b.getAttribute("data-theme-choice") === theme) selectedThemeButton = b;
+});
+var selectedThemeMode = selectedThemeButton
+  ? selectedThemeButton.getAttribute("data-theme-mode") || "" : "";
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
 // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -156,6 +156,12 @@ var appliedTheme = null;
         themeBtns.forEach(function (b) {
   b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
 });
+var selectedThemeButton = null;
+themeBtns.forEach(function (b) {
+  if (b.getAttribute("data-theme-choice") === theme) selectedThemeButton = b;
+});
+var selectedThemeMode = selectedThemeButton
+  ? selectedThemeButton.getAttribute("data-theme-mode") || "" : "";
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
 // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -166,6 +166,12 @@ var appliedTheme = null;
         themeBtns.forEach(function (b) {
   b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
 });
+var selectedThemeButton = null;
+themeBtns.forEach(function (b) {
+  if (b.getAttribute("data-theme-choice") === theme) selectedThemeButton = b;
+});
+var selectedThemeMode = selectedThemeButton
+  ? selectedThemeButton.getAttribute("data-theme-mode") || "" : "";
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
 // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -141,6 +141,12 @@ var appliedTheme = null;
         themeBtns.forEach(function (b) {
   b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
 });
+var selectedThemeButton = null;
+themeBtns.forEach(function (b) {
+  if (b.getAttribute("data-theme-choice") === theme) selectedThemeButton = b;
+});
+var selectedThemeMode = selectedThemeButton
+  ? selectedThemeButton.getAttribute("data-theme-mode") || "" : "";
 // Point a swap card at one of its baked variants ("l"/"d"): pixels (unless the caller is
 // supplying themed ones), alt text, label, id, viewer link and stage backing.
 // Point a card's <img> at a plain URL, releasing whatever blob it was holding first.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -8,7 +8,7 @@
         <!-- Apply the Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
-        <script>try{var p=new URLSearchParams(location.search),t=localStorage.getItem("cp-page-theme")==="system"?"":(p.get("theme")||p.get("uiMode")||localStorage.getItem("cp-theme:compose-m3"));if(t==="light"||t==="dark")document.documentElement.classList.add("cp-scheme-"+t);}catch(e){}</script>
+        <script>try{var p=new URLSearchParams(location.search),m={"theme:com.example.BrandLightThemeCatalog":"light","theme:com.example.BrandDarkThemeCatalog":"dark"},t=localStorage.getItem("cp-page-theme")==="system"?"":(p.get("theme")||p.get("uiMode")||localStorage.getItem("cp-theme:compose-m3"));t=m[t]||t;if(t==="light"||t==="dark")document.documentElement.classList.add("cp-scheme-"+t);}catch(e){}</script>
       </head>
       <body>
         <header class="cp-site-header">
@@ -76,8 +76,8 @@
         <span class="cp-theme cp-theme-bar" role="group" aria-label="Preview theme">
           <button type="button" class="cp-theme-btn" data-theme-choice="light">Day</button>
           <button type="button" class="cp-theme-btn" data-theme-choice="dark">Night</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandLightThemeCatalog" title="Brand · Brand Light">Brand Light</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandDarkThemeCatalog" title="Brand · Brand Dark">Brand Dark</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandLightThemeCatalog" data-theme-mode="light" title="Brand · Brand Light">Brand Light</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandDarkThemeCatalog" data-theme-mode="dark" title="Brand · Brand Dark">Brand Dark</button>
         </span>
         <button type="button" class="cp-bg-btn cp-bg-toggle" aria-pressed="false" title="Show the transparent checkerboard behind the preview">Transparent</button>
         <button type="button" class="cp-bg-btn cp-zoom-toggle" aria-pressed="false" title="Show the preview at full width instead of fitting it to the screen">Fit width</button>
@@ -109,8 +109,8 @@
           <select id="cp-theme" class="cp-knob-theme" data-theme-active="0" data-has-declared-themes="true" data-fixed-theme="false" tabindex="-1">
             <option value="light" selected>Day (Default)</option>
             <option value="dark">Night (Default)</option>
-            <optgroup label="Brand"><option value="theme:com.example.BrandLightThemeCatalog">Brand Light</option>
-<option value="theme:com.example.BrandDarkThemeCatalog">Brand Dark</option></optgroup>
+            <optgroup label="Brand"><option value="theme:com.example.BrandLightThemeCatalog" data-theme-mode="light">Brand Light</option>
+<option value="theme:com.example.BrandDarkThemeCatalog" data-theme-mode="dark">Brand Dark</option></optgroup>
           </select>
         </span>
           <details class="cp-group" data-cp-group="size">
@@ -365,8 +365,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
@@ -303,8 +303,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -265,8 +265,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -263,8 +263,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history-local.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history-local.html
@@ -246,8 +246,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history.html
@@ -246,8 +246,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-inspect.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-inspect.html
@@ -261,8 +261,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -262,8 +262,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -258,8 +258,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-rc-players.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-rc-players.html
@@ -273,8 +273,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
@@ -256,8 +256,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -259,8 +259,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-theme-overflow.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-theme-overflow.html
@@ -8,7 +8,7 @@
         <!-- Apply the Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
-        <script>try{var p=new URLSearchParams(location.search),t=localStorage.getItem("cp-page-theme")==="system"?"":(p.get("theme")||p.get("uiMode")||localStorage.getItem("cp-theme:compose-m3"));if(t==="light"||t==="dark")document.documentElement.classList.add("cp-scheme-"+t);}catch(e){}</script>
+        <script>try{var p=new URLSearchParams(location.search),m={"theme:com.example.BaselineDarkThemeCatalog":"dark","theme:com.example.BaselineLightThemeCatalog":"light","theme:com.example.DarkHighContrastThemeCatalog":"dark","theme:com.example.DarkMediumContrastThemeCatalog":"dark","theme:com.example.LightHighContrastThemeCatalog":"light","theme:com.example.LightMediumContrastThemeCatalog":"light"},t=localStorage.getItem("cp-page-theme")==="system"?"":(p.get("theme")||p.get("uiMode")||localStorage.getItem("cp-theme:compose-m3"));t=m[t]||t;if(t==="light"||t==="dark")document.documentElement.classList.add("cp-scheme-"+t);}catch(e){}</script>
       </head>
       <body>
         <header class="cp-site-header">
@@ -72,12 +72,12 @@
         <span class="cp-theme cp-theme-bar" role="group" aria-label="Preview theme">
           <button type="button" class="cp-theme-btn" data-theme-choice="light">Day</button>
           <button type="button" class="cp-theme-btn" data-theme-choice="dark">Night</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BaselineDarkThemeCatalog">Baseline Dark</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BaselineLightThemeCatalog">Baseline Light</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.DarkHighContrastThemeCatalog">Dark High Contrast</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.DarkMediumContrastThemeCatalog">Dark Medium Contrast</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.LightHighContrastThemeCatalog">Light High Contrast</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.LightMediumContrastThemeCatalog">Light Medium Contrast</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BaselineDarkThemeCatalog" data-theme-mode="dark">Baseline Dark</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BaselineLightThemeCatalog" data-theme-mode="light">Baseline Light</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.DarkHighContrastThemeCatalog" data-theme-mode="dark">Dark High Contrast</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.DarkMediumContrastThemeCatalog" data-theme-mode="dark">Dark Medium Contrast</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.LightHighContrastThemeCatalog" data-theme-mode="light">Light High Contrast</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.LightMediumContrastThemeCatalog" data-theme-mode="light">Light Medium Contrast</button>
         </span>
         <button type="button" class="cp-bg-btn cp-bg-toggle" aria-pressed="false" title="Show the transparent checkerboard behind the preview">Transparent</button>
         <button type="button" class="cp-bg-btn cp-zoom-toggle" aria-pressed="false" title="Show the preview at full width instead of fitting it to the screen">Fit width</button>
@@ -121,12 +121,12 @@
           <select id="cp-theme" class="cp-knob-theme" data-theme-active="0" data-has-declared-themes="true" data-fixed-theme="false" tabindex="-1">
             <option value="light">Day (Default)</option>
             <option value="dark" selected>Night (Default)</option>
-            <option value="theme:com.example.BaselineDarkThemeCatalog">Baseline Dark</option>
-<option value="theme:com.example.BaselineLightThemeCatalog">Baseline Light</option>
-<option value="theme:com.example.DarkHighContrastThemeCatalog">Dark High Contrast</option>
-<option value="theme:com.example.DarkMediumContrastThemeCatalog">Dark Medium Contrast</option>
-<option value="theme:com.example.LightHighContrastThemeCatalog">Light High Contrast</option>
-<option value="theme:com.example.LightMediumContrastThemeCatalog">Light Medium Contrast</option>
+            <option value="theme:com.example.BaselineDarkThemeCatalog" data-theme-mode="dark">Baseline Dark</option>
+<option value="theme:com.example.BaselineLightThemeCatalog" data-theme-mode="light">Baseline Light</option>
+<option value="theme:com.example.DarkHighContrastThemeCatalog" data-theme-mode="dark">Dark High Contrast</option>
+<option value="theme:com.example.DarkMediumContrastThemeCatalog" data-theme-mode="dark">Dark Medium Contrast</option>
+<option value="theme:com.example.LightHighContrastThemeCatalog" data-theme-mode="light">Light High Contrast</option>
+<option value="theme:com.example.LightMediumContrastThemeCatalog" data-theme-mode="light">Light Medium Contrast</option>
           </select>
         </span>
           <details class="cp-group" data-cp-group="size">
@@ -273,8 +273,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -8,7 +8,7 @@
         <!-- Apply the Transparent choice before first paint (no checkerboard flash).
              A `?bg=` on the URL is an explicit, shareable choice and outranks the sticky one. -->
         <script>try{var b=new URLSearchParams(location.search).get("bg");if(b?b==="off":localStorage.getItem("cp-bg")==="off")document.documentElement.classList.add("cp-bg-transparent");}catch(e){}</script>
-        <script>try{var p=new URLSearchParams(location.search),t=localStorage.getItem("cp-page-theme")==="system"?"":(p.get("theme")||p.get("uiMode")||localStorage.getItem("cp-theme:compose-m3"));if(t==="light"||t==="dark")document.documentElement.classList.add("cp-scheme-"+t);}catch(e){}</script>
+        <script>try{var p=new URLSearchParams(location.search),m={"theme:com.example.BrandLightThemeCatalog":"light","theme:com.example.BrandDarkThemeCatalog":"dark"},t=localStorage.getItem("cp-page-theme")==="system"?"":(p.get("theme")||p.get("uiMode")||localStorage.getItem("cp-theme:compose-m3"));t=m[t]||t;if(t==="light"||t==="dark")document.documentElement.classList.add("cp-scheme-"+t);}catch(e){}</script>
       </head>
       <body>
         <header class="cp-site-header">
@@ -72,8 +72,8 @@
         <span class="cp-theme cp-theme-bar" role="group" aria-label="Preview theme">
           <button type="button" class="cp-theme-btn" data-theme-choice="light">Day</button>
           <button type="button" class="cp-theme-btn" data-theme-choice="dark">Night</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandLightThemeCatalog" title="Brand · Brand Light">Brand Light</button>
-          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandDarkThemeCatalog" title="Brand · Brand Dark">Brand Dark</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandLightThemeCatalog" data-theme-mode="light" title="Brand · Brand Light">Brand Light</button>
+          <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.BrandDarkThemeCatalog" data-theme-mode="dark" title="Brand · Brand Dark">Brand Dark</button>
           <button type="button" class="cp-theme-btn" data-theme-choice="theme:com.example.HighContrastThemeCatalog">High Contrast</button>
         </span>
         <button type="button" class="cp-bg-btn cp-bg-toggle" aria-pressed="false" title="Show the transparent checkerboard behind the preview">Transparent</button>
@@ -107,8 +107,8 @@
             <option value="light">Day (Default)</option>
             <option value="dark" selected>Night (Default)</option>
             <option value="theme:com.example.HighContrastThemeCatalog">High Contrast</option>
-<optgroup label="Brand"><option value="theme:com.example.BrandLightThemeCatalog">Brand Light</option>
-<option value="theme:com.example.BrandDarkThemeCatalog">Brand Dark</option></optgroup>
+<optgroup label="Brand"><option value="theme:com.example.BrandLightThemeCatalog" data-theme-mode="light">Brand Light</option>
+<option value="theme:com.example.BrandDarkThemeCatalog" data-theme-mode="dark">Brand Dark</option></optgroup>
           </select>
         </span>
           <details class="cp-group" data-cp-group="size">
@@ -255,8 +255,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -253,8 +253,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -258,8 +258,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -249,8 +249,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
@@ -241,8 +241,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -303,8 +303,10 @@
     // (daemon or Wasm). On a static bundle the select is disabled but the seeding above may still
     // have copied a remembered localStorage value into el.value — honoring it would tint the
     // stage while ServeBundleHost keeps returning the UNCHANGED baked PNG. Keep bgDefault there.
-    var chosen =
-      !el.disabled && (el.value === "light" || el.value === "dark") ? el.value : "";
+    var selectedOption = el.options[el.selectedIndex];
+    var chosen = !el.disabled && selectedOption
+      ? selectedOption.getAttribute("data-theme-mode") ||
+        (el.value === "light" || el.value === "dark" ? el.value : "") : "";
     var m = chosen || bgDefault;
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");


### PR DESCRIPTION
## Summary

- resolve unambiguous light/dark modes for declared `ThemeCatalog` providers
- apply the selected mode to page chrome, theme chips, and card/viewer stage backgrounds
- update tests and generated browser fixtures

## Root cause

Declared themes were treated as palette-only choices, so page-theme and stage-background logic ignored their light/dark mode and fell back to the OS or baked preview variant.

## Validation

- `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.ServePageThemeTest' --tests 'ee.schimke.composeai.cli.serve.ServeViewerThemeBarTest' --tests 'ee.schimke.composeai.cli.serve.ServeWebGridThumbnailTest' --tests 'ee.schimke.composeai.cli.serve.ServeWebFixtureTest'`
- preview-harness visual verification of the declared dark theme: dark page chrome, pressed dark-theme chip, and dark card stage
- `./gradlew ktfmtFormatAll`
