### PR TITLE
fix(build): publish data-focus-connector-desktop for the bundle-render e2e

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,6 +136,8 @@ tasks.register("functionalTestWithAndroid") {
 //       api :data-preview-overrides-core
 //     implementation :data-deviceframe-connector (device-art bezel compositing — post-capture)
 //       api :data-deviceframe-core
+//     implementation :data-focus-connector-desktop (drives @FocusedPreview focus/press on desktop)
+//       api :data-focus-core
 //     implementation :lottie-preview-runtime (Compottie-backed kind=LOTTIE render path)
 //     implementation :svg-preview-runtime (Skia loadSvgPainter kind=SVG render path)
 //   plus :common-io (the Okio file-IO foundation those modules read/write through).
@@ -150,6 +152,8 @@ val bundleRenderFunctionalTestPublishTargets =
     ":data-displayfilter-core",
     ":data-deviceframe-connector",
     ":data-deviceframe-core",
+    ":data-focus-connector-desktop",
+    ":data-focus-core",
     ":daemon:core",
     ":renderer-xr-client",
     ":data-layoutinspector-core",


### PR DESCRIPTION
**`main` is red** on `Bundle Render E2E`, and has been since #3699 — the failure was just hard to see, because a fast merge cadence kept cancelling CI runs before they completed. The run on `d447169` is the first to finish in a while, and it fails.

## Cause

#3699 added `implementation(project(":data-focus-connector-desktop"))` to `:renderer-desktop`, but didn't add it to `bundleRenderFunctionalTestPublishTargets` — the hand-maintained list of renderer-desktop's internal modules the e2e pre-publishes to mavenLocal.

An `implementation` project dependency still lands in the published POM at runtime scope, so the synthetic `:app` project the functional tests build resolved renderer-desktop and then died on its transitive dep:

```
Could not find ee.schimke.composeai:data-focus-connector-desktop:1.1.1-SNAPSHOT
  Searched in: file:/home/runner/.m2/repository/…, https://dl.google.com/dl/android/maven2/…
  Required by: project ':app' > ee.schimke.composeai:renderer-desktop:1.1.1-SNAPSHOT
```

That took out both `BundleRenderEndToEndFunctionalTest` and `BundleDaemonEndToEndFunctionalTest` (2 failed of 93).

## Fix

Adds `:data-focus-connector-desktop` and its one `api` dep `:data-focus-core`. Everything else it needs — `:common-io`, `:daemon:core`, `:data-render-compose` — is already in the list, and both new modules already apply `composeai.maven-publishing`, so nothing else was required.

The comment block above the list documents the dependency closure it mirrors; it's updated in step, since that comment is the only thing keeping a hand-maintained list honest.

## Test plan — and its limit, stated plainly

- [x] `./gradlew :cli:installDist :gradle-plugin:publishToMavenLocal` then `./gradlew functionalTestWithBundleRender -Pbundle.render.e2e=true` (the two-phase invocation CI uses). **The `Could not find data-focus-connector-desktop` error is gone** — the string no longer appears in any functional-test result — and `~/.m2/repository/ee/schimke/composeai/` now contains `data-focus-connector-desktop` and `data-focus-core`.
- [x] `./gradlew ktfmtCheckAll`.

I could **not** run those two e2e tests to completion in this container, and I don't want to claim otherwise. They drive a nested Gradle build through the Tooling API, and this sandbox's `~/.gradle/gradle.properties` pins `org.gradle.java.home=/root/.cache/coo-ee/jdk-gl/17` plus a truststore in `org.gradle.jvmargs`, so the spawned daemon can never match the requested context:

```
Caused by: The newly created daemon process has a different context than expected.
  Context mismatch: JVM is incompatible.
```

That is environmental, identical before and after this change, and absent on CI. As a control that TestKit itself is healthy here, `BundleFunctionalTest` runs 18/18 green in the same container — only the two Tooling-API-driven tests hit the mismatch. CI is the verifier for the full pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SamkbmKYKnb7XhJUU5TYbM)_