### PR TITLE
fix(serve): filter, focus and theme-lane corrections for the catalog tree

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1119,6 +1119,16 @@ object ServeWeb {
     /** The variant shown by default (server-side): light, else dark, else the neutral render. */
     val default: ServePreview
       get() = light ?: dark ?: neutral!!
+
+    /**
+     * The render the grid actually paints, which on a **dark-first** system is the dark one —
+     * [default] prefers light regardless, and `swapCard` has always opened on the system's own
+     * lane. Anything describing the card to a visitor has to agree with the pixels beside it: a
+     * tree built from [default] would label a dark-first catalog's cards from their light twins and
+     * send every variant link into the light lane while the card next to it is showing dark.
+     */
+    fun rendered(darkFirst: Boolean): ServePreview =
+      if (darkFirst) (dark ?: light ?: neutral!!) else default
   }
 
   /**
@@ -1471,6 +1481,32 @@ object ServeWeb {
         .map { if (it.isLetterOrDigit() || it == '_' || it == '-') it else '-' }
         .joinToString("")
 
+  /**
+   * One anchor per card, minted once for the whole page.
+   *
+   * Two things depend on this happening in a single place. The grid and the tree must not compute
+   * the anchor differently — they name the same element. And the anchors have to be **injective**:
+   * [cardAnchorId] folds everything outside the HTML-id alphabet to `-`, and a preview id may
+   * legitimately contain `/`, `?`, `#` or a space, so `Foo/Bar` and `Foo?Bar` would otherwise mint
+   * one id for two cards and `getElementById` would send both rows — and both fragment URLs — to
+   * whichever card came first. A collision takes a numeric suffix, exactly as the group slugs do.
+   */
+  private fun mintCardAnchors(cards: List<GridCard>): Map<String, String> {
+    val used = HashSet<String>()
+    val out = LinkedHashMap<String, String>()
+    cards.forEach { card ->
+      val base = cardAnchorId(card.default.id)
+      var candidate = base
+      var n = 2
+      while (!used.add(candidate)) {
+        candidate = "$base-$n"
+        n++
+      }
+      out[card.default.id] = candidate
+    }
+    return out
+  }
+
   /** One **primary-axis** variant of a component: a distinct state or props render. */
   private class TreeVariant(val label: String, val href: String)
 
