### PR TITLE
docs(versioning): stop overselling API stability

### DIFF
--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -4,7 +4,9 @@ Cross-cutting design doc for what counts as a public contract in this repo, how 
 
 ## 1. The contracts
 
-Nine externally-observable surfaces, each with its own evolution story. Anything **not** in this list is internal and may move without notice.
+Nine externally-observable surfaces, each with its own evolution story. Anything **not** in this list is internal and may move without notice — with the caveat below, and read alongside [VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced), which records how much of the machinery described here is actually implemented.
+
+> **The list is not exhaustive.** At least two versioned formats are exchanged with detached consumers without appearing above: `bundle.json` inside a packed preview bundle (read by the CLI and the bundle viewer, carrying `BUNDLE_SCHEMA_VERSION`) and `daemon-launch.json` from the published `daemon-launch-builder` (read by VS Code's `daemonProcess.ts`, which gates on its `schemaVersion`, and by the non-Gradle integrations in [NON_GRADLE_INTEGRATION.md](NON_GRADLE_INTEGRATION.md)). Both carry their own schema version and both would strand existing artifacts or producers if changed carelessly. Treat "not in this list" as "not yet classified", not as licence to break them.
 
 | # | Surface | Lives in | Consumed by | Stability tier |
 |---|---|---|---|---|
@@ -24,7 +26,7 @@ The annotation library and per-data-product schemas are intentionally narrow. Th
 
 ### 2.1 Daemon JSON-RPC (surface 1)
 
-**Negotiation:** `initialize` request carries a single `protocolVersion: Int`; the daemon answers with its own plus a `ServerCapabilities` bag, and any mismatch is `InvalidRequest` and the daemon exits. Range negotiation — client and daemon each sending `{min, max}` and operating at `min(client.max, server.max)` — is **not in 1.0.0**; it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-status-at-10)).
+**Negotiation:** `initialize` request carries a single `protocolVersion: Int`; the daemon answers with its own plus a `ServerCapabilities` bag, and any mismatch is `InvalidRequest` and the daemon exits. Range negotiation — client and daemon each sending `{min, max}` and operating at `min(client.max, server.max)` — is **not in 1.0.0**; it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)).
 
 **Feature detection:** capability bag, never daemon `semver`. The bag already covers `supportedOverrides`, `dataProducts`, `dataExtensions`, `previewExtensions`, `knownDevices`, `backend`, `androidSdk`, `recordingFormats`, `interactive`, `recording`. New features add a capability entry, not a behavior change under an existing field.
 
@@ -40,13 +42,13 @@ The annotation library and per-data-product schemas are intentionally narrow. Th
 - New required fields.
 - Changed default values that flip behavior.
 
-**Enums.** Every `@Serializable enum` on the wire is decoded tolerantly: unknown values map to an `UNKNOWN` sentinel rather than throwing. Without this, every new enum value is a silent break for old clients. See [VERSIONING.md § 4.1](VERSIONING.md#41-enum-discipline).
+**Enums.** Wire enums *should* decode tolerantly — unknown values mapping to an `UNKNOWN` sentinel rather than throwing — because without it every new enum value is a silent break for old clients. **Most existing enums in `Messages.kt` do not do this yet** (`FileKind` and `ChangeType` among them), so treat it as the rule for enums you add, not as a property of the current corpus. See [VERSIONING.md § 4.1](VERSIONING.md#41-enum-discipline).
 
 **Test:** the JSON fixture corpus under [docs/daemon/protocol-fixtures/](daemon/protocol-fixtures/) round-trips on both Kotlin and TypeScript sides. Adding a message ⇒ add the fixture in the same PR. Renaming a field ⇒ either bump `protocolVersion` or revert.
 
 ### 2.2 `previews.json` (surface 2)
 
-**Versioning:** top-level `schemaVersion: int`. Tolerant readers everywhere — unknown fields ignored, missing optional fields treated as default.
+**Versioning:** intended to be a top-level `schemaVersion: int`, but **the field is not written today** — neither the daemon's nor the viewer's `PreviewManifest` carries one, so a reader cannot tell which shape it has. What is real is tolerant reading: unknown fields ignored, missing optional fields defaulted.
 
 **Negotiation:** none in-band. The plugin and daemon ship in lockstep; the CLI / VS Code extension treat `previews.json` as opaque except for fields they explicitly model. Any reader that crosses the process boundary keys off `schemaVersion` and ignores fields it doesn't understand.
 
@@ -63,24 +65,24 @@ Each kind owns its own `schemaVersion: Int`. Producers evolve independently of t
 ### 2.4 Gradle plugin DSL (surface 4)
 
 **Stability tiers.** As of 1.0.0 there are two, not three — the DSL has no opt-in tier, which makes the surface *stricter* than the scheme below, not looser:
-- Public — semver-governed. Property type changes, removals, and renames are breaking changes that bump the plugin major. Enforced by Kotlin BCV on `:gradle-plugin` ([VERSIONING.md § 9](VERSIONING.md#9-compatibility-testing)).
+- Public — semver-governed. Property type changes, removals, and renames are breaking changes that bump the plugin major. **Enforced by review, not by tooling** — Kotlin BCV is not wired up on this module ([VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)).
 - Internal — `internal` Kotlin visibility. No contract.
 
-The `@Stable` / `@Incubating` split, with `@Incubating` opt-in via `composePreview { incubating = true }` and a warning at apply time, is **not in 1.0.0** — it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-status-at-10)). Until it does, a new DSL property is public and semver-governed the moment it ships, so add one only when you're willing to keep it.
+The `@Stable` / `@Incubating` split, with `@Incubating` opt-in via `composePreview { incubating = true }` and a warning at apply time, is **not in 1.0.0** — it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)). Until it does, a new DSL property is public and semver-governed the moment it ships, so add one only when you're willing to keep it.
 
