### PR TITLE
fix(daemon): preserve natural pixel input coordinates

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -38,8 +38,9 @@ import java.util.concurrent.TimeUnit
  *
  * **Pixel coords.** `interactive/input` carries image-natural pixel coords (the same pixel space
  * the renderer renders to — see `INTERACTIVE.md § 6/§ 7`). `ImageComposeScene.sendPointerEvent`
- * takes scene-px which equals natural pixels at density 1.0; we divide by the held density before
- * dispatch. Null coords (e.g. for keyboard events, which we no-op anyway) skip the dispatch.
+ * also takes physical scene pixels; density only controls dp-to-pixel layout inside the scene and
+ * must not be applied to pointer coordinates a second time. Null coords (e.g. for keyboard events,
+ * which we no-op anyway) skip the dispatch.
  *
  * **Shared with the recording lane.** Pointer and key translation live in `DesktopSceneInput.kt`
  * ([ScenePointerDispatch] / [SceneKeyDispatch]) and are used verbatim by [DesktopRecordingSession],
@@ -301,13 +302,10 @@ class DesktopInteractiveSession(
   }
 
   /**
-   * Convert image-natural pixel coords (what `interactive/input` carries on the wire) to
-   * scene-space [androidx.compose.ui.geometry.Offset] for `sendPointerEvent`. The scene's density
-   * scales between the two coordinate systems.
+   * Image-natural pixels and `ImageComposeScene` pointer positions share one physical-pixel space.
    */
   private fun sceneOffset(px: Int, py: Int): androidx.compose.ui.geometry.Offset {
-    val d = state.density.density
-    return androidx.compose.ui.geometry.Offset(px.toFloat() / d, py.toFloat() / d)
+    return androidx.compose.ui.geometry.Offset(px.toFloat(), py.toFloat())
   }
 
   /** For tests that want to peek at the held scene's identity without exposing it permanently. */

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -1095,8 +1095,10 @@ class DesktopRecordingSession(
   }
 
   private fun sceneOffset(px: Int, py: Int): androidx.compose.ui.geometry.Offset {
-    val d = state.density.density
-    return androidx.compose.ui.geometry.Offset(px.toFloat() / d, py.toFloat() / d)
+    // Recording scripts use the same image-natural pixel contract as interactive/input.
+    // ImageComposeScene pointer positions are already physical pixels; density only scales dp
+    // during layout, so applying it here again shifts every non-1x input toward the top-left.
+    return androidx.compose.ui.geometry.Offset(px.toFloat(), py.toFloat())
   }
 }
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
@@ -115,6 +115,67 @@ class DesktopInteractiveSessionTest {
     )
   }
 
