### PR TITLE
fix(render): tighten the native-env pruning and its diagnosis

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -659,22 +659,51 @@ class DoctorCommand(
   private fun checkDesktopNatives(modules: Map<String, ModuleInfo>) {
     val desktopModules = modules.filterValues { rendersThroughSkiko(it) }
     if (desktopModules.isEmpty()) return
-    val result =
+
+    // Evaluate against every JVM a render could actually fork into, not just the daemon's. A module
+    // whose render task carries its own launcher (a raised render JDK, or an explicit
+    // `composePreview.renderJavaVersion`) is the case that matters most here: store libraries on
+    // the path of a *system* JDK is the mixed-glibc trap, and reading the daemon's `java.home`
+    // instead would report a Nix daemon as healthy while the render dies (issue #3690).
+    val candidates =
+      (desktopModules.values.mapNotNull { it.renderPreviewsTask?.javaLauncherPath } +
+          listOfNotNull(daemonJavaHome))
+        .distinct()
+        .ifEmpty { listOf(null) }
+    val canonicalize = { path: String ->
+      runCatching { File(path).canonicalPath }.getOrDefault(path)
+    }
+    val results = candidates.map { javaHome ->
       DesktopNativesCheck.evaluateDesktopNatives(
         osName = System.getProperty("os.name") ?: "",
-        renderJavaHome = daemonJavaHome,
+        renderJavaHome = javaHome,
         ldLibraryPath = System.getenv("LD_LIBRARY_PATH"),
         exists = { path -> File(path).exists() },
         // Resolved through symlinks so a store lib dir reached via a link farm
         // (`~/.cache/coo-ee/desktop-gl/lib`, `~/.nix-profile/lib`) is still recognised as one.
-        canonicalize = { path -> runCatching { File(path).canonicalPath }.getOrDefault(path) },
+        canonicalize = canonicalize,
       )
+    }
+    // The worst verdict wins: one render JVM that cannot load skiko breaks that module's previews
+    // regardless of how healthy the others look.
+    val result = results.firstOrNull { !it.ok } ?: results.first()
+
     val check = DesktopNativesCheck.interpret(result, inClaudeCloud = inClaudeCloud)
     addCheck(
       check.copy(
         detail =
           listOfNotNull(
               check.detail,
+              "evaluated against ${result.renderJavaHome ?: "an unknown JVM"}" +
+                if (candidates.size > 1) " (of ${candidates.size} candidate render JVMs)" else "",
+              // The desktop render task is not a `Test`, so the Tooling model does not report its
+              // launcher: a CMP module that pins `composePreview.renderJavaVersion` is invisible
+              // here. Only worth saying where it could change the answer — a store daemon with
+              // store libraries on the path, which is exactly the healthy-looking configuration
+              // that a pinned system render JDK turns into the #3690 failure.
+              "a CMP module pinning composePreview.renderJavaVersion is not visible to this check; " +
+                "the render task prunes store dirs for such a JVM itself"
+                  .takeIf { !result.loaderReadsSystemCache && result.storeDirsOnPath.isNotEmpty() },
               "affects ${desktopModules.size} CMP/Desktop module(s): ${desktopModules.keys.joinToString(", ")}",
             )
             .joinToString(". ")

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1922,12 +1922,16 @@ internal object ComposePreviewTasks {
 
       if (withSidecar.isNotEmpty()) {
         sb.append("\n\nPer-preview render errors (from .error.json sidecars):")
-        // Grouped by exception + message: one broken dependency reports itself once with a count
-        // instead of a thousand identical lines, and genuinely distinct failures still each get a
-        // line. Preview order is preserved, so the first failure stays at the top.
+        // Grouped by exception + message + source frame: one broken dependency reports itself once
+        // with a count instead of a thousand identical lines, and genuinely distinct failures still
+        // each get a line. The frame belongs in the key — two previews throwing
+        // `IllegalStateException("missing state")` from different composables are different bugs,
+        // and printing the first one's `at Foo.kt:12` beside a count would blame a file that has
+        // nothing to do with the others. Preview order is preserved, so the first failure stays at
+        // the top.
         val groups = withSidecar.groupBy { id ->
           val s = sidecars.getValue(id)
-          s.exception to s.message
+          Triple(s.exception, s.message, s.topAppFrame)
         }
         var shown = 0
         for ((_, ids) in groups.entries.take(5)) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderNativeEnv.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderNativeEnv.kt
@@ -104,19 +104,24 @@ internal object RenderNativeEnv {
     if (!osName.lowercase().contains("linux")) return Decision.Inherit
     if (mode.equals(MODE_INHERIT, ignoreCase = true)) return Decision.Inherit
 
-    val entries = ldLibraryPath.orEmpty().split(':').filter { it.isNotBlank() }
-    if (entries.isEmpty()) return Decision.Inherit
+    val entries = ldLibraryPath.orEmpty().split(':')
+    if (entries.none { it.isNotBlank() }) return Decision.Inherit
 
     // The subject is the JVM that will actually run the render: the pinned executable when the
     // plugin raised the render JDK, otherwise the daemon's own home (the historical default).
     val subject = renderJavaExecutable ?: daemonJavaHome ?: return Decision.Inherit
     if (isStorePath(canonicalize(subject))) return Decision.Inherit
 
-    val (dropped, kept) = entries.partition { isStorePath(canonicalize(it)) }
+    // Blank entries are kept in place, not filtered out: glibc reads an empty element as the
+    // current directory, so dropping one silently removes a search location that has nothing to do
+    // with the store — and "everything else exactly as inherited" is the whole contract here.
+    val (dropped, kept) = entries.partition { it.isNotBlank() && isStorePath(canonicalize(it)) }
     if (dropped.isEmpty()) return Decision.Inherit
 
     return Decision.Sanitized(
-      value = kept.joinToString(":").ifEmpty { null },
+      // Removed only when nothing at all survives. An empty *string* would not mean the same
+      // thing as an absent variable, and a surviving `""` element is a real search location.
+      value = if (kept.isEmpty()) null else kept.joinToString(":"),
       kept = kept,
       dropped = dropped,
       explanation =

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -248,7 +248,30 @@ abstract class RenderPreviewsTask : DefaultTask() {
    */
   @get:org.gradle.api.tasks.Optional @get:Input abstract val renderJavaExecutable: Property<String>
 
+  /**
+   * The `composeai.render.nativeEnv` mode ([RenderNativeEnv.SYS_PROP_MODE]) this execution renders
+   * under, as a declared input.
+   *
+   * A task input rather than a bare `System.getProperty` read inside the action, because the task
+   * is `@CacheableTask` and a failed render still writes outputs (the `.error.json` sidecars). A
+   * run with `-Dcomposeai.render.nativeEnv=inherit` that failed every preview would otherwise stay
+   * UP-TO-DATE — or be restored from the cache — after the override was dropped, so the fix would
+   * never get a chance to run.
+   *
+   * `LD_LIBRARY_PATH` itself is deliberately *not* declared: it differs between every developer
+   * machine and CI, so keying outputs on it would cost build-cache sharing to catch a case the
+   * `--rerun` guidance in `docs/DESKTOP_NATIVE_DEPS.md` already covers (a failed render is an
+   * up-to-date output whatever the environment reason).
+   */
+  @get:org.gradle.api.tasks.Optional @get:Input abstract val nativeEnvMode: Property<String>
+
+  @get:Inject protected abstract val providerFactory: org.gradle.api.provider.ProviderFactory
+
   init {
+    // Conventioned here rather than at each registration site: three tasks register this type
+    // (desktop render, Lottie, SVG) and a site that forgot it would silently go back to reading
+    // the property at execution time, i.e. back to the staleness this input exists to prevent.
+    nativeEnvMode.convention(providerFactory.systemProperty(RenderNativeEnv.SYS_PROP_MODE))
     // Explicit empty default so the desktop `composePreviewRender` registration (which never sets
     // `includeKinds`) has a configured value for this non-optional `@Input` rather than relying on
     // the managed-`SetProperty` implicit empty convention — keeps "render every kind" the default
@@ -692,6 +715,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
         renderJavaExecutable = renderJavaExecutable.orNull,
         daemonJavaHome = System.getProperty("java.home"),
         ldLibraryPath = System.getenv(RenderNativeEnv.VAR),
+        mode = nativeEnvMode.orNull,
       )
     if (decision is RenderNativeEnv.Decision.Sanitized) {
       logger.info("composePreviewRender: ${decision.explanation}")

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
@@ -203,6 +203,45 @@ class MissingPreviewMessageTest {
   }
 
   @Test
+  fun `formatMissingPreviewsMessage keeps distinct source frames apart`() {
+    // Same exception and message, different composables: three separate bugs. Collapsing them
+    // under the first one's frame would blame `A.kt:10` for failures in files it never touched.
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews = listOf("A", "B").map { previewWithCapture(it, "renders/$it.png") },
+      )
+    val sidecars =
+      mapOf(
+        "A" to
+          ComposePreviewTasks.ErrorSidecar(
+            exception = "java.lang.IllegalStateException",
+            message = "missing state",
+            topAppFrame = ComposePreviewTasks.ErrorSidecar.TopAppFrame("A.kt", 10, "APreview"),
+          ),
+        "B" to
+          ComposePreviewTasks.ErrorSidecar(
+            exception = "java.lang.IllegalStateException",
+            message = "missing state",
+            topAppFrame = ComposePreviewTasks.ErrorSidecar.TopAppFrame("B.kt", 20, "BPreview"),
+          ),
+      )
+
+    val msg =
+      ComposePreviewTasks.formatMissingPreviewsMessage(
+        manifest = manifest,
+        missingIds = listOf("A", "B"),
+        sidecars = sidecars,
+      )
+
+    assertThat(msg).contains("A.kt:10")
+    assertThat(msg).contains("B.kt:20")
+    // Two lines, each naming its own preview — not one line claiming "2 previews".
+    assertThat(msg).doesNotContain("2 previews")
+  }
+
+  @Test
   fun `formatMissingPreviewsMessage leads with the real cause, not the cascade`() {
     val manifest =
       PreviewManifest(

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderNativeEnvTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderNativeEnvTest.kt
@@ -65,6 +65,21 @@ class RenderNativeEnvTest {
   }
 
   @Test
+  fun `an empty entry is a search location too, and survives pruning`() {
+    // glibc reads an empty LD_LIBRARY_PATH element as the current directory. It is not a store
+    // path, so "everything else exactly as inherited" has to include it — position and all.
+    val decision =
+      decide(
+        renderJavaExecutable = "/usr/lib/jvm/java-21-openjdk-amd64/bin/java",
+        ldLibraryPath = ":/root/.cache/coo-ee/desktop-gl/lib:/opt/lib",
+      )
+
+    val sanitized = decision as RenderNativeEnv.Decision.Sanitized
+    assertThat(sanitized.value).isEqualTo(":/opt/lib")
+    assertThat(sanitized.dropped).containsExactly("/root/.cache/coo-ee/desktop-gl/lib")
+  }
+
+  @Test
   fun `a store render JVM keeps everything it inherited`() {
     // LD_LIBRARY_PATH is the *only* channel a patchelf'd store loader reads, and the doctor's own
     // remediation is to point it at /usr/lib/x86_64-linux-gnu. Pruning here would break that.

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosis.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosis.kt
@@ -62,7 +62,13 @@ internal object NativeLoadDiagnosis {
     val informative =
       natives.firstOrNull { namesTheReason(it.message.orEmpty()) } ?: natives.lastOrNull()
     informative?.let { native ->
-      val explanation = explain(native)
+      // Is this skiko's library, or a preview's own JNI dependency? A preview that calls
+      // System.loadLibrary("foo") on a host without libfoo throws the same UnsatisfiedLinkError,
+      // and answering it with skiko advice would be wrong twice over — misattributing the failure,
+      // and latching it so a later *real* skiko failure is dismissed as a cascade of it.
+      val skiko = chain.any(::mentionsSkiko)
+      val explanation = explain(native, skiko)
+      if (!skiko) return Diagnosis(explanation, cascade = false)
       // First one wins: later previews in this JVM see the cascade, not another copy of the cause.
       val alreadySeen = !firstFailure.compareAndSet(null, explanation)
       return Diagnosis(explanation, cascade = alreadySeen)
@@ -115,13 +121,34 @@ internal object NativeLoadDiagnosis {
       // depend on skiko's API surface for this — match by name.
       t.javaClass.name == "org.jetbrains.skiko.LibraryLoadException"
 
+  /**
+   * Whether [t] identifies Skia/skiko — by exception type, message (the `libskiko-…so` path the
+   * loader reports), or a frame in skiko's own loader. Checked across the whole cause chain, since
+   * the innermost `UnsatisfiedLinkError` names the file while the frames naming skiko sit above it.
+   */
+  private fun mentionsSkiko(t: Throwable): Boolean {
+    val message = t.message.orEmpty()
+    if (message.contains("libskiko") || message.contains("skiko-linux")) return true
+    if (t.javaClass.name.startsWith("org.jetbrains.skiko")) return true
+    return t.stackTrace.any {
+      it.className.startsWith("org.jetbrains.skiko") ||
+        it.className.startsWith("org.jetbrains.skia")
+    }
+  }
+
   private fun isSkiaInitCascade(t: Throwable): Boolean {
     if (t !is NoClassDefFoundError && t !is ExceptionInInitializerError) return false
     val message = t.message.orEmpty()
     return message.contains("org.jetbrains.skia") || message.contains("org.jetbrains.skiko")
   }
 
-  private fun explain(native: Throwable): String {
+  /**
+   * @param skiko whether the failure is skiko's own library load. When false this is a preview's
+   *   (or a dependency's) JNI library, so the explanation stays about *that* library — the glibc
+   *   and missing-soname reasoning is identical, the attribution is not.
+   */
+  private fun explain(native: Throwable, skiko: Boolean): String {
+    val subject = if (skiko) "skiko's native library" else "A native library this preview loads"
     val message = native.message.orEmpty()
     val javaHome = System.getProperty("java.home").orEmpty()
     val ldPath = System.getenv("LD_LIBRARY_PATH").orEmpty()
@@ -131,7 +158,8 @@ internal object NativeLoadDiagnosis {
       val requiredBy = REQUIRED_BY.find(message)?.groupValues?.get(1)
       val fromStore = requiredBy != null && STORE_PREFIXES.any { requiredBy.startsWith(it) }
       return buildString {
-        append("skiko's native library could not be loaded because this process mixed two glibc ")
+        append(subject)
+        append(" could not be loaded because this process mixed two glibc ")
         append("builds: the loader wanted `")
         append(glibcVersion)
         append("`")
@@ -161,15 +189,21 @@ internal object NativeLoadDiagnosis {
 
     val missing = MISSING_SONAME.find(message)?.groupValues?.get(1)
     if (missing != null) {
-      return "skiko's native library could not be loaded: `$missing` was not found by the render " +
-        "JVM's loader (java.home=${javaHome.ifEmpty { "unknown" }}, " +
-        "LD_LIBRARY_PATH=`${ldPath.ifEmpty { "(unset)" }}`). It is a direct DT_NEEDED dependency " +
-        "of libskiko — install it (Debian/Ubuntu: libgl1, libx11-6, libfontconfig1, libstdc++6) " +
-        "or put its directory on the render JVM's LD_LIBRARY_PATH. `compose-preview doctor` " +
-        "reports this as env.desktop-natives."
+      val where =
+        "was not found by the render JVM's loader (java.home=${javaHome.ifEmpty { "unknown" }}, " +
+          "LD_LIBRARY_PATH=`${ldPath.ifEmpty { "(unset)" }}`)"
+      return if (skiko) {
+        "$subject could not be loaded: `$missing` $where. It is a direct DT_NEEDED dependency of " +
+          "libskiko — install it (Debian/Ubuntu: libgl1, libx11-6, libfontconfig1, libstdc++6) or " +
+          "put its directory on the render JVM's LD_LIBRARY_PATH. `compose-preview doctor` " +
+          "reports this as env.desktop-natives."
+      } else {
+        "$subject could not be loaded: `$missing` $where. Install it, or put its directory on the " +
+          "render JVM's LD_LIBRARY_PATH."
+      }
     }
 
-    return "skiko's native library could not be loaded (java.home=" +
+    return "$subject could not be loaded (java.home=" +
       "${javaHome.ifEmpty { "unknown" }}, LD_LIBRARY_PATH=`${ldPath.ifEmpty { "(unset)" }}`): " +
       message.ifEmpty { native.javaClass.name }
   }

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosisTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosisTest.kt
@@ -77,6 +77,32 @@ class NativeLoadDiagnosisTest {
   }
 
   @Test
+  fun `a preview's own JNI library is not blamed on skiko`() {
+    // A preview (or one of its dependencies) calling System.loadLibrary on a host without that
+    // library throws the same UnsatisfiedLinkError. Answering it with libskiko advice would
+    // misattribute the failure — and latching it would dismiss a later real skiko failure as a
+    // cascade of something unrelated.
+    val ownLib =
+      UnsatisfiedLinkError(
+        "/opt/app/libtokenizer.so: libtokenizer.so: cannot open shared object file: " +
+          "No such file or directory"
+      )
+
+    val diagnosis = NativeLoadDiagnosis.diagnose(ownLib)
+
+    assertNotNull(diagnosis)
+    assertFalse(diagnosis!!.cascade)
+    assertTrue(diagnosis.text.contains("libtokenizer.so"))
+    assertFalse(diagnosis.text.contains("skiko"))
+    assertFalse(diagnosis.text.contains("libgl1"))
+
+    // And it did not take the latch: the next skiko failure is still reported as the first one.
+    val skiko = NativeLoadDiagnosis.diagnose(glibcSkewFailure())
+    assertFalse(skiko!!.cascade)
+    assertTrue(skiko.text.contains("skiko"))
+  }
+
+  @Test
   fun `later previews are reported as a cascade of the first failure`() {
     val first = NativeLoadDiagnosis.diagnose(glibcSkewFailure())
     val second =


### PR DESCRIPTION
Follow-up to #3701 (issue #3690), addressing the review comments it collected after merge. Five
places where the first cut was either too broad or too quiet:

**1. Blank `LD_LIBRARY_PATH` entries were dropped along with the store dirs.** glibc reads an empty
element as the current directory, so `:/nix/store/x/lib:/opt/lib` quietly lost a search location
that has nothing to do with the store — against the "everything else exactly as inherited" contract.
Blank entries now survive in place, and the variable is removed only when nothing at all is left.

**2. The native diagnosis blamed skiko for every `UnsatisfiedLinkError`.** A preview calling
`System.loadLibrary("foo")` on a host without `libfoo` got skiko remediation for its own JNI
dependency — and the JVM-global latch then dismissed a later *real* skiko failure as a cascade of
it. Classification now requires skiko evidence in the cause chain (exception type, the
`libskiko-…so` path in the message, or a frame in skiko's loader). Anything else keeps the same
glibc / missing-soname reasoning under its own name and never takes the latch.

**3. The `renderAll` summary merged distinct source frames.** Grouping by exception + message alone
collapsed several previews throwing `IllegalStateException("missing state")` from different
composables onto the first one's `at Foo.kt:12`, blaming a file that had nothing to do with the
others. The frame is part of the grouping key now.

**4. `composeai.render.nativeEnv` wasn't a task input.** The task is `@CacheableTask` and a failed
render still writes outputs (the `.error.json` sidecars), so a run under
`-Dcomposeai.render.nativeEnv=inherit` that failed every preview stayed UP-TO-DATE — or restored
from cache — once the override was dropped, and the fix never got to run. It's a declared `@Input`
now, conventioned in the task's `init` so all three registration sites (desktop, Lottie, SVG) get it
without having to remember. `LD_LIBRARY_PATH` itself stays undeclared on purpose: it differs on
every machine, so keying outputs on it would trade away build-cache sharing to catch what the
`--rerun` guidance in `DESKTOP_NATIVE_DEPS.md` already covers.

**5. `doctor` judged the daemon's JVM, not the render toolchain.** With a Nix daemon and a system
JDK render worker — the exact #3690 configuration — `env.desktop-natives` read the daemon's
`java.home`, concluded "store JVM, all fine", and missed the skew. It now evaluates every candidate
render JVM the Tooling model knows about, reports the worst verdict, and names the JVM it judged.

One limit worth stating rather than papering over: the desktop `composePreviewRender` is not a
`Test` task, so the Tooling model doesn't report its launcher — a CMP module pinning
`composePreview.renderJavaVersion` is still invisible to the check. Teaching the model about the
desktop render task is a change to a published Tooling interface, so I'd rather do it deliberately
than smuggle it into a fix PR. The check now says so in its detail where it could matter, and the
render task itself prunes correctly for that JVM regardless — it makes the decision from inside the
task, where the real executable is known.

## Test plan

- `./gradlew :gradle-plugin:test :cli:test :renderer-desktop:test :renderer-android:test
  ktfmtCheckAll` — BUILD SUCCESSFUL.
- New cases: an empty `LD_LIBRARY_PATH` element survives pruning
  (`RenderNativeEnvTest`); a preview's own JNI failure is diagnosed under its own name, doesn't
  mention skiko, and leaves the latch free for a later real skiko failure (`NativeLoadDiagnosisTest`);
  two previews with the same exception+message but different frames stay on separate lines
  (`MissingPreviewMessageTest`).

Non-visual change — plugin/renderer/CLI plumbing and error reporting; no rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFbgVkkvhUmSGE8sfbJ5n)_