### PR TITLE
fix(cli): report the render error sidecar instead of guessing NO-SOURCE

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1252,26 +1252,16 @@ class ShowCommand(args: List<String>) : Command(args) {
       val policy = missingRendersPolicy?.lowercase()
       val prefix =
         if (policy in setOf("warn", "ignore")) "missing-renders policy=$policy — " else ""
-      System.err.println(
-        "${prefix}Render task completed but produced no PNG for ${missing.size} of " +
-          "${filtered.size} preview(s):"
-      )
       // List the offenders so the CI log is self-diagnosing — no need to download the
-      // `composePreviewRender-reports` artifact just to learn *which* previews failed.
-      for (r in missing) {
-        val nullCoords =
-          r.captures
-            .filter { it.pngPath == null && !it.optional }
-            .joinToString(", ") { captureCoordLabel(it) }
-            .ifEmpty { "default" }
-        val moduleTag = if (r.module.isNotBlank()) " (${r.module})" else ""
-        System.err.println("  - ${r.id}$moduleTag — no PNG for: $nullCoords")
-      }
+      // `composePreviewRender-reports` artifact just to learn *which* previews failed — and read
+      // the renderer's `.error.json` sidecar beside each one so a preview that rendered and *threw*
+      // reports its exception instead of the NO-SOURCE build-wiring guess (issue #3741).
       System.err.println(
-        "Check the Gradle output above — a common cause is the `composePreviewRender` task " +
-          "reporting NO-SOURCE, which means the renderer test class wasn't found on " +
-          "testClassesDirs. Per-preview stack traces are in the `composePreviewRender-reports` " +
-          "artifact attached to the run."
+        formatMissingRenderReport(
+          collectMissingRenders(missing, outcome.manifests),
+          total = filtered.size,
+          prefix = prefix,
+        )
       )
       System.out.flush()
       if (shouldFailOnMissingRenders()) exitProcess(2)
@@ -1478,10 +1468,15 @@ class RenderCommand(args: List<String>) : Command(args) {
           val policy = missingRendersPolicy?.lowercase()
           val prefix =
             if (policy in setOf("warn", "ignore")) "missing-renders policy=$policy — " else ""
+          // Same report `show` prints: the `.error.json` sidecar beside each would-be output tells
+          // "the preview threw" apart from "the render task never ran" (issue #3741).
           System.err.println(
-            "${prefix}Render task completed but produced no PNG for ${missing.size} preview(s):"
+            formatMissingRenderReport(
+              collectMissingRenders(missing, manifests),
+              total = filtered.size,
+              prefix = prefix,
+            )
           )
-          for (r in missing) System.err.println("  ${r.id}")
           if (shouldFailOnMissingRenders()) exitProcess(2)
         }
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
@@ -1,0 +1,354 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.cli.serve.RenderFailureFrame
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/*
+ * Why this file exists (issue #3741).
+ *
+ * When a preview renders nothing, `show` / `render` used to print one fixed paragraph blaming the
+ * *build wiring* ("`composePreviewRender` reported NO-SOURCE, the renderer test class wasn't on
+ * testClassesDirs"). That guess is wrong whenever the render task actually ran and the preview
+ * threw — and in that case the renderer has already written the precise cause next to where the
+ * PNG would have gone:
+ *
+ *   <module>/build/compose-previews/renders/<Stem>.png.error.json
+ *
+ * The two cases want opposite remedies (fix the classpath vs. fix the composable), so the report
+ * distinguishes them explicitly: a sidecar means "rendered and threw — build wiring is fine", no
+ * sidecar means "the task really was skipped" and keeps the historical NO-SOURCE guidance.
+ */
+
+/**
+ * The renderer's per-preview `compose-preview-error/v1` sidecar, as the CLI reads it.
+ *
+ * Mirrors the writer (`renderer-android/.../RenderErrorSidecar.kt`, the desktop equivalent in
+ * `DesktopRendererMain.kt`) and the schema owned by the gradle plugin
+ * (`gradle-plugin/.../PreviewRenderError.kt`) — `:gradle-plugin` is a separate included build, so
+ * the CLI cannot depend on that type. Only the fields this report consumes are modelled;
+ * `ignoreUnknownKeys` keeps a newer renderer's extra fields harmless. The frame type is the
+ * serve-side [RenderFailureFrame] rather than a second `file`/`line`/`function` triple.
+ */
+@Serializable
+data class RenderErrorSidecar(
+  val schema: String = "",
+  val exception: String = "",
+  val message: String = "",
+  val topAppFrame: RenderFailureFrame? = null,
+  /**
+   * The renderer's one-sentence explanation when the failure was a native-library load rather than
+   * the preview's own code. Empty for an ordinary preview throw and for older sidecars.
+   */
+  val diagnosis: String = "",
+  /** Full `Throwable.printStackTrace()` text, including any `Caused by:` chain. */
+  val stackTrace: String = "",
+)
+
+/**
+ * One preview that produced no PNG, paired with whatever the renderer left beside its would-be
+ * output. [sidecar] is `null` when no `.error.json` was found — the "render was skipped" case.
+ */
+data class MissingRender(
+  val id: String,
+  val module: String,
+  /** Human-readable capture coordinates that came back empty, e.g. `default`, `500ms`. */
+  val coords: String,
+  /** The preview's own class FQN — used to pick a stack frame in the *user's* package. */
+  val className: String = "",
+  val sidecar: RenderErrorSidecar? = null,
+)
+
+/** One `Caused by:` entry of a stack trace. */
+data class RenderErrorCause(val exception: String, val message: String)
+
+/** Sidecar file name suffix: the would-be output path with `.error.json` appended. */
+const val RENDER_ERROR_SIDECAR_SUFFIX: String = ".error.json"
+
+private const val RENDER_ERROR_SCHEMA_PREFIX = "compose-preview-error/"
+
+private val sidecarJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * Read the `<output>.error.json` sidecar beside [expectedOutput] (the absolute path the PNG / data
+ * product *would* have been written to). Returns `null` when there is no sidecar, when it is
+ * unreadable, or when its schema isn't a `compose-preview-error` version — all of which mean "we
+ * learned nothing here", never "the render succeeded".
+ */
+fun readRenderErrorSidecar(
+  expectedOutput: File,
+  fileSystem: FileSystem = SystemFileSystem,
+): RenderErrorSidecar? {
+  val path = (expectedOutput.path + RENDER_ERROR_SIDECAR_SUFFIX).toPath()
+  if (!fileSystem.exists(path)) return null
+  val text = runCatching { fileSystem.read(path) { readUtf8() } }.getOrNull() ?: return null
+  val decoded =
+    runCatching { sidecarJson.decodeFromString(RenderErrorSidecar.serializer(), text) }.getOrNull()
+      ?: return null
+  return decoded.takeIf { it.schema.startsWith(RENDER_ERROR_SCHEMA_PREFIX) }
+}
+
+/**
+ * Pair each missing preview with its sidecar, looking beside every output the manifest says that
+ * preview should have produced (each capture's `renderOutput`, then its data products). The first
+ * sidecar found wins — one broken composable fails all of its outputs with the same throwable.
+ *
+ * Uses the manifest rather than the [PreviewResult] because a missing capture carries no path:
+ * `pngPath` is null precisely because the file isn't there, so the *expected* location has to come
+ * from `renderOutput` resolved against the module's `build/compose-previews` directory — the same
+ * resolution [PreviewResultBuilder.build] does for outputs that exist.
+ */
+fun collectMissingRenders(
+  missing: List<PreviewResult>,
+  manifests: List<Pair<PreviewModule, PreviewManifest>>,
+  fileSystem: FileSystem = SystemFileSystem,
+): List<MissingRender> {
+  val moduleByPath = manifests.associate { (module, _) -> module.gradlePath to module }
+  val previewsByModule = manifests.associate { (module, manifest) ->
+    module.gradlePath to manifest.previews.associateBy { it.id }
+  }
+  return missing.map { result ->
+    val module = moduleByPath[result.module]
+    val preview = previewsByModule[result.module]?.get(result.id)
+    val relativeOutputs =
+      buildList {
+          preview?.captures?.forEach { if (it.renderOutput.isNotEmpty()) add(it.renderOutput) }
+          preview?.dataProducts?.forEach { if (it.output.isNotEmpty()) add(it.output) }
+          // Manifests written before `renderOutput` was mandatory, and previews whose captures were
+          // globbed away entirely, still render to the default stem.
+          add("renders/${result.id}.png")
+        }
+        .distinct()
+    val sidecar = module?.let { m ->
+      relativeOutputs.firstNotNullOfOrNull { rel ->
+        readRenderErrorSidecar(m.projectDir.resolve("build/compose-previews/$rel"), fileSystem)
+      }
+    }
+    MissingRender(
+      id = result.id,
+      module = result.module,
+      coords = missingCaptureCoords(result),
+      className = result.className,
+      sidecar = sidecar,
+    )
+  }
+}
+
+/** The capture coordinates of [result] that came back without a PNG, for the offender list. */
+internal fun missingCaptureCoords(result: PreviewResult): String =
+  result.captures
+    .filter { it.pngPath == null && !it.optional }
+    .joinToString(", ") { captureCoordLabel(it) }
+    .ifEmpty { "default" }
+
+/**
+ * The stderr report for a run that produced no PNG for [missing] of [total] previews. Pure function
+ * over already-read sidecars — the disk read lives in [readRenderErrorSidecar] — so the wording of
+ * both branches is unit-testable without standing up a Gradle render.
+ *
+ * [prefix] carries the `missing-renders policy=…` tag when the policy opts the exit code down.
+ */
+fun formatMissingRenderReport(
+  missing: List<MissingRender>,
+  total: Int,
+  prefix: String = "",
+): String {
+  val sb = StringBuilder()
+  sb
+    .append(prefix)
+    .append("Render task completed but produced no PNG for ")
+    .append(missing.size)
+    .append(" of ")
+    .append(total)
+    .append(" preview(s):")
+  for (entry in missing) {
+    val moduleTag = if (entry.module.isNotBlank()) " (${entry.module})" else ""
+    sb.append("\n  - ").append(entry.id).append(moduleTag).append(" — no PNG for: ")
+    sb.append(entry.coords)
+    entry.sidecar?.let { sb.appendSidecarDetail(it, entry.className) }
+  }
+  val threw = missing.filter { it.sidecar != null }
+  val skipped = missing.filter { it.sidecar == null }
+  if (threw.isNotEmpty()) {
+    // The whole point of issue #3741: an error sidecar proves the render task ran, so the
+    // NO-SOURCE / testClassesDirs guidance below must NOT be printed for these.
+    sb
+      .append("\n")
+      .append(threw.size)
+      .append(" preview(s) rendered and then threw — the build wiring is fine. Full stack traces ")
+      .append("are in the `<render>.png")
+      .append(RENDER_ERROR_SIDECAR_SUFFIX)
+      .append("` sidecar beside each preview's would-be output.")
+  }
+  if (skipped.isNotEmpty()) {
+    if (threw.isNotEmpty()) {
+      sb
+        .append("\nNo error sidecar for ")
+        .append(skipped.size)
+        .append(" preview(s) (")
+        .append(skipped.take(5).joinToString(", ") { it.id })
+        .append(if (skipped.size > 5) ", …): " else "): ")
+    } else {
+      sb.append("\n")
+    }
+    sb.append(
+      "Check the Gradle output above — a common cause is the `composePreviewRender` task " +
+        "reporting NO-SOURCE, which means the renderer test class wasn't found on " +
+        "testClassesDirs. Per-preview stack traces are in the `composePreviewRender-reports` " +
+        "artifact attached to the run."
+    )
+  }
+  return sb.toString()
+}
+
+/**
+ * The `threw X: msg (at File.kt:42 in fn)` detail lines for one failing preview.
+ *
+ * Leads with the **root** cause rather than the outermost throwable: the renderer invokes the
+ * preview reflectively, so the outer exception is routinely a `InvocationTargetException` that says
+ * nothing at all, while the last `Caused by:` in the trace is the real failure (issue #3741's case:
+ * `NoClassDefFoundError: com/google/wear/services/ambient/AmbientComponentState`).
+ */
+private fun StringBuilder.appendSidecarDetail(sidecar: RenderErrorSidecar, className: String) {
+  val chain = causeChainOf(sidecar.stackTrace)
+  val root = chain.lastOrNull()
+  val exception = root?.exception?.takeIf { it.isNotBlank() } ?: sidecar.exception
+  val message = if (root != null) root.message else sidecar.message
+  val frame = preferredAppFrame(sidecar.stackTrace, className) ?: sidecar.topAppFrame
+  append("\n      threw ").append(exception.substringAfterLast('.'))
+  if (message.isNotBlank()) append(": ").append(message)
+  if (frame != null && frame.file.isNotBlank()) {
+    append(" (at ").append(frame.file)
+    if (frame.line > 0) append(':').append(frame.line)
+    if (frame.function.isNotBlank()) append(" in ").append(frame.function)
+    append(')')
+  }
+  if (chain.isNotEmpty()) {
+    // The whole `Caused by:` chain, outermost first — the wrapper says *how* the renderer reached
+    // the failure (reflective invoke, class initialisation), which the root cause alone hides.
+    val names =
+      (listOf(sidecar.exception) + chain.map { it.exception })
+        .filter { it.isNotBlank() }
+        .map { it.substringAfterLast('.') }
+    append("\n        chain: ").append(names.joinToString(" → "))
+  }
+  if (sidecar.diagnosis.isNotBlank()) append("\n        ").append(sidecar.diagnosis)
+}
+
+/**
+ * Every `Caused by:` entry of [stackTrace], outermost cause first. Empty when the trace carries no
+ * cause chain — the outermost throwable is then the whole story and the sidecar's own `exception` /
+ * `message` already describe it.
+ */
+fun causeChainOf(stackTrace: String): List<RenderErrorCause> =
+  stackTrace
+    .lineSequence()
+    .map { it.trim() }
+    .filter { it.startsWith(CAUSED_BY_PREFIX) }
+    .map { header ->
+      val body = header.removePrefix(CAUSED_BY_PREFIX).trim()
+      val split = body.indexOf(": ")
+      if (split < 0) RenderErrorCause(body, "")
+      else RenderErrorCause(body.substring(0, split), body.substring(split + 2).trim())
+    }
+    .toList()
+
+/**
+ * The deepest `Caused by:` entry of [stackTrace] — the failure worth leading with, since the outer
+ * throwable is routinely a reflective wrapper. `null` when the trace has no cause chain.
+ */
+fun rootCauseOf(stackTrace: String): RenderErrorCause? = causeChainOf(stackTrace).lastOrNull()
+
+/**
+ * The first stack frame belonging to the *user's own* package, searching the deepest `Caused by:`
+ * section first.
+ *
+ * The renderer's `topAppFrame` is computed from the outermost throwable's frames with a
+ * skip-the-framework-prefixes heuristic, which lands on whichever tooling frame invoked the
+ * composable — in issue #3741 that was `KeyboardDataProduct.kt:148`, a data-product frame in *this*
+ * project, while the frame worth showing was the consumer's `AmbientAwareActivity.kt:76`. Anchoring
+ * on the preview class's own package instead makes the one-line summary point at a file the user
+ * can open. Package prefixes are tried longest-first (exact package, then parents down to two
+ * segments) so a sibling package of the preview still counts, but `com.` never does.
+ *
+ * Returns `null` when nothing matches, leaving the sidecar's `topAppFrame` as the fallback.
+ */
+fun preferredAppFrame(stackTrace: String, previewClassName: String): RenderFailureFrame? {
+  val prefixes = packagePrefixesOf(previewClassName)
+  if (prefixes.isEmpty() || stackTrace.isBlank()) return null
+  val sections = traceSections(stackTrace)
+  for (section in sections.asReversed()) {
+    for (prefix in prefixes) {
+      val frame = section.firstNotNullOfOrNull { line ->
+        parseFrame(line)?.takeIf { it.className.startsWith("$prefix.") }
+      }
+      if (frame != null) {
+        return RenderFailureFrame(file = frame.file, line = frame.line, function = frame.function)
+      }
+    }
+  }
+  return null
+}
+
+private const val CAUSED_BY_PREFIX = "Caused by:"
+
+/**
+ * Split a printed stack trace into its throwable sections: the outermost throwable first, then one
+ * per `Caused by:`. `Suppressed:` blocks stay attached to the section they were printed in — they
+ * are not part of the cause chain the report walks.
+ */
+private fun traceSections(stackTrace: String): List<List<String>> {
+  val sections = mutableListOf<MutableList<String>>(mutableListOf())
+  for (line in stackTrace.lineSequence()) {
+    if (line.trim().startsWith(CAUSED_BY_PREFIX)) sections += mutableListOf<String>()
+    sections.last() += line
+  }
+  return sections
+}
+
+private data class ParsedFrame(
+  val className: String,
+  val function: String,
+  val file: String,
+  val line: Int,
+)
+
+/** `\tat com.example.Foo$bar.invoke(Foo.kt:42)` → its parts; `null` for any other line. */
+private fun parseFrame(line: String): ParsedFrame? {
+  val match = FRAME_REGEX.find(line) ?: return null
+  val (qualified, location) = match.destructured
+  val className = qualified.substringBeforeLast('.', "")
+  val function = qualified.substringAfterLast('.')
+  if (className.isEmpty()) return null
+  val colon = location.lastIndexOf(':')
+  val file = if (colon > 0) location.substring(0, colon) else location
+  val lineNumber = if (colon > 0) location.substring(colon + 1).toIntOrNull() ?: 0 else 0
+  // `(Unknown Source)` / `(Native Method)` carry no file — useless as a "open this file" pointer.
+  if (lineNumber <= 0) return null
+  return ParsedFrame(className, function, file, lineNumber)
+}
+
+/**
+ * `at [<module>/]<class>.<method>(<file>:<line>)`. The optional leading group swallows the
+ * classloader / module qualifier a JPMS-aware JVM prints (`app//com.example.Foo.bar(...)`,
+ * `java.base@17/java.lang.reflect.Method.invoke(...)`) — `/` never appears in a class name, so it
+ * is unambiguous.
+ */
+private val FRAME_REGEX = Regex("""^\s*at\s+(?:[\w.@$]*/{1,2})?([\w$.<>-]+)\(([^()]*)\)""")
+
+/**
+ * Package prefixes to accept as "the user's own code", longest first: the preview class's package,
+ * then each parent down to two segments. Two is the floor because a one-segment prefix (`com`,
+ * `org`) would match every library on the classpath.
+ */
+private fun packagePrefixesOf(className: String): List<String> {
+  val pkg = className.substringBeforeLast('.', "")
+  if (pkg.isEmpty()) return emptyList()
+  val segments = pkg.split('.')
+  if (segments.size < 2) return emptyList()
+  return (segments.size downTo 2).map { segments.take(it).joinToString(".") }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
@@ -1,0 +1,299 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #3741: a preview that produced no PNG used to be reported with one fixed paragraph blaming
+ * the build wiring ("`composePreviewRender` reported NO-SOURCE — the renderer test class wasn't on
+ * testClassesDirs"), even when the renderer had already written the precise cause to
+ * `<render>.png.error.json` beside the would-be output.
+ *
+ * These cover the seam that decides between the two: [collectMissingRenders] reads the sidecar off
+ * disk, [formatMissingRenderReport] turns "expected output + sidecar (or none)" into the message.
+ */
+class MissingRenderReportTest {
+
+  private lateinit var workspace: File
+  private lateinit var moduleDir: File
+
+  @BeforeTest
+  fun setUp() {
+    workspace = createTempDirectory("missing-render-report").toFile()
+    moduleDir = workspace.resolve("app").apply { mkdirs() }
+  }
+
+  @AfterTest
+  fun tearDown() {
+    workspace.deleteRecursively()
+  }
+
+  // The failure reported in issue #3741, verbatim in shape: the renderer invokes the preview
+  // reflectively, so the outermost throwable is a useless InvocationTargetException whose only
+  // stack frames belong to this project's own data-product plumbing, while the cause chain names
+  // the real problem (a Wear Services class that only exists on-device) and passes through the
+  // consumer's own source file.
+  private val wearStackTrace =
+    """
+    java.lang.reflect.InvocationTargetException
+    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
+    	at ee.schimke.composeai.renderer.KeyboardDataProduct.AroundComposable${'$'}lambda${'$'}2(KeyboardDataProduct.kt:148)
+    Caused by: java.lang.NoClassDefFoundError: com/google/wear/services/ambient/AmbientComponentState
+    	at com.example.wear.ambient.AmbientAwareActivity.rememberAmbientState(AmbientAwareActivity.kt:76)
+    	at com.example.wear.WearAppKt.WearApp(WearApp.kt:31)
+    	at androidx.compose.runtime.ComposerImpl.doCompose(Composer.kt:3300)
+    """
+      .trimIndent()
+
+  private fun sidecarJson(stackTrace: String = wearStackTrace) =
+    """
+    {
+      "schema": "compose-preview-error/v1",
+      "exception": "java.lang.reflect.InvocationTargetException",
+      "message": "",
+      "topAppFrame": {
+        "file": "KeyboardDataProduct.kt",
+        "line": 148,
+        "function": "AroundComposable${'$'}lambda${'$'}2"
+      },
+      "stackTrace": ${escapeJson(stackTrace)}
+    }
+    """
+      .trimIndent()
+
+  private fun escapeJson(text: String): String =
+    '"' + text.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n") + '"'
+
+  private val previewId = "com.example.wear.WearAppKt.WearAppPreview_Devices - Large Round"
+
+  private fun manifests(renderOutput: String = "renders/WearAppPreview.png") =
+    listOf(
+      PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
+        PreviewManifest(
+          module = ":app",
+          variant = "debug",
+          previews =
+            listOf(
+              PreviewInfo(
+                id = previewId,
+                functionName = "WearAppPreview",
+                className = "com.example.wear.WearAppKt",
+                captures = listOf(Capture(renderOutput = renderOutput)),
+              )
+            ),
+        )
+    )
+
+  private fun missingResult(id: String = previewId) =
+    PreviewResult(
+      id = id,
+      module = ":app",
+      functionName = "WearAppPreview",
+      className = "com.example.wear.WearAppKt",
+      captures = listOf(CaptureResult(pngPath = null)),
+    )
+
+  private fun writeSidecar(relative: String, json: String = sidecarJson()) {
+    val file = moduleDir.resolve("build/compose-previews/$relative$RENDER_ERROR_SIDECAR_SUFFIX")
+    file.parentFile.mkdirs()
+    file.writeText(json)
+  }
+
+  @Test
+  fun `an error sidecar beside the expected output replaces the NO-SOURCE guess`() {
+    writeSidecar("renders/WearAppPreview.png")
+
+    val entries = collectMissingRenders(listOf(missingResult()), manifests())
+    val message = formatMissingRenderReport(entries, total = 35)
+
+    // The whole point of the issue: the render task demonstrably ran (it wrote a sidecar), so the
+    // build-wiring guess must not be printed at all.
+    assertFalse(message.contains("NO-SOURCE"), message)
+    assertFalse(message.contains("testClassesDirs"), message)
+    assertContains(message, "1 of 35 preview(s)")
+    // The real cause, from the `Caused by:` chain — not the reflective wrapper the sidecar's own
+    // `exception` field names.
+    assertContains(message, "NoClassDefFoundError")
+    assertContains(message, "com/google/wear/services/ambient/AmbientComponentState")
+    assertContains(message, "chain: InvocationTargetException → NoClassDefFoundError")
+    // And the consumer's own frame rather than the data-product frame `topAppFrame` recorded.
+    assertContains(message, "AmbientAwareActivity.kt:76")
+    assertFalse(message.contains("KeyboardDataProduct.kt"), message)
+    assertContains(message, "rendered and then threw")
+  }
+
+  @Test
+  fun `no sidecar keeps the historical NO-SOURCE guidance`() {
+    // Nothing written to disk: the render task really was skipped.
+    val entries = collectMissingRenders(listOf(missingResult()), manifests())
+    assertNull(entries.single().sidecar)
+
+    val message = formatMissingRenderReport(entries, total = 35)
+
+    assertContains(message, "NO-SOURCE")
+    assertContains(message, "testClassesDirs")
+    assertContains(message, previewId)
+    assertFalse(message.contains("rendered and then threw"), message)
+  }
+
+  @Test
+  fun `a mixed run reports both causes and never blames the wiring for the thrower`() {
+    writeSidecar("renders/WearAppPreview.png")
+    // The second preview isn't in the manifest and has no sidecar anywhere — the skip case.
+    val skipped = missingResult(id = "com.example.wear.WearAppKt.OtherPreview")
+    val entries = collectMissingRenders(listOf(missingResult(), skipped), manifests())
+    assertNotNull(entries.first().sidecar)
+    assertNull(entries.last().sidecar)
+
+    val message = formatMissingRenderReport(entries, total = 35)
+
+    assertContains(message, "NoClassDefFoundError")
+    // The skip-class entry keeps its own guidance, scoped to the previews it applies to.
+    assertContains(message, "No error sidecar for 1 preview(s)")
+    assertContains(message, "NO-SOURCE")
+    assertContains(message, "1 preview(s) rendered and then threw")
+  }
+
+  @Test
+  fun `the sidecar is found beside a data product output too`() {
+    // A preview whose only declared output is a data product (no capture renderOutput) still gets
+    // its sidecar found — the renderer writes it beside whichever artefact it was producing.
+    val manifests =
+      listOf(
+        PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
+          PreviewManifest(
+            module = ":app",
+            variant = "debug",
+            previews =
+              listOf(
+                PreviewInfo(
+                  id = previewId,
+                  functionName = "WearAppPreview",
+                  className = "com.example.wear.WearAppKt",
+                  captures = listOf(Capture(renderOutput = "")),
+                  dataProducts =
+                    listOf(PreviewDataProduct(kind = "gif", output = "data/anim/Wear.gif")),
+                )
+              ),
+          )
+      )
+    writeSidecar("data/anim/Wear.gif")
+
+    val entries = collectMissingRenders(listOf(missingResult()), manifests)
+
+    assertNotNull(entries.single().sidecar)
+  }
+
+  @Test
+  fun `an unreadable or foreign sidecar is treated as absent`() {
+    val png = moduleDir.resolve("build/compose-previews/renders/WearAppPreview.png")
+    png.parentFile.mkdirs()
+
+    assertNull(readRenderErrorSidecar(png), "no sidecar on disk")
+
+    writeSidecar("renders/WearAppPreview.png", json = "{ not json at all ")
+    assertNull(readRenderErrorSidecar(png), "unparseable sidecar")
+
+    writeSidecar(
+      "renders/WearAppPreview.png",
+      json = """{"schema":"some-other-tool/v9","exception":"Boom","stackTrace":""}""",
+    )
+    assertNull(readRenderErrorSidecar(png), "foreign schema")
+
+    writeSidecar("renders/WearAppPreview.png")
+    assertEquals(
+      "java.lang.reflect.InvocationTargetException",
+      readRenderErrorSidecar(png)?.exception,
+    )
+  }
+
+  @Test
+  fun `the cause chain is read outermost-first with the root last`() {
+    val chain = causeChainOf(wearStackTrace)
+    assertEquals(1, chain.size)
+    assertEquals("java.lang.NoClassDefFoundError", chain.single().exception)
+    assertEquals("com/google/wear/services/ambient/AmbientComponentState", chain.single().message)
+
+    val nested =
+      wearStackTrace +
+        "\nCaused by: java.lang.ClassNotFoundException: com.google.wear.services.ambient." +
+        "AmbientComponentState\n\tat java.base/jdk.internal.loader.ClassLoaders" +
+        "${'$'}AppClassLoader.loadClass(ClassLoaders.java:641)"
+    assertEquals("java.lang.ClassNotFoundException", rootCauseOf(nested)?.exception)
+    assertEquals(2, causeChainOf(nested).size)
+    // No `Caused by:` at all — the outermost throwable is the whole story.
+    assertNull(rootCauseOf("java.lang.IllegalStateException: boom\n\tat A.b(A.kt:1)"))
+  }
+
+  @Test
+  fun `the preferred frame is the deepest one in the preview's own package`() {
+    val frame = preferredAppFrame(wearStackTrace, "com.example.wear.WearAppKt")
+    assertNotNull(frame)
+    // `com.example.wear.ambient` is a sibling package of the preview's own, reached by walking the
+    // package prefix outwards — and it sits deeper in the cause chain than `WearAppKt.WearApp`.
+    assertEquals("AmbientAwareActivity.kt", frame.file)
+    assertEquals(76, frame.line)
+    assertEquals("rememberAmbientState", frame.function)
+
+    // A preview class that shares nothing with any frame leaves the sidecar's own topAppFrame as
+    // the fallback (the caller does that; here the chooser simply declines).
+    assertNull(preferredAppFrame(wearStackTrace, "zz.unrelated.PreviewsKt"))
+    assertNull(preferredAppFrame(wearStackTrace, "NoPackagePreviews"))
+  }
+
+  @Test
+  fun `frame lines with no source location are skipped`() {
+    val trace =
+      """
+      java.lang.RuntimeException: boom
+      	at com.example.wear.Gen.invoke(Unknown Source)
+      	at com.example.wear.Real.render(Real.kt:12)
+      """
+        .trimIndent()
+    val frame = preferredAppFrame(trace, "com.example.wear.WearAppKt")
+    assertEquals("Real.kt", frame?.file)
+    assertEquals(12, frame?.line)
+  }
+
+  @Test
+  fun `a native-load diagnosis is surfaced alongside the exception`() {
+    val json =
+      """
+      {
+        "schema": "compose-preview-error/v1",
+        "exception": "java.lang.ExceptionInInitializerError",
+        "message": "",
+        "diagnosis": "skiko's native library could not be loaded (libGL.so.1 missing)",
+        "stackTrace": "java.lang.ExceptionInInitializerError\n\tat org.jetbrains.skia.Surface.<clinit>(Surface.kt:1)"
+      }
+      """
+        .trimIndent()
+    writeSidecar("renders/WearAppPreview.png", json)
+
+    val message =
+      formatMissingRenderReport(collectMissingRenders(listOf(missingResult()), manifests()), 35)
+
+    assertContains(message, "ExceptionInInitializerError")
+    assertContains(message, "libGL.so.1 missing")
+  }
+
+  @Test
+  fun `the policy prefix survives`() {
+    val message =
+      formatMissingRenderReport(
+        listOf(MissingRender(id = "A", module = ":app", coords = "default")),
+        total = 1,
+        prefix = "missing-renders policy=warn — ",
+      )
+    assertTrue(message.startsWith("missing-renders policy=warn — "), message)
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1854,6 +1854,13 @@ internal object ComposePreviewTasks {
      * ordinary preview throw, and for sidecars written by an older renderer.
      */
     val diagnosis: String = "",
+    /**
+     * Full `Throwable.printStackTrace()` text. Read for its `Caused by:` chain and for a stack
+     * frame in the user's own package — [exception] alone is routinely the reflective wrapper the
+     * renderer's `invoke` produced, and [topAppFrame] is derived from that wrapper's frames
+     * (issue #3741). Empty for a sidecar written by a renderer that predates the field.
+     */
+    val stackTrace: String = "",
   ) {
     @kotlinx.serialization.Serializable
     internal data class TopAppFrame(
@@ -1902,6 +1909,48 @@ internal object ComposePreviewTasks {
       if (sidecar != null) result[id] = sidecar
     }
     return result
+  }
+
+  /**
+   * What one sidecar actually says, once its stack trace has been read: the deepest `Caused by:`
+   * (or the sidecar's own exception when there is no chain), the best source frame, and a compact
+   * rendering of the chain. Also the grouping key for the per-preview list — two previews are "the
+   * same failure" when all of this matches, so one broken dependency reports itself once with a
+   * count while genuinely different bugs each keep their own line.
+   */
+  internal data class RenderErrorInsight(
+    val exception: String,
+    val message: String,
+    val frame: ErrorSidecar.TopAppFrame?,
+    /** `InvocationTargetException → NoClassDefFoundError`, or empty when there is no chain. */
+    val chain: String,
+  )
+
+  /**
+   * Read [sidecar] the way a human would: lead with the root cause rather than the reflective
+   * wrapper the renderer's `invoke` produced, and point at a frame in the preview's own package
+   * (from [previewClassName]) rather than at the tooling frame that called it. Falls back to the
+   * sidecar's own `exception` / `message` / `topAppFrame` whenever the trace offers nothing better
+   * — including for sidecars written by a renderer that predates the `stackTrace` field.
+   */
+  internal fun renderErrorInsight(
+    sidecar: ErrorSidecar,
+    previewClassName: String,
+  ): RenderErrorInsight {
+    val chain = RenderErrorTrace.causeChain(sidecar.stackTrace)
+    val root = chain.lastOrNull()
+    val names =
+      (listOf(sidecar.exception) + chain.map { it.exception })
+        .filter { it.isNotBlank() }
+        .map { it.substringAfterLast('.') }
+    return RenderErrorInsight(
+      exception = root?.exception?.takeIf { it.isNotBlank() } ?: sidecar.exception,
+      message = if (root != null) root.message else sidecar.message,
+      frame =
+        RenderErrorTrace.preferredAppFrame(sidecar.stackTrace, previewClassName)
+          ?: sidecar.topAppFrame,
+      chain = if (chain.isEmpty()) "" else names.joinToString(" → "),
+    )
   }
 
   internal fun formatMissingPreviewsMessage(
@@ -1957,25 +2006,26 @@ internal object ComposePreviewTasks {
         // and printing the first one's `at Foo.kt:12` beside a count would blame a file that has
         // nothing to do with the others. Preview order is preserved, so the first failure stays at
         // the top.
-        val groups = withSidecar.groupBy { id ->
-          val s = sidecars.getValue(id)
-          Triple(s.exception, s.message, s.topAppFrame)
+        val classNames = manifest.previews.associate { it.id to it.className }
+        val insights = withSidecar.associateWith { id ->
+          renderErrorInsight(sidecars.getValue(id), classNames[id].orEmpty())
         }
+        val groups = withSidecar.groupBy { insights.getValue(it) }
         var shown = 0
-        for ((_, ids) in groups.entries.take(5)) {
-          val s = sidecars.getValue(ids.first())
+        for ((insight, ids) in groups.entries.take(5)) {
           shown += ids.size
           sb.append("\n  - ")
           if (ids.size == 1) sb.append(ids.first()).append(": ")
-          sb.append(s.exception.substringAfterLast('.'))
-          if (s.message.isNotBlank()) sb.append(": ").append(s.message)
-          s.topAppFrame?.let { f ->
+          sb.append(insight.exception.substringAfterLast('.'))
+          if (insight.message.isNotBlank()) sb.append(": ").append(insight.message)
+          insight.frame?.let { f ->
             if (f.file.isNotBlank()) {
               sb.append(" (at ").append(f.file)
               if (f.line > 0) sb.append(':').append(f.line)
               sb.append(')')
             }
           }
+          if (insight.chain.isNotBlank()) sb.append(" — chain: ").append(insight.chain)
           if (ids.size > 1) {
             sb.append(" — ").append(ids.size).append(" previews, e.g. ")
             sb.append(ids.take(3).joinToString(", "))

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderErrorTrace.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderErrorTrace.kt
@@ -1,0 +1,118 @@
+package ee.schimke.composeai.plugin
+
+/**
+ * Reads the useful parts out of a render-error sidecar's printed stack trace: the `Caused by:`
+ * chain, and the first stack frame belonging to the *user's own* package.
+ *
+ * Both exist because the sidecar's headline fields are routinely uninformative (issue #3741). The
+ * renderer invokes each preview reflectively, so `exception` is often
+ * `java.lang.reflect.InvocationTargetException` — the actual failure lives at the end of the cause
+ * chain. And `topAppFrame` is computed with a skip-the-framework-prefixes heuristic over the
+ * *outermost* throwable's frames, which lands on whichever tooling frame did the invoking
+ * (`KeyboardDataProduct.kt:148` in the reported case) rather than on the consumer file the reader
+ * can actually open (`AmbientAwareActivity.kt:76`).
+ *
+ * Deliberately duplicated in `:cli` (`MissingRenderReport.kt`): `:gradle-plugin` is a separate
+ * included build, so there is no module both can depend on — the same reason `ErrorSidecar` mirrors
+ * the renderer's schema here. Keep the two in step; a drift degrades the message, never the build.
+ */
+internal object RenderErrorTrace {
+
+  private const val CAUSED_BY_PREFIX = "Caused by:"
+
+  /**
+   * `at [<module>/]<class>.<method>(<file>:<line>)`. The optional leading group swallows the module
+   * / classloader qualifier a JPMS-aware JVM prints (`app//com.example.Foo.bar(…)`,
+   * `java.base@17/java.lang.reflect.Method.invoke(…)`); `/` never appears in a class name.
+   */
+  private val FRAME_REGEX = Regex("^\\s*at\\s+(?:[\\w.@\$]*/{1,2})?([\\w\$.<>-]+)\\(([^()]*)\\)")
+
+  /** One `Caused by:` entry. */
+  data class Cause(val exception: String, val message: String)
+
+  /** Every `Caused by:` entry of [stackTrace], outermost cause first. */
+  fun causeChain(stackTrace: String): List<Cause> =
+    stackTrace
+      .lineSequence()
+      .map { it.trim() }
+      .filter { it.startsWith(CAUSED_BY_PREFIX) }
+      .map { header ->
+        val body = header.removePrefix(CAUSED_BY_PREFIX).trim()
+        val split = body.indexOf(": ")
+        if (split < 0) Cause(body, "")
+        else Cause(body.substring(0, split), body.substring(split + 2).trim())
+      }
+      .toList()
+
+  /** The deepest cause — the failure worth leading with. `null` when there is no chain. */
+  fun rootCause(stackTrace: String): Cause? = causeChain(stackTrace).lastOrNull()
+
+  /**
+   * The first frame in the preview's own package, searching the deepest `Caused by:` section first.
+   * Package prefixes are tried longest-first (exact package, then parents down to two segments), so
+   * a sibling package of the preview counts but `com.` never does. `null` when nothing matches,
+   * leaving the sidecar's own `topAppFrame` as the fallback.
+   */
+  fun preferredAppFrame(
+    stackTrace: String,
+    previewClassName: String,
+  ): ComposePreviewTasks.ErrorSidecar.TopAppFrame? {
+    val prefixes = packagePrefixes(previewClassName)
+    if (prefixes.isEmpty() || stackTrace.isBlank()) return null
+    for (section in sections(stackTrace).asReversed()) {
+      for (prefix in prefixes) {
+        val frame = section.firstNotNullOfOrNull { line ->
+          parseFrame(line)?.takeIf { it.className.startsWith("$prefix.") }
+        }
+        if (frame != null) {
+          return ComposePreviewTasks.ErrorSidecar.TopAppFrame(
+            file = frame.file,
+            line = frame.line,
+            function = frame.function,
+          )
+        }
+      }
+    }
+    return null
+  }
+
+  /** The throwable sections of a printed trace: outermost first, then one per `Caused by:`. */
+  private fun sections(stackTrace: String): List<List<String>> {
+    val out = mutableListOf<MutableList<String>>(mutableListOf())
+    for (line in stackTrace.lineSequence()) {
+      if (line.trim().startsWith(CAUSED_BY_PREFIX)) out += mutableListOf<String>()
+      out.last() += line
+    }
+    return out
+  }
+
+  private data class ParsedFrame(
+    val className: String,
+    val function: String,
+    val file: String,
+    val line: Int,
+  )
+
+  private fun parseFrame(line: String): ParsedFrame? {
+    val match = FRAME_REGEX.find(line) ?: return null
+    val (qualified, location) = match.destructured
+    val className = qualified.substringBeforeLast('.', "")
+    if (className.isEmpty()) return null
+    val colon = location.lastIndexOf(':')
+    val lineNumber = if (colon > 0) location.substring(colon + 1).toIntOrNull() ?: 0 else 0
+    // `(Unknown Source)` / `(Native Method)` carry no file — useless as an "open this" pointer.
+    if (lineNumber <= 0) return null
+    return ParsedFrame(
+      className = className,
+      function = qualified.substringAfterLast('.'),
+      file = location.substring(0, colon),
+      line = lineNumber,
+    )
+  }
+
+  private fun packagePrefixes(className: String): List<String> {
+    val segments = className.substringBeforeLast('.', "").split('.').filter { it.isNotEmpty() }
+    if (segments.size < 2) return emptyList()
+    return (segments.size downTo 2).map { segments.take(it).joinToString(".") }
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
@@ -281,4 +281,102 @@ class MissingPreviewMessageTest {
     // Before the per-preview list, which is where it was previously buried.
     assertThat(msg.indexOf(rootCause)).isLessThan(msg.indexOf("Per-preview render errors"))
   }
+
+  /**
+   * Issue #3741's sidecar, in shape: the renderer invokes the preview reflectively, so the
+   * sidecar's own `exception` is a content-free `InvocationTargetException` and its `topAppFrame`
+   * points at the tooling frame that did the invoking. Everything a reader needs is in the trace.
+   */
+  private val reflectiveWrapperTrace =
+    """
+    java.lang.reflect.InvocationTargetException
+    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
+    	at ee.schimke.composeai.renderer.KeyboardDataProduct.AroundComposable${'$'}lambda${'$'}2(KeyboardDataProduct.kt:148)
+    Caused by: java.lang.NoClassDefFoundError: com/google/wear/services/ambient/AmbientComponentState
+    	at com.example.wear.ambient.AmbientAwareActivity.rememberAmbientState(AmbientAwareActivity.kt:76)
+    	at com.example.wear.WearAppKt.WearApp(WearApp.kt:31)
+    	at androidx.compose.runtime.ComposerImpl.doCompose(Composer.kt:3300)
+    """
+      .trimIndent()
+
+  private val reflectiveWrapperSidecar =
+    ComposePreviewTasks.ErrorSidecar(
+      exception = "java.lang.reflect.InvocationTargetException",
+      message = "",
+      topAppFrame =
+        ComposePreviewTasks.ErrorSidecar.TopAppFrame(
+          file = "KeyboardDataProduct.kt",
+          line = 148,
+          function = "AroundComposable${'$'}lambda${'$'}2",
+        ),
+      stackTrace = reflectiveWrapperTrace,
+    )
+
+  @Test
+  fun `formatMissingPreviewsMessage leads with the Caused by root, not the reflective wrapper`() {
+    val manifest =
+      PreviewManifest(
+        module = "wear",
+        variant = "debug",
+        previews =
+          listOf(
+            previewWithCapture("WearAppPreview_Devices - Large Round", "renders/WearApp.png")
+              .copy(className = "com.example.wear.WearAppKt")
+          ),
+      )
+
+    val msg =
+      ComposePreviewTasks.formatMissingPreviewsMessage(
+        manifest = manifest,
+        missingIds = listOf("WearAppPreview_Devices - Large Round"),
+        sidecars = mapOf("WearAppPreview_Devices - Large Round" to reflectiveWrapperSidecar),
+      )
+
+    // The wrapper alone ("InvocationTargetException at KeyboardDataProduct.kt:148") named neither
+    // the failure nor a file the reader owns — both live in the cause chain.
+    assertThat(msg).contains("NoClassDefFoundError")
+    assertThat(msg).contains("com/google/wear/services/ambient/AmbientComponentState")
+    assertThat(msg).contains("chain: InvocationTargetException → NoClassDefFoundError")
+    assertThat(msg).contains("AmbientAwareActivity.kt:76")
+    assertThat(msg).doesNotContain("KeyboardDataProduct.kt")
+    assertThat(msg).doesNotContain("NO-SOURCE")
+  }
+
+  @Test
+  fun `renderErrorInsight falls back to the sidecar fields without a stack trace`() {
+    // Sidecars written by an older renderer carry no `stackTrace`; nothing about the message may
+    // depend on it.
+    val insight =
+      ComposePreviewTasks.renderErrorInsight(
+        ComposePreviewTasks.ErrorSidecar(
+          exception = "java.lang.IllegalStateException",
+          message = "missing state",
+          topAppFrame = ComposePreviewTasks.ErrorSidecar.TopAppFrame("A.kt", 10, "APreview"),
+        ),
+        previewClassName = "com.example.PreviewsKt",
+      )
+
+    assertThat(insight.exception).isEqualTo("java.lang.IllegalStateException")
+    assertThat(insight.message).isEqualTo("missing state")
+    assertThat(insight.frame?.file).isEqualTo("A.kt")
+    assertThat(insight.chain).isEmpty()
+  }
+
+  @Test
+  fun `renderErrorInsight prefers the deepest frame in the preview's own package`() {
+    val insight =
+      ComposePreviewTasks.renderErrorInsight(
+        reflectiveWrapperSidecar,
+        previewClassName = "com.example.wear.WearAppKt",
+      )
+
+    assertThat(insight.frame?.file).isEqualTo("AmbientAwareActivity.kt")
+    assertThat(insight.frame?.line).isEqualTo(76)
+    assertThat(insight.frame?.function).isEqualTo("rememberAmbientState")
+
+    // A preview from an unrelated package matches no frame, so the sidecar's own stays.
+    val unrelated =
+      ComposePreviewTasks.renderErrorInsight(reflectiveWrapperSidecar, "zz.other.PreviewsKt")
+    assertThat(unrelated.frame?.file).isEqualTo("KeyboardDataProduct.kt")
+  }
 }


### PR DESCRIPTION
Fixes #3741.

## Summary

When a preview produced no PNG, `compose-preview show` / `render` printed one fixed paragraph blaming the *build wiring* — "a common cause is `composePreviewRender` reporting NO-SOURCE, which means the renderer test class wasn't found on testClassesDirs" — even when the renderer had already written the precise cause next to where the PNG would have gone (`<module>/build/compose-previews/renders/<Stem>.png.error.json`). In the reported case 34 of 35 previews rendered fine, so the wiring was demonstrably not the problem.

The CLI now reads that sidecar for every missing preview and reports the two cases separately, because their remedies are opposite:

- **error JSON present** → the preview rendered and *threw*. Report the exception; say the build wiring is fine; do **not** print the NO-SOURCE text.
- **no error JSON** → the render really was skipped. Keep the historical NO-SOURCE guidance (now scoped to just those previews when a run mixes both).

Two details that decide whether the one-line summary is useful, applied on both the CLI side and the gradle-plugin side (which already split the two cases but still led with the wrapper):

- **Lead with the `Caused by:` root**, not the outermost throwable. The renderer invokes previews reflectively, so `exception` is routinely a content-free `java.lang.reflect.InvocationTargetException` while the real failure (`NoClassDefFoundError: com/google/wear/services/ambient/AmbientComponentState`) sits at the end of the chain. The whole chain is printed compactly (`chain: InvocationTargetException → NoClassDefFoundError`) so the wrapper isn't lost.
- **Prefer a stack frame in the preview's own package.** The sidecar's `topAppFrame` is computed from the *wrapper's* frames with a skip-the-framework-prefixes heuristic, which landed on `KeyboardDataProduct.kt:148` — a data-product frame in this project — while the frame worth showing was the consumer's `AmbientAwareActivity.kt:76`. Package prefixes are tried longest-first (exact package, then parents down to two segments), deepest cause section first; the sidecar's own frame remains the fallback.

## Before / after

Before (`compose-preview show`, one preview of 35 missing, sidecar on disk and ignored):

```
Render task completed but produced no PNG for 1 of 35 preview(s):
  - com.example.wear.WearAppKt.WearAppPreview_Devices - Large Round (:app) — no PNG for: default
Check the Gradle output above — a common cause is the `composePreviewRender` task reporting NO-SOURCE, which means the renderer test class wasn't found on testClassesDirs. Per-preview stack traces are in the `composePreviewRender-reports` artifact attached to the run.
```

After (same inputs, actual output captured from `MissingRenderReportTest`):

```
Render task completed but produced no PNG for 1 of 35 preview(s):
  - com.example.wear.WearAppKt.WearAppPreview_Devices - Large Round (:app) — no PNG for: default
      threw NoClassDefFoundError: com/google/wear/services/ambient/AmbientComponentState (at AmbientAwareActivity.kt:76 in rememberAmbientState)
        chain: InvocationTargetException → NoClassDefFoundError
1 preview(s) rendered and then threw — the build wiring is fine. Full stack traces are in the `<render>.png.error.json` sidecar beside each preview's would-be output.
```

With no sidecar on disk the message is unchanged from before — that is the case the NO-SOURCE text was written for.

Gradle-plugin side, same sidecar, per-preview line:

```
- before:  - …WearAppPreview_Devices - Large Round: InvocationTargetException (at KeyboardDataProduct.kt:148)
- after:   - …WearAppPreview_Devices - Large Round: NoClassDefFoundError: com/google/wear/services/ambient/AmbientComponentState (at AmbientAwareActivity.kt:76) — chain: InvocationTargetException → NoClassDefFoundError
```

## Files changed

- `cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt` (new) — sidecar DTO (mirrors `compose-preview-error/v1`; reuses the existing `RenderFailureFrame`), `readRenderErrorSidecar` (the one disk read), `collectMissingRenders` (expected output path per preview, from the manifest's `renderOutput` / data products), and the pure `formatMissingRenderReport`.
- `cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt` — `ShowCommand` and `RenderCommand` now emit that report instead of the fixed paragraph.
- `gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderErrorTrace.kt` (new) — cause-chain + preferred-frame reader (deliberately duplicated from the CLI copy; `:gradle-plugin` is a separate included build, same reason `ErrorSidecar` mirrors the renderer schema).
- `gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt` — `ErrorSidecar` gains `stackTrace`; `renderErrorInsight` feeds the per-preview line and its grouping key.
- Tests: `cli/src/test/.../MissingRenderReportTest.kt` (new, 10 cases), `gradle-plugin/src/test/.../MissingPreviewMessageTest.kt` (+3 cases).

## Test plan

Commands run in this session, with results:

- `./gradlew :cli:test --tests "ee.schimke.composeai.cli.MissingRenderReportTest"` → BUILD SUCCESSFUL, 10 tests, 0 failures.
- `./gradlew :gradle-plugin:test --tests "ee.schimke.composeai.plugin.MissingPreviewMessageTest"` → BUILD SUCCESSFUL, 10 tests (7 pre-existing + 3 new), 0 failures.
- `./gradlew :cli:test :gradle-plugin:test` → BUILD SUCCESSFUL; 2023 CLI tests and 433 plugin tests, 0 failures / 0 errors across both.
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest :gradle-plugin:ktfmtFormatMain :gradle-plugin:ktfmtFormatTest` → BUILD SUCCESSFUL (result committed).

Negative check that the new tests actually bite: with `collectMissingRenders` temporarily forced to return `sidecar = null` (exactly the pre-change behaviour — the old code never looked for a sidecar), 4 of the 10 new CLI tests fail, including `an error sidecar beside the expected output replaces the NO-SOURCE guess`. The stub was reverted before committing.

Not run: `:gradle-plugin:functionalTest` (TestKit) and any end-to-end render. The functional tests that assert on this message all use no-sidecar scenarios, which this change leaves byte-identical, and the strings they grep for (`render produced no output file`, `NO-SOURCE`, `missing-renders policy=warn`) are untouched on that path.

Text-only change (CLI stderr diagnostics + Gradle failure message), so there is no rendered surface to show.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_