### PR TITLE
fix(cli): keep every render-error sidecar, and only quote fresh ones

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -452,6 +452,13 @@ abstract class Command(
     val results: List<PreviewResult>,
     val discoveredPreviewCount: Int,
     /**
+     * Per-task dispositions captured from the Tooling API during this invocation. Carried on the
+     * outcome because reporting has to distinguish "the renderer ran and the preview threw" from
+     * "the renderer was skipped and that `.error.json` is last week's" — see
+     * [renderTaskEvidenceOf].
+     */
+    val taskOutcomes: Map<String, GradleTaskOutcome> = emptyMap(),
+    /**
      * Preview ids this run rendered, or `null` when it rendered everything the modules declare.
      * Non-null means the Gradle drive was narrowed to the `--id` / `--filter` request
      * (issue #3730), so the previews outside it carry whatever the *previous* run left on disk —
@@ -633,6 +640,7 @@ abstract class Command(
       results = results,
       discoveredPreviewCount =
         raw.discoveredPreviewCount.takeIf { it > 0 } ?: manifests.sumOf { it.second.previews.size },
+      taskOutcomes = raw.taskOutcomes,
       renderedIds = raw.renderedIds,
     )
   }
@@ -1372,11 +1380,15 @@ class ShowCommand(args: List<String>) : Command(args) {
       // List the offenders so the CI log is self-diagnosing — no need to download the
       // `composePreviewRender-reports` artifact just to learn *which* previews failed — and read
       // the renderer's `.error.json` sidecar beside each one so a preview that rendered and *threw*
-      // reports its exception instead of the NO-SOURCE build-wiring guess (issue #3741).
+      // reports its exception instead of the NO-SOURCE build-wiring guess (issue #3741). The task
+      // outcomes go along so a sidecar left by an earlier run isn't quoted as this run's finding
+      // when `composePreviewRender` was skipped (NO-SOURCE) this time.
       System.err.println(
-        formatMissingRenderReport(
-          collectMissingRenders(missing, outcome.manifests),
+        missingRenderReport(
+          missing = missing,
+          manifests = outcome.manifests,
           total = filtered.size,
+          taskOutcomes = outcome.taskOutcomes,
           prefix = prefix,
         )
       )
@@ -1572,7 +1584,22 @@ class RenderCommand(args: List<String>) : Command(args) {
         }
         val one = filtered.single()
         if (one.pngPath == null) {
-          System.err.println("Render produced no PNG for: ${one.id}")
+          // This branch used to exit with a bare "Render produced no PNG", throwing away the very
+          // sidecar issue #3741 exists to surface — so it goes through the same report `show` and
+          // the no-`--output` path below print. `missing` is empty only when the absent PNG is by
+          // design (an XR_SUBSPACE preview, an `optional` capture); `--output` still can't produce
+          // the file, so say so plainly. No policy prefix here: `--missing-renders warn` opts the
+          // *gate* down, and this exit is `--output` failing to deliver the file it was asked for.
+          System.err.println(
+            if (missing.isEmpty()) "Render produced no PNG for: ${one.id}"
+            else
+              missingRenderReport(
+                missing = missing,
+                manifests = manifests,
+                total = filtered.size,
+                taskOutcomes = gradle.lastTaskOutcomes(),
+              )
+          )
           exitProcess(2)
         }
         File(one.pngPath).copyTo(File(output), overwrite = true)
@@ -1587,11 +1614,14 @@ class RenderCommand(args: List<String>) : Command(args) {
           val prefix =
             if (policy in setOf("warn", "ignore")) "missing-renders policy=$policy — " else ""
           // Same report `show` prints: the `.error.json` sidecar beside each would-be output tells
-          // "the preview threw" apart from "the render task never ran" (issue #3741).
+          // "the preview threw" apart from "the render task never ran" (issue #3741), and the task
+          // outcomes keep a sidecar left by an earlier run from being quoted as this run's finding.
           System.err.println(
-            formatMissingRenderReport(
-              collectMissingRenders(missing, manifests),
+            missingRenderReport(
+              missing = missing,
+              manifests = manifests,
               total = filtered.size,
+              taskOutcomes = gradle.lastTaskOutcomes(),
               prefix = prefix,
             )
           )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
@@ -22,6 +22,13 @@ import okio.Path.Companion.toPath
  * The two cases want opposite remedies (fix the classpath vs. fix the composable), so the report
  * distinguishes them explicitly: a sidecar means "rendered and threw — build wiring is fine", no
  * sidecar means "the task really was skipped" and keeps the historical NO-SOURCE guidance.
+ *
+ * Two things that took a second pass to get right (#3779's review):
+ * - A sidecar is only *this run's* finding when the renderer actually ran — see
+ *   [RenderTaskEvidence]. A skipped (NO-SOURCE) render leaves the previous run's `.error.json` in
+ *   place, and quoting it as evidence would assert the opposite of what happened.
+ * - A preview's outputs fail independently, so all of their sidecars are read, not just the first —
+ *   see [collectMissingRenders].
  */
 
 /**
@@ -50,8 +57,45 @@ data class RenderErrorSidecar(
 )
 
 /**
+ * One `.error.json` found beside one of a preview's would-be outputs.
+ *
+ * Kept as `output` + payload rather than a bare [RenderErrorSidecar] because a multi-capture
+ * preview fails per *output*: the 500ms frame and the 1000ms frame are separate render attempts and
+ * can die differently (one throws from the composable, the next from a scroll data product).
+ * Collapsing them to one sidecar reports the first exception against every missing coordinate,
+ * which misdiagnoses the later captures.
+ */
+data class MissingRenderSidecar(
+  /** Module-relative path of the output the sidecar sits beside, e.g. `renders/Foo_500ms.png`. */
+  val output: String,
+  val sidecar: RenderErrorSidecar,
+)
+
+/**
+ * Whether the renderer task ran in *this* invocation for the module a missing preview belongs to.
+ *
+ * An `.error.json` on disk is only evidence about this run if the renderer had a chance to rewrite
+ * it. The renderer deletes the previous sidecar at the start of every render attempt, so when it
+ * runs, what's left is current — but when `composePreviewRender` is skipped (NO-SOURCE: the classic
+ * "the renderer test class wasn't on testClassesDirs" wiring bug) the file beside the would-be
+ * output is whatever an earlier run left there. Reporting that as "this preview rendered and threw
+ * — the build wiring is fine" states the exact opposite of what happened.
+ */
+enum class RenderTaskEvidence {
+  /** The module's `composePreviewRender` executed (or was up-to-date) in this invocation. */
+  RAN,
+  /** It was skipped — NO-SOURCE, or skipped because a dependency failed. Sidecars are leftovers. */
+  DID_NOT_RUN,
+  /**
+   * No task-outcome information was supplied. The sidecar is taken at face value, which is the
+   * pre-#3779 behaviour; both CLI call sites (`show`, `render`) pass real evidence.
+   */
+  UNKNOWN,
+}
+
+/**
  * One preview that produced no PNG, paired with whatever the renderer left beside its would-be
- * output. [sidecar] is `null` when no `.error.json` was found — the "render was skipped" case.
+ * outputs. [sidecars] is empty when no `.error.json` was found — the "render was skipped" case.
  */
 data class MissingRender(
   val id: String,
@@ -60,8 +104,22 @@ data class MissingRender(
   val coords: String,
   /** The preview's own class FQN — used to pick a stack frame in the *user's* package. */
   val className: String = "",
-  val sidecar: RenderErrorSidecar? = null,
-)
+  val sidecars: List<MissingRenderSidecar> = emptyList(),
+  /** Whether the renderer ran this invocation — see [RenderTaskEvidence]. */
+  val renderTask: RenderTaskEvidence = RenderTaskEvidence.UNKNOWN,
+) {
+  /** First sidecar found, if any. Convenience for callers that only want "did it throw at all". */
+  val sidecar: RenderErrorSidecar?
+    get() = sidecars.firstOrNull()?.sidecar
+
+  /** Sidecars this run is entitled to present as its own findings. */
+  val threwThisRun: Boolean
+    get() = sidecars.isNotEmpty() && renderTask != RenderTaskEvidence.DID_NOT_RUN
+
+  /** Sidecars that survive from an earlier run because the renderer never ran this time. */
+  val hasStaleSidecars: Boolean
+    get() = sidecars.isNotEmpty() && renderTask == RenderTaskEvidence.DID_NOT_RUN
+}
 
 /** One `Caused by:` entry of a stack trace. */
 data class RenderErrorCause(val exception: String, val message: String)
@@ -93,19 +151,27 @@ fun readRenderErrorSidecar(
 }
 
 /**
- * Pair each missing preview with its sidecar, looking beside every output the manifest says that
- * preview should have produced (each capture's `renderOutput`, then its data products). The first
- * sidecar found wins — one broken composable fails all of its outputs with the same throwable.
+ * Pair each missing preview with its sidecars, looking beside every output the manifest says that
+ * preview should have produced (each capture's `renderOutput`, then its data products). **Every**
+ * sidecar found is kept, not just the first: one broken composable does fail all of its outputs
+ * with the same throwable (the report groups those back into one line), but a time / scroll /
+ * animation fan-out is a sequence of independent render attempts, so the 1000ms capture can fail
+ * differently from the 500ms one and deserves to say so.
  *
  * Uses the manifest rather than the [PreviewResult] because a missing capture carries no path:
  * `pngPath` is null precisely because the file isn't there, so the *expected* location has to come
  * from `renderOutput` resolved against the module's `build/compose-previews` directory — the same
  * resolution [PreviewResultBuilder.build] does for outputs that exist.
+ *
+ * [renderTaskEvidence] answers "did the renderer run for this module in this invocation?" given the
+ * module's gradle path; see [RenderTaskEvidence]. The default keeps the sidecar at face value for
+ * callers with no build to ask.
  */
 fun collectMissingRenders(
   missing: List<PreviewResult>,
   manifests: List<Pair<PreviewModule, PreviewManifest>>,
   fileSystem: FileSystem = SystemFileSystem,
+  renderTaskEvidence: (String) -> RenderTaskEvidence = { RenderTaskEvidence.UNKNOWN },
 ): List<MissingRender> {
   val moduleByPath = manifests.associate { (module, _) -> module.gradlePath to module }
   val previewsByModule = manifests.associate { (module, manifest) ->
@@ -123,20 +189,69 @@ fun collectMissingRenders(
           add("renders/${result.id}.png")
         }
         .distinct()
-    val sidecar = module?.let { m ->
-      relativeOutputs.firstNotNullOfOrNull { rel ->
-        readRenderErrorSidecar(m.projectDir.resolve("build/compose-previews/$rel"), fileSystem)
-      }
-    }
+    val sidecars =
+      module?.let { m ->
+        relativeOutputs.mapNotNull { rel ->
+          readRenderErrorSidecar(m.projectDir.resolve("build/compose-previews/$rel"), fileSystem)
+            ?.let { MissingRenderSidecar(output = rel, sidecar = it) }
+        }
+      } ?: emptyList()
     MissingRender(
       id = result.id,
       module = result.module,
       coords = missingCaptureCoords(result),
       className = result.className,
-      sidecar = sidecar,
+      sidecars = sidecars,
+      renderTask = renderTaskEvidence(result.module),
     )
   }
 }
+
+/**
+ * The renderer task both backends register — Robolectric on Android, the JVM renderer on desktop.
+ */
+private const val RENDER_TASK_NAME = "composePreviewRender"
+
+/**
+ * What [taskOutcomes] says about module [modulePath]'s renderer task in this invocation.
+ *
+ * `SKIPPED` is the case that matters: Gradle reports NO-SOURCE that way, and NO-SOURCE is precisely
+ * the wiring bug the historical guidance was written for — a run where the sidecar on disk cannot
+ * have come from this render. Every other disposition means the task's inputs were current or its
+ * action executed, so what's beside the would-be output is this run's own work. An **absent** entry
+ * means no event was seen for the task at all; that can't happen for a module that reaches this
+ * report (`readableRenderModules` already drops modules whose `composePreviewRenderAll` — which
+ * `dependsOn` the renderer — produced no outcome), so it is reported as
+ * [RenderTaskEvidence.UNKNOWN] rather than guessed either way.
+ */
+internal fun renderTaskEvidenceOf(
+  modulePath: String,
+  taskOutcomes: Map<String, GradleTaskOutcome>,
+): RenderTaskEvidence {
+  val path = ":" + modulePath.trim(':') + ":" + RENDER_TASK_NAME
+  val outcome = taskOutcomes[path] ?: return RenderTaskEvidence.UNKNOWN
+  return if (outcome.disposition == GradleTaskDisposition.SKIPPED) RenderTaskEvidence.DID_NOT_RUN
+  else RenderTaskEvidence.RAN
+}
+
+/**
+ * The whole "read the sidecars, format the report" pass, as `show` and both halves of `render` use
+ * it. One entry point so no caller can accidentally reintroduce a path that reports a missing
+ * render without its sidecar — which is exactly what `render --output` did until it was routed
+ * through here.
+ */
+internal fun missingRenderReport(
+  missing: List<PreviewResult>,
+  manifests: List<Pair<PreviewModule, PreviewManifest>>,
+  total: Int,
+  taskOutcomes: Map<String, GradleTaskOutcome> = emptyMap(),
+  prefix: String = "",
+): String =
+  formatMissingRenderReport(
+    collectMissingRenders(missing, manifests) { renderTaskEvidenceOf(it, taskOutcomes) },
+    total = total,
+    prefix = prefix,
+  )
 
 /** The capture coordinates of [result] that came back without a PNG, for the offender list. */
 internal fun missingCaptureCoords(result: PreviewResult): String =
@@ -169,10 +284,26 @@ fun formatMissingRenderReport(
     val moduleTag = if (entry.module.isNotBlank()) " (${entry.module})" else ""
     sb.append("\n  - ").append(entry.id).append(moduleTag).append(" — no PNG for: ")
     sb.append(entry.coords)
-    entry.sidecar?.let { sb.appendSidecarDetail(it, entry.className) }
+    // Identical sidecars collapse to one line — one broken composable writes the same throwable
+    // beside every one of its outputs, and printing it once per capture buries the run's real
+    // shape. Distinct ones are labelled with the output they came from, because that is the only
+    // thing that ties an exception to the coordinate that produced it.
+    val groups = entry.sidecars.groupBy({ it.sidecar }, { it.output })
+    for ((sidecar, outputs) in groups) {
+      sb.appendSidecarDetail(
+        sidecar = sidecar,
+        className = entry.className,
+        // A single failure needs no output label; the entry line above already names the preview.
+        outputs = if (groups.size > 1) outputs else emptyList(),
+        stale = entry.hasStaleSidecars,
+      )
+    }
   }
-  val threw = missing.filter { it.sidecar != null }
-  val skipped = missing.filter { it.sidecar == null }
+  val threw = missing.filter { it.threwThisRun }
+  val stale = missing.filter { it.hasStaleSidecars }
+  // Everything the render task's own behaviour, rather than the composable's, has to explain: no
+  // sidecar at all, or one the renderer had no chance to refresh.
+  val unexplained = missing.filter { it.sidecars.isEmpty() || it.hasStaleSidecars }
   if (threw.isNotEmpty()) {
     // The whole point of issue #3741: an error sidecar proves the render task ran, so the
     // NO-SOURCE / testClassesDirs guidance below must NOT be printed for these.
@@ -184,14 +315,26 @@ fun formatMissingRenderReport(
       .append(RENDER_ERROR_SIDECAR_SUFFIX)
       .append("` sidecar beside each preview's would-be output.")
   }
-  if (skipped.isNotEmpty()) {
+  if (stale.isNotEmpty()) {
+    // Never claim to have observed what this run didn't do: the renderer was skipped, so the
+    // sidecar quoted above describes some earlier run and the wiring guidance below still applies.
+    sb
+      .append("\n")
+      .append(stale.size)
+      .append(" preview(s) have a `<render>.png")
+      .append(RENDER_ERROR_SIDECAR_SUFFIX)
+      .append("` sidecar on disk, but `composePreviewRender` did not run in this invocation ")
+      .append("(skipped / NO-SOURCE) — that sidecar is left over from an earlier run and says ")
+      .append("nothing about this one.")
+  }
+  if (unexplained.isNotEmpty()) {
     if (threw.isNotEmpty()) {
       sb
-        .append("\nNo error sidecar for ")
-        .append(skipped.size)
+        .append("\nNo sidecar from this run for ")
+        .append(unexplained.size)
         .append(" preview(s) (")
-        .append(skipped.take(5).joinToString(", ") { it.id })
-        .append(if (skipped.size > 5) ", …): " else "): ")
+        .append(unexplained.take(5).joinToString(", ") { it.id })
+        .append(if (unexplained.size > 5) ", …): " else "): ")
     } else {
       sb.append("\n")
     }
@@ -206,20 +349,31 @@ fun formatMissingRenderReport(
 }
 
 /**
- * The `threw X: msg (at File.kt:42 in fn)` detail lines for one failing preview.
+ * The `threw X: msg (at File.kt:42 in fn)` detail lines for one of a failing preview's sidecars.
  *
  * Leads with the **root** cause rather than the outermost throwable: the renderer invokes the
  * preview reflectively, so the outer exception is routinely a `InvocationTargetException` that says
  * nothing at all, while the last `Caused by:` in the trace is the real failure (issue #3741's case:
  * `NoClassDefFoundError: com/google/wear/services/ambient/AmbientComponentState`).
+ *
+ * [outputs] labels the line when a preview's outputs failed differently; empty for the ordinary
+ * one-failure case. [stale] marks a sidecar the renderer had no chance to refresh this run.
  */
-private fun StringBuilder.appendSidecarDetail(sidecar: RenderErrorSidecar, className: String) {
+private fun StringBuilder.appendSidecarDetail(
+  sidecar: RenderErrorSidecar,
+  className: String,
+  outputs: List<String> = emptyList(),
+  stale: Boolean = false,
+) {
   val chain = causeChainOf(sidecar.stackTrace)
   val root = chain.lastOrNull()
   val exception = root?.exception?.takeIf { it.isNotBlank() } ?: sidecar.exception
   val message = if (root != null) root.message else sidecar.message
   val frame = preferredAppFrame(sidecar.stackTrace, className) ?: sidecar.topAppFrame
-  append("\n      threw ").append(exception.substringAfterLast('.'))
+  append("\n      ")
+  if (outputs.isNotEmpty()) append(outputs.joinToString(", ")).append(" — ")
+  if (stale) append("earlier run — ")
+  append("threw ").append(exception.substringAfterLast('.'))
   if (message.isNotBlank()) append(": ").append(message)
   if (frame != null && frame.file.isNotBlank()) {
     append(" (at ").append(frame.file)
@@ -240,13 +394,18 @@ private fun StringBuilder.appendSidecarDetail(sidecar: RenderErrorSidecar, class
 }
 
 /**
- * Every `Caused by:` entry of [stackTrace], outermost cause first. Empty when the trace carries no
- * cause chain — the outermost throwable is then the whole story and the sidecar's own `exception` /
- * `message` already describe it.
+ * Every `Caused by:` entry of [stackTrace]'s **primary** chain, outermost cause first. Empty when
+ * the trace carries no cause chain — the outermost throwable is then the whole story and the
+ * sidecar's own `exception` / `message` already describe it.
+ *
+ * `Suppressed:` branches are excluded: a suppressed throwable with a cause of its own (the ordinary
+ * shape for a `use {}` / try-with-resources body that threw and then failed to close) is printed by
+ * `printStackTrace()` as an *indented* `Caused by:`, so trimming every line first made it
+ * indistinguishable from the real chain — and, being printed last, it won the `lastOrNull()` that
+ * picks the root cause. The close failure would then be reported as the render's root cause.
  */
 fun causeChainOf(stackTrace: String): List<RenderErrorCause> =
-  stackTrace
-    .lineSequence()
+  primaryTraceLines(stackTrace)
     .map { it.trim() }
     .filter { it.startsWith(CAUSED_BY_PREFIX) }
     .map { header ->
@@ -295,15 +454,55 @@ fun preferredAppFrame(stackTrace: String, previewClassName: String): RenderFailu
 }
 
 private const val CAUSED_BY_PREFIX = "Caused by:"
+private const val SUPPRESSED_PREFIX = "Suppressed:"
+
+/**
+ * [stackTrace]'s lines with every `Suppressed:` branch removed, indentation preserved.
+ *
+ * `Throwable.printStackTrace()` nests by indentation and nothing else: a suppressed throwable's
+ * caption, frames, **and its own `Caused by:` chain** are printed one tab deeper than the throwable
+ * that suppressed it (`printEnclosedStackTrace` passes `prefix + "\t"` for suppressed and the
+ * unchanged `prefix` for causes). So a block that starts at indent *n* runs until the first
+ * non-blank line indented less than *n* — everything in between belongs to the suppressed branch,
+ * not to the chain the report walks. Concretely:
+ * ```
+ * Caused by: java.io.IOException: disk gone      <- primary chain, indent 0
+ * 	at App.write(App.kt:3)
+ * 	Suppressed: java.lang.RuntimeException: close failed
+ * 		at App.close(App.kt:4)
+ * 	Caused by: java.net.SocketException: reset    <- the *suppressed* one's cause, indent 1
+ * ```
+ */
+private fun primaryTraceLines(stackTrace: String): List<String> {
+  val out = mutableListOf<String>()
+  var suppressedIndent: Int? = null
+  for (line in stackTrace.lineSequence()) {
+    if (line.isBlank()) {
+      if (suppressedIndent == null) out += line
+      continue
+    }
+    val indent = line.takeWhile { it == ' ' || it == '\t' }.length
+    suppressedIndent?.let { if (indent < it) suppressedIndent = null }
+    if (line.trimStart().startsWith(SUPPRESSED_PREFIX)) {
+      // An outer block's bound wins: a suppressed-of-a-suppressed stays inside the outer one.
+      suppressedIndent = minOf(suppressedIndent ?: indent, indent)
+      continue
+    }
+    if (suppressedIndent != null) continue
+    out += line
+  }
+  return out
+}
 
 /**
  * Split a printed stack trace into its throwable sections: the outermost throwable first, then one
- * per `Caused by:`. `Suppressed:` blocks stay attached to the section they were printed in — they
- * are not part of the cause chain the report walks.
+ * per `Caused by:`. `Suppressed:` branches are dropped entirely (see [primaryTraceLines]) so
+ * neither the cause chain nor the frame search can wander into one — the frame the report prints
+ * has to belong to the failure it names.
  */
 private fun traceSections(stackTrace: String): List<List<String>> {
   val sections = mutableListOf<MutableList<String>>(mutableListOf())
-  for (line in stackTrace.lineSequence()) {
+  for (line in primaryTraceLines(stackTrace)) {
     if (line.trim().startsWith(CAUSED_BY_PREFIX)) sections += mutableListOf<String>()
     sections.last() += line
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
@@ -158,7 +158,7 @@ class MissingRenderReportTest {
 
     assertContains(message, "NoClassDefFoundError")
     // The skip-class entry keeps its own guidance, scoped to the previews it applies to.
-    assertContains(message, "No error sidecar for 1 preview(s)")
+    assertContains(message, "No sidecar from this run for 1 preview(s)")
     assertContains(message, "NO-SOURCE")
     assertContains(message, "1 preview(s) rendered and then threw")
   }
@@ -284,6 +284,251 @@ class MissingRenderReportTest {
 
     assertContains(message, "ExceptionInInitializerError")
     assertContains(message, "libGL.so.1 missing")
+  }
+
+  // ---- Follow-ups to #3779's review (issue #3741) ----
+
+  private fun simpleSidecarJson(exception: String, message: String, stackTrace: String) =
+    """
+    {
+      "schema": "compose-preview-error/v1",
+      "exception": ${escapeJson(exception)},
+      "message": ${escapeJson(message)},
+      "stackTrace": ${escapeJson(stackTrace)}
+    }
+    """
+      .trimIndent()
+
+  /** A two-capture time fan-out: `500ms` and `1000ms`, each with its own would-be output. */
+  private fun fanoutManifests() =
+    listOf(
+      PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
+        PreviewManifest(
+          module = ":app",
+          variant = "debug",
+          previews =
+            listOf(
+              PreviewInfo(
+                id = previewId,
+                functionName = "WearAppPreview",
+                className = "com.example.wear.WearAppKt",
+                captures =
+                  listOf(
+                    Capture(advanceTimeMillis = 500, renderOutput = "renders/Wear_500ms.png"),
+                    Capture(advanceTimeMillis = 1000, renderOutput = "renders/Wear_1000ms.png"),
+                  ),
+              )
+            ),
+        )
+    )
+
+  private fun fanoutResult() =
+    PreviewResult(
+      id = previewId,
+      module = ":app",
+      functionName = "WearAppPreview",
+      className = "com.example.wear.WearAppKt",
+      captures =
+        listOf(
+          CaptureResult(advanceTimeMillis = 500, pngPath = null),
+          CaptureResult(advanceTimeMillis = 1000, pngPath = null),
+        ),
+    )
+
+  @Test
+  fun `each missing capture keeps its own sidecar`() {
+    // Two captures of one preview, failing differently — the later frame advances the clock into a
+    // coroutine that isn't ready. Collapsing to the first sidecar would report the 500ms exception
+    // against both coordinates and hide this entirely.
+    writeSidecar(
+      "renders/Wear_500ms.png",
+      simpleSidecarJson(
+        "java.lang.IllegalStateException",
+        "no theme provided",
+        "java.lang.IllegalStateException: no theme provided\n" +
+          "\tat com.example.wear.WearAppKt.WearApp(WearApp.kt:31)",
+      ),
+    )
+    writeSidecar(
+      "renders/Wear_1000ms.png",
+      simpleSidecarJson(
+        "java.lang.NullPointerException",
+        "animation target was null",
+        "java.lang.NullPointerException: animation target was null\n" +
+          "\tat com.example.wear.WearAppKt.WearAnim(WearApp.kt:57)",
+      ),
+    )
+
+    val entries = collectMissingRenders(listOf(fanoutResult()), fanoutManifests())
+    assertEquals(2, entries.single().sidecars.size)
+
+    val message = formatMissingRenderReport(entries, total = 2)
+
+    assertContains(message, "IllegalStateException")
+    assertContains(message, "no theme provided")
+    assertContains(message, "NullPointerException")
+    assertContains(message, "animation target was null")
+    // Each exception is tied to the output that produced it, so a reader can tell which coordinate
+    // died which way.
+    assertContains(message, "renders/Wear_500ms.png — threw IllegalStateException")
+    assertContains(message, "renders/Wear_1000ms.png — threw NullPointerException")
+  }
+
+  @Test
+  fun `one throwable across several outputs still reports one line`() {
+    // The common case: one broken composable fails every output with the same exception. Reporting
+    // it once per output would be noise, so identical sidecars collapse — and stay unlabelled.
+    val json =
+      simpleSidecarJson(
+        "java.lang.IllegalStateException",
+        "no theme provided",
+        "java.lang.IllegalStateException: no theme provided\n" +
+          "\tat com.example.wear.WearAppKt.WearApp(WearApp.kt:31)",
+      )
+    writeSidecar("renders/Wear_500ms.png", json)
+    writeSidecar("renders/Wear_1000ms.png", json)
+
+    val message =
+      formatMissingRenderReport(collectMissingRenders(listOf(fanoutResult()), fanoutManifests()), 2)
+
+    assertEquals(1, message.lines().count { it.contains("threw IllegalStateException") }, message)
+    assertFalse(message.contains("renders/Wear_500ms.png —"), message)
+  }
+
+  @Test
+  fun `a sidecar left by an earlier run is never reported as this run's finding`() {
+    // `composePreviewRender` was skipped this time (NO-SOURCE — the wiring bug the historical
+    // guidance was written for), so the `.error.json` on disk is last run's. Claiming "rendered and
+    // then threw — the build wiring is fine" would state the exact opposite of what happened.
+    writeSidecar("renders/WearAppPreview.png")
+
+    val entries =
+      collectMissingRenders(listOf(missingResult()), manifests()) { RenderTaskEvidence.DID_NOT_RUN }
+    val message = formatMissingRenderReport(entries, total = 35)
+
+    assertFalse(message.contains("rendered and then threw"), message)
+    assertFalse(message.contains("the build wiring is fine"), message)
+    assertContains(message, "did not run in this invocation")
+    assertContains(message, "earlier run — threw NoClassDefFoundError")
+    // ...and the wiring guidance the sidecar had suppressed comes back, because that is now the
+    // live hypothesis.
+    assertContains(message, "NO-SOURCE")
+    assertContains(message, "testClassesDirs")
+  }
+
+  @Test
+  fun `a sidecar from a render that did run keeps the thrown-here wording`() {
+    writeSidecar("renders/WearAppPreview.png")
+
+    val entries =
+      collectMissingRenders(listOf(missingResult()), manifests()) { RenderTaskEvidence.RAN }
+    val message = formatMissingRenderReport(entries, total = 35)
+
+    assertContains(message, "rendered and then threw")
+    assertFalse(message.contains("earlier run"), message)
+    assertFalse(message.contains("NO-SOURCE"), message)
+  }
+
+  @Test
+  fun `render-task evidence comes from the module's own composePreviewRender outcome`() {
+    val skipped =
+      mapOf(
+        ":app:composePreviewRender" to
+          GradleTaskOutcome(":app:composePreviewRender", GradleTaskDisposition.SKIPPED)
+      )
+    assertEquals(RenderTaskEvidence.DID_NOT_RUN, renderTaskEvidenceOf(":app", skipped))
+    // The gradle path is carried with and without its leading colon depending on the caller.
+    assertEquals(RenderTaskEvidence.DID_NOT_RUN, renderTaskEvidenceOf("app", skipped))
+
+    for (disposition in
+      listOf(
+        GradleTaskDisposition.SUCCESS,
+        GradleTaskDisposition.UP_TO_DATE,
+        GradleTaskDisposition.FROM_CACHE,
+        GradleTaskDisposition.FAILED,
+      )) {
+      val outcomes =
+        mapOf(
+          ":app:composePreviewRender" to GradleTaskOutcome(":app:composePreviewRender", disposition)
+        )
+      assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", outcomes), "$disposition")
+    }
+
+    // Another module's skip says nothing about this one, and no evidence stays "unknown" rather
+    // than being guessed either way.
+    assertEquals(RenderTaskEvidence.UNKNOWN, renderTaskEvidenceOf(":other", skipped))
+    assertEquals(RenderTaskEvidence.UNKNOWN, renderTaskEvidenceOf(":app", emptyMap()))
+  }
+
+  @Test
+  fun `the single-preview report render --output prints carries the sidecar`() {
+    // `render --output` exits as soon as the one matched preview has no PNG. It goes through the
+    // same report as every other missing render, so the exception the renderer already wrote down
+    // reaches the user instead of a bare "Render produced no PNG".
+    writeSidecar("renders/WearAppPreview.png")
+
+    val message =
+      missingRenderReport(missing = listOf(missingResult()), manifests = manifests(), total = 1)
+
+    assertContains(message, previewId)
+    assertContains(message, "NoClassDefFoundError")
+    assertContains(message, "AmbientAwareActivity.kt:76")
+  }
+
+  // A `use {}` body that threw and then failed to close: `printStackTrace()` prints the suppressed
+  // throwable's own `Caused by:` indented under it, *after* the primary chain's deepest cause.
+  // Verbatim JDK output shape (`Throwable.printEnclosedStackTrace`).
+  private val suppressedStackTrace =
+    """
+    java.lang.reflect.InvocationTargetException
+    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
+    Caused by: java.lang.IllegalStateException: body failed
+    	at com.example.wear.WearAppKt.WearApp(WearApp.kt:31)
+    Caused by: java.io.IOException: disk gone
+    	at com.example.wear.ambient.AmbientAwareActivity.rememberAmbientState(AmbientAwareActivity.kt:76)
+    	Suppressed: java.lang.RuntimeException: close failed
+    		at com.example.wear.io.Closer.close(Closer.kt:12)
+    	Caused by: java.net.SocketException: connection reset by peer
+    		at com.example.wear.io.Socket.reset(Socket.kt:99)
+    """
+      .trimIndent()
+
+  @Test
+  fun `a suppressed exception's own cause is not mistaken for the root cause`() {
+    val chain = causeChainOf(suppressedStackTrace)
+
+    assertEquals(
+      listOf("java.lang.IllegalStateException", "java.io.IOException"),
+      chain.map { it.exception },
+      "the suppressed branch's `Caused by:` must not join the primary chain",
+    )
+    assertEquals("java.io.IOException", rootCauseOf(suppressedStackTrace)?.exception)
+    assertEquals("disk gone", rootCauseOf(suppressedStackTrace)?.message)
+  }
+
+  @Test
+  fun `the preferred frame never comes from a suppressed branch`() {
+    val frame = preferredAppFrame(suppressedStackTrace, "com.example.wear.WearAppKt")
+
+    // The deepest *primary* section is the IOException's, not the suppressed close failure's —
+    // whose frames sit in `com.example.wear.io` and would otherwise win by being printed last.
+    assertEquals("AmbientAwareActivity.kt", frame?.file)
+    assertEquals(76, frame?.line)
+  }
+
+  @Test
+  fun `a suppressed exception with no cause of its own is still skipped for frames`() {
+    val trace =
+      """
+      java.lang.IllegalStateException: body failed
+      	at com.example.wear.WearAppKt.WearApp(WearApp.kt:31)
+      	Suppressed: java.lang.RuntimeException: close failed
+      		at com.example.wear.io.Closer.close(Closer.kt:12)
+      """
+        .trimIndent()
+
+    assertTrue(causeChainOf(trace).isEmpty(), "a suppressed caption is not a `Caused by:`")
+    assertEquals("WearApp.kt", preferredAppFrame(trace, "com.example.wear.WearAppKt")?.file)
   }
 
   @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderErrorTrace.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderErrorTrace.kt
@@ -19,6 +19,7 @@ package ee.schimke.composeai.plugin
 internal object RenderErrorTrace {
 
   private const val CAUSED_BY_PREFIX = "Caused by:"
+  private const val SUPPRESSED_PREFIX = "Suppressed:"
 
   /**
    * `at [<module>/]<class>.<method>(<file>:<line>)`. The optional leading group swallows the module
@@ -30,10 +31,17 @@ internal object RenderErrorTrace {
   /** One `Caused by:` entry. */
   data class Cause(val exception: String, val message: String)
 
-  /** Every `Caused by:` entry of [stackTrace], outermost cause first. */
+  /**
+   * Every `Caused by:` entry of [stackTrace]'s **primary** chain, outermost cause first.
+   *
+   * `Suppressed:` branches are excluded. A suppressed throwable that has a cause of its own — the
+   * ordinary shape for a `use {}` body that threw and then failed to close — is printed by
+   * `printStackTrace()` as an *indented* `Caused by:`, so trimming every line first made it
+   * indistinguishable from the real chain and, being printed last, it won the `lastOrNull()` that
+   * picks the root cause. See [primaryLines].
+   */
   fun causeChain(stackTrace: String): List<Cause> =
-    stackTrace
-      .lineSequence()
+    primaryLines(stackTrace)
       .map { it.trim() }
       .filter { it.startsWith(CAUSED_BY_PREFIX) }
       .map { header ->
@@ -76,10 +84,45 @@ internal object RenderErrorTrace {
     return null
   }
 
-  /** The throwable sections of a printed trace: outermost first, then one per `Caused by:`. */
+  /**
+   * [stackTrace]'s lines with every `Suppressed:` branch removed, indentation preserved.
+   *
+   * `printStackTrace()` nests by indentation and nothing else: a suppressed throwable's caption,
+   * frames, **and its own `Caused by:` chain** are printed one tab deeper than the throwable that
+   * suppressed it (`printEnclosedStackTrace` passes `prefix + "\t"` for suppressed and the
+   * unchanged `prefix` for causes), so a block that starts at indent *n* runs until the first
+   * non-blank line indented less than *n*. Mirrors `MissingRenderReport.primaryTraceLines` in
+   * `:cli`.
+   */
+  private fun primaryLines(stackTrace: String): List<String> {
+    val out = mutableListOf<String>()
+    var suppressedIndent: Int? = null
+    for (line in stackTrace.lineSequence()) {
+      if (line.isBlank()) {
+        if (suppressedIndent == null) out += line
+        continue
+      }
+      val indent = line.takeWhile { it == ' ' || it == '\t' }.length
+      suppressedIndent?.let { if (indent < it) suppressedIndent = null }
+      if (line.trimStart().startsWith(SUPPRESSED_PREFIX)) {
+        // An outer block's bound wins: a suppressed-of-a-suppressed stays inside the outer one.
+        suppressedIndent = minOf(suppressedIndent ?: indent, indent)
+        continue
+      }
+      if (suppressedIndent != null) continue
+      out += line
+    }
+    return out
+  }
+
+  /**
+   * The throwable sections of a printed trace: outermost first, then one per `Caused by:`.
+   * `Suppressed:` branches are dropped (see [primaryLines]) so the frame this picks belongs to the
+   * failure the message names.
+   */
   private fun sections(stackTrace: String): List<List<String>> {
     val out = mutableListOf<MutableList<String>>(mutableListOf())
-    for (line in stackTrace.lineSequence()) {
+    for (line in primaryLines(stackTrace)) {
       if (line.trim().startsWith(CAUSED_BY_PREFIX)) out += mutableListOf<String>()
       out.last() += line
     }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
@@ -379,4 +379,47 @@ class MissingPreviewMessageTest {
       ComposePreviewTasks.renderErrorInsight(reflectiveWrapperSidecar, "zz.other.PreviewsKt")
     assertThat(unrelated.frame?.file).isEqualTo("KeyboardDataProduct.kt")
   }
+
+  /**
+   * A `use {}` body that threw and then failed to close. `printStackTrace()` prints the suppressed
+   * throwable's own `Caused by:` indented under it and *after* the primary chain's deepest cause —
+   * verbatim JDK output shape (`Throwable.printEnclosedStackTrace`).
+   */
+  private val suppressedTrace =
+    """
+    java.lang.reflect.InvocationTargetException
+    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
+    Caused by: java.lang.IllegalStateException: body failed
+    	at com.example.wear.WearAppKt.WearApp(WearApp.kt:31)
+    Caused by: java.io.IOException: disk gone
+    	at com.example.wear.ambient.AmbientAwareActivity.rememberAmbientState(AmbientAwareActivity.kt:76)
+    	Suppressed: java.lang.RuntimeException: close failed
+    		at com.example.wear.io.Closer.close(Closer.kt:12)
+    	Caused by: java.net.SocketException: connection reset by peer
+    		at com.example.wear.io.Socket.reset(Socket.kt:99)
+    """
+      .trimIndent()
+
+  @Test
+  fun `a suppressed exception's own cause never becomes the root cause`() {
+    // Trimming every line before matching made the indented `Caused by:` of the suppressed close
+    // failure indistinguishable from the primary chain — and, printed last, it won `lastOrNull()`.
+    assertThat(RenderErrorTrace.causeChain(suppressedTrace).map { it.exception })
+      .containsExactly("java.lang.IllegalStateException", "java.io.IOException")
+      .inOrder()
+    assertThat(RenderErrorTrace.rootCause(suppressedTrace)?.exception)
+      .isEqualTo("java.io.IOException")
+    assertThat(RenderErrorTrace.rootCause(suppressedTrace)?.message).isEqualTo("disk gone")
+  }
+
+  @Test
+  fun `the preferred frame never comes from a suppressed branch`() {
+    // The deepest *primary* section is the IOException's; the suppressed branch's frames live in
+    // `com.example.wear.io` and would otherwise win the reversed section scan by being printed
+    // last.
+    val frame = RenderErrorTrace.preferredAppFrame(suppressedTrace, "com.example.wear.WearAppKt")
+
+    assertThat(frame?.file).isEqualTo("AmbientAwareActivity.kt")
+    assertThat(frame?.line).isEqualTo(76)
+  }
 }


### PR DESCRIPTION
Follow-up to #3779 (issue #3741): four P2 review findings that were left unaddressed when that PR merged. All four held; each is fixed with a test that is red against the pre-fix logic (verified by reverting each fix in turn — see the test plan).

Text-only change: the CLI's stderr diagnostic and two stack-trace parsers. Nothing renderable is affected.

## 1. Preserve sidecars for every missing capture — **held**

A multi-capture preview renders each coordinate separately, and both renderers write the `.error.json` beside the *specific* output they were producing (`DesktopRendererMain.writeErrorSidecar(targetFile, …)` is called per target file, per `@PreviewParameter` value and per capture). `collectMissingRenders` used `firstNotNullOfOrNull`, so the 500ms frame's exception was reported against every missing coordinate and a differently-failing 1000ms frame vanished.

`MissingRender.sidecar` is now `MissingRender.sidecars: List<MissingRenderSidecar>` (output path + payload). The report groups by sidecar content, so the common case — one broken composable failing all of its outputs with the same throwable — still prints one line with no output label, and genuinely distinct failures each get a line prefixed with the output that produced them:

```
  - com.example.WearAppKt.WearAppPreview (:app) — no PNG for: 500ms, 1000ms
      renders/Wear_500ms.png — threw IllegalStateException: no theme provided (at WearApp.kt:31 in WearApp)
      renders/Wear_1000ms.png — threw NullPointerException: animation target was null (at WearApp.kt:57 in WearAnim)
```

## 2. Report sidecars before the `--output` early exit — **held**

`render --output` hit `if (one.pngPath == null) { System.err.println("Render produced no PNG for: …"); exitProcess(2) }` before the sidecar branch, so exactly the exception #3779 exists to surface was thrown away. That branch now prints the same report every other missing render gets, via a single shared entry point (`missingRenderReport`) so a future caller can't reintroduce a sidecar-less path. The bare message survives only for the case where the missing PNG is by design (`XR_SUBSPACE`, an `optional` capture) and there is therefore nothing to report. No policy prefix in this branch: `--missing-renders warn` opts the *gate* down, while this exit is `--output` failing to deliver the file it was asked for — exit 2 is unchanged.

## 3. Reject stale sidecars after a failed build — **held, but not for the reason given, so the fix is narrower**

The literal scenario in the finding (a *compilation* error leaving `show` to read an old sidecar) can't reach the report: `readableRenderModules` already drops any module whose `:m:composePreviewRenderAll` produced no task outcome or a SKIPPED one, and that task `dependsOn` the renderer — so a module whose compile failed never contributes previews to `missing` at all.

The underlying bug is real through a different door, and it is worse: **`composePreviewRender` reporting NO-SOURCE**. That is the exact wiring bug the historical guidance was written for, and it is the one case where `composePreviewRenderAll` still runs (its dependency merely "succeeded" as skipped), finds no PNGs, and the CLI then quotes yesterday's `.error.json` as "this preview rendered and then threw — the build wiring is fine". Precisely inverted.

There is no timestamp in the sidecar schema, and mtime is not usable: a legitimately UP-TO-DATE render leaves the previous sidecar untouched, so "older than this invocation" does not mean stale. What *is* knowable at the call site is the renderer task's disposition, which the Tooling API already captures (`GradleConnection.lastTaskOutcomes()`). `RenderModulesOutcome` now carries it, and `renderTaskEvidenceOf` maps it: SKIPPED → `DID_NOT_RUN`, any other disposition → `RAN`, absent → `UNKNOWN` (not guessed — and unreachable in practice, per the paragraph above). A `DID_NOT_RUN` sidecar is still printed, because its content is useful, but it is labelled and the wiring guidance comes back:

```
      earlier run — threw NoClassDefFoundError: com/google/wear/… (at AmbientAwareActivity.kt:76 …)
1 preview(s) have a `<render>.png.error.json` sidecar on disk, but `composePreviewRender` did not
run in this invocation (skipped / NO-SOURCE) — that sidecar is left over from an earlier run and
says nothing about this one.
No sidecar from this run for 1 preview(s) (…): Check the Gradle output above — a common cause is …
```

Residual, stated rather than papered over: when the renderer task itself FAILED mid-run, previews it never reached keep their older sidecars and are still reported as `RAN`. Distinguishing those needs a per-preview timestamp the schema doesn't have; the alternative (calling every sidecar from a failed render stale) would suppress the #3690 native-load diagnosis, which is written by exactly that kind of run.

## 4. Exclude suppressed causes from the main cause chain — **held, both parsers**

Confirmed against real JDK output rather than from memory — `Throwable.printEnclosedStackTrace` passes `prefix + "\t"` for suppressed entries and the *unchanged* prefix for causes, so a suppressed throwable's own `Caused by:` is printed indented, and when the suppression sits on the deepest cause it is printed **last**:

```
java.lang.reflect.InvocationTargetException
	at …
Caused by: java.lang.IllegalStateException: body failed
	at …
Caused by: java.io.IOException: disk gone
	at …
	Suppressed: java.lang.RuntimeException: close failed
		at …
	Caused by: java.net.SocketException: connection reset by peer
		at …
```

Both parsers trimmed every line before matching, so `lastOrNull()` reported `SocketException: connection reset by peer` — a `use {}` close failure — as the render's root cause, and the reversed section scan picked its frames as the source pointer. Both `MissingRenderReport` and its `:gradle-plugin` twin `RenderErrorTrace` now drop suppressed branches by indentation (a block at indent *n* runs until the first non-blank line indented less than *n*) before walking the chain or searching for a frame.

## Test plan

- `./gradlew :cli:test` — green (full suite).
- `./gradlew :gradle-plugin:test` — green (full suite).
- `./gradlew :cli:ktfmtFormat` / `:gradle-plugin:ktfmtFormat` — applied before committing.
- Red-then-green, each fix reverted in isolation against the new tests:
  - `firstNotNullOfOrNull` restored → `each missing capture keeps its own sidecar` FAILS.
  - trace parsers restored to `lineSequence().map { it.trim() }` → `a suppressed exception's own cause is not mistaken for the root cause` + `the preferred frame never comes from a suppressed branch` FAIL in `:cli`, and the two same-named tests FAIL in `:gradle-plugin`.
  - render-task evidence ignored (`renderTask = UNKNOWN` unconditionally) → `a sidecar left by an earlier run is never reported as this run's finding` FAILS.
- One caveat, stated plainly: the `--output` test (`the single-preview report render --output prints carries the sidecar`) covers the shared report the branch now calls, not the branch's own wiring — the pre-fix code had that decision inlined in `RenderCommand.run()` inside `withGradle`, with no seam a unit test could reach, so this one is new-behaviour coverage rather than a regression test. The wiring itself is a two-line diff visible in `Commands.kt`.
- `RenderTaskEvidence` mapping is covered directly (`render-task evidence comes from the module's own composePreviewRender outcome`), including the leading-colon-or-not gradle path and the "another module's skip says nothing about this one" case.

Fixes the four unaddressed review findings on #3779.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_