### PR TITLE
fix(rc-player): preserve lexical theme and canvas scope

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -194,7 +194,6 @@ import ee.schimke.composeai.rcplayer.protocol.RcImpulseStart
 import ee.schimke.composeai.rcplayer.protocol.RcIntegerExpression
 import ee.schimke.composeai.rcplayer.protocol.RcLayoutAnimation
 import ee.schimke.composeai.rcplayer.protocol.RcLayoutCompute
-import ee.schimke.composeai.rcplayer.protocol.RcLayoutContent
 import ee.schimke.composeai.rcplayer.protocol.RcLoopOperation
 import ee.schimke.composeai.rcplayer.protocol.RcMarqueeModifier
 import ee.schimke.composeai.rcplayer.protocol.RcMatrixExpression
@@ -214,7 +213,6 @@ import ee.schimke.composeai.rcplayer.protocol.RcPathExpression
 import ee.schimke.composeai.rcplayer.protocol.RcPathTween
 import ee.schimke.composeai.rcplayer.protocol.RcRippleModifier
 import ee.schimke.composeai.rcplayer.protocol.RcRootContentBehavior
-import ee.schimke.composeai.rcplayer.protocol.RcRootLayout
 import ee.schimke.composeai.rcplayer.protocol.RcRoundedClipRectModifier
 import ee.schimke.composeai.rcplayer.protocol.RcScrollModifier
 import ee.schimke.composeai.rcplayer.protocol.RcTextAttribute
@@ -357,8 +355,6 @@ public fun RcComposePlayer(
   }
   val linkedDocument = remember(document) { RcDocumentLinker.link(document) }
   val layout = remember(linkedDocument) { RcLayoutTree.build(linkedDocument) }
