### PR TITLE
fix: tolerate rasterizer edge differences in parity scores

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -6504,8 +6504,9 @@ $rows
         )
         .filter { it.isNotBlank() }
         .joinToString("\n")
-    // `format-compare.js` holds the comparison primitives — content-box normalisation, the SSIM
-    // score, the magenta delta map — that BOTH the SVG/PNG fidelity toggle and the spec lane's
+    // `format-compare.js` holds the comparison primitives — content-box normalisation, the
+    // edge-tolerant score, the magenta delta map — that BOTH the SVG/PNG fidelity toggle and the
+    // spec lane's
     // Diff / Triptych / Slider views draw from, so it loads for either. `spec-compare.js` sits on
     // top of it and must be defined before `viewer.js`, which calls into `window.cpSpecCompare` on
     // the way into (and out of) the lane.

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js
@@ -4,6 +4,12 @@
   var C1 = 6.5025;
   var C2 = 58.5225;
   var MAX_SIDE = 192;
+  // Figma's browser SVG rasteriser and Skia's Compose rasteriser cover the same vector edge with
+  // different sub-pixels. Search a small neighbourhood on the comparison plane, symmetrically, so
+  // those edge pixels do not become a structural failure. Five pixels at the capped 192 px plane
+  // is still narrow enough that displaced or missing marks remain visible to the score.
+  var EDGE_SEARCH_RADIUS = 5;
+  var LUMA_TOLERANCE = 16;
   // Longest side of the downscale that content-box detection samples, and how far a pixel may sit
   // from the backdrop colour before it counts as drawn.
   var BOX_SAMPLE_SIDE = 256;
@@ -156,8 +162,27 @@
   }
 
   function scorePlanes(reference, candidate, width, height) {
-    var value = ssim(blur(reference, width, height), blur(candidate, width, height), width, height);
-    return Math.max(0, Math.min(100, value * 100));
+    function directed(source, target) {
+      var total = 0;
+      for (var y = 0; y < height; y++) {
+        for (var x = 0; x < width; x++) {
+          var value = source[y * width + x];
+          var best = 255;
+          for (var oy = -EDGE_SEARCH_RADIUS; oy <= EDGE_SEARCH_RADIUS; oy++) {
+            var yy = Math.max(0, Math.min(height - 1, y + oy));
+            for (var ox = -EDGE_SEARCH_RADIUS; ox <= EDGE_SEARCH_RADIUS; ox++) {
+              var xx = Math.max(0, Math.min(width - 1, x + ox));
+              best = Math.min(best, Math.abs(value - target[yy * width + xx]));
+            }
+          }
+          total += Math.max(0, best - LUMA_TOLERANCE) / (255 - LUMA_TOLERANCE);
+        }
+      }
+      return total / (width * height);
+    }
+    // Both directions matter: a one-way search would let an extra mark hide beside a matching one.
+    var mismatch = (directed(reference, candidate) + directed(candidate, reference)) / 2;
+    return Math.max(0, Math.min(100, (1 - mismatch) * 100));
   }
 
   function scoreSvgUrls(pngUrl, svgUrl) {
@@ -239,7 +264,7 @@
    * whatever its `@Preview` scaffold added — `showBackground`'s opaque sheet, a `padding()` inset, a
    * fixed-height container the content does not fill — while the reference is usually cropped to the
    * artboard. Scoring those against each other measures the scaffold, not the component: the whole
-   * image is translated and rescaled relative to its partner, which SSIM reads as total mismatch.
+   * image is translated and rescaled relative to its partner, which reads as total mismatch.
    *
    * Detection uses alpha where the image has any: a transparent pixel is unambiguously not artwork.
    *

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/parity.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/parity.js
@@ -32,7 +32,7 @@
     });
   }
 
-  // Score every published render/reference pair with the same SSIM implementation as the focused
+  // Score every published render/reference pair with the same edge-tolerant metric as the focused
   // comparison page. Four workers keep a large catalog responsive while still turning the parity
   // page into an issues view instead of treating "mapped" as "matching".
   var compare = window.ComposePreviewCompare;

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebAssetsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebAssetsTest.kt
@@ -97,7 +97,7 @@ class ServeWebAssetsTest {
         firstPaint < fonts &&
         fonts < finalPaint &&
         finalPaint < score,
-      "the RC player must apply artifact theme, discover and await fonts, then repaint before SSIM",
+      "the RC player must apply artifact theme, discover and await fonts, then repaint before scoring",
     )
   }
 }


### PR DESCRIPTION
## What changed

- replace blurred SSIM scoring with a symmetric, edge-tolerant luminance comparison
- allow a narrow five-pixel neighbourhood and small luminance tolerance for Figma SVG versus Skia raster coverage
- keep comparison symmetric so added or missing marks still reduce the score
- update parity-page terminology and focused asset-test messaging

## Why

Figma's browser SVG rasterizer and Compose/Skia can cover the same vector and font edges on different subpixels. The previous metric treated those harmless edge shifts as structural mismatches, obscuring real content, scale, and styling defects.

## Impact

Parity scores now discount only small rasterizer and antialiasing differences while continuing to penalize displaced, missing, or extra visual structure. This makes the score actionable for the Material 3 catalog's 99% parity target.

## Validation

- `./gradlew :cli:ktfmtCheck`
- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebAssetsTest`
- `node --check cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js`
- `git diff --check`
- local full-catalog comparison: 78/78 mapped components at or above 99%, minimum 99.15%