### PR TITLE
feat: annotate per-reference Figma backgrounds

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -162,6 +162,13 @@ on:
         required: false
         type: string
         default: ''
+      figma-contents-only:
+        description: >
+          Whether published Figma references include only the mapped node. Set false to include
+          overlapping layers, such as a component-sheet background. Defaults true, matching Figma.
+        required: false
+        type: boolean
+        default: true
       fold-artifact:
         description: 'Name of an artifact (uploaded by a prior caller job) holding a pre-built render bundle to fold in as its own top-level section AFTER generate — e.g. a re-themed sibling catalog. Empty ⇒ no fold-in. Requires fold-bundle, fold-spec, fold-section.'
         required: false
@@ -1066,6 +1073,7 @@ jobs:
           # with no Figma references) those entries are skipped with a warning and
           # the rest of the manifest still publishes.
           FIGMA_TOKEN: ${{ secrets.figma_token }}
+          FIGMA_CONTENTS_ONLY: ${{ inputs.figma-contents-only }}
         run: |
           set -euo pipefail
           if [ ! -f "design-map.json" ]; then
@@ -1087,7 +1095,8 @@ jobs:
           node compose-ai-tools/scripts/design-artifacts/emit-design-references.mjs \
             --out "$GITHUB_WORKSPACE/out" \
             --repo "$GITHUB_WORKSPACE" \
-            --spec "${{ inputs.spec }}"
+            --spec "${{ inputs.spec }}" \
+            --figma-contents-only "$FIGMA_CONTENTS_ONLY"
 
       # The design-parity dashboard's feed (`parity/activity.json`) — recent
       # commits, recent Figma versions/comments, and the mapping gaps behind

--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
@@ -28,6 +28,9 @@ package ee.schimke.composeai.preview
  *   absence is a finding rather than a gap — the kit retired the pattern, never published it, or
  *   publishes something close enough to mislead. An empty [reference] otherwise means only "nobody
  *   has looked yet", and a consumer cannot tell the two apart.
