### PR TITLE
fix(figma-svg): preserve variant state exports

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -791,6 +791,12 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
       previewId = info.id,
       className = info.className,
       functionName = info.methodName,
+      // Preserve the concrete preview identity for every file-backed post-capture product.
+      // Synthetic `@OverrideVariant` previews share class + function with their base; the generic
+      // RenderSpec default would otherwise make their figma-svg outputs overwrite one another.
+      // The one-shot payload reshape also stamps this today, but keeping it on the resolved spec
+      // covers held/render paths and keeps both daemon backends symmetric.
+      outputBaseName = info.id,
       overrides = bakedOverrides,
       // Explicit LIGHT, not null. A null uiMode emits no `uiMode=` token in the routed payload,
       // and Robolectric qualifiers apply incrementally (`setQualifiers("+…")`), so a token-less

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.devices.frameDpOverriddenBy
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.OverrideVariantSpec
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import kotlinx.serialization.Serializable
@@ -185,7 +187,9 @@ class PreviewManifestRouter(
       inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
       inbound["clearBackground"]?.let { append("clearBackground=").append(it).append(';') }
       inbound["svgBackground"]?.let { append("svgBackground=").append(it).append(';') }
-      inbound["overrides"]?.let { append("overrides=").append(it).append(';') }
+      overridesTokenFor(inbound["overrides"], resolved.overrides)?.let {
+        append("overrides=").append(it).append(';')
+      }
       inbound["mode"]?.let { append("mode=").append(it).append(';') }
       // Manifest-resolved kind forwards through verbatim; an inbound `kind=` override (rare —
       // currently only test fixtures emit one) wins for parity with the other override fields.
@@ -235,6 +239,32 @@ class PreviewManifestRouter(
     return map
   }
 
+  /** Layers a live request override over the synthetic preview's baked `@OverrideVariant` seed. */
+  private fun overridesTokenFor(
+    inboundToken: String?,
+    baseOverrides: PreviewOverrides?,
+  ): String? {
+    if (baseOverrides == null) return inboundToken
+    val inbound =
+      inboundToken?.let {
+        runCatching {
+            json.decodeFromString(
+              PreviewOverrides.serializer(),
+              String(java.util.Base64.getUrlDecoder().decode(it), Charsets.UTF_8),
+            )
+          }
+          .getOrNull()
+      }
+    val merged = inbound.layeredOver(baseOverrides) ?: return inboundToken
+    return java.util.Base64.getUrlEncoder()
+      .withoutPadding()
+      .encodeToString(
+        json
+          .encodeToString(PreviewOverrides.serializer(), merged)
+          .toByteArray(Charsets.UTF_8)
+      )
+  }
+
   companion object {
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -262,6 +292,7 @@ private fun PreviewManifestEntry.renderSpec(): RenderSpec {
     backgroundColor = resolved.backgroundColor,
     device = resolved.device,
     outputBaseName = resolved.outputBaseName,
+    overrides = resolved.overrides,
     kind = resolved.kind,
     previewName = resolved.name,
     wrapperClassName = resolved.wrapperClassName,
@@ -307,6 +338,8 @@ data class PreviewManifestEntry(
    * the flat fields below.
    */
   val params: PreviewParamsEntry? = null,
+  /** Baked state seed for a synthetic `_VARIANT_` preview emitted by discovery. */
+  val overrides: OverrideVariantSpec? = null,
   val widthPx: Int? = null,
   val heightPx: Int? = null,
   val density: Float? = null,
@@ -411,6 +444,11 @@ data class PreviewManifestEntry(
     val showBackground = showBackground ?: p?.showBackground ?: true
     val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
     val wrapperClassName = p?.wrapperClassName
+    val bakedOverrides =
+      overrides
+        ?.toNamedOverrides()
+        ?.takeIf { it.isNotEmpty() }
+        ?.let { PreviewOverrides(namedOverrides = it) }
     return ResolvedRenderParams(
       widthPx = resolvedWidthPx,
       heightPx = resolvedHeightPx,
@@ -422,6 +460,7 @@ data class PreviewManifestEntry(
       kind = kind,
       name = name,
       wrapperClassName = wrapperClassName,
+      overrides = bakedOverrides,
       wrapWidth = wrapWidth,
       wrapHeight = wrapHeight,
       uiMode = uiMode,
@@ -549,6 +588,8 @@ data class ResolvedRenderParams(
   val kind: String? = null,
   val name: String? = null,
   val wrapperClassName: String? = null,
+  /** Baked state seed for a synthetic `_VARIANT_` preview. */
+  val overrides: PreviewOverrides? = null,
   /**
    * AS-parity wrap-content flags (see [RenderSpec.wrapWidth]). Set when the preview declares no
    * explicit size / device / non-Compose surface, so [widthPx]/[heightPx] are a sandbox bound and

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgManifestUiModeTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgManifestUiModeTest.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.data.overrides.OverrideSeed
+import ee.schimke.composeai.data.overrides.OverrideSeedKind
+import ee.schimke.composeai.data.overrides.OverrideVariantSpec
 import java.io.File
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -24,6 +27,61 @@ import org.junit.rules.TemporaryFolder
 class FigmaSvgManifestUiModeTest {
 
   @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `manifest override variant changes the exported figma svg`() {
+    val outputDir = tempFolder.newFolder("renders-manifest-override-variant")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val baseId = "CheckboxButtonChecked"
+    val variantId = "CheckboxButtonChecked_VARIANT_unchecked"
+    fun entry(id: String, overrides: OverrideVariantSpec? = null) =
+      PreviewManifestEntry(
+        id = id,
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "OverridableSquare",
+        widthPx = 32,
+        heightPx = 32,
+        density = 1.0f,
+        overrides = overrides,
+      )
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            entry(baseId),
+            entry(
+              variantId,
+              OverrideVariantSpec(
+                name = "unchecked",
+                seeds =
+                  listOf(
+                    OverrideSeed(
+                      key = "fill",
+                      kind = OverrideSeedKind.COLOR,
+                      raw = "#FF42A5F5",
+                    )
+                  ),
+              ),
+            ),
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      host.submit(RenderRequest.Render(payload = "previewId=$baseId"), timeoutMs = 120_000)
+      host.submit(RenderRequest.Render(payload = "previewId=$variantId"), timeoutMs = 120_000)
+
+      val dataDir = outputDir.parentFile!!.resolve("data")
+      val baseSvg = dataDir.resolve(baseId).resolve("compose-figma.svg").readText()
+      val variantSvg = dataDir.resolve(variantId).resolve("compose-figma.svg").readText()
+      assertTrue("base SVG must retain the author-default red fill", baseSvg.contains("#EF5350"))
+      assertTrue("variant SVG must carry its baked blue fill", variantSvg.contains("#42A5F5"))
+      assertTrue("base and variant SVGs must differ", baseSvg != variantSvg)
+    } finally {
+      host.shutdown()
+    }
+  }
 
   @Test
   fun `manifest uiMode renders the light id light and the dark id dark`() {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterRoutingTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterRoutingTest.kt
@@ -1,5 +1,12 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.OverrideSeed
+import ee.schimke.composeai.data.overrides.OverrideSeedKind
+import ee.schimke.composeai.data.overrides.OverrideVariantSpec
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import java.util.Base64
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -24,6 +31,63 @@ import org.junit.Test
  * `InvokeComposable`.
  */
 class PreviewManifestRouterRoutingTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun `routePayload applies manifest variant seed and lets a live override win`() {
+    val previewId = "CheckboxButtonChecked_VARIANT_unchecked"
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = previewId,
+              className = "com.example.WearPreviewsKt",
+              functionName = "CheckboxButtonChecked",
+              overrides =
+                OverrideVariantSpec(
+                  name = "unchecked",
+                  seeds =
+                    listOf(
+                      OverrideSeed(
+                        key = "checked",
+                        kind = OverrideSeedKind.BOOLEAN,
+                        raw = "false",
+                      )
+                    ),
+                ),
+            )
+          )
+      )
+    val router = PreviewManifestRouter(manifest = manifest)
+
+    val baked =
+      RenderSpec.parseFromPayloadOrNull(router.routePayload("previewId=$previewId"))
+    assertEquals(
+      PreviewOverrideValue.BooleanValue(false),
+      baked!!.overrides!!.namedOverrides!!["checked"],
+    )
+
+    val live =
+      PreviewOverrides(
+        namedOverrides = mapOf("checked" to PreviewOverrideValue.BooleanValue(true))
+      )
+    val liveToken =
+      Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(
+          json.encodeToString(PreviewOverrides.serializer(), live).toByteArray(Charsets.UTF_8)
+        )
+    val layered =
+      RenderSpec.parseFromPayloadOrNull(
+        router.routePayload("previewId=$previewId;overrides=$liveToken")
+      )
+    assertEquals(
+      PreviewOverrideValue.BooleanValue(true),
+      layered!!.overrides!!.namedOverrides!!["checked"],
+    )
+  }
 
   @Test
   fun `routePayload forwards wrapperClassName from nested params`() {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -18,6 +18,7 @@ class RenderSpecFromInfoTest {
       )
 
     assertEquals("preview-id", spec.previewId)
+    assertEquals("preview-id", spec.outputBaseName)
   }
 
   @Test
@@ -33,7 +34,33 @@ class RenderSpecFromInfoTest {
       )
 
     assertEquals("preview-id", spec.previewId)
+    assertEquals("preview-id", spec.outputBaseName)
     assertEquals(300, spec.widthPx)
+  }
+
+  @Test
+  fun `override variants sharing a function keep distinct artifact identities`() {
+    val base =
+      renderSpecFromInfo(
+        PreviewInfoDto(
+          id = "CheckboxButtonChecked",
+          className = "com.example.CatalogPreviewsKt",
+          methodName = "CheckboxButtonChecked",
+          params = PreviewParamsDto(),
+        )
+      )
+    val variant =
+      renderSpecFromInfo(
+        PreviewInfoDto(
+          id = "CheckboxButtonChecked_VARIANT_unchecked",
+          className = "com.example.CatalogPreviewsKt",
+          methodName = "CheckboxButtonChecked",
+          params = PreviewParamsDto(),
+        )
+      )
+
+    assertEquals("CheckboxButtonChecked", base.outputBaseName)
+    assertEquals("CheckboxButtonChecked_VARIANT_unchecked", variant.outputBaseName)
   }
 
   @Test

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -506,6 +506,14 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
       previewId = info.id,
       className = info.className,
       functionName = info.methodName,
+      // A discovered preview id is the concrete artifact identity, not merely a lookup key.
+      // `@OverrideVariant` previews deliberately share their base's function, so leaving the
+      // RenderSpec default (`<class>-<function>`) here makes the base and every synthetic state
+      // overwrite one `data/<outputBaseName>/compose-figma.svg`. The PNG bake is unaffected (it
+      // runs through the standalone renderer), which is why catalogs could show the right state
+      // beside a base-state SVG. Keep each preview's post-capture products isolated exactly like
+      // PreviewManifestRouter does.
+      outputBaseName = info.id,
       overrides = bakedOverrides,
     )
   // A *missing* params block means "params unknown", NOT "params empty" — the incremental

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -2,6 +2,9 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.WallpaperOverride
+import ee.schimke.composeai.data.overrides.OverrideSeed
+import ee.schimke.composeai.data.overrides.OverrideSeedKind
+import ee.schimke.composeai.data.overrides.OverrideVariantSpec
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -31,6 +34,58 @@ import org.junit.rules.TemporaryFolder
 class OverrideIntegrationTest {
 
   @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun discoveredOverrideVariantKeepsItsOwnFigmaSvgAndState() {
+    val outputDir = tempFolder.newFolder("renders-discovered-override-variant")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val baseId = "FilledButton_Light"
+    val variantId = "FilledButton_Light_VARIANT_disabled"
+    fun info(id: String, overrides: OverrideVariantSpec? = null) =
+      PreviewInfoDto(
+        id = id,
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        methodName = "OverridableSquare",
+        params = PreviewParamsDto(widthDp = 32, heightDp = 32, density = 1.0f),
+        overrides = overrides,
+      )
+    val byId =
+      listOf(
+          info(baseId),
+          info(
+            variantId,
+            OverrideVariantSpec(
+              name = "disabled",
+              seeds =
+                listOf(OverrideSeed(key = "fill", kind = OverrideSeedKind.COLOR, raw = "#FF42A5F5")),
+            ),
+          ),
+        )
+        .associate { it.id to renderSpecFromInfo(it) }
+    val host =
+      DesktopHost(
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(listOf(PreviewOverridesPreviewOverrideExtension()))
+          ),
+        previewSpecResolver = byId::get,
+      )
+    host.start()
+    try {
+      host.submit(RenderRequest.Render(payload = "previewId=$baseId"), timeoutMs = 30_000)
+      host.submit(RenderRequest.Render(payload = "previewId=$variantId"), timeoutMs = 30_000)
+
+      val dataDir = outputDir.parentFile!!.resolve("data")
+      val baseSvg = dataDir.resolve(baseId).resolve("compose-figma.svg").readText()
+      val variantSvg = dataDir.resolve(variantId).resolve("compose-figma.svg").readText()
+      assertTrue("base SVG must retain the author-default red fill", baseSvg.contains("#EF5350"))
+      assertTrue("variant SVG must carry its baked blue fill", variantSvg.contains("#42A5F5"))
+      assertNotEquals("base and variant SVGs must not collide", baseSvg, variantSvg)
+    } finally {
+      host.shutdown()
+    }
+  }
 
   @Test
   fun widthPxOverrideChangesRenderedDimensions() {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -49,8 +49,26 @@ class RenderSpecFromInfoTest {
     assertNull(spec.fontScale)
     assertNull(spec.device)
     assertEquals("Foo", spec.previewId)
+    assertEquals("Foo", spec.outputBaseName)
     assertEquals("com.example.FooKt", spec.className)
     assertEquals("Foo", spec.functionName)
+  }
+
+  @Test
+  fun `override variants sharing a function keep distinct artifact identities`() {
+    val base = renderSpecFromInfo(info(params = PreviewParamsDto()))
+    val variant =
+      renderSpecFromInfo(
+        PreviewInfoDto(
+          id = "Foo_VARIANT_disabled",
+          className = "com.example.FooKt",
+          methodName = "Foo",
+          params = PreviewParamsDto(),
+        )
+      )
+
+    assertEquals("Foo", base.outputBaseName)
+    assertEquals("Foo_VARIANT_disabled", variant.outputBaseName)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- preserve baked `@OverrideVariant` seeds when Android routes previews from the production manifest
- key Android and Desktop post-capture artifacts by the concrete preview ID so synthetic states cannot collide with their base preview
- add end-to-end SVG regressions for a Wear checkbox state and a Material 3 button state

## Root cause

The baked PNG renderer already applied variant seeds, but the Android manifest router discarded the manifest's `overrides` field before the daemon generated SVG data products. On Desktop, the seed was preserved, but base and synthetic variant previews shared the default class/function-derived `outputBaseName`, causing their SVG artifact directories to collide.

## Impact

Variant-state SVG exports now retain their own state and artifact identity while base previews remain unchanged. Live per-render overrides continue to layer over baked variant seeds.

## Validation

- `:daemon:android:testDebugUnitTest`
  - `PreviewManifestRouterRoutingTest`
  - `RenderSpecFromInfoTest`
  - Wear-named `FigmaSvgManifestUiModeTest.manifest override variant changes the exported figma svg`
- `:daemon:desktop:test`
  - `RenderSpecFromInfoTest`
  - M3-named `OverrideIntegrationTest.discoveredOverrideVariantKeepsItsOwnFigmaSvgAndState`
- both modified production modules compiled successfully
- `git diff --check`

Closes #3616