### PR TITLE
feat(cli): check a11y for each --permutations variant, at its own configuration

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.io.SystemFileSystem
 import java.awt.image.BufferedImage
 import java.io.File
@@ -1722,21 +1723,41 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
   override fun implicitExtensions(): List<String> = listOf(extensionId)
 
   /**
+   * One preview a data-product hook has been asked to produce for.
+   *
+   * [previewId] is the id to **address the daemon with** — always one the plugin discovered, since
+   * `PreviewIndex.byId` is an exact lookup against `previews.json`. [entryId] is the id to **key
+   * the result on**, which is what a consumer looks up. They differ only for a `--permutations`
+   * variant: `Foo_dark` is synthesised client-side, so the fetch names `Foo` and carries
+   * [overrides] — the dark/RTL/font-scale configuration the daemon threads into its re-render —
+   * while the result is filed under `Foo_dark` (issue #3762).
+   *
+   * [overrides] is `null` for a plain preview, which is also the "no params bag" case.
+   */
+  data class RequestedPreview(
+    val previewId: String,
+    val entryId: String,
+    val overrides: PreviewOverrides? = null,
+  ) {
+    /** True when this is a client-side permutation rather than a declared preview. */
+    val isPermutation: Boolean
+      get() = entryId != previewId
+  }
+
+  /**
    * One module's share of the work [produceAdditionalDataProducts] has to do.
    *
-   * [previewIds] is **already narrowed** to the invocation's `--id` / `--filter` — implementations
+   * [previews] is **already narrowed** to the invocation's `--id` / `--filter` — implementations
    * fan out over it rather than over `manifest.previews`, so `a11y --filter Foo` pays for one
    * per-preview daemon render instead of the module's full set (issue #3742). A module none of
    * whose previews the request selects never becomes a request at all.
    *
    * [consumerPreviewIds] is every id a *consumer* of the sidecar may look up — the manifest
    * expanded through [PreviewPermutationsCli], which is the id space `PreviewResult`s carry and so
-   * the one the extension renderers annotate against. Coverage is measured against this, not
-   * against [previewIds]: a `--permutations accessibility` run can produce data for every declared
-   * preview and still leave `Foo_dark` unaddressed, and a report that called itself complete there
-   * would let the renderer synthesise a clean row for a permutation nobody rendered.
+   * the one the extension renderers annotate against. Coverage is measured against this rather than
+   * against what was fetched, so a run that skipped a permutation is reported as not covering it.
    *
-   * [narrowed] is true exactly when [previewIds] is a strict subset of the module's previews, i.e.
+   * [narrowed] is true exactly when [previews] is a strict subset of [consumerPreviewIds], i.e.
    * when whatever this hook writes covers only part of the module. The sidecars are *per-module*
    * reports, so a narrowed run that writes one wholesale discards the findings for previews the
    * user didn't ask about — the analogue of the `.cli-state.json` problem #3730 had to solve.
@@ -1745,7 +1766,7 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
   data class DataProductRequest(
     val module: PreviewModule,
     val manifest: PreviewManifest,
-    val previewIds: List<String>,
+    val previews: List<RequestedPreview>,
     val consumerPreviewIds: List<String>,
     val narrowed: Boolean,
   )
@@ -1778,41 +1799,33 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
   protected fun dataProductRequests(
     manifests: List<Pair<PreviewModule, PreviewManifest>>
   ): List<DataProductRequest> = manifests.mapNotNull { (module, manifest) ->
-    val requested = requestedPreviewIds(manifest)
+    val consumerIds = mutableListOf<String>()
+    val requested = mutableListOf<RequestedPreview>()
+    for (preview in manifest.previews) {
+      // Fetch order within a preview is load-bearing: the daemon keys its artefacts by preview id,
+      // so each permutation's overlay lands on top of the last. [RequestedPreview] production keeps
+      // the declared preview *first* here, and `DaemonA11yFetcher` reverses that so the base render
+      // is the one left on disk under its own id. See its `fetch` KDoc.
+      for (expanded in PreviewPermutationsCli.expand(listOf(preview), permutations)) {
+        consumerIds += expanded.id
+        if (!matchesRequest(expanded.id)) continue
+        requested +=
+          RequestedPreview(
+            previewId = preview.id,
+            entryId = expanded.id,
+            overrides = PreviewPermutationsCli.overridesFor(preview, expanded),
+          )
+      }
+    }
     if (requested.isEmpty()) null
-    else {
-      warnAboutPermutationSubstitution(module, requested)
+    else
       DataProductRequest(
         module = module,
         manifest = manifest,
-        previewIds = requested,
-        consumerPreviewIds =
-          PreviewPermutationsCli.expand(manifest.previews, permutations).map { it.id },
-        narrowed = requested.size < manifest.previews.size,
+        previews = requested,
+        consumerPreviewIds = consumerIds,
+        narrowed = requested.size < consumerIds.size,
       )
-    }
-  }
-
-  /**
-   * Say out loud when the request only matched through `--permutations` expansion, so this run
-   * fetched the *declared* preview instead (see [requestedPreviewIds]).
-   *
-   * Data products are produced for the declared preview at its own parameters: the daemon has no
-   * per-permutation lane, and its artefacts are keyed by preview id
-   * (`build/compose-previews/data/<id>/`), so several permutations of one preview would overwrite
-   * each other's overlay and hierarchy files. What the user sees is that the permutation row they
-   * asked about carries no data — and without this line, that reads as a clean result.
-   */
-  private fun warnAboutPermutationSubstitution(module: PreviewModule, requested: List<String>) {
-    val substituted = requested.filterNot { matchesRequest(it) }
-    if (substituted.isEmpty()) return
-    System.err.println(
-      "compose-preview $extensionId: ${module.gradlePath} — the request matched " +
-        "${substituted.size} preview(s) only through --permutations expansion, so $extensionId " +
-        "data is produced for the declared preview(s) (${substituted.joinToString(", ")}) at " +
-        "their own parameters. The permutation row itself will carry no $extensionId data; " +
-        "per-permutation production is not implemented (issue #3762)."
-    )
   }
 
   /**
@@ -1959,12 +1972,12 @@ class A11yCommand(args: List<String>) : ReportCommand(args, "a11y") {
     }
     val fetcher = DaemonA11yFetcher(onLog = { System.err.println("[daemon a11y] $it") })
     for (request in requests) {
-      val (module, manifest, previewIds, consumerPreviewIds, narrowed) = request
+      val (module, manifest, previews, consumerPreviewIds, narrowed) = request
       attemptedAnyModule = true
       if (verbose && narrowed) {
         System.err.println(
-          "compose-preview a11y: ${module.gradlePath} fetching ATF for ${previewIds.size} of " +
-            "${manifest.previews.size} preview(s); the rest keep whatever the last run recorded, " +
+          "compose-preview a11y: ${module.gradlePath} fetching ATF for ${previews.size} of " +
+            "${consumerPreviewIds.size} preview(s); the rest keep whatever the last run recorded, " +
             "and the report is marked partial for any still uncovered."
         )
       }
@@ -1973,7 +1986,7 @@ class A11yCommand(args: List<String>) : ReportCommand(args, "a11y") {
           projectDir = module.projectDir,
           modulePath = module.gradlePath,
           moduleName = manifest.module,
-          previewIds = previewIds,
+          previews = previews,
           // A narrowed run only speaks for the previews it fetched, so the fetcher carries the
           // rest of the module's report forward and marks what it still doesn't cover as partial
           // rather than publishing a module-wide report full of silent gaps (issue #3742).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.render.session.DataProductException
 import ee.schimke.composeai.render.session.RenderSession
@@ -12,6 +14,9 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
@@ -52,8 +57,20 @@ internal class DaemonA11yFetcher(
    * handshake; defaults to [projectDir] when the caller doesn't have a separate workspace root
    * handy (single-module projects).
    *
-   * [narrowed] says whether [previewIds] is a subset of what the module declares — true when `--id`
-   * / `--filter` cut the fan-out down (issue #3742). It decides **merge vs. wholesale rewrite**: a
+   * [previews] pairs the id each fetch is *addressed* with against the id its entry is *filed*
+   * under. They differ for a `--permutations` variant: the daemon only knows the previews the
+   * plugin discovered, so `Foo_dark` is fetched as `Foo` carrying the dark-mode
+   * [ee.schimke.composeai.daemon.protocol.PreviewOverrides] in the params bag, and filed as
+   * `Foo_dark` (issue #3762).
+   *
+   * Permutations are fetched **before** the declared preview, and their artefacts snapshotted as
+   * each one lands. The daemon writes overlay + hierarchy to `data/<previewId>/`, keyed by the id
+   * it was asked for rather than by the overrides — so without both of those, four permutations of
+   * one preview would overwrite each other and every entry would end up pointing at whichever
+   * render finished last.
+   *
+   * [narrowed] says whether [previews] is a subset of what the module declares — true when `--id` /
+   * `--filter` cut the fan-out down (issue #3742). It decides **merge vs. wholesale rewrite**: a
    * narrowed run carries forward the entries of previews it didn't ask about (minus the ones that
    * never really ran — see [carryForward]), the same bargain the `.cli-state.json` carry-forward
    * strikes for previews a narrowed render skipped (#3730), while a full run rewrites and so stays
@@ -71,9 +88,9 @@ internal class DaemonA11yFetcher(
     projectDir: File,
     modulePath: String,
     moduleName: String,
-    previewIds: List<String>,
+    previews: List<ReportCommand.RequestedPreview>,
     workspaceRoot: File = projectDir,
-    modulePreviewIds: List<String> = previewIds,
+    modulePreviewIds: List<String> = previews.map { it.entryId },
     narrowed: Boolean = false,
   ): Outcome {
     val descriptorFile = File(projectDir, "build/compose-previews/daemon-launch.json")
@@ -115,7 +132,12 @@ internal class DaemonA11yFetcher(
       // so it must not overwrite what a previous run actually found. See [mergeEntries].
       val failedIds = mutableSetOf<String>()
       var anyFetchOk = false
-      for (previewId in previewIds) {
+      // Permutations first, the declared preview last. Every fetch writes its artefacts to
+      // `data/<previewId>/`, so the last render of a given preview is the one left there — and that
+      // should be the preview's own, since its entry is the one keyed by that id.
+      for (preview in previews.sortedBy { !it.isPermutation }) {
+        val previewId = preview.previewId
+        val entryId = preview.entryId
         val payload =
           try {
             live
@@ -123,24 +145,28 @@ internal class DaemonA11yFetcher(
                 previewId = previewId,
                 kind = ATF_KIND,
                 inline = true,
+                params = fetchParams(preview),
                 timeout = 120.seconds,
               )
               .payload
           } catch (e: DataProductException) {
-            onLog("a11y fetch for '$previewId' failed: code=${e.code} ${e.wireMessage}")
+            onLog("a11y fetch for '$entryId' failed: code=${e.code} ${e.wireMessage}")
             null
           } catch (e: RenderSessionException) {
-            onLog("a11y fetch for '$previewId' transport error: ${e.message}")
+            onLog("a11y fetch for '$entryId' transport error: ${e.message}")
             null
           }
-        if (payload != null) anyFetchOk = true else failedIds += previewId
+        if (payload != null) anyFetchOk = true else failedIds += entryId
+        // Take the artefacts this render just produced before the next fetch of the same preview
+        // overwrites them.
+        if (preview.isPermutation) snapshotArtifacts(projectDir, from = previewId, to = entryId)
         val findings = payload?.let(::parseFindings).orEmpty()
         entries.add(
           AccessibilityEntry(
-            previewId = previewId,
+            previewId = entryId,
             findings = findings,
-            nodes = readNodes(projectDir, previewId),
-            annotatedPath = relativeOverlayPath(projectDir, previewId),
+            nodes = readNodes(projectDir, entryId),
+            annotatedPath = relativeOverlayPath(projectDir, entryId),
           )
         )
       }
@@ -149,7 +175,7 @@ internal class DaemonA11yFetcher(
       // so downstream consumers (the python PR-comment helper, CLI exit-code policy) can tell
       // "ATF didn't run" apart from "ATF ran cleanly." When `previewIds` is empty there's nothing
       // to report on either way, so leave `status` null.
-      val atfAvailable = anyFetchOk || previewIds.isEmpty()
+      val atfAvailable = anyFetchOk || previews.isEmpty()
       val status = if (atfAvailable) null else A11Y_REPORT_STATUS_ATF_UNAVAILABLE
       val reportFile =
         writeReport(
@@ -289,6 +315,49 @@ internal class DaemonA11yFetcher(
   }
 
   /**
+   * The `params` bag for one fetch: the permutation's render overrides, plus a forced re-render so
+   * the daemon produces the artefact at *those* overrides rather than serving whatever the shared
+   * per-preview file already holds. `null` for a declared preview, which wants its own defaults and
+   * can reuse a cached render.
+   */
+  private fun fetchParams(preview: ReportCommand.RequestedPreview): JsonElement? {
+    val overrides = preview.overrides ?: return null
+    return buildJsonObject {
+      put(DataFetchParams.PARAM_FORCE_RERENDER, JsonPrimitive(true))
+      put(
+        DataFetchParams.PARAM_OVERRIDES,
+        json.encodeToJsonElement(PreviewOverrides.serializer(), overrides),
+      )
+    }
+  }
+
+  /**
+   * Copy the artefacts the daemon just wrote for [from] into [to]'s own directory, so a permutation
+   * keeps the overlay and hierarchy of *its* render.
+   *
+   * The daemon keys `data/<previewId>/` by the id it was asked for, and a permutation is fetched
+   * under its declared preview's id — so these files are transient: the next fetch of the same
+   * preview replaces them. `fetchData` returns only after the render completes, so copying here is
+   * safe. Best-effort: a permutation whose artefacts can't be copied still keeps its findings,
+   * which came back inline in the payload rather than through the filesystem.
+   */
+  private fun snapshotArtifacts(projectDir: File, from: String, to: String) {
+    val sourceDir = projectDir.resolve("build/compose-previews/data/$from")
+    if (!sourceDir.isDirectory) return
+    val targetDir = projectDir.resolve("build/compose-previews/data/$to")
+    for (name in SNAPSHOT_FILES) {
+      val source = sourceDir.resolve(name)
+      if (!source.isFile) continue
+      try {
+        targetDir.mkdirs()
+        source.copyTo(targetDir.resolve(name), overwrite = true)
+      } catch (e: Exception) {
+        onLog("could not snapshot $name for '$to': ${e.message}")
+      }
+    }
+  }
+
+  /**
    * Resolve the daemon-side overlay PNG (`a11y-overlay.png`) for [previewId] relative to the
    * accessibility.json that will be written. Returns null when the file is absent.
    */
