### PR TITLE
fix(serve): page a preview from the revision that published it

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -598,6 +598,27 @@ class ServeBundleHost(
       branchPath(commit, previewId, bakedBranchPaths, { it.catalogRead }, { it.renders }),
     )
 
+  /**
+   * A preview this catalog published at [commit] but does **not** list today, as a record the
+   * viewer can page.
+   *
+   * This is the other half of resolving a retired id. [pinnedRender] finds its pixels; without this
+   * the *page* around them still 404s, because the session's preview list is built from the branch
+   * tip and a renamed-away id is not in it — so a permalink made before the rename would answer
+   * with an image but not with the page a person actually opened.
+   *
+   * Null for an id this revision didn't publish either, and null when its catalog can't be read:
+   * inventing a page for an id nothing confirms would be worse than admitting we don't have it.
+   * Deliberately minimal — an id and whatever name that revision gave it. Everything else the
+   * viewer draws (axes, siblings, references, knobs) describes the *current* catalog, and a pinned
+   * page has all of those lanes off anyway.
+   */
+  fun pinnedPreview(commit: String, previewId: String): ServePreview? {
+    val paths = pinnedManifest?.forCommit(commit) ?: return null
+    if (!paths.catalogRead || previewId !in paths.renders) return null
+    return ServePreview(id = previewId, label = paths.labels[previewId] ?: previewId)
+  }
+
   /** [referenceId]'s canonical reference raster as published at [commit]. See [pinnedRender]. */
   fun pinnedReference(commit: String, referenceId: String): PinnedOutcome =
     pinnedAsset(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -619,6 +619,17 @@ class ServeBundleHost(
     return ServePreview(id = previewId, label = paths.labels[previewId] ?: previewId)
   }
 
+  /**
+   * Whether [commit]'s own catalog could be read — i.e. whether it is entitled to answer for what
+   * that revision published.
+   *
+   * The page lookup needs this separately from [pinnedPreview], because "no such preview then" and
+   * "I could not ask" must lead to different pages: the first is a 404, the second falls back to
+   * the tip. Returning null from [pinnedPreview] alone cannot say which happened.
+   */
+  fun pinnedCatalogIsAuthoritative(commit: String): Boolean =
+    pinnedManifest?.forCommit(commit)?.catalogRead == true
+
   /** [referenceId]'s canonical reference raster as published at [commit]. See [pinnedRender]. */
   fun pinnedReference(commit: String, referenceId: String): PinnedOutcome =
     pinnedAsset(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3743,14 +3743,32 @@ class ServeHttpServer(
     ) { renderHost ->
       val previewId = call.parameters["name"]
       val revisions = catalogRevisions(renderHost)
+      // Which catalog decides what this page is *about*. Unpinned it is the session's own list;
+      // under a pin it is the revision's own catalog, asked FIRST — the same authority rule the
+      // asset lanes follow, and for the same reason. Asking the tip first looks harmless while a
+      // preview merely moved, but it hands back today's metadata for an id that revision never
+      // published (whose render correctly 404s, so the page would render around a broken image),
+      // and today's component name for a route id that has since moved between components.
+      //
+      // Off the request dispatcher, because a cold lookup fetches that revision's manifests: the
+      // route takes any syntactically valid sha, so leaving it here would let concurrent requests
+      // for distinct shas hold Ktor's request threads through several round trips each.
       val preview = previewId?.let { id ->
-        renderHost.previews.firstOrNull { it.id == id }
-          // A permalink outlives the id it names. When a preview is renamed or reorganised away,
-          // every link made before that names an id this session's list — built from the branch
-          // tip — no longer contains, and the page 404s even though the revision it is pinned to
-          // published that preview and this server can still serve its pixels. Under a pin, the
-          // revision's own catalog gets to answer for it.
-          ?: revisions.pinned?.let { pin -> catalogBundleHost(renderHost)?.pinnedPreview(pin, id) }
+        val host = catalogBundleHost(renderHost)
+        val pinnedPreview =
+          revisions.pinned?.let { pin ->
+            withContext(Dispatchers.IO) { host?.pinnedPreview(pin, id) }
+          }
+        // The fallback is for a revision whose catalog could not be READ — never for one that
+        // was read and does not list this id. [ServeBundleHost.pinnedCatalogIsAuthoritative]
+        // tells those apart; without it, "the manifest says no" would quietly become "ask the
+        // tip", which is the failure #3769 removed from the asset lanes.
+        val revisionAnswers =
+          revisions.pinned?.let { pin ->
+            withContext(Dispatchers.IO) { host?.pinnedCatalogIsAuthoritative(pin) }
+          } == true
+        pinnedPreview
+          ?: if (revisionAnswers) null else renderHost.previews.firstOrNull { it.id == id }
       }
       if (preview == null) {
         respondNotFoundHtml("That preview does not exist in this catalog.")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3742,7 +3742,16 @@ class ServeHttpServer(
       onMissing = { respondNotFoundHtml("That design system was not found on this server.") },
     ) { renderHost ->
       val previewId = call.parameters["name"]
-      val preview = previewId?.let { id -> renderHost.previews.firstOrNull { it.id == id } }
+      val revisions = catalogRevisions(renderHost)
+      val preview = previewId?.let { id ->
+        renderHost.previews.firstOrNull { it.id == id }
+          // A permalink outlives the id it names. When a preview is renamed or reorganised away,
+          // every link made before that names an id this session's list — built from the branch
+          // tip — no longer contains, and the page 404s even though the revision it is pinned to
+          // published that preview and this server can still serve its pixels. Under a pin, the
+          // revision's own catalog gets to answer for it.
+          ?: revisions.pinned?.let { pin -> catalogBundleHost(renderHost)?.pinnedPreview(pin, id) }
+      }
       if (preview == null) {
         respondNotFoundHtml("That preview does not exist in this catalog.")
         return@withLeasedSession
@@ -3958,7 +3967,7 @@ class ServeHttpServer(
           // never both.
           historyInlineJson = localHistoryJson,
           historyLocalRenders = localHistoryJson != null,
-          revisions = catalogRevisions(renderHost),
+          revisions = revisions,
         ),
         ContentType.Text.Html,
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
@@ -50,6 +50,15 @@ class ServePinnedManifest(
     val renders: Map<String, String>,
     /** Design-reference id → its canonical raster's path on the branch. */
     val references: Map<String, String>,
+    /**
+     * Preview id → the component it belonged to, when that revision's catalog named one.
+     *
+     * The bare minimum needed to *page* a preview this catalog no longer has: a permalink to one
+     * that has since been renamed away resolves its pixels from [renders], but the viewer also has
+     * to put a name on the page, and the session's own preview list — built from the tip — has
+     * nothing to say about an id it no longer contains.
+     */
+    val labels: Map<String, String> = emptyMap(),
     /** Whether `catalog.json` was fetched and parsed at this commit. */
     val catalogRead: Boolean = false,
     /** Whether `references/index.json` was fetched and parsed at this commit. */
@@ -84,11 +93,14 @@ class ServePinnedManifest(
     // function, which must not touch the map it is being computed into.
     val paths =
       byCommit.computeIfAbsent(pin) {
+        // One read of catalog.json, two maps out of it — the paths a pinned asset resolves
+        // through and the labels a pinned page needs to name a preview the tip no longer lists.
         val catalog = read(pin, ServeCatalogRevision.CATALOG_FILE, ::parseCatalog)
         val references = read(pin, ServeCatalogRevision.REFERENCES_FILE, ::parseReferences)
         Paths(
-          renders = catalog.orEmpty(),
+          renders = catalog?.paths.orEmpty(),
           references = references.orEmpty(),
+          labels = catalog?.labels.orEmpty(),
           catalogRead = catalog != null,
           referencesRead = references != null,
         )
@@ -100,11 +112,7 @@ class ServePinnedManifest(
   }
 
   /** Null when the manifest could not be read at all — distinct from "read, and it lists none". */
-  private fun read(
-    commit: String,
-    file: String,
-    parse: (String) -> Map<String, String>?,
-  ): Map<String, String>? =
+  private fun <T> read(commit: String, file: String, parse: (String) -> T?): T? =
     runCatching { fetch(commit, file)?.toString(Charsets.UTF_8)?.let(parse) }.getOrNull()
 
   companion object {
@@ -139,14 +147,27 @@ class ServePinnedManifest(
      * Tolerant by design: this reads a file published by an older CLI than the one reading it, so a
      * malformed component or image is skipped rather than failing the whole map.
      */
-    fun parseCatalog(json: String): Map<String, String>? {
+    /** What one revision's `catalog.json` says, read in a single pass. */
+    data class CatalogEntries(
+      /** Preview id → image path. */
+      val paths: Map<String, String>,
+      /** Preview id → the component that declared it, where the catalog names one. */
+      val labels: Map<String, String>,
+    )
+
+    fun parseCatalog(json: String): CatalogEntries? {
       val components =
         runCatching { JSON.parseToJsonElement(json).jsonObject["components"]?.jsonArray }
           .getOrNull() ?: return null
       val paths = LinkedHashMap<String, String>()
+      val labels = LinkedHashMap<String, String>()
       for (component in components) {
-        val images =
-          runCatching { component.jsonObject["images"]?.jsonArray }.getOrNull() ?: continue
+        val obj = runCatching { component.jsonObject }.getOrNull() ?: continue
+        val componentId =
+          runCatching { obj["componentId"]?.jsonPrimitive?.content }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+        val images = runCatching { obj["images"]?.jsonArray }.getOrNull() ?: continue
         for (image in images) {
           val path =
             runCatching { image.jsonObject["path"]?.jsonPrimitive?.content }
@@ -162,10 +183,12 @@ class ServePinnedManifest(
           // here and then applying last-wins would let a rejected entry overwrite the served one
           // under a shared id — a pin answering with bytes that revision never exposed, arrived at
           // by faithfully copying half of the loader's rule.
-          paths[ServeCatalogStore.previewIdFor(path)] = path
+          val id = ServeCatalogStore.previewIdFor(path)
+          paths[id] = path
+          componentId?.let { labels[id] = it }
         }
       }
-      return paths
+      return CatalogEntries(paths, labels)
     }
 
     /** `references/index.json` → reference id → the canonical raster's path on the branch. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
@@ -185,7 +185,11 @@ class ServePinnedManifest(
           // by faithfully copying half of the loader's rule.
           val id = ServeCatalogStore.previewIdFor(path)
           paths[id] = path
-          componentId?.let { labels[id] = it }
+          // The label follows the winning path, including when the winner has no component name —
+          // otherwise a collision resolved in favour of an unnamed entry leaves the *loser's*
+          // component behind, and the page attributes one component's render to another. Whichever
+          // declaration owns the pixels owns the name, even when that name is nothing.
+          if (componentId != null) labels[id] = componentId else labels.remove(id)
         }
       }
       return CatalogEntries(paths, labels)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
@@ -13,7 +13,7 @@ class ServePinnedManifestTest {
 
   @Test
   fun `catalog images key by the id the loader serves them under`() {
-    val paths =
+    val entries =
       ServePinnedManifest.parseCatalog(
         """
         {"schema":"design-parity-catalog/v1","components":[
@@ -23,7 +23,7 @@ class ServePinnedManifestTest {
           {"componentId":"Card","images":[{"path":"images/card/ideal.png"}]}]}
         """
           .trimIndent()
-      )
+      )!!
 
     // Keyed by ServeCatalogStore.previewIdFor, so a pinned id and a served id are the same string
     // by construction — the join this whole class exists to make.
@@ -33,8 +33,12 @@ class ServePinnedManifestTest {
         "button-filled__ideal__default__light" to "images/button-filled/ideal__default__light.png",
         "card__ideal" to "images/card/ideal.png",
       ),
-      paths,
+      entries.paths,
     )
+    // The component each id belonged to, which is all a pinned page needs to name a preview the
+    // live catalog no longer lists.
+    assertEquals("Button/Filled", entries.labels["button-filled__ideal__default__dark"])
+    assertEquals("Card", entries.labels["card__ideal"])
   }
 
   @Test
@@ -64,14 +68,15 @@ class ServePinnedManifestTest {
     assertNull(ServePinnedManifest.parseCatalog("""{"components":"not-an-array"}"""))
     assertNull(ServePinnedManifest.parseReferences("nonsense"))
     // Read, and it genuinely lists none — an answer, not an absence.
-    assertEquals(emptyMap(), ServePinnedManifest.parseCatalog("""{"components":[]}"""))
+    assertEquals(emptyMap(), ServePinnedManifest.parseCatalog("""{"components":[]}""")?.paths)
     assertEquals(emptyMap(), ServePinnedManifest.parseReferences("""{"references":[]}"""))
     // A single malformed entry costs only itself, not the rest of the map.
     assertEquals(
       mapOf("card__ideal" to "images/card/ideal.png"),
       ServePinnedManifest.parseCatalog(
-        """{"components":[{"images":[{"nopath":1},{"path":"images/card/ideal.png"}]}]}"""
-      ),
+          """{"components":[{"images":[{"nopath":1},{"path":"images/card/ideal.png"}]}]}"""
+        )
+        ?.paths,
     )
   }
 
@@ -83,9 +88,10 @@ class ServePinnedManifestTest {
     assertEquals(
       mapOf("foo__bar__baz" to "images/foo/bar__baz.png"),
       ServePinnedManifest.parseCatalog(
-        """{"components":[{"images":[
+          """{"components":[{"images":[
              {"path":"images/foo__bar/baz.png"},{"path":"images/foo/bar__baz.png"}]}]}"""
-      ),
+        )
+        ?.paths,
     )
     // …but only among entries the loader would actually have served. An ineligible path (outside
     // images/, or not a PNG) never reaches the live map, so letting one win a collision here would
@@ -93,16 +99,18 @@ class ServePinnedManifestTest {
     assertEquals(
       mapOf("foo__bar__baz" to "images/foo__bar/baz.png"),
       ServePinnedManifest.parseCatalog(
-        """{"components":[{"images":[
+          """{"components":[{"images":[
              {"path":"images/foo__bar/baz.png"},{"path":"foo/bar__baz.png"}]}]}"""
-      ),
+        )
+        ?.paths,
     )
     assertEquals(
       emptyMap(),
       ServePinnedManifest.parseCatalog(
-        """{"components":[{"images":[
+          """{"components":[{"images":[
              {"path":"images/a/../../secret.png"},{"path":"images/b/c.svg"}]}]}"""
-      ),
+        )
+        ?.paths,
     )
     // References go the other way, because their importer discards a duplicate id rather than
     // overwriting: first wins. The asymmetry mirrors the two loaders, not one another.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
@@ -112,6 +112,16 @@ class ServePinnedManifestTest {
         )
         ?.paths,
     )
+    // The label follows the winning path even when the winner is unnamed: leaving the loser's
+    // component behind would attribute one component's render to another.
+    val collided =
+      ServePinnedManifest.parseCatalog(
+        """{"components":[
+             {"componentId":"Named","images":[{"path":"images/foo__bar/baz.png"}]},
+             {"images":[{"path":"images/foo/bar__baz.png"}]}]}"""
+      )!!
+    assertEquals("images/foo/bar__baz.png", collided.paths["foo__bar__baz"])
+    assertNull(collided.labels["foo__bar__baz"])
     // References go the other way, because their importer discards a duplicate id rather than
     // overwriting: first wins. The asymmetry mirrors the two loaders, not one another.
     assertEquals(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
@@ -281,6 +281,17 @@ class ServePinnedRevisionTest {
     // …and the id is genuinely absent from the live catalog, so this is not the tip's map quietly
     // answering: without the pinned manifest the request above has nowhere to resolve.
     assertEquals(404, get("http://127.0.0.1:$port/$system/render/$retiredId.png").first)
+
+    // The PAGE is what a person actually opened, and it has to resolve too — the session's preview
+    // list is built from the tip, so a renamed-away id is not in it and the viewer used to 404 on
+    // a permalink whose pixels this server could serve perfectly well.
+    val page = text("http://127.0.0.1:$port/$system/p/$retiredId?at=$oldCommit")
+    assertTrue(page.contains("data-preview-id=\"$retiredId\""), page)
+    assertTrue(page.contains("Pinned to catalog revision"), page)
+    // Named by the component that revision declared it under, rather than by the bare id.
+    assertTrue(page.contains("Button/Filled"), page)
+    // Unpinned, the id is simply gone — a retired preview is not resurrected onto the live catalog.
+    assertEquals(404, get("http://127.0.0.1:$port/$system/p/$retiredId").first)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
@@ -392,7 +392,12 @@ class ServePinnedRevisionTest {
 
   @Test
   fun `a load reads one commit rather than a moving branch`() {
-    val asked = java.util.Collections.synchronizedList(mutableListOf<String>())
+    // CopyOnWriteArrayList, not a synchronized list: a catalog load keeps background threads
+    // fetching (vectors, rc-compare) after it returns, so they are still appending while the
+    // assertions below read. A synchronized list needs the caller to hold its monitor to iterate —
+    // `any {}` and even `toList()` do not — and the miss is a ConcurrentModificationException that
+    // shows up as a CI flake rather than on the run that wrote it.
+    val asked = java.util.concurrent.CopyOnWriteArrayList<String>()
     startWith { url ->
       asked += url
       fetch(url)
@@ -411,7 +416,12 @@ class ServePinnedRevisionTest {
 
   @Test
   fun `a branch with no readable history still loads, by name`() {
-    val asked = java.util.Collections.synchronizedList(mutableListOf<String>())
+    // CopyOnWriteArrayList, not a synchronized list: a catalog load keeps background threads
+    // fetching (vectors, rc-compare) after it returns, so they are still appending while the
+    // assertions below read. A synchronized list needs the caller to hold its monitor to iterate —
+    // `any {}` and even `toList()` do not — and the miss is a ConcurrentModificationException that
+    // shows up as a CI flake rather than on the run that wrote it.
+    val asked = java.util.concurrent.CopyOnWriteArrayList<String>()
     val port = startWith { url ->
       asked += url
       if (url == ServeCatalogRevision.commitsFeedUrl(repo, branch)) null else fetch(url)
@@ -460,6 +470,43 @@ class ServePinnedRevisionTest {
     // exactly the historical links this feature exists to share; the lane is admission-bounded now,
     // so the probe costs at most one permitted read and the GET behind it is served from cache.
     assertEquals(200, head)
+  }
+
+  @Test
+  fun `a preview the pinned revision never had has no page either`() {
+    // The mirror image of the retired case: an id today's catalog lists but that revision did not
+    // publish — a preview ADDED since. Its render already 404s, so serving a page built from
+    // today's metadata would wrap a broken image in a banner claiming the pixels cannot change.
+    val olderCatalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+        {"componentId":"Legacy","images":[{"path":"images/legacy/ideal.png"}]}]}
+      """
+        .trimIndent()
+    val port = startWith { url ->
+      val old = "https://raw.githubusercontent.com/$repo/$oldCommit/"
+      if (url == "${old}catalog.json") olderCatalog.encodeToByteArray() else fetch(url)
+    }
+
+    assertEquals(404, get("http://127.0.0.1:$port/$system/p/$previewId?at=$oldCommit").first)
+    assertEquals(
+      404,
+      get("http://127.0.0.1:$port/$system/render/$previewId.png?at=$oldCommit").first,
+    )
+    // Unpinned it is an ordinary preview of the live catalog, untouched by any of this.
+    assertEquals(200, get("http://127.0.0.1:$port/$system/p/$previewId").first)
+  }
+
+  @Test
+  fun `a revision whose catalog cannot be read leaves the page to the live catalog`() {
+    // "I could not ask that revision" is not "that revision says no". The page falls back to the
+    // session's own preview rather than 404ing a link that may well be good.
+    val port = startWith { url ->
+      val old = "https://raw.githubusercontent.com/$repo/$oldCommit/"
+      if (url == "${old}catalog.json") null else fetch(url)
+    }
+
+    assertEquals(200, get("http://127.0.0.1:$port/$system/p/$previewId?at=$oldCommit").first)
   }
 
   private fun get(url: String): Pair<Int, ByteArray> =

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -286,6 +286,13 @@ The rules the lane holds to, each of which exists because its opposite would mak
   A manifest that **was read** is authoritative about its own revision: an id it doesn't list was
   not published then, and the answer is a 404 rather than whatever happens to sit at today's path in
   that commit. The tip's map is the fallback only for a manifest that could not be read at all.
+
+  That revision's catalog also answers for the **page**, not just the pixels. A permalink outlives
+  the id it names: when a preview is renamed or reorganised away, every link made before that names
+  an id the session's list — built from the tip — no longer contains, and `/p/<id>?at=<sha>` used to
+  404 even though the pinned revision published it and the server could serve its render. Under a
+  pin, a preview the revision's own catalog lists is paged from there, named by the component it
+  belonged to. Unpinned it stays gone: a retired preview is not resurrected onto the live catalog.
 - **A load reads one commit, not a branch.** The feed is resolved first and every asset of that load
   is fetched through the sha it returned, so a publish landing mid-load can't leave the pages
   advertising one revision while serving a mixture of two. It also means the live catalog and a pin


### PR DESCRIPTION
The last finding from #3768's review, and the last item on the permalinks list.

## The asset opened; the page didn't

A permalink outlives the id it names. When a preview is renamed or reorganised away — which for renders is *any* path change, since the id is derived from the path — every link made before that carries an id the session's preview list no longer contains, because that list is built from the branch tip. #3769 made the **render** resolve at a revision that has it. `handleViewer` still looked the preview up in the tip's list, so `/p/<id>?at=<sha>` answered "That preview does not exist in this catalog" for a link whose pixels this server could serve perfectly well.

Under a pin, the revision's own catalog now answers for the page too.

## What it synthesizes, and what it refuses to

Deliberately the bare minimum: the id, and the component that revision declared it under, so the page carries a name rather than a bare slug. Everything else the viewer draws — axes, sibling variants, references, knobs — describes the *current* catalog and would be a fabrication here; a pinned page has all of those lanes off anyway (#3768).

Two things it won't do:
- **Unpinned, the id stays gone.** A retired preview is not resurrected onto the live catalog.
- **A revision whose catalog can't be read synthesizes nothing.** Inventing a page for an id nothing confirms is worse than admitting we don't have it — the same rule as the authoritative-miss change in #3769.

The label map costs no extra fetch: `catalog.json` is now parsed **once** into both the paths a pinned asset resolves through and the labels a pinned page names it by. (Threading it as a second read was my first cut; that's a second network round trip per commit for a string, which the single-pass parse avoids.)

## Test plan

- `ServePinnedRevisionTest` — the retired-preview case now asserts the *page* as well as the render: `/p/<retired-id>?at=<sha>` serves the viewer with that id and the pin banner, named by the component (`Button/Filled`), while the same id unpinned still 404s.
- `ServePinnedManifestTest` — `parseCatalog` returns paths and labels from one pass, with the label map asserted per id.
- `./gradlew :cli:test :cli:ktfmtCheck` green.

No visual change: the pinned viewer's markup is what #3768 already captured in `serve-viewer-pinned-lanes`; this only decides whether that page is reachable for an id the tip has dropped.

## That's the list

With this, everything raised across #3758 / #3768 / #3769 is either landed or deliberately declined and written down — the catalog **grid** stays unpinnable (its thumbnails are prebaked from the loaded catalog, so pinning means re-fetching a page of historical images per visit; pinning is per-preview and per-comparison, which is the granularity of shared links).

One thing outside this work that I can't fix from here: `VS Code Extension E2E (interactive-a-d)` has failed identically on every PR in this series — scenario B times out at exactly 180000ms while scenario A in the same run takes 179–181s. It's the extension's real-Gradle edit loop sitting on its time budget, unrelated to `serve`; it wants a raised timeout or a split scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SazNBCPVGgAe1ERifMgPGF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SazNBCPVGgAe1ERifMgPGF)_