### PR TITLE
fix(cli): force every permutation's own render, discard a failed restore

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
@@ -202,23 +202,28 @@ internal class DaemonA11yFetcher(
         // preview, holds the override's pixels. One forced fetch at default overrides fixes both,
         // so it runs even when the declared preview has no entry to file (`--id Foo_dark`): the
         // report gains nothing, but the render on disk stops lying about which configuration it is.
-        val payload = fetchOne(previewId, base?.entryId ?: previewId, forcedDefaultParams())
-        if (base == null) {
-          if (payload == null) {
-            onLog(
-              "could not restore the default render of '$previewId' after its permutations; " +
-                "renders/$previewId.png may still hold a permutation's pixels"
-            )
-          }
-          continue
+        val payload = fetchOne(previewId, base?.entryId ?: previewId, forcedFetchParams(null))
+        if (payload == null) {
+          onLog(
+            "could not restore the default render of '$previewId' after its permutations; " +
+              "renders/$previewId.png may still hold a permutation's pixels"
+          )
+          // Everything under `data/<previewId>/` is still the last permutation's, including the
+          // `a11y-atf.json` sitting at this preview's own cache path — which the *next* run's
+          // unforced fetch would happily serve as the base's findings. Delete them: absent is the
+          // one state that reads correctly here, both for this report (no overlay, no nodes) and
+          // for that next fetch, which sees a missing file and re-renders.
+          discardArtifacts(projectDir, previewId)
         }
+        if (base == null) continue
         if (payload != null) anyFetchOk = true else failedIds += base.entryId
         entries.add(
           AccessibilityEntry(
             previewId = base.entryId,
             findings = payload?.let(::parseFindings).orEmpty(),
-            nodes = readNodes(projectDir, base.entryId),
-            annotatedPath = relativeOverlayPath(projectDir, base.entryId),
+            nodes = if (payload != null) readNodes(projectDir, base.entryId) else emptyList(),
+            annotatedPath =
+              if (payload != null) relativeOverlayPath(projectDir, base.entryId) else null,
           )
         )
       }
@@ -367,15 +372,27 @@ internal class DaemonA11yFetcher(
   }
 
   /**
-   * The `params` bag for one fetch: the permutation's render overrides, plus a forced re-render so
-   * the daemon produces the artefact at *those* overrides rather than serving whatever the shared
-   * per-preview file already holds. `null` for a declared preview, which wants its own defaults and
-   * can reuse a cached render.
+   * The `params` bag for one fetch: `null` for a declared preview with no permutations in play,
+   * which wants its own defaults and may reuse a cached render — that reuse is the narrow fast
+   * fetch #3742 exists to keep. Every permutation gets [forcedFetchParams].
+   *
+   * The force flag hangs off **being a permutation**, not off carrying a non-empty override bag. A
+   * declared `@Preview(fontScale = 2.0f)` expands to a `_fontscale-2x` variant whose params equal
+   * the base's, so [PreviewPermutationsCli.overridesFor] returns `null` for it — and an unforced
+   * fetch of that variant would serve whatever the *previous* permutation left at the shared cache
+   * path, filing the RTL render's findings under the 2× id. Forced with no overrides is the honest
+   * request for it: its configuration genuinely is the base's.
    */
-  private fun fetchParams(preview: ReportCommand.RequestedPreview): JsonElement? {
-    val overrides = preview.overrides ?: return null
-    return buildJsonObject {
-      put(DataFetchParams.PARAM_FORCE_RERENDER, JsonPrimitive(true))
+  private fun fetchParams(preview: ReportCommand.RequestedPreview): JsonElement? =
+    if (preview.isPermutation) forcedFetchParams(preview.overrides) else null
+
+  /**
+   * A forced re-render carrying [overrides] (or none), so the daemon produces the artefact at
+   * *that* configuration rather than serving whatever the shared per-preview file already holds.
+   */
+  private fun forcedFetchParams(overrides: PreviewOverrides?): JsonElement = buildJsonObject {
+    put(DataFetchParams.PARAM_FORCE_RERENDER, JsonPrimitive(true))
+    if (overrides != null) {
       put(
         DataFetchParams.PARAM_OVERRIDES,
         json.encodeToJsonElement(PreviewOverrides.serializer(), overrides),
@@ -384,12 +401,23 @@ internal class DaemonA11yFetcher(
   }
 
   /**
-   * The `params` bag for the declared preview's fetch when a permutation of it already ran: a
-   * forced re-render carrying **no** overrides, so the daemon rebuilds this preview at its own
-   * configuration instead of serving the file the override left at the shared cache path.
+   * Delete every per-render artefact under `data/[previewId]/`, because what's there describes a
+   * render this preview isn't and no fresh render replaced it.
+   *
+   * Includes `a11y-atf.json`, which is not a report input but *is* the file
+   * `FileBackedDataProductRegistry` serves: it only queues a re-render when that file is
+   * **missing**, so leaving a permutation's copy behind would hand the next unforced fetch of this
+   * preview the override's findings. Deleting makes that next fetch a real render.
    */
-  private fun forcedDefaultParams(): JsonElement = buildJsonObject {
-    put(DataFetchParams.PARAM_FORCE_RERENDER, JsonPrimitive(true))
+  private fun discardArtifacts(projectDir: File, previewId: String) {
+    val dir = projectDir.resolve("build/compose-previews/data/$previewId")
+    for (name in PER_RENDER_FILES) {
+      try {
+        dir.resolve(name).delete()
+      } catch (e: Exception) {
+        onLog("could not discard stale $name for '$previewId': ${e.message}")
+      }
+    }
   }
 
   /**
@@ -493,5 +521,15 @@ internal class DaemonA11yFetcher(
      * `data/<previewId>/` and read back from there by [readNodes] / [relativeOverlayPath].
      */
     private val SNAPSHOT_FILES = listOf("a11y-overlay.png", "a11y-hierarchy.json")
+
+    /**
+     * Everything `AccessibilityDataProducer.writeArtifacts` puts under `data/<previewId>/` for one
+     * render — the two [SNAPSHOT_FILES] plus the cached data product and the touch-target
+     * derivation, neither of which this report reads but both of which describe the render that
+     * produced them. [discardArtifacts] removes the set, so nothing is left claiming to be a
+     * configuration it isn't.
+     */
+    private val PER_RENDER_FILES =
+      listOf("a11y-atf.json", "a11y-hierarchy.json", "a11y-touchTargets.json", "a11y-overlay.png")
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
@@ -158,17 +158,15 @@ internal class DaemonA11yFetcher(
       for ((previewId, group) in previews.groupBy { it.previewId }) {
         val permutations = group.filter { it.isPermutation }
         val base = group.firstOrNull { !it.isPermutation }
-        // Whether any permutation of this preview actually rendered — i.e. whether the artefacts in
-        // `data/<previewId>/` describe an override rather than the declared preview. A permutation
-        // whose fetch failed never reached a render, so it left the directory exactly as it found
-        // it. See the discard below, which this gates.
-        var overridden = false
+        // Take a copy of whatever `data/<previewId>/` holds *before* any override renders as this
+        // preview, so the state can be put back if the restoring fetch below fails. Held rather
+        // than reconstructed: what's there now is this preview's own last render, which is true of
+        // it and may be what an existing report entry points at.
+        val heldArtifacts =
+          if (permutations.isEmpty()) null else holdArtifacts(projectDir, previewId)
         for (preview in permutations) {
           val payload = fetchOne(previewId, preview.entryId, fetchParams(preview))
-          if (payload != null) {
-            anyFetchOk = true
-            overridden = true
-          } else failedIds += preview.entryId
+          if (payload != null) anyFetchOk = true else failedIds += preview.entryId
           // Copy this render's artefacts out before the next fetch of the same preview replaces
           // them — but only when the fetch produced something. On a failure the directory still
           // holds the *previous* configuration's files, and snapshotting those would file another
@@ -216,30 +214,28 @@ internal class DaemonA11yFetcher(
             "could not restore the default render of '$previewId' after its permutations; " +
               "renders/$previewId.png may still hold a permutation's pixels"
           )
-          // Everything under `data/<previewId>/` is still the last permutation's, including the
-          // `a11y-atf.json` sitting at this preview's own cache path — which the *next* run's
-          // unforced fetch would happily serve as the base's findings. Delete them: absent is the
-          // one state that reads correctly here, both for this report (no overlay, no nodes) and
-          // for that next fetch, which sees a missing file and re-renders.
+          // Nothing replaced the permutation's files, so `data/<previewId>/` still describes an
+          // override — including the `a11y-atf.json` at this preview's own cache path, which the
+          // *next* run's unforced fetch would serve as the base's findings. Roll the directory
+          // back to what it held before the permutations ran.
           //
-          // Only when a permutation genuinely rendered, though. If every fetch of this preview
-          // failed — an unavailable extension fails them all alike — then nothing overwrote the
-          // directory and what's there is the base's own earlier render, which is still true of
-          // the preview and may be what a carried-forward entry points at.
-          if (overridden) discardArtifacts(projectDir, previewId)
+          // Rolling back rather than deleting matters for the entry that isn't rewritten: on
+          // `--id Foo_dark` there is no fresh `Foo` entry, so a narrowed run carries the previous
+          // one forward — `annotatedPath` and all. Deleting would leave that carried entry
+          // pointing at a file this run had just removed.
+          restoreArtifacts(projectDir, previewId, heldArtifacts)
         }
+        releaseHeldArtifacts(heldArtifacts)
         if (base == null) continue
         if (payload != null) anyFetchOk = true else failedIds += base.entryId
-        // Artefacts are only this preview's if this fetch rendered, or if no permutation ever
-        // displaced them — the same condition the discard above turns on.
-        val artefactsAreOurs = payload != null || !overridden
+        // Read unconditionally: this fetch either rendered, or the roll-back put this preview's own
+        // previous render back, so either way the directory is the declared preview's.
         entries.add(
           AccessibilityEntry(
             previewId = base.entryId,
             findings = payload?.let(::parseFindings).orEmpty(),
-            nodes = if (artefactsAreOurs) readNodes(projectDir, base.entryId) else emptyList(),
-            annotatedPath =
-              if (artefactsAreOurs) relativeOverlayPath(projectDir, base.entryId) else null,
+            nodes = readNodes(projectDir, base.entryId),
+            annotatedPath = relativeOverlayPath(projectDir, base.entryId),
           )
         )
       }
@@ -425,28 +421,77 @@ internal class DaemonA11yFetcher(
    * **missing**, so leaving a permutation's copy behind would hand the next unforced fetch of this
    * preview the override's findings. Deleting makes that next fetch a real render.
    */
-  private fun discardArtifacts(projectDir: File, previewId: String) {
+  /**
+   * Copy `data/[previewId]/`'s per-render artefacts aside, before any permutation renders as this
+   * preview, and return the directory holding them. [restoreArtifacts] puts them back.
+   *
+   * A file that was absent is recorded by its absence in the hold directory, so a roll-back deletes
+   * it — the permutation created it, and this preview had nothing there.
+   *
+   * A file that can't be copied is recorded the same way, deliberately: after a failed hold we no
+   * longer know what this preview's own artefact was, and rolling back to "absent" costs a
+   * re-render on the next fetch, while rolling back to "whatever the override left" would serve
+   * another configuration's findings under this id. The re-render is the cheaper mistake.
+   */
+  private fun holdArtifacts(projectDir: File, previewId: String): File? {
+    val dir = projectDir.resolve("build/compose-previews/data/$previewId")
+    val hold = projectDir.resolve("build/compose-previews/.a11y-pre-permutation/$previewId")
+    return try {
+      hold.deleteRecursively()
+      hold.mkdirs()
+      for (name in PER_RENDER_FILES) {
+        val source = dir.resolve(name)
+        if (source.isFile) source.copyTo(hold.resolve(name), overwrite = true)
+      }
+      hold
+    } catch (e: Exception) {
+      onLog("could not hold the pre-permutation artefacts of '$previewId': ${e.message}")
+      null
+    }
+  }
+
+  /**
+   * Put `data/[previewId]/` back to what [holdArtifacts] captured: each held file copied in, each
+   * file it did not hold deleted.
+   *
+   * With no [held] directory — the hold itself failed — every per-render file is deleted instead.
+   * The directory then reads as "nothing rendered", which the registry answers with a real
+   * re-render; leaving the override's files would answer it with the wrong configuration's cache.
+   */
+  private fun restoreArtifacts(projectDir: File, previewId: String, held: File?) {
     val dir = projectDir.resolve("build/compose-previews/data/$previewId")
     for (name in PER_RENDER_FILES) {
-      val file = dir.resolve(name)
-      // `File.delete()` returns false rather than throwing when the file is locked or the
-      // directory isn't writable, so re-check existence: a silently surviving `a11y-atf.json` is
-      // exactly what the next unforced fetch would serve as this preview's findings, which is the
-      // failure this call exists to prevent. Say so rather than assume the delete worked.
-      val gone =
-        try {
-          file.delete()
-          !file.exists()
-        } catch (e: Exception) {
-          onLog("could not discard stale $name for '$previewId': ${e.message}")
-          false
+      val target = dir.resolve(name)
+      val source = held?.resolve(name)?.takeIf { it.isFile }
+      try {
+        if (source != null) {
+          dir.mkdirs()
+          source.copyTo(target, overwrite = true)
+          continue
         }
-      if (!gone && file.exists()) {
+        target.delete()
+      } catch (e: Exception) {
+        onLog("could not roll back $name for '$previewId': ${e.message}")
+      }
+      // `File.delete()` returns false rather than throwing when the file is locked or its directory
+      // isn't writable, so check rather than assume: a surviving `a11y-atf.json` is exactly what a
+      // later unforced fetch would serve as this preview's findings.
+      if (source == null && target.exists()) {
         onLog(
-          "could not discard stale $name for '$previewId'; a later fetch of that preview may " +
-            "serve a permutation's render"
+          "could not roll back $name for '$previewId'; a later fetch of that preview may serve " +
+            "a permutation's render"
         )
       }
+    }
+  }
+
+  /** Drop the hold directory once the outcome is decided, restored from or not. */
+  private fun releaseHeldArtifacts(held: File?) {
+    if (held == null) return
+    try {
+      held.deleteRecursively()
+    } catch (e: Exception) {
+      onLog("could not clean up ${held.path}: ${e.message}")
     }
   }
 
@@ -556,8 +601,8 @@ internal class DaemonA11yFetcher(
      * Everything `AccessibilityDataProducer.writeArtifacts` puts under `data/<previewId>/` for one
      * render — the two [SNAPSHOT_FILES] plus the cached data product and the touch-target
      * derivation, neither of which this report reads but both of which describe the render that
-     * produced them. [discardArtifacts] removes the set, so nothing is left claiming to be a
-     * configuration it isn't.
+     * produced them. [holdArtifacts] / [restoreArtifacts] move the set as a unit, so the directory
+     * is never left half-describing one configuration and half another.
      */
     private val PER_RENDER_FILES =
       listOf("a11y-atf.json", "a11y-hierarchy.json", "a11y-touchTargets.json", "a11y-overlay.png")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
@@ -158,9 +158,17 @@ internal class DaemonA11yFetcher(
       for ((previewId, group) in previews.groupBy { it.previewId }) {
         val permutations = group.filter { it.isPermutation }
         val base = group.firstOrNull { !it.isPermutation }
+        // Whether any permutation of this preview actually rendered — i.e. whether the artefacts in
+        // `data/<previewId>/` describe an override rather than the declared preview. A permutation
+        // whose fetch failed never reached a render, so it left the directory exactly as it found
+        // it. See the discard below, which this gates.
+        var overridden = false
         for (preview in permutations) {
           val payload = fetchOne(previewId, preview.entryId, fetchParams(preview))
-          if (payload != null) anyFetchOk = true else failedIds += preview.entryId
+          if (payload != null) {
+            anyFetchOk = true
+            overridden = true
+          } else failedIds += preview.entryId
           // Copy this render's artefacts out before the next fetch of the same preview replaces
           // them — but only when the fetch produced something. On a failure the directory still
           // holds the *previous* configuration's files, and snapshotting those would file another
@@ -213,17 +221,25 @@ internal class DaemonA11yFetcher(
           // unforced fetch would happily serve as the base's findings. Delete them: absent is the
           // one state that reads correctly here, both for this report (no overlay, no nodes) and
           // for that next fetch, which sees a missing file and re-renders.
-          discardArtifacts(projectDir, previewId)
+          //
+          // Only when a permutation genuinely rendered, though. If every fetch of this preview
+          // failed — an unavailable extension fails them all alike — then nothing overwrote the
+          // directory and what's there is the base's own earlier render, which is still true of
+          // the preview and may be what a carried-forward entry points at.
+          if (overridden) discardArtifacts(projectDir, previewId)
         }
         if (base == null) continue
         if (payload != null) anyFetchOk = true else failedIds += base.entryId
+        // Artefacts are only this preview's if this fetch rendered, or if no permutation ever
+        // displaced them — the same condition the discard above turns on.
+        val artefactsAreOurs = payload != null || !overridden
         entries.add(
           AccessibilityEntry(
             previewId = base.entryId,
             findings = payload?.let(::parseFindings).orEmpty(),
-            nodes = if (payload != null) readNodes(projectDir, base.entryId) else emptyList(),
+            nodes = if (artefactsAreOurs) readNodes(projectDir, base.entryId) else emptyList(),
             annotatedPath =
-              if (payload != null) relativeOverlayPath(projectDir, base.entryId) else null,
+              if (artefactsAreOurs) relativeOverlayPath(projectDir, base.entryId) else null,
           )
         )
       }
@@ -412,10 +428,24 @@ internal class DaemonA11yFetcher(
   private fun discardArtifacts(projectDir: File, previewId: String) {
     val dir = projectDir.resolve("build/compose-previews/data/$previewId")
     for (name in PER_RENDER_FILES) {
-      try {
-        dir.resolve(name).delete()
-      } catch (e: Exception) {
-        onLog("could not discard stale $name for '$previewId': ${e.message}")
+      val file = dir.resolve(name)
+      // `File.delete()` returns false rather than throwing when the file is locked or the
+      // directory isn't writable, so re-check existence: a silently surviving `a11y-atf.json` is
+      // exactly what the next unforced fetch would serve as this preview's findings, which is the
+      // failure this call exists to prevent. Say so rather than assume the delete worked.
+      val gone =
+        try {
+          file.delete()
+          !file.exists()
+        } catch (e: Exception) {
+          onLog("could not discard stale $name for '$previewId': ${e.message}")
+          false
+        }
+      if (!gone && file.exists()) {
+        onLog(
+          "could not discard stale $name for '$previewId'; a later fetch of that preview may " +
+            "serve a permutation's render"
+        )
       }
     }
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
@@ -603,6 +603,40 @@ class DaemonA11yFetcherTest {
     )
   }
 
+  @Test
+  fun `artefacts survive when no permutation ever rendered`() {
+    val projectDir = newTempFolder("module-permutation-none-rendered")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+    val dataDir = File(projectDir, "build/compose-previews/data/Foo")
+    dataDir.mkdirs()
+    File(dataDir, "a11y-overlay.png").writeText("foo-own-render")
+    File(dataDir, "a11y-atf.json").writeText("""{"findings":[]}""")
+
+    // Every fetch fails — an unavailable extension fails them all alike — so no render happened
+    // and `data/Foo/` still holds Foo's own earlier one. Discarding it here would delete a valid
+    // cache and, on a narrowed run, strand a carried-forward entry pointing at the overlay.
+    DaemonA11yFetcher(factory = FakeFactory(mapOf("Foo" to null)))
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo"),
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f)),
+          ),
+      )
+
+    assertEquals("foo-own-render", File(dataDir, "a11y-overlay.png").readText())
+    assertTrue(File(dataDir, "a11y-atf.json").exists())
+    // The entry still shows the preview was attempted and produced nothing this run, but its own
+    // artefacts are honestly still its own, so the report may point at them.
+    val base = readReport(projectDir).entries.single { it.previewId == "Foo" }
+    assertEquals("data/Foo/a11y-overlay.png", base.annotatedPath)
+    assertEquals(emptyList(), base.findings)
+  }
+
   // ---------- narrowed runs merge rather than clobber (#3742) ----------
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
@@ -637,6 +637,107 @@ class DaemonA11yFetcherTest {
     assertEquals(emptyList(), base.findings)
   }
 
+  @Test
+  fun `a failed restore rolls back to the base's own render, not to nothing`() {
+    val projectDir = newTempFolder("module-permutation-rollback")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+    val dataDir = File(projectDir, "build/compose-previews/data/Foo")
+    dataDir.mkdirs()
+    File(dataDir, "a11y-overlay.png").writeText("foos-own-render")
+    File(dataDir, "a11y-atf.json").writeText("""{"findings":[]}""")
+    // `--id Foo_dark` files no fresh `Foo` entry, so the narrowed merge carries the previous one
+    // forward — `annotatedPath` included. Deleting the overlay would strand that reference.
+    writeExistingReport(
+      projectDir,
+      AccessibilityEntry(
+        previewId = "Foo",
+        findings = listOf(finding("ERROR", "TextContrast", "seen earlier")),
+        annotatedPath = "data/Foo/a11y-overlay.png",
+      ),
+    )
+
+    // The permutation renders as `Foo` and overwrites its artefacts; the restoring fetch errors.
+    val factory =
+      FakeFactory(
+        payloads = emptyMap(),
+        payloadByCall = mapOf(1 to atfPayload(emptyList()), 2 to null),
+        onFetch = { _, ordinal ->
+          if (ordinal == 1) {
+            File(dataDir, "a11y-overlay.png").writeText("dark-pixels")
+            File(dataDir, "a11y-atf.json").writeText("""{"findings":[{"level":"ERROR"}]}""")
+          }
+        },
+      )
+
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f))
+          ),
+        modulePreviewIds = listOf("Foo", "Foo_dark"),
+        narrowed = true,
+      )
+
+    assertEquals(
+      "foos-own-render",
+      File(dataDir, "a11y-overlay.png").readText(),
+      "the carried-forward entry's overlay must survive the roll-back",
+    )
+    assertEquals("""{"findings":[]}""", File(dataDir, "a11y-atf.json").readText())
+    val carried = readReport(projectDir).entries.single { it.previewId == "Foo" }
+    assertEquals("data/Foo/a11y-overlay.png", carried.annotatedPath)
+    assertEquals("seen earlier", carried.findings.single().message)
+    // The hold directory is transient — it must not survive as a stray build output.
+    assertFalse(File(projectDir, "build/compose-previews/.a11y-pre-permutation/Foo").exists())
+  }
+
+  @Test
+  fun `a render that landed but did not report is still rolled back`() {
+    val projectDir = newTempFolder("module-permutation-render-no-payload")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+    val dataDir = File(projectDir, "build/compose-previews/data/Foo")
+    dataDir.mkdirs()
+    File(dataDir, "a11y-atf.json").writeText("""{"findings":[]}""")
+
+    // A permutation render can land and its fetch still error — an unparseable ATF payload comes
+    // back as a failure after the artefacts were written. Keying the roll-back off "did a payload
+    // come back" would skip it and leave the override's data product at this preview's cache path.
+    val factory =
+      FakeFactory(
+        payloads = emptyMap(),
+        payloadByCall = mapOf(1 to null, 2 to null),
+        onFetch = { _, ordinal ->
+          if (ordinal == 1) {
+            File(dataDir, "a11y-atf.json").writeText("""{"findings":[{"level":"ERROR"}]}""")
+          }
+        },
+      )
+
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo"),
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f)),
+          ),
+      )
+
+    assertEquals(
+      """{"findings":[]}""",
+      File(dataDir, "a11y-atf.json").readText(),
+      "the next unforced fetch must not be served the permutation's data product",
+    )
+  }
+
   // ---------- narrowed runs merge rather than clobber (#3742) ----------
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
@@ -521,6 +521,88 @@ class DaemonA11yFetcherTest {
     assertNull(readReport(projectDir).entries.single().annotatedPath)
   }
 
+  @Test
+  fun `a permutation whose overrides collapse to the base is still forced`() {
+    val projectDir = newTempFolder("module-permutation-no-op")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+
+    // `@Preview(fontScale = 2.0f)` expands to a `_fontscale-2x` variant whose params equal the
+    // base's, so `overridesFor` hands back null. Unforced, that fetch would serve whatever the
+    // preceding RTL render left at the shared cache path and file it under the 2× id.
+    val factory = FakeFactory(mapOf("Foo" to atfPayload(emptyList())))
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo_rtl", PreviewOverrides(localeTag = "ar-XB")),
+            ReportCommand.RequestedPreview("Foo", "Foo_fontscale-2x", overrides = null),
+          ),
+        modulePreviewIds = listOf("Foo", "Foo_rtl", "Foo_fontscale-2x"),
+        narrowed = true,
+      )
+
+    val noOp = factory.calls[1].params?.jsonObject
+    assertEquals(
+      true,
+      noOp?.get(DataFetchParams.PARAM_FORCE_RERENDER)?.jsonPrimitive?.content?.toBoolean(),
+      "a permutation with an empty override bag still needs its own render",
+    )
+    assertNull(noOp?.get(DataFetchParams.PARAM_OVERRIDES), "...at the base configuration")
+  }
+
+  @Test
+  fun `a failed restore discards the permutation's artefacts instead of filing them as the base`() {
+    val projectDir = newTempFolder("module-permutation-restore-fails")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+    val dataDir = File(projectDir, "build/compose-previews/data/Foo")
+
+    // The permutation renders as `Foo` and leaves its artefacts — including the cached
+    // `a11y-atf.json` — under `Foo`. Then the restoring fetch errors, so nothing replaces them.
+    val factory =
+      FakeFactory(
+        payloads = emptyMap(),
+        payloadByCall = mapOf(1 to atfPayload(emptyList()), 2 to null),
+        onFetch = { _, ordinal ->
+          if (ordinal == 1) {
+            dataDir.mkdirs()
+            File(dataDir, "a11y-overlay.png").writeText("dark-pixels")
+            File(dataDir, "a11y-hierarchy.json").writeText("""{"nodes":[]}""")
+            File(dataDir, "a11y-atf.json").writeText("""{"findings":[]}""")
+          }
+        },
+      )
+
+    DaemonA11yFetcher(factory = factory)
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo"),
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f)),
+          ),
+      )
+
+    val base = readReport(projectDir).entries.single { it.previewId == "Foo" }
+    assertNull(base.annotatedPath, "the overlay left under `Foo` is the permutation's")
+    assertEquals(emptyList(), base.nodes, "so is the hierarchy")
+    // And the cached data product goes too: `FileBackedDataProductRegistry` only re-renders when
+    // the file is missing, so leaving it would serve the permutation's findings to the next run.
+    assertFalse(File(dataDir, "a11y-atf.json").exists())
+    assertFalse(File(dataDir, "a11y-overlay.png").exists())
+    // The permutation's own snapshot, taken before the failure, is untouched.
+    assertEquals(
+      "dark-pixels",
+      File(projectDir, "build/compose-previews/data/Foo_dark/a11y-overlay.png").readText(),
+    )
+  }
+
   // ---------- narrowed runs merge rather than clobber (#3742) ----------
 
   @Test