@@ -350,5 +419,11 @@ internal class DaemonA11yFetcher(
 
   companion object {
     private const val ATF_KIND = "a11y/atf"
+
+    /**
+     * The per-preview artefacts a permutation needs a copy of. Both are written by the daemon into
+     * `data/<previewId>/` and read back from there by [readNodes] / [relativeOverlayPath].
+     */
+    private val SNAPSHOT_FILES = listOf("a11y-overlay.png", "a11y-hierarchy.json")
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
@@ -132,41 +132,93 @@ internal class DaemonA11yFetcher(
       // so it must not overwrite what a previous run actually found. See [mergeEntries].
       val failedIds = mutableSetOf<String>()
       var anyFetchOk = false
-      // Permutations first, the declared preview last. Every fetch writes its artefacts to
-      // `data/<previewId>/`, so the last render of a given preview is the one left there — and that
-      // should be the preview's own, since its entry is the one keyed by that id.
-      for (preview in previews.sortedBy { !it.isPermutation }) {
-        val previewId = preview.previewId
-        val entryId = preview.entryId
-        val payload =
-          try {
-            live
-              .fetchData(
-                previewId = previewId,
-                kind = ATF_KIND,
-                inline = true,
-                params = fetchParams(preview),
-                timeout = 120.seconds,
-              )
-              .payload
-          } catch (e: DataProductException) {
-            onLog("a11y fetch for '$entryId' failed: code=${e.code} ${e.wireMessage}")
-            null
-          } catch (e: RenderSessionException) {
-            onLog("a11y fetch for '$entryId' transport error: ${e.message}")
-            null
+
+      fun fetchOne(previewId: String, entryId: String, params: JsonElement?): JsonElement? =
+        try {
+          live
+            .fetchData(
+              previewId = previewId,
+              kind = ATF_KIND,
+              inline = true,
+              params = params,
+              timeout = 120.seconds,
+            )
+            .payload
+        } catch (e: DataProductException) {
+          onLog("a11y fetch for '$entryId' failed: code=${e.code} ${e.wireMessage}")
+          null
+        } catch (e: RenderSessionException) {
+          onLog("a11y fetch for '$entryId' transport error: ${e.message}")
+          null
+        }
+
+      // Group by the id the daemon is addressed with, because everything that needs care here is
+      // per *declared* preview: its permutations share one artefact directory, one cached
+      // data-product file, and one `renders/<id>.png`.
+      for ((previewId, group) in previews.groupBy { it.previewId }) {
+        val permutations = group.filter { it.isPermutation }
+        val base = group.firstOrNull { !it.isPermutation }
+        for (preview in permutations) {
+          val payload = fetchOne(previewId, preview.entryId, fetchParams(preview))
+          if (payload != null) anyFetchOk = true else failedIds += preview.entryId
+          // Copy this render's artefacts out before the next fetch of the same preview replaces
+          // them — but only when the fetch produced something. On a failure the directory still
+          // holds the *previous* configuration's files, and snapshotting those would file another
+          // permutation's overlay and hierarchy under this one's id.
+          if (payload != null) snapshotArtifacts(projectDir, from = previewId, to = preview.entryId)
+          entries.add(
+            AccessibilityEntry(
+              previewId = preview.entryId,
+              findings = payload?.let(::parseFindings).orEmpty(),
+              nodes = if (payload != null) readNodes(projectDir, preview.entryId) else emptyList(),
+              annotatedPath =
+                if (payload != null) relativeOverlayPath(projectDir, preview.entryId) else null,
+            )
+          )
+        }
+
+        if (permutations.isEmpty()) {
+          // Nothing overrode this preview, so the ordinary cached path is fine — this is the narrow
+          // fast fetch #3742 exists to keep.
+          val preview = base ?: continue
+          val payload = fetchOne(previewId, preview.entryId, null)
+          if (payload != null) anyFetchOk = true else failedIds += preview.entryId
+          entries.add(
+            AccessibilityEntry(
+              previewId = preview.entryId,
+              findings = payload?.let(::parseFindings).orEmpty(),
+              nodes = readNodes(projectDir, preview.entryId),
+              annotatedPath = relativeOverlayPath(projectDir, preview.entryId),
+            )
+          )
+          continue
+        }
+
+        // A permutation is rendered *as* this preview, so once one has run, two things under the
+        // declared id describe the override rather than the preview: the data product it wrote sits
+        // at this preview's own cache path — and an unforced fetch serves that existing file rather
+        // than re-rendering, since `FileBackedDataProductRegistry` only queues a re-render when the
+        // file is *missing* — and `renders/<previewId>.png`, which `buildResults` hashes as this
+        // preview, holds the override's pixels. One forced fetch at default overrides fixes both,
+        // so it runs even when the declared preview has no entry to file (`--id Foo_dark`): the
+        // report gains nothing, but the render on disk stops lying about which configuration it is.
+        val payload = fetchOne(previewId, base?.entryId ?: previewId, forcedDefaultParams())
+        if (base == null) {
+          if (payload == null) {
+            onLog(
+              "could not restore the default render of '$previewId' after its permutations; " +
+                "renders/$previewId.png may still hold a permutation's pixels"
+            )
           }
-        if (payload != null) anyFetchOk = true else failedIds += entryId
-        // Take the artefacts this render just produced before the next fetch of the same preview
-        // overwrites them.
-        if (preview.isPermutation) snapshotArtifacts(projectDir, from = previewId, to = entryId)
-        val findings = payload?.let(::parseFindings).orEmpty()
+          continue
+        }
+        if (payload != null) anyFetchOk = true else failedIds += base.entryId
         entries.add(
           AccessibilityEntry(
-            previewId = entryId,
-            findings = findings,
-            nodes = readNodes(projectDir, entryId),
-            annotatedPath = relativeOverlayPath(projectDir, entryId),
+            previewId = base.entryId,
+            findings = payload?.let(::parseFindings).orEmpty(),
+            nodes = readNodes(projectDir, base.entryId),
+            annotatedPath = relativeOverlayPath(projectDir, base.entryId),
           )
         )
       }
@@ -332,6 +384,15 @@ internal class DaemonA11yFetcher(
   }
 
   /**
+   * The `params` bag for the declared preview's fetch when a permutation of it already ran: a
+   * forced re-render carrying **no** overrides, so the daemon rebuilds this preview at its own
+   * configuration instead of serving the file the override left at the shared cache path.
+   */
+  private fun forcedDefaultParams(): JsonElement = buildJsonObject {
+    put(DataFetchParams.PARAM_FORCE_RERENDER, JsonPrimitive(true))
+  }
+
+  /**
    * Copy the artefacts the daemon just wrote for [from] into [to]'s own directory, so a permutation
    * keeps the overlay and hierarchy of *its* render.
    *
@@ -340,17 +401,24 @@ internal class DaemonA11yFetcher(
    * preview replaces them. `fetchData` returns only after the render completes, so copying here is
    * safe. Best-effort: a permutation whose artefacts can't be copied still keeps its findings,
    * which came back inline in the payload rather than through the filesystem.
+   *
+   * A file the latest render *didn't* produce is deleted from [to] rather than left alone: the
+   * target directory may hold an earlier run's copy, and keeping it would let [readNodes] and
+   * [relativeOverlayPath] hand this permutation a hierarchy or overlay from a render it isn't.
    */
   private fun snapshotArtifacts(projectDir: File, from: String, to: String) {
     val sourceDir = projectDir.resolve("build/compose-previews/data/$from")
-    if (!sourceDir.isDirectory) return
     val targetDir = projectDir.resolve("build/compose-previews/data/$to")
     for (name in SNAPSHOT_FILES) {
       val source = sourceDir.resolve(name)
-      if (!source.isFile) continue
+      val target = targetDir.resolve(name)
       try {
+        if (!source.isFile) {
+          target.delete()
+          continue
+        }
         targetDir.mkdirs()
-        source.copyTo(targetDir.resolve(name), overwrite = true)
+        source.copyTo(target, overwrite = true)
       } catch (e: Exception) {
         onLog("could not snapshot $name for '$to': ${e.message}")
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewPermutationsCli.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewPermutationsCli.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.UiMode
+
 internal object PreviewPermutationsCli {
   const val PROPERTY: String = "composePreview.permutations"
   private const val ACCESSIBILITY: String = "accessibility"
@@ -43,6 +46,31 @@ internal object PreviewPermutationsCli {
         )
     }
   }
+
+  /**
+   * The render overrides that turn [base] into [expanded] — `null` when [expanded] *is* the base,
+   * or when it differs in nothing this can express.
+   *
+   * These permutations are synthesised client-side, so the daemon has never heard of `Foo_dark`:
+   * `PreviewIndex.byId` resolves against the plugin-written `previews.json`. What it *does* accept
+   * is a fetch for the declared `Foo` carrying [PreviewOverrides] in the params bag, which it
+   * threads into the re-render. Reading the override back off the expanded params — rather than
+   * mapping the id suffix — keeps this honest if [expand] ever grows an axis: the override is
+   * derived from the same `PreviewParams` the render would have used (issue #3762).
+   */
+  fun overridesFor(base: PreviewInfo, expanded: PreviewInfo): PreviewOverrides? {
+    if (expanded.id == base.id) return null
+    val darkened = expanded.params.uiMode != base.params.uiMode && isNight(expanded.params.uiMode)
+    val overrides =
+      PreviewOverrides(
+        uiMode = if (darkened) UiMode.DARK else null,
+        localeTag = expanded.params.locale.takeIf { it != base.params.locale },
+        fontScale = expanded.params.fontScale.takeIf { it != base.params.fontScale },
+      )
+    return overrides.takeIf { it.uiMode != null || it.localeTag != null || it.fontScale != null }
+  }
+
+  private fun isNight(uiMode: Int): Boolean = (uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES
 
   private fun PreviewInfo.accessibilityVariant(
     idSuffix: String,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yCommandTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.daemon.protocol.UiMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -227,7 +228,7 @@ class A11yCommandTest {
     val requests = cmd.requestsFor(listOf(manifest("app", "Alpha", "Beta", "Gamma")))
 
     val request = requests.single()
-    assertEquals(listOf("Alpha", "Beta", "Gamma"), request.previewIds)
+    assertEquals(listOf("Alpha", "Beta", "Gamma"), request.previews.map { it.entryId })
     assertFalse(request.narrowed, "a full module is not a partial report")
   }
 
@@ -240,7 +241,7 @@ class A11yCommandTest {
 
     val request = cmd.requestsFor(listOf(manifest("app", "Alpha", "Beta", "Gamma"))).single()
 
-    assertEquals(listOf("Alpha"), request.previewIds)
+    assertEquals(listOf("Alpha"), request.previews.map { it.entryId })
     assertTrue(request.narrowed, "a subset of the module must merge into the module's report")
   }
 
@@ -252,39 +253,58 @@ class A11yCommandTest {
 
     val request = cmd.requestsFor(listOf(manifest("app", "AlphaPreview", "BetaPreview"))).single()
 
-    assertEquals(listOf("AlphaPreview", "BetaPreview"), request.previewIds)
+    assertEquals(listOf("AlphaPreview", "BetaPreview"), request.previews.map { it.entryId })
     assertFalse(request.narrowed)
   }
 
   @Test
-  fun `an exact permutation id resolves to the preview the daemon can address`() {
+  fun `an exact permutation id is addressed as its declared preview, with overrides`() {
     // `--permutations accessibility` synthesises `Foo_dark` client-side; the daemon's PreviewIndex
-    // only knows the ids the plugin discovered, and resolves them exactly. Asking it for `Foo_dark`
-    // gets "unknown preview", which on a narrowed run is the *only* fetch and so fails the command
-    // outright. Match on the expansion the user saw, address the base preview.
+    // only knows the ids the plugin discovered and resolves them exactly, so asking it for
+    // `Foo_dark` gets "unknown preview". The request names `Foo` and carries the dark-mode
+    // configuration instead — and files the result under the id the user asked about (#3762).
     val cmd = TestableReportCommand(listOf("--id", "Foo_dark", "--permutations", "accessibility"))
 
     val request = cmd.requestsFor(listOf(manifest("app", "Foo", "Bar"))).single()
 
-    assertEquals(listOf("Foo"), request.previewIds)
-    assertTrue(request.narrowed, "one of two previews")
+    val requested = request.previews.single()
+    assertEquals("Foo", requested.previewId, "the daemon-addressable id")
+    assertEquals("Foo_dark", requested.entryId, "the id a consumer looks up")
+    assertEquals(UiMode.DARK, requested.overrides?.uiMode)
+    assertTrue(requested.isPermutation)
+    assertTrue(request.narrowed, "one of eight expanded previews")
+  }
+
+  @Test
+  fun `each accessibility permutation carries the configuration it stands for`() {
+    val cmd = TestableReportCommand(listOf("--filter", "Foo", "--permutations", "accessibility"))
+
+    val byEntry =
+      cmd.requestsFor(listOf(manifest("app", "Foo"))).single().previews.associateBy { it.entryId }
+
+    assertEquals(null, byEntry.getValue("Foo").overrides, "the declared preview renders as itself")
+    assertEquals(UiMode.DARK, byEntry.getValue("Foo_dark").overrides?.uiMode)
+    assertEquals("ar-XB", byEntry.getValue("Foo_rtl").overrides?.localeTag)
+    assertEquals(2.0f, byEntry.getValue("Foo_fontscale-2x").overrides?.fontScale)
+    // Every fetch still addresses the one preview the plugin discovered.
+    assertEquals(setOf("Foo"), byEntry.values.map { it.previewId }.toSet())
   }
 
   @Test
   fun `coverage is measured against the ids a consumer will look up`() {
-    // The trap: a one-preview module where the request substitutes to the only declared preview.
-    // Measured against the manifest, the report covers everything and would call itself complete —
-    // and `A11yReportRenderer` would then synthesise a clean row for `Foo_dark`, the exact variant
-    // nobody rendered. Coverage has to be measured in the id space the results carry.
+    // A one-preview module: the request covers one of the four ids the results will carry, so the
+    // report must call itself partial rather than let the renderer synthesise clean rows for the
+    // three permutations nobody asked for.
     val cmd = TestableReportCommand(listOf("--id", "Foo_dark", "--permutations", "accessibility"))
 
     val request = cmd.requestsFor(listOf(manifest("app", "Foo"))).single()
 
-    assertEquals(listOf("Foo"), request.previewIds)
+    assertEquals(listOf("Foo_dark"), request.previews.map { it.entryId })
     assertEquals(
       listOf("Foo", "Foo_dark", "Foo_rtl", "Foo_fontscale-2x"),
       request.consumerPreviewIds,
     )
+    assertTrue(request.narrowed)
   }
 
   @Test
@@ -293,24 +313,15 @@ class A11yCommandTest {
 
     val request = cmd.requestsFor(listOf(manifest("app", "Foo", "Bar"))).single()
 
-    assertEquals(request.previewIds, request.consumerPreviewIds)
+    assertEquals(request.previews.map { it.entryId }, request.consumerPreviewIds)
   }
 
   @Test
-  fun `substituting a permutation for its declared preview says so on stderr`() {
-    // The substitution is correct (it's the only id the daemon can serve) but it means the row the
-    // user asked about carries no a11y data. Silence there reads as a clean result.
+  fun `a permutation request no longer warns about substitution`() {
+    // It used to say the permutation row would carry no data, because the run fetched the declared
+    // preview at its own parameters instead. It now fetches the permutation's configuration, so
+    // there is nothing to apologise for.
     val cmd = TestableReportCommand(listOf("--id", "Foo_dark", "--permutations", "accessibility"))
-
-    val err = captureStderr { cmd.requestsFor(listOf(manifest("app", "Foo", "Bar"))) }
-
-    assertTrue("--permutations expansion" in err, "expected a substitution warning, got: $err")
-    assertTrue("Foo" in err, "expected the declared preview named, got: $err")
-  }
-
-  @Test
-  fun `an ordinary request says nothing about permutations`() {
-    val cmd = TestableReportCommand(listOf("--id", "Foo"))
 
     val err = captureStderr { cmd.requestsFor(listOf(manifest("app", "Foo", "Bar"))) }
 
@@ -318,14 +329,19 @@ class A11yCommandTest {
   }
 
   @Test
-  fun `a filter under permutations fetches each base preview once`() {
-    // The expanded view has four `Foo*` rows; fetching per row would pay four daemon renders for
-    // an id space the daemon doesn't even have.
+  fun `a filter under permutations fetches every matching permutation`() {
+    // Each expanded row is its own render at its own configuration, and checking a11y across those
+    // configurations is the point of `--permutations accessibility` — dark contrast, RTL layout,
+    // 2x font scale. Deduplicating them back to the declared preview would report one result four
+    // times over.
     val cmd = TestableReportCommand(listOf("--filter", "Foo", "--permutations", "accessibility"))
 
     val request = cmd.requestsFor(listOf(manifest("app", "Foo", "Bar"))).single()
 
-    assertEquals(listOf("Foo"), request.previewIds)
+    assertEquals(
+      listOf("Foo", "Foo_dark", "Foo_rtl", "Foo_fontscale-2x"),
+      request.previews.map { it.entryId },
+    )
   }
 
   @Test
@@ -338,7 +354,7 @@ class A11yCommandTest {
     // No session opened, no daemon started, and no `accessibility.json` written for `:wear` — the
     // module isn't attempted, so it can't be reported as ATF-unavailable either.
     assertEquals(listOf(":app"), requests.map { it.module.gradlePath })
-    assertEquals(listOf("Alpha"), requests.single().previewIds)
+    assertEquals(listOf("Alpha"), requests.single().previews.map { it.entryId })
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
@@ -359,6 +359,168 @@ class DaemonA11yFetcherTest {
     )
   }
 
+  @Test
+  fun `the declared preview is re-rendered at its own configuration after a permutation`() {
+    val projectDir = newTempFolder("module-permutation-force-base")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+
+    val factory = FakeFactory(mapOf("Foo" to atfPayload(emptyList())))
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo"),
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f)),
+          ),
+      )
+
+    // The permutation was rendered *as* `Foo`, so it left its data product at `Foo`'s own cache
+    // path. `FileBackedDataProductRegistry` only queues a re-render when that file is *missing*, so
+    // an unforced base fetch would serve the permutation's artefact and file it as the base.
+    val baseParams = factory.calls.last().params?.jsonObject
+    assertEquals(
+      true,
+      baseParams?.get(DataFetchParams.PARAM_FORCE_RERENDER)?.jsonPrimitive?.content?.toBoolean(),
+      "the base fetch after a permutation must force a re-render",
+    )
+    assertNull(
+      baseParams?.get(DataFetchParams.PARAM_OVERRIDES),
+      "...at default overrides, which is what makes it the base",
+    )
+  }
+
+  @Test
+  fun `a permutation-only request still restores the declared preview's render`() {
+    val projectDir = newTempFolder("module-permutation-only")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+
+    val factory = FakeFactory(mapOf("Foo" to atfPayload(emptyList())))
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f))
+          ),
+        modulePreviewIds = listOf("Foo", "Foo_dark"),
+        narrowed = true,
+      )
+
+    // `--id Foo_dark` asks for one entry, but the render that produced it overwrote
+    // `renders/Foo.png` — which `buildResults` hashes as the declared preview. So the restore runs
+    // even though it has no entry to file.
+    assertEquals(2, factory.calls.size, "expected the permutation plus a restoring base fetch")
+    assertEquals(
+      true,
+      factory.calls
+        .last()
+        .params
+        ?.jsonObject
+        ?.get(DataFetchParams.PARAM_FORCE_RERENDER)
+        ?.jsonPrimitive
+        ?.content
+        ?.toBoolean(),
+    )
+    assertEquals(
+      listOf("Foo_dark"),
+      readReport(projectDir).entries.map { it.previewId },
+      "the restore is a side effect, not a result — it files no entry",
+    )
+  }
+
+  @Test
+  fun `a failed permutation does not inherit the previous permutation's artefacts`() {
+    val projectDir = newTempFolder("module-permutation-failed-snapshot")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+    val dataDir = File(projectDir, "build/compose-previews/data/Foo")
+
+    // Only the first fetch renders; the second errors, so `data/Foo/` still holds the *first*
+    // permutation's overlay when it returns.
+    val factory =
+      FakeFactory(
+        payloads = emptyMap(),
+        payloadByCall =
+          mapOf(1 to atfPayload(emptyList()), 2 to null, 3 to atfPayload(emptyList())),
+        onFetch = { _, ordinal ->
+          if (ordinal != 2) {
+            dataDir.mkdirs()
+            File(dataDir, "a11y-overlay.png").writeBytes("render-$ordinal".toByteArray())
+          }
+        },
+      )
+
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f)),
+            ReportCommand.RequestedPreview("Foo", "Foo_rtl", PreviewOverrides(localeTag = "ar-XB")),
+          ),
+        modulePreviewIds = listOf("Foo", "Foo_dark", "Foo_rtl"),
+        narrowed = true,
+      )
+
+    assertEquals(
+      "render-1",
+      File(projectDir, "build/compose-previews/data/Foo_dark/a11y-overlay.png").readText(),
+    )
+    assertFalse(
+      File(projectDir, "build/compose-previews/data/Foo_rtl/a11y-overlay.png").exists(),
+      "a failed fetch has no artefacts of its own, and must not adopt the last one's",
+    )
+    assertNull(readReport(projectDir).entries.single { it.previewId == "Foo_rtl" }.annotatedPath)
+  }
+
+  @Test
+  fun `a snapshot drops a stale artefact the latest render did not produce`() {
+    val projectDir = newTempFolder("module-permutation-stale-snapshot")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+    val dataDir = File(projectDir, "build/compose-previews/data/Foo")
+    val darkDir = File(projectDir, "build/compose-previews/data/Foo_dark")
+    darkDir.mkdirs()
+    File(darkDir, "a11y-overlay.png").writeText("from-an-earlier-run")
+
+    // This render produces a hierarchy but no overlay (the overlay-only path is optional). The copy
+    // loop has nothing to overwrite the earlier run's PNG with, so it must remove it — otherwise
+    // `annotatedPath` points a reader at pixels from a render that isn't this one.
+    val factory =
+      FakeFactory(
+        payloads = mapOf("Foo" to atfPayload(emptyList())),
+        onFetch = { _, _ ->
+          dataDir.mkdirs()
+          File(dataDir, "a11y-hierarchy.json").writeText("""{"nodes":[]}""")
+        },
+      )
+
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f))
+          ),
+        modulePreviewIds = listOf("Foo", "Foo_dark"),
+        narrowed = true,
+      )
+
+    assertFalse(File(darkDir, "a11y-overlay.png").exists(), "stale overlay should be dropped")
+    assertNull(readReport(projectDir).entries.single().annotatedPath)
+  }
+
   // ---------- narrowed runs merge rather than clobber (#3742) ----------
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
 import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
