### PR TITLE
fix(cli): read freshness from the renderer that owns the preview's output

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
@@ -72,17 +72,20 @@ data class MissingRenderSidecar(
 )
 
 /**
- * Whether the renderer task ran in *this* invocation for the module a missing preview belongs to.
+ * Whether the renderer task that **owns a missing preview's outputs** ran in *this* invocation —
+ * which task that is depends on the preview's kind and the module's backend, see
+ * [renderTaskEvidenceOf].
  *
- * An `.error.json` on disk is only evidence about this run if the renderer had a chance to rewrite
- * it. The renderer deletes the previous sidecar at the start of every render attempt, so when it
- * runs, what's left is current — but when `composePreviewRender` is skipped (NO-SOURCE: the classic
- * "the renderer test class wasn't on testClassesDirs" wiring bug) the file beside the would-be
- * output is whatever an earlier run left there. Reporting that as "this preview rendered and threw
- * — the build wiring is fine" states the exact opposite of what happened.
+ * An `.error.json` on disk is only evidence about this run if that renderer had a chance to rewrite
+ * it. It deletes the previous sidecar at the start of every render attempt, so when it runs, what's
+ * left is current — but when it is skipped (NO-SOURCE: the classic "the renderer test class wasn't
+ * on testClassesDirs" wiring bug) the file beside the would-be output is whatever an earlier run
+ * left there. Reporting that as "this preview rendered and threw — the build wiring is fine" states
+ * the exact opposite of what happened. Reading the *wrong* task's outcome makes the same mistake in
+ * the other direction, which is why the owner is resolved per preview rather than per module.
  */
 enum class RenderTaskEvidence {
-  /** The module's `composePreviewRender` executed (or was up-to-date) in this invocation. */
+  /** The owning renderer task executed (or was up-to-date) in this invocation. */
   RAN,
   /** It was skipped — NO-SOURCE, or skipped because a dependency failed. Sidecars are leftovers. */
   DID_NOT_RUN,
@@ -163,15 +166,17 @@ fun readRenderErrorSidecar(
  * from `renderOutput` resolved against the module's `build/compose-previews` directory — the same
  * resolution [PreviewResultBuilder.build] does for outputs that exist.
  *
- * [renderTaskEvidence] answers "did the renderer run for this module in this invocation?" given the
- * module's gradle path; see [RenderTaskEvidence]. The default keeps the sidecar at face value for
- * callers with no build to ask.
+ * [renderTaskEvidence] answers "did the renderer that owns this preview's outputs run in this
+ * invocation?", given the module's gradle path and the preview's kind; see [RenderTaskEvidence].
+ * The default keeps the sidecar at face value for callers with no build to ask.
  */
 fun collectMissingRenders(
   missing: List<PreviewResult>,
   manifests: List<Pair<PreviewModule, PreviewManifest>>,
   fileSystem: FileSystem = SystemFileSystem,
-  renderTaskEvidence: (String) -> RenderTaskEvidence = { RenderTaskEvidence.UNKNOWN },
+  renderTaskEvidence: (module: String, kind: String) -> RenderTaskEvidence = { _, _ ->
+    RenderTaskEvidence.UNKNOWN
+  },
 ): List<MissingRender> {
   val moduleByPath = manifests.associate { (module, _) -> module.gradlePath to module }
   val previewsByModule = manifests.associate { (module, manifest) ->
@@ -180,15 +185,19 @@ fun collectMissingRenders(
   return missing.map { result ->
     val module = moduleByPath[result.module]
     val preview = previewsByModule[result.module]?.get(result.id)
-    val relativeOutputs =
+    val declaredOutputs =
       buildList {
           preview?.captures?.forEach { if (it.renderOutput.isNotEmpty()) add(it.renderOutput) }
           preview?.dataProducts?.forEach { if (it.output.isNotEmpty()) add(it.output) }
-          // Manifests written before `renderOutput` was mandatory, and previews whose captures were
-          // globbed away entirely, still render to the default stem.
-          add("renders/${result.id}.png")
         }
         .distinct()
+    // The default stem is a *fallback*, not an extra candidate: manifests written before
+    // `renderOutput` was mandatory, and previews the manifest doesn't describe at all, still render
+    // to `renders/<id>.png`. Probing it alongside a declared output resurrects the dead — nothing
+    // deletes a stale `.error.json` (`cleanStaleRenders` walks `png`/`gif` only), so a preview that
+    // has since moved to a time-fanout or kind-specific directory still has its pre-move sidecar on
+    // disk, and reporting it beside the current failure claims two throws where one happened.
+    val relativeOutputs = declaredOutputs.ifEmpty { listOf("renders/${result.id}.png") }
     val sidecars =
       module?.let { m ->
         relativeOutputs.mapNotNull { rel ->
@@ -202,34 +211,63 @@ fun collectMissingRenders(
       coords = missingCaptureCoords(result),
       className = result.className,
       sidecars = sidecars,
-      renderTask = renderTaskEvidence(result.module),
+      renderTask = renderTaskEvidence(result.module, result.params.kind),
     )
   }
 }
 
 /**
- * The renderer task both backends register — Robolectric on Android, the JVM renderer on desktop.
+ * The renderer task every backend registers — Robolectric on Android, the JVM renderer on desktop.
  */
 private const val RENDER_TASK_NAME = "composePreviewRender"
 
 /**
- * What [taskOutcomes] says about module [modulePath]'s renderer task in this invocation.
+ * Preview kinds the **Android** backend renders from their own task rather than from
+ * [RENDER_TASK_NAME], because Robolectric can inflate neither (`RobolectricRenderTest` skips both):
+ * a Lottie asset needs Compottie and an SVG needs Skia, so `AndroidPreviewSupport` registers
+ * `composePreviewRenderLottie` / `composePreviewRenderSvg` on the desktop renderer's classpath and
+ * folds each into `composePreviewRenderAll` — writing their sidecars into their own disjoint
+ * `lottie-renders/` / `svg-renders/` output dirs.
+ *
+ * They matter here because they run *independently* of the Robolectric task: a NO-SOURCE
+ * `composePreviewRender` says nothing about a Lottie preview whose own renderer ran and threw two
+ * seconds ago. Reading the wrong task's outcome would label that live exception "earlier run" and
+ * send the reader off to fix `testClassesDirs` — the original bug, pointed the other way.
+ *
+ * The desktop backend has no such split (`RenderPreviewsTask` renders every kind), which is exactly
+ * how [renderTaskEvidenceOf] tells the two apart: no kind task in the graph ⇒ no split ⇒
+ * [RENDER_TASK_NAME] owns the output.
+ */
+private val KIND_RENDER_TASKS =
+  mapOf("LOTTIE" to "composePreviewRenderLottie", "SVG" to "composePreviewRenderSvg")
+
+/**
+ * What [taskOutcomes] says about the task that owns a [kind] preview's outputs in module
+ * [modulePath], for this invocation.
  *
  * `SKIPPED` is the case that matters: Gradle reports NO-SOURCE that way, and NO-SOURCE is precisely
  * the wiring bug the historical guidance was written for — a run where the sidecar on disk cannot
  * have come from this render. Every other disposition means the task's inputs were current or its
- * action executed, so what's beside the would-be output is this run's own work. An **absent** entry
- * means no event was seen for the task at all; that can't happen for a module that reaches this
- * report (`readableRenderModules` already drops modules whose `composePreviewRenderAll` — which
- * `dependsOn` the renderer — produced no outcome), so it is reported as
- * [RenderTaskEvidence.UNKNOWN] rather than guessed either way.
+ * action executed, so what's beside the would-be output is this run's own work.
+ *
+ * An **absent** entry for the owning task is [RenderTaskEvidence.UNKNOWN] rather than a guess in
+ * either direction. For [RENDER_TASK_NAME] that can't happen for a module that reaches this report
+ * (`readableRenderModules` already drops modules whose `composePreviewRenderAll` — which
+ * `dependsOn` every renderer task — produced no outcome). For a kind task it means this module has
+ * no such task at all, i.e. the non-Android backend, where [RENDER_TASK_NAME] is the owner — so the
+ * lookup falls back to it rather than reporting `UNKNOWN` for every desktop Lottie preview.
  */
 internal fun renderTaskEvidenceOf(
   modulePath: String,
+  kind: String,
   taskOutcomes: Map<String, GradleTaskOutcome>,
 ): RenderTaskEvidence {
-  val path = ":" + modulePath.trim(':') + ":" + RENDER_TASK_NAME
-  val outcome = taskOutcomes[path] ?: return RenderTaskEvidence.UNKNOWN
+  val prefix = ":" + modulePath.trim(':') + ":"
+  val kindTask = KIND_RENDER_TASKS[kind.uppercase()]
+  val outcome =
+    kindTask?.let { taskOutcomes[prefix + it] }
+      ?: taskOutcomes[prefix + RENDER_TASK_NAME]
+      ?: return RenderTaskEvidence.UNKNOWN
   return if (outcome.disposition == GradleTaskDisposition.SKIPPED) RenderTaskEvidence.DID_NOT_RUN
   else RenderTaskEvidence.RAN
 }
@@ -248,7 +286,9 @@ internal fun missingRenderReport(
   prefix: String = "",
 ): String =
   formatMissingRenderReport(
-    collectMissingRenders(missing, manifests) { renderTaskEvidenceOf(it, taskOutcomes) },
+    collectMissingRenders(missing, manifests) { module, kind ->
+      renderTaskEvidenceOf(module, kind, taskOutcomes)
+    },
     total = total,
     prefix = prefix,
   )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
@@ -403,7 +403,9 @@ class MissingRenderReportTest {
     writeSidecar("renders/WearAppPreview.png")
 
     val entries =
-      collectMissingRenders(listOf(missingResult()), manifests()) { RenderTaskEvidence.DID_NOT_RUN }
+      collectMissingRenders(listOf(missingResult()), manifests()) { _, _ ->
+        RenderTaskEvidence.DID_NOT_RUN
+      }
     val message = formatMissingRenderReport(entries, total = 35)
 
     assertFalse(message.contains("rendered and then threw"), message)
@@ -421,7 +423,7 @@ class MissingRenderReportTest {
     writeSidecar("renders/WearAppPreview.png")
 
     val entries =
-      collectMissingRenders(listOf(missingResult()), manifests()) { RenderTaskEvidence.RAN }
+      collectMissingRenders(listOf(missingResult()), manifests()) { _, _ -> RenderTaskEvidence.RAN }
     val message = formatMissingRenderReport(entries, total = 35)
 
     assertContains(message, "rendered and then threw")
@@ -429,16 +431,17 @@ class MissingRenderReportTest {
     assertFalse(message.contains("NO-SOURCE"), message)
   }
 
+  private fun outcomes(vararg entries: Pair<String, GradleTaskDisposition>) =
+    entries.associate { (task, disposition) ->
+      ":app:$task" to GradleTaskOutcome(":app:$task", disposition)
+    }
+
   @Test
   fun `render-task evidence comes from the module's own composePreviewRender outcome`() {
-    val skipped =
-      mapOf(
-        ":app:composePreviewRender" to
-          GradleTaskOutcome(":app:composePreviewRender", GradleTaskDisposition.SKIPPED)
-      )
-    assertEquals(RenderTaskEvidence.DID_NOT_RUN, renderTaskEvidenceOf(":app", skipped))
+    val skipped = outcomes("composePreviewRender" to GradleTaskDisposition.SKIPPED)
+    assertEquals(RenderTaskEvidence.DID_NOT_RUN, renderTaskEvidenceOf(":app", "COMPOSE", skipped))
     // The gradle path is carried with and without its leading colon depending on the caller.
-    assertEquals(RenderTaskEvidence.DID_NOT_RUN, renderTaskEvidenceOf("app", skipped))
+    assertEquals(RenderTaskEvidence.DID_NOT_RUN, renderTaskEvidenceOf("app", "COMPOSE", skipped))
 
     for (disposition in
       listOf(
@@ -447,17 +450,190 @@ class MissingRenderReportTest {
         GradleTaskDisposition.FROM_CACHE,
         GradleTaskDisposition.FAILED,
       )) {
-      val outcomes =
-        mapOf(
-          ":app:composePreviewRender" to GradleTaskOutcome(":app:composePreviewRender", disposition)
-        )
-      assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", outcomes), "$disposition")
+      assertEquals(
+        RenderTaskEvidence.RAN,
+        renderTaskEvidenceOf(":app", "COMPOSE", outcomes("composePreviewRender" to disposition)),
+        "$disposition",
+      )
     }
 
     // Another module's skip says nothing about this one, and no evidence stays "unknown" rather
     // than being guessed either way.
-    assertEquals(RenderTaskEvidence.UNKNOWN, renderTaskEvidenceOf(":other", skipped))
-    assertEquals(RenderTaskEvidence.UNKNOWN, renderTaskEvidenceOf(":app", emptyMap()))
+    assertEquals(RenderTaskEvidence.UNKNOWN, renderTaskEvidenceOf(":other", "COMPOSE", skipped))
+    assertEquals(RenderTaskEvidence.UNKNOWN, renderTaskEvidenceOf(":app", "COMPOSE", emptyMap()))
+  }
+
+  @Test
+  fun `Lottie and SVG evidence comes from their own renderer task, not Robolectric`() {
+    // Android renders `kind=LOTTIE` / `kind=SVG` from separate tasks folded into
+    // `composePreviewRenderAll` — Robolectric can inflate neither. A NO-SOURCE
+    // `composePreviewRender` therefore says nothing about them: their sidecars are this run's.
+    val robolectricSkipped =
+      outcomes(
+        "composePreviewRender" to GradleTaskDisposition.SKIPPED,
+        "composePreviewRenderLottie" to GradleTaskDisposition.SUCCESS,
+        "composePreviewRenderSvg" to GradleTaskDisposition.SUCCESS,
+      )
+    assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", "LOTTIE", robolectricSkipped))
+    assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", "SVG", robolectricSkipped))
+    // ...while an ordinary Compose preview in the same module *is* stale — the task that owns it
+    // was the one that didn't run.
+    assertEquals(
+      RenderTaskEvidence.DID_NOT_RUN,
+      renderTaskEvidenceOf(":app", "COMPOSE", robolectricSkipped),
+    )
+
+    // And the converse: the Lottie task skipped while Robolectric ran.
+    val lottieSkipped =
+      outcomes(
+        "composePreviewRender" to GradleTaskDisposition.SUCCESS,
+        "composePreviewRenderLottie" to GradleTaskDisposition.SKIPPED,
+      )
+    assertEquals(
+      RenderTaskEvidence.DID_NOT_RUN,
+      renderTaskEvidenceOf(":app", "LOTTIE", lottieSkipped),
+    )
+    assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", "COMPOSE", lottieSkipped))
+
+    // The desktop backend has no kind tasks at all — `composePreviewRender` renders every kind
+    // there, so it is the owner and the answer must not degrade to UNKNOWN.
+    val desktop = outcomes("composePreviewRender" to GradleTaskDisposition.SUCCESS)
+    assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", "LOTTIE", desktop))
+    assertEquals(
+      RenderTaskEvidence.DID_NOT_RUN,
+      renderTaskEvidenceOf(
+        ":app",
+        "SVG",
+        outcomes("composePreviewRender" to GradleTaskDisposition.SKIPPED),
+      ),
+    )
+  }
+
+  @Test
+  fun `a Lottie failure is not labelled stale when Robolectric was NO-SOURCE`() {
+    // End to end through the report: the Android Lottie renderer wrote this sidecar seconds ago.
+    // Calling it an "earlier run" and pointing at testClassesDirs is the original bug inverted.
+    val lottieManifests =
+      listOf(
+        PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
+          PreviewManifest(
+            module = ":app",
+            variant = "debug",
+            previews =
+              listOf(
+                PreviewInfo(
+                  id = previewId,
+                  functionName = "WearAppPreview",
+                  className = "com.example.wear.WearAppKt",
+                  params = PreviewParams(kind = "LOTTIE"),
+                  captures = listOf(Capture(renderOutput = "lottie-renders/Wear.png")),
+                )
+              ),
+          )
+      )
+    writeSidecar("lottie-renders/Wear.png")
+    val lottieResult = missingResult().copy(params = PreviewParams(kind = "LOTTIE"))
+
+    val message =
+      missingRenderReport(
+        missing = listOf(lottieResult),
+        manifests = lottieManifests,
+        total = 1,
+        taskOutcomes =
+          outcomes(
+            "composePreviewRender" to GradleTaskDisposition.SKIPPED,
+            "composePreviewRenderLottie" to GradleTaskDisposition.SUCCESS,
+          ),
+      )
+
+    assertContains(message, "rendered and then threw")
+    assertFalse(message.contains("earlier run"), message)
+    assertFalse(message.contains("testClassesDirs"), message)
+  }
+
+  @Test
+  fun `the legacy default stem is only probed when the manifest declares no output`() {
+    // The preview used to render to `renders/<id>.png` and now declares a fanout output. Nothing
+    // deletes the old sidecar — `cleanStaleRenders` walks `png`/`gif` only — so probing the default
+    // stem alongside the declared one reports a years-old exception as if it happened just now.
+    writeSidecar(
+      "renders/Wear_500ms.png",
+      simpleSidecarJson(
+        "java.lang.IllegalStateException",
+        "no theme provided",
+        "java.lang.IllegalStateException: no theme provided\n" +
+          "\tat com.example.wear.WearAppKt.WearApp(WearApp.kt:31)",
+      ),
+    )
+    writeSidecar(
+      "renders/$previewId.png",
+      simpleSidecarJson(
+        "java.lang.NoSuchMethodError",
+        "long gone",
+        "java.lang.NoSuchMethodError: long gone\n" +
+          "\tat com.example.wear.WearAppKt.Removed(WearApp.kt:9)",
+      ),
+    )
+    val declared =
+      listOf(
+        PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
+          PreviewManifest(
+            module = ":app",
+            variant = "debug",
+            previews =
+              listOf(
+                PreviewInfo(
+                  id = previewId,
+                  functionName = "WearAppPreview",
+                  className = "com.example.wear.WearAppKt",
+                  captures = listOf(Capture(renderOutput = "renders/Wear_500ms.png")),
+                )
+              ),
+          )
+      )
+
+    val entries = collectMissingRenders(listOf(missingResult()), declared)
+    assertEquals(listOf("renders/Wear_500ms.png"), entries.single().sidecars.map { it.output })
+
+    val message = formatMissingRenderReport(entries, total = 1)
+    assertContains(message, "IllegalStateException")
+    assertFalse(message.contains("NoSuchMethodError"), message)
+    assertFalse(message.contains("long gone"), message)
+  }
+
+  @Test
+  fun `the default stem still answers for a preview the manifest does not describe`() {
+    // The fallback's actual job: a manifest predating `renderOutput`, or a preview globbed away
+    // entirely, still renders to `renders/<id>.png` and its sidecar must be found there.
+    writeSidecar("renders/$previewId.png")
+
+    val bare =
+      listOf(
+        PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
+          PreviewManifest(
+            module = ":app",
+            variant = "debug",
+            previews =
+              listOf(
+                PreviewInfo(
+                  id = previewId,
+                  functionName = "WearAppPreview",
+                  className = "com.example.wear.WearAppKt",
+                  captures = listOf(Capture(renderOutput = "")),
+                )
+              ),
+          )
+      )
+
+    assertNotNull(collectMissingRenders(listOf(missingResult()), bare).single().sidecar)
+
+    // ...and for a preview the manifest doesn't describe at all — `manifests()` knows only
+    // `previewId`, so this one falls back to its own default stem.
+    val unknownId = "com.example.wear.WearAppKt.OtherPreview"
+    writeSidecar("renders/$unknownId.png")
+    assertNotNull(
+      collectMissingRenders(listOf(missingResult(id = unknownId)), manifests()).single().sidecar
+    )
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #3789 (issue #3741): two P2 review findings that landed on its head commit after it had auto-merged, so they arrive as a separate PR. **Both held**, and both bite #3789's own fix rather than pre-existing code.

Text-only change: the CLI's stderr diagnostic. Nothing renderable is affected.

## 1. Use the output-owning renderer for freshness evidence — **held**

Verified in `AndroidPreviewSupport.kt`: the Android backend registers `composePreviewRenderLottie` (line 3183) and `composePreviewRenderSvg` (line 3231) as `RenderPreviewsTask`s on the desktop renderer's classpath, each with `includeKinds` restricted to its kind and its own disjoint output dir (`lottie-renders/`, `svg-renders/`), and folds both into `composePreviewRenderAll` (lines 3258-3260) alongside the Robolectric `composePreviewRender`. Robolectric can inflate neither — `RobolectricRenderTest` skips `kind=LOTTIE` and `kind=SVG` — which is *why* they exist as separate tasks, and they run independently of it.

So #3789's `renderTaskEvidenceOf`, which looked only at `composePreviewRender`, returned `DID_NOT_RUN` for a Lottie or SVG preview whenever the Robolectric task was NO-SOURCE — labelling an exception written seconds ago "earlier run" and pointing the reader at `testClassesDirs`. That is the original #3741 bug pointed the other way, and mislabelling a *current* exception as stale is the same class of error as quoting a stale one as current.

Evidence is now read from the task that owns the preview's outputs, selected by kind:

```kotlin
private val KIND_RENDER_TASKS =
  mapOf("LOTTIE" to "composePreviewRenderLottie", "SVG" to "composePreviewRenderSvg")
```

with a deliberate fallback: if the kind task is **absent from the task-outcome map**, this module has no such task in its graph, i.e. it is the non-Android backend, where `RenderPreviewsTask`/`composePreviewRender` renders every kind and therefore owns the output. That presence check is what distinguishes the two backends without the CLI having to know which one it is talking to — and it is sound because the kind tasks are unconditional `composePreviewRenderAll` dependencies on Android, so a run that reaches this report has an outcome for them (an `onlyIf`-disabled task is SKIPPED, which is still an event). An unrecognised kind, or no `composePreviewRender` either, stays `UNKNOWN` rather than guessing.

Net effect, all covered by tests: Robolectric NO-SOURCE + Lottie SUCCESS → the Lottie preview is `RAN` (its exception is reported as this run's) while an ordinary Compose preview in the same module is correctly `DID_NOT_RUN`.

## 2. Ignore the legacy fallback when outputs are declared — **held**

Confirmed the premise at the source: `ComposePreviewTasks.cleanStaleRenders` filters `walkBottomUp()` to `it.extension == "png" || it.extension == "gif"`, so a `<stem>.png.error.json` is never deleted by stale-render cleanup. A preview that used to render to `renders/<id>.png` and now declares a different `renderOutput` (time fanout, or the `lottie-renders/` directory above) keeps its pre-move sidecar on disk indefinitely.

`collectMissingRenders` appended `renders/<id>.png` unconditionally. Before #3789 the collapsing `firstNotNullOfOrNull` hid the consequence — the declared output came first in the list and won — but #3789 keeps every sidecar it finds, so the dead exception started being reported beside the live one as if both had happened in this run. The reviewer is right that this interacts with the per-output change specifically.

The default stem is now a fallback rather than an extra candidate — used only when the manifest supplies no capture and no data-product output, which is its actual job (manifests predating mandatory `renderOutput`, and previews the manifest doesn't describe at all). Both of those paths keep dedicated tests.

Known limitation, unchanged by this PR and worth stating rather than implying otherwise: a `@PreviewParameter` fan-out writes per-value sidecars at `<stem>_<label>.png.error.json`, and neither the declared template output nor the default stem probes those, so a per-value failure's sidecar is still not discovered. That is a separate gap in what the CLI looks for, not something either finding introduced.

## Test plan

- `./gradlew :cli:test` — green (full suite).
- `./gradlew :gradle-plugin:test` — green (full suite, untouched by this PR but re-run on the new base).
- `./gradlew :cli:ktfmtFormat` — applied before committing.
- Red-then-green: with both fixes reverted in place (evidence back to `composePreviewRender` only, default stem appended unconditionally), exactly the three new tests fail —
  - `Lottie and SVG evidence comes from their own renderer task, not Robolectric` FAILS
  - `a Lottie failure is not labelled stale when Robolectric was NO-SOURCE` FAILS (end-to-end through the report: asserts the message says "rendered and then threw" and contains neither "earlier run" nor "testClassesDirs")
  - `the legacy default stem is only probed when the manifest declares no output` FAILS
- `the default stem still answers for a preview the manifest does not describe` pins the fallback's real job, so fix 2 can't be "simplified" into dropping it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_