### PR TITLE
fix(driver): keep the no-arg discovery methods on the published artifact

### DIFF
--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -455,6 +455,12 @@ class GradleConnection(
    * model was built) are recorded in [lastDiscoveryFailures] rather than silently dropped, so an
    * empty result can be explained (issue #3).
    */
+  // @JvmOverloads because this is a published artifact: a Kotlin default parameter compiles to a
+  // single method taking the parameter plus a synthetic bridge, so the no-arg entry point an
+  // already-compiled consumer links against simply vanishes — NoSuchMethodError on upgrade, from a
+  // change that reads as purely additive in source. The generated overloads keep the old signatures
+  // and spare Java callers a mandatory argument.
+  @JvmOverloads
   fun findPreviewModules(timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS): List<PreviewModule> {
     // The *caller's* budget, not a constant of its own. Configuring every project on a cold daemon
     // is exactly where this overruns — the friction log's "doctor reports the project unusable when
@@ -473,6 +479,7 @@ class GradleConnection(
    * user-visible error rather than silently building an empty task list against a dir that doesn't
    * exist.
    */
+  @JvmOverloads
   fun findPreviewModule(
     gradlePath: String,
     timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,


### PR DESCRIPTION
Follow-up to #3722 — the review comment that caught this arrived after it had already merged, so the
break is currently on `main`.

#3722 made the discovery budget configurable by adding a defaulted parameter to
`findPreviewModules` / `findPreviewModule`. In Kotlin that is source-compatible and binary-**in**
compatible: the pair compiles to a single method taking the parameter plus a synthetic
`$default` bridge, so the no-arg entry point an already-compiled consumer links against stops
existing. `gradle-preview-driver` is a published artifact (`composeai.maven-publishing`), so
upgrading it would have produced `NoSuchMethodError` from a change that reads as purely additive in
source — and Java callers would have been forced to pass a timeout they never asked about.

`@JvmOverloads` restores both signatures.

## Test plan

Verified in the bytecode rather than by inspection, since "it looks additive" is exactly the
reasoning that caused this:

```
$ javap -cp api/gradle-preview-driver/build/classes/kotlin/main \
    ee.schimke.composeai.cli.GradleConnection | grep findPreviewModule
  public final java.util.List<…PreviewModule> findPreviewModules(long);
  public final java.util.List<…PreviewModule> findPreviewModules();          ← restored
  public final …PreviewModule findPreviewModule(java.lang.String, long);
  public final …PreviewModule findPreviewModule(java.lang.String);           ← restored
```

- `./gradlew :gradle-preview-driver:compileKotlin :cli:test ktfmtCheckAll` — BUILD SUCCESSFUL.

Worth noting for later: nothing in CI would have caught this. There's no binary-compatibility
validator on the published modules, so a source-compatible signature change to a published API is
currently invisible until a consumer upgrades. That's a gap worth its own issue rather than a fix
smuggled in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFbgVkkvhUmSGE8sfbJ5n)_