@@ -37,6 +38,8 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 /**
@@ -45,6 +48,11 @@ import kotlinx.serialization.json.put
  * reads — one entry per preview, in input order, findings preserved.
  */
 class DaemonA11yFetcherTest {
+
+  /** Plain declared previews — no `--permutations` in play, so entry id == fetch id. */
+  private fun declared(vararg ids: String): List<ReportCommand.RequestedPreview> = ids.map {
+    ReportCommand.RequestedPreview(previewId = it, entryId = it)
+  }
 
   private fun newTempFolder(prefix: String): File =
     java.nio.file.Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
@@ -67,7 +75,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview", "BetaPreview"),
+        previews = declared("AlphaPreview", "BetaPreview"),
       )
 
     assertTrue(outcome is DaemonA11yFetcher.Outcome.Ok, "expected Ok, got $outcome")
@@ -108,7 +116,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
       )
 
     assertTrue(outcome is DaemonA11yFetcher.Outcome.Ok, "expected Ok, got $outcome")
@@ -130,7 +138,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
       )
 
     assertTrue(outcome is DaemonA11yFetcher.Outcome.DescriptorMissing)
@@ -162,7 +170,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview", "BetaPreview"),
+        previews = declared("AlphaPreview", "BetaPreview"),
       )
 
     assertTrue(outcome is DaemonA11yFetcher.Outcome.Ok, "expected Ok, got $outcome")
