### PR TITLE
docs(parity): correct the parity plan after review

### DIFF
--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -238,9 +238,12 @@ Each acceptance record carries: a stable `id`; a **mandatory** `issue` URL; the 
 (`system` / `component` / `previewId` / `referenceId` / `variant`); an optional `element` selector
 (see the annotation-contract prerequisite in §5, when the region came from an annotated element
 rather than a drag); `mask` and `acceptedCandidate` paths; **three** hashes — `referenceSha256`,
-`acceptedCandidateSha256` **and `maskSha256`**; an optional structured `finding` matcher (e.g.
-`{ kind: "color", token: "onSecondaryContainer", expected: …, actual: … }`) for the checks
-design-parity runs that are not pixel comparisons; and free-text `note` + `acceptedAt`.
+`acceptedCandidateSha256` **and `maskSha256`**; the **canonical plane the mask was authored
+against** — a `plane: "content-box" | "full-canvas"` discriminant plus the resolved
+`{x, y, width, height}` box, without which the plane gate (step 2 below) cannot be evaluated at
+all; an optional structured `finding` matcher (e.g. `{ kind: "color", token: …, expected: …,
+actual: … }`) for the checks design-parity runs that are not pixel comparisons; and free-text
+`note` + `acceptedAt`.
 
 **The mask must be hashed, not just referenced by path.** The mask is the thing that decides *what
 gets suppressed*, so an edited or swapped `mask.png` with an unchanged JSON record silently widens
@@ -300,8 +303,15 @@ plane:
 | Source | Native space | Transform into the canonical plane |
 | --- | --- | --- |
 | Reference annotation `bounds` | the **full reference raster** (`DesignAnnotation` KDoc: "the annotated image's own pixel space") | subtract `(referenceBox.x, referenceBox.y)`; scale 1; clip |
-| Drag rectangle on the reference panel | CSS/display pixels of the `<img>` | scale by `rasterWidth / displayWidth`, then subtract the box origin; clip |
-| Render-side annotation `bounds` | **render** pixel space | map through the candidate content box → the shared box, i.e. subtract `(candidateBox.x, candidateBox.y)` then scale by `referenceBox.width / candidateBox.width`; clip |
+| Drag rectangle on the reference panel | CSS/display pixels of the `<img>` | scale by `rasterWidth / displayWidth` and `rasterHeight / displayHeight`, then subtract the box origin; clip |
+| Render-side annotation `bounds` | **render** pixel space | subtract `(candidateBox.x, candidateBox.y)`, then scale **x and y independently** — `referenceBox.width / candidateBox.width` for x, `referenceBox.height / candidateBox.height` for y; clip |
+
+**The two axes scale independently, and that is not a rounding detail.** `boxCanvas` stretches each
+source box onto the target width and height separately, and the comparison explicitly *supports*
+the two content boxes having different aspect ratios — `aspectDelta` reports the proportion
+difference as a finding rather than normalising it away. So a reference and a render that disagree
+about proportion (exactly the case an acceptance is most likely to be sitting on) would put a
+single-ratio mask at the right x and the wrong y.
 
 A selection that clips to empty is refused at authoring time rather than stored as a zero-area mask.
 
@@ -323,23 +333,48 @@ referenceId, variant)`:
    the acceptance is `invalidated: reference-changed`. It contributes no suppression, and the page
    says so. An acceptance targeting a reference that publishes no `sha256` is refused at validation
    time.
-2. **Score everything outside the union of masks normally.** This is the ordinary path and is
-   untouched by acceptance; a regression anywhere else scores exactly as it does today.
-3. **Inside each mask, compare the current candidate against `accepted-candidate.png`** — not
+2. **Plane gate.** Recompute the plane for this pair. If its `plane` discriminant or resolved box
+   disagrees with the acceptance's recorded one — a candidate that has crossed `MIN_BOX_COVERAGE`
+   since the acceptance was authored — it is `invalidated: plane-changed`. Comparing across two
+   different coordinate planes is meaningless, so this has to precede any pixel work.
+3. **Score everything outside the union of masks normally** — where "outside" means excluded in
+   **both** roles, see below. This is the ordinary path; a regression anywhere else scores exactly
+   as it does today.
+4. **Inside each mask, compare the current candidate against `accepted-candidate.png`** — not
    against the reference. Match within tolerance ⇒ that mask's pixels are suppressed from the
    *effective* diff. Mismatch ⇒ `invalidated: candidate-changed`, nothing is suppressed, and the
    region is reported as a new difference.
-4. **Element check.** When the acceptance names an `element`, resolve it against the current
+5. **Element check.** When the acceptance names an `element`, resolve it against the current
    annotation layer. Missing, or moved beyond a bounds tolerance ⇒ `invalidated: element-moved`.
    This is what catches "the glyph disappeared" as distinct from "the glyph is still the wrong
    colour", which a rectangular ignore region fundamentally cannot.
-5. **Report raw, accepted and unaccepted separately.** The raw finding is never destroyed. The
+6. **Report raw, accepted and unaccepted separately.** The raw finding is never destroyed. The
    comparison shows all three numbers and the delta map gains an "accepted" tint distinct from the
    magenta of unaccepted difference, so an acceptance is *visible* rather than a hole in the data.
 
+#### Masked pixels must be excluded in both roles, in both directions
+
+Step 3 says "outside the union of masks", and the obvious reading — skip masked pixels when
+iterating — is **not sufficient**, because of how `scorePlanes` actually works. Each directed pass
+takes a source pixel and searches a ±`EDGE_SEARCH_RADIUS` (5 px) neighbourhood of the *target* plane
+for its best match. So an unmasked pixel just outside a mask can find its best match at a target
+pixel *inside* the mask — and since the inside pixels are accepted-but-different by construction,
+that match can erase a real mismatch. A regression within 5 score-plane pixels of an accepted region
+would score as clean.
+
+The rule therefore has to be: **a masked coordinate is excluded both as a scored source and as a
+candidate neighbour, in both directed passes.** A source pixel whose entire neighbourhood is masked
+contributes nothing rather than falling back to a best-of-nothing default.
+
+This is precisely the kind of thing two implementations can agree on for ordinary inputs and diverge
+on at the boundary, so the conformance fixtures in the next section must include **a regression
+placed within `EDGE_SEARCH_RADIUS` of a mask edge** as a named case. Without it, both engines can
+pass the suite and still let an accepted region hide its neighbour.
+
 This is deliberately more expensive than a threshold or an ignore rectangle, and that expense is the
-point: the epic's non-goals rule out anything that can hide an unrelated regression, and steps 3 and
-4 are what make an accepted colour delta unable to mask a missing glyph.
+point: the epic's non-goals rule out anything that can hide an unrelated regression, and steps 4 and
+5 — plus the neighbourhood exclusion above — are what make an accepted colour delta unable to mask a
+missing glyph or the regression sitting next to it.
 
 ### Two engines, one semantics
 
@@ -387,7 +422,7 @@ type at all, and the projection throws the tag away: `themeAnnotation` collapses
 `node.role ?: node.testTag ?: node.textSnippet()` into a single `role` string, and
 `typographyAnnotation` sets `role` from `textSnippet()` alone, dropping the tag entirely. So an
 `element` selector keyed on "role / testTag" is not a selector — a node carrying a common role
-(`Button`) and a unique `testTag` loses the only part that identified it, and the gate-4 element
+(`Button`) and a unique `testTag` loses the only part that identified it, and the element
 check would either resolve the wrong one of several repeated roles or fail to resolve at all. Both
 outcomes are worse than no element check: one silently moves an acceptance onto a different element,
 the other permanently reports `element-moved`.
@@ -453,7 +488,7 @@ Sequenced so each step is independently useful and nothing is blocked on the cro
 ### Phase 4 — Resolution
 
 11. **Detect resolved** (raw difference gone, acceptance still present), **invalidated** (any of the
-    four gates in §4), and **stale** (issue closed, acceptance remains) — surfaced on the dashboard
+    any of the four invalidation causes in §4 — reference-changed, plane-changed, candidate-changed, element-moved), and **stale** (issue closed, acceptance remains) — surfaced on the dashboard
     and as a gate in the offline run.
 12. **Document** the reporting → triage → acceptance → verification → closure loop in
     `docs/public-preview-server.md`, beside the existing parity view section.

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -192,6 +192,21 @@ Both are changes to `push-branch.sh`, which is shared with other publishers, so 
 that exercise **both orderings** — index-wins-then-render-retries and render-wins-then-index-retries.
 A test for only the first ordering would pass against the broken design.
 
+**And index-vs-index is a third ordering, which delta-on-tip makes *worse*.** Two issue-triggered
+jobs can overlap: an older job queries the issue list, a close or relabel lands, a newer job queries
+and pushes first, and the older job then loses its race — at which point delta-on-tip does exactly
+the wrong thing, faithfully reapplying its own **stale** blob onto the new tip. The older snapshot
+wins and the badges stay wrong until the next issue event or the daily reconciliation. Delta-on-tip
+is the right rule against the render publisher (whose tree never contains a competing index) and the
+wrong one against another index publisher (whose tree contains a *fresher* one).
+
+Fix it at the job level rather than in the helper: give the index workflow a **`concurrency` group
+per system with `cancel-in-progress: true`**, so a superseded query never reaches the push at all.
+That is the natural shape for an event-triggered regeneration — the newest event's snapshot is the
+only one anyone wants — and it needs no cross-repo coordination. If a job must be allowed to finish,
+the alternative is to **re-query on each retry** rather than reusing the blob it computed before the
+race. Either way, add **index-vs-index** to the race tests alongside the two above.
+
 Two alternatives, if that turns out to be more surgery on a shared helper than is wanted:
 
 - **Serialize the two publishers** with a shared `concurrency` group per system, so an index commit
@@ -337,24 +352,33 @@ referenceId, variant)`:
    disagrees with the acceptance's recorded one — a candidate that has crossed `MIN_BOX_COVERAGE`
    since the acceptance was authored — it is `invalidated: plane-changed`. Comparing across two
    different coordinate planes is meaningless, so this has to precede any pixel work.
