### PR TITLE
fix(cli): raise the default build timeout above what a cold render costs

### DIFF
--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -455,14 +455,14 @@ class GradleConnection(
    * model was built) are recorded in [lastDiscoveryFailures] rather than silently dropped, so an
    * empty result can be explained (issue #3).
    */
-  fun findPreviewModules(): List<PreviewModule> {
-    // Same budget as a build, and for the same reason: configuring every project on a cold daemon
-    // is exactly where this overruns. The friction log's "doctor reports the project unusable when
-    // it is usable" was this timeout firing — the model query cancelled, and doctor reported
-    // "could not query Gradle project model … cancel requested but timed out" for a project whose
-    // `list` and `render` then both worked.
-    val result =
-      runBuildAction(DiscoverPreviewModulesAction(), timeoutSeconds = DEFAULT_TIMEOUT_SECONDS)
+  fun findPreviewModules(timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS): List<PreviewModule> {
+    // The *caller's* budget, not a constant of its own. Configuring every project on a cold daemon
+    // is exactly where this overruns — the friction log's "doctor reports the project unusable when
+    // it is usable" was this firing, cancelling the model query for a project whose `list` and
+    // `render` then both worked — but a hardcoded number is the wrong fix in both directions:
+    // `--timeout 60` could not bound a hung discovery, and `--timeout 1800` could not rescue a
+    // legitimately slow one.
+    val result = runBuildAction(DiscoverPreviewModulesAction(), timeoutSeconds = timeoutSeconds)
     discoveryFailures = result?.failures ?: emptyList()
     return result?.modules ?: emptyList()
   }
@@ -473,9 +473,12 @@ class GradleConnection(
    * user-visible error rather than silently building an empty task list against a dir that doesn't
    * exist.
    */
-  fun findPreviewModule(gradlePath: String): PreviewModule? {
+  fun findPreviewModule(
+    gradlePath: String,
+    timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+  ): PreviewModule? {
     val normalized = gradlePath.removePrefix(":")
-    return findPreviewModules().firstOrNull { it.gradlePath == normalized }
+    return findPreviewModules(timeoutSeconds).firstOrNull { it.gradlePath == normalized }
   }
 
   override fun close() {

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -456,7 +456,13 @@ class GradleConnection(
    * empty result can be explained (issue #3).
    */
   fun findPreviewModules(): List<PreviewModule> {
-    val result = runBuildAction(DiscoverPreviewModulesAction(), timeoutSeconds = 300)
+    // Same budget as a build, and for the same reason: configuring every project on a cold daemon
+    // is exactly where this overruns. The friction log's "doctor reports the project unusable when
+    // it is usable" was this timeout firing — the model query cancelled, and doctor reported
+    // "could not query Gradle project model … cancel requested but timed out" for a project whose
+    // `list` and `render` then both worked.
+    val result =
+      runBuildAction(DiscoverPreviewModulesAction(), timeoutSeconds = DEFAULT_TIMEOUT_SECONDS)
     discoveryFailures = result?.failures ?: emptyList()
     return result?.modules ?: emptyList()
   }

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -62,6 +62,21 @@ class GradleConnection(
    */
   private val extraArguments: List<String> = emptyList(),
 ) : AutoCloseable {
+  companion object {
+    /**
+     * Wall-clock budget a Gradle invocation gets before it is cancelled.
+     *
+     * Was 300s, which a real cold render did not fit in: a single-preview render on a cold daemon
+     * measured 309s, and two of two runs at the old default timed out at ~320s while the same
+     * render with a longer budget finished. A timeout that the documented default cannot survive
+     * teaches callers to distrust the tool rather than to pass `--timeout`.
+     *
+     * Not a diagnosis of *why* a warm single-preview render can take five minutes — that is worth
+     * its own investigation, and a bigger constant is not the answer to it.
+     */
+    const val DEFAULT_TIMEOUT_SECONDS: Long = 600
+  }
+
   private val connector = GradleConnector.newConnector().forProjectDirectory(projectDir)
   private val connection = connector.connect()
   private var modelAccessFailure: GradleAccessFailure? = null
@@ -99,7 +114,7 @@ class GradleConnection(
 
   fun runTasks(
     vararg tasks: String,
-    timeoutSeconds: Long = 300,
+    timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
     arguments: List<String> = emptyList(),
   ): Boolean {
     val tokenSource: CancellationTokenSource = GradleConnector.newCancellationTokenSource()
@@ -125,7 +140,13 @@ class GradleConnection(
         schedule(
           object : java.util.TimerTask() {
             override fun run() {
-              System.err.println("Build timed out after ${timeoutSeconds}s, cancelling...")
+              // Names the flag: this reads as a hung build otherwise, and the fix — "ask for more
+              // time" — is not something a caller can guess from "cancelling...".
+              System.err.println(
+                "Build timed out after ${timeoutSeconds}s, cancelling. " +
+                  "If the build was still making progress, rerun with a longer budget: " +
+                  "--timeout ${timeoutSeconds * 2}"
+              )
               TerminalProgress.error()
               tokenSource.cancel()
             }

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
@@ -63,13 +63,14 @@ class GradlePreviewDriver(projectRoot: File, private val options: DriverOptions 
    * CLI's default auto-inject path always supplies a current plugin, so this only matters for
    * projects that manually pin an older plugin version *and* disable auto-inject.
    */
-  fun discoverModules(): List<PreviewModule> = connection.findPreviewModules()
+  fun discoverModules(): List<PreviewModule> = connection.findPreviewModules(options.timeoutSeconds)
 
   /**
    * Resolve a single subproject by its Gradle path (with or without the leading colon). Returns
    * `null` when no project with that path applies the plugin.
    */
-  fun discoverModule(gradlePath: String): PreviewModule? = connection.findPreviewModule(gradlePath)
+  fun discoverModule(gradlePath: String): PreviewModule? =
+    connection.findPreviewModule(gradlePath, options.timeoutSeconds)
 
   /**
    * Drive a render against [request].modules. Returns a [RenderOutcome] carrying the build's

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
@@ -126,8 +126,12 @@ data class DriverOptions(
   val verbose: Boolean = false,
   /** Emit per-task heartbeat lines on stderr every 15s, plus OSC progress for TTYs. */
   val progress: Boolean = false,
-  /** Gradle build timeout. Default 300s matches the CLI. */
-  val timeoutSeconds: Long = 300,
+  /**
+   * Gradle build timeout. Shares [GradleConnection.DEFAULT_TIMEOUT_SECONDS] with the CLI — `render`
+   * always passes this value explicitly, so a literal here would silently override the connection's
+   * own default and leave the published driver on a budget a cold render does not fit in.
+   */
+  val timeoutSeconds: Long = GradleConnection.DEFAULT_TIMEOUT_SECONDS,
   /**
    * Extra Tooling-API arguments prepended to every build / model query — primarily for
    * `--init-script <path>` injection. The CLI uses this to auto-apply its plugin to projects that

--- a/cli/completions/compose-preview.fish
+++ b/cli/completions/compose-preview.fish
@@ -176,7 +176,7 @@ for sub in $__cp_render_cmds
     complete -c compose-preview -f -n "__compose_preview_using_command $sub" \
         -l verbose -s v -d 'Show full Gradle build output'
     complete -c compose-preview -x -n "__compose_preview_using_command $sub" \
-        -l timeout -d 'Gradle build timeout in seconds (default 300)'
+        -l timeout -d 'Gradle build timeout in seconds (default 600)'
     complete -c compose-preview -x -n "__compose_preview_using_command $sub" \
         -l with-extension -a 'a11y' -d 'Enable a data extension for this run'
     complete -c compose-preview -x -n "__compose_preview_using_command $sub" \

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -308,7 +308,7 @@ abstract class Command(
       // Resolve via the Tooling API so --module works with nested
       // Gradle paths (e.g. `--module auth:composables`) and reflects
       // any custom `project.projectDir` override.
-      val one = gradle.findPreviewModule(explicitModule)
+      val one = gradle.findPreviewModule(explicitModule, timeoutSeconds)
       if (one == null) {
         gradle.lastModelAccessFailure?.let {
           System.err.println(
@@ -330,7 +330,7 @@ abstract class Command(
       return listOf(one)
     }
 
-    val modules = gradle.findPreviewModules()
+    val modules = gradle.findPreviewModules(timeoutSeconds)
     if (modules.isEmpty()) {
       gradle.lastModelAccessFailure?.let {
         System.err.println("Could not query Gradle project model.")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -126,7 +126,8 @@ abstract class Command(
   protected val exactId: String? = args.flagValue("--id")
   protected val verbose: Boolean = "--verbose" in args || "-v" in args
   protected val progress: Boolean = verbose || "--progress" in args
-  protected val timeoutSeconds: Long = args.flagValue("--timeout")?.toLongOrNull() ?: 300
+  protected val timeoutSeconds: Long =
+    args.flagValue("--timeout")?.toLongOrNull() ?: GradleConnection.DEFAULT_TIMEOUT_SECONDS
   /** When true, drop previews with no `changed=true` capture from JSON output. */
   protected val changedOnly: Boolean = "--changed-only" in args
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -245,7 +245,7 @@ private fun printFullUsage() {
                            `--json` is set so escape sequences don't pollute captured output.
       --progress           Print per-task milestone/heartbeat lines to stderr
       --verbose, -v        Show full Gradle build output (implies --progress)
-      --timeout <seconds>  Gradle build timeout (default: 300)
+      --timeout <seconds>  Gradle build timeout (default: 600)
       --fail-on <level>    a11y: exit non-zero on 'errors' or 'warnings' (default: mirror Gradle)
       --with-extension <id>
                            Enable a data extension for this run (repeatable; comma-separated


### PR DESCRIPTION
From the cold-start friction log — the one blocker in it that lives in this repo rather than in the
installer.

`SKILL.md` documents `--timeout <seconds>  Gradle build timeout (default: 300)`. Renders in this repo
don't fit in it:

| Run | Preview | Timeout | Wall | Result |
| --- | --- | --- | --- | --- |
| 1 | `FontScale150Preview` (cold) | 850 | **309s** | ✓ |
| 2 | `FontScale200Preview` | *default 300* | 321s | ✗ `Build timed out after 300s, cancelling...` |
| 3 | `FontScale200Preview` | 850 | **62s** | ✓ |
| 4 | `FontScale100Preview` | *default 300* | 323s | ✗ `Build timed out after 300s, cancelling...` |

The cold render exceeds the default outright, and both runs at the default failed. A default the
documented happy path cannot survive teaches callers to distrust the tool rather than to pass the
flag — especially since the message reads as a hung build rather than a budget they can raise.

So: **600s**, and the message now names the flag with a concrete larger value.

```
Build timed out after 600s, cancelling. If the build was still making progress,
rerun with a longer budget: --timeout 1200
```

**What this deliberately isn't.** It is not an explanation for why a *warm* single-preview render can
take five minutes — run 3 did the same work in 62s. The reporter flagged that the correlation with
the flag value itself is suspicious on four data points, and I agree; that deserves its own
investigation, and a bigger constant is not the answer to it. This change only stops the documented
default from being a guaranteed failure in the meantime.

The constant moved to `GradleConnection.DEFAULT_TIMEOUT_SECONDS` so the CLI flag default and the
Tooling-API call site can't drift apart — they were two independent `300` literals.

## Test plan

- `./gradlew :cli:test ktfmtCheckAll` — BUILD SUCCESSFUL.
- `--timeout` still overrides; only the fallback changed.

Non-visual change — CLI default and an error message.

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFbgVkkvhUmSGE8sfbJ5n)_