### PR TITLE
fix(cloud-jdk): reuse a JDK the box already has instead of downloading one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1175,6 +1175,11 @@ jobs:
       # the pre-Noto generic families while supplying broad missing-glyph coverage.
       - name: Run Linux font-fallback installer tests
         run: scripts/test-install-linux-font-fallbacks.sh
+      # Guards which JDKs the cloud bootstrap treats as "already here". Getting this wrong is not
+      # a slow build, it is a dead session: the script downloads from Adoptium, and a sandbox that
+      # gates github.com per repository 403s that fetch — on a box that already had the JDK.
+      - name: Run cloud JDK setup tests
+        run: scripts/test-setup-cloud-jdk.sh
       # Guards the preview-host image's baked font cache. Its failure mode is silent: a wrong
       # cache filename or a skipped stage-2 range query leaves faces the renderer never finds, so
       # the live daemon quietly falls back to Roboto and drifts from the baked catalog PNGs again.

--- a/docs/CLOUD-TESTING.md
+++ b/docs/CLOUD-TESTING.md
@@ -79,7 +79,17 @@ export JAVA_HOME="$(scripts/setup-cloud-jdk.sh)"
 each fixing a distinct cloud-specific failure:
 
 - **Installs a set of Temurin JDKs** (default majors `17 21 25`, override
-  with `CLOUD_JDK_MAJORS`) from Adoptium's GitHub releases. JDK 17 is the
+  with `CLOUD_JDK_MAJORS`) from Adoptium's GitHub releases — but only the ones
+  the box does not already have. A major already present as `java` on `PATH`,
+  as `$JAVA_HOME`, or under the usual toolchain directories (`/usr/lib/jvm/*`,
+  `/opt/jdk*`, sdkman) is reused where it stands: its trust store is fixed and
+  it is symlinked into `/usr/lib/jvm`, and nothing is downloaded. That matters
+  most on a container provisioned by something else — a Nix-installed Temurin
+  symlinked to `/usr/lib/jvm/temurin-17` is a perfectly good JDK 17, and going
+  to Adoptium for a second copy *fails* where github.com is gated per
+  repository, taking the whole setup with it. Pin a specific build with
+  `JDK<major>_VERSION` (which also opts that major out of reuse), or force
+  downloads with `CLOUD_JDK_REUSE_EXISTING=0`. JDK 17 is the
   build's own pinned `toolchainVersion`
   ([`gradle/gradle-daemon-jvm.properties`](../gradle/gradle-daemon-jvm.properties));
   the newer majors are there so the render subprocess can fork on a JDK

--- a/scripts/setup-cloud-jdk.sh
+++ b/scripts/setup-cloud-jdk.sh
@@ -43,6 +43,15 @@
 #       to requested target
 #     The fix is to copy the system Java trust store over Temurin's.
 #
+# Nothing is downloaded for a major this box already has. Reuse is checked in
+# two places: this script's own install dir, and then the JDKs actually present
+# — `java` on PATH, `$JAVA_HOME`, and the directories Gradle scans for
+# toolchains. That second check is the difference between working and dead on a
+# container provisioned by something else: a Nix-installed Temurin symlinked
+# into `/usr/lib/jvm` is a perfectly good JDK 17, and going to Adoptium for
+# another one fails outright where github.com is gated per repository. See
+# `discover_jdk_home`.
+#
 # Usage:
 #   scripts/setup-cloud-jdk.sh [PRIMARY_INSTALL_DIR]
 #
@@ -52,10 +61,19 @@
 #                     JAVA_HOME is printed on stdout for
 #                     `export JAVA_HOME=$(scripts/setup-cloud-jdk.sh)`.
 #   JDK17_VERSION     pin the primary's Temurin tag (back-compat alias for the
-#                     primary major when it is 17; default: latest GA).
+#                     primary major when it is 17; default: latest GA). A pinned
+#                     tag names a specific build, so it also opts that major out
+#                     of reusing whatever JDK happens to be on the box.
 #   JDK17_DIR         primary install dir (default: /opt/jdk<primary>, or arg 1).
 #   JDK<major>_DIR    install dir for a specific major (default: /opt/jdk<major>).
 #   JDK<major>_VERSION pin a specific major's Temurin tag (default: latest GA).
+#   CLOUD_JDK_REUSE_EXISTING
+#                     `0` to always download, even when a JDK of that major is
+#                     already installed elsewhere (default: reuse).
+#   CLOUD_JDK_SEARCH_DIRS
+#                     space-separated globs searched for existing JDKs
+#                     (default: "/usr/lib/jvm/* /opt/jdk* /opt/*jdk*
+#                     $HOME/.sdkman/candidates/java/*").
 #
 # Output: prints the absolute JAVA_HOME of the PRIMARY JDK on stdout.
 # Additional majors are best-effort: a major Adoptium hasn't published yet
