### PR TITLE
fix(figma-svg): preserve delegated draws and axis mirrors

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1286,6 +1286,10 @@ internal object ComposeLayoutInspector {
           density = density,
         ),
       drawRaster = drawRaster,
+      // Capability from the live modifier-node chain, not the serialized element name. A custom
+      // NodeElement may delegate its entire draw to a CacheDrawModifierNode while exposing no
+      // `onDraw` lambda for the vector/raster replay tiers (Material 3 wavy progress indicators).
+      drawsContent = drawsContent,
       modifiesDrawnContent =
         DrawContentEffectProbe.modifiesContent(modifiers, captureW, captureH, density),
       transform = coordinates.scaleIn(rootCoords),
@@ -1295,7 +1299,10 @@ internal object ComposeLayoutInspector {
 
   /**
    * The node's draw-time scale relative to the root — the product of every `graphicsLayer` scale
-   * between it and the root — or null for the identity (the overwhelmingly common case).
+   * between it and the root — or null for the identity (the overwhelmingly common case). The sign
+   * is retained for an axis-aligned mirror such as Material 3's vertical slider track (`scaleY =
+   * -1`); the previous distance-only measurement erased it and exported the active track at the
+   * opposite end.
    *
    * Measured, not reflected: two of the node's own corner offsets are mapped into root space and
    * compared against their un-transformed span. That reads the *composed* transform through the
@@ -1317,9 +1324,26 @@ internal object ComposeLayoutInspector {
         val origin = rootCoordinates.localPositionOf(this, Offset.Zero)
         val right = rootCoordinates.localPositionOf(this, Offset(w.toFloat(), 0f))
         val down = rootCoordinates.localPositionOf(this, Offset(0f, h.toFloat()))
+        val xAxis = right - origin
+        val yAxis = down - origin
+
+        fun signedAxisScale(delta: Offset, localExtent: Int, horizontal: Boolean): Float {
+          val magnitude = delta.getDistance() / localExtent
+          // A rotated axis cannot be represented by LayoutInspectorTransform's scale-only model;
+          // preserve its old positive magnitude. For an axis-aligned vector, however, the dominant
+          // component's sign is the mirror information SVG placement needs.
+          val along = if (horizontal) delta.x else delta.y
+          val across = if (horizontal) delta.y else delta.x
+          return if (kotlin.math.abs(along) >= kotlin.math.abs(across) && along < 0f) {
+            -magnitude
+          } else {
+            magnitude
+          }
+        }
+
         LayoutInspectorTransform(
-          scaleX = (right - origin).getDistance() / w,
-          scaleY = (down - origin).getDistance() / h,
+          scaleX = signedAxisScale(xAxis, w, horizontal = true),
+          scaleY = signedAxisScale(yAxis, h, horizontal = false),
         )
       } catch (_: Throwable) {
         return null
@@ -2183,6 +2207,9 @@ internal object ComposeLayoutInspector {
     val modifierInfo: List<ModifierInfo>
       get() = LayoutTreeAccess.modifierInfo(raw)
 
+    val drawsContent: Boolean
+      get() = LayoutTreeAccess.hasDrawModifierNode(raw)
+
     val children: List<LayoutNodeFacade>
       get() = LayoutTreeAccess.children(raw).map(::LayoutNodeFacade)
   }
@@ -2209,6 +2236,64 @@ internal object ComposeLayoutInspector {
     fun modifierInfo(node: Any): List<ModifierInfo> =
       (call(node, "getModifierInfo") as? Iterable<*>)?.filterIsInstance<ModifierInfo>()
         ?: emptyList()
+
+    /**
+     * Whether this layout node's live modifier-node chain draws content.
+     *
+     * Looking only at [ModifierInfo.modifier] misses modern custom `Modifier.NodeElement`s whose
+     * element is merely configuration while their node delegates to a `CacheDrawModifierNode`.
+     * Material 3's wavy progress indicators take exactly that path: the element exposes no
+     * replayable `onDraw`, but its immediate delegate implements `DrawModifierNode`. Walk both the
+     * ordinary node chain and each delegating node's delegate ring, using reflection so the capture
+     * remains compatible with Compose versions whose internal accessor suffix is `$ui` or
+     * `$ui_release`.
+     */
+    fun hasDrawModifierNode(node: Any): Boolean {
+      val nodes =
+        sequenceOf("getNodes\$ui_release", "getNodes\$ui", "getNodes")
+          .mapNotNull { call(node, it) }
+          .firstOrNull() ?: return false
+      val head =
+        sequenceOf("getHead\$ui_release", "getHead\$ui", "getHead")
+          .mapNotNull { call(nodes, it) }
+          .firstOrNull() ?: return false
+      val drawType =
+        runCatching {
+            Class.forName(
+              "androidx.compose.ui.node.DrawModifierNode",
+              false,
+              node.javaClass.classLoader,
+            )
+          }
+          .getOrNull() ?: return false
+      val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<Any, Boolean>())
+
+      fun visitsDraw(candidate: Any?): Boolean {
+        if (candidate == null || !seen.add(candidate)) return false
+        if (drawType.isInstance(candidate)) return true
+        val delegate =
+          sequenceOf("getDelegate\$ui_release", "getDelegate\$ui", "getDelegate")
+            .mapNotNull { call(candidate, it) }
+            .firstOrNull()
+        return visitsDraw(delegate)
+      }
+
+      var current: Any? = head
+      while (current != null && seen.add(current)) {
+        val chainNode = current
+        if (drawType.isInstance(chainNode)) return true
+        val delegate =
+          sequenceOf("getDelegate\$ui_release", "getDelegate\$ui", "getDelegate")
+            .mapNotNull { call(chainNode, it) }
+            .firstOrNull()
+        if (visitsDraw(delegate)) return true
+        current =
+          sequenceOf("getChild\$ui_release", "getChild\$ui", "getChild")
+            .mapNotNull { call(chainNode, it) }
+            .firstOrNull()
+      }
+      return false
+    }
 
     fun children(node: Any): List<Any> =
       // The child accessors carry an internal-visibility suffix that differs by build: Android

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -131,7 +131,12 @@ object LayoutInspectorProduct {
   // an app's artwork — the geometry can't — and it is what lets the figma-svg export annotate an
   // icon with its canonical fonts.google.com identity ([MaterialIconRef]). Additive — older entries
   // decode with `vectorName = null`, which exports exactly as before.
-  const val SCHEMA_VERSION: Int = 15
+  // v16: each node reports `drawsContent` when its live modifier-node chain contains a
+  // `DrawModifierNode`. This covers modern delegated `CacheDrawModifierNode` implementations whose
+  // element exposes no replayable `onDraw` lambda (Material 3's wavy progress indicators). The
+  // hybrid figma-svg export uses the signal to crop an otherwise-unrepresentable leaf from the
+  // rendered frame. Additive — older entries decode it as false.
+  const val SCHEMA_VERSION: Int = 16
   const val FILE: String = "layout-inspector.json"
 }
 
