### PR TITLE
fix(daemon): run the press-settling frame under the preview's locale

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -101,6 +101,7 @@ class DesktopInteractiveSession(
       scene = { state.scene },
       defaultTimeMillis = { engine.currentFrameNanoTime() / 1_000_000L },
       defaultFrameNanos = { engine.currentFrameNanoTime() },
+      settleFrame = { nanoTime -> engine.renderSettlingFrame(state, nanoTime) },
     )
 
   override val isClosed: Boolean

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -436,6 +436,7 @@ class DesktopRecordingSession(
       scene = { state.scene },
       defaultTimeMillis = { 0L },
       defaultFrameNanos = { 0L },
+      settleFrame = { nanoTime -> engine.renderSettlingFrame(state, nanoTime) },
     )
 
   private fun pointerIdOrDefault(event: RecordingScriptEvent): Int = event.pointerId ?: 0

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopSceneInput.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopSceneInput.kt
@@ -53,11 +53,16 @@ internal data class ScenePointer(val offset: Offset, val type: PointerType)
  * @param defaultFrameNanos frame clock used for the settling render [press] runs when a call site
  *   passes `frameNanos = null`. Same contract as [defaultTimeMillis]: wall clock live, virtual
  *   `tNanos` under scripted playback.
+ * @param settleFrame renders the throwaway frame that settles a [press]. A lambda rather than a
+ *   `scene().render()` here because that frame has to carry the session's whole render discipline —
+ *   the `localeTag` JVM-default-`Locale` scope, and closing the snapshot it allocates. See
+ *   [RenderEngine.renderSettlingFrame].
  */
 internal class ScenePointerDispatch(
   private val scene: () -> ImageComposeScene,
   private val defaultTimeMillis: () -> Long,
   private val defaultFrameNanos: () -> Long,
+  private val settleFrame: (nanoTime: Long) -> Unit,
 ) {
 
   /**
@@ -99,7 +104,7 @@ internal class ScenePointerDispatch(
   ) {
     active[id] = ScenePointer(offset, type)
     send(PointerEventType.Press, timeMillis)
-    scene().render(nanoTime = frameNanos ?: defaultFrameNanos())
+    settleFrame(frameNanos ?: defaultFrameNanos())
   }
 
   fun move(id: Int, offset: Offset, type: PointerType, timeMillis: Long? = null) {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -628,6 +628,29 @@ class RenderEngine(
   internal fun currentFrameNanoTime(): Long = frameNanoTime()
 
   /**
+   * One frame whose *pixels are thrown away* — the settling render [ScenePointerDispatch.press]
+   * runs so Compose's gesture detectors observe a press before the next event can arrive.
+   *
+   * Under the same JVM-default-`Locale` override [renderOnce] wraps its frames in, and for the same
+   * reason: a press can compose new content, and `rememberResourceEnvironment` caches what it
+   * resolves — so a settling frame run at the host default would bake default-language
+   * `stringResource(...)` text into a `localeTag` preview that the localized capture afterwards
+   * cannot undo.
+   *
+   * The returned snapshot is closed rather than left to a cleaner: it owns native Skia memory, and
+   * a held session presses many times between captures.
+   */
+  @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+  internal fun renderSettlingFrame(state: SceneState, nanoTime: Long) {
+    val previousDefaultLocale = overrideJvmDefaultLocale(effectiveLocaleTag(state.spec.localeTag))
+    try {
+      state.scene.render(nanoTime = nanoTime).close()
+    } finally {
+      restoreJvmDefaultLocale(previousDefaultLocale)
+    }
+  }
+
+  /**
    * v2 phase 2 — drive the held scene through enough frames to settle (two `scene.render()` calls,
    * same heuristic as the one-shot path) and encode the latest pixels to PNG. Reusable across
    * inputs in the interactive path; called exactly once by the [render] wrapper.

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
@@ -7,6 +7,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
 import kotlin.math.abs
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -172,6 +173,78 @@ class DesktopInteractiveSessionTest {
         session.close()
       }
     } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * The press-settling render (#3697) is a real frame and composes whatever the press invalidated,
+   * so it has to run inside the `localeTag` JVM-default-`Locale` scope every other frame runs in —
+   * `rememberResourceEnvironment` caches what it resolves, and a `stringResource(...)` first
+   * resolved at the host default on a press is not re-resolved by the capture that follows.
+   */
+  @Test
+  fun press_settling_frame_composes_under_the_preview_locale() {
+    val outputDir = tempFolder.newFolder("interactive-press-locale-renders")
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = outputDir),
+        previewSpecResolver = { previewId ->
+          if (previewId == PRESS_LOCALE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "PressLocaleProbeSquare",
+              widthPx = 64,
+              heightPx = 64,
+              localeTag = "de",
+              outputBaseName = "press-locale-probe-square",
+            )
+          } else null
+        },
+      )
+    val hostDefault = java.util.Locale.getDefault()
+    host.start()
+    try {
+      // A host default that is emphatically not the override, so "composed under de" can't be an
+      // accident of the machine the test runs on.
+      java.util.Locale.setDefault(java.util.Locale.forLanguageTag("en-US"))
+      val session =
+        host.acquireInteractiveSession(
+          previewId = PRESS_LOCALE_PREVIEW_ID,
+          classLoader = DesktopInteractiveSessionTest::class.java.classLoader!!,
+        )
+      try {
+        session.render(requestId = RenderHost.nextRequestId())
+
+        // Read the probe straight after the dispatch and *before* any capture render: what it holds
+        // is what the settling frame composed under, not what a later frame corrected it to.
+        PressLocaleProbe.reset()
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "test-press-locale",
+            kind = InteractiveInputKind.POINTER_DOWN,
+            pixelX = 32,
+            pixelY = 32,
+            pointerId = 0,
+          )
+        )
+
+        assertEquals(
+          "the press must have recomposed the fixture — without that there is no settling frame " +
+            "to make a claim about",
+          true,
+          PressLocaleProbe.composedUnder != null,
+        )
+        assertEquals(
+          "the settling frame must compose under the preview's localeTag, not the host default",
+          "de",
+          PressLocaleProbe.composedUnder,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      java.util.Locale.setDefault(hostDefault)
       host.shutdown()
     }
   }