-**Negotiation:** none. Gradle resolves the plugin coordinate; `apply()` validates the AGP/Kotlin/Compose versions present and either accepts or fails closed with a specific error. See § 2.5.
+**Negotiation:** none. Gradle resolves the plugin coordinate. `apply()` checks the Gradle version only — see § 2.5 for what it does not check.
 
 **Additive change is free:** new `Property<T>` with a `convention(...)`, new nested extension blocks, new enum values on properties (because Gradle doesn't strict-decode user input).
 
 **Breaking change:** retype, rename, or remove. Goes through the deprecation cycle in [VERSIONING.md § 5](VERSIONING.md#5-deprecation-policy).
 
-**Enforced by:** `binary-compatibility-validator` (Kotlin BCV) on the plugin's Kotlin API.
+**Enforced by:** review. Kotlin BCV is named throughout these docs as the gate, but it is not configured on this module ([VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)).
 
 ### 2.5 Toolchain matrix (surface 5)
 
-**Negotiation:** plugin `apply()` reads the resolved AGP version (and, where it can, Kotlin and Compose runtime versions) and compares against a baked-in compatibility table. Out-of-range → fail with the exact message "compose-preview X.Y supports AGP A.B–C.D; found E.F".
+**Negotiation:** intended to be `apply()` reading the resolved AGP version (and, where it can, Kotlin and Compose) and failing out-of-range consumers with "compose-preview X.Y supports AGP A.B–C.D; found E.F". **Not implemented** — `apply()` gates the Gradle version and nothing else, so an unsupported toolchain surfaces as whatever error it happens to produce.
 
-**Documented:** [docs/RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md) is the authoritative table. `apply()` consults a generated subset of it.
+**Documented:** [docs/RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md) collects the known-good combinations and skew notes. Nothing generates a table from it, and `apply()` does not consult it; `compose-preview doctor` is the closest thing, and it reports rather than gates.
 
 **Tested:** an `integration` workflow runs the sample renders against the matrix corners (current, current-1, next-RC) on every plugin release.
 
@@ -102,7 +104,7 @@ The annotation library has no negotiation surface — the plugin's discovery tas
 
 **Deprecation:** flags follow the cycle in [VERSIONING.md § 5](VERSIONING.md#5-deprecation-policy) — warn for two minors, then remove.
 
-**Negotiation:** `compose-preview --version`. The `compose-preview <cmd> --json-schema` capability probe is **not in 1.0.0** — it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-status-at-10)); until then CI and agents read `--help`.
+**Negotiation:** `compose-preview --version`. The `compose-preview <cmd> --json-schema` capability probe is **not in 1.0.0** — it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)); until then CI and agents read `--help`.
 
 ### 2.8 MCP tool names (surface 8)
 
@@ -124,14 +126,14 @@ The annotation library has no negotiation surface — the plugin's discovery tas
 
 | Pair | Window | Rationale |
 |---|---|---|
-| VS Code extension ↔ daemon | Extension supports daemon `protocolVersion` N..N-1 | Marketplace and project cadences diverge |
+| VS Code extension ↔ daemon | **Intended:** extension supports daemon `protocolVersion` N..N-1, because marketplace and project cadences diverge. **Today:** lockstep — see below | |
 | CLI ↔ plugin | Lockstep within a project | Mitigated by `version=catalog` |
 | Daemon ↔ in-repo plugin | Lockstep | Same build |
 | MCP server ↔ agent | Server keeps tool names stable indefinitely | Agents pin names in config |
 | GH action consumers | All published actions remain functional indefinitely | SHA-pinned references in workflows |
 | Plugin DSL consumers | Major-N plugin supports DSL written for major-N source | Standard Gradle plugin semver |
 
-The VS Code N..N-1 window is the only place we actively decode two protocol versions in the same binary. Everywhere else we either ship in lockstep or freeze the contract.
+The VS Code N..N-1 window is the only place we would decode two protocol versions in the same binary — and it **does not work yet**. `daemonProtocol.ts` exports a single hard-coded `PROTOCOL_VERSION`, and `JsonRpcServer.handleInitialize` rejects any value but its own, so a marketplace extension one version behind the project's daemon fails the handshake rather than degrading. That is the exact staggered-release case the window exists for; bumping `protocolVersion` today means a coordinated release, not a supported skew. Everywhere else we ship in lockstep or freeze the contract.
 
 ## 4. What this design explicitly does not do
 
@@ -143,7 +145,7 @@ The VS Code N..N-1 window is the only place we actively decode two protocol vers
 
 ## 5. Stability tags in code
 
-The intended scheme — each public type carrying one of these tags — is **not applied as of 1.0.0**; it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-status-at-10)):
+The intended scheme — each public type carrying one of these tags — is **not applied as of 1.0.0**; it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)):
 
 - `// API: stable` — semver-governed.
 - `// API: incubating` — opt-in, may change.

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -6,7 +6,7 @@ Cross-cutting design doc for what counts as a public contract in this repo, how 
 
 Nine externally-observable surfaces, each with its own evolution story. Anything **not** in this list is internal and may move without notice — with the caveat below, and read alongside [VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced), which records how much of the machinery described here is actually implemented.
 
