### PR TITLE
feat(apply): add fork-safe render/publish phase split

### DIFF
--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -154,6 +154,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Two `synchronize` events on one PR would otherwise race: the older render
+# can finish last, and its publisher then overwrites the shared render
+# branches and sticky comments with stale pixels.
+concurrency:
+  group: compose-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   render:
     runs-on: ubuntu-latest
@@ -188,6 +195,13 @@ permissions:
   contents: write         # renders push to compose-preview/pr
   pull-requests: write    # sticky comment upsert
   actions: read           # cross-run artifact download
+
+# Publishers can finish out of order too, so serialize them per head branch.
+# NOT cancel-in-progress: a publisher that is already pushing should finish,
+# and the next one supersedes it on the same shared branch anyway.
+concurrency:
+  group: compose-preview-publish-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
 
 jobs:
   publish:
@@ -238,6 +252,15 @@ Two values are in there because the publish job cannot recover them itself:
 |---|---|
 | `_pr_number` | `github.event.workflow_run.pull_requests` is **empty for fork PRs** — the one case this whole path exists for. |
 | `_scope_modules` | The publish job never checked the PR out, so it can't classify the diff. Without the render job's scope, [change-scoped runs](#change-scoped-rendering) would report every unrendered module's baseline as a *Removed* preview. |
+| `_pipelines` | The resolved `only` / `skip` set. Re-resolving from the publish call's own inputs would default all four on, and the upsert for a pipeline that never ran would patch its existing sticky comment to "no changes". |
+| `_ab_config` | Read from the checkout, which on the publish side is the *base* branch — so a PR that adds or edits an [A/B config](#ab-comparison-of-preview-variants) would otherwise be graded against the old grouping. |
+
+Both sides of every comparison travel, not just the new renders: the
+comparators fail closed on a missing baseline, so an absent
+`_resource_baselines/renders` would turn renderer anti-aliasing noise into a
+false resource diff, and a missing `_notification_baseline_findings.json` reads
+as an empty baseline — reporting every surviving preview as *Added* and losing
+removals entirely.
 
 `_previews.json` is rewritten on the way in. The CLI emits **absolute**
 `pngPath` values pointing into the render runner's Gradle build directories, so
@@ -249,9 +272,22 @@ bundle already holds copied pixels.
 
 The publish job holds a write token, so it is worth being precise about what it
 runs: the base branch's checkout, this action, and nothing else. It never
-checks out the PR, never invokes Gradle, and never installs the CLI. The
-handoff is data — treat a PR-authored artifact as untrusted input if you add
-steps of your own that read it.
+checks out the PR, never invokes Gradle, and never installs the CLI.
+
+**The artifact is treated as hostile.** It was produced by a job that ran the
+PR's own Gradle build, and the pipelines write their push metadata as each
+surface completes — so a later pipeline, still executing fork code, can rewrite
+what an earlier one staged. Push *control* therefore never comes from the
+artifact: the destination branch, commit message and skip flag are rebuilt on
+the publish side from the same literals the single-job path uses, so a
+`_push_branch` rewritten to `main` aims nothing at the default branch. A
+`.github/` tree found in a staging dir is dropped before the push, since
+`push-branch.sh` commits the directory wholesale and a workflow file landing on
+a render branch would run on its own `push` trigger. The staging dirs
+contribute pixels; every decision is made from the action's own constants.
+
+If you add steps of your own to the publish job, hold that line — anything read
+out of the handoff is PR-authored input.
 
 It does **not** make the render itself trusted. A fork PR still runs its own
 code on the render runner; that job just has nothing worth stealing (read-only

--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -119,6 +119,145 @@ removed. (`only: a11y` alone silently drops the notifications pipeline, since
 deliberately render no notification previews.) The two jobs use disjoint
 baseline branches and sticky-comment markers, so they never collide.
 
+## Fork PRs
+
+The basic usage above works for PRs raised from a branch in the repository
+itself. It cannot work for a PR from a **fork**, and no `permissions:` block
+fixes that: on a `pull_request` event from a fork, `GITHUB_TOKEN` is read-only
+for *every* scope. So the render push 403s, and the sticky comment can't be
+posted either — commenting is a write too.
+
+**`pull_request_target` is not the fix.** It hands out a write-scoped token and
+the repository's secrets, and rendering previews means checking out the PR's
+own code and running its Gradle build. That is arbitrary code execution with a
+write token — the classic pwn request. A workflow that renders untrusted code
+must never hold the token that publishes the result.
+
+Split those two responsibilities across two workflows instead. The render job
+stays unprivileged and hands its output to a publish job that runs the **base
+branch's** code and never executes anything from the PR:
+
+```yaml
+# .github/workflows/compose-preview.yml — untrusted. Renders, publishes nothing.
+name: Compose Preview
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+# Needed by the paths that still publish inline: the baseline push on `main`
+# and same-repo PRs. On a fork PR GitHub downgrades the token to read-only no
+# matter what this block says — which is the whole reason the split exists.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup           # your java + SDK + cache composite
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.0.0
+        with:
+          # Same-repo PRs and baseline pushes keep the single-job path, which
+          # already holds a write token. Only fork PRs need the split.
+          phase: ${{ github.event.pull_request.head.repo.fork && 'render' || 'all' }}
+      - uses: actions/upload-artifact@v7
+        if: github.event.pull_request.head.repo.fork
+        with:
+          name: compose-preview-handoff
+          path: _compose_preview_handoff/
+          if-no-files-found: error
+          retention-days: 1
+```
+
+```yaml
+# .github/workflows/compose-preview-publish.yml — trusted. Pushes and comments.
+name: Compose Preview Publish
+on:
+  workflow_run:
+    workflows: [Compose Preview]
+    types: [completed]
+
+permissions:
+  contents: write         # renders push to compose-preview/pr
+  pull-requests: write    # sticky comment upsert
+  actions: read           # cross-run artifact download
+
+jobs:
+  publish:
+    # A failed render has nothing worth publishing, and a stale comment is
+    # better than one built from a partial envelope.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # This checkout is the BASE branch's code, never the PR's. Nothing from
+      # the fork is executed in this job — the handoff is read as data only.
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v7
+        id: handoff
+        continue-on-error: true
+        with:
+          name: compose-preview-handoff
+          path: _compose_preview_handoff
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Same-repo runs publish inline and upload no handoff, so this workflow
+      # fires with nothing to do. That's the common case, not an error.
+      - id: pr
+        if: steps.handoff.outcome == 'success'
+        run: echo "number=$(cat _compose_preview_handoff/_pr_number)" >> "$GITHUB_OUTPUT"
+
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.0.0
+        if: steps.pr.outputs.number != ''
+        with:
+          phase: publish
+          pr-number: ${{ steps.pr.outputs.number }}
+```
+
+### What travels between the jobs
+
+`phase: render` stages one directory (`handoff-dir`, default
+`_compose_preview_handoff`) holding everything the publish half reads off disk:
+the staged PR renders and their push metadata, the fetched baselines, the
+resolved base SHA, and the per-surface staging dirs for resources / a11y /
+notifications.
+
+Two values are in there because the publish job cannot recover them itself:
+
+| File | Why it can't be recomputed |
+|---|---|
+| `_pr_number` | `github.event.workflow_run.pull_requests` is **empty for fork PRs** — the one case this whole path exists for. |
+| `_scope_modules` | The publish job never checked the PR out, so it can't classify the diff. Without the render job's scope, [change-scoped runs](#change-scoped-rendering) would report every unrendered module's baseline as a *Removed* preview. |
+
+`_previews.json` is rewritten on the way in. The CLI emits **absolute**
+`pngPath` values pointing into the render runner's Gradle build directories, so
+the envelope is rebased onto `<handoff-dir>/current/` and the renders that are
+still read on the publish side are copied there with it. Everything else in the
+bundle already holds copied pixels.
+
+### What this does and doesn't buy you
+
+The publish job holds a write token, so it is worth being precise about what it
+runs: the base branch's checkout, this action, and nothing else. It never
+checks out the PR, never invokes Gradle, and never installs the CLI. The
+handoff is data — treat a PR-authored artifact as untrusted input if you add
+steps of your own that read it.
+
+It does **not** make the render itself trusted. A fork PR still runs its own
+code on the render runner; that job just has nothing worth stealing (read-only
+token, no secrets). Keep `persist-credentials: false` on its checkout so the
+token isn't left in `.git/config` for the build to find.
+
 ## Version skew
 
 > **What used to be the single most common way this action breaks.** Pinning

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -231,6 +231,7 @@ runs:
         DEV_BRANCH: ${{ inputs.development-branch }}
         MODE_OVERRIDE: ${{ inputs.mode }}
         PHASE: ${{ inputs.phase }}
+        HANDOFF_DIR: ${{ inputs.handoff-dir }}
         ONLY: ${{ inputs.only }}
         SKIP: ${{ inputs.skip }}
       run: |
@@ -239,6 +240,35 @@ runs:
           all|render|publish) ;;
           *) echo "::error::phase must be one of all|render|publish (got '$PHASE')."; exit 1 ;;
         esac
+
+        # A publish job that re-resolved the pipeline set from its own inputs
+        # would default all four on. A render invoked with `only: compose`
+        # would then reach the notification upsert with no notification data,
+        # and it would patch any existing sticky comment to "no changes" for a
+        # pipeline that never ran. So the render job's resolution travels with
+        # the handoff, and `only` / `skip` need not be repeated on the publish
+        # call. Parsed strictly: this file crosses a trust boundary, so each
+        # field must be exactly 0 or 1 and anything else fails the run rather
+        # than being coerced into an enabled pipeline.
+        if [ "$PHASE" = "publish" ] && [ -f "$HANDOFF_DIR/_pipelines" ]; then
+          staged=$(tr -d '[:space:]' < "$HANDOFF_DIR/_pipelines")
+          if [[ "$staged" =~ ^[01],[01],[01],[01]$ ]]; then
+            IFS=',' read -r compose resources a11y notifications <<< "$staged"
+            echo "compose-preview: publishing the render job's pipeline set ($staged)."
+          else
+            echo "::error::Malformed _pipelines in the handoff ('$staged'); expected four 0/1 fields."
+            exit 1
+          fi
+          publish_mode="$MODE_OVERRIDE"
+          [ "$publish_mode" = "auto" ] && publish_mode=comment
+          echo "mode=$publish_mode" >> "$GITHUB_OUTPUT"
+          echo "phase=$PHASE" >> "$GITHUB_OUTPUT"
+          echo "compose=$compose" >> "$GITHUB_OUTPUT"
+          echo "resources=$resources" >> "$GITHUB_OUTPUT"
+          echo "a11y=$a11y" >> "$GITHUB_OUTPUT"
+          echo "notifications=$notifications" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
         # All four pipelines start ON, then `only` filters down, then `skip`
         # removes any pipelines explicitly turned off.
         compose=1; resources=1; a11y=1; notifications=1
@@ -321,6 +351,7 @@ runs:
       shell: bash
       env:
         HANDOFF_DIR: ${{ inputs.handoff-dir }}
+        AB_CONFIG: ${{ inputs.ab-config }}
       run: |
         set -euo pipefail
         if [ ! -d "$HANDOFF_DIR" ]; then
@@ -334,13 +365,63 @@ runs:
           base=$(basename "$entry")
           # The staged current renders are addressed in place; everything else
           # is read from the workspace root.
-          [ "$base" = "current" ] && continue
+          case "$base" in current|current-resources) continue ;; esac
           # Replace rather than merge: `cp -a dir existing-dir` would nest the
           # staged tree one level deeper instead of overwriting it.
           rm -rf "${GITHUB_WORKSPACE:?}/$base"
           cp -a "$entry" "$GITHUB_WORKSPACE/$base"
           restored=$((restored + 1))
         done
+
+        # --- Everything below treats the handoff as hostile input. ---
+        #
+        # This job holds a write-scoped token; the artifact was produced by a
+        # job that ran the PR's own Gradle build. The pipelines write their
+        # push metadata as each surface finishes, but later pipelines — still
+        # executing fork code — run before the handoff is staged, so any file
+        # in here is reachable by an attacker, including one written earlier.
+        #
+        # Push *control* therefore never comes from the artifact. The staging
+        # dirs supply pixels and nothing else: the destination branch, the
+        # commit message and the skip flag are all rebuilt here from the same
+        # literals the single-job path uses. Without this, `_pr_renders/
+        # _push_branch` rewritten to `main` would aim a write token at the
+        # default branch.
+        reset_push_meta() {
+          stage="$1"; branch="$2"; label="$3"
+          [ -d "$stage" ] || return 0
+          # `git add -A` in push-branch.sh commits whatever is in the stage
+          # dir. A workflow file pushed onto a render branch would run on its
+          # own `push` trigger, so drop `.github/` outright — no render
+          # pipeline legitimately writes one. GITHUB_TOKEN is refused workflow
+          # writes unless the caller granted `workflows: write`; this makes the
+          # render branches safe even when they did.
+          if [ -d "$stage/.github" ]; then
+            echo "::warning::Dropped an unexpected .github/ tree from $stage before pushing."
+            rm -rf "$stage/.github"
+          fi
+          printf '%s' "$branch" > "$stage/_push_branch"
+          printf '%s' "$label"  > "$stage/_push_msg"
+          printf '0'            > "$stage/_skip_if_unchanged"
+        }
+        # Comment mode is the only mode the split supports, so these are the
+        # PR-render branches — never a baseline branch, never `main`.
+        reset_push_meta _pr_renders          'compose-preview/pr'               'compose-preview: PR renders'
+        reset_push_meta _pr_resource_renders 'compose-preview/resources/pr'     'compose-preview: PR resource renders'
+        reset_push_meta _a11y_renders        'compose-preview/a11y/pr'          'compose-preview: PR a11y renders'
+        reset_push_meta _notification_renders 'compose-preview/notifications/pr' 'compose-preview: PR notification renders'
+
+        # The A/B config is read from the checkout, which here is the base
+        # branch — so a PR that adds or edits one would otherwise be graded
+        # against the old grouping, unlike the single-job path. Restore the
+        # render job's copy at the configured path. It is parsed as data
+        # (ABTestConfig.load) and only ever groups rows in the comment.
+        if [ -n "${AB_CONFIG:-}" ] && [ -f "$HANDOFF_DIR/_ab_config" ]; then
+          mkdir -p "$(dirname "$AB_CONFIG")"
+          cp "$HANDOFF_DIR/_ab_config" "$AB_CONFIG"
+          echo "compose-preview: restored the PR's A/B config to $AB_CONFIG."
+        fi
+
         echo "compose-preview: restored $restored handoff entr(ies) from $HANDOFF_DIR."
 
     # Change-scoped rendering (see compute-scope.py). Always runs so its
@@ -861,6 +942,11 @@ runs:
         SCOPE_MODULES: ${{ steps.scope.outputs.modules }}
         PR_INPUT_NUMBER: ${{ inputs.pr-number }}
         EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        AB_CONFIG: ${{ inputs.ab-config }}
+        WANT_COMPOSE: ${{ steps.resolve.outputs.compose }}
+        WANT_RESOURCES: ${{ steps.resolve.outputs.resources }}
+        WANT_A11Y: ${{ steps.resolve.outputs.a11y }}
+        WANT_NOTIFICATIONS: ${{ steps.resolve.outputs.notifications }}
       run: |
         set -euo pipefail
         rm -rf "$HANDOFF_DIR"
@@ -871,13 +957,30 @@ runs:
         # and a no-change run stages no `_pr_renders` at all — the publish job
         # then finds nothing staged and skips its push, same as a single-job
         # run would.
+        # Both sides of every comparison have to travel, not just the renders.
+        # The comparators fail closed on a missing baseline — an absent
+        # `_resource_baselines/renders` turns renderer/AA noise into a false
+        # resource diff, and notification-previews.py reads a missing
+        # `_notification_baseline_findings.json` as empty, which reports every
+        # surviving preview as Added and loses removals entirely.
         for f in _baselines _base_sha _pr_renders \
-                 _resources.json _resource_base_sha _pr_resource_renders \
+                 _resources.json _resource_baselines _resource_base_sha _pr_resource_renders \
                  _a11y_renders _a11y_comment.md \
-                 _notification_renders _notification_comment.md; do
+                 _notification_renders _notification_comment.md \
+                 _notification_baseline_findings.json; do
           [ -e "$f" ] || continue
           cp -a "$f" "$HANDOFF_DIR/$f"
         done
+
+        # `only` / `skip` resolution, so the publish call needs neither.
+        printf '%s,%s,%s,%s' "$WANT_COMPOSE" "$WANT_RESOURCES" "$WANT_A11Y" "$WANT_NOTIFICATIONS" \
+          > "$HANDOFF_DIR/_pipelines"
+
+        # The publish job checks out the base branch, so a PR that adds or
+        # edits the A/B config would otherwise be graded against the old one.
+        if [ -n "${AB_CONFIG:-}" ] && [ -f "$AB_CONFIG" ]; then
+          cp "$AB_CONFIG" "$HANDOFF_DIR/_ab_config"
+        fi
 
         # The publish job can't classify the PR diff itself (it never checks
         # the PR out), so the resolved scope travels with the renders.
@@ -896,6 +999,23 @@ runs:
             --output-dir "$HANDOFF_DIR/current" \
             --path-prefix "$HANDOFF_DIR/current" \
             --rewrite-json "$HANDOFF_DIR/_previews.json"
+        fi
+
+        # Resource captures carry absolute pngPaths too, and
+        # `compare-resources` runs them through the same `_is_changed`
+        # perceptual filter, so they need the same rebasing.
+        if [ -s _resources.json ]; then
+          # The resource baselines JSON is fetched into `_baselines/` while its
+          # renders land in `_resource_baselines/renders` — mirror the paths
+          # the comment step itself uses rather than guessing a matched pair.
+          RES_BASELINES_ARG=()
+          [ -f _baselines/resource-baselines.json ] && \
+            RES_BASELINES_ARG=(--baselines _baselines/resource-baselines.json)
+          python3 "$ACTION_PATH/../lib/compare-previews.py" stage-handoff-resources _resources.json \
+            "${RES_BASELINES_ARG[@]}" \
+            --output-dir "$HANDOFF_DIR/current-resources" \
+            --path-prefix "$HANDOFF_DIR/current-resources" \
+            --rewrite-json "$HANDOFF_DIR/_resources.json"
         fi
 
         echo "compose-preview: staged fork-safe handoff in $HANDOFF_DIR ($(du -sh "$HANDOFF_DIR" | cut -f1))."

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -147,6 +147,35 @@ inputs:
       Override the event-based mode selector: `auto` (default), `baseline`,
       `comment`, or `skip`.
     default: 'auto'
+  phase:
+    description: >
+      Split the action across two jobs so a **fork** PR can still get a
+      preview comment. On a `pull_request` from a fork, `GITHUB_TOKEN` is
+      read-only for every scope regardless of the workflow's `permissions:`
+      block, so neither the render push nor the comment upsert can succeed —
+      and `pull_request_target` is not the answer, because rendering means
+      building the PR's own code with a write-scoped token.
+
+        - `all` (default) — render, push and comment in one job. Correct for
+          same-repo PRs and for baseline runs on the development branch.
+        - `render` — run the pipelines and stage everything the publish half
+          needs into `handoff-dir`, then stop. Needs no write permission and
+          no secrets, so it is safe to run against untrusted PR code. The
+          caller uploads `handoff-dir` as an artifact.
+        - `publish` — skip rendering entirely; restore a `handoff-dir` the
+          caller has already downloaded, then push the renders and upsert the
+          comments. Runs from the base repository's own code (a `workflow_run`
+          job), so it holds the write token without ever executing PR code.
+
+      `publish` implies `mode: comment` and installs no CLI. See the
+      "Fork PRs" section of README.md for the two workflows.
+    default: 'all'
+  handoff-dir:
+    description: >
+      Directory the `render` phase stages into and the `publish` phase
+      restores from. Must match on both sides — the staged render envelope
+      carries paths relative to it.
+    default: '_compose_preview_handoff'
   ab-config:
     description: >
       Path (relative to the checkout) to the A/B comparison config JSON. When
