### PR TITLE
build(deps): update Remote Compose alphas to the alpha17 triple

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -173,27 +173,30 @@ horologist = "0.7.15"
 #    verified-together alpha. alpha14 / alpha07 is the next such pair:
 #    `RemoteDensity.from` dropped its trailing `Context` arg and now derives
 #    density solely from the `RemoteCreationDisplayInfo` it's handed.
-compose-remote = "1.0.0-alpha16"
+#    alpha17 / alpha09 is the current such pair: `remote-material3:1.0.0-alpha09`
+#    declares `remote-creation`/`remote-creation-compose` 1.0.0-alpha17 in its POM,
+#    and `glance-wear:1.0.0-alpha16` does the same, so all three move together.
+compose-remote = "1.0.0-alpha17"
 # Matches what the `compose-bom-compat` Compose artifacts already resolve collection to; pinned
 # explicitly because `:third-party-rc-embedded-player` names `ObjectIntMap`/`IntObjectMap` directly.
 androidx-collection = "1.6.0"
 # `FontRequest` / `FontsContractCompat` — the downloadable-fonts provider API the vendored embedded
 # player's typeface resolver uses to service `google:` font prefixes.
 androidx-core = "1.19.0"
-#    alpha08 does not exist: the whole `androidx.wear.compose.remote` group stops
-#    at alpha07 on Google Maven (remote-material3 / remote-core / remote-player all
-#    404), so #2823's bump made `:samples:design-catalog-remote-m3` unresolvable and
-#    took `main` red. Back to alpha07 until the wear side actually publishes; when it
-#    does, bump it together with `compose-remote` as the paragraph above requires.
-wear-compose-remote = "1.0.0-alpha08"
+#    Check Google Maven before bumping: the `androidx.wear.compose.remote` group
+#    publishes behind `androidx.compose.remote`, and #2823 once pinned a version that
+#    didn't exist yet (every artifact 404'd), making `:samples:design-catalog-remote-m3`
+#    unresolvable and taking `main` red. Bump it together with `compose-remote`, to the
+#    version whose POM names the `compose-remote` pin above.
+wear-compose-remote = "1.0.0-alpha09"
 # Glance Wear — the Wear OS *widget* layer on top of Remote Compose. Used by
 # `:samples:design-catalog-remote-m3` to sticker the widget **container** (the
 # squircle the host draws around widget content) via the
-# `wear-tooling-preview` artifact's `WearWidgetPreview` wrapper. alpha13 is
-# built against compose-remote alpha14 (see its POM), so bump this in lockstep
+# `wear-tooling-preview` artifact's `WearWidgetPreview` wrapper. alpha16 is
+# built against compose-remote alpha17 (see its POM), so bump this in lockstep
 # with the `compose-remote` pin above — a skewed pair risks the same
 # creation/player version drift the Remote Compose comment describes.
-glance-wear = "1.0.0-alpha15"
+glance-wear = "1.0.0-alpha16"
 # Pre-release compose-ui artifacts used by `:samples:remotecompose`, which
 # deliberately diverges from `compose-bom-stable` (1.10.x) to track what
 # wear-compose-remote-material3 alpha pulls in transitively — compose 1.11.0+

--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -57,11 +57,12 @@ done
 ## Version skew
 
 Upstream builds this player against the **in-tree** `remote-core` / `remote-player-core`. We build
-it against the published alphas the version catalog pins (`compose-remote = 1.0.0-alpha15`). The
+it against the published alphas the version catalog pins (`compose-remote = 1.0.0-alpha17`). The
 player reaches a number of `@RestrictTo(LIBRARY_GROUP)` members, and `CoreDataAccessors.kt` reaches
 private `CoreDocument` state **reflectively** (upstream guards those names with its own
-`CoreReflectionGuardTest`). Both are sensitive to the gap between `androidx-main` and alpha15, so a
-snapshot refresh should be paired with a render of the `rc-compare` lane, not just a compile.
+`CoreReflectionGuardTest`). Both are sensitive to the gap between `androidx-main` and the pinned
+alpha, so a snapshot refresh should be paired with a render of the `rc-compare` lane, not just a
+compile.
 
 ## Local modifications
 
@@ -84,6 +85,13 @@ androidx tree against the published alphas".
   `CapturedDocument` overload). `CapturedDocument` in alpha15 carries neither a `lambdas` nor a
   `pendingIntents` property. Same reasoning; that overload is for live capture, which this vendored
   copy does not use.
+
+**Both deltas are now revertable and awaiting a snapshot refresh.** As of `compose-remote`
+1.0.0-alpha17 (the current pin) `LambdaAction` and `PendingIntentAction` are public with public
+`Companion.parseId`, and `CapturedDocument` carries `lambdas` + `pendingIntents`. Restoring the two
+blocks verbatim means re-adding the upstream `lambdas` / `pendingIntents` parameters to `RcPlayer`,
+so it belongs with the next re-vendor from `androidx-main`, not with a version-catalog bump. Neither
+delta is on the draw path, so the `rc-compare` lane is unaffected until then.
 
 Neither delta is on the draw path. If a future alpha exposes the two action types, both blocks
 revert to upstream verbatim.


