### PR TITLE
docs(versioning): name what 1.0.0 does and doesn't turn on

### DIFF
--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -24,7 +24,7 @@ The annotation library and per-data-product schemas are intentionally narrow. Th
 
 ### 2.1 Daemon JSON-RPC (surface 1)
 
-**Negotiation:** `initialize` request carries `protocolVersion: {min, max}` (post-1.0; today a single `int`). The daemon answers with its own `{min, max}` plus a `ServerCapabilities` bag. Both sides operate at `min(client.max, server.max)`. Mismatched ranges → `InvalidRequest`, daemon exits.
+**Negotiation:** `initialize` request carries a single `protocolVersion: Int`; the daemon answers with its own plus a `ServerCapabilities` bag, and any mismatch is `InvalidRequest` and the daemon exits. Range negotiation — client and daemon each sending `{min, max}` and operating at `min(client.max, server.max)` — is **not in 1.0.0**; it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-status-at-10)).
 
 **Feature detection:** capability bag, never daemon `semver`. The bag already covers `supportedOverrides`, `dataProducts`, `dataExtensions`, `previewExtensions`, `knownDevices`, `backend`, `androidSdk`, `recordingFormats`, `interactive`, `recording`. New features add a capability entry, not a behavior change under an existing field.
 
@@ -62,10 +62,11 @@ Each kind owns its own `schemaVersion: Int`. Producers evolve independently of t
 
 ### 2.4 Gradle plugin DSL (surface 4)
 
-**Stability tiers** (post-1.0):
-- `@Stable` — public, semver-governed. Property type changes, removals, and renames are breaking changes that bump the plugin major.
-- `@Incubating` — public but explicitly opt-in via `composePreview { incubating = true }`. May change in any release; warning at apply time.
+**Stability tiers.** As of 1.0.0 there are two, not three — the DSL has no opt-in tier, which makes the surface *stricter* than the scheme below, not looser:
+- Public — semver-governed. Property type changes, removals, and renames are breaking changes that bump the plugin major. Enforced by Kotlin BCV on `:gradle-plugin` ([VERSIONING.md § 9](VERSIONING.md#9-compatibility-testing)).
 - Internal — `internal` Kotlin visibility. No contract.
+
+The `@Stable` / `@Incubating` split, with `@Incubating` opt-in via `composePreview { incubating = true }` and a warning at apply time, is **not in 1.0.0** — it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-status-at-10)). Until it does, a new DSL property is public and semver-governed the moment it ships, so add one only when you're willing to keep it.
 
 **Negotiation:** none. Gradle resolves the plugin coordinate; `apply()` validates the AGP/Kotlin/Compose versions present and either accepts or fails closed with a specific error. See § 2.5.
 
@@ -101,7 +102,7 @@ The annotation library has no negotiation surface — the plugin's discovery tas
 
 **Deprecation:** flags follow the cycle in [VERSIONING.md § 5](VERSIONING.md#5-deprecation-policy) — warn for two minors, then remove.
 
-**Negotiation:** `compose-preview --version` and `compose-preview <cmd> --json-schema` (post-1.0) let CI and agents detect capability without parsing `--help`.
+**Negotiation:** `compose-preview --version`. The `compose-preview <cmd> --json-schema` capability probe is **not in 1.0.0** — it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-status-at-10)); until then CI and agents read `--help`.
 
 ### 2.8 MCP tool names (surface 8)
 
@@ -142,7 +143,7 @@ The VS Code N..N-1 window is the only place we actively decode two protocol vers
 
 ## 5. Stability tags in code
 
-Post-1.0 each public type carries one of:
+The intended scheme — each public type carrying one of these tags — is **not applied as of 1.0.0**; it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-status-at-10)):
 
 - `// API: stable` — semver-governed.
 - `// API: incubating` — opt-in, may change.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -29,7 +29,7 @@ For plugin, CLI, extension, MCP, annotations:
 - **Minor** — additive change: new feature, new flag, new DSL property, new annotation, new CLI subcommand, new MCP tool. New optional fields on existing types.
 - **Patch** — bug fix with no contract change. No new public surface.
 
-Pre-1.0 (today): minor bumps may carry breaking changes with a clear note in CHANGELOG. Post-1.0 they may not.
+Through the `0.x` line, minor bumps could carry breaking changes with a clear note in CHANGELOG. From `1.0.0` they may not — see § 10.
 
 ## 3. What counts as breaking
 
@@ -80,7 +80,7 @@ Bumping `protocolVersion` requires:
 - Daemon support for the previous version for one minor cycle (clients may take longer to ship).
 - Updated fixture corpus.
 
