### PR TITLE
fix(serve): correct the exploded 3D view's masks, shadows and bounds

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeExplodedSvg.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeExplodedSvg.kt
@@ -45,12 +45,16 @@ internal object ServeExplodedSvg {
   /**
    * The exploded-view options a request asks for.
    *
-   * Out-of-range and unparseable values fall back to the default rather than 400ing: this is a
-   * *view* axis on an export URL, not a render override, so a stale bookmark or a slider that
-   * over-shoots should still produce a picture. ([ExplodedSvg] clamps the angles it is handed for
-   * the same reason.) Depth is the exception that needs clamping here rather than there — its
-   * constructor rejects an out-of-range value outright, since a caller passing 40 planes is asking
-   * for 40 copies of the drawing.
+   * Unparseable values fall back to the default and out-of-range ones are clamped, rather than
+   * 400ing: this is a *view* axis on an export URL, not a render override, so a stale bookmark or a
+   * hand-typed angle should still produce a picture. Which side does the clamping differs by knob,
+   * and deliberately:
+   * - **Angles and separation** are clamped by [ExplodedSvg] itself, because the bound is a
+   *   property of the projection (and, for separation, is relative to the drawing's own size —
+   *   something only the renderer knows).
+   * - **Depth** is clamped here, because `Options`' constructor *rejects* an out-of-range value
+   *   outright: a caller asking for 40 planes is asking for 40 structural copies of the drawing,
+   *   which is a request to refuse rather than a picture to draw.
    */
   fun optionsFrom(params: (String) -> String?): ExplodedSvg.Options {
     val defaults = ExplodedSvg.Options()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4025,15 +4025,29 @@ class ServeHttpServer(
           null
         } else {
           try {
-            when {
-              scroll -> renderHost.renderScrollSvg(previewId, overrides)
-              // Web mode routes through the host's web variant: a catalog-backed host links its
-              // raster crops to their published branch files instead of embedding them (the
-              // default host keeps the self-contained bytes). The font-`@import` rewrite below
-              // applies either way.
-              webMode -> renderHost.renderSvgForWeb(previewId, overrides)
-              else -> renderHost.renderSvg(previewId, overrides)
-            }
+            val produced =
+              when {
+                scroll -> renderHost.renderScrollSvg(previewId, overrides)
+                // Web mode routes through the host's web variant: a catalog-backed host links its
+                // raster crops to their published branch files instead of embedding them (the
+                // default host keeps the self-contained bytes). The font-`@import` rewrite below
+                // applies either way.
+                webMode -> renderHost.renderSvgForWeb(previewId, overrides)
+                else -> renderHost.renderSvg(previewId, overrides)
+              }
+            // Both post-render rewrites run with the permit still held. The `mode=web` one is a
+            // regex pass over a string, but the exploded projection parses the whole SVG into a
+            // DOM, structurally copies it once per sheet and re-serializes — comparable to a
+            // render on a large catalog export. Outside the semaphore, a public host could be
+            // asked for a hundred different `explodeTilt=` values at once and would run all of
+            // them in parallel, which is precisely what this route's load shedding exists to
+            // prevent. Inside it, the burst queues like any other render and sheds with a 503.
+            if (produced is SvgOutcome.Ok && (webMode || exploded != null)) {
+              var text = produced.svg.toString(Charsets.UTF_8)
+              if (webMode) text = webModeSvg(text)
+              if (exploded != null) text = ExplodedSvg.render(text, exploded)
+              produced.copy(svg = text.toByteArray(Charsets.UTF_8))
+            } else produced
           } finally {
             renderSemaphore.release()
           }
@@ -4049,17 +4063,12 @@ class ServeHttpServer(
       }
       is SvgOutcome.Ok -> {
         // The render host produces the self-contained (embedded) SVG and caches it; the web and
-        // exploded variants are cheap per-response rewrites of those bytes, so every mode shares
-        // one render + cache. Web mode runs first: it rewrites the `@font-face` block the exploded
-        // view then carries through untouched, whereas the reverse order would have it hunting for
-        // that block inside a reserialized document.
-        val svg =
-          if (webMode || exploded != null) {
-            var text = outcome.svg.toString(Charsets.UTF_8)
-            if (webMode) text = webModeSvg(text)
-            if (exploded != null) text = ExplodedSvg.render(text, exploded)
-            text.toByteArray(Charsets.UTF_8)
-          } else outcome.svg
+        // exploded variants are per-response rewrites of those bytes, so every mode shares one
+        // render + cache. Both were already applied above, inside the semaphore — web mode first,
+        // since it rewrites the `@font-face` block the exploded view then carries through
+        // untouched, whereas the reverse order would have it hunting for that block inside a
+        // reserialized document.
+        val svg = outcome.svg
         val contentType = ContentType.parse(ComposeFigmaSvgProduct.MEDIA_TYPE_SVG)
         // The vector lane drops overrides exactly like the PNG one: a `figma/<slug>.svg` read off
         // the delivery branch was drawn at the preview's discovery-time axes, so serving it for a

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -458,22 +458,30 @@
     if (raw === "") return true; // a bare `?exploded`
     return ["1", "true", "on", "yes"].indexOf(String(raw).toLowerCase()) >= 0;
   }
+  // A server-side Remote Compose player pick cannot survive the exploded view, so entering it
+  // releases the pick rather than hiding it. `rcPlayer=cmp-jvm` is a renderer choice, not a mode,
+  // so it outlives a return to the static lane — and the server routes it to the desktop player's
+  // own subprocess *before* it ever looks at `exploded=`, leaving the chip pressed over an
+  // untouched flat SVG. There is nothing to explode there either way: that lane renders a Remote
+  // Compose document, which carries none of the `<g id="…">` composable nesting this view splits
+  // on.
+  //
+  // Resetting the STATE rather than filtering `rcPlayer` out of the request string is the whole
+  // point: the string is copied into the page URL by syncUrl() and read back by the lane picker's
+  // label, so a filtered request left the address bar and the "current renderer" chip both naming
+  // a player that is no longer drawing anything.
+  function dropRcPlayerPick() {
+    if (!rcPlayerPicked) return;
+    rcPlayerPicked = false;
+    rcPlayerBackend = rcDefaultBackend;
+    if (typeof syncLaneSelect === "function") syncLaneSelect();
+  }
   // Whether pressing 3D is what turned the vector lane on. Leaving 3D then hands the lane back
   // rather than stranding the visitor on a flat SVG they never asked for — but only in that case:
   // someone who was already reading the SVG and exploded it should get their SVG back, not a PNG.
   var explodeEnabledSvg = false;
   function withExplode(ext, qs) {
     if (ext !== ".svg" || !explodeOn()) return qs;
-    // Drop any Remote Compose player pick. `rcPlayer=cmp-jvm` survives a return to the static lane
-    // (it is a renderer choice, not a mode), and the server routes it to the desktop player's own
-    // subprocess *before* it ever looks at `exploded=` — so the chip would sit pressed over an
-    // untouched flat SVG. There is nothing to explode there either way: that lane renders a Remote
-    // Compose document, which carries none of the `<g id="…">` composable nesting this view splits
-    // on. The exploded view is of the LAYERED export, so it asks for the layered export.
-    qs = (qs || "")
-      .split("&")
-      .filter(function (p) { return p && p.indexOf("rcPlayer=") !== 0; })
-      .join("&");
     var parts = ["exploded=1"];
     EXPLODE_KNOBS.forEach(function (pair) {
       var el = document.getElementById(pair[0]);
@@ -1738,6 +1746,7 @@
       if (root) root.setAttribute("data-exploded", turnOn ? "1" : "0");
       syncExplodeControls();
       urlPush = true;
+      if (turnOn) dropRcPlayerPick();
       if (turnOn && svgToggle && !svgOn()) {
         // Turning SVG on is itself a lane change; let its handler drive the render so there is
         // exactly one request, with `exploded=1` already folded in by withSnapshotFormat.
@@ -2399,13 +2408,23 @@
         // authored default. The next refresh would then render a camera nobody asked for and
         // rewrite the shared URL to match it, which is the opposite of the documented fallback.
         var raw = q.get(pair[1]);
-        var num = raw === null ? NaN : Number(raw);
-        var min = parseFloat(el.getAttribute("min"));
-        var max = parseFloat(el.getAttribute("max"));
-        var usable =
-          raw !== null && raw !== "" && isFinite(num) &&
-          (isNaN(min) || num >= min) && (isNaN(max) || num <= max);
-        el.value = usable ? raw : (el.getAttribute("data-cp-default") || el.value);
+        var num = raw === null || raw === "" ? NaN : Number(raw);
+        if (isFinite(num)) {
+          // Finite but out of range is CLAMPED, not rejected — `ExplodedSvg` clamps the angles and
+          // the separation it is handed, so `?explodeTilt=76` renders at 75° from the endpoint and
+          // must open at 75° here too rather than snapping to the default and rewriting the URL
+          // out from under whoever shared it.
+          var min = parseFloat(el.getAttribute("min"));
+          var max = parseFloat(el.getAttribute("max"));
+          if (!isNaN(min) && num < min) num = min;
+          if (!isNaN(max) && num > max) num = max;
+          el.value = String(num);
+        } else {
+          // Only a value the browser cannot parse falls back. Assigning it raw would be worse than
+          // useless: `<input type="range">` sanitizes an unparseable value to its MIDPOINT, so a
+          // stale `?explodeTilt=nope` rendered a camera nobody asked for.
+          el.value = el.getAttribute("data-cp-default") || el.value;
+        }
         updateExplodeReadout(el);
       });
       syncExplodeControls();

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -449,8 +449,31 @@
   function explodeOn() {
     return !!(explodeToggle && explodeToggle.getAttribute("aria-pressed") === "true");
   }
+  // The same boolean forms `ServeExplodedSvg.enabled` accepts, so a hand-typed or bookmarked
+  // `?exploded=on` opens the view the render endpoint would serve for that URL — rather than
+  // showing the flat PNG and then dropping the parameter on the next sync, which is what a
+  // stricter reading here produced.
+  function explodeParamOn(raw) {
+    if (raw === null || raw === undefined) return false;
+    if (raw === "") return true; // a bare `?exploded`
+    return ["1", "true", "on", "yes"].indexOf(String(raw).toLowerCase()) >= 0;
+  }
+  // Whether pressing 3D is what turned the vector lane on. Leaving 3D then hands the lane back
+  // rather than stranding the visitor on a flat SVG they never asked for — but only in that case:
+  // someone who was already reading the SVG and exploded it should get their SVG back, not a PNG.
+  var explodeEnabledSvg = false;
   function withExplode(ext, qs) {
     if (ext !== ".svg" || !explodeOn()) return qs;
+    // Drop any Remote Compose player pick. `rcPlayer=cmp-jvm` survives a return to the static lane
+    // (it is a renderer choice, not a mode), and the server routes it to the desktop player's own
+    // subprocess *before* it ever looks at `exploded=` — so the chip would sit pressed over an
+    // untouched flat SVG. There is nothing to explode there either way: that lane renders a Remote
+    // Compose document, which carries none of the `<g id="…">` composable nesting this view splits
+    // on. The exploded view is of the LAYERED export, so it asks for the layered export.
+    qs = (qs || "")
+      .split("&")
+      .filter(function (p) { return p && p.indexOf("rcPlayer=") !== 0; })
+      .join("&");
     var parts = ["exploded=1"];
     EXPLODE_KNOBS.forEach(function (pair) {
       var el = document.getElementById(pair[0]);
@@ -1574,11 +1597,17 @@
   // SVG chip and forget this one.
   function dropVectorModes() {
     if (svgToggle) svgToggle.setAttribute("aria-pressed", "false");
-    if (explodeToggle && explodeOn()) {
-      explodeToggle.setAttribute("aria-pressed", "false");
-      if (root) root.setAttribute("data-exploded", "0");
-      syncExplodeControls();
-    }
+    clearExploded();
+  }
+  // Un-press the 3D chip and re-sync its controls. Shared by every path that leaves the vector
+  // lane — the interactive lanes above, and the SVG chip being switched off — so a future lane
+  // can't drop one and forget the other.
+  function clearExploded() {
+    if (!explodeToggle || !explodeOn()) return;
+    explodeToggle.setAttribute("aria-pressed", "false");
+    if (root) root.setAttribute("data-exploded", "0");
+    syncExplodeControls();
+    explodeEnabledSvg = false;
   }
   // The stage lane the current transition is leaving, latched by enterMode before it tears that
   // lane down. Read by specActualUrl, which cannot otherwise tell whether the snapshot <img> holds
@@ -1684,6 +1713,11 @@
       // iframe / spec image that is still on screen, with its chip still pressed. The daemon and
       // Wasm lanes were already routed this way; the RC canvas, the RC/Wasm frame and the spec
       // lane are the same case.
+      // The exploded view is a view OF the vector export, so leaving the vector lane leaves it
+      // too. Without this the 3D chip stayed pressed over a flat PNG, its sliders stayed live, and
+      // the copied/downloaded SVG stayed exploded while the stage showed something else — three
+      // controls describing a frame that is no longer on screen.
+      if (!turnOn) clearExploded();
       if (turnOn && (live.checked || wasmActive() || rcActive() || rcWasmActive() || specActive())) {
         setMode("png"); // enterMode("png") reads svgOn() → renders the .svg
       } else {
@@ -1707,9 +1741,12 @@
       if (turnOn && svgToggle && !svgOn()) {
         // Turning SVG on is itself a lane change; let its handler drive the render so there is
         // exactly one request, with `exploded=1` already folded in by withSnapshotFormat.
+        // Remembered so leaving 3D can hand the lane back (see explodeEnabledSvg).
+        explodeEnabledSvg = true;
         svgToggle.click();
         return;
       }
+      if (!turnOn) explodeEnabledSvg = false;
       refreshSnapshot();
     });
   }
@@ -2350,13 +2387,25 @@
     // angles someone tried. A knob the entry doesn't carry resets to its authored default rather
     // than keeping the live value, which would leave the page disagreeing with its own address.
     if (explodeToggle) {
-      var explodeWanted = q.get("exploded") === "1" || q.get("exploded") === "true";
+      var explodeWanted = explodeParamOn(q.get("exploded"));
       explodeToggle.setAttribute("aria-pressed", explodeWanted ? "true" : "false");
       if (root) root.setAttribute("data-exploded", explodeWanted ? "1" : "0");
       EXPLODE_KNOBS.forEach(function (pair) {
         var el = document.getElementById(pair[0]);
         if (!el) return;
-        el.value = q.get(pair[1]) || el.getAttribute("data-cp-default") || el.value;
+        // Validate before assigning. `<input type="range">` runs the browser's value-sanitization
+        // algorithm on whatever it is given, and a value it can't parse — a stale
+        // `?explodeTilt=nope`, or one outside min..max — lands on the range's MIDPOINT, not on the
+        // authored default. The next refresh would then render a camera nobody asked for and
+        // rewrite the shared URL to match it, which is the opposite of the documented fallback.
+        var raw = q.get(pair[1]);
+        var num = raw === null ? NaN : Number(raw);
+        var min = parseFloat(el.getAttribute("min"));
+        var max = parseFloat(el.getAttribute("max"));
+        var usable =
+          raw !== null && raw !== "" && isFinite(num) &&
+          (isNaN(min) || num >= min) && (isNaN(max) || num <= max);
+        el.value = usable ? raw : (el.getAttribute("data-cp-default") || el.value);
         updateExplodeReadout(el);
       });
       syncExplodeControls();
@@ -2368,9 +2417,18 @@
       // vector lane back off: the visitor may have been reading the plain SVG before they exploded
       // it, and that is the state Back should return them to.
       if (explodeWanted && svgToggle && !svgOn()) {
+        explodeEnabledSvg = true;
         svgToggle.setAttribute("aria-pressed", "true");
         snapshotExt = ".svg";
         root.setAttribute("data-mode", "svg");
+      } else if (!explodeWanted && explodeEnabledSvg && svgToggle) {
+        // Back out of an entry that 3D created: the vector lane has no URL parameter of its own,
+        // so without this the restored page keeps the SVG that 3D switched it to and shows a flat
+        // vector render the visitor never chose. Only when 3D is what turned it on.
+        explodeEnabledSvg = false;
+        svgToggle.setAttribute("aria-pressed", "false");
+        snapshotExt = ".png";
+        root.setAttribute("data-mode", "snapshot");
       }
     }
     ["focus", "gestures"].forEach(function (f) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -507,6 +507,16 @@ class ServeHttpRoutingTest {
       getFull("/svg-catalog/render/$previewId.svg?exploded=1&explodeTilt=nope&explodeDepth=999")
     assertEquals(200, bogusCode)
     assertEquals(3, Regex("class=\"cp-exploded-plane\"").findAll(bogus).count())
+
+    // A hand-typed separation far past anything the slider offers is bounded, not obeyed: past
+    // ~2.1e6 the canvas numbers stop surviving formatting and the picture collapses instead of
+    // merely spreading out.
+    val (hugeCode, huge, _) =
+      getFull("/svg-catalog/render/$previewId.svg?exploded=1&explodeGap=3000000")
+    assertEquals(200, hugeCode)
+    assertEquals(3, Regex("class=\"cp-exploded-plane\"").findAll(huge).count())
+    val height = Regex("<svg[^>]*\\bheight=\"([\\d.]+)\"").find(huge)!!.groupValues[1].toDouble()
+    assertTrue(height < 10_000, "the stack is bounded, not 3 million units tall: $height")
   }
 
   /** `?exploded=0` is the explicit off state a bookmarked URL can carry; it changes nothing. */

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvg.kt
@@ -134,18 +134,6 @@ object ExplodedSvg {
    */
   private val UNINFORMATIVE_LAYER_NAMES = setOf("ReusableComposeNode", "Layer", "Root")
 
-  /**
-   * Group attributes that describe the group *as a whole*, and so may ride only the plane holding
-   * that group's own drawing.
-   * - `id` names the composable. Repeated across every plane that carries a transform-only copy of
-   *   the group, one composable would import into Figma as N same-named layers.
-   * - `filter` is the elevation drop shadow. A filter is recomputed from whatever its element
-   *   actually renders, so copying it onto the fragments would give a `Card`'s shadow to its own
-   *   surface (right) *and* mint a second, text-shaped shadow on the plane holding its `Text`
-   *   (wrong — nothing casts that in the flat export).
-   */
-  private val OWNING_PLANE_ONLY_ATTRS = setOf("id", "filter")
-
   /** Elements that paint. Assigned to a plane; never descended into. */
   private val DRAWING_TAGS =
     setOf(
@@ -388,26 +376,51 @@ object ExplodedSvg {
 
     fun resources(): List<Element> = resourceElements
 
-    fun walk(el: Element, depth: Int) {
+    /**
+     * Named group → the shallowest plane any drawing in its subtree lands on. Equals the group's
+     * own plane whenever it paints anything itself; for an elevated wrapper that paints only
+     * through a nested child, it is that child's plane. Keyed by identity, since layer ids repeat.
+     */
+    private val firstPlane = java.util.IdentityHashMap<Element, Int>()
+
+    /**
+     * The one plane a group's rendered whole-group effects (its `filter`) belong on — the
+     * shallowest plane it is retained on, which is where it first appears in the stack. Equal to
+     * its nesting level whenever the group paints anything itself.
+     */
+    fun owningPlane(group: Element): Int = firstPlane[group] ?: -1
+
+    /** Shallowest plane any drawing under [el] occupies, or null when it paints nothing at all. */
+    fun walk(el: Element, depth: Int): Int? {
       val tag = el.localNameOf()
       // Recorded, then never descended into: a `<g id="material-icon-…">` inside `<defs>` is a
       // drawing to `<use>`, not a level of composable nesting.
       if (tag in RESOURCE_TAGS) {
         resourceElements.add(el)
-        return
+        return null
       }
       if (tag in DRAWING_TAGS) {
         occupied[planeOf(depth)] = true
-        return
+        return planeOf(depth)
       }
-      if (tag !in GROUP_TAGS) return
+      if (tag !in GROUP_TAGS) return null
       val id = el.getAttribute("id").takeIf { it.isNotBlank() }
       val childDepth = if (id != null) depth + 1 else depth
+      var first: Int? = null
+      for (child in el.childElements()) {
+        val childPlane = walk(child, childDepth) ?: continue
+        if (first == null || childPlane < first) first = childPlane
+      }
       if (id != null) {
+        firstPlane[el] = first ?: planeOf(childDepth)
+        // The LABEL stays on the nesting level, not on `first`. The label column's whole claim is
+        // "this sheet is depth N of the composable tree", so a non-painting wrapper belongs at its
+        // own level — moving its name down to wherever its child happens to draw would leave a
+        // nameless sheet above it and misreport the structure.
         val label = displayName(el, id)
         if (label != null) names[planeOf(childDepth)].add(label)
       }
-      for (child in el.childElements()) walk(child, childDepth)
+      return first
     }
 
     /**
@@ -454,10 +467,9 @@ object ExplodedSvg {
    * nothing on this plane survives, so empty scaffolding is never emitted.
    *
    * Groups are copied for their `transform` / `clip-path` / `opacity`, which is what keeps a
-   * plane's elements in the position and shape they had in the flat drawing.
-   * [OWNING_PLANE_ONLY_ATTRS] are the exception — they ride only the plane the group's own drawing
-   * belongs to, because every other plane holds a *fragment* of that group, and an attribute that
-   * described the whole would silently describe the fragment instead.
+   * plane's elements in the position and shape they had in the flat drawing. Two attributes
+   * describe the group *as a whole* and so must not be repeated onto every fragment; they answer
+   * different questions, so they get different rules (see the call site).
    */
   private fun copyForPlane(
     out: Document,
@@ -477,11 +489,14 @@ object ExplodedSvg {
     val kept = src.childElements().mapNotNull { copyForPlane(out, it, childDepth, plane, scan) }
     if (kept.isEmpty()) return null
     val copy = out.createElementNS(SVG_NS, tag)
-    copyAttributesExcept(
-      src,
-      copy,
-      if (scan.planeOf(childDepth) == plane) emptySet() else OWNING_PLANE_ONLY_ATTRS,
-    )
+    // Two different "once" rules, because the two attributes answer different questions.
+    val skip = HashSet<String>(2)
+    // `id` names the composable at its nesting level, exactly where the label column puts it.
+    if (scan.planeOf(childDepth) != plane) skip.add("id")
+    // `filter` is a rendered effect and must survive: it rides the shallowest plane the group is
+    // retained on, which is the nesting level whenever the group paints anything itself.
+    if (id != null && scan.owningPlane(src) != plane) skip.add("filter")
+    copyAttributesExcept(src, copy, skip)
     for (child in kept) copy.appendChild(child)
     return copy
   }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvg.kt
@@ -13,7 +13,6 @@ import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.max
 import kotlin.math.min
-import kotlin.math.roundToInt
 import kotlin.math.sin
 import org.w3c.dom.Document
 import org.w3c.dom.Element
@@ -135,6 +134,18 @@ object ExplodedSvg {
    */
   private val UNINFORMATIVE_LAYER_NAMES = setOf("ReusableComposeNode", "Layer", "Root")
 
+  /**
+   * Group attributes that describe the group *as a whole*, and so may ride only the plane holding
+   * that group's own drawing.
+   * - `id` names the composable. Repeated across every plane that carries a transform-only copy of
+   *   the group, one composable would import into Figma as N same-named layers.
+   * - `filter` is the elevation drop shadow. A filter is recomputed from whatever its element
+   *   actually renders, so copying it onto the fragments would give a `Card`'s shadow to its own
+   *   surface (right) *and* mint a second, text-shaped shadow on the plane holding its `Text`
+   *   (wrong — nothing casts that in the flat export).
+   */
+  private val OWNING_PLANE_ONLY_ATTRS = setOf("id", "filter")
+
   /** Elements that paint. Assigned to a plane; never descended into. */
   private val DRAWING_TAGS =
     setOf(
@@ -193,16 +204,19 @@ object ExplodedSvg {
     // walk skips <defs>/<clipPath>/… so a hoisted Material-icon `<g id="material-icon-…">` inside
     // <defs> never counts as a nesting level.
     val scan = Scan(options.maxDepth)
-    for (child in root.childElements()) {
-      if (child.localNameOf() in RESOURCE_TAGS) continue
-      scan.walk(child, 0)
-    }
+    for (child in root.childElements()) scan.walk(child, 0)
     val planeCount = scan.planeCount()
     if (planeCount == 0) return svg
 
     val spin = options.spinDeg.coerceIn(SPIN_RANGE) * PI / 180.0
     val tilt = options.tiltDeg.coerceIn(TILT_RANGE) * PI / 180.0
-    val gap = options.gap?.takeIf { it.isFinite() && it > 0.0 } ?: autoGap(box, planeCount)
+    // The separation is bounded relative to the drawing rather than by an absolute number, because
+    // "how far apart is too far" only means anything next to the sheet's own size. Past this the
+    // sheets are specks at the ends of a ribbon of whitespace — and far enough past it, the canvas
+    // dimensions stop being representable at all (see [fmt]).
+    val gap =
+      options.gap?.takeIf { it.isFinite() && it > 0.0 }?.coerceAtMost(maxGap(box))
+        ?: autoGap(box, planeCount)
 
     val a = cos(spin)
     val b = cos(tilt) * sin(spin)
@@ -245,18 +259,41 @@ object ExplodedSvg {
       }
     }
 
-    // The label column: a leader line out to a fixed x, then the names. Sized from the longest
-    // label so nothing is clipped by the viewBox (an SVG has no overflow to scroll into).
-    val labelPlanes =
-      if (options.labels) (0 until planeCount).map { it to scan.labelFor(it) } else emptyList()
+    // The label column: a leader line out to a fixed x, then the names. Laid out BEFORE the canvas
+    // is sized, because collision avoidance moves labels off their sheet's own y — at a small
+    // separation on a deep stack the run of nudges carries the last label well past the lowest
+    // sheet corner, and an SVG has no overflow to scroll into, so a canvas measured from the sheets
+    // alone would simply crop them.
     val leaderLength = fontSize * 3.5
     val labelX = maxX + leaderLength
-    val labelWidth = labelPlanes.maxOfOrNull { estimateTextWidth(it.second, fontSize) } ?: 0.0
+    val labels =
+      if (!options.labels) emptyList()
+      else
+        layoutLabels(
+          planeCount = planeCount,
+          label = scan::labelFor,
+          box = box,
+          a = a,
+          b = b,
+          c = c,
+          d = d,
+          baseE = baseE,
+          baseF = baseF,
+          planeOffsetY = ::planeOffsetY,
+          fontSize = fontSize,
+        )
+    val labelWidth = labels.maxOfOrNull { estimateTextWidth(it.text, fontSize) } ?: 0.0
+    for (placement in labels) {
+      // Half a line either side of the baseline: the text is centred on `labelY`
+      // (`dominant-baseline: middle`).
+      minY = min(minY, placement.labelY - fontSize)
+      maxY = max(maxY, placement.labelY + fontSize)
+    }
     val pad = max(16.0, fontSize)
     val canvasMinX = minX - pad
     val canvasMinY = minY - pad
     val canvasWidth =
-      (maxX - minX) + 2 * pad + if (labelPlanes.isEmpty()) 0.0 else leaderLength + labelWidth
+      (maxX - minX) + 2 * pad + if (labels.isEmpty()) 0.0 else leaderLength + labelWidth
     val canvasHeight = (maxY - minY) + 2 * pad
 
     val out = newDocument()
@@ -274,11 +311,17 @@ object ExplodedSvg {
     outSvg.setAttribute("data-exploded", "true")
     outSvg.setAttribute("data-exploded-planes", planeCount.toString())
 
-    // Resources first, verbatim and exactly once. Duplicating them per plane would multiply the
-    // embedded WOFF2 payloads by the plane count for no benefit.
-    for (child in root.childElements()) {
-      if (child.localNameOf() in RESOURCE_TAGS) outSvg.appendChild(out.importNode(child, true))
-    }
+    // Resources, verbatim and exactly once. Duplicating them per plane would multiply the embedded
+    // WOFF2 payloads by the plane count for no benefit.
+    //
+    // **Hoisted from wherever they sit, not just the root.** A `Modifier.clip` layer's `<clipPath>`
+    // is emitted by `FigmaLayeredSvg` *inline*, as a sibling of the named group it masks, deep in
+    // the content tree — so collecting only the root's resource children would drop every one of
+    // them while the copied `<g clip-path="url(#clip-N)">` wrapper kept pointing at the missing id,
+    // and a rounded image would spill out of its mask (or vanish outright, depending on how the
+    // renderer treats a dangling reference). Hoisting is safe because a `clipPath`'s contents
+    // resolve in the user space of the element that *references* it, not the one it is nested in.
+    for (resource in scan.resources()) outSvg.appendChild(out.importNode(resource, true))
     outSvg.appendChild(chromeStyle(out))
     outSvg.appendChild(canvasRect(out, canvasMinX, canvasMinY, canvasWidth, canvasHeight))
 
@@ -315,24 +358,7 @@ object ExplodedSvg {
       planesGroup.appendChild(g)
     }
 
-    if (labelPlanes.isNotEmpty()) {
-      outSvg.appendChild(
-        labelsGroup(
-          out,
-          labelPlanes,
-          box,
-          a,
-          b,
-          c,
-          d,
-          baseE,
-          baseF,
-          ::planeOffsetY,
-          labelX,
-          fontSize,
-        )
-      )
-    }
+    if (labels.isNotEmpty()) outSvg.appendChild(labelsGroup(out, labels, labelX, fontSize))
 
     return serialize(out)
   }
@@ -351,12 +377,25 @@ object ExplodedSvg {
     private val occupied = BooleanArray(MAX_PLANES + 1)
     /** Plane index → composable names owning that plane's drawing, in document order. */
     private val names = Array(MAX_PLANES + 1) { LinkedHashSet<String>() }
+    /**
+     * Every resource element in the source, at whatever depth it sits, in document order — the
+     * `<defs>`/`<style>` at the root *and* the `<clipPath>`s `FigmaLayeredSvg` emits inline beside
+     * the layers they mask. Collected here so they can be hoisted once into the output.
+     */
+    private val resourceElements = ArrayList<Element>()
 
     fun planeOf(depth: Int): Int = min(depth, maxDepth)
 
+    fun resources(): List<Element> = resourceElements
+
     fun walk(el: Element, depth: Int) {
       val tag = el.localNameOf()
-      if (tag in RESOURCE_TAGS) return
+      // Recorded, then never descended into: a `<g id="material-icon-…">` inside `<defs>` is a
+      // drawing to `<use>`, not a level of composable nesting.
+      if (tag in RESOURCE_TAGS) {
+        resourceElements.add(el)
+        return
+      }
       if (tag in DRAWING_TAGS) {
         occupied[planeOf(depth)] = true
         return
@@ -415,10 +454,10 @@ object ExplodedSvg {
    * nothing on this plane survives, so empty scaffolding is never emitted.
    *
    * Groups are copied for their `transform` / `clip-path` / `opacity`, which is what keeps a
-   * plane's elements in the position and shape they had in the flat drawing. A retained group keeps
-   * its `id` only on the plane its own drawing belongs to — every other plane holds a
-   * transform-carrying copy of the same group, and repeating the id across all of them would turn
-   * one composable into N same-named layers on a Figma import.
+   * plane's elements in the position and shape they had in the flat drawing.
+   * [OWNING_PLANE_ONLY_ATTRS] are the exception — they ride only the plane the group's own drawing
+   * belongs to, because every other plane holds a *fragment* of that group, and an attribute that
+   * described the whole would silently describe the fragment instead.
    */
   private fun copyForPlane(
     out: Document,
@@ -441,7 +480,7 @@ object ExplodedSvg {
     copyAttributesExcept(
       src,
       copy,
-      if (scan.planeOf(childDepth) == plane) emptySet() else setOf("id"),
+      if (scan.planeOf(childDepth) == plane) emptySet() else OWNING_PLANE_ONLY_ATTRS,
     )
     for (child in kept) copy.appendChild(child)
     return copy
@@ -458,9 +497,29 @@ object ExplodedSvg {
    * leader gains a bend rather than overlapping.
    */
   @Suppress("LongParameterList")
-  private fun labelsGroup(
-    out: Document,
-    planes: List<Pair<Int, String>>,
+  /** One label's resolved geometry: where its leader starts, and where its text ends up. */
+  private data class LabelPlacement(
+    val plane: Int,
+    val text: String,
+    val anchorX: Double,
+    val anchorY: Double,
+    val labelY: Double,
+  )
+
+  /**
+   * Resolve every label's position without emitting anything, so the caller can size the canvas
+   * around the result.
+   *
+   * A label starts level with the projected midpoint of its sheet's right edge. Sheets are emitted
+   * bottom-up but read top-down, so the pass runs from the topmost and pushes each subsequent label
+   * down to keep a minimum line spacing — which means the column can extend past the lowest sheet
+   * corner whenever the separation is smaller than a line of text. That overflow is exactly what
+   * the caller has to include in the viewBox.
+   */
+  @Suppress("LongParameterList")
+  private fun layoutLabels(
+    planeCount: Int,
+    label: (Int) -> String,
     box: ViewBox,
     a: Double,
     b: Double,
@@ -469,6 +528,26 @@ object ExplodedSvg {
     baseE: Double,
     baseF: Double,
     planeOffsetY: (Int) -> Double,
+    fontSize: Double,
+  ): List<LabelPlacement> {
+    val edgeX = box.minX + box.width
+    val edgeY = box.minY + box.height / 2.0
+    val anchorX = a * edgeX + c * edgeY + baseE
+    val minSpacing = fontSize * 1.6
+    val out = ArrayList<LabelPlacement>(planeCount)
+    var previousY: Double? = null
+    for (plane in (planeCount - 1) downTo 0) {
+      val anchorY = b * edgeX + d * edgeY + baseF + planeOffsetY(plane)
+      val labelY = previousY?.let { max(anchorY, it + minSpacing) } ?: anchorY
+      previousY = labelY
+      out.add(LabelPlacement(plane, label(plane), anchorX, anchorY, labelY))
+    }
+    return out
+  }
+
+  private fun labelsGroup(
+    out: Document,
+    placements: List<LabelPlacement>,
     labelX: Double,
     fontSize: Double,
   ): Element {
@@ -476,18 +555,7 @@ object ExplodedSvg {
     group.setAttribute("class", "cp-exploded-labels")
     group.setAttribute("font-size", fmt(fontSize))
 
-    val edgeX = box.minX + box.width
-    val edgeY = box.minY + box.height / 2.0
-    val anchorX = a * edgeX + c * edgeY + baseE
-    // Sheets are emitted bottom-up but read top-down, so lay the labels out from the topmost.
-    val ordered = planes.sortedByDescending { it.first }
-    val minSpacing = fontSize * 1.6
-    var previousY: Double? = null
-    for ((plane, text) in ordered) {
-      val anchorY = b * edgeX + d * edgeY + baseF + planeOffsetY(plane)
-      val labelY = previousY?.let { max(anchorY, it + minSpacing) } ?: anchorY
-      previousY = labelY
-
+    for ((plane, text, anchorX, anchorY, labelY) in placements) {
       val dot = out.createElementNS(SVG_NS, "circle")
       dot.setAttribute("class", "cp-exploded-leader-dot")
       dot.setAttribute("cx", fmt(anchorX))
@@ -602,6 +670,14 @@ object ExplodedSvg {
   /** Total sheet separation, in long-edges of the source drawing, that [autoGap] will spend. */
   private const val STACK_BUDGET = 1.6
 
+  /**
+   * Ceiling for a caller-supplied [Options.gap], in long-edges of the source drawing. Generous —
+   * four sheet-heights apart is already far looser than anything the viewer's slider offers — but
+   * finite, so a hand-typed or stale `?explodeGap=3000000` produces a very spread-out picture
+   * instead of a canvas whose numbers no longer fit the format.
+   */
+  private fun maxGap(box: ViewBox): Double = max(box.width, box.height) * 4.0
+
   private fun viewBoxOf(root: Element): ViewBox? {
     val raw = root.getAttribute("viewBox").trim()
     if (raw.isNotEmpty()) {
@@ -686,10 +762,18 @@ object ExplodedSvg {
     return out
   }
 
-  /** Compact number formatting — SVG attributes carry a lot of these and trailing zeros add up. */
+  /**
+   * Compact number formatting — SVG attributes carry a lot of these and trailing zeros add up.
+   *
+   * Rounds through `Long`, not `Int`: `(value * 1000).roundToInt()` saturates at `Int.MAX_VALUE`
+   * for anything past ~2.1e6, so a single absurd coordinate would not merely be ugly but would
+   * *silently collapse* every dimension it touched onto 2147483.647 — a cropped or empty picture
+   * rather than a large one. [Options.gap] is clamped upstream so this is defence in depth, but the
+   * formatter is the last place a bad number can still turn into a wrong drawing.
+   */
   private fun fmt(value: Double): String {
     if (!value.isFinite()) return "0"
-    val rounded = (value * 1000.0).roundToInt() / 1000.0
+    val rounded = Math.round(value * 1000.0) / 1000.0
     return if (rounded == rounded.toLong().toDouble()) rounded.toLong().toString()
     else rounded.toString()
   }

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvgTest.kt
@@ -135,6 +135,48 @@ class ExplodedSvgTest {
     assertEquals(1, parse(ExplodedSvg.render(elevated)).descendants("filter").size)
   }
 
+  /**
+   * The other half of the filter rule. An elevated layer that paints nothing itself — a wrapper
+   * whose whole job is the shadow, drawing only through a nested named child — is retained on no
+   * plane at its own nominal depth. Keying the filter on that depth would strip it from every
+   * fragment and lose the shadow entirely, which is worse than the duplication it replaced. It
+   * rides the shallowest plane the group survives on instead, which for such a wrapper is its
+   * child's.
+   */
+  @Test
+  fun `an elevated wrapper that paints only through a child keeps its shadow`() {
+    val wrapper =
+      """
+      <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+      <filter id="shadow-3"><feDropShadow dx="0" dy="2" stdDeviation="2"/></filter>
+      <g transform="translate(0, 0)">
+        <g id="Elevated" filter="url(#shadow-3)">
+          <g id="Surface"><rect x="10" y="10" width="80" height="60" rx="8" fill="#FFFFFF"/></g>
+        </g>
+      </g>
+      </svg>
+      """
+        .trimIndent()
+    val out = ExplodedSvg.render(wrapper)
+    val filters =
+      parse(out).descendants("g").map { it.getAttribute("filter") }.filter { it.isNotBlank() }
+    assertEquals("kept exactly once, not lost and not duplicated", 1, filters.size)
+    assertEquals("url(#shadow-3)", filters.single())
+    // It rides the plane the wrapper first appears on — the one holding the drawing it elevates.
+    val planes = planes(out)
+    assertTrue(
+      "the shadow is on the plane that draws the surface",
+      planes.last().descendants("g").any { it.getAttribute("filter") == "url(#shadow-3)" },
+    )
+    // The wrapper is still named at its own nesting level; only the shadow moved.
+    assertEquals("Surface", planes.last().getAttribute("data-layers"))
+    assertEquals(
+      "the wrapper is still named at its own nesting level",
+      "Elevated",
+      planes[1].getAttribute("data-layers"),
+    )
+  }
+
   @Test
   fun `resources are carried over exactly once`() {
     val root = parse(ExplodedSvg.render(layered))

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvgTest.kt
@@ -102,10 +102,115 @@ class ExplodedSvgTest {
     assertEquals(listOf("Text"), ids(planes[2]))
   }
 
+  /**
+   * An elevation shadow is a `filter` on the named group that wraps a composable's surface *and*
+   * its descendants. A filter renders from whatever its element actually draws, so copying it onto
+   * every plane's fragment of that group gives the `Card` its intended silhouette shadow **and**
+   * mints a second, text-shaped shadow on the plane holding its `Text` — something nothing casts in
+   * the flat export.
+   */
+  @Test
+  fun `an elevation filter rides only the plane holding the elevated surface`() {
+    val elevated =
+      """
+      <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+      <filter id="shadow-2"><feDropShadow dx="0" dy="2" stdDeviation="2"/></filter>
+      <g transform="translate(0, 0)">
+        <g id="Card" filter="url(#shadow-2)">
+          <rect x="10" y="10" width="80" height="60" rx="8" fill="#FFFFFF"/>
+          <g id="Text"><text x="20" y="40">Hello</text></g>
+        </g>
+      </g>
+      </svg>
+      """
+        .trimIndent()
+    val planes = planes(ExplodedSvg.render(elevated))
+    fun filters(plane: Element) =
+      plane.descendants("g").map { it.getAttribute("filter") }.filter { it.isNotBlank() }
+    // Plane 1 owns the Card's own surface, so the shadow belongs there…
+    assertEquals(listOf("url(#shadow-2)"), filters(planes[1]))
+    // …and nowhere else: plane 2 holds only a transform-carrying fragment of the same group.
+    assertEquals(emptyList<String>(), filters(planes[2]))
+    // The def still rides along for the plane that does reference it.
+    assertEquals(1, parse(ExplodedSvg.render(elevated)).descendants("filter").size)
+  }
+
   @Test
   fun `resources are carried over exactly once`() {
     val root = parse(ExplodedSvg.render(layered))
     assertEquals(1, root.descendants("clipPath").size)
+  }
+
+  /**
+   * `FigmaLayeredSvg` emits a `Modifier.clip` mask *inline* — as a sibling of the named layer it
+   * masks, deep in the content tree — not as a child of the SVG root. Collecting only the root's
+   * resources dropped every one of them while the copied `<g clip-path="url(#clip-0)">` wrapper
+   * kept referencing the missing id, so a rounded image spilled out of its mask (or vanished,
+   * depending on how the renderer treats a dangling reference). Every plane that carries the
+   * reference must therefore find the def.
+   */
+  @Test
+  fun `a clip mask nested in the content tree is hoisted, not dropped`() {
+    val nestedClip =
+      """
+      <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+      <g transform="translate(0, 0)">
+        <g id="Card">
+          <rect x="0" y="0" width="100" height="100" fill="#FFFFFF"/>
+          <clipPath id="clip-0"><rect x="10" y="10" width="80" height="80" rx="12"/></clipPath>
+          <g clip-path="url(#clip-0)">
+            <g id="Image"><rect x="0" y="0" width="100" height="100" fill="#E8DEF8"/></g>
+          </g>
+        </g>
+      </g>
+      </svg>
+      """
+        .trimIndent()
+    val out = ExplodedSvg.render(nestedClip)
+    val root = parse(out)
+    val defs = root.descendants("clipPath")
+    assertEquals("hoisted exactly once", 1, defs.size)
+    assertEquals("clip-0", defs.single().getAttribute("id"))
+    // …and hoisted to the root, so it is not carried inside (or dropped with) any one sheet.
+    assertEquals("svg", (defs.single().parentNode as Element).localName)
+    // The plane that holds the masked drawing still references it.
+    val masked = planes(out).last().descendants("g").filter { it.hasAttribute("clip-path") }
+    assertEquals(listOf("url(#clip-0)"), masked.map { it.getAttribute("clip-path") })
+  }
+
+  /**
+   * Labels are nudged apart to keep a readable line spacing, which at a small separation carries
+   * the column past the lowest sheet corner. An SVG has no overflow to scroll into, so a canvas
+   * measured from the sheets alone would simply crop them.
+   */
+  @Test
+  fun `a label pushed clear of its sheet still fits the canvas`() {
+    val out = ExplodedSvg.render(layered, ExplodedSvg.Options(gap = 1.0))
+    val root = parse(out)
+    val viewBox = root.getAttribute("viewBox").split(" ").map { it.toDouble() }
+    val bottom = viewBox[1] + viewBox[3]
+    val labels = root.descendants("text").filter { it.getAttribute("class") == "cp-exploded-label" }
+    assertEquals(3, labels.size)
+    // The nudges are what makes this a real test: with a 1-unit gap the sheets are effectively
+    // stacked, so the labels can only be told apart by having been pushed down.
+    val ys = labels.map { it.getAttribute("y").toDouble() }
+    assertTrue("labels were spread: $ys", ys.max() - ys.min() > 10.0)
+    for (y in ys) assertTrue("label at $y is inside the canvas (bottom $bottom)", y < bottom)
+  }
+
+  /**
+   * A hand-typed or stale `?explodeGap=3000000` must produce a picture, not a canvas whose numbers
+   * no longer survive formatting — `(v * 1000).roundToInt()` saturates past ~2.1e6 and would
+   * collapse every dimension onto the same value.
+   */
+  @Test
+  fun `an absurd separation is bounded rather than overflowing the canvas`() {
+    val root = parse(ExplodedSvg.render(layered, ExplodedSvg.Options(gap = 3_000_000.0)))
+    val viewBox = root.getAttribute("viewBox").split(" ").map { it.toDouble() }
+    assertTrue("height is finite and sane: ${viewBox[3]}", viewBox[3] in 100.0..20_000.0)
+    // Still genuinely exploded — the bound loosens the stack, it doesn't collapse it.
+    val planes = planes(ExplodedSvg.render(layered, ExplodedSvg.Options(gap = 3_000_000.0)))
+    assertEquals(3, planes.size)
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #3700, which merged while I was working through its review. Four of these are real defects in the shipped view; the rest harden its URL surface. Each was verified against the code before fixing — the two that turned out to be genuine drawing bugs are the ones I'd want a reviewer to look at.

## Drawing correctness

**Nested clip masks were dropped.** `FigmaLayeredSvg` emits a `Modifier.clip` `<clipPath>` *inline* — as a sibling of the layer it masks, deep in the content tree — not as a child of the SVG root. Collecting only the root's resources discarded every one of them while the copied `<g clip-path="url(#clip-N)">` wrapper kept pointing at the missing id, so a rounded image spilled out of its mask (or vanished, depending on how the renderer treats a dangling reference). Resources are now hoisted from wherever they sit, which is safe because a `clipPath`'s contents resolve in the user space of the element that *references* it, not the one it's nested in.

**Elevation shadows were duplicated per sheet.** A `filter` on a named group renders from whatever that element actually draws. Copying it onto every plane's fragment gave a `Card` its intended silhouette shadow **and** minted a second, text-shaped shadow on the sheet holding its `Text` — something nothing casts in the flat export. `filter` now rides only the plane owning the elevated surface, the same rule `id` already followed; both live in one named set so the next such attribute has an obvious home.

**Collision-nudged labels could be clipped.** Labels are pushed apart to keep a readable line spacing, which at a small separation carries the column past the lowest sheet corner — and an SVG has no overflow to scroll into. Labels are now laid out *before* the viewBox is sized, and their extents fold into it.

**A huge separation collapsed the picture rather than spreading it.** `fmt` rounded through `Int`, which saturates past ~2.1e6, so `?explodeGap=3000000` silently folded every dimension onto 2147483.647. It rounds through `Long` now, and the gap is bounded relative to the drawing's own size — belt and braces, since the formatter is the last place a bad number can still become a wrong drawing.

## URL and lane behaviour

- **3D no longer strands a pressed chip over a Remote Compose player's SVG.** `rcPlayer=cmp-jvm` survives a return to the static lane, and the server routes it to the desktop player's subprocess *before* it looks at `exploded=`. There's nothing to explode there either way — that lane renders a Remote Compose document, which carries none of the `<g id="…">` nesting this view splits on — so the view drops the parameter and asks for the layered export.
- **Switching SVG off clears 3D.** It previously left the chip pressed, its sliders live, and the SVG copy/download exploded while the stage showed a flat PNG.
- **Back out of an entry that 3D created restores the format it was entered from.** The vector lane has no URL parameter of its own, so 3D turning it on was invisible to history; only that case is undone, so someone who was already reading the SVG still gets their SVG back.
- **The viewer accepts the same `exploded=` boolean forms the render endpoint does** (bare, `on`, `yes`), instead of showing the flat PNG for a hand-typed URL and then dropping the parameter on the next sync.
- **Camera knobs are validated before assignment.** `<input type="range">` sanitizes an unparseable value to its *midpoint*, not to the authored default — so `?explodeTilt=nope` rendered a camera nobody asked for and rewrote the shared URL to match it.

## Load shedding

The exploded rewrite now runs **inside** the render semaphore. Unlike `mode=web`'s regex pass, it parses the SVG into a DOM, structurally copies it once per sheet and re-serializes. Outside the permit, a public host asked for a hundred different `explodeTilt=` values at once would have run all of them in parallel — exactly what this route's load shedding exists to prevent. Inside it, a burst queues like any other render and sheds with a 503.

## Deliberately not done here

Codex also flagged that the consumer-facing `?exploded=1` lane should be documented in [`yschimke/skills`](https://github.com/yschimke/skills) per `docs/AGENTS.md`. That's a separate repo and isn't in this session's scope, so it needs its own change — flagging it rather than silently skipping it.

## Test plan

- `./gradlew :data-layoutinspector-core:test` — 18 `ExplodedSvgTest` cases, 4 new, one per drawing defect above: the hoisted nested mask (present exactly once, at the root, still referenced by the masked plane), the elevation filter on the owning plane only, a label nudged clear of its sheet staying inside the canvas, and an absurd gap producing a bounded picture that is still exploded.
- `./gradlew :cli:test` — green, including a new `ServeHttpRoutingTest` assertion that `?explodeGap=3000000` returns a sanely-sized stack rather than a collapsed one.
- `npx playwright test … pages-snapshot` — 96 passed. The committed exploded goldens are **byte-identical**, which is the point: these are edge-case fixes, so the default picture must not move.

`Serve render lanes honor overrides` is expected to fail here for the reason documented in #3700 — two live-daemon-stream tests that are already red on `main` and untouched by this diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vq9v33ZPideWib3VmahzHG)_