### PR TITLE
fix(render): rank doctor verdicts, and stop non-skiko failures flooding the log

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DesktopNativesCheck.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DesktopNativesCheck.kt
@@ -217,12 +217,13 @@ internal object DesktopNativesCheck {
           "`ldconfig -p` use the *system* loader and will look fine even when the render fails."
       } else null
 
-    if (result.glibcSkew) {
-      // Deliberately a warning rather than an error: the Gradle plugin prunes these directories
-      // from the render JVM's own environment (`RenderNativeEnv`), so a render driven through it
-      // works on this box as it stands. Anything else that starts a JVM from this environment — a
-      // bare `java -jar`, an IDE, another Gradle plugin — still gets the mixed process image, so
-      // the state is worth reporting rather than hiding.
+    // Checked *after* the missing-library branch below would be wrong, and this ordering is the
+    // whole point: a glibc skew is a warning (the plugin prunes the store dirs for its own render
+    // JVM, so renders driven through it still work), while a library the loader cannot find at all
+    // is an error (nothing renders, by any route). Reporting the warning first on a box that has
+    // both would hide the fatal condition behind the survivable one — and warnings exit 0, so
+    // doctor would pass a project whose previews cannot render.
+    if (result.glibcSkew && result.missing.isEmpty()) {
       return DoctorCheck(
         id = id,
         category = "env",
@@ -303,6 +304,17 @@ internal object DesktopNativesCheck {
           append(". LD_LIBRARY_PATH as inherited by this process: ")
           append(if (result.ldLibraryPath.isEmpty()) "(unset)" else result.ldLibraryPath.toString())
           storeNote?.let { append(". $it") }
+          // Both conditions at once: the missing library is the fatal one and owns the status, but
+          // the skew is still on this box and still worth naming — otherwise fixing the missing lib
+          // leaves a second, differently-shaped failure waiting behind it.
+          if (result.glibcSkew) {
+            append(
+              ". Also on this box: LD_LIBRARY_PATH mixes ${result.storeDirsOnPath.size} " +
+                "package-store director(ies) into a system render JVM " +
+                "(${result.storeDirsOnPath.joinToString(", ")}), which is its own failure mode — " +
+                "see docs/DESKTOP_NATIVE_DEPS.md."
+            )
+          }
         },
       remediation =
         DoctorRemediation(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -685,8 +685,14 @@ class DoctorCommand(
       )
     }
     // The worst verdict wins: one render JVM that cannot load skiko breaks that module's previews
-    // regardless of how healthy the others look.
-    val result = results.firstOrNull { !it.ok } ?: results.first()
+    // regardless of how healthy the others look. Ranked, not just "first not-ok" — a missing
+    // native dep is an `error` and a glibc skew only a `warning`, and the candidates are ordered by
+    // where they came from, not by severity. Taking the first not-ok would let an earlier
+    // candidate's warning hide a later one whose renders cannot work at all.
+    val result =
+      results.firstOrNull { it.missing.isNotEmpty() }
+        ?: results.firstOrNull { !it.ok }
+        ?: results.first()
 
     val check = DesktopNativesCheck.interpret(result, inClaudeCloud = inClaudeCloud)
     addCheck(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -665,9 +665,13 @@ class DoctorCommand(
     // `composePreview.renderJavaVersion`) is the case that matters most here: store libraries on
     // the path of a *system* JDK is the mixed-glibc trap, and reading the daemon's `java.home`
     // instead would report a Nix daemon as healthy while the render dies (issue #3690).
+    // Per module: its own launcher when the model reports one, the daemon only as *that module's*
+    // fallback. Adding the daemon unconditionally would judge a JVM nothing renders on — and since
+    // the worst verdict wins below, an unused daemon that cannot resolve a library would fail
+    // doctor for a project whose every render is fine.
     val candidates =
-      (desktopModules.values.mapNotNull { it.renderPreviewsTask?.javaLauncherPath } +
-          listOfNotNull(daemonJavaHome))
+      desktopModules.values
+        .map { it.renderPreviewsTask?.javaLauncherPath ?: daemonJavaHome }
         .distinct()
         .ifEmpty { listOf(null) }
     val canonicalize = { path: String ->

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -685,10 +685,11 @@ class DoctorCommand(
       )
     }
     // The worst verdict wins: one render JVM that cannot load skiko breaks that module's previews
-    // regardless of how healthy the others look. Ranked, not just "first not-ok" — a missing
-    // native dep is an `error` and a glibc skew only a `warning`, and the candidates are ordered by
-    // where they came from, not by severity. Taking the first not-ok would let an earlier
-    // candidate's warning hide a later one whose renders cannot work at all.
+    // regardless of how healthy the others look. Ranked by severity rather than by "first not-ok",
+    // because the candidates are ordered by where they came from — so an earlier candidate's
+    // warning would otherwise hide a later one whose renders cannot work at all, and warnings exit
+    // 0. Same order [DesktopNativesCheck.interpret] uses, so the selected result and the status it
+    // is reported under agree.
     val result =
       results.firstOrNull { it.missing.isNotEmpty() }
         ?: results.firstOrNull { !it.ok }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DesktopNativesCheckTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DesktopNativesCheckTest.kt
@@ -158,6 +158,34 @@ class DesktopNativesCheckTest {
   }
 
   @Test
+  fun `a missing lib outranks a glibc skew, so doctor still reports an error`() {
+    // Both conditions on one box. The skew is survivable — the plugin prunes the store dirs for
+    // its own render JVM — while a library the loader cannot find at all means nothing renders by
+    // any route. Reporting the warning would exit 0 on a project whose previews cannot render.
+    val result =
+      DesktopNativesCheck.evaluateDesktopNatives(
+        osName = "Linux",
+        renderJavaHome = "/usr/lib/jvm/java-21-openjdk-amd64",
+        ldLibraryPath = "/root/.cache/coo-ee/desktop-gl/lib",
+        // The store dir supplies everything except libGL, so the skew *and* a missing lib.
+        exists = {
+          it.startsWith("/root/.cache/coo-ee/desktop-gl/lib/") && !it.endsWith("libGL.so.1")
+        },
+        canonicalize = { "/nix/store/6ljs-cooee-desktop-gl/lib" },
+      )
+
+    assertTrue(result.glibcSkew)
+    assertEquals(listOf("libGL.so.1"), result.missing.map { it.soname })
+
+    val check = DesktopNativesCheck.interpret(result, inClaudeCloud = true)
+    assertEquals("error", check.status)
+    assertTrue(check.message.contains("libGL.so.1"))
+    // The skew is not dropped on the floor — fixing the missing lib would otherwise leave a
+    // second, differently-shaped failure waiting behind it.
+    assertTrue(check.detail!!.contains("package-store"))
+  }
+
+  @Test
   fun `store libs on a store JVM's path are the documented fix, not a warning`() {
     val result =
       DesktopNativesCheck.evaluateDesktopNatives(

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosis.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosis.kt
@@ -34,10 +34,24 @@ internal object NativeLoadDiagnosis {
    * failures are not what a `Could not initialize class org.jetbrains.skia…` cascades from, so they
    * must never be mistaken for its cause.
    */
-  private val reportedNonSkiko: MutableSet<String> =
-    java.util.Collections.newSetFromMap(java.util.concurrent.ConcurrentHashMap())
-
   private const val MAX_REMEMBERED_NON_SKIKO = 64
+
+  /**
+   * FIFO-bounded rather than a plain set: the bound must not be able to turn reporting *off* (a
+   * full set that refuses new entries hides a library never seen before) nor turn dedup off (a full
+   * set that clears wholesale re-reports everything it just forgot). Evicting the oldest entry does
+   * neither — every distinct failure is reported, and a failure stays deduped until 64 *other*
+   * distinct ones have pushed it out.
+   */
+  private val reportedNonSkiko: MutableSet<String> =
+    java.util.Collections.newSetFromMap(
+      java.util.Collections.synchronizedMap(
+        object : LinkedHashMap<String, Boolean>(16, 0.75f, false) {
+          override fun removeEldestEntry(eldest: Map.Entry<String, Boolean>): Boolean =
+            size > MAX_REMEMBERED_NON_SKIKO
+        }
+      )
+    )
 
   /** Roots whose libraries carry the store's own glibc rather than the host's. */
   private val STORE_PREFIXES = listOf("/nix/store/", "/gnu/store/")
@@ -126,19 +140,8 @@ internal object NativeLoadDiagnosis {
       "ldLibraryPath" to env("LD_LIBRARY_PATH").orEmpty(),
     )
 
-  /**
-   * Whether [explanation] is being reported for the first time in this JVM. Bounded, because an
-   * unbounded set here would be a slow leak in a long-lived worker.
-   */
-  private fun firstReportOf(explanation: String): Boolean {
-    // Clearing rather than refusing, when the bound is reached. Short-circuiting on size would
-    // report *every* later failure as already-seen — including one never encountered before — so a
-    // genuinely new broken library would be silently dropped from the log forever. Dropping the
-    // history instead costs at most one repeated line per distinct failure, which is the direction
-    // to err in for something whose whole job is making a failure visible once.
-    if (reportedNonSkiko.size >= MAX_REMEMBERED_NON_SKIKO) reportedNonSkiko.clear()
-    return reportedNonSkiko.add(explanation)
-  }
+  /** Whether [explanation] is being reported for the first time in this JVM. */
+  private fun firstReportOf(explanation: String): Boolean = reportedNonSkiko.add(explanation)
 
   /** Test seam — both latches are JVM-global state, so tests must be able to clear them. */
   internal fun resetForTesting() {

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosis.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosis.kt
@@ -25,8 +25,19 @@ import java.util.concurrent.atomic.AtomicReference
  */
 internal object NativeLoadDiagnosis {
 
-  /** The first native-load explanation seen in this JVM, if any. */
+  /** The first *skiko* native-load explanation seen in this JVM, if any. */
   private val firstFailure = AtomicReference<String?>(null)
+
+  /**
+   * Non-skiko native failures already reported in this JVM, so a broken application JNI library
+   * gets one log line rather than one per preview. Deliberately separate from [firstFailure]: those
+   * failures are not what a `Could not initialize class org.jetbrains.skia…` cascades from, so they
+   * must never be mistaken for its cause.
+   */
+  private val reportedNonSkiko: MutableSet<String> =
+    java.util.Collections.newSetFromMap(java.util.concurrent.ConcurrentHashMap())
+
+  private const val MAX_REMEMBERED_NON_SKIKO = 64
 
   /** Roots whose libraries carry the store's own glibc rather than the host's. */
   private val STORE_PREFIXES = listOf("/nix/store/", "/gnu/store/")
@@ -41,10 +52,12 @@ internal object NativeLoadDiagnosis {
 
   /**
    * @property text the sentence written to the sidecar and (for the first failure) the build log.
-   * @property cascade true when this preview only failed because an *earlier* one already broke
-   *   Skia in this JVM. Reported on the sidecar all the same — the panel shows one card at a time,
-   *   so a card that just says "could not initialize class" is useless — but logged only once, or
-   *   the build output becomes the very cascade this exists to collapse.
+   * @property cascade true when this failure has already been accounted for in this JVM — either an
+   *   earlier preview broke Skia and this one inherited the wreckage, or the same native library
+   *   already failed to load for a previous preview. Reported on the sidecar all the same — the
+   *   panel shows one card at a time, so a card that just says "could not initialize class" is
+   *   useless — but logged only once, or the build output becomes the very flood this exists to
+   *   collapse.
    */
   data class Diagnosis(val text: String, val cascade: Boolean)
 
@@ -68,7 +81,14 @@ internal object NativeLoadDiagnosis {
       // and latching it so a later *real* skiko failure is dismissed as a cascade of it.
       val skiko = chain.any(::mentionsSkiko)
       val explanation = explain(native, skiko)
-      if (!skiko) return Diagnosis(explanation, cascade = false)
+      if (!skiko) {
+        // Kept out of the Skia latch — a missing application JNI library says nothing about
+        // skiko — but still reported once per JVM. Every preview that touches the same broken
+        // library raises the same error, and a warm worker would otherwise print a thousand
+        // identical lines: the exact log flood the latch exists to prevent, arriving by a
+        // different door.
+        return Diagnosis(explanation, cascade = !firstReportOf(explanation))
+      }
       // First one wins: later previews in this JVM see the cascade, not another copy of the cause.
       val alreadySeen = !firstFailure.compareAndSet(null, explanation)
       return Diagnosis(explanation, cascade = alreadySeen)
@@ -106,9 +126,18 @@ internal object NativeLoadDiagnosis {
       "ldLibraryPath" to env("LD_LIBRARY_PATH").orEmpty(),
     )
 
-  /** Test seam — the latch is JVM-global state, so tests must be able to clear it. */
+  /**
+   * Whether [explanation] is being reported for the first time in this JVM. Bounded: a preview set
+   * that manages to produce dozens of *distinct* native failures has bigger problems than a noisy
+   * log, and an unbounded set here would be a slow leak in a long-lived worker.
+   */
+  private fun firstReportOf(explanation: String): Boolean =
+    reportedNonSkiko.size < MAX_REMEMBERED_NON_SKIKO && reportedNonSkiko.add(explanation)
+
+  /** Test seam — both latches are JVM-global state, so tests must be able to clear them. */
   internal fun resetForTesting() {
     firstFailure.set(null)
+    reportedNonSkiko.clear()
   }
 
   /** Whether a message says *why* the load failed, rather than only which file failed to load. */

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosis.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosis.kt
@@ -127,12 +127,18 @@ internal object NativeLoadDiagnosis {
     )
 
   /**
-   * Whether [explanation] is being reported for the first time in this JVM. Bounded: a preview set
-   * that manages to produce dozens of *distinct* native failures has bigger problems than a noisy
-   * log, and an unbounded set here would be a slow leak in a long-lived worker.
+   * Whether [explanation] is being reported for the first time in this JVM. Bounded, because an
+   * unbounded set here would be a slow leak in a long-lived worker.
    */
-  private fun firstReportOf(explanation: String): Boolean =
-    reportedNonSkiko.size < MAX_REMEMBERED_NON_SKIKO && reportedNonSkiko.add(explanation)
+  private fun firstReportOf(explanation: String): Boolean {
+    // Clearing rather than refusing, when the bound is reached. Short-circuiting on size would
+    // report *every* later failure as already-seen — including one never encountered before — so a
+    // genuinely new broken library would be silently dropped from the log forever. Dropping the
+    // history instead costs at most one repeated line per distinct failure, which is the direction
+    // to err in for something whose whole job is making a failure visible once.
+    if (reportedNonSkiko.size >= MAX_REMEMBERED_NON_SKIKO) reportedNonSkiko.clear()
+    return reportedNonSkiko.add(explanation)
+  }
 
   /** Test seam — both latches are JVM-global state, so tests must be able to clear them. */
   internal fun resetForTesting() {

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosisTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosisTest.kt
@@ -116,8 +116,8 @@ class NativeLoadDiagnosisTest {
     assertTrue(NativeLoadDiagnosis.diagnose(failure())!!.cascade)
     assertTrue(NativeLoadDiagnosis.diagnose(failure())!!.cascade)
 
-    // A never-seen library is still news after the dedupe bound is reached — the point of the
-    // bookkeeping is to report each failure once, not to go quiet after N of them.
+    // Past the bound, both halves of the contract still hold. A never-seen library is news (a
+    // bound that refuses new entries would hide it forever)...
     repeat(80) { i ->
       NativeLoadDiagnosis.diagnose(
         UnsatisfiedLinkError("/opt/app/lib$i.so: lib$i.so: cannot open shared object file")
@@ -130,6 +130,16 @@ class NativeLoadDiagnosisTest {
         )
       )
     assertFalse(fresh!!.cascade)
+
+    // ...and a *recent* repeat is still deduped, which a wholesale clear-on-full would have
+    // broken: the log would flood again every time the history refilled.
+    val repeatOfFresh =
+      NativeLoadDiagnosis.diagnose(
+        UnsatisfiedLinkError(
+          "/opt/app/libbrandnew.so: libbrandnew.so: cannot open shared object file"
+        )
+      )
+    assertTrue(repeatOfFresh!!.cascade)
 
     // A *different* library is news again, and still not a Skia cascade.
     val other =

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosisTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosisTest.kt
@@ -96,10 +96,33 @@ class NativeLoadDiagnosisTest {
     assertFalse(diagnosis.text.contains("skiko"))
     assertFalse(diagnosis.text.contains("libgl1"))
 
-    // And it did not take the latch: the next skiko failure is still reported as the first one.
+    // And it did not take the Skia latch: the next skiko failure is still reported as the first.
     val skiko = NativeLoadDiagnosis.diagnose(glibcSkewFailure())
     assertFalse(skiko!!.cascade)
     assertTrue(skiko.text.contains("skiko"))
+  }
+
+  @Test
+  fun `the same missing app library is reported once per JVM, not once per preview`() {
+    // Every preview touching the broken library raises the same error. Without its own
+    // bookkeeping, a warm worker would print a thousand identical lines — the flood the Skia
+    // latch exists to prevent, arriving through a different door.
+    fun failure() =
+      UnsatisfiedLinkError(
+        "/opt/app/libtokenizer.so: libtokenizer.so: cannot open shared object file"
+      )
+
+    assertFalse(NativeLoadDiagnosis.diagnose(failure())!!.cascade)
+    assertTrue(NativeLoadDiagnosis.diagnose(failure())!!.cascade)
+    assertTrue(NativeLoadDiagnosis.diagnose(failure())!!.cascade)
+
+    // A *different* library is news again, and still not a Skia cascade.
+    val other =
+      NativeLoadDiagnosis.diagnose(
+        UnsatisfiedLinkError("/opt/app/libcodec.so: libcodec.so: cannot open shared object file")
+      )
+    assertFalse(other!!.cascade)
+    assertTrue(other.text.contains("libcodec.so"))
   }
 
   @Test

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosisTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/NativeLoadDiagnosisTest.kt
@@ -116,6 +116,21 @@ class NativeLoadDiagnosisTest {
     assertTrue(NativeLoadDiagnosis.diagnose(failure())!!.cascade)
     assertTrue(NativeLoadDiagnosis.diagnose(failure())!!.cascade)
 
+    // A never-seen library is still news after the dedupe bound is reached — the point of the
+    // bookkeeping is to report each failure once, not to go quiet after N of them.
+    repeat(80) { i ->
+      NativeLoadDiagnosis.diagnose(
+        UnsatisfiedLinkError("/opt/app/lib$i.so: lib$i.so: cannot open shared object file")
+      )
+    }
+    val fresh =
+      NativeLoadDiagnosis.diagnose(
+        UnsatisfiedLinkError(
+          "/opt/app/libbrandnew.so: libbrandnew.so: cannot open shared object file"
+        )
+      )
+    assertFalse(fresh!!.cascade)
+
     // A *different* library is news again, and still not a Skia cascade.
     val other =
       NativeLoadDiagnosis.diagnose(


### PR DESCRIPTION
Two review follow-ups to the native-diagnosis work in #3703 — it merged before these landed, so
they come as their own change.

**1. `doctor` picked the first candidate render JVM that wasn't `ok`.** But `ok` is false for two
very different things: a missing native dep (which `interpret` reports as an **error**) and a glibc
skew (a **warning**). Candidates are ordered by where they came from — task launchers first, then the
daemon — not by severity, so an earlier candidate's warning could hide a later one whose renders
cannot work at all, and `doctor` would exit 0 on a project that can't render. Missing deps are now
selected ahead of skew.

**2. Keeping non-skiko native failures out of the Skia latch reintroduced the log flood.** Splitting
them off (so a preview's own JNI dependency is never blamed on skiko) meant every preview touching
the same broken library counted as a fresh first report — and `writeErrorSidecar` logs every
diagnosis whose `cascade` is false. A warm worker rendering a catalog would print one
`Render failed (native)` line per preview: exactly the flood the JVM-wide bookkeeping exists to
prevent, arriving through a different door. They now get their own bookkeeping — one report per
distinct explanation per JVM, bounded at 64 so a long-lived worker can't accumulate them — while
staying entirely out of the Skia cascade, which is what the split was for.

## Test plan

- `./gradlew :renderer-desktop:test :cli:test ktfmtCheckAll` — BUILD SUCCESSFUL.
- New case: the same missing application library is reported once and then as a repeat, a
  *different* library is news again, and neither is treated as a Skia cascade.

Non-visual change — diagnosis bookkeeping and a doctor verdict ranking.

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFbgVkkvhUmSGE8sfbJ5n)_