### PR TITLE
fix(render): provide hosted font fallbacks

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -481,68 +481,9 @@ runs:
       if: steps.scope.outputs.mode != 'skip'
       shell: bash
       run: |
-        # Deterministic multilingual rendering. Skiko resolves any glyph a
-        # preview's own FontFamily doesn't cover through the system fontconfig
-        # set, so a `@Preview(locale = "ja" / "ar" / …)` renders tofu on a runner
-        # that happens to lack CJK / Arabic / emoji faces. Install the Noto
-        # fallbacks so those previews render the same on every runner.
-        #
-        # FALLBACK ONLY — apps keep control of their own typography, and the
-        # existing Latin default is preserved unchanged:
-        #   * A preview's declared FontFamily (and any face an app bundles into
-        #     the font path ahead of its render — e.g. its branded .ttf copied
-        #     into ~/.local/share/fonts + fc-cache, as design-parity does) wins:
-        #     Compose matches those by family name and never consults the generic
-        #     sans/serif/mono aliases. An app that ships its own CJK font renders
-        #     in that font, exactly as on-device.
-        #   * fonts-noto-core also carries Noto Sans/Serif, and fontconfig's
-        #     60-latin.conf ranks Noto ahead of DejaVu for the generic families.
-        #     Left alone, installing it would silently switch every default-font
-        #     preview's Latin text to Noto — broad baseline churn, not just
-        #     missing-glyph fill. So we pin the generics back to whatever they
-        #     resolved to *before* the install, keeping Noto a pure last-resort
-        #     fill for the codepoints the prior default lacks (CJK, Arabic, …).
-
-        # 1. Record the pre-install generic defaults so we can preserve them.
-        #    fc-match ships with the runner's base fontconfig; if it can't read a
-        #    generic (empty), fall back to the historical DejaVu default rather
-        #    than leaving the generic unpinned (and so churnable).
-        prev_sans="$(fc-match -f '%{family}\n' sans-serif 2>/dev/null | head -n1 | cut -d, -f1)"
-        prev_serif="$(fc-match -f '%{family}\n' serif 2>/dev/null | head -n1 | cut -d, -f1)"
-        prev_mono="$(fc-match -f '%{family}\n' monospace 2>/dev/null | head -n1 | cut -d, -f1)"
-        : "${prev_sans:=DejaVu Sans}"
-        : "${prev_serif:=DejaVu Serif}"
-        : "${prev_mono:=DejaVu Sans Mono}"
-
-        # 2. Install the Noto fallbacks.
-        sudo apt-get update -qq
-        sudo apt-get install -y -qq --no-install-recommends \
-          fonts-noto-cjk fonts-noto-core fonts-noto-color-emoji
-
-        # 3. Pin the generic families back to the recorded defaults so Noto stays
-        #    fallback-only. A strong prepend beats 60-latin's Noto preference; the
-        #    prior default lands first and Noto is only reached for glyphs it
-        #    lacks. If a generic didn't resolve (empty), skip it rather than pin
-        #    an empty family.
-        {
-          echo '<?xml version="1.0"?>'
-          echo '<!DOCTYPE fontconfig SYSTEM "fonts.dtd">'
-          echo '<fontconfig>'
-          for pair in "sans-serif:$prev_sans" "serif:$prev_serif" "monospace:$prev_mono"; do
-            generic="${pair%%:*}"; family="${pair#*:}"
-            [ -n "$family" ] || continue
-            printf '  <match target="pattern"><test qual="any" name="family"><string>%s</string></test><edit name="family" mode="prepend" binding="strong"><string>%s</string></edit></match>\n' "$generic" "$family"
-          done
-          echo '</fontconfig>'
-        } | sudo tee /etc/fonts/conf.d/99-preserve-generic-latin-default.conf >/dev/null
-
-        fc-cache -f >/dev/null
-
-        # 4. Log the resolved generics so any render shift is traceable to a font
-        #    change rather than a silent default swap.
-        echo "generic sans-serif → $(fc-match -f '%{family}\n' sans-serif) (was: ${prev_sans:-none})"
-        echo "generic serif      → $(fc-match -f '%{family}\n' serif) (was: ${prev_serif:-none})"
-        echo "generic monospace  → $(fc-match -f '%{family}\n' monospace) (was: ${prev_mono:-none})"
+        # github.action_path points at .github/actions/apply in both a local checkout and a remote
+        # action download; the shared installer is three directories above it.
+        bash "${GITHUB_ACTION_PATH}/../../../scripts/install-linux-font-fallbacks.sh"
 
     # Resolve the same directory the renderer's `GoogleFontCache` uses, via the
     # same XDG rule as `composeAiFontsCacheDir` in the Gradle plugin. Computed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1171,6 +1171,10 @@ jobs:
       # fail silently in production (a delivery branch just stops regenerating).
       - name: Run design-artifacts scope-step tests
         run: scripts/design-artifacts/test-scope-step.sh