@@ -201,10 +230,15 @@ runs:
         REF_NAME: ${{ github.ref_name }}
         DEV_BRANCH: ${{ inputs.development-branch }}
         MODE_OVERRIDE: ${{ inputs.mode }}
+        PHASE: ${{ inputs.phase }}
         ONLY: ${{ inputs.only }}
         SKIP: ${{ inputs.skip }}
       run: |
         set -euo pipefail
+        case "$PHASE" in
+          all|render|publish) ;;
+          *) echo "::error::phase must be one of all|render|publish (got '$PHASE')."; exit 1 ;;
+        esac
         # All four pipelines start ON, then `only` filters down, then `skip`
         # removes any pipelines explicitly turned off.
         compose=1; resources=1; a11y=1; notifications=1
@@ -235,6 +269,13 @@ runs:
         # Mode selection. `auto` maps event_name → mode; explicit values pass
         # through. `skip` aborts the whole action with a notice.
         mode="$MODE_OVERRIDE"
+        # The publish half runs on `workflow_run`, which `auto` maps to `skip`
+        # (it is neither a PR nor a push to the development branch). There is
+        # only ever one thing a publish job does, so resolve it directly rather
+        # than making every consumer pass `mode: comment` alongside `phase`.
+        if [ "$PHASE" = "publish" ] && [ "$mode" = "auto" ]; then
+          mode=comment
+        fi
         if [ "$mode" = "auto" ]; then
           case "$EVENT_NAME" in
             pull_request|pull_request_target)
