### PR TITLE
fix(daemon): repair the Android harness lane broken by #3759's test fixture

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -769,12 +769,17 @@ private const val MODULE_ID_PROP = "composeai.daemon.moduleId"
  * this resolver maps it back to the class/function and display properties from `previews.json`.
  */
 private fun previewIndexBackedSpecResolver(previewIndex: PreviewIndex): ((String) -> RenderSpec?)? {
-  // A row-addressed id (issue #3749) resolves to its base entry plus the row token; the token has
-  // to reach the spec or the held session would compose value 0 under the row's id — silently the
-  // wrong state, and worse than the "unknown previewId" a caller used to get here.
+  // A row-addressed id (issue #3749) resolves to its base entry plus the row token. Both halves
+  // have to reach the spec: the token, or the held session composes value 0 under the row's id
+  // (silently the wrong state, worse than the "unknown previewId" a caller used to get here); and
+  // `outputBaseName`, which `renderSpecFromInfo` takes from the BASE entry — leaving it would make
+  // a row render overwrite `<base>.png` and the data products keyed off it, the same clobber the
+  // router lane avoids by suffixing the stem.
   return { previewId ->
     previewIndex.rowResolved(previewId)?.let {
-      renderSpecFromInfo(it.info).copy(previewParameterRow = it.row)
+      val base = renderSpecFromInfo(it.info)
+      if (it.row == null) base
+      else base.copy(previewParameterRow = it.row, outputBaseName = previewId)
     }
   }
 }

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -883,6 +883,31 @@ fun ThemedTintedSquare(@PreviewParameter(SquareTintProvider::class) tint: Long) 
 }
 
 /**
+ * `@PreviewParameter` fixture whose two values carry labels differing **only by case** (issue #3749
+ * review follow-up). Android sibling of the desktop copy in this file's twin — the two
+ * `RedFixturePreviews.kt` files share a package, so the class sets must agree or the Android
+ * harness lane loads a facade referencing classes its classpath doesn't have.
+ *
+ * [PreviewParameterLabels][ee.schimke.composeai.renderer.PreviewParameterLabels] compares labels
+ * case-*sensitively* when deciding whether a fan-out collides, so this provider legitimately emits
+ * `<stem>_Dark.png` AND `<stem>_dark.png` on a case-sensitive filesystem. A row resolver that folds
+ * case unconditionally maps both ids onto the first value; `Dark` is green (`0xFF43A047`) and
+ * `dark` is blue (`0xFF1E88E5`) so that mistake shows up as the wrong pixels rather than as a pass.
+ */
+class CaseTintProvider : PreviewParameterProvider<CaseTint> {
+  override val values = sequenceOf(CaseTint("Dark", 0xFF43A047L), CaseTint("dark", 0xFF1E88E5L))
+}
+
+/** A labelled tint for [CaseTintProvider]; `name` is what the label derivation picks up. */
+data class CaseTint(val name: String, val tint: Long)
+
+@Preview
+@Composable
+fun CaseLabelledSquare(@PreviewParameter(CaseTintProvider::class) swatch: CaseTint) {
+  Box(modifier = Modifier.fillMaxSize().background(Color(swatch.tint)))
+}
+
+/**
  * Retired-slot fixture (issue #3324): a `Scaffold` + `TopAppBar` around a `LazyColumn` that scrolls
  * a few rows in before the frame is captured, so the rows that left the viewport are retired —
  * composed, still carrying their text, but **unplaced** — while the app bar stays put. Mirrors the

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -399,7 +399,10 @@ internal constructor(
         "scroll-gif" -> "render/scroll/gif"
         else -> return null
       }
-    val info = byId(previewId) ?: return null
+    // A row id carries its base's scroll intent (issue #3749) — `@ScrollingPreview` annotates the
+    // function, not one provider value — so resolve through the row-aware lookup or a
+    // `<base>_Dark` scroll-long render fails with "no matching dataProducts[].scroll entry".
+    val info = rowResolved(previewId)?.info ?: return null
     return info.dataProducts.firstOrNull { it.kind == kind }?.scroll
   }
 
@@ -429,7 +432,9 @@ internal constructor(
    * a separate output rather than a rival static frame.
    */
   fun staticScrollFor(previewId: String): ScrollCaptureDto? {
-    val info = byId(previewId) ?: return null
+    // Row-aware for the same reason as [scrollCaptureFor]: without it an `END` static row silently
+    // renders at the resting top instead of the scrolled-to-end frame its base asked for.
+    val info = rowResolved(previewId)?.info ?: return null
     val scrolls = info.captures.mapNotNull { it.scroll }
     if (scrolls.isEmpty()) return null
     if (!scrolls.all { it.mode.equals("END", ignoreCase = true) }) return null

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -483,12 +483,17 @@ private const val MODULE_ID_PROP = "composeai.daemon.moduleId"
  * without held-state semantics.
  */
 private fun previewIndexBackedSpecResolver(previewIndex: PreviewIndex): ((String) -> RenderSpec?)? {
-  // A row-addressed id (issue #3749) resolves to its base entry plus the row token; the token has
-  // to reach the spec or the held session would compose value 0 under the row's id — silently the
-  // wrong state, and worse than the "unknown previewId" a caller used to get here.
+  // A row-addressed id (issue #3749) resolves to its base entry plus the row token. Both halves
+  // have to reach the spec: the token, or the held session composes value 0 under the row's id
+  // (silently the wrong state, worse than the "unknown previewId" a caller used to get here); and
+  // `outputBaseName`, which `renderSpecFromInfo` takes from the BASE entry — leaving it would make
+  // a row render overwrite `<base>.png` and the data products keyed off it, the same clobber the
+  // router lane avoids by suffixing the stem.
   return { previewId ->
     previewIndex.rowResolved(previewId)?.let {
-      renderSpecFromInfo(it.info).copy(previewParameterRow = it.row)
+      val base = renderSpecFromInfo(it.info)
+      if (it.row == null) base
+      else base.copy(previewParameterRow = it.row, outputBaseName = previewId)
     }
   }
 }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
@@ -130,10 +130,10 @@ object PreviewParameterSupport {
         requestedIndex != null ->
           requestedIndex.takeIf { it < values.size }
             // The sequence ran dry before reaching the requested index, so `values` IS the whole
-            // fan-out — list its rows. That makes an over-request (`PARAM_999`) the cheap way for a
-            // caller to discover what a provider actually offers, which is the only discovery path
-            // there is: `previews.json` carries one entry per parameterized function and can't
-            // enumerate the provider (issue #3749).
+            // fan-out — list its rows. That makes an over-request (`PARAM_255`, the highest the
+            // ceiling above admits) the cheap way for a caller to discover what a provider actually
+            // offers, which is the only discovery path there is: `previews.json` carries one entry
+            // per parameterized function and can't enumerate the provider (issue #3749).
             ?: throw PreviewParameterLoadException(
               "@PreviewParameter(provider = $providerClassName) on $functionName has no row " +
                 "$requestedIndex — it yields ${values.size} value(s); " +
@@ -184,11 +184,20 @@ object PreviewParameterSupport {
   fun rowSuffixes(values: List<Any?>): List<String> =
     PreviewParameterLabels.suffixesFor(values).map { it.removePrefix("_") }
 
-  /** The index a `PARAM_<n>` row token names, or `null` for a label token. */
+  /**
+   * The index a `PARAM_<n>` row token names, or `null` for a label token.
+   *
+   * The suffix must be **digits only** — the same grammar [PreviewParameterLabels] reserves. Going
+   * through `toIntOrNull` alone would accept signed spellings that label derivation happily keeps
+   * as labels: `PARAM_-0` parses to 0 and passes a `>= 0` check, so `<stem>_PARAM_-0.png` — a real
+   * labelled row on disk — would silently bind value 0 instead. The two grammars have to be the
+   * same one or a token means different things to the writer and the reader.
+   */
   private fun rowIndex(row: String): Int? =
-    if (row.startsWith(INDEX_ROW_PREFIX))
-      row.removePrefix(INDEX_ROW_PREFIX).toIntOrNull()?.takeIf { it >= 0 }
-    else null
+    if (row.startsWith(INDEX_ROW_PREFIX)) {
+      val digits = row.removePrefix(INDEX_ROW_PREFIX)
+      if (digits.isNotEmpty() && digits.all { it in '0'..'9' }) digits.toIntOrNull() else null
+    } else null
 
   /**
    * Opens [this] method for reflective invocation. Guarded with `runCatching`: a SecurityManager or

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
@@ -108,4 +108,11 @@ class PreviewParameterLabelsTest {
       )
     assertEquals(listOf("_PARAM_x", "_PARAM_1a", "_PARAMS_1"), suffixes)
   }
+
+  /** Only digits are reserved, so a signed spelling stays a label and remains addressable. */
+  @Test
+  fun `a signed PARAM spelling is not reserved`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(Labeled("PARAM_-0"), Labeled("Dark")))
+    assertEquals(listOf("_PARAM_-0", "_Dark"), suffixes)
+  }
 }

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterRowMatchTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterRowMatchTest.kt
@@ -68,4 +68,16 @@ class PreviewParameterRowMatchTest {
       failure?.message?.contains("beyond the ${PreviewParameterSupport.MAX_ROW_SCAN}-row"),
     )
   }