### PR DESCRIPTION
## Summary

Bumps the three Remote Compose artifact groups to their latest published alphas. They have to move as a set:

| Group | Was | Now |
|---|---|---|
| `androidx.compose.remote:*` | 1.0.0-alpha16 | **1.0.0-alpha17** |
| `androidx.wear.compose.remote:remote-material3` | 1.0.0-alpha08 | **1.0.0-alpha09** |
| `androidx.glance.wear:*` | 1.0.0-alpha15 | **1.0.0-alpha16** |

`remote-material3:1.0.0-alpha09` and `glance-wear:1.0.0-alpha16` both declare `remote-creation` / `remote-creation-compose` **1.0.0-alpha17** in their POMs, so this is a mutually-rebuilt triple — exactly the lockstep condition the existing catalog comments demand. Verified against Google Maven rather than assumed.

### Catalog comment refresh

The `wear-compose-remote` note claimed the whole `androidx.wear.compose.remote` group 404s past alpha07, which is why #2823 took `main` red. That group now publishes through alpha09, so the note is rewritten as the general rule it was really encoding: the wear group publishes behind `androidx.compose.remote`, so check Google Maven and pick the version whose POM names the `compose-remote` pin.

### Undocumented breaking change worth flagging

alpha17 **removes the `RemoteText(String, …)` overload**, leaving only the `RemoteString` ones. This is not in the [release notes](https://developer.android.com/jetpack/androidx/releases/compose-remote), which list alpha17 as purely additive; I found it by diffing `RemoteTextKt` between the alpha16 and alpha17 AARs (`RemoteText-wvUeXTI`, the `String` variant, is gone).

No call site in this repo passes a bare `String` — every `RemoteText(label)` here already takes a `RemoteString` — so nothing needed migrating. The sibling `homeassistant-remotecompose` repo did need six call sites fixed ([#563](https://github.com/yschimke/homeassistant-remotecompose/pull/563), merged); flagging it here so the next person bumping doesn't rediscover it.

### PROVENANCE.md

The vendored embedded player's "Version skew" section still cited a `compose-remote = 1.0.0-alpha15` pin. Corrected, and the doc now records that **both local deltas are finally revertable**: verified against the alpha17 AAR that `LambdaAction` and `PendingIntentAction` are public with public `Companion.parseId`, and `CapturedDocument` now carries `lambdas` + `pendingIntents`.

I did **not** revert them here. Restoring the two blocks verbatim means re-adding upstream's `lambdas` / `pendingIntents` parameters to `RcPlayer`, which belongs with the next re-vendor from `androidx-main`, not a version-catalog bump. Neither delta is on the draw path, so `rc-compare` is unaffected until then.

## Test plan

Compiled locally against the new triple, all green:

```
./gradlew :data-remotecompose-connector:compileDebugKotlin \
          :third-party-rc-embedded-player:compileDebugKotlin \
          :third-party-rc-embedded-player-jvm:compileKotlin
BUILD SUCCESSFUL

./gradlew :samples:remotecompose:compileDebugKotlin \
          :samples:design-catalog-remote-m3:compileDebugKotlin \
          :samples:wear-widget:compileDebugKotlin \
          :wear-preview-runtime:compileDebugKotlin
BUILD SUCCESSFUL
```

The vendored player was the module at risk — it reaches `@RestrictTo(LIBRARY_GROUP)` members and reflects into private `CoreDocument` state, both sensitive to alpha drift. It compiles clean with no new warnings beyond the pre-existing `nativeCanvas` deprecations.

### Rendered output is unchanged

A Remote Compose bump *can* move rendered output — the creation and player sides both changed — so this is the check that actually matters, and CI has now run it against this branch:

- **CMP/Wasm parity**: `0 regression(s), 0 improvement(s), 27 unchanged (±0.25 pp), 0 new, 0 dropped`
- **CMP Remote Compose Player**, **Daemon Harness** (desktop real / desktop fake / android real), **Renderer Android Unit Tests**, **Build Samples**, **Apply compose-preview**, **A11y + notification previews** — all green
- 67 checks total, zero failures

So alpha17 moves no pixels here and no baselines needed rebaselining.

Cross-checked downstream in the same way: [#563](https://github.com/yschimke/homeassistant-remotecompose/pull/563) rendered its 229 preview PNGs and its pixel-diff gate passed 21/21, with the preview bot reporting 292 functions / 369 variants unchanged.

No before/after images are embedded because there is no visual delta to show — the diff is two files, a version catalog and a provenance doc, with no source edits to any renderable surface. The evidence that the pixels did not move is the parity and render lanes above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2BA1XXXvGGzhDW4JgToFY)_