### PR TITLE
chore(release): cut the next release as 1.0.0

### DIFF
--- a/docs/NON_GRADLE_INTEGRATION.md
+++ b/docs/NON_GRADLE_INTEGRATION.md
@@ -239,7 +239,7 @@ fun main() {
 }
 ```
 
-Maven coordinates (pre-1.0):
+Maven coordinates (unstable API — see the caveat below):
 
 ```kotlin
 implementation("ee.schimke.composeai:render-session-api:<version>")
@@ -321,8 +321,9 @@ Pass `--help` to any of them for the full flag list.
 - **`previews.json` schema versioning.** The wire field is `"schema":
   "compose-previews/v1"`. The daemon tolerates unknown fields; clients
   that produce manifests should round-trip schema-stable fields.
-- **Maven Central artifacts are pre-1.0.** Pin to a specific version;
-  expect API changes across minor versions until 1.0.
+- **These Maven Central artifacts do not carry a stability guarantee
+  yet.** Pin to a specific version; expect API changes across releases
+  until the surface settles.
 
 ## Reference
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -24,6 +24,18 @@ In **Settings → Actions → General → Workflow permissions**, tick **"Allow 
 
    > **The heavy CI suite is skipped on release PRs, so no admin bypass is needed to merge.** A release PR only bumps the version manifest / `CHANGELOG.md` / version strings in docs — no source or build inputs change. The build/test/security/preview workflows (`ci`, `codeql`, `compose-preview`, `daemon-harness`, `integration`, `report-schemas`, `format`) gate each job with `if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}`, so they report **skipped** only on a release PR — i.e. one whose head branch is `release-please--*` **and** whose author is the release bot. (The branch name alone is contributor-controlled, so the author check is what stops a human/fork PR from naming its branch `release-please--…` to skip CI and abuse "skipped == passing"; switch the login if you move release-please to a GitHub App token.) Branch protection treats a skipped required check as passing, so the required checks go green instantly. The cheap PR-hygiene checks (`pr-title`, `no-agent-attribution`) still run — a release PR passes both. The guard is at job level on purpose: a `branches` filter on the trigger would leave the required check stuck *pending* and block the merge instead.
 
+## The 1.0.0 override — delete it once v1.0.0 is published
+
+[`release-please-config.json`](../release-please-config.json) currently pins the root package with `"release-as": "1.0.0"`, so the next release cuts as **1.0.0** instead of the `0.19.x` patch the conventional-commit history would otherwise produce. Nothing else about the chain changes: the release PR is still titled `chore(main): release 1.0.0`, and merging it tags, drafts, builds, and finalizes exactly as described above.
+
+**`release-as` is sticky — it is not consumed by the release it forces.** Left in place, every subsequent release PR proposes 1.0.0 again, the tag already exists, and the release wedges. (This repo has been bitten by it: an override pinning 0.7.0 outlived its release and had to be dropped by hand.) So the moment `v1.0.0` is published:
+
+1. Delete the `"release-as": "1.0.0"` line from `release-please-config.json`.
+2. Delete `bump-minor-pre-major` / `bump-patch-for-minor-pre-major` in the same edit — both keys only ever apply while the major version is `0`, so they go inert at 1.0.0 and are then just misleading config.
+3. Land that as a `chore:` PR. The next `Release PR` run re-reads the config and proposes a normal semver bump.
+
+**What versioning looks like after 1.0.0.** Those two pre-major keys are what made `feat:` land as a *patch* bump for the whole `0.x` line (which is how a repo with this much history is still on a `0.19.x` version). Once they're gone the usual semver mapping applies: `fix:` → patch, `feat:` → minor, `feat!:` / `BREAKING CHANGE` → **major**. Titling a PR `feat!:` after 1.0.0 therefore cuts 2.0.0, not 1.0.1 — worth a second look at PR titles for the first few releases.
+
 ## Fallback paths
 
 If the automatic chain ever leaves a release half-published (e.g. Maven Central rejected an upload, CLI build failed), you can re-run the build/publish against an existing tag without touching release-please:
@@ -52,9 +64,9 @@ republishing the release.
    - **Gradle plugin** — `ee.schimke.composeai:compose-preview-plugin`
    - **Android renderer AAR** — `ee.schimke.composeai:renderer-android`
    - **Preview annotations** — `ee.schimke.composeai:preview-annotations`
-   - **Daemon core** (pre-1.0) — `ee.schimke.composeai:daemon-core` — renderer-agnostic JSON-RPC server, protocol types, RenderHost interface
-   - **Daemon desktop** (pre-1.0) — `ee.schimke.composeai:daemon-desktop` — Compose Multiplatform desktop backend (DesktopHost + DaemonMain)
-   - **Daemon android** (pre-1.0) — `ee.schimke.composeai:daemon-android` — Robolectric backend; Compose / Roborazzi / UI-test stay `compileOnly`, consumer supplies runtime versions
+   - **Daemon core** (unstable API) — `ee.schimke.composeai:daemon-core` — renderer-agnostic JSON-RPC server, protocol types, RenderHost interface
+   - **Daemon desktop** (unstable API) — `ee.schimke.composeai:daemon-desktop` — Compose Multiplatform desktop backend (DesktopHost + DaemonMain)
+   - **Daemon android** (unstable API) — `ee.schimke.composeai:daemon-android` — Robolectric backend; Compose / Roborazzi / UI-test stay `compileOnly`, consumer supplies runtime versions
    - **Data product connectors** — `ee.schimke.composeai:data-*-connector` artifacts used by daemon modules, including recomposition
 
    Maven Central is the only Maven coordinate source — we no longer mirror jars onto GitHub Packages. Consumers point Gradle at `mavenCentral()` and resolve every module from there.