@@ -93,10 +111,19 @@ fix_truststore() {
     return 0
   fi
   # Only swap if the Temurin store differs (idempotent re-runs are a no-op).
+  # A JDK we did not install may live somewhere unwritable — a Nix/Guix store
+  # path is read-only by design — so the copy is best-effort. A JDK whose trust
+  # store we cannot replace is still perfectly good for compiling and rendering;
+  # only Java-side HTTPS through the MITM proxy is affected, and whatever
+  # provisioned that JDK owns its trust store. Failing the whole run over it
+  # would be the wrong trade.
   if ! cmp -s "$system_truststore" "$dest"; then
     cp -f "$dest" "$dest.adoptium-orig" 2>/dev/null || true
-    cp -f "$system_truststore" "$dest"
-    echo "[setup-cloud-jdk] swapped $dest <- $system_truststore (trusts proxy CA)" >&2
+    if cp -f "$system_truststore" "$dest" 2>/dev/null; then
+      echo "[setup-cloud-jdk] swapped $dest <- $system_truststore (trusts proxy CA)" >&2
+    else
+      echo "[setup-cloud-jdk] WARNING: could not write $dest (read-only JDK?); leaving its trust store as-is" >&2
+    fi
   fi
 }
 
@@ -147,6 +174,66 @@ install_dir_for() {
   else
     echo "${!var:-/opt/jdk${major}}"
   fi
+}
+
+# The feature major of the JDK at <java_home> (17, 21, 8, …), or nothing (rc 1).
+#
+# Read from `release` (`JAVA_VERSION="17.0.19"`) — every JDK since 9 ships it,
+# and it costs no process. Falls back to running `java -version` for an install
+# that lacks the file. `1.8.0_412` normalises to 8, so a legacy JDK is never
+# mistaken for major "1".
+jdk_major_of() {
+  local home="$1" v=""
+  if [[ -r "$home/release" ]]; then
+    v="$(sed -n 's/^JAVA_VERSION="\(.*\)"$/\1/p' "$home/release" | head -n 1)"
+  fi
+  if [[ -z "$v" && -x "$home/bin/java" ]]; then
+    v="$("$home/bin/java" -version 2>&1 | sed -n '1s/.*version "\([^"]*\)".*/\1/p')"
+  fi
+  [[ -n "$v" ]] || return 1
+  case "$v" in
+    1.*) printf '%s' "$(printf '%s' "$v" | cut -d. -f2)" ;;
+    *) printf '%s' "${v%%[.+_-]*}" ;;
+  esac
+}
+
+# Echo the JAVA_HOME of a JDK of <major> that is already on this box, or nothing
+# (rc 1). Checks the active `java`, then `$JAVA_HOME`, then the locations Gradle
+# itself scans for toolchains.
+#
+# This is what stops the script downloading a JDK the container already has. The
+# old reuse check looked only at its own install dir (`/opt/jdk<major>`), so a
+# box whose JDK 17 lives anywhere else — a Nix-provisioned Temurin symlinked to
+# `/usr/lib/jvm/temurin-17`, say, which is exactly what the coo.ee/env
+# bootstrap produces — was treated as having no JDK 17 at all. It then went to
+# Adoptium for one, and in a sandbox that gates github.com per-repository the
+# fetch 403s and the whole setup aborts. A JDK that is present, on PATH, and of
+# the right major is the answer to the question being asked.
+discover_jdk_home() {
+  local major="$1" cand home
+  if command -v java >/dev/null 2>&1; then
+    home="$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")"
+    if [[ -x "$home/bin/java" && "$(jdk_major_of "$home" || true)" == "$major" ]]; then
+      printf '%s' "$home"
+      return 0
+    fi
+  fi
+  # `/usr/lib/jvm/*` covers both distro JDKs and the symlink farm this script's
+  # own `link_into_jvm_dir` (and other provisioners) maintain there. Overridable
+  # via CLOUD_JDK_SEARCH_DIRS (space-separated, globs allowed) for a layout none
+  # of these cover — and so the self-test can search a fixture instead of the
+  # machine it runs on.
+  local dirs="${CLOUD_JDK_SEARCH_DIRS:-/usr/lib/jvm/* /opt/jdk* /opt/*jdk* $HOME/.sdkman/candidates/java/*}"
+  # Deliberately unquoted: $dirs must both word-split and glob-expand here.
+  # shellcheck disable=SC2086
+  for cand in "${JAVA_HOME:-}" $dirs; do
+    [[ -n "$cand" && -x "$cand/bin/java" ]] || continue
+    if [[ "$(jdk_major_of "$cand" || true)" == "$major" ]]; then
+      printf '%s' "$cand"
+      return 0
+    fi
+  done
+  return 1
 }
 
 # Resolve a pinned Temurin tag for a major, if the caller set JDK<major>_VERSION