-  val contentStateOperationScopes =
-    remember(linkedDocument) { linkedDocument.operations.collectContentStateOperationScopes() }
   LaunchedEffect(linkedDocument, layout) {
     // Layout rendering consumes paint operations through component content rather than walking
     // the document root. AndroidX still applies root-level diagnostics during document execution.
@@ -397,9 +393,7 @@ public fun RcComposePlayer(
     state.beginFrame(frameNanos / 1_000_000_000f)
     // beginFrame resets derived text to the document's literals, so the ids the layout's own data
     // operations publish must be recomputed before this same composition measures and draws.
-    contentStateOperationScopes.forEach { operations ->
-      state.applyContentStateOperations(operations, theme)
-    }
+    state.applyLayoutContentStateOperations(linkedDocument.operations, theme)
     LookaheadScope {
       CompositionLocalProvider(
         LocalRcLookaheadScope provides this,
@@ -1693,7 +1687,11 @@ private fun Modifier.applyComponentModifiers(
           else result
         is RcMarqueeModifier -> result.applyAndroidXMarquee(operation, state)
         is RcNoArg ->
-          if (operation.opcode == RcOpcodes.MODIFIER_DRAW_CONTENT && !appliedCanvasOperations) {
+          if (
+            operation.opcode == RcOpcodes.MODIFIER_DRAW_CONTENT &&
+              !appliedCanvasOperations &&
+              modifiers.ordered.drop(operationIndex + 1).none { it is RcPaddingModifier }
+          ) {
             applyCanvasOperations(result)
           } else result
         else -> result
@@ -4203,25 +4201,4 @@ private fun blendMode(value: Int): BlendMode =
     27 -> BlendMode.Color
     28 -> BlendMode.Luminosity
     else -> BlendMode.SrcOver
-  }
-
-/**
- * Collects, in document order, the state operations layout containers carry beside their
- * components.
- *
- * The layout tree keeps only components, so these — a `TEXT_LOOKUP_INT` publishing a card title or
- * a `COLOR_EXPRESSIONS` feeding a background modifier — have no other execution site in the layout
- * path. Operations nested in a container that owns its own execution (CanvasOperations,
- * LayoutCompute) are left to that owner; only the direct children of a LayoutComponentContent are
- * replayed here. RootLayout also executes direct ComponentData before it paints its children.
- */
-private fun List<RcLinkedNode>.collectContentStateOperationScopes(): List<List<RcLinkedNode>> =
-  buildList {
-    this@collectContentStateOperationScopes.filterIsInstance<RcLinkedNode.Container>().forEach {
-      container ->
-      if (container.operation is RcRootLayout || container.operation is RcLayoutContent) {
-        add(container.children.filterIsInstance<RcLinkedNode.Operation>())
-      }
-      addAll(container.children.collectContentStateOperationScopes())
-    }
   }

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -30,6 +30,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcImageAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcImpulseStart
 import ee.schimke.composeai.rcplayer.protocol.RcIntegerConstant
 import ee.schimke.composeai.rcplayer.protocol.RcIntegerExpression
+import ee.schimke.composeai.rcplayer.protocol.RcLayoutContent
 import ee.schimke.composeai.rcplayer.protocol.RcLongConstant
 import ee.schimke.composeai.rcplayer.protocol.RcLoopOperation
 import ee.schimke.composeai.rcplayer.protocol.RcMatrixConstant
@@ -41,6 +42,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcPathData
 import ee.schimke.composeai.rcplayer.protocol.RcPathExpression
 import ee.schimke.composeai.rcplayer.protocol.RcRootContentBehavior
 import ee.schimke.composeai.rcplayer.protocol.RcRootContentDescription
+import ee.schimke.composeai.rcplayer.protocol.RcRootLayout
 import ee.schimke.composeai.rcplayer.protocol.RcTextData
 import ee.schimke.composeai.rcplayer.protocol.RcTextFromFloat
 import ee.schimke.composeai.rcplayer.protocol.RcTextLength
@@ -561,36 +563,73 @@ public class RcPlayerState(
     var currentTheme = RcTheme.UNSPECIFIED
     children.forEach { child ->
       val operation = (child as? RcLinkedNode.Operation)?.operation
-      if (operation is RcTheme) {
-        currentTheme = operation.theme
-        return@forEach
-      }
-      val visible =
-        requestedTheme == RcTheme.UNSPECIFIED ||
-          currentTheme == RcTheme.UNSPECIFIED ||
-          currentTheme == requestedTheme
-      if (!visible) return@forEach
-      when (operation) {
-        // Float producers run before the text operations that reference them: a TEXT_FROM_FLOAT
-        // reading an id no expression has computed resolves to the reference's own NaN bits and
-        // formats as garbage. Wire order is the document's order, so one pass suffices.
-        is RcFloatExpression -> applyFloatExpression(operation)
-        is RcIntegerExpression -> applyIntegerExpression(operation)
-        is RcColorTheme -> applyColorTheme(operation, requestedTheme)
-        is RcColorExpression -> applyColorExpression(operation)
-        is RcColorAttribute -> applyColorAttribute(operation)
-        is RcIdLookup,
-        is RcDataMapLookup -> applyDataOperation(operation)
-        is RcTextMerge,
-        is RcTextLength,
-        is RcTextSubtext,
-        is RcTextTransform,
-        is RcTextFromFloat,
-        is RcTextLookup,
-        is RcTextLookupInt -> applyTextOperation(operation)
-        else -> Unit
+      currentTheme = applyContentStateOperation(operation, currentTheme, requestedTheme)
+    }
+  }
+
+  /**
+   * Replays state operations from layout-content containers with lexical theme scoping.
+   *
+   * A nested content block inherits the theme active in its parent, but any theme markers it
+   * contains stop at that container's boundary. This mirrors the wire tree without letting a dark
+   * branch suppress an otherwise untagged sibling.
+   */
+  public fun applyLayoutContentStateOperations(
+    children: List<RcLinkedNode>,
+    requestedTheme: Int = RcTheme.UNSPECIFIED,
+  ) {
+    fun applyScope(nodes: List<RcLinkedNode>, inheritedTheme: Int, applyDirect: Boolean) {
+      var currentTheme = inheritedTheme
+      nodes.forEach { node ->
+        when (node) {
+          is RcLinkedNode.Operation ->
+            if (applyDirect) {
+              currentTheme =
+                applyContentStateOperation(node.operation, currentTheme, requestedTheme)
+            }
+          is RcLinkedNode.Container -> {
+            val isContentScope = node.operation is RcRootLayout || node.operation is RcLayoutContent
+            applyScope(node.children, currentTheme, isContentScope)
+          }
+        }
       }
     }
+
+    applyScope(children, RcTheme.UNSPECIFIED, applyDirect = false)
+  }
+
+  private fun applyContentStateOperation(
+    operation: RcOperation?,
+    currentTheme: Int,
+    requestedTheme: Int,
+  ): Int {
+    if (operation is RcTheme) return operation.theme
+    val visible =
+      requestedTheme == RcTheme.UNSPECIFIED ||
+        currentTheme == RcTheme.UNSPECIFIED ||
+        currentTheme == requestedTheme
+    if (!visible) return currentTheme
+    when (operation) {
+      // Float producers run before the text operations that reference them: a TEXT_FROM_FLOAT
+      // reading an id no expression has computed resolves to the reference's own NaN bits and
+      // formats as garbage. Wire order is the document's order, so one pass suffices.
+      is RcFloatExpression -> applyFloatExpression(operation)
+      is RcIntegerExpression -> applyIntegerExpression(operation)
+      is RcColorTheme -> applyColorTheme(operation, requestedTheme)
+      is RcColorExpression -> applyColorExpression(operation)
+      is RcColorAttribute -> applyColorAttribute(operation)
+      is RcIdLookup,
+      is RcDataMapLookup -> applyDataOperation(operation)
+      is RcTextMerge,
+      is RcTextLength,
+      is RcTextSubtext,
+      is RcTextTransform,
+      is RcTextFromFloat,
+      is RcTextLookup,
+      is RcTextLookupInt -> applyTextOperation(operation)
+      else -> Unit
+    }
+    return currentTheme
   }
 
   public fun executeLayoutCompute(children: List<RcLinkedNode>) {

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerStateTest.kt
@@ -30,6 +30,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcIdMap
 import ee.schimke.composeai.rcplayer.protocol.RcImageAttribute
 import ee.schimke.composeai.rcplayer.protocol.RcIntegerConstant
 import ee.schimke.composeai.rcplayer.protocol.RcIntegerExpression
+import ee.schimke.composeai.rcplayer.protocol.RcLayoutContent
 import ee.schimke.composeai.rcplayer.protocol.RcLongConstant
 import ee.schimke.composeai.rcplayer.protocol.RcLoopOperation
 import ee.schimke.composeai.rcplayer.protocol.RcMatrixConstant
@@ -38,6 +39,7 @@ import ee.schimke.composeai.rcplayer.protocol.RcMatrixVectorMath
 import ee.schimke.composeai.rcplayer.protocol.RcNamedVariable
 import ee.schimke.composeai.rcplayer.protocol.RcRootContentBehavior
 import ee.schimke.composeai.rcplayer.protocol.RcRootContentDescription
+import ee.schimke.composeai.rcplayer.protocol.RcRootLayout
 import ee.schimke.composeai.rcplayer.protocol.RcTextData
 import ee.schimke.composeai.rcplayer.protocol.RcTextFromFloat
 import ee.schimke.composeai.rcplayer.protocol.RcTextLength
@@ -933,23 +935,48 @@ class RcPlayerStateTest {
   }
 
   @Test
-  fun resetsThemeFilteringBetweenLayoutContentScopes() {
+  fun preservesParentThemeWithoutLeakingAChildThemeIntoItsSibling() {
     val state = RcPlayerState(RcDocument(RcHeader(RcVersion(0, 1, 0)), emptyList()))
-    val darkScope =
-      listOf<RcLinkedNode>(
-        RcLinkedNode.Operation(RcTheme(RcTheme.DARK)),
-        RcLinkedNode.Operation(RcColorTheme(30, 0, 0, 0, 0xffeeeeee.toInt(), 0xff111111.toInt())),
-      )
-    val followingScope =
-      listOf<RcLinkedNode>(
-        RcLinkedNode.Operation(RcColorTheme(31, 0, 0, 0, 0xffabcdef.toInt(), 0xff123456.toInt()))
+    val tree =
+      listOf(
+        RcLinkedNode.Container(
+          RcRootLayout(1),
+          listOf(
+            RcLinkedNode.Operation(RcTheme(RcTheme.LIGHT)),
+            RcLinkedNode.Container(
+              RcLayoutContent(2),
+              listOf(
+                RcLinkedNode.Operation(
+                  RcColorTheme(30, 0, 0, 0, 0xffeeeeee.toInt(), 0xff111111.toInt())
+                )
+              ),
+            ),
+            RcLinkedNode.Container(
+              RcLayoutContent(3),
+              listOf(
+                RcLinkedNode.Operation(RcTheme(RcTheme.DARK)),
+                RcLinkedNode.Operation(
+                  RcColorTheme(31, 0, 0, 0, 0xffabcdef.toInt(), 0xff123456.toInt())
+                ),
+              ),
+            ),
+            RcLinkedNode.Container(
+              RcLayoutContent(4),
+              listOf(
+                RcLinkedNode.Operation(
+                  RcColorTheme(32, 0, 0, 0, 0xfffedcba.toInt(), 0xff654321.toInt())
+                )
+              ),
+            ),
+          ),
+        )
       )
 
-    state.applyContentStateOperations(darkScope, RcTheme.LIGHT)
-    state.applyContentStateOperations(followingScope, RcTheme.LIGHT)
+    state.applyLayoutContentStateOperations(tree, RcTheme.LIGHT)
 
-    assertEquals(0, state.color(30))
-    assertEquals(0xffabcdef.toInt(), state.color(31))
+    assertEquals(0xffeeeeee.toInt(), state.color(30))
+    assertEquals(0, state.color(31))
+    assertEquals(0xfffedcba.toInt(), state.color(32))
   }
 
   @Test


### PR DESCRIPTION
## What changed

- replay layout state operations with lexical theme scoping: nested content inherits its parent theme, while child theme markers cannot leak into siblings
- defer an early `DrawContent` marker when padding remains, keeping canvas decoration outside padding as required by the latest `main`
- add regression coverage for parent-theme inheritance and sibling isolation

## Why

PR #3649 addressed a Codex review comment by resetting theme state per collected content container. The initial implementation reset nested scopes too aggressively, which dropped derived button labels in the CMP/Wasm renderer. Its merge-conflict resolution also applied `DrawContent` before a later padding modifier, undoing the canvas/padding fix from #3648. GitHub auto-merged #3649 before its non-blocking parity report completed, so this is the focused follow-up.

## Validation

- `./gradlew :rc-player-runtime:desktopTest :rc-player-compose:desktopTest --no-daemon`
- `./gradlew :rc-player-wasm:wasmPlayerDist --no-daemon`
- rendered the published `design-artifacts/remote-m3` parity corpus locally: 27/27 documents rendered, including restored labels for `FilledRemoteButton`, `NamedLabelRemoteButton`, and `ButtonGroupRemote`
- the three Linux CI regressions moved locally from approximately 0.79%/0.79%/0.28% mismatch to 0.24%/0.24%/0.01%; the fresh Linux workflow remains authoritative for whole-corpus parity