@@ -1490,12 +1526,11 @@ object ServeWeb {
    * same set the viewer would, rather than a second opinion about what belongs together.
    */
   private fun primaryVariants(
-    card: GridCard,
+    default: ServePreview,
     all: List<ServePreview>,
     darkFirst: Boolean,
     href: (ServePreview) -> String,
   ): List<TreeVariant> {
-    val default = card.default
     val lane = themeLane(default, darkFirst)
     val defaultState = default.state ?: "default"
     val rows = mutableListOf<TreeVariant>()
@@ -2210,7 +2245,11 @@ object ServeWeb {
       if (!hasTree) ""
       else
         "\n      var treeGroups = document.querySelectorAll(\".cp-tree-group\");" +
-          "\n      var treeLinks = document.querySelectorAll(\".cp-tree-link\");"
+          "\n      var treeComponents = document.querySelectorAll(\".cp-tree-component\");" +
+          "\n      var treeLinks = document.querySelectorAll(\".cp-tree-link\");" +
+          // The tree's own roving-tab-stop pass, published so `apply()` can call it from outside
+          // the tree script's closure once the filter has changed which rows are on screen.
+          "\n      var cpTreeStops = null;"
     val tabDecls =
       if (hasTabs)
         "\n      var tabBtns = document.querySelectorAll(\".cp-tab\");" +
@@ -2284,18 +2323,30 @@ object ServeWeb {
     // construction (its cards are filtered out by tab), and hiding those rows would delete the
     // navigation instead of filtering it. Re-reflecting last picks up the expansion a search opens.
     val treePost =
-      if (hasTabs)
-        "\n        treeGroups.forEach(function (g) {" +
+      if (!hasTree) ""
+      else
+      // Component rows first: each follows the card it points at, so a search never leaves a row
+      // that scrolls to something hidden. Then the group rows follow their sub-group, which by
+      // now has collapsed if the filter emptied it.
+      "\n        treeComponents.forEach(function (c) {" +
+          "\n          var card = document.getElementById(c.getAttribute(\"data-group\"));" +
+          "\n          if (c.parentElement) c.parentElement.hidden = !!(card && card.hidden);" +
+          "\n        });" +
+          "\n        treeGroups.forEach(function (g) {" +
           "\n          var sub = document.getElementById(g.getAttribute(\"data-group\"));" +
           "\n          if (g.parentElement) g.parentElement.hidden = !!(sub && sub.hidden);" +
           "\n        });" +
-          "\n        tabBtns.forEach(function (t) {" +
-          "\n          var node = t.closest(\".cp-tree-node\");" +
-          "\n          var sec = document.getElementById(t.getAttribute(\"aria-controls\"));" +
-          "\n          if (node) node.hidden = q !== \"\" && !!(sec && sec.hidden);" +
-          "\n        });" +
-          "\n        reflectTabs();"
-      else ""
+          (if (hasTabs)
+            "\n        tabBtns.forEach(function (t) {" +
+              "\n          var node = t.closest(\".cp-tree-node\");" +
+              "\n          var sec = document.getElementById(t.getAttribute(\"aria-controls\"));" +
+              "\n          if (node) node.hidden = q !== \"\" && !!(sec && sec.hidden);" +
+              "\n        });" +
+              "\n        reflectTabs();"
+          else "") +
+          // Last word on the roving tab stop: the rows that just appeared or vanished change which
+          // one should hold it, and `reflectTabs` only ever knew about sections and groups.
+          "\n        if (cpTreeStops) cpTreeStops();"
     val tabWiring =
       if (hasTabs)
         "\n      tabBtns.forEach(function (t) {" +
@@ -2554,6 +2605,10 @@ object ServeWeb {
           openGroup = r.getAttribute("data-group");
         }
       });
+      function parentRow(row) {
+        var list = row.closest("ul.cp-tree-children");
+        return list ? list.previousElementSibling : null;
+      }
       function reflectTree() {
         treeLinks.forEach(function (r) {
           if (!r.hasAttribute("aria-expanded")) return;
@@ -2569,8 +2624,17 @@ object ServeWeb {
           openCard = null;
         } else if (row.classList.contains("cp-tree-component")) {
           openCard = id;
+          // And the group that HOLDS it. A click can only reach a component whose group is already
+          // open, but a `#cp-card-…` fragment can name one in any group — and leaving `openGroup`
+          // on whichever group the server expanded would scroll to the card while keeping its own
+          // row, and every variant under it, collapsed out of the tree.
+          var owner = parentRow(row);
+          if (owner && owner.classList.contains("cp-tree-group")) {
+            openGroup = owner.getAttribute("data-group");
+          }
         }
         reflectTree();
+        syncTabStops();
       }
       // The fragment is part of the address this page describes, and `cpUrlState` deliberately
       // preserves whatever hash is already there when it rewrites the query. So a click that moves
@@ -2612,10 +2676,20 @@ object ServeWeb {
         visibleRows().forEach(function (i) { i.tabIndex = i === el ? 0 : -1; });
         el.focus();
       }
-      function parentRow(row) {
-        var list = row.closest("ul.cp-tree-children");
-        return list ? list.previousElementSibling : null;
+      // A `role="tree"` is ONE tab stop: Tab enters it, the arrow keys move within it, Tab leaves.
+      // Nothing established that until a first arrow press called `focusRow`, so every visible row
+      // sat in the normal tab order until then — the whole point of the pattern, lost on the one
+      // pass that matters, and worse the deeper the tree got. Keeps an existing stop if it is still
+      // on screen (so a filter does not yank focus) and otherwise hands it to the first row.
+      function syncTabStops() {
+        var rows = visibleRows();
+        if (!rows.length) return;
+        var stop = null;
+        rows.forEach(function (r) { if (!stop && r.tabIndex === 0) stop = r; });
+        if (!stop) stop = rows[0];
+        rows.forEach(function (r) { r.tabIndex = r === stop ? 0 : -1; });
       }
+      cpTreeStops = syncTabStops;
       tree.addEventListener("keydown", function (e) {
         var items = visibleRows();
         var at = items.indexOf(document.activeElement);
@@ -2682,6 +2756,7 @@ object ServeWeb {
         }
         return row || tab ? { tab: tab, row: row, id: id } : null;
       }
+      syncTabStops();
       var landing = hashTarget();
       if (landing) {
         if (landing.row) openRow(landing.row);
@@ -4962,6 +5037,7 @@ object ServeWeb {
           it.renderFailure == null && (isNonDefaultState(it) || hasNonDefaultProps(it))
         }
       )
+    val cardAnchors = mintCardAnchors(groups)
     val renderFailureSummary =
       previews
         .mapNotNull { it.renderFailure }
@@ -5132,7 +5208,7 @@ object ServeWeb {
     // rather than from position, so a row keeps pointing at the same component as the catalog
     // grows.
     fun cardHtml(card: GridCard): String {
-      val anchor = " id=\"${cardAnchorId(card.default.id)}\""
+      val anchor = " id=\"${cardAnchors.getValue(card.default.id)}\""
       return if (card.swappable) swapCard(card, anchor) else singleCard(card.default, anchor)
     }
     val cards =
@@ -5168,14 +5244,17 @@ object ServeWeb {
       }
     }
     // The component row for a card: its grid label, the card's own anchor, and the primary-axis
-    // variants the grid folded out from under it.
-    fun treeComponent(card: GridCard): TreeComponent =
-      TreeComponent(
-        label = gridDisplayName(card.default),
-        anchorId = cardAnchorId(card.default.id),
-        variants = primaryVariants(card, previews, darkFirst) { viewerHref(it) },
-        href = viewerHref(card.default),
+    // variants the grid folded out from under it. Built from the render the grid actually paints,
+    // which on a dark-first system is the dark one.
+    fun treeComponent(card: GridCard): TreeComponent {
+      val shown = card.rendered(darkFirst)
+      return TreeComponent(
+        label = gridDisplayName(shown),
+        anchorId = cardAnchors.getValue(card.default.id),
+        variants = primaryVariants(shown, previews, darkFirst) { viewerHref(it) },
+        href = viewerHref(shown),
       )
+    }
     val tabBar =
       when {
         hasTabs -> catalogTreeHtml(sections, ::treeComponent)

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -533,6 +533,10 @@ html.cp-js .cp-tree-link[aria-expanded="false"] + .cp-tree-children { display: n
 }
 /* Level three and four. Each nests one step further in and loses a little weight, so depth reads
    at a glance rather than having to be counted: group → component → variant. */
+/* A component row jumps to a card, so a card needs the same clearance under the sticky toolbar
+   that sections and sub-groups already get — without it every component jump parks the preview's
+   top edge behind the toolbar. */
+.cp-card { scroll-margin-top: calc(var(--cp-sticky-tools, 64px) + 12px); }
 .cp-tree-components { margin: 2px 0 4px 12px;
   border-left: 1px solid var(--md-sys-color-outline-variant); }
 .cp-tree-component { display: flex; align-items: center; gap: 6px; min-height: 30px;

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -2875,6 +2875,33 @@ class ServeWebFixtureTest {
         .containsMatchIn(landingTreeDepth),
       "theme stays a secondary axis and earns no tree row",
     )
+    // A filter that hides a card must hide the row pointing at it, at EVERY level and in both tree
+    // modes — otherwise a search leaves rows that scroll to nothing.
+    assertTrue(
+      landingTreeDepth.contains("treeComponents.forEach(function (c) {") &&
+        landingGrouped.contains("treeComponents.forEach(function (c) {") &&
+        landingGrouped.contains("treeGroups.forEach(function (g) {"),
+      "the search filter follows the tree down to its component rows, outline trees included",
+    )
+    // A `role="tree"` is one tab stop. Nothing established that until the first arrow press, so
+    // every visible row sat in the tab order until then.
+    assertTrue(
+      landingTreeDepth.contains("function syncTabStops()") &&
+        landingTreeDepth.contains("cpTreeStops = syncTabStops;") &&
+        landingTreeDepth.contains("if (cpTreeStops) cpTreeStops();"),
+      "the tree keeps a single roving tab stop, re-synced whenever the filter moves rows",
+    )
+    // A `#cp-card-…` fragment can name a component in any group, not just the one the server
+    // expanded — its own row has to open along with it.
+    assertTrue(
+      landingTreeDepth.contains("var owner = parentRow(row);"),
+      "landing on a component's fragment opens the group that holds it",
+    )
+    // Cards are jump targets now, so they need the clearance sections and sub-groups already have.
+    assertTrue(
+      assetText("serve.css").contains(".cp-card { scroll-margin-top:"),
+      "a card cleared the sticky toolbar when a component row jumps to it",
+    )
     assertFalse(
       landingGrouped.contains("data-tab=") ||
         landingGrouped.contains("localStorage.getItem(\"cp-tab:"),

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -253,7 +253,9 @@
       if (input) { var urlQuery = urlParam("q"); if (urlQuery) input.value = urlQuery; }
       var navGroups = document.querySelectorAll(".cp-subgroup");
       var treeGroups = document.querySelectorAll(".cp-tree-group");
+      var treeComponents = document.querySelectorAll(".cp-tree-component");
       var treeLinks = document.querySelectorAll(".cp-tree-link");
+      var cpTreeStops = null;
       var stored = null;
 try { stored = localStorage.getItem("cp-theme:default"); } catch (e) {}
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
@@ -361,6 +363,15 @@ applyThemeChoice();
         if (count) count.textContent = q === "" ? (total + " preview" + (total === 1 ? "" : "s")) : (shown + " of " + total);
         if (empty) empty.hidden = shown !== 0;
         navGroups.forEach(function (g) { g.hidden = !g.querySelector(".cp-card:not([hidden])"); });
+        treeComponents.forEach(function (c) {
+          var card = document.getElementById(c.getAttribute("data-group"));
+          if (c.parentElement) c.parentElement.hidden = !!(card && card.hidden);
+        });
+        treeGroups.forEach(function (g) {
+          var sub = document.getElementById(g.getAttribute("data-group"));
+          if (g.parentElement) g.parentElement.hidden = !!(sub && sub.hidden);
+        });
+        if (cpTreeStops) cpTreeStops();
       }
       if (input) input.addEventListener("input", function () {
         // Typing REPLACES rather than pushes: a five-character filter must not bury the page the
@@ -435,6 +446,10 @@ applyThemeChoice();
             openGroup = r.getAttribute("data-group");
           }
         });
+        function parentRow(row) {
+          var list = row.closest("ul.cp-tree-children");
+          return list ? list.previousElementSibling : null;
+        }
         function reflectTree() {
           treeLinks.forEach(function (r) {
             if (!r.hasAttribute("aria-expanded")) return;
@@ -450,8 +465,17 @@ applyThemeChoice();
             openCard = null;
           } else if (row.classList.contains("cp-tree-component")) {
             openCard = id;
+            // And the group that HOLDS it. A click can only reach a component whose group is already
+            // open, but a `#cp-card-…` fragment can name one in any group — and leaving `openGroup`
+            // on whichever group the server expanded would scroll to the card while keeping its own
+            // row, and every variant under it, collapsed out of the tree.
+            var owner = parentRow(row);
+            if (owner && owner.classList.contains("cp-tree-group")) {
+              openGroup = owner.getAttribute("data-group");
+            }
           }
           reflectTree();
+          syncTabStops();
         }
         // The fragment is part of the address this page describes, and `cpUrlState` deliberately
         // preserves whatever hash is already there when it rewrites the query. So a click that moves
@@ -493,10 +517,20 @@ applyThemeChoice();
           visibleRows().forEach(function (i) { i.tabIndex = i === el ? 0 : -1; });
           el.focus();
         }
-        function parentRow(row) {
-          var list = row.closest("ul.cp-tree-children");
-          return list ? list.previousElementSibling : null;
+        // A `role="tree"` is ONE tab stop: Tab enters it, the arrow keys move within it, Tab leaves.
+        // Nothing established that until a first arrow press called `focusRow`, so every visible row
+        // sat in the normal tab order until then — the whole point of the pattern, lost on the one
+        // pass that matters, and worse the deeper the tree got. Keeps an existing stop if it is still
+        // on screen (so a filter does not yank focus) and otherwise hands it to the first row.
+        function syncTabStops() {
+          var rows = visibleRows();
+          if (!rows.length) return;
+          var stop = null;
+          rows.forEach(function (r) { if (!stop && r.tabIndex === 0) stop = r; });
+          if (!stop) stop = rows[0];
+          rows.forEach(function (r) { r.tabIndex = r === stop ? 0 : -1; });
         }
+        cpTreeStops = syncTabStops;
         tree.addEventListener("keydown", function (e) {
           var items = visibleRows();
           var at = items.indexOf(document.activeElement);
@@ -563,6 +597,7 @@ applyThemeChoice();
           }
           return row || tab ? { tab: tab, row: row, id: id } : null;
         }
+        syncTabStops();
         var landing = hashTarget();
         if (landing) {
           if (landing.row) openRow(landing.row);

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -269,7 +269,9 @@
   if (input) { var urlQuery = urlParam("q"); if (urlQuery) input.value = urlQuery; }
   var navGroups = document.querySelectorAll(".cp-subgroup");
   var treeGroups = document.querySelectorAll(".cp-tree-group");
+  var treeComponents = document.querySelectorAll(".cp-tree-component");
   var treeLinks = document.querySelectorAll(".cp-tree-link");
+  var cpTreeStops = null;
   var tabBtns = document.querySelectorAll(".cp-tab");
   var treeGroups = document.querySelectorAll(".cp-tree-group");
   var tabSections = document.querySelectorAll(".cp-section");
@@ -324,6 +326,10 @@
     if (empty) empty.hidden = shown !== 0;
     navGroups.forEach(function (g) { g.hidden = !g.querySelector(".cp-card:not([hidden])"); });
     tabSections.forEach(function (s) { s.hidden = !s.querySelector(".cp-card:not([hidden])"); });
+    treeComponents.forEach(function (c) {
+      var card = document.getElementById(c.getAttribute("data-group"));
+      if (c.parentElement) c.parentElement.hidden = !!(card && card.hidden);
+    });
     treeGroups.forEach(function (g) {
       var sub = document.getElementById(g.getAttribute("data-group"));
       if (g.parentElement) g.parentElement.hidden = !!(sub && sub.hidden);
@@ -334,6 +340,7 @@
       if (node) node.hidden = q !== "" && !!(sec && sec.hidden);
     });
     reflectTabs();
+    if (cpTreeStops) cpTreeStops();
   }
   if (input) input.addEventListener("input", function () {
     // Typing REPLACES rather than pushes: a five-character filter must not bury the page the
@@ -425,6 +432,10 @@
         openGroup = r.getAttribute("data-group");
       }
     });
+    function parentRow(row) {
+      var list = row.closest("ul.cp-tree-children");
+      return list ? list.previousElementSibling : null;
+    }
     function reflectTree() {
       treeLinks.forEach(function (r) {
         if (!r.hasAttribute("aria-expanded")) return;
@@ -440,8 +451,17 @@
         openCard = null;
       } else if (row.classList.contains("cp-tree-component")) {
         openCard = id;
+        // And the group that HOLDS it. A click can only reach a component whose group is already
+        // open, but a `#cp-card-…` fragment can name one in any group — and leaving `openGroup`
+        // on whichever group the server expanded would scroll to the card while keeping its own
+        // row, and every variant under it, collapsed out of the tree.
+        var owner = parentRow(row);
+        if (owner && owner.classList.contains("cp-tree-group")) {
+          openGroup = owner.getAttribute("data-group");
+        }
       }
       reflectTree();
+      syncTabStops();
     }
     // The fragment is part of the address this page describes, and `cpUrlState` deliberately
     // preserves whatever hash is already there when it rewrites the query. So a click that moves
@@ -484,10 +504,20 @@
       visibleRows().forEach(function (i) { i.tabIndex = i === el ? 0 : -1; });
       el.focus();
     }
-    function parentRow(row) {
-      var list = row.closest("ul.cp-tree-children");
-      return list ? list.previousElementSibling : null;
+    // A `role="tree"` is ONE tab stop: Tab enters it, the arrow keys move within it, Tab leaves.
+    // Nothing established that until a first arrow press called `focusRow`, so every visible row
+    // sat in the normal tab order until then — the whole point of the pattern, lost on the one
+    // pass that matters, and worse the deeper the tree got. Keeps an existing stop if it is still
+    // on screen (so a filter does not yank focus) and otherwise hands it to the first row.
+    function syncTabStops() {
+      var rows = visibleRows();
+      if (!rows.length) return;
+      var stop = null;
+      rows.forEach(function (r) { if (!stop && r.tabIndex === 0) stop = r; });
+      if (!stop) stop = rows[0];
+      rows.forEach(function (r) { r.tabIndex = r === stop ? 0 : -1; });
     }
+    cpTreeStops = syncTabStops;
     tree.addEventListener("keydown", function (e) {
       var items = visibleRows();
       var at = items.indexOf(document.activeElement);
@@ -554,6 +584,7 @@
       }
       return row || tab ? { tab: tab, row: row, id: id } : null;
     }
+    syncTabStops();
     var landing = hashTarget();
     if (landing) {
       if (landing.row) openRow(landing.row);

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-tree-depth.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-tree-depth.html
@@ -207,7 +207,9 @@
       if (input) { var urlQuery = urlParam("q"); if (urlQuery) input.value = urlQuery; }
       var navGroups = document.querySelectorAll(".cp-subgroup");
       var treeGroups = document.querySelectorAll(".cp-tree-group");
+      var treeComponents = document.querySelectorAll(".cp-tree-component");
       var treeLinks = document.querySelectorAll(".cp-tree-link");
+      var cpTreeStops = null;
       var stored = null;
 try { stored = localStorage.getItem("cp-theme:compose-m3"); } catch (e) {}
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
@@ -315,6 +317,15 @@ applyThemeChoice();
         if (count) count.textContent = q === "" ? (total + " preview" + (total === 1 ? "" : "s")) : (shown + " of " + total);
         if (empty) empty.hidden = shown !== 0;
         navGroups.forEach(function (g) { g.hidden = !g.querySelector(".cp-card:not([hidden])"); });
+        treeComponents.forEach(function (c) {
+          var card = document.getElementById(c.getAttribute("data-group"));
+          if (c.parentElement) c.parentElement.hidden = !!(card && card.hidden);
+        });
+        treeGroups.forEach(function (g) {
+          var sub = document.getElementById(g.getAttribute("data-group"));
+          if (g.parentElement) g.parentElement.hidden = !!(sub && sub.hidden);
+        });
+        if (cpTreeStops) cpTreeStops();
       }
       if (input) input.addEventListener("input", function () {
         // Typing REPLACES rather than pushes: a five-character filter must not bury the page the
@@ -389,6 +400,10 @@ applyThemeChoice();
             openGroup = r.getAttribute("data-group");
           }
         });
+        function parentRow(row) {
+          var list = row.closest("ul.cp-tree-children");
+          return list ? list.previousElementSibling : null;
+        }
         function reflectTree() {
           treeLinks.forEach(function (r) {
             if (!r.hasAttribute("aria-expanded")) return;
@@ -404,8 +419,17 @@ applyThemeChoice();
             openCard = null;
           } else if (row.classList.contains("cp-tree-component")) {
             openCard = id;
+            // And the group that HOLDS it. A click can only reach a component whose group is already
+            // open, but a `#cp-card-…` fragment can name one in any group — and leaving `openGroup`
+            // on whichever group the server expanded would scroll to the card while keeping its own
+            // row, and every variant under it, collapsed out of the tree.
+            var owner = parentRow(row);
+            if (owner && owner.classList.contains("cp-tree-group")) {
+              openGroup = owner.getAttribute("data-group");
+            }
           }
           reflectTree();
+          syncTabStops();
         }
         // The fragment is part of the address this page describes, and `cpUrlState` deliberately
         // preserves whatever hash is already there when it rewrites the query. So a click that moves
@@ -447,10 +471,20 @@ applyThemeChoice();
           visibleRows().forEach(function (i) { i.tabIndex = i === el ? 0 : -1; });
           el.focus();
         }
-        function parentRow(row) {
-          var list = row.closest("ul.cp-tree-children");
-          return list ? list.previousElementSibling : null;
+        // A `role="tree"` is ONE tab stop: Tab enters it, the arrow keys move within it, Tab leaves.
+        // Nothing established that until a first arrow press called `focusRow`, so every visible row
+        // sat in the normal tab order until then — the whole point of the pattern, lost on the one
+        // pass that matters, and worse the deeper the tree got. Keeps an existing stop if it is still
+        // on screen (so a filter does not yank focus) and otherwise hands it to the first row.
+        function syncTabStops() {
+          var rows = visibleRows();
+          if (!rows.length) return;
+          var stop = null;
+          rows.forEach(function (r) { if (!stop && r.tabIndex === 0) stop = r; });
+          if (!stop) stop = rows[0];
+          rows.forEach(function (r) { r.tabIndex = r === stop ? 0 : -1; });
         }
+        cpTreeStops = syncTabStops;
         tree.addEventListener("keydown", function (e) {
           var items = visibleRows();
           var at = items.indexOf(document.activeElement);
@@ -517,6 +551,7 @@ applyThemeChoice();
           }
           return row || tab ? { tab: tab, row: row, id: id } : null;
         }
+        syncTabStops();
         var landing = hashTarget();
         if (landing) {
           if (landing.row) openRow(landing.row);


### PR DESCRIPTION
Six follow-ups to the deeper tree in #3739, all reachable from the UI. #3739 merged while these were being written, so they land here rather than on that branch.

## What was wrong

**The search filter never learned about the rows the tree grew.** It hid cards and collapsed emptied sub-groups, but component rows stayed put — visible links scrolling to hidden cards — and its tree pass was gated on the catalog having sections, so an outline tree kept whole empty family branches. The pass now runs in both modes and follows the tree down to its components.

**The roving tab stop was never initialised.** A `role="tree"` is one tab stop, but nothing established that until the first arrow press called `focusRow` — until then every visible row sat in the normal tab sequence. That gets worse the deeper the tree goes, and an outline tree had no roving behaviour at all. It is now set with the widget and re-synced whenever the filter changes which rows are on screen, keeping an existing visible stop rather than yanking focus back to the top on every keystroke.

**Card anchors were not injective.** Preview ids may contain `/`, `?`, `#` or a space, all of which folded to `-`, so `Foo/Bar` and `Foo?Bar` minted one DOM id and both tree rows — and both fragment URLs — resolved to whichever card came first. Anchors are minted once for the page, deduped, and shared by the grid and the tree so the two cannot disagree.

**A `#cp-card-…` fragment opened the component but not its group,** so the page scrolled to the card while its own row and its variants stayed collapsed out of the tree.

**Cards had no `scroll-margin-top`.** Sections and sub-groups have it precisely because the toolbar is sticky, so every component jump parked the preview's top edge behind it.

**The tree described the wrong render on a dark-first system.** Labels, links and the variant lane came from `GridCard.default`, which prefers light, while the grid paints dark — so the tree labelled cards from their light twins and sent every variant link into the light lane while the card beside it showed dark. It now uses the render `swapCard` opens on.

## Visual evidence

Rendering is unchanged by design — five of the six are behavioural (filter, focus, id minting, fragment handling, theme lane), and the sixth is scroll offset, which no static capture shows. The committed page fixtures for `serve-landing-tree-depth`, `serve-landing-grouped` and `serve-landing-sections` are regenerated in this PR and the visual-diff bot diffs all three; the tree's appearance in them is the same as on `main`, which is the intended result. The pixels for the feature itself are in #3739.

## Test plan

- `./gradlew :cli:test` — green. New assertions pin each fix: the filter's component-row pass in both tree modes, `syncTabStops` being published and called from the filter, the owning-group resolution on fragment landing, and `.cp-card`'s scroll clearance in the stylesheet.
- Full `pages-snapshot` harness — 104 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNKmA16L2b1Ngw2gRoz83Z)_