### PR TITLE
fix(daemon): compose recording frames under the preview's locale

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -226,7 +226,7 @@ class DesktopRecordingSession(
           // diff is deferred (post-loop), to keep evidence ordering; the pixels are frozen here.
           // The
           // placeholder is FAILED so a (bug) skipped finalization fails closed.
-          val snapshot = frameBytes(state.scene.render(nanoTime = tNanos), frameIndex)
+          val snapshot = frameBytes(renderRecordingFrame(tNanos), frameIndex)
           pendingPixels.add(PendingPixelAssert(evidence.size, snapshot, e))
           evidence.add(failedEvidence(e, "assert.pixels: not evaluated"))
         } else {
@@ -236,7 +236,7 @@ class DesktopRecordingSession(
         nextEventIdx++
       }
 
-      val image = state.scene.render(nanoTime = tNanos)
+      val image = renderRecordingFrame(tNanos)
       writeFramePng(image, frameIndex, virtualTimeMs = tMs)
     }
     // Post-loop: diff each deferred assert.pixels' frozen snapshot against its baseline.
@@ -438,6 +438,19 @@ class DesktopRecordingSession(
       defaultFrameNanos = { 0L },
       settleFrame = { nanoTime -> engine.renderSettlingFrame(state, nanoTime) },
     )
+
+  /**
+   * One recording frame off the held scene, composed inside the preview's locale scope.
+   *
+   * Every `scene.render` in this class goes through here (issue #3721). A recording composes on its
+   * own playback / live-tick thread, so a bare render is two bugs at once: it can run while a
+   * *different* held session has the process-global JVM default `Locale` installed and resolve
+   * `stringResource(...)` in that session's language, and — since a recording recomposes on every
+   * dispatched input, not just at `setUp` — a **localized** recording would re-resolve its own
+   * strings at the host default from the first input onward.
+   */
+  private fun renderRecordingFrame(tNanos: Long): Image =
+    RenderEngine.withPreviewLocale(state.spec.localeTag) { state.scene.render(nanoTime = tNanos) }
 
   private fun pointerIdOrDefault(event: RecordingScriptEvent): Int = event.pointerId ?: 0
 
@@ -846,7 +859,7 @@ class DesktopRecordingSession(
           captureLiveEvent(scriptEvent)
         }
 
