### PR TITLE
fix(design-artifacts): preserve Figma reference scale

### DIFF
--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -436,6 +436,10 @@ export function planDesignReferences({ designMap, spec, catalog }) {
           path: `${REFERENCES_DIR}/${id}.png`,
           width: image.width,
           height: image.height,
+          // Newer exporters may retain the @Preview renderer density on the image. It is
+          // driver-only here and lets a Figma component be requested at the exact non-default
+          // density that produced its Compose sticker.
+          ...(typeof image.density === "number" ? { density: image.density } : {}),
         },
         source: {
           provider: providerFor(entry.source),

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -396,6 +396,24 @@ test("planDesignReferences carries a declared board density to the driver", () =
   assert.equal(records[1].origin.density, undefined);
 });
 
+test("planDesignReferences carries an image renderer density to the raster target", () => {
+  const catalog = structuredClone(CATALOG);
+  catalog.components[0].images[0].density = 3;
+  const designMap = {
+    components: [
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatPreview",
+        source: "figma",
+        ref: "figma:abc/73:5",
+      },
+    ],
+  };
+
+  const { records } = planDesignReferences({ designMap, spec: SPEC, catalog });
+
+  assert.equal(records[0].raster.density, 3);
+});
+
 test("planDesignReferences warns rather than throwing when a handle maps to nothing", () => {
   const designMap = {
     components: [{ code: "ui/Other.kt#NotInTheSpec", source: "claude-design", ref: "x.html" }],

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -28,11 +28,11 @@
  *    token is present (`FIGMA_TOKEN` / `FIGMA_PAT` / `FIGMA_ACCESS_TOKEN`). No token ⇒ the entry is
  *    skipped with a warning, which is the normal state for a fork or a PR run.
  *
- * Every raster is then fitted to the dimensions of the catalog sticker it is mapped to and hashed,
- * so the server can verify it before advertising the reference. Fitted, not stretched: a raster
- * within rounding distance is resampled, and one authored at genuinely different proportions is
- * scaled to fit and letterboxed rather than distorted into the sticker's shape. See
- * png-resample.mjs for why that distinction matters.
+ * Every raster is then placed on a canvas matching the catalog sticker and hashed, so the server
+ * can verify it before advertising the reference. Figma components are exported at the Compose
+ * renderer's density and centred without enlargement; other rasters within rounding distance are
+ * resampled, while genuinely different proportions are fitted and letterboxed. See
+ * png-resample.mjs for why those distinctions matter.
  *
  * ## Failure posture
  *
@@ -54,7 +54,7 @@ import {
   planDesignReferences,
   referenceManifest,
 } from "./design-references.mjs";
-import { fitRgba, isRoundingDelta, resampleRgba } from "./png-resample.mjs";
+import { fitRgba, isRoundingDelta, placeRgba, resampleRgba } from "./png-resample.mjs";
 import { layoutFromNode } from "@design-parity/adapter-figma";
 import { scaleTree } from "./reference-layout.mjs";
 import { withReferenceAnnotations } from "@design-parity/catalog-export";
@@ -208,7 +208,7 @@ function suppliedRaster(ref) {
 /** Obtain the raw raster for one planned record, or null with a warning. */
 async function sourceRaster(record) {
   const { source, ref } = record.origin;
-  const target = { width: record.raster.width, height: record.raster.height };
+  const target = targetFor(record);
 
   const supplied = suppliedRaster(ref);
   if (supplied) return readPng(supplied);
@@ -239,6 +239,14 @@ async function sourceRaster(record) {
 
   warn(`${record.id}: don't know how to rasterise a '${source}' reference from '${ref}'`);
   return null;
+}
+
+function targetFor(record) {
+  return {
+    width: record.raster.width,
+    height: record.raster.height,
+    ...(record.raster.density ? { density: record.raster.density } : {}),
+  };
 }
 
 /**
@@ -277,12 +285,12 @@ if (FIGMA_TOKEN) {
       .filter((record) => parseFigmaRef(record.origin.ref) && !suppliedRaster(record.origin.ref))
       .map((record) => ({
         ref: record.origin.ref,
-        target: { width: record.raster.width, height: record.raster.height },
+        target: targetFor(record),
       })),
   );
 }
 for (const record of records) {
-  const target = { width: record.raster.width, height: record.raster.height };
+  const target = targetFor(record);
   let raster;
   try {
     raster = await sourceRaster(record);
@@ -303,36 +311,59 @@ for (const record of records) {
       })
     : undefined;
 
-  // Where the artwork ends up inside the published raster. Full-bleed unless a fit letterboxes it.
+  // Where the artwork ends up inside the published raster. Full-bleed unless it is placed/fitted.
   let placement = { width: target.width, height: target.height, x: 0, y: 0 };
   if (raster.width !== target.width || raster.height !== target.height) {
-    const rounding = isRoundingDelta(raster.width, raster.height, target.width, target.height);
-    const message =
-      `${record.id}: ${rounding ? "resampling" : "fitting"} reference ` +
-      `${raster.width}x${raster.height} -> ${target.width}x${target.height}`;
-    if (rounding) {
-      // Sub-pixel: the proportions already agree, so stretch and say nothing.
-      console.log(`design-references: ${message}`);
-      raster = {
-        width: target.width,
-        height: target.height,
-        data: resampleRgba(raster.data, raster.width, raster.height, target.width, target.height),
-      };
+    if (raster.preserveScale) {
+      // A Figma component is exported at the Compose renderer's density. Its artboard is normally
+      // tight while the target sticker includes scaffold padding, so centre it at that natural
+      // size. Scaling it up to fill the canvas is the bug that made correctly sized components
+      // appear ~1.5x too large in the comparison lane.
+      const placed = placeRgba(
+        raster.data,
+        raster.width,
+        raster.height,
+        target.width,
+        target.height,
+      );
+      placement = placed.box;
+      const reduced = placed.box.width !== raster.width || placed.box.height !== raster.height;
+      const message =
+        `${record.id}: placing density-matched reference ${raster.width}x${raster.height} ` +
+        `on ${target.width}x${target.height} canvas`;
+      if (reduced) warn(`${message} (too large; reduced to fit)`);
+      else console.log(`design-references: ${message}`);
+      raster = { width: target.width, height: target.height, data: placed.data };
     } else {
-      // A real size difference. Stretching here would republish the design at proportions its
-      // author never drew, so scale it to fit and leave the remainder transparent — the comparison
-      // normalises to the content box, so the padding costs nothing and the shape survives.
-      const fitted = fitRgba(raster.data, raster.width, raster.height, target.width, target.height);
-      placement = fitted.box;
-      if (fitted.box.width !== target.width || fitted.box.height !== target.height) {
-        warn(
-          `${message} (letterboxed to ${fitted.box.width}x${fitted.box.height} — the reference's ` +
-            `proportions differ from the sticker's)`
-        );
-      } else {
+      const rounding = isRoundingDelta(raster.width, raster.height, target.width, target.height);
+      const message =
+        `${record.id}: ${rounding ? "resampling" : "fitting"} reference ` +
+        `${raster.width}x${raster.height} -> ${target.width}x${target.height}`;
+      if (rounding) {
+        // Sub-pixel: the proportions already agree, so stretch and say nothing.
         console.log(`design-references: ${message}`);
+        raster = {
+          width: target.width,
+          height: target.height,
+          data: resampleRgba(raster.data, raster.width, raster.height, target.width, target.height),
+        };
+      } else {
+        // A real size difference. Stretching here would republish the design at proportions its
+        // author never drew, so scale it to fit and leave the remainder transparent — the
+        // comparison normalises to the content box, so the padding costs nothing and the shape
+        // survives.
+        const fitted = fitRgba(raster.data, raster.width, raster.height, target.width, target.height);
+        placement = fitted.box;
+        if (fitted.box.width !== target.width || fitted.box.height !== target.height) {
+          warn(
+            `${message} (letterboxed to ${fitted.box.width}x${fitted.box.height} — the reference's ` +
+              `proportions differ from the sticker's)`,
+          );
+        } else {
+          console.log(`design-references: ${message}`);
+        }
+        raster = { width: target.width, height: target.height, data: fitted.data };
       }
-      raster = { width: target.width, height: target.height, data: fitted.data };
     }
   }
 

--- a/scripts/design-artifacts/figma-rest-raster.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.mjs
@@ -1,5 +1,8 @@
 import { PNG } from "pngjs";
 
+/** Compose Desktop's renderer density when an @Preview does not override it. */
+export const DEFAULT_RENDER_DENSITY = 2.625;
+
 /** `figma:<fileKey>/<nodeId>` -> `{ fileKey, nodeId }`, or null. */
 export function parseFigmaRef(ref) {
   const match = /^figma:([^/]+)\/(.+)$/.exec(String(ref ?? ""));
@@ -81,8 +84,11 @@ export class FigmaRestRasterizer {
   scaleFor(parsed, target) {
     const entry = this.nodes.get(this.nodeKey(parsed));
     if (entry instanceof Error) throw entry;
-    const width = entry?.document?.absoluteBoundingBox?.width;
-    const raw = width ? target.width / width : 2;
+    const requested = target?.density;
+    const raw =
+      typeof requested === "number" && Number.isFinite(requested) && requested > 0
+        ? requested
+        : DEFAULT_RENDER_DENSITY;
     // Four decimals keep requests stable and batch components rendered at the same density while
     // remaining far below a physical pixel of error at Figma's maximum scale.
     return Number(Math.min(4, Math.max(0.01, raw)).toFixed(4));
@@ -187,6 +193,9 @@ export class FigmaRestRasterizer {
             data: decoded.data,
             document: node?.document,
             styles: node?.styles,
+            // This export was requested at the renderer's density. The emitter must preserve that
+            // scale when it adds the preview canvas around the tight Figma component.
+            preserveScale: true,
           };
         })(),
       );

--- a/scripts/design-artifacts/figma-rest-raster.test.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.test.mjs
@@ -2,7 +2,11 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { PNG } from "pngjs";
 
-import { FigmaRestRasterizer, parseFigmaRef } from "./figma-rest-raster.mjs";
+import {
+  DEFAULT_RENDER_DENSITY,
+  FigmaRestRasterizer,
+  parseFigmaRef,
+} from "./figma-rest-raster.mjs";
 
 function json(value, init) {
   return new Response(JSON.stringify(value), {
@@ -63,7 +67,36 @@ test("batches nodes and equal-scale image exports, then caches duplicate rasters
   assert.equal(calls.filter((url) => url.includes("/images/")).length, 1);
   assert.equal(calls.filter((url) => url.includes("cdn.test")).length, 2);
   assert.match(calls.find((url) => url.includes("/nodes?")), /ids=1%3A1%2C2%3A2/);
-  assert.match(calls.find((url) => url.includes("/images/")), /scale=2/);
+  assert.match(
+    calls.find((url) => url.includes("/images/")),
+    new RegExp(`scale=${DEFAULT_RENDER_DENSITY}`),
+  );
+});
+
+test("exports at renderer density instead of scaling a tight node to the padded canvas", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url.includes("/nodes?")) {
+      return json({ nodes: { "1:1": { document: { absoluteBoundingBox: { width: 95 } } } } });
+    }
+    if (url.includes("/images/")) return json({ images: { "1:1": "https://cdn.test/1:1" } });
+    return new Response(onePixelPng(), { status: 200 });
+  };
+  const rasterizer = new FigmaRestRasterizer({ token: "token", fetchImpl });
+
+  await rasterizer.rasterize("figma:file/1:1", { width: 382, height: 210 });
+
+  const imageUrl = calls.find((url) => url.includes("/images/"));
+  assert.equal(new URL(imageUrl).searchParams.get("scale"), "2.625");
+  assert.notEqual(new URL(imageUrl).searchParams.get("scale"), "4");
+});
+
+test("honours an explicit preview renderer density", async () => {
+  const rasterizer = new FigmaRestRasterizer({ token: "token", fetchImpl: async () => json({}) });
+  const parsed = parseFigmaRef("figma:file/1:1");
+  rasterizer.nodes.set(rasterizer.nodeKey(parsed), { document: { absoluteBoundingBox: { width: 95 } } });
+  assert.equal(rasterizer.scaleFor(parsed, { width: 382, height: 210, density: 3 }), 3);
 });
 
 test("retries a rate-limited batch once and respects Retry-After", async () => {

--- a/scripts/design-artifacts/png-resample.mjs
+++ b/scripts/design-artifacts/png-resample.mjs
@@ -126,3 +126,39 @@ export function fitRgba(data, width, height, targetWidth, targetHeight) {
   }
   return { data: out, box };
 }
+
+/**
+ * Centre a raster on a transparent target canvas without enlarging it.
+ *
+ * This is the operation a density-matched component export needs. Its pixel dimensions already
+ * describe the component at the renderer's scale; fitting it upward to consume a padded preview
+ * canvas would change that scale. An oversized source is still reduced uniformly so it remains
+ * representable rather than being clipped.
+ */
+export function placeRgba(data, width, height, targetWidth, targetHeight) {
+  if (width <= 0 || height <= 0 || targetWidth <= 0 || targetHeight <= 0) {
+    throw new Error(`place: bad dimensions ${width}x${height} -> ${targetWidth}x${targetHeight}`);
+  }
+  const scale = Math.min(1, targetWidth / width, targetHeight / height);
+  const placedWidth = Math.max(1, Math.min(targetWidth, Math.round(width * scale)));
+  const placedHeight = Math.max(1, Math.min(targetHeight, Math.round(height * scale)));
+  const box = {
+    width: placedWidth,
+    height: placedHeight,
+    x: Math.floor((targetWidth - placedWidth) / 2),
+    y: Math.floor((targetHeight - placedHeight) / 2),
+  };
+  const placed =
+    placedWidth === width && placedHeight === height
+      ? data
+      : resampleRgba(data, width, height, placedWidth, placedHeight);
+  if (box.width === targetWidth && box.height === targetHeight) return { data: placed, box };
+  const out = Buffer.alloc(targetWidth * targetHeight * 4);
+  const rowBytes = box.width * 4;
+  for (let y = 0; y < box.height; y++) {
+    const from = y * rowBytes;
+    const to = ((y + box.y) * targetWidth + box.x) * 4;
+    out.set(placed.subarray(from, from + rowBytes), to);
+  }
+  return { data: out, box };
+}

--- a/scripts/design-artifacts/png-resample.test.mjs
+++ b/scripts/design-artifacts/png-resample.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { fitBox, fitRgba, isRoundingDelta, resampleRgba } from "./png-resample.mjs";
+import { fitBox, fitRgba, isRoundingDelta, placeRgba, resampleRgba } from "./png-resample.mjs";
 
 /** An RGBA buffer whose pixels are produced by `fn(x, y)` returning `[r,g,b,a]`. */
 function raster(width, height, fn) {
@@ -124,4 +124,21 @@ test("fitRgba is a plain resample when the proportions already agree", () => {
 test("fitRgba rejects bad dimensions rather than emitting a malformed buffer", () => {
   const data = raster(2, 2, () => [0, 0, 0, 255]);
   assert.throws(() => fitRgba(data, 2, 2, 0, 4), /bad dimensions/);
+});
+
+test("placeRgba centres a density-matched component without enlarging it", () => {
+  const data = raster(2, 2, () => [10, 20, 30, 255]);
+  const { data: out, box } = placeRgba(data, 2, 2, 6, 4);
+  assert.deepEqual(box, { width: 2, height: 2, x: 2, y: 1 });
+  const alphaAt = (x, y) => out[(y * 6 + x) * 4 + 3];
+  assert.equal(alphaAt(1, 1), 0);
+  assert.equal(alphaAt(2, 1), 255);
+  assert.equal(alphaAt(3, 2), 255);
+  assert.equal(alphaAt(4, 2), 0);
+});
+
+test("placeRgba only scales when the source would overflow the target", () => {
+  const data = raster(4, 2, () => [1, 2, 3, 255]);
+  const { box } = placeRgba(data, 4, 2, 2, 2);
+  assert.deepEqual(box, { width: 2, height: 1, x: 0, y: 0 });
 });


### PR DESCRIPTION
## Summary

- export Figma reference nodes at the Compose renderer density instead of scaling tight nodes to the padded sticker width
- center density-matched Figma rasters on the transparent sticker canvas without enlarging them
- apply the same placement transform to reference layout annotations and retain explicit per-image densities when available

This fixes the Material 3 outlined-button case: a 95-unit Figma node on a 382px padded sticker was previously clamped to a 4x export and expanded to fill the canvas; it now exports at the default 2.625x renderer density and is centered at its natural size.

## Tests

- node --test png-resample.test.mjs figma-rest-raster.test.mjs reference-layout.test.mjs design-references.test.mjs (55 passed)
- git diff --check