-Post-1.0 the daemon advertises a `{min, max}` range and serves both. The VS Code extension supports `current..current-1` daemons.
+Range negotiation — the daemon advertising a `{min, max}` and serving both — is **not in 1.0.0** and is deferred to a later `1.x` (§ 10). `initialize` carries a single `protocolVersion: Int` today, and [`JsonRpcServer`](../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt) fails the handshake on any mismatch. Until it lands, the VS Code extension's `current..current-1` support window is a client-side concern, not something the daemon negotiates.
 
 ## 5. Deprecation policy
 
@@ -137,8 +137,19 @@ Three layers, all required to remain green on `main`:
 
 Adding a public type or annotation without updating the BCV golden file is a CI failure. Adding a wire message without a fixture is a CI failure. Bumping the AGP corner without a green integration run is a CI failure.
 
-## 10. Pre-1.0 disclaimer
+## 10. Status at 1.0
 
-Until `1.0.0`, the rules in §§ 2–5 are aspirational; the project may break any contract in any release with a CHANGELOG note. The contracts in [API_STABILITY.md](API_STABILITY.md) become enforceable at 1.0.
+Through the `0.x` line the rules in §§ 2–5 were aspirational — any contract could break in any release with a CHANGELOG note. **From `1.0.0` they are in effect**, and the contracts in [API_STABILITY.md](API_STABILITY.md) are enforceable: breaking a listed surface requires a major.
 