-        val image = state.scene.render(nanoTime = tNanos)
+        val image = renderRecordingFrame(tNanos)
         writeFramePng(image, liveFrameCount, virtualTimeMs = tMs)
         liveFrameCount++
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingLocaleTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingLocaleTest.kt
@@ -1,0 +1,127 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import java.util.Locale
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Issue #3721 — the **recording** lane composes under the preview's `localeTag`, on every frame.
+ *
+ * A recording is not one composition: it drives a virtual frame clock and renders a frame per tick,
+ * on its own playback / live-tick thread. Those renders used to call `scene.render` directly, which
+ * left them outside the locale scope entirely — so a `localeTag` recording composed its *first*
+ * frame in the target language (that one comes from `setUp`) and every frame after it at the host
+ * default, and an unlocalized recording could compose under whatever a concurrent held session had
+ * installed.
+ *
+ * The fixture recomposes per frame precisely so the frames after the first are visible here; a
+ * probe that only records on the initial composition would pass either way.
+ */
+class DesktopRecordingLocaleTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private var savedRecordingsDir: String? = null
+
+  @After
+  fun tearDown() {
+    val saved = savedRecordingsDir
+    if (saved == null) System.clearProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    else System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, saved)
+  }
+
+  @Test
+  fun every_recorded_frame_composes_under_the_preview_locale() {
+    val hostDefault = Locale.getDefault()
+    val outputDir = tempFolder.newFolder("recording-locale-renders")
+    val recordingsRoot = tempFolder.newFolder("recording-locale-root")
+    savedRecordingsDir = savedRecordingsDir ?: System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = outputDir),
+        previewSpecResolver = { previewId ->
+          if (previewId == PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "FrameTickLocaleProbeSquare",
+              widthPx = 64,
+              heightPx = 64,
+              localeTag = "de",
+              outputBaseName = PREVIEW_ID,
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      // A host default that is emphatically not the override, so "composed under de" can't be an
+      // accident of the machine the test runs on.
+      Locale.setDefault(Locale.forLanguageTag("en-US"))
+      PressLocaleProbe.reset()
+      val session =
+        host.acquireRecordingSession(
+          previewId = PREVIEW_ID,
+          recordingId = "rec-locale",
+          classLoader = DesktopRecordingLocaleTest::class.java.classLoader!!,
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+          live = false,
+        )
+      try {
+        // The script's last `tMs` is what sets the recording's length
+        // (`totalFrames = durationMs * fps / 1000 + 1`), so the late event is what makes the
+        // playback loop render a *run* of frames instead of the single one a `tMs = 0` script
+        // would produce — and the frames after the first are the whole point here.
+        session.postScript(
+          listOf(
+            RecordingScriptEvent(tMs = 0L, kind = "input.click", pixelX = 32, pixelY = 32),
+            RecordingScriptEvent(
+              tMs = SCRIPT_SPAN_MS,
+              kind = "input.click",
+              pixelX = 32,
+              pixelY = 32,
+            ),
+          )
+        )
+        session.stop()
+
+        val observed = PressLocaleProbe.observedByThread.values.flatMap { it.toList() }
+        assertTrue(
+          "the recording must have composed more than once, or a per-frame claim asserts " +
+            "nothing; saw $observed",
+          observed.size > 1,
+        )
+        assertEquals(
+          "every recorded frame must compose under the preview's localeTag; saw $observed",
+          emptyList<String>(),
+          observed.filterNot { it.startsWith("de") },
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      PressLocaleProbe.reset()
+      Locale.setDefault(hostDefault)
+      host.shutdown()
+    }
+  }
+
+  private companion object {
+    const val PREVIEW_ID = "frame-tick-locale-probe-square"
+    const val FPS = 30
+
+    /**
+     * Virtual span of the script, so playback renders ~10 frames at [FPS] rather than the single
+     * frame a `tMs = 0` script produces.
+     */
+    const val SCRIPT_SPAN_MS = 300L
+  }
+}

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -569,6 +569,30 @@ object PressLocaleProbe {
 }
 
 /**
+ * Recomposes on **every frame** and publishes the locale each one ran under to [PressLocaleProbe].
+ *
+ * [PressLocaleProbeSquare] only recomposes once, on the press — enough to say what the settling
+ * frame ran under, but silent about the frames after it. A recording renders a frame per tick and
+ * is the lane where "the composition kept running long after `setUp`" matters, so its probe has to
+ * report on every one of them.
+ */
+@Composable
+fun FrameTickLocaleProbeSquare() {
+  var tick by remember { mutableStateOf(0L) }
+  PressLocaleProbe.record()
+  LaunchedEffect(Unit) {
+    while (true) {
+      withFrameNanos { tick = it }
+    }
+  }
+  Box(
+    modifier =
+      Modifier.fillMaxSize()
+        .background(if (tick % 2L == 0L) Color(0xFFEF5350) else Color(0xFF66BB6A))
+  )
+}
+
+/**
  * Recomposes on a pointer press and publishes the locale it recomposed under to [PressLocaleProbe].
  *
  * The press-settling render is a frame like any other — it composes whatever the press invalidated


### PR DESCRIPTION
Follow-up to #3724 (it merged while I was addressing its review, so this rides a fresh branch). Part of #3721.

## The gap

#3724 routed four locale-scoped regions through the gate, and its own body argued that guarding some but not all would be worse than guarding none — then left the recording lane's frame loop out. Its three `scene.render` sites called the scene directly:

- the scripted playback frame (`DesktopRecordingSession.kt:239`)
- the `assert.pixels` snapshot (`:229`)
- the live tick loop (`:849`)

## Two bugs, not one

**The race**, in a lane the gate didn't reach. A recording composes on its own playback / live-tick thread, so an unlocalized recording could compose while another held session had its locale installed — #3718, unfixed for recordings.

**A plain correctness bug, independent of concurrency.** A recording recomposes on *every dispatched input*, not only at `setUp`. So a **localized** recording re-resolved its own strings at the host default from the first frame onward. The new test, run against the pre-fix code, records exactly that:

```
[de, en-US, en-US, en-US, en-US, en-US, en-US, en-US, en-US, de]
```

German only for the `setUp` composition and for the press-settling frame that #3711 had already routed through `renderSettlingFrame`. **Eight of ten frames of a `localeTag = "de"` recording were rendered in English.** Anyone recording a localized preview has been getting that, with no signal.

## The fix

All three sites go through one `renderRecordingFrame(tNanos)` helper, which is the whole change on the production side.

## Test plan

- **`DesktopRecordingLocaleTest`** — a `localeTag = "de"` scripted recording with the host default pinned to `en-US`; asserts every composition ran under `de`. Verified red before the fix with the output above, green after.
- The fixture matters here: **`FrameTickLocaleProbeSquare`** recomposes per frame, which is what makes the frames after the first visible at all. `PressLocaleProbeSquare` only recomposes on the press, so a probe built on it would have gone green against the broken code — the test also guards itself (`composed more than once`) so it can't silently degrade into that.
- The script spans 300 ms deliberately: `totalFrames = durationMs * fps / 1000 + 1`, so a `tMs = 0` script renders exactly one frame and proves nothing about the loop.
- `./gradlew :daemon:desktop:test` — green, full module.
- `./gradlew ktfmtFormat` — clean.

No visual change to any committed render: this fixes which language a *recording's* frames compose in, and recordings aren't part of the render corpus.

## Still open on #3721

Stage 2 (refuse a localized held session on a daemon that already holds seats) and Stage 3 (locale-keyed daemon ids). Also worth noting there, now confirmed against published bytecode: the global switch cannot be plumbed away — `Locale.current` on desktop is hardwired to `java.util.Locale.getDefault()` in both 1.11.1 and 1.12.0-rc01, and `LocalProvidableLocaleList` has no reader in any `ui` / `ui-text` / `foundation` artifact. Written up for upstream in yschimke/m3-catalog#54.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RikE7Eshj4b7fYYm1eBCPU)_