@@ -192,7 +200,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview", "BetaPreview"),
+        previews = declared("AlphaPreview", "BetaPreview"),
       )
 
     assertTrue(outcome is DaemonA11yFetcher.Outcome.Ok, "expected Ok, got $outcome")
@@ -203,6 +211,152 @@ class DaemonA11yFetcherTest {
         File(projectDir, "build/compose-previews/accessibility.json").readText(),
       )
     assertNull(report.status, "partial success should not stamp a status")
+  }
+
+  // ---------- permutations are fetched at their own overrides (#3762) ----------
+
+  @Test
+  fun `a permutation is addressed as its declared preview and filed under its own id`() {
+    val projectDir = newTempFolder("module-permutation")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+
+    val factory = FakeFactory(mapOf("Foo" to atfPayload(emptyList())))
+    val outcome =
+      DaemonA11yFetcher(factory = factory)
+        .fetch(
+          projectDir = projectDir,
+          modulePath = "",
+          moduleName = "sample",
+          previews =
+            listOf(
+              ReportCommand.RequestedPreview("Foo", "Foo"),
+              ReportCommand.RequestedPreview(
+                "Foo",
+                "Foo_dark",
+                PreviewOverrides(uiMode = ee.schimke.composeai.daemon.protocol.UiMode.DARK),
+              ),
+            ),
+        )
+
+    assertTrue(outcome is DaemonA11yFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    // The daemon only knows `Foo` — `PreviewIndex.byId` is an exact lookup — so both fetches
+    // address it, and the permutation carries its configuration in the params bag instead.
+    assertEquals(listOf("Foo", "Foo"), factory.calls.map { it.previewId })
+    val overrideParams = factory.calls.first { it.params != null }.params!!.jsonObject
+    assertEquals(
+      "dark",
+      overrideParams[DataFetchParams.PARAM_OVERRIDES]
+        ?.jsonObject
+        ?.get("uiMode")
+        ?.jsonPrimitive
+        ?.content,
+    )
+    // ...and the artefact is forced fresh, since the shared per-preview file may hold the other
+    // configuration's render.
+    assertEquals(
+      true,
+      overrideParams[DataFetchParams.PARAM_FORCE_RERENDER]?.jsonPrimitive?.content?.toBoolean(),
+    )
+    // The report is keyed by what a consumer looks up.
+    assertEquals(
+      setOf("Foo", "Foo_dark"),
+      readReport(projectDir).entries.map { it.previewId }.toSet(),
+    )
+  }
+
+  @Test
+  fun `the declared preview is fetched last so its artefacts are the ones left on disk`() {
+    val projectDir = newTempFolder("module-permutation-order")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+    val dataDir = File(projectDir, "build/compose-previews/data/Foo")
+
+    // Stand in for the daemon: every render writes the overlay to `data/<previewId>/`, keyed by the
+    // id it was asked for rather than by the overrides — which is exactly why they collide.
+    val factory =
+      FakeFactory(
+        payloads = mapOf("Foo" to atfPayload(emptyList())),
+        onFetch = { _, ordinal ->
+          dataDir.mkdirs()
+          File(dataDir, "a11y-overlay.png").writeBytes("render-$ordinal".toByteArray())
+        },
+      )
+
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo"),
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f)),
+          ),
+      )
+
+    // The permutation kept a copy of its own render...
+    assertEquals(
+      "render-1",
+      File(projectDir, "build/compose-previews/data/Foo_dark/a11y-overlay.png").readText(),
+    )
+    // ...and `data/Foo/` ends up holding the declared preview's, because it was fetched last.
+    assertEquals("render-2", File(dataDir, "a11y-overlay.png").readText())
+    val report = readReport(projectDir)
+    assertEquals(
+      "data/Foo_dark/a11y-overlay.png",
+      report.entries.single { it.previewId == "Foo_dark" }.annotatedPath,
+    )
+    assertEquals(
+      "data/Foo/a11y-overlay.png",
+      report.entries.single { it.previewId == "Foo" }.annotatedPath,
+    )
+  }
+
+  @Test
+  fun `each permutation keeps the findings of its own render`() {
+    val projectDir = newTempFolder("module-permutation-findings")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+
+    // Findings come back inline in the payload, so they are per-render even though every fetch
+    // addresses the same preview. Call 1 is the permutation (fetched first), call 2 the base.
+    val factory =
+      FakeFactory(
+        payloads = emptyMap(),
+        payloadByCall =
+          mapOf(
+            1 to atfPayload(listOf(finding("ERROR", "TextContrast", "dark-only"))),
+            2 to atfPayload(emptyList()),
+          ),
+      )
+
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo"),
+            ReportCommand.RequestedPreview(
+              "Foo",
+              "Foo_dark",
+              PreviewOverrides(uiMode = ee.schimke.composeai.daemon.protocol.UiMode.DARK),
+            ),
+          ),
+      )
+
+    val report = readReport(projectDir)
+    assertEquals(
+      "dark-only",
+      report.entries.single { it.previewId == "Foo_dark" }.findings.single().message,
+    )
+    assertEquals(
+      emptyList(),
+      report.entries.single { it.previewId == "Foo" }.findings,
+      "the declared preview's own render was clean",
+    )
   }
 
   // ---------- narrowed runs merge rather than clobber (#3742) ----------