### PR DESCRIPTION
Follow-up to #3776 (issue #3762). Two review findings landed after that PR merged; both are the same failure mode it was written to kill — **one render's results filed under another id** — so they belong with it rather than in the backlog.

## 1. A permutation whose overrides collapse to the base was fetched unforced

`PreviewPermutationsCli.expand` synthesises `_dark` / `_rtl` / `_fontscale-2x` from the declared preview's params. When the preview *already* declares the value — `@Preview(fontScale = 2.0f)`, or `locale = "ar-XB"` — the expanded variant's params equal the base's, so `overridesFor` correctly returns `null`: there is nothing to override.

`fetchParams` then keyed the force flag off *having overrides*, so that variant was fetched unforced. `FileBackedDataProductRegistry` only queues a re-render when the file is **missing**, and by that point the preceding permutation had already written `a11y-atf.json` at the shared per-preview cache path — so the 2× entry was served the RTL render's findings and artefacts.

The force flag now hangs off **being a permutation**. Forced with an empty override bag is the honest request for such a variant: its configuration genuinely is the base's, and it still needs a render of its own rather than its neighbour's leftovers.

## 2. A failed restore left the base entry wearing the permutation's artefacts

#3776 added a forced default-overrides fetch that rebuilds the declared preview after its permutations ran as it. When *that* fetch failed, the base entry still read `a11y-hierarchy.json` and `a11y-overlay.png` off `data/<previewId>/` — where the last permutation had left them — while an earlier successful permutation had already set `anyFetchOk`, so the report carried no `atf-unavailable` status either. Net effect: the base preview read as checked-and-clean, illustrated with a different configuration's overlay.

Those reads are now gated on a non-null payload, and the whole directory is discarded on a failed restore — `a11y-atf.json` included. That file is not a report input, but it *is* the one the registry serves, so leaving a permutation's copy behind would hand the **next** run's unforced fetch of that preview the override's findings. Deleting it makes that next fetch a real render.

`a11y-touchTargets.json` goes with them: same producer, same render, not read here but equally untrue of the preview it sits under.

## Test plan

- [x] `./gradlew :cli:test` — full CLI suite green.
- [x] `./gradlew :cli:ktfmtFormat`.
- [x] `a permutation whose overrides collapse to the base is still forced` — the no-op variant's params bag carries `forceRerender: true` and **no** `overrides`. Fails on pre-change code, where the bag is `null`.
- [x] `a failed restore discards the permutation's artefacts instead of filing them as the base` — the base entry gets no `annotatedPath` and no nodes, `a11y-atf.json` and `a11y-overlay.png` are gone from the shared directory, and the permutation's own snapshot (taken before the failure) is untouched.

Not visual — CLI orchestration and its tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_