### PR TITLE
Refactor Wear gesture samples around public AndroidX APIs

### DIFF
--- a/data/gestures/connector/src/main/java/com/google/wear/input/GestureEvent.java
+++ b/data/gestures/connector/src/main/java/com/google/wear/input/GestureEvent.java
@@ -1,0 +1,13 @@
+package com.google.wear.input;
+
+/**
+ * Preview-classpath placeholder for the device-only Wear SDK type referenced by Wear Compose.
+ *
+ * <p>The public Wear Compose artifact links its internal gesture bridge against this class, but the
+ * Google Wear input SDK is only present on supported watches. Robolectric reflects the bridge's
+ * method signatures while installing {@code ShadowSdkGestureInputManager}, so it needs the type to
+ * exist even though the shadow never constructs or reads an event.
+ */
+public final class GestureEvent {
+  private GestureEvent() {}
+}

--- a/data/gestures/connector/src/main/java/com/google/wear/input/GestureInputManager.java
+++ b/data/gestures/connector/src/main/java/com/google/wear/input/GestureInputManager.java
@@ -1,0 +1,12 @@
+package com.google.wear.input;
+
+/**
+ * Preview-classpath placeholder for Wear's device-only gesture manager.
+ *
+ * <p>All calls to Wear Compose's SDK bridge are replaced by {@code
+ * ee.schimke.composeai.daemon.ShadowSdkGestureInputManager}; this class exists only so Robolectric
+ * can resolve the bridge's field and private-method signatures while instrumenting it off-watch.
+ */
+public final class GestureInputManager {
+  private GestureInputManager() {}
+}

--- a/data/gestures/connector/src/test/kotlin/ee/schimke/composeai/daemon/ShadowSdkGestureInputManagerTest.kt
+++ b/data/gestures/connector/src/test/kotlin/ee/schimke/composeai/daemon/ShadowSdkGestureInputManagerTest.kt
@@ -1,8 +1,18 @@
 package ee.schimke.composeai.daemon
 