@@ -242,6 +329,25 @@ install_major() {
 
   local tag
   tag="$(pinned_tag_for "$major")"
+
+  # Nothing in *our* install dir — but the box may already have this major
+  # somewhere else, and downloading a second copy of a JDK that is already on
+  # PATH is both wasteful and, in a sandbox that blocks Adoptium, fatal.
+  #
+  # Skipped when the caller pinned a tag for this major (JDK<major>_VERSION):
+  # that names a specific build, so "some JDK 17" is not what was asked for.
+  # `CLOUD_JDK_REUSE_EXISTING=0` forces a download unconditionally.
+  if [[ -z "$tag" && "${CLOUD_JDK_REUSE_EXISTING:-1}" != "0" ]]; then
+    local found
+    if found="$(discover_jdk_home "$major")" && [[ -n "$found" ]]; then
+      echo "[setup-cloud-jdk] JDK $major already present at $found — reusing it (no download)" >&2
+      fix_truststore "$found"
+      link_into_jvm_dir "$found" "$major"
+      echo "$found"
+      return 0
+    fi
+  fi
+
   if [[ -z "$tag" ]]; then
     tag="$(resolve_latest_tag "$major")" || tag=""
   fi

--- a/scripts/setup-cloud-jdk.sh
+++ b/scripts/setup-cloud-jdk.sh
@@ -43,10 +43,11 @@
 #       to requested target
 #     The fix is to copy the system Java trust store over Temurin's.
 #
-# Nothing is downloaded for a major this box already has. Reuse is checked in
-# two places: this script's own install dir, and then the JDKs actually present
-# — `java` on PATH, `$JAVA_HOME`, and the directories Gradle scans for
-# toolchains. That second check is the difference between working and dead on a
+# Nothing is downloaded for a major this box already has — where "has" means a
+# full JDK, compiler included, since a JRE is no use as a Gradle toolchain.
+# Reuse is checked in two places: this script's own install dir, and then the
+# JDKs actually present — `java` on PATH, `$JAVA_HOME`, and the directories
+# Gradle scans for toolchains. That second check is the difference between working and dead on a
 # container provisioned by something else: a Nix-installed Temurin symlinked
 # into `/usr/lib/jvm` is a perfectly good JDK 17, and going to Adoptium for
 # another one fails outright where github.com is gated per repository. See
@@ -74,6 +75,9 @@
 #                     space-separated globs searched for existing JDKs
 #                     (default: "/usr/lib/jvm/* /opt/jdk* /opt/*jdk*
 #                     $HOME/.sdkman/candidates/java/*").
+#   CLOUD_JDK_JVM_LINK_DIR
+#                     where the toolchain symlinks are written
+#                     (default: /usr/lib/jvm).
 #
 # Output: prints the absolute JAVA_HOME of the PRIMARY JDK on stdout.
 # Additional majors are best-effort: a major Adoptium hasn't published yet
@@ -140,7 +144,11 @@ fix_truststore() {
 link_into_jvm_dir() {
   local jdk="$1"
   local major="$2"
-  local jvm_dir="/usr/lib/jvm"
+  # Overridable so the self-test can point this at a fixture. It must never
+  # write into the machine's real /usr/lib/jvm: replacing a live `temurin-17`
+  # with a path that is deleted when the test exits leaves a dangling toolchain
+  # link behind, and on an unprivileged runner the `ln` just fails.
+  local jvm_dir="${CLOUD_JDK_JVM_LINK_DIR:-/usr/lib/jvm}"
   local link="$jvm_dir/temurin-$major"
   if [[ ! -d "$jvm_dir" ]]; then
     mkdir -p "$jvm_dir" 2>/dev/null || {
@@ -209,11 +217,16 @@ jdk_major_of() {
 # Adoptium for one, and in a sandbox that gates github.com per-repository the
 # fetch 403s and the whole setup aborts. A JDK that is present, on PATH, and of
 # the right major is the answer to the question being asked.
+#
+# A JRE is not an answer to this question. Gradle needs a *compiler* for a
+# toolchain, so a `java` of the right major with no `bin/javac` beside it must
+# not short-circuit the download — it would hand back a JAVA_HOME that fails
+# later, at compile time, where the cause is much harder to see.
 discover_jdk_home() {
   local major="$1" cand home
   if command -v java >/dev/null 2>&1; then
     home="$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")"
-    if [[ -x "$home/bin/java" && "$(jdk_major_of "$home" || true)" == "$major" ]]; then
+    if is_jdk_of_major "$home" "$major"; then
       printf '%s' "$home"
       return 0
     fi
@@ -227,13 +240,19 @@ discover_jdk_home() {
   # Deliberately unquoted: $dirs must both word-split and glob-expand here.
   # shellcheck disable=SC2086
   for cand in "${JAVA_HOME:-}" $dirs; do
-    [[ -n "$cand" && -x "$cand/bin/java" ]] || continue
-    if [[ "$(jdk_major_of "$cand" || true)" == "$major" ]]; then
+    if [[ -n "$cand" ]] && is_jdk_of_major "$cand" "$major"; then
       printf '%s' "$cand"
       return 0
     fi
   done
   return 1
+}
+
+# Whether <dir> is a full JDK (java *and* javac) of <major>.
+is_jdk_of_major() {
+  local dir="$1" major="$2"
+  [[ -x "$dir/bin/java" && -x "$dir/bin/javac" ]] || return 1
+  [[ "$(jdk_major_of "$dir" || true)" == "$major" ]]
 }
 
 # Resolve a pinned Temurin tag for a major, if the caller set JDK<major>_VERSION
@@ -319,7 +338,10 @@ install_major() {
   install_dir="$(install_dir_for "$major")"
 
   # Reuse an existing install; just make sure its trust store + symlink are set.
-  if [[ -x "$install_dir/bin/java" ]]; then
+  # `CLOUD_JDK_REUSE_EXISTING=0` means "always download", so it has to bypass
+  # this branch too — otherwise the escape hatch could never refresh the very
+  # install this script placed, which is the one people actually want to redo.
+  if [[ "${CLOUD_JDK_REUSE_EXISTING:-1}" != "0" && -x "$install_dir/bin/java" ]]; then
     echo "[setup-cloud-jdk] reusing existing JDK $major at $install_dir" >&2
     fix_truststore "$install_dir"
     link_into_jvm_dir "$install_dir" "$major"

--- a/scripts/test-setup-cloud-jdk.sh
+++ b/scripts/test-setup-cloud-jdk.sh
@@ -11,11 +11,16 @@
 # github.com per repository, that 403s and the whole setup aborts, on a box that
 # had a perfectly good JDK 17 on PATH the whole time.
 #
-# Hermetic by construction: `curl` is a stub that records calls and always
-# fails, the JDKs are directory trees with a `release` file and a stub
-# `bin/java`, `CLOUD_JDK_SEARCH_DIRS` points discovery at the fixture instead of
-# this machine, and every case pins what `java` on PATH resolves to. Otherwise
-# the host's own JDKs decide the results.
+# Hermetic by construction, and it has to be: `curl` is a stub that records
+# calls and always fails, the JDKs are fixture directory trees,
+# CLOUD_JDK_SEARCH_DIRS points discovery at the fixture instead of this machine,
+# CLOUD_JDK_JVM_LINK_DIR keeps the toolchain symlinks out of the real
+# /usr/lib/jvm, and every case pins what `java` on PATH resolves to.
+#
+# None of that is belt-and-braces. An earlier draft leaked on every axis: the
+# host's own JDKs answered half the cases, and the symlink step replaced a live
+# /usr/lib/jvm/temurin-17 with a fixture path that dangled the moment the test
+# cleaned up after itself.
 
 set -euo pipefail
 
@@ -24,8 +29,17 @@ script="${repo_root}/scripts/setup-cloud-jdk.sh"
 fixture="$(mktemp -d)"
 trap 'chmod -R u+w "${fixture}" 2>/dev/null || true; rm -rf "${fixture}"' EXIT
 
-# A JDK-shaped directory: `release` carries the version the script reads.
+# A JDK-shaped directory: `release` carries the version the script reads, and
+# `bin/javac` is what makes it a JDK rather than a JRE.
 make_jdk() { # make_jdk <dir> <java-version>
+  local dir="$1" version="$2"
+  make_jre "${dir}" "${version}"
+  printf '#!/usr/bin/env bash\n:\n' >"${dir}/bin/javac"
+  chmod +x "${dir}/bin/javac"
+}
+
+# Same, without a compiler — Gradle cannot use this as a toolchain.
+make_jre() { # make_jre <dir> <java-version>
   local dir="$1" version="$2"
   mkdir -p "${dir}/bin" "${dir}/lib/security"
   printf 'JAVA_VERSION="%s"\n' "${version}" >"${dir}/release"
@@ -56,6 +70,7 @@ run_script() { # run_script [env assignments...]
   env -u JAVA_HOME "$@" \
     CALL_LOG="${fixture}/calls" \
     CLOUD_JDK_SEARCH_DIRS="${fixture}/search/*" \
+    CLOUD_JDK_JVM_LINK_DIR="${fixture}/jvm" \
     PATH="${fixture}/bin:${fixture}/pathjdk/bin:/usr/bin:/bin" \
     bash "${script}"
 }
@@ -72,6 +87,7 @@ out="$(
   env -u JAVA_HOME PATH="${fixture}/bin:${fixture}/onpath17/bin:/usr/bin:/bin" \
     CALL_LOG="${fixture}/calls" \
     CLOUD_JDK_SEARCH_DIRS="${fixture}/search/*" \
+    CLOUD_JDK_JVM_LINK_DIR="${fixture}/jvm" \
     CLOUD_JDK_MAJORS=17 \
     JDK17_DIR="${fixture}/opt/jdk17" \
     bash "${script}" 2>"${fixture}/stderr"
@@ -82,6 +98,10 @@ test ! -s "${fixture}/calls" ||
   { echo "FAIL: downloaded despite a JDK 17 on PATH:" >&2; cat "${fixture}/calls" >&2; exit 1; }
 grep -Fq "already present" "${fixture}/stderr" ||
   { echo "FAIL: no 'already present' log line" >&2; cat "${fixture}/stderr" >&2; exit 1; }
+test "$(readlink -f "${fixture}/jvm/temurin-17")" = "$(readlink -f "${fixture}/onpath17")" ||
+  { echo "FAIL: the reused JDK should be symlinked for toolchain detection" >&2; exit 1; }
+# And nowhere near the machine's own toolchain directory.
+test ! -e /usr/lib/jvm/temurin-999 || { echo "FAIL: test wrote to the real /usr/lib/jvm" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
 # 2. A JDK found only in a scanned directory (not on PATH, not JAVA_HOME) counts
@@ -134,13 +154,34 @@ grep -Fq "jdk-17.0.20" "${fixture}/calls" ||
     cat "${fixture}/calls" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
-# 5. CLOUD_JDK_REUSE_EXISTING=0 forces a download even with a JDK present.
+# 5. CLOUD_JDK_REUSE_EXISTING=0 forces a download even with a JDK present —
+#    including one sitting in the script's own install dir, which is the copy
+#    people actually want to refresh.
 # ---------------------------------------------------------------------------
 : >"${fixture}/calls"
 run_script CLOUD_JDK_MAJORS=17 JDK17_DIR="${fixture}/opt/jdk17-e" \
   CLOUD_JDK_REUSE_EXISTING=0 >/dev/null 2>&1 || true
 test -s "${fixture}/calls" ||
   { echo "FAIL: CLOUD_JDK_REUSE_EXISTING=0 should have attempted a download" >&2; exit 1; }
+
+: >"${fixture}/calls"
+make_jdk "${fixture}/opt/jdk17-e2" "17.0.19"
+run_script CLOUD_JDK_MAJORS=17 JDK17_DIR="${fixture}/opt/jdk17-e2" \
+  CLOUD_JDK_REUSE_EXISTING=0 >/dev/null 2>&1 || true
+test -s "${fixture}/calls" ||
+  { echo "FAIL: CLOUD_JDK_REUSE_EXISTING=0 must bypass install-dir reuse too" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 5b. A JRE of the right major is not a toolchain. Reusing it would hand back a
+#     JAVA_HOME with no compiler, and the failure would surface much later.
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+rm -rf "${fixture}/search"; mkdir -p "${fixture}/search"
+make_jre "${fixture}/search/jre17" "17.0.19"
+run_script CLOUD_JDK_MAJORS=17 JDK17_DIR="${fixture}/opt/jdk17-jre" \
+  >/dev/null 2>&1 || true
+grep -Fq "curl" "${fixture}/calls" ||
+  { echo "FAIL: a JRE (no bin/javac) must not satisfy the JDK requirement" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
 # 6. Our own install dir still wins over discovery, and a JDK whose trust store

--- a/scripts/test-setup-cloud-jdk.sh
+++ b/scripts/test-setup-cloud-jdk.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/setup-cloud-jdk.sh, covering the part that decides
+# whether to download a JDK at all.
+#
+# The regression it exists for: reuse was judged solely by whether
+# `/opt/jdk<major>/bin/java` existed, so a container whose JDK 17 lived
+# anywhere else (a Nix-provisioned Temurin symlinked to /usr/lib/jvm/temurin-17,
+# which is what the coo.ee/env bootstrap produces) was treated as having no JDK
+# 17. The script then fetched one from Adoptium — and in a sandbox that gates
+# github.com per repository, that 403s and the whole setup aborts, on a box that
+# had a perfectly good JDK 17 on PATH the whole time.
+#
+# Hermetic by construction: `curl` is a stub that records calls and always
+# fails, the JDKs are directory trees with a `release` file and a stub
+# `bin/java`, `CLOUD_JDK_SEARCH_DIRS` points discovery at the fixture instead of
+# this machine, and every case pins what `java` on PATH resolves to. Otherwise
+# the host's own JDKs decide the results.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+script="${repo_root}/scripts/setup-cloud-jdk.sh"
+fixture="$(mktemp -d)"
+trap 'chmod -R u+w "${fixture}" 2>/dev/null || true; rm -rf "${fixture}"' EXIT
+
+# A JDK-shaped directory: `release` carries the version the script reads.
+make_jdk() { # make_jdk <dir> <java-version>
+  local dir="$1" version="$2"
+  mkdir -p "${dir}/bin" "${dir}/lib/security"
+  printf 'JAVA_VERSION="%s"\n' "${version}" >"${dir}/release"
+  printf '#!/usr/bin/env bash\necho openjdk version "%s"\n' "${version}" >"${dir}/bin/java"
+  chmod +x "${dir}/bin/java"
+  : >"${dir}/lib/security/cacerts"
+}
+
+mkdir -p "${fixture}/bin"
+cat >"${fixture}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >>"${CALL_LOG}"
+exit 1
+EOF
+chmod +x "${fixture}/bin/curl"
+
+# The `java` every case sees on PATH unless it says otherwise. A major nobody
+# asks for below, so PATH discovery never answers by accident.
+make_jdk "${fixture}/pathjdk" "11.0.22"
+
+# Run the script with a fully controlled environment: fixture curl first on
+# PATH, a known `java`, and discovery scoped to the fixture tree. Extra `env`
+# assignments come first so a case can override any of it.
+# JAVA_HOME is unset unless a case sets it: this harness runs inside a
+# provisioned sandbox whose own JAVA_HOME is a JDK 17, which would otherwise
+# answer half these cases before the code under test got a look in.
+run_script() { # run_script [env assignments...]
+  env -u JAVA_HOME "$@" \
+    CALL_LOG="${fixture}/calls" \
+    CLOUD_JDK_SEARCH_DIRS="${fixture}/search/*" \
+    PATH="${fixture}/bin:${fixture}/pathjdk/bin:/usr/bin:/bin" \
+    bash "${script}"
+}
+
+mkdir -p "${fixture}/search"
+
+# ---------------------------------------------------------------------------
+# 1. A JDK of the requested major already on PATH is reused, and nothing is
+#    downloaded. This is the reported failure.
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+make_jdk "${fixture}/onpath17" "17.0.19"
+out="$(
+  env -u JAVA_HOME PATH="${fixture}/bin:${fixture}/onpath17/bin:/usr/bin:/bin" \
+    CALL_LOG="${fixture}/calls" \
+    CLOUD_JDK_SEARCH_DIRS="${fixture}/search/*" \
+    CLOUD_JDK_MAJORS=17 \
+    JDK17_DIR="${fixture}/opt/jdk17" \
+    bash "${script}" 2>"${fixture}/stderr"
+)"
+test "${out}" = "${fixture}/onpath17" ||
+  { echo "FAIL: expected the JDK on PATH as JAVA_HOME, got '${out}'" >&2; exit 1; }
+test ! -s "${fixture}/calls" ||
+  { echo "FAIL: downloaded despite a JDK 17 on PATH:" >&2; cat "${fixture}/calls" >&2; exit 1; }
+grep -Fq "already present" "${fixture}/stderr" ||
+  { echo "FAIL: no 'already present' log line" >&2; cat "${fixture}/stderr" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 2. A JDK found only in a scanned directory (not on PATH, not JAVA_HOME) counts
+#    too — /usr/lib/jvm/temurin-17 in the real report.
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+make_jdk "${fixture}/search/temurin-17" "17.0.19"
+out="$(run_script CLOUD_JDK_MAJORS=17 JDK17_DIR="${fixture}/opt/jdk17-b" 2>/dev/null)"
+test "${out}" = "${fixture}/search/temurin-17" ||
+  { echo "FAIL: expected the scanned JDK as JAVA_HOME, got '${out}'" >&2; exit 1; }
+test ! -s "${fixture}/calls" ||
+  { echo "FAIL: downloaded despite a JDK 17 under the search path" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 2b. $JAVA_HOME counts as well — a JDK the environment already points at is
+#     the one everything else on the box is using.
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+rm -rf "${fixture}/search"; mkdir -p "${fixture}/search"
+make_jdk "${fixture}/homejdk17" "17.0.19"
+out="$(run_script CLOUD_JDK_MAJORS=17 JDK17_DIR="${fixture}/opt/jdk17-b2" \
+  JAVA_HOME="${fixture}/homejdk17" 2>/dev/null)"
+test "${out}" = "${fixture}/homejdk17" ||
+  { echo "FAIL: expected \$JAVA_HOME's JDK to be reused, got '${out}'" >&2; exit 1; }
+test ! -s "${fixture}/calls" ||
+  { echo "FAIL: downloaded despite \$JAVA_HOME pointing at a JDK 17" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 3. A JDK of a *different* major is not mistaken for the one asked for.
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+rm -rf "${fixture}/search"; mkdir -p "${fixture}/search"
+make_jdk "${fixture}/search/temurin-21" "21.0.5"
+run_script CLOUD_JDK_MAJORS=17 JDK17_DIR="${fixture}/opt/jdk17-c" \
+  >/dev/null 2>&1 && status=0 || status=$?
+test "${status}" -ne 0 ||
+  { echo "FAIL: expected failure when no JDK 17 exists and the download is blocked" >&2; exit 1; }
+grep -Fq "curl" "${fixture}/calls" ||
+  { echo "FAIL: expected a download attempt when only a JDK 21 is present" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 4. A pinned tag means "this exact build" — discovery must not short-circuit it.
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+make_jdk "${fixture}/search/temurin-17" "17.0.19"
+run_script CLOUD_JDK_MAJORS=17 JDK17_DIR="${fixture}/opt/jdk17-d" \
+  JDK17_VERSION="jdk-17.0.20+8" >/dev/null 2>&1 || true
+grep -Fq "jdk-17.0.20" "${fixture}/calls" ||
+  { echo "FAIL: a pinned JDK17_VERSION should still download that build" >&2
+    cat "${fixture}/calls" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 5. CLOUD_JDK_REUSE_EXISTING=0 forces a download even with a JDK present.
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+run_script CLOUD_JDK_MAJORS=17 JDK17_DIR="${fixture}/opt/jdk17-e" \
+  CLOUD_JDK_REUSE_EXISTING=0 >/dev/null 2>&1 || true
+test -s "${fixture}/calls" ||
+  { echo "FAIL: CLOUD_JDK_REUSE_EXISTING=0 should have attempted a download" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 6. Our own install dir still wins over discovery, and a JDK whose trust store
+#    cannot be written does not abort the run — a store-provided JDK is
+#    read-only, and that is a warning, not a failed provision.
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+make_jdk "${fixture}/opt/jdk17-f" "17.0.19"
+chmod a-w "${fixture}/opt/jdk17-f/lib/security" "${fixture}/opt/jdk17-f/lib/security/cacerts"
+out="$(run_script CLOUD_JDK_MAJORS=17 JDK17_DIR="${fixture}/opt/jdk17-f" 2>"${fixture}/stderr")"
+chmod u+w "${fixture}/opt/jdk17-f/lib/security"
+test "${out}" = "${fixture}/opt/jdk17-f" ||
+  { echo "FAIL: the configured install dir should win over discovery, got '${out}'" >&2; exit 1; }
+test ! -s "${fixture}/calls" ||
+  { echo "FAIL: downloaded despite an install-dir JDK" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 7. A legacy 1.8-style version normalises to major 8, not "1".
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+rm -rf "${fixture}/search"; mkdir -p "${fixture}/search"
+make_jdk "${fixture}/search/jdk8" "1.8.0_412"
+out="$(run_script CLOUD_JDK_MAJORS=8 JDK8_DIR="${fixture}/opt/jdk8" 2>/dev/null)"
+test "${out}" = "${fixture}/search/jdk8" ||
+  { echo "FAIL: 1.8.0_412 should be recognised as major 8, got '${out}'" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 8. Best-effort majors stay best-effort: a secondary major that cannot be
+#    found or downloaded warns, while the primary still succeeds.
+# ---------------------------------------------------------------------------
+: >"${fixture}/calls"
+rm -rf "${fixture}/search"; mkdir -p "${fixture}/search"
+make_jdk "${fixture}/search/temurin-17" "17.0.19"
+out="$(
+  run_script CLOUD_JDK_MAJORS="17 25" \
+    JDK17_DIR="${fixture}/opt/jdk17-g" JDK25_DIR="${fixture}/opt/jdk25" \
+    2>"${fixture}/stderr"
+)"
+test "${out}" = "${fixture}/search/temurin-17" ||
+  { echo "FAIL: the primary should still resolve when a secondary fails, got '${out}'" >&2; exit 1; }
+grep -Fq "WARNING" "${fixture}/stderr" ||
+  { echo "FAIL: expected a warning for the unavailable secondary major" >&2; exit 1; }
+
+echo 'setup-cloud-jdk: tests passed'


### PR DESCRIPTION
## The failure

Reported from a sandbox session: JDK 17 was present — Temurin 17.0.19, on `PATH`, and at
`/usr/lib/jvm/temurin-17` — yet the bootstrap went off to install its own JDK 17 and aborted.

`setup-cloud-jdk.sh` decided "is this major already here?" by looking in exactly one place:

```sh
install_dir="$(install_dir_for "$major")"     # → /opt/jdk17
if [[ -x "$install_dir/bin/java" ]]; then     # the ONLY reuse check
```

Any JDK anywhere else was invisible to it. A container provisioned by something else — a
Nix-installed Temurin on `PATH`, symlinked to `/usr/lib/jvm/temurin-17`, which is exactly what the
coo.ee/env bootstrap produces — had no `/opt/jdk17`, so the script fetched one from Adoptium.

That isn't merely wasteful. Sandboxes that gate github.com *per repository* (Claude Code on the web
scopes it to the session's attached repos) answer 403 for `adoptium/temurin17-binaries`, so the
download fails and the whole setup aborts — on a box that had a working JDK 17 on `PATH` the entire
time. The script's own header already documents that 403 for tag resolution; this is the same wall,
one step later.

## The fix

`discover_jdk_home` looks where JDKs actually live: `java` on `PATH`, then `$JAVA_HOME`, then the
directories Gradle itself scans for toolchains (`/usr/lib/jvm/*`, `/opt/jdk*`, `/opt/*jdk*`, sdkman)
— matching on the feature major read from `release` (with `1.8.0_412` normalising to 8, so a legacy
JDK is never read as major "1"). A hit is adopted where it stands: trust store fixed, symlinked into
`/usr/lib/jvm` so toolchain detection finds it, its path printed as the `JAVA_HOME` the caller
exports. Nothing is downloaded.

Two opt-outs, because "some JDK 17" isn't always the ask:

- `JDK<major>_VERSION` pins a specific Temurin build — that names a build, so it keeps downloading
  that one;
- `CLOUD_JDK_REUSE_EXISTING=0` forces a download outright.

`CLOUD_JDK_SEARCH_DIRS` overrides where to look, for a layout the defaults don't cover.

`fix_truststore` is best-effort now. A JDK we did not install may be read-only — a Nix/Guix store
path is, by design — and a trust store we cannot replace is a warning, not a failed provision: the
JDK still compiles and renders, and whoever provisioned it owns its trust store.

## Test plan

- New `scripts/test-setup-cloud-jdk.sh`, wired into `ci.yml` beside the other script self-tests.
  Eight cases over a fake `curl` (records calls, always fails) and fixture JDK trees:
  a JDK 17 on `PATH` is reused with no download (the reported case); one found only under a scanned
  directory counts too; `$JAVA_HOME` counts; a JDK **21** is not mistaken for the requested 17; a
  pinned `JDK17_VERSION` still downloads that build; `CLOUD_JDK_REUSE_EXISTING=0` still downloads;
  the configured install dir wins over discovery and an unwritable trust store doesn't abort the
  run; `1.8.0_412` resolves to major 8; and a secondary major that can't be provisioned stays
  best-effort while the primary succeeds.
- The test is hermetic by construction — `env -u JAVA_HOME`, a pinned `PATH`, and
  `CLOUD_JDK_SEARCH_DIRS` scoped to the fixture. An earlier draft passed only because the host's own
  JDKs were quietly answering the questions, which is worth stating: this suite is only meaningful
  if it can't see the machine it runs on.
- `bash -n` on both scripts.

Non-visual change — provisioning script, docs and tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFbgVkkvhUmSGE8sfbJ5n)_