### PR TITLE
fix(daemon): make preview/rows work on the production desktop host

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1008,23 +1008,85 @@ open class RobolectricHost(
             append("previewParameterLimit=").append(spec.previewParameterLimit)
           }
       )
-    val slotIdx = 0
+    // Only slot 0 is reachable through the bridge — slots 1..N-1 live in worker JVMs with no
+    // ParameterRows lane — and a held interactive session pins exactly that slot
+    // ([INTERACTIVE_SLOT_INDEX] is 0 since #3072). While one is held, the slot's loop is inside
+    // `runHeldInteractiveSession` draining `interactiveCommands` and never polls `requests`, so an
+    // enqueued enumeration would sit until the timeout. That is far worse here than for a render:
+    // this call is synchronous on the JSON-RPC reader thread, so blocking on it also stops the
+    // `interactive/stop` that would release the slot from ever being read — a deterministic stall
+    // rather than a slow answer. Fail immediately and tell the caller what to do instead.
+    checkNotPinnedByInteractiveSession(previewId)
+    val slotIdx = INTERACTIVE_SLOT_INDEX
     val slot = DaemonHostBridge.slot(slotIdx)
     // Same publish-then-enqueue order `submitInProcess` uses, so the enumeration reads the same
     // (possibly just-swapped) bytecode the next render would.
     publishChildLoaderForSlot(slotIdx)
-    slot.requests.put(request)
+    // Register the result queue BEFORE enqueueing, so the sandbox side can post with a plain
+    // `results[id]?.put(...)` — no `computeIfAbsent` — and a reply that arrives after this call has
+    // given up is dropped instead of resurrecting a map entry nobody will ever drain.
     val resultQueue = DaemonHostBridge.results.computeIfAbsent(request.id) { LinkedBlockingQueue() }
     val raw =
-      resultQueue.poll(PARAMETER_ROWS_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-        ?: error("previewParameterRows('$previewId') timed out after ${PARAMETER_ROWS_TIMEOUT_MS}ms")
-    DaemonHostBridge.results.remove(request.id)
+      try {
+        slot.requests.put(request)
+        // Poll in slices rather than one long wait: a session can be acquired between the check
+        // above and this point, and the queued request would then never be drained. Re-checking
+        // each slice turns that race into the same fast, actionable failure instead of the full
+        // timeout. The abandoned request stays on the queue and is drained (and its reply dropped)
+        // when the held session releases the slot.
+        pollParameterRows(resultQueue, previewId)
+          ?: error(
+            "previewParameterRows('$previewId') timed out after ${PARAMETER_ROWS_TIMEOUT_MS}ms"
+          )
+      } finally {
+        DaemonHostBridge.results.remove(request.id)
+      }
     if (raw is Throwable) throw raw
     @Suppress("UNCHECKED_CAST")
     val labels = raw as? List<String> ?: error("unexpected ParameterRows reply: ${raw.javaClass}")
     return labels.mapIndexed { index, label ->
       PreviewParameterRow(index = index, label = label, id = PreviewRowAddress.rowId(baseId, label))
     }
+  }
+
+  /**
+   * Throws when a held interactive session owns [INTERACTIVE_SLOT_INDEX], which is the only slot
+   * that can answer a row enumeration. [IllegalStateException] (not
+   * [UnsupportedOperationException]) on purpose: the host *can* enumerate, it just can't right now,
+   * and `MethodNotFound` would tell a client to stop asking permanently.
+   */
+  private fun checkNotPinnedByInteractiveSession(previewId: String) {
+    val held = activeInteractiveStreamId.get() ?: return
+    throw IllegalStateException(
+      "RobolectricHost: cannot enumerate @PreviewParameter rows for previewId='$previewId' while " +
+        "interactive session '$held' holds sandbox slot $INTERACTIVE_SLOT_INDEX — enumeration " +
+        "runs inside that sandbox and the held-session loop does not serve it. Call " +
+        "interactive/stop first, or enumerate before starting the session."
+    )
+  }
+
+  /**
+   * Waits for the sandbox's reply in [PARAMETER_ROWS_POLL_SLICE_MS] slices up to
+   * [PARAMETER_ROWS_TIMEOUT_MS], aborting early if a session pins the slot mid-wait. Returns null
+   * only on a genuine timeout.
+   */
+  private fun pollParameterRows(queue: LinkedBlockingQueue<Any>, previewId: String): Any? {
+    val deadline = System.nanoTime() + PARAMETER_ROWS_TIMEOUT_MS * 1_000_000
+    while (System.nanoTime() < deadline) {
+      queue.poll(PARAMETER_ROWS_POLL_SLICE_MS, TimeUnit.MILLISECONDS)?.let {
+        return it
+      }
+      checkNotPinnedByInteractiveSession(previewId)
+    }
+    return null
+  }
+
+  /**
+   * Test seam for the held-session pin, so the [previewParameterRows] refusal can be covered
+   * without booting a sandbox and standing up a real interactive session.
+   */
+  internal fun pinInteractiveSlotForTest(streamId: String?) {
+    activeInteractiveStreamId.set(streamId)
   }
 
   /** The in-process (slot 0) half of [submit] — the pre-pool path, unchanged. */
