### PR TITLE
fix(serve): stop a knob edit spending the previous history entry to auto-enable Wasm

### DIFF
--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -598,11 +598,15 @@
   function withMode(url, mode) {
     return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
   }
-  function refreshLinks() {
+  // [skipUrlSync] refreshes the copyable links WITHOUT touching history. Only one caller wants it:
+  // a path that is about to hand the URL to a lane transition, where syncing first would replace
+  // the entry the visitor came from moments before that transition pushes a new one — spending the
+  // previous state to write an intermediate nobody asked for. See `onKnobEdited`.
+  function refreshLinks(skipUrlSync) {
     // The page's own URL is kept in step with the controls for the same reason the direct links
     // are: what's on screen should be something you can bookmark or hand to someone. Every path
     // that changes viewer state already refreshes the links, so this one call covers all of them.
-    syncUrl();
+    if (!skipUrlSync) syncUrl();
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
@@ -2274,14 +2278,16 @@
   // [discrete] marks an edit that earns its own history entry (a value picked from a closed set),
   // as opposed to a continuous one (typing a label) that replaces.
   //
-  // It pushes here for every route BUT `enable-wasm`: that path ends in `setMode("wasm")`, and
-  // `enterMode` already pushes for the lane change. Pushing in both places would leave an
-  // intermediate `choice + png` entry between the two — a state that cannot apply the choice it
-  // names — so Back would land there instead of on the previous choice.
+  // The `enable-wasm` route writes no history here at all — not a push, and not the replace a
+  // non-discrete edit would otherwise do. That path ends in `setMode("wasm")`, and `enterMode`
+  // syncs with a push of its own for the lane change. Doing anything here first spends the entry
+  // the visitor came from on an intermediate `choice + png` state — one that cannot apply the
+  // choice it names — and Back then lands on that instead of on the previous choice. Suppressing
+  // only the push is not enough: the replace clobbers the same entry just as thoroughly.
   function onKnobEdited(discrete) {
     var route = knobRoute();
     if (discrete && route !== "enable-wasm") urlPush = true;
-    refreshLinks();
+    refreshLinks(route === "enable-wasm");
     if (route === "wasm") {
       if (wasmReady && wasmFrame.contentWindow) {
         wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -4347,7 +4347,9 @@ class ServeWebFixtureTest {
       "the URL field is taken out of the flow rather than given a third of the line",
     )
     assertTrue(
-      assetText("viewer.js").contains("function refreshLinks()") &&
+      // Matched without the parameter list — the helper's existence is the contract, not its
+      // arity, which grew a `skipUrlSync` opt-out for the wasm auto-enable path.
+      assetText("viewer.js").contains("function refreshLinks(") &&
         assetText("viewer.js").contains("location.origin"),
       "the links are rebuilt from location.origin as the controls change",
     )


### PR DESCRIPTION
## Summary

Follow-up to #3712, which merged before this could be pushed to it.

On a statically-served catalog that offers a Wasm tier, a knob edit takes the `enable-wasm` route: `onKnobEdited` syncs the URL, then `setMode("wasm")` hands off to `enterMode`, which syncs again with a push for the lane change.

#3712 stopped the first sync from **pushing**. That was half the problem — a sync that doesn't push **replaces**, and a replace clobbers the entry the visitor came from just as thoroughly. One pick still ended with:

```
[…, choice+png]            ← the previous entry, overwritten by the replace
[…, choice+png, choice+wasm]  ← then the lane-change push
```

so Back landed on an intermediate `choice + png` state — one that cannot apply the choice it names — instead of on the previous choice. Credit to the reviewer on #3712 for spotting that suppressing the push wasn't sufficient.

The route now writes no history there at all. `refreshLinks` takes a `skipUrlSync` opt-out — the copyable links, SVG match and report link still refresh, only the history write is withheld — so `enterMode`'s push is the single entry a pick produces and the previous one survives.

## Scope

- **Predates the picker.** The same replace-then-push ran for a *typed* knob on this route; the picker only made the consequence visible. Both are fixed.
- **First edit only**, either way: the edit is what flips the page into Wasm. Every edit after it routes as `wasm` and replaces exactly as before, so typing a label still can't bury the page under an entry per keystroke.
- Every other route (`wasm`, `live`, `snapshot`, `none`) is untouched.

## Test plan

- `./gradlew :cli:test :cli:ktfmtCheck` — green (1820 tests).
- One fixture assertion matched `function refreshLinks()` including its empty parameter list — the same brittleness as the two `onKnobEdited()` matches in #3712 — and now matches the helper rather than its arity.

**Verification limit, stated plainly:** the `enable-wasm` route needs a catalog that ships a Wasm app, which this environment has none of, and `wasmToggle` is captured at script init so the route can't be synthesised after page load. I verified in Chromium on the `none` route that a pick adds exactly one entry and Back restores the previous value; the `enable-wasm` path is argued from the code, not executed. A reviewer with a Wasm-backed catalog to hand can confirm it in one pick.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CiA5Tw6bNjcy9dUQtXD7tY)_