### PR TITLE
fix: match Figma and render layout annotations

### DIFF
--- a/.github/actions/vscode-preview-baselines/action.yml
+++ b/.github/actions/vscode-preview-baselines/action.yml
@@ -55,6 +55,11 @@ runs:
       working-directory: vscode-extension
       run: npm run harness:contract
 
+    - name: Test comparison scoring and annotation matching
+      shell: bash
+      working-directory: vscode-extension
+      run: npm run harness:compare
+
     - name: Fetch prior baselines
       shell: bash
       env:

--- a/.github/actions/vscode-preview-comment/action.yml
+++ b/.github/actions/vscode-preview-comment/action.yml
@@ -68,6 +68,11 @@ runs:
       working-directory: vscode-extension
       run: npm run harness:contract
 
+    - name: Test comparison scoring and annotation matching
+      shell: bash
+      working-directory: vscode-extension
+      run: npm run harness:compare
+
     - name: Fetch baselines
       shell: bash
       env:

--- a/.github/workflows/vscode-preview-baselines.yml
+++ b/.github/workflows/vscode-preview-baselines.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths:
       - 'vscode-extension/**'
+      - 'cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js'
       - '.github/actions/vscode-preview-baselines/**'
       - '.github/actions/vscode-preview-comment/**'
       - '.github/actions/lib/vscode-preview-diff.py'

--- a/.github/workflows/vscode-preview-comment.yml
+++ b/.github/workflows/vscode-preview-comment.yml
@@ -18,6 +18,7 @@ on:
       - 'vscode-extension/tsconfig.webview.json'
       - 'vscode-extension/package.json'
       - 'vscode-extension/package-lock.json'
+      - 'cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js'
       - '.github/actions/vscode-preview-baselines/**'
       - '.github/actions/vscode-preview-comment/**'
       - '.github/actions/lib/vscode-preview-diff.py'

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js
@@ -565,7 +565,8 @@
     scoreImages: scoreImages,
     normaliseImageUrls: normaliseImageUrls,
     diffCanvases: diffCanvases,
-    compareImageUrls: compareImageUrls
+    compareImageUrls: compareImageUrls,
+    matchAnnotationItems: matchAnnotationItems
   };
 
   var referenceRoot = document.getElementById("cp-reference-compare");