+ * * [referenceContentsOnly] defaults to true. Set it to false only when the referenced Figma node
+ *   intentionally relies on overlapping sheet content, such as an authored backdrop. Keeping this
+ *   next to [reference] avoids changing unrelated previews on the same component sheet.
  *
  * ```kotlin
  * @file:CatalogGroup("Buttons")
@@ -111,6 +114,7 @@ annotation class CatalogComponent(
   // Declaration order is source API here; the grouping is documented above instead.
   val referenceSet: String = "",
   val noReference: String = "",
+  val referenceContentsOnly: Boolean = true,
 )
 
 /**

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -159,6 +159,8 @@ data class CatalogEntry(
    * consumer cannot tell apart from a null [reference] alone.
    */
   val noReference: String? = null,
+  /** COMPONENT: whether a Figma export contains only [reference]'s own content. */
+  val referenceContentsOnly: Boolean = true,
   val parallel: String? = null,
   val state: String? = null,
   val props: List<CatalogVariantProp> = emptyList(),

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/CatalogEntryWireTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/CatalogEntryWireTest.kt
@@ -20,7 +20,8 @@ class CatalogEntryWireTest {
             "catalog": {
               "role": "COMPONENT",
               "componentId": "Button/Filled",
-              "parallel": "FilledButton"
+              "parallel": "FilledButton",
+              "referenceContentsOnly": false
             }
           }]
         }
@@ -29,6 +30,7 @@ class CatalogEntryWireTest {
       )
 
     assertEquals("FilledButton", manifest.previews.single().catalog?.parallel)
+    assertEquals(false, manifest.previews.single().catalog?.referenceContentsOnly)
   }
 
   @Test
@@ -92,6 +94,7 @@ class CatalogEntryWireTest {
       )
 
     assertEquals(false, manifest.previews.single().catalog?.perBreakpoint)
+    assertEquals(true, manifest.previews.single().catalog?.referenceContentsOnly)
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -815,6 +815,11 @@ data class CatalogEntry(
    * kit retired this", which a consumer cannot infer from silence.
    */
   val noReference: String? = null,
+  /**
+   * COMPONENT only: whether a Figma export contains only [reference]'s own content. `false` opts
+   * this one reference into overlapping sheet layers without changing any other preview.
+   */
+  val referenceContentsOnly: Boolean = true,
   /** COMPONENT only: component id of the counterpart in the `compareWith` sibling system. */
   val parallel: String? = null,
   /** VARIANT only: the interaction/state this render shows (`pressed`, `disabled`, …). */

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1137,6 +1137,7 @@ object PreviewDiscovery {
       reference = annStringOrNull(component, "reference"),
       referenceSet = annStringOrNull(component, "referenceSet"),
       noReference = annStringOrNull(component, "noReference"),
+      referenceContentsOnly = annBoolean(component, "referenceContentsOnly", default = true),
       parallel = annStringOrNull(component, "parallel"),
       perBreakpoint = annBoolean(component, "perBreakpoint"),
     )
@@ -1148,9 +1149,9 @@ object PreviewDiscovery {
     return raw?.takeIf { it.isNotBlank() }
   }
 
-  /** Reads a `Boolean` annotation parameter, defaulting to false when absent or not a boolean. */
-  private fun annBoolean(ann: AnnotationInfo, param: String): Boolean =
-    runCatching { ann.parameterValues.getValue(param) as? Boolean }.getOrNull() ?: false
+  /** Reads a `Boolean` annotation parameter, using [default] when absent or not a boolean. */
+  private fun annBoolean(ann: AnnotationInfo, param: String, default: Boolean = false): Boolean =
+    runCatching { ann.parameterValues.getValue(param) as? Boolean }.getOrNull() ?: default
 
   /** Reads a `String[]` annotation parameter (ClassGraph yields an `Object[]`) as a list. */
   private fun annStringArray(ann: AnnotationInfo, param: String): List<String> {

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -858,6 +858,7 @@ class DiscoveryFunctionalTest {
           val perBreakpoint: Boolean = false,
           val referenceSet: String = "",
           val noReference: String = "",
+          val referenceContentsOnly: Boolean = true,
         )
 
         @Retention(AnnotationRetention.BINARY)
@@ -895,6 +896,7 @@ class DiscoveryFunctionalTest {
           caption = "Highest emphasis; the primary action.",
           reference = "figma:AbCdEf/10:5",
           referenceSet = "figma:AbCdEf/10:1",
+          referenceContentsOnly = false,
           parallel = "FilledButton",
         )
         @Preview @Composable fun FilledButton() {}
@@ -965,6 +967,7 @@ class DiscoveryFunctionalTest {
     // against, `referenceSet` the family a screen's sibling variant matches through.
     assertThat(filled.reference).isEqualTo("figma:AbCdEf/10:5")
     assertThat(filled.referenceSet).isEqualTo("figma:AbCdEf/10:1")
+    assertThat(filled.referenceContentsOnly).isFalse()
 
     // Variant: parent id on componentId, state + parsed `key=value` prop, own caption.
     val pressed = byFn.getValue("FilledButtonPressed").catalog
@@ -983,6 +986,7 @@ class DiscoveryFunctionalTest {
     assertThat(plain.parallel).isNull()
     assertThat(plain.reference).isNull()
     assertThat(plain.referenceSet).isNull()
+    assertThat(plain.referenceContentsOnly).isTrue()
     // Said nothing either way, so `noReference` is silent too. This is the "nobody has looked yet"
     // case the stated-absence assertion below has to stay distinguishable from.
     assertThat(plain.noReference).isNull()

--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -463,6 +463,9 @@ export function planDesignReferences({ designMap, spec, catalog }) {
           ref: entry.ref,
           previewId: entry.previewId,
           density: entry.density,
+          ...(typeof entry.referenceContentsOnly === "boolean"
+            ? { referenceContentsOnly: entry.referenceContentsOnly }
+            : {}),
         },
       };
       if (entry.ref) record.source.uri = entry.ref;

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -396,6 +396,22 @@ test("planDesignReferences carries a declared board density to the driver", () =
   assert.equal(records[1].origin.density, undefined);
 });
 
+test("planDesignReferences carries a per-reference contents-only override to the driver", () => {
+  const designMap = {
+    components: [
+      {
+        code: "meshcore-components/src/commonMain/kotlin/ui/ChatBodyPreviews.kt#ContactChatPreview",
+        source: "figma",
+        ref: "figma:abc/73:5",
+        referenceContentsOnly: false,
+      },
+    ],
+  };
+
+  const { records } = planDesignReferences({ designMap, spec: SPEC, catalog: CATALOG });
+  assert.equal(records[0].origin.referenceContentsOnly, false);
+});
+
 test("planDesignReferences carries an image renderer density to the raster target", () => {
   const catalog = structuredClone(CATALOG);
   catalog.components[0].images[0].density = 3;

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -193,10 +193,20 @@ async function rasterizeHtml(file, target) {
   }
 }
 
-const figmaRasterizer = new FigmaRestRasterizer({
-  token: FIGMA_TOKEN,
-  contentsOnly: FIGMA_CONTENTS_ONLY,
-});
+const figmaRasterizers = new Map();
+
+function referenceContentsOnly(record) {
+  return record.origin?.referenceContentsOnly ?? FIGMA_CONTENTS_ONLY;
+}
+
+function figmaRasterizerFor(contentsOnly) {
+  let rasterizer = figmaRasterizers.get(contentsOnly);
+  if (!rasterizer) {
+    rasterizer = new FigmaRestRasterizer({ token: FIGMA_TOKEN, contentsOnly });
+    figmaRasterizers.set(contentsOnly, rasterizer);
+  }
+  return rasterizer;
+}
 
 /** A pre-rendered PNG for this ref under `--reference-images`, or null. */
 function suppliedRaster(ref) {
@@ -241,7 +251,7 @@ async function sourceRaster(record) {
       warn(`${record.id}: skipping figma reference ${ref} — no FIGMA_TOKEN in this run`);
       return null;
     }
-    return figmaRasterizer.rasterize(ref, target);
+    return figmaRasterizerFor(referenceContentsOnly(record)).rasterize(ref, target);
   }
 
   warn(`${record.id}: don't know how to rasterise a '${source}' reference from '${ref}'`);
