### PR TITLE
fix(rc-player): keep canvas decorations outside padding

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -1566,7 +1566,34 @@ private fun Modifier.applyComponentModifiers(
   if (fillMissingDimensions && modifiers.height == null) result = result.fillMaxHeight()
   var appliedWidth = false
   var appliedHeight = false
+  var appliedCanvasOperations = false
+  fun applyCanvasOperations(modifier: Modifier): Modifier {
+    val operations = canvasOperations ?: return modifier
+    appliedCanvasOperations = true
+    return modifier.drawWithContent {
+      rcTrace(RcTraceCategory.FRAME, "rc:drawCanvas") {
+        drawOperations(
+          operations,
+          state,
+          RcPaintState(),
+          mutableMapOf(),
+          textMeasurer,
+          images,
+          RcFloatFunctionRuntime(),
+          theme,
+          filterTheme = true,
+          drawContent = { drawContent() },
+        )
+      }
+    }
+  }
   modifiers.ordered.forEach { operation ->
+    // AndroidX paints CanvasOperations at the component's full bounds, temporarily undoing the
+    // content-padding inset. Put the Compose draw wrapper outside the first padding modifier to
+    // preserve that behaviour while retaining wire order for the ordinary modifiers.
+    if (operation is RcPaddingModifier && !appliedCanvasOperations) {
+      result = applyCanvasOperations(result)
+    }
     result =
       when (operation) {
         is RcWidthModifier ->
@@ -1609,23 +1636,8 @@ private fun Modifier.applyComponentModifiers(
   }
   modifiers.marquee?.let { result = result.applyAndroidXMarquee(it, state) }
   modifiers.scroll?.let { result = result.applyAndroidXScroll(it, state, geometryComponentIds) }
-  if (canvasOperations != null) {
-    result = result.drawWithContent {
-      rcTrace(RcTraceCategory.FRAME, "rc:drawCanvas") {
-        drawOperations(
-          canvasOperations,
-          state,
-          RcPaintState(),
-          mutableMapOf(),
-          textMeasurer,
-          images,
-          RcFloatFunctionRuntime(),
-          theme,
-          filterTheme = true,
-          drawContent = { drawContent() },
-        )
-      }
-    }
+  if (!appliedCanvasOperations) {
+    result = applyCanvasOperations(result)
   }
   if (modifiers.clicks.any { it.type != RcClickActionType.CLICK }) {
     result = result.applyAndroidXMultiClick(modifiers.clicks, state)

--- a/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
+++ b/rc-player/compose/src/desktopTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcLayoutRenderTest.kt
@@ -214,6 +214,54 @@ class RcLayoutRenderTest {
   }
 
   @Test
+  fun canvasDecorationPaintsAtFullBoundsBeforeContentPadding() {
+    val purple = 0xff3b3444.toInt()
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(1, 0, 0), legacyWidth = 100, legacyHeight = 60, modern = false),
+        listOf(
+          RcRootLayout(1),
+          RcLayoutContent(2),
+          RcCanvasLayout(3, 30),
+          width(100f),
+          height(60f),
+          RcPaddingModifier(
+            RcFloatWord.literal(20f),
+            RcFloatWord.literal(10f),
+            RcFloatWord.literal(20f),
+            RcFloatWord.literal(10f),
+          ),
+          RcNoArg(RcOpcodes.CANVAS_OPERATIONS),
+          RcPaintData(listOf(4, purple)),
+          RcDraw4(
+            RcOpcodes.DRAW_RECT,
+            RcFloatWord.literal(0f),
+            RcFloatWord.literal(0f),
+            RcFloatWord.literal(100f),
+            RcFloatWord.literal(60f),
+          ),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+          RcNoArg(RcOpcodes.CONTAINER_END),
+        ),
+      )
+    val scene =
+      ImageComposeScene(width = 100, height = 60, density = Density(1f)) {
+        RcComposePlayer(document)
+      }
+    try {
+      val bitmap = Bitmap().apply { allocN32Pixels(100, 60) }
+      check(scene.render().readPixels(bitmap))
+
+      assertEquals(purple, bitmap.getColor(5, 5), "decoration must not start at the padding inset")
+      assertEquals(purple, bitmap.getColor(95, 55), "decoration must cover the full component")
+    } finally {
+      scene.close()
+    }
+  }
+
+  @Test
   fun marqueeClipsOverflowingLayoutContent() {
     val red = 0xffff0000.toInt()
     val blue = 0xff0000ff.toInt()


### PR DESCRIPTION
## What changed

- apply component `CanvasOperations` outside the first content padding modifier
- preserve the wire order of ordinary component modifiers
- add a pixel regression test proving decorations paint across the component's full bounds

## Root cause

The modifier-order work moved padding into the ordered Compose modifier chain, but `CanvasOperations` were still appended after that chain. Material card decoration was therefore measured and painted at the content inset, clipping its top and left edges and changing the apparent card bounds. This is not a global canvas offset; the density and text wrapping are correct.

## Validation

- `./gradlew :rc-player-compose:desktopTest --tests 'ee.schimke.composeai.rcplayer.compose.RcLayoutRenderTest.canvasDecorationPaintsAtFullBoundsBeforeContentPadding' --console=plain`
- `./gradlew --quiet ktfmtCheckAll`