@@ -599,6 +600,164 @@
   }
 
   /**
+   * Pair the annotations that describe the same element on each side.
+   *
+   * Figma commonly exposes a much deeper tree than Compose semantics (state layers, icon
+   * containers, dividers, and so on). Drawing both flattened trees independently therefore gives
+   * unrelated ordinal numbers and, in a menu, can put ninety Figma boxes beside six Compose
+   * boxes. Use the design side as the inventory and consume each reference item at most once.
+   * Candidate bounds are first mapped into the reference frame by the same width-derived uniform
+   * scale used by design-parity's structural layout diff; aligning the two largest layout boxes
+   * also removes a preview scaffold/crop offset. Role/label similarity breaks geometric ties.
+   *
+   * The result contains min(reference, actual) items for every kind present on both sides. An
+   * annotation kind captured on only one side is retained as a useful inspection-only layer.
+   */
+  function matchAnnotationItems(reference, actual) {
+    reference = Array.isArray(reference) ? reference.filter(annotationHasBounds) : [];
+    actual = Array.isArray(actual) ? actual.filter(annotationHasBounds) : [];
+    if (!reference.length || !actual.length) return { reference: reference, actual: actual };
+
+    var referenceFrame = largestAnnotationFrame(reference);
+    var actualFrame = largestAnnotationFrame(actual);
+    var scale = referenceFrame && actualFrame && actualFrame.width > 0
+      ? referenceFrame.width / actualFrame.width
+      : 1;
+    var kinds = [];
+    reference.concat(actual).forEach(function (item) {
+      if (kinds.indexOf(item.kind) < 0) kinds.push(item.kind);
+    });
+
+    var pairs = [];
+    var referenceOnly = [];
+    var actualOnly = [];
+    kinds.forEach(function (kind) {
+      var refs = [];
+      var cands = [];
+      reference.forEach(function (item, index) {
+        if (item.kind === kind) refs.push({ item: item, index: index });
+      });
+      actual.forEach(function (item, index) {
+        if (item.kind === kind) cands.push({ item: item, index: index });
+      });
+      if (!refs.length) {
+        actualOnly = actualOnly.concat(cands);
+        return;
+      }
+      if (!cands.length) {
+        referenceOnly = referenceOnly.concat(refs);
+        return;
+      }
+
+      var used = {};
+      cands.forEach(function (cand) {
+        var mapped = mapAnnotationBounds(cand.item.bounds, referenceFrame, actualFrame, scale);
+        var best = -1;
+        var bestCost = Infinity;
+        refs.forEach(function (ref, refIndex) {
+          if (used[refIndex]) return;
+          var cost = annotationMatchCost(ref.item, cand.item, ref.item.bounds, mapped, referenceFrame);
+          if (cost < bestCost) {
+            bestCost = cost;
+            best = refIndex;
+          }
+        });
+        // Once the design inventory is exhausted, extra render nodes have no design element to
+        // compare with. Deliberately omit them rather than restarting/reusing ordinal numbers.
+        if (best < 0) return;
+        used[best] = true;
+        pairs.push({ reference: refs[best], actual: cand });
+      });
+    });
+
+    // Both legends follow design order, so a shared ordinal identifies the same element on the two
+    // panels even when the Compose tree arrived in a different traversal order.
+    pairs.sort(function (a, b) { return a.reference.index - b.reference.index; });
+    var referenceOut = [];
+    var actualOut = [];
+    pairs.forEach(function (pair, index) {
+      var ordinal = index + 1;
+      referenceOut.push(withAnnotationOrdinal(pair.reference.item, ordinal));
+      actualOut.push(withAnnotationOrdinal(pair.actual.item, ordinal));
+    });
+    referenceOnly.forEach(function (entry) {
+      referenceOut.push(withAnnotationOrdinal(entry.item, referenceOut.length + 1));
+    });
+    actualOnly.forEach(function (entry) {
+      actualOut.push(withAnnotationOrdinal(entry.item, actualOut.length + 1));
+    });
+    return { reference: referenceOut, actual: actualOut };
+  }
+
+  function annotationHasBounds(item) {
+    var b = item && item.bounds;
+    return !!b && isFinite(b.x) && isFinite(b.y) && isFinite(b.width) && isFinite(b.height) &&
+      b.width > 0 && b.height > 0;
+  }
+
+  function largestAnnotationFrame(items) {
+    var layouts = items.filter(function (item) { return item.kind === "layout"; });
+    var pool = layouts.length ? layouts : items;
+    var largest = null;
+    pool.forEach(function (item) {
+      if (!largest || item.bounds.width * item.bounds.height > largest.width * largest.height) {
+        largest = item.bounds;
+      }
+    });
+    return largest;
+  }
+
+  function mapAnnotationBounds(bounds, referenceFrame, actualFrame, scale) {
+    if (!referenceFrame || !actualFrame) return bounds;
+    return {
+      x: referenceFrame.x + (bounds.x - actualFrame.x) * scale,
+      y: referenceFrame.y + (bounds.y - actualFrame.y) * scale,
+      width: bounds.width * scale,
+      height: bounds.height * scale
+    };
+  }
+
+  function annotationText(value) {
+    return String(value || "").trim().toLowerCase().replace(/\b(?:px|dp|sp)\b/g, "u");
+  }
+
+  function annotationRoleFamily(value) {
+    return annotationText(value)
+      .replace(/\b(?:first|last)\b/g, "")
+      .replace(/\b\d+\b/g, "")
+      .replace(/[^a-z]+/g, " ")
+      .trim();
+  }
+
+  function annotationMatchCost(ref, cand, rb, cb, frame) {
+    var fw = frame && frame.width > 0 ? frame.width : Math.max(rb.width, cb.width, 1);
+    var fh = frame && frame.height > 0 ? frame.height : Math.max(rb.height, cb.height, 1);
+    var rcx = rb.x + rb.width / 2;
+    var rcy = rb.y + rb.height / 2;
+    var ccx = cb.x + cb.width / 2;
+    var ccy = cb.y + cb.height / 2;
+    var position = Math.hypot((rcx - ccx) / fw, (rcy - ccy) / fh);
+    var size = Math.abs(rb.width - cb.width) / fw + Math.abs(rb.height - cb.height) / fh;
+    var cost = position + size * 0.5;
+    var rr = annotationText(ref.role);
+    var cr = annotationText(cand.role);
+    if (rr && cr) {
+      if (rr === cr) cost -= 0.06;
+      else if (annotationRoleFamily(rr) === annotationRoleFamily(cr)) cost -= 0.03;
+      else cost += 0.02;
+    }
+    if (annotationText(ref.label) === annotationText(cand.label)) cost -= 0.04;
+    return cost;
+  }
+
+  function withAnnotationOrdinal(item, ordinal) {
+    var copy = {};
+    Object.keys(item).forEach(function (key) { copy[key] = item[key]; });
+    copy.comparisonOrdinal = ordinal;
+    return copy;
+  }
+
+  /**
    * Draw the typography / layout annotation layers over the reference and actual panels.
    *
    * Annotation bounds are in each image's own pixel space, and the two frames are routinely
@@ -615,6 +774,7 @@
     } catch (error) {
       return;
     }
+    payload = matchAnnotationItems(payload.reference, payload.actual);
     var toggles = root.querySelectorAll("[data-cp-annotation-kind]");
     if (!toggles.length) return;
 
@@ -640,7 +800,7 @@
       var legend = document.createElement("ol");
       legend.className = "cp-annotation-legend";
       panel.items.forEach(function (item, index) {
-        var ordinal = String(index + 1);
+        var ordinal = String(item.comparisonOrdinal || index + 1);
         var box = document.createElement("div");
         box.className = "cp-annotation cp-annotation--" + item.kind;
         box.setAttribute("data-cp-kind", item.kind);

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -284,6 +284,7 @@
         "package": "npm run compile && vsce package --no-dependencies",
         "harness:snapshot": "node esbuild.webview.mjs && playwright test -c preview-harness/playwright.config.mjs snapshot",
         "harness:contract": "node esbuild.webview.mjs && playwright test -c preview-harness/playwright.config.mjs contract",
+        "harness:compare": "playwright test -c preview-harness/playwright.config.mjs format-compare-scorer.spec.mjs",
         "harness:serve-lanes": "playwright test -c preview-harness/serve-lanes.config.mjs",
         "harness:playground": "playwright test -c preview-harness/playground.config.mjs",
         "harness:bundle-upload": "playwright test -c preview-harness/bundle-upload.config.mjs"

--- a/vscode-extension/preview-harness/fixtures/menu-dropdown-annotations.recorded.json
+++ b/vscode-extension/preview-harness/fixtures/menu-dropdown-annotations.recorded.json
@@ -1,0 +1,1775 @@
+{
+    "source": "https://preview.coo.ee/m3-catalog/compare/menu-dropdown__ideal__default__light?reference=menu-dropdown__ideal__default__light",
+    "recorded": "2026-08-11",
+    "reference": [
+        {
+            "bounds": {
+                "height": 847,
+                "width": 603,
+                "x": 0,
+                "y": 0
+            },
+            "detail": {
+                "cornerRadius": "16",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "r 16px"
+        },
+        {
+            "bounds": {
+                "height": 847,
+                "width": 603,
+                "x": 0,
+                "y": 0
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad t 2px b 2px",
+            "role": "List 1 content"
+        },
+        {
+            "bounds": {
+                "height": 93,
+                "width": 603,
+                "x": 0,
+                "y": 6
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "2",
+                "padding.end": "4",
+                "padding.start": "4",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad e 4px s 4px · gap 2px · r 4px",
+            "role": "Label 01 - First"
+        },
+        {
+            "bounds": {
+                "height": 93,
+                "width": 580,
+                "x": 12,
+                "y": 6
+            },
+            "detail": {
+                "gap": "8",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "6",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad t 6px e 12px s 12px · gap 8px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 32
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 12,
+                "width": 325,
+                "x": 12,
+                "y": 104
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/8px",
+            "role": "Divider"
+        },
+        {
+            "bounds": {
+                "height": 139,
+                "width": 603,
+                "x": 0,
+                "y": 6
+            },
+            "detail": {
+                "gap": "4",
+                "padding.bottom": "2",
+                "padding.end": "4",
+                "padding.start": "4",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/4px · gap 4px",
+            "role": "Menu-item 01 - First"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 12
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "10",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 10px · r 4px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 12
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "8",
+                "padding.bottom": "12",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "12",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 12px · gap 8px · r 4px",
+            "role": "State Layer"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 46
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 46
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 46
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 46
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 12,
+                "width": 638,
+                "x": 12,
+                "y": 151
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/8px",
+            "role": "Divider"
+        },
+        {
+            "bounds": {
+                "height": 139,
+                "width": 603,
+                "x": 0,
+                "y": 145
+            },
+            "detail": {
+                "gap": "4",
+                "padding.bottom": "2",
+                "padding.end": "4",
+                "padding.start": "4",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/4px · gap 4px",
+            "role": "Menu-item 02"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 151
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "10",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 10px · r 4px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 151
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "8",
+                "padding.bottom": "12",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "12",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 12px · gap 8px · r 4px",
+            "role": "State Layer"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 186
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 186
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 186
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 186
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 12,
+                "width": 638,
+                "x": 12,
+                "y": 290
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/8px",
+            "role": "Divider"
+        },
+        {
+            "bounds": {
+                "height": 139,
+                "width": 603,
+                "x": 0,
+                "y": 284
+            },
+            "detail": {
+                "gap": "4",
+                "padding.bottom": "2",
+                "padding.end": "4",
+                "padding.start": "4",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/4px · gap 4px",
+            "role": "Menu-item 03"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 290
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "10",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 10px · r 4px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 290
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "8",
+                "padding.bottom": "12",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "12",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 12px · gap 8px · r 4px",
+            "role": "State Layer"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 325
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 325
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 325
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 325
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 12,
+                "width": 638,
+                "x": 12,
+                "y": 429
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/8px",
+            "role": "Divider"
+        },
+        {
+            "bounds": {
+                "height": 139,
+                "width": 603,
+                "x": 0,
+                "y": 423
+            },
+            "detail": {
+                "gap": "4",
+                "padding.bottom": "2",
+                "padding.end": "4",
+                "padding.start": "4",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/4px · gap 4px",
+            "role": "Menu-item 04"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 429
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "10",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 10px · r 4px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 429
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "8",
+                "padding.bottom": "12",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "12",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 12px · gap 8px · r 4px",
+            "role": "State Layer"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 464
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 464
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 464
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 464
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 12,
+                "width": 638,
+                "x": 12,
+                "y": 568
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/8px",
+            "role": "Divider"
+        },
+        {
+            "bounds": {
+                "height": 139,
+                "width": 603,
+                "x": 0,
+                "y": 562
+            },
+            "detail": {
+                "gap": "4",
+                "padding.bottom": "2",
+                "padding.end": "4",
+                "padding.start": "4",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/4px · gap 4px",
+            "role": "Menu-item 05"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 568
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "10",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 10px · r 4px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 568
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "8",
+                "padding.bottom": "12",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "12",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 12px · gap 8px · r 4px",
+            "role": "State Layer"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 603
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 603
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 603
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 603
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 12,
+                "width": 638,
+                "x": 12,
+                "y": 707
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/8px",
+            "role": "Divider"
+        },
+        {
+            "bounds": {
+                "height": 139,
+                "width": 557,
+                "x": 0,
+                "y": 725
+            },
+            "detail": {
+                "gap": "4",
+                "padding.bottom": "2",
+                "padding.end": "4",
+                "padding.start": "4",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/4px · gap 4px",
+            "role": "Menu-item 06"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 533,
+                "x": 12,
+                "y": 731
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "10",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 10px · r 4px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 533,
+                "x": 12,
+                "y": 731
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "8",
+                "padding.bottom": "12",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "12",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 12px · gap 8px · r 4px",
+            "role": "State Layer"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 765
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 765
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 406,
+                "x": 128,
+                "y": 765
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "36",
+                "padding.start": "0",
+                "padding.top": "0",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 0px e 36px b 0px s 0px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 452,
+                "y": 765
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 452,
+                "y": 765
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 6px/8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 12,
+                "width": 638,
+                "x": 12,
+                "y": 870
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/8px",
+            "role": "Divider"
+        },
+        {
+            "bounds": {
+                "height": 93,
+                "width": 603,
+                "x": 0,
+                "y": 702
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "2",
+                "padding.end": "4",
+                "padding.start": "4",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad e 4px s 4px · gap 2px · r 4px",
+            "role": "Label 02"
+        },
+        {
+            "bounds": {
+                "height": 93,
+                "width": 580,
+                "x": 12,
+                "y": 702
+            },
+            "detail": {
+                "gap": "8",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "6",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad t 6px e 12px s 12px · gap 8px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 728
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 12,
+                "width": 325,
+                "x": 12,
+                "y": 800
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/8px",
+            "role": "Divider"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 406,
+                "x": 104,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "20",
+                "padding.start": "0",
+                "padding.top": "0",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 0px e 20px b 0px s 0px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 406,
+                "x": 104,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "20",
+                "padding.start": "0",
+                "padding.top": "0",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 0px e 20px b 0px s 0px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 406,
+                "x": 104,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "20",
+                "padding.start": "0",
+                "padding.top": "0",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 0px e 20px b 0px s 0px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 406,
+                "x": 104,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "20",
+                "padding.start": "0",
+                "padding.top": "0",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 0px e 20px b 0px s 0px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 23,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 406,
+                "x": 104,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "20",
+                "padding.start": "0",
+                "padding.top": "0",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 0px e 20px b 0px s 0px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 475,
+                "y": 818
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 139,
+                "width": 603,
+                "x": 0,
+                "y": 702
+            },
+            "detail": {
+                "gap": "4",
+                "padding.bottom": "2",
+                "padding.end": "4",
+                "padding.start": "4",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/4px · gap 4px",
+            "role": "Menu-item 12 - Last"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 707
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "10",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 10px · r 4px",
+            "role": "Content"
+        },
+        {
+            "bounds": {
+                "height": 128,
+                "width": 580,
+                "x": 12,
+                "y": 707
+            },
+            "detail": {
+                "cornerRadius": "4",
+                "gap": "8",
+                "padding.bottom": "12",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "12",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 12px · gap 8px · r 4px",
+            "role": "State Layer"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 742
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Leading element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 46,
+                "y": 742
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "2",
+                "padding.start": "2",
+                "padding.top": "2",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad 2px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 742
+            },
+            "detail": {
+                "gap": "8",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "gap 8px",
+            "role": "Trailing element"
+        },
+        {
+            "bounds": {
+                "height": 58,
+                "width": 58,
+                "x": 499,
+                "y": 742
+            },
+            "detail": {
+                "padding.bottom": "6",
+                "padding.end": "7",
+                "padding.start": "8",
+                "padding.top": "6",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 6px e 7px b 6px s 8px",
+            "role": "Icon"
+        },
+        {
+            "bounds": {
+                "height": 12,
+                "width": 638,
+                "x": 12,
+                "y": 847
+            },
+            "detail": {
+                "padding.bottom": "2",
+                "padding.end": "8",
+                "padding.start": "8",
+                "padding.top": "2",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "pad 2px/8px",
+            "role": "Divider"
+        },
+        {
+            "bounds": {
+                "height": 847,
+                "width": 35,
+                "x": 557,
+                "y": 0
+            },
+            "detail": {
+                "padding.bottom": "110",
+                "padding.end": "0",
+                "padding.start": "8",
+                "padding.top": "12",
+                "spacingSource": "derived",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "≈pad t 12px e 0px b 110px s 8px",
+            "role": "Scrollbar"
+        },
+        {
+            "bounds": {
+                "height": 493,
+                "width": 12,
+                "x": 580,
+                "y": 35
+            },
+            "detail": {
+                "cornerRadius": "100",
+                "unit": "px"
+            },
+            "kind": "layout",
+            "label": "r 100px",
+            "role": "Scrollbar"
+        }
+    ],
+    "actual": [
+        {
+            "bounds": {
+                "height": 767,
+                "width": 546,
+                "x": 29,
+                "y": 18
+            },
+            "detail": {
+                "cornerRadius": "16",
+                "unit": "dp"
+            },
+            "kind": "layout",
+            "label": "r 16dp"
+        },
+        {
+            "bounds": {
+                "height": 126,
+                "width": 546,
+                "x": 29,
+                "y": 23
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "0",
+                "unit": "dp"
+            },
+            "kind": "layout",
+            "label": "pad 0dp/12dp"
+        },
+        {
+            "bounds": {
+                "height": 126,
+                "width": 546,
+                "x": 29,
+                "y": 149
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "0",
+                "unit": "dp"
+            },
+            "kind": "layout",
+            "label": "pad 0dp/12dp"
+        },
+        {
+            "bounds": {
+                "height": 126,
+                "width": 546,
+                "x": 29,
+                "y": 275
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "0",
+                "unit": "dp"
+            },
+            "kind": "layout",
+            "label": "pad 0dp/12dp"
+        },
+        {
+            "bounds": {
+                "height": 126,
+                "width": 546,
+                "x": 29,
+                "y": 401
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "0",
+                "unit": "dp"
+            },
+            "kind": "layout",
+            "label": "pad 0dp/12dp"
+        },
+        {
+            "bounds": {
+                "height": 126,
+                "width": 546,
+                "x": 29,
+                "y": 527
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "0",
+                "unit": "dp"
+            },
+            "kind": "layout",
+            "label": "pad 0dp/12dp"
+        },
+        {
+            "bounds": {
+                "height": 126,
+                "width": 546,
+                "x": 29,
+                "y": 653
+            },
+            "detail": {
+                "padding.bottom": "0",
+                "padding.end": "12",
+                "padding.start": "12",
+                "padding.top": "0",
+                "unit": "dp"
+            },
+            "kind": "layout",
+            "label": "pad 0dp/12dp"
+        }
+    ]
+}

--- a/vscode-extension/preview-harness/format-compare-scorer.spec.mjs
+++ b/vscode-extension/preview-harness/format-compare-scorer.spec.mjs
@@ -28,6 +28,12 @@ const SCORER = readFileSync(
     ),
     "utf8",
 );
+const RECORDED_MENU = JSON.parse(
+    readFileSync(
+        resolve(here, "fixtures/menu-dropdown-annotations.recorded.json"),
+        "utf8",
+    ),
+);
 
 /** Load the real asset into a page with an origin, then score the four synthetic pairs. */
 async function scorePairs(page) {
@@ -147,5 +153,131 @@ test.describe("format-compare · design reference scorer", () => {
     test("unrelated content still reads as a mismatch", async ({ page }) => {
         const { unrelated } = await scorePairs(page);
         expect(unrelated.percent).toBeLessThan(75);
+    });
+});
+
+test.describe("format-compare · annotation correspondence", () => {
+    test("reduces the recorded menu-dropdown report from 94 vs 7 to seven shared elements", async ({
+        page,
+    }) => {
+        await page.goto("/preview-harness/index.html");
+        await page.addScriptTag({ content: SCORER });
+        const result = await page.evaluate((payload) => {
+            const matched = window.ComposePreviewCompare.matchAnnotationItems(
+                payload.reference,
+                payload.actual,
+            );
+            return {
+                referenceBefore: payload.reference.length,
+                actualBefore: payload.actual.length,
+                reference: matched.reference,
+                actual: matched.actual,
+            };
+        }, RECORDED_MENU);
+
+        expect(RECORDED_MENU.source).toContain("menu-dropdown__ideal__default__light");
+        expect(result.referenceBefore).toBe(94);
+        expect(result.actualBefore).toBe(7);
+        expect(result.reference).toHaveLength(7);
+        expect(result.actual).toHaveLength(7);
+        expect(result.reference.map((item) => item.comparisonOrdinal)).toEqual([
+            1, 2, 3, 4, 5, 6, 7,
+        ]);
+        expect(result.actual.map((item) => item.comparisonOrdinal)).toEqual([
+            1, 2, 3, 4, 5, 6, 7,
+        ]);
+        expect(result.reference.slice(1).map((item) => item.role)).toEqual([
+            "Menu-item 01 - First",
+            "Menu-item 02",
+            "Menu-item 03",
+            "Menu-item 04",
+            "Menu-item 05",
+            // The render's last visible row aligns with Figma's last item. Figma's item 06 is
+            // lower/off-viewport in this recorded layout despite appearing earlier in traversal.
+            "Menu-item 12 - Last",
+        ]);
+    });
+
+    test("pairs the shallow render tree with the same positioned Figma elements", async ({
+        page,
+    }) => {
+        await page.goto("/preview-harness/index.html");
+        await page.addScriptTag({ content: SCORER });
+        const matched = await page.evaluate(() => {
+            const b = (x, y, width, height) => ({ x, y, width, height });
+            const layout = (role, bounds, label = "spacing") => ({
+                kind: "layout",
+                bounds,
+                label,
+                ...(role ? { role } : {}),
+            });
+            const reference = [layout(undefined, b(0, 0, 603, 847), "r 16px")];
+            // A Figma menu item has several nested layout nodes. Only the outer item corresponds
+            // to the single shallow row exposed by Compose semantics.
+            for (let i = 0; i < 6; i++) {
+                const y = 6 + i * 139;
+                reference.push(layout(`Menu-item ${i + 1}`, b(0, y, 603, 139)));
+                reference.push(layout("Content", b(12, y + 6, 580, 128)));
+                reference.push(layout("State Layer", b(12, y + 6, 580, 128)));
+                reference.push(
+                    layout("Leading element", b(46, y + 40, 58, 58)),
+                );
+                reference.push(layout("Icon", b(46, y + 40, 58, 58)));
+            }
+            const actual = [layout(undefined, b(29, 18, 546, 767), "r 16dp")];
+            for (let i = 0; i < 6; i++) {
+                actual.push(
+                    layout(
+                        undefined,
+                        b(29, 23 + i * 126, 546, 126),
+                        "pad 0dp/12dp",
+                    ),
+                );
+            }
+            return window.ComposePreviewCompare.matchAnnotationItems(
+                reference,
+                actual,
+            );
+        });
+
+        expect(matched.reference).toHaveLength(7);
+        expect(matched.actual).toHaveLength(7);
+        expect(matched.reference.slice(1).map((item) => item.role)).toEqual([
+            "Menu-item 1",
+            "Menu-item 2",
+            "Menu-item 3",
+            "Menu-item 4",
+            "Menu-item 5",
+            "Menu-item 6",
+        ]);
+        expect(matched.reference.map((item) => item.comparisonOrdinal)).toEqual(
+            [1, 2, 3, 4, 5, 6, 7],
+        );
+        expect(matched.actual.map((item) => item.comparisonOrdinal)).toEqual([
+            1, 2, 3, 4, 5, 6, 7,
+        ]);
+    });
+
+    test("drops render-only elements after the Figma inventory is exhausted", async ({
+        page,
+    }) => {
+        await page.goto("/preview-harness/index.html");
+        await page.addScriptTag({ content: SCORER });
+        const counts = await page.evaluate(() => {
+            const item = (y) => ({
+                kind: "layout",
+                bounds: { x: 0, y, width: 100, height: 20 },
+                label: "row",
+            });
+            const matched = window.ComposePreviewCompare.matchAnnotationItems(
+                [item(0), item(20)],
+                [item(0), item(20), item(40), item(60)],
+            );
+            return {
+                reference: matched.reference.length,
+                actual: matched.actual.length,
+            };
+        });
+        expect(counts).toEqual({ reference: 2, actual: 2 });
     });
 });


### PR DESCRIPTION
## What changed

- pair Figma and Compose layout annotations before rendering legends and overlays
- normalize candidate geometry into the Figma frame, remove scaffold offsets, and use role/label similarity to break positional ties
- consume each Figma element once and omit unmatched deeper/render-only nodes
- assign the same ordinal to both sides of every matched element
- record the live Material 3 menu-dropdown annotation payload as a regression fixture
- add a dedicated `harness:compare` command to PR and main preview CI workflows

## Why

The menu-dropdown comparison independently numbered 94 Figma layout nodes and 7 Compose nodes. The two legends therefore described different elements, and deep Figma-only layers obscured the useful comparison.

The recorded regression now resolves that real 94-vs-7 payload to seven shared elements. Its final visible Compose row matches Figma's `Menu-item 12 - Last` positionally instead of the earlier-but-off-viewport `Menu-item 06`.

## Impact

Layout annotations now compare corresponding elements with shared numbers. When one side exposes a deeper tree, unmatched nodes are skipped instead of being presented as false counterparts.

## Validation

- `npm run harness:compare` — 7 passed, including the recorded 94→7 menu-dropdown case
- focused CLI web asset/theme tests — passed
- `node --check cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js`
- `git diff --check`
