### PR TITLE
fix(a11y-report): record every unchecked variant, not just whole functions

### DIFF
--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -165,11 +165,12 @@ def select_variants(
       findings would falsely imply they were (same reasoning as the Tile
       exclusion above). See issue #3742.
 
-    ``unchecked``, when given, collects the previewIds dropped by that last
-    rule: previews this manifest still declares but this run never looked
-    at. The caller records them so `comment` can tell them apart from
-    previews that are absent because they were *deleted* — those really are
-    resolved findings and must still be reported.
+    ``unchecked``, when given, collects every previewId this manifest still
+    declares that the run never looked at — including a variant whose
+    *sibling* was checked, since the baseline may have selected the sibling
+    (issue #3764). The caller records them so `comment` can tell them apart
+    from previews that are absent because they were *deleted* — those really
+    are resolved findings and must still be reported.
     """
     module = manifest["module"]
     by_fn: dict[str, list[dict]] = {}
@@ -191,20 +192,15 @@ def select_variants(
         candidates = (
             [p for p in group if p["id"] in a11y_by_id] if partial else group
         )
+        # Every declared variant this run didn't look at, not just the ones
+        # whose whole function went unchecked. A baseline row can name a
+        # *sibling* of the variant checked here — `Foo_large_round` outranks
+        # `Foo_small_round`, so a run narrowed to the small one leaves the
+        # large one absent from the current keys — and without recording it,
+        # `comment` reads that absence as a fixed finding (issue #3764).
+        if partial and unchecked is not None:
+            unchecked.extend(p["id"] for p in group if p["id"] not in a11y_by_id)
         if not candidates:
-            # Still declared, just never checked. Record the id the baseline
-            # would have carried for this function so the caller can exclude
-            # it from "resolved" without excluding genuine deletions.
-            if unchecked is not None:
-                unchecked.append(
-                    min(
-                        group,
-                        key=lambda p: (
-                            device_priority((p.get("params") or {}).get("device")),
-                            p["id"],
-                        ),
-                    )["id"]
-                )
             continue
         chosen = min(
             candidates,

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -222,6 +222,29 @@ class SelectVariantsTest(unittest.TestCase):
         self.assertEqual([r["previewId"] for r in rows], ["x.Checked"])
         self.assertEqual(unchecked, ["x.Skipped"])
 
+    def test_partial_report_records_an_unchecked_sibling_variant(self):
+        # `Foo_large_round` outranks `Foo_small_round`, so a baseline row for
+        # this function names the large one. A run narrowed to the small one
+        # leaves the large one unchecked — and if that isn't recorded, the
+        # comment step reads its absence as a resolved finding (#3764).
+        manifest = {
+            "module": "sample-wear",
+            "previews": [
+                _preview(id="x.Foo_large_round", function="Foo",
+                         render="large.png", device="id:wearos_large_round"),
+                _preview(id="x.Foo_small_round", function="Foo",
+                         render="small.png", device="id:wearos_small_round"),
+            ],
+        }
+        a11y_by_id = {"x.Foo_small_round": {"previewId": "x.Foo_small_round",
+                                            "findings": []}}
+
+        unchecked: list[str] = []
+        rows = ar.select_variants(manifest, a11y_by_id, True, unchecked)
+
+        self.assertEqual([r["previewId"] for r in rows], ["x.Foo_small_round"])
+        self.assertEqual(unchecked, ["x.Foo_large_round"])
+
     def test_complete_report_reports_nothing_as_unchecked(self):
         manifest = {
             "module": "sample",
@@ -821,6 +844,23 @@ class CommentTest(unittest.TestCase):
             [survivor],
             baseline_entries=[baseline, survivor],
             unchecked_previews=[{"module": "sample-wear", "previewId": "x.Gone"}],
+        )
+        self.assertNotIn("Resolved", body)
+
+    def test_unchecked_sibling_variant_is_not_reported_as_resolved(self):
+        # End of the same path as the select_variants test above: the baseline
+        # carried a finding on the variant this run never checked.
+        baseline = self._entry(
+            function="Foo", preview_id="x.Foo_large_round",
+            findings=[_finding(level="ERROR")],
+        )
+        current = self._entry(function="Foo", preview_id="x.Foo_small_round")
+        body = self._run_comment(
+            [current],
+            baseline_entries=[baseline],
+            unchecked_previews=[
+                {"module": "sample-wear", "previewId": "x.Foo_large_round"}
+            ],
         )
         self.assertNotIn("Resolved", body)
 


### PR DESCRIPTION
Fixes #3764. Follow-up to #3757, which added partial-coverage handling for narrowed `compose-preview a11y` runs and left this case behind.

## What was wrong

`select_variants` collected "still declared but never checked" ids only when a function's **entire** variant group went unchecked:

```python
candidates = [p for p in group if p["id"] in a11y_by_id] if partial else group
if not candidates:
    unchecked.append(min(group, key=…)["id"])   # only here
    continue
```

When one variant was checked and a sibling wasn't, the group still had a candidate, so nothing was recorded. Device priority picks `Foo_large_round` over `Foo_small_round`, so a baseline row for that function names the large one — and a run narrowed to the small one leaves the large one absent from both `current_keys` and `uncheckedPreviews`. `cmd_comment` then reads that absence as a fixed finding.

It's the same false claim #3757 exists to prevent, one level down: variant granularity rather than function granularity.

## Before / after

Driving the real helper at `d4c90a2` and at this commit, with a function declaring both round variants, a run that checked only `Foo_small_round`, and a baseline carrying an ERROR on `Foo_large_round`:

```
main (d4c90a2)   unchecked=[]                         claims Resolved: True
fixed            unchecked=['x.Foo_large_round']      claims Resolved: False
```

## The fix

Record every declared id in the group that's absent from `a11y_by_id`, and leave the `if not candidates` branch responsible only for skipping the row. The whole-group case is a subset of the new rule, so it keeps working — a single-variant function still reports exactly its one id.

## Test plan

- [x] `python3 -m unittest test_a11y_report` — 44 tests.
- [x] New: `select_variants` records an unchecked **sibling** variant while still choosing the checked one for the row.
- [x] New: `cmd_comment` doesn't report that sibling's baseline finding as resolved.
- [x] Existing partial-coverage tests unchanged — whole-function-unchecked still recorded, a genuinely deleted preview still reports as resolved, a complete report still records nothing.
- [x] Reproduction above run against both the merged helper and this one.

Low severity in practice: it needs a narrowed a11y run feeding `copy-annotated` → `comment` against a baseline. CI runs a11y unnarrowed, where nothing is ever unchecked.

Not visual — a CI report helper and its tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_