### PR TITLE
test(e2e): wait for the settled render in the interactive edit scenario

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -693,6 +693,10 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         api.resetMessages();
         const observations: Record<string, unknown> = {};
         const cmpNeedle = path.join("samples", "cmp");
+        // Read once, before any work: `budgetWithin` derives each bounded wait
+        // from what is LEFT of the Mocha ceiling, which only works if the
+        // deadline is an absolute instant rather than a fresh `this.timeout()`.
+        const deadlineAt = Date.now() + this.timeout();
 
         assertRefreshRendered(
             api,
@@ -749,9 +753,27 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             // `waitFor` timeout naming the same file. What it stops failing on
             // is the transient moment between the two, which no user could see
             // as anything but a card that fills in a second later.
+            const capturesOnDisk = (p: PreviewRecord, moduleDir: string) => {
+                const captures = p.captures ?? [];
+                return (
+                    captures.length > 0 &&
+                    captures.every((c) =>
+                        fs.existsSync(
+                            fullRenderPath(repoRoot, moduleDir, c.renderOutput),
+                        ),
+                    )
+                );
+            };
             const afterAdd = await waitFor(
                 `setPreviews after adding ${tag}, with its capture on disk`,
-                this.timeout(),
+                // Bounded, NOT `this.timeout()`. Waiting on the settled state
+                // means a preview whose PNG never arrives no longer trips the
+                // B1 assertion immediately — so an unbounded wait would burn
+                // the whole Mocha ceiling and report a bare
+                // `Timeout of 1800000ms exceeded`, losing the one diagnostic
+                // that names the missing file. That is the trade this budget
+                // (plus `describeState` below) buys back.
+                budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
                 500,
                 () => {
                     const msgs = api.getPostedMessages();
@@ -762,22 +784,48 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                             p.id.endsWith(tag),
                         );
                         if (matching.length === 0) return false;
-                        return matching.every((p) => {
+                        return matching.every((p) =>
+                            capturesOnDisk(p, m.moduleDir),
+                        );
+                    });
+                },
+                // What the old immediate assertion used to say, now said by the
+                // wait that replaced it: which preview arrived, and which of its
+                // captures is not on disk. A regression here reports the same
+                // path it always did.
+                () => {
+                    const latest = latestSetPreviewsMatching(
+                        api.getPostedMessages(),
+                        (m) =>
+                            m.moduleDir.includes(cmpNeedle) &&
+                            m.previews.some((p) => p.id.endsWith(tag)),
+                    );
+                    if (!latest) {
+                        return `no setPreviews for ${cmpNeedle} ever named ${tag}`;
+                    }
+                    const matching = latest.previews.filter((p) =>
+                        p.id.endsWith(tag),
+                    );
+                    return matching
+                        .map((p) => {
                             const captures = p.captures ?? [];
-                            return (
-                                captures.length > 0 &&
-                                captures.every((c) =>
-                                    fs.existsSync(
-                                        fullRenderPath(
-                                            repoRoot,
-                                            m.moduleDir,
-                                            c.renderOutput,
-                                        ),
+                            if (captures.length === 0) {
+                                return `preview ${p.id} arrived with 0 captures`;
+                            }
+                            const missing = captures
+                                .map((c) =>
+                                    fullRenderPath(
+                                        repoRoot,
+                                        latest.moduleDir,
+                                        c.renderOutput,
                                     ),
                                 )
-                            );
-                        });
-                    });
+                                .filter((resolved) => !fs.existsSync(resolved));
+                            return missing.length === 0
+                                ? `preview ${p.id} has every capture on disk`
+                                : `preview ${p.id} capture(s) not on disk: ${missing.join(", ")}`;
+                        })
+                        .join("; ");
                 },
             );
             const matched = afterAdd.previews.filter((p) => p.id.endsWith(tag));

--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -736,8 +736,21 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                 await api.triggerRefresh(cmpFile, true, "full"),
                 ":samples:cmp render",
             );
