### PR TITLE
refactor(rc-embedded-player): restore upstream action dispatch

### DIFF
--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -70,31 +70,23 @@ See the `rc-embedded` column of the catalogs' `rc-compare.html` for the current 
 the baked PNG. Local deltas over the upstream snapshot are listed here as they are made, each with
 the upstream tracking issue it was reported under.
 
-Each delta below is a **build-against-published-alpha** gap, not a rendering fix: upstream compiles
-this player against the in-tree `remote-creation-compose`, where these symbols are public and
-present. They are grouped in the tracking issue as "the embedded player cannot be built outside the
-androidx tree against the published alphas".
+### Resolved: the two action-dispatch deltas (restored at alpha17)
 
-- **Named-action dispatch for `LambdaAction` / `PendingIntentAction` dropped** (`RcPlayer.kt`, the
-  `LocalRemoteNamedActionHandler` block). `LambdaAction` does not exist in
-  `remote-creation-compose:1.0.0-alpha15`, and `PendingIntentAction` is `internal` there, so
-  `parseId` is not callable from outside the module. The handler now forwards straight to
-  `onNamedAction`. Both paths are *interactive click dispatch*; the render lane never fires an
-  action, so nothing the comparison measures is affected.
-- **`CapturedDocument` lambda/pending-intent forwarding dropped** (`RcPlayer.kt`, the
-  `CapturedDocument` overload). `CapturedDocument` in alpha15 carries neither a `lambdas` nor a
-  `pendingIntents` property. Same reasoning; that overload is for live capture, which this vendored
-  copy does not use.
+Two deltas used to live here — the `LocalRemoteNamedActionHandler` block and the `CapturedDocument`
+overload's `lambdas` / `pendingIntents` forwarding, both in `RcPlayer.kt`. They were
+**build-against-published-alpha** gaps rather than rendering fixes: `LambdaAction` did not exist in
+`remote-creation-compose:1.0.0-alpha15`, `PendingIntentAction` was `internal` there so `parseId` was
+not callable from outside the module, and `CapturedDocument` carried neither property.
 
-**Both deltas are now revertable and awaiting a snapshot refresh.** As of `compose-remote`
-1.0.0-alpha17 (the current pin) `LambdaAction` and `PendingIntentAction` are public with public
-`Companion.parseId`, and `CapturedDocument` carries `lambdas` + `pendingIntents`. Restoring the two
-blocks verbatim means re-adding the upstream `lambdas` / `pendingIntents` parameters to `RcPlayer`,
-so it belongs with the next re-vendor from `androidx-main`, not with a version-catalog bump. Neither
-delta is on the draw path, so the `rc-compare` lane is unaffected until then.
+`compose-remote` 1.0.0-alpha17 publishes all three: `LambdaAction` and `PendingIntentAction` are
+public with public `Companion.parseId`, and `CapturedDocument` carries `lambdas` + `pendingIntents`.
+Both blocks are now **restored to upstream verbatim** and this module carries no action-dispatch
+delta. The `lambdas` / `pendingIntents` parameters on `RcPlayer` were never dropped — only their
+uses were — so the restore was confined to the two bodies plus the two imports.
 
-Neither delta is on the draw path. If a future alpha exposes the two action types, both blocks
-revert to upstream verbatim.
+Kept as a record because the shape recurs: when this module cannot reach a symbol upstream compiles
+against in-tree, dropping the call and noting it here is the house pattern, and the note is what
+makes the delta findable once a later alpha closes the gap.
 
 - **GMS font-provider certificates inlined as source** (`GmsFontProviderCertificates.kt`; the
   `GoogleFontR` import is gone from `EmbeddedPlayerTypefaceResolver.kt` and `RcPlayerTextLayout.kt`).

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -56,6 +56,8 @@ import androidx.compose.remote.core.operations.layout.LayoutComponent
 import androidx.compose.remote.core.operations.layout.LayoutComponentContent
 import androidx.compose.remote.core.operations.utilities.AnimatedFloatExpression
 import androidx.compose.remote.core.operations.utilities.NanMap
+import androidx.compose.remote.creation.compose.action.LambdaAction
+import androidx.compose.remote.creation.compose.action.PendingIntentAction
 import androidx.compose.remote.creation.compose.capture.CapturedDocument
 import androidx.compose.remote.player.compose.ExperimentalRemotePlayerApi
 import androidx.compose.remote.player.core.platform.AndroidRemoteContext