-The work needed to make 1.0 honourable is tracked in the repo's open issues.
+Four *discovery* mechanisms these documents describe are **not part of 1.0.0**. They were always written as post-1.0 evolution rather than 1.0 gates, and cutting 1.0.0 does not make them retroactively true — so they are named here rather than left implied:
+
+| Mechanism | Where it's described | State at 1.0.0 |
+|---|---|---|
+| `protocolVersion: {min, max}` range negotiation | § 4.5, [API_STABILITY.md § 2.1](API_STABILITY.md#21-daemon-json-rpc-surface-1) | Not implemented — single `Int`, handshake fails closed on mismatch |
+| `compose-preview <cmd> --json-schema` | [API_STABILITY.md § 2.7](API_STABILITY.md#27-cli-argv-surface-7) | Not implemented — capability detection is `--version` plus `--help` |
+| `// API: stable` / `// API: incubating` source tags | [API_STABILITY.md § 5](API_STABILITY.md#5-stability-tags-in-code) | Not applied — Kotlin BCV is the enforced boundary for the plugin and annotations modules |
+| `@Stable` / `@Incubating` DSL tiers, opt-in via `composePreview { incubating = true }` | [API_STABILITY.md § 2.4](API_STABILITY.md#24-gradle-plugin-dsl-surface-4) | Not implemented — every public DSL property is semver-governed, with no opt-in tier to escape into |
+
+None of the four weakens the stability promise. Three are ways to *discover* the contract rather than the contract itself, and the missing DSL tier makes the surface stricter — with no incubating escape hatch, a property is committed the moment it ships. The guarantees stand on the deprecation policy (§ 5), the tolerant-decode rules (§ 4), and the three test layers in § 9, all live today. Each mechanism lands in a later `1.x` as an additive change.
+
+The 1.0 readiness punch list itself was [issue #798](https://github.com/yschimke/compose-ai-tools/issues/798), closed as completed.

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -1,6 +1,6 @@
 # Preview daemon — IPC protocol
 
-> **Status:** v2 contract. Pre-1.0 — wire shape may break across minor versions in a coordinated daemon + client release. v2 made `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` opt-in via `extensions/enable` (see § 3a); v1 clients fail the `protocolVersion` check.
+> **Status:** v2 contract. The wire shape may still break across artifact minor versions, in a coordinated daemon + client release — `protocolVersion` is decoupled from the artifact semver ([VERSIONING.md § 8](../VERSIONING.md#8-release-coordination)), and range negotiation is deferred past 1.0.0 ([§ 10](../VERSIONING.md#10-status-at-10)), so a bump means old clients fail the handshake rather than being served the old version. v2 made `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` opt-in via `extensions/enable` (see § 3a); v1 clients fail the `protocolVersion` check.
 
 This document is the authoritative wire-format spec for the JSON-RPC channel between the VS Code extension and the per-module preview daemon. It is referenced by [DESIGN.md § 5](DESIGN.md).
 

--- a/docs/daemon/STREAMING.md
+++ b/docs/daemon/STREAMING.md
@@ -142,9 +142,9 @@ binary header followed by the payload bytes:
 ```
 
 `StreamFrameHeader` in `:daemon:core` is the canonical pack/parse
-implementation; `StreamFrameHeaderTest` pins the round-trip. Pre-1.0
-binary clients are not supported on the wire today; the JSON envelope is
-the only sanctioned transport.
+implementation; `StreamFrameHeaderTest` pins the round-trip. Binary
+clients are not supported on the wire today; the JSON envelope is the
+only sanctioned transport.
 
 ## Client model — newest-wins queue + canvas paint
 


### PR DESCRIPTION
## Summary

Follow-up to #3710, which pinned `"release-as": "1.0.0"`. Codex flagged a P1 on that PR: the policy docs switch on the version number, so cutting 1.0.0 flips statements from "planned" to "claimed" without any code moving. That's a real gap, and this is the reconciliation — it didn't make #3710 because that PR merged while this commit was being pushed.

Codex named two mechanisms; auditing the rest of the policy docs found **four** described but unimplemented:

| Mechanism | State in the tree |
|---|---|
| `protocolVersion: {min, max}` range negotiation | `InitializeParams` / `InitializeResult` carry a single `Int` ([Messages.kt:83,137](https://github.com/yschimke/compose-ai-tools/blob/main/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt#L83)); `JsonRpcServer` fails the handshake on mismatch |
| CLI `<cmd> --json-schema` capability probe | No implementation anywhere under `cli/` |
| `// API: stable` / `// API: incubating` source tags | Not applied; Kotlin BCV is the real enforced boundary |
| `@Stable` / `@Incubating` DSL tiers + `composePreview { incubating = true }` | Zero occurrences of `Incubating` under `gradle-plugin/` or `api/` |

**Where I landed, and why it isn't a blocker for 1.0.** All four are documented as *post-1.0 evolution* — "post-1.0; today a single `int`", "`--json-schema` (post-1.0)" — not as gates on cutting 1.0, and the 1.0 readiness punch list (#798) is closed as completed. Three of them are ways to **discover** the contract rather than the contract itself, and the missing DSL tier makes the surface *stricter*, not looser: with no incubating escape hatch, a DSL property is committed the moment it ships. The compatibility guarantees rest on the deprecation policy (§ 5), the tolerant-decode rules (§ 4), and the three test layers (§ 9) — all live today.

So rather than weaken any contract, this names the four in a table in `VERSIONING.md § 10` and says at each description site that it isn't in 1.0.0 and lands in a later `1.x` as an additive change.

Also in scope:

- **`VERSIONING.md § 10` rewritten** from "Pre-1.0 disclaimer" to "Status at 1.0" — §§ 2–5 stop being aspirational and the `API_STABILITY.md` contracts become enforceable. That's the part of 1.0 that *is* real, and it was previously phrased as a future event.
- **`PROTOCOL.md` status line** promised "coordinated daemon + client release" without noting that a `protocolVersion` mismatch fails the handshake closed — which is exactly what the deferred range negotiation would have softened. Now says so, and links § 8 for why a protocol bump doesn't imply an artifact major.
- **Remaining "pre-1.0" phrasings** that meant "the version number is below 1.0" (`STREAMING.md`), left over from the same sweep in #3710.

**If you'd rather 1.0 mean more than this** — i.e. implement range negotiation and `--json-schema` before the release cuts — say so and I'll do that instead; reverting the override is one line. This PR takes the reading that 1.0 turns on the *guarantees*, with the discovery mechanisms following in 1.x.

## Test plan

- Docs only — no code, no build files. `.github/ci/format-paths.json` ignores `docs/**` and `**/*.md`, so the `format` gate is scoped out.
- Every claim of non-implementation verified against the tree, not inferred: `grep` for `Incubating` across `gradle-plugin/` + `api/` returns 0; `json-schema` across `cli/` returns 0; `protocolVersion` is `Int` at both `Messages.kt:83` and `:137`, with the mismatch branch at `JsonRpcServer.kt:747`.
- New cross-doc anchors (`#10-status-at-10`, `#24-gradle-plugin-dsl-surface-4`, `#8-release-coordination`, `#9-compatibility-testing`) match their headings' GitHub slugs, and the relative path from `docs/` to `daemon/core/.../JsonRpcServer.kt` resolves.
- Non-visual change — no rendered surfaces affected, so no before/after images.

---
_Generated by [Claude Code](https://claude.ai/code/session_015iYCc36RqdAi8y9MLfvKRo)_