+import android.view.View
+import ee.schimke.composeai.daemon.protocol.GestureKindOverride
+import kotlin.Function1
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 import org.robolectric.annotation.Implements
 
 /**
@@ -17,7 +27,14 @@ import org.robolectric.annotation.Implements
  * intercept. Touching `value()` here makes a regression to the class-literal form fail loudly in this
  * test instead of mid-render.
  */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], shadows = [ShadowSdkGestureInputManager::class])
 class ShadowSdkGestureInputManagerTest {
+
+  @After
+  fun resetController() {
+    GestureStateController.resetForNewSession()
+  }
 
   @Test
   fun `shadow targets SdkGestureInputManagerImpl by className`() {
@@ -38,5 +55,68 @@ class ShadowSdkGestureInputManagerTest {
     // ever renumbers these, the shadow's detection wire names go stale — pin them here.
     assertEquals(1, GestureStateController.SDK_ACTION_PRIMARY)
     assertEquals(2, GestureStateController.SDK_ACTION_DISMISS)
+  }
+
+  @Test
+  fun `shadow makes Wear gestures available and dispatches through the framework callback`() {
+    val shadow = ShadowSdkGestureInputManager()
+    val context = RuntimeEnvironment.getApplication()
+    val view = View(context)
+    var dispatchedAction: Int? = null
+
+    assertFalse(shadow.isAvailable(context))
+    GestureStateController.armDetection(true)
+    assertTrue(shadow.isAvailable(context))
+    assertTrue(
+      shadow.shouldShowIndicator(
+        key = "samplewear:test",
+        sdkGestureAction = GestureStateController.SDK_ACTION_PRIMARY,
+        isOverlay = false,
+      )
+    )
+
+    shadow.subscribeToSdkGestureAction(
+      view = view,
+      sdkGestureAction = GestureStateController.SDK_ACTION_PRIMARY,
+      enabledInAmbient = false,
+    ) { dispatchedAction = it }
+
+    assertEquals(listOf("primary"), GestureStateController.snapshot().detected)
+    assertEquals(1, GestureStateController.invoke(GestureKindOverride.PRIMARY))
+    assertEquals(GestureStateController.SDK_ACTION_PRIMARY, dispatchedAction)
+
+    shadow.unsubscribeFromSdkGestureAction(view, GestureStateController.SDK_ACTION_PRIMARY)
+    assertTrue(GestureStateController.snapshot().detected.isEmpty())
+  }
+
+  @Test
+  fun `Robolectric applies the shadow to Wear Compose's real SDK bridge`() {
+    val bridgeClass =
+      Class.forName("androidx.wear.compose.material3.onehandedgesture.SdkGestureInputManagerImpl")
+    val bridge = bridgeClass.getDeclaredConstructor().newInstance()
+    val isAvailable = bridgeClass.getDeclaredMethod("isAvailable", android.content.Context::class.java)
+    val context = RuntimeEnvironment.getApplication()
+
+    assertEquals(false, isAvailable.invoke(bridge, context))
+    GestureStateController.armDetection(true)
+    assertEquals(true, isAvailable.invoke(bridge, context))
+
+    val view = View(context)
+    val subscribe =
+      bridgeClass.getDeclaredMethod(
+        "subscribeToSdkGestureAction",
+        View::class.java,
+        Int::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+        Function1::class.java,
+      )
+    subscribe.invoke(
+      bridge,
+      view,
+      GestureStateController.SDK_ACTION_PRIMARY,
+      false,
+      { _: Int -> Unit },
+    )
+    assertEquals(listOf("primary"), GestureStateController.snapshot().detected)
   }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRobolectricPropertiesTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRobolectricPropertiesTask.kt
@@ -115,10 +115,13 @@ abstract class GenerateRobolectricPropertiesTask : DefaultTask() {
     // `ShadowWearTimeSource` replaces the `currentTimeMillis()` both Wear Material and Wear
     // Material3 `TimeText` read, so a preview showing the time renders a fixed `10:10` instead of
     // the host wall clock and stops diffing on every run (issue #3239).
+    // `ShadowSdkGestureInputManager` replaces Wear Material3's device-only gesture bridge so raw
+    // public `Modifier.oneHandedGesture` components remain registrable and testable off-watch.
     val shadowsLine =
       "shadows=ee.schimke.composeai.renderer.ShadowFontsContractCompat," +
         "ee.schimke.composeai.renderer.ShadowAsyncImagePainter," +
-        "ee.schimke.composeai.renderer.ShadowWearTimeSource"
+        "ee.schimke.composeai.renderer.ShadowWearTimeSource," +
+        "ee.schimke.composeai.daemon.ShadowSdkGestureInputManager"
     // `androidx.wear.compose.materialcore.ResourcesKt` is a CLASS name, not a package: Robolectric
     // matches `instrumentedPackages` entries as plain class-name prefixes, so naming the class
     // instruments exactly the one `ShadowWearTimeSource` targets — and nothing else in Wear's
@@ -126,7 +129,8 @@ abstract class GenerateRobolectricPropertiesTask : DefaultTask() {
     // didn't rewrite, so dropping this leaves the shadow inert and Wear clocks drifting. Inert when
     // the consumer has no wear-compose.
     val instrumentedPackagesLine =
-      "instrumentedPackages=coil.compose,androidx.wear.compose.materialcore.ResourcesKt"
+      "instrumentedPackages=coil.compose,androidx.wear.compose.materialcore.ResourcesKt," +
+        "androidx.wear.compose.material3.onehandedgesture.SdkGestureInputManagerImpl"
     // `sdk=` and `graphicsMode=` live here (not on `@Config`/`@GraphicsMode`
     // on `RobolectricRenderTestBase`) to avoid JUnit's `AnnotationParser`
     // resolving `@Config.application()`'s `android.app.Application` default

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/GenerateRobolectricPropertiesTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/GenerateRobolectricPropertiesTaskTest.kt
@@ -64,6 +64,16 @@ class GenerateRobolectricPropertiesTaskTest {
   }
 
   @Test
+  fun `the Wear gesture input shadow is registered with its target class instrumented`() {
+    listOf(false, true).forEach { useConsumerApplication ->
+      val body = generate(useConsumerApplication, override = null, compileSdk = 36)
+      assertThat(body).contains("ee.schimke.composeai.daemon.ShadowSdkGestureInputManager")
+      assertThat(body)
+        .contains("androidx.wear.compose.material3.onehandedgesture.SdkGestureInputManagerImpl")
+    }
+  }
+
+  @Test
   fun `useConsumerApplication drops application line but keeps sdk graphicsMode shadows`() {
     val body = generate(useConsumerApplication = true, override = null, compileSdk = 36)
     assertThat(body).contains("sdk=36")

--- a/samples/wear/build.gradle.kts
+++ b/samples/wear/build.gradle.kts
@@ -47,21 +47,9 @@ dependencies {
   implementation(libs.wear.compose.ui.tooling)
   // Wear navigation — `SwipeDismissableNavHost` drives the gesture-gallery flow in `Gestures.kt`.
   implementation(libs.wear.compose.navigation)
-  // `androidx.compose.animation.graphics` — renders wear-compose-material3's shipped gesture
-  // indicator AVDs (`wear_one_handed_gesture_*_indicator_animation`) via the official
-  // `AnimatedImageVector.animatedVectorResource` API. wear-compose-material3 depends on it at
-  // `runtime` scope only, so declare it here to compile against `AnimatedImageVector`.
-  implementation("androidx.compose.animation:animation-graphics")
   implementation(libs.compose.ui.tooling.preview)
+  implementation(libs.roborazzi.annotations)
   debugImplementation("androidx.compose.ui:ui-tooling")
-
-  // `:data-gestures-connector` — the Wear OS one-handed-gesture data extension. `Gestures.kt`
-  // wires its screens with the connector's `reportedOneHandedGesture` / `GestureHint` seam so the
-  // handlers show up in `compose/gestures` and are drivable via `renderNow.overrides.gestures`.
-  // Static `@Preview` rendering doesn't run the daemon extension chain, so previews activate an
-  // explicit indicator state; the daemon path activates the same state from
-  // `overrides.gestures.showHints`.
-  implementation(project(":data-gestures-connector"))
 
   // `:data-ambient-connector` — the Wear OS ambient-mode data extension. The
   // connector's `AmbientOverrideExtension` (an `AroundComposableExtension` planned

--- a/samples/wear/src/main/kotlin/com/example/samplewear/GestureHintPreviews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/GestureHintPreviews.kt
@@ -19,36 +19,36 @@ import androidx.wear.compose.material3.FilledTonalButton
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.onehandedgesture.GestureAction
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureClickIndicator
+import androidx.wear.compose.material3.onehandedgesture.oneHandedGesture
 import androidx.wear.tooling.preview.devices.WearDevices
-import ee.schimke.composeai.daemon.GestureHint
-import ee.schimke.composeai.daemon.GestureType
-import ee.schimke.composeai.daemon.reportedOneHandedGesture
-import ee.schimke.composeai.preview.GestureHintPreview
+import com.github.takahirom.roborazzi.annotations.ManualClockOptions
+import com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions
+import kotlinx.coroutines.launch
 
 /**
  * A normal Wear media screen with **two** one-handed gestures: a primary double-pinch that toggles
  * play/pause, and a dismiss wrist-turn mapped to back. Each button wraps its **content** (the label)
- * in `GestureHint`, so the real one-handed gesture indicator swaps the label for that gesture's
- * animation on-device while the button pill stays put — the design guide's on-button hint.
+ * in [OneHandedGestureClickIndicator], so the public Wear API swaps the label for that gesture's
+ * animation on-device while the button pill stays put.
  *
- * Crucially this is **ordinary app code**: there is no preview-only flag, no capture mode, nothing
- * that "sets up" a hint. Each `GestureHint` reads the connector's force-show state, so whether the
- * hints appear is decided entirely from *outside* the screen — by the daemon's
- * `renderNow.overrides.gestures.showHints`, or, for a static `@Preview`, by the `@GestureHintPreview`
- * annotation below. Because the override flips one shared state, **both** hints show together, which
- * is what a full-screen preview wants: every gesture the screen offers, illustrated at once.
+ * [showIndicators] is state injection rather than a second rendering implementation: previews can
+ * capture a stable animation frame while production leaves it false and lets
+ * `onGestureAvailable` drive the exact same public indicator state.
  */
 @Composable
-fun MediaGestureScreen(onDismiss: () -> Unit = {}) {
+fun MediaGestureScreen(showIndicators: Boolean = false, onDismiss: () -> Unit = {}) {
   var playing by remember { mutableStateOf(false) }
   val playSource = remember { MutableInteractionSource() }
   val backSource = remember { MutableInteractionSource() }
   val playConfiguration =
-    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:media-play")
-  val playIndicatorState = rememberGestureIndicatorState()
+    rememberGestureConfiguration(GestureAction.Primary, key = "samplewear:media-play")
+  val playIndicatorState = rememberGestureIndicatorState(forceShow = showIndicators)
   val backConfiguration =
-    rememberGestureConfiguration(GestureType.DISMISS, key = "samplewear:media-back")
-  val backIndicatorState = rememberGestureIndicatorState()
+    rememberGestureConfiguration(GestureAction.Dismiss, key = "samplewear:media-back")
+  val backIndicatorState = rememberGestureIndicatorState(forceShow = showIndicators)
+  val coroutineScope = androidx.compose.runtime.rememberCoroutineScope()
   ScreenScaffold {
     Column(
       modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp),
@@ -60,20 +60,18 @@ fun MediaGestureScreen(onDismiss: () -> Unit = {}) {
         onClick = { playing = !playing },
         interactionSource = playSource,
         modifier =
-          Modifier.reportedOneHandedGesture(
-            type = GestureType.PRIMARY,
-            label = if (playing) "Pause" else "Play",
+          Modifier.oneHandedGesture(
             gestureConfiguration = playConfiguration,
-            showIndicator = playIndicatorState::showIndicator,
             interactionSource = playSource,
+            onGestureLabel = if (playing) "Pause" else "Play",
+            onGestureAvailable = {
+              coroutineScope.launch { playIndicatorState.showIndicator() }
+            },
           ) {
             playing = !playing
           },
       ) {
-        GestureHint(
-          gestureConfiguration = playConfiguration,
-          indicatorState = playIndicatorState,
-        ) {
+        OneHandedGestureClickIndicator(playConfiguration, playIndicatorState) {
           Text(if (playing) "Pause" else "Play")
         }
       }
@@ -82,20 +80,18 @@ fun MediaGestureScreen(onDismiss: () -> Unit = {}) {
         onClick = onDismiss,
         interactionSource = backSource,
         modifier =
-          Modifier.reportedOneHandedGesture(
-            type = GestureType.DISMISS,
-            label = "Back",
+          Modifier.oneHandedGesture(
             gestureConfiguration = backConfiguration,
-            showIndicator = backIndicatorState::showIndicator,
             interactionSource = backSource,
+            onGestureLabel = "Back",
+            onGestureAvailable = {
+              coroutineScope.launch { backIndicatorState.showIndicator() }
+            },
           ) {
             onDismiss()
           },
       ) {
-        GestureHint(
-          gestureConfiguration = backConfiguration,
-          indicatorState = backIndicatorState,
-        ) {
+        OneHandedGestureClickIndicator(backConfiguration, backIndicatorState) {
           Text("Back")
         }
       }
@@ -104,11 +100,7 @@ fun MediaGestureScreen(onDismiss: () -> Unit = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// The same full-screen screen, captured hint-off and hint-on. The screen
-// definition is identical for both — only the `@GestureHintPreview` annotation
-// differs, which force-shows the indicators through `GestureOverrideExtension` at
-// render time. (Daemon-driven `renderNow.overrides.gestures.showHints = true`
-// reaches the same seam live, with no annotation at all.)
+// The same full-screen component, captured with its public indicator states at rest and forced on.
 // ---------------------------------------------------------------------------
 
 /** The resting screen — no override, so both gesture hints stay hidden (as they would off-watch). */
@@ -118,10 +110,12 @@ fun MediaGestureScreenPreview() {
   MaterialTheme { MediaGestureScreen() }
 }
 
-/** The same screen with `@GestureHintPreview` force-showing both hints — no change to the screen. */
+/** The same component with its state override showing both inline indicators. */
 @Preview(name = "Media — hints on", device = WearDevices.LARGE_ROUND, showBackground = true)
-@GestureHintPreview
+@RoboComposePreviewOptions(
+  manualClockOptions = [ManualClockOptions(advanceTimeMillis = 800L)]
+)
 @Composable
 fun MediaGestureScreenHintPreview() {
-  MaterialTheme { MediaGestureScreen() }
+  MaterialTheme { MediaGestureScreen(showIndicators = true) }
 }

--- a/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
@@ -1,24 +1,13 @@
 package com.example.samplewear
 
-import androidx.compose.animation.graphics.ExperimentalAnimationGraphicsApi
-import androidx.compose.animation.graphics.res.animatedVectorResource
-import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
-import androidx.compose.animation.graphics.vector.AnimatedImageVector
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -29,13 +18,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
@@ -48,45 +32,45 @@ import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Card
 import androidx.wear.compose.material3.FilledTonalButton
 import androidx.wear.compose.material3.ListHeader
-import androidx.wear.compose.material3.LocalContentColor
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TimeText
 import androidx.wear.compose.material3.TitleCard
 import androidx.wear.compose.material3.onehandedgesture.LocalOneHandedGestureEnabled
+import androidx.wear.compose.material3.onehandedgesture.GestureAction
 import androidx.wear.compose.material3.onehandedgesture.GesturePriority
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureDefaults
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureClickIndicatorState
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureClickIndicator
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureConfiguration
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureHorizontalPageIndicator
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGesturePageIndicatorState
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureScrollIndicator
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureScrollIndicatorState
+import androidx.wear.compose.material3.onehandedgesture.oneHandedGesture
 import androidx.wear.compose.material3.onehandedgesture.rememberOneHandedGestureConfiguration
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
-import ee.schimke.composeai.daemon.GestureHint
-import ee.schimke.composeai.daemon.GestureType
-import ee.schimke.composeai.daemon.reportedOneHandedGesture
 import kotlinx.coroutines.launch
 
 /**
  * A one-handed-gesture gallery for Wear OS, navigated with [SwipeDismissableNavHost].
  *
- * Each screen wires the real `Modifier.oneHandedGesture` API (via the `:data-gestures-connector`
- * [reportedOneHandedGesture] seam, so the handlers also surface in the `compose/gestures` data
- * product) and demonstrates one gesture affordance from the Wear design guide:
- * - **primary** — the double-pinch primary action on a [Button], with a [GestureHint].
+ * Each screen follows the AndroidX samples and uses the public one-handed gesture APIs directly:
+ * - **primary** — the double-pinch primary action on a [Button], with an inline
+ *   [OneHandedGestureClickIndicator].
  * - **dismiss** — the wrist-turn dismiss action mapped to back navigation.
  * - **scroll** — the primary gesture driving `scrollDown` on a list.
  * - **page** — the primary gesture driving `scrollToNextPage` on a pager.
  * - **disabled** — a screen that opts out via `LocalOneHandedGestureEnabled = false`.
  *
- * On-device the gestures fire from the watch's sensors (Pixel Watch 3+); off-device they no-op, so
- * the connector's data product is what makes the wiring observable and invokable under `@Preview`.
+ * On-device the gestures fire from the watch's sensors (Pixel Watch 3+). The preview renderer fakes
+ * Wear's SDK gesture input manager, so these unmodified public-API components can also register,
+ * report availability, and receive gestures under Robolectric. Previews drive the same public
+ * indicator states explicitly for deterministic animation capture.
  */
 object GestureRoutes {
   const val HOME = "home"
@@ -96,17 +80,16 @@ object GestureRoutes {
   const val PAGE = "page"
   const val DISABLED = "disabled"
   const val HINT_BUTTON = "hint-button"
-  const val HINT_FLOATING = "hint-floating"
 }
 
 @Composable
 internal fun rememberGestureConfiguration(
-  type: GestureType,
+  action: GestureAction,
   key: String,
   priority: GesturePriority = GesturePriority.Clickable,
 ): OneHandedGestureConfiguration =
   rememberOneHandedGestureConfiguration(
-    action = type.toGestureAction(),
+    action = action,
     gestureId = key,
     priority = priority,
   )
@@ -168,7 +151,6 @@ fun GestureGalleryApp(
         composable(GestureRoutes.PAGE) { PageGestureScreen() }
         composable(GestureRoutes.DISABLED) { DisabledGestureScreen() }
         composable(GestureRoutes.HINT_BUTTON) { ButtonHintScreen() }
-        composable(GestureRoutes.HINT_FLOATING) { FloatingHintScreen() }
       }
     }
   }
@@ -226,14 +208,6 @@ private fun GestureHomeScreen(onOpen: (String) -> Unit) {
       }
       item {
         FilledTonalButton(
-          onClick = { onOpen(GestureRoutes.HINT_FLOATING) },
-          modifier = Modifier.fillMaxWidth(),
-        ) {
-          Text("Floating hint")
-        }
-      }
-      item {
-        FilledTonalButton(
           onClick = { onOpen(GestureRoutes.DISABLED) },
           modifier = Modifier.fillMaxWidth(),
         ) {
@@ -245,49 +219,13 @@ private fun GestureHomeScreen(onOpen: (String) -> Unit) {
 }
 
 /**
- * Renders wear-compose-material3's shipped gesture-indicator AVD
- * (`wear_one_handed_gesture_{primary,dismiss}_indicator_animation`) as a static, tinted icon via the
- * official `androidx.compose.animation.graphics` API — the same drawable + API
- * one-handed gesture indicator draws internally, shown here at its resting frame so the gesture
- * illustration is visible in a still capture (the interactive indicator only flashes it on-device).
- */
-@OptIn(ExperimentalAnimationGraphicsApi::class)
-@Composable
-private fun GestureHintIcon(
-  type: GestureType,
-  modifier: Modifier = Modifier,
-  size: Dp = 40.dp,
-  tint: Color = LocalContentColor.current,
-) {
-  val resId =
-    when (type) {
-      GestureType.DISMISS ->
-        androidx.wear.compose.material3.R.drawable
-          .wear_one_handed_gesture_dismiss_indicator_animation
-      else ->
-        androidx.wear.compose.material3.R.drawable
-          .wear_one_handed_gesture_primary_indicator_animation
-    }
-  val avd = AnimatedImageVector.animatedVectorResource(resId)
-  Image(
-    painter = rememberAnimatedVectorPainter(avd, atEnd = false),
-    contentDescription = null,
-    colorFilter = ColorFilter.tint(tint),
-    modifier = modifier.size(size),
-  )
-}
-
-/**
- * A titled full-screen gesture demo: a [ListHeader] title, the shipped [GestureHintIcon] gesture
- * illustration, an instruction line, and the interactive affordance centred below — the layout the
- * catalog's full-screen Wear stickers use so the screen reads clearly instead of a bare control lost
- * on the watch face.
+ * A small sample screen shell. Gesture behavior remains in the reusable component passed as
+ * [control], just as it would in application code.
  */
 @Composable
 private fun GestureDemoScreen(
   title: String,
   instruction: String,
-  gestureType: GestureType? = null,
   control: @Composable () -> Unit,
 ) {
   ScreenScaffold {
@@ -297,40 +235,35 @@ private fun GestureDemoScreen(
       verticalArrangement = Arrangement.Center,
     ) {
       ListHeader { Text(title) }
-      gestureType?.let { GestureHintIcon(it, modifier = Modifier.padding(bottom = 4.dp)) }
       Text(instruction, textAlign = TextAlign.Center)
       Box(modifier = Modifier.padding(top = 12.dp)) { control() }
     }
   }
 }
 
-/** The double-pinch primary action on a play/pause [Button], wrapped in its [GestureHint]. */
+/** AndroidX-style button whose indicator owns the inline content and hides it while animating. */
 @Composable
 private fun PlayGestureButton(forceHint: Boolean) {
   var playing by remember { mutableStateOf(false) }
   val interactionSource = remember { MutableInteractionSource() }
   val gestureConfiguration =
-    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:play")
-  val indicatorState = rememberGestureIndicatorState()
-  GestureHint(
-    gestureConfiguration = gestureConfiguration,
-    indicatorState = indicatorState,
-    forceShow = forceHint,
+    rememberGestureConfiguration(GestureAction.Primary, key = "samplewear:play")
+  val indicatorState = rememberGestureIndicatorState(forceShow = forceHint)
+  val coroutineScope = rememberCoroutineScope()
+  Button(
+    onClick = { playing = !playing },
+    interactionSource = interactionSource,
+    modifier =
+      Modifier.oneHandedGesture(
+        gestureConfiguration = gestureConfiguration,
+        interactionSource = interactionSource,
+        onGestureLabel = if (playing) "Pause" else "Play",
+        onGestureAvailable = { coroutineScope.launch { indicatorState.showIndicator() } },
+      ) {
+        playing = !playing
+      },
   ) {
-    Button(
-      onClick = { playing = !playing },
-      interactionSource = interactionSource,
-      modifier =
-        Modifier.reportedOneHandedGesture(
-          type = GestureType.PRIMARY,
-          label = if (playing) "Pause" else "Play",
-          gestureConfiguration = gestureConfiguration,
-          showIndicator = indicatorState::showIndicator,
-          interactionSource = interactionSource,
-        ) {
-          playing = !playing
-        },
-    ) {
+    OneHandedGestureClickIndicator(gestureConfiguration, indicatorState) {
       Text(if (playing) "Pause" else "Play")
     }
   }
@@ -342,7 +275,6 @@ fun PrimaryActionScreen(forceHint: Boolean = false) {
   GestureDemoScreen(
     title = "Primary",
     instruction = "Double-pinch to play",
-    gestureType = GestureType.PRIMARY,
   ) {
     PlayGestureButton(forceHint)
   }
@@ -353,32 +285,26 @@ fun PrimaryActionScreen(forceHint: Boolean = false) {
 fun DismissActionScreen(onDismiss: () -> Unit = {}, forceHint: Boolean = false) {
   val interactionSource = remember { MutableInteractionSource() }
   val gestureConfiguration =
-    rememberGestureConfiguration(GestureType.DISMISS, key = "samplewear:dismiss")
-  val indicatorState = rememberGestureIndicatorState()
+    rememberGestureConfiguration(GestureAction.Dismiss, key = "samplewear:dismiss")
+  val indicatorState = rememberGestureIndicatorState(forceShow = forceHint)
+  val coroutineScope = rememberCoroutineScope()
   GestureDemoScreen(
     title = "Dismiss",
     instruction = "Wrist-turn to go back",
-    gestureType = GestureType.DISMISS,
   ) {
-    GestureHint(
-      gestureConfiguration = gestureConfiguration,
-      indicatorState = indicatorState,
-      forceShow = forceHint,
+    FilledTonalButton(
+      onClick = onDismiss,
+      interactionSource = interactionSource,
+      modifier =
+        Modifier.oneHandedGesture(
+          gestureConfiguration = gestureConfiguration,
+          interactionSource = interactionSource,
+          onGestureLabel = "Dismiss",
+          onGestureAvailable = { coroutineScope.launch { indicatorState.showIndicator() } },
+          onGesture = onDismiss,
+        ),
     ) {
-      FilledTonalButton(
-        onClick = onDismiss,
-        interactionSource = interactionSource,
-        modifier =
-          Modifier.reportedOneHandedGesture(
-            type = GestureType.DISMISS,
-            label = "Dismiss",
-            gestureConfiguration = gestureConfiguration,
-            showIndicator = indicatorState::showIndicator,
-            interactionSource = interactionSource,
-          ) {
-            onDismiss()
-          },
-      ) {
+      OneHandedGestureClickIndicator(gestureConfiguration, indicatorState) {
         Text("Back")
       }
     }
@@ -389,9 +315,13 @@ fun DismissActionScreen(onDismiss: () -> Unit = {}, forceHint: Boolean = false) 
 @Composable
 fun ScrollGestureScreen(forceHint: Boolean = false) {
   val listState = rememberTransformingLazyColumnState()
-  val interactionSource = remember { MutableInteractionSource() }
+  val coroutineScope = rememberCoroutineScope()
   val gestureConfiguration =
-    rememberGestureConfiguration(GestureType.SCROLL, key = "samplewear:scroll")
+    rememberGestureConfiguration(
+      GestureAction.Primary,
+      key = "samplewear:scroll",
+      priority = GesturePriority.Scrollable,
+    )
   val indicatorState = rememberScrollGestureIndicatorState(forceHint)
   ScreenScaffold(scrollState = listState) { contentPadding ->
     Box(modifier = Modifier.fillMaxSize()) {
@@ -400,12 +330,10 @@ fun ScrollGestureScreen(forceHint: Boolean = false) {
         contentPadding = contentPadding,
         modifier =
           Modifier.fillMaxSize()
-            .reportedOneHandedGesture(
-              type = GestureType.SCROLL,
-              label = "Scroll down",
+            .oneHandedGesture(
               gestureConfiguration = gestureConfiguration,
-              showIndicator = indicatorState::showIndicator,
-              interactionSource = interactionSource,
+              onGestureLabel = "Scroll down",
+              onGestureAvailable = { coroutineScope.launch { indicatorState.showIndicator() } },
             ) {
               OneHandedGestureDefaults.scrollDown(listState)
             },
@@ -434,9 +362,13 @@ fun ScrollGestureScreen(forceHint: Boolean = false) {
 @Composable
 fun PageGestureScreen(forceHint: Boolean = false) {
   val pagerState = rememberPagerState(initialPage = 0, pageCount = { 4 })
-  val interactionSource = remember { MutableInteractionSource() }
+  val coroutineScope = rememberCoroutineScope()
   val gestureConfiguration =
-    rememberGestureConfiguration(GestureType.PAGE, key = "samplewear:page")
+    rememberGestureConfiguration(
+      GestureAction.Primary,
+      key = "samplewear:page",
+      priority = GesturePriority.Scrollable,
+    )
   val indicatorState = rememberPageGestureIndicatorState(forceHint)
   ScreenScaffold {
     Box(modifier = Modifier.fillMaxSize()) {
@@ -444,12 +376,10 @@ fun PageGestureScreen(forceHint: Boolean = false) {
         state = pagerState,
         modifier =
           Modifier.fillMaxSize()
-            .reportedOneHandedGesture(
-              type = GestureType.PAGE,
-              label = "Next page",
+            .oneHandedGesture(
               gestureConfiguration = gestureConfiguration,
-              showIndicator = indicatorState::showIndicator,
-              interactionSource = interactionSource,
+              onGestureLabel = "Next page",
+              onGestureAvailable = { coroutineScope.launch { indicatorState.showIndicator() } },
             ) {
               OneHandedGestureDefaults.scrollToNextPage(pagerState)
             },
@@ -481,17 +411,16 @@ fun PageGestureScreen(forceHint: Boolean = false) {
 fun DisabledGestureScreen() {
   val interactionSource = remember { MutableInteractionSource() }
   val gestureConfiguration =
-    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:disabled-play")
+    rememberGestureConfiguration(GestureAction.Primary, key = "samplewear:disabled-play")
   CompositionLocalProvider(LocalOneHandedGestureEnabled provides false) {
     GestureDemoScreen(title = "Disabled", instruction = "Gestures off on this screen") {
       Button(
         onClick = {},
         modifier =
-          Modifier.reportedOneHandedGesture(
-            type = GestureType.PRIMARY,
-            label = "Play (disabled)",
+          Modifier.oneHandedGesture(
             gestureConfiguration = gestureConfiguration,
             interactionSource = interactionSource,
+            onGestureLabel = "Play (disabled)",
           ) {},
       ) {
         Text("Tap only")
@@ -501,101 +430,13 @@ fun DisabledGestureScreen() {
 }
 
 /**
- * The design guide's **button hint**: the gesture-indicator icon drawn *within* the target element,
- * tinted to match the button's content colour (`onPrimary`). This is the affordance
- * one-handed gesture indicator flashes over the button on-device; here it's composited statically so
- * the "icon on the button" treatment is visible in a still frame.
+ * The AndroidX button-hint pattern. [OneHandedGestureClickIndicator] owns the button content, so
+ * the normal label is hidden while the hint is visible instead of being painted underneath it.
  */
 @Composable
 fun ButtonHintScreen(showHint: Boolean = true) {
-  val interactionSource = remember { MutableInteractionSource() }
-  val gestureConfiguration =
-    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:button-hint")
-  GestureDemoScreen(title = "Button hint", instruction = "Icon drawn on the button") {
-    Box(contentAlignment = Alignment.Center) {
-      Button(
-        onClick = {},
-        interactionSource = interactionSource,
-        modifier =
-          Modifier.reportedOneHandedGesture(
-            type = GestureType.PRIMARY,
-            label = "Play",
-            gestureConfiguration = gestureConfiguration,
-            interactionSource = interactionSource,
-          ) {},
-      ) {
-        Text("Play")
-      }
-      if (showHint) {
-        GestureHintIcon(
-          type = GestureType.PRIMARY,
-          size = 28.dp,
-          tint = MaterialTheme.colorScheme.onPrimary,
-        )
-      }
-    }
-  }
-}
-
-/**
- * The design guide's **floating hint**: a `Tertiary` bubble overlay carrying the gesture-indicator
- * icon (`onTertiary`) with a pointer aimed at the target element. Shown above the play button.
- */
-@Composable
-fun FloatingHintScreen(showHint: Boolean = true) {
-  val interactionSource = remember { MutableInteractionSource() }
-  val gestureConfiguration =
-    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:floating-hint")
-  GestureDemoScreen(title = "Floating hint", instruction = "Bubble points to the button") {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-      if (showHint) {
-        FloatingHintBubble()
-        Spacer(Modifier.size(8.dp))
-      }
-      Button(
-        onClick = {},
-        interactionSource = interactionSource,
-        modifier =
-          Modifier.reportedOneHandedGesture(
-            type = GestureType.PRIMARY,
-            label = "Play",
-            gestureConfiguration = gestureConfiguration,
-            interactionSource = interactionSource,
-          ) {},
-      ) {
-        Text("Play")
-      }
-    }
-  }
-}
-
-/** The tertiary hint bubble + downward pointer used by [FloatingHintScreen]. */
-@Composable
-private fun FloatingHintBubble() {
-  val container = MaterialTheme.colorScheme.tertiary
-  val onContainer = MaterialTheme.colorScheme.onTertiary
-  Column(horizontalAlignment = Alignment.CenterHorizontally) {
-    Row(
-      modifier =
-        Modifier.clip(RoundedCornerShape(percent = 50))
-          .background(container)
-          .padding(horizontal = 12.dp, vertical = 6.dp),
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
-      GestureHintIcon(type = GestureType.PRIMARY, size = 24.dp, tint = onContainer)
-      Spacer(Modifier.width(6.dp))
-      Text("Double-pinch", color = onContainer)
-    }
-    Canvas(modifier = Modifier.size(width = 16.dp, height = 8.dp)) {
-      val pointer =
-        Path().apply {
-          moveTo(0f, 0f)
-          lineTo(size.width, 0f)
-          lineTo(size.width / 2f, size.height)
-          close()
-        }
-      drawPath(pointer, color = container)
-    }
+  GestureDemoScreen(title = "Button hint", instruction = "Double-pinch to play") {
+    PlayGestureButton(forceHint = showHint)
   }
 }
 
@@ -622,7 +463,11 @@ fun ScrollIndicatorStickerPreview() {
   GestureSticker {
     val listState = rememberTransformingLazyColumnState()
     val gestureConfiguration =
-      rememberGestureConfiguration(GestureType.SCROLL, key = "samplewear:scroll-sticker")
+      rememberGestureConfiguration(
+        GestureAction.Primary,
+        key = "samplewear:scroll-sticker",
+        priority = GesturePriority.Scrollable,
+      )
     OneHandedGestureScrollIndicator(
       gestureConfiguration = gestureConfiguration,
       indicatorState = rememberScrollGestureIndicatorState(forceShow = true),
@@ -637,7 +482,11 @@ fun ScrollIndicatorStickerPreview() {
 fun PageIndicatorStickerPreview() {
   GestureSticker {
     val gestureConfiguration =
-      rememberGestureConfiguration(GestureType.PAGE, key = "samplewear:page-sticker")
+      rememberGestureConfiguration(
+        GestureAction.Primary,
+        key = "samplewear:page-sticker",
+        priority = GesturePriority.Scrollable,
+      )
     OneHandedGestureHorizontalPageIndicator(
       gestureConfiguration = gestureConfiguration,
       indicatorState = rememberPageGestureIndicatorState(forceShow = true),
@@ -686,10 +535,4 @@ fun DisabledGestureScreenPreview() {
 @Composable
 fun ButtonHintScreenPreview() {
   MaterialTheme { ButtonHintScreen(showHint = true) }
-}
-
-@WearPreviewLargeRound
-@Composable
-fun FloatingHintScreenPreview() {
-  MaterialTheme { FloatingHintScreen(showHint = true) }
 }

--- a/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
@@ -54,6 +54,8 @@ import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import com.github.takahirom.roborazzi.annotations.ManualClockOptions
+import com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions
 import kotlinx.coroutines.launch
 
 /**
@@ -452,6 +454,9 @@ private fun GestureSticker(content: @Composable () -> Unit) {
 }
 
 @Preview(showBackground = false)
+@RoboComposePreviewOptions(
+  manualClockOptions = [ManualClockOptions(advanceTimeMillis = 800L)]
+)
 @Composable
 fun PrimaryActionStickerPreview() {
   GestureSticker { PlayGestureButton(forceHint = true) }
@@ -502,12 +507,18 @@ fun GestureGalleryPreview() {
 }
 
 @WearPreviewLargeRound
+@RoboComposePreviewOptions(
+  manualClockOptions = [ManualClockOptions(advanceTimeMillis = 800L)]
+)
 @Composable
 fun PrimaryActionScreenPreview() {
   MaterialTheme { PrimaryActionScreen(forceHint = true) }
 }
 
 @WearPreviewLargeRound
+@RoboComposePreviewOptions(
+  manualClockOptions = [ManualClockOptions(advanceTimeMillis = 800L)]
+)
 @Composable
 fun DismissActionScreenPreview() {
   MaterialTheme { DismissActionScreen(forceHint = true) }
@@ -532,6 +543,9 @@ fun DisabledGestureScreenPreview() {
 }
 
 @WearPreviewLargeRound
+@RoboComposePreviewOptions(
+  manualClockOptions = [ManualClockOptions(advanceTimeMillis = 800L)]
+)
 @Composable
 fun ButtonHintScreenPreview() {
   MaterialTheme { ButtonHintScreen(showHint = true) }

--- a/samples/wear/src/test/kotlin/com/example/samplewear/GestureHintPreviewPixelTest.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/GestureHintPreviewPixelTest.kt
@@ -5,18 +5,14 @@ import java.io.File
 import org.junit.Test
 
 /**
- * End-to-end verification that `@GestureHintPreview` actually force-shows the one-handed-gesture hint
- * through the renderer's Compose pipeline. Reads the files produced by
+ * End-to-end verification that a clean component can expose its public one-handed-gesture
+ * indicator state for deterministic preview capture. Reads the files produced by
  * `:samples:wear:composePreviewRenderAll` (wired in via `composePreview { renderBeforeUnitTests =
  * true }`) and pixel-asserts that the hint-off vs hint-on renders differ.
  *
- * The two previews render the *same* `MediaGestureScreen()` — ordinary app code with no preview-only
- * flags. The only difference is the `@GestureHintPreview` annotation on one of them. If they
- * hash-match, the override didn't reach `GestureHint`:
- * - discovery dropped the annotation from `previews.json` (the `gestureHint` capture arrives null), or
- * - the renderer didn't wrap the composition with `:data-gestures-connector`'s
- *   `GestureOverrideExtension`, or
- * - `GestureHint`'s forced-still peak-frame path stopped drawing the configured gesture action.
+ * The two previews render the same `MediaGestureScreen`: one at rest and one with
+ * `showIndicators = true`. Both paths use `OneHandedGestureClickIndicatorState.showIndicator()`;
+ * there is no alternate hint UI to overlap the button content.
  */
 class GestureHintPreviewPixelTest {
 
@@ -24,7 +20,8 @@ class GestureHintPreviewPixelTest {
 
   private val hintOffPng = File(rendersDir, "MediaGestureScreenPreview_Media_hints_off.png")
 
-  private val hintOnPng = File(rendersDir, "MediaGestureScreenHintPreview_Media_hints_on.png")
+  private val hintOnPng =
+    File(rendersDir, "MediaGestureScreenHintPreview_Media_hints_on_TIME_800ms.png")
 
   @Test
   fun `hint-off and hint-on renders differ`() {


### PR DESCRIPTION
Closes #3651.

## What changed

- Refactor the Wear gesture gallery around the public AndroidX `oneHandedGesture` modifier and indicator state APIs.
- Use `OneHandedGestureClickIndicator` as inline button content so the normal label is hidden during the hint animation instead of overlapping it.
- Hoist indicator state for deterministic preview overrides and capture the public animation at 800 ms.
- Remove the sample's dependency on the gesture connector and its hand-built gesture artwork.
- Register the Robolectric Wear SDK gesture-input shadow for generated preview tests.
- Add off-watch placeholder signature types and tests that exercise AndroidX's real internal SDK bridge through the shadow.

## Why

The existing examples mixed production gesture components with preview-only reporting and custom hint UI, making the samples look contrived and obscuring the intended AndroidX usage. The refactor keeps application components clean while making their public indicator state injectable for previews and animation capture.

Wear's proprietary gesture manager is absent under Robolectric. Generated preview properties now instrument and shadow AndroidX's bridge so availability, subscription, detection, dispatch, and unsubscribe can be tested without a watch.

## Validation

- `:samples:wear:compileDebugKotlin`
- `:data-gestures-connector:testDebugUnitTest`
- `:gradle-plugin:test`
- `:samples:wear:testDebugUnitTest --tests com.example.samplewear.GestureHintPreviewPixelTest`
- `git diff --check`