### PR TITLE
feat(rc-js-player): implement FontData opcode 189

### DIFF
--- a/cli/src/main/resources/rc-player/bundle.js
+++ b/cli/src/main/resources/rc-player/bundle.js
@@ -34,6 +34,7 @@ var RC = (() => {
     googleFontsUrl: () => googleFontsUrl,
     namedFontStack: () => namedFontStack,
     parseFamily: () => parseFamily,
+    registerEmbeddedFont: () => registerEmbeddedFont,
     resetWebFonts: () => resetWebFonts,
     webFontsReady: () => webFontsReady
   });
@@ -15666,6 +15667,32 @@ ${inner}`;
   _Custom.OP_CODE = 93;
   var Custom = _Custom;
 
+  // src/core/operations/FontData.ts
+  var _FontData = class _FontData extends Operation {
+    constructor(mFontId, mType, mFontData) {
+      super();
+      this.mFontId = mFontId;
+      this.mType = mType;
+      this.mFontData = mFontData;
+    }
+    write(_buffer) {
+    }
+    apply(context) {
+      context.loadFont(this.mFontId, this.mFontData);
+    }
+    deepToString(indent) {
+      return `${indent}FontData(${this.mFontId}, ${this.mFontData.length} bytes)`;
+    }
+    static read(buffer, operations) {
+      const fontId = buffer.readId();
+      const type = buffer.readInt();
+      const fontData = buffer.readBuffer();
+      operations.push(new _FontData(fontId, type, fontData));
+    }
+  };
+  _FontData.OP_CODE = 189;
+  var FontData = _FontData;
+
   // src/core/Operations.ts
   var _Operations = class _Operations {
     static init() {
@@ -15701,6 +15728,7 @@ ${inner}`;
       m.set(ClipPath.OP_CODE, ClipPath.read);
       m.set(TextData.OP_CODE, TextData.read);
       m.set(BitmapData.OP_CODE, BitmapData.read);
+      m.set(FontData.OP_CODE, FontData.read);
       m.set(PaintData.OP_CODE, PaintData.read);
       m.set(PathData.OP_CODE, PathData.read);
       m.set(FloatConstant.OP_CODE, FloatConstant.read);
@@ -17769,6 +17797,7 @@ void main() {
   }
   var stylesheets = /* @__PURE__ */ new Map();
   var variants = /* @__PURE__ */ new Map();
