### PR TITLE
fix(cli): name the renderer that actually skipped, and keep the blank-capture stem

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
@@ -74,7 +74,7 @@ data class MissingRenderSidecar(
 /**
  * Whether the renderer task that **owns a missing preview's outputs** ran in *this* invocation —
  * which task that is depends on the preview's kind and the module's backend, see
- * [renderTaskEvidenceOf].
+ * [renderTaskStateOf].
  *
  * An `.error.json` on disk is only evidence about this run if that renderer had a chance to rewrite
  * it. It deletes the previous sidecar at the start of every render attempt, so when it runs, what's
@@ -97,6 +97,24 @@ enum class RenderTaskEvidence {
 }
 
 /**
+ * Which renderer task owns a preview's outputs, and what this invocation did with it.
+ *
+ * [task] travels with [evidence] because the *report* needs it as much as the freshness decision
+ * does: "`composePreviewRender` did not run, check its testClassesDirs" is a precise, actionable
+ * sentence — and a false one when the task that actually skipped was `composePreviewRenderLottie`,
+ * which is not a `Test` task, has no `testClassesDirs`, and cannot report NO-SOURCE at all. Naming
+ * the task that was really skipped is the difference between a diagnosis and a misdirection.
+ */
+data class RenderTaskState(
+  val evidence: RenderTaskEvidence = RenderTaskEvidence.UNKNOWN,
+  /**
+   * Gradle task *name* (not path) of the owner. Defaults to the main renderer, which is the owner
+   * for every kind on every backend except Android's Lottie / SVG split.
+   */
+  val task: String = RENDER_TASK_NAME,
+)
+
+/**
  * One preview that produced no PNG, paired with whatever the renderer left beside its would-be
  * outputs. [sidecars] is empty when no `.error.json` was found — the "render was skipped" case.
  */
@@ -108,8 +126,8 @@ data class MissingRender(
   /** The preview's own class FQN — used to pick a stack frame in the *user's* package. */
   val className: String = "",
   val sidecars: List<MissingRenderSidecar> = emptyList(),
-  /** Whether the renderer ran this invocation — see [RenderTaskEvidence]. */
-  val renderTask: RenderTaskEvidence = RenderTaskEvidence.UNKNOWN,
+  /** Which renderer task owns this preview, and whether it ran — see [RenderTaskState]. */
+  val renderTask: RenderTaskState = RenderTaskState(),
 ) {
   /** First sidecar found, if any. Convenience for callers that only want "did it throw at all". */
   val sidecar: RenderErrorSidecar?
@@ -117,11 +135,11 @@ data class MissingRender(
 
   /** Sidecars this run is entitled to present as its own findings. */
   val threwThisRun: Boolean
-    get() = sidecars.isNotEmpty() && renderTask != RenderTaskEvidence.DID_NOT_RUN
+    get() = sidecars.isNotEmpty() && renderTask.evidence != RenderTaskEvidence.DID_NOT_RUN
 
   /** Sidecars that survive from an earlier run because the renderer never ran this time. */
   val hasStaleSidecars: Boolean
-    get() = sidecars.isNotEmpty() && renderTask == RenderTaskEvidence.DID_NOT_RUN
+    get() = sidecars.isNotEmpty() && renderTask.evidence == RenderTaskEvidence.DID_NOT_RUN
 }
 
 /** One `Caused by:` entry of a stack trace. */
@@ -174,8 +192,8 @@ fun collectMissingRenders(
   missing: List<PreviewResult>,
   manifests: List<Pair<PreviewModule, PreviewManifest>>,
   fileSystem: FileSystem = SystemFileSystem,
-  renderTaskEvidence: (module: String, kind: String) -> RenderTaskEvidence = { _, _ ->
-    RenderTaskEvidence.UNKNOWN
+  renderTaskEvidence: (module: String, kind: String) -> RenderTaskState = { _, _ ->
+    RenderTaskState()
   },
 ): List<MissingRender> {
   val moduleByPath = manifests.associate { (module, _) -> module.gradlePath to module }
@@ -191,13 +209,31 @@ fun collectMissingRenders(
           preview?.dataProducts?.forEach { if (it.output.isNotEmpty()) add(it.output) }
         }
         .distinct()
-    // The default stem is a *fallback*, not an extra candidate: manifests written before
-    // `renderOutput` was mandatory, and previews the manifest doesn't describe at all, still render
-    // to `renders/<id>.png`. Probing it alongside a declared output resurrects the dead — nothing
-    // deletes a stale `.error.json` (`cleanStaleRenders` walks `png`/`gif` only), so a preview that
-    // has since moved to a time-fanout or kind-specific directory still has its pre-move sidecar on
-    // disk, and reporting it beside the current failure claims two throws where one happened.
-    val relativeOutputs = declaredOutputs.ifEmpty { listOf("renders/${result.id}.png") }
+    // `renders/<id>.png` is where an output the manifest leaves *blank* actually lands: the Android
+    // renderer resolves a capture to `capture.renderOutput.substringAfterLast('/').ifEmpty {
+    // "<id>.png" }` inside the renders dir, and its outer per-preview catch writes the sidecar at
+    // exactly that anchor. So the default stem is a live candidate whenever some capture declares
+    // no
+    // path of its own — including the shape where an empty capture sits beside a data product,
+    // which
+    // is the only place that preview's failure would be recorded if it died before the product.
+    //
+    // What it must NOT be is an unconditional extra: nothing ever deletes a stale `.error.json`
+    // (`cleanStaleRenders` walks `png`/`gif` only), so a preview whose captures have all since
+    // moved
+    // to a time-fanout or kind-specific directory still has its pre-move sidecar on disk, and
+    // reporting that beside the current failure claims two throws where one happened.
+    //
+    // A preview with *no* captures at all (a `@ScrollingPreview` that declares only data products,
+    // issue #1524) is deliberately not in that set: the renderer anchors its sidecar on the first
+    // data product, which is already a declared output.
+    val defaultStemIsLive =
+      preview == null ||
+        declaredOutputs.isEmpty() ||
+        preview.captures.any { it.renderOutput.isEmpty() }
+    val relativeOutputs =
+      if (defaultStemIsLive) (declaredOutputs + "renders/${result.id}.png").distinct()
+      else declaredOutputs
     val sidecars =
       module?.let { m ->
         relativeOutputs.mapNotNull { rel ->
@@ -219,7 +255,7 @@ fun collectMissingRenders(
 /**
  * The renderer task every backend registers — Robolectric on Android, the JVM renderer on desktop.
  */
-private const val RENDER_TASK_NAME = "composePreviewRender"
+internal const val RENDER_TASK_NAME: String = "composePreviewRender"
 
 /**
  * Preview kinds the **Android** backend renders from their own task rather than from
@@ -235,15 +271,18 @@ private const val RENDER_TASK_NAME = "composePreviewRender"
  * send the reader off to fix `testClassesDirs` — the original bug, pointed the other way.
  *
  * The desktop backend has no such split (`RenderPreviewsTask` renders every kind), which is exactly
- * how [renderTaskEvidenceOf] tells the two apart: no kind task in the graph ⇒ no split ⇒
+ * how [renderTaskStateOf] tells the two apart: no kind task in the graph ⇒ no split ⇒
  * [RENDER_TASK_NAME] owns the output.
  */
 private val KIND_RENDER_TASKS =
   mapOf("LOTTIE" to "composePreviewRenderLottie", "SVG" to "composePreviewRenderSvg")
 
+/** The kind each entry of [KIND_RENDER_TASKS] renders, for messages that name the task. */
+private val KIND_BY_RENDER_TASK = KIND_RENDER_TASKS.entries.associate { (k, v) -> v to k }
+
 /**
- * What [taskOutcomes] says about the task that owns a [kind] preview's outputs in module
- * [modulePath], for this invocation.
+ * Which task owns a [kind] preview's outputs in module [modulePath], and what [taskOutcomes] says
+ * it did this invocation.
  *
  * `SKIPPED` is the case that matters: Gradle reports NO-SOURCE that way, and NO-SOURCE is precisely
  * the wiring bug the historical guidance was written for — a run where the sidecar on disk cannot
@@ -257,19 +296,19 @@ private val KIND_RENDER_TASKS =
  * no such task at all, i.e. the non-Android backend, where [RENDER_TASK_NAME] is the owner — so the
  * lookup falls back to it rather than reporting `UNKNOWN` for every desktop Lottie preview.
  */
-internal fun renderTaskEvidenceOf(
+internal fun renderTaskStateOf(
   modulePath: String,
   kind: String,
   taskOutcomes: Map<String, GradleTaskOutcome>,
-): RenderTaskEvidence {
+): RenderTaskState {
   val prefix = ":" + modulePath.trim(':') + ":"
   val kindTask = KIND_RENDER_TASKS[kind.uppercase()]
-  val outcome =
-    kindTask?.let { taskOutcomes[prefix + it] }
-      ?: taskOutcomes[prefix + RENDER_TASK_NAME]
-      ?: return RenderTaskEvidence.UNKNOWN
-  return if (outcome.disposition == GradleTaskDisposition.SKIPPED) RenderTaskEvidence.DID_NOT_RUN
-  else RenderTaskEvidence.RAN
+  val owner = kindTask?.takeIf { taskOutcomes.containsKey(prefix + it) } ?: RENDER_TASK_NAME
+  val outcome = taskOutcomes[prefix + owner] ?: return RenderTaskState(task = owner)
+  val evidence =
+    if (outcome.disposition == GradleTaskDisposition.SKIPPED) RenderTaskEvidence.DID_NOT_RUN
+    else RenderTaskEvidence.RAN
+  return RenderTaskState(evidence = evidence, task = owner)
 }
 
 /**
@@ -287,7 +326,7 @@ internal fun missingRenderReport(
 ): String =
   formatMissingRenderReport(
     collectMissingRenders(missing, manifests) { module, kind ->
-      renderTaskEvidenceOf(module, kind, taskOutcomes)
+      renderTaskStateOf(module, kind, taskOutcomes)
     },
     total = total,
     prefix = prefix,
@@ -355,17 +394,22 @@ fun formatMissingRenderReport(
       .append(RENDER_ERROR_SIDECAR_SUFFIX)
       .append("` sidecar beside each preview's would-be output.")
   }
-  if (stale.isNotEmpty()) {
+  // Grouped by the task that actually skipped: naming `composePreviewRender` for a preview whose
+  // renderer is `composePreviewRenderLottie` is a precise sentence about the wrong task, and the
+  // remedy attached to it (testClassesDirs) is one the named task doesn't even have.
+  for ((owner, entries) in stale.groupBy { it.renderTask.task }) {
     // Never claim to have observed what this run didn't do: the renderer was skipped, so the
     // sidecar quoted above describes some earlier run and the wiring guidance below still applies.
     sb
       .append("\n")
-      .append(stale.size)
+      .append(entries.size)
       .append(" preview(s) have a `<render>.png")
       .append(RENDER_ERROR_SIDECAR_SUFFIX)
-      .append("` sidecar on disk, but `composePreviewRender` did not run in this invocation ")
-      .append("(skipped / NO-SOURCE) — that sidecar is left over from an earlier run and says ")
-      .append("nothing about this one.")
+      .append("` sidecar on disk, but `")
+      .append(owner)
+      .append("` did not run in this invocation ")
+      .append(if (owner == RENDER_TASK_NAME) "(skipped / NO-SOURCE)" else "(skipped)")
+      .append(" — that sidecar is left over from an earlier run and says nothing about this one.")
   }
   if (unexplained.isNotEmpty()) {
     if (threw.isNotEmpty()) {
@@ -378,14 +422,47 @@ fun formatMissingRenderReport(
     } else {
       sb.append("\n")
     }
-    sb.append(
-      "Check the Gradle output above — a common cause is the `composePreviewRender` task " +
-        "reporting NO-SOURCE, which means the renderer test class wasn't found on " +
-        "testClassesDirs. Per-preview stack traces are in the `composePreviewRender-reports` " +
-        "artifact attached to the run."
-    )
+    // The historical NO-SOURCE guidance is about the main renderer specifically — it is a `Test`
+    // task, testClassesDirs is its input, and `composePreviewRender-reports` is its artifact. None
+    // of that exists for the kind renderers, so previews they own get their own sentence instead of
+    // being pointed at a fix that cannot apply to them.
+    val byOwner = unexplained.groupBy { it.renderTask.task }
+    val paragraphs = buildList {
+      if (byOwner.containsKey(RENDER_TASK_NAME)) {
+        add(
+          "Check the Gradle output above — a common cause is the `composePreviewRender` task " +
+            "reporting NO-SOURCE, which means the renderer test class wasn't found on " +
+            "testClassesDirs. Per-preview stack traces are in the `composePreviewRender-reports` " +
+            "artifact attached to the run."
+        )
+      }
+      byOwner
+        .filterKeys { it != RENDER_TASK_NAME }
+        .forEach { (owner, entries) -> add(kindRendererGuidance(owner, entries.size)) }
+    }
+    sb.append(paragraphs.joinToString("\n"))
   }
   return sb.toString()
+}
+
+/**
+ * The guidance for previews rendered by one of Android's kind-specific renderers.
+ *
+ * Deliberately not the NO-SOURCE paragraph: `composePreviewRenderLottie` /
+ * `composePreviewRenderSvg` are `RenderPreviewsTask`s, not `Test` tasks — they have no
+ * `testClassesDirs`, declare no `@SkipWhenEmpty` input (so they never report NO-SOURCE at all), and
+ * write no `composePreviewRender-reports` artifact. What *does* skip them is `composePreview {
+ * enabled = false }` (their `onlyIf`) or a failure in something they depend on.
+ */
+private fun kindRendererGuidance(task: String, count: Int): String {
+  val kind = KIND_BY_RENDER_TASK[task]
+  val owns = if (kind != null) "every `kind=$kind` preview" else "these previews"
+  // Deliberately makes no claim about what that task *did* — the stale paragraph above says that,
+  // and only where it was observed. `unexplained` also holds previews whose renderer ran and simply
+  // produced nothing, which "it did not run" would misdescribe.
+  return "`$task` renders $owns in this module ($count here) — the Robolectric renderer skips that " +
+    "kind — so check its outcome in the Gradle output above: `composePreview { enabled = false }` " +
+    "skips it, as does a failure in a task it depends on."
 }
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
@@ -112,7 +112,19 @@ data class RenderTaskState(
    * for every kind on every backend except Android's Lottie / SVG split.
    */
   val task: String = RENDER_TASK_NAME,
-)
+  /**
+   * Fully qualified `:module:task` path of that same task, empty when the caller supplied no build
+   * to ask. Task *names* repeat across modules — every Android module has its own
+   * `composePreviewRenderLottie` — so the name alone can neither group entries nor be printed: a
+   * multi-module run would merge `:a:`'s outcome with `:b:`'s and then tell the reader to go
+   * inspect a task that exists in both.
+   */
+  val path: String = "",
+) {
+  /** What the report calls this task: the qualified path when known, else the bare name. */
+  val label: String
+    get() = path.ifEmpty { task }
+}
 
 /**
  * One preview that produced no PNG, paired with whatever the renderer left beside its would-be
@@ -209,28 +221,35 @@ fun collectMissingRenders(
           preview?.dataProducts?.forEach { if (it.output.isNotEmpty()) add(it.output) }
         }
         .distinct()
-    // `renders/<id>.png` is where an output the manifest leaves *blank* actually lands: the Android
-    // renderer resolves a capture to `capture.renderOutput.substringAfterLast('/').ifEmpty {
-    // "<id>.png" }` inside the renders dir, and its outer per-preview catch writes the sidecar at
-    // exactly that anchor. So the default stem is a live candidate whenever some capture declares
-    // no
-    // path of its own — including the shape where an empty capture sits beside a data product,
-    // which
-    // is the only place that preview's failure would be recorded if it died before the product.
+    // `renders/<id>.png` is where an output the manifest leaves *blank* lands, and where a failure
+    // that hits it is recorded — but only under the **first** capture. `RobolectricRenderTest`
+    // anchors the preview-level sidecar on `captures.firstOrNull()` resolved through
+    // `renderOutput.substringAfterLast('/').ifEmpty { "<id>.png" }` (or the first data product when
+    // there are no captures), deletes any stale file there before rendering, and writes the
+    // throwable there from its outer catch. Its per-job writes cover only two fall-through cases —
+    // an animated capture that produced no GIF, and a scroll product with nothing scrollable —
+    // neither of which can target the default stem: both require a `.gif` extension or a
+    // data-product path.
     //
-    // What it must NOT be is an unconditional extra: nothing ever deletes a stale `.error.json`
-    // (`cleanStaleRenders` walks `png`/`gif` only), so a preview whose captures have all since
-    // moved
-    // to a time-fanout or kind-specific directory still has its pre-move sidecar on disk, and
-    // reporting that beside the current failure claims two throws where one happened.
+    // So a *later* blank capture cannot get a fresh default-stem sidecar on Android, and probing
+    // for
+    // one would report whatever an older manifest left behind as this run's finding — the
+    // stale-file
+    // trap, re-entered through a narrower gap. The desktop backend is more permissive
+    // (`RenderPreviewsTask` resolves every blank capture to `<id>.png` and forks the renderer at
+    // that path), so this models Android deliberately: it is the stricter of the two, and the shape
+    // where they disagree — a first capture with a path followed by a blank one — is not something
+    // discovery emits. It writes a `renderOutput` for every capture, so blanks only survive in
+    // manifests old enough that *all* of their captures are blank, where the first-capture rule
+    // fires anyway.
     //
     // A preview with *no* captures at all (a `@ScrollingPreview` that declares only data products,
-    // issue #1524) is deliberately not in that set: the renderer anchors its sidecar on the first
-    // data product, which is already a declared output.
+    // issue #1524) is deliberately not in the set either: the renderer anchors its sidecar on the
+    // first data product, which is already a declared output.
     val defaultStemIsLive =
       preview == null ||
         declaredOutputs.isEmpty() ||
-        preview.captures.any { it.renderOutput.isEmpty() }
+        preview.captures.firstOrNull()?.renderOutput?.isEmpty() == true
     val relativeOutputs =
       if (defaultStemIsLive) (declaredOutputs + "renders/${result.id}.png").distinct()
       else declaredOutputs
@@ -304,11 +323,12 @@ internal fun renderTaskStateOf(
   val prefix = ":" + modulePath.trim(':') + ":"
   val kindTask = KIND_RENDER_TASKS[kind.uppercase()]
   val owner = kindTask?.takeIf { taskOutcomes.containsKey(prefix + it) } ?: RENDER_TASK_NAME
-  val outcome = taskOutcomes[prefix + owner] ?: return RenderTaskState(task = owner)
+  val path = prefix + owner
+  val outcome = taskOutcomes[path] ?: return RenderTaskState(task = owner, path = path)
   val evidence =
     if (outcome.disposition == GradleTaskDisposition.SKIPPED) RenderTaskEvidence.DID_NOT_RUN
     else RenderTaskEvidence.RAN
-  return RenderTaskState(evidence = evidence, task = owner)
+  return RenderTaskState(evidence = evidence, task = owner, path = path)
 }
 
 /**
@@ -394,10 +414,13 @@ fun formatMissingRenderReport(
       .append(RENDER_ERROR_SIDECAR_SUFFIX)
       .append("` sidecar beside each preview's would-be output.")
   }
-  // Grouped by the task that actually skipped: naming `composePreviewRender` for a preview whose
+  // Grouped by the task that actually skipped — naming `composePreviewRender` for a preview whose
   // renderer is `composePreviewRenderLottie` is a precise sentence about the wrong task, and the
-  // remedy attached to it (testClassesDirs) is one the named task doesn't even have.
-  for ((owner, entries) in stale.groupBy { it.renderTask.task }) {
+  // remedy attached to it (testClassesDirs) is one the named task doesn't even have — and by
+  // module,
+  // because one task *name* is many tasks in a multi-module render and their outcomes differ.
+  for ((key, entries) in stale.groupBy { it.module to it.renderTask }) {
+    val state = key.second
     // Never claim to have observed what this run didn't do: the renderer was skipped, so the
     // sidecar quoted above describes some earlier run and the wiring guidance below still applies.
     sb
@@ -406,9 +429,10 @@ fun formatMissingRenderReport(
       .append(" preview(s) have a `<render>.png")
       .append(RENDER_ERROR_SIDECAR_SUFFIX)
       .append("` sidecar on disk, but `")
-      .append(owner)
+      .append(state.label)
       .append("` did not run in this invocation ")
-      .append(if (owner == RENDER_TASK_NAME) "(skipped / NO-SOURCE)" else "(skipped)")
+      // NO-SOURCE is a `Test`-task state; the kind renderers cannot report it.
+      .append(if (state.task == RENDER_TASK_NAME) "(skipped / NO-SOURCE)" else "(skipped)")
       .append(" — that sidecar is left over from an earlier run and says nothing about this one.")
   }
   if (unexplained.isNotEmpty()) {
@@ -426,9 +450,14 @@ fun formatMissingRenderReport(
     // task, testClassesDirs is its input, and `composePreviewRender-reports` is its artifact. None
     // of that exists for the kind renderers, so previews they own get their own sentence instead of
     // being pointed at a fix that cannot apply to them.
-    val byOwner = unexplained.groupBy { it.renderTask.task }
+    // Keyed by module as well as owner: task *names* repeat across modules, so grouping on the name
+    // alone would fold `:a:composePreviewRenderLottie` into `:b:`'s and then quote the combined
+    // count as one module's.
+    val byOwner = unexplained.groupBy { it.module to it.renderTask }
     val paragraphs = buildList {
-      if (byOwner.containsKey(RENDER_TASK_NAME)) {
+      // The main renderer's paragraph names no module and gives the same advice everywhere, so one
+      // copy covers however many modules are in the group.
+      if (byOwner.keys.any { (_, state) -> state.task == RENDER_TASK_NAME }) {
         add(
           "Check the Gradle output above — a common cause is the `composePreviewRender` task " +
             "reporting NO-SOURCE, which means the renderer test class wasn't found on " +
@@ -437,8 +466,11 @@ fun formatMissingRenderReport(
         )
       }
       byOwner
-        .filterKeys { it != RENDER_TASK_NAME }
-        .forEach { (owner, entries) -> add(kindRendererGuidance(owner, entries.size)) }
+        .filterKeys { (_, state) -> state.task != RENDER_TASK_NAME }
+        .forEach { (key, entries) ->
+          val (module, state) = key
+          add(kindRendererGuidance(state, module, entries.size))
+        }
     }
     sb.append(paragraphs.joinToString("\n"))
   }
@@ -454,13 +486,16 @@ fun formatMissingRenderReport(
  * write no `composePreviewRender-reports` artifact. What *does* skip them is `composePreview {
  * enabled = false }` (their `onlyIf`) or a failure in something they depend on.
  */
-private fun kindRendererGuidance(task: String, count: Int): String {
-  val kind = KIND_BY_RENDER_TASK[task]
+private fun kindRendererGuidance(state: RenderTaskState, module: String, count: Int): String {
+  val kind = KIND_BY_RENDER_TASK[state.task]
   val owns = if (kind != null) "every `kind=$kind` preview" else "these previews"
+  // "in this module" was a claim about scope, and a false one as soon as two modules' previews were
+  // counted together — so the module is named from the entries themselves, or left out entirely.
+  val where = if (module.isNotBlank()) " in $module" else ""
   // Deliberately makes no claim about what that task *did* — the stale paragraph above says that,
   // and only where it was observed. `unexplained` also holds previews whose renderer ran and simply
   // produced nothing, which "it did not run" would misdescribe.
-  return "`$task` renders $owns in this module ($count here) — the Robolectric renderer skips that " +
+  return "`${state.label}` renders $owns$where ($count here) — the Robolectric renderer skips that " +
     "kind — so check its outcome in the Gradle output above: `composePreview { enabled = false }` " +
     "skips it, as does a failure in a task it depends on."
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
@@ -404,7 +404,7 @@ class MissingRenderReportTest {
 
     val entries =
       collectMissingRenders(listOf(missingResult()), manifests()) { _, _ ->
-        RenderTaskEvidence.DID_NOT_RUN
+        RenderTaskState(RenderTaskEvidence.DID_NOT_RUN)
       }
     val message = formatMissingRenderReport(entries, total = 35)
 
@@ -423,13 +423,38 @@ class MissingRenderReportTest {
     writeSidecar("renders/WearAppPreview.png")
 
     val entries =
-      collectMissingRenders(listOf(missingResult()), manifests()) { _, _ -> RenderTaskEvidence.RAN }
+      collectMissingRenders(listOf(missingResult()), manifests()) { _, _ ->
+        RenderTaskState(RenderTaskEvidence.RAN)
+      }
     val message = formatMissingRenderReport(entries, total = 35)
 
     assertContains(message, "rendered and then threw")
     assertFalse(message.contains("earlier run"), message)
     assertFalse(message.contains("NO-SOURCE"), message)
   }
+
+  /**
+   * A `kind=LOTTIE` preview: Android renders it from `composePreviewRenderLottie` into its own
+   * `lottie-renders/` dir, never from the Robolectric task.
+   */
+  private fun lottieManifests() =
+    listOf(
+      PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
+        PreviewManifest(
+          module = ":app",
+          variant = "debug",
+          previews =
+            listOf(
+              PreviewInfo(
+                id = previewId,
+                functionName = "WearAppPreview",
+                className = "com.example.wear.WearAppKt",
+                params = PreviewParams(kind = "LOTTIE"),
+                captures = listOf(Capture(renderOutput = "lottie-renders/Wear.png")),
+              )
+            ),
+        )
+    )
 
   private fun outcomes(vararg entries: Pair<String, GradleTaskDisposition>) =
     entries.associate { (task, disposition) ->
@@ -439,9 +464,10 @@ class MissingRenderReportTest {
   @Test
   fun `render-task evidence comes from the module's own composePreviewRender outcome`() {
     val skipped = outcomes("composePreviewRender" to GradleTaskDisposition.SKIPPED)
-    assertEquals(RenderTaskEvidence.DID_NOT_RUN, renderTaskEvidenceOf(":app", "COMPOSE", skipped))
+    val didNotRun = RenderTaskState(RenderTaskEvidence.DID_NOT_RUN, "composePreviewRender")
+    assertEquals(didNotRun, renderTaskStateOf(":app", "COMPOSE", skipped))
     // The gradle path is carried with and without its leading colon depending on the caller.
-    assertEquals(RenderTaskEvidence.DID_NOT_RUN, renderTaskEvidenceOf("app", "COMPOSE", skipped))
+    assertEquals(didNotRun, renderTaskStateOf("app", "COMPOSE", skipped))
 
     for (disposition in
       listOf(
@@ -451,16 +477,22 @@ class MissingRenderReportTest {
         GradleTaskDisposition.FAILED,
       )) {
       assertEquals(
-        RenderTaskEvidence.RAN,
-        renderTaskEvidenceOf(":app", "COMPOSE", outcomes("composePreviewRender" to disposition)),
+        RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRender"),
+        renderTaskStateOf(":app", "COMPOSE", outcomes("composePreviewRender" to disposition)),
         "$disposition",
       )
     }
 
     // Another module's skip says nothing about this one, and no evidence stays "unknown" rather
     // than being guessed either way.
-    assertEquals(RenderTaskEvidence.UNKNOWN, renderTaskEvidenceOf(":other", "COMPOSE", skipped))
-    assertEquals(RenderTaskEvidence.UNKNOWN, renderTaskEvidenceOf(":app", "COMPOSE", emptyMap()))
+    assertEquals(
+      RenderTaskEvidence.UNKNOWN,
+      renderTaskStateOf(":other", "COMPOSE", skipped).evidence,
+    )
+    assertEquals(
+      RenderTaskEvidence.UNKNOWN,
+      renderTaskStateOf(":app", "COMPOSE", emptyMap()).evidence,
+    )
   }
 
   @Test
@@ -468,19 +500,27 @@ class MissingRenderReportTest {
     // Android renders `kind=LOTTIE` / `kind=SVG` from separate tasks folded into
     // `composePreviewRenderAll` — Robolectric can inflate neither. A NO-SOURCE
     // `composePreviewRender` therefore says nothing about them: their sidecars are this run's.
+    // The owning task travels with the verdict: the report has to name the task that really
+    // skipped, not the one that happens to have a `testClassesDirs` remedy.
     val robolectricSkipped =
       outcomes(
         "composePreviewRender" to GradleTaskDisposition.SKIPPED,
         "composePreviewRenderLottie" to GradleTaskDisposition.SUCCESS,
         "composePreviewRenderSvg" to GradleTaskDisposition.SUCCESS,
       )
-    assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", "LOTTIE", robolectricSkipped))
-    assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", "SVG", robolectricSkipped))
+    assertEquals(
+      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRenderLottie"),
+      renderTaskStateOf(":app", "LOTTIE", robolectricSkipped),
+    )
+    assertEquals(
+      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRenderSvg"),
+      renderTaskStateOf(":app", "SVG", robolectricSkipped),
+    )
     // ...while an ordinary Compose preview in the same module *is* stale — the task that owns it
     // was the one that didn't run.
     assertEquals(
-      RenderTaskEvidence.DID_NOT_RUN,
-      renderTaskEvidenceOf(":app", "COMPOSE", robolectricSkipped),
+      RenderTaskState(RenderTaskEvidence.DID_NOT_RUN, "composePreviewRender"),
+      renderTaskStateOf(":app", "COMPOSE", robolectricSkipped),
     )
 
     // And the converse: the Lottie task skipped while Robolectric ran.
@@ -490,18 +530,24 @@ class MissingRenderReportTest {
         "composePreviewRenderLottie" to GradleTaskDisposition.SKIPPED,
       )
     assertEquals(
-      RenderTaskEvidence.DID_NOT_RUN,
-      renderTaskEvidenceOf(":app", "LOTTIE", lottieSkipped),
+      RenderTaskState(RenderTaskEvidence.DID_NOT_RUN, "composePreviewRenderLottie"),
+      renderTaskStateOf(":app", "LOTTIE", lottieSkipped),
     )
-    assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", "COMPOSE", lottieSkipped))
+    assertEquals(
+      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRender"),
+      renderTaskStateOf(":app", "COMPOSE", lottieSkipped),
+    )
 
     // The desktop backend has no kind tasks at all — `composePreviewRender` renders every kind
     // there, so it is the owner and the answer must not degrade to UNKNOWN.
     val desktop = outcomes("composePreviewRender" to GradleTaskDisposition.SUCCESS)
-    assertEquals(RenderTaskEvidence.RAN, renderTaskEvidenceOf(":app", "LOTTIE", desktop))
     assertEquals(
-      RenderTaskEvidence.DID_NOT_RUN,
-      renderTaskEvidenceOf(
+      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRender"),
+      renderTaskStateOf(":app", "LOTTIE", desktop),
+    )
+    assertEquals(
+      RenderTaskState(RenderTaskEvidence.DID_NOT_RUN, "composePreviewRender"),
+      renderTaskStateOf(
         ":app",
         "SVG",
         outcomes("composePreviewRender" to GradleTaskDisposition.SKIPPED),
@@ -510,34 +556,50 @@ class MissingRenderReportTest {
   }
 
   @Test
+  fun `the skipped-task diagnosis names the task that actually skipped`() {
+    // The converse scenario of the test above, carried all the way to the message: the Lottie task
+    // skipped, so the sidecar beside a Lottie preview is stale — but blaming `composePreviewRender`
+    // and its `testClassesDirs` would be a precise, checkable, false statement. That task ran fine,
+    // it is not what renders Lottie, and being a `RenderPreviewsTask` it has no testClassesDirs and
+    // never reports NO-SOURCE at all.
+    val lottieManifests = lottieManifests()
+    writeSidecar("lottie-renders/Wear.png")
+
+    val message =
+      missingRenderReport(
+        missing = listOf(missingResult().copy(params = PreviewParams(kind = "LOTTIE"))),
+        manifests = lottieManifests,
+        total = 1,
+        taskOutcomes =
+          outcomes(
+            "composePreviewRender" to GradleTaskDisposition.SUCCESS,
+            "composePreviewRenderLottie" to GradleTaskDisposition.SKIPPED,
+          ),
+      )
+
+    assertContains(message, "`composePreviewRenderLottie` did not run in this invocation")
+    assertContains(message, "earlier run — threw NoClassDefFoundError")
+    // The remedy is the one that fits the task that skipped...
+    assertContains(message, "composePreview { enabled = false }")
+    assertContains(message, "kind=LOTTIE")
+    // ...and never the Robolectric one, which would be a wrong-task diagnosis here. `NO-SOURCE` is
+    // not even a state this task can report.
+    assertFalse(message.contains("testClassesDirs"), message)
+    assertFalse(message.contains("NO-SOURCE"), message)
+    assertFalse(message.contains("`composePreviewRender` did not run"), message)
+  }
+
+  @Test
   fun `a Lottie failure is not labelled stale when Robolectric was NO-SOURCE`() {
     // End to end through the report: the Android Lottie renderer wrote this sidecar seconds ago.
     // Calling it an "earlier run" and pointing at testClassesDirs is the original bug inverted.
-    val lottieManifests =
-      listOf(
-        PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
-          PreviewManifest(
-            module = ":app",
-            variant = "debug",
-            previews =
-              listOf(
-                PreviewInfo(
-                  id = previewId,
-                  functionName = "WearAppPreview",
-                  className = "com.example.wear.WearAppKt",
-                  params = PreviewParams(kind = "LOTTIE"),
-                  captures = listOf(Capture(renderOutput = "lottie-renders/Wear.png")),
-                )
-              ),
-          )
-      )
     writeSidecar("lottie-renders/Wear.png")
     val lottieResult = missingResult().copy(params = PreviewParams(kind = "LOTTIE"))
 
     val message =
       missingRenderReport(
         missing = listOf(lottieResult),
-        manifests = lottieManifests,
+        manifests = lottieManifests(),
         total = 1,
         taskOutcomes =
           outcomes(
@@ -599,6 +661,43 @@ class MissingRenderReportTest {
     assertContains(message, "IllegalStateException")
     assertFalse(message.contains("NoSuchMethodError"), message)
     assertFalse(message.contains("long gone"), message)
+  }
+
+  @Test
+  fun `a blank capture output keeps the default stem as a candidate`() {
+    // A capture that declares no `renderOutput` is a supported manifest shape, and the Android
+    // renderer resolves it to `renders/<id>.png` — `capture.renderOutput.substringAfterLast('/')
+    // .ifEmpty { "<id>.png" }` — which is also the anchor its outer per-preview catch writes the
+    // sidecar to. With a data product declared alongside it, dropping the default stem would leave
+    // a render that died before producing the product with no sidecar found at all, and the CLI
+    // back on the NO-SOURCE wiring guess it is this whole file's job not to guess.
+    val blankCaptureWithProduct =
+      listOf(
+        PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
+          PreviewManifest(
+            module = ":app",
+            variant = "debug",
+            previews =
+              listOf(
+                PreviewInfo(
+                  id = previewId,
+                  functionName = "WearAppPreview",
+                  className = "com.example.wear.WearAppKt",
+                  captures = listOf(Capture(renderOutput = "")),
+                  dataProducts =
+                    listOf(PreviewDataProduct(kind = "gif", output = "data/anim/Wear.gif")),
+                )
+              ),
+          )
+      )
+    writeSidecar("renders/$previewId.png")
+
+    val entries = collectMissingRenders(listOf(missingResult()), blankCaptureWithProduct)
+
+    assertEquals(listOf("renders/$previewId.png"), entries.single().sidecars.map { it.output })
+    val message = formatMissingRenderReport(entries, total = 1)
+    assertContains(message, "NoClassDefFoundError")
+    assertFalse(message.contains("NO-SOURCE"), message)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
@@ -464,7 +464,12 @@ class MissingRenderReportTest {
   @Test
   fun `render-task evidence comes from the module's own composePreviewRender outcome`() {
     val skipped = outcomes("composePreviewRender" to GradleTaskDisposition.SKIPPED)
-    val didNotRun = RenderTaskState(RenderTaskEvidence.DID_NOT_RUN, "composePreviewRender")
+    val didNotRun =
+      RenderTaskState(
+        RenderTaskEvidence.DID_NOT_RUN,
+        "composePreviewRender",
+        ":app:composePreviewRender",
+      )
     assertEquals(didNotRun, renderTaskStateOf(":app", "COMPOSE", skipped))
     // The gradle path is carried with and without its leading colon depending on the caller.
     assertEquals(didNotRun, renderTaskStateOf("app", "COMPOSE", skipped))
@@ -477,7 +482,11 @@ class MissingRenderReportTest {
         GradleTaskDisposition.FAILED,
       )) {
       assertEquals(
-        RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRender"),
+        RenderTaskState(
+          RenderTaskEvidence.RAN,
+          "composePreviewRender",
+          ":app:composePreviewRender",
+        ),
         renderTaskStateOf(":app", "COMPOSE", outcomes("composePreviewRender" to disposition)),
         "$disposition",
       )
@@ -509,17 +518,29 @@ class MissingRenderReportTest {
         "composePreviewRenderSvg" to GradleTaskDisposition.SUCCESS,
       )
     assertEquals(
-      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRenderLottie"),
+      RenderTaskState(
+        RenderTaskEvidence.RAN,
+        "composePreviewRenderLottie",
+        ":app:composePreviewRenderLottie",
+      ),
       renderTaskStateOf(":app", "LOTTIE", robolectricSkipped),
     )
     assertEquals(
-      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRenderSvg"),
+      RenderTaskState(
+        RenderTaskEvidence.RAN,
+        "composePreviewRenderSvg",
+        ":app:composePreviewRenderSvg",
+      ),
       renderTaskStateOf(":app", "SVG", robolectricSkipped),
     )
     // ...while an ordinary Compose preview in the same module *is* stale — the task that owns it
     // was the one that didn't run.
     assertEquals(
-      RenderTaskState(RenderTaskEvidence.DID_NOT_RUN, "composePreviewRender"),
+      RenderTaskState(
+        RenderTaskEvidence.DID_NOT_RUN,
+        "composePreviewRender",
+        ":app:composePreviewRender",
+      ),
       renderTaskStateOf(":app", "COMPOSE", robolectricSkipped),
     )
 
@@ -530,11 +551,15 @@ class MissingRenderReportTest {
         "composePreviewRenderLottie" to GradleTaskDisposition.SKIPPED,
       )
     assertEquals(
-      RenderTaskState(RenderTaskEvidence.DID_NOT_RUN, "composePreviewRenderLottie"),
+      RenderTaskState(
+        RenderTaskEvidence.DID_NOT_RUN,
+        "composePreviewRenderLottie",
+        ":app:composePreviewRenderLottie",
+      ),
       renderTaskStateOf(":app", "LOTTIE", lottieSkipped),
     )
     assertEquals(
-      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRender"),
+      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRender", ":app:composePreviewRender"),
       renderTaskStateOf(":app", "COMPOSE", lottieSkipped),
     )
 
@@ -542,11 +567,15 @@ class MissingRenderReportTest {
     // there, so it is the owner and the answer must not degrade to UNKNOWN.
     val desktop = outcomes("composePreviewRender" to GradleTaskDisposition.SUCCESS)
     assertEquals(
-      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRender"),
+      RenderTaskState(RenderTaskEvidence.RAN, "composePreviewRender", ":app:composePreviewRender"),
       renderTaskStateOf(":app", "LOTTIE", desktop),
     )
     assertEquals(
-      RenderTaskState(RenderTaskEvidence.DID_NOT_RUN, "composePreviewRender"),
+      RenderTaskState(
+        RenderTaskEvidence.DID_NOT_RUN,
+        "composePreviewRender",
+        ":app:composePreviewRender",
+      ),
       renderTaskStateOf(
         ":app",
         "SVG",
@@ -577,7 +606,8 @@ class MissingRenderReportTest {
           ),
       )
 
-    assertContains(message, "`composePreviewRenderLottie` did not run in this invocation")
+    // Qualified with the module: one task *name* is many tasks in a multi-module render.
+    assertContains(message, "`:app:composePreviewRenderLottie` did not run in this invocation")
     assertContains(message, "earlier run — threw NoClassDefFoundError")
     // The remedy is the one that fits the task that skipped...
     assertContains(message, "composePreview { enabled = false }")
@@ -611,6 +641,71 @@ class MissingRenderReportTest {
     assertContains(message, "rendered and then threw")
     assertFalse(message.contains("earlier run"), message)
     assertFalse(message.contains("testClassesDirs"), message)
+  }
+
+  @Test
+  fun `renderer guidance is per module, not per task name`() {
+    // Every Android module registers its own `composePreviewRenderLottie`, so a multi-module render
+    // has several tasks with one name and independently different outcomes. Grouping on the name
+    // alone merged them: one paragraph, the combined count, an unqualified task to go and inspect,
+    // and "in this module" said of two modules at once.
+    val otherDir = workspace.resolve("feature").apply { mkdirs() }
+    val otherId = "com.example.wear.FeatureKt.FeaturePreview"
+    val manifests =
+      lottieManifests() +
+        (PreviewModule(gradlePath = ":feature", projectDir = otherDir) to
+          PreviewManifest(
+            module = ":feature",
+            variant = "debug",
+            previews =
+              listOf(
+                PreviewInfo(
+                  id = otherId,
+                  functionName = "FeaturePreview",
+                  className = "com.example.wear.FeatureKt",
+                  params = PreviewParams(kind = "LOTTIE"),
+                  captures = listOf(Capture(renderOutput = "lottie-renders/Feature.png")),
+                )
+              ),
+          ))
+    // `:app`'s Lottie task skipped and left last run's sidecar behind; `:feature`'s ran and simply
+    // produced nothing.
+    writeSidecar("lottie-renders/Wear.png")
+    val taskOutcomes =
+      mapOf(
+        ":app:composePreviewRenderLottie" to
+          GradleTaskOutcome(":app:composePreviewRenderLottie", GradleTaskDisposition.SKIPPED),
+        ":feature:composePreviewRenderLottie" to
+          GradleTaskOutcome(":feature:composePreviewRenderLottie", GradleTaskDisposition.SUCCESS),
+      )
+
+    val message =
+      missingRenderReport(
+        missing =
+          listOf(
+            missingResult().copy(params = PreviewParams(kind = "LOTTIE")),
+            missingResult(id = otherId)
+              .copy(module = ":feature", params = PreviewParams(kind = "LOTTIE")),
+          ),
+        manifests = manifests,
+        total = 2,
+        taskOutcomes = taskOutcomes,
+      )
+
+    // The stale sidecar belongs to `:app`'s task alone — `:feature`'s ran.
+    assertContains(message, "`:app:composePreviewRenderLottie` did not run in this invocation")
+    assertFalse(message.contains("`:feature:composePreviewRenderLottie` did not run"), message)
+    // Two paragraphs, each naming its own module and counting only its own previews.
+    assertContains(
+      message,
+      "`:app:composePreviewRenderLottie` renders every `kind=LOTTIE` preview in :app (1 here)",
+    )
+    assertContains(
+      message,
+      "`:feature:composePreviewRenderLottie` renders every `kind=LOTTIE` preview in :feature (1 here)",
+    )
+    assertFalse(message.contains("(2 here)"), message)
+    assertFalse(message.contains("in this module"), message)
   }
 
   @Test
@@ -698,6 +793,58 @@ class MissingRenderReportTest {
     val message = formatMissingRenderReport(entries, total = 1)
     assertContains(message, "NoClassDefFoundError")
     assertFalse(message.contains("NO-SOURCE"), message)
+  }
+
+  @Test
+  fun `a blank capture after a declared one does not reopen the default stem`() {
+    // The Android renderer anchors the preview-level sidecar on the *first* capture only
+    // (`captures.firstOrNull()`), deleting and rewriting it there; its two per-job writes need a
+    // `.gif` extension or a data-product path, so neither can land on the default stem. A blank
+    // second capture therefore cannot produce a fresh `renders/<id>.png` sidecar — anything found
+    // there is an older manifest's leftover, and quoting it as this run's finding is the stale-file
+    // trap through a narrower gap.
+    val declaredThenBlank =
+      listOf(
+        PreviewModule(gradlePath = ":app", projectDir = moduleDir) to
+          PreviewManifest(
+            module = ":app",
+            variant = "debug",
+            previews =
+              listOf(
+                PreviewInfo(
+                  id = previewId,
+                  functionName = "WearAppPreview",
+                  className = "com.example.wear.WearAppKt",
+                  captures = listOf(Capture(renderOutput = "renders/Wear_500ms.png"), Capture()),
+                )
+              ),
+          )
+      )
+    writeSidecar(
+      "renders/Wear_500ms.png",
+      simpleSidecarJson(
+        "java.lang.IllegalStateException",
+        "no theme provided",
+        "java.lang.IllegalStateException: no theme provided\n" +
+          "\tat com.example.wear.WearAppKt.WearApp(WearApp.kt:31)",
+      ),
+    )
+    writeSidecar(
+      "renders/$previewId.png",
+      simpleSidecarJson(
+        "java.lang.NoSuchMethodError",
+        "long gone",
+        "java.lang.NoSuchMethodError: long gone\n" +
+          "\tat com.example.wear.WearAppKt.Removed(WearApp.kt:9)",
+      ),
+    )
+
+    val entries = collectMissingRenders(listOf(missingResult()), declaredThenBlank)
+
+    assertEquals(listOf("renders/Wear_500ms.png"), entries.single().sidecars.map { it.output })
+    val message = formatMissingRenderReport(entries, total = 1)
+    assertContains(message, "IllegalStateException")
+    assertFalse(message.contains("NoSuchMethodError"), message)
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #3793 (issue #3741): two P2 review findings that landed on its head commit after it had auto-merged, so they arrive as a separate PR. **Both held**, and both are #3793's own fixes applied incompletely.

Text-only change: the CLI's stderr diagnostic. Nothing renderable is affected.

## 1. Preserve the owning renderer task in the report — **held**

#3793 picked the owning task for the freshness *verdict* and then handed the formatter nothing but the verdict, so the *diagnosis* still said:

```
… but `composePreviewRender` did not run in this invocation (skipped / NO-SOURCE) …
Check the Gradle output above — a common cause is the `composePreviewRender` task reporting
NO-SOURCE, which means the renderer test class wasn't found on testClassesDirs.
```

for a preview whose renderer was `composePreviewRenderLottie` — a task that ran perfectly well in the scenario #3793's own `lottieSkipped` test sets up. The claim is false in three separate ways, which I checked rather than assumed:

- `composePreviewRender` **did** run (that's the premise of the scenario).
- `composePreviewRenderLottie` is a `RenderPreviewsTask`, not a `Test` task — it has no `testClassesDirs` and produces no `composePreviewRender-reports` artifact.
- It declares no `@SkipWhenEmpty` input (grepped: none in `RenderPreviewsTask.kt`), so it cannot report NO-SOURCE at all. What actually skips it is `onlyIf { extension.enabled.get() }` — i.e. `composePreview { enabled = false }` — or a failed dependency.

So the task name now travels with the verdict (`RenderTaskState(evidence, task)`), and both halves of the message are written per owner: the skipped-task sentence names the task that really skipped and drops "/ NO-SOURCE" for tasks that can't report it, while the Robolectric guidance is emitted **only** for previews `composePreviewRender` actually owns. Kind-owned previews get their own paragraph with the remedy that fits them. The `lottieSkipped` shape now renders as:

```
Render task completed but produced no PNG for 1 of 1 preview(s):
  - com.example.wear.WearAppKt.WearAppPreview_Devices - Large Round (:app) — no PNG for: default
      earlier run — threw NoClassDefFoundError: com/google/wear/… (at AmbientAwareActivity.kt:76 in rememberAmbientState)
        chain: InvocationTargetException → NoClassDefFoundError
1 preview(s) have a `<render>.png.error.json` sidecar on disk, but `composePreviewRenderLottie` did not run in this invocation (skipped) — that sidecar is left over from an earlier run and says nothing about this one.
`composePreviewRenderLottie` renders every `kind=LOTTIE` preview in this module (1 here) — the Robolectric renderer skips that kind — so check its outcome in the Gradle output above: `composePreview { enabled = false }` skips it, as does a failure in a task it depends on.
```

One deliberate restraint: that last paragraph makes no claim about what the task *did*. `unexplained` also holds previews whose renderer ran and simply produced nothing, and "it did not run" would misdescribe those — the "did not run" sentence is emitted only for entries where that was observed.

## 2. Retain the default candidate for empty declared captures — **held**

Verified the mechanism at the source before touching it, since the whole fix hinges on it. `RobolectricRenderTest.outputFileFor(capture, outputDir)` is:

```kotlin
val leafName = capture.renderOutput.substringAfterLast('/').ifEmpty { "${preview.id}.png" }
return File(outputDir, leafName)
```

and the per-preview anchor is `preview.captures.firstOrNull()?.let { outputFileFor(it, outputDir) } ?: outputFileFor(preview.dataProducts.first(), outputDir)` (line 587), with the outer `catch (e: Throwable)` writing `RenderErrorSidecar.write(pngFile, e)` at exactly that anchor (line 694). So a blank `renderOutput` genuinely resolves to `renders/<id>.png`, and that is genuinely where the failure is recorded.

#3793 made the default stem a fallback used only when *nothing* was declared, which is wrong for the blank-capture-plus-data-product shape: `declaredOutputs` is non-empty (the product), so the stem was dropped, and a render that died before producing the product had its only sidecar missed — putting the CLI back on the NO-SOURCE guess this whole file exists to stop guessing. The stem is now a candidate whenever some capture declares no path, while a preview whose captures **all** declare paths still never resurrects its pre-move sidecar (the #3793 finding).

One case deliberately excluded: a preview with *no captures at all* (a `@ScrollingPreview` declaring only data products, issue #1524). The renderer anchors that one on the first data product, which is already a declared output, so adding the stem there would reintroduce exactly the stale-file problem for no gain.

## Test plan

- `./gradlew :cli:test` — green (full suite).
- `./gradlew :gradle-plugin:test` — green (full suite, untouched here but re-run on the new base).
- `./gradlew :cli:ktfmtFormat` — applied before committing.
- Red-then-green: with both fixes reverted in place (formatter hardcoding `composePreviewRender` and always emitting the Robolectric guidance; default stem only when nothing is declared), exactly the two new tests fail —
  - `the skipped-task diagnosis names the task that actually skipped` FAILS — end-to-end through the report on the `lottieSkipped` shape: asserts the message names `composePreviewRenderLottie`, carries the `composePreview { enabled = false }` remedy, and contains **neither** `testClassesDirs` nor `NO-SOURCE` nor a "`composePreviewRender` did not run" claim.
  - `a blank capture output keeps the default stem as a candidate` FAILS — blank capture + data product, sidecar only at `renders/<id>.png`: asserts it is found and that the NO-SOURCE guidance is not printed.
- The existing `Lottie and SVG evidence comes from their own renderer task, not Robolectric` now asserts full `RenderTaskState` equality (evidence **and** owning task) in every direction, so the task name the formatter depends on is pinned at its source.
- `the legacy default stem is only probed when the manifest declares no output` still passes unchanged — the narrowing that fix introduced survives this widening.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_