+
+  /**
+   * `PARAM_-0` is a label, not a position. The reserved-label grammar is digits-only, so label
+   * derivation keeps that spelling — and `"-0".toIntOrNull()` returning 0 would otherwise make the
+   * parser bind value 0 instead of the labelled row that is actually on disk.
+   */
+  @Test
+  fun `signed and non-digit index spellings stay labels`() {
+    assertEquals(1, PreviewParameterSupport.matchLabel(listOf("Dark", "PARAM_-0"), "PARAM_-0"))
+    assertEquals(1, PreviewParameterSupport.matchLabel(listOf("Dark", "PARAM_+1"), "PARAM_+1"))
+    assertEquals(1, PreviewParameterSupport.matchLabel(listOf("Dark", "PARAM_x"), "PARAM_x"))
+  }
 }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterSupport.kt
@@ -135,10 +135,10 @@ object PreviewParameterSupport {
         requestedIndex != null ->
           requestedIndex.takeIf { it < values.size }
             // The sequence ran dry before reaching the requested index, so `values` IS the whole
-            // fan-out — list its rows. That makes an over-request (`PARAM_999`) the cheap way for a
-            // caller to discover what a provider actually offers, which is the only discovery path
-            // there is: `previews.json` carries one entry per parameterized function and can't
-            // enumerate the provider (issue #3749).
+            // fan-out — list its rows. That makes an over-request (`PARAM_255`, the highest the
+            // ceiling above admits) the cheap way for a caller to discover what a provider actually
+            // offers, which is the only discovery path there is: `previews.json` carries one entry
+            // per parameterized function and can't enumerate the provider (issue #3749).
             ?: throw PreviewParameterLoadException(
               "@PreviewParameter(provider = $providerClassName) on $functionName has no row " +
                 "$requestedIndex — it yields ${values.size} value(s); " +
@@ -189,11 +189,20 @@ object PreviewParameterSupport {
   fun rowSuffixes(values: List<Any?>): List<String> =
     PreviewParameterLabels.suffixesFor(values).map { it.removePrefix("_") }
 
-  /** The index a `PARAM_<n>` row token names, or `null` for a label token. */
+  /**
+   * The index a `PARAM_<n>` row token names, or `null` for a label token.
+   *
+   * The suffix must be **digits only** — the same grammar [PreviewParameterLabels] reserves. Going
+   * through `toIntOrNull` alone would accept signed spellings that label derivation happily keeps
+   * as labels: `PARAM_-0` parses to 0 and passes a `>= 0` check, so `<stem>_PARAM_-0.png` — a real
+   * labelled row on disk — would silently bind value 0 instead. The two grammars have to be the
+   * same one or a token means different things to the writer and the reader.
+   */
   private fun rowIndex(row: String): Int? =
-    if (row.startsWith(INDEX_ROW_PREFIX))
-      row.removePrefix(INDEX_ROW_PREFIX).toIntOrNull()?.takeIf { it >= 0 }
-    else null
+    if (row.startsWith(INDEX_ROW_PREFIX)) {
+      val digits = row.removePrefix(INDEX_ROW_PREFIX)
+      if (digits.isNotEmpty() && digits.all { it in '0'..'9' }) digits.toIntOrNull() else null
+    } else null
 
   /**
    * Opens [this] method for reflective invocation. Guarded with `runCatching`: a SecurityManager or

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
@@ -115,4 +115,11 @@ class PreviewParameterLabelsTest {
       )
     assertEquals(listOf("_PARAM_x", "_PARAM_1a", "_PARAMS_1"), suffixes)
   }
+
+  /** Only digits are reserved, so a signed spelling stays a label and remains addressable. */
+  @Test
+  fun `a signed PARAM spelling is not reserved`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(Labeled("PARAM_-0"), Labeled("Dark")))
+    assertEquals(listOf("_PARAM_-0", "_Dark"), suffixes)
+  }
 }

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterRowMatchTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterRowMatchTest.kt
@@ -72,4 +72,16 @@ class PreviewParameterRowMatchTest {
       failure?.message?.contains("beyond the ${PreviewParameterSupport.MAX_ROW_SCAN}-row"),
     )
   }