+  /** Issue #3646 — hosted live input is expressed in the rendered frame's natural pixels. */
+  @Test
+  fun high_density_click_uses_natural_pixels_without_rescaling() {
+    val outputDir = tempFolder.newFolder("interactive-high-density-renders")
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = outputDir),
+        previewSpecResolver = { previewId ->
+          if (previewId == HIGH_DENSITY_TARGET_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "HighDensityClickTargetSquare",
+              widthPx = 168,
+              heightPx = 168,
+              density = 2.625f,
+              outputBaseName = "high-density-click-target-square",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = HIGH_DENSITY_TARGET_PREVIEW_ID,
+          classLoader = DesktopInteractiveSessionTest::class.java.classLoader!!,
+        )
+      try {
+        val first = session.render(requestId = RenderHost.nextRequestId())
+        assertTrue(
+          "fixture must start red",
+          pixelMatchPct(readPng(File(first.pngPath!!)), 0xEF5350, 8) >= 0.95,
+        )
+
+        // The target occupies x=115.5..168 and y=0..52.5 natural pixels. Its centre is well
+        // outside the target if incorrectly divided by density (142 / 2.625 ≈ 54).
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "test-high-density-target",
+            kind = InteractiveInputKind.CLICK,
+            pixelX = 142,
+            pixelY = 26,
+          )
+        )
+
+        val second = session.render(requestId = RenderHost.nextRequestId())
+        val greenMatch =
+          pixelMatchPct(readPng(File(second.pngPath!!)), 0x66BB6A, perChannelTolerance = 8)
+        assertTrue(
+          "expected the natural-pixel click to hit at density 2.625; got " +
+            "${"%.2f".format(greenMatch * 100)}% green",
+          greenMatch >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   @Test
   fun live_render_advances_frame_clock_with_monotonic_wall_time() {
     val outputDir = tempFolder.newFolder("interactive-frame-clock-renders")
@@ -513,6 +574,7 @@ class DesktopInteractiveSessionTest {
   companion object {
     private const val FIXTURE_PREVIEW_ID = "click-toggle-square"
     private const val FRAME_CLOCK_PREVIEW_ID = "frame-clock-square"
+    private const val HIGH_DENSITY_TARGET_PREVIEW_ID = "high-density-click-target-square"
     private const val KEY_PRESS_PREVIEW_ID = "key-press-color-square"
     private const val TAGGED_TARGET_PREVIEW_ID = "tagged-click-target-square"
   }

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -484,6 +484,28 @@ fun TaggedClickTargetSquare() {
 }
 
 /**
+ * High-density coordinate-contract fixture for the hosted live/recording lanes. The only clickable
+ * node is pinned to the top-right: at 2.625x its centre is around (142, 26) in a 168px frame.
+ * Dividing that natural-pixel x coordinate by density moves the event to ~54px and misses it.
+ */
+@Composable
+fun HighDensityClickTargetSquare() {
+  var clicked by remember { mutableStateOf(false) }
+  val color = if (clicked) Color(0xFF66BB6A) else Color(0xFFEF5350)
+  Box(modifier = Modifier.fillMaxSize().background(color)) {
+    Box(
+      modifier =
+        Modifier.align(Alignment.TopEnd).size(20.dp).pointerInput(Unit) {
+          awaitPointerEventScope {
+            awaitFirstDown()
+            clicked = true
+          }
+        }
+    )
+  }
+}
+
+/**
  * Live interactive fixture that exposes Compose's frame clock as pixels. It starts red and turns
  * green after at least 250 ms of frame-clock time has elapsed. If [ImageComposeScene.render] is
  * called without an explicit timestamp, every frame is rendered at `nanoTime = 0` and this preview

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -108,7 +108,9 @@ on-screen card untouched.
 
 The webview reports image-natural pixel coordinates. It reads
 `naturalWidth`/`naturalHeight` and scales `offsetX`/`offsetY` by their
-displayed-vs-natural ratio.
+displayed-vs-natural ratio. Those values are physical scene pixels: Desktop
+passes them directly to `ImageComposeScene.sendPointerEvent`. Preview density
+already shaped the scene's dp-to-pixel layout and must not scale input again.
 
 ## 7. Click capture
 


### PR DESCRIPTION
## Summary

- pass hosted Live-preview pointer coordinates to `ImageComposeScene` in their existing natural-pixel space
- keep recording-script input on the same coordinate contract
- add a density-2.625, off-centre stateful-control regression fixture and test
- document that preview density must not be applied to physical pointer coordinates a second time

## Root cause

The browser correctly sent coordinates in rendered-frame natural pixels, but the Desktop held-session path divided them by preview density before dispatch. At the M3 catalog's density of 2.625, clicks were shifted toward the top-left and missed the intended stateful control. Existing coverage used density 1, which hid the error.

## Impact

Hosted Live-preview clicks now reach the intended Compose control and state changes are reflected in subsequent frames. Recording scripts receive the same correction.

## Validation

- `./gradlew :daemon:desktop:test --tests 'ee.schimke.composeai.daemon.DesktopInteractiveSessionTest' --tests 'ee.schimke.composeai.daemon.DesktopRecordingSessionTest'`
- `./gradlew :daemon:desktop:ktfmtFormat`
- regression test verified red/green: fails with the former density division and passes with natural-pixel dispatch

No rendered UI pixels change; this is input plumbing, so visual before/after evidence is not applicable.

Closes #3646