-3. **Score everything outside the union of masks normally** — where "outside" means excluded in
-   **both** roles, see below. This is the ordinary path; a regression anywhere else scores exactly
-   as it does today.
-4. **Inside each mask, compare the current candidate against `accepted-candidate.png`** — not
-   against the reference. Match within tolerance ⇒ that mask's pixels are suppressed from the
-   *effective* diff. Mismatch ⇒ `invalidated: candidate-changed`, nothing is suppressed, and the
-   region is reported as a new difference.
-5. **Element check.** When the acceptance names an `element`, resolve it against the current
+3. **Candidate gate.** Inside each mask, compare the current candidate against
+   `accepted-candidate.png` — not against the reference. Match within tolerance ⇒ the acceptance
+   stays valid. Mismatch ⇒ `invalidated: candidate-changed`, and the region is reported as a new
+   difference.
+4. **Element gate.** When the acceptance names an `element`, resolve it against the current
    annotation layer. Missing, or moved beyond a bounds tolerance ⇒ `invalidated: element-moved`.
    This is what catches "the glyph disappeared" as distinct from "the glyph is still the wrong
    colour", which a rectangular ignore region fundamentally cannot.
+5. **Only now, score** — everything outside the union of the **still-valid** masks, where "outside"
+   means excluded in **both** roles (see below). An invalidated acceptance suppresses nothing.
 6. **Report raw, accepted and unaccepted separately.** The raw finding is never destroyed. The
    comparison shows all three numbers and the delta map gains an "accepted" tint distinct from the
    magenta of unaccepted difference, so an acceptance is *visible* rather than a hole in the data.
 
+**All four gates run before any scoring, and that ordering is load-bearing.** The tempting order —
+score first, then check the acceptances and report the failures — does not work, because scoring
+with a mask excluded is not something you can undo afterwards. The exclusion removes those
+coordinates from the *neighbourhood search* in both directed passes, so the contribution of every
+pixel near the mask is computed differently; adding the region back into the report afterwards
+cannot reconstruct what the score would have been had the mask never been applied. An acceptance
+that turns out to be `candidate-changed` or `element-moved` would therefore keep inflating the
+effective score it was no longer entitled to suppress. Validate first, then score once against the
+surviving set.
+
 #### Masked pixels must be excluded in both roles, in both directions
 
-Step 3 says "outside the union of masks", and the obvious reading — skip masked pixels when
+Step 5 says "outside the union of masks", and the obvious reading — skip masked pixels when
 iterating — is **not sufficient**, because of how `scorePlanes` actually works. Each directed pass
 takes a source pixel and searches a ±`EDGE_SEARCH_RADIUS` (5 px) neighbourhood of the *target* plane
 for its best match. So an unmasked pixel just outside a mask can find its best match at a target
@@ -371,10 +395,36 @@ on at the boundary, so the conformance fixtures in the next section must include
 placed within `EDGE_SEARCH_RADIUS` of a mask edge** as a named case. Without it, both engines can
 pass the suite and still let an accepted region hide its neighbour.
 
