### PR TITLE
docs(cli): correct what --preview promises about narrowing and precedence

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -226,10 +226,12 @@ private fun printFullUsage() {
                            `<className>.<functionName>`, equals its bare function name, or is
                            a case-insensitive substring of its id (the --filter rule). It may
                            therefore match several previews — `--preview Foo` also takes
-                           `FooBar`; reach for --id when exactly one is meant. Narrows the
-                           Gradle render like --id / --filter; combining the three intersects
-                           them (on render-matrix and serve, which host a single preview, the
-                           tightest of the three given wins). `record --preview` takes the
+                           `FooBar`; reach for --id when exactly one is meant. Combining the
+                           three intersects them — every selector you pass has to match —
+                           everywhere, render-matrix and serve included. Narrows the Gradle
+                           render like --id / --filter on the preview render commands;
+                           show-resources filters its output only, since the resource render
+                           task is not scoped by any of the three. `record --preview` takes the
                            same forms but must land on exactly one preview, so it tries them
                            in order and an ambiguous reference is an error. `history
                            --preview` is a different flag: an exact preview-id filter over

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
@@ -405,6 +405,13 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
       // `--preview` is honoured here too so the selector vocabulary is uniform (issue #3744), but
       // only in its id-shaped forms: a resource capture is an XML `<vector>` / `<adaptive-icon>`,
       // not a `@Preview` function, so there is no class or function name to reference.
+      //
+      // This filters **output**, not the render. `renderModules` above runs
+      // `composePreviewRenderAndroidResources` without `scopeToPreviewRequest`, so every Android
+      // module's resources are captured whichever selector is passed — `--id` and `--filter`
+      // included; the resource task takes no id filter and there is no resource manifest to
+      // narrow against ahead of it. `help --all` says so rather than implying the render
+      // narrowing that the preview commands do get.
       val matches =
         previewIdMatchesRequest(it.id, exactId = exactId, filter = filter, previewRef = previewRef)
       matches && (!changedOnly || it.anyChanged())


### PR DESCRIPTION
Follow-up to #3780 (issue #3744) — two claims in `help --all` that PR left behind. Review caught them just as it merged, so they land separately.

## 1. The precedence sentence outlived the precedence

`help --all` said:

> combining the three intersects them (on render-matrix and serve, which host a single preview, the tightest of the three given wins)

The parenthetical stopped being true inside the same PR: `render-matrix` and `serve` were moved onto the shared `previewIdMatchesRequest`, which requires every selector passed to match. `--id A --preview B` now exits "no previews matched" everywhere, rather than rendering `A` on those two commands. Text now says intersection, without exception.

## 2. `show-resources` doesn't narrow the render, and can't be made to cheaply

The flag description promised, flatly, that `--preview` "narrows the Gradle render like `--id` / `--filter`". `ShowResourcesCommand` calls `renderModules` **without** `scopeToPreviewRequest`:

```kotlin
renderModules(
  silenceStdout = jsonOutput,
  moduleFilter = { isAndroidModule(it) },
  taskFor = { ":${it.gradlePath}:composePreviewRenderAndroidResources" },
)
```

so `composePreviewRenderAndroidResources` captures every Android module's resources whatever selector is passed — and this is not a `--preview` regression: `--id` and `--filter` have always been output filters on this command. The resource task takes no id filter, and there is no resource manifest to narrow against ahead of the task that produces it, so scoping it is a real change rather than a doc fix.

Given that, the honest move is to stop promising the saving: the help text now says the narrowing applies to the preview render commands and that `show-resources` filters its output only. Noted at `applyResourceFilters` too, so the next reader doesn't have to re-derive it from the `renderModules` call site.

## Test plan

- [x] `./gradlew :cli:test` — full CLI suite green (`CliHelpTest` and friends read the usage text, so a broken block would fail here).
- [x] `./gradlew :cli:ktfmtFormat`.

No behaviour change — help text plus one explanatory comment. Text-only, so nothing visual to show.

## Related

The third finding from that review round is a genuine pre-existing bug rather than a doc slip, and is filed as #3786: selecting a `@PreviewParameter` row id (`serve --id Foo_PARAM_1`) drops the module during `modulesMatchingPreviewRequest`, because the discovery manifest holds only the base `Foo` and the row ids don't exist yet. That predates `--preview` — it arrived with the row ids in #3772 — so it isn't fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_