### PR TITLE
fix(serve): stop HEAD probes and crawlers reaching the remaining live renders

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2234,6 +2234,9 @@ class ServeHttpServer(
     // featured catalog is idle — the common case, not a rare one.
     val featuredRender =
       featured?.heroPreviewId?.let { id ->
+        // Same rule as the viewer and the catalog landing: the URL below inherits the request's
+        // query, so a shared `/?widthPx=1200` names a re-render the baked size does not describe.
+        if (requestCarriesOverrides()) return@let null
         val size = catalogMetaSeen[featured.system]?.heroRenderSize ?: return@let null
         val path =
           "/${WebEscaping.urlEncodeSegment(featured.system)}/render/" +
@@ -2278,15 +2281,27 @@ class ServeHttpServer(
    * would resume every suspended daemon on the box, and a sitemap fetch is the last request that
    * should cost that. A catalog that has never been resident contributes nothing yet and appears
    * once it has been seen.
+   *
+   * Deliberately does **not** call [rememberCatalogMeta] to freshen a resident host, even though it
+   * could: that path bakes the hero thumbnail ([ServeHeroImages.heroFor] renders, decodes and
+   * rescales a PNG) and reads render sizes, and doing it here would put that work on the Ktor
+   * request coroutine for every listed system — the home index moves the same work to
+   * `Dispatchers.IO` precisely because it is not free. A sitemap needs two lightweight fields, so
+   * it reads them straight off the resident host and falls back to whatever a previous page view
+   * already remembered.
    */
   private fun crawlableCatalogs(): List<ServeSiteIndex.CatalogEntry> =
     listedCatalogs().mapNotNull { system ->
-      sessions.peekHost(system)?.let { rememberCatalogMeta(system, it) }
-      val meta = catalogMetaSeen[system] ?: return@mapNotNull null
+      val host = sessions.peekHost(system)
+      val meta = catalogMetaSeen[system]
+      val previewIds = host?.previews?.map { it.id } ?: meta?.previewIds ?: return@mapNotNull null
+      val generatedAt =
+        host?.let { catalogBundleHost(it)?.provenance?.generatedAt }
+          ?: meta?.provenance?.generatedAt
       ServeSiteIndex.CatalogEntry(
         system = system,
-        previewIds = meta.previewIds,
-        lastModified = meta.provenance?.generatedAt,
+        previewIds = previewIds,
+        lastModified = generatedAt,
       )
     }
 
@@ -3134,6 +3149,10 @@ class ServeHttpServer(
    */
   private suspend fun RoutingContext.handleStorybookIframe(sessionInPath: Boolean) {
     if (rejectBadToken()) return
+    // Renders a story unconditionally — there is no baked lane here. A chrome-less frame for
+    // screenshot tools is never an unfurl target (and is robots-disallowed), so a bodyless probe
+    // gets nothing but the render bill.
+    if (rejectHeadProbe()) return
     val sessionId = selectedSessionId(sessionInPath)
     withLeasedSession(sessionId) { renderHost ->
       val storyId = call.request.queryParameters["id"]
@@ -3623,7 +3642,12 @@ class ServeHttpServer(
     // ([DAEMON_ONLY_RENDER_SUFFIXES]) are produced on demand whether or not a query is present.
     // The override half is keyed on param names rather than a parse — the check has to be cheap,
     // and erring toward refusing costs a probe nothing (the caller GETs instead).
-    if ((requestCarriesOverrides() || wantsDaemonOnlyRenderProduct()) && rejectHeadProbe()) return
+    if (
+      (requestCarriesOverrides() ||
+        wantsDaemonOnlyRenderProduct() ||
+        !renderWouldReplayBakedBytes(sessionInPath)) && rejectHeadProbe()
+    )
+      return
     val sessionId = selectedSessionId(sessionInPath)
     withLeasedSession(sessionId) { renderHost ->
       val rawName = call.parameters["name"]
@@ -4245,6 +4269,29 @@ class ServeHttpServer(
   private fun RoutingContext.wantsDaemonOnlyRenderProduct(): Boolean {
     val name = call.parameters["name"] ?: return false
     return DAEMON_ONLY_RENDER_SUFFIXES.any { name.endsWith(it) }
+  }
+
+  /**
+   * Whether a bare `/render/{name}` can be answered from published bytes alone — the only case
+   * where replaying the GET pipeline for a HEAD is free.
+   *
+   * "It ends in `.png`" is not enough. A plain [ServeRenderHost] has no bake at all, and a
+   * catalog's **deferred** previews ([ServeHost.liveOnlyPreviewIds]) are published without one, so
+   * those go to the daemon even with no query string — the probe would take the render semaphore
+   * and start a daemon purely to have the body discarded. [ServeHost.bakedRenderSize] answers
+   * exactly this question for the cost of a PNG header read, and is null for both.
+   *
+   * Also requires the session to be **resident**: [ServeSessionRegistry.peekHost] never resumes, so
+   * a probe for a suspended catalog is refused rather than waking it. Both refusals are safe for
+   * the unfurl case — an image fetcher issues a GET, and the page URLs an unfurler probes do not
+   * come through this route.
+   */
+  private fun RoutingContext.renderWouldReplayBakedBytes(sessionInPath: Boolean): Boolean {
+    // Only a HEAD pays for this lookup; a GET is going to do the work regardless.
+    if (call.request.local.method != HttpMethod.Head) return true
+    val name = call.parameters["name"]?.removeSuffix(".png") ?: return false
+    val host = sessions.peekHost(selectedSessionId(sessionInPath)) ?: return false
+    return host.bakedRenderSize(name) != null
   }
 
   private suspend fun RoutingContext.rejectHeadProbe(): Boolean {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSiteIndex.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSiteIndex.kt
@@ -121,9 +121,16 @@ internal object ServeSiteIndex {
       "/*/index.json",
       "/iframe.html",
       "/*/iframe.html",
-      // Non-PNG render formats — the figma-svg export and the Remote Compose document. Both are
-      // for tools, and the SVG in particular is far larger than the PNG beside it.
+      // Non-PNG render products. Every one of these is *made* on request — the figma-svg export,
+      // the slot / accessibility / annotation inspection layers, the captured Remote Compose
+      // document — so unlike `<id>.png` there is no bake to serve and each goes through a
+      // daemon-backed producer and the shared render semaphore. The viewer assets name them, so a
+      // crawler that walks the page finds them; without these rules it would execute exactly the
+      // work the rest of this policy exists to suppress.
       "/*.svg$",
+      "/*.slots$",
+      "/*.a11y$",
+      "/*.annotations$",
       "/*.rc$",
     )
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -1412,6 +1412,8 @@ class ServeHttpRoutingTest {
         "a bodyless probe must not produce $suffix",
       )
     }
+    // A chrome-less story frame has no baked lane at all.
+    assertEquals(405, head("/compose-m3/iframe.html?id=$previewId").first)
     assertEquals(200, head("/compose-m3/render/$previewId.png").first, "the bake still answers")
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSiteIndexTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSiteIndexTest.kt
@@ -31,6 +31,22 @@ class ServeSiteIndexTest {
    * the same path with an override query re-renders — and the grid links the override forms, so a
    * crawler that followed them would render every preview in every theme.
    */
+  /**
+   * The non-PNG render products have no bake to serve — each is made through a daemon-backed
+   * producer and the shared render semaphore — and the viewer assets name them, so a crawler that
+   * walks a page will find them. Blocking only `.svg` and `.rc` left three that execute exactly the
+   * work this policy exists to suppress.
+   */
+  @Test
+  fun `every made-on-request render product is closed to crawlers`() {
+    val robots = ServeSiteIndex.robotsTxt(isPublic = true, sitemapUrl = null)
+    for (suffix in listOf("svg", "slots", "a11y", "annotations", "rc")) {
+      assertTrue(robots.contains("Disallow: /*.$suffix$"), "closes .$suffix: $robots")
+    }
+    // The baked PNG is the one render URL that stays open — it is the og:image.
+    assertFalse(robots.contains("Disallow: /*.png"), "the bake stays crawlable: $robots")
+  }
+
   @Test
   fun `query strings are closed on the render lane only`() {
     val robots = ServeSiteIndex.robotsTxt(isPublic = true, sitemapUrl = null)

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-exploded.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-exploded.html
@@ -57,7 +57,7 @@
 
 
       <div class="cp-preview-primary" aria-label="Preview renderer">
-      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" title="Static snapshot — click for the live, interactive preview">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" data-default-lane-label="Live preview" title="Static snapshot — click for the live, interactive preview">
             <span class="cp-live-dot" aria-hidden="true"></span>
             <span id="cp-live-toggle-label">Live preview</span>
           </button>


### PR DESCRIPTION
## Why

Follow-up to #3717. Four review findings arrived on that PR after it had already merged, so they never landed. Three are real gaps in the HEAD/crawler guards it introduced; one is an inconsistency between three pages that should agree.

Also included, as a separate first commit: `ServeWebFixtureTest` is **already failing on a clean checkout of `main`** (122d747), before any change of mine.

## What changed

**A bare `<id>.png` is not always a baked replay.** #3717's guard assumed it was, and refused HEAD only for override-bearing renders and the non-PNG products. But a plain `ServeRenderHost` has no bake at all, and a catalog's **deferred** previews (`liveOnlyPreviewIds`) are published without one — so `HEAD /render/<id>.png` still reached the daemon and took the render semaphore purely to have its body discarded, which is the same defect #3717 set out to fix. It now requires the session to be **resident** and the id to actually **have baked bytes**; `ServeHost.bakedRenderSize` answers both for the cost of a PNG header read and is null in exactly the two cases above. `peekHost` never resumes, so a probe can't wake a suspended catalog either.

Both refusals are safe for unfurling: an image fetcher issues a GET, and the page URLs an unfurler probes don't come through this route.

**`/iframe.html` refuses HEAD outright.** The chrome-less story frame renders unconditionally — there is no baked lane — and it's a screenshot-tool surface that is robots-disallowed and never an unfurl target.

**robots.txt closes every made-on-request render product.** It blocked `.svg` and `.rc` but left `.slots`, `.a11y` and `.annotations` crawlable, though each goes through the same daemon-backed producer and shared render semaphore. The viewer assets name them, so an indexing crawler that walks a page would have found and executed exactly the work the rest of the policy exists to suppress.

**Crawler metadata comes off the request dispatcher.** `crawlableCatalogs()` called `rememberCatalogMeta` for each resident host directly from the Ktor request coroutine. That path bakes the hero thumbnail — `ServeHeroImages.heroFor` renders, decodes and rescales a PNG — and reads render sizes, for *every listed system*, on a crawler's `robots.txt` or `sitemap.xml` fetch. `handleHomeIndex` moves the same work to `Dispatchers.IO` precisely because it isn't free. A sitemap needs two lightweight fields (preview ids, `generatedAt`), so it now reads those straight off the resident host and falls back to remembered metadata, doing no render work at all rather than merely relocating it.

**The homepage drops its image dimensions when the URL carries overrides.** #3717 added that guard to the viewer and the catalog landing but not to the front door, which still attached the baked hero size to a `featuredRender` URL built with the full query suffix — so a shared `/?widthPx=1200` advertised an override render alongside the original PNG's size. All three pages now use the same check.

## The pre-existing `main` failure (first commit)

`serve-viewer-exploded.html` still carries the old `cp-live-toggle` markup (`title="Static snapshot — …"`) while `ServeWeb` now renders `data-default-lane-label`. It reproduces on `origin/main` with my changes stashed, so it is not caused by this branch — it looks like a semantic merge race, with #3709 changing the toggle's markup and #3712 landing alongside it, each green on its own branch and stale together.

Regenerated with `UPDATE_SERVE_WEB_FIXTURES=true`, which is what the failure message prescribes once main is merged in. One line, one file, kept as its own commit so it can be reviewed or reverted independently of the rest.

No visual evidence: nothing rendered changes. The diff is HTTP-method guards, two robots.txt lines, a metadata read path, and one `<meta>` tag condition. The golden regen is a markup resync that makes the fixture match what `main` already renders — it changes no pixels.

## Test plan

- `./gradlew ktfmtCheckAll :cli:test` — green on this branch. The same command on clean `origin/main` fails `ServeWebFixtureTest`, which is what the first commit fixes.
- Extended `HEAD is refused on the lanes whose GET does real work`: adds `/iframe.html` alongside the work lanes and the five non-PNG render suffixes, and still asserts the baked PNG answers `200`.
- New `every made-on-request render product is closed to crawlers`: all five suffixes carry a `Disallow`, and `.png` deliberately does not — it is the `og:image`.
- Existing coverage that had to keep passing: the gated-host concealment test (`404`, no `Allow`), the view-tally test, and the eight-route HEAD-matches-GET test, which is what pins the guards to the work lanes rather than the browse surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaAPNqjKC8rqonbraRjid3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaAPNqjKC8rqonbraRjid3)_