+#### A score-plane pixel can straddle the mask edge
+
+The exclusion rule above is stated in score-plane coordinates, but the mask is authored in the
+canonical plane, and the two are not the same resolution. `scoreImages` downsamples each whole
+content box with a smoothed `drawImage` **before** `scorePlanes` runs, capped at `MAX_SIDE = 192`.
+So a single score-plane pixel can have a source footprint that straddles the mask edge, and by the
+time the mask is mapped down it is a binary answer about a pixel that is genuinely part accepted and
+part not. Either choice is wrong in one direction: drop it and an adjacent regression can hide
+inside the boundary ring; keep it and accepted pixels bleed into the score they were supposed to
+leave alone.
+
+**Resolve it conservatively: a score-plane pixel is masked only if its *entire* source footprint is
+masked.** A partially-covered pixel is scored normally. That biases the boundary ring toward
+over-reporting — an accepted difference may leak a thin halo into the score — which is the correct
+direction to be wrong given the non-goals: an acceptance that reports slightly too much is a
+cosmetic annoyance, one that reports too little is the failure mode the whole model exists to
+prevent. The halo is also bounded and explainable, so the page can say so rather than looking like
+an unexplained residue.
+
+The alternative — evaluating mask boundaries at canonical resolution and only then downsampling — is
+more faithful but means restructuring the scoring path around the mask. Worth revisiting if the halo
+turns out to be visible in practice; not worth it up front.
+
+Either way, **the fixtures must include a mask edge deliberately not aligned to the score-plane
+grid**, since an axis-aligned fixture at a convenient scale would never exercise this at all.
+
 This is deliberately more expensive than a threshold or an ignore rectangle, and that expense is the
-point: the epic's non-goals rule out anything that can hide an unrelated regression, and steps 4 and
-5 — plus the neighbourhood exclusion above — are what make an accepted colour delta unable to mask a
-missing glyph or the regression sitting next to it.
+point: the epic's non-goals rule out anything that can hide an unrelated regression, and gates 3 and
+4 — plus the neighbourhood exclusion and the footprint rule above — are what make an accepted colour
+delta unable to mask a missing glyph or the regression sitting next to it.
 
 ### Two engines, one semantics
 
@@ -427,13 +477,38 @@ check would either resolve the wrong one of several repeated roles or fail to re
 outcomes are worse than no element check: one silently moves an acceptance onto a different element,
 the other permanently reports `element-moved`.
 
-The fix is a **distinct, additive selector field on the annotation contract** — carry `testTag` (and
-the semantics `ref` that `SemanticsRefs` already assigns as a stable, content-independent node
-handle) as their own fields rather than folding them into the display `role`. `role` stays what it
-is: a human-facing label for the legend. Selection prefers `ref`, then `testTag`, then falls back to
-the drag rectangle — never to `role`, which is a label and not an identity. This is a
+The fix is a **distinct, additive selector field on the annotation contract** — carry `testTag` and
+the semantics `ref` as their own fields rather than folding them into the display `role`. `role`
+stays what it is: a human-facing label for the legend, never an identity. This is a
 `compose-preview-annotations/v1` addition and should be sequenced with the semantics-layer wiring
 above, in Phase 2 step 5.
+
+**But not every `ref` is durable, and preferring `ref` blindly is worse than having no selector.**
+`SemanticsRefs` anchors on the test tag when there is one (`r/tag:submit`), falls back to the role
+(`r/role:Button`), and — the problem — **indexes siblings that share an anchor**
+(`r/role:Button[0]`, `r/role:Button[1]`; see `SemanticsRefsTest`). That index is a structural
+occurrence number, so inserting or reordering repeated-role siblings makes the *same* ref string
+resolve to a *different node*. It resolves successfully, so nothing falls through to a second
+choice; and if the new occupant sits in roughly the old bounds, the element gate passes too. The
+acceptance silently transfers to another element — the exact failure the gate exists to prevent,
+arrived at through the mechanism meant to prevent it.
+
+So durability is a property to **test for, not assume**:
+
+| Ref shape | Durable? | Use as acceptance identity |
+| --- | --- | --- |
+| `r/tag:<tag>` | yes — a tag change moves the ref, which is detectable | **yes** |
+| `r/role:<role>[n]` | no — the index is positional and silently retargets | **no** |
+| `r/role:<role>` (lone anchor) | no — gaining a sibling turns it into `[0]`/`[1]` | no, but fails *loudly* |
+| `r/node` | no — purely structural | no |
+
+**Persist an element selector only when it is a `tag:`-anchored ref or another producer-defined
+stable identity. Otherwise keep the drag rectangle** and accept the region geometrically, with no
+element gate. A geometric acceptance is weaker — it cannot tell "the glyph disappeared" from "the
+glyph is still wrong" — but it is honest about what it knows, whereas an indexed ref claims an
+identity it cannot keep. The non-indexed `r/role:` case is worth distinguishing in the
+implementation because its failure is the safe one: it stops resolving and reports `element-moved`
+rather than pointing somewhere new.
 
 Reporting an issue from a selection must **not** accept the difference. Filing and accepting are
 separate, deliberate acts by separate artifacts — one is a GitHub issue the visitor's own browser
@@ -458,11 +533,31 @@ Sequenced so each step is independently useful and nothing is blocked on the cro
    a locator built entirely server-side would record the *default* variant while the embedded
    screenshot shows whatever the reporter had dialled in — the index would key the issue to one
    identity and the pixels would show another, and the acceptance lookup in Phase 3 would then miss.
-   The override-dependent fields (variant, active overrides, comparison URL, raw score — the score
-   is only ever known client-side anyway) need their own placeholders that `refreshReportLink()`
-   substitutes from live viewer state, on the same "write an input value, never an href" rule the
-   existing substitution already follows. The JS-off path keeps the server-rendered defaults, which
-   are correct for a page nobody has touched.
+   The override-dependent fields (variant, active overrides, comparison URL) need their own
+   placeholders that `refreshReportLink()` substitutes from live viewer state, on the same "write an
+   input value, never an href" rule the existing substitution already follows. The JS-off path keeps
+   the server-rendered defaults, which are correct for a page nobody has touched.
+
+   **The raw score is a separate problem: the surface with the report form is not the surface that
+   knows the score.** The form (`cp-report-body`) and `refreshReportLink()` live only on the viewer,
+   and the viewer's always-available live number is `scoreSvgUrls` — PNG against the *generated
+   SVG*, a render-fidelity measurement that has nothing to do with the design reference. Emitting
+   that as the locator's parity score would be silently wrong in the most expensive way: a plausible
+   number, mislabelled, feeding an index. The reference-vs-render score exists in two places —
+   `spec-compare.js` on the viewer, but **only while the Spec lane is open**, and the focused
+   comparison page, which computes it on every load and has **no report form at all** (its body is
+   the triptych, the overlay, `url-state.js` and `format-compare.js`).
+
+   So Phase 1 step 1 has to pick a surface rather than assume one:
+
+   - **Add the report form to the focused comparison.** Preferred. It is the page that always has a
+     concrete `(previewId, referenceId)` pair *and* the score, it is where element selection lands
+     in Phase 2 (so the two arrive together), and it is where a reporter is standing when they see
+     the difference — §1's finding 1 already argued that.
+   - **On the viewer, emit the score only when the Spec lane has computed one**, and omit the field
+     otherwise. A missing field is honest; a wrong one is not. With multiple references the viewer
+     also has no client-side notion of which one is selected, so the `referenceId` half of the
+     locator is only reliable once the lane is up.
 2. **`compose-preview-issues/v1` + reader + staging.** `ServeParityIssues.kt`, `ServeCatalogStore`
    staging, fixture-backed tests. Serves nothing yet.
 3. **Producer + regeneration workflow.** `parity-issues.mjs` / `emit-parity-issues.mjs` here; the