@@ -576,6 +649,7 @@ class DesktopInteractiveSessionTest {
     private const val FRAME_CLOCK_PREVIEW_ID = "frame-clock-square"
     private const val HIGH_DENSITY_TARGET_PREVIEW_ID = "high-density-click-target-square"
     private const val KEY_PRESS_PREVIEW_ID = "key-press-color-square"
+    private const val PRESS_LOCALE_PREVIEW_ID = "press-locale-probe-square"
     private const val TAGGED_TARGET_PREVIEW_ID = "tagged-click-target-square"
   }
 }

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -506,6 +506,51 @@ fun HighDensityClickTargetSquare() {
 }
 
 /**
+ * Records the JVM default `Locale` each time [PressLocaleProbeSquare] composes.
+ *
+ * `localeTag` is applied by pointing the JVM default `Locale` at the override for the duration of a
+ * composition / frame — that is what CMP `stringResource(...)` resolves against on desktop (see
+ * `RenderEngine.overrideJvmDefaultLocale`). So "which locale was live while this composed" *is* the
+ * JVM default at composition time, and reading it is how a test can tell whether a given frame ran
+ * inside the override or outside it.
+ */
+object PressLocaleProbe {
+  @Volatile var composedUnder: String? = null
+
+  fun record() {
+    composedUnder = java.util.Locale.getDefault().toLanguageTag()
+  }
+
+  fun reset() {
+    composedUnder = null
+  }
+}
+
+/**
+ * Recomposes on a pointer press and publishes the locale it recomposed under to [PressLocaleProbe].
+ *
+ * The press-settling render is a frame like any other — it composes whatever the press invalidated
+ * — so it has to run inside the same `localeTag` scope as the capture frames, or a localized
+ * preview caches host-language resources on a press it can never re-resolve.
+ */
+@Composable
+fun PressLocaleProbeSquare() {
+  var pressed by remember { mutableStateOf(false) }
+  PressLocaleProbe.record()
+  Box(
+    modifier =
+      Modifier.fillMaxSize()
+        .background(if (pressed) Color(0xFF66BB6A) else Color(0xFFEF5350))
+        .pointerInput(Unit) {
+          awaitPointerEventScope {
+            awaitFirstDown()
+            pressed = true
+          }
+        }
+  )
+}
+
+/**
  * Live interactive fixture that exposes Compose's frame clock as pixels. It starts red and turns
  * green after at least 250 ms of frame-clock time has elapsed. If [ImageComposeScene.render] is
  * called without an explicit timestamp, every frame is rendered at `nanoTime = 0` and this preview

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -366,6 +366,14 @@ empty and no selection is painted at all (issue #3697). Tap detection has
 the same exposure, which is why the click path already rendered between
 its press and release by hand.
 
+The settling frame goes through `RenderEngine.renderSettlingFrame`, not
+`scene.render` directly: it composes whatever the press invalidated, so
+it carries the same `localeTag` JVM-default-`Locale` scope the capture
+frames run under (`rememberResourceEnvironment` caches what it resolves,
+and a `stringResource(...)` first resolved at the host default is not
+re-resolved by the capture that follows), and it closes the snapshot it
+allocates instead of leaving native Skia memory to a cleaner.
+
 ## 9.10 v3 Android pointer
 
 Android click dispatch requires sandbox pinning: see


### PR DESCRIPTION
Follow-up to #3711 — it merged while I was working through its review, so this rides a fresh branch rather than stacking on the merged one. Both findings were real.

## The settling frame escaped the `localeTag` scope

`localeTag` is applied by pointing the JVM default `Locale` at the override *for the duration of a frame* — that is what CMP `stringResource(...)` resolves against on desktop. `renderOnce` re-applies it around every held-scene frame precisely because a held session recomposes on each input and `rememberResourceEnvironment` re-reads `Locale.current`.

The press-settling render #3711 added — and the click fast-path's tick, which predates it — ran outside that scope. A press composes whatever it invalidated, so on a localized preview it could resolve and cache host-language `stringResource(...)` text that the capture frame afterwards has no reason to re-resolve. `driveStaticScrollToEnd` already carries a comment spelling out this exact hazard, for the same reason.

## The discarded snapshot wasn't closed

`ImageComposeScene.render(nanoTime)` allocates an `org.jetbrains.skia.Image` whose pixels the settling frame throws away. Native memory doesn't pressure the JVM into collecting it promptly, and a held session presses many times between captures.

## The fix

Both belong to the same frame, so both live in one place: `RenderEngine.renderSettlingFrame(state, nanoTime)` — locale scope in, snapshot closed on the way out. `ScenePointerDispatch` takes it as a `settleFrame` lambda instead of calling `scene().render(...)` itself, so the interactive and recording lanes get identical treatment and the pointer translator stays ignorant of locales.

## Test plan

* New `PressLocaleProbeSquare` fixture records the JVM default locale each time it composes, and recomposes on a press. `DesktopInteractiveSessionTest.press_settling_frame_composes_under_the_preview_locale` reads the probe **straight after the dispatch and before any capture render**, so what it asserts is what the *settling* frame composed under — `de` on a `localeTag = "de"` spec, with the host default deliberately set to `en-US` first so a pass can't be an accident of the machine. Verified red without the locale scope.
* `./gradlew :daemon:desktop:test` — green, full module.
* Re-ran the `serve-lanes` e2e against a rebuilt daemon-backed serve booted the way CI boots it: **12 passed**, so #3697's drag fix is unaffected.
* `./gradlew ktfmtFormat` — clean.

No visual change: this only affects which locale a throwaway frame composes under and when a discarded snapshot is freed. The rendered pixels of #3711's drag selection are unchanged — evidence for those is in [`renders/live-input-drag-selection/`](https://github.com/yschimke/compose-ai-tools/tree/main/renders/live-input-drag-selection), landed with #3711.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RikE7Eshj4b7fYYm1eBCPU)_