### PR TITLE
feat(design-references): publish variant bindings as secondary references

### DIFF
--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -824,8 +824,16 @@ which via `tier`:
   gates on.
 - A **secondary** is a tagged binding (`{"size": "l"}`), carrying its `slot` so a report can name
   the cell. It documents one square of the variant matrix. Worth *checking* and worth *reporting*,
-  but a size cell that drifts is not the component being wrong, so a secondary that resolves to
-  nothing is a **coverage note** rather than a warning and never fails the export.
+  but a size cell that drifts is not the component being wrong — so **everything a secondary has to
+  say is a coverage note**, never a warning: whether it maps to no sticker, cannot be paired to a
+  `previewId`, or fails to rasterize (a Figma node the run's token can't reach). One unrenderable
+  size cell must not cost the catalog every reference it did resolve.
+
+A binding that is dropped is always *named*. The two arrays are authored independently, so drift is
+reported from both sides — a tagged `ref` with no `previewId` in the same slot, and a tagged
+`previewId` no `ref` claims. Skipping one silently would let the run report complete secondary
+coverage while omitting cells the author wrote down, which is the failure the per-lane tally exists
+to prevent.
 
 A secondary joins on its own `previewId`, not on the function name the primary uses — an
 `@OverrideVariant` cell shares its base's `@Preview` function, so the function index cannot tell

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -829,6 +829,12 @@ which via `tier`:
   `previewId`, or fails to rasterize (a Figma node the run's token can't reach). One unrenderable
   size cell must not cost the catalog every reference it did resolve.
 
+`tier` is load-bearing beyond the export, too: the parity feed derives its `UNRENDERED_REFERENCE`
+gap from the reference manifest, and every record of one entry — the default and each of its cells
+— carries the same code handle. Only a **primary** answers "does this component have its
+reference?", or a surviving `size=l` cell would report the component as covered while its default
+render had no spec at all.
+
 A binding that is dropped is always *named*. The two arrays are authored independently, so drift is
 reported from both sides — a tagged `ref` with no `previewId` in the same slot, and a tagged
 `previewId` no `ref` claims. Skipping one silently would let the run report complete secondary

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -812,6 +812,38 @@ gets filename-sanitized on its way into a bundle, while the function name is the
 files already agree on. A design-map entry that maps to no published sticker is a warning, not an
 error — a repo may map more components for its own parity run than it publishes.
 
+#### Primary and secondary references
+
+design-parity lets one code component bind an **array** of refs — the untagged default plus one per
+authored `state` / `size` / `theme`. Those bindings are not peers, and the manifest says which is
+which via `tier`:
+
+- The **primary** is the untagged binding: the component's default render, the picture a reader
+  forms of the component, and the one a divergence is least excusable in. Exactly one is required
+  — an ambiguous or all-tagged array is refused rather than guessed at — and it is what `--strict`
+  gates on.
+- A **secondary** is a tagged binding (`{"size": "l"}`), carrying its `slot` so a report can name
+  the cell. It documents one square of the variant matrix. Worth *checking* and worth *reporting*,
+  but a size cell that drifts is not the component being wrong, so a secondary that resolves to
+  nothing is a **coverage note** rather than a warning and never fails the export.
+
+A secondary joins on its own `previewId`, not on the function name the primary uses — an
+`@OverrideVariant` cell shares its base's `@Preview` function, so the function index cannot tell
+`xs` from the default render and would bind every cell to the same sticker.
+
+Before this split the driver published the primary and dropped the rest, so m3-catalog's variant
+renders had nothing to diff against even though `design-map.json` had bound every one of them to
+its kit node: **78 references for 78 components, and none for the 345 variant bindings beside
+them**. The Figma rasterizer batches 50 node ids per request, so publishing those costs single-digit
+extra REST calls rather than one per reference.
+
+The export reports the two lanes separately:
+
+```
+design-references: published 423/423 reference(s) to references/ — 78/78 primary,
+  345/345 secondary (0 warning(s), 0 coverage note(s))
+```
+
 Pixels come from, in precedence order: a pre-rendered PNG under `--reference-images` (for a repo
 that already rasterizes references in an earlier job), a committed `.html` mock rasterized with
 Playwright's Chromium against the fonts the workflow already staged, a committed `.png`, or a