@@ -86,7 +98,7 @@ that forwards to the canonical script — kept so historical
 `raw.githubusercontent.com/yschimke/compose-ai-tools/.../scripts/install.sh`
 URLs keep resolving.
 
-The `daemon-*` artifacts are **pre-1.0**; their public API is not yet stable. Expect breakage across minor versions until the surface settles. See [docs/daemon/DESIGN.md § 17](daemon/DESIGN.md) for the architectural decisions and § 19 for the captureToImage fallback path.
+The `daemon-*` artifacts carry **no API-stability guarantee**; their public API is not yet settled. Expect breakage across minor versions until the surface settles. See [docs/daemon/DESIGN.md § 17](daemon/DESIGN.md) for the architectural decisions and § 19 for the captureToImage fallback path.
 
 Required secrets on the repository:
 

--- a/docs/daemon/STREAMING.md
+++ b/docs/daemon/STREAMING.md
@@ -1,6 +1,6 @@
 # Live frame streaming (`composestream/1`)
 
-**Status: pre-1.0, additive on top of the existing `interactive/*` surface.**
+**Status: unstable, additive on top of the existing `interactive/*` surface.**
 A daemon that hasn't grown the new methods rejects `stream/start` with
 `MethodNotFound (-32601)`; the panel falls back to the existing
 `<img src=…>` swap path. No `protocolVersion` bump.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,7 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "release-as": "1.0.0",
       "draft": true,
       "extra-files": [
         ".github/actions/install/README.md",


### PR DESCRIPTION
## Summary

Pins the root package in `release-please-config.json` with `"release-as": "1.0.0"`, so the next release cuts as **1.0.0** instead of the `0.19.x` patch the conventional-commit history would produce.

The open release PR #3692 (`chore(main): release 0.19.62`) is not stale work to redo — the `update-release-pr` job re-runs release-please on the next push to `main`, re-reads this config, and rewrites that same PR to `chore(main): release 1.0.0`. Merging it then tags, drafts, builds, and finalizes exactly as before; nothing else in the release chain changes.

### The removal step, documented

`release-as` is **sticky** — it isn't consumed by the release it forces. Left in place, every later release PR proposes 1.0.0 again, the tag already exists, and the release wedges. This repo has already been bitten by that once (an override pinning 0.7.0 that outlived its release). So `docs/RELEASING.md` grows a section saying, in order: delete the override once `v1.0.0` publishes, delete `bump-minor-pre-major` / `bump-patch-for-minor-pre-major` with it (they only apply while the major is `0`, so they go inert at 1.0.0), land it as a `chore:` PR.

That section also spells out what changes for PR titles afterwards. Those two pre-major keys are why `feat:` has been landing as a *patch* bump for the whole `0.x` line; once they're gone the usual mapping applies — `fix:` → patch, `feat:` → **minor**, `feat!:` / `BREAKING CHANGE` → **major**. A `feat!:` title after 1.0.0 cuts 2.0.0, not 1.0.1.

I left the two pre-major keys in place here rather than removing them in the same commit: they're inert at 1.0.0 either way, and keeping them means this PR can't quietly change `0.x` bumping behaviour if 1.0.0 doesn't cut for some reason.

### Docs that said "pre-1.0"

Five places used "pre-1.0" to mean "the version number is below 1.0" — statements that go false the moment this lands. Each of them was really an unstable-API caveat, so they now say that directly (`docs/RELEASING.md` daemon artifacts ×4, `docs/NON_GRADLE_INTEGRATION.md` ×2, `docs/daemon/STREAMING.md` status line). No stability guarantee is added or withdrawn — flag it if you'd rather 1.0.0 mean something stronger for the `daemon-*` surface, since that's a call for you, not the version bump.

## Test plan

- `release-please-config.json` parses, and `release-as` is a valid package-level key in the [release-please config schema](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json) the file already pins via `$schema`.
- Confirmed against release-please's [`src/strategies/base.ts`](https://github.com/googleapis/release-please/blob/main/src/strategies/base.ts) that `buildNewVersion` short-circuits to `Version.parse(this.releaseAs)` before any bump computation, and that the `changelogEmpty` skip is not a concern here — there are releasable `fix:` / `feat:` commits on `main` since `v0.19.61`, which is why release PR #3692 already exists.
- Docs-and-config only: no Kotlin touched, and `.github/ci/format-paths.json` ignores `docs/**`, `**/*.md`, and `**/*.json`, so the `format` gate is scoped out.
- Non-visual change — no rendered surfaces affected, so no before/after images.

---
_Generated by [Claude Code](https://claude.ai/code/session_015iYCc36RqdAi8y9MLfvKRo)_