@@ -232,7 +386,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
         modulePreviewIds = listOf("AlphaPreview", "BetaPreview"),
         narrowed = true,
       )
@@ -264,7 +418,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
         modulePreviewIds = listOf("AlphaPreview", "AlphaPreview_dark"),
         narrowed = false,
       )
@@ -286,7 +440,7 @@ class DaemonA11yFetcherTest {
       projectDir = projectDir,
       modulePath = "",
       moduleName = "sample",
-      previewIds = listOf("AlphaPreview"),
+      previews = declared("AlphaPreview"),
       modulePreviewIds = listOf("AlphaPreview", "BetaPreview"),
     )
 
@@ -318,7 +472,7 @@ class DaemonA11yFetcherTest {
       projectDir = projectDir,
       modulePath = "",
       moduleName = "sample",
-      previewIds = listOf("AlphaPreview", "BetaPreview"),
+      previews = declared("AlphaPreview", "BetaPreview"),
     )
 
     assertFalse(readReport(projectDir).partial)
@@ -340,7 +494,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
         modulePreviewIds = listOf("AlphaPreview", "BetaPreview"),
         narrowed = true,
       )
@@ -376,7 +530,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview", "GammaPreview"),
+        previews = declared("AlphaPreview", "GammaPreview"),
         modulePreviewIds = listOf("AlphaPreview", "BetaPreview", "GammaPreview"),
         narrowed = true,
       )
