### PR TITLE
fix(cli): narrow the Gradle render to the previews --id/--filter names

### DIFF
--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -71,8 +71,11 @@ class GradleConnection(
      * render with a longer budget finished. A timeout that the documented default cannot survive
      * teaches callers to distrust the tool rather than to pass `--timeout`.
      *
-     * Not a diagnosis of *why* a warm single-preview render can take five minutes — that is worth
-     * its own investigation, and a bigger constant is not the answer to it.
+     * Those five minutes were never the *render*: the CLI drove `composePreviewRenderAll` at full
+     * width and filtered the rows client-side, so asking for one preview rendered all 64 in the
+     * module — 317s where 3s would do (issue #3730). The CLI now forwards the request as
+     * `-PcomposePreview.idFilter` (see `PreviewRenderScope`), so this budget is back to being what
+     * it was meant to be: headroom for a genuinely cold daemon, not cover for a 100× overshoot.
      */
     const val DEFAULT_TIMEOUT_SECONDS: Long = 600
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -431,6 +431,13 @@ abstract class Command(
     val manifests: List<Pair<PreviewModule, PreviewManifest>>,
     val results: List<PreviewResult>,
     val discoveredPreviewCount: Int,
+    /**
+     * Preview ids this run rendered, or `null` when it rendered everything the modules declare.
+     * Non-null means the Gradle drive was narrowed to the `--id` / `--filter` request
+     * (issue #3730), so the previews outside it carry whatever the *previous* run left on disk —
+     * often nothing at all. Reporting has to say so rather than count them as render failures.
+     */
+    val renderedIds: Set<String>? = null,
   )
 
   /**
@@ -444,6 +451,12 @@ abstract class Command(
     val modules: List<PreviewModule>,
     val discoveredPreviewCount: Int,
     val taskOutcomes: Map<String, GradleTaskOutcome> = emptyMap(),
+    /**
+     * Preview ids this run actually asked Gradle to render, or `null` when it rendered everything.
+     * Threaded into [buildResults] so a narrowed render doesn't drop the `.cli-state.json` shas of
+     * the previews it deliberately skipped — see [PreviewRenderScope].
+     */
+    val renderedIds: Set<String>? = null,
   )
 
   /**
@@ -472,8 +485,8 @@ abstract class Command(
     var outcome: RawRenderOutcome? = null
     withGradle(silenceStdout = silenceStdout) { gradle ->
       val modules = withGradleStdout(silenceStdout) { resolveModules(gradle).filter(moduleFilter) }
-      val (buildOk, modulesToRead, discoveredPreviewCount, taskOutcomes) =
-        if (modules.isEmpty()) Quad(true, emptyList(), 0, emptyMap<String, GradleTaskOutcome>())
+      outcome =
+        if (modules.isEmpty()) RawRenderOutcome(true, emptyList(), 0)
         else {
           // Explicit discover pass before the render so `shards=auto` sees a fresh previews.json at
           // render-configuration time (see [runDiscover]). Kept as a first-class step — not an
@@ -490,13 +503,13 @@ abstract class Command(
                 discoverySucceeded = discoverySucceeded,
               )
             } else modules
-          if (scopeToPreviewRequest) {
-            warnIfPreviewFilterStillRendersExtraRows(
-              renderModules,
-              discoveryManifests,
-              discoverySucceeded = discoverySucceeded,
-            )
-          }
+          // Narrow the render itself to the requested previews rather than rendering the module and
+          // discarding the rows afterwards (issue #3730). Only for the preview-shaped pipeline:
+          // `show-resources` drives a resource manifest whose entries aren't `@Preview`s at all.
+          val scope =
+            if (scopeToPreviewRequest)
+              previewRenderScope(renderModules, discoveryManifests, discoverySucceeded)
+            else PreviewRenderScope.FULL
           val xrArgs =
             provisionXrCompositeArgs(gradle, renderModules, silenceStdout, discoverFirst = false)
           val tasks = renderModules.map(taskFor).toTypedArray()
@@ -504,28 +517,67 @@ abstract class Command(
             if (renderModules.isEmpty()) true
             else {
               withGradleStdout(silenceStdout) {
-                runGradle(gradle, *tasks, arguments = gradleArguments + xrArgs)
+                runGradle(gradle, *tasks, arguments = gradleArguments + xrArgs + scope.gradleArgs)
               }
             }
           if (!ok) reportRenderFailures(gradle)
           val outcomes = gradle.lastTaskOutcomes()
-          val readableModules = readableRenderModules(renderModules, taskFor, outcomes)
-          val discoveredPreviewCount =
-            if (scopeToPreviewRequest) discoveryManifests.sumOf { it.second.previews.size } else 0
-          Quad(ok, readableModules, discoveredPreviewCount, outcomes)
+          RawRenderOutcome(
+            buildOk = ok,
+            modules = readableRenderModules(renderModules, taskFor, outcomes),
+            discoveredPreviewCount =
+              if (scopeToPreviewRequest) discoveryManifests.sumOf { it.second.previews.size }
+              else 0,
+            taskOutcomes = outcomes,
+            renderedIds = scope.renderedIds,
+          )
         }
-      outcome =
-        RawRenderOutcome(
-          buildOk = buildOk,
-          modules = modulesToRead,
-          discoveredPreviewCount = discoveredPreviewCount,
-          taskOutcomes = taskOutcomes,
-        )
     }
     return outcome ?: error("renderModules: gradle block did not produce an outcome")
   }
 
-  private data class Quad<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
+  /**
+   * The `-PcomposePreview.idFilter` narrowing for this invocation's `--id` / `--filter`, plus the
+   * stderr diagnostics that go with it. Shared by the [renderModules] pipeline (`show`, `a11y`,
+   * reports) and by `render`, which drives Gradle itself.
+   *
+   * Returns [PreviewRenderScope.FULL] — render everything, the pre-#3730 behaviour — whenever the
+   * request can't be resolved to an exact id list: no filter, no modules, or a discovery pass that
+   * failed (the render task depends on discovery and is the authoritative retry, so a stale or
+   * missing manifest must never be allowed to narrow it).
+   */
+  internal fun previewRenderScope(
+    renderModules: List<PreviewModule>,
+    discoveryManifests: List<Pair<PreviewModule, PreviewManifest>>,
+    discoverySucceeded: Boolean,
+  ): PreviewRenderScope.Scope {
+    if (exactId == null && filter == null) return PreviewRenderScope.FULL
+    if (renderModules.isEmpty()) return PreviewRenderScope.FULL
+    val flag = if (exactId != null) "--id" else "--filter"
+    if (!discoverySucceeded) {
+      System.err.println(
+        "compose-preview: preview discovery failed, so $flag could not narrow the render; " +
+          "rendering all resolved modules so Gradle can retry discovery."
+      )
+      return PreviewRenderScope.FULL
+    }
+    val byPath = renderModules.map { it.gradlePath }.toSet()
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = discoveryManifests.filter { (module, _) -> module.gradlePath in byPath },
+        exactId = exactId,
+        filter = filter,
+        permutations = permutations,
+      )
+    scope.note?.let { System.err.println("compose-preview: $flag $it; rendering the full module.") }
+    if (verbose && scope.narrowed) {
+      System.err.println(
+        "compose-preview: $flag narrowed the render to ${scope.renderedIds?.size ?: 0} preview(s) " +
+          "via -P${PreviewRenderScope.GRADLE_PROPERTY}"
+      )
+    }
+    return scope
+  }
 
   /**
    * Standard "discover modules → run `:composePreviewRenderAll` → load manifests → build results"
@@ -547,7 +599,7 @@ abstract class Command(
         scopeToPreviewRequest = true,
       )
     val manifests = readAllManifests(raw.modules)
-    val results = if (manifests.isEmpty()) emptyList() else buildResults(manifests)
+    val results = if (manifests.isEmpty()) emptyList() else buildResults(manifests, raw.renderedIds)
     return RenderModulesOutcome(
       buildOk = raw.buildOk,
       modules = raw.modules,
@@ -555,6 +607,7 @@ abstract class Command(
       results = results,
       discoveredPreviewCount =
         raw.discoveredPreviewCount.takeIf { it > 0 } ?: manifests.sumOf { it.second.previews.size },
+      renderedIds = raw.renderedIds,
     )
   }
 
@@ -633,9 +686,16 @@ abstract class Command(
    *
    * The top-level `pngPath` / `sha256` / `changed` on [PreviewResult] mirror the first capture
    * verbatim so existing agents keep working.
+   *
+   * [renderedIds] names the previews this run actually re-rendered, or `null` for "all of them". It
+   * only matters once the render is narrowed (issue #3730): a preview that was deliberately skipped
+   * and has no PNG on disk must keep the sha the previous run recorded, or the next full render
+   * would report it as `changed` purely because the CLI forgot it. A skipped preview whose PNG *is*
+   * on disk needs nothing special — its sha still matches, so it reads as unchanged.
    */
   protected fun buildResults(
-    manifests: List<Pair<PreviewModule, PreviewManifest>>
+    manifests: List<Pair<PreviewModule, PreviewManifest>>,
+    renderedIds: Set<String>? = null,
   ): List<PreviewResult> {
     val base = PreviewResultBuilder.build(manifests)
     val imageSizeOverride = ImageSizeOverride.detect()
@@ -652,12 +712,41 @@ abstract class Command(
       val prior = readState(module).shas
       val updated = mutableMapOf<String, String>()
       for (result in moduleResults) {
+        val skipped = renderedIds != null && result.id !in renderedIds
         val overlayed = applyImageOverrideAndStateDiff(result, prior, updated, imageSizeOverride)
+        if (skipped) carryForwardSkippedState(result.id, prior, updated)
         out += annotateExtensions(overlayed, module)
       }
       writeState(module, CliState(updated))
     }
     return out
+  }
+
+  /**
+   * Re-adopt every `.cli-state.json` entry belonging to [id] that this run didn't rewrite
+   * (issue #3730).
+   *
+   * A narrowed render leaves the previews it skipped with no PNG to hash, so
+   * [applyImageOverrideAndStateDiff] writes no sha for them — and a dropped entry reads as
+   * "first-ever render" next time, which would make the following full render report every skipped
+   * preview as `changed`. The render didn't happen, so nothing about those previews' last known
+   * pixels changed either: keep what the previous run recorded.
+   *
+   * It has to work off the prior *keys* rather than the result's captures, because a
+   * `@PreviewParameter` preview whose fan-out files are all absent has **no** captures — the CLI
+   * globs those rows off disk, so an unrendered parameterized preview presents as zero rows rather
+   * than one empty one, and there is nothing to hang a carried-forward sha on. Matching is scoped
+   * to the `<id>` / `<id>#…` family so a sibling (`Foo_Dark` next to `Foo`) can't be dragged along,
+   * and [MutableMap.putIfAbsent] means a sha this run actually computed always wins.
+   */
+  private fun carryForwardSkippedState(
+    id: String,
+    prior: Map<String, String>,
+    updated: MutableMap<String, String>,
+  ) {
+    for ((key, sha) in prior) {
+      if (key == id || key.startsWith("$id#")) updated.putIfAbsent(key, sha)
+    }
   }
 
   /**
@@ -793,39 +882,6 @@ abstract class Command(
       filter = filter,
       discoverySucceeded = discoverySucceeded,
     )
-
-  private fun warnIfPreviewFilterStillRendersExtraRows(
-    renderModules: List<PreviewModule>,
-    manifests: List<Pair<PreviewModule, PreviewManifest>>,
-    discoverySucceeded: Boolean,
-  ) {
-    if (exactId == null && filter == null) return
-    if (renderModules.isEmpty()) return
-    val flag = if (exactId != null) "--id" else "--filter"
-    if (!discoverySucceeded) {
-      System.err.println(
-        "compose-preview: preview discovery failed, so $flag could not narrow the render; " +
-          "rendering all resolved modules so Gradle can retry discovery."
-      )
-      return
-    }
-    val byPath = renderModules.map { it.gradlePath }.toSet()
-    val rendersExtraRows =
-      manifests
-        .filter { (module, _) -> module.gradlePath in byPath }
-        .any { (_, manifest) ->
-          manifest.previews.any {
-            !previewIdMatchesRequest(it.id, exactId = exactId, filter = filter)
-          }
-        }
-    if (!rendersExtraRows) return
-    System.err.println(
-      "compose-preview: $flag narrowed the render to matching module(s) " +
-        renderModules.joinToString(", ") { it.gradlePath } +
-        "; Gradle still renders the full selected module task, so other previews in those " +
-        "module(s) may execute but will not be printed."
-    )
-  }
 
   private fun stateFile(module: PreviewModule): File =
     module.projectDir.resolve("build/compose-previews/.cli-state.json")
@@ -1118,12 +1174,15 @@ class ShowCommand(args: List<String>) : Command(args) {
     val all = outcome.results
     val modules = outcome.modules
     val filtered = applyFilters(all)
+    // Counts reflect the full discovered set so an agent using `--changed-only` can still see
+    // "60 unchanged, 0 changed" and skip a follow-up query — but only when the run actually
+    // rendered that set. Once `--id` / `--filter` narrows the Gradle drive (issue #3730) the
+    // previews outside the request were deliberately not rendered, so counting their absent PNGs
+    // as `missing` would report 63 render failures for a run that did exactly what was asked.
+    val countsScope = if (outcome.renderedIds == null) all else all.filter { matchesRequest(it) }
 
     if (filtered.isEmpty()) {
-      // Counts reflect the full discovered set so an agent using
-      // `--changed-only` can still see "60 unchanged, 0 changed"
-      // and skip a follow-up query.
-      if (jsonOutput) println(encodeResponse(emptyList(), countsScope = all))
+      if (jsonOutput) println(encodeResponse(emptyList(), countsScope = countsScope))
       else println("No previews matched.")
       System.out.flush()
       // A build failure outranks "no match": exit 3 advertises a healthy build that simply had
@@ -1132,7 +1191,7 @@ class ShowCommand(args: List<String>) : Command(args) {
     }
 
     if (jsonOutput) {
-      println(encodeResponse(filtered, countsScope = all))
+      println(encodeResponse(filtered, countsScope = countsScope))
     } else {
       var lastModule: String? = null
       for (r in filtered) {
@@ -1313,11 +1372,44 @@ class RenderCommand(args: List<String>) : Command(args) {
         }
       }
     withGradle { gradle ->
-      val modules = resolveModules(gradle)
-      val xrArgs = provisionXrCompositeArgs(gradle, modules, silenceStdout = false)
+      val resolved = resolveModules(gradle)
+      // Discover first so `--id` / `--filter` can be resolved to the exact ids Gradle should
+      // render, instead of rendering every module at full width and dropping the rows afterwards
+      // (issue #3730). `show` gets this from the shared [renderModules] pipeline; `render` drives
+      // Gradle itself, so it repeats the two steps here.
+      val discoverySucceeded = runDiscover(gradle, resolved, silenceStdout = false)
+      val discoveryManifests = if (discoverySucceeded) readAllManifests(resolved) else emptyList()
+      // `--bundle` packs a whole *module's* previews into one portable artifact, and
+      // `BundlePreviewTask` omits any preview whose PNG isn't on disk — so narrowing under
+      // `--bundle` would quietly ship a bundle containing a single preview, and dropping the
+      // non-matching modules would stop producing their bundles at all. That command keeps its
+      // pre-#3730 full-width behaviour; the render is the cheap half of it anyway.
+      val modules =
+        if (bundle) resolved
+        else
+          modulesMatchingPreviewRequest(
+            resolved,
+            discoveryManifests,
+            exactId = exactId,
+            filter = filter,
+            discoverySucceeded = discoverySucceeded,
+          )
+      if (modules.isEmpty()) {
+        System.err.println("No previews matched.")
+        exitProcess(3)
+      }
+      val scope =
+        if (bundle) PreviewRenderScope.FULL
+        else previewRenderScope(modules, discoveryManifests, discoverySucceeded)
+      val xrArgs =
+        provisionXrCompositeArgs(gradle, modules, silenceStdout = false, discoverFirst = false)
       val tasks = previewTasksFor(modules.map { it.gradlePath }).toTypedArray()
       if (
-        !runGradle(gradle, *tasks, arguments = gradleArgsWithForce(bundleGradleArgs()) + xrArgs)
+        !runGradle(
+          gradle,
+          *tasks,
+          arguments = gradleArgsWithForce(bundleGradleArgs()) + xrArgs + scope.gradleArgs,
+        )
       ) {
         reportRenderFailures(gradle)
         exitProcess(2)
@@ -1326,7 +1418,7 @@ class RenderCommand(args: List<String>) : Command(args) {
       if (bundle) reportBundles(modules)
 
       val manifests = readAllManifests(modules)
-      val all = buildResults(manifests)
+      val all = buildResults(manifests, scope.renderedIds)
       // `render` ignores `--changed-only` so the agent can ask "render
       // the world, but report only what changed" via a follow-up
       // `show --changed-only`.
@@ -1666,7 +1758,7 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
       System.err.println(message)
       exitProcess(2)
     }
-    val results = if (manifests.isEmpty()) emptyList() else buildResults(manifests)
+    val results = if (manifests.isEmpty()) emptyList() else buildResults(manifests, raw.renderedIds)
     val outcome =
       RenderModulesOutcome(
         buildOk = raw.buildOk,
@@ -1676,6 +1768,7 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
         discoveredPreviewCount =
           raw.discoveredPreviewCount.takeIf { it > 0 }
             ?: manifests.sumOf { it.second.previews.size },
+        renderedIds = raw.renderedIds,
       )
 
     if (outcome.manifests.isEmpty()) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -208,8 +208,11 @@ private fun printFullUsage() {
 
     Options:
       --module <name>      Target module (default: auto-detect all)
-      --filter <pattern>   Case-insensitive substring match on preview id
-      --id <exact>         Exact match on preview id
+      --filter <pattern>   Case-insensitive substring match on preview id. Narrows the Gradle
+                           render itself, not just the printed rows: only the matching
+                           previews are rendered, and only in the modules that declare them.
+                           Previews outside the match keep whatever PNG the last run wrote.
+      --id <exact>         Exact match on preview id (narrows the render like --filter)
       --json               Emit JSON (show, list, a11y, devices)
       --brief              JSON only: drop functionName/className/sourceFile/params
       --changed-only       JSON only (show, a11y): drop previews with no changed capture

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewPermutationsCli.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewPermutationsCli.kt
@@ -13,7 +13,12 @@ internal object PreviewPermutationsCli {
   fun expandManifest(manifest: PreviewManifest, values: List<String>): PreviewManifest =
     manifest.copy(previews = expand(manifest.previews, values))
 
-  private fun expand(previews: List<PreviewInfo>, values: List<String>): List<PreviewInfo> {
+  /**
+   * The previews [values] expands [previews] into, in render order. Internal rather than private so
+   * [PreviewRenderScope] can ask "which ids will this one manifest entry actually produce?" without
+   * synthesising a whole manifest around it.
+   */
+  fun expand(previews: List<PreviewInfo>, values: List<String>): List<PreviewInfo> {
     if (clean(values).none { it.equals(ACCESSIBILITY, ignoreCase = true) }) return previews
     return previews.flatMap { preview ->
       if (preview.params.kind != "COMPOSE") listOf(preview)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
@@ -1,0 +1,117 @@
+package ee.schimke.composeai.cli
+
+/**
+ * Turns a `--id` / `--filter` request into the Gradle property that actually narrows the render
+ * (issue #3730).
+ *
+ * Before this, `--id` / `--filter` were applied **client-side**: the CLI drove
+ * `:module:composePreviewRenderAll` at full width and then dropped the non-matching rows from its
+ * own output. Asking for one preview therefore rendered every preview in the module — measured at
+ * 317s instead of 3s on `samples/cmp` (64 previews), which also overran the CLI's own timeout and
+ * made single-preview renders *fail*. The plugin has honoured `composePreview.idFilter` on both
+ * backends since #2977; the CLI simply wasn't passing it.
+ *
+ * **Why an explicit id list rather than forwarding the pattern.** `--filter` is a
+ * *case-insensitive* substring match on the id ([previewIdMatchesRequest]);
+ * `composePreview.idFilter` is case-**sensitive** (`PreviewNameFilter.matchesId`). Forwarding the
+ * raw pattern would silently render a *narrower* set than the CLI then expects to print, so a
+ * `--filter homescreen` that used to match `HomeScreenPreview` would come back with no PNG. Instead
+ * the CLI resolves the request against the discovery manifest it has already read and forwards the
+ * exact ids, each anchored with [ANCHOR] so a base id can't drag in its own `_VARIANT_` / row
+ * fan-out siblings. The two matchers never have to agree, because only one of them ever runs.
+ *
+ * **Why only when it genuinely narrows.** A filtered `composePreviewRender` is not build-cacheable
+ * (`RenderPreviewsTask`'s `outputs.cacheIf` — a filtered run leaves every other module PNG at
+ * whatever the last run wrote, so its output dir isn't the module's complete render set).
+ * Forwarding a filter that selects *everything* would therefore buy nothing and cost the build
+ * cache, so [forRequest] returns no arguments in that case.
+ */
+internal object PreviewRenderScope {
+
+  /** The Gradle property `composePreviewRender` reads id patterns from, on both backends. */
+  const val GRADLE_PROPERTY: String = "composePreview.idFilter"
+
+  /**
+   * Mirror of `PreviewNameFilter.ANCHOR` — the prefix that makes a pattern an exact match rather
+   * than a substring one. Load-bearing here: ids are hierarchical, so an unanchored `Button` would
+   * also select `Button_Dark` and every `@PreviewParameter` row under it, quietly re-widening the
+   * render this class exists to narrow.
+   */
+  const val ANCHOR: String = "="
+
+  /**
+   * The narrowing decision for one render invocation.
+   *
+   * [gradleArgs] are appended to the render's Gradle argument list. [renderedIds] is the set of
+   * preview ids this run will actually (re-)render, **after** permutation expansion, or `null` when
+   * the run renders everything — the CLI uses it to leave the `.cli-state.json` entries of
+   * deliberately-skipped previews alone instead of forgetting their sha. [note] is a human-readable
+   * reason the narrowing was declined, for `--verbose`; `null` when there is nothing to say.
+   */
+  data class Scope(
+    val gradleArgs: List<String> = emptyList(),
+    val renderedIds: Set<String>? = null,
+    val note: String? = null,
+  ) {
+    val narrowed: Boolean
+      get() = gradleArgs.isNotEmpty()
+  }
+
+  /** The unnarrowed scope — render everything, as the CLI did before #3730. */
+  val FULL: Scope = Scope()
+
+  /**
+   * Resolve [exactId] / [filter] against the discovery [manifests] of the modules about to render.
+   *
+   * [permutations] is the active `--permutations` list: the CLI matches a request against the
+   * *expanded* ids a user sees in `show` output (`Foo_dark`), but forwards the *unexpanded* id
+   * (`Foo`) because the render applies its id filter before expanding — see
+   * `RenderPreviewsTask.render`.
+   *
+   * Returns [FULL] when there is no request, when nothing matched (the caller renders no module at
+   * all in that case), or when the request selects every discovered preview.
+   */
+  fun forRequest(
+    manifests: List<Pair<PreviewModule, PreviewManifest>>,
+    exactId: String?,
+    filter: String?,
+    permutations: List<String> = emptyList(),
+  ): Scope {
+    if (exactId == null && filter == null) return FULL
+    if (manifests.isEmpty()) return FULL
+
+    val selected = linkedSetOf<String>()
+    val renderedIds = linkedSetOf<String>()
+    var discovered = 0
+    for ((_, manifest) in manifests) {
+      for (preview in manifest.previews) {
+        discovered++
+        val expanded = PreviewPermutationsCli.expand(listOf(preview), permutations).map { it.id }
+        if (expanded.none { previewIdMatchesRequest(it, exactId = exactId, filter = filter) })
+          continue
+        selected += preview.id
+        renderedIds += expanded
+      }
+    }
+
+    if (selected.isEmpty()) return FULL
+    if (selected.size == discovered) return FULL
+
+    // `previewIdFilterProperty` splits the property on `,`, so an id carrying a comma would be torn
+    // into two patterns that each match nothing — and a filter matching nothing *fails* the render.
+    // No discovered id should contain one (ids derive from Kotlin identifiers and are
+    // path-sanitised), so this is a guard rather than a code path: decline the narrowing and render
+    // wide instead of breaking the run.
+    val unsafe = selected.filter { it.contains(',') || it.isBlank() }
+    if (unsafe.isNotEmpty()) {
+      return Scope(
+        note =
+          "could not narrow the Gradle render: ${unsafe.size} matching preview id(s) contain a " +
+            "comma, which $GRADLE_PROPERTY cannot express (e.g. '${unsafe.first()}')"
+      )
+    }
+
+    val patterns = selected.joinToString(",") { ANCHOR + it }
+    return Scope(gradleArgs = listOf("-P$GRADLE_PROPERTY=$patterns"), renderedIds = renderedIds)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/NarrowedRenderStateTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/NarrowedRenderStateTest.kt
@@ -1,0 +1,126 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * `.cli-state.json` across a **narrowed** render (issue #3730).
+ *
+ * Now that `--id` / `--filter` narrows the Gradle drive, the previews outside the request are
+ * deliberately not re-rendered — and on a clean tree they have no PNG at all. The change-detection
+ * state has to survive that: forgetting their sha would make the *next* full render report every
+ * one of them as `changed`, which is precisely the signal the documented agent loop ("re-render,
+ * read the entries marked changed") depends on being trustworthy.
+ */
+class NarrowedRenderStateTest {
+
+  private class ResultHarness : Command(emptyList()) {
+    override fun run() = Unit
+
+    fun results(
+      module: PreviewModule,
+      manifest: PreviewManifest,
+      renderedIds: Set<String>? = null,
+    ): List<PreviewResult> = buildResults(listOf(module to manifest), renderedIds)
+  }
+
+  private fun png(dir: File, name: String, byte: Byte = 1) {
+    dir.resolve(name).apply { parentFile.mkdirs() }.writeBytes(byteArrayOf(byte, 2, 3))
+  }
+
+  /** `Kept` renders every run; `Skipped` is plain; `Param` fans out over a provider. */
+  private fun manifest() =
+    PreviewManifest(
+      module = "app",
+      variant = "debug",
+      previews =
+        listOf(
+          PreviewInfo(
+            id = "Kept",
+            functionName = "Kept",
+            className = "com.example.PreviewsKt",
+            captures = listOf(Capture(renderOutput = "renders/Kept.png")),
+          ),
+          PreviewInfo(
+            id = "Skipped",
+            functionName = "Skipped",
+            className = "com.example.PreviewsKt",
+            captures = listOf(Capture(renderOutput = "renders/Skipped.png")),
+          ),
+          PreviewInfo(
+            id = "Param",
+            functionName = "Param",
+            className = "com.example.PreviewsKt",
+            params = PreviewParams(previewParameterProviderClassName = "com.example.Provider"),
+            captures = listOf(Capture(renderOutput = "renders/Param.png")),
+          ),
+        ),
+    )
+
+  private fun fullRender(renders: File) {
+    png(renders, "Kept.png")
+    png(renders, "Skipped.png")
+    png(renders, "Param_light.png")
+    png(renders, "Param_dark.png")
+  }
+
+  @Test
+  fun `previews a narrowed render skipped are not reported as changed by the next full render`() {
+    val projectDir = Files.createTempDirectory("narrowed-render-state").toFile()
+    val renders = projectDir.resolve("build/compose-previews/renders")
+    val module = PreviewModule("app", projectDir)
+    val manifest = manifest()
+
+    // 1. A full render seeds state for everything.
+    fullRender(renders)
+    ResultHarness().results(module, manifest)
+
+    // 2. `--id Kept` on a clean renders dir: only `Kept` comes back.
+    renders.deleteRecursively()
+    png(renders, "Kept.png")
+    val narrowed = ResultHarness().results(module, manifest, renderedIds = setOf("Kept"))
+    assertEquals(false, narrowed.single { it.id == "Kept" }.changed)
+    // The skipped ones have nothing on disk, so they report no PNG and an unknown diff — never a
+    // spurious `changed = true`.
+    assertNull(narrowed.single { it.id == "Skipped" }.pngPath)
+    assertNull(narrowed.single { it.id == "Skipped" }.changed)
+
+    // 3. The next full render sees the same pixels as step 1, so nothing changed.
+    fullRender(renders)
+    val full = ResultHarness().results(module, manifest)
+    assertEquals(false, full.single { it.id == "Skipped" }.changed)
+    // The parameterized fan-out is the case the per-capture pass can't reach: with no files on disk
+    // it has zero captures, so its `Param#<n>` keys only survive via `carryForwardSkippedState`.
+    assertEquals(listOf(false, false), full.single { it.id == "Param" }.captures.map { it.changed })
+  }
+
+  @Test
+  fun `a re-render that actually changes the pixels is still reported`() {
+    val projectDir = Files.createTempDirectory("narrowed-render-state").toFile()
+    val renders = projectDir.resolve("build/compose-previews/renders")
+    val module = PreviewModule("app", projectDir)
+    val manifest = manifest()
+
+    fullRender(renders)
+    ResultHarness().results(module, manifest)
+
+    renders.deleteRecursively()
+    png(renders, "Kept.png")
+    ResultHarness().results(module, manifest, renderedIds = setOf("Kept"))
+
+    // Carrying state forward must not blind the next run to a real diff: `Skipped` renders to
+    // different bytes this time.
+    png(renders, "Kept.png")
+    png(renders, "Skipped.png", byte = 9)
+    png(renders, "Param_light.png")
+    png(renders, "Param_dark.png", byte = 9)
+    val full = ResultHarness().results(module, manifest)
+
+    assertEquals(true, full.single { it.id == "Skipped" }.changed)
+    // Fan-out rows are ordered by label, so `_dark` (the one rewritten) is capture 0.
+    assertEquals(listOf(true, false), full.single { it.id == "Param" }.captures.map { it.changed })
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRenderScopeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRenderScopeTest.kt
@@ -1,0 +1,182 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the `--id` / `--filter` → `-PcomposePreview.idFilter` narrowing (issue #3730).
+ *
+ * The bug this pins: `compose-preview show --filter FontScale200Preview` on a 64-preview module
+ * drove `composePreviewRenderAll` at full width and threw the other 63 rows away afterwards — 317s
+ * of rendering for a 3s request, which also overran the CLI's own timeout and made the single
+ * -preview render *fail*. The plugin has honoured the property on both backends since #2977.
+ */
+class PreviewRenderScopeTest {
+
+  private fun module(path: String): PreviewModule =
+    PreviewModule(path, File("/tmp/compose-preview-test/${path.replace(':', '/')}"))
+
+  private fun manifest(
+    module: PreviewModule,
+    vararg ids: String,
+  ): Pair<PreviewModule, PreviewManifest> =
+    module to
+      PreviewManifest(
+        module = module.gradlePath,
+        variant = "debug",
+        previews =
+          ids.map { id ->
+            PreviewInfo(
+              id = id,
+              functionName = id.substringAfterLast('.'),
+              className = "com.example.PreviewsKt",
+              params = PreviewParams(kind = "COMPOSE"),
+            )
+          },
+      )
+
+  @Test
+  fun `no request renders everything`() {
+    val app = module("app")
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = listOf(manifest(app, "HomePreview", "SettingsPreview")),
+        exactId = null,
+        filter = null,
+      )
+
+    assertEquals(emptyList(), scope.gradleArgs)
+    assertNull(scope.renderedIds)
+  }
+
+  @Test
+  fun `exact id forwards a single anchored pattern`() {
+    val app = module("app")
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = listOf(manifest(app, "HomePreview", "SettingsPreview", "HomePreview_Dark")),
+        exactId = "HomePreview",
+        filter = null,
+      )
+
+    // Anchored: an unanchored `HomePreview` would also select `HomePreview_Dark`, re-widening the
+    // render this exists to narrow.
+    assertEquals(listOf("-PcomposePreview.idFilter==HomePreview"), scope.gradleArgs)
+    assertEquals(setOf("HomePreview"), scope.renderedIds)
+  }
+
+  @Test
+  fun `case-insensitive filter is resolved to exact ids the plugin can match`() {
+    val app = module("app")
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = listOf(manifest(app, "HomeScreenPreview", "SettingsPreview")),
+        exactId = null,
+        filter = "homescreen",
+      )
+
+    // The CLI's `--filter` is case-INSENSITIVE; `composePreview.idFilter` is case-sensitive.
+    // Forwarding the pattern verbatim would render nothing and report a missing PNG, so the CLI
+    // resolves the request against the manifest it already read and forwards the id it found.
+    assertEquals(listOf("-PcomposePreview.idFilter==HomeScreenPreview"), scope.gradleArgs)
+  }
+
+  @Test
+  fun `a request that selects everything is not forwarded`() {
+    val app = module("app")
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = listOf(manifest(app, "HomePreview", "HomeSettingsPreview")),
+        exactId = null,
+        filter = "Home",
+      )
+
+    // Nothing to save, and a filtered `composePreviewRender` is deliberately not build-cacheable
+    // (`RenderPreviewsTask.outputs.cacheIf`) — so forwarding a no-op filter would cost the cache
+    // for no gain.
+    assertEquals(emptyList(), scope.gradleArgs)
+    assertNull(scope.renderedIds)
+  }
+
+  @Test
+  fun `ids are unioned across the modules that will render`() {
+    val app = module("app")
+    val wear = module("wear")
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests =
+          listOf(
+            manifest(app, "LowBatteryPreview", "HomePreview"),
+            manifest(wear, "LowBatteryTilePreview", "ComplicationPreview"),
+          ),
+        exactId = null,
+        filter = "LowBattery",
+      )
+
+    // One Gradle invocation carries one property, so the list is the union — safe because the
+    // caller has already dropped any module with no match (`modulesMatchingPreviewRequest`), and a
+    // filter matching nothing in a module it *does* render would fail that render.
+    assertEquals(
+      listOf("-PcomposePreview.idFilter==LowBatteryPreview,=LowBatteryTilePreview"),
+      scope.gradleArgs,
+    )
+  }
+
+  @Test
+  fun `permutation siblings are matched on the expanded id and rendered via the base id`() {
+    val app = module("app")
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = listOf(manifest(app, "HomePreview", "SettingsPreview")),
+        exactId = "HomePreview_dark",
+        filter = null,
+        permutations = listOf("accessibility"),
+      )
+
+    // `--permutations accessibility` synthesizes `HomePreview_dark` client-side, but the render
+    // applies its id filter BEFORE expanding (`RenderPreviewsTask.render`), so the property has to
+    // name the base id.
+    assertEquals(listOf("-PcomposePreview.idFilter==HomePreview"), scope.gradleArgs)
+    // Every id the run will actually produce, for the `.cli-state.json` bookkeeping.
+    assertEquals(
+      setOf("HomePreview", "HomePreview_dark", "HomePreview_rtl", "HomePreview_fontscale-2x"),
+      scope.renderedIds,
+    )
+  }
+
+  @Test
+  fun `an id carrying a comma declines the narrowing rather than breaking the render`() {
+    val app = module("app")
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = listOf(manifest(app, "Home,Preview", "SettingsPreview")),
+        exactId = null,
+        filter = "Home",
+      )
+
+    assertEquals(emptyList(), scope.gradleArgs)
+    assertTrue(
+      scope.note!!.contains("comma"),
+      "the declined narrowing explains itself: ${scope.note}",
+    )
+  }
+
+  @Test
+  fun `a request that matches nothing renders wide`() {
+    val app = module("app")
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = listOf(manifest(app, "HomePreview")),
+        exactId = "NoSuchPreview",
+        filter = null,
+      )
+
+    // The caller drops every module in this case, so nothing renders at all — forwarding a filter
+    // that matches nothing would turn "no previews matched" (exit 3) into a hard render failure.
+    assertEquals(emptyList(), scope.gradleArgs)
+    assertNull(scope.renderedIds)
+  }
+}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
@@ -28,7 +28,12 @@ class RenderFunctionalTest {
     encodeDefaults = true
   }
 
-  private fun createTestProject(): File {
+  /**
+   * [extraPreviewNames] adds one more `@Preview` composable per entry, in its own file. Default
+   * empty so the single-preview fixture the missing-render tests read with `previews.single()` is
+   * unchanged; a filtered render needs at least two so there is something to leave out.
+   */
+  private fun createTestProject(extraPreviewNames: List<String> = emptyList()): File {
     val projectDir = tempDir.root
 
     File(projectDir, "settings.gradle.kts")
@@ -103,7 +108,87 @@ class RenderFunctionalTest {
           .trimIndent()
       )
 
+    for (name in extraPreviewNames) {
+      File(srcDir, "$name.kt")
+        .writeText(
+          """
+          package test
+
+          import androidx.compose.ui.tooling.preview.Preview
+          import androidx.compose.foundation.background
+          import androidx.compose.foundation.layout.Box
+          import androidx.compose.foundation.layout.size
+          import androidx.compose.runtime.Composable
+          import androidx.compose.ui.Modifier
+          import androidx.compose.ui.graphics.Color
+          import androidx.compose.ui.unit.dp
+
+          @Preview
+          @Composable
+          fun $name() {
+              Box(modifier = Modifier.size(100.dp).background(Color.Blue))
+          }
+          """
+            .trimIndent()
+        )
+    }
+
     return projectDir
+  }
+
+  @Test
+  fun `an id-filtered composePreviewRenderAll gates only on the previews it rendered`() {
+    // Issue #3730: the CLI now narrows the render with `-PcomposePreview.idFilter` instead of
+    // rendering the whole module and dropping the rows afterwards. The post-condition has to move
+    // with it, or the very run the filter asked for fails on the PNGs it deliberately skipped.
+    val projectDir = createTestProject(extraPreviewNames = listOf("BlueBoxPreview"))
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
+
+    val manifestFile = File(projectDir, "build/compose-previews/previews.json")
+    val manifest = json.decodeFromString<PreviewManifest>(manifestFile.readText())
+    assertThat(manifest.previews).hasSize(2)
+    val target = manifest.previews.first { it.functionName == "RedBoxPreview" }
+
+    // Exactly what a narrowed render leaves behind: the requested preview's PNG, and nothing for
+    // the other one. (`-x composePreviewRender` stands in for the renderer, which this synthetic
+    // project can't resolve — see the class kdoc.)
+    File(projectDir, "build/compose-previews/${target.captures.single().renderOutput}").also {
+      it.parentFile.mkdirs()
+      it.writeBytes(byteArrayOf(1, 2, 3))
+    }
+
+    // Unfiltered, that state is a genuine wiring failure and must still fail.
+    val unfiltered =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewRenderAll", "-x", "composePreviewRender")
+        .withPluginClasspath()
+        .buildAndFail()
+    assertThat(unfiltered.output).contains("render produced no output file")
+
+    // Filtered to the preview that did render, the same state is exactly correct.
+    val filtered =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments(
+          "composePreviewRenderAll",
+          "-x",
+          "composePreviewRender",
+          "-PcomposePreview.idFilter==${target.id}",
+        )
+        .withPluginClasspath()
+        .build()
+
+    // SUCCESS, not UP-TO-DATE: the filters are declared inputs, so changing one re-runs the check
+    // rather than letting a previous run's marker stand in for it — which is how the narrowed
+    // render appeared to pass a gate it had merely never reached.
+    assertThat(filtered.task(":composePreviewRenderAll")?.outcome)
+      .isEqualTo(org.gradle.testkit.runner.TaskOutcome.SUCCESS)
   }
 
   @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1686,6 +1686,13 @@ internal object ComposePreviewTasks {
         .orElse("full")
     val missingRendersProvider = missingRendersProperty(project)
     val permutationsProvider = previewPermutationsProperty(project)
+    // The same selection the render applies (issue #3730). Declared as task inputs as well as read
+    // in the action: without them a filtered run and an unfiltered run have identical inputs, so
+    // whichever ran second would be UP-TO-DATE and skip validation entirely — which is how a
+    // narrowed render appeared to "satisfy" a gate it had merely never reached.
+    val nameFilterProvider = previewFilterProperty(project)
+    val idFilterProvider = previewIdFilterProperty(project)
+    val idExcludeProvider = previewIdExcludeProperty(project)
     project.tasks.register("composePreviewRenderAll", DefaultTask::class.java) {
       group = "compose preview"
       dependsOn(renderTask)
@@ -1696,6 +1703,9 @@ internal object ComposePreviewTasks {
       inputs.property("tier", tierProvider)
       inputs.property("missingRenders", missingRendersProvider)
       inputs.property("permutations", permutationsProvider)
+      inputs.property("previewFilter", nameFilterProvider)
+      inputs.property("previewIdFilter", idFilterProvider)
+      inputs.property("previewIdExclude", idExcludeProvider)
       outputs.file(validationMarker).withPropertyName("validationMarker")
       doLast {
         val isFastTier = tierProvider.get() == "fast"
@@ -1746,14 +1756,32 @@ internal object ComposePreviewTasks {
         // capture's renderOutput lands on disk — report back one missing
         // entry per preview with at least one missing capture.
         val outDir = previewOutputDir.get().asFile
+        // Only gate on what this run was actually asked to render. A `--preview` / `--preview-id`
+        // render deliberately leaves every other preview alone (its PNG stays at whatever the last
+        // run wrote, or absent on a clean tree), so validating the whole manifest would fail the
+        // narrowed render itself — the reason issue #3730's one-line "just pass the property" fix
+        // needed this half too. Filters are applied to the RAW previews and the result expanded,
+        // mirroring `RenderPreviewsTask.render`'s order exactly, so a permutation sibling of a
+        // selected preview is still checked.
+        val validated =
+          PreviewPermutations.expand(
+            selectFilteredPreviews(
+              manifestRaw.previews,
+              nameFilters = nameFilterProvider.get(),
+              idFilters = idFilterProvider.get(),
+              idExcludes = idExcludeProvider.get(),
+            ),
+            permutationsProvider.get(),
+          )
         // Files owned by non-parameterized siblings — exclude them
         // from the `<stem>_*` glob so a `Foo_header.png` that
         // belongs to a different preview never gets treated as
         // part of `Foo`'s fan-out.
-        val missing = missingPreviewOutputIds(manifest, outDir, isFastTier)
+        val missing = missingPreviewOutputIds(manifest, outDir, isFastTier, validate = validated)
         if (missing.isNotEmpty()) {
           val sidecars = readErrorSidecarsFor(manifest, missing, outDir)
-          val message = formatMissingPreviewsMessage(manifest, missing, sidecars)
+          val message =
+            formatMissingPreviewsMessage(manifest.copy(previews = validated), missing, sidecars)
           // `composePreview.missingRenders` controls escalation: `fail` (default) preserves
           // the historical hard error that catches whole-module classpath misconfig; `warn`
           // and `ignore` let multi-module CI runs ride out a handful of stubborn previews
@@ -1969,10 +1997,52 @@ internal object ComposePreviewTasks {
     }
   }
 
+  /**
+   * The previews a filtered render actually renders: name filter first, then the id filter over
+   * what it kept, then the id exclusions — the same compose-in-order policy as
+   * `RenderPreviewsTask.render` and `PreviewFilter.select`.
+   *
+   * Unlike those, this **never throws on an empty result**. It exists to narrow the
+   * `composePreviewRenderAll` post-condition, where a filter matching nothing has already been
+   * reported by the render task that ran first; failing again here would replace that specific
+   * error ("--preview matched no previews for 'Fooo'. Available: …") with a confusing missing-PNG
+   * report.
+   */
+  internal fun selectFilteredPreviews(
+    previews: List<PreviewInfo>,
+    nameFilters: List<String>,
+    idFilters: List<String>,
+    idExcludes: List<String>,
+  ): List<PreviewInfo> {
+    var kept = previews
+    if (nameFilters.any { it.isNotBlank() }) {
+      kept = kept.filter { PreviewNameFilter.matches(nameFilters, it.functionName, it.className) }
+    }
+    if (idFilters.any { it.isNotBlank() }) {
+      kept = kept.filter { PreviewNameFilter.matchesId(idFilters, it.id) }
+    }
+    if (idExcludes.any { it.isNotBlank() }) {
+      kept = kept.filterNot { PreviewNameFilter.matchesId(idExcludes, it.id) }
+    }
+    return kept
+  }
+
+  /**
+   * The ids in [validate] whose render produced no file on disk.
+   *
+   * [validate] defaults to the whole manifest and is narrowed only when the render itself was
+   * narrowed (`--preview` / `-PcomposePreview.idFilter` / …, issue #3730): a filtered run
+   * deliberately leaves every other preview unrendered, so gating on the full manifest would fail
+   * the very run the filter was asked for. [manifest] stays the **complete** set regardless,
+   * because `siblingNames` — which stops a sibling's `Foo_header.png` being counted as part of
+   * `Foo`'s `@PreviewParameter` fan-out — is only correct when it can see previews outside the
+   * filter.
+   */
   internal fun missingPreviewOutputIds(
     manifest: PreviewManifest,
     outDir: java.io.File,
     isFastTier: Boolean,
+    validate: List<PreviewInfo> = manifest.previews,
   ): List<String> {
     val siblingNames =
       manifest.previews
@@ -1984,7 +2054,7 @@ internal object ComposePreviewTasks {
         .map { java.io.File(outDir, it).name }
         .toSet()
 
-    return manifest.previews
+    return validate
       .filter { p ->
         val captureMissing =
           p.captures.any { c ->

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/FilteredRenderValidationTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/FilteredRenderValidationTest.kt
@@ -1,0 +1,154 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.Capture
+import ee.schimke.composeai.discovery.PreviewInfo
+import ee.schimke.composeai.discovery.PreviewManifest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * `composePreviewRenderAll`'s missing-render post-condition, under a **narrowed** render
+ * (issue #3730).
+ *
+ * The gate exists to catch a whole-module wiring failure (`composePreviewRender` silently reporting
+ * NO-SOURCE), and it did that by requiring a PNG for every entry in the manifest. That is exactly
+ * wrong for a filtered run: `-PcomposePreview.filter` / `.idFilter` deliberately renders a subset
+ * and leaves every other preview at whatever the previous run wrote — nothing at all on a clean
+ * tree — so the gate would fail the very run the filter asked for. It only *appeared* to pass
+ * before because the validation task's inputs didn't mention the filters, so a second run with a
+ * different filter came back UP-TO-DATE and never reached the check.
+ */
+class FilteredRenderValidationTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private fun preview(id: String, functionName: String = id) =
+    PreviewInfo(
+      id = id,
+      functionName = functionName,
+      className = "com.example.PreviewsKt",
+      captures = listOf(Capture(renderOutput = "renders/$id.png")),
+    )
+
+  private val previews =
+    listOf(
+      preview("FontScale100Preview"),
+      preview("FontScale150Preview"),
+      preview("FontScale200Preview"),
+    )
+
+  private val manifest = PreviewManifest(module = "cmp", variant = "debug", previews = previews)
+
+  private fun render(vararg ids: String) {
+    val renders = tempDir.root.resolve("renders").apply { mkdirs() }
+    for (id in ids) renders.resolve("$id.png").writeBytes(byteArrayOf(1, 2, 3))
+  }
+
+  @Test
+  fun `an unfiltered run still gates on every preview`() {
+    render("FontScale100Preview")
+
+    val missing =
+      ComposePreviewTasks.missingPreviewOutputIds(manifest, tempDir.root, isFastTier = false)
+
+    assertThat(missing).containsExactly("FontScale150Preview", "FontScale200Preview")
+  }
+
+  @Test
+  fun `an id-filtered run gates only on the previews it rendered`() {
+    render("FontScale200Preview")
+
+    val validated =
+      ComposePreviewTasks.selectFilteredPreviews(
+        previews,
+        nameFilters = emptyList(),
+        idFilters = listOf("=FontScale200Preview"),
+        idExcludes = emptyList(),
+      )
+    val missing =
+      ComposePreviewTasks.missingPreviewOutputIds(
+        manifest,
+        tempDir.root,
+        isFastTier = false,
+        validate = validated,
+      )
+
+    assertThat(missing).isEmpty()
+  }
+
+  @Test
+  fun `a filtered run still fails when the preview it did ask for produced nothing`() {
+    // The gate keeps its teeth where it matters: the requested preview blew up, and a narrowed
+    // render must not become a way to render nothing and call it a success.
+    val validated =
+      ComposePreviewTasks.selectFilteredPreviews(
+        previews,
+        nameFilters = listOf("FontScale200Preview"),
+        idFilters = emptyList(),
+        idExcludes = emptyList(),
+      )
+    val missing =
+      ComposePreviewTasks.missingPreviewOutputIds(
+        manifest,
+        tempDir.root,
+        isFastTier = false,
+        validate = validated,
+      )
+
+    assertThat(missing).containsExactly("FontScale200Preview")
+  }
+
+  @Test
+  fun `excluded ids drop out of the gate`() {
+    render("FontScale100Preview")
+
+    val validated =
+      ComposePreviewTasks.selectFilteredPreviews(
+        previews,
+        nameFilters = emptyList(),
+        idFilters = emptyList(),
+        idExcludes = listOf("FontScale150Preview", "FontScale200Preview"),
+      )
+
+    assertThat(validated.map { it.id }).containsExactly("FontScale100Preview")
+    assertThat(
+        ComposePreviewTasks.missingPreviewOutputIds(
+          manifest,
+          tempDir.root,
+          isFastTier = false,
+          validate = validated,
+        )
+      )
+      .isEmpty()
+  }
+
+  @Test
+  fun `filters compose in the same order the render applies them`() {
+    // name filter first, then the id filter over what it kept — mirroring
+    // `RenderPreviewsTask.render` / `PreviewFilter.select`.
+    val validated =
+      ComposePreviewTasks.selectFilteredPreviews(
+        previews,
+        nameFilters = listOf("FontScale1*"),
+        idFilters = listOf("*200*"),
+        idExcludes = emptyList(),
+      )
+
+    assertThat(validated).isEmpty()
+  }
+
+  @Test
+  fun `an empty filter list keeps every preview`() {
+    assertThat(
+        ComposePreviewTasks.selectFilteredPreviews(
+          previews,
+          nameFilters = listOf("", "  "),
+          idFilters = emptyList(),
+          idExcludes = emptyList(),
+        )
+      )
+      .isEqualTo(previews)
+  }
+}


### PR DESCRIPTION
Fixes #3730.

`compose-preview show/render --id X` drove `:module:composePreviewRenderAll` at full width and dropped the non-matching rows **client-side**, so asking for one preview rendered every preview in the module. On `samples/cmp` (64 previews) that is 317s where 3s would do, and it overran the CLI's own timeout often enough that single-preview renders failed outright — the mechanism behind the cold-start friction log's blocker 4.

## What changed

**The CLI forwards the request.** `PreviewRenderScope` resolves `--id` / `--filter` against the discovery manifest the CLI already reads, and forwards the exact ids as `-PcomposePreview.idFilter==ID1,=ID2,…` — the property the plugin has honoured on both backends since #2977.

Explicit ids rather than the raw pattern, because the two matchers disagree on purpose: `--filter` is a *case-insensitive* substring match on the id, `composePreview.idFilter` is case-**sensitive**. Forwarding the pattern would render a narrower set than the CLI then expects to print, so `--filter homescreen` would come back with no PNG for `HomeScreenPreview`. Resolving the ids client-side means only one matcher ever runs. Each id is anchored with `=` so a base id can't drag in its own `_VARIANT_` / row fan-out.

The property is passed **only when it genuinely narrows** — a filtered `composePreviewRender` is deliberately not build-cacheable (`outputs.cacheIf`), so a filter that selects everything would cost the build cache for no gain.

**The missing-render gate had to move with it — this is why the issue wasn't a one-line PR.** `composePreviewRenderAll` validated the whole manifest, so a filtered run failed on the 63 PNGs it was asked *not* to produce. It only appeared to pass in the issue's experiment because the validation task's inputs never mentioned the filters, so a second run came back UP-TO-DATE and never reached the check. Verified by reverting just the plugin half and re-running the narrowed render:

```
> composePreviewRenderAll: render produced no output file for 63 of 66 preview(s) …
BUILD FAILED in 55s
```

The three filter properties are now declared inputs, and the gate validates the selected previews only — applied to the raw manifest and then permutation-expanded, mirroring `RenderPreviewsTask.render`'s order exactly. It keeps its teeth where it matters: a filtered run whose requested preview produced nothing still fails.

**Reporting follows the render.** `show`'s `counts` are scoped to the request rather than the module (otherwise a narrowed run reports 63 previews as `missing`), and `.cli-state.json` carries the shas of skipped previews forward so the next full render doesn't call them all `changed`. That includes `@PreviewParameter` fan-outs, whose rows are globbed off disk and so present as *zero* captures when nothing rendered — the one case a per-capture carry-forward can't reach.

**`render --bundle` keeps rendering the full module.** `BundlePreviewTask` omits previews whose PNG isn't on disk, so narrowing would quietly ship a one-preview bundle.

## Measurements

`samples/cmp`, `renders/` deleted first, `--no-build-cache`, so these are the render itself:

| Scenario | Wall | PNGs |
| --- | --- | --- |
| `composePreviewRenderAll` | 6m 17s | 64 |
| `composePreviewRenderAll` with the id filter for one preview | **2s** | **1** |

Through the CLI, warm daemon: `show --module samples:cmp --filter FontScale200Preview` → 20s, 1 PNG, exit 0.

Note the unfiltered path is cheap when the build cache hits (a restore is ~1s); the 317s lands on every cache miss, i.e. exactly the edit→render loop this flag exists for.

## Test plan

- New `PreviewRenderScopeTest` (8) — anchoring, the case-insensitivity mismatch, union across modules, permutation ids, the "selects everything" and "matches nothing" opt-outs, and the comma guard.
- New `FilteredRenderValidationTest` (6) — the narrowed gate, its remaining teeth, exclusions, and filter composition order.
- New `NarrowedRenderStateTest` (2) — state survives a narrowed render, and a real pixel diff is still reported afterwards.
- New `RenderFunctionalTest` case — same on-disk state fails unfiltered and succeeds filtered, asserting `SUCCESS` (not `UP-TO-DATE`) so the declared inputs are pinned.
- `./gradlew ktfmtCheckAll :cli:test :gradle-plugin:test` green; `:gradle-plugin:functionalTest --tests "*RenderFunctionalTest*"` green (6/6).
- End-to-end on `samples/cmp`: full render → narrowed render → full render reports **0** spurious `changed`; `list` still sees all 66 previews.

No visual surface changes — this is render-scheduling and CLI plumbing, so the rendered pixels are identical (the sha of a re-rendered preview is unchanged, which the state test above depends on).
