### PR TITLE
fix(a11y-report): don't let same-named modules delete each other's renders

### DIFF
--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -122,13 +122,19 @@ def load_previews(build_dir: Path) -> tuple[dict, dict, str | None, bool]:
 
 
 def module_identity(build_dir: Path) -> str:
-    """Gradle-path-ish label for the module whose outputs live in ``build_dir``.
+    """Gradle-path-ish *directory name* for the module whose outputs live in
+    ``build_dir``.
 
-    Used only to disambiguate modules whose ``previews.json`` ``module`` field
-    collides — that field is ``project.name``, the leaf, so ``:foo:app`` and
-    ``:bar:app`` are both ``app`` (issue #3763). Mirrors the translation the
-    a11y pipeline already does in shell to match its skip list:
+    Used only to disambiguate the ``renders/`` subdirectory of modules whose
+    ``previews.json`` ``module`` field collides — that field is
+    ``project.name``, the leaf, so ``:foo:app`` and ``:bar:app`` are both
+    ``app`` (issue #3763). Mirrors the translation the a11y pipeline already
+    does in shell to match its skip list:
     ``foo/bar/build/compose-previews`` → ``foo:bar``.
+
+    Deliberately *not* the module's identity for diffing: the report keys stay
+    `manifest["module"]` so they never depend on which other modules happened
+    to take part in a run.
 
     Falls back to the directory itself when it doesn't follow the
     ``<module>/build/compose-previews`` convention, which keeps this total for
@@ -146,13 +152,17 @@ def module_identity(build_dir: Path) -> str:
         if len(parts) >= 3 and parts[-2:] == ("build", "compose-previews")
         else build_dir
     )
-    module_dir = module_dir.resolve()
+    resolved = module_dir.resolve()
+    relative = resolved
     try:
-        module_dir = module_dir.relative_to(Path.cwd())
+        relative = resolved.relative_to(Path.cwd())
     except ValueError:
         pass
-    safe = [p for p in module_dir.parts if p not in ("/", "", ".", "..")]
-    return ":".join(safe) or build_dir.name
+    safe = [p for p in relative.parts if p not in ("/", "", ".", "..")]
+    # Never empty: `--build-dir .` relativizes to nothing, and an empty name
+    # would make `renders/<dir>` the shared `renders/` root — which is rmtree'd
+    # per module, so it would delete every other module's PNGs.
+    return ":".join(safe) or resolved.name or "module"
 
 
 def is_dynamic_preview(preview: dict) -> bool:
@@ -300,9 +310,7 @@ def cmd_copy_annotated(args: argparse.Namespace) -> int:
     # first render is copied. `module` is `project.name`, so `:foo:app` and
     # `:bar:app` both report `app` — and the per-module renders dir below is
     # rmtree'd before it is written, so the second module would delete the
-    # first one's PNGs (issue #3763). Only a genuine collision is renamed, which
-    # keeps every ordinary run byte-identical to before and so leaves the
-    # published baseline's keys alone.
+    # first one's PNGs (issue #3763).
     loaded = [(Path(raw), *load_previews(Path(raw))) for raw in build_dirs]
     leaf_counts = Counter(manifest["module"] for _, manifest, _, _, _ in loaded)
 
@@ -310,16 +318,18 @@ def cmd_copy_annotated(args: argparse.Namespace) -> int:
         module_unchecked: list[str] = []
         rows = select_variants(manifest, a11y_by_id, partial, module_unchecked)
 
+        # `module` stays the manifest's name — it is the diff key `comment`
+        # matches against the published baseline, so it must be a property of
+        # the module alone and never depend on which *other* modules took part
+        # in this run. Only the directory the renders land in is disambiguated,
+        # and only when it would otherwise be shared.
         module = manifest["module"]
-        if leaf_counts[module] > 1:
-            module = module_identity(build_dir)
-            for row in rows:
-                row["module"] = module
+        renders_dir = module if leaf_counts[module] == 1 else module_identity(build_dir)
         unchecked_previews.extend(
             {"module": module, "previewId": preview_id}
             for preview_id in module_unchecked
         )
-        renders_out = out_dir / "renders" / module
+        renders_out = out_dir / "renders" / renders_dir
         if renders_out.exists():
             shutil.rmtree(renders_out)
         renders_out.mkdir(parents=True, exist_ok=True)
@@ -351,6 +361,11 @@ def cmd_copy_annotated(args: argparse.Namespace) -> int:
                     shutil.copy2(src, renders_out / annotated_basename)
             findings_summary.append({
                 "module": row["module"],
+                # Where this row's images live under `renders/`. Normally the
+                # module name; disambiguated when two modules share one. Absent
+                # from baselines written before #3763, which is why every
+                # reader falls back to `module`.
+                "rendersDir": renders_dir,
                 "functionName": row["functionName"],
                 "sourceFile": row["sourceFile"],
                 "previewId": row["previewId"],
@@ -455,7 +470,10 @@ def _findings_table(findings: list[dict]) -> list[str]:
 
 def _entry_block(entry: dict, ref: str, repo: str, image_width: int) -> list[str]:
     fn = entry["functionName"]
-    module = entry["module"]
+    # Images live under the row's renders dir, which is the module name unless
+    # two modules shared it (#3763). Baselines written before that carry no
+    # `rendersDir`, and for them the module name is exactly where it was.
+    module = entry.get("rendersDir") or entry["module"]
     variant = entry["variant"]
     findings = entry["findings"]
 

--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -34,6 +34,7 @@ import argparse
 import json
 import shutil
 import sys
+from collections import Counter
 from pathlib import Path
 
 
@@ -118,6 +119,32 @@ def load_previews(build_dir: Path) -> tuple[dict, dict, str | None, bool]:
         for entry in report.get("entries", []):
             a11y_by_id[entry["previewId"]] = entry
     return manifest, a11y_by_id, status, partial
+
+
+def module_identity(build_dir: Path) -> str:
+    """Gradle-path-ish label for the module whose outputs live in ``build_dir``.
+
+    Used only to disambiguate modules whose ``previews.json`` ``module`` field
+    collides — that field is ``project.name``, the leaf, so ``:foo:app`` and
+    ``:bar:app`` are both ``app`` (issue #3763). Mirrors the translation the
+    a11y pipeline already does in shell to match its skip list:
+    ``foo/bar/build/compose-previews`` → ``foo:bar``.
+
+    Falls back to the directory itself when it doesn't follow the
+    ``<module>/build/compose-previews`` convention, which keeps this total for
+    ad-hoc invocations rather than raising on them.
+    """
+    parts = build_dir.parts
+    module_dir = (
+        Path(*parts[:-2])
+        if len(parts) >= 3 and parts[-2:] == ("build", "compose-previews")
+        else build_dir
+    )
+    try:
+        module_dir = module_dir.relative_to(Path.cwd())
+    except ValueError:
+        pass
+    return ":".join(p for p in module_dir.parts if p not in ("/", "")) or build_dir.name
 
 
 def is_dynamic_preview(preview: dict) -> bool:
@@ -261,13 +288,25 @@ def cmd_copy_annotated(args: argparse.Namespace) -> int:
     # same-named projects; that identity problem is tracked in issue #3763.
     unchecked_previews: list[dict] = []
 
-    for raw_build_dir in build_dirs:
-        build_dir = Path(raw_build_dir)
-        manifest, a11y_by_id, status, partial = load_previews(build_dir)
+    # Load every module up front so a leaf-name collision is visible before the
+    # first render is copied. `module` is `project.name`, so `:foo:app` and
+    # `:bar:app` both report `app` — and the per-module renders dir below is
+    # rmtree'd before it is written, so the second module would delete the
+    # first one's PNGs (issue #3763). Only a genuine collision is renamed, which
+    # keeps every ordinary run byte-identical to before and so leaves the
+    # published baseline's keys alone.
+    loaded = [(Path(raw), *load_previews(Path(raw))) for raw in build_dirs]
+    leaf_counts = Counter(manifest["module"] for _, manifest, _, _, _ in loaded)
+
+    for build_dir, manifest, a11y_by_id, status, partial in loaded:
         module_unchecked: list[str] = []
         rows = select_variants(manifest, a11y_by_id, partial, module_unchecked)
 
         module = manifest["module"]
+        if leaf_counts[module] > 1:
+            module = module_identity(build_dir)
+            for row in rows:
+                row["module"] = module
         unchecked_previews.extend(
             {"module": module, "previewId": preview_id}
             for preview_id in module_unchecked

--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -133,6 +133,12 @@ def module_identity(build_dir: Path) -> str:
     Falls back to the directory itself when it doesn't follow the
     ``<module>/build/compose-previews`` convention, which keeps this total for
     ad-hoc invocations rather than raising on them.
+
+    The result names a directory under ``renders/``, so the path is resolved
+    and stripped of ``.`` / ``..`` components first. Without that, an ad-hoc
+    ``--build-dir ../build/compose-previews`` yields ``..``, and the
+    ``shutil.rmtree(renders/<module>)`` in `copy-annotated` would take out the
+    whole output tree.
     """
     parts = build_dir.parts
     module_dir = (
@@ -140,11 +146,13 @@ def module_identity(build_dir: Path) -> str:
         if len(parts) >= 3 and parts[-2:] == ("build", "compose-previews")
         else build_dir
     )
+    module_dir = module_dir.resolve()
     try:
         module_dir = module_dir.relative_to(Path.cwd())
     except ValueError:
         pass
-    return ":".join(p for p in module_dir.parts if p not in ("/", "")) or build_dir.name
+    safe = [p for p in module_dir.parts if p not in ("/", "", ".", "..")]
+    return ":".join(safe) or build_dir.name
 
 
 def is_dynamic_preview(preview: dict) -> bool:

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -510,11 +510,19 @@ class CopyAnnotatedTest(unittest.TestCase):
         ))
 
         findings = json.loads((out / "findings.json").read_text())
-        modules = sorted({e["module"] for e in findings["entries"]})
-        self.assertEqual(len(modules), 2, f"expected two distinct modules, got {modules}")
         # Both modules' renders survive, each under its own directory.
         surviving = sorted(p.name for p in (out / "renders").rglob("*.png"))
         self.assertEqual(surviving, ["Alpha.png", "Beta.png"])
+        dirs = sorted({e["rendersDir"] for e in findings["entries"]})
+        self.assertEqual(len(dirs), 2, f"expected two renders dirs, got {dirs}")
+        # ...while the diff key stays the module's own name, so it can't shift
+        # under the baseline when the set of modules in a run changes.
+        self.assertEqual({e["module"] for e in findings["entries"]}, {"app"})
+        for entry in findings["entries"]:
+            self.assertTrue(
+                (out / "renders" / entry["rendersDir"] / entry["cleanBasename"]).exists(),
+                entry,
+            )
 
     def test_unique_leaf_names_keep_their_plain_module_key(self):
         # The disambiguation must not fire on an ordinary run: the published
@@ -533,6 +541,12 @@ class CopyAnnotatedTest(unittest.TestCase):
         findings = json.loads((out / "findings.json").read_text())
         self.assertEqual(
             sorted({e["module"] for e in findings["entries"]}),
+            ["sample-phone", "sample-wear"],
+        )
+        # No collision, so the renders tree keeps the layout the published
+        # baseline branch already has — nothing to migrate.
+        self.assertEqual(
+            sorted({e["rendersDir"] for e in findings["entries"]}),
             ["sample-phone", "sample-wear"],
         )
 

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -310,6 +310,23 @@ class SelectVariantsTest(unittest.TestCase):
         self.assertFalse(partial)
 
 
+class ModuleIdentityTest(unittest.TestCase):
+    def test_translates_a_build_dir_to_a_gradle_path(self):
+        self.assertEqual(
+            ar.module_identity(Path("foo/app/build/compose-previews")), "foo:app"
+        )
+
+    def test_never_yields_a_traversal_component(self):
+        # `renders/<identity>` is rmtree'd before it is written, so an identity
+        # of `..` would delete the whole output tree.
+        for raw in ("../build/compose-previews", "./build/compose-previews",
+                    "a/../b/build/compose-previews"):
+            identity = ar.module_identity(Path(raw))
+            self.assertNotIn("..", identity.split(":"), raw)
+            self.assertNotIn(".", identity.split(":"), raw)
+            self.assertTrue(identity, raw)
+
+
 class CopyAnnotatedTest(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -460,6 +460,65 @@ class CopyAnnotatedTest(unittest.TestCase):
         findings = json.loads((out / "findings.json").read_text())
         self.assertEqual(findings["status"], "atf-unavailable")
 
+    def _sibling_module(self, dirname: str, module: str, fn: str) -> Path:
+        """A second build dir whose manifest reports `module` as its name."""
+        other = self.tmp / dirname
+        (other / "renders").mkdir(parents=True)
+        (other / "renders" / f"{fn}.png").write_bytes(b"clean-" + fn.encode())
+        (other / "previews.json").write_text(json.dumps({
+            "module": module,
+            "variant": "debug",
+            "previews": [
+                _preview(id=f"p.{fn}", function=fn, render=f"renders/{fn}.png"),
+            ],
+            "dataExtensionReports": {"a11y": "accessibility.json"},
+        }))
+        (other / "accessibility.json").write_text(json.dumps({
+            "module": module,
+            "entries": [{"previewId": f"p.{fn}", "findings": []}],
+        }))
+        return other
+
+    def test_same_leaf_named_modules_do_not_delete_each_others_renders(self):
+        # `module` is `project.name`, so `:foo:app` and `:bar:app` both say
+        # `app` — and `renders/<module>/` is rmtree'd before it's written, so
+        # the second module used to wipe the first one's PNGs (#3763).
+        first = self._sibling_module("foo/app/build/compose-previews", "app", "Alpha")
+        second = self._sibling_module("bar/app/build/compose-previews", "app", "Beta")
+
+        out = self.tmp / "out"
+        import argparse
+        ar.cmd_copy_annotated(argparse.Namespace(
+            build_dir=[str(first), str(second)], output_dir=str(out),
+        ))
+
+        findings = json.loads((out / "findings.json").read_text())
+        modules = sorted({e["module"] for e in findings["entries"]})
+        self.assertEqual(len(modules), 2, f"expected two distinct modules, got {modules}")
+        # Both modules' renders survive, each under its own directory.
+        surviving = sorted(p.name for p in (out / "renders").rglob("*.png"))
+        self.assertEqual(surviving, ["Alpha.png", "Beta.png"])
+
+    def test_unique_leaf_names_keep_their_plain_module_key(self):
+        # The disambiguation must not fire on an ordinary run: the published
+        # baseline's findings.json is keyed by these names, and renaming them
+        # would make every preview look new on the next comparison.
+        other = self._sibling_module(
+            "elsewhere/phone/build/compose-previews", "sample-phone", "Phone"
+        )
+
+        out = self.tmp / "out"
+        import argparse
+        ar.cmd_copy_annotated(argparse.Namespace(
+            build_dir=[str(self.build), str(other)], output_dir=str(out),
+        ))
+
+        findings = json.loads((out / "findings.json").read_text())
+        self.assertEqual(
+            sorted({e["module"] for e in findings["entries"]}),
+            ["sample-phone", "sample-wear"],
+        )
+
     def test_propagates_atf_unavailable_status_to_findings(self):
         # Simulate the daemon-failure shape `DaemonA11yFetcher` writes when no
         # per-preview ATF fetch succeeds: top-level `status` set, entries


### PR DESCRIPTION
Fixes #3763.

## What was wrong

`previews.json` reports `module` as `project.name` — the leaf — so `:foo:app` and `:bar:app` both say `app`. `copy-annotated` used that as the module identity everywhere, and the per-module renders directory is cleared before it's written:

```python
renders_out = out_dir / "renders" / module
if renders_out.exists():
    shutil.rmtree(renders_out)
```

With both modules in one run, the second **deletes the first one's PNGs**, and the `findings.json` rows already emitted for the first point at basenames under a directory holding someone else's renders.

## The fix

The unique value was already in hand and being discarded: the a11y pipeline derives a gradle path from each build dir to match its skip list (`foo/bar/build/compose-previews` → `foo:bar`) and then passes only `--build-dir`. `module_identity()` does the same translation in the helper — so no plugin change and no `previews.json` schema change.

The load-bearing decision is **what that value is allowed to name**. It disambiguates the renders *directory* only:

- **`module` stays `manifest["module"]`.** It's the key `comment` diffs against the published baseline, so it has to be a property of the module alone. Deriving it from the run's collision set would make a module's identity depend on which *other* modules took part — add `:bar:app` and the untouched `:foo:app` flips from `app` to `foo:app`; skip one of the two and it flips back, announcing every one of that module's outstanding findings as resolved. That false-resolution mode is what the preceding work on this file exists to remove.
- **`rendersDir` is new, per row, and disambiguated only on a genuine collision.** Readers fall back to `module` when it's absent, which is exactly where an older baseline's images already live. Nothing migrates.

Verified the keys don't move with the module set:

```
both modules present               diff keys = [('app', 'p.Alpha'), ('app', 'p.Beta')]
one skip-listed (bar removed)      diff keys = [('app', 'p.Alpha')]
```

`(module, previewId)` stays unique even when two modules share a name, because previewIds are fully-qualified class names. The residue is cosmetic: those two modules share a heading in the readme's `by_module` grouping.

`module_identity` is also hardened for the directory role it now has — it resolves the path and strips `.` / `..`, and never returns empty. Both were live foot-guns: `--build-dir ../build/compose-previews` yielded `..` (so `renders/..` is the output root) and `--build-dir .` yielded `''` (so `renders/` itself) — either one `rmtree`'d the whole tree.

## Reachability

Latent in this repo, which is why it hasn't bitten: of 122 included projects the only duplicate leaf is `android` (`:samples:android` and `:daemon:android`), and `:daemon:android` applies no preview plugin, so it never writes a `previews.json` and never reaches `copy-annotated`. It's reachable by any consumer with two preview-producing projects sharing a leaf name.

## Test plan

- [x] `python3 -m unittest test_a11y_report` — 48 tests.
- [x] Two build dirs both reporting `module: "app"`: **both** modules' renders survive under distinct `rendersDir`s, every row's image resolves, and the diff key stays `app` for both. Verified the renders-deletion half fails on `main` (`4d55b04`):
  ```
  FAIL: test_same_leaf_named_modules_do_not_delete_each_others_renders
  AssertionError: 1 != 2 : expected two distinct modules, got ['app']
  ```
- [x] Unique leaf names keep both their `module` key **and** their existing renders layout — the guard that none of this fires on an ordinary run.
- [x] `module_identity` translates a build dir to a gradle path, and never yields `.`, `..` or an empty name.
- [x] Existing multi-build-dir, atf-unavailable, readme and comment tests unchanged.

Not visual — a CI report helper and its tests.