@@ -488,8 +583,9 @@ Sequenced so each step is independently useful and nothing is blocked on the cro
 ### Phase 4 — Resolution
 
 11. **Detect resolved** (raw difference gone, acceptance still present), **invalidated** (any of the
-    any of the four invalidation causes in §4 — reference-changed, plane-changed, candidate-changed, element-moved), and **stale** (issue closed, acceptance remains) — surfaced on the dashboard
-    and as a gate in the offline run.
+    four causes in §4 — `reference-changed`, `plane-changed`, `candidate-changed`, `element-moved`),
+    and **stale** (issue closed, acceptance remains) — surfaced on the dashboard and as a gate in
+    the offline run.
 12. **Document** the reporting → triage → acceptance → verification → closure loop in
     `docs/public-preview-server.md`, beside the existing parity view section.
 

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -31,7 +31,7 @@ machinery.
 | Design references | [`ServeDesignReferences.kt`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignReferences.kt) | `compose-preview-references/v1` — one reference per exact preview id, canonical PNG, **optional `sha256`**, provider/revision provenance |
 | Focused comparison | `ServeWeb.referenceComparisonPage`, route `GET /{system}/compare/{previewId}?reference=<id>` | Reference / Diff / Actual triptych, opacity overlay, annotation layers |
 | Annotations | [`ServeAnnotations.kt`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAnnotations.kt), [`ServeDesignAnnotations.kt`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDesignAnnotations.kt) | Numbered boxes with `bounds` in each panel's own pixel space, `role`, structured `detail`. Reference side authored by the producer; render side derivable from the `compose/semantics` tree |
-| Scoring | [`format-compare.js`](../../cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js) | SSIM over content-box-normalised, downscaled gray planes + a magenta delta map — **entirely in the visitor's browser** |
+| Scoring | [`format-compare.js`](../../cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js) | `scorePlanes` — a **bidirectional edge-tolerant nearest-neighbour search** over content-box-normalised gray planes — plus a magenta delta map, **entirely in the visitor's browser** |
 | Parity dashboard | [`ServeParityDashboard.kt`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityDashboard.kt), route `/{system}/parity(.json)` | Coverage (live), drift correlation, merged activity feed, mapping gaps |
 | Published snapshot precedent | [`ServeParityActivity.kt`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityActivity.kt) + [`parity-activity.mjs`](../../scripts/design-artifacts/parity-activity.mjs) | The exact pattern the issue index should copy — see §3 |
 | Catalog refresh | [`ServeCatalogRefresher.kt`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt) | Polls each `design-artifacts/<system>` branch head and re-fetches on **any** new commit |
@@ -47,11 +47,22 @@ difference. **Recommendation: do not invent a component page.** Put issues on th
 focused comparison, the grid cards, and the dashboard, which is what the epic's presentation section
 actually asks for once "component page" is read as "the page you are on when you see the problem".
 
-**2. Scoring is client-side, in a normalised space.** `format-compare.js` crops each side to its
-content box, redraws both into one shared box, and scores there. So a mask expressed in raw
-reference pixels is *not* directly usable — it has to ride through the same `normalisedBoxes`
-transform the score uses. This is the single largest implementation constraint and §4 designs around
-it.
+**2. Scoring is client-side, in a candidate-sized normalised space — and it is not SSIM.** Two
+details matter and both were easy to get wrong:
+
+- **The active scorer is `scorePlanes`**, a bidirectional nearest-neighbour search within
+  `EDGE_SEARCH_RADIUS = 5` px with a `LUMA_TOLERANCE = 16` floor, scored symmetrically in both
+  directions. `ssim` / `globalSsim` are still in the file but **have no callers**. Anything that
+  claims to reproduce the server's verdict — the mask algorithm, the cross-engine conformance
+  fixtures in §4 — has to reproduce *that* edge-search behaviour, not an SSIM window.
+- **There are already two planes, both keyed off the candidate.** The score runs on a plane capped
+  at `MAX_SIDE = 192` px on its longest side; the diff map and triptych run on the uncapped
+  candidate content box. Both take their dimensions from `boxes.candidate`, which moves with device
+  size, density and content — so neither is a stable place to *store* anything. At 192 px an
+  `EDGE_SEARCH_RADIUS` of 5 is also a very coarse neighbourhood for a glyph-sized region.
+
+This is the single largest implementation constraint, and it is why §4 gives acceptance its own
+canonical plane rather than reusing either of these.
 
 **3. The reference already carries a fingerprint.** `DesignReferenceRaster.sha256` is optional today
 and verified at ingestion when present. The epic's "require the reference fingerprint to match"
