### PR TITLE
docs(cli): say that record takes the first selector, not the intersection

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -233,9 +233,11 @@ private fun printFullUsage() {
                            preview render commands; show-resources filters its output only,
                            since the resource render task is not scoped by any of the three.
                            `record` is the exception, because it needs exactly one preview:
-                           it takes the first of --id / --preview / --filter you gave and
-                           resolves that alone, in stages, erroring on an ambiguous
-                           reference. `history --preview` is a different flag again: an exact
+                           --id beats --preview beats --filter — a fixed order, not the order
+                           you typed them — and it resolves that one alone, in stages,
+                           erroring on an ambiguous reference. So `record --filter Foo --id
+                           Bar` records Bar. `history --preview` is a different flag again: an
+                           exact
                            preview-id filter over archived entries.
       --json               Emit JSON (show, list, a11y, devices)
       --brief              JSON only: drop functionName/className/sourceFile/params

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -227,15 +227,16 @@ private fun printFullUsage() {
                            a case-insensitive substring of its id (the --filter rule). It may
                            therefore match several previews — `--preview Foo` also takes
                            `FooBar`; reach for --id when exactly one is meant. Combining the
-                           three intersects them — every selector you pass has to match —
-                           everywhere, render-matrix and serve included. Narrows the Gradle
-                           render like --id / --filter on the preview render commands;
-                           show-resources filters its output only, since the resource render
-                           task is not scoped by any of the three. `record --preview` takes the
-                           same forms but must land on exactly one preview, so it tries them
-                           in order and an ambiguous reference is an error. `history
-                           --preview` is a different flag: an exact preview-id filter over
-                           archived entries.
+                           three intersects them — every selector you pass has to match — on
+                           every command that selects a *set*, render-matrix and serve
+                           included. Narrows the Gradle render like --id / --filter on the
+                           preview render commands; show-resources filters its output only,
+                           since the resource render task is not scoped by any of the three.
+                           `record` is the exception, because it needs exactly one preview:
+                           it takes the first of --id / --preview / --filter you gave and
+                           resolves that alone, in stages, erroring on an ambiguous
+                           reference. `history --preview` is a different flag again: an exact
+                           preview-id filter over archived entries.
       --json               Emit JSON (show, list, a11y, devices)
       --brief              JSON only: drop functionName/className/sourceFile/params
       --changed-only       JSON only (show, a11y): drop previews with no changed capture


### PR DESCRIPTION
Follow-up to #3787, which merged while this correction was being written.

That PR replaced a stale precedence sentence with "combining the three intersects them — every selector you pass has to match — **everywhere**". The "everywhere" is wrong for one command. `RecordPreviewCommand`:

```kotlin
private val recordedPreviewRef: String? = exactId ?: previewRef ?: filter
```

`record` needs exactly **one** preview, so it takes the first selector given and puts that through `resolvePreviewId`'s staged resolver — an ambiguous reference is an error there, rather than a set to narrow. `record --id A --preview B` records `A`; the intersection claim would have a reader expect it to record nothing.

That behaviour is deliberate and documented at the field, so this corrects the help text rather than the code. The `record` sentence that followed already described the staged resolver, but read as an addendum to a rule it actually contradicts — it now names `record` as the exception up front and says which selector wins.

## Test plan

- [x] `./gradlew :cli:test` — full CLI suite green (the usage text is read by tests, so a malformed block fails here).
- [x] `./gradlew :cli:ktfmtFormat`.

Help text only, no behaviour change. Nothing visual.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_