### PR TITLE
fix(apply): tar the fork handoff so nested module paths can upload

### DIFF
--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -283,6 +283,16 @@ the staged PR renders and their push metadata, the fetched baselines, the
 resolved base SHA, and the per-surface staging dirs for resources / a11y /
 notifications.
 
+The directory itself contains just two entries — `handoff.tar` and
+`_pr_number`. Everything else lives inside the tarball because
+`actions/upload-artifact` refuses any path containing a colon, and a gradle
+module path is full of them (`_pr_renders/renders/ai:sample:wear-gemini/…`).
+Those directory names cannot be sanitised: `_pr_renders` is pushed verbatim to
+the render branch, so its layout *is* the image URL in the comment and has to
+keep matching the baselines. `_pr_number` stays outside so the caller can read
+it back for `pr-number`; the publish phase unpacks the rest before anything
+reads it.
+
 Two values are in there because the publish job cannot recover them itself:
 
 | File | Why it can't be recomputed |

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -403,6 +403,17 @@ runs:
                "render job's artifact into it before calling this action."
           exit 1
         fi
+
+        # Unpack what the render phase tarred up. The tarball exists because
+        # `actions/upload-artifact` refuses paths containing a colon, which
+        # every nested gradle module path has — see the staging step. A
+        # handoff without one predates that change and is used as-is.
+        if [ -f "$HANDOFF_DIR/handoff.tar" ]; then
+          tar -xf "$HANDOFF_DIR/handoff.tar" -C "$HANDOFF_DIR"
+          rm -f "$HANDOFF_DIR/handoff.tar"
+          echo "compose-preview: unpacked handoff.tar."
+        fi
+
         restored=0
         for entry in "$HANDOFF_DIR"/* "$HANDOFF_DIR"/.[!.]*; do
           [ -e "$entry" ] || continue
@@ -1111,6 +1122,28 @@ runs:
             --path-prefix "$HANDOFF_DIR/current-resources" \
             --rewrite-json "$HANDOFF_DIR/_resources.json"
         fi
+
+        # Pack into a tarball, because `actions/upload-artifact` rejects a
+        # colon anywhere in a path and a gradle module path is full of them:
+        # `_pr_renders/renders/ai:sample:wear-gemini/Foo.png` fails the upload
+        # outright ("Contains the following character: Colon"), taking every
+        # nested-module project with it.
+        #
+        # Renaming those directories is not an option. `_pr_renders` is pushed
+        # verbatim to the render branch, so its layout *is* the
+        # `raw.githubusercontent.com/…/renders/<module>/<basename>` URL in the
+        # comment, and it has to keep matching the baselines already on
+        # `compose-preview/main`. Tar preserves the tree exactly and the
+        # publish side unpacks it before anything reads it.
+        #
+        # `_pr_number` stays outside the tarball: the caller reads it to pass
+        # `pr-number` back in, and it never contains a colon.
+        tar -cf "$HANDOFF_DIR.tar" -C "$HANDOFF_DIR" .
+        pr_number=$(cat "$HANDOFF_DIR/_pr_number")
+        rm -rf "$HANDOFF_DIR"
+        mkdir -p "$HANDOFF_DIR"
+        mv "$HANDOFF_DIR.tar" "$HANDOFF_DIR/handoff.tar"
+        printf '%s' "$pr_number" > "$HANDOFF_DIR/_pr_number"
 
         echo "compose-preview: staged fork-safe handoff in $HANDOFF_DIR ($(du -sh "$HANDOFF_DIR" | cut -f1))."
         echo "::notice::compose-preview/apply: render phase complete — upload '$HANDOFF_DIR' and run the publish phase to push renders and post the comment."


### PR DESCRIPTION
## The bug

The fork-safe split is unusable for any project with nested Gradle modules. `actions/upload-artifact` refuses any path containing a colon, and a Gradle module path is full of them:

```
The path for one of the files in artifact is not valid:
  /_pr_renders/renders/ai:sample:wear-gemini/DefaultPreview_Devices_Small_Round.png.
  Contains the following character:  Colon :
```

The render completes, the handoff stages correctly, and then the upload fails — so the publish job never runs and the fork PR gets no comment. Hit on the first real fork run against `google/horologist`.

This never surfaced before the split because `_pr_renders` is **pushed via git**, where colons are fine. `phase: render` made it an upload artifact for the first time.

## Why not just rename the directories

Because that layout is load-bearing in two places at once:

- `_pr_renders` is pushed **verbatim** to the render branch, so its structure *is* the `raw.githubusercontent.com/…/renders/<module>/<basename>` URL embedded in the PR comment.
- Those paths must keep matching the baselines already on `compose-preview/main`, or every preview reads as new.

Sanitising `:` → `_` would either break the comment's images or silently invalidate every existing baseline.

## The fix

Pack the staged tree into `handoff.tar` and unpack it on the publish side. The layout stays byte-identical; the colons simply never reach the artifact API.

`_pr_number` stays *outside* the tarball, because the caller reads it to pass `pr-number` back in — and it never contains a colon. So the uploaded directory holds exactly two entries:

```
_compose_preview_handoff/handoff.tar
_compose_preview_handoff/_pr_number
```

The publish side unpacks before anything reads the handoff, and treats a tarball-less handoff as pre-change (used as-is), so an in-flight run straddling the upgrade doesn't break.

## Test plan

- Round-trip simulation with the two bash blocks extracted verbatim from `action.yml`, using the exact failing module name `ai:sample:wear-gemini`:
  - asserts **no colon appears in any path upload-artifact would see**
  - unpacks into a *different* workspace root and asserts the colon-bearing tree is restored byte-for-byte, including `_pr_renders/renders/ai:sample:wear-gemini/DefaultPreview_Devices_Small_Round.png`, the push metadata, and the staged `current/` renders
- `python3 .github/actions/lib/test_compare_previews.py` — 110 pass
- `action.yml` parses; every bash step body passes `bash -n`

Not exercised here: a real fork PR. The consumer side needs no change — the documented upload still points at `handoff-dir`.

## Note for consumers already on the split

Anyone pinning a SHA before this needs to bump it; the failure is a hard upload error on the render job, not a silent degradation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzGvRNrQeHD1f4myvDX2iA)_