--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -349,7 +349,7 @@ function narrowToMappedPreviewId(matches, mappedPreviewId, fn, warnings) {
  * so m3-catalog's 446 variant renders — the entire size x shape matrix — had nothing to diff
  * against even though `design-map.json` had bound every one of them to its kit node.
  */
-function designBindings(entry, warnings) {
+function designBindings(entry, warnings, notes) {
   const tagOf = (item) =>
     item && typeof item === "object"
       ? Object.fromEntries(
@@ -373,18 +373,44 @@ function designBindings(entry, warnings) {
 
   const refs = Array.isArray(entry.ref) ? entry.ref : [];
   const previewIds = Array.isArray(entry.previewId) ? entry.previewId : [];
+  const label = functionNameOf(entry?.code) ?? entry?.code ?? "?";
+  const matchedSlots = [];
   for (const ref of refs) {
     if (isUntagged(ref)) continue;
     const slot = tagOf(ref);
     // Pair by slot, not by position: the two arrays are written independently and design-parity
     // does not promise they are ordered alike.
     const mate = previewIds.find((p) => sameSlot(tagOf(p), slot));
+    matchedSlots.push(slot);
     const refUri = typeof ref === "string" ? ref : ref?.ref;
     const previewId = typeof mate === "string" ? mate : mate?.previewId;
-    if (typeof refUri !== "string" || !refUri || typeof previewId !== "string" || !previewId) {
+    // A binding that cannot be paired is DROPPED — and a drop has to be said out loud. The tally
+    // downstream counts emitted records, so a silent skip would report complete secondary coverage
+    // while quietly omitting a cell the author wrote down. Silent truncation reading as full
+    // coverage is the failure this lane is meant to end, not one to reintroduce a level down.
+    if (typeof refUri !== "string" || !refUri) {
+      notes.push(`${label} [${describeSlot(slot)}]: tagged ref is not a usable reference handle`);
+      continue;
+    }
+    if (typeof previewId !== "string" || !previewId) {
+      notes.push(
+        `${label} [${describeSlot(slot)}]: tagged ref has no previewId binding in the same slot, ` +
+          `so there is no sticker to compare it against`,
+      );
       continue;
     }
     bindings.push({ entry: { ...entry, ref: refUri, previewId }, tier: "secondary", slot });
+  }
+  // …and the mirror case: a tagged previewId whose slot no ref claims. The arrays are authored
+  // independently, so drift shows up from either side.
+  for (const mate of previewIds) {
+    const slot = tagOf(mate);
+    if (Object.keys(slot).length === 0) continue;
+    if (matchedSlots.some((claimed) => sameSlot(claimed, slot))) continue;
+    notes.push(
+      `${label} [${describeSlot(slot)}]: previewId binding has no ref in the same slot, ` +
+        `so there is no design node to compare against`,
+    );
   }
   return bindings;
 }
@@ -469,7 +495,7 @@ export function planDesignReferences({ designMap, spec, catalog }) {
   const ordinals = new Map();
 
   for (const rawEntry of designMap?.components ?? []) {
-    for (const binding of designBindings(rawEntry, warnings)) {
+    for (const binding of designBindings(rawEntry, warnings, notes)) {
     const { entry, tier, slot } = binding;
     // A secondary never fails the run; its misses are coverage notes.
     const report = tier === "primary" ? warnings : notes;

--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -330,17 +330,81 @@ function narrowToMappedPreviewId(matches, mappedPreviewId, fn, warnings) {
 }
 
 /**
- * Reduce a variant-aware design-map entry to the untagged binding the catalog overview publishes.
+ * Split a variant-aware design-map entry into its **primary** binding and its **secondary** ones.
  *
  * design-parity accepts `ref` / `previewId` arrays so one code component can bind every authored
- * state, size and theme. The catalog reference lane currently publishes one inert raster per
- * component, however, and historically understood only scalar bindings. Treating an array as a
- * raster handle made the whole entry fail-soft out of the bundle, which made adding exact parity
- * coverage remove the component's previously published reference.
+ * state, size and theme. Those bindings are not peers:
  *
- * The untagged item is the array form's default binding. Publish that one here; the parity workflow
- * continues to consume the complete arrays directly. Refuse ambiguous or all-tagged arrays instead
- * of guessing which state represents the component.
+ * * The **untagged** item is the component's default render — the picture a reader forms of the
+ *   component, and the one a divergence is least excusable in. It is the primary, and it is what
+ *   `--strict` gates on. Exactly one is required; an ambiguous or all-tagged array is refused
+ *   rather than guessed at, because picking a state to stand for the component is not a decision
+ *   this driver can make.
+ * * Every **tagged** item — `{size: "l"}`, `{state: "xs-square"}` — is a secondary. A size cell
+ *   that drifts is worth reporting, but it is not the component being wrong, and a run must not
+ *   fail over one. So secondaries are planned, rasterised and published like any other reference,
+ *   and their misses land in `notes` rather than `warnings`.
+ *
+ * That split is the whole point: before it, the driver published the primary and dropped the rest,
+ * so m3-catalog's 446 variant renders — the entire size x shape matrix — had nothing to diff
+ * against even though `design-map.json` had bound every one of them to its kit node.
+ */
+function designBindings(entry, warnings) {
+  const tagOf = (item) =>
+    item && typeof item === "object"
+      ? Object.fromEntries(
+          ["state", "theme", "size"].filter((k) => item[k]).map((k) => [k, item[k]]),
+        )
+      : {};
+  const isUntagged = (item) => Object.keys(tagOf(item)).length === 0;
+
+  // A scalar entry is a lone primary — the shape every design-map had before arrays existed.
+  if (!Array.isArray(entry?.ref) && !Array.isArray(entry?.previewId)) {
+    const primary = primaryDesignBinding(entry, warnings);
+    return primary ? [{ entry: primary, tier: "primary", slot: {} }] : [];
+  }
+
+  const primary = primaryDesignBinding(entry, warnings);
+  const bindings = primary ? [{ entry: primary, tier: "primary", slot: {} }] : [];
+  // A refused primary takes its secondaries with it: without the untagged binding there is no
+  // agreement about what the component *is*, and publishing its size cells alone would put a
+  // matrix on the page under a component that has no reference of its own.
+  if (!primary) return bindings;
+
+  const refs = Array.isArray(entry.ref) ? entry.ref : [];
+  const previewIds = Array.isArray(entry.previewId) ? entry.previewId : [];
+  for (const ref of refs) {
+    if (isUntagged(ref)) continue;
+    const slot = tagOf(ref);
+    // Pair by slot, not by position: the two arrays are written independently and design-parity
+    // does not promise they are ordered alike.
+    const mate = previewIds.find((p) => sameSlot(tagOf(p), slot));
+    const refUri = typeof ref === "string" ? ref : ref?.ref;
+    const previewId = typeof mate === "string" ? mate : mate?.previewId;
+    if (typeof refUri !== "string" || !refUri || typeof previewId !== "string" || !previewId) {
+      continue;
+    }
+    bindings.push({ entry: { ...entry, ref: refUri, previewId }, tier: "secondary", slot });
+  }
+  return bindings;
+}
+
+/** A slot tag as a reader sees it in a report line: `size=l`, `state=xs-square, theme=dark`. */
+function describeSlot(slot) {
+  const parts = Object.entries(slot ?? {}).map(([k, v]) => `${k}=${v}`);
+  return parts.length > 0 ? parts.join(", ") : "default";
+}
+
+/** Whether two slot tags name the same cell. */
+function sameSlot(a, b) {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) if (a[key] !== b[key]) return false;
+  return keys.size > 0;
+}
+
+/**
+ * Reduce a variant-aware design-map entry to the untagged binding — see [designBindings], which
+ * layers the secondary bindings around this.
  */
 function primaryDesignBinding(entry, warnings) {
   const primary = (value, field) => {
@@ -394,6 +458,10 @@ function primaryDesignBinding(entry, warnings) {
  */
 export function planDesignReferences({ designMap, spec, catalog }) {
   const warnings = [];
+  // Secondary-coverage observations. Kept apart from [warnings] because `--strict` gates on those:
+  // a size cell the kit has no node for is a coverage fact to report, not a reason to fail the
+  // export and cost the catalog every reference it *did* resolve.
+  const notes = [];
   const records = [];
   const index = imagesByPreviewFunction(spec, catalog);
   // Only built when the spec-driven index yields nothing for an entry — see [imagesByPreviewId].
@@ -401,25 +469,41 @@ export function planDesignReferences({ designMap, spec, catalog }) {
   const ordinals = new Map();
 
   for (const rawEntry of designMap?.components ?? []) {
-    const entry = primaryDesignBinding(rawEntry, warnings);
-    if (!entry) continue;
+    for (const binding of designBindings(rawEntry, warnings)) {
+    const { entry, tier, slot } = binding;
+    // A secondary never fails the run; its misses are coverage notes.
+    const report = tier === "primary" ? warnings : notes;
+    const where = tier === "primary" ? "" : ` [${describeSlot(slot)}]`;
     const fn = functionNameOf(entry?.code);
     if (!fn) {
-      warnings.push(`design-map entry has no 'path#Member' code handle: ${entry?.code ?? "?"}`);
+      report.push(`design-map entry has no 'path#Member' code handle: ${entry?.code ?? "?"}`);
       continue;
     }
     // Function name first — it is the join a spec-led catalog needs, and it stays authoritative
     // where a spec exists. An annotation-led catalog has no `groups` for that index to walk, so
     // fall back to the entry's own `previewId`, which the export stamps on every catalog image.
-    let allMatches = index.get(fn);
+    //
+    // A SECONDARY inverts that: it is defined by its `previewId` and nothing else. The function
+    // index is keyed by the entry's code handle, which every binding of the entry shares, so a
+    // secondary that fell back to it would bind its size cell to the PRIMARY's sticker — and
+    // publish a reference for `xs` against the default render, which is worse than no reference
+    // at all because it scores as a divergence nobody introduced.
+    let allMatches;
     let joinedOnPreviewId = false;
-    if ((!allMatches || allMatches.length === 0) && typeof entry?.previewId === "string") {
-      allMatches = matchesForPreviewId(byPreviewId, entry.previewId);
+    if (tier === "secondary") {
+      allMatches =
+        typeof entry?.previewId === "string" ? matchesForPreviewId(byPreviewId, entry.previewId) : [];
       joinedOnPreviewId = allMatches.length > 0;
+    } else {
+      allMatches = index.get(fn);
+      if ((!allMatches || allMatches.length === 0) && typeof entry?.previewId === "string") {
+        allMatches = matchesForPreviewId(byPreviewId, entry.previewId);
+        joinedOnPreviewId = allMatches.length > 0;
+      }
     }
     if (!allMatches || allMatches.length === 0) {
-      warnings.push(
-        `design-map '${fn}' matches no published sticker — no catalog.spec.json ` +
+      report.push(
+        `design-map '${fn}'${where} matches no published sticker — no catalog.spec.json ` +
           `preview names that @Preview function, no published image carries its previewId, ` +
           `or its component rendered nothing`,
       );
@@ -429,7 +513,7 @@ export function planDesignReferences({ designMap, spec, catalog }) {
     // field is a no-op at best; skip it so the intent reads once.
     const matches = joinedOnPreviewId
       ? allMatches
-      : narrowToMappedPreviewId(allMatches, entry?.previewId, fn, warnings);
+      : narrowToMappedPreviewId(allMatches, entry?.previewId, fn, report);
     if (matches.length === 0) continue;
     for (const { componentId, image, specComponent } of matches) {
       const previewId = servePreviewId(image.path);
@@ -440,6 +524,12 @@ export function planDesignReferences({ designMap, spec, catalog }) {
         id,
         previewId,
         label: `${componentId} — ${entry.source ?? "design"}`,
+        // Which lane this reference sits in. The primary is the component's default render and the
+        // one `--strict` gates on; a secondary documents one cell of its variant matrix and is
+        // reported rather than enforced. Consumers that only ever showed one reference per
+        // component can filter on it; older readers ignore it and see the set they always did.
+        tier,
+        ...(tier === "secondary" ? { slot } : {}),
         raster: {
           path: `${REFERENCES_DIR}/${id}.png`,
           width: image.width,
@@ -473,8 +563,9 @@ export function planDesignReferences({ designMap, spec, catalog }) {
       if (entry.ref) record.source.uri = entry.ref;
       records.push(record);
     }
+    }
   }
-  return { records, warnings };
+  return { records, warnings, notes };
 }
 
 /**

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -259,7 +259,7 @@ test("planDesignReferences maps design-map entries onto serve preview ids", () =
   assert.equal(records[1].origin.ref, "design/ContactChat.dark.html");
 });
 
-test("planDesignReferences publishes the untagged binding from variant arrays", () => {
+test("planDesignReferences publishes the untagged binding as the primary", () => {
   const designMap = {
     components: [
       {
@@ -283,13 +283,107 @@ test("planDesignReferences publishes the untagged binding from variant arrays", 
   const { records, warnings } = planDesignReferences({ designMap, spec: SPEC, catalog: CATALOG });
 
   assert.deepEqual(warnings, []);
-  assert.equal(records.length, 1);
-  assert.equal(records[0].origin.ref, "figma:abc/73:5");
-  assert.equal(
-    records[0].origin.previewId,
-    "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview",
-  );
-  assert.equal(records[0].source.uri, "figma:abc/73:5");
+  // The untagged binding leads and is the primary — the component's default render, and the one
+  // `--strict` gates on. Its id and ordinal are unchanged by the secondaries beside it.
+  const primary = records.find((r) => r.tier === "primary");
+  assert.equal(primary.origin.ref, "figma:abc/73:5");
+  assert.equal(primary.origin.previewId, "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview");
+  assert.equal(primary.source.uri, "figma:abc/73:5");
+  assert.equal(primary.slot, undefined);
+});
+
+// The m3-catalog shape: annotation-led (no spec `groups`), so images carry the discovery
+// `previewId` and an `@OverrideVariant` cell shares its base's @Preview FUNCTION name. That
+// sharing is why a secondary has to join on its previewId — the function name cannot tell the
+// `xs` cell from the default render.
+const MATRIX_CATALOG = {
+  components: [
+    {
+      componentId: "Button/Filled",
+      images: [
+        {
+          path: "images/button-filled/ideal__default__light.png",
+          state: "default",
+          theme: "light",
+          previewId: "ee.m3.ButtonsKt.FilledButton_Light",
+          width: 100,
+          height: 40,
+        },
+        {
+          path: "images/button-filled/ideal__xs.png",
+          state: "xs",
+          previewId: "ee.m3.ButtonsKt.FilledButton_Light_VARIANT_xs",
+          width: 80,
+          height: 32,
+        },
+      ],
+    },
+  ],
+};
+
+const MATRIX_MAP = {
+  components: [
+    {
+      code: "catalog/src/main/kotlin/sections/Buttons.kt#FilledButton",
+      source: "figma",
+      ref: [{ ref: "figma:abc/1:1" }, { ref: "figma:abc/1:2", size: "xs" }],
+      previewId: [
+        { previewId: "ee.m3.ButtonsKt.FilledButton_Light" },
+        { previewId: "ee.m3.ButtonsKt.FilledButton_Light_VARIANT_xs", size: "xs" },
+      ],
+    },
+  ],
+};
+
+test("planDesignReferences publishes each tagged binding as a secondary against its own sticker", () => {
+  const { records, warnings, notes } = planDesignReferences({
+    designMap: MATRIX_MAP,
+    spec: {},
+    catalog: MATRIX_CATALOG,
+  });
+
+  assert.deepEqual(warnings, []);
+  assert.deepEqual(notes, []);
+
+  const primary = records.find((r) => r.tier === "primary");
+  assert.equal(primary.previewId, "button-filled__ideal__default__light");
+  assert.equal(primary.origin.ref, "figma:abc/1:1");
+  assert.equal(primary.slot, undefined);
+
+  const secondary = records.filter((r) => r.tier === "secondary");
+  assert.equal(secondary.length, 1);
+  assert.equal(secondary[0].origin.ref, "figma:abc/1:2");
+  assert.deepEqual(secondary[0].slot, { size: "xs" });
+  // The whole point: it binds the `xs` sticker, NOT the default render the function name would
+  // have handed it.
+  assert.equal(secondary[0].previewId, "button-filled__ideal__xs");
+});
+
+test("a secondary that maps to no sticker is a note, never a warning", () => {
+  const designMap = {
+    components: [
+      {
+        ...MATRIX_MAP.components[0],
+        previewId: [
+          { previewId: "ee.m3.ButtonsKt.FilledButton_Light" },
+          { previewId: "ee.m3.ButtonsKt.FilledButton_Light_VARIANT_nope", size: "xs" },
+        ],
+      },
+    ],
+  };
+
+  const { records, warnings, notes } = planDesignReferences({
+    designMap,
+    spec: {},
+    catalog: MATRIX_CATALOG,
+  });
+
+  // `--strict` gates on warnings, and a missing size cell must not cost the catalog its primary.
+  assert.deepEqual(warnings, []);
+  assert.equal(notes.length, 1);
+  assert.match(notes[0], /size=xs/);
+  assert.equal(records.filter((r) => r.tier === "primary").length, 1);
+  assert.equal(records.filter((r) => r.tier === "secondary").length, 0);
 });
 
 test("planDesignReferences accepts string defaults in variant arrays", () => {
@@ -313,12 +407,9 @@ test("planDesignReferences accepts string defaults in variant arrays", () => {
   const { records, warnings } = planDesignReferences({ designMap, spec: SPEC, catalog: CATALOG });
 
   assert.deepEqual(warnings, []);
-  assert.equal(records.length, 1);
-  assert.equal(records[0].origin.ref, "figma:abc/73:5");
-  assert.equal(
-    records[0].origin.previewId,
-    "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview",
-  );
+  const primary = records.find((r) => r.tier === "primary");
+  assert.equal(primary.origin.ref, "figma:abc/73:5");
+  assert.equal(primary.origin.previewId, "ee.components.ui.ChatBodyPreviewsKt.ContactChatPreview");
 });
 
 test("planDesignReferences warns before dropping invalid scalar and array refs", () => {

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -359,6 +359,43 @@ test("planDesignReferences publishes each tagged binding as a secondary against 
   assert.equal(secondary[0].previewId, "button-filled__ideal__xs");
 });
 
+test("a tagged binding that cannot be paired is reported, not silently dropped", () => {
+  const designMap = {
+    components: [
+      {
+        code: "catalog/src/main/kotlin/sections/Buttons.kt#FilledButton",
+        source: "figma",
+        ref: [
+          { ref: "figma:abc/1:1" },
+          { ref: "figma:abc/1:2", size: "xs" },
+          // Authored, but the previewId array never names this slot.
+          { ref: "figma:abc/1:3", size: "xl" },
+        ],
+        previewId: [
+          { previewId: "ee.m3.ButtonsKt.FilledButton_Light" },
+          { previewId: "ee.m3.ButtonsKt.FilledButton_Light_VARIANT_xs", size: "xs" },
+          // …and the mirror: a previewId slot no ref claims.
+          { previewId: "ee.m3.ButtonsKt.FilledButton_Light_VARIANT_l", size: "l" },
+        ],
+      },
+    ],
+  };
+
+  const { records, warnings, notes } = planDesignReferences({
+    designMap,
+    spec: {},
+    catalog: MATRIX_CATALOG,
+  });
+
+  assert.deepEqual(warnings, []);
+  // Both directions of drift are named. Without this the run would report "1/1 secondary, 0 notes"
+  // — complete coverage — while having dropped two authored bindings on the floor.
+  assert.equal(notes.length, 2);
+  assert.ok(notes.some((n) => n.includes("size=xl") && n.includes("no previewId binding")));
+  assert.ok(notes.some((n) => n.includes("size=l") && n.includes("no ref in the same slot")));
+  assert.equal(records.filter((r) => r.tier === "secondary").length, 1);
+});
+
 test("a secondary that maps to no sticker is a note, never a warning", () => {
   const designMap = {
     components: [

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -88,6 +88,24 @@ const warn = (message) => {
   console.log(`::warning::design-references: ${message}`);
 };
 
+// Coverage notes: everything a SECONDARY reference has to say. Kept out of [warnings] because
+// `--strict` gates on those, and the primary/secondary contract is that a variant cell can go
+// missing without failing the export — otherwise one unrenderable size cell costs the catalog every
+// reference it did resolve, which is the trade this lane was capped by to begin with.
+const notes = [];
+const note = (message) => {
+  notes.push(message);
+  console.log(`design-references: note: ${message}`);
+};
+
+/**
+ * Report something about ONE record, routed by its tier: a primary's trouble is a warning the
+ * export can be gated on, a secondary's is a note. Every per-record report goes through here so the
+ * routing cannot be forgotten at one call site and silently re-gate the run.
+ */
+const warnFor = (record, message) =>
+  record?.tier === "secondary" ? note(message) : warn(message);
+
 function readJson(file, { comments = false } = {}) {
   const text = fs.readFileSync(file, "utf8");
   return JSON.parse(comments ? stripComments(text) : text);
@@ -141,7 +159,7 @@ planWarnings.forEach(warn);
 // the component's problem. Failing the export over one would cost the catalog every reference it
 // did resolve, which is the trade that capped this lane at one reference per component to begin
 // with.
-planNotes.forEach((note) => console.log(`design-references: note: ${note}`));
+planNotes.forEach(note);
 
 if (records.length === 0) {
   console.log("design-references: no design-map entry maps to a published sticker; nothing to do");
@@ -243,14 +261,14 @@ async function sourceRaster(record) {
   if (typeof ref === "string" && ref.toLowerCase().endsWith(".png")) {
     const file = path.resolve(REPO, ref);
     if (fs.existsSync(file)) return readPng(file);
-    warn(`${record.id}: committed PNG ${ref} is missing`);
+    warnFor(record, `${record.id}: committed PNG ${ref} is missing`);
     return null;
   }
 
   if (typeof ref === "string" && ref.toLowerCase().endsWith(".html")) {
     const file = path.resolve(REPO, ref);
     if (!fs.existsSync(file)) {
-      warn(`${record.id}: HTML reference ${ref} is missing`);
+      warnFor(record, `${record.id}: HTML reference ${ref} is missing`);
       return null;
     }
     return rasterizeHtml(file, target);
@@ -258,13 +276,13 @@ async function sourceRaster(record) {
 
   if (parseFigmaRef(ref)) {
     if (!FIGMA_TOKEN) {
-      warn(`${record.id}: skipping figma reference ${ref} — no FIGMA_TOKEN in this run`);
+      warnFor(record, `${record.id}: skipping figma reference ${ref} — no FIGMA_TOKEN in this run`);
       return null;
     }
     return figmaRasterizerFor(referenceContentsOnly(record)).rasterize(ref, target);
   }
 
-  warn(`${record.id}: don't know how to rasterise a '${source}' reference from '${ref}'`);
+  warnFor(record, `${record.id}: don't know how to rasterise a '${source}' reference from '${ref}'`);
   return null;
 }
 
@@ -296,7 +314,7 @@ function referenceDensity(record) {
   const density = record.origin?.density;
   if (density === undefined) return undefined;
   if (typeof density !== "number" || !Number.isFinite(density) || density <= 0) {
-    warn(`${record.id}: ignoring density '${density}' — it must be a positive number`);
+    warnFor(record, `${record.id}: ignoring density '${density}' — it must be a positive number`);
     return undefined;
   }
   return density;
@@ -327,7 +345,7 @@ for (const record of records) {
   try {
     raster = await sourceRaster(record);
   } catch (error) {
-    warn(`${record.id}: ${error.message}`);
+    warnFor(record, `${record.id}: ${error.message}`);
     raster = null;
   }
   if (!raster) {
@@ -363,7 +381,7 @@ for (const record of records) {
       const message =
         `${record.id}: placing density-matched reference ${raster.width}x${raster.height} ` +
         `on ${target.width}x${target.height} canvas`;
-      if (reduced) warn(`${message} (too large; reduced to fit)`);
+      if (reduced) warnFor(record, `${message} (too large; reduced to fit)`);
       else console.log(`design-references: ${message}`);
       raster = { width: target.width, height: target.height, data: placed.data };
     } else {
@@ -387,7 +405,8 @@ for (const record of records) {
         const fitted = fitRgba(raster.data, raster.width, raster.height, target.width, target.height);
         placement = fitted.box;
         if (fitted.box.width !== target.width || fitted.box.height !== target.height) {
-          warn(
+          warnFor(
+            record,
             `${message} (letterboxed to ${fitted.box.width}x${fitted.box.height} — the reference's ` +
               `proportions differ from the sticker's)`,
           );
@@ -465,7 +484,7 @@ console.log(
   `design-references: published ${written}/${records.length} reference(s) to ` +
     `${REFERENCES_DIR}/ — ${primary.published}/${primary.planned} primary, ` +
     `${secondary.published}/${secondary.planned} secondary ` +
-    `(${warnings.length} warning(s), ${planNotes.length} coverage note(s))`,
+    `(${warnings.length} warning(s), ${notes.length} coverage note(s))`,
 );
 if (secondary.planned === 0 && records.length > 0) {
   console.log(

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -130,8 +130,18 @@ if (drift.length > 0) {
   process.exit(1);
 }
 
-const { records, warnings: planWarnings } = planDesignReferences({ designMap, spec, catalog });
+const {
+  records,
+  warnings: planWarnings,
+  notes: planNotes,
+} = planDesignReferences({ designMap, spec, catalog });
 planWarnings.forEach(warn);
+// Secondary-coverage observations. Printed, never counted as warnings: `--strict` exists to stop a
+// catalog publishing a WRONG primary, and a size cell the kit has no node for is neither wrong nor
+// the component's problem. Failing the export over one would cost the catalog every reference it
+// did resolve, which is the trade that capped this lane at one reference per component to begin
+// with.
+planNotes.forEach((note) => console.log(`design-references: note: ${note}`));
 
 if (records.length === 0) {
   console.log("design-references: no design-map entry maps to a published sticker; nothing to do");
@@ -443,10 +453,26 @@ fs.writeFileSync(
 
 writeReferenceAnnotations();
 
+// Report the two lanes separately. A run that publishes 78 primaries and 300 secondaries has very
+// different coverage from one that publishes 78 and none, and the single total hid that.
+const tallyOf = (tier) => {
+  const of = records.filter((r) => r.tier === tier);
+  return { planned: of.length, published: of.filter((r) => r.rastered !== false).length };
+};
+const primary = tallyOf("primary");
+const secondary = tallyOf("secondary");
 console.log(
   `design-references: published ${written}/${records.length} reference(s) to ` +
-    `${REFERENCES_DIR}/ (${warnings.length} warning(s))`,
+    `${REFERENCES_DIR}/ — ${primary.published}/${primary.planned} primary, ` +
+    `${secondary.published}/${secondary.planned} secondary ` +
+    `(${warnings.length} warning(s), ${planNotes.length} coverage note(s))`,
 );
+if (secondary.planned === 0 && records.length > 0) {
+  console.log(
+    "design-references: no secondary references — every design-map entry binds a single " +
+      "scalar ref, so only each component's default render has a spec to diff against.",
+  );
+}
 
 if (written === 0) {
   // Nothing to serve: leave no half-empty directory behind for the branch to carry.

--- a/scripts/design-artifacts/parity-activity.mjs
+++ b/scripts/design-artifacts/parity-activity.mjs
@@ -365,6 +365,13 @@ export function mappingGaps({
   if (referenceManifest) {
     const published = new Set(
       (referenceManifest.references ?? [])
+        // Only a PRIMARY answers "does this component have its reference?". Every record of an
+        // entry — the default binding and each of its size/state cells — carries the same `code`
+        // handle, so counting secondaries would let a surviving `size=l` cell mask a missing
+        // default render: the gap would go quiet precisely when the binding it exists to protect
+        // is the one that failed. A manifest written before tiers existed carries no `tier`, and
+        // every record in it was a primary.
+        .filter((r) => (r?.tier ?? "primary") === "primary")
         .map((r) => r?.source?.attributes?.code)
         .filter((code) => typeof code === "string"),
     );

--- a/scripts/design-artifacts/parity-activity.test.mjs
+++ b/scripts/design-artifacts/parity-activity.test.mjs
@@ -456,6 +456,63 @@ test("a sanitised catalog id is not mistaken for a dangling mapping", () => {
   );
 });
 
+test("a surviving secondary does not mask a primary that failed to rasterise", () => {
+  // Every record of one entry — the default binding and each of its size/state cells — carries the
+  // same `code` handle. Keyed on the handle alone, a published `size=l` cell would answer "yes,
+  // this component has its reference" while the DEFAULT render had none, silencing the gap exactly
+  // where it matters most.
+  const designMap = {
+    components: [
+      {
+        code: "ui/Foo.kt#Bar",
+        ref: [{ ref: "figma:abc/1:1" }, { ref: "figma:abc/1:2", size: "l" }],
+        previewId: [{ previewId: "pkg.FooKt.Bar" }, { previewId: "pkg.FooKt.Bar_L", size: "l" }],
+      },
+    ],
+  };
+  const secondaryOnly = {
+    references: [
+      { tier: "secondary", slot: { size: "l" }, source: { attributes: { code: "ui/Foo.kt#Bar" } } },
+    ],
+  };
+
+  assert.deepEqual(
+    mappingGaps({
+      designMap,
+      catalogPreviewIds: ["pkg.FooKt.Bar", "pkg.FooKt.Bar_L"],
+      referenceManifest: secondaryOnly,
+    }).map((g) => g.kind),
+    [GAP_KINDS.UNRENDERED_REFERENCE],
+    "a secondary alone leaves the primary's absence reported",
+  );
+
+  // With the primary present the gap closes, whatever its secondaries did.
+  assert.deepEqual(
+    mappingGaps({
+      designMap,
+      catalogPreviewIds: ["pkg.FooKt.Bar", "pkg.FooKt.Bar_L"],
+      referenceManifest: {
+        references: [
+          { tier: "primary", source: { attributes: { code: "ui/Foo.kt#Bar" } } },
+          ...secondaryOnly.references,
+        ],
+      },
+    }),
+    [],
+  );
+
+  // A manifest written before tiers existed carries none, and every record in it was a primary.
+  assert.deepEqual(
+    mappingGaps({
+      designMap,
+      catalogPreviewIds: ["pkg.FooKt.Bar", "pkg.FooKt.Bar_L"],
+      referenceManifest: { references: [{ source: { attributes: { code: "ui/Foo.kt#Bar" } } }] },
+    }),
+    [],
+    "an untiered record still counts as the primary it was",
+  );
+});
+
 test("no reference manifest means no derived gaps — absent is not the same as empty", () => {
   const gaps = mappingGaps({
     designMap,


### PR DESCRIPTION
## Summary

A design-map entry may bind an **array** of refs — the untagged default plus one per authored `state` / `size` / `theme` — and the driver published only the untagged one. So m3-catalog ships **78 references for 78 components and nothing for the 345 variant bindings beside them**: the entire size × shape matrix has no spec to diff against, even though `design-map.json` had bound every cell to its kit node and design-parity's own run was already comparing them.

The collapse was a compatibility shim, not a decision. Arrays arrived after this lane did, and treating one as a raster handle failed the whole entry out of the bundle — so adding exact parity coverage would have *removed* a component's existing reference. Picking the untagged item stopped that, and capped the lane at one reference per component.

## The split

The bindings aren't peers, so this separates them rather than flattening them:

| | Primary | Secondary |
|---|---|---|
| Which binding | the untagged one | each tagged one (`{"size": "l"}`) |
| What it is | the component's default render | one square of the variant matrix |
| How many | exactly one, refused if ambiguous | any number, `slot` recorded |
| A miss is | a **warning** — `--strict` gates on it | a **coverage note** — never fails the export |

That's the point of the tiering: a size cell that drifts is worth reporting, but it isn't the component being wrong, and it must not cost the catalog every reference it *did* resolve.

A secondary joins on its own `previewId` rather than the function name the primary uses. An `@OverrideVariant` cell shares its base's `@Preview` function, so the function index can't tell `xs` from the default render — falling back to it bound every cell to the primary's sticker, publishing an `xs` reference against the default render. That scores as a divergence nobody introduced, which is worse than no reference at all. A test asserts the secondary binds its own sticker.

## Measured against the real published catalog

Planner run over the live `design-artifacts/m3-catalog` catalog and m3-catalog's `design-map.json`:

```
primary:   78          ← unchanged, same ids, same pixels
secondary: 345         ← was 0
warnings:  0
notes:     0
```

```
button-filled references (11):
  primary   button-filled__ideal__default__light   figma:ocdac…/57994:2324
  secondary button-filled__ideal__xs               figma:ocdac…/57994:2326
  secondary button-filled__ideal__xs-square        figma:ocdac…/57994:2316
  secondary button-filled__ideal__m                figma:ocdac…/57994:2322
  …                                                (11 cells, each its own node)
```

Every cell binds its own sticker and its own kit node — `xs` → `57994:2326`, which is `Type=Round, Size=XSmall, State=Enabled` in the kit.

## Cost

Lower than I first estimated. The Figma rasterizer batches **50 node ids per request**, so 78 → 423 nodes is roughly 2 → 9 REST calls, not one per reference.

## Compatibility

- **Primary records are byte-identical** — same id, same ordinal, same origin, same pixels. A catalog that publishes no arrays is completely unaffected, and the export says so explicitly when it finds no secondaries.
- `tier` and `slot` are additive manifest fields. `ServeDesignReferences.kt` parses with `ignoreUnknownKeys = true`, so an older server serves them as ordinary references — which is the desired behaviour: each variant sticker gets its spec in the compare lane.

## Test plan

- `node --test scripts/design-artifacts/design-references.test.mjs` — 32 pass, 0 fail (was 30).
- Two new cases: a tagged binding publishes as a secondary **against its own sticker** (fixture in the annotation-led m3-catalog shape, where the function name is shared and so can't discriminate); and a secondary that maps to nothing lands in `notes` with `warnings` empty and the primary still published.
- Two existing cases renamed and re-pointed from "only the untagged one is published" to the new contract.
- Full driver suite: 600 pass / 5 fail, and the same 5 fail on a clean tree (missing optional deps — `pngjs`, the `catalog-export` package). No new failures.

## Not in this PR

The viewer doesn't yet *show* the tier — a secondary appears as an ordinary reference. The manifest carries the field, so badging or filtering the matrix in the compare lane is a follow-up rather than a blocker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CiA5Tw6bNjcy9dUQtXD7tY)_