@@ -401,7 +555,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
       )
 
     val report = readReport(projectDir)
@@ -436,7 +590,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
         modulePreviewIds = listOf("AlphaPreview", "BetaPreview"),
         narrowed = true,
       )
@@ -466,7 +620,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
         modulePreviewIds = listOf("AlphaPreview", "BetaPreview"),
         narrowed = true,
       )
@@ -495,7 +649,7 @@ class DaemonA11yFetcherTest {
       projectDir = projectDir,
       modulePath = "",
       moduleName = "sample",
-      previewIds = listOf("AlphaPreview"),
+      previews = declared("AlphaPreview"),
     )
 
     // The unnarrowed run is the only thing that ever evicts an entry for a preview that no longer
@@ -519,7 +673,7 @@ class DaemonA11yFetcherTest {
           projectDir = projectDir,
           modulePath = "",
           moduleName = "sample",
-          previewIds = listOf("AlphaPreview"),
+          previews = declared("AlphaPreview"),
           modulePreviewIds = listOf("AlphaPreview", "BetaPreview"),
           narrowed = true,
         )
@@ -546,7 +700,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
         modulePreviewIds = listOf("AlphaPreview", "BetaPreview"),
         narrowed = true,
       )
@@ -568,7 +722,7 @@ class DaemonA11yFetcherTest {
         projectDir = projectDir,
         modulePath = "",
         moduleName = "sample",
-        previewIds = listOf("AlphaPreview"),
+        previews = declared("AlphaPreview"),
       )
 
     assertTrue(outcome is DaemonA11yFetcher.Outcome.OpenFailed)