@@ -147,15 +158,44 @@ workflow **in the catalog repo** (`m3-catalog`), triggered on `issues:
 `parity/issues.json`, and commits **that one file** onto `design-artifacts/<system>`. Serving hosts
 pick it up on their next refresh tick with no render.
 
-Two consequences to design for:
+Two consequences to design for, both sharper than they first look:
 
-- The index is written by a *different* job than the one that writes the rest of the branch, so it
-  must never rewrite anything else, and the render pipeline must not clobber it. Simplest safe rule:
-  `design-artifacts-reusable.yml` **preserves** an existing `parity/issues.json` when re-publishing
-  rather than treating the bundle as authoritative for that path. Worth an explicit test.
-- One delivery branch can carry issues from several repositories (a catalog whose components are
-  implemented elsewhere). `repository` is per-issue in the schema, so this works, but the emitter
-  needs to be told which repos to scan rather than assuming `github.repository`.
+**The two publishers race, and the existing push helper resolves that race by discarding one side.**
+`design-artifacts-reusable.yml` publishes through
+[`push-branch.sh`](../../.github/actions/apply/lib/push-branch.sh), which computes `TREE=$(git
+write-tree)` **once, before** its retry loop, and on a non-fast-forward re-fetches the tip and
+re-parents *that same tree* onto it. It never merges files from the newly fetched parent. So
+"preserve an existing `parity/issues.json` when re-publishing" is not sufficient: the preservation
+would be a copy step that runs before the race is discovered, and an index committed during a render
+publish is dropped wholesale by the reparent — leaving badges stale until the next issue event
+happens to fire, which could be days.
+
+Three ways out, in increasing order of cost:
+
+1. **Re-run the preservation inside the retry loop** — on each fetch, read `parity/issues.json` out
+   of the fetched parent, restage it, and recompute the tree before `commit-tree`. Requires touching
+   `push-branch.sh` (shared with other publishers, so the change must be opt-in via an env var
+   naming the paths to carry forward).
+2. **Serialize the two publishers** with a shared GitHub Actions `concurrency` group per system, so
+   an index commit and a render publish never overlap. Cheapest, but couples two workflows in two
+   repos and turns a fast index update into something that can queue behind a 30-minute render.
+3. **Keep the index off the delivery branch entirely** — publish it as its own branch or release
+   asset that `ServeCatalogStore` fetches separately. Cleanest isolation, most new plumbing.
+
+**Recommended: (1)**, with the carried-forward path list explicit and unit-tested, because it fixes
+the race for any future file with the same "written by a different job" shape rather than only this
+one. This should be settled before Phase 1 step 3 ships, not after — the failure is silent and
+looks like "the index is just a bit behind".
+
+**Cross-repository triggers.** One delivery branch can carry issues from several repositories (a
+catalog whose components are implemented elsewhere). `repository` is per-issue in the schema, so the
+*format* handles it — but a workflow triggered only by `issues:` events in the catalog repo never
+wakes when someone closes or relabels an issue in one of the other scanned repos, so those rows go
+stale indefinitely. Telling the emitter which repos to scan is necessary and not sufficient. Every
+configured source repo needs either a `repository_dispatch` into the catalog repo from its own
+`issues:` workflow, or the whole thing needs a scheduled reconciliation pass as a backstop.
+**Recommended: both** — dispatch for latency, a daily cron for the repos nobody remembered to wire
+up. A reconciliation pass is cheap here precisely because regenerating the index costs no render.
 
 Both the serve host and the design-parity CI run read the same file. Neither ever calls the GitHub
 API at page-render time — same rule that keeps the host away from Figma.
@@ -172,16 +212,25 @@ Committed in the **source** repo, beside `design-map.json`:
       known-differences.json                       # compose-preview-known-differences/v1
       known-differences/
         m3-iconbutton-tonal-glyph/
-          mask.png                                 # binary mask, reference raster pixel space
-          accepted-candidate.png                   # the render crop that was accepted
+          mask.png                                 # binary mask, canonical (reference) plane
+          accepted-candidate.png                   # the accepted crop, same plane
 
 Each acceptance record carries: a stable `id`; a **mandatory** `issue` URL; the locator scope
 (`system` / `component` / `previewId` / `referenceId` / `variant`); an optional `element` selector
-(annotation `role` / `testTag`, when the region came from an annotated element rather than a drag);
-`mask` and `acceptedCandidate` paths; `referenceSha256`; `acceptedCandidateSha256`; an optional
-structured `finding` matcher (e.g. `{ kind: "color", token: "onSecondaryContainer", expected: …,
-actual: … }`) for the checks design-parity runs that are not pixel comparisons; and free-text
-`note` + `acceptedAt`.
+(see the annotation-contract prerequisite in §5, when the region came from an annotated element
+rather than a drag); `mask` and `acceptedCandidate` paths; **three** hashes — `referenceSha256`,
+`acceptedCandidateSha256` **and `maskSha256`**; an optional structured `finding` matcher (e.g.
+`{ kind: "color", token: "onSecondaryContainer", expected: …, actual: … }`) for the checks
+design-parity runs that are not pixel comparisons; and free-text `note` + `acceptedAt`.
+
+**The mask must be hashed, not just referenced by path.** The mask is the thing that decides *what
+gets suppressed*, so an edited or swapped `mask.png` with an unchanged JSON record silently widens
+the accepted region — hiding regressions the record still claims are in scope, with no invalidation
+anywhere. That is a direct breach of the safety requirement the whole model exists for, and it is
+the one tampering path the other two hashes do not cover. A mask whose bytes don't match its
+`maskSha256` is a **hard validation failure** (the acceptance is refused outright and reported),
+not an invalidation that degrades to "compare normally" — a mask we cannot trust is a broken
+artifact, not a stale one.
 
 The schema is defined **here**, in this repo, because `serve` is a consumer and this is where the
 other wire contracts (`compose-preview-references/v1`, `compose-preview-annotations/v1`,
@@ -191,20 +240,34 @@ sequenced as such (§6).
 
 ### Coordinate space — the real problem
 
-The mask has to be authored somewhere stable and applied somewhere normalised.
+The mask has to be authored somewhere stable, and the accepted pixels have to be *stored* somewhere
+stable. Neither of the planes `format-compare.js` already builds qualifies, because both are sized
+from `boxes.candidate` (finding 2 in §1): the same component re-rendered at a different device size
+or density produces a different plane, so a stored crop would mismatch on dimensions alone and every
+acceptance would false-invalidate as `candidate-changed` — or would need a resample whose resampling
+error immediately swamps the tight per-pixel tolerance §7 calls for.
 
-- **Author in reference-raster pixel space.** The reference is a published PNG with fixed
-  dimensions, a `sha256`, and annotation bounds already expressed in that space. The render's pixel
-  space is not stable — it moves with device size, density, font scale and any override in force.
-- **Apply after normalisation.** `normalisedBoxes(referenceImage, candidateImage)` already computes
-  each side's content box and the shared output box. The mask goes through the *reference* side of
-  that same transform, giving mask coverage in the shared space that both the score and the delta
-  map live in. No new geometry, and the mask automatically follows a reference re-exported at a
-  different scale.
-- **`accepted-candidate.png` is stored in the shared normalised space**, cropped to the mask's
-  bounding box. Storing it in raw render pixels would make it invalid the moment anyone changes a
-  device size, which is precisely the kind of silent staleness the acceptance model exists to catch
-  *deliberately*, not accidentally.
+So acceptance gets **its own canonical plane, defined by the reference**:
+
+- **The canonical plane is the reference's content box, at the reference raster's own resolution.**
+  The reference is a published PNG with fixed dimensions and a `sha256` that the acceptance already
+  pins, so this plane is byte-stable by construction — it cannot move unless the reference changes,
+  and a changed reference is already gate 1. Annotation bounds are in this space too.
+- **`mask.png` is authored in it directly.** No transform, no scale factor to get wrong.
+- **`accepted-candidate.png` is stored in it**, cropped to the mask's bounding box. Evaluating an
+  acceptance therefore means resampling the *current* candidate's content box into the canonical
+  plane — one resample of the live frame, against a stored crop that never moves — rather than
+  storing a crop in a plane that moves under it.
+- **Suppression is then mapped into whichever plane is being reported.** The canonical plane, the
+  score plane and the diff plane are all content-box crops related by an affine scale, so the mask's
+  coverage maps into each with the same arithmetic `boxCanvas` already does. Do the *comparison* at
+  canonical resolution and the *reporting* wherever the surface lives; do not do the comparison at
+  the 192 px score plane, where a glyph is a handful of pixels and a 5 px edge search covers most of
+  it.
+
+This costs one extra resample per acceptance per comparison, on a page that is already decoding two
+PNGs and walking them pixel by pixel. That is the right trade for making "did this exact accepted
+region change?" a question with a stable answer.
 
 ### Evaluation order (the safety requirements, as an algorithm)
 
@@ -250,6 +313,11 @@ things depending on which tool you asked. Options considered:
 `ServeParityActivityStore` (one committed fixture, two languages, both tests load it), it is cheap,
 and it fails loudly.
 
+The fixtures have to pin the **active** scorer's behaviour, not a textbook one: `scorePlanes`'
+bidirectional search at `EDGE_SEARCH_RADIUS = 5`, its `LUMA_TOLERANCE = 16` floor, and the
+`MAX_SIDE = 192` cap on the score plane are all load-bearing to the number that comes out. A fixture
+suite written against SSIM windows would pass in both engines and describe neither.
+
 ---
 
 ## 5. Element selection on the focused comparison
@@ -259,13 +327,33 @@ as numbered boxes. Element selection is therefore: make an annotation box clicka
 selection become the reported region. Manual drag-rectangle is the fallback for the common catalog
 that publishes no annotations.
 
-One nuance found while reading the handler: `handleReferenceComparison` sources the *actual* layer
-from `annotationsForPreview` — the **producer-authored** `annotations/index.json`, not the
-semantics-derived layer `ServeDesignAnnotations` builds for the viewer's inspection overlays. So on
-most catalogs the render side of this page has no annotations to click. Feeding the semantics-derived
-layer into this page (as the viewer already does) is a small, independently useful change and should
-land **before** element selection, or the feature ships with nothing to select on the side that
-matters most.
+Two prerequisites came out of reading the handler and the annotation model, and **both** have to
+land before element selection can back an acceptance.
+
+**The render side of this page has nothing to click.** `handleReferenceComparison` sources the
+*actual* layer from `annotationsForPreview` — the **producer-authored** `annotations/index.json` —
+not the semantics-derived layer `ServeDesignAnnotations` builds for the viewer's inspection
+overlays. So on most catalogs the render column carries no annotations at all. Feeding the
+semantics-derived layer into this page (as the viewer already does) is small and independently
+useful.
+
+**`DesignAnnotation` cannot express a stable element identity.** There is no `testTag` field on the
+type at all, and the projection throws the tag away: `themeAnnotation` collapses
+`node.role ?: node.testTag ?: node.textSnippet()` into a single `role` string, and
+`typographyAnnotation` sets `role` from `textSnippet()` alone, dropping the tag entirely. So an
+`element` selector keyed on "role / testTag" is not a selector — a node carrying a common role
+(`Button`) and a unique `testTag` loses the only part that identified it, and the gate-4 element
+check would either resolve the wrong one of several repeated roles or fail to resolve at all. Both
+outcomes are worse than no element check: one silently moves an acceptance onto a different element,
+the other permanently reports `element-moved`.
+
+The fix is a **distinct, additive selector field on the annotation contract** — carry `testTag` (and
+the semantics `ref` that `SemanticsRefs` already assigns as a stable, content-independent node
+handle) as their own fields rather than folding them into the display `role`. `role` stays what it
+is: a human-facing label for the legend. Selection prefers `ref`, then `testTag`, then falls back to
+the drag rectangle — never to `role`, which is a label and not an identity. This is a
+`compose-preview-annotations/v1` addition and should be sequenced with the semantics-layer wiring
+above, in Phase 2 step 5.
 
 Reporting an issue from a selection must **not** accept the difference. Filing and accepting are
 separate, deliberate acts by separate artifacts — one is a GitHub issue the visitor's own browser
@@ -281,8 +369,20 @@ Sequenced so each step is independently useful and nothing is blocked on the cro
 
 1. **Locator contract + richer issue body.** Extend `ServeIssueReport.Context` with `componentId`,
    `referenceId`, variant axes, active overrides, comparison URL and raw scores; emit the
-   `compose-parity-locator/v1` block alongside the existing prose table. Pure Kotlin + tests, no new
-   files on the wire. *Smallest useful PR; everything else keys off it.*
+   `compose-parity-locator/v1` block alongside the existing prose table. No new files on the wire —
+   but **not pure Kotlin**, see below. *Smallest useful PR; everything else keys off it.*
+
+   The server fills the form's hidden `body` for the settings the page was **served** at, and
+   `viewer.js`'s `refreshReportLink()` then rewrites exactly one thing: it swaps `{{render}}` for
+   the live `/render` URL. Every other character of the body stays the initial server template. So
+   a locator built entirely server-side would record the *default* variant while the embedded
+   screenshot shows whatever the reporter had dialled in — the index would key the issue to one
+   identity and the pixels would show another, and the acceptance lookup in Phase 3 would then miss.
+   The override-dependent fields (variant, active overrides, comparison URL, raw score — the score
+   is only ever known client-side anyway) need their own placeholders that `refreshReportLink()`
+   substitutes from live viewer state, on the same "write an input value, never an href" rule the
+   existing substitution already follows. The JS-off path keeps the server-rendered defaults, which
+   are correct for a page nobody has touched.
 2. **`compose-preview-issues/v1` + reader + staging.** `ServeParityIssues.kt`, `ServeCatalogStore`
    staging, fixture-backed tests. Serves nothing yet.
 3. **Producer + regeneration workflow.** `parity-issues.mjs` / `emit-parity-issues.mjs` here; the
@@ -323,9 +423,17 @@ Sequenced so each step is independently useful and nothing is blocked on the cro
   selection as an acceptance stub" from the focused comparison is the obvious follow-up, and worth
   deciding on before Phase 3 rather than after.
 - **Tolerance is a threshold, and the epic is against thresholds.** Step 3 of §4 needs *some*
-  tolerance for the candidate-vs-accepted-candidate comparison (PNG re-encoding, resampling). It
-  should be tight, fixed, and per-pixel rather than aggregate — an aggregate tolerance is exactly the
-  global threshold the non-goals rule out.
+  tolerance for the candidate-vs-accepted-candidate comparison (PNG re-encoding, and the one
+  resample of the live candidate into the canonical plane). It should be tight, fixed, and
+  **per-pixel rather than aggregate** — an aggregate tolerance is exactly the global threshold the
+  non-goals rule out. Pinning the canonical plane to the reference (§4) is what keeps that resample
+  to a single, well-defined step instead of a moving target; if the tolerance still has to be loose
+  enough to be uncomfortable, that is the signal to store the accepted candidate losslessly at
+  canonical resolution rather than to widen it.
+- **Fixing the publish race means touching a shared helper.** `push-branch.sh` is used by other
+  publishers, so the carry-forward behaviour in §3 has to be opt-in (an env var naming the paths)
+  and covered by its own test. A change that silently altered how every publisher resolves a race
+  would be a much worse bug than the one it fixes.
 - **Cross-repo schema ownership.** Defining the known-difference schema here and consuming it in
   `design-parity` means a version bump is a two-repo change. The conformance fixtures are the
   mitigation; a `v1`-frozen-then-`v2` discipline (as with the other wire formats) is the other.

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -170,22 +170,41 @@ would be a copy step that runs before the race is discovered, and an index commi
 publish is dropped wholesale by the reparent — leaving badges stale until the next issue event
 happens to fire, which could be days.
 
-Three ways out, in increasing order of cost:
+**The race is asymmetric, and the fix has to be too.** The two publishers are not peers: the render
+publisher's tree is authoritative for the whole bundle *except* the index, and the index publisher's
+tree is authoritative for *only* the index. A single symmetric "carry these paths forward" rule
+breaks in one of the two orderings — an index publisher enabling carry-forward on
+`parity/issues.json` would replace its own freshly-generated blob with the stale copy from the
+fetched parent and never publish anything, while an index publisher *without* it reparents its stale
+render tree and rolls back whatever renders just landed. So each side gets the rule that matches
+what it actually owns:
 
-1. **Re-run the preservation inside the retry loop** — on each fetch, read `parity/issues.json` out
-   of the fetched parent, restage it, and recompute the tree before `commit-tree`. Requires touching
-   `push-branch.sh` (shared with other publishers, so the change must be opt-in via an env var
-   naming the paths to carry forward).
-2. **Serialize the two publishers** with a shared GitHub Actions `concurrency` group per system, so
-   an index commit and a render publish never overlap. Cheapest, but couples two workflows in two
-   repos and turns a fast index update into something that can queue behind a 30-minute render.
-3. **Keep the index off the delivery branch entirely** — publish it as its own branch or release
-   asset that `ServeCatalogStore` fetches separately. Cleanest isolation, most new plumbing.
+- **Render publisher — carry forward.** On each fetch inside the retry loop, take
+  `parity/issues.json` from the fetched parent, restage it, recompute the tree, then `commit-tree`.
+  Its own tree wins everywhere else.
+- **Index publisher — one-path delta.** Never build a tree from a working directory at all. On each
+  fetched tip, start from the **parent's** tree and replace exactly one path with its own new index
+  blob. Everything else comes from the parent by construction, so a render that landed mid-flight is
+  preserved whichever order the two pushes arrive in.
 
-**Recommended: (1)**, with the carried-forward path list explicit and unit-tested, because it fixes
-the race for any future file with the same "written by a different job" shape rather than only this
-one. This should be settled before Phase 1 step 3 ships, not after — the failure is silent and
-looks like "the index is just a bit behind".
+Both are changes to `push-branch.sh`, which is shared with other publishers, so both must be opt-in
+(one env var naming paths to carry forward, one selecting delta-on-tip mode) and covered by tests
+that exercise **both orderings** — index-wins-then-render-retries and render-wins-then-index-retries.
+A test for only the first ordering would pass against the broken design.
+
+Two alternatives, if that turns out to be more surgery on a shared helper than is wanted:
+
+- **Serialize the two publishers** with a shared `concurrency` group per system, so an index commit
+  and a render publish never overlap. Cheapest to build, but couples two workflows across two repos
+  and turns a fast index update into something that can queue behind a 30-minute render.
+- **Keep the index off the delivery branch entirely** — its own branch or a release asset that
+  `ServeCatalogStore` fetches separately. Cleanest isolation, most new plumbing, and it gives up the
+  "one branch is the whole catalog" property the rest of the design leans on.
+
+**Recommended: the two-sided rule above.** It fixes the race for any future file with the same
+"written by a different job" shape rather than only this one. Settle it before Phase 1 step 3 ships —
+the failure is silent and looks like "the index is just a bit behind", or worse, like renders
+mysteriously reverting.
 
 **Cross-repository triggers.** One delivery branch can carry issues from several repositories (a
 catalog whose components are implemented elsewhere). `repository` is per-issue in the schema, so the
@@ -252,8 +271,9 @@ So acceptance gets **its own canonical plane, defined by the reference**:
 - **The canonical plane is the reference's content box, at the reference raster's own resolution.**
   The reference is a published PNG with fixed dimensions and a `sha256` that the acceptance already
   pins, so this plane is byte-stable by construction — it cannot move unless the reference changes,
-  and a changed reference is already gate 1. Annotation bounds are in this space too.
-- **`mask.png` is authored in it directly.** No transform, no scale factor to get wrong.
+  and a changed reference is already gate 1.
+- **`mask.png` is authored in it directly** — but *nothing else is already in it*, and that is the
+  easy mistake. See the translation rules below.
 - **`accepted-candidate.png` is stored in it**, cropped to the mask's bounding box. Evaluating an
   acceptance therefore means resampling the *current* candidate's content box into the canonical
   plane — one resample of the live frame, against a stored crop that never moves — rather than
@@ -268,6 +288,31 @@ So acceptance gets **its own canonical plane, defined by the reference**:
 This costs one extra resample per acceptance per comparison, on a page that is already decoding two
 PNGs and walking them pixel by pixel. That is the right trade for making "did this exact accepted
 region change?" a question with a stable answer.
+
+#### Translating a selection into the canonical plane
+
+The canonical plane is a **crop**, so its origin is `(referenceBox.x, referenceBox.y)` in the
+reference raster — generally non-zero. Nothing a human or the UI hands us starts there, and treating
+any of these as already-canonical shifts the mask by the content-box origin, which silently targets
+the wrong pixels. Every source needs an explicit transform, and every result needs clipping to the
+plane:
+
+| Source | Native space | Transform into the canonical plane |
+| --- | --- | --- |
+| Reference annotation `bounds` | the **full reference raster** (`DesignAnnotation` KDoc: "the annotated image's own pixel space") | subtract `(referenceBox.x, referenceBox.y)`; scale 1; clip |
+| Drag rectangle on the reference panel | CSS/display pixels of the `<img>` | scale by `rasterWidth / displayWidth`, then subtract the box origin; clip |
+| Render-side annotation `bounds` | **render** pixel space | map through the candidate content box → the shared box, i.e. subtract `(candidateBox.x, candidateBox.y)` then scale by `referenceBox.width / candidateBox.width`; clip |
+
+A selection that clips to empty is refused at authoring time rather than stored as a zero-area mask.
+
+**One stability hazard to pin down before implementing.** `normalisedBoxes` does not always use the
+content box: when either side's box covers less than `MIN_BOX_COVERAGE` (5%) of its canvas it falls
+back to the **full canvas** for *both* sides. So the plane's definition can flip between "content
+box" and "full raster" depending on the candidate's coverage — which the reference's `sha256` does
+not pin. An acceptance must therefore record **which of the two the plane was** (a `plane:
+"content-box" | "full-canvas"` discriminant plus the resolved box), and a comparison whose fallback
+disagrees with the recorded one is `invalidated: plane-changed` rather than silently compared in the
+wrong space.
 
 ### Evaluation order (the safety requirements, as an algorithm)
 


### PR DESCRIPTION
Follow-up to #3681, which merged before its review findings could be applied. Docs only.

Codex left seven findings on that PR and five more across two rounds on this one. I checked every one against the code before touching the doc, and **all twelve hold** — including two factual errors about existing behaviour and one hole in the safety guarantee the whole model exists for. New PR rather than more commits on the merged branch, per the merged-PR rule in `CLAUDE.md`.

## Factual errors about existing code

**The browser comparison is not SSIM-scored.** Every active image-scoring route in `format-compare.js` calls `scorePlanes` — a bidirectional nearest-neighbour search at `EDGE_SEARCH_RADIUS = 5` with a `LUMA_TOLERANCE = 16` floor. `ssim` and `globalSsim` are still in the file and have **no callers** (`globalSsim` is reachable only from `ssim`, which nothing calls). This is not just wording: §4 proposes cross-engine conformance fixtures, and a suite written against SSIM windows would pass in both engines while describing neither.

**Storing the accepted candidate "in the shared normalised space" is not stable.** `normaliseImageUrls` sizes that plane from `boxes.candidate`, so it moves with device size and density — a stored crop would mismatch on dimensions alone and false-invalidate as `candidate-changed`. There are in fact *two* candidate-derived planes: the score plane is additionally capped at `MAX_SIDE = 192`, where a 5 px edge search covers most of a glyph-sized region. Acceptance now gets **its own canonical plane defined by the reference content box** — byte-stable by construction, since the reference is already pinned by `sha256`.

## Holes in the safety guarantee

**An accepted region could hide the regression next to it.** This is the important one. "Score everything outside the mask" read as "skip masked pixels when iterating" is insufficient: each directed `scorePlanes` pass searches a ±5 px neighbourhood of the *target* plane for a best match, so an unmasked pixel just outside a mask can match an accepted-but-different pixel *inside* it and have its mismatch erased. A regression within `EDGE_SEARCH_RADIUS` of an accepted region would score clean — exactly what the epic's "new differences inside or outside the accepted element still require review" forbids. Masked coordinates are now excluded **both as scored sources and as candidate neighbours, in both directed passes**, and the conformance fixtures require a named case with a regression inside that radius of a mask edge (both engines could otherwise pass the suite and still leak).

**The mask wasn't hashed.** The schema pinned `referenceSha256` and `acceptedCandidateSha256` but not the mask — the artifact that decides *what gets suppressed*. An edited `mask.png` with an unchanged JSON record would silently widen the accepted region with no invalidation. Added `maskSha256`, as a hard validation failure rather than a soft invalidation: a mask we can't trust is a broken artifact, not a stale one.

## Coordinate-space corrections

**A selection is never already in the canonical plane.** The plane is a *crop*, so its origin is `(referenceBox.x, referenceBox.y)` and is generally non-zero — but `DesignAnnotation.bounds` are in the **full** raster space, a drag rectangle is in display pixels, and a render-side annotation is in render pixels. Replaced the incorrect "annotation bounds are in this space too" with an explicit per-source transform table; a selection clipping to empty is refused at authoring time.

**Both axes scale independently.** `boxCanvas` stretches a source box onto the target width and height separately, and differing aspect ratios are explicitly supported — `aspectDelta` reports the proportion difference as a finding rather than normalising it away. A single width ratio would place a render-side mask at the right x and the wrong y, on precisely the mismatched-proportion pairs an acceptance is most likely to sit on.

**The plane definition can flip.** `normalisedBoxes` falls back to the **full canvas for both sides** when either content box covers less than `MIN_BOX_COVERAGE` (5%), so the plane can flip between content-box and full-raster on a candidate the reference's `sha256` does not pin. The `plane` discriminant and resolved box are now **fields on the record** (Phase 3 builds the schema from that list, so prose alone left the gate unimplementable), and the check is step 2 of the algorithm since comparing across two planes is meaningless.

## Design and delivery gaps

**`DesignAnnotation` can't express element identity.** There's no `testTag` field; `themeAnnotation` collapses `node.role ?: node.testTag ?: node.textSnippet()` into one `role` string and `typographyAnnotation` drops the tag entirely. So an `element` selector keyed on "role / testTag" isn't a selector. Added a distinct additive selector field (the semantics `ref` that `SemanticsRefs` already assigns, then `testTag`) as a Phase 2 prerequisite; `role` stays a legend label, never an identity.

**The publish race is asymmetric.** `push-branch.sh` computes `TREE=$(git write-tree)` once, *before* its retry loop, and on a non-fast-forward reparents that same stale tree — it never merges files from the fetched parent. `design-artifacts-reusable.yml` publishes through exactly this helper. A symmetric carry-forward rule covers only one ordering: the render publisher's tree owns everything *except* the index, the index publisher's owns *only* the index. Split into carry-forward on the render side and one-path delta-on-tip on the index side, both opt-in, with tests required for **both** orderings.

**Cross-repo triggers.** A workflow triggered only by `issues:` in the catalog repo never wakes when someone closes or relabels an issue in another scanned repo. Now: `repository_dispatch` per source repo for latency, plus a scheduled reconciliation backstop.

**Phase 1 step 1 is not "pure Kotlin".** `viewer.js`'s `refreshReportLink()` substitutes exactly one thing — `{{render}}` — leaving every other character as the server template rendered at the settings the page was *served* at. A server-built locator would record the default variant beside an overridden screenshot, keying the index to one identity while the pixels show another. Override-dependent fields need client-managed placeholders.

## Test plan

Docs only — no build, test, or rendered surface is affected, so there is no visual evidence to embed. Each claim was verified by reading the cited code: `format-compare.js` (`scorePlanes` and its `directed` neighbourhood search, `normalisedBoxes`, `boxCanvas`, `normaliseImageUrls`, `scoreImages`, `aspectDelta`, the constants block), `viewer.js` `refreshReportLink`, `ServeAnnotations.kt`, `ServeDesignAnnotations.kt`, `ComposeSemanticsModels.kt`, `.github/actions/apply/lib/push-branch.sh`, and the publish step in `design-artifacts-reusable.yml`.

Refs #3680

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVGf6MmwV8gHZ8xScG5siq)_