+      # The reusable catalog workflow and preview-host images share this installer. It must keep
+      # the pre-Noto generic families while supplying broad missing-glyph coverage.
+      - name: Run Linux font-fallback installer tests
+        run: scripts/test-install-linux-font-fallbacks.sh
       # Guards the preview-host image's baked font cache. Its failure mode is silent: a wrong
       # cache filename or a skipped stage-2 range query leaves faces the renderer never finds, so
       # the live daemon quietly falls back to Roboto and drifts from the baked catalog PNGs again.

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -486,9 +486,8 @@ jobs:
       - name: Install desktop (Skiko) render deps
         if: ${{ inputs.desktop-render }}
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends \
-            xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig
+          compose-ai-tools/scripts/install-linux-font-fallbacks.sh \
+            xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1
 
       # Same font cache as the single-job pipeline. The save key carries the shard index because
       # Actions caches are immutable: N shards saving one `…-<run_id>` key would have the first win
@@ -800,9 +799,8 @@ jobs:
       - name: Install desktop (Skiko) render deps
         if: ${{ inputs.desktop-render }}
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends \
-            xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig
+          compose-ai-tools/scripts/install-linux-font-fallbacks.sh \
+            xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1
 
       # Restore the downloadable-font cache (the matching save runs after the render,
       # below). The Android renderer's GoogleFont shadow and the figma-svg export fetch

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -231,45 +231,8 @@ jobs:
       # Remote Android rows don't need them, but the packages are harmless there).
       - name: Install desktop (Skiko) render deps
         run: |
-          sudo apt-get update -qq
-          # `fonts-noto-*` are FALLBACK faces so a `@Preview(locale = "ja"/"ar"/…)`
-          # catalog variant renders real glyphs instead of tofu on runners whose
-          # base image lacks CJK/Arabic/emoji. A catalog's own declared FontFamily
-          # still wins (Compose matches it by name, never via the generic aliases);
-          # Noto only fills the codepoints the catalog's own fonts don't provide.
-          #
-          # Record the generic Latin defaults BEFORE the install: fonts-noto-core
-          # carries Noto Sans/Serif and fontconfig's 60-latin.conf ranks Noto
-          # ahead of DejaVu, so installing it would otherwise silently switch the
-          # generic sans/serif/mono default to Noto — broad baseline churn instead
-          # of missing-glyph fill. (fc-match is present on the runner; if it can't
-          # read a generic, fall back to the historical DejaVu default.)
-          prev_sans="$(fc-match -f '%{family}\n' sans-serif 2>/dev/null | head -n1 | cut -d, -f1)"
-          prev_serif="$(fc-match -f '%{family}\n' serif 2>/dev/null | head -n1 | cut -d, -f1)"
-          prev_mono="$(fc-match -f '%{family}\n' monospace 2>/dev/null | head -n1 | cut -d, -f1)"
-          : "${prev_sans:=DejaVu Sans}"
-          : "${prev_serif:=DejaVu Serif}"
-          : "${prev_mono:=DejaVu Sans Mono}"
-          sudo apt-get install -y -qq --no-install-recommends \
-            xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig \
-            fonts-noto-cjk fonts-noto-core fonts-noto-color-emoji
-          # Pin the generics back to the recorded defaults so Noto stays
-          # fallback-only. Strong prepend beats 60-latin's Noto preference.
-          {
-            echo '<?xml version="1.0"?>'
-            echo '<!DOCTYPE fontconfig SYSTEM "fonts.dtd">'
-            echo '<fontconfig>'
-            for pair in "sans-serif:$prev_sans" "serif:$prev_serif" "monospace:$prev_mono"; do
-              generic="${pair%%:*}"; family="${pair#*:}"
-              [ -n "$family" ] || continue
-              printf '  <match target="pattern"><test qual="any" name="family"><string>%s</string></test><edit name="family" mode="prepend" binding="strong"><string>%s</string></edit></match>\n' "$generic" "$family"
-            done
-            echo '</fontconfig>'
-          } | sudo tee /etc/fonts/conf.d/99-preserve-generic-latin-default.conf >/dev/null
-          fc-cache -f >/dev/null
-          echo "generic sans-serif → $(fc-match -f '%{family}\n' sans-serif) (was: ${prev_sans})"
-          echo "generic serif      → $(fc-match -f '%{family}\n' serif) (was: ${prev_serif})"
-          echo "generic monospace  → $(fc-match -f '%{family}\n' monospace) (was: ${prev_mono})"
+          scripts/install-linux-font-fallbacks.sh \
+            xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1
 
       # The export engine lives in the (private) design-parity repo, but its
       # building blocks are published to npm. The driver