@@ -582,8 +736,18 @@ class DaemonA11yFetcherTest {
   // -------------------------------------------------------------------------
   // Fake factory + session
 
-  private class FakeFactory(private val payloads: Map<String, JsonElement?>) :
-    RenderSessionFactory {
+  /** One `data/fetch` the fetcher made: the id it addressed and the params bag it sent. */
+  data class FetchCall(val previewId: String, val params: JsonElement?)
+
+  private class FakeFactory(
+    private val payloads: Map<String, JsonElement?>,
+    /** Records every fetch, in order, so a test can assert on ids, order and params. */
+    val calls: MutableList<FetchCall> = mutableListOf(),
+    /** Runs before each fetch returns — lets a test simulate the daemon writing artefacts. */
+    private val onFetch: (String, Int) -> Unit = { _, _ -> },
+    /** Payload override by call ordinal, for asserting per-permutation results differ. */
+    private val payloadByCall: Map<Int, JsonElement?> = emptyMap(),
+  ) : RenderSessionFactory {
     override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
 
     override fun open(config: RenderSessionConfig): RenderSession =
@@ -591,6 +755,9 @@ class DaemonA11yFetcherTest {
         workspaceRoot = config.workspaceRoot.absolutePath,
         modulePath = ":sample",
         payloads = payloads,
+        calls = calls,
+        onFetch = onFetch,
+        payloadByCall = payloadByCall,
       )
   }
 
@@ -612,7 +779,13 @@ class DaemonA11yFetcherTest {
     override val workspaceRoot: String,
     override val modulePath: String,
     private val payloads: Map<String, JsonElement?>,
+    val calls: MutableList<FetchCall> = mutableListOf(),
+    private val onFetch: (String, Int) -> Unit = { _, _ -> },
+    private val payloadByCall: Map<Int, JsonElement?> = emptyMap(),
   ) : RenderSession {
+    fun payloadFor(previewId: String, ordinal: Int): JsonElement? =
+      if (payloadByCall.containsKey(ordinal)) payloadByCall[ordinal] else payloads[previewId]
+
     override val initializeResult: InitializeResult =
       InitializeResult(
         protocolVersion = 2,
@@ -649,8 +822,15 @@ class DaemonA11yFetcherTest {
       inline: Boolean,
       params: JsonElement?,
       timeout: kotlin.time.Duration,
-    ): DataFetchResult =
-      DataFetchResult(kind = kind, schemaVersion = 1, payload = payloads[previewId])
+    ): DataFetchResult {
+      calls += FetchCall(previewId, params)
+      onFetch(previewId, calls.size)
+      return DataFetchResult(
+        kind = kind,
+        schemaVersion = 1,
+        payload = payloadFor(previewId, calls.size),
+      )
+    }
 
     override fun subscribeData(
       previewId: String,


### PR DESCRIPTION
Fixes #3762.

## What was wrong

`--permutations accessibility` synthesises `Foo_dark` / `Foo_rtl` / `Foo_fontscale-2x` client-side, and the *point* of those variants is that a11y differs across them — dark-mode contrast, RTL layout, 2× font scale. The daemon has never heard of them: `PreviewIndex.byId` resolves against the plugin-written `previews.json`, so a fetch for `Foo_dark` came back "unknown preview".

A full run got away with it — the base ids it also fetched succeeded, and the failures landed as empty-findings rows that read as *clean*. A narrowed run had no cover and failed outright. Either way the variant was never actually checked.

## Why this turned out to be doable CLI-side

The issue assumed this needed override-aware artefact naming in the daemon first. It doesn't, for the fetch itself: `data/fetch` already decodes `PreviewOverrides` out of its params bag and threads them into the re-render for **any** `requiresRerender` kind, which `a11y/atf` is — the serve host drives its `?scroll=long` lane exactly this way. So a permutation is fetched as its **declared** preview carrying the overrides the expansion implies, and filed under the id a consumer looks up.

The overrides are read back off the expanded `PreviewParams` rather than mapped from the id suffix, so if `expand` grows an axis the override comes along for free.

## The artefact collision, which is why this isn't just an id swap

The daemon keys `data/<previewId>/` by the id it was asked for, not by the overrides, so four renders of one preview overwrite each other's `a11y-overlay.png` and `a11y-hierarchy.json`. Two things keep it honest:

- **Permutations are fetched before the declared preview**, so the file left in `data/Foo/` is `Foo`'s own render — the entry keyed by that id gets the artefacts that belong to it.
- **Each permutation's artefacts are copied to `data/<entryId>/` as soon as its fetch returns**, before the next render replaces them. `fetchData` returns after the render completes, so there's nothing racy about the copy.

Findings never needed any of this — they come back inline in the payload, which is why a permutation still reports correctly even if its artefact copy fails.

Coverage already measured itself against the expanded id space (from #3757), so `partial` now reports genuine per-permutation results instead of flagging every synthetic id as unchecked. The substitution warning added when this gap was documented is deleted along with the gap.

## Test plan

- [x] `./gradlew :cli:test` — full CLI suite green.
- [x] `DaemonA11yFetcherTest` — a permutation is addressed as its declared preview while filed under its own id, with `uiMode: dark` and a forced re-render in the params bag; the declared preview is fetched last so `data/Foo/` holds its render while `data/Foo_dark/` holds the permutation's, and each entry's `annotatedPath` points at its own; each permutation keeps the findings of its own render (a dark-only finding lands on `Foo_dark`, and `Foo` stays clean).
- [x] `A11yCommandTest` — `--id Foo_dark` produces `previewId=Foo, entryId=Foo_dark, overrides.uiMode=DARK`; each accessibility permutation carries the configuration it stands for (`_dark`→uiMode, `_rtl`→`ar-XB`, `_fontscale-2x`→2.0) while every fetch addresses the one declared preview; `--filter Foo` now fetches all four variants rather than deduplicating them to one; coverage still measured against the consumer id space; the old substitution warning is gone.
- [x] `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest`.

**Not verified end-to-end**, and worth a reviewer's eye: ATF fetches are unreliable in this container (each blows the 30s re-render budget), so I could not confirm against a live daemon that the ATF findings genuinely differ between, say, a light and dark render of the same preview. The plumbing is unit-tested and the daemon-side override path is the one the serve host already uses in production, but the end-to-end claim rests on that rather than on a run I did.

Not visual — CLI orchestration and its tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_