+
+  /**
+   * `PARAM_-0` is a label, not a position. The reserved-label grammar is digits-only, so label
+   * derivation keeps that spelling — and `"-0".toIntOrNull()` returning 0 would otherwise make the
+   * parser bind value 0 instead of the labelled row that is actually on disk.
+   */
+  @Test
+  fun `signed and non-digit index spellings stay labels`() {
+    assertEquals(1, PreviewParameterSupport.matchLabel(listOf("Dark", "PARAM_-0"), "PARAM_-0"))
+    assertEquals(1, PreviewParameterSupport.matchLabel(listOf("Dark", "PARAM_+1"), "PARAM_+1"))
+    assertEquals(1, PreviewParameterSupport.matchLabel(listOf("Dark", "PARAM_x"), "PARAM_x"))
+  }
 }


### PR DESCRIPTION
Follow-up to #3759, which merged before this landed. **`main` is currently red** on `Daemon Harness (android, real renderer)` because of it — the first commit here is the repair.

## The break

#3759 added a `CaseTintProvider` / `CaseTint` / `CaseLabelledSquare` fixture to `:daemon:desktop`'s `testFixtures/…/RedFixturePreviews.kt`. There are **two** files by that name — one per daemon module — and they share the package `ee.schimke.composeai.daemon`, so they compile to competing `RedFixturePreviewsKt` facades. The Android real-renderer lane resolves that facade against a classpath carrying the desktop testFixtures jar, so it loaded a facade referencing `CaseTint`, a class that lane doesn't have:

