### PR TITLE
fix(daemon): serialise the process-global localeTag override

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -415,7 +415,8 @@ class RenderEngine(
     // `SceneState`. Keeping it on the held state would let a locale-overridden
     // interactive/recording
     // session leak its locale onto every other render in the same daemon until it closed;
-    // [renderOnce] re-applies it around each frame instead. See [overrideJvmDefaultLocale].
+    // [renderOnce] re-applies it around each frame instead. See [enterPreviewLocale], which also
+    // serialises the switch against every other composition in the process (issue #3721).
     // Announce the scene before anything composes into it — see [sceneLifecycleListener]. Guarded
     // because a producer-side failure must never fail the render it is only observing.
     val lifecyclePreviewId = spec.previewId
@@ -429,7 +430,7 @@ class RenderEngine(
         )
       }
     }
-    val previousDefaultLocale = overrideJvmDefaultLocale(effectiveLocaleTag(spec.localeTag))
+    val localeScope = enterPreviewLocale(spec.localeTag)
     try {
       // Composable-level spans nest *inside* `compose:setContent`, which is the phase that actually
       // composes — so the trace reads "setContent took 40ms, and here is which composable spent
@@ -609,7 +610,7 @@ class RenderEngine(
     } finally {
       // Composition is done (or threw) — drop the process-global locale switch so it never outlives
       // the composition window, whether or not the scene is held past this point.
-      restoreJvmDefaultLocale(previousDefaultLocale)
+      localeScope.close()
     }
     return SceneState(
       spec = spec,
@@ -642,12 +643,7 @@ class RenderEngine(
    */
   @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
   internal fun renderSettlingFrame(state: SceneState, nanoTime: Long) {
-    val previousDefaultLocale = overrideJvmDefaultLocale(effectiveLocaleTag(state.spec.localeTag))
-    try {
-      state.scene.render(nanoTime = nanoTime).close()
-    } finally {
-      restoreJvmDefaultLocale(previousDefaultLocale)
-    }
+    withPreviewLocale(state.spec.localeTag) { state.scene.render(nanoTime = nanoTime).close() }
   }
 
   /**
@@ -699,7 +695,7 @@ class RenderEngine(
     // re-reads `androidx.compose.ui.text.intl.Locale.current`, so the override must be live for the
     // frame to keep resolving CMP `stringResource(...)` in the target locale; restored immediately
     // after the capture so the switch never spans two renders.
-    val previousDefaultLocale = overrideJvmDefaultLocale(effectiveLocaleTag(state.spec.localeTag))
+    val localeScope = enterPreviewLocale(state.spec.localeTag)
     val rawImage =
       try {
         // Render two frames so any LaunchedEffect / animations have a tick to settle. Same
@@ -708,7 +704,7 @@ class RenderEngine(
         trace.section("compose:frame") { renderFrame(state, useWallClockFrameTime) }
         trace.section("compose:captureFrame") { renderFrame(state, useWallClockFrameTime) }
       } finally {
-        restoreJvmDefaultLocale(previousDefaultLocale)
+        localeScope.close()
       }
     // AS-parity wrap crop: a no-size preview measured smaller than the sandbox, so crop the frame
     // to
@@ -1465,12 +1461,7 @@ class RenderEngine(
     // `rememberResourceEnvironment` caches what it resolves — so without this a localized END
     // capture would bake default-language `stringResource(...)` text into the items the drive
     // brought on screen, and re-applying the locale for the final frames alone would not undo it.
-    val previousDefaultLocale = overrideJvmDefaultLocale(effectiveLocaleTag(state.spec.localeTag))
-    try {
-      driveStaticScrollToEndLocalized(state, intent)
-    } finally {
-      restoreJvmDefaultLocale(previousDefaultLocale)
-    }
+    withPreviewLocale(state.spec.localeTag) { driveStaticScrollToEndLocalized(state, intent) }
   }
 
   @OptIn(
@@ -1811,9 +1802,9 @@ class RenderEngine(
      * + the RTL direction). Without this, a `@Preview(locale = "de")` override reached the layout
      *   direction but `stringResource(...)` still rendered the base (English) copy.
      *
-     * Serialized-render assumption: the daemon renders one scene at a time on the compose thread —
-     * the same assumption the `contextClassLoader` install in [setUp] already relies on — so this
-     * process-global switch can't race a concurrent render.
+     * **Not safe to call bare.** The switch is process-global and held sessions each compose on
+     * their own thread, so every use goes through [withPreviewLocale] / [enterPreviewLocale], which
+     * serialise it.
      */
     internal fun overrideJvmDefaultLocale(effectiveTag: String?): java.util.Locale? {
       effectiveTag ?: return null
@@ -1825,6 +1816,80 @@ class RenderEngine(
     /** Restore a JVM default [java.util.Locale] captured by [overrideJvmDefaultLocale]. */
     internal fun restoreJvmDefaultLocale(previous: java.util.Locale?) {
       if (previous != null) java.util.Locale.setDefault(previous)
+    }
+
+    /**
+     * Process-wide gate over the JVM default [java.util.Locale] (issue #3721).
+     *
+     * `fair = true` deliberately. Unlocalized renders are the readers here, and on a busy
+     * multi-seat serve they never stop arriving — a non-fair lock would let them starve a localized
+     * session's writer indefinitely.
+     *
+     * Static, not per-[RenderEngine]: the thing being guarded is one JVM-wide static, and a daemon
+     * (or a test) can hold several engines.
+     */
+    private val localeGate = java.util.concurrent.locks.ReentrantReadWriteLock(true)
+
+    /** An entered locale scope, released exactly once by [PreviewLocaleScope.close]. */
+    internal class PreviewLocaleScope internal constructor(private val release: () -> Unit) {
+      fun close() = release()
+    }
+
+    /**
+     * Claim the locale gate for a render of [localeTag] and apply the override, returning the scope
+     * that releases both. **The caller must `close()` it in a `finally`.**
+     *
+     * [withPreviewLocale] is the form to reach for; this exists for [setUp], whose scope is a
+     * 180-line `try`/`catch` that a lambda would re-indent wholesale.
+     *
+     * The reader/writer split is inverted from the usual intuition, and that inversion is the whole
+     * design:
+     * - a render with **no** locale override is a **reader** — it doesn't touch the global, it only
+     *   depends on it staying put. Any number run concurrently, and the cost is one uncontended
+     *   read-lock acquire per frame, which is what makes this affordable in the common case.
+     * - a render **with** an override is a **writer** — it mutates the global, so it excludes
+     *   everyone.
+     *
+     * Without this, two held sessions (each on its own scene executor — one-shot renders are
+     * already serialised onto [DesktopHost]'s single render thread, held sessions are not) could
+     * sit inside a locale scope at the same time: the unlocalized one resolves
+     * `stringResource(...)` under the other's language and `rememberResourceEnvironment` caches it,
+     * and two localized scopes could restore out of order and leave the daemon's default moved for
+     * good.
+     *
+     * **Enter this on the thread that composes, never around a cross-thread wait.** Held sessions
+     * reach the engine through `submit(...).get()`; a scope entered on the calling side of that
+     * wait would deadlock against the executor thread that needs it.
+     */
+    internal fun enterPreviewLocale(localeTag: String?): PreviewLocaleScope {
+      val effectiveTag = effectiveLocaleTag(localeTag)
+      if (effectiveTag == null) {
+        localeGate.readLock().lock()
+        return PreviewLocaleScope { localeGate.readLock().unlock() }
+      }
+      // A read→write upgrade deadlocks on ReentrantReadWriteLock rather than failing. It can't
+      // happen while one SceneState means one locale for its whole render — this turns a future
+      // violation of that invariant into a diagnosable exception instead of a hung daemon.
+      check(localeGate.readHoldCount == 0) {
+        "enterPreviewLocale($effectiveTag) would upgrade a read lock this thread already holds; a " +
+          "localized render must not nest inside an unlocalized one"
+      }
+      localeGate.writeLock().lock()
+      val previousDefaultLocale = overrideJvmDefaultLocale(effectiveTag)
+      return PreviewLocaleScope {
+        restoreJvmDefaultLocale(previousDefaultLocale)
+        localeGate.writeLock().unlock()
+      }
+    }
+
+    /** [enterPreviewLocale] around [block], released on the way out however it leaves. */
+    internal fun <T> withPreviewLocale(localeTag: String?, block: () -> T): T {
+      val scope = enterPreviewLocale(localeTag)
+      try {
+        return block()
+      } finally {
+        scope.close()
+      }
     }
 
     private fun localeProviders(localeTag: String?): Array<ProvidedValue<*>> {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
+import kotlin.concurrent.thread
 import kotlin.math.abs
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -248,6 +249,122 @@ class DesktopInteractiveSessionTest {
       host.shutdown()
     }
   }
+
+  /**
+   * Issue #3721 — a localized session must not lend its locale to a concurrent unlocalized one.
+   *
+   * `localeTag` is applied by moving the *process-global* JVM default `Locale` for the duration of
+   * a composition. One-shot renders are safe because [DesktopHost] serialises them onto a single
+   * render thread, but every held session composes on its own
+   * `compose-ai-daemon-interactive-scene-<previewId>` executor — so two sessions can be inside
+   * `RenderEngine`'s locale-scoped regions at the same time, and the unlocalized one resolves
+   * `stringResource(...)` under the other's language. `rememberResourceEnvironment` caches what it
+   * resolves, so a later frame does not reliably correct it.
+   *
+   * The leak is a window rather than a state, so the test opens it deliberately: the German session
+   * parks *inside* its composition (holding the override), and only then is the unlocalized session
+   * pressed. Waiting on the parked session first is what makes the failing direction reliable —
+   * under the bug the unlocalized press is unblocked and composes within milliseconds of being
+   * asked, well inside [LEAK_WINDOW_MS]. The passing direction needs no timing at all: the fix
+   * blocks that press until the German frame finishes.
+   */
+  @Test
+  fun a_localized_session_does_not_leak_its_locale_to_a_concurrent_session() {
+    val outputDir = tempFolder.newFolder("interactive-concurrent-locale-renders")
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = outputDir),
+        previewSpecResolver = { previewId ->
+          when (previewId) {
+            LOCALIZED_PREVIEW_ID -> localeProbeSpec(previewId, localeTag = "de")
+            UNLOCALIZED_PREVIEW_ID -> localeProbeSpec(previewId, localeTag = null)
+            else -> null
+          }
+        },
+      )
+    val hostDefault = java.util.Locale.getDefault()
+    host.start()
+    try {
+      java.util.Locale.setDefault(java.util.Locale.forLanguageTag("en-US"))
+      val classLoader = DesktopInteractiveSessionTest::class.java.classLoader!!
+      val localized =
+        host.acquireInteractiveSession(previewId = LOCALIZED_PREVIEW_ID, classLoader = classLoader)
+      val unlocalized =
+        host.acquireInteractiveSession(
+          previewId = UNLOCALIZED_PREVIEW_ID,
+          classLoader = classLoader,
+        )
+      try {
+        localized.render(requestId = RenderHost.nextRequestId())
+        unlocalized.render(requestId = RenderHost.nextRequestId())
+
+        // Arm the gate only for the German session's scene thread, then reset so the bootstrap
+        // renders above don't count toward what either session observed.
+        PressLocaleProbe.reset()
+        val gate = java.util.concurrent.CountDownLatch(1)
+        val reached = java.util.concurrent.CountDownLatch(1)
+        PressLocaleProbe.gate = gate
+        PressLocaleProbe.gateReached = reached
+        PressLocaleProbe.gateThreadMarker = LOCALIZED_PREVIEW_ID
+
+        val localizedPress = thread { localized.dispatch(press(LOCALIZED_PREVIEW_ID)) }
+        try {
+          assertTrue(
+            "the localized session must reach its gated composition, or the window this test " +
+              "needs was never opened",
+            reached.await(60, java.util.concurrent.TimeUnit.SECONDS),
+          )
+
+          // The German override is live right now. Press the *other* session from another thread —
+          // under the fix this blocks until the gate opens, so it cannot be awaited here.
+          val unlocalizedPress = thread { unlocalized.dispatch(press(UNLOCALIZED_PREVIEW_ID)) }
+          Thread.sleep(LEAK_WINDOW_MS)
+          gate.countDown()
+          unlocalizedPress.join(60_000)
+        } finally {
+          gate.countDown()
+          localizedPress.join(60_000)
+        }
+
+        val leaked = PressLocaleProbe.observedOn(UNLOCALIZED_PREVIEW_ID)
+        assertTrue(
+          "the unlocalized session must have composed at all, or this asserts nothing",
+          leaked.isNotEmpty(),
+        )
+        assertEquals(
+          "an unlocalized session composed under the concurrent session's locale; saw $leaked",
+          emptyList<String>(),
+          leaked.filter { it.startsWith("de") },
+        )
+      } finally {
+        unlocalized.close()
+        localized.close()
+      }
+    } finally {
+      PressLocaleProbe.reset()
+      java.util.Locale.setDefault(hostDefault)
+      host.shutdown()
+    }
+  }
+
+  private fun localeProbeSpec(previewId: String, localeTag: String?) =
+    RenderSpec(
+      className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+      functionName = "PressLocaleProbeSquare",
+      widthPx = 64,
+      heightPx = 64,
+      localeTag = localeTag,
+      outputBaseName = previewId,
+    )
+
+  private fun press(streamId: String) =
+    InteractiveInputParams(
+      frameStreamId = streamId,
+      kind = InteractiveInputKind.POINTER_DOWN,
+      pixelX = 32,
+      pixelY = 32,
+      pointerId = 0,
+    )
 
   @Test
   fun live_render_advances_frame_clock_with_monotonic_wall_time() {
@@ -650,6 +767,15 @@ class DesktopInteractiveSessionTest {
     private const val HIGH_DENSITY_TARGET_PREVIEW_ID = "high-density-click-target-square"
     private const val KEY_PRESS_PREVIEW_ID = "key-press-color-square"
     private const val PRESS_LOCALE_PREVIEW_ID = "press-locale-probe-square"
+    private const val LOCALIZED_PREVIEW_ID = "locale-probe-localized"
+    private const val UNLOCALIZED_PREVIEW_ID = "locale-probe-unlocalized"
+
+    /**
+     * How long the unlocalized press is left running while the localized session holds the
+     * override. Only the *failing* direction depends on it: an unblocked press composes within
+     * milliseconds, so this is orders of magnitude more than a real leak needs.
+     */
+    private const val LEAK_WINDOW_MS = 2_000L
     private const val TAGGED_TARGET_PREVIEW_ID = "tagged-click-target-square"
   }
 }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineLocaleTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineLocaleTest.kt
@@ -2,8 +2,10 @@ package ee.schimke.composeai.daemon
 
 import java.util.Locale
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -92,6 +94,101 @@ class RenderEngineLocaleTest {
         androidx.compose.ui.text.intl.Locale.current.language,
       )
       RenderEngine.restoreJvmDefaultLocale(previous)
+    } finally {
+      Locale.setDefault(original)
+    }
+  }
+
+  // --- The process-wide gate (issue #3721). The concurrency behaviour it exists for is asserted
+  // against real held sessions in `DesktopInteractiveSessionTest`; these pin the contract of the
+  // helper itself, which needs no Skiko.
+
+  @Test
+  fun withPreviewLocaleAppliesAndRestoresAroundTheBlock() {
+    val original = Locale.getDefault()
+    try {
+      Locale.setDefault(Locale.forLanguageTag("en-US"))
+      val marker = Locale.getDefault()
+      val seen = RenderEngine.withPreviewLocale("de") { Locale.getDefault().language }
+      assertEquals("the block must run under the override", "de", seen)
+      assertSame("and the previous default must be back afterwards", marker, Locale.getDefault())
+    } finally {
+      Locale.setDefault(original)
+    }
+  }
+
+  @Test
+  fun withPreviewLocaleRestoresWhenTheBlockThrows() {
+    val original = Locale.getDefault()
+    try {
+      Locale.setDefault(Locale.forLanguageTag("en-US"))
+      val marker = Locale.getDefault()
+      try {
+        RenderEngine.withPreviewLocale<Unit>("de") { error("boom") }
+      } catch (_: IllegalStateException) {}
+      assertSame(
+        "a throwing render must not leave the daemon's default locale moved",
+        marker,
+        Locale.getDefault(),
+      )
+    } finally {
+      Locale.setDefault(original)
+    }
+  }
+
+  /**
+   * `renderOnce` nests `driveStaticScrollToEnd` inside itself, and both go through the gate — so
+   * same-mode nesting has to be reentrant on both sides or a localized scrolling capture deadlocks
+   * against itself.
+   */
+  @Test
+  fun withPreviewLocaleNestsInEitherMode() {
+    val original = Locale.getDefault()
+    try {
+      Locale.setDefault(Locale.forLanguageTag("en-US"))
+      val nestedWrite =
+        RenderEngine.withPreviewLocale("de") {
+          RenderEngine.withPreviewLocale("de") { Locale.getDefault().language }
+        }
+      assertEquals("de", nestedWrite)
+      assertEquals(
+        "en",
+        RenderEngine.withPreviewLocale(null) {
+          RenderEngine.withPreviewLocale(null) { Locale.getDefault().language }
+        },
+      )
+      // Restoration unwinds to the outer scope's locale, not to whatever the inner one captured.
+      assertEquals("en-US", Locale.getDefault().toLanguageTag())
+    } finally {
+      Locale.setDefault(original)
+    }
+  }
+
+  /**
+   * A read→write upgrade is the one nesting `ReentrantReadWriteLock` cannot serve: it blocks
+   * forever rather than failing. It can't happen while one `SceneState` means one locale for a
+   * whole render, but a future caller that breaks that invariant must get a diagnosable exception
+   * instead of a hung daemon.
+   */
+  @Test
+  fun withPreviewLocaleRefusesAReadToWriteUpgrade() {
+    val original = Locale.getDefault()
+    try {
+      Locale.setDefault(Locale.forLanguageTag("en-US"))
+      val failure =
+        try {
+          RenderEngine.withPreviewLocale(null) {
+            RenderEngine.withPreviewLocale("de") { "should not reach here" }
+          }
+          null
+        } catch (e: IllegalStateException) {
+          e
+        }
+      assertNotNull("a localized render nested inside an unlocalized one must fail loudly", failure)
+      assertTrue(
+        "the message should name the upgrade; got \"${failure?.message}\"",
+        failure?.message?.contains("upgrade") == true,
+      )
     } finally {
       Locale.setDefault(original)
     }

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -517,12 +517,54 @@ fun HighDensityClickTargetSquare() {
 object PressLocaleProbe {
   @Volatile var composedUnder: String? = null
 
+  /**
+   * Every locale seen, keyed by the composing thread's name.
+   *
+   * A held session composes on its own `compose-ai-daemon-interactive-scene-<previewId>` executor,
+   * so the thread name is which *session* composed — which is what a concurrency test needs, since
+   * two sessions share this one object.
+   */
+  val observedByThread: java.util.concurrent.ConcurrentHashMap<String, MutableList<String>> =
+    java.util.concurrent.ConcurrentHashMap()
+
+  /**
+   * Held open, mid-composition, on threads whose name contains [gateThreadMarker].
+   *
+   * A locale leak is a *window*, not a state: it needs one session to be inside the override while
+   * another composes. Parking the localized session inside its composition is how a test opens that
+   * window on purpose instead of hoping the scheduler produces it.
+   */
+  @Volatile var gate: java.util.concurrent.CountDownLatch? = null
+
+  /** Counted down once a gated composition has recorded and is about to park. */
+  @Volatile var gateReached: java.util.concurrent.CountDownLatch? = null
+
+  @Volatile var gateThreadMarker: String? = null
+
   fun record() {
-    composedUnder = java.util.Locale.getDefault().toLanguageTag()
+    val thread = Thread.currentThread().name
+    val tag = java.util.Locale.getDefault().toLanguageTag()
+    composedUnder = tag
+    observedByThread
+      .computeIfAbsent(thread) { java.util.Collections.synchronizedList(mutableListOf()) }
+      .add(tag)
+    val marker = gateThreadMarker
+    if (marker != null && thread.contains(marker)) {
+      gateReached?.countDown()
+      gate?.await(30, java.util.concurrent.TimeUnit.SECONDS)
+    }
   }
+
+  /** Locales recorded by composing threads whose name contains [threadMarker]. */
+  fun observedOn(threadMarker: String): List<String> =
+    observedByThread.entries.filter { it.key.contains(threadMarker) }.flatMap { it.value.toList() }
 
   fun reset() {
     composedUnder = null
+    observedByThread.clear()
+    gate = null
+    gateReached = null
+    gateThreadMarker = null
   }
 }
 

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -374,6 +374,45 @@ and a `stringResource(...)` first resolved at the host default is not
 re-resolved by the capture that follows), and it closes the snapshot it
 allocates instead of leaving native Skia memory to a cleaner.
 
+## 9.8 The `localeTag` scope is a process-wide reader/writer gate
+
+Applying `localeTag` means moving the **process-global** JVM default
+`Locale`: CMP `stringResource(...)` resolves through
+`androidx.compose.ui.text.intl.Locale.current`, which on desktop reads
+that default. One-shot renders are safe by construction — `DesktopHost`
+funnels them through its single `compose-ai-daemon-host` thread — but
+**held sessions are not**: each interactive session composes on its own
+`compose-ai-daemon-interactive-scene-<previewId>` executor, and recording
+sessions on their own playback / live-tick threads.
+
+Every locale-scoped region therefore goes through
+`RenderEngine.withPreviewLocale` — `setUp`, `renderOnce`,
+`driveStaticScrollToEnd`, `renderSettlingFrame` — which gates them on one
+static `ReentrantReadWriteLock` (issue #3721). The polarity is inverted
+from the usual intuition, and that inversion is the point:
+
+- a render with **no** locale override is a **reader**. It doesn't touch
+  the global, it only depends on it staying put, so any number run
+  concurrently and the cost is one uncontended acquire per frame.
+- a render **with** an override is a **writer**, and excludes everyone.
+
+Three constraints hold this together:
+
+- The lock is **static**, because the thing it guards is. A daemon (or a
+  test) can hold several `RenderEngine`s against one JVM.
+- It is **fair**, because unlocalized readers never stop arriving on a
+  busy multi-seat serve and would otherwise starve a localized writer.
+- It is taken **on the composing thread only, never around a cross-thread
+  wait** — held sessions reach the engine through `submit(...).get()`, so
+  a lock held on the calling side of that wait deadlocks against the
+  executor thread that needs it. `withPreviewLocale` also rejects a
+  read→write upgrade outright, since `ReentrantReadWriteLock` would hang
+  rather than fail on one.
+
+Adding a fifth region that moves the locale without going through
+`withPreviewLocale` reopens the bug; guarding only some of them is worse
+than guarding none, because it looks handled.
+
 ## 9.10 v3 Android pointer
 
 Android click dispatch requires sandbox pinning: see


### PR DESCRIPTION
Stages 0 and 1 of the plan in #3721. Fixes #3718.

## The defect, reproduced

Applying `localeTag` means moving the **process-global** JVM default `Locale` — that is what CMP `stringResource(...)` resolves against on desktop. One-shot renders are safe because `DesktopHost` funnels them through its single `compose-ai-daemon-host` thread, but every held session composes on its own `compose-ai-daemon-interactive-scene-<previewId>` executor. Two sessions could therefore sit inside a locale scope at the same time.

`DesktopInteractiveSessionTest.a_localized_session_does_not_leak_its_locale_to_a_concurrent_session` stands up exactly that: two held sessions on one host, one `localeTag = "de"` and one without, host default pinned to `en-US`. On `main` it fails with

```
an unlocalized session composed under the concurrent session's locale; saw [de]
```

A leak is a *window*, not a state, so the test opens it deliberately rather than hoping the scheduler produces one: the German session parks **inside** its composition (via a gate in `PressLocaleProbe`, holding the override), and only once it has parked is the unlocalized session pressed. The failing direction is reliable because an unblocked press composes within milliseconds of being asked, against a 2 s window; the passing direction needs no timing at all, since the fix blocks that press outright.

## The fix

All four scoped regions — `setUp`, `renderOnce`, `driveStaticScrollToEnd`, `renderSettlingFrame` — now go through one gate, `enterPreviewLocale` (with a `withPreviewLocale` lambda form). Guarding some but not all would be worse than guarding none: it would look handled while the longest window stayed open.

The reader/writer split is inverted from the usual intuition, and that inversion is the design:

- an **unlocalized** render is a **reader** — it never touches the global, it only depends on it staying put. Any number run concurrently, and the cost in the common case is one uncontended acquire per frame.
- a **localized** render is the **writer**, and excludes everyone.

Three constraints hold it together, all of them load-bearing:

- **Static**, not per-`RenderEngine` — the thing guarded is one JVM-wide static, and a daemon (or a test) can hold several engines.
- **Fair** — unlocalized readers never stop arriving on a busy multi-seat serve, and a non-fair lock would starve a localized writer indefinitely.
- **Entered on the composing thread only**, never around a cross-thread wait. Held sessions reach the engine through `submit(...).get()`; a scope entered on the calling side of that wait deadlocks against the executor thread that needs it.

`ReentrantReadWriteLock` hangs rather than fails on a read→write upgrade, so `enterPreviewLocale` rejects one outright. It cannot happen while one `SceneState` means one locale for a whole render — but a future caller who breaks that invariant should get a diagnosable exception instead of a hung daemon.

`setUp` takes the scope-object form rather than the lambda deliberately: its region is a 180-line `try`/`catch` that a lambda would re-indent wholesale, reflowing ~100 lines of unrelated comments through the diff for no benefit.

## Test plan

- **The repro**, above — verified red on `main`, green here, and re-run 3× for stability since it is a threading test.
- **`RenderEngineLocaleTest`** gains four unit tests for the gate's own contract: apply/restore around the block, restore when the block throws, same-mode nesting works in both modes (`renderOnce` nests `driveStaticScrollToEnd`, so a localized scrolling capture would otherwise deadlock against itself), and a read→write upgrade fails loudly with a message naming the upgrade.
- `./gradlew :daemon:desktop:test` — green, full module.
- **`serve-lanes` e2e against a rebuilt daemon-backed serve**, booted the way CI boots it: **12 passed**. Every live frame now takes the read lock, so this is the check that the common path neither deadlocks nor regresses.
- **Localized render still works end to end through the write path**: `GET /compose-m3/render/template-appscaffold__ideal__default__light__compact.png?localeTag=de` → 200, and the German copy is really there (`Posteingang`, `Morgen Mittagessen?`) rather than the English baseline. That is the smoke test that the exclusive path composes rather than hanging.
- `./gradlew ktfmtFormat` — clean.

No visual change: this changes when compositions may run relative to each other, not what they paint.

## Not in this PR

Stages 2 and 3 stay open on #3721 — refusing a localized *held* session on a daemon that already holds seats (which bounds how long an exclusive writer can ever be held), and locale-keyed daemon ids in `ServePerPreviewDaemonPool` (worth paying only once Stage 1 contention is measured rather than assumed). Also noted there: `renderers/desktop` keeps its own copy of the override helpers and is single-threaded today, so this lock does not cover it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RikE7Eshj4b7fYYm1eBCPU)_