@@ -2055,6 +2117,13 @@ open class RobolectricHost(
      * is metadata, not a render, so it must never inherit the render timeout's open-endedness.
      */
     private const val PARAMETER_ROWS_TIMEOUT_MS: Long = 30_000L
+
+    /**
+     * Slice length for [pollParameterRows]. Short enough that a session acquired mid-wait is
+     * noticed promptly, coarse enough not to spin — same trade-off [INTERACTIVE_WORKER_POLL_MS]
+     * makes on the acquire side.
+     */
+    private const val PARAMETER_ROWS_POLL_SLICE_MS: Long = 100L
   }
 
   override fun shutdown(timeoutMs: Long) {
@@ -2418,7 +2487,11 @@ open class RobolectricHost(
               } catch (t: Throwable) {
                 unwrapInvocationTarget(t)
               }
-            DaemonHostBridge.results.computeIfAbsent(id) { LinkedBlockingQueue() }.put(reply)
+            // Plain lookup, not `computeIfAbsent`: the host registers the queue before it enqueues,
+            // so a missing entry means the caller already gave up (it aborted when a held
+            // interactive session took the slot). Dropping the reply is correct there; recreating
+            // the entry would leak a queue nobody drains.
+            DaemonHostBridge.results[id]?.put(reply)
           }
           "Render" -> {
             val id = request.javaClass.getMethod("getId").invoke(request) as Long

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricRowEnumerationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricRowEnumerationTest.kt
@@ -64,6 +64,40 @@ class RobolectricRowEnumerationTest {
     assertTrue(DaemonHostBridge.slot(0).requests.isEmpty())
   }
 
+  /**
+   * Review follow-up. `INTERACTIVE_SLOT_INDEX` is 0 (since #3072), the same in-process sandbox
+   * enumeration needs — and slots 1..N-1 are worker JVMs with no ParameterRows lane, so there is
+   * nowhere else to send it. While a session is held, that slot's loop sits in
+   * `runHeldInteractiveSession` draining `interactiveCommands` and never polls `requests`.
+   *
+   * Enqueueing anyway would block for the full 30s timeout, and because this call is synchronous on
+   * the JSON-RPC reader thread it would also stop the `interactive/stop` that releases the slot from
+   * being read at all — a deterministic stall, not a slow answer. So it must refuse immediately, and
+   * leave nothing on the queue for the session's loop to trip over when it resumes.
+   */
+  @Test
+  fun `a held interactive session makes enumeration refuse rather than stall`() {
+    val router = router(entry("Screen", "com.example.TintProvider"))
+    router.pinInteractiveSlotForTest("android-stream-1")
+    try {
+      val start = System.nanoTime()
+      val failure = runCatching { router.previewParameterRows("Screen") }.exceptionOrNull()
+      val elapsedMs = (System.nanoTime() - start) / 1_000_000
+
+      assertTrue(
+        "expected IllegalStateException naming the held session, got $failure",
+        failure is IllegalStateException && failure.message?.contains("android-stream-1") == true,
+      )
+      assertTrue("must fail fast, not wait out the timeout — took ${elapsedMs}ms", elapsedMs < 5_000)
+      assertTrue(
+        "a refused enumeration must not leave a request for the held loop to find",
+        DaemonHostBridge.slot(0).requests.isEmpty(),
+      )
+    } finally {
+      router.pinInteractiveSlotForTest(null)
+    }
+  }
+
   @Test
   fun `an unknown previewId is rejected before any sandbox work`() {
     val failure =

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -323,6 +323,63 @@ open class DesktopHost(
   }
 
   /**
+   * Issue #3749 — enumerate [previewId]'s `@PreviewParameter` rows.
+   *
+   * Lives on [DesktopHost] rather than on [PreviewManifestRouter] because the router is a
+   * harness-only subclass: production desktop daemons mount a plain [DesktopHost] with a
+   * `PreviewIndex`-backed [previewSpecResolver] (see `DaemonMain`), and an implementation on the
+   * router alone would answer `MethodNotFound` on every real launch. Both resolvers already carry
+   * the provider FQN and, for a row-addressed id, the row token — so one implementation serves
+   * both.
+   *
+   * The **metadata gate** comes first: a preview that declares no provider has no rows, and
+   * answering that from the resolver alone keeps the common call — which a client makes for every
+   * preview it lists — off the classloader entirely.
+   */
+  override fun previewParameterRows(previewId: String): List<PreviewParameterRow> {
+    val resolver =
+      previewSpecResolver
+        ?: throw UnsupportedOperationException(
+          "DesktopHost has no previewSpecResolver; pass one at construction time to enable " +
+            "@PreviewParameter row enumeration"
+        )
+    val spec =
+      resolver(previewId)
+        ?: throw IllegalArgumentException(
+          "DesktopHost.previewSpecResolver returned null for previewId='$previewId'"
+        )
+    val provider =
+      spec.previewParameterProviderClassName?.takeIf { it.isNotBlank() } ?: return emptyList()
+    // A row-addressed id resolves too and answers with the whole row set — a client holding
+    // `Foo_Dark` is asking "what else is there". Both resolvers set `previewParameterRow` when they
+    // split one, so the base id comes back off the suffix rather than being re-derived here (where
+    // the longest-parameterized-prefix rule isn't available).
+    val baseId =
+      spec.previewParameterRow?.let {
+        previewId.removeSuffix("_$it").takeIf { base -> base != previewId }
+      } ?: previewId
+    val limit =
+      spec.previewParameterLimit.coerceAtMost(
+        ee.schimke.composeai.renderer.PreviewParameterSupport.MAX_ROW_SCAN
+      )
+    // Enumerate on the same disposable child loader a render would use, so a provider edited since
+    // the daemon started is read fresh rather than off the bytecode it booted with. A fresh
+    // provider instance is constructed per call (`PreviewParameterSupport.loadValues` news it up),
+    // so this shares no state with a concurrent render's own enumeration.
+    val values =
+      ee.schimke.composeai.renderer.PreviewParameterSupport.loadValues(
+        providerFqn = provider,
+        limit = limit,
+        classLoader = userClassloaderHolder?.currentChildLoader() ?: javaClass.classLoader,
+      )
+    return ee.schimke.composeai.renderer.PreviewParameterSupport.rowSuffixes(values).mapIndexed {
+      index,
+      label ->
+      PreviewParameterRow(index = index, label = label, id = PreviewRowAddress.rowId(baseId, label))
+    }
+  }
+
+  /**
    * v2 — allocate a [DesktopInteractiveSession] holding a long-lived
    * [androidx.compose.ui.ImageComposeScene] for [previewId]. The session resolves [previewId] to a
    * [RenderSpec] via the [previewSpecResolver] supplied at construction; if no resolver is wired,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -245,41 +245,6 @@ class PreviewManifestRouter(
   /** A previewId resolved against the manifest: the entry to render, and which row of it. */
   internal data class Addressed(val entry: PreviewManifestEntry, val row: String?)
 
-  override fun previewParameterRows(previewId: String): List<PreviewParameterRow> {
-    // Row-addressed ids resolve too, and answer with the *whole* row set: a client holding
-    // `Foo_Dark` is asking "what else is there", and making it strip the suffix itself would hand
-    // back the same longest-base ambiguity `rowAddressed` exists to resolve.
-    val entry =
-      rowAddressed(previewId)?.entry
-        ?: throw IllegalArgumentException(
-          "no manifest entry for previewId='$previewId'. Manifest knows: ${byId.keys}"
-        )
-    val baseId = entry.id
-    val resolved = entry.resolved()
-    // Metadata gate (issue #3749): an ordinary preview has no rows, and answering that from
-    // discovery alone keeps the common call off the classloader entirely. Only a declared provider
-    // earns the reflective enumeration below.
-    val provider =
-      resolved.previewParameterProviderClassName?.takeIf { it.isNotBlank() } ?: return emptyList()
-    val limit =
-      resolved.previewParameterLimit.coerceAtMost(
-        ee.schimke.composeai.renderer.PreviewParameterSupport.MAX_ROW_SCAN
-      )
-    // Enumerate on the same disposable child loader a render would use, so a provider edited since
-    // the daemon started is read fresh rather than off the bytecode it booted with.
-    val values =
-      ee.schimke.composeai.renderer.PreviewParameterSupport.loadValues(
-        providerFqn = provider,
-        limit = limit,
-        classLoader = userClassloaderHolder?.currentChildLoader() ?: javaClass.classLoader,
-      )
-    return ee.schimke.composeai.renderer.PreviewParameterSupport.rowSuffixes(values).mapIndexed {
-      index,
-      label ->
-      PreviewParameterRow(index = index, label = label, id = PreviewRowAddress.rowId(baseId, label))
-    }
-  }
-
   private fun parseInboundPayload(payload: String): Map<String, String> {
     val map = mutableMapOf<String, String>()
     for (entry in payload.split(';')) {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRowEnumerationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRowEnumerationTest.kt
@@ -97,6 +97,42 @@ class PreviewManifestRowEnumerationTest {
     assertEquals(listOf("Screen_Dark", "Screen_dark"), rows.map { it.id })
   }
 
+  /**
+   * Review follow-up: the implementation must live on [DesktopHost], not on the router.
+   * [PreviewManifestRouter] is harness-only (`-Dcomposeai.harness.previewsManifest`); every
+   * production desktop launch mounts a plain [DesktopHost] with a `PreviewIndex`-backed resolver
+   * (`DaemonMain`). A router-only override answered `MethodNotFound` on the path real users take —
+   * and the harness tests couldn't see it, because the harness is exactly the path that *does*
+   * mount a router.
+   */
+  @Test
+  fun `a plain DesktopHost with a resolver enumerates too`() {
+    val spec =
+      RenderSpec(
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "CaseLabelledSquare",
+        previewParameterProviderClassName = "ee.schimke.composeai.daemon.CaseTintProvider",
+      )
+    val host = DesktopHost(previewSpecResolver = { id -> spec.takeIf { id == "Screen" } })
+
+    assertEquals(
+      listOf("Screen_Dark", "Screen_dark"),
+      host.previewParameterRows("Screen").map { it.id },
+    )
+  }
+
+  /**
+   * No resolver at all is the one case that genuinely can't enumerate — MethodNotFound is right.
+   */
+  @Test
+  fun `a DesktopHost with no resolver reports the capability as unsupported`() {
+    val failure = runCatching { DesktopHost().previewParameterRows("Screen") }.exceptionOrNull()
+    assertTrue(
+      "expected UnsupportedOperationException, got $failure",
+      failure is UnsupportedOperationException,
+    )
+  }
+
   @Test
   fun `an unknown previewId is rejected as an argument error`() {
     val failure =

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -428,9 +428,12 @@ Where enumeration runs differs by backend, and it has to. Desktop enumerates in-
 
 `serve` does not use this method — its Gradle path renders before it starts the server, so `ServeParameterRows` reads the fan-out back off disk, which is stronger evidence (the manifest says who owns which file) and needs no daemon.
 
+**Android caveat — a held interactive session blocks enumeration.** `INTERACTIVE_SLOT_INDEX` is slot 0, the same in-process sandbox enumeration needs, and slots 1..N-1 are worker JVMs with no enumeration lane. While a session is held, that slot's loop drains `interactiveCommands` and never polls the render queue, so `preview/rows` fails fast with an `Internal` error naming the holding stream rather than blocking — this call is synchronous on the reader thread, so waiting it out would also stop the `interactive/stop` that releases the slot from being read. Enumerate before starting a session, or stop the session first.
+
 Errors:
 - `InvalidParams` (-32602) — unknown `previewId`.
-- `MethodNotFound` (-32601) — the host can't enumerate at all. Clients should fall back to the bare id.
+- `MethodNotFound` (-32601) — the host can't enumerate at all (no `previewSpecResolver` wired). Clients should fall back to the bare id.
+- `Internal` (-32603) — enumeration was possible but failed or was unavailable right now: a provider that throws, a missing provider class, or the Android held-session case above. Retryable, unlike `MethodNotFound`.
 
 ### `history/list` (phase H2)
 


### PR DESCRIPTION
Review follow-up to #3788, which auto-merged before these landed. Two findings, both cases where the enumeration RPC's own tests **structurally could not** have caught the bug.

## `preview/rows` was dead on every production desktop daemon

`PreviewManifestRouter` is harness-only — mounted only when `-Dcomposeai.harness.previewsManifest` is set. Every real desktop launch mounts a plain `DesktopHost` with a `PreviewIndex`-backed `previewSpecResolver` (`DaemonMain`). The override went on the router, so `preview/rows` answered `MethodNotFound` on the path users actually take.

The harness lanes passed *because* the harness is the one path that mounts a router — the test and the bug were in complementary halves of the same fork. That's the part worth remembering: a green harness lane is not evidence about the production wiring when the harness is what supplies the wiring.

Moved to `DesktopHost`, keyed off `previewSpecResolver`. Both resolvers already carry the provider FQN and, for a row-addressed id, the row token, so one implementation serves the manifest-backed and index-backed paths; the router override is deleted rather than duplicated. A missing resolver — the only genuine "cannot enumerate" — still reports `MethodNotFound`.

## Android could deterministically stall on a held interactive session

`INTERACTIVE_SLOT_INDEX` is **slot 0** (since #3072; a nearby comment claiming slot 1 is stale and misled my first read), which is the same in-process sandbox enumeration needs. Slots 1..N-1 are worker JVMs with no `ParameterRows` lane, so there is nowhere else to send it. While a session is held, that slot's loop drains `interactiveCommands` and never polls `requests` — an enqueued enumeration sat for the full 30s.

Worse than a slow answer: this call is synchronous on the JSON-RPC reader thread, so blocking also stopped the `interactive/stop` that would release the slot from ever being read.

Now it:
- refuses immediately with an `IllegalStateException` naming the holding stream — mapped to a retryable `Internal`, deliberately not `MethodNotFound`, since the host *can* enumerate, just not right now;
- re-checks the pin on every 100ms poll slice, so a session acquired between the check and the enqueue aborts fast instead of waiting out the timeout;
- registers the result queue **before** enqueueing so the sandbox can post with a plain `results[id]?.put(...)` — a reply for an abandoned request is dropped rather than resurrecting a map entry nobody drains.

## Not taken: serialising desktop enumeration on the render queue (P2)

`PreviewParameterSupport.loadValues` constructs a fresh provider via `ctor.newInstance()` on every call, so a concurrent `preview/rows` and render share no provider instance state. The review's supporting claim — that `RenderRequest.ParameterRows` "explicitly promises serialization on the render queue" — reads the KDoc backwards: that type exists because Android's answer is only obtainable *inside the sandbox*, and `DesktopHost`'s queue branch explicitly rejects it.

Routing desktop enumeration through the render queue would also put a metadata call behind arbitrarily long renders, defeating the gate that makes it cheap enough to call per-preview — which is the whole reason the method is usable. A provider with mutable *static* state could still interleave, but such a provider is already non-deterministic across ordinary renders; that's a provider bug, not something this lane should serialise around.

## Test plan

| Lane | What it pins |
| --- | --- |
| `:daemon:desktop` `a plain DesktopHost with a resolver enumerates too` | the exact production wiring the router override missed |
| `:daemon:desktop` `a DesktopHost with no resolver reports the capability as unsupported` | `MethodNotFound` stays correct for the one real "can't enumerate" case |
| `:daemon:android` `a held interactive session makes enumeration refuse rather than stall` | fails in <5s (not the 30s timeout), message names the holding stream, and leaves **nothing** on slot 0's queue for the held loop to trip over when it resumes |

Existing `preview/rows` coverage from #3788 is unchanged and still green. Docs: `PROTOCOL.md` gains the Android held-session caveat and an `Internal` (-32603) error row distinguishing "failed / unavailable now, retry" from "this daemon can't do it".

**Visual evidence: N/A** — protocol plumbing and slot arbitration; nothing rendered changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SamkbmKYKnb7XhJUU5TYbM)_