+            // Wait for the SETTLED state, not the first message that names the
+            // new preview. Discovery announces the id as soon as it has scanned
+            // the recompiled classes, which is before the renderer has written
+            // that preview's PNG — so a wait that stops at "the id is present"
+            // races the render and fails on a slow runner (issue: `B. edit a
+            // @Preview source` flaking with "capture … not on disk").
+            //
+            // This does NOT weaken invariant B1 below. The bug B1 exists to
+            // catch is a *permanent* placeholder — the panel advertising a
+            // preview whose PNG never arrives — and that still fails, as a
+            // `waitFor` timeout naming the same file. What it stops failing on
+            // is the transient moment between the two, which no user could see
+            // as anything but a card that fills in a second later.
             const afterAdd = await waitFor(
-                `setPreviews after adding ${tag}`,
+                `setPreviews after adding ${tag}, with its capture on disk`,
                 this.timeout(),
                 500,
                 () => {
@@ -745,7 +758,25 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                     return latestSetPreviewsMatching(msgs, (m) => {
                         if (m.previews.length === 0) return false;
                         if (!m.moduleDir.includes(cmpNeedle)) return false;
-                        return m.previews.some((p) => p.id.endsWith(tag));
+                        const matching = m.previews.filter((p) =>
+                            p.id.endsWith(tag),
+                        );
+                        if (matching.length === 0) return false;
+                        return matching.every((p) => {
+                            const captures = p.captures ?? [];
+                            return (
+                                captures.length > 0 &&
+                                captures.every((c) =>
+                                    fs.existsSync(
+                                        fullRenderPath(
+                                            repoRoot,
+                                            m.moduleDir,
+                                            c.renderOutput,
+                                        ),
+                                    ),
+                                )
+                            );
+                        });
                     });
                 },
             );


### PR DESCRIPTION
## The failure

`VS Code Extension E2E (interactive-a-d)` → `B. edit a @Preview source, refresh, expect new id; revert, expect it gone`:

```
AssertionError: preview com.example.samplecmp.PreviewsKt.Interactive1786613284693
capture renders/Interactive1786613284693.png not on disk at
…/samples/cmp/build/compose-previews/renders/Interactive1786613284693.png
```

It surfaced on #3750, which is why I looked — but nothing in that PR can cause it. That diff touched the serve pages surface, an api contract module, `scripts/design-artifacts/`, CSS/JS assets and docs; inside `vscode-extension/` it touched only `preview-harness/`, not `src/`, and nothing under `gradle-plugin/`, `renderers/`, `daemon/` or `samples/`. This scenario exercises exactly those paths and none of the changed ones.

## The race

The scenario appends a `@Preview` to a source file, triggers a full refresh, and waits for a `setPreviews` message naming the new id. **Discovery announces the id as soon as it has scanned the recompiled classes** — before the renderer has written that preview's PNG. The wait stops on that first message, and the assertion immediately after checks the file. The run log shows the gap plainly: `composePreviewDiscover` at 09:29:13, assertion failure at 09:29:21.

## The fix

The wait now requires the **settled** state — the message must name the preview *and* its captures must be on disk — instead of stopping at the first message that mentions it.

Invariant B1 is unchanged in what it guarantees. The bug it exists to catch is a *permanent* placeholder — the panel advertising a preview whose PNG never arrives — and that still fails the test. What no longer fails is the transient moment between discovery and render, which a user could only ever see as a card that fills in a second later.

That trade only holds if the wait is **bounded** (thanks to the review catch on the first commit, which my original description got wrong). Waiting for the settled state means a never-arriving PNG no longer trips the B1 assertion immediately, so an unbounded `this.timeout()` wait would have burned the rest of the Mocha ceiling and reported a bare `Timeout of 1800000ms exceeded`, losing the one diagnostic worth having. Scenario B now derives a `deadlineAt` up front and spends `budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS)` — the machinery scenarios D and E already use — and supplies a `describeState` callback that reports which preview arrived, whether it had zero captures, and the full path of each capture missing from disk. A genuine regression fails within three minutes, naming the same file the old assertion named.

The sibling waits earlier in scenario B still pass `this.timeout()` and share that latent weakness. Left alone deliberately: they are not what flaked, and widening this beyond the failing wait would make the change harder to judge.

## Test plan

- `npm run compile:host` and the Prettier check in `vscode-extension/` — clean.
- The scenario itself is the CI job on this PR (`VS Code Extension E2E (interactive-a-d)`); it needs the real Gradle render, a ~5 minute run not reproducible in this sandbox. Note that CI on `main` is red across the last several runs for unrelated reasons, so this job's own tick is the signal, not the run's overall conclusion.