@@ -289,14 +299,17 @@ let written = 0;
 /** Reference id -> a `{ layout }` shim; `referenceAnnotations` reads only that field. */
 const annotatedReferences = {};
 if (FIGMA_TOKEN) {
-  await figmaRasterizer.prepare(
-    records
-      .filter((record) => parseFigmaRef(record.origin.ref) && !suppliedRaster(record.origin.ref))
-      .map((record) => ({
-        ref: record.origin.ref,
-        target: targetFor(record),
-      })),
-  );
+  for (const contentsOnly of [true, false]) {
+    const requests = records
+      .filter(
+        (record) =>
+          referenceContentsOnly(record) === contentsOnly &&
+          parseFigmaRef(record.origin.ref) &&
+          !suppliedRaster(record.origin.ref),
+      )
+      .map((record) => ({ ref: record.origin.ref, target: targetFor(record) }));
+    if (requests.length > 0) await figmaRasterizerFor(contentsOnly).prepare(requests);
+  }
 }
 for (const record of records) {
   const target = targetFor(record);

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -72,6 +72,7 @@ const SPEC = arg("spec", "catalog.spec.json");
 const REFERENCE_IMAGES = arg("reference-images");
 const EXEC = arg("chromium", process.env.DESIGN_REFERENCES_CHROMIUM || undefined);
 const STRICT = process.argv.includes("--strict");
+const FIGMA_CONTENTS_ONLY = arg("figma-contents-only", "true") !== "false";
 
 const FIGMA_TOKEN =
   process.env.FIGMA_TOKEN || process.env.FIGMA_PAT || process.env.FIGMA_ACCESS_TOKEN || "";
@@ -192,7 +193,10 @@ async function rasterizeHtml(file, target) {
   }
 }
 