-> **The list is not exhaustive.** At least two versioned formats are exchanged with detached consumers without appearing above: `bundle.json` inside a packed preview bundle (read by the CLI and the bundle viewer, carrying `BUNDLE_SCHEMA_VERSION`) and `daemon-launch.json` from the published `daemon-launch-builder` (read by VS Code's `daemonProcess.ts`, which gates on its `schemaVersion`, and by the non-Gradle integrations in [NON_GRADLE_INTEGRATION.md](NON_GRADLE_INTEGRATION.md)). Both carry their own schema version and both would strand existing artifacts or producers if changed carelessly. Treat "not in this list" as "not yet classified", not as licence to break them.
+> **The list is not exhaustive.** At least two versioned formats are exchanged with detached consumers without appearing above: `bundle.json` inside a packed preview bundle (read by the CLI and the bundle viewer, carrying `BUNDLE_SCHEMA_VERSION`) and `daemon-launch.json` from the published `daemon-launch-builder` (read by VS Code's `daemonProcess.ts`, which requires `schemaVersion` to equal its own exactly and otherwise discards the descriptor and forces a re-run, and by the non-Gradle integrations in [NON_GRADLE_INTEGRATION.md](NON_GRADLE_INTEGRATION.md)). Both carry their own schema version and both would strand existing artifacts or producers if changed carelessly. Treat "not in this list" as "not yet classified", not as licence to break them.
 
 | # | Surface | Lives in | Consumed by | Stability tier |
 |---|---|---|---|---|
@@ -44,7 +44,7 @@ The annotation library and per-data-product schemas are intentionally narrow. Th
 
 **Enums.** Wire enums *should* decode tolerantly — unknown values mapping to an `UNKNOWN` sentinel rather than throwing — because without it every new enum value is a silent break for old clients. **Most existing enums in `Messages.kt` do not do this yet** (`FileKind` and `ChangeType` among them), so treat it as the rule for enums you add, not as a property of the current corpus. See [VERSIONING.md § 4.1](VERSIONING.md#41-enum-discipline).
 
-**Test:** the JSON fixture corpus under [docs/daemon/protocol-fixtures/](daemon/protocol-fixtures/) round-trips on both Kotlin and TypeScript sides. Adding a message ⇒ add the fixture in the same PR. Renaming a field ⇒ either bump `protocolVersion` or revert.
+**Test:** the JSON fixture corpus under [docs/daemon/protocol-fixtures/](daemon/protocol-fixtures/). Kotlin round-trips it; **TypeScript does not** — `daemonProtocol.test.ts` parses with `JSON.parse(...) as T` and asserts selected properties on a subset of the files, so an unasserted field can drift. Adding a message ⇒ add the fixture in the same PR (nothing enforces this — see [VERSIONING.md § 9](VERSIONING.md#9-compatibility-testing)). Renaming a field ⇒ either bump `protocolVersion` or revert.
 
 ### 2.2 `previews.json` (surface 2)
 
@@ -82,7 +82,7 @@ The `@Stable` / `@Incubating` split, with `@Incubating` opt-in via `composePrevi
 
 **Negotiation:** intended to be `apply()` reading the resolved AGP version (and, where it can, Kotlin and Compose) and failing out-of-range consumers with "compose-preview X.Y supports AGP A.B–C.D; found E.F". **Not implemented** — `apply()` gates the Gradle version and nothing else, so an unsupported toolchain surfaces as whatever error it happens to produce.
 
-**Documented:** [docs/RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md) collects the known-good combinations and skew notes. Nothing generates a table from it, and `apply()` does not consult it; `compose-preview doctor` is the closest thing, and it reports rather than gates.
+**Documented:** nowhere, as a matrix. [docs/RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md) is titled "Renderer compatibility notes" and is exactly that — skew failure modes, mitigations, and desktop Compose/Skiko floors — not a table of supported AGP × Kotlin × Compose × Robolectric combinations. Nothing generates one, and `apply()` consults nothing; `compose-preview doctor` is the closest thing and it reports rather than gates.
 
 **Tested:** the `integration` workflow runs sample renders on every PR — against fixtures (including an `agp8-min` floor) and moving external `main` refs, **not** pinned current / current-1 / next-RC corners. It catches real breakage; it does not prove matrix coverage.
 

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -50,11 +50,11 @@ The annotation library and per-data-product schemas are intentionally narrow. Th
 
 **Versioning:** intended to be a top-level `schemaVersion: int`, but **the field is not written today** — neither the daemon's nor the viewer's `PreviewManifest` carries one, so a reader cannot tell which shape it has. What is real is tolerant reading: unknown fields ignored, missing optional fields defaulted.
 
-**Negotiation:** none in-band. The plugin and daemon ship in lockstep; the CLI / VS Code extension treat `previews.json` as opaque except for fields they explicitly model. Any reader that crosses the process boundary keys off `schemaVersion` and ignores fields it doesn't understand.
+**Negotiation:** none in-band, and — with no `schemaVersion` written — **none possible**. The plugin and daemon ship in lockstep, which is what makes this work today; the CLI / VS Code extension treat `previews.json` as opaque except for fields they explicitly model and ignore what they don't understand. A reader cannot detect a shape change, so lockstep is load-bearing rather than belt-and-braces.
 
 **Additive change is free:** new optional fields, new optional metadata blocks.
 
-**Breaking change:** bump `schemaVersion` and bump the daemon `protocolVersion` in the same release — clients should never see the new shape against an old daemon.
+**Breaking change:** until the `schemaVersion` field exists there is nothing to bump, so a shape change relies entirely on plugin and daemon shipping together — bump the daemon `protocolVersion` in the same release so a stale client fails the handshake instead of misreading the manifest. Add the carrier first if you need a change readers can actually detect.
 
 ### 2.3 Data products (surface 3)
 
@@ -84,7 +84,7 @@ The `@Stable` / `@Incubating` split, with `@Incubating` opt-in via `composePrevi
 
 **Documented:** [docs/RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md) collects the known-good combinations and skew notes. Nothing generates a table from it, and `apply()` does not consult it; `compose-preview doctor` is the closest thing, and it reports rather than gates.
 
-**Tested:** an `integration` workflow runs the sample renders against the matrix corners (current, current-1, next-RC) on every plugin release.
+**Tested:** the `integration` workflow runs sample renders on every PR — against fixtures (including an `agp8-min` floor) and moving external `main` refs, **not** pinned current / current-1 / next-RC corners. It catches real breakage; it does not prove matrix coverage.
 
 **Evolution rule:** the matrix is allowed to slide. A plugin minor may drop support for an AGP version older than 18 months. A plugin major may drop two AGP majors at once. Any drop is documented in CHANGELOG with the exact "from X.Y you must be on AGP ≥ A.B".
 
@@ -141,7 +141,7 @@ The VS Code N..N-1 window is the only place we would decode two protocol version
 - **No multiplexing.** One daemon, one client, one stdio pair.
 - **No on-the-wire schema migration.** Old client + new daemon → daemon serves the old protocol if it's in range; otherwise fail closed.
 - **No silent flag renames in CLI or DSL.** Every rename is a deprecation cycle.
-- **No automatic enum-value conversion.** Tolerant decode maps unknown to `UNKNOWN`; clients decide what to do.
+- **No automatic enum-value conversion.** Where tolerant decode exists, unknown maps to `UNKNOWN` and the client decides what to do. Most wire enums don't have it yet (§ 2.1), so today an unknown value throws instead.
 
 ## 5. Stability tags in code
 
@@ -151,7 +151,7 @@ The intended scheme — each public type carrying one of these tags — is **not
 - `// API: incubating` — opt-in, may change.
 - No tag — internal; do not depend on.
 
-Kotlin BCV runs on the plugin module and the annotations module. The daemon protocol is governed by the fixture corpus, not BCV (because internal types may move freely as long as the wire shape is stable).
+Kotlin BCV is intended to run on the plugin module and the annotations module. **It is not configured on either** ([VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)), so no tooling currently catches an API break. The daemon protocol would be governed by the fixture corpus rather than BCV in any case, since internal types may move freely as long as the wire shape is stable.
 
 ## 6. References
 

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -13,7 +13,7 @@ Nine externally-observable surfaces, each with its own evolution story. Anything
 | 1 | Daemon JSON-RPC over stdio | `daemon/core/.../protocol/Messages.kt`, [docs/daemon/PROTOCOL.md](daemon/PROTOCOL.md) | VS Code extension, MCP supervisor, any future client | Stable |
 | 2 | `previews.json` on disk | `gradle-plugin/.../DiscoverPreviewsTask.kt` | Daemon, CLI, CI workflows | Stable |
 | 3 | Per-data-product payload schemas | `data/<feature>/connector/`, [docs/daemon/DATA-PRODUCTS.md](daemon/DATA-PRODUCTS.md) | Daemon clients (versioned per-kind) | Stable per-kind |
-| 4 | Gradle plugin DSL (`composePreview { … }`) | `gradle-plugin/.../PreviewExtension.kt` | Consumer `build.gradle.kts` | Stable |
+| 4 | Gradle plugin DSL (`composePreview { … }`) | `gradle-plugin/gradle-plugin-config/.../PreviewExtension.kt` — published as `ee.schimke.composeai:compose-preview-config` | Consumer `build.gradle.kts` | Stable |
 | 5 | AGP × Kotlin × Compose × Robolectric matrix | [docs/RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md), [docs/AGENTS.md](AGENTS.md) | Consumers' transitive resolution | Documented, gated |
 | 6 | Preview annotations (`@ScrollingPreview`, `@AnimatedPreview`) | `api/preview-annotations/` | Consumer source code | Stable |
 | 7 | CLI argv (`compose-preview …`) | `cli/.../Args.kt`, `cli/.../Main.kt` | CI scripts, agents, GH actions | Stable |
@@ -64,8 +64,10 @@ Each kind owns its own `schemaVersion: Int`. Producers evolve independently of t
 
 ### 2.4 Gradle plugin DSL (surface 4)
 
+**Where the DSL lives.** Not in `:gradle-plugin`. `PreviewExtension` / `DaemonExtension` are in the separately published `:gradle-plugin-config` (`ee.schimke.composeai:compose-preview-config`, plugin id `…preview.config`), which the runtime plugin `api`-depends on. That artifact is the **load-bearing** one for compatibility: a consumer pins the config plugin while the CLI injects the runtime plugin at its own version, and Gradle conflict-resolves the two to a single version on the buildscript classpath. It is the artifact any binary-compatibility gate should target first — see [AGENTS.md](AGENTS.md) on the config-only plugin.
+
 **Stability tiers.** As of 1.0.0 there are two, not three — the DSL has no opt-in tier, which makes the surface *stricter* than the scheme below, not looser:
-- Public — semver-governed. Property type changes, removals, and renames are breaking changes that bump the plugin major. **Enforced by review, not by tooling** — Kotlin BCV is not wired up on this module ([VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)).
+- Public — semver-governed. Property type changes, removals, and renames are breaking changes that bump the plugin major. **Enforced by review, not by tooling** — Kotlin BCV is not wired up on `:gradle-plugin-config` or anywhere else ([VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)).
 - Internal — `internal` Kotlin visibility. No contract.
 
 The `@Stable` / `@Incubating` split, with `@Incubating` opt-in via `composePreview { incubating = true }` and a warning at apply time, is **not in 1.0.0** — it lands in a later `1.x` (see [VERSIONING.md § 10](VERSIONING.md#10-what-is-and-is-not-enforced)). Until it does, a new DSL property is public and semver-governed the moment it ships, so add one only when you're willing to keep it.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -114,7 +114,7 @@ The plugin declares a **supported matrix** in [RENDERER_COMPATIBILITY.md](RENDER
 
 **What `apply()` actually gates today is the Gradle version** ([`GradleVersionCheck.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GradleVersionCheck.kt)); there is no AGP / Kotlin / Compose comparison at configuration time, so an out-of-matrix consumer gets whatever failure the toolchain produces rather than a named supported range. `compose-preview doctor` is not a substitute: it prints the resolved AGP and Kotlin versions as an informational check and flags known dependency mismatches ([`CompatRules.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt) is given dependency maps and the Gradle version, not the AGP/Kotlin versions), so it evaluates no matrix predicate at all.
 
-The CI integration suite runs sample renders against several toolchain points, but they are not maintained as explicit current / current-1 / next-RC cells.
+The CI integration suite renders against several toolchain points, but not as explicit current / current-1 / next-RC cells — and only one cell runs per PR, with the full matrix reserved for `main` and the nightly cron (§ 9).
 
 ## 7. Branch conventions (GH actions)
 
@@ -140,9 +140,9 @@ Three layers were designed; this is what each one actually does today.
 
 | Layer | Intended gate | Reality |
 |---|---|---|
-| **Fixture corpus** — `docs/daemon/protocol-fixtures/` | Adding a wire message without a fixture fails CI | Round-trips on Kotlin and TypeScript for the messages it covers, but `MessagesTest.fixtureInventoryMatchesExpected` compares against a **hand-maintained** set. A new message type adds no entry, so it lands green with no fixture; history, interactive, stream, XR, recording, and extension methods are already uncovered |
+| **Fixture corpus** — `docs/daemon/protocol-fixtures/` | Adding a wire message without a fixture fails CI | Kotlin round-trips the fixtures it covers. **TypeScript does not round-trip** — `daemonProtocol.test.ts` does `JSON.parse(...) as T` and asserts selected properties on 16 of the 28 fixtures, so a renamed field nobody asserts passes. And the inventory (`MessagesTest.fixtureInventoryMatchesExpected`) is a **hand-maintained** set: a new message adds no entry and lands green. History, interactive, stream, XR, recording and extension methods are already uncovered |
 | **Kotlin BCV** — `:gradle-plugin`, `:preview-annotations` | Changing a public API without updating the golden file fails CI | **Not wired.** No `binary-compatibility-validator` plugin, no `.api` golden files, no `apiCheck` in any workflow. Nothing catches a breaking API change |
-| **Toolchain integration matrix** — `.github/workflows/integration.yml` | Bumping a matrix corner without a green run fails CI | Runs sample renders, and does gate merges — but against fixtures and moving external repositories rather than pinned current / current-1 / next-RC cells |
+| **Toolchain integration matrix** — `.github/workflows/integration.yml` | Bumping a matrix corner without a green run fails CI | Two different things. **On a PR:** one cell (`wear-os-samples (ComposeStarter)`); `agp8-min` is skipped, and a diff touching only safe paths skips the matrix entirely with the required legs re-emitted green. **On `main` + the nightly cron:** the full matrix, so AGP-floor drift surfaces within a day rather than on the PR. Either way the cells are external repositories and fixtures, not pinned current / current-1 / next-RC |
 
 The fixture corpus and the integration suite are real tests that catch real regressions. What none of the three currently provides is the *exhaustive* coverage the rules above assume.
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -82,12 +82,13 @@ Clients gate features on `ServerCapabilities` entries, not on `daemonVersion` se
 
 Bumping `protocolVersion` requires:
 
-- A coordinated daemon + every-client release.
+- A coordinated daemon + every-client release. **This is the only mechanism that works today** — see below.
 - A migration note in [docs/daemon/PROTOCOL.md](daemon/PROTOCOL.md).
-- Daemon support for the previous version for one minor cycle (clients may take longer to ship).
 - Updated fixture corpus.
 
-Range negotiation — the daemon advertising a `{min, max}` and serving both — is **not in 1.0.0** and is deferred to a later `1.x` (§ 10). `initialize` carries a single `protocolVersion: Int` today, and [`JsonRpcServer`](../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt) fails the handshake on any mismatch. Until it lands, the VS Code extension's `current..current-1` support window does not exist in any form: the extension sends one hard-coded version and the daemon rejects anything else, so "a coordinated daemon + every-client release" is the only way a bump works, and "daemon support for the previous version for one minor cycle" above is an aspiration rather than something the code can currently do.
+Serving the previous version for one minor cycle, so clients can ship on their own schedule, is what this list *should* require. It is left out because the daemon cannot do it: there is no way to satisfy it, and a requirement no one can meet is worse than an acknowledged gap. Restore it here in the same change that implements range negotiation.
+
+Range negotiation — the daemon advertising a `{min, max}` and serving both — is **not in 1.0.0** and is deferred to a later `1.x` (§ 10). `initialize` carries a single `protocolVersion: Int` today, and [`JsonRpcServer`](../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt) fails the handshake on any mismatch. Until it lands, the VS Code extension's `current..current-1` support window does not exist in any form: the extension sends one hard-coded version and the daemon rejects anything else, which is why a coordinated release is the only way a bump works and why the previous-version requirement is held back rather than listed.
 
 ## 5. Deprecation policy
 
@@ -109,7 +110,7 @@ Exceptions are permitted only for security fixes, documented in CHANGELOG.
 The plugin declares a **supported matrix** in [RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md). The matrix slides on its own cadence:
 
 - Adding a newer corner is **additive** (any minor).
-- Dropping a corner older than 18 months is permitted at any **minor** with one release of warning (`apply()` prints "AGP X.Y is deprecated; will be unsupported in compose-preview Z.0").
+- Dropping a corner older than 18 months is permitted at any **minor** with one release of warning. That warning has to go in the CHANGELOG and release notes: `apply()` never sees an AGP, Kotlin, or Compose version, so it cannot print the "AGP X.Y is deprecated; will be unsupported in compose-preview Z.0" message this rule used to promise, and a consumer gets no in-build notice at all.
 - Dropping multiple majors at once requires a plugin **major**.
 
 **What `apply()` actually gates today is the Gradle version** ([`GradleVersionCheck.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GradleVersionCheck.kt)); there is no AGP / Kotlin / Compose comparison at configuration time, so an out-of-matrix consumer gets whatever failure the toolchain produces rather than a named supported range. `compose-preview doctor` is not a substitute: it prints the resolved AGP and Kotlin versions as an informational check and flags known dependency mismatches ([`CompatRules.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt) is given dependency maps and the Gradle version, not the AGP/Kotlin versions), so it evaluates no matrix predicate at all.
@@ -141,7 +142,7 @@ Three layers were designed; this is what each one actually does today.
 | Layer | Intended gate | Reality |
 |---|---|---|
 | **Fixture corpus** — `docs/daemon/protocol-fixtures/` | Adding a wire message without a fixture fails CI | Kotlin round-trips the fixtures it covers. **TypeScript does not round-trip** — `daemonProtocol.test.ts` does `JSON.parse(...) as T` and asserts selected properties on 16 of the 28 fixtures, so a renamed field nobody asserts passes. And the inventory (`MessagesTest.fixtureInventoryMatchesExpected`) is a **hand-maintained** set: a new message adds no entry and lands green. History, interactive, stream, XR, recording and extension methods are already uncovered |
-| **Kotlin BCV** — `:gradle-plugin`, `:preview-annotations` | Changing a public API without updating the golden file fails CI | **Not wired.** No `binary-compatibility-validator` plugin, no `.api` golden files, no `apiCheck` in any workflow. Nothing catches a breaking API change |
+| **Kotlin BCV** — named for `:gradle-plugin` and `:preview-annotations` | Changing a public API without updating the golden file fails CI | **Not wired.** No `binary-compatibility-validator` plugin, no `.api` golden files, no `apiCheck` in any workflow. Nothing catches a breaking API change. Note the named modules are also the wrong target: the DSL consumers compile against is `:gradle-plugin-config`, the artifact that gets conflict-resolved between a pinned config plugin and a CLI-injected runtime |
 | **Toolchain integration matrix** — `.github/workflows/integration.yml` | Bumping a matrix corner without a green run fails CI | Two different things. **On a PR:** one cell (`wear-os-samples (ComposeStarter)`); `agp8-min` is skipped, and a diff touching only safe paths skips the matrix entirely with the required legs re-emitted green. **On `main` + the nightly cron:** the full matrix, so AGP-floor drift surfaces within a day rather than on the PR. Either way the cells are external repositories and fixtures, not pinned current / current-1 / next-RC |
 
 The fixture corpus and the integration suite are real tests that catch real regressions. What none of the three currently provides is the *exhaustive* coverage the rules above assume.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -172,6 +172,8 @@ What is described but **not implemented**:
 | `// API: stable` / `// API: incubating` source tags | [API_STABILITY.md § 5](API_STABILITY.md#5-stability-tags-in-code) | Not applied |
 | `@Stable` / `@Incubating` DSL tiers | [API_STABILITY.md § 2.4](API_STABILITY.md#24-gradle-plugin-dsl-surface-4) | Not implemented — no opt-in tier exists |
 
-Each is additive and can land in any `1.x`. Until one does, do not cite it as a guarantee — in a PR description, in docs, or to a consumer.
+Most are additive and can land in any `1.x`. Until one does, do not cite it as a guarantee — in a PR description, in docs, or to a consumer.
+
+**Range negotiation is the exception: it cannot be done additively in the shape described.** `protocolVersion` is typed as a number on both sides (`InitializeParams.protocolVersion: Int` in `Messages.kt`, `protocolVersion: number` in the TypeScript interface and [PROTOCOL.md § 3](daemon/PROTOCOL.md)), so sending `{min, max}` in that field makes either peer fail to decode the handshake before any negotiation could happen — the one message where failing closed is guaranteed. It needs either a coordinated `protocolVersion` bump, or a staged rollout that adds the range as a **new optional field** an existing peer ignores while the numeric field keeps working, then retires the numeric one a cycle later. Chicken-and-egg worth noting: the staged path is the only one that doesn't require the coordinated release that range negotiation exists to avoid.
 
 The earlier 1.0 readiness punch list was [issue #798](https://github.com/yschimke/compose-ai-tools/issues/798); it covered feature completeness, not the enforcement above.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -17,6 +17,8 @@ Different surfaces use different schemes — pick the right one for the contract
 | `previews.json` | Integer | `schemaVersion` field |
 | Per-data-product payload | Integer | `schemaVersion` per `DataProductCapability` |
 | `HistoryEntry` sidecar JSON | Integer | `schemaVersion` field |
+| `bundle.json` in a packed preview bundle | Integer | `schemaVersion` field (`BUNDLE_SCHEMA_VERSION`) |
+| `daemon-launch.json` from `daemon-launch-builder` | Integer | `schemaVersion` field |
 | GH composite actions | Semver via tag/SHA | Consumer `uses:` ref |
 
 Plugin / CLI / extension share one release-please-driven semver chain (see [RELEASING.md](RELEASING.md)). Protocol and schema integers are independent.
@@ -43,6 +45,7 @@ By surface:
 - **Annotation library** — removing a parameter, renaming a parameter, retyping a parameter, reordering an annotation array literal default.
 - **Daemon protocol** — anything outside the additive list in [API_STABILITY.md § 2.1](API_STABILITY.md#21-daemon-json-rpc-surface-1).
 - **`previews.json` / `HistoryEntry` schemas** — same as the protocol: removed/renamed fields, semantic changes.
+- **`bundle.json` / `daemon-launch.json`** — same again, and these two matter more than their absence from [API_STABILITY.md § 1](API_STABILITY.md#1-the-contracts) suggests: a packed bundle outlives the CLI that wrote it, and `daemon-launch.json` is read by VS Code and by non-Gradle producers. Bump the format's `schemaVersion` and keep readers tolerant of the older value.
 - **GH actions** — removing an input, changing a default that would change observed behavior for a workflow that didn't override it, renaming a default branch convention.
 
 Anything else is additive.
@@ -84,7 +87,7 @@ Bumping `protocolVersion` requires:
 - Daemon support for the previous version for one minor cycle (clients may take longer to ship).
 - Updated fixture corpus.
 
-Range negotiation — the daemon advertising a `{min, max}` and serving both — is **not in 1.0.0** and is deferred to a later `1.x` (§ 10). `initialize` carries a single `protocolVersion: Int` today, and [`JsonRpcServer`](../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt) fails the handshake on any mismatch. Until it lands, the VS Code extension's `current..current-1` support window is a client-side concern, not something the daemon negotiates.
+Range negotiation — the daemon advertising a `{min, max}` and serving both — is **not in 1.0.0** and is deferred to a later `1.x` (§ 10). `initialize` carries a single `protocolVersion: Int` today, and [`JsonRpcServer`](../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt) fails the handshake on any mismatch. Until it lands, the VS Code extension's `current..current-1` support window does not exist in any form: the extension sends one hard-coded version and the daemon rejects anything else, so "a coordinated daemon + every-client release" is the only way a bump works, and "daemon support for the previous version for one minor cycle" above is an aspiration rather than something the code can currently do.
 
 ## 5. Deprecation policy
 
@@ -109,7 +112,7 @@ The plugin declares a **supported matrix** in [RENDERER_COMPATIBILITY.md](RENDER
 - Dropping a corner older than 18 months is permitted at any **minor** with one release of warning (`apply()` prints "AGP X.Y is deprecated; will be unsupported in compose-preview Z.0").
 - Dropping multiple majors at once requires a plugin **major**.
 
-**What `apply()` actually gates today is the Gradle version** ([`GradleVersionCheck.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GradleVersionCheck.kt)); there is no AGP / Kotlin / Compose comparison at configuration time, so an out-of-matrix consumer gets whatever failure the toolchain produces rather than a named supported range. `compose-preview doctor` diagnoses skew after the fact ([`CompatRules.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt)), which is a report, not a gate.
+**What `apply()` actually gates today is the Gradle version** ([`GradleVersionCheck.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GradleVersionCheck.kt)); there is no AGP / Kotlin / Compose comparison at configuration time, so an out-of-matrix consumer gets whatever failure the toolchain produces rather than a named supported range. `compose-preview doctor` is not a substitute: it prints the resolved AGP and Kotlin versions as an informational check and flags known dependency mismatches ([`CompatRules.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt) is given dependency maps and the Gradle version, not the AGP/Kotlin versions), so it evaluates no matrix predicate at all.
 
 The CI integration suite runs sample renders against several toolchain points, but they are not maintained as explicit current / current-1 / next-RC cells.
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -21,6 +21,8 @@ Different surfaces use different schemes — pick the right one for the contract
 
 Plugin / CLI / extension share one release-please-driven semver chain (see [RELEASING.md](RELEASING.md)). Protocol and schema integers are independent.
 
+> **Two of those carriers don't exist yet.** `previews.json` and the `HistoryEntry` sidecar are both listed above as carrying a `schemaVersion` field, and neither actually writes one. The per-data-product and bundle schemas do. See § 10.
+
 ## 2. Semver rules for the published artifacts
 
 For plugin, CLI, extension, MCP, annotations:
@@ -51,13 +53,15 @@ These apply to surfaces 1, 2, 3, and the history sidecar.
 
 ### 4.1 Enum discipline
 
-Every enum that crosses a process boundary is decoded **tolerantly**:
+Every enum that crosses a process boundary should be decoded **tolerantly**:
 
 - An unknown string maps to a per-enum `UNKNOWN` value (Kotlin) or a falsy sentinel (TypeScript).
 - Code branching on the enum has an explicit `else` / default arm.
 - The fixture corpus has at least one fixture per enum that exercises a synthetic future value to prove tolerance.
 
-Adding a new enum value is **additive** under this rule. Without tolerant decode, every new enum value is a silent break — the rule is what makes the additive promise real.
+Adding a new enum value is **additive** under this rule. Without tolerant decode, every new enum value is a silent break — the rule is what would make the additive promise real.
+
+> **Not true of the existing wire enums.** Most `@Serializable` enums in `Messages.kt` are plain enums with no `UNKNOWN` member and no custom serializer — `FileKind` and `ChangeType` are two of many. `ignoreUnknownKeys` covers unknown *fields*, not unknown enum *values*, so a peer sending a newly added value today makes decoding throw. Treat this section as the rule for enums you add or touch, not as a description of the current corpus. Retrofitting the rest is [tracked work](#10-what-is-and-is-not-enforced), not a shipped guarantee.
 
 ### 4.2 Unknown fields
 
@@ -105,9 +109,9 @@ The plugin declares a **supported matrix** in [RENDERER_COMPATIBILITY.md](RENDER
 - Dropping a corner older than 18 months is permitted at any **minor** with one release of warning (`apply()` prints "AGP X.Y is deprecated; will be unsupported in compose-preview Z.0").
 - Dropping multiple majors at once requires a plugin **major**.
 
-`apply()` enforces the matrix at configuration time. Out-of-range versions fail with a specific error message naming both the consumer's version and the supported range.
+**What `apply()` actually gates today is the Gradle version** ([`GradleVersionCheck.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GradleVersionCheck.kt)); there is no AGP / Kotlin / Compose comparison at configuration time, so an out-of-matrix consumer gets whatever failure the toolchain produces rather than a named supported range. `compose-preview doctor` diagnoses skew after the fact ([`CompatRules.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt)), which is a report, not a gate.
 
-The CI integration suite covers at least three matrix points: current, current-1, and next-RC.
+The CI integration suite runs sample renders against several toolchain points, but they are not maintained as explicit current / current-1 / next-RC cells.
 
 ## 7. Branch conventions (GH actions)
 
@@ -129,27 +133,41 @@ Daemon protocol versions and per-data-product schema versions are decoupled — 
 
 ## 9. Compatibility testing
 
-Three layers, all required to remain green on `main`:
+Three layers were designed; this is what each one actually does today.
 
-1. **Fixture corpus** — `docs/daemon/protocol-fixtures/` round-trips on Kotlin and TypeScript.
-2. **Kotlin BCV** — `binary-compatibility-validator` on `:gradle-plugin` and `:preview-annotations`.
-3. **Toolchain integration matrix** — `.github/workflows/integration.yml` runs sample renders against the AGP matrix corners.
-
-Adding a public type or annotation without updating the BCV golden file is a CI failure. Adding a wire message without a fixture is a CI failure. Bumping the AGP corner without a green integration run is a CI failure.
-
-## 10. Status at 1.0
-
-Through the `0.x` line the rules in §§ 2–5 were aspirational — any contract could break in any release with a CHANGELOG note. **From `1.0.0` they are in effect**, and the contracts in [API_STABILITY.md](API_STABILITY.md) are enforceable: breaking a listed surface requires a major.
-
-Four *discovery* mechanisms these documents describe are **not part of 1.0.0**. They were always written as post-1.0 evolution rather than 1.0 gates, and cutting 1.0.0 does not make them retroactively true — so they are named here rather than left implied:
-
-| Mechanism | Where it's described | State at 1.0.0 |
+| Layer | Intended gate | Reality |
 |---|---|---|
-| `protocolVersion: {min, max}` range negotiation | § 4.5, [API_STABILITY.md § 2.1](API_STABILITY.md#21-daemon-json-rpc-surface-1) | Not implemented — single `Int`, handshake fails closed on mismatch |
-| `compose-preview <cmd> --json-schema` | [API_STABILITY.md § 2.7](API_STABILITY.md#27-cli-argv-surface-7) | Not implemented — capability detection is `--version` plus `--help` |
-| `// API: stable` / `// API: incubating` source tags | [API_STABILITY.md § 5](API_STABILITY.md#5-stability-tags-in-code) | Not applied — Kotlin BCV is the enforced boundary for the plugin and annotations modules |
-| `@Stable` / `@Incubating` DSL tiers, opt-in via `composePreview { incubating = true }` | [API_STABILITY.md § 2.4](API_STABILITY.md#24-gradle-plugin-dsl-surface-4) | Not implemented — every public DSL property is semver-governed, with no opt-in tier to escape into |
+| **Fixture corpus** — `docs/daemon/protocol-fixtures/` | Adding a wire message without a fixture fails CI | Round-trips on Kotlin and TypeScript for the messages it covers, but `MessagesTest.fixtureInventoryMatchesExpected` compares against a **hand-maintained** set. A new message type adds no entry, so it lands green with no fixture; history, interactive, stream, XR, recording, and extension methods are already uncovered |
+| **Kotlin BCV** — `:gradle-plugin`, `:preview-annotations` | Changing a public API without updating the golden file fails CI | **Not wired.** No `binary-compatibility-validator` plugin, no `.api` golden files, no `apiCheck` in any workflow. Nothing catches a breaking API change |
+| **Toolchain integration matrix** — `.github/workflows/integration.yml` | Bumping a matrix corner without a green run fails CI | Runs sample renders, and does gate merges — but against fixtures and moving external repositories rather than pinned current / current-1 / next-RC cells |
 
-None of the four weakens the stability promise. Three are ways to *discover* the contract rather than the contract itself, and the missing DSL tier makes the surface stricter — with no incubating escape hatch, a property is committed the moment it ships. The guarantees stand on the deprecation policy (§ 5), the tolerant-decode rules (§ 4), and the three test layers in § 9, all live today. Each mechanism lands in a later `1.x` as an additive change.
+The fixture corpus and the integration suite are real tests that catch real regressions. What none of the three currently provides is the *exhaustive* coverage the rules above assume.
 
-The 1.0 readiness punch list itself was [issue #798](https://github.com/yschimke/compose-ai-tools/issues/798), closed as completed.
+## 10. What is and is not enforced
+
+**Read §§ 2–9 as the intended policy, not as a description of shipped machinery.** `1.0.0` is a version number: it ended the `0.x` convention where a minor could break anything, and it says we intend to treat the surfaces in [API_STABILITY.md](API_STABILITY.md) as contracts. It did **not** turn on the enforcement these documents describe. An earlier revision of this section claimed those mechanisms were live; they are not, and the difference matters to anyone deciding how much to depend on a surface.
+
+What holds today rests on review and convention:
+
+- We do not knowingly break a listed surface without a major.
+- The deprecation cycle in § 5 is followed when a surface is retired.
+- The fixture corpus and the integration suite catch real regressions within their coverage (§ 9).
+
+What is described but **not implemented**:
+
+| Mechanism | Described in | State |
+|---|---|---|
+| Kotlin BCV on `:gradle-plugin` / `:preview-annotations` | § 9 | No plugin, no `.api` golden files, no CI check — a breaking API change ships silently |
+| Tolerant enum decode across the wire | § 4.1 | Most `Messages.kt` enums have no `UNKNOWN`; a new value from a peer throws |
+| `apply()`-time AGP × Kotlin × Compose gate | § 6 | Only the Gradle version is checked; `doctor` reports skew but does not gate |
+| Exhaustive fixture coverage | § 9 | Inventory is a hand-maintained set; a new message lands green with no fixture |
+| `schemaVersion` on `previews.json` and the `HistoryEntry` sidecar | § 1 | Field absent from both — a reader cannot tell a supported document from a future one |
+| `protocolVersion: {min, max}` range negotiation | § 4.5, [API_STABILITY.md § 2.1](API_STABILITY.md#21-daemon-json-rpc-surface-1) | Single `Int`; the daemon rejects any value but its own |
+| VS Code ↔ daemon `N..N-1` window | [API_STABILITY.md § 3](API_STABILITY.md#3-multi-version-support-window) | Not possible while the above holds — the extension sends one hard-coded version and a mismatch fails the handshake |
+| `compose-preview <cmd> --json-schema` | [API_STABILITY.md § 2.7](API_STABILITY.md#27-cli-argv-surface-7) | Not implemented; capability detection is `--version` plus `--help` |
+| `// API: stable` / `// API: incubating` source tags | [API_STABILITY.md § 5](API_STABILITY.md#5-stability-tags-in-code) | Not applied |
+| `@Stable` / `@Incubating` DSL tiers | [API_STABILITY.md § 2.4](API_STABILITY.md#24-gradle-plugin-dsl-surface-4) | Not implemented — no opt-in tier exists |
+
+Each is additive and can land in any `1.x`. Until one does, do not cite it as a guarantee — in a PR description, in docs, or to a consumer.
+
+The earlier 1.0 readiness punch list was [issue #798](https://github.com/yschimke/compose-ai-tools/issues/798); it covered feature completeness, not the enforcement above.

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -1,6 +1,6 @@
 # Preview daemon — IPC protocol
 
-> **Status:** v2 contract. The wire shape may still break across artifact minor versions, in a coordinated daemon + client release — `protocolVersion` is decoupled from the artifact semver ([VERSIONING.md § 8](../VERSIONING.md#8-release-coordination)), and range negotiation is deferred past 1.0.0 ([§ 10](../VERSIONING.md#10-status-at-10)), so a bump means old clients fail the handshake rather than being served the old version. v2 made `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` opt-in via `extensions/enable` (see § 3a); v1 clients fail the `protocolVersion` check.
+> **Status:** v2 contract. The wire shape may still break across artifact minor versions, in a coordinated daemon + client release — `protocolVersion` is decoupled from the artifact semver ([VERSIONING.md § 8](../VERSIONING.md#8-release-coordination)), and range negotiation is deferred past 1.0.0 ([§ 10](../VERSIONING.md#10-what-is-and-is-not-enforced)), so a bump means old clients fail the handshake rather than being served the old version. v2 made `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` opt-in via `extensions/enable` (see § 3a); v1 clients fail the `protocolVersion` check.
 
 This document is the authoritative wire-format spec for the JSON-RPC channel between the VS Code extension and the per-module preview daemon. It is referenced by [DESIGN.md § 5](DESIGN.md).
 


### PR DESCRIPTION
## Summary

`VERSIONING.md` and `API_STABILITY.md` describe enforcement machinery that mostly isn't built, and #3716 made it worse — its § 10 asserted the guarantees were "live today". They aren't. This walks that back and marks each site as intent rather than fact.

Every claim below was checked against the tree, not inferred from the docs:

| Claim in the docs | What's actually there |
|---|---|
| Kotlin BCV gates `:gradle-plugin` / `:preview-annotations` (named in **three** places) | No BCV plugin applied, no `.api` golden files, no `apiCheck` in any workflow. A breaking API change ships silently |
| Wire enums decode tolerantly to `UNKNOWN` | Most `Messages.kt` enums are plain enums — `FileKind`, `ChangeType` among them. `ignoreUnknownKeys` covers unknown *fields*, not unknown enum *values* |
| `apply()` fails an out-of-matrix consumer with "supports AGP A.B–C.D; found E.F" | `apply()` checks the Gradle version only. `doctor` reports skew, which is a report, not a gate |
| `previews.json` + `HistoryEntry` carry `schemaVersion` | Neither writes one — not in the daemon's `PreviewManifest`, the viewer's, or `HistoryEntry` |
| A wire message without a fixture fails CI | `fixtureInventoryMatchesExpected` compares against a hand-maintained set, so a new message lands green. History, interactive, stream, XR, recording and extension methods are already uncovered |
| VS Code supports daemon `protocolVersion` N..N-1 | `daemonProtocol.ts` exports one hard-coded `PROTOCOL_VERSION = 2`; `handleInitialize` rejects anything else. The staggered-release case the window exists for fails the handshake |
| "Anything not in this list is internal" | `bundle.json` (CLI + bundle-viewer) and `daemon-launch.json` (VS Code's `daemonProcess.ts`, plus the documented non-Gradle integrations) are versioned formats read by detached consumers and appear in no list |

**What the docs now say.** § 10 becomes "What is and is not enforced": `1.0.0` is a version number that ended the `0.x` free-for-all and states an intent, and it explicitly did not switch on enforcement. What genuinely holds is named — review, the deprecation cycle, and the real coverage the fixture and integration suites do have — followed by a table of what's described but missing. Each description site says the same thing locally, so a reader who lands mid-document isn't misled.

Nothing here changes behaviour or weakens a contract we were actually keeping; it stops claiming ones we weren't.

## Test plan

- Each row verified directly: `grep` for `binary-compatibility-validator` / `apiValidation` / `*.api` / `apiCheck` → nothing; `UNKNOWN` appears 4× against 31 `enum class` in `Messages.kt`; `GradleVersionCheck.kt` is the only `apply()`-time gate; `PreviewManifest` (both copies) and `HistoryEntry` have no `schemaVersion`; `MessagesTest.fixtureInventoryMatchesExpected` is a literal `setOf(...)`; `PROTOCOL_VERSION = 2` in `daemonProtocol.ts` vs the `!=` rejection at `JsonRpcServer.kt:747`.
- Anchors updated where § 10's heading changed — no `#10-status-at-10` references remain anywhere in the repo.
- Docs only; `.github/ci/format-paths.json` ignores `docs/**`, so the `format` gate is scoped out.

## Follow-ups this implies

Not in this PR, and each is additive whenever it's wanted: wire up BCV, retrofit `UNKNOWN` onto the wire enums, add the two `schemaVersion` carriers, derive the fixture inventory from the protocol surface, and either implement the N-1 window or drop it from the docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_015iYCc36RqdAi8y9MLfvKRo)_