### PR TITLE
fix(serve): bound the pinned lane, and read a load through one commit

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -592,14 +592,14 @@ class ServeBundleHost(
    * current bytes: a permalink that silently answers with today's render is the bug this whole
    * feature exists to fix, and it would be undetectable from the outside.
    */
-  fun pinnedRender(commit: String, previewId: String): ByteArray? =
+  fun pinnedRender(commit: String, previewId: String): PinnedOutcome =
     pinnedAsset(
       commit,
       branchPath(commit, previewId, bakedBranchPaths, { it.catalogRead }, { it.renders }),
     )
 
   /** [referenceId]'s canonical reference raster as published at [commit]. See [pinnedRender]. */
-  fun pinnedReference(commit: String, referenceId: String): ByteArray? =
+  fun pinnedReference(commit: String, referenceId: String): PinnedOutcome =
     pinnedAsset(
       commit,
       branchPath(
@@ -610,6 +610,28 @@ class ServeBundleHost(
         { it.references },
       ),
     )
+
+  /**
+   * What came of a pinned read. [Missing] and [Busy] are kept apart because they are different
+   * statements about the world — "that revision published no such asset", which is permanent and
+   * belongs in a 404, versus "this server would not go and look right now", which is temporary and
+   * belongs in a 503. Collapsing them would teach a visitor (or a link checker) that a perfectly
+   * good permalink is dead.
+   */
+  sealed interface PinnedOutcome {
+    data class Ok(val bytes: ByteArray) : PinnedOutcome {
+      // Arrays get identity equals/hashCode, which a data class would silently inherit. Nothing
+      // compares these today; defining them keeps that from becoming a surprise if anything does.
+      override fun equals(other: Any?): Boolean =
+        this === other || (other is Ok && bytes.contentEquals(other.bytes))
+
+      override fun hashCode(): Int = bytes.contentHashCode()
+    }
+
+    data object Missing : PinnedOutcome
+
+    data object Busy : PinnedOutcome
+  }
 
   /**
    * Where [id]'s asset lived **at [commit]**, preferring that commit's own manifest over the tip's
@@ -651,25 +673,68 @@ class ServeBundleHost(
    * capacity it simply drops an arbitrary entry: with a long tail of one-off links there is no
    * recency order worth maintaining, and the cost of a miss is one small fetch.
    */
-  private fun pinnedAsset(commit: String, path: String?): ByteArray? {
-    val fetch = fetchPinnedAsset ?: return null
-    val safePath = ServeCatalogRevision.normalizePath(path) ?: return null
-    val pin = ServeCatalogRevision.normalize(commit) ?: return null
+  private fun pinnedAsset(commit: String, path: String?): PinnedOutcome {
+    val fetch = fetchPinnedAsset ?: return PinnedOutcome.Missing
+    val safePath = ServeCatalogRevision.normalizePath(path) ?: return PinnedOutcome.Missing
+    val pin = ServeCatalogRevision.normalize(commit) ?: return PinnedOutcome.Missing
     val key = "$pin/$safePath"
     pinnedCache[key]?.let {
-      return it
+      return PinnedOutcome.Ok(it)
     }
-    val bytes = runCatching { fetch(pin, safePath) }.getOrNull() ?: return null
+    // A URL this branch has already refused is refused again from memory. Without it, a page whose
+    // images all 404 re-asks the branch once per image, and a visitor reloading it does so again —
+    // the same wasted round trips a *successful* pin only pays once for.
+    if (key in pinnedMisses) return PinnedOutcome.Missing
+    // Admission. Every other lane that reaches out is bounded; this one was not, and it is the only
+    // lane whose target a *request* chooses — `?at=<any syntactically valid sha>` names a fetch, so
+    // an anonymous caller could otherwise open as many concurrent branch reads as it liked and hold
+    // an IO worker for each. A bounded permit turns that into a queue with a ceiling, and a caller
+    // that cannot get a permit in time is told the server is busy rather than told the revision
+    // does not exist — those are different answers and a permalink must not confuse them.
+    if (!pinnedPermits.tryAcquire(PINNED_FETCH_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS))
+      return PinnedOutcome.Busy
+    val bytes =
+      try {
+        // Re-checked under the permit: while this caller waited, the fetch it is queued behind may
+        // have been for exactly this URL — the common case on a page whose images share a commit.
+        pinnedCache[key] ?: runCatching { fetch(pin, safePath) }.getOrNull()
+      } finally {
+        pinnedPermits.release()
+      }
+    if (bytes == null) {
+      remember(pinnedMisses, key, MAX_PINNED_MISS_ENTRIES)
+      return PinnedOutcome.Missing
+    }
     synchronized(pinnedCache) {
       if (pinnedCache.size >= MAX_PINNED_CACHE_ENTRIES) {
         pinnedCache.keys.firstOrNull()?.let(pinnedCache::remove)
       }
       pinnedCache[key] = bytes
     }
-    return bytes
+    return PinnedOutcome.Ok(bytes)
+  }
+
+  private fun remember(set: MutableSet<String>, key: String, max: Int) {
+    synchronized(set) {
+      if (set.size >= max) set.firstOrNull()?.let(set::remove)
+      set.add(key)
+    }
   }
 
   private val pinnedCache = java.util.concurrent.ConcurrentHashMap<String, ByteArray>()
+
+  /**
+   * URLs this branch answered nothing for. Deliberately keyed like [pinnedCache] and deliberately
+   * *not* time-bounded: `(commit, path)` is immutable, so "that revision has no such file" is a
+   * permanent fact — unlike a transient failure, which this cannot tell apart and therefore
+   * remembers too. That is the accepted cost: the set is small and drops entries under pressure, so
+   * a blip strands a pin until eviction rather than for the life of the process, and the far more
+   * common case (a genuinely absent asset, asked for repeatedly) stops costing round trips.
+   */
+  private val pinnedMisses: MutableSet<String> =
+    java.util.Collections.synchronizedSet(LinkedHashSet())
+
+  private val pinnedPermits = java.util.concurrent.Semaphore(MAX_CONCURRENT_PINNED_FETCHES)
 
   /** [previewId]'s baked PNG only if it is already local — never fetches. */
   private fun localBakedPng(previewId: String): okio.Path? =
@@ -921,6 +986,27 @@ class ServeBundleHost(
      * would trade a real memory cost against traffic that mostly never repeats.
      */
     private const val MAX_PINNED_CACHE_ENTRIES = 32
+
+    /**
+     * How many URLs this branch has already refused are remembered, so a page of absent pinned
+     * images stops costing round trips. Larger than the hit cache because a miss costs bytes to
+     * remember and a hit costs a whole PNG.
+     */
+    private const val MAX_PINNED_MISS_ENTRIES = 256
+
+    /**
+     * Concurrent branch reads the pinned lane may have in flight. Small: these are small files off
+     * a CDN, the caches absorb repeats, and the number exists to bound what an anonymous caller can
+     * make this server do — not to make pinned pages fast.
+     */
+    private const val MAX_CONCURRENT_PINNED_FETCHES = 4
+
+    /**
+     * How long a pinned read waits for a permit before answering "busy". Long enough that an
+     * ordinary page's images queue through rather than failing, short enough that a flood is shed
+     * instead of parking request threads.
+     */
+    private const val PINNED_FETCH_WAIT_SECONDS = 5L
 
     // Fallback render density for a cmp-jvm render when `previews.json` declares none — the desktop
     // renderer's own default (a 200dp preview bakes to 525px), so an unspecified preview still

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -247,7 +247,26 @@ class ServeCatalogStore(
     val repo = sourceRepo?.takeIf { it.isNotBlank() } ?: this.repo
     val branchPrefix = sourceBranchPrefix?.takeIf { it.isNotBlank() } ?: this.branchPrefix
     val branch = "$branchPrefix$system"
-    val base = "https://raw.githubusercontent.com/$repo/$branch/"
+
+    // The branch's publish history, read BEFORE anything else — because its head decides what the
+    // rest of this load reads. Its tail is what a visitor can pin back to. Best-effort: an empty
+    // list leaves the catalog serving exactly as before, minus the permalink affordance.
+    val revisions = fetchRevisions(repo, branch)
+    val deliveryCommit = revisions.firstOrNull()?.commit
+
+    // **A load reads one commit, not a branch.** Resolving the tip and then fetching by branch name
+    // leaves a whole load's worth of requests — catalog.json, then hundreds of assets over several
+    // minutes — free to straddle a publish landing mid-flight: the pages would advertise one
+    // revision while serving a mixture of two, and a permalink minted from that page would name a
+    // commit whose bytes the visitor never saw. Pinning the base to the sha we resolved makes the
+    // load atomic by construction. It also means the ordinary served catalog and a pin to that same
+    // revision read the identical URLs, so the two can never disagree.
+    //
+    // Falls back to the branch when the feed could not be read: an un-pinned load is what this did
+    // before permalinks existed, and it is strictly better than not serving the catalog at all.
+    val base =
+      deliveryCommit?.let { "https://raw.githubusercontent.com/$repo/$it/" }
+        ?: "https://raw.githubusercontent.com/$repo/$branch/"
 
     val catalogBytes =
       try {
@@ -255,13 +274,6 @@ class ServeCatalogStore(
       } catch (e: Exception) {
         return Result.Failed(system, "could not fetch catalog.json: ${e.message}")
       } ?: return Result.Failed(system, "could not fetch $base$CATALOG_FILE")
-    // The branch's publish history. Its head is the revision this load is reading — what a
-    // permalink pins to, and something `raw.githubusercontent.com` cannot tell us (it answers a
-    // branch name with bytes and nothing else) — and the rest is what a visitor can pin *back* to.
-    // Read once per load rather than per page view. Best-effort: an empty list leaves the catalog
-    // serving exactly as before, minus the permalink affordance.
-    val revisions = fetchRevisions(repo, branch)
-    val deliveryCommit = revisions.firstOrNull()?.commit
 
     val catalog =
       try {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1997,13 +1997,27 @@ class ServeHttpServer(
    * the URL carries the bearer token, and licensing a shared proxy to keep private catalog imagery
    * for a year is not a trade a permalink is worth.
    */
-  private suspend fun RoutingContext.respondPinnedAsset(bytes: ByteArray?, missing: String) {
-    if (bytes == null) {
-      call.respondText(missing, status = HttpStatusCode.NotFound)
-      return
+  private suspend fun RoutingContext.respondPinnedAsset(
+    outcome: ServeBundleHost.PinnedOutcome?,
+    missing: String,
+  ) {
+    when (outcome) {
+      is ServeBundleHost.PinnedOutcome.Ok -> {
+        markGeneration("pinned-asset", prebakedImageCacheControl(isPublic))
+        call.respondBytes(outcome.bytes, ContentType.Image.PNG)
+      }
+      // The lane is admission-bounded, and a shed request is not a dead link. Saying so with a 503
+      // + Retry-After keeps a link checker (and a visitor) from concluding that a revision which
+      // exists is gone, and tells a well-behaved client when to come back.
+      ServeBundleHost.PinnedOutcome.Busy -> {
+        call.response.headers.append(HttpHeaders.RetryAfter, "5")
+        call.respondText(
+          "busy reading that revision from the delivery branch; try again shortly",
+          status = HttpStatusCode.ServiceUnavailable,
+        )
+      }
+      else -> call.respondText(missing, status = HttpStatusCode.NotFound)
     }
-    markGeneration("pinned-asset", prebakedImageCacheControl(isPublic))
-    call.respondBytes(bytes, ContentType.Image.PNG)
   }
 
   /** Canonical, inert PNG for a design reference. Original HTML/Figma sources are never served. */
@@ -2020,7 +2034,7 @@ class ServeHttpServer(
       // historical render — a comparison of two moments rather than of two sides.
       if (pinnedCommit != null) {
         respondPinnedAsset(
-          bytes =
+          outcome =
             catalogBundleHost(renderHost)?.let {
               withContext(Dispatchers.IO) { it.pinnedReference(pinnedCommit, referenceId) }
             },
@@ -4108,7 +4122,7 @@ class ServeHttpServer(
           return@withLeasedSession
         }
         respondPinnedAsset(
-          bytes =
+          outcome =
             catalogBundleHost(renderHost)?.let {
               withContext(Dispatchers.IO) { it.pinnedRender(pinnedCommit, previewId) }
             },
@@ -4699,10 +4713,14 @@ class ServeHttpServer(
   private fun RoutingContext.renderWouldReplayBakedBytes(sessionInPath: Boolean): Boolean {
     // Only a HEAD pays for this lookup; a GET is going to do the work regardless.
     if (call.request.local.method != HttpMethod.Head) return true
-    // A pinned render is answered from the delivery branch, not from published bytes on disk — a
-    // bodyless probe would spend a remote fetch. Same trade as an override-bearing render, which
-    // this route already refuses to amplify.
-    if (call.request.queryParameters[ServeCatalogRevision.PARAM] != null) return false
+    // A pinned render answers HEAD, which it did not before, and the reason it now can is that the
+    // lane became admission-bounded: a probe costs at most one permitted branch read, and the GET
+    // that follows it is served from the cache that read filled. Refusing was the wrong trade — an
+    // unfurler probes an `og:image` before fetching it, so a blanket 405 dropped the preview card
+    // on exactly the historical links this feature exists to share.
+    // Free when the bytes are already resident; otherwise one permitted branch read, which is the
+    // same thing the GET behind the probe would spend and which the cache then serves.
+    if (call.request.queryParameters[ServeCatalogRevision.PARAM] != null) return true
     val name = call.parameters["name"]?.removeSuffix(".png") ?: return false
     val host = sessions.peekHost(selectedSessionId(sessionInPath)) ?: return false
     return host.bakedRenderSize(name) != null

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
@@ -72,19 +72,28 @@ class ServePinnedRevisionTest {
       .trimIndent()
 
   /**
-   * The stubbed branch. The tip serves the current bytes; `<oldCommit>` serves the older ones, and
-   * every other commit serves nothing — which is what a pin naming a publish this branch never had
-   * looks like from here.
+   * The stubbed branch.
+   *
+   * `<newCommit>` — the feed's head — serves the current bytes, and the load reads it *by sha*:
+   * resolving the tip first and fetching everything through it is what makes a load atomic, so the
+   * branch-name base below is only the fallback for a feed that could not be read. `<oldCommit>`
+   * serves the older bytes, and every other commit serves nothing, which is what a pin naming a
+   * publish this branch never had looks like from here.
    */
   private val fetch: (String) -> ByteArray? = { url ->
-    val tip = "https://raw.githubusercontent.com/$repo/$branch/"
+    val tip = "https://raw.githubusercontent.com/$repo/$newCommit/"
+    val byBranch = "https://raw.githubusercontent.com/$repo/$branch/"
     val old = "https://raw.githubusercontent.com/$repo/$oldCommit/"
     when (url) {
       ServeCatalogRevision.commitsFeedUrl(repo, branch) -> feed.encodeToByteArray()
-      "${tip}catalog.json" -> catalogJson.encodeToByteArray()
-      "${tip}references/index.json" -> referencesJson.encodeToByteArray()
-      "${tip}references/button.png" -> currentReference
-      "${tip}images/button-filled/ideal__default__dark.png" -> currentRender
+      "${tip}catalog.json",
+      "${byBranch}catalog.json" -> catalogJson.encodeToByteArray()
+      "${tip}references/index.json",
+      "${byBranch}references/index.json" -> referencesJson.encodeToByteArray()
+      "${tip}references/button.png",
+      "${byBranch}references/button.png" -> currentReference
+      "${tip}images/button-filled/ideal__default__dark.png",
+      "${byBranch}images/button-filled/ideal__default__dark.png" -> currentRender
       "${old}references/button.png" -> historicalReference
       "${old}images/button-filled/ideal__default__dark.png" -> historicalRender
       else -> null
@@ -368,6 +377,78 @@ class ServePinnedRevisionTest {
     assertFalse(pinned.contains("cp-annotations"), pinned)
     assertFalse(pinned.contains("cp-annotation-toggle"), pinned)
     assertFalse(pinned.contains("data-cp-annotation-kind"), pinned)
+  }
+
+  @Test
+  fun `a load reads one commit rather than a moving branch`() {
+    val asked = java.util.Collections.synchronizedList(mutableListOf<String>())
+    startWith { url ->
+      asked += url
+      fetch(url)
+    }
+
+    // The feed is read first, and everything the load reads afterwards is addressed by the sha it
+    // resolved — so a publish landing mid-load cannot leave the pages advertising one revision
+    // while serving a mixture of two.
+    val reads = asked.toList()
+    assertEquals(ServeCatalogRevision.commitsFeedUrl(repo, branch), reads.first())
+    assertTrue(
+      reads.drop(1).all { it.startsWith("https://raw.githubusercontent.com/$repo/$newCommit/") },
+      "read by branch name rather than by sha: $reads",
+    )
+  }
+
+  @Test
+  fun `a branch with no readable history still loads, by name`() {
+    val asked = java.util.Collections.synchronizedList(mutableListOf<String>())
+    val port = startWith { url ->
+      asked += url
+      if (url == ServeCatalogRevision.commitsFeedUrl(repo, branch)) null else fetch(url)
+    }
+
+    // No feed ⇒ no revision to pin the load to, so it reads the branch exactly as it did before
+    // permalinks existed. Serving the catalog matters more than serving it atomically.
+    assertTrue(
+      asked.any { it == "https://raw.githubusercontent.com/$repo/$branch/catalog.json" },
+      "did not fall back to the branch: ${asked.toList()}",
+    )
+    assertEquals(200, get("http://127.0.0.1:$port/$system/render/$previewId.png").first)
+  }
+
+  @Test
+  fun `a pinned url the branch refuses is not asked about twice`() {
+    val fetches = java.util.concurrent.atomic.AtomicInteger()
+    val absent = "3333333333333333333333333333333333333333"
+    val port = startWith { url ->
+      if (url.startsWith("https://raw.githubusercontent.com/$repo/$absent/"))
+        fetches.incrementAndGet()
+      fetch(url)
+    }
+
+    repeat(4) {
+      assertEquals(
+        404,
+        get("http://127.0.0.1:$port/$system/render/$previewId.png?at=$absent").first,
+      )
+    }
+
+    // Two manifest reads for the commit (memoised by ServePinnedManifest) and one asset read that
+    // came back empty (remembered as a miss). Without the negative cache each of the four requests
+    // pays for the asset again — and a page of broken pinned images pays once per image.
+    assertEquals(3, fetches.get())
+  }
+
+  @Test
+  fun `a pinned render answers a HEAD probe, so a shared link still unfurls`() {
+    val port = start().port
+    val url = "http://127.0.0.1:$port/$system/render/$previewId.png?at=$oldCommit"
+
+    val head = client.newCall(Request.Builder().url(url).head().build()).execute().use { it.code }
+
+    // An unfurler probes an og:image before fetching it. Refusing dropped the preview card on
+    // exactly the historical links this feature exists to share; the lane is admission-bounded now,
+    // so the probe costs at most one permitted read and the GET behind it is served from cache.
+    assertEquals(200, head)
   }
 
   private fun get(url: String): Pair<Int, ByteArray> =

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -286,6 +286,19 @@ The rules the lane holds to, each of which exists because its opposite would mak
   A manifest that **was read** is authoritative about its own revision: an id it doesn't list was
   not published then, and the answer is a 404 rather than whatever happens to sit at today's path in
   that commit. The tip's map is the fallback only for a manifest that could not be read at all.
+- **A load reads one commit, not a branch.** The feed is resolved first and every asset of that load
+  is fetched through the sha it returned, so a publish landing mid-load can't leave the pages
+  advertising one revision while serving a mixture of two. It also means the live catalog and a pin
+  to that same revision read identical URLs. A branch whose feed can't be read falls back to
+  fetching by name, exactly as before permalinks existed.
+- **The pinned lane is bounded, and says which kind of "no" it means.** It is the only lane whose
+  target a *request* chooses (`?at=<any valid sha>` names a fetch), so branch reads run behind a
+  small permit pool, a URL the branch already refused is remembered rather than re-asked, and a
+  shed request answers `503` + `Retry-After` — never `404`, because "busy" and "that revision
+  published no such asset" are different facts and a link checker must not confuse them. Being
+  bounded is also what lets the lane answer **HEAD**: an unfurler probes an `og:image` before
+  fetching it, so refusing dropped the preview card on precisely the historical links this feature
+  exists to share.
 - **The response is `immutable`** (on a public box — a token-gated one keeps `no-store` like every
   other private response), because `(commit, path)` is immutable by construction.
 


### PR DESCRIPTION
The three deferred P2s from #3758's review. They turn out to be one story: bounding the lane is what makes answering HEAD safe.

## A load reads one commit, not a branch

The commit feed is now resolved **before** anything else, and every asset of that load is fetched through the sha it returned.

Resolving the tip and then fetching by branch name left a whole load — `catalog.json` plus hundreds of assets over several minutes — free to straddle a publish landing mid-flight. The pages would advertise one revision while serving a mixture of two, and a permalink minted from such a page would name a commit whose bytes the visitor never saw. Pinning the base makes the load atomic by construction, and it has a second benefit worth having on its own: the ordinary served catalog and a pin to that same revision now read *identical URLs*, so the two can't disagree. A branch whose feed can't be read falls back to fetching by name, exactly as before permalinks existed.

## The pinned lane is bounded, and distinguishes its two kinds of "no"

It's the only lane whose target a **request** chooses — `?at=<any syntactically valid sha>` names a fetch — so an anonymous caller could open as many concurrent branch reads as it liked and hold an IO worker for each. Now:

- reads run behind a small permit pool (4), so a flood becomes a queue with a ceiling;
- a URL the branch already refused is remembered, so a page of absent pinned images stops costing a round trip per image (and a reload doesn't pay again);
- a shed request answers **`503` + `Retry-After`**, never `404`. "Busy" and "that revision published no such asset" are different facts about the world, and reporting the first as the second teaches a visitor — or a link checker — that a perfectly good permalink is dead.

The negative cache is deliberately not time-bounded, and the tradeoff is written down in the code: `(commit, path)` is immutable so an absent asset is permanently absent, but a transient failure is indistinguishable and gets remembered too. It's kept small and drops entries under pressure, so a blip strands a pin until eviction rather than for the life of the process.

## A pinned render answers HEAD

Being bounded is what makes this safe: a probe costs at most one permitted read, and the GET behind it is served from the cache that read filled. Refusing was the wrong trade — an unfurler probes an `og:image` before fetching it, so the blanket `405` dropped the preview card on exactly the historical links this feature exists to share.

## Test plan

- Four new cases in `ServePinnedRevisionTest`: the feed is read first and everything after it is addressed by sha; a branch with no readable feed still loads by name; a refused pinned URL is asked about once (3 reads for 4 requests — two manifests plus one asset); and a pinned render answers a HEAD probe with 200.
- Updating the existing stub was itself a check on the change: every pre-existing test failed until the branch stub served the resolved sha, which is the load reading one commit rather than a moving branch.
- `./gradlew :cli:test :cli:ktfmtCheck` green.

No visual change — nothing here touches a page's markup.

## Still open

The P1 from #3768's review: `/p/<retired-id>?at=<sha>` 404s because `handleViewer` looks the preview up in the session's tip-derived list, so a permalink to a since-renamed preview finds its asset but not its page. That needs the viewer to take preview metadata from a historical catalog, which is a change to its model rather than a patch — next, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SazNBCPVGgAe1ERifMgPGF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SazNBCPVGgAe1ERifMgPGF)_