@@ -416,16 +418,15 @@ public fun RcPlayer(
             LocalRemoteActionHandler provides onAction,
             LocalRemoteNamedActionHandler provides
                 { name, value ->
-                    // LOCAL DELTA (compose-ai-tools) — see PROVENANCE.md.
-                    // Upstream routes `LambdaAction`/`PendingIntentAction` named actions to the
-                    // `lambdas` / `pendingIntents` maps here. Neither is reachable from the
-                    // published alpha we build against: `LambdaAction` does not exist in
-                    // remote-creation-compose 1.0.0-alpha15, and `PendingIntentAction` is
-                    // `internal` there, so `parseId` cannot be called from outside the module.
-                    // Dropped rather than reimplemented: both are *interactive click dispatch*,
-                    // and this vendored copy exists to render static captured documents for the
-                    // rc-compare lane, which never fires an action. Restore this block when the
-                    // pinned alpha exposes the two types.
+                    val lambdaId = LambdaAction.parseId(name)
+                    if (lambdaId != null) {
+                        lambdas[lambdaId]?.invoke()
+                    } else {
+                        val pendingIntentId = PendingIntentAction.parseId(name)
+                        if (pendingIntentId != null) {
+                            pendingIntents[pendingIntentId]?.send()
+                        }
+                    }
                     onNamedAction(name, value, stateUpdater)
                 },
             LocalRcCustomPlugins provides customPlugins,
@@ -485,10 +486,8 @@ public fun RcPlayer(
         onAction = onAction,
         onNamedAction = onNamedAction,
         customPlugins = customPlugins,
-        // LOCAL DELTA (compose-ai-tools) — see PROVENANCE.md. Upstream forwards
-        // `capturedDocument.lambdas` / `.pendingIntents`; neither property exists on
-        // `CapturedDocument` in remote-creation-compose 1.0.0-alpha15. Same reasoning as the
-        // named-action handler above: interactive dispatch, unused by the render lane.
+        lambdas = capturedDocument.lambdas,
+        pendingIntents = capturedDocument.pendingIntents,
     )
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #3760. The vendored embedded player carried two local deltas, both in `RcPlayer.kt`, that existed only because the symbols upstream compiles against in-tree were not reachable from the published alpha. alpha17 publishes all of them, so both blocks go back to upstream verbatim and the module now carries **no action-dispatch delta**.

| Delta | Blocker at alpha15 | alpha17 |
|---|---|---|
| `LocalRemoteNamedActionHandler` dispatch | `LambdaAction` absent; `PendingIntentAction` `internal`, so `parseId` uncallable from outside the module | both public, `Companion.parseId` public |
| `CapturedDocument` lambda / pending-intent forwarding | neither property existed on the type | both present |

The `lambdas` / `pendingIntents` **parameters** on `RcPlayer` were never dropped — only their uses were — so the restore is confined to the two bodies plus two imports.

### Scope: a targeted restore, not a re-snapshot

Worth stating plainly, because "refresh the vendored copy" could reasonably mean something much larger. The vendored tree diverges from upstream in several other ways that are **deliberate** and are left untouched here:

- the dropped `autoUpdate` parameter on both `RcPlayer` overloads
- `withInfiniteAnimationFrameMillis` instead of `withFrameMillis` (documented in-file: it keeps `waitForIdle()` from hanging under `ComposeTestRule` and lets `@Preview` tooling pause the animation)
- the `enableEncodedImageReferences()` call ahead of the `CapturedDocument` parse
- the local file splits (`RcPlayerDispatch.kt`, `RcPlayerDrawing.kt`, `RcPlayerEasing.kt`, …), which is also why a wholesale `diff -r` against upstream is noisy rather than clean

Only the two documented deltas moved.

### Verification that "verbatim" is literally true

Diffed the restored file against the pinned upstream snapshot (`androidx-main` `c8e7d738`, the commit `PROVENANCE.md` records) and confirmed **zero** residual differences across the `LambdaAction` / `PendingIntentAction` / `parseId` regions:

```
$ diff -u RcPlayer.upstream.kt <vendored> | grep -iE 'lambda|pendingintent|parseId|LOCAL DELTA'
(no output)
```

### `PROVENANCE.md`

The two bullets are replaced by a "Resolved" section recording what the deltas were, why they existed, and what closed them. Kept rather than deleted because the shape recurs — when this module can't reach a symbol upstream compiles against in-tree, dropping the call and noting it here is the house pattern, and the note is what makes such a delta findable once a later alpha closes the gap.

## Test plan

```
./gradlew :third-party-rc-embedded-player:compileDebugKotlin \
          :third-party-rc-embedded-player-jvm:compileKotlin
BUILD SUCCESSFUL

./gradlew :third-party-rc-embedded-player:test \
          :third-party-rc-embedded-player-jvm:test
BUILD SUCCESSFUL   # 23 result files, 0 failures, 0 errors

./gradlew :third-party-rc-embedded-player:ktfmtCheck
BUILD SUCCESSFUL   # unchanged — upstream's source is already Google-style
```

Checked that `RcPlayer.kt` is **not** in `:third-party-rc-embedded-player-jvm`'s shared source list before restoring code that names `android.app.PendingIntent`; the desktop module compiles a explicit subset that excludes it, and it still builds.

**No visual evidence, and the reasoning is load-bearing rather than an exemption.** Both restored blocks are *interactive click dispatch* — they run when a user taps a captured document. The `rc-compare` lane renders static documents and never fires an action, so this cannot move a pixel in it; that is the same argument the original deltas were justified by, applied in reverse. The render lanes on this PR should confirm it by showing no change. What this *does* change is behavior no render exercises: a host embedding a `CapturedDocument` now gets its lambdas and pending intents dispatched instead of silently dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2BA1XXXvGGzhDW4JgToFY)_