@@ -715,6 +720,14 @@ data class LayoutInspectorNode(
    * decodes with `drawRaster = null`. See [LayoutInspectorDrawRaster].
    */
   val drawRaster: LayoutInspectorDrawRaster? = null,
+  /**
+   * True when the live modifier-node chain contains a `DrawModifierNode`, including a draw node
+   * delegated by a custom `Modifier.NodeElement`. Unlike inspecting serialized modifier names, this
+   * detects modern components whose drawing implementation is hidden behind a
+   * `CacheDrawModifierNode`; the hybrid SVG exporter can then preserve an unvectorisable leaf by
+   * cropping its rendered frame region. Additive (v16): older captures decode as false.
+   */
+  val drawsContent: Boolean = false,
   /**
    * True when this node's `drawWithContent` obscures pixels produced by `drawContent()` through a
    * clip, mask, alpha fade, clear blend, or omission. Such an effect is not represented by the

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -772,6 +772,14 @@ object FigmaLayeredSvg {
     val fittedHeight = vec.viewportHeight.toDouble() * scaleY
     val x = layer.left + (layer.width - fittedWidth) / 2.0
     val y = layer.top + (layer.height - fittedHeight) / 2.0
+    // A negative Compose graphics-layer scale mirrors around the layer's centre. SVG's negative
+    // scale mirrors around the origin, so move the origin to the far edge on each flipped axis
+    // before applying it. Keeping fitted sizes positive also leaves all centring/aspect-fit logic
+    // above unchanged for the overwhelmingly common non-mirrored case.
+    val translateX = if (vec.flipX) x + fittedWidth else x
+    val translateY = if (vec.flipY) y + fittedHeight else y
+    val emittedScaleX = if (vec.flipX) -scaleX else scaleX
+    val emittedScaleY = if (vec.flipY) -scaleY else scaleY
     val sb = StringBuilder()
     // A stock Material icon names itself on its own layer: the canonical fonts.google.com icon
     // name, its style, and the CDN URL of that exact drawing. The geometry below is still the one
@@ -795,7 +803,7 @@ object FigmaLayeredSvg {
       .append('\n')
     sb
       .append(
-        """$indent  <g transform="translate(${fmt(x)} ${fmt(y)}) scale(${fmt(scaleX)} ${fmt(scaleY)})"${opacityAttr(layer.contentOpacity)}>"""
+        """$indent  <g transform="translate(${fmt(translateX)} ${fmt(translateY)}) scale(${fmt(emittedScaleX)} ${fmt(emittedScaleY)})"${opacityAttr(layer.contentOpacity)}>"""
       )
       .append('\n')
     if (iconId != null) {

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -160,6 +160,9 @@ data class FigmaSvgVector(
    */
   val scaleX: Double = 1.0,
   val scaleY: Double = 1.0,
+  /** The captured graphics-layer mirrors this vector around the corresponding placed axis. */
+  val flipX: Boolean = false,
+  val flipY: Boolean = false,
   /**
    * True when the paths were recorded from the node's own draw lambda rather than an `ImageVector`
    * — which also decides what coordinate space [viewportWidth]/[viewportHeight] are in, and so how
@@ -937,6 +940,8 @@ data class FigmaSvgModel(
       fillBounds: Boolean,
       scaleX: Double = 1.0,
       scaleY: Double = 1.0,
+      flipX: Boolean = false,
+      flipY: Boolean = false,
     ): FigmaSvgVector? {
       if (viewportWidth <= 0f || viewportHeight <= 0f) return null
       val emittable =
@@ -965,6 +970,8 @@ data class FigmaSvgModel(
           fillBounds = fillBounds,
           scaleX = scaleX,
           scaleY = scaleY,
+          flipX = flipX,
+          flipY = flipY,
           fromDrawCapture = fromDrawCapture,
           // A draw capture is imperative chrome (a slider groove, a progress arc), never an
           // `ImageVector` — so it can't be a Material icon whatever its name says.
@@ -1014,8 +1021,12 @@ data class FigmaSvgModel(
       // — the render draws those measured values at `× scale`, so each is scaled into drawn space
       // before it is used (issue #2615). Identity (`1.0`) for the overwhelming majority of nodes,
       // where every expression below is unchanged.
-      val scaleX = transform?.scaleX?.toDouble() ?: 1.0
-      val scaleY = transform?.scaleY?.toDouble() ?: 1.0
+      // Geometry magnitudes shrink/grow with the layer; a negative captured axis additionally
+      // mirrors vector content but must never turn lengths (corner radii, text sizes) negative.
+      val signedScaleX = transform?.scaleX?.toDouble() ?: 1.0
+      val signedScaleY = transform?.scaleY?.toDouble() ?: 1.0
+      val scaleX = abs(signedScaleX)
+      val scaleY = abs(signedScaleY)
       // A corner radius is a single length against a box scaled on both axes; with the uniform
       // scale Wear's edge transform applies, the mean is exactly that scale.
       val scaleMean = (scaleX + scaleY) / 2.0
@@ -1106,8 +1117,10 @@ data class FigmaSvgModel(
           layoutWidth = painted?.let { it.right - it.left } ?: size.width,
           layoutHeight = painted?.let { it.bottom - it.top } ?: size.height,
           fillBounds = hasFillBoundsContentScale(),
-          scaleX = transform?.scaleX?.toDouble() ?: 1.0,
-          scaleY = transform?.scaleY?.toDouble() ?: 1.0,
+          scaleX = scaleX,
+          scaleY = scaleY,
+          flipX = signedScaleX < 0.0,
+          flipY = signedScaleY < 0.0,
         )
         ?.let { vec ->
           val box = painted ?: bounds
@@ -2090,7 +2103,8 @@ data class FigmaSvgModel(
      * `Modifier.drawBehind {…}.placeholder(state)` chain still paints its own imperative art into
      * the frame, and that art is not something the vector export can otherwise represent.
      */
-    private fun LayoutInspectorNode.hasCustomDraw(): Boolean = modifiers.any { it.isCustomDraw() }
+    private fun LayoutInspectorNode.hasCustomDraw(): Boolean =
+      drawsContent || modifiers.any { it.isCustomDraw() }
 
     private fun LayoutInspectorModifier.isCustomDraw(): Boolean =
       name in DRAW_MODIFIERS && !placeholder

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -370,6 +370,41 @@ class FigmaLayeredSvgTest {
     assertTrue(svg, svg.contains("""transform="translate(10 20) scale(2 1)""""))
   }
 
+  @Test
+  fun drawCapturedVectorRetainsAnAxisMirror() {
+    // Material 3 implements a bottom-to-top VerticalSlider track by drawing in its normal local
+    // coordinates through `scale(1f, -1f)`. Bounds retain the same axis-aligned box, so only the
+    // signed captured transform distinguishes the intended mirror from an ordinary track.
+    val node =
+      LayoutInspectorNode(
+        nodeId = "vertical-track",
+        component = "Spacer",
+        bounds = bounds(10, 20, 52, 938),
+        size = LayoutInspectorSize(42, 918),
+        transform = LayoutInspectorTransform(scaleX = 1f, scaleY = -1f),
+        vectorGraphic =
+          LayoutInspectorVectorGraphic(
+            viewportWidth = 42f,
+            viewportHeight = 918f,
+            fromDrawCapture = true,
+            paths =
+              listOf(
+                LayoutInspectorVectorPath(
+                  pathData = "M0,0 L42,0 L42,918 L0,918 Z",
+                  fillArgb = "#FF6750A4",
+                )
+              ),
+          ),
+      )
+
+    val svg = render(node)
+
+    assertTrue(
+      "the origin moves to the bottom edge before the negative Y scale\n$svg",
+      svg.contains("""transform="translate(10 938) scale(1 -1)""""),
+    )
+  }
+
   /**
    * Issue #2853: Jetsnack's `Profile/Animating FAB content` draws a square icon into a box the
    * animation has shrunk — the icon is *clipped*, never distorted. Inferring a scale from the ratio

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModelCanvasDrawTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModelCanvasDrawTest.kt
@@ -59,6 +59,31 @@ class FigmaSvgModelCanvasDrawTest {
   }
 
   @Test
+  fun delegatedDrawNodeWithoutAnInspectableDrawLambdaStillUsesAFrameCrop() {
+    // A custom Modifier.NodeElement can delegate to CacheDrawModifierNode without exposing an
+    // inspectable `drawWithCache` element. The live node-chain capability is then the only evidence
+    // that this otherwise-empty Spacer paints (Material 3's wavy progress indicators).
+    val node =
+      LayoutInspectorNode(
+        nodeId = "delegated-draw",
+        component = "Spacer",
+        bounds = bounds(3, 5, 103, 45),
+        size = LayoutInspectorSize(100, 40),
+        drawsContent = true,
+      )
+
+    val m = model(node, captureCanvasDraws = true)
+
+    assertEquals("one full-node raster target", 1, m.rasterTargets.size)
+    val target = m.rasterTargets.single()
+    assertEquals(3, target.left)
+    assertEquals(5, target.top)
+    assertEquals(103, target.right)
+    assertEquals(45, target.bottom)
+    assertNotNull("the delegated draw survives as a background image", m.root.background)
+  }
+
+  @Test
   fun aBackgroundOnlyLeafStillCountsAsPaintingSoItContributesExtent() {
     // A draw-only Spacer paints nothing but its background raster; `paints` must see the background
     // or the layer contributes no extent and the export falls back to the 32×32 padding canvas.

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgDrawRasterRenderTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgDrawRasterRenderTest.kt
@@ -13,12 +13,18 @@ import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.runtime.tooling.LocalInspectionTables
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.CacheDrawModifierNode
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
@@ -175,6 +181,41 @@ class FigmaSvgDrawRasterRenderTest {
   }
 
   @Test
+  fun `a delegated cache draw node survives as a frame raster`() {
+    // Material 3's wavy indicators are custom NodeElements that delegate their drawing to a
+    // CacheDrawModifierNode. This fixture deliberately exposes no inspectable onDraw lambda, so
+    // only the live node-chain capability can prevent the otherwise-empty Box from disappearing.
+    val svg =
+      exportSvg("delegated-cache-draw", withFrame = true) {
+        Box(Modifier.size(width = 120.dp, height = 12.dp).delegatedCacheDraw())
+      }
+
+    assertTrue("the delegated draw must not export as an empty layer:\n$svg", svg.contains("<image "))
+    assertTrue(
+      "raster sidecar is written",
+      File(rootDir, "delegated-cache-draw/figma-raster").listFiles().orEmpty().isNotEmpty(),
+    )
+  }
+
+  @Test
+  fun `an axis-mirrored draw node keeps its negative scale`() {
+    // Material 3's reverse-direction VerticalSlider applies the same `scaleY = -1f` to its track.
+    val svg =
+      exportSvg("mirrored-draw", withFrame = true) {
+        Box(
+          Modifier.size(width = 44.dp, height = 120.dp)
+            .graphicsLayer(scaleY = -1f)
+            .drawBehind { drawRect(Color(0xFF6750A4)) }
+        )
+      }
+
+    assertTrue(
+      "the track vector must retain Material's vertical mirror:\n$svg",
+      Regex("""scale\([^)]* -1(?:\.0+)?\)""").containsMatchIn(svg),
+    )
+  }
+
+  @Test
   fun `a generic content clip is detected from behavior and uses a frame crop`() {
     val svg =
       exportSvg("content-clip", withFrame = true) {
@@ -252,4 +293,27 @@ private fun InspectableContent(
   currentComposer.collectParameterInformation()
   capture.add(currentComposer.compositionData)
   CompositionLocalProvider(LocalInspectionTables provides capture, content = content)
+}
+
+private fun Modifier.delegatedCacheDraw(): Modifier = this then DelegatedCacheDrawElement
+
+/** A custom node element with no draw lambda of its own, matching Material 3's wavy indicators. */
+private data object DelegatedCacheDrawElement : ModifierNodeElement<DelegatedCacheDrawNode>() {
+  override fun create(): DelegatedCacheDrawNode = DelegatedCacheDrawNode()
+
+  override fun update(node: DelegatedCacheDrawNode) = Unit
+
+  override fun InspectorInfo.inspectableProperties() {
+    name = "delegatedCacheDraw"
+  }
+}
+
+private class DelegatedCacheDrawNode : DelegatingNode() {
+  @Suppress("unused")
+  private val drawDelegate =
+    delegate(
+      CacheDrawModifierNode {
+        onDrawBehind { drawRect(Color(0xFF6750A4)) }
+      }
+    )
 }


### PR DESCRIPTION
## What

- detect live `DrawModifierNode` implementations, including delegated `CacheDrawModifierNode` instances, and preserve otherwise-unrepresentable content as frame raster crops
- retain the sign of axis-aligned Compose transforms and emit mirrored SVG vector groups correctly
- bump the layout-inspector capture schema to v16 for the additive `drawsContent` capability
- add model, SVG serialization, and Android render regressions for both cases

## Why

Material 3 wavy progress indicators implement drawing through custom modifier nodes that delegate to `CacheDrawModifierNode`. The exporter only inspected replayable modifier elements, so these components became empty SVG layers.

Material 3's reverse-direction vertical slider mirrors its track with `scaleY = -1f`. Transform capture measured vector distance, which discarded the sign and placed the active track at the opposite end in SVG.

This fixes the reported previews:

- `progress-linearwavy__ideal__default__light__compact`
- `progress-circularwavy__ideal__default__light`
- `slider-vertical__ideal__default__light`

## Verification

- `:data-layoutinspector-core:ktfmtCheck`
- `:data-layoutinspector-connector:ktfmtCheck`
- `:renderer-android:ktfmtCheck`
- `:data-layoutinspector-core:test`
- `:data-layoutinspector-connector:test`
- `:renderer-android:testDebugUnitTest --tests ee.schimke.composeai.renderer.FigmaSvgDrawRasterRenderTest`
