### PR TITLE
fix(cli): refuse a pre-permutation hold that could not be cleared

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
@@ -438,6 +438,17 @@ internal class DaemonA11yFetcher(
     val hold = projectDir.resolve("build/compose-previews/.a11y-pre-permutation/$previewId")
     return try {
       hold.deleteRecursively()
+      // `deleteRecursively()` reports failure by returning false, and a hold directory that still
+      // holds an *earlier* run's files is worse than none: a file this run's base doesn't have
+      // would look held, and the roll-back would reinstate a stale overlay or ATF payload as the
+      // preview's current one. An empty directory is the only usable starting point.
+      if (PER_RENDER_FILES.any { hold.resolve(it).exists() }) {
+        onLog(
+          "could not clear the pre-permutation hold for '$previewId' at ${hold.path}; " +
+            "rolling back will discard its artefacts instead of restoring them"
+        )
+        return null
+      }
       hold.mkdirs()
       for (name in PER_RENDER_FILES) {
         val source = dir.resolve(name)
@@ -485,14 +496,21 @@ internal class DaemonA11yFetcher(
     }
   }
 
-  /** Drop the hold directory once the outcome is decided, restored from or not. */
+  /**
+   * Drop the hold directory once the outcome is decided, restored from or not. A failure here is
+   * not fatal — [holdArtifacts] re-checks that the directory is clear before trusting it — but it
+   * is worth saying, since the leftovers cost the *next* run its roll-back.
+   */
   private fun releaseHeldArtifacts(held: File?) {
     if (held == null) return
-    try {
-      held.deleteRecursively()
-    } catch (e: Exception) {
-      onLog("could not clean up ${held.path}: ${e.message}")
-    }
+    val cleared =
+      try {
+        held.deleteRecursively()
+      } catch (e: Exception) {
+        onLog("could not clean up ${held.path}: ${e.message}")
+        false
+      }
+    if (!cleared && held.exists()) onLog("could not clean up ${held.path}")
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
@@ -738,6 +738,48 @@ class DaemonA11yFetcherTest {
     )
   }
 
+  @Test
+  fun `a hold left by an earlier run is not reinstated`() {
+    val projectDir = newTempFolder("module-permutation-stale-hold")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+    val dataDir = File(projectDir, "build/compose-previews/data/Foo")
+    dataDir.mkdirs()
+    File(dataDir, "a11y-atf.json").writeText("""{"findings":[]}""")
+    // An earlier run's hold, carrying an overlay this run's base does not have. If the hold were
+    // reused rather than cleared, the roll-back would treat that image as the preview's current
+    // one and reinstate a render from two runs ago.
+    val hold = File(projectDir, "build/compose-previews/.a11y-pre-permutation/Foo")
+    hold.mkdirs()
+    File(hold, "a11y-overlay.png").writeText("from-two-runs-ago")
+
+    DaemonA11yFetcher(
+        factory =
+          FakeFactory(
+            payloads = emptyMap(),
+            payloadByCall = mapOf(1 to atfPayload(emptyList()), 2 to null),
+          )
+      )
+      .fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previews =
+          listOf(
+            ReportCommand.RequestedPreview("Foo", "Foo"),
+            ReportCommand.RequestedPreview("Foo", "Foo_dark", PreviewOverrides(fontScale = 2.0f)),
+          ),
+      )
+
+    assertFalse(
+      File(dataDir, "a11y-overlay.png").exists(),
+      "the stale hold must not be reinstated as this preview's overlay",
+    )
+    // What this run actually held is restored, so the base keeps its own data product.
+    assertEquals("""{"findings":[]}""", File(dataDir, "a11y-atf.json").readText())
+    assertFalse(hold.exists(), "and the hold is released either way")
+  }
+
   // ---------- narrowed runs merge rather than clobber (#3742) ----------
 
   @Test


### PR DESCRIPTION
Follow-up to #3784 (issue #3762), which merged while this was being written.

That PR replaced the "delete the base's artefacts when the restoring fetch fails" recovery with a hold-and-roll-back: `data/<previewId>/` is copied aside before any permutation renders as the preview, and copied back if the restore fails. The hold directory is per preview and reused across runs, cleared with `deleteRecursively()`.

`deleteRecursively()` reports failure by **returning false**, not by throwing — a locked file, a read-only parent — and the result went unchecked. An uncleared hold is worse than no hold at all: a file this run's base doesn't have would still be sitting there looking held, and the roll-back would copy an older run's overlay or ATF payload back as the preview's *current* one. That is the same class of lie the whole permutation series exists to remove, just sourced from a previous run rather than a sibling configuration.

So `holdArtifacts` now verifies the directory is genuinely empty before trusting it, and returns `null` when it isn't. A `null` hold makes the roll-back **discard** instead of restoring, which costs a re-render on the next fetch — the cheaper of the two mistakes, since the alternative is serving the wrong render as this preview's findings. It logs, because a degraded path that says nothing is indistinguishable from a healthy one.

`releaseHeldArtifacts` checks its own result for the same reason: a hold it fails to clean up is a hold the *next* run has to refuse.

## Test plan

- [x] `./gradlew :cli:test` — full CLI suite green.
- [x] `./gradlew :cli:ktfmtFormat`.
- [x] `a hold left by an earlier run is not reinstated` — seeds a stale hold containing an overlay this run's base doesn't have, fails the restoring fetch, and asserts the stale overlay is not copied into `data/Foo/` while the ATF payload this run actually held is.

**Honest scope note:** that test exercises the clearing path (where `deleteRecursively()` succeeds and the stale file is removed before the hold is populated), not the refusal path. A delete failure can't be simulated portably from a unit test — a temp directory is always deletable, and the obvious tricks (`chmod` on the parent) are no-ops when the tests run as root, which they do in this container. The guard is therefore defensive code verified by reading, with the observable half covered above.

Not visual — CLI orchestration and its tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_