### PR TITLE
fix: stage font installer for preview host image

### DIFF
--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -107,6 +107,8 @@ jobs:
           touch deploy/image/m2/.keep
           mkdir -p deploy/image/release-assets
           touch deploy/image/release-assets/.keep
+          mkdir -p deploy/image/scripts
+          cp scripts/install-linux-font-fallbacks.sh deploy/image/scripts/
 
       - uses: ./.github/actions/setup
         if: ${{ inputs.build_from_source }}


### PR DESCRIPTION
## Summary

- stage the shared Linux font-fallback installer inside the `deploy/image` Docker build context
- keep the existing narrow image context and Dockerfile paths unchanged

## Root cause

The `0.19.60` release's non-blocking `preview-host-image / publish` job failed because `deploy/image/Dockerfile` copies `scripts/install-linux-font-fallbacks.sh`, while BuildKit only receives `deploy/image` as its context. The repository-level script was therefore unavailable and cache-key calculation failed before the image build began.

## Impact

The next release can build and publish the preview-host image normally. This is suitable for the planned `0.19.61` release.

## Validation

- `scripts/test-install-linux-font-fallbacks.sh`
- workflow YAML parsed with Ruby Psych
- `git diff --check`

A Dockerfile `--check` run was unavailable because the installed Docker CLI does not support that flag.