+  var embeddedFaces = /* @__PURE__ */ new Map();
   var done = /* @__PURE__ */ new Set();
   var waiting = /* @__PURE__ */ new Map();
   function variantKey(family, weight, italic, axes = []) {
@@ -17877,6 +17906,39 @@ void main() {
     variants.set(key, p);
     return p;
   }
+  function embeddedFamily(fontId, data) {
+    let hash = 2166136261;
+    for (const byte of data) {
+      hash ^= byte;
+      hash = Math.imul(hash, 16777619);
+    }
+    return `__rc_font_${fontId}_${data.length}_${(hash >>> 0).toString(16)}`;
+  }
+  function registerEmbeddedFont(fontId, data, onLoaded) {
+    const family = embeddedFamily(fontId, data);
+    const key = `embedded|${family}`;
+    if (onLoaded && !done.has(key)) {
+      const set = waiting.get(key) ?? /* @__PURE__ */ new Set();
+      set.add(onLoaded);
+      waiting.set(key, set);
+    }
+    if (variants.has(key)) return family;
+    let load;
+    if (typeof document === "undefined" || !document.fonts || typeof FontFace === "undefined") {
+      load = Promise.resolve();
+    } else {
+      const bytes = data.slice().buffer;
+      const face = new FontFace(family, bytes);
+      embeddedFaces.set(key, face);
+      document.fonts.add(face);
+      load = face.load().then(() => void 0).catch((e) => {
+        console.warn(`WebFonts: embedded font ${fontId} could not be loaded`, e);
+      });
+    }
+    const promise = load.then(() => notify(key));
+    variants.set(key, promise);
+    return family;
+  }
   async function webFontsReady() {
     let pending = [...variants.values()];
     while (pending.length > 0) {
@@ -17887,6 +17949,10 @@ void main() {
     }
   }
   function resetWebFonts() {
+    if (typeof document !== "undefined" && document.fonts) {
+      embeddedFaces.forEach((face) => document.fonts.delete(face));
+    }
+    embeddedFaces.clear();
     stylesheets.clear();
     axisSpans.clear();
     variants.clear();
@@ -18012,6 +18078,8 @@ void main() {
         }
         throw new Error("No canvas factory available for graphics layers");
       };
+      /** Embedded FontData families, keyed by the same document id used by TYPEFACE/CoreText. */
+      this.embeddedFontFamilies = /* @__PURE__ */ new Map();
       // --- Typeface resolution ---
       /**
        * Called when a named family finishes loading, so a player that already painted a frame in the
@@ -18043,6 +18111,14 @@ void main() {
     getText(id) {
       return this.textCache.get(id) ?? null;
     }
+    loadFont(fontId, data) {
+      const current = this.embeddedFontFamilies.get(fontId);
+      if (current?.data === data) return;
+      this.embeddedFontFamilies.set(fontId, {
+        data,
+        family: registerEmbeddedFont(fontId, data, this.onFontLoaded ?? void 0)
+      });
+    }
     /**
      * CSS stack for a `PaintBundle.TYPEFACE` operand.
      *
@@ -18060,6 +18136,11 @@ void main() {
      */
     fontStackForTypeface(fontType) {
       if (fontType < RemoteComposeState.START_ID) return cssFontStackFor(fontType);
+      const embedded = this.embeddedFontFamilies.get(fontType);
+      if (embedded) {
+        this.googleFamily = null;
+        return namedFontStack(embedded.family);
+      }
       const family = this.getText(fontType);
       if (!family) return cssFontStackFor(0);
       const { source, name } = parseFamily(family);
@@ -19887,6 +19968,11 @@ void main() {
     // --- Bitmap ---
     loadBitmap(imageId, encoding, type, width, height, bitmap) {
       this.canvasPaintContext.loadBitmap(imageId, encoding, type, width, height, bitmap);
+    }
+    // --- Font ---
+    loadFont(fontId, fontData) {
+      super.loadFont(fontId, fontData);
+      this.canvasPaintContext.loadFont(fontId, fontData);
     }
     // --- Text ---
     loadText(id, text) {

--- a/docs/design/RC_PLAYER_TYPEFACES.md
+++ b/docs/design/RC_PLAYER_TYPEFACES.md
@@ -18,8 +18,8 @@ question:
 
 | | built-in ids | named (local) | `google:` downloadable | embedded `FontData` |
 | --- | --- | --- | --- | --- |
-| **JS** (vendored TS player, in-browser) | ✅ concrete stacks | ⚠️ passed to CSS; host must have the face | ✅ fetched from the Google Fonts CSS API | ❌ bytes stored, never registered |
-| **JS** — font-variation axes | ✅ `wght` exactly, `wdth` quantised to the nine `font-stretch` keywords | — | ✅ requested as axis *ranges*, which is what makes the face variable | ❌ other axes have no canvas expression |
+| **JS** (vendored TS player, in-browser) | ✅ concrete stacks | ⚠️ passed to CSS; host must have the face | ✅ fetched from the Google Fonts CSS API | ✅ registered as a `FontFace` keyed by document font id |
+| **JS** — font-variation axes | ✅ `wght` exactly, `wdth` quantised to the nine `font-stretch` keywords | — | ✅ requested as axis *ranges*, which is what makes the face variable | ⚠️ the same canvas `wght`/`wdth` support; other axes have no canvas expression |
 | **CMP Wasm** (this repo's player, in-browser) | ✅ from the host manifest | ✅ if the manifest carries it | ⚠️ manifest only — no fetch | ✅ `decodeInlineFonts` |
 | **CMP Wasm** — font-variation axes | ✅ layout ops (`CoreText`) | — | — | ❌ canvas ops (reported, not silent) |
 | **Java** (AOSP `remote-player-view`, server-side) | ✅ framework typefaces | ⚠️ `/system/fonts/` filename scan | ✅ served by `RcGoogleFontTypefaceResolver` | ✅ `Font.Builder(ByteBuffer)` |
@@ -50,21 +50,12 @@ viewer disagree about the *same* document:
    and then `java` both got a shim over the shared `GoogleFontCache` — for the view player, a
    `TypefaceResolver` installed on the `RemoteComposePlayer` that serves `google:` names from that
    cache and delegates everything else to `DefaultTypefaceResolver` (see the Java section).
-2. **Embedded `FontData` is supported by exactly the two lanes nobody looks at first.** The Java and
-   CMP Wasm lanes build a real face from the document's own bytes; neither vendored embedded player
-   (Android or JVM) consults them at all, and the JS lane is **worse than "ignores them"** — the
-   `FontData` opcode (189) is not in its operation registry, and an opcode the registry doesn't know
-   makes `RemoteComposeBuffer.inflateFromBuffer` warn `Unknown operation opcode` and **return**,
-   dropping every remaining operation in the buffer. So a document that ships its typeface doesn't
-   merely render in a substituted face there; it renders *truncated* from the font onward. (The
-   player does carry a `RemoteContext.loadFont` that would stash the bytes, but nothing calls it —
-   it is dead code with no decoder in front of it. `rc-compare` already flags such a render, via the
-   same `Unknown operation opcode` warning, as `truncated`.)
-
-   Closing it in the JS lane is a decoder (a `FontData` operation reading `fontId`/`type`/`data` and
-   calling the existing `loadFont`) plus a `FontFace` registration keyed by font id, so a paint's
-   typeface id resolves to the embedded family rather than to a text-table name. That is the one
-   typeface gap this document still records as open.
+2. **Embedded `FontData` remains absent from the two vendored embedded players.** Java and CMP Wasm
+   build a face from the document's bytes, while CMP Android and CMP JVM still ignore them. The JS
+   lane now decodes opcode 189, registers the bytes as a collision-resistant `FontFace` alias, and
+   resolves both canvas paint and `CoreText` through that alias. Its registration joins the same
+   readiness/repaint path as downloadable fonts, and a browser fixture verifies that an operation
+   after `FontData` still draws in the embedded face rather than the decoder truncating the stream.
 
 ## Where the files come from
 

--- a/docs/design/RC_TEXT_METRICS.md
+++ b/docs/design/RC_TEXT_METRICS.md
@@ -89,8 +89,8 @@ for the `default` role; a canvas paint's built-in family id is decoded straight 
 `FontFamily.Default`. On a lane with no manifest — all three rendered here — both land on the same
 face and the comparison is sound. On a lane that installs one (cmp-wasm does) they can differ, and an
 apparent wrapping or advance divergence there might be this fixture rather than the player. Pinning
-the face via embedded `FontData` closes it; until then, read cmp-wasm's mode fixtures with that in
-mind.
+the face via embedded `FontData` closes it. The Java, CMP Wasm and JS lanes now support that pin;
+the two vendored embedded-player lanes still substitute their host face.
 
 With that caveat noted, the point stands: where the host stack actually broke, clipped or ellipsised
 the line, against where the player thinks the line ends, is a picture rather than an adjective.
@@ -244,10 +244,9 @@ which is what the fixture is for.
   contract; the JS canvas backend uses `actualBoundingBoxLeft` / `actualBoundingBoxRight` where the
   browser supplies them and falls back to the advance box otherwise.
 - **A pinned face.** The fixtures use the lane's default family, which leaves every reading entangled
-  with typeface resolution. Embedding the face as `FontData` fixes that for `java` and `cmp-wasm`;
-  the JS lane doesn't have opcode 189 in its registry and truncates the document rather than
-  substituting. That missing operation is tracked by
-  [#3647](https://github.com/yschimke/compose-ai-tools/issues/3647).
+  with typeface resolution. Embedding the face as `FontData` now pins `java`, `cmp-wasm` and `js`;
+  both vendored embedded-player lanes still ignore the bytes. Add support there before reading a
+  five-lane residual as a measurement difference.
 - **A machine-readable metric dump.** The numbers are currently rendered into the image. A per-lane
   JSON table would let the comparison be asserted rather than read, which is what turns this from a
   diagnostic into a gate.

--- a/scripts/design-artifacts/rc-font-data.test.mjs
+++ b/scripts/design-artifacts/rc-font-data.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * FontData (opcode 189) in the shipped JS player.
+ *
+ * The fixture is assembled from the wire primitives here and embeds the catalog's Orbitron face.
+ * Its drawable text operation deliberately follows FontData: before opcode 189 was registered the
+ * decoder returned at that byte, so the canvas stayed empty. The face has visibly different
+ * metrics from the browser fallback, which also proves the decoded bytes are selected by typeface
+ * id rather than merely skipped without truncating the document.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "../..");
+const BUNDLE = path.join(ROOT, "cli/src/main/resources/rc-player/bundle.js");
+const FONT = path.join(ROOT, "samples/design-catalog-m3/src/main/resources/fonts/orbitron-400.ttf");
+const FAMILY_ID = 42;
+const TEXT_ID = 43;
+const SPECIMEN = "FONTDATA 0123456789";
+
+let browser;
+let skip = false;
+
+before(async () => {
+  try {
+    const { chromium } = await import("playwright");
+    browser = await chromium.launch({ headless: true, args: ["--no-sandbox"] });
+  } catch (e) {
+    skip = `chromium unavailable: ${String(e).split("\n")[0]}`;
+  }
+});
+
+after(async () => browser?.close());
+
+/** A minimal modern Remote Compose document containing canvas text after FontData. */
+function fontDataFixture(font, embedded = true) {
+  const bytes = [];
+  const scratch = new DataView(new ArrayBuffer(4));
+  const byte = (v) => bytes.push(v & 0xff);
+  const short = (v) => { byte(v >>> 8); byte(v); };
+  const int = (v) => {
+    scratch.setInt32(0, v, false);
+    for (let i = 0; i < 4; i++) byte(scratch.getUint8(i));
+  };
+  const floatBits = (v) => { scratch.setFloat32(0, v, false); return scratch.getInt32(0, false); };
+  const buffer = (data) => { int(data.length); for (const v of data) byte(v); };
+  const utf8 = (value) => buffer(new TextEncoder().encode(value));
+
+  // Header v1.1 (document API 7, where FontData was added), 256 x 96.
+  byte(0); int(0x048c0001); int(1); int(0); int(2);
+  short(5); short(4); int(256);
+  short(6); short(4); int(96);
+
+  if (embedded) {
+    // The family name and FontData intentionally share an id, matching AndroidX authoring.
+    byte(102); int(FAMILY_ID); utf8("Embedded Orbitron");
+    byte(189); int(FAMILY_ID); int(0); buffer(font);
+  }
+
+  // Everything below must survive opcode 189.
+  byte(102); int(TEXT_ID); utf8(SPECIMEN);
+  byte(40); int(6);
+  int(4); int(0xff111111 | 0);                       // COLOR
+  int(1); int(floatBits(32));                        // TEXT_SIZE
+  int(16 | (400 << 16)); int(embedded ? FAMILY_ID : 0); // TYPEFACE
+  byte(43); int(TEXT_ID); int(0); int(-1); int(0); int(-1);
+  int(floatBits(8)); int(floatBits(52)); byte(0);     // DRAW_TEXT_RUN
+  return Uint8Array.from(bytes);
+}
+
+test("FontData does not truncate following ops and its face draws canvas text", async (t) => {
+  if (skip) return t.skip(skip);
+  if (!fs.existsSync(BUNDLE)) return t.skip("player bundle is not built");
+  if (!fs.existsSync(FONT)) return t.skip("Orbitron fixture font is not vendored");
+
+  const page = await browser.newPage({ viewport: { width: 256, height: 96 } });
+  const warnings = [];
+  page.on("console", (message) => {
+    if (message.type() === "warning") warnings.push(message.text());
+  });
+  try {
+    await page.setContent("<canvas id='embedded' width='256' height='96'></canvas><canvas id='fallback' width='256' height='96'></canvas>");
+    await page.addScriptTag({ path: BUNDLE });
+    const fixture = fontDataFixture(fs.readFileSync(FONT));
+    const fallbackFixture = fontDataFixture(new Uint8Array(), false);
+    const result = await page.evaluate(async ({ fixture, fallbackFixture }) => {
+      const render = async (id, bytes) => {
+        const canvas = document.querySelector(`#${id}`);
+        const player = new window.RcdPlayer(canvas);
+        await player.loadFromArrayBuffer(Uint8Array.from(bytes).buffer);
+        await player.fontsReady();
+        player.repaint();
+        return {
+          operationCount: player.getDocument().getNumberOfOps(),
+          pixels: [...canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height).data],
+        };
+      };
+      const embedded = await render("embedded", fixture);
+      const fallback = await render("fallback", fallbackFixture);
+      let painted = 0;
+      let differing = 0;
+      for (let i = 0; i < embedded.pixels.length; i++) {
+        if (i % 4 === 3 && embedded.pixels[i] !== 0) painted++;
+        if (embedded.pixels[i] !== fallback.pixels[i]) differing++;
+      }
+      const faces = [];
+      document.fonts.forEach((face) => {
+        if (face.family.includes("__rc_font_")) faces.push(`${face.family}:${face.status}`);
+      });
+      return {
+        operationCount: embedded.operationCount,
+        painted,
+        differing,
+        faces,
+      };
+    }, { fixture: [...fixture], fallbackFixture: [...fallbackFixture] });
+
+    assert.equal(warnings.some((w) => w.includes("Unknown operation opcode: 189")), false, warnings.join("\n"));
+    assert.ok(result.operationCount >= 6, `ops after FontData were lost: ${result.operationCount}`);
+    assert.ok(result.painted > 0, "DrawText after FontData did not reach the canvas");
+    assert.ok(result.faces.some((face) => face.endsWith(":loaded")), result.faces.join(", "));
+    assert.ok(result.differing > 0, "embedded face rendered the same pixels as the fallback face");
+  } finally {
+    await page.close();
+  }
+});

--- a/third_party/remote-compose-player/src/core/Operations.ts
+++ b/third_party/remote-compose-player/src/core/Operations.ts
@@ -118,6 +118,7 @@ import {
     PatternArgument, PatternDefine
 } from './operations/loom/PatternOperations';
 import { Custom } from './operations/layout/managers/Custom';
+import { FontData } from './operations/FontData';
 
 export class Operations {
     private static readonly sMap = new Map<number, CompanionOperationFn>();
@@ -165,6 +166,7 @@ export class Operations {
         // Data operations
         m.set(TextData.OP_CODE, TextData.read);
         m.set(BitmapData.OP_CODE, BitmapData.read);
+        m.set(FontData.OP_CODE, FontData.read);
         m.set(PaintData.OP_CODE, PaintData.read);
         m.set(PathData.OP_CODE, PathData.read);
         m.set(FloatConstant.OP_CODE, FloatConstant.read);

--- a/third_party/remote-compose-player/src/core/operations/FontData.ts
+++ b/third_party/remote-compose-player/src/core/operations/FontData.ts
@@ -1,0 +1,35 @@
+// FontData: embedded raw font bytes (opcode 189).
+
+import { Operation } from '../Operation';
+import type { WireBuffer } from '../WireBuffer';
+import type { RemoteContext } from '../RemoteContext';
+
+/** Mirrors AndroidX FontData: font id, currently-unused type, and a font file. */
+export class FontData extends Operation {
+    static readonly OP_CODE = 189;
+
+    constructor(
+        readonly mFontId: number,
+        readonly mType: number,
+        readonly mFontData: Uint8Array,
+    ) {
+        super();
+    }
+
+    write(_buffer: WireBuffer): void { /* read-only player */ }
+
+    apply(context: RemoteContext): void {
+        context.loadFont(this.mFontId, this.mFontData);
+    }
+
+    deepToString(indent: string): string {
+        return `${indent}FontData(${this.mFontId}, ${this.mFontData.length} bytes)`;
+    }
+
+    static read(buffer: WireBuffer, operations: Operation[]): void {
+        const fontId = buffer.readId();
+        const type = buffer.readInt();
+        const fontData = buffer.readBuffer();
+        operations.push(new FontData(fontId, type, fontData));
+    }
+}

--- a/third_party/remote-compose-player/src/rc2json.ts
+++ b/third_party/remote-compose-player/src/rc2json.ts
@@ -100,6 +100,7 @@ const OP_NAMES: Record<number, string> = {
     186: "MATRIX_CONSTANT",
     187: "MATRIX_EXPRESSION",
     188: "MATRIX_VECTOR_MATH",
+    189: "DATA_FONT",
     190: "DRAW_TO_BITMAP",
     191: "WAKE_IN",
     192: "ID_LOOKUP",

--- a/third_party/remote-compose-player/src/web/CanvasPaintContext.ts
+++ b/third_party/remote-compose-player/src/web/CanvasPaintContext.ts
@@ -6,8 +6,9 @@ import { isNaNBits, idFromBits, floatToRawIntBits } from '../core/operations/Uti
 import { transpileAgslToGlsl } from '../core/shader/AgslTranspiler';
 import { WebGLShaderRenderer } from './shader/WebGLShaderRenderer';
 import { RemoteComposeState } from '../core/RemoteComposeState';
-import { ensureWebFont, parseFamily, cssQuoted } from './WebFonts';
+import { ensureWebFont, parseFamily, cssQuoted, registerEmbeddedFont } from './WebFonts';
 import type { ShaderData } from '../core/operations/ShaderData';
+import type { RemoteContext } from '../core/RemoteContext';
 
 /** One font-variation axis of the current paint: an OpenType tag and the value asked for. */
 interface FontAxis {
@@ -241,6 +242,20 @@ export class CanvasPaintContext extends PaintContext {
 
     getText(id: number): string | null { return this.textCache.get(id) ?? null; }
 
+    /** Embedded FontData families, keyed by the same document id used by TYPEFACE/CoreText. */
+    private embeddedFontFamilies = new Map<number, { data: Uint8Array; family: string }>();
+
+    loadFont(fontId: number, data: Uint8Array): void {
+        // FontData is applied in both the data and paint passes. Avoid hashing a potentially large
+        // font file again on every frame; a changed operation carries a different byte-array view.
+        const current = this.embeddedFontFamilies.get(fontId);
+        if (current?.data === data) return;
+        this.embeddedFontFamilies.set(fontId, {
+            data,
+            family: registerEmbeddedFont(fontId, data, this.onFontLoaded ?? undefined),
+        });
+    }
+
     // --- Typeface resolution ---
 
     /**
@@ -267,6 +282,11 @@ export class CanvasPaintContext extends PaintContext {
      */
     private fontStackForTypeface(fontType: number): string {
         if (fontType < RemoteComposeState.START_ID) return cssFontStackFor(fontType);
+        const embedded = this.embeddedFontFamilies.get(fontType);
+        if (embedded) {
+            this.googleFamily = null;
+            return namedFontStack(embedded.family);
+        }
         const family = this.getText(fontType);
         // A named family whose text id resolves to nothing means the document referenced a string it
         // never loaded; treat it as unstyled rather than painting a stack named "null".

--- a/third_party/remote-compose-player/src/web/WebFonts.ts
+++ b/third_party/remote-compose-player/src/web/WebFonts.ts
@@ -1,12 +1,13 @@
-// WebFonts: on-demand registration of *named* font families, served from Google Fonts.
+// WebFonts: browser registration of named and document-embedded font families.
 //
-// A Remote Compose document names its typeface in one of two ways. The four generic ids
+// A Remote Compose document names its typeface in three ways. The four generic ids
 // (`0=DEFAULT, 1=SANS_SERIF, 2=SERIF, 3=MONOSPACE`) are a closed set that `cssFontStackFor` maps to
 // the concrete faces Android resolves them to. Anything else — `RemoteFontFamily.Named("Orbitron")`
 // — reaches the paint layer as the document's *text id* for the family name, not as a name, because
 // `CoreText.updateVariables` falls through to `mType = mFontFamilyId` for a family it doesn't
 // recognise. Resolving that id back through the text table is what turns it into a family a browser
-// can be asked for; this module is what makes the ask resolvable, by registering the face.
+// can be asked for. A FontData operation can attach bytes to that same id instead; this module
+// registers both sources and gives an embedded face a collision-resistant private CSS family.
 //
 // Fetching from Google Fonts (rather than vendoring) is the only approach that generalises: a
 // document may name *any* family, and the set isn't known until the document is read. The faces
@@ -149,6 +150,9 @@ const stylesheets = new Map<string, Promise<void>>();
  * six weights the family publishes.
  */
 const variants = new Map<string, Promise<void>>();
+
+/** FontFace objects created from inline FontData, retained for reset and document-font matching. */
+const embeddedFaces = new Map<string, FontFace>();
 
 /** Variants that have finished, so a settled one is never re-announced. See [notify]. */
 const done = new Set<string>();
@@ -388,6 +392,57 @@ export function ensureWebFont(
     return p;
 }
 
+/** Stable, CSS-safe family alias for an embedded face. */
+function embeddedFamily(fontId: number, data: Uint8Array): string {
+    // Font ids are document-local and commonly start at 42, so the bytes must participate in the
+    // alias: two players on one page can otherwise register different faces under the same family.
+    let hash = 0x811C9DC5;
+    for (const byte of data) {
+        hash ^= byte;
+        hash = Math.imul(hash, 0x01000193);
+    }
+    return `__rc_font_${fontId}_${data.length}_${(hash >>> 0).toString(16)}`;
+}
+
+/**
+ * Register FontData bytes with the browser and return the family name canvas can use immediately.
+ *
+ * The load joins [webFontsReady], just like a downloadable named face. Interactive players receive
+ * [onLoaded] once and repaint; single-shot renderers await the same promise before keeping a frame.
+ */
+export function registerEmbeddedFont(
+    fontId: number,
+    data: Uint8Array,
+    onLoaded?: () => void,
+): string {
+    const family = embeddedFamily(fontId, data);
+    const key = `embedded|${family}`;
+    if (onLoaded && !done.has(key)) {
+        const set = waiting.get(key) ?? new Set<() => void>();
+        set.add(onLoaded);
+        waiting.set(key, set);
+    }
+    if (variants.has(key)) return family;
+
+    let load: Promise<void>;
+    if (typeof document === 'undefined' || !document.fonts || typeof FontFace === 'undefined') {
+        // node-canvas has no FontFaceSet. Keep the alias/fallback behaviour deterministic there.
+        load = Promise.resolve();
+    } else {
+        // Copy the exact view: a WireBuffer may be backed by a larger allocation than this font.
+        const bytes = data.slice().buffer;
+        const face = new FontFace(family, bytes);
+        embeddedFaces.set(key, face);
+        document.fonts.add(face);
+        load = face.load().then(() => undefined).catch((e) => {
+            console.warn(`WebFonts: embedded font ${fontId} could not be loaded`, e);
+        });
+    }
+    const promise = load.then(() => notify(key));
+    variants.set(key, promise);
+    return family;
+}
+
 /**
  * Resolves when every family requested so far has settled.
  *
@@ -408,6 +463,10 @@ export async function webFontsReady(): Promise<void> {
 
 /** Drop all registration state. Tests only. */
 export function resetWebFonts(): void {
+    if (typeof document !== 'undefined' && document.fonts) {
+        embeddedFaces.forEach((face) => document.fonts.delete(face));
+    }
+    embeddedFaces.clear();
     stylesheets.clear();
     axisSpans.clear();
     variants.clear();

--- a/third_party/remote-compose-player/src/web/WebRemoteContext.ts
+++ b/third_party/remote-compose-player/src/web/WebRemoteContext.ts
@@ -176,6 +176,13 @@ export class WebRemoteContext extends RemoteContext {
         this.canvasPaintContext.loadBitmap(imageId, encoding, type, width, height, bitmap);
     }
 
+    // --- Font ---
+
+    override loadFont(fontId: number, fontData: Uint8Array): void {
+        super.loadFont(fontId, fontData);
+        this.canvasPaintContext.loadFont(fontId, fontData);
+    }
+
     // --- Text ---
 
     loadText(id: number, text: string): void {

--- a/third_party/remote-compose-player/src/web/main.ts
+++ b/third_party/remote-compose-player/src/web/main.ts
@@ -361,7 +361,7 @@ export { createPlayer, RcPlayerElement, base64ToArrayBuffer };
 export type { RcPlayerOptions, RcPlayerHandle } from './RcPlayerElement';
 // Named-family web fonts. `configureWebFonts` is the switch an embedder needs: a webview whose CSP
 // forbids the font origins, or a hermetic CI lane, turns it off and renders the fallback stack.
-export { configureWebFonts, webFontsReady, googleFontsUrl, googleFontsAxisUrl, ensureWebFont, parseFamily, cssQuoted, resetWebFonts, GOOGLE_PREFIX } from './WebFonts';
+export { configureWebFonts, webFontsReady, googleFontsUrl, googleFontsAxisUrl, ensureWebFont, registerEmbeddedFont, parseFamily, cssQuoted, resetWebFonts, GOOGLE_PREFIX } from './WebFonts';
 export { namedFontStack, cssFontStackFor } from './CanvasPaintContext';
 export type { WebFontConfig } from './WebFonts';
 


### PR DESCRIPTION
## Summary

- decode and register Remote Compose `FontData` (opcode 189) in the vendored TypeScript player
- expose embedded font bytes to the browser paint context as collision-safe `FontFace` aliases
- resolve both canvas paint text and `CoreText` layout text through the embedded face
- rebuild the shipped CLI player bundle and update the typeface/text-metrics documentation

## Why

The JS operation registry did not recognize opcode 189, so encountering an embedded font truncated the rest of the document. This prevented the browser lane from rendering pinned-face text-metrics fixtures and made cross-player comparisons conflate font resolution with measurement differences.

## Impact

Documents containing `FontData` continue decoding, wait or repaint for the embedded face through the existing font-readiness path, and consistently select that face by document font id.

## Validation

- `RC_COMPARE_CHROMIUM="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" node --test rc-font-data.test.mjs` — 1 passed
- `RC_COMPARE_CHROMIUM="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" node --test rc-webfonts.test.mjs` — 12 passed
- rebuilt `cli/src/main/resources/rc-player/bundle.js` with esbuild
- `git diff --check`

Closes #3647