### PR TITLE
fix(bundle): publish complete executable downloads

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleClasspathHydration.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleClasspathHydration.kt
@@ -22,50 +22,118 @@ internal object BundleClasspathHydration {
     output: File,
     fileSystem: FileSystem = SystemFileSystem,
     resolve: (BundleReader.ExternalClasspath) -> ByteArray?,
+  ): File =
+    hydrate(
+      source = source,
+      output = output,
+      fileSystem = fileSystem,
+      resolveClasspath = resolve,
+      resolveResource = { null },
+    )
+
+  /**
+   * Hydrate both whole classpath entries and resources lifted out of `classes/app.jar`. The result
+   * is published atomically, so a failed resolver never leaves a thin bundle at [output].
+   */
+  fun hydrate(
+    source: File,
+    output: File,
+    fileSystem: FileSystem = SystemFileSystem,
+    resolveClasspath: (BundleReader.ExternalClasspath) -> ByteArray?,
+    resolveResource: (BundleReader.ExternalResource) -> ByteArray?,
   ): File {
     val metadata = BundleReader.readMetadata(source)
-    val external = metadata.manifest.externalClasspath
+    val externalClasspath = metadata.manifest.externalClasspath
+    val externalResources = metadata.manifest.externalResources
     output.parentFile?.mkdirs()
-    if (fileSystem.exists(output.path.toPath())) fileSystem.delete(output.path.toPath())
-    fileSystem.copy(source.path.toPath(), output.path.toPath())
-    if (external.isEmpty()) return output
+    val temporary =
+      File(
+        output.parentFile,
+        "${output.name}.${Thread.currentThread().id}.${System.nanoTime()}.hydrate-tmp",
+      )
+    val temporaryPath = temporary.path.toPath()
+    if (fileSystem.exists(temporaryPath)) fileSystem.delete(temporaryPath)
 
-    val additions = LinkedHashMap<String, ByteArray>()
-    for (entry in external) {
-      require(entry.path == "classes/app.jar") {
-        "unsupported external classpath path '${entry.path}'"
+    try {
+      fileSystem.copy(source.path.toPath(), temporaryPath)
+      if (externalClasspath.isEmpty() && externalResources.isEmpty()) {
+        fileSystem.atomicMove(temporaryPath, output.path.toPath())
+        return output
       }
-      require(entry.sha256.length == 64 && entry.sha256.all { it in '0'..'9' || it in 'a'..'f' }) {
-        "external classpath sha256 '${entry.sha256}' is malformed"
-      }
-      val bytes =
-        checkNotNull(resolve(entry)) {
-          "external classpath ${entry.path} (${entry.sha256}) is unavailable"
+
+      val zip = BundleReader.extractZipBytes(source)
+      val additions = LinkedHashMap<String, ByteArray>()
+      for (entry in externalClasspath) {
+        require(entry.path == "classes/app.jar") {
+          "unsupported external classpath path '${entry.path}'"
         }
-      check(bytes.size.toLong() == entry.size) {
-        "external classpath ${entry.path}: ${bytes.size} bytes != declared ${entry.size}"
+        validateHash(entry.sha256, "external classpath")
+        val bytes =
+          checkNotNull(resolveClasspath(entry)) {
+            "external classpath ${entry.path} (${entry.sha256}) is unavailable"
+          }
+        verifyBlob(entry.path, entry.sha256, entry.size, bytes)
+        additions[entry.path] = bytes
       }
-      check(sha256Hex(bytes) == entry.sha256) {
-        "external classpath ${entry.path}: sha256 mismatch"
-      }
-      additions[entry.path] = bytes
-    }
 
-    val zip = BundleReader.extractZipBytes(source)
-    val manifest =
-      readZipEntry(zip, "bundle.json") ?: error("bundle.json missing in ${source.path}")
-    val root = json.parseToJsonElement(manifest.decodeToString()) as JsonObject
-    additions["bundle.json"] =
-      JsonObject(root.toMutableMap().apply { remove("externalClasspath") })
-        .toString()
-        .encodeToByteArray()
-    rewriteRawZipEntries(
-      output,
-      additions,
-      removals = setOf(BundleSigning.SIGNATURES_PATH),
-      fileSystem = fileSystem,
-    )
-    return output
+      if (externalResources.isNotEmpty()) {
+        val resources = LinkedHashMap<String, ByteArray>()
+        for (entry in externalResources) {
+          require(
+            entry.path.isNotBlank() && !entry.path.startsWith("/") && ".." !in entry.path.split("/")
+          ) {
+            "external resource path '${entry.path}' is invalid"
+          }
+          validateHash(entry.sha256, "external resource")
+          val bytes =
+            checkNotNull(resolveResource(entry)) {
+              "external resource ${entry.path} (${entry.sha256}) is unavailable"
+            }
+          verifyBlob(entry.path, entry.sha256, entry.size, bytes)
+          resources[entry.path] = bytes
+        }
+        val appJar =
+          additions["classes/app.jar"]
+            ?: readZipEntry(zip, "classes/app.jar")
+            ?: error("classes/app.jar missing while restoring external resources")
+        additions["classes/app.jar"] = addOrReplaceZipEntries(appJar, resources)
+      }
+
+      val manifest =
+        readZipEntry(zip, "bundle.json") ?: error("bundle.json missing in ${source.path}")
+      val root = json.parseToJsonElement(manifest.decodeToString()) as JsonObject
+      additions["bundle.json"] =
+        JsonObject(
+            root.toMutableMap().apply {
+              if (externalClasspath.isNotEmpty()) remove("externalClasspath")
+              if (externalResources.isNotEmpty()) remove("externalResources")
+            }
+          )
+          .toString()
+          .encodeToByteArray()
+      rewriteRawZipEntries(
+        temporary,
+        additions,
+        removals = setOf(BundleSigning.SIGNATURES_PATH),
+        fileSystem = fileSystem,
+      )
+      fileSystem.atomicMove(temporaryPath, output.path.toPath())
+      return output
+    } catch (e: Exception) {
+      if (fileSystem.exists(temporaryPath)) fileSystem.delete(temporaryPath)
+      throw e
+    }
+  }
+
+  private fun validateHash(sha256: String, label: String) {
+    require(sha256.length == 64 && sha256.all { it in '0'..'9' || it in 'a'..'f' }) {
+      "$label sha256 '$sha256' is malformed"
+    }
+  }
+
+  private fun verifyBlob(path: String, sha256: String, size: Long, bytes: ByteArray) {
+    check(bytes.size.toLong() == size) { "$path: ${bytes.size} bytes != declared $size" }
+    check(sha256Hex(bytes) == sha256) { "$path: sha256 mismatch" }
   }
 
   private fun readZipEntry(zip: ByteArray, wanted: String): ByteArray? {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1108,6 +1108,7 @@ class ServeCommand(args: List<String>) : Command(args) {
               live = daemon,
               baked = fallback(),
               perPreviewResolve = state.perPreviewResolve,
+              executableBundleAvailable = state.executableBundleAvailable,
               executableBundleProvider = state.executableBundleProvider,
               perPreviewStreamCount = state.perPreviewStreamCount,
               perPreviewRenderStats = state.perPreviewRenderStats,
@@ -2699,6 +2700,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           previewAliases = alias,
           bakedFallback = bakedFallback,
           perPreviewResolve = perPreviewPool::get,
+          executableBundleAvailable = { daemonId -> fetchPerPreviewBundle(daemonId) != null },
           executableBundleProvider = { daemonId ->
             fetchPerPreviewBundle(daemonId)?.takeIf(File::isFile)?.readBytes()
           },

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -67,6 +67,8 @@ class ServeCatalogLiveHost(
    * per-preview lane, leaving the plain monolithic-only host.
    */
   private val perPreviewResolve: ((daemonId: String) -> ServeHost?)? = null,
+  /** Availability probe backed by the publication-aware per-preview fetcher. */
+  private val executableBundleAvailable: ((daemonId: String) -> Boolean)? = null,
   /** Hydrated per-preview bundle bytes for the viewer's executable download lane. */
   private val executableBundleProvider: ((daemonId: String) -> ByteArray?)? = null,
   /** Live upstream stream count across the pooled per-preview daemons (supplied by the pool). */
@@ -145,7 +147,9 @@ class ServeCatalogLiveHost(
   private val clock: () -> Long = System::currentTimeMillis,
 ) : ServeHost {
   override fun canDownloadExecutableBundle(previewId: String): Boolean =
-    executableBundleProvider != null && alias[previewId] != null
+    alias[previewId]?.let { daemonId ->
+      executableBundleProvider != null && executableBundleAvailable?.invoke(daemonId) == true
+    } == true
 
   override fun executableBundle(previewId: String): ByteArray? =
     alias[previewId]?.let { executableBundleProvider?.invoke(it) }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -697,7 +697,7 @@ class ServeCatalogStore(
             val safeStems = uniquePerPreviewStems(alias.values)
             val fetchPerPreview: (String) -> File? = { daemonId ->
               safeStems[daemonId]?.let { stem ->
-                fetchPerPreviewBundle(stem, liveBundle, base, dir, safe)
+                fetchPerPreviewBundle(stem, liveBundle, base, dir, safe, res.dir)
               }
             }
             if (
@@ -1005,6 +1005,7 @@ class ServeCatalogStore(
     base: String,
     dir: File,
     system: String,
+    externalResourcesDir: File?,
   ): File? {
     val previewsDir = File(File(dir, LIVE_BUNDLE_DIR), PER_PREVIEW_DIR)
     val previewsRoot = previewsDir.canonicalFile.toPath()
@@ -1014,7 +1015,10 @@ class ServeCatalogStore(
       return null
     }
     // Cached on disk from a prior request for the same id (the pool reopens lazily on eviction).
-    if (target.isFile && target.length() > 0) return target
+    if (target.isFile && target.length() > 0) {
+      if (isCompleteExecutableBundle(target)) return target
+      target.delete()
+    }
     val prefix = liveBundle.path.trim('/')
     val rel = "$PER_PREVIEW_DIR/$stem.png"
     val url = if (prefix.isEmpty()) "$base$rel" else "$base$prefix/$rel"
@@ -1029,9 +1033,14 @@ class ServeCatalogStore(
     thin.writeBytes(bytes)
     val hydrated =
       runCatching {
-          BundleClasspathHydration.hydrate(thin, target) { entry ->
-            fetchExternalClasspathBlob(entry, base, prefix, system)
-          }
+          BundleClasspathHydration.hydrate(
+            source = thin,
+            output = target,
+            resolveClasspath = { entry -> fetchExternalClasspathBlob(entry, base, prefix, system) },
+            resolveResource = { entry ->
+              readMaterializedExternalResource(entry, externalResourcesDir)
+            },
+          )
         }
         .onFailure {
           System.err.println(
@@ -1040,7 +1049,36 @@ class ServeCatalogStore(
         }
         .getOrNull()
     thin.delete()
+    if (hydrated != null && !isCompleteExecutableBundle(hydrated)) {
+      hydrated.delete()
+      return null
+    }
     return hydrated
+  }
+
+  /** A cached download is usable without a sibling pool and was not split as view-only. */
+  private fun isCompleteExecutableBundle(bundle: File): Boolean =
+    runCatching {
+        BundleReader.readMetadata(bundle).manifest.let { manifest ->
+          manifest.resolution != "view-only" &&
+            manifest.externalClasspath.isEmpty() &&
+            manifest.externalResources.isEmpty()
+        }
+      }
+      .getOrDefault(false)
+
+  /** Read one already-verified external resource from the monolithic bundle's materialized pool. */
+  private fun readMaterializedExternalResource(
+    entry: BundleReader.ExternalResource,
+    externalResourcesDir: File?,
+  ): ByteArray? {
+    val root = externalResourcesDir?.canonicalFile?.toPath() ?: return null
+    if (entry.path.isBlank() || entry.path.startsWith("/") || ".." in entry.path.split("/")) {
+      return null
+    }
+    val file = File(externalResourcesDir, entry.path).canonicalFile
+    if (!file.toPath().startsWith(root) || !file.isFile) return null
+    return file.readBytes()
   }
 
   /** Fetch and verify one whole classpath entry into the shared content-addressed cache. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3158,7 +3158,11 @@ class ServeHttpServer(
     if (rejectBadToken()) return
     withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
       val previewId = call.parameters["name"]
-      if (previewId == null || !renderHost.canDownloadExecutableBundle(previewId)) {
+      val available =
+        previewId?.let {
+          withContext(Dispatchers.IO) { renderHost.canDownloadExecutableBundle(it) }
+        } == true
+      if (!available) {
         call.respondText("executable bundle unavailable", status = HttpStatusCode.NotFound)
         return@withLeasedSession
       }
@@ -3266,6 +3270,10 @@ class ServeHttpServer(
         projectHistory
           ?.takeIf { catalogBundleHost(renderHost)?.provenance == null }
           ?.let { history -> withContext(Dispatchers.IO) { history.timelineJsonFor(preview.id) } }
+      // The publication-aware probe may fetch and hydrate this preview's bundle on its first use;
+      // keep that trusted-branch I/O off Ktor's request dispatcher.
+      val executableBundleAvailable =
+        withContext(Dispatchers.IO) { renderHost.canDownloadExecutableBundle(preview.id) }
       markGeneration(
         "static-page",
         viewerCacheControl(githubAuthConfigured = githubAuth != null, isPublic = isPublic),
@@ -3289,7 +3297,7 @@ class ServeHttpServer(
           hasSvgExport = renderHost.hasSvgExportFor(preview.id),
           hasScrollExport = renderHost.hasScrollExportFor(preview.id),
           executableBundleHref =
-            if (renderHost.canDownloadExecutableBundle(preview.id))
+            if (executableBundleAvailable)
               "$basePath/bundle/${WebEscaping.urlEncodeSegment(preview.id)}${requestQuerySuffix()}"
             else null,
           // The inspection layers: the accessibility focus map needs an a11y-capable daemon, the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -56,6 +56,8 @@ data class ServeSessionState(
    * plain sessions and for a branch that ships only the monolithic bundle.
    */
   val perPreviewResolve: ((daemonId: String) -> ServeHost?)? = null,
+  /** Probe whether a published, hydrated per-preview bundle is actually available. */
+  val executableBundleAvailable: ((daemonId: String) -> Boolean)? = null,
   /** Resolve a hydrated, self-contained per-preview bundle for download. */
   val executableBundleProvider: ((daemonId: String) -> ByteArray?)? = null,
   /** Live upstream stream count across the pooled per-preview daemons (see [perPreviewResolve]). */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleClasspathHydrationTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleClasspathHydrationTest.kt
@@ -9,6 +9,7 @@ import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
@@ -47,6 +48,72 @@ class BundleClasspathHydrationTest {
     assertContentEquals("PK".encodeToByteArray(), output.readBytes().copyOfRange(0, 2))
   }
 
+  @Test
+  fun `failed hydration never publishes the thin derivative and a later retry succeeds`() {
+    val dir = kotlin.io.path.createTempDirectory("bundle-hydration-retry-test").toFile()
+    val appJar = "APP-JAR".encodeToByteArray()
+    val sha = sha256(appJar)
+    val source = File(dir, "thin.png")
+    source.writeBytes(
+      zipOf(
+        mapOf(
+          "bundle.json" to
+            """{"schemaVersion":8,"backend":"desktop","previewIds":["A"],"coverPreviewId":"A","classpath":[{"kind":"module","path":"classes/app.jar"}],"modulePath":":app","producedBy":"test","externalClasspath":[{"path":"classes/app.jar","sha256":"$sha","size":${appJar.size}}]}"""
+              .encodeToByteArray(),
+          "previews.json" to """{"previews":[{"id":"A"}]}""".encodeToByteArray(),
+        )
+      )
+    )
+
+    val output = File(dir, "complete.png")
+    assertFailsWith<IllegalStateException> {
+      BundleClasspathHydration.hydrate(source, output) { null }
+    }
+    assertFalse(output.exists(), "a failed hydration must not cache the thin source as complete")
+
+    BundleClasspathHydration.hydrate(source, output) { appJar }
+    assertContentEquals(appJar, entries(output).getValue("classes/app.jar"))
+  }
+
+  @Test
+  fun `hydrate re-embeds external resources into app jar`() {
+    val dir = kotlin.io.path.createTempDirectory("bundle-resource-hydration-test").toFile()
+    val font = "FONT-BYTES".encodeToByteArray()
+    val fontSha = sha256(font)
+    val appJar = zipOf(mapOf("example/A.class" to byteArrayOf(1, 2, 3)))
+    val source = File(dir, "external-resources.png")
+    source.writeBytes(
+      zipOf(
+        mapOf(
+          "bundle.json" to
+            """{"schemaVersion":8,"backend":"desktop","previewIds":["A"],"coverPreviewId":"A","classpath":[{"kind":"module","path":"classes/app.jar"}],"modulePath":":app","producedBy":"test","externalResources":[{"path":"fonts/Test.ttf","sha256":"$fontSha","size":${font.size}}]}"""
+              .encodeToByteArray(),
+          "previews.json" to """{"previews":[{"id":"A"}]}""".encodeToByteArray(),
+          "classes/app.jar" to appJar,
+          BundleSigning.SIGNATURES_PATH to "stale".encodeToByteArray(),
+        )
+      )
+    )
+
+    val output = File(dir, "complete.png")
+    BundleClasspathHydration.hydrate(
+      source = source,
+      output = output,
+      resolveClasspath = { null },
+      resolveResource = { font },
+    )
+
+    val outer = entries(output)
+    assertContentEquals(
+      font,
+      zipEntries(outer.getValue("classes/app.jar")).getValue("fonts/Test.ttf"),
+    )
+    val manifest =
+      Json.parseToJsonElement(outer.getValue("bundle.json").decodeToString()).jsonObject
+    assertFalse("externalResources" in manifest)
+    assertFalse(BundleSigning.SIGNATURES_PATH in outer)
+  }
+
   private fun zipOf(entries: Map<String, ByteArray>): ByteArray {
     val out = ByteArrayOutputStream()
     ZipOutputStream(out).use { zip ->
@@ -60,8 +127,12 @@ class BundleClasspathHydrationTest {
   }
 
   private fun entries(file: File): Map<String, ByteArray> {
+    return zipEntries(BundleReader.extractZipBytes(file))
+  }
+
+  private fun zipEntries(bytes: ByteArray): Map<String, ByteArray> {
     val out = LinkedHashMap<String, ByteArray>()
-    ZipInputStream(ByteArrayInputStream(BundleReader.extractZipBytes(file))).use { zip ->
+    ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
       while (true) {
         val entry = zip.nextEntry ?: break
         if (!entry.isDirectory) out[entry.name] = zip.readBytes()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -158,6 +158,7 @@ class ServeCatalogLiveHostTest {
         mapOf(catalogId to daemonId),
         live,
         baked,
+        executableBundleAvailable = { it == daemonId },
         executableBundleProvider = {
           requested = it
           bytes
@@ -168,6 +169,26 @@ class ServeCatalogLiveHostTest {
     assertFalse(composite.canDownloadExecutableBundle(androidOnlyId))
     assertEquals(bytes.toList(), composite.executableBundle(catalogId)?.toList())
     assertEquals(daemonId, requested)
+  }
+
+  @Test
+  fun `executable download is not advertised when the per-preview bundle is unpublished`() {
+    val (_, live, baked) = host()
+    var providerCalled = false
+    val composite =
+      ServeCatalogLiveHost(
+        mapOf(catalogId to daemonId),
+        live,
+        baked,
+        executableBundleAvailable = { false },
+        executableBundleProvider = {
+          providerCalled = true
+          byteArrayOf(1)
+        },
+      )
+
+    assertFalse(composite.canDownloadExecutableBundle(catalogId))
+    assertFalse(providerCalled)
   }
 
   private fun themeOverride(provider: String = "com.example.BrandDark") =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1,11 +1,14 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.BundleReader
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
 import java.util.Collections
+import java.util.zip.ZipInputStream
 import javax.imageio.ImageIO
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -1237,6 +1240,58 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `the per-preview fetcher re-embeds the live bundle's external resources`() {
+    val font = "FONT-BYTES".encodeToByteArray()
+    val sha = shaHex(font)
+    val manifest =
+      """{"schemaVersion":8,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a","classpath":[{"kind":"module","path":"classes/app.jar"}],"modulePath":":app","producedBy":"test","externalResources":[{"path":"fonts/Test.ttf","sha256":"$sha","size":${font.size}}]}"""
+    val bundleBytes = polyglotBundle(manifest)
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Button/Filled","images":[
+         {"path":"images/button-filled/ideal__default__dark.png","previewId":"FilledButton_Dark"}]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.encodeToByteArray()
+        url.endsWith("bundle/compose-m3-bundle.png") -> bundleBytes
+        url.endsWith("bundle/previews/FilledButton_Dark.png") -> bundleBytes
+        url.endsWith("bundle/res/$sha") -> font
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    var fetchPerPreview: ((String) -> File?)? = null
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = {
+          TrustStore(
+            branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+          )
+        },
+        fetch = fetch,
+        buildTrustedBundle = { _, _, _, _, _, fetcher ->
+          fetchPerPreview = fetcher
+          true
+        },
+      )
+    store.load("compose-m3")
+
+    val hydrated = assertNotNull(fetchPerPreview?.invoke("FilledButton_Dark"))
+    val outer = zipEntries(BundleReader.extractZipBytes(hydrated))
+    val hydratedManifest =
+      Json.parseToJsonElement(outer.getValue("bundle.json").decodeToString()).jsonObject
+    assertFalse("externalResources" in hydratedManifest)
+    val appJar = zipEntries(outer.getValue("classes/app.jar"))
+    assertContentEquals(font, appJar.getValue("fonts/Test.ttf"))
+  }
+
+  @Test
   fun `daemon ids that sanitize to the same stem skip the per-preview lane`() {
     // `bundle split` disambiguates colliding sanitised ids with -2/-3 suffixes the server can't
     // reconstruct, so two daemon ids that sanitise to one stem ("Foo Bar" and "Foo_Bar" → Foo_Bar)
@@ -1575,6 +1630,16 @@ class ServeCatalogStoreTest {
         }
         .toByteArray()
     return cover + zip
+  }
+
+  private fun zipEntries(bytes: ByteArray): Map<String, ByteArray> = buildMap {
+    ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+      while (true) {
+        val entry = zip.nextEntry ?: break
+        if (!entry.isDirectory) put(entry.name, zip.readBytes())
+        zip.closeEntry()
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- publish hydrated per-preview bundles atomically so failed hydration cannot leave a thin bundle cached as executable
- restore external resources into classes/app.jar and clear the external resource declarations
- advertise executable downloads only when the exact per-preview bundle is published and can be hydrated

## Root cause

The initial implementation in #3641 copied the thin derivative to its cache target before hydration completed, restored only external classpath entries, and inferred download capability from preview aliases rather than actual bundle publication. This could cache an incomplete bundle, omit lifted resources from downloads, or render a download link that returned 404.

## Impact

Downloaded bundles are now self-contained and executable. Missing or colliding per-preview publications no longer produce a misleading download action.

## Validation

- focused CLI tests for hydration, catalog storage, live-host capability, HTTP routing, and web fixtures
- repository formatting and commit hooks

Follow-up to #3641.