### PR TITLE
fix(cli): let a @PreviewParameter row id select its module and narrow the render

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1141,6 +1141,68 @@ internal fun previewIdMatchesRequest(
 }
 
 /**
+ * Like [previewIdMatchesRequest], but a selector naming one of [preview]'s **`@PreviewParameter`
+ * rows** also counts as a match (issue #3786).
+ *
+ * Discovery emits one manifest entry per parameterized *function* — it reads bytecode and cannot
+ * instantiate a `PreviewParameterProvider` — so the manifest holds `Foo` and has never heard of
+ * `Foo_PARAM_1`. `serve` synthesises the row ids later, from the fan-out on disk
+ * ([ServeParameterRows][ee.schimke.composeai.cli.serve.ServeParameterRows]), but module selection
+ * and render narrowing both run *before* that, against the manifest. Matching on the manifest alone
+ * therefore dropped the module and the command exited with "no previews discovered" — precisely
+ * when the caller had been most specific.
+ *
+ * **Why a prefix test is safe here**, where a bare `substringBeforeLast('_')` would not be: this
+ * doesn't guess at the id grammar. It anchors on a real manifest id that *declares a provider*, so
+ * the only previews whose rows we admit are the ones that genuinely have rows. A declared preview
+ * whose id ends in `_1` is in the manifest under its own name and matches directly; the worst case
+ * for a false positive is a selector that happens to start with a parameterized preview's id — and
+ * that costs only the render narrowing, never a wrong answer.
+ *
+ * The row lane is deliberately per-selector rather than "any selector looks like a row": the three
+ * selectors intersect ([previewIdMatchesRequest]), so `--id Foo_PARAM_1 --filter Foo` has to keep
+ * holding. When no selector is a row address this reduces exactly to [previewIdMatchesRequest].
+ */
+internal fun previewMatchesRequestIncludingRows(
+  preview: PreviewInfo,
+  exactId: String?,
+  filter: String?,
+  previewRef: String? = null,
+): Boolean {
+  val id = preview.id
+  val parameterized = !preview.params.previewParameterProviderClassName.isNullOrBlank()
+  fun rowOf(selector: String) = parameterized && isRowAddressOf(id, selector)
+  if (exactId != null && id != exactId && !rowOf(exactId)) return false
+  if (filter != null && !id.contains(filter, ignoreCase = true) && !rowOf(filter)) return false
+  if (
+    previewRef != null &&
+      !previewMatchesReference(
+        previewRef,
+        id,
+        className = preview.className,
+        functionName = preview.functionName,
+      ) &&
+      !rowOf(previewRef)
+  ) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Whether [selector] spells a row of [baseId] — `<baseId>_<row>` with a non-empty row token, the
+ * same `<stem>_<suffix>` shape the fan-out renderer writes to disk (docs/RENDER_FILENAMES.md) and
+ * the daemon accepts on `renderNow`.
+ *
+ * Only ever called for a preview that declares a provider, so "looks like a row of a preview that
+ * has rows" is the whole claim being made.
+ */
+private fun isRowAddressOf(baseId: String, selector: String): Boolean =
+  selector.length > baseId.length + 1 &&
+    selector.startsWith(baseId) &&
+    selector[baseId.length] == '_'
+
+/**
  * The `--preview <ref>` rule (issue #3744) — one preview, one boolean, no dependence on the rest of
  * the candidate set.
  *
@@ -1185,14 +1247,15 @@ internal fun modulesMatchingPreviewRequest(
   val matchingPaths =
     manifests
       .filter { (_, manifest) ->
+        // Row-aware (issue #3786): a module whose only match is `Foo_PARAM_1` must survive, because
+        // the row ids don't exist until `serve` reads the rendered fan-out back off disk — long
+        // after this narrowing ran.
         manifest.previews.any {
-          previewIdMatchesRequest(
-            it.id,
+          previewMatchesRequestIncludingRows(
+            it,
             exactId = exactId,
             filter = filter,
             previewRef = previewRef,
-            className = it.className,
-            functionName = it.functionName,
           )
         }
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
@@ -89,17 +89,29 @@ internal object PreviewRenderScope {
       for (preview in manifest.previews) {
         discovered++
         val expanded = PreviewPermutationsCli.expand(listOf(preview), permutations).map { it.id }
+        // Issue #3786 — a `@PreviewParameter` row selector (`Foo_PARAM_1`) names an id that only
+        // comes into existence once the fan-out is on disk, so it can never match a manifest entry
+        // here. Selecting its *base* keeps the #3730 narrowing working for row requests instead of
+        // falling through to `selected.isEmpty() -> FULL` and rendering the whole module.
+        val rowAddressed =
+          previewMatchesRequestIncludingRows(
+            preview,
+            exactId = exactId,
+            filter = filter,
+            previewRef = previewRef,
+          )
         if (
-          expanded.none {
-            previewIdMatchesRequest(
-              it,
-              exactId = exactId,
-              filter = filter,
-              previewRef = previewRef,
-              className = preview.className,
-              functionName = preview.functionName,
-            )
-          }
+          !rowAddressed &&
+            expanded.none {
+              previewIdMatchesRequest(
+                it,
+                exactId = exactId,
+                filter = filter,
+                previewRef = previewRef,
+                className = preview.className,
+                functionName = preview.functionName,
+              )
+            }
         )
           continue
         selected += preview.id

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
@@ -1,0 +1,196 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Issue #3786 — selecting a `@PreviewParameter` **row id** must not drop the module before the rows
+ * exist.
+ *
+ * `serve` hosts one entry per row (#3772) with ids of the shape `<baseId>_<row>`, and accepts a row
+ * id as a selector. But the ids are synthesised late, from the fan-out the render pass wrote to
+ * disk — discovery emits one entry per parameterized *function*, so the manifest holds `Foo` and
+ * has never heard of `Foo_PARAM_1`. Module selection and render narrowing both run against that
+ * manifest, *before* the expansion, so `serve --id Foo_PARAM_1` used to exit with "no previews
+ * discovered": the row-selecting branch in `ServeCommand` was unreachable on the Gradle path.
+ *
+ * The substring form accidentally worked from the other direction (`--filter Foo` keeps the module,
+ * then serves all of Foo's rows), so this only bit when someone named a row precisely — exactly
+ * when they were being most specific.
+ */
+class PreviewRowSelectorTest {
+
+  private fun module(path: String) =
+    PreviewModule(path, File("/tmp/compose-preview-test/${path.replace(':', '/')}"))
+
+  private fun preview(id: String, parameterized: Boolean = false) =
+    PreviewInfo(
+      id = id,
+      functionName = id.substringAfterLast('.'),
+      className = "com.example.PreviewsKt",
+      params =
+        PreviewParams(
+          kind = "COMPOSE",
+          previewParameterProviderClassName =
+            if (parameterized) "com.example.SwatchProvider" else null,
+        ),
+    )
+
+  private fun manifest(module: PreviewModule, vararg previews: PreviewInfo) =
+    module to
+      PreviewManifest(module = module.gradlePath, variant = "debug", previews = previews.toList())
+
+  // ---------- module selection: the bug from the issue ----------
+
+  /** The reproduce case: `compose-preview serve --module :app --id Foo_PARAM_1`. */
+  @Test
+  fun `a row id keeps the module that owns its base preview`() {
+    val app = module(":app")
+
+    val selected =
+      modulesMatchingPreviewRequest(
+        modules = listOf(app),
+        manifests = listOf(manifest(app, preview("Foo", parameterized = true))),
+        exactId = "Foo_PARAM_1",
+        filter = null,
+      )
+
+    assertEquals(listOf(":app"), selected.map { it.gradlePath })
+  }
+
+  /**
+   * `--filter` and `--preview` name the same row and were broken the same way (#3744 widened it).
+   */
+  @Test
+  fun `filter and preview accept a row id too`() {
+    val app = module(":app")
+    val manifests = listOf(manifest(app, preview("Foo", parameterized = true)))
+
+    assertEquals(
+      listOf(":app"),
+      modulesMatchingPreviewRequest(listOf(app), manifests, exactId = null, filter = "Foo_PARAM_1")
+        .map { it.gradlePath },
+    )
+    assertEquals(
+      listOf(":app"),
+      modulesMatchingPreviewRequest(
+          listOf(app),
+          manifests,
+          exactId = null,
+          filter = null,
+          previewRef = "Foo_PARAM_1",
+        )
+        .map { it.gradlePath },
+    )
+  }
+
+  /**
+   * The row lane must not become a blanket "keep everything on a miss". A preview with no provider
+   * has no rows, so a selector that matches nothing there is still definitively wrong — and the "no
+   * previews discovered" diagnostic for a typo depends on it.
+   */
+  @Test
+  fun `a row-shaped selector still drops a module whose preview has no provider`() {
+    val app = module(":app")
+
+    val selected =
+      modulesMatchingPreviewRequest(
+        modules = listOf(app),
+        manifests = listOf(manifest(app, preview("Foo", parameterized = false))),
+        exactId = "Foo_PARAM_1",
+        filter = null,
+      )
+
+    assertTrue(selected.isEmpty(), "a non-parameterized Foo cannot own Foo_PARAM_1: $selected")
+  }
+
+  /** And an unrelated module is still dropped — the narrowing is preserved where it's valid. */
+  @Test
+  fun `a row id does not keep modules that own no matching base`() {
+    val app = module(":app")
+    val wear = module(":wear")
+
+    val selected =
+      modulesMatchingPreviewRequest(
+        modules = listOf(app, wear),
+        manifests =
+          listOf(
+            manifest(app, preview("Foo", parameterized = true)),
+            manifest(wear, preview("Tile", parameterized = true)),
+          ),
+        exactId = "Foo_PARAM_1",
+        filter = null,
+      )
+
+    assertEquals(listOf(":app"), selected.map { it.gradlePath })
+  }
+
+  /**
+   * The prefix test is anchored on a real manifest id *plus* its provider, so it doesn't mis-handle
+   * the case the issue flagged against a naive `substringBeforeLast('_')`: a declared preview whose
+   * id genuinely ends in `_1` is matched under its own name.
+   */
+  @Test
+  fun `a declared preview whose id ends in an underscore digit matches as itself`() {
+    val app = module(":app")
+
+    val selected =
+      modulesMatchingPreviewRequest(
+        modules = listOf(app),
+        manifests = listOf(manifest(app, preview("Foo_1"), preview("Bar"))),
+        exactId = "Foo_1",
+        filter = null,
+      )
+
+    assertEquals(listOf(":app"), selected.map { it.gradlePath })
+  }
+
+  /** The selectors intersect, so a row id on one must not cancel a normal match on another. */
+  @Test
+  fun `an intersecting id and filter both still apply`() {
+    val app = module(":app")
+    val manifests = listOf(manifest(app, preview("Foo", parameterized = true)))
+
+    assertEquals(
+      listOf(":app"),
+      modulesMatchingPreviewRequest(listOf(app), manifests, exactId = "Foo_PARAM_1", filter = "Foo")
+        .map { it.gradlePath },
+    )
+    // A filter that Foo cannot satisfy still drops it, row id or not.
+    assertTrue(
+      modulesMatchingPreviewRequest(
+          listOf(app),
+          manifests,
+          exactId = "Foo_PARAM_1",
+          filter = "Unrelated",
+        )
+        .isEmpty()
+    )
+  }
+
+  // ---------- render narrowing: keep #3730's optimisation for row requests ----------
+
+  /**
+   * Keeping the module is only half the answer. Without this the scope would select nothing and
+   * fall back to `FULL`, paying for every preview in the module — the exact cost #3730 removed, and
+   * the cost the issue expected option (3) to incur. Selecting the *base* preserves it.
+   */
+  @Test
+  fun `a row id narrows the gradle render to its base preview`() {
+    val app = module(":app")
+
+    val scope =
+      PreviewRenderScope.forRequest(
+        manifests = listOf(manifest(app, preview("Foo", parameterized = true), preview("Other"))),
+        exactId = "Foo_PARAM_1",
+        filter = null,
+      )
+
+    assertEquals(
+      listOf("-P${PreviewRenderScope.GRADLE_PROPERTY}=${PreviewRenderScope.ANCHOR}Foo"),
+      scope.gradleArgs,
+    )
+  }
+}


### PR DESCRIPTION
Fixes #3786.

`compose-preview serve --module :app --id Foo_PARAM_1` exited with `serve: no previews discovered`. The row-selecting branch in `ServeCommand` was unreachable on the Gradle-backed path.

Row ids are synthesised late — `ServeParameterRows` reads them off the fan-out the render pass wrote to disk. Module selection runs long before that, against the **discovery manifest**, and discovery emits one entry per parameterized *function*: the manifest holds `Foo` and has never heard of `Foo_PARAM_1`. So `modulesMatchingPreviewRequest` dropped the module before the rows could exist.

As the issue notes, the substring form accidentally worked from the other direction — `--filter Foo` keeps the module and then serves all of Foo's rows — so this only bit when someone named a row precisely, i.e. exactly when they were being most specific.

## The rule

`previewMatchesRequestIncludingRows` adds a row lane to the shared matcher: a selector spelled `<id>_<row>` also matches when that manifest entry **declares a provider**.

Anchoring on a real manifest id *plus* its provider is what makes a prefix test safe here where the issue's option (2) — a bare `substringBeforeLast('_')` — would not be. It never guesses at the id grammar:

- a declared preview whose id genuinely ends in `_1` is in the manifest under its own name and matches directly (the mis-handling the issue flagged);
- a preview with **no** provider still drops a row-shaped selector, so "no previews discovered" survives as the typo diagnostic — this is narrower than option (3), which would have kept the module on *any* miss;
- the worst case for a false keep is a selector that happens to start with a parameterized preview's id, which costs only the render narrowing, never a wrong answer.

The lane is per-selector rather than "any selector looks like a row", because the three selectors intersect: `--id Foo_PARAM_1 --filter Foo` has to keep holding. When no selector is a row address it reduces exactly to `previewIdMatchesRequest`.

## Both passes, so the optimisation survives

Keeping the module is only half the answer. `PreviewRenderScope.forRequest` would then select nothing and hit its `selected.isEmpty() -> FULL` fallback, paying for every preview in the module — the cost #3730 removed, and the cost the issue expected option (3) to incur. Selecting the **base** preview instead preserves the narrowing, so a row request renders exactly the fan-out it needs (`-PcomposePreview.idFilter=…Foo`).

On the issue's open question — whether anything relies on "no match ⇒ empty module list" to report "no previews matched": it does, and that path is untouched. A module with no parameterized preview still drops a non-matching selector, which is what produces that message; `serve`'s own later "no previews matched (--id/--filter excluded them all)" is a separate check against the expanded row list.

## Test plan

New `PreviewRowSelectorTest` — 7 tests, all ran, 0 failures:

| Test | Pins |
| --- | --- |
| `a row id keeps the module that owns its base preview` | the issue's reproduce case |
| `filter and preview accept a row id too` | `--filter` and `--preview` (#3744 widened the gap to a third selector) |
| `a row-shaped selector still drops a module whose preview has no provider` | the row lane is not a blanket keep-everything |
| `a row id does not keep modules that own no matching base` | unrelated modules still drop |
| `a declared preview whose id ends in an underscore digit matches as itself` | the naive-grammar hazard option (2) would have hit |
| `an intersecting id and filter both still apply` | intersect semantics preserved in both directions |
| `a row id narrows the gradle render to its base preview` | #3730's narrowing kept, not traded away |

Full `:cli:test` suite green — this changes a matcher shared by `render`, `show`, `a11y` and `record`, so the regression surface is the whole CLI, not just `serve`.

**Visual evidence: N/A** — selector plumbing; nothing rendered changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SamkbmKYKnb7XhJUU5TYbM)_