--- a/deploy/cloudrun/Dockerfile
+++ b/deploy/cloudrun/Dockerfile
@@ -30,11 +30,9 @@
 # (no GPU on the host). This mirrors what the repo's own CI installs for headless
 # desktop renders (.github/workflows/ci.yml).
 FROM eclipse-temurin:17.0.19_10-jdk AS base
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-      libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core \
-      libgl1 libglx-mesa0 libgl1-mesa-dri \
- && rm -rf /var/lib/apt/lists/*
+COPY scripts/install-linux-font-fallbacks.sh /usr/local/bin/install-linux-font-fallbacks
+RUN COMPOSEAI_CLEAN_APT=1 /usr/local/bin/install-linux-font-fallbacks \
+      libfreetype6 libfontconfig1 libgl1 libglx-mesa0 libgl1-mesa-dri
 ENV LIBGL_ALWAYS_SOFTWARE=1 \
     GRADLE_USER_HOME=/root/.gradle \
     SERVE_MODULE=:samples:cmp

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -29,13 +29,10 @@ ARG CP_VERSION=0.19.59
 # and binds it correctly. See deploy/image/README.md § "Containment".
 # ---------------------------------------------------------------------------
 FROM eclipse-temurin:21.0.11_10-jdk AS base
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-      libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core \
-      libgl1 libglx-mesa0 libgl1-mesa-dri \
-      curl ca-certificates git \
-      bubblewrap \
- && rm -rf /var/lib/apt/lists/*
+COPY scripts/install-linux-font-fallbacks.sh /usr/local/bin/install-linux-font-fallbacks
+RUN COMPOSEAI_CLEAN_APT=1 /usr/local/bin/install-linux-font-fallbacks \
+      libfreetype6 libfontconfig1 libgl1 libglx-mesa0 libgl1-mesa-dri \
+      curl ca-certificates git bubblewrap
 ENV LIBGL_ALWAYS_SOFTWARE=1 \
     GRADLE_USER_HOME=/root/.gradle
 

--- a/scripts/install-linux-font-fallbacks.sh
+++ b/scripts/install-linux-font-fallbacks.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Install the Linux dependencies passed as arguments plus a deterministic Noto fallback set for
+# Skiko text rendering. Preserve the generic families that were selected before Noto was installed:
+# apps keep their declared typography, while missing Arabic, Indic, Thai, CJK and emoji glyphs fall
+# through to Noto instead of tofu.
+
+set -euo pipefail
+
+if [[ "${EUID}" -eq 0 ]]; then
+  root=()
+else
+  root=(sudo)
+fi
+
+generic_family() {
+  local generic="$1"
+  local fallback="$2"
+  local family=""
+
+  if command -v fc-match >/dev/null 2>&1; then
+    family="$(fc-match -f '%{family}\n' "${generic}" 2>/dev/null | head -n1 | cut -d, -f1)"
+  fi
+  printf '%s' "${family:-${fallback}}"
+}
+
+xml_escape() {
+  sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g"
+}
+
+prev_sans="$(generic_family sans-serif 'DejaVu Sans')"
+prev_serif="$(generic_family serif 'DejaVu Serif')"
+prev_mono="$(generic_family monospace 'DejaVu Sans Mono')"
+
+"${root[@]}" apt-get update -qq
+"${root[@]}" apt-get install -y -qq --no-install-recommends \
+  fontconfig fonts-dejavu-core fonts-noto-cjk fonts-noto-core fonts-noto-color-emoji "$@"
+
+conf_dir="${FONTCONFIG_CONF_DIR:-/etc/fonts/conf.d}"
+conf_file="${conf_dir}/99-composeai-preserve-generic-fonts.conf"
+tmp_file="$(mktemp)"
+trap 'rm -f "${tmp_file}"' EXIT
+
+{
+  echo '<?xml version="1.0"?>'
+  echo '<!DOCTYPE fontconfig SYSTEM "fonts.dtd">'
+  echo '<fontconfig>'
+  for pair in "sans-serif:${prev_sans}" "serif:${prev_serif}" "monospace:${prev_mono}"; do
+    generic="${pair%%:*}"
+    family="${pair#*:}"
+    escaped_family="$(printf '%s' "${family}" | xml_escape)"
+    printf '  <match target="pattern"><test qual="any" name="family"><string>%s</string></test><edit name="family" mode="prepend" binding="strong"><string>%s</string></edit></match>\n' \
+      "${generic}" "${escaped_family}"
+  done
+  echo '</fontconfig>'
+} >"${tmp_file}"
+
+"${root[@]}" mkdir -p "${conf_dir}"
+"${root[@]}" install -m 0644 "${tmp_file}" "${conf_file}"
+fc-cache -f >/dev/null
+
+echo "generic sans-serif -> $(fc-match -f '%{family}\n' sans-serif) (was: ${prev_sans})"
+echo "generic serif      -> $(fc-match -f '%{family}\n' serif) (was: ${prev_serif})"
+echo "generic monospace  -> $(fc-match -f '%{family}\n' monospace) (was: ${prev_mono})"
+
+if [[ "${COMPOSEAI_CLEAN_APT:-0}" == "1" ]]; then
+  "${root[@]}" rm -rf /var/lib/apt/lists/*
+fi

--- a/scripts/test-install-linux-font-fallbacks.sh
+++ b/scripts/test-install-linux-font-fallbacks.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+fixture="$(mktemp -d)"
+trap 'rm -rf "${fixture}"' EXIT
+
+mkdir -p "${fixture}/bin" "${fixture}/fontconfig"
+
+cat >"${fixture}/bin/fc-match" <<'EOF'
+#!/usr/bin/env bash
+case "${*: -1}" in
+  sans-serif) printf 'Existing & Sans,Alias\n' ;;
+  serif) printf 'Existing Serif\n' ;;
+  monospace) printf 'Existing Mono\n' ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat >"${fixture}/bin/fc-cache" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CALL_LOG}"
+EOF
+
+cat >"${fixture}/bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+printf 'apt-get %s\n' "$*" >>"${CALL_LOG}"
+EOF
+
+cat >"${fixture}/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+
+chmod +x "${fixture}/bin/"*
+
+CALL_LOG="${fixture}/calls" \
+  FONTCONFIG_CONF_DIR="${fixture}/fontconfig" \
+  PATH="${fixture}/bin:${PATH}" \
+  bash "${repo_root}/scripts/install-linux-font-fallbacks.sh" libgl1 libfreetype6 >/dev/null
+
+conf="${fixture}/fontconfig/99-composeai-preserve-generic-fonts.conf"
+test -f "${conf}"
+grep -Fq '<string>Existing &amp; Sans</string>' "${conf}"
+grep -Fq '<string>Existing Serif</string>' "${conf}"
+grep -Fq '<string>Existing Mono</string>' "${conf}"
+grep -Fq 'fonts-noto-cjk fonts-noto-core fonts-noto-color-emoji libgl1 libfreetype6' \
+  "${fixture}/calls"
+grep -Fq -- '-f' "${fixture}/calls"
+
+echo 'install-linux-font-fallbacks: tests passed'

--- a/site/reference/fonts.md
+++ b/site/reference/fonts.md
@@ -35,6 +35,18 @@ the resolved fallback chain Compose actually picked.
 - It does not measure font file size, CFF subsetting, or runtime download cost — that is a build-tools / Play asset delivery question.
 - It does not validate whether a glyph is *visually* correct (Han ideograph variants, complex script shaping) — that requires designer review against the rendered PNG.
 
+## Hosted Linux fallback coverage
+
+The GitHub preview actions, reusable design-catalog workflow, and official preview-server images
+install Noto's core, CJK, and color-emoji families as system fallbacks. Skiko therefore fills glyphs
+that an app's selected family does not contain—Arabic, Indic, Thai, CJK, and emoji—without requiring
+the app to rewrite its `MaterialTheme` for previews. The installer preserves the host's existing
+generic sans, serif, and monospace choices, and an app's explicitly bundled family still wins.
+
+Direct local CLI renders continue to use the operating system's installed fallback fonts, just as
+the application does at runtime. Install equivalent Noto packages on a minimal Linux workstation if
+it does not already provide those scripts.
+
 ## Use cases
 
 - Catch accidental fallback to `sans-serif` after a `FontFamily.Resolver` refactor.


### PR DESCRIPTION
## What
- centralize Linux Noto fallback provisioning in one tested installer
- use it from the preview-diff action, both reusable design-artifact render paths, and the compose-ai-tools catalog workflow
- bake the same fallback set into the public preview-host and Cloud Run images
- document hosted versus local font fallback behavior

## Why
Compose Desktop/Skiko correctly asks the system font manager for glyphs missing from an app-selected family. Minimal CI runners and the live preview images only installed DejaVu, however, so locale overrides such as Arabic, Devanagari, Thai, Japanese, Korean, and Chinese could render tofu. Downstream catalogs then had to vendor fonts and rewrite their Material typography even though real applications normally rely on platform fallback.

## Behavior
The installer adds Noto Core, CJK, and color emoji while pinning sans-serif, serif, and monospace to whatever each host selected before installation. Explicit app fonts therefore remain authoritative; Noto is used only for missing glyphs.

## Verification
- `scripts/test-install-linux-font-fallbacks.sh`
- Bash syntax checks for the installer and test
- Ruby YAML parsing for the changed action/workflows
- `scripts/design-artifacts/test-scope-systems.sh`
- `scripts/design-artifacts/test-scope-step.sh`
- `git diff --check`