-const figmaRasterizer = new FigmaRestRasterizer({ token: FIGMA_TOKEN });
+const figmaRasterizer = new FigmaRestRasterizer({
+  token: FIGMA_TOKEN,
+  contentsOnly: FIGMA_CONTENTS_ONLY,
+});
 
 /** A pre-rendered PNG for this ref under `--reference-images`, or null. */
 function suppliedRaster(ref) {

--- a/scripts/design-artifacts/figma-rest-raster.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.mjs
@@ -47,12 +47,14 @@ export class FigmaRestRasterizer {
     sleep = (millis) => new Promise((resolve) => setTimeout(resolve, millis)),
     batchSize = 50,
     maxAttempts = 5,
+    contentsOnly = true,
   }) {
     this.token = token;
     this.fetchImpl = fetchImpl;
     this.sleep = sleep;
     this.batchSize = batchSize;
     this.maxAttempts = maxAttempts;
+    this.contentsOnly = contentsOnly;
     this.nodes = new Map();
     this.imageUrls = new Map();
     this.rasters = new Map();
@@ -157,7 +159,8 @@ export class FigmaRestRasterizer {
         try {
           const url =
             `https://api.figma.com/v1/images/${encodeURIComponent(fileKey)}` +
-            `?ids=${encodeURIComponent(batch.join(","))}&format=png&scale=${scale}`;
+            `?ids=${encodeURIComponent(batch.join(","))}&format=png&scale=${scale}` +
+            `&contents_only=${this.contentsOnly}`;
           const response = await this.fetchWithRetry(url, { headers: this.headers() }, "figma images");
           const json = await response.json();
           for (const nodeId of batch) {

--- a/scripts/design-artifacts/figma-rest-raster.test.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.test.mjs
@@ -70,6 +70,36 @@ test("batches nodes and equal-scale image exports, then caches duplicate rasters
     calls.find((url) => url.includes("/images/")),
     /scale=2.625/,
   );
+  assert.equal(
+    new URL(calls.find((url) => url.includes("/images/"))).searchParams.get("contents_only"),
+    "true",
+  );
+});
+
+test("can include overlapping Figma layers such as component-sheet backgrounds", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url.includes("/nodes?")) {
+      return json({ nodes: { "1:1": { document: { absoluteBoundingBox: { width: 10 } } } } });
+    }
+    if (url.includes("/images/")) return json({ images: { "1:1": "https://cdn.test/1:1" } });
+    return new Response(onePixelPng(), { status: 200 });
+  };
+  const rasterizer = new FigmaRestRasterizer({
+    token: "token",
+    fetchImpl,
+    contentsOnly: false,
+  });
+
+  await rasterizer.rasterize("figma:file/1:1", {
+    width: 20,
+    height: 20,
+    density: 2.625,
+  });
+
+  const imageUrl = calls.find((url) => url.includes("/images/"));
+  assert.equal(new URL(imageUrl).searchParams.get("contents_only"), "false");
 });
 
 test("exports at renderer density instead of scaling a tight node to the padded canvas", async () => {


### PR DESCRIPTION
## What changed

- add `referenceContentsOnly` to `@CatalogComponent`, defaulting to `true`
- carry the annotation through preview discovery and the public preview wire format
- propagate per-reference metadata from design-map planning into Figma rasterization
- retain `figma-contents-only` as the conservative workflow-wide fallback
- route references through separate contents-only/background-inclusive raster batches

## Why

Transparent component nodes can rely on overlapping component-sheet backgrounds, but enabling overlaps for a whole catalog risks capturing unrelated labels and neighbouring specimens. The choice belongs next to the specific reference annotation.

## Impact

A preview can opt in with `referenceContentsOnly = false`; all existing annotations and catalogs retain contents-only exports.

## Validation

- `./gradlew ktfmtFormatAll`
- `./gradlew :preview-data-api:test --tests '*CatalogEntryWireTest*'`
- `./gradlew :gradle-plugin:functionalTest --tests '*DiscoveryFunctionalTest*CatalogComponent*'`
- `./gradlew :preview-annotations:allTests :gradle-plugin:preview-discovery:test`
- `node --test scripts/design-artifacts/design-references.test.mjs scripts/design-artifacts/figma-rest-raster.test.mjs` — 35 tests passed
- reusable workflow YAML parsed successfully