```
compose-ai-daemon: host.submit(5) failed:
  java.lang.NoClassDefFoundError: ee/schimke/composeai/daemon/CaseTint
```

The render then never reports, and `S3_5RecompileSaveLoopRealModeTest` dies on its 2-minute `renderFinished` poll — which is the `IllegalStateException at S3_5RecompileSaveLoopRealModeTest.kt:217` seen on #3759's last two CI runs.

The fixture is now mirrored into the Android copy, matching how `SquareTintProvider` / `ThemedTintedSquare` already exist in both.

> **Why this wasn't caught pre-merge:** the local flag is `-Pharness.target=android`. I was passing `-Ptarget=android`, which Gradle accepts and silently ignores, so every "Android" run was really the desktop lane — fast and green. With the right flag the failure reproduces every time.

## Also in this PR

Three row-resolution gaps from the last Codex review pass on #3759, all of the same shape — *resolves to the wrong thing rather than failing*:

- **`PARAM_-0` is a label, not a position.** The reserved-label grammar is digits-only, so derivation keeps that spelling, but `"-0".toIntOrNull()` returned `0` and passed the non-negative check — binding value 0 instead of the labelled row that is actually on disk. Both grammars are digits-only now.
- **`PreviewIndex.scrollCaptureFor` / `staticScrollFor` still did exact lookups.** A row of a preview combining `@PreviewParameter` with `@ScrollingPreview` lost its scroll intent: an `END` row rendered at the resting top, a `scroll-long` row failed outright. `@ScrollingPreview` annotates the *function*, so the intent belongs to every row — both now resolve through the row-aware lookup.
- **The `PreviewIndex` fallback lane kept the base `outputBaseName`.** A row render there would overwrite `<base>.png` and the data products keyed off it. It now takes the requested id, matching what the router lane already does by suffixing the stem.

## Test plan

- [x] `:daemon:harness:test -Pharness.host=real -Pharness.target=android` — **43 tests, 21 skipped, 0 failed** (same counts CI reports, now green). Before this change, on the same checkout and flag: `S3_5RecompileSaveLoopRealModeTest` fails at 158–166s against a 44s pass on unmodified `main` — verified with a `main` worktree as a control.
- [x] `:daemon:harness:test -Pharness.host=real -Pharness.target=desktop` — 43 tests, 18 skipped, 0 failed.
- [x] `:daemon:core:test`, `:daemon:desktop:test`, `:daemon:android:testDebugUnitTest`, `:renderer-desktop:test`, `:renderer-android:test`.
- [x] `./gradlew ktfmtCheckAll`.

New coverage: `PreviewParameterRowMatchTest` gains signed/non-digit spellings (`PARAM_-0`, `PARAM_+1`, `PARAM_x` stay labels) and `PreviewParameterLabelsTest` pins that derivation keeps them, in both renderer modules.

No visual surface changes — this is fixture wiring and id resolution; every preview renders exactly as it did after #3759.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SamkbmKYKnb7XhJUU5TYbM)_