@@ -257,14 +298,50 @@ runs:
         fi
 
         echo "mode=$mode" >> "$GITHUB_OUTPUT"
+        echo "phase=$PHASE" >> "$GITHUB_OUTPUT"
         echo "compose=$compose" >> "$GITHUB_OUTPUT"
         echo "resources=$resources" >> "$GITHUB_OUTPUT"
         echo "a11y=$a11y" >> "$GITHUB_OUTPUT"
         echo "notifications=$notifications" >> "$GITHUB_OUTPUT"
-        echo "compose-preview: mode=$mode; pipelines: compose=$compose resources=$resources a11y=$a11y notifications=$notifications"
+        echo "compose-preview: phase=$PHASE mode=$mode; pipelines: compose=$compose resources=$resources a11y=$a11y notifications=$notifications"
         if [ "$mode" = "skip" ]; then
           echo "::notice::No pipeline applicable for event=$EVENT_NAME ref=$REF_NAME — skipping."
         fi
+
+    # Publish half of the fork-safe split. Runs before everything else so the
+    # steps that follow — scope resolution included — see a fully restored
+    # workspace and need no publish-specific special-casing of their own.
+    #
+    # The caller has already downloaded the render job's artifact into
+    # `handoff-dir`; this lifts its contents back to the workspace root, where
+    # the push / comment steps expect them. `current/` deliberately stays put:
+    # the staged envelope's `pngPath` values point at `<handoff-dir>/current/…`.
+    - name: Restore fork-safe handoff
+      if: steps.resolve.outputs.phase == 'publish'
+      shell: bash
+      env:
+        HANDOFF_DIR: ${{ inputs.handoff-dir }}
+      run: |
+        set -euo pipefail
+        if [ ! -d "$HANDOFF_DIR" ]; then
+          echo "::error::phase=publish but '$HANDOFF_DIR' does not exist. Download the" \
+               "render job's artifact into it before calling this action."
+          exit 1
+        fi
+        restored=0
+        for entry in "$HANDOFF_DIR"/* "$HANDOFF_DIR"/.[!.]*; do
+          [ -e "$entry" ] || continue
+          base=$(basename "$entry")
+          # The staged current renders are addressed in place; everything else
+          # is read from the workspace root.
+          [ "$base" = "current" ] && continue
+          # Replace rather than merge: `cp -a dir existing-dir` would nest the
+          # staged tree one level deeper instead of overwriting it.
+          rm -rf "${GITHUB_WORKSPACE:?}/$base"
+          cp -a "$entry" "$GITHUB_WORKSPACE/$base"
+          restored=$((restored + 1))
+        done
+        echo "compose-preview: restored $restored handoff entr(ies) from $HANDOFF_DIR."
 
     # Change-scoped rendering (see compute-scope.py). Always runs so its
     # `mode` output is the single source of truth downstream: it passes the
@@ -293,10 +370,28 @@ runs:
         REPO: ${{ github.repository }}
         PR_INPUT_NUMBER: ${{ inputs.pr-number }}
         EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        PHASE: ${{ steps.resolve.outputs.phase }}
+        HANDOFF_DIR: ${{ inputs.handoff-dir }}
       run: |
         set -euo pipefail
         MODE="$RESOLVE_MODE"
         MODULES="full"
+        # A publish job has no PR diff to classify — it never checked the PR
+        # out. Reuse the scope the render job resolved instead of recomputing
+        # it: defaulting to `full` here would tell the comparator that every
+        # module was rendered, and each baseline the scoped render skipped
+        # would be reported as a Removed preview.
+        if [ "$PHASE" = "publish" ]; then
+          if [ -f "$HANDOFF_DIR/_scope_modules" ]; then
+            MODULES=$(cat "$HANDOFF_DIR/_scope_modules")
+            [ -z "$MODULES" ] && MODULES="full"
+            [ "$MODULES" != "full" ] && \
+              echo "::notice::compose-preview/apply: publishing a change-scoped render — modules: $MODULES"
+          fi
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "modules=$MODULES" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
         if [ "$MODE" = "comment" ] \
            && [ "$EVENT_NAME" = "pull_request" ] \
            && [ "$SCOPE_OVERRIDE" != "full" ] \
@@ -375,7 +470,7 @@ runs:
     # reuses the skew guard's tested detection (single source of truth).
     - name: Resolve CLI version
       id: clivers
-      if: steps.scope.outputs.mode != 'skip'
+      if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip')
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -404,7 +499,7 @@ runs:
     # composite resolves against the consumer's $GITHUB_WORKSPACE, breaking
     # external use). Tag bumped per release by release-please.
     - name: Install CLI from source
-      if: steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version == 'source'
+      if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version == 'source')
       # zizmor: ignore[known-vulnerable-actions] same-repo release action trips GitHub Advisories API 403 under GITHUB_TOKEN
       uses: yschimke/compose-ai-tools/.github/actions/install-cli@v0.11.5 # x-release-please-version
 
@@ -414,7 +509,7 @@ runs:
     # cleanly with "command not found" when selected without a CLI.
     - name: Install CLI from release
       id: install-release
-      if: steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none'
+      if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none')
       # zizmor: ignore[known-vulnerable-actions] same-repo release action trips GitHub Advisories API 403 under GITHUB_TOKEN
       uses: yschimke/compose-ai-tools/.github/actions/install@v0.11.5 # x-release-please-version
       with:
@@ -433,7 +528,7 @@ runs:
     # no Gradle cost — runs before doctor so the headline is the skew, not the
     # confusing symptom.
     - name: Check CLI / plugin version skew
-      if: steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none'
+      if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none')
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -454,7 +549,7 @@ runs:
     # actionable error. A non-zero doctor surfaces as a `::warning::`
     # annotation so it's still visible in the run summary.
     - name: Run compose-preview doctor
-      if: steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'none'
+      if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'none')
       shell: bash
       run: |
         echo "::group::compose-preview doctor"
@@ -478,7 +573,7 @@ runs:
           || echo "pixelmatch install failed; falling back to strict-bytes diff" >&2
 
     - name: Install fallback CJK / Arabic / emoji fonts
-      if: steps.scope.outputs.mode != 'skip'
+      if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip')
       shell: bash
       run: |
         # github.action_path points at .github/actions/apply in both a local checkout and a remote
@@ -492,7 +587,7 @@ runs:
     # will actually read rather than an empty `~/.cache` sibling.
     - name: Resolve downloadable-font cache dir
       id: fonts-dir
-      if: inputs.fonts-cache == 'true' && steps.scope.outputs.mode != 'skip'
+      if: steps.resolve.outputs.phase != 'publish' && (inputs.fonts-cache == 'true' && steps.scope.outputs.mode != 'skip')
       shell: bash
       run: |
         set -euo pipefail
@@ -510,7 +605,7 @@ runs:
     # paying the downloads still persists them, so the rerun starts warm.
     - name: Restore downloadable-font cache
       id: fonts-cache-restore
-      if: inputs.fonts-cache == 'true' && steps.scope.outputs.mode != 'skip'
+      if: steps.resolve.outputs.phase != 'publish' && (inputs.fonts-cache == 'true' && steps.scope.outputs.mode != 'skip')
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.fonts-dir.outputs.dir }}
@@ -531,7 +626,7 @@ runs:
 
     - name: Run pipelines
       id: pipelines
-      if: steps.scope.outputs.mode != 'skip'
+      if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip')
       shell: bash
       # Pipelines run back-to-back rather than in parallel: all four
       # invoke Gradle (directly or via the CLI) and all four `git fetch`
@@ -675,7 +770,7 @@ runs:
     # separate workflow jobs on the same commit) will race to save: the loser
     # logs a "key already exists" warning, which is the expected steady state.
     - name: Save downloadable-font cache
-      if: always() && inputs.fonts-cache == 'true' && steps.fonts-dir.outputs.dir != ''
+      if: steps.resolve.outputs.phase != 'publish' && (always() && inputs.fonts-cache == 'true' && steps.fonts-dir.outputs.dir != '')
       continue-on-error: true
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
@@ -688,7 +783,7 @@ runs:
     # the output value (not merely whether the rc file exists) avoids noisy,
     # empty artifact steps on every successful run.
     - name: Upload composePreviewRender reports
-      if: always() && steps.pipelines.outputs.compose_render_rc != '' && steps.pipelines.outputs.compose_render_rc != '0'
+      if: steps.resolve.outputs.phase != 'publish' && (always() && steps.pipelines.outputs.compose_render_rc != '' && steps.pipelines.outputs.compose_render_rc != '0')
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: composePreviewRender-reports
@@ -716,7 +811,7 @@ runs:
         retention-days: 14
 
     - name: Upload composePreviewRenderAndroidResources reports
-      if: always() && steps.pipelines.outputs.resources_render_rc != '' && steps.pipelines.outputs.resources_render_rc != '0'
+      if: steps.resolve.outputs.phase != 'publish' && (always() && steps.pipelines.outputs.resources_render_rc != '' && steps.pipelines.outputs.resources_render_rc != '0')
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: composePreviewRenderAndroidResources-reports
@@ -728,7 +823,7 @@ runs:
         retention-days: 14
 
     - name: Upload CLI JSON output on failure
-      if: always() && ((steps.pipelines.outputs.worst != '' && steps.pipelines.outputs.worst != '0') || (steps.pipelines.outputs.compose_render_rc != '' && steps.pipelines.outputs.compose_render_rc != '0') || (steps.pipelines.outputs.resources_render_rc != '' && steps.pipelines.outputs.resources_render_rc != '0'))
+      if: steps.resolve.outputs.phase != 'publish' && (always() && ((steps.pipelines.outputs.worst != '' && steps.pipelines.outputs.worst != '0') || (steps.pipelines.outputs.compose_render_rc != '' && steps.pipelines.outputs.compose_render_rc != '0') || (steps.pipelines.outputs.resources_render_rc != '' && steps.pipelines.outputs.resources_render_rc != '0')))
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: preview-cli-output
@@ -739,7 +834,7 @@ runs:
         retention-days: 14
 
     - name: Upload notification renders artifact
-      if: always() && steps.resolve.outputs.notifications == '1' && hashFiles('_notification_renders/findings.json') != ''
+      if: steps.resolve.outputs.phase != 'publish' && (always() && steps.resolve.outputs.notifications == '1' && hashFiles('_notification_renders/findings.json') != '')
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: notification-previews
@@ -747,12 +842,71 @@ runs:
         if-no-files-found: warn
         retention-days: 14
 
+    # Render half of the fork-safe split: collect everything the publish job
+    # reads off disk into one directory for the caller to upload.
+    #
+    # Most of it is already self-contained — `_pr_renders` and `_baselines`
+    # hold copied PNGs, and the `_*_renders` staging dirs carry their own push
+    # metadata. `_previews.json` is the exception: its `pngPath` values are
+    # absolute paths into this runner's Gradle build dirs, which do not exist
+    # on the publish runner. `stage-handoff` copies the renders that are still
+    # read there (the sha-differing ones, which is all `_is_changed` opens) and
+    # rebases every path onto `<handoff-dir>/current/`.
+    - name: Stage fork-safe handoff
+      if: steps.resolve.outputs.phase == 'render' && steps.scope.outputs.mode != 'skip'
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        HANDOFF_DIR: ${{ inputs.handoff-dir }}
+        SCOPE_MODULES: ${{ steps.scope.outputs.modules }}
+        PR_INPUT_NUMBER: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+        rm -rf "$HANDOFF_DIR"
+        mkdir -p "$HANDOFF_DIR"
+
+        # Everything the push / comment steps read, per surface. Absent
+        # entries are skipped: a run with `only: compose` stages compose alone,
+        # and a no-change run stages no `_pr_renders` at all — the publish job
+        # then finds nothing staged and skips its push, same as a single-job
+        # run would.
+        for f in _baselines _base_sha _pr_renders \
+                 _resources.json _resource_base_sha _pr_resource_renders \
+                 _a11y_renders _a11y_comment.md \
+                 _notification_renders _notification_comment.md; do
+          [ -e "$f" ] || continue
+          cp -a "$f" "$HANDOFF_DIR/$f"
+        done
+
+        # The publish job can't classify the PR diff itself (it never checks
+        # the PR out), so the resolved scope travels with the renders.
+        printf '%s' "${SCOPE_MODULES:-full}" > "$HANDOFF_DIR/_scope_modules"
+
+        # `github.event.workflow_run.pull_requests` is empty for fork PRs, so
+        # the number has to be carried too. The caller reads this back and
+        # passes it as `pr-number`.
+        printf '%s' "${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}" > "$HANDOFF_DIR/_pr_number"
+
+        if [ -s _previews.json ]; then
+          BASELINES_ARG=()
+          [ -f _baselines/baselines.json ] && BASELINES_ARG=(--baselines _baselines/baselines.json)
+          python3 "$ACTION_PATH/../lib/compare-previews.py" stage-handoff _previews.json \
+            "${BASELINES_ARG[@]}" \
+            --output-dir "$HANDOFF_DIR/current" \
+            --path-prefix "$HANDOFF_DIR/current" \
+            --rewrite-json "$HANDOFF_DIR/_previews.json"
+        fi
+
+        echo "compose-preview: staged fork-safe handoff in $HANDOFF_DIR ($(du -sh "$HANDOFF_DIR" | cut -f1))."
+        echo "::notice::compose-preview/apply: render phase complete — upload '$HANDOFF_DIR' and run the publish phase to push renders and post the comment."
+
     # Pushes + comments run as top-level steps so artifact uploads /
     # comment upserts get named log lines in the workflow run, and so
     # GHA's `if:` can gate them per pipeline.
 
     - name: Push compose baseline / PR renders
-      if: steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.compose == '1'
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.compose == '1')
       shell: bash
       env:
         REPO: ${{ github.repository }}
@@ -787,7 +941,7 @@ runs:
     - name: Publish compose baseline render history
       # Baseline mode only: history.json describes a delivery branch, and PR render branches are
       # short-lived so a timeline over them would be noise.
-      if: steps.scope.outputs.mode == 'baseline' && steps.resolve.outputs.compose == '1'
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode == 'baseline' && steps.resolve.outputs.compose == '1')
       shell: bash
       env:
         REPO: ${{ github.repository }}
@@ -897,7 +1051,7 @@ runs:
         done
 
     - name: Push resource baseline / PR renders
-      if: steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.resources == '1'
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.resources == '1')
       shell: bash
       env:
         REPO: ${{ github.repository }}
@@ -927,7 +1081,7 @@ runs:
         bash "$ACTION_PATH/lib/push-branch.sh"
 
     - name: Generate compose PR comment body
-      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.compose == '1'
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.compose == '1')
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -989,7 +1143,7 @@ runs:
     # `resources == '1'` so `only: resources` runs still produce the
     # resource sticky comment when compose is skipped.
     - name: Generate resource PR comment body
-      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.resources == '1'
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.resources == '1')
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -1030,7 +1184,7 @@ runs:
           > _comment_body_resources.md
 
     - name: Post or update compose PR comment
-      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.compose == '1' && hashFiles('_comment_body.md') != ''
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.compose == '1' && hashFiles('_comment_body.md') != '')
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -1062,7 +1216,7 @@ runs:
         bash "$ACTION_PATH/lib/post-comment.sh"
 
     - name: Post or update resource PR comment
-      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.resources == '1' && hashFiles('_comment_body_resources.md') != ''
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.resources == '1' && hashFiles('_comment_body_resources.md') != '')
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -1105,7 +1259,7 @@ runs:
 
     - name: Push a11y baseline / PR renders
       id: push-a11y
-      if: steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.a11y == '1'
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.a11y == '1')
       shell: bash
       env:
         REPO: ${{ github.repository }}
@@ -1129,7 +1283,7 @@ runs:
         echo "head_sha=$(cat "$SHA_OUTPUT_FILE" 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
 
     - name: Re-render a11y comment body with pushed SHA
-      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.a11y == '1' && hashFiles('_a11y_comment.md') != ''
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.a11y == '1' && hashFiles('_a11y_comment.md') != '')
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -1148,7 +1302,7 @@ runs:
           > _a11y_comment.md
 
     - name: Upsert a11y PR comment
-      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.a11y == '1' && hashFiles('_a11y_comment.md') != ''
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.a11y == '1' && hashFiles('_a11y_comment.md') != '')
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -1165,7 +1319,7 @@ runs:
 
     - name: Push notifications baseline / PR renders
       id: push-notifications
-      if: steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.notifications == '1'
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.notifications == '1')
       shell: bash
       env:
         REPO: ${{ github.repository }}
@@ -1189,7 +1343,7 @@ runs:
         echo "head_sha=$(cat "$SHA_OUTPUT_FILE" 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
 
     - name: Re-render notification comment body with pushed SHA
-      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1' && hashFiles('_notification_comment.md') != ''
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1' && hashFiles('_notification_comment.md') != '')
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -1209,7 +1363,7 @@ runs:
           > _notification_comment.md
 
     - name: Upsert notification PR comment
-      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1'
+      if: steps.resolve.outputs.phase != 'render' && (steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1')
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -1246,7 +1400,7 @@ runs:
     # still get their artifacts uploaded + the PR diff posted before this
     # flips the workflow red.
     - name: Surface pipeline failures
-      if: steps.scope.outputs.mode != 'skip'
+      if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip')
       shell: bash
       env:
         WORST_RC: ${{ steps.pipelines.outputs.worst }}

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -1952,6 +1952,70 @@ def cmd_stage_handoff(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_stage_handoff_resources(args: argparse.Namespace) -> int:
+    """`stage-handoff` for the Android-resource envelope.
+
+    Resource captures carry absolute `pngPath` values just like composables,
+    and `compare-resources` runs them through the same `_is_changed`
+    perceptual filter (with `size_aware=True`), so they need the same
+    treatment or a fork PR's resource diff is decided against paths that don't
+    exist on the publish runner — which fails closed, reporting renderer noise
+    as a real change.
+
+    Layout mirrors `copy-changed-resources`: `<module>/<destRelative>`, where
+    `destRelative` has already had its leading `renders/` stripped and the
+    module's gradle path has been translated to a filesystem one.
+    """
+    cli_json = Path(args.cli_json)
+    out_dir = Path(args.output_dir)
+    prefix = args.path_prefix.rstrip("/")
+    rewrite_json = Path(args.rewrite_json)
+
+    baselines: dict[str, dict] = {}
+    if getattr(args, "baselines", None):
+        baselines = _load_baselines(Path(args.baselines))
+
+    raw_bytes = cli_json.read_bytes()
+    if raw_bytes.startswith(b"\xef\xbb\xbf"):
+        raw_bytes = raw_bytes[3:]
+    raw = json.loads(raw_bytes.decode("utf-8"))
+
+    staged = 0
+    rewritten = 0
+    for resource in raw.get("resources", []) or []:
+        module = (resource.get("module") or "").lstrip(":").replace(":", "/")
+        resource_id = resource.get("id")
+        if not resource_id:
+            continue
+        for capture in resource.get("captures", []) or []:
+            render_output = capture.get("renderOutput") or ""
+            png_path = capture.get("pngPath")
+            if not render_output or not png_path:
+                continue
+            dest_rel = _resource_render_dest(render_output)
+            key = f"{module}::{resource_id}::{render_output}"
+            sha = capture.get("sha256") or ""
+            bl = baselines.get(key)
+            if sha and bl is not None and bl.get("sha256") != sha:
+                src = Path(png_path)
+                if src.exists():
+                    dest = out_dir / module / dest_rel
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src, dest)
+                    staged += 1
+            capture["pngPath"] = f"{prefix}/{module}/{dest_rel}"
+            rewritten += 1
+
+    rewrite_json.parent.mkdir(parents=True, exist_ok=True)
+    rewrite_json.write_text(json.dumps(raw))
+    print(
+        f"Staged {staged} current resource render(s) and rebased {rewritten} "
+        f"pngPath(s) onto {prefix}/",
+        file=sys.stderr,
+    )
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -2052,6 +2116,16 @@ def main() -> int:
     sh.add_argument("--rewrite-json", required=True,
                     help="Path to write the rebased envelope to")
 
+    shr = sub.add_parser(
+        "stage-handoff-resources",
+        help="stage-handoff for the `show-resources` envelope",
+    )
+    shr.add_argument("cli_json", help="Path to compose-preview show-resources --json output")
+    shr.add_argument("--baselines", help="resource-baselines.json for the baseline branch")
+    shr.add_argument("--output-dir", required=True)
+    shr.add_argument("--path-prefix", required=True)
+    shr.add_argument("--rewrite-json", required=True)
+
     gen_res = sub.add_parser(
         "generate-resources",
         help="Stage the rendered PNGs / GIFs from `compose-preview show-resources --json` "
@@ -2117,6 +2191,7 @@ def main() -> int:
         "compare": cmd_compare,
         "copy-changed": cmd_copy_changed,
         "stage-handoff": cmd_stage_handoff,
+        "stage-handoff-resources": cmd_stage_handoff_resources,
         "generate-resources": cmd_generate_resources,
         "copy-changed-resources": cmd_copy_changed_resources,
         "compare-resources": cmd_compare_resources,

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -1852,6 +1852,107 @@ def cmd_compare_resources(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# stage-handoff mode
+# ---------------------------------------------------------------------------
+
+def _rewritten_png_path(prefix: str, module: str, basename: str) -> str:
+    """Workspace-relative path a staged current render lands at.
+
+    Deliberately relative: the publish job restores the handoff into its own
+    `$GITHUB_WORKSPACE` — a different runner with a different absolute root —
+    and every action step runs with the workspace as cwd, so a relative path
+    is the only form that survives the trip. Module stays verbatim: a gradle
+    path like `samples:android` is one directory segment here, matching how
+    `generate` and `copy-changed` already lay out `renders/<module>/`.
+    """
+    return f"{prefix}/{module}/{basename}"
+
+
+def cmd_stage_handoff(args: argparse.Namespace) -> int:
+    """Stage the current renders a later publish job needs, and rebase the envelope.
+
+    The fork-safe split renders in an unprivileged job and pushes / comments
+    from a trusted one, so everything the publish half reads off disk has to
+    travel between them as an artifact. `_pr_renders` and `_baselines` are
+    already self-contained copies; `_previews.json` is not — it carries
+    *absolute* `pngPath` values (see `docs/daemon/PROTOCOL.md`) pointing into
+    the render job's Gradle build directories, which do not exist on the
+    publish runner.
+
+    So: copy the current PNGs the publish half still reads, and rewrite every
+    `pngPath` to its workspace-relative staged location.
+
+    Only rows that have a baseline entry with a *different* sha are copied,
+    because those are the only ones whose bytes get read again. `compare`
+    reaches for a current PNG solely through `_is_changed`, and every call site
+    guards on the key being present in the baselines, so a **new** preview is
+    never opened — its pixels already travel in `_pr_renders`, and staging them
+    a second time would double the artifact on the very run (no baseline branch
+    yet) where every preview is new. An **unchanged** row is never opened
+    either, since `_is_changed` fast-paths on a sha match before touching disk.
+
+    Both still get their path rewritten: one uniform resolution rule beats a
+    mix of staged-relative and stale-absolute paths, and the rewritten path
+    simply points at a file nothing opens.
+    """
+    cli_json = Path(args.cli_json)
+    out_dir = Path(args.output_dir)
+    prefix = args.path_prefix.rstrip("/")
+    rewrite_json = Path(args.rewrite_json)
+
+    baselines: dict[str, dict] = {}
+    if getattr(args, "baselines", None):
+        baselines = _load_baselines(Path(args.baselines))
+
+    raw_bytes = cli_json.read_bytes()
+    if raw_bytes.startswith(b"\xef\xbb\xbf"):
+        raw_bytes = raw_bytes[3:]
+    raw = json.loads(raw_bytes.decode("utf-8"))
+    entries = raw["previews"] if isinstance(raw, dict) and "previews" in raw else raw
+
+    staged = 0
+    rewritten = 0
+
+    def handle(row: dict, key: str, module: str, preview_id: str) -> None:
+        nonlocal staged, rewritten
+        png_path = row.get("pngPath") or ""
+        if not png_path:
+            return
+        basename = _render_basename(png_path, preview_id)
+        sha = row.get("sha256") or ""
+        bl = baselines.get(key)
+        if sha and bl is not None and bl.get("sha256") != sha:
+            src = Path(png_path)
+            if src.exists():
+                dest = out_dir / module / basename
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dest)
+                staged += 1
+        row["pngPath"] = _rewritten_png_path(prefix, module, basename)
+        rewritten += 1
+
+    for entry in entries:
+        module = entry["module"]
+        preview_id = entry["id"]
+        captures = entry.get("captures") or []
+        if not captures:
+            handle(entry, f"{module}/{preview_id}", module, preview_id)
+            continue
+        for idx, capture in enumerate(captures):
+            key = f"{module}/{preview_id}" if idx == 0 else f"{module}/{preview_id}#{idx}"
+            handle(capture, key, module, preview_id)
+
+    rewrite_json.parent.mkdir(parents=True, exist_ok=True)
+    rewrite_json.write_text(json.dumps(raw))
+    print(
+        f"Staged {staged} current render(s) and rebased {rewritten} pngPath(s) "
+        f"onto {prefix}/",
+        file=sys.stderr,
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -1933,6 +2034,24 @@ def main() -> int:
     cp.add_argument("--baseline-renders",
                     help="Directory containing baseline PNGs (renders/<module>/<basename>)")
 
+    sh = sub.add_parser(
+        "stage-handoff",
+        help="Stage current renders + rebase pngPath for a fork-safe publish job",
+    )
+    sh.add_argument("cli_json", help="Path to compose-preview show --json output")
+    sh.add_argument("--baselines",
+                    help="baselines.json for the current baseline branch. Omit when no "
+                         "baseline exists — every row then reads as new and no current "
+                         "render needs staging.")
+    sh.add_argument("--output-dir", required=True,
+                    help="Directory to copy current PNGs into (<dir>/<module>/<basename>)")
+    sh.add_argument("--path-prefix", required=True,
+                    help="Workspace-relative prefix written into the rewritten envelope's "
+                         "pngPath values. Must be where --output-dir lands after the "
+                         "publish job restores the handoff.")
+    sh.add_argument("--rewrite-json", required=True,
+                    help="Path to write the rebased envelope to")
+
     gen_res = sub.add_parser(
         "generate-resources",
         help="Stage the rendered PNGs / GIFs from `compose-preview show-resources --json` "
@@ -1997,6 +2116,7 @@ def main() -> int:
         "generate": cmd_generate,
         "compare": cmd_compare,
         "copy-changed": cmd_copy_changed,
+        "stage-handoff": cmd_stage_handoff,
         "generate-resources": cmd_generate_resources,
         "copy-changed-resources": cmd_copy_changed_resources,
         "compare-resources": cmd_compare_resources,

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -2604,5 +2604,88 @@ class StageHandoffTest(unittest.TestCase):
                          "change it.")
 
 
+class StageHandoffResourcesTest(unittest.TestCase):
+    """`stage-handoff-resources` — the resource half of the same bridge."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.renders = self.tmp / "build" / "res"
+        self.renders.mkdir(parents=True)
+
+    def _run(self, envelope, baselines=None):
+        from types import SimpleNamespace
+        cli_json = self.tmp / "_resources.json"
+        cli_json.write_text(json.dumps(envelope))
+        bl_path = None
+        if baselines is not None:
+            bl_path = self.tmp / "resource-baselines.json"
+            bl_path.write_text(json.dumps(baselines))
+        out_dir = self.tmp / "_handoff" / "current-resources"
+        rewrite = self.tmp / "_handoff" / "_resources.json"
+        rc = cp.cmd_stage_handoff_resources(SimpleNamespace(
+            cli_json=str(cli_json),
+            baselines=str(bl_path) if bl_path else None,
+            output_dir=str(out_dir),
+            path_prefix="_handoff/current-resources",
+            rewrite_json=str(rewrite),
+        ))
+        self.assertEqual(rc, 0)
+        return out_dir, json.loads(rewrite.read_text())
+
+    def _envelope(self, png, sha):
+        return {"resources": [{
+            "module": ":samples:android", "id": "drawable/foo", "type": "drawable",
+            "captures": [{"renderOutput": "renders/resources/drawable/foo.png",
+                          "pngPath": png, "sha256": sha, "variant": {}}],
+        }]}
+
+    def test_changed_resource_is_staged_and_rebased(self):
+        png = self.renders / "foo.png"
+        png.write_bytes(b"new")
+        out_dir, rewritten = self._run(
+            self._envelope(str(png), "new"),
+            baselines={"samples/android::drawable/foo::renders/resources/drawable/foo.png":
+                       {"sha256": "old"}},
+        )
+        self.assertTrue((out_dir / "samples/android" / "resources/drawable/foo.png").exists(),
+                        "compare-resources runs the same _is_changed perceptual filter, "
+                        "so a sha-differing resource's bytes are read on the publish side.")
+        self.assertEqual(rewritten["resources"][0]["captures"][0]["pngPath"],
+                         "_handoff/current-resources/samples/android/resources/drawable/foo.png")
+
+    def test_unchanged_resource_is_not_staged(self):
+        png = self.renders / "foo.png"
+        png.write_bytes(b"same")
+        out_dir, _ = self._run(
+            self._envelope(str(png), "same"),
+            baselines={"samples/android::drawable/foo::renders/resources/drawable/foo.png":
+                       {"sha256": "same"}},
+        )
+        self.assertFalse((out_dir / "samples/android" / "resources/drawable/foo.png").exists())
+
+    def test_rebased_resource_envelope_round_trips(self):
+        png = self.renders / "foo.png"
+        png.write_bytes(b"new")
+        out_dir, rewritten = self._run(
+            self._envelope(str(png), "new"),
+            baselines={"samples/android::drawable/foo::renders/resources/drawable/foo.png":
+                       {"sha256": "old"}},
+        )
+        workspace = self.tmp / "publish-workspace"
+        (workspace / "_handoff").mkdir(parents=True)
+        shutil.copytree(out_dir, workspace / "_handoff" / "current-resources")
+        restored = workspace / "_resources.json"
+        restored.write_text(json.dumps(rewritten))
+
+        rows = cp.load_resource_results(restored)
+        key = "samples/android::drawable/foo::renders/resources/drawable/foo.png"
+        self.assertIn(key, rows, "The staged key must match load_resource_results' "
+                                 "gradle-path translation or the row reads as new.")
+        rel = rows[key]["pngPath"]
+        self.assertFalse(rel.is_absolute())
+        self.assertTrue((workspace / rel).exists())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -2467,5 +2467,142 @@ class CompareResourcesAgainstEmptyBaselineTest(unittest.TestCase):
         self.assertIn("`drawable/foo`", buf.getvalue())
 
 
+class StageHandoffTest(unittest.TestCase):
+    """`stage-handoff` — the render→publish bridge for fork-safe runs.
+
+    What matters here is that the publish job, restoring this output into a
+    fresh workspace, can still resolve every PNG `compare` will actually open.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.renders = self.tmp / "build" / "renders"
+        self.renders.mkdir(parents=True)
+
+    def _render(self, name: str, content: bytes) -> str:
+        p = self.renders / name
+        p.write_bytes(content)
+        return str(p)
+
+    def _run(self, envelope, baselines=None):
+        from types import SimpleNamespace
+        cli_json = self.tmp / "_previews.json"
+        cli_json.write_text(json.dumps(envelope))
+        bl_path = None
+        if baselines is not None:
+            bl_path = self.tmp / "baselines.json"
+            bl_path.write_text(json.dumps(baselines))
+        out_dir = self.tmp / "_handoff" / "current"
+        rewrite = self.tmp / "_handoff" / "_previews.json"
+        rc = cp.cmd_stage_handoff(SimpleNamespace(
+            cli_json=str(cli_json),
+            baselines=str(bl_path) if bl_path else None,
+            output_dir=str(out_dir),
+            path_prefix="_handoff/current",
+            rewrite_json=str(rewrite),
+        ))
+        self.assertEqual(rc, 0)
+        return out_dir, json.loads(rewrite.read_text())
+
+    def _envelope(self, previews):
+        return {"schema": "compose-preview-show/v1", "previews": previews}
+
+    def test_changed_render_is_staged_and_path_rebased(self):
+        png = self._render("Fn.png", b"new-bytes")
+        out_dir, rewritten = self._run(
+            self._envelope([_entry(id="Fn", module="app", png=png, sha="new")]),
+            baselines={"app/Fn": {"sha256": "old", "renderBasename": "Fn.png"}},
+        )
+        self.assertTrue((out_dir / "app" / "Fn.png").exists(),
+                        "A sha-differing row's bytes are read again by _is_changed.")
+        self.assertEqual(rewritten["previews"][0]["pngPath"],
+                         "_handoff/current/app/Fn.png")
+
+    def test_unchanged_render_is_rebased_but_not_copied(self):
+        png = self._render("Fn.png", b"same-bytes")
+        out_dir, rewritten = self._run(
+            self._envelope([_entry(id="Fn", module="app", png=png, sha="same")]),
+            baselines={"app/Fn": {"sha256": "same", "renderBasename": "Fn.png"}},
+        )
+        self.assertFalse((out_dir / "app" / "Fn.png").exists(),
+                         "_is_changed fast-paths on a sha match without touching disk.")
+        self.assertEqual(rewritten["previews"][0]["pngPath"],
+                         "_handoff/current/app/Fn.png",
+                         "Every row is rebased so path resolution stays uniform.")
+
+    def test_no_baselines_stages_nothing(self):
+        png = self._render("Fn.png", b"bytes")
+        out_dir, rewritten = self._run(
+            self._envelope([_entry(id="Fn", module="app", png=png, sha="new")]))
+        self.assertFalse(out_dir.exists(),
+                         "With no baseline every row is new; compare never opens a "
+                         "current PNG, and _pr_renders already carries the pixels.")
+        self.assertEqual(rewritten["previews"][0]["pngPath"],
+                         "_handoff/current/app/Fn.png")
+
+    def test_new_preview_is_not_staged(self):
+        png = self._render("Fn.png", b"bytes")
+        out_dir, _rewritten = self._run(
+            self._envelope([_entry(id="Fn", module="app", png=png, sha="new")]),
+            baselines={"app/Other": {"sha256": "x", "renderBasename": "Other.png"}},
+        )
+        self.assertFalse((out_dir / "app" / "Fn.png").exists(),
+                         "Every _is_changed call site guards on the key being in "
+                         "baselines, so a new preview's bytes are never re-read.")
+
+    def test_multi_capture_rows_are_keyed_like_load_cli_output(self):
+        a = self._render("Fn.png", b"a")
+        b = self._render("Fn_SCROLL_end.png", b"b")
+        out_dir, rewritten = self._run(
+            self._envelope([_entry(id="Fn", module="app", captures=[
+                _capture(png=a, sha="a-new"),
+                _capture(png=b, sha="b-same"),
+            ])]),
+            baselines={
+                "app/Fn": {"sha256": "a-old", "renderBasename": "Fn.png"},
+                "app/Fn#1": {"sha256": "b-same", "renderBasename": "Fn_SCROLL_end.png"},
+            },
+        )
+        self.assertTrue((out_dir / "app" / "Fn.png").exists())
+        self.assertFalse((out_dir / "app" / "Fn_SCROLL_end.png").exists(),
+                         "Capture #1 matched its baseline sha — the `#<n>` key has to "
+                         "line up with load_cli_output or it would read as changed.")
+        caps = rewritten["previews"][0]["captures"]
+        self.assertEqual(caps[0]["pngPath"], "_handoff/current/app/Fn.png")
+        self.assertEqual(caps[1]["pngPath"], "_handoff/current/app/Fn_SCROLL_end.png")
+
+    def test_failed_render_without_png_is_left_alone(self):
+        _out_dir, rewritten = self._run(
+            self._envelope([_entry(id="Fn", module="app", png=None, sha=None)]))
+        self.assertIsNone(rewritten["previews"][0]["pngPath"],
+                          "A row with no PNG is a render failure _collect_failures "
+                          "still needs to see as empty.")
+
+    def test_rebased_envelope_round_trips_through_load_cli_output(self):
+        png = self._render("Fn.png", b"new-bytes")
+        out_dir, rewritten = self._run(
+            self._envelope([_entry(id="Fn", module="app", png=png, sha="new")]),
+            baselines={"app/Fn": {"sha256": "old", "renderBasename": "Fn.png"}},
+        )
+        # The publish job restores the handoff under its own workspace root and
+        # runs with that root as cwd, so the relative path has to resolve there.
+        workspace = self.tmp / "publish-workspace"
+        (workspace / "_handoff").mkdir(parents=True)
+        shutil.copytree(out_dir, workspace / "_handoff" / "current")
+        restored = workspace / "_previews.json"
+        restored.write_text(json.dumps(rewritten))
+
+        rows = cp.load_cli_output(restored)
+        rel = rows["app/Fn"]["pngPath"]
+        self.assertFalse(Path(rel).is_absolute())
+        self.assertTrue((workspace / rel).exists(),
+                        "compare() opens pngPath relative to cwd; the publish job "
+                        "cds to the workspace root.")
+        self.assertEqual(rows["app/Fn"]["renderBasename"], "Fn.png",
+                         "renderBasename drives the image URL, so rebasing must not "
+                         "change it.")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

`apply` can't post a preview comment on a PR raised from a **fork**. On a `pull_request` event from a fork, `GITHUB_TOKEN` is read-only for every scope regardless of the workflow's `permissions:` block — so the render push 403s, and the sticky comment can't be posted either, since commenting is a write too.

The trigger that *does* hand out a write token, `pull_request_target`, is the wrong tool here: rendering previews means checking out the PR's own code and running its Gradle build, so a job holding that token would be executing untrusted code with write access to the repository.

This came out of reviewing [google/horologist#2783](https://github.com/google/horologist/pull/2783), which hit exactly this and landed on `pull_request_target` + `ref: head.sha` as the workaround.

## What

Split the action across two jobs instead of two triggers:

| `phase` | Runs | Needs |
|---|---|---|
| `all` (default, unchanged) | render + push + comment in one job | write token |
| `render` | pipelines only, stages the handoff, then stops | nothing — read-only token, no secrets |
| `publish` | restores the handoff, pushes and comments | write token, but runs the **base branch's** code and never executes anything from the PR |

`publish` implies `mode: comment`, installs no CLI, and picks the render job's pipeline selection back up, so a consumer passes `phase` and `pr-number` rather than repeating the whole invocation.

Nothing changes for existing consumers: `all` is the default and every existing step keeps its original `if:` condition, now wrapped with a phase guard.

## Design notes

**Where the seam is.** Steps up to and including `Run pipelines` are the render half; everything from `Push compose baseline / PR renders` onward is the publish half. Two surfaces (a11y, notifications) already re-render their comment body *after* the push to pin image URLs to the pushed SHA, so deferring the publish side was an established pattern rather than a new one.

**The artifact is treated as hostile.** It is produced by a job that ran the PR's own Gradle build, and the pipelines write their push metadata as each surface completes — so a later pipeline, still executing fork code, can rewrite what an earlier one staged. Push *control* therefore never comes from the artifact: destination branch, commit message and skip flag are rebuilt on the publish side from the same literals the single-job path uses, so a `_push_branch` rewritten to `main` aims nothing at the default branch. A `.github/` tree found in a staging dir is dropped before the push, since `push-branch.sh` commits the directory wholesale and a workflow file landing on a render branch would run on its own `push` trigger. The staging dirs contribute pixels; every decision is made from the action's own constants.

**What has to travel between the jobs**, because the publish job cannot recover it:

- `_pr_number` — `github.event.workflow_run.pull_requests` is empty for fork PRs, which is the one case this whole path exists for.
- `_scope_modules` — the publish job never checked the PR out, so it can't classify the diff. Without the render job's scope, a change-scoped run would report every unrendered module's baseline as a *Removed* preview.
- `_pipelines` — the resolved `only` / `skip` set. Re-resolving from the publish call's own inputs would default all four on, and the upsert for a pipeline that never ran would patch its sticky comment to "no changes". Parsed strictly: four `0`/`1` fields, anything else fails the run rather than being coerced into an enabled pipeline.
- `_ab_config` — read from the checkout, which on the publish side is the base branch, so a PR that adds or edits an A/B config would otherwise be graded against the old grouping.

Both sides of every comparison travel, not just the new renders, because the comparators fail closed on a missing baseline: an absent `_resource_baselines/renders` turns renderer anti-aliasing noise into a false resource diff, and a missing `_notification_baseline_findings.json` reads as an empty baseline, reporting every surviving preview as *Added* and losing removals.

**Why the envelopes get rewritten.** The CLI emits **absolute** `pngPath` values pointing into the render runner's Gradle build directories, which don't exist on the publish runner. New `stage-handoff` and `stage-handoff-resources` subcommands copy the renders the publish side still opens and rebase every path onto a workspace-relative `handoff-dir/current/`. Resource captures need this as much as composables do — `compare-resources` runs them through the same `_is_changed` perceptual filter.

**Why only some renders are staged.** `compare` reaches for a current PNG solely through `_is_changed`, and every call site guards on the key being present in the baselines. So a *new* preview is never re-read — its pixels already travel in `_pr_renders`, and staging them again would double the artifact on precisely the run (no baseline branch yet) where every preview is new. An *unchanged* row isn't read either, since `_is_changed` fast-paths on a sha match before touching disk. Both still get their path rewritten, so path resolution stays uniform.

## Test plan

- `python3 .github/actions/lib/test_compare_previews.py` — 110 pass, 11 new. Covers: changed rows staged and rebased, unchanged rows rebased but not copied, new rows not staged, no-baselines staging nothing, multi-capture `#N` keys lining up with `load_cli_output`, failed renders (no PNG) left alone, the resource variants of the same, and round trips that restore each bundle into a *different* workspace root and assert the relative paths resolve there.
- Simulated the `render` → `publish` handoff end to end with the bash steps extracted verbatim from `action.yml`: staged 1 of 3 renders (the sha-differing one), restored the bundle into a fresh workspace, and generated a correct comment body with commit-pinned `raw.githubusercontent.com` URLs and the change-scope note carried across.
- Replayed the push-control attack against the restore step: a handoff with `_push_branch` = `main`, `_skip_if_unchanged` = `1` and a planted `.github/workflows/evil.yml` comes out aimed at `compose-preview/pr`, with the workflow file dropped and the renders intact.
- `action.yml`, every bash step body, and all four README workflow examples parse.

Not exercised here: a real fork PR against a live repo. The reference workflows in the new README section are the intended first consumer.

## Docs

New **Fork PRs** section in `.github/actions/apply/README.md` with both workflows (including the concurrency groups that keep overlapping `synchronize` events from letting an older render's publisher overwrite the shared branches with stale pixels), a table of what travels in the handoff, and an explicit note on what the publish job does and does not make trusted — the render job still runs fork code, it just has nothing worth stealing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzGvRNrQeHD1f4myvDX2iA)_