### PR TITLE
fix(previews): detect empty compiled outputs

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -9,6 +9,7 @@ import io.github.classgraph.MethodInfo
 import io.github.classgraph.MethodParameterInfo
 import io.github.classgraph.ScanResult
 import java.io.File
+import java.util.zip.ZipFile
 import kotlin.math.roundToInt
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -409,6 +410,40 @@ object PreviewDiscovery {
     // ClassGraph to the project element and method-walked.
     val classpath = existingClassDirs + existingProjectJars + filteredDependencyJars
 
+    // A successfully restored compile-task cache entry can still be semantically empty: Gradle
+    // reports FROM-CACHE, but the output directory contains no classes. Asset discovery below can
+    // then make the manifest non-empty and hide the broken compilation completely (#3600). Avoid
+    // treating "no @Preview methods" as suspicious (many modules legitimately have none); the
+    // stronger invariant is source inputs + declared project outputs + zero project class files.
+    // `sourceFiles` also supplies source-location metadata and can include `src/*Test` trees even
+    // though the class outputs above are for the production compilation. Exclude those source sets
+    // from this invariant so a test-only module does not produce a false cache-corruption warning.
+    val sourceFileCount = input.sourceFiles.count { it.isFile && !it.isTestSourceSetFile() }
+    val classDirCounts = input.classDirs.associateWith(::classFileCount)
+    val projectJarCounts = input.projectClassJars.associateWith(::classFileCount)
+    val declaredProjectOutputs = input.classDirs.isNotEmpty() || input.projectClassJars.isNotEmpty()
+    val projectClassFileCount = classDirCounts.values.sum() + projectJarCounts.values.sum()
+    val emptyCompiledOutputs =
+      sourceFileCount > 0 && declaredProjectOutputs && projectClassFileCount == 0
+    if (emptyCompiledOutputs) {
+      warnings.add(
+        buildString {
+          append(
+            "composePreview: module '${input.moduleName}' has $sourceFileCount source file(s) "
+          )
+          append("but its declared class outputs contain 0 .class files. ")
+          append("A compile task may have restored an empty build-cache entry; rerun with ")
+          append("--no-build-cache --rerun-tasks. Resolved project class outputs:")
+          classDirCounts.forEach { (file, count) ->
+            append("\n  classDir: $file (exists=${file.exists()}, classFiles=$count)")
+          }
+          projectJarCounts.forEach { (file, count) ->
+            append("\n  projectClassJar: $file (exists=${file.exists()}, classFiles=$count)")
+          }
+        }
+      )
+    }
+
     val previews = mutableListOf<PreviewInfo>()
     // Populated only on the diagnostics path (failOnEmpty + 0 previews)
     // so we can tell users whether ClassGraph saw any classes at all,
@@ -688,10 +723,20 @@ object PreviewDiscovery {
     // path below so consumers still see the cause without the build
     // breaking on it.
     val previewAnnotationsMissing = scanClassCount > 0 && reachablePreviewFqns.isEmpty()
-    if (normalized.isEmpty() && input.failOnEmpty) {
+    val codePreviewCount = allPreviews.count { it.params.kind !in ASSET_PREVIEW_KINDS }
+    // Preserve asset-only modules as valid: the stricter failure applies only when the original
+    // zero-preview contract fires, or when the source/output invariant above proves compilation is
+    // empty. This catches #3600 without making --fail-on-empty reject intentional asset catalogs.
+    if ((normalized.isEmpty() || emptyCompiledOutputs) && input.failOnEmpty) {
+      val failureSummary =
+        if (emptyCompiledOutputs) {
+          "empty compiled outputs ($codePreviewCount code previews; ${allPreviews.size} total)"
+        } else {
+          "0 code previews discovered; ${allPreviews.size} total including assets"
+        }
       val diagnostics =
         buildEmptyDiagnostics(
-          header = "composePreview: failOnEmpty diagnostics (0 previews discovered):",
+          header = "composePreview: failOnEmpty diagnostics ($failureSummary):",
           existingClassDirs = existingClassDirs,
           allClassDirs = input.classDirs,
           projectJars = existingProjectJars,
@@ -712,8 +757,8 @@ object PreviewDiscovery {
         }
       return Outcome.Failure(
         reason =
-          "composePreview: discovered 0 previews in module '${input.moduleName}' — " +
-            "$reason. See diagnostics above.",
+          "composePreview: $failureSummary in module '${input.moduleName}' — $reason. " +
+            "See diagnostics above.",
         diagnostics = diagnostics,
         warnings = warnings.toList(),
       )
@@ -1193,7 +1238,8 @@ object PreviewDiscovery {
    * token catalogs.
    */
   /**
-   * Canvas for a synthetic theme sheet: 900x760dp at density 1 (`dpi=160`), so the PNG is 900x760px.
+   * Canvas for a synthetic theme sheet: 900x760dp at density 1 (`dpi=160`), so the PNG is
+   * 900x760px.
    *
    * These previews have no `@Preview` of their own to size them, so they used to fall back to the
    * 400x800dp sandbox — and a theme sheet does not fit in it. A Wear scheme alone is 21 colour rows
@@ -1380,6 +1426,29 @@ object PreviewDiscovery {
     }
     return out
   }
+
+  private val ASSET_PREVIEW_KINDS = setOf(PreviewKind.LOTTIE, PreviewKind.SVG)
+
+  private fun File.isTestSourceSetFile(): Boolean {
+    val marker = "/src/"
+    val normalized = absolutePath.replace(File.separatorChar, '/')
+    val sourceSet =
+      normalized.substringAfter(marker, missingDelimiterValue = "").substringBefore('/')
+    return sourceSet.contains("test", ignoreCase = true)
+  }
+
+  private fun classFileCount(file: File): Int =
+    when {
+      file.isDirectory -> file.walkTopDown().count { it.isFile && it.extension == "class" }
+      file.isFile && file.extension.equals("jar", ignoreCase = true) ->
+        runCatching {
+            ZipFile(file).use { zip ->
+              zip.entries().asSequence().count { it.name.endsWith(".class") }
+            }
+          }
+          .getOrDefault(0)
+      else -> 0
+    }
 
   /**
    * Rewrite each capture's `renderOutput` (and each `dataProduct.output`) to a shorter, shell-safe

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -95,6 +95,13 @@ object PreviewDiscovery {
      */
     val projectClassJars: List<File> = emptyList(),
     /**
+     * The class directories produced by the active compilation. Discovery may scan several
+     * compatibility fallbacks in [classDirs], but those can contain stale classes from an inactive
+     * target and must not satisfy the empty-compile integrity check. Empty falls back to
+     * [classDirs] for non-Gradle callers that do not distinguish the two sets.
+     */
+    val activeClassDirs: List<File> = emptyList(),
+    /**
      * Whether this module's render backend can draw `@ColorCatalog` sheets. `true` (the default)
      * for the Android backend, which renders them; `false` for the desktop backend, which can't yet
      * (#2135). When `false`, the synthetic `CATALOG` captures are emitted `optional` so a missing
@@ -413,25 +420,35 @@ object PreviewDiscovery {
     // A successfully restored compile-task cache entry can still be semantically empty: Gradle
     // reports FROM-CACHE, but the output directory contains no classes. Asset discovery below can
     // then make the manifest non-empty and hide the broken compilation completely (#3600). Avoid
-    // treating "no @Preview methods" as suspicious (many modules legitimately have none); the
-    // stronger invariant is source inputs + declared project outputs + zero project class files.
-    // `sourceFiles` also supplies source-location metadata and can include `src/*Test` trees even
-    // though the class outputs above are for the production compilation. Exclude those source sets
-    // from this invariant so a test-only module does not produce a false cache-corruption warning.
-    val sourceFileCount = input.sourceFiles.count { it.isFile && !it.isTestSourceSetFile() }
-    val classDirCounts = input.classDirs.associateWith(::classFileCount)
+    // treating "no @Preview methods" as suspicious (many modules legitimately have none). Only
+    // source files that actually declare @Preview establish the stronger invariant. This avoids
+    // false positives for valid source-only constructs (typealiases, expect declarations and
+    // package docs) as well as intentional asset-only modules. Test source sets are excluded
+    // because the project outputs here belong to the production compilation.
+    //
+    // Check only the active compilation output. [Input.classDirs] deliberately contains fallback
+    // layouts for discovery compatibility; stale classes in an inactive target must not hide an
+    // empty cache restore in the compilation that just ran.
+    val previewSourceFiles =
+      input.sourceFiles.filter {
+        it.isFile && !it.isTestSourceSetFile() && it.declaresPreviewAnnotation()
+      }
+    val integrityClassDirs = input.activeClassDirs.ifEmpty { input.classDirs }
+    val classDirCounts = integrityClassDirs.associateWith(::classFileCount)
     val projectJarCounts = input.projectClassJars.associateWith(::classFileCount)
-    val declaredProjectOutputs = input.classDirs.isNotEmpty() || input.projectClassJars.isNotEmpty()
+    val declaredProjectOutputs =
+      integrityClassDirs.isNotEmpty() || input.projectClassJars.isNotEmpty()
     val projectClassFileCount = classDirCounts.values.sum() + projectJarCounts.values.sum()
     val emptyCompiledOutputs =
-      sourceFileCount > 0 && declaredProjectOutputs && projectClassFileCount == 0
+      previewSourceFiles.isNotEmpty() && declaredProjectOutputs && projectClassFileCount == 0
     if (emptyCompiledOutputs) {
       warnings.add(
         buildString {
           append(
-            "composePreview: module '${input.moduleName}' has $sourceFileCount source file(s) "
+            "composePreview: module '${input.moduleName}' has ${previewSourceFiles.size} " +
+              "source file(s) declaring @Preview "
           )
-          append("but its declared class outputs contain 0 .class files. ")
+          append("but its active class outputs contain 0 .class files. ")
           append("A compile task may have restored an empty build-cache entry; rerun with ")
           append("--no-build-cache --rerun-tasks. Resolved project class outputs:")
           classDirCounts.forEach { (file, count) ->
@@ -757,8 +774,13 @@ object PreviewDiscovery {
         }
       return Outcome.Failure(
         reason =
-          "composePreview: $failureSummary in module '${input.moduleName}' — $reason. " +
-            "See diagnostics above.",
+          if (emptyCompiledOutputs) {
+            "composePreview: $failureSummary in module '${input.moduleName}' — $reason. " +
+              "See diagnostics above."
+          } else {
+            "composePreview: discovered 0 previews in module '${input.moduleName}' " +
+              "($failureSummary) — $reason. See diagnostics above."
+          },
         diagnostics = diagnostics,
         warnings = warnings.toList(),
       )
@@ -1428,6 +1450,16 @@ object PreviewDiscovery {
   }
 
   private val ASSET_PREVIEW_KINDS = setOf(PreviewKind.LOTTIE, PreviewKind.SVG)
+
+  // Source-level signal for the empty-compile guard. Anchoring at the start of a code line avoids
+  // examples in line comments and KDoc; accepting a qualified prefix covers annotation use without
+  // an import. A user-defined multi-preview annotation also contains @Preview when its declaration
+  // lives in this module, so an empty compilation of that wrapper still trips the guard.
+  private val PREVIEW_SOURCE_ANNOTATION =
+    Regex("""(?m)^[\t ]*@(?!file:)(?:[A-Za-z_][A-Za-z0-9_.]*\.)?Preview(?=[\t (\r\n])""")
+
+  private fun File.declaresPreviewAnnotation(): Boolean =
+    runCatching { PREVIEW_SOURCE_ANNOTATION.containsMatchIn(readText()) }.getOrDefault(false)
 
   private fun File.isTestSourceSetFile(): Boolean {
     val marker = "/src/"

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
@@ -78,4 +78,69 @@ class LottieAssetDiscoveryTest {
     val res = tempDir.newFolder("empty")
     assertThat(discover(res).previews).isEmpty()
   }
+
+  @Test
+  fun `asset preview cannot mask empty compiled outputs`() {
+    val project = tempDir.newFolder("empty-compile")
+    val classes = project.resolve("classes").apply { mkdirs() }
+    val source =
+      project.resolve("src/main/kotlin/Previews.kt").apply {
+        parentFile.mkdirs()
+        writeText("fun Preview() = Unit")
+      }
+    val resources = project.resolve("resources").apply { mkdirs() }
+    resources.resolve("spin.json").writeText("""{"v":"5.7.0","layers":[]}""")
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classes),
+          dependencyJars = emptyList(),
+          sourceFiles = listOf(source),
+          moduleName = ":app",
+          variantName = "desktop",
+          projectDirectory = project,
+          failOnEmpty = false,
+          resourceDirs = listOf(resources),
+        )
+      ) as PreviewDiscovery.Outcome.Success
+
+    assertThat(outcome.manifest.previews).hasSize(1)
+    val warning = outcome.warnings.joinToString("\n")
+    assertThat(warning).contains("declared class outputs contain 0 .class files")
+    assertThat(warning).contains("--no-build-cache --rerun-tasks")
+    assertThat(warning).contains("classFiles=0")
+  }
+
+  @Test
+  fun `failOnEmpty rejects asset-only discovery when compiled outputs are empty`() {
+    val project = tempDir.newFolder("asset-only-failure")
+    val classes = project.resolve("classes").apply { mkdirs() }
+    val source =
+      project.resolve("src/main/kotlin/Previews.kt").apply {
+        parentFile.mkdirs()
+        writeText("fun Preview() = Unit")
+      }
+    val resources = project.resolve("resources").apply { mkdirs() }
+    resources.resolve("spin.json").writeText("""{"v":"5.7.0","layers":[]}""")
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classes),
+          dependencyJars = emptyList(),
+          sourceFiles = listOf(source),
+          moduleName = ":app",
+          variantName = "desktop",
+          projectDirectory = project,
+          failOnEmpty = true,
+          resourceDirs = listOf(resources),
+        )
+      )
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Failure::class.java)
+    val failure = outcome as PreviewDiscovery.Outcome.Failure
+    assertThat(failure.reason).contains("empty compiled outputs")
+    assertThat(failure.reason).contains("0 code previews; 1 total")
+  }
 }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
@@ -86,7 +86,7 @@ class LottieAssetDiscoveryTest {
     val source =
       project.resolve("src/main/kotlin/Previews.kt").apply {
         parentFile.mkdirs()
-        writeText("fun Preview() = Unit")
+        writeText("@Preview\nfun preview() = Unit")
       }
     val resources = project.resolve("resources").apply { mkdirs() }
     resources.resolve("spin.json").writeText("""{"v":"5.7.0","layers":[]}""")
@@ -107,7 +107,7 @@ class LottieAssetDiscoveryTest {
 
     assertThat(outcome.manifest.previews).hasSize(1)
     val warning = outcome.warnings.joinToString("\n")
-    assertThat(warning).contains("declared class outputs contain 0 .class files")
+    assertThat(warning).contains("active class outputs contain 0 .class files")
     assertThat(warning).contains("--no-build-cache --rerun-tasks")
     assertThat(warning).contains("classFiles=0")
   }
@@ -119,7 +119,7 @@ class LottieAssetDiscoveryTest {
     val source =
       project.resolve("src/main/kotlin/Previews.kt").apply {
         parentFile.mkdirs()
-        writeText("fun Preview() = Unit")
+        writeText("@Preview\nfun preview() = Unit")
       }
     val resources = project.resolve("resources").apply { mkdirs() }
     resources.resolve("spin.json").writeText("""{"v":"5.7.0","layers":[]}""")
@@ -142,5 +142,70 @@ class LottieAssetDiscoveryTest {
     val failure = outcome as PreviewDiscovery.Outcome.Failure
     assertThat(failure.reason).contains("empty compiled outputs")
     assertThat(failure.reason).contains("0 code previews; 1 total")
+  }
+
+  @Test
+  fun `source-only declarations do not flag an intentional asset-only module`() {
+    val project = tempDir.newFolder("intentional-asset-only")
+    val classes = project.resolve("classes").apply { mkdirs() }
+    val source =
+      project.resolve("src/main/kotlin/Aliases.kt").apply {
+        parentFile.mkdirs()
+        writeText("typealias PreviewName = String\nexpect class PlatformValue")
+      }
+    val resources = project.resolve("resources").apply { mkdirs() }
+    resources.resolve("spin.json").writeText("""{"v":"5.7.0","layers":[]}""")
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classes),
+          dependencyJars = emptyList(),
+          sourceFiles = listOf(source),
+          moduleName = ":assets",
+          variantName = "desktop",
+          projectDirectory = project,
+          failOnEmpty = false,
+          resourceDirs = listOf(resources),
+        )
+      ) as PreviewDiscovery.Outcome.Success
+
+    assertThat(outcome.manifest.previews).hasSize(1)
+    assertThat(outcome.warnings.joinToString("\n")).doesNotContain("empty build-cache entry")
+  }
+
+  @Test
+  fun `stale fallback classes do not mask an empty active compilation output`() {
+    val project = tempDir.newFolder("stale-fallback")
+    val activeClasses = project.resolve("classes/kotlin/desktop/main").apply { mkdirs() }
+    val staleClasses = project.resolve("classes/kotlin/jvm/main").apply { mkdirs() }
+    staleClasses.resolve("Stale.class").writeBytes(byteArrayOf())
+    val source =
+      project.resolve("src/main/kotlin/Previews.kt").apply {
+        parentFile.mkdirs()
+        writeText("@Preview\nfun preview() = Unit")
+      }
+    val resources = project.resolve("resources").apply { mkdirs() }
+    resources.resolve("spin.json").writeText("""{"v":"5.7.0","layers":[]}""")
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(staleClasses, activeClasses),
+          activeClassDirs = listOf(activeClasses),
+          dependencyJars = emptyList(),
+          sourceFiles = listOf(source),
+          moduleName = ":app",
+          variantName = "desktop",
+          projectDirectory = project,
+          failOnEmpty = false,
+          resourceDirs = listOf(resources),
+        )
+      ) as PreviewDiscovery.Outcome.Success
+
+    val warning = outcome.warnings.joinToString("\n")
+    assertThat(warning).contains("active class outputs contain 0 .class files")
+    assertThat(warning).contains(activeClasses.absolutePath)
+    assertThat(warning).doesNotContain(staleClasses.absolutePath)
   }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -293,6 +293,29 @@ internal object ComposePreviewTasks {
         },
       )
 
+    // Discovery scans every compatible layout above, but the cache-integrity guard must examine
+    // only the output of the compilation this project actually exposes. Otherwise stale classes
+    // left in an inactive fallback (for example `jvm/main` beside an active `desktop/main`) can
+    // mask a valid-but-empty cache restore. Resolve lazily so Kotlin tasks registered after this
+    // plugin still participate.
+    val activeSourceClassDirs =
+      project.files(
+        project.provider {
+          val activeCompileTask = DESKTOP_COMPILE_TASK_CANDIDATES.firstOrNull {
+            it in project.tasks.names
+          }
+          val relativePath =
+            when (activeCompileTask) {
+              "compileKotlinJvm" -> "classes/kotlin/jvm/main"
+              "compileKotlinDesktop" -> "classes/kotlin/desktop/main"
+              "compileAndroidMain" -> "classes/kotlin/android/main"
+              "compileKotlin" -> "classes/kotlin/main"
+              else -> null
+            }
+          relativePath?.let { listOf(project.layout.buildDirectory.dir(it).get()) }.orEmpty()
+        }
+      )
+
     // Processed-resources output dirs, in the same priority order as [sourceClassDirs]. Linked onto
     // the render classpath so a `@Preview` can load a classpath resource (e.g. a Lottie `.json`
     // asset) at render time. Non-existent dirs resolve to nothing — harmless on resource-free
@@ -333,6 +356,7 @@ internal object ComposePreviewTasks {
         resolveDependencyConfigName,
         previewOutputDir,
         extension,
+        activeSourceClassDirs = activeSourceClassDirs,
         // Desktop fallback can resolve a KMP-Android module's androidRuntimeClasspath, whose
         // single AGP variant trips AmbiguousArtifactsFailure under a forced artifactType view —
         // allow discovery to go lenient *for that config only* so `compose-preview list` never
@@ -1482,6 +1506,7 @@ internal object ComposePreviewTasks {
     dependencyConfigName: () -> String,
     previewOutputDir: Provider<Directory>,
     extension: PreviewExtension,
+    activeSourceClassDirs: FileCollection = sourceClassDirs,
     // Desktop callers pass `true`: the desktop runtime-config fallback can land on a
     // KMP-Android module's `androidRuntimeClasspath` (a `:shared` module with no
     // `jvm("desktop")` target), whose single AGP `android` variant trips an
@@ -1504,6 +1529,7 @@ internal object ComposePreviewTasks {
     return project.tasks.register("composePreviewDiscover", DiscoverPreviewsTask::class.java) {
       this.catalogRenderSupported.set(catalogRenderSupported)
       classDirs.from(sourceClassDirs)
+      activeClassDirs.from(activeSourceClassDirs)
       sourceFiles.from(
         project.fileTree("src") {
           include("**/*.kt")

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -40,6 +40,16 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   abstract val classDirs: ConfigurableFileCollection
 
   /**
+   * Class directories produced by the active compilation. [classDirs] can include compatibility
+   * fallbacks for several Kotlin targets; stale classes in one of those inactive directories must
+   * not hide an empty output restored for the compilation that discovery depends on.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val activeClassDirs: ConfigurableFileCollection
+
+  /**
    * The module's own compiled classes laid out as directories, sourced from AGP's scoped `PROJECT`
    * `CLASSES` artifact (`variant.artifacts.forScope(PROJECT).toGet(CLASSES, …)`). Wired by the
    * Android backend in addition to [classDirs]; resolving the scoped artifact also creates the
@@ -201,6 +211,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         lottieRenderSubdir = lottieRenderSubdir.getOrElse("renders"),
         svgRenderSubdir = svgRenderSubdir.getOrElse("renders"),
         projectClassJars = scopedClassJars,
+        activeClassDirs = activeClassDirs.files.toList(),
         catalogRenderSupported = catalogRenderSupported.getOrElse(true),
         isWear = isWear,
         retargetWearPreviews = retargetWearPreviews.getOrElse(true),

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -309,7 +309,11 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // Filtered-out previews keep their PNGs on disk (protected by the raw-manifest fan-out guard
     // below), so an unrelated broken preview is never scheduled and can't poison a filtered run.
     val nameFiltered =
-      selectNamedPreviews(rawManifest.previews, previewFilters.getOrElse(emptyList()))
+      selectNamedPreviews(
+        rawManifest.previews,
+        previewFilters.getOrElse(emptyList()),
+        previewsJson.get().asFile.absolutePath,
+      )
 
     // Id filter (issue #2966) — narrows to individual fan-out members within the functions the name
     // filter kept, which is the granularity a catalog's per-theme `modePriority` needs to skip the
@@ -317,7 +321,12 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // before tier/kind/catalog filtering, and so `--preview Foo --preview-id *_Light` composes.
     val idFiltered =
       excludePreviewIds(
-        selectPreviewIds(nameFiltered, previewIdFilters.getOrElse(emptyList())),
+        selectPreviewIds(
+          nameFiltered,
+          previewIdFilters.getOrElse(emptyList()),
+          previewsJson.get().asFile.absolutePath,
+          rawManifest.previews,
+        ),
         previewIdExcludes.getOrElse(emptyList()),
       )
 
@@ -868,6 +877,7 @@ private val SYNTHETIC_CATALOG_KINDS_UNSUPPORTED_ON_DESKTOP =
 internal fun selectNamedPreviews(
   previews: List<PreviewInfo>,
   filters: List<String>,
+  manifestPath: String? = null,
 ): List<PreviewInfo> {
   val cleaned = filters.map(String::trim).filter(String::isNotEmpty)
   if (cleaned.isEmpty()) return previews
@@ -884,6 +894,7 @@ internal fun selectNamedPreviews(
       append("composePreviewRender --preview matched no previews for ")
       append(cleaned.joinToString(", ") { "'$it'" })
       append(".")
+      appendManifestContext(previews, manifestPath)
       if (available.isEmpty()) {
         append(" This module has no discovered previews — run composePreviewDiscover to confirm.")
       } else {
@@ -920,6 +931,8 @@ internal fun selectNamedPreviews(
 internal fun selectPreviewIds(
   previews: List<PreviewInfo>,
   filters: List<String>,
+  manifestPath: String? = null,
+  manifestPreviews: List<PreviewInfo> = previews,
 ): List<PreviewInfo> {
   val cleaned = filters.map(String::trim).filter(String::isNotEmpty)
   if (cleaned.isEmpty()) return previews
@@ -933,6 +946,7 @@ internal fun selectPreviewIds(
       append("composePreviewRender --preview-id matched no previews for ")
       append(cleaned.joinToString(", ") { "'$it'" })
       append(".")
+      appendManifestContext(manifestPreviews, manifestPath)
       if (available.isEmpty()) {
         append(" This module has no discovered previews — run composePreviewDiscover to confirm.")
       } else {
@@ -947,6 +961,19 @@ internal fun selectPreviewIds(
       }
     }
   )
+}
+
+private fun StringBuilder.appendManifestContext(
+  previews: List<PreviewInfo>,
+  manifestPath: String?,
+) {
+  val assetCount = previews.count {
+    it.params.kind == PreviewKind.LOTTIE || it.params.kind == PreviewKind.SVG
+  }
+  val codeCount = previews.size - assetCount
+  append(" Manifest contains $codeCount code preview(s) and $assetCount asset preview(s)")
+  manifestPath?.let { append(" at $it") }
+  append(".")
 }
 
 /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposePreviewCompileTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposePreviewCompileTaskTest.kt
@@ -69,4 +69,28 @@ class ComposePreviewCompileTaskTest {
 
     assertThat(deps).contains(compileTask.get())
   }
+
+  @Test
+  fun `desktop integrity check uses only the highest priority active compilation output`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.configurations.create("runtimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+    project.tasks.register("compileKotlin", DefaultTask::class.java)
+    project.tasks.register("compileKotlinDesktop", DefaultTask::class.java)
+
+    val discover =
+      project.tasks.named("composePreviewDiscover", DiscoverPreviewsTask::class.java).get()
+    val buildDir = project.layout.buildDirectory.get().asFile.invariantSeparatorsPath
+
+    assertThat(discover.activeClassDirs.files).hasSize(1)
+    assertThat(discover.activeClassDirs.singleFile.invariantSeparatorsPath)
+      .endsWith("/build/classes/kotlin/desktop/main")
+    assertThat(discover.classDirs.files.map { it.invariantSeparatorsPath })
+      .containsAtLeast("$buildDir/classes/kotlin/main", "$buildDir/classes/kotlin/jvm/main")
+  }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectNamedPreviewsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectNamedPreviewsTest.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
 import ee.schimke.composeai.discovery.PreviewInfo
+import ee.schimke.composeai.discovery.PreviewKind
+import ee.schimke.composeai.discovery.PreviewParams
 import org.gradle.api.GradleException
 import org.junit.Test
 
@@ -72,5 +74,28 @@ class SelectNamedPreviewsTest {
         e
       }
     assertThat(thrown!!.message).contains("no discovered previews")
+  }
+
+  @Test
+  fun `no match reports manifest path and separates code from asset previews`() {
+    val asset =
+      PreviewInfo(
+        id = "svg__badge",
+        functionName = "svg/badge.svg",
+        className = "",
+        params = PreviewParams(kind = PreviewKind.SVG),
+      )
+
+    val thrown =
+      try {
+        selectNamedPreviews(listOf(asset), listOf("HomePreview"), "/tmp/previews.json")
+        null
+      } catch (e: GradleException) {
+        e
+      }
+
+    val message = thrown!!.message
+    assertThat(message).contains("0 code preview(s) and 1 asset preview(s)")
+    assertThat(message).contains("/tmp/previews.json")
   }
 }


### PR DESCRIPTION
## Summary

- detect source-bearing modules whose declared project class outputs contain zero `.class` files
- warn with resolved output paths, class counts, and an actionable no-cache rebuild command
- make `failOnEmpty` reject the corrupted asset-only state without rejecting intentional asset-only modules
- include the manifest path and code/asset preview counts in no-match render errors

## Root cause

A valid-but-empty remote cache entry for `:samples:cmp:compileKotlin` restored no class files. Discovery still found resource previews, so the non-empty asset manifest masked the missing compiled outputs and downstream filter failures incorrectly suggested that the user’s filter was wrong.

The repository evidence does not establish how the empty archive was originally produced. This change guards the invariant at discovery time regardless of producer.

## User impact

The failure now points directly to empty compiler outputs and recommends:

```
--no-build-cache --rerun-tasks
```

No-match render errors also identify the source `previews.json` and distinguish code previews from asset previews.

## Validation

- `./gradlew -p gradle-plugin --no-daemon --no-configuration-cache --max-workers=2 :preview-discovery:test --tests ee.schimke.composeai.discovery.LottieAssetDiscoveryTest :test --tests ee.schimke.composeai.plugin.SelectNamedPreviewsTest --tests ee.schimke.composeai.plugin.SelectPreviewIdsTest`
- `git diff origin/main...HEAD --check`

Fixes #3600