### PR TITLE
fix(serve): make a pinned revision authoritative about what it published

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -593,11 +593,23 @@ class ServeBundleHost(
    * feature exists to fix, and it would be undetectable from the outside.
    */
   fun pinnedRender(commit: String, previewId: String): ByteArray? =
-    pinnedAsset(commit, branchPath(commit, previewId, bakedBranchPaths) { it.renders })
+    pinnedAsset(
+      commit,
+      branchPath(commit, previewId, bakedBranchPaths, { it.catalogRead }, { it.renders }),
+    )
 
   /** [referenceId]'s canonical reference raster as published at [commit]. See [pinnedRender]. */
   fun pinnedReference(commit: String, referenceId: String): ByteArray? =
-    pinnedAsset(commit, branchPath(commit, referenceId, referenceBranchPaths) { it.references })
+    pinnedAsset(
+      commit,
+      branchPath(
+        commit,
+        referenceId,
+        referenceBranchPaths,
+        { it.referencesRead },
+        { it.references },
+      ),
+    )
 
   /**
    * Where [id]'s asset lived **at [commit]**, preferring that commit's own manifest over the tip's
@@ -611,16 +623,23 @@ class ServeBundleHost(
    * - a **reference** carries its id and its raster path independently, so the id survives while
    *   the path moves. The tip's map then resolves confidently to a path that commit never had.
    *
-   * The tip's map stays as the fallback because it is right in the common case and costs no fetch,
-   * so a commit whose manifests can't be read degrades to the behaviour that existed before rather
-   * than to nothing.
+   * The tip's map is the fallback for **an absent manifest only**, not for an id the manifest
+   * doesn't list. A readable manifest is authoritative about its own revision: if it doesn't name
+   * the id, that revision did not publish it, and the honest answer is nothing. Falling back there
+   * would serve whatever happens to sit at today's path in that commit — a file the revision may
+   * well contain, under an id its own manifest says it never published.
    */
   private fun branchPath(
     commit: String,
     id: String,
     tip: Map<String, String>,
+    wasRead: (ServePinnedManifest.Paths) -> Boolean,
     select: (ServePinnedManifest.Paths) -> Map<String, String>,
-  ): String? = pinnedManifest?.forCommit(commit)?.let(select)?.get(id) ?: tip[id]
+  ): String? {
+    val paths = pinnedManifest?.forCommit(commit)
+    if (paths != null && wasRead(paths)) return select(paths)[id]
+    return tip[id]
+  }
 
   /**
    * One published asset at one commit, memoised.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2174,6 +2174,8 @@ class ServeHttpServer(
         respondNotFoundHtml("That preview has no matching design reference.")
         return@withLeasedSession
       }
+      val revisions = catalogRevisions(renderHost)
+      val pinned = revisions.pinned != null
       markGeneration("static-page", pageCacheControl())
       call.respondText(
         ServeWeb.referenceComparisonPage(
@@ -2192,9 +2194,16 @@ class ServeHttpServer(
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
           version = BUNDLE_VERSION,
           displayTitle = catalogBundleHost(renderHost)?.title,
-          referenceAnnotations = renderHost.annotationsForReference(reference.id),
-          actualAnnotations = renderHost.annotationsForPreview(previewId),
-          revisions = catalogRevisions(renderHost),
+          // Annotation layers describe the CURRENT catalog's layout and typography. Drawing them
+          // over a pinned pair would overlay today's bounds on historical pixels and label the
+          // result as that revision's spec — the same "current output on a pinned page" the viewer
+          // refuses, arriving through a payload rather than a lane. They are published per catalog
+          // load, not per revision, so there is nothing historical to draw instead.
+          referenceAnnotations =
+            if (pinned) emptyList() else renderHost.annotationsForReference(reference.id),
+          actualAnnotations =
+            if (pinned) emptyList() else renderHost.annotationsForPreview(previewId),
+          revisions = revisions,
         ),
         ContentType.Text.Html,
       )
@@ -4075,6 +4084,26 @@ class ServeHttpServer(
             "only the baked render is published per revision; drop " +
               "'${ServeCatalogRevision.PARAM}' to ask the daemon for this product",
             status = HttpStatusCode.NotFound,
+          )
+          return@withLeasedSession
+        }
+        // A product can also be selected by *query* rather than by suffix: `?scroll=long` is a
+        // full-page capture, `?rcPlayer=cmp-jvm` is a different player's raster, and any override
+        // (`fontScale`, `device`, `knob.…`) asks for pixels rendered to order. None of those is a
+        // published byte, so answering with the plain baked PNG would hand back a 200 that
+        // silently ignores half the URL — two links claiming different things returning identical
+        // pixels. Refusing names the conflict instead.
+        val onDemand =
+          requestCarriesOverrides() ||
+            call.request.queryParameters["scroll"] != null ||
+            call.request.queryParameters["rcPlayer"] != null ||
+            call.request.queryParameters["mode"] != null ||
+            ServeExplodedSvg.PARAMS.any { call.request.queryParameters[it] != null }
+        if (onDemand) {
+          call.respondText(
+            "'${ServeCatalogRevision.PARAM}' pins the published render, which cannot be " +
+              "re-rendered to order; drop the pin or drop the render parameters",
+            status = HttpStatusCode.BadRequest,
           )
           return@withLeasedSession
         }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
@@ -34,17 +34,32 @@ class ServePinnedManifest(
   private val maxCommits: Int = MAX_COMMITS,
 ) {
 
-  /** One commit's published layout. */
+  /**
+   * One commit's published layout.
+   *
+   * Each lane records **whether its manifest was read**, separately from what it contained, because
+   * the two answer different questions and only one of them licenses a fallback. "The manifest says
+   * this revision had no such id" is an answer — the asset was not published then, and the request
+   * is a 404. "I could not read the manifest" is an absence of one, and there the tip's map is
+   * better than nothing. Collapsing them would let a pin serve a file that merely happens to exist
+   * at that commit under today's path, i.e. claim an asset was published in a revision whose own
+   * manifest omits it.
+   */
   data class Paths(
     /** Preview id → its baked render's path on the branch. */
     val renders: Map<String, String>,
     /** Design-reference id → its canonical raster's path on the branch. */
     val references: Map<String, String>,
+    /** Whether `catalog.json` was fetched and parsed at this commit. */
+    val catalogRead: Boolean = false,
+    /** Whether `references/index.json` was fetched and parsed at this commit. */
+    val referencesRead: Boolean = false,
   ) {
     val isEmpty: Boolean
       get() = renders.isEmpty() && references.isEmpty()
 
     companion object {
+      /** Nothing was read — every lookup falls back to the tip's map. */
       val NONE = Paths(emptyMap(), emptyMap())
     }
   }
@@ -61,27 +76,36 @@ class ServePinnedManifest(
    */
   fun forCommit(commit: String): Paths {
     val pin = ServeCatalogRevision.normalize(commit) ?: return Paths.NONE
-    byCommit[pin]?.let {
-      return it
-    }
+    // `computeIfAbsent` rather than get-then-put: the two panels of a comparison page (and every
+    // image of a pinned grid) race into this method at once, and a check-then-fetch lets each of
+    // them fetch both manifests before any of them stores a result — the memoisation this class
+    // promises, spent. ConcurrentHashMap serialises the mapping function per key, so the first
+    // caller fetches and the rest wait for its answer. The eviction stays outside the mapping
+    // function, which must not touch the map it is being computed into.
     val paths =
-      Paths(
-        renders = read(pin, ServeCatalogRevision.CATALOG_FILE, ::parseCatalog),
-        references = read(pin, ServeCatalogRevision.REFERENCES_FILE, ::parseReferences),
-      )
-    synchronized(byCommit) {
-      if (byCommit.size >= maxCommits) byCommit.keys.firstOrNull()?.let(byCommit::remove)
-      byCommit[pin] = paths
+      byCommit.computeIfAbsent(pin) {
+        val catalog = read(pin, ServeCatalogRevision.CATALOG_FILE, ::parseCatalog)
+        val references = read(pin, ServeCatalogRevision.REFERENCES_FILE, ::parseReferences)
+        Paths(
+          renders = catalog.orEmpty(),
+          references = references.orEmpty(),
+          catalogRead = catalog != null,
+          referencesRead = references != null,
+        )
+      }
+    if (byCommit.size > maxCommits) {
+      synchronized(byCommit) { byCommit.keys.firstOrNull { it != pin }?.let(byCommit::remove) }
     }
     return paths
   }
 
+  /** Null when the manifest could not be read at all — distinct from "read, and it lists none". */
   private fun read(
     commit: String,
     file: String,
-    parse: (String) -> Map<String, String>,
-  ): Map<String, String> =
-    runCatching { fetch(commit, file)?.toString(Charsets.UTF_8)?.let(parse) }.getOrNull().orEmpty()
+    parse: (String) -> Map<String, String>?,
+  ): Map<String, String>? =
+    runCatching { fetch(commit, file)?.toString(Charsets.UTF_8)?.let(parse) }.getOrNull()
 
   companion object {
 
@@ -101,10 +125,10 @@ class ServePinnedManifest(
      * Tolerant by design: this reads a file published by an older CLI than the one reading it, so a
      * malformed component or image is skipped rather than failing the whole map.
      */
-    fun parseCatalog(json: String): Map<String, String> {
+    fun parseCatalog(json: String): Map<String, String>? {
       val components =
         runCatching { JSON.parseToJsonElement(json).jsonObject["components"]?.jsonArray }
-          .getOrNull() ?: return emptyMap()
+          .getOrNull() ?: return null
       val paths = LinkedHashMap<String, String>()
       for (component in components) {
         val images =
@@ -114,17 +138,21 @@ class ServePinnedManifest(
             runCatching { image.jsonObject["path"]?.jsonPrimitive?.content }
               .getOrNull()
               ?.takeIf { it.isNotBlank() } ?: continue
-          paths.putIfAbsent(ServeCatalogStore.previewIdFor(path), path)
+          // LAST declaration wins, because that is what the live loader does
+          // (`bakedPathById[id] = path`). Two paths can flatten to one route id, and a pin that
+          // resolved such a collision the other way would serve different pixels than the same
+          // catalog served while it was current — the one thing a revision must never do.
+          paths[ServeCatalogStore.previewIdFor(path)] = path
         }
       }
       return paths
     }
 
     /** `references/index.json` → reference id → the canonical raster's path on the branch. */
-    fun parseReferences(json: String): Map<String, String> {
+    fun parseReferences(json: String): Map<String, String>? {
       val references =
         runCatching { JSON.parseToJsonElement(json).jsonObject["references"]?.jsonArray }
-          .getOrNull() ?: return emptyMap()
+          .getOrNull() ?: return null
       val paths = LinkedHashMap<String, String>()
       for (reference in references) {
         val obj = runCatching { reference.jsonObject }.getOrNull() ?: continue
@@ -135,6 +163,10 @@ class ServePinnedManifest(
           runCatching { obj["raster"]?.jsonObject?.get("path")?.jsonPrimitive?.content }
             .getOrNull()
             ?.takeIf { it.isNotBlank() } ?: continue
+        // FIRST declaration wins here, and the asymmetry with the renders above is deliberate: the
+        // reference importer discards a duplicate id (`seen.add(reference.id)`), so first-wins is
+        // what the served catalog does. Each lane mirrors its own loader rather than both being
+        // made consistent with each other.
         paths.putIfAbsent(id, path)
       }
       return paths

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
@@ -118,6 +118,20 @@ class ServePinnedManifest(
     private val JSON = Json { ignoreUnknownKeys = true }
 
     /**
+     * The same eligibility rule [ServeCatalogStore] plans an image by: inside `images/`, a PNG, no
+     * traversal. An entry that fails it is one the live catalog never served, so a pinned request
+     * must not resolve to it either.
+     *
+     * Deliberately *not* mirrored: the loader's `maxImages` ceiling. That is a property of the
+     * server reading the catalog, not of the revision — a box with a different cap would otherwise
+     * disagree with itself about what a commit published.
+     */
+    private fun isServable(path: String): Boolean =
+      path.startsWith("${ServeCatalogStore.IMAGES_DIR}/") &&
+        path.endsWith(".png") &&
+        ".." !in path.split("/")
+
+    /**
      * `catalog.json` → preview id → image path, keyed exactly as the loader keys the live catalog
      * ([ServeCatalogStore.previewIdFor]), so a pinned id and a served id are the same string by
      * construction rather than by coincidence.
@@ -137,11 +151,17 @@ class ServePinnedManifest(
           val path =
             runCatching { image.jsonObject["path"]?.jsonPrimitive?.content }
               .getOrNull()
-              ?.takeIf { it.isNotBlank() } ?: continue
+              ?.takeIf(::isServable) ?: continue
           // LAST declaration wins, because that is what the live loader does
           // (`bakedPathById[id] = path`). Two paths can flatten to one route id, and a pin that
           // resolved such a collision the other way would serve different pixels than the same
           // catalog served while it was current — the one thing a revision must never do.
+          //
+          // Which is also why the eligibility filter above has to run FIRST. The loader plans only
+          // the images it would serve, so an entry it rejects never reaches its map; accepting one
+          // here and then applying last-wins would let a rejected entry overwrite the served one
+          // under a shared id — a pin answering with bytes that revision never exposed, arrived at
+          // by faithfully copying half of the loader's rule.
           paths[ServeCatalogStore.previewIdFor(path)] = path
         }
       }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
@@ -3,6 +3,8 @@ package ee.schimke.composeai.cli.serve
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ServePinnedManifestTest {
@@ -54,18 +56,45 @@ class ServePinnedManifestTest {
   }
 
   @Test
-  fun `a manifest this reader does not understand yields no paths rather than failing`() {
-    // Published by an older (or newer) CLI than the one reading it, truncated, or simply a 404 page
-    // — every one of these degrades to "resolve through the tip's map instead".
-    assertEquals(emptyMap(), ServePinnedManifest.parseCatalog(""))
-    assertEquals(emptyMap(), ServePinnedManifest.parseCatalog("<html>404</html>"))
-    assertEquals(emptyMap(), ServePinnedManifest.parseCatalog("""{"components":"not-an-array"}"""))
-    assertEquals(emptyMap(), ServePinnedManifest.parseReferences("""{"references":[{"id":1}]}"""))
+  fun `a manifest this reader cannot parse is distinguishable from one that lists nothing`() {
+    // The distinction decides whether a fallback to the tip's map is licensed at all, so it is the
+    // parser's job to answer "was this a manifest?" separately from "what did it contain?".
+    assertNull(ServePinnedManifest.parseCatalog(""))
+    assertNull(ServePinnedManifest.parseCatalog("<html>404</html>"))
+    assertNull(ServePinnedManifest.parseCatalog("""{"components":"not-an-array"}"""))
+    assertNull(ServePinnedManifest.parseReferences("nonsense"))
+    // Read, and it genuinely lists none — an answer, not an absence.
+    assertEquals(emptyMap(), ServePinnedManifest.parseCatalog("""{"components":[]}"""))
+    assertEquals(emptyMap(), ServePinnedManifest.parseReferences("""{"references":[]}"""))
     // A single malformed entry costs only itself, not the rest of the map.
     assertEquals(
       mapOf("card__ideal" to "images/card/ideal.png"),
       ServePinnedManifest.parseCatalog(
         """{"components":[{"images":[{"nopath":1},{"path":"images/card/ideal.png"}]}]}"""
+      ),
+    )
+  }
+
+  @Test
+  fun `each lane resolves a duplicate id the way its own loader does`() {
+    // Two paths can flatten to one route id. The live loader assigns (`bakedPathById[id] = path`),
+    // so the LAST declaration is what a visitor sees — and a pin to that same commit must agree,
+    // or the revision serves different pixels than it served while current.
+    assertEquals(
+      mapOf("foo__bar__baz" to "images/foo/bar__baz.png"),
+      ServePinnedManifest.parseCatalog(
+        """{"components":[{"images":[
+             {"path":"images/foo__bar/baz.png"},{"path":"images/foo/bar__baz.png"}]}]}"""
+      ),
+    )
+    // References go the other way, because their importer discards a duplicate id rather than
+    // overwriting: first wins. The asymmetry mirrors the two loaders, not one another.
+    assertEquals(
+      mapOf("dup" to "references/first.png"),
+      ServePinnedManifest.parseReferences(
+        """{"references":[
+             {"id":"dup","raster":{"path":"references/first.png"}},
+             {"id":"dup","raster":{"path":"references/second.png"}}]}"""
       ),
     )
   }
@@ -105,6 +134,27 @@ class ServePinnedManifestTest {
     // A branch that cannot answer for a commit will not start answering, and a page of broken
     // pinned images must not re-ask once per image.
     assertEquals(2, fetches.get())
+  }
+
+  @Test
+  fun `a readable manifest is authoritative, an unreadable one licenses the fallback`() {
+    val readable =
+      ServePinnedManifest(
+        fetch = { _, file ->
+          if (file == ServeCatalogRevision.CATALOG_FILE)
+            """{"components":[{"images":[{"path":"images/card/ideal.png"}]}]}""".encodeToByteArray()
+          else null
+        }
+      )
+
+    val paths = readable.forCommit(commit)
+
+    // The catalog was read, so what it does not list, that revision did not publish — the caller
+    // must not fall back to the tip's map for an id this manifest omits.
+    assertTrue(paths.catalogRead)
+    assertNull(paths.renders["never-published"])
+    // The reference manifest was NOT readable, which is an absence rather than an answer.
+    assertFalse(paths.referencesRead)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
@@ -87,6 +87,23 @@ class ServePinnedManifestTest {
              {"path":"images/foo__bar/baz.png"},{"path":"images/foo/bar__baz.png"}]}]}"""
       ),
     )
+    // …but only among entries the loader would actually have served. An ineligible path (outside
+    // images/, or not a PNG) never reaches the live map, so letting one win a collision here would
+    // answer a pin with bytes that revision never exposed.
+    assertEquals(
+      mapOf("foo__bar__baz" to "images/foo__bar/baz.png"),
+      ServePinnedManifest.parseCatalog(
+        """{"components":[{"images":[
+             {"path":"images/foo__bar/baz.png"},{"path":"foo/bar__baz.png"}]}]}"""
+      ),
+    )
+    assertEquals(
+      emptyMap(),
+      ServePinnedManifest.parseCatalog(
+        """{"components":[{"images":[
+             {"path":"images/a/../../secret.png"},{"path":"images/b/c.svg"}]}]}"""
+      ),
+    )
     // References go the other way, because their importer discards a duplicate id rather than
     // overwriting: first wins. The asymmetry mirrors the two loaders, not one another.
     assertEquals(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
@@ -305,6 +305,71 @@ class ServePinnedRevisionTest {
     )
   }
 
+  @Test
+  fun `a render asked for to order is refused under a pin, not answered with the baked one`() {
+    val port = start().port
+
+    // These select a DIFFERENT product by query rather than by suffix: a full-page capture, another
+    // player's raster, an overridden render. Answering any of them with the plain baked PNG would
+    // be a 200 that silently ignores half the URL.
+    for (query in
+      listOf(
+        "scroll=long",
+        "rcPlayer=cmp-jvm",
+        "fontScale=1.5",
+        "device=pixel_8",
+        "knob.size=xl",
+      )) {
+      val url = "http://127.0.0.1:$port/$system/render/$previewId.png?at=$oldCommit&$query"
+      assertEquals(400, get(url).first, query)
+    }
+    // The bare pinned render is unaffected — refusing the combination is not refusing the pin.
+    assertContentEquals(
+      historicalRender,
+      bytes("http://127.0.0.1:$port/$system/render/$previewId.png?at=$oldCommit"),
+    )
+  }
+
+  @Test
+  fun `an id the pinned catalog does not list is not answered from the tip's paths`() {
+    // The old commit publishes a catalog that lists ONLY the legacy component, while the path the
+    // tip knows this preview by happens to resolve at that commit too. A readable manifest is the
+    // authority on its own revision: it does not list this id, so the answer is nothing — not the
+    // file sitting at today's path.
+    val oldCatalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+        {"componentId":"Legacy","images":[{"path":"images/legacy/ideal.png"}]}]}
+      """
+        .trimIndent()
+    val port = startWith { url ->
+      val old = "https://raw.githubusercontent.com/$repo/$oldCommit/"
+      when (url) {
+        "${old}catalog.json" -> oldCatalog.encodeToByteArray()
+        else -> fetch(url)
+      }
+    }
+
+    // …even though the tip's path for it does resolve at that commit (the default stub serves it).
+    assertEquals(
+      404,
+      get("http://127.0.0.1:$port/$system/render/$previewId.png?at=$oldCommit").first,
+    )
+  }
+
+  @Test
+  fun `a pinned comparison draws no annotation layer from the current catalog`() {
+    val port = start().port
+
+    val pinned = text("http://127.0.0.1:$port/$system/compare/$previewId?at=$oldCommit")
+
+    // Annotations describe the current catalog's layout, so over historical pixels they would
+    // label today's bounds as that revision's spec. The controls go with the payload.
+    assertFalse(pinned.contains("cp-annotations"), pinned)
+    assertFalse(pinned.contains("cp-annotation-toggle"), pinned)
+    assertFalse(pinned.contains("data-cp-annotation-kind"), pinned)
+  }
+
   private fun get(url: String): Pair<Int, ByteArray> =
     client.newCall(Request.Builder().url(url).build()).execute().use { response ->
       response.code to (response.body?.bytes() ?: ByteArray(0))

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -267,13 +267,25 @@ The rules the lane holds to, each of which exists because its opposite would mak
 
   The lanes that have no historical answer refuse rather than fall through: `/render/<id>.svg?at=…`
   (and the `.slots` / `.a11y` / `.annotations` / `.rc` products) is a `404` naming the reason, so a
-  hand-typed URL cannot get today's export under an old sha either.
+  hand-typed URL cannot get today's export under an old sha either. A product selected by **query**
+  goes the same way with a `400` — `?at=<sha>&scroll=long`, `&rcPlayer=cmp-jvm`, or any override
+  (`fontScale`, `device`, `knob.…`) asks for pixels rendered to order, and answering with the plain
+  baked PNG would be a 200 that silently ignores half the URL. The comparison page's **annotation
+  layers** are suppressed under a pin for the same reason: they are published per catalog load, not
+  per revision, so drawing them would label today's bounds as that revision's spec.
 - **A revision resolves its paths from its own manifests.** The `catalog.json` and
   `references/index.json` *at the pinned commit* decide where an asset lived, not the tip's map. The
   two lanes need it for opposite reasons: a render's id is derived from its path, so a rename
   retires the id a permalink names and today's map cannot resolve it under any path; a reference's
   id survives a path change, so today's map resolves it confidently to a path that commit never had.
-  Both manifests are memoised per commit, and an unreadable one falls back to the tip's map.
+  Both manifests are memoised per commit (one fetch even when a page's images race in together),
+  and each lane resolves a duplicate id the way its own loader does — last-wins for renders,
+  first-wins for references — so a pin can never disagree with what that commit served while it was
+  current.
+
+  A manifest that **was read** is authoritative about its own revision: an id it doesn't list was
+  not published then, and the answer is a 404 rather than whatever happens to sit at today's path in
+  that commit. The tip's map is the fallback only for a manifest that could not be read at all.
 - **The response is `immutable`** (on a public box — a token-gated one keeps `no-store` like every
   other private response), because `(commit, path)` is immutable by construction.
 


### PR DESCRIPTION
Third round on historical permalinks (#3723 → #3758 → #3768), addressing #3768's review. Four ways a pin could still be answered with something that revision did not publish.

## A readable manifest is the authority on its own revision

#3768 fell back to the tip's map whenever the pinned manifest lacked the id — including when the manifest was read perfectly well and simply doesn't list it. That served whatever happens to sit at *today's* path in that commit, under an id that commit's own manifest omits.

The parsers now report **"was this a manifest?"** separately from **"what did it contain?"**, and the fallback applies only to the former. "That revision published no such asset" is an answer (404); "I couldn't read the manifest" is an absence of one, and only there is the tip's map better than nothing.

## A product selected by query is refused, not silently substituted

`?at=<sha>&scroll=long`, `&rcPlayer=cmp-jvm`, and any override (`fontScale`, `device`, `knob.…`) each ask for pixels rendered to order. #3768 answered them with the plain baked PNG under a 200 — half the URL ignored, and two links claiming different things returning identical bytes. They now 400 with the conflict named, which is the rule the suffix products (`.svg` / `.slots` / `.a11y` / `.annotations` / `.rc`) already got; these just arrive by a different route.

## The comparison page draws no annotation layers under a pin

They're published per catalog load, not per revision, so over historical pixels they labelled *today's* layout and typography as that revision's spec — the same "current output on a pinned page" the viewer refuses, arriving as a payload rather than a lane.

## Duplicate ids resolve as each lane's own loader resolves them

Two image paths can flatten to one route id. The live loader assigns (`bakedPathById[id] = path`) so **last wins**; the reference importer discards a duplicate id so **first wins**. #3768 used first-wins for both, so a pin could break a collision the other way and serve different pixels than that same catalog served while it was current. Each lane now mirrors its own loader — the asymmetry is the point, and it's commented as such.

Plus: the per-commit memo loads under `computeIfAbsent`, so the two panels of a comparison racing into it cost one pair of manifest fetches rather than two.

## Not in this PR

`/p/<retired-id>?at=<sha>` still 404s. #3768 made the *asset* resolve at a revision that has it, but `handleViewer` looks the preview up in the session's tip-derived list, so the **page** for an id that has since been renamed away is still rejected. Fixing it means synthesizing preview metadata from a historical catalog for ids the session doesn't know — a real change to the viewer's model rather than a patch, so I'd rather do it deliberately than bolt it on here. The four P2s from #3758's review (atomic fetch-through-the-sha at load, negative caching + admission on pinned fetches, pinned `og:image` HEAD probes) are also still open.

## Test plan

- `ServePinnedManifestTest` — unparseable vs. read-and-lists-nothing, the authority flags, and each lane's duplicate-id precedence pinned explicitly.
- `ServePinnedRevisionTest` — a query-selected product refused while the bare pin still serves; an id the pinned catalog omits 404ing *even though* the tip's path for it resolves at that commit; a pinned comparison carrying no annotation markup.
- `./gradlew :cli:test :cli:ktfmtCheck` green.

No visual change: the only page-affecting edit removes annotation controls from a pinned comparison, which the committed fixtures don't exercise (they carry no annotations under a pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SazNBCPVGgAe1ERifMgPGF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SazNBCPVGgAe1ERifMgPGF)_