### PR TITLE
fix(serve): make site isolation an allowlist, not a chase

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -246,6 +246,15 @@ class ServeBundleStore(
       // File(root, ".")/File(root, "..") resolve to the upload root or its parent, and add() calls
       // deleteRecursively() on that path before unpacking — which would wipe the wrong directory.
       if (trimmed.isEmpty() || trimmed.all { it == '.' }) return null
+      // …and reject a name that collides with one of the server's own top-level routes. Such a
+      // session is ambiguous everywhere — Ktor scores the constant segment above `/{system}`, so
+      // `/api/` could never reach a bundle called `api` at its own landing anyway — and on a
+      // top-level site it is worse than ambiguous: the site interceptor lets a reserved first
+      // segment through as "that's a route, not a session", and a path the routes don't actually
+      // match (`/api/`) then falls to `/{system}/` and serves the foreign bundle. Refusing the
+      // NAME is what makes "a reserved segment is never a session" true, which is the invariant
+      // the interceptor rests on.
+      if (trimmed in ServeSites.RESERVED_SYSTEMS) return null
       return trimmed.takeIf { it.matches(Regex("[A-Za-z0-9._@-]{1,128}")) }
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfig.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfig.kt
@@ -181,6 +181,13 @@ data class ServeCatalogsConfig(
     fun validateEntry(entry: Entry): String? =
       when {
         !SYSTEM_RE.matches(entry.system) -> "invalid catalog system id '${entry.system}'"
+        // A slug-shaped id can still be one of the server's own top-level routes, which the
+        // registry refuses to name a session ([ServeSessionRegistry.register]) — so the entry
+        // would parse, validate, be scheduled for loading, and then fail at registration with a
+        // runtime error instead of the ordinary malformed-entry warning. Say so here, where the
+        // three callers (startup filtering, `problems()`, the admin add) all read it.
+        entry.system in ServeSites.RESERVED_SYSTEMS ->
+          "catalog system id '${entry.system}' is one of the server's own routes"
         entry.repo != null && !REPO_RE.matches(entry.repo) ->
           "catalog '${entry.system}' has an invalid repo '${entry.repo}'"
         entry.attributionRepos.any { !REPO_RE.matches(it) } ->

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -434,8 +434,25 @@ class ServeHttpServer(
             current.response.headers.append(HttpHeaders.Location, "/$rest$query")
             current.respond(HttpStatusCode.PermanentRedirect)
             finish()
-          } else if (isForeignSession(first)) {
-            current.respondText("not found", status = HttpStatusCode.NotFound)
+          } else if (!isRootedRoute(first)) {
+            // The site's OWN styled 404, not a bare string. This refusal is the most likely 404 on
+            // a site hostname (every mistyped path lands here), so answering it in plain text
+            // would undo the one-skin-per-hostname property for exactly the page a visitor is
+            // most likely to see.
+            val skin = current.siteSkin()
+            current.respondText(
+              ServeWeb.notFoundPage(
+                "That page was not found on this site.",
+                token,
+                isPublic,
+                version = BUNDLE_VERSION,
+                siteName = skin.first,
+                themeCss = skin.second,
+                themeStorageKey = skin.third,
+              ),
+              ContentType.Text.Html,
+              HttpStatusCode.NotFound,
+            )
             finish()
           }
         }
@@ -1013,7 +1030,10 @@ class ServeHttpServer(
    * one hostname wearing two skins. Read through [ServeSessionRegistry.peekHost], which never
    * resumes: a 404 must not wake a daemon to find out what colour to be.
    */
-  private fun RoutingContext.siteSkin(): Triple<String, String, String> {
+  private fun RoutingContext.siteSkin(): Triple<String, String, String> = call.siteSkin()
+
+  /** As [siteSkin], from the call alone — the site interceptor has no [RoutingContext]. */
+  private fun ApplicationCall.siteSkin(): Triple<String, String, String> {
     val system = siteSystem() ?: return Triple("", "", "")
     val host = sessions.peekHost(system)
     val bundle = host?.let { catalogBundleHost(it) }
@@ -1331,7 +1351,14 @@ class ServeHttpServer(
       call.request.queryParameters["from"]?.let { raw ->
         val system = raw.substringBefore('/')
         val previewId = raw.substringAfter('/', "")
+        // `?from=` is supplied by the caller, not by the selector this page renders — so narrowing
+        // the selector does not narrow this. On a site host a `from` naming a neighbour would
+        // otherwise seed the editor with that catalog's Kotlin source, which is the one-catalog
+        // contract broken by a query parameter. Ignored rather than refused: the playground still
+        // opens, on its sample.
+        val siteSystem = siteSystem()
         if (system.isBlank() || previewId.isBlank()) null
+        else if (siteSystem != null && system != siteSystem) null
         // On the IO dispatcher: an uncached seed is a synchronous GitHub GET with 10 s connect +
         // 10 s read, and running that on the routing dispatcher lets a handful of concurrent
         // handoffs during GitHub latency stall every other route on this host.
@@ -2638,44 +2665,29 @@ class ServeHttpServer(
       ?: appCatalogSessions
 
   /**
-   * Every catalog id this server publishes under a `/<system>/` path, listed or not. Used only by
-   * the top-level-site interceptor to tell "a first path segment that names a catalog" from "a
-   * first path segment that names a route" — so a site host's rewrite touches `/wear-m3/…` and
-   * leaves `/render/…`, `/assets/…` and the rest alone.
+   * Whether [first] — a request's first path segment on a **site host** — names one of the server's
+   * own routes, and so is not a session at all. Everything else 404s there.
+   *
+   * This is an **allowlist**, deliberately. The gate used to enumerate what was *foreign* — catalog
+   * ids, then registered sessions, then `<system>@<rev>` — and each review round found another way
+   * for a session to exist that the enumeration had not met: an uploaded bundle, a suspended entry
+   * that `peekHost` reports as absent, and finally a `--revisions` ref like `main`, which is not
+   * registered at all until the generic route leases it and the factory *builds* it. A list of
+   * things to refuse can only ever chase that. The set of constant first segments is closed and
+   * already written down ([ServeSites.RESERVED_SYSTEMS]), so a site host now serves its own system,
+   * serves the routes, and refuses everything else — including whatever the next session kind is.
+   *
+   * The cost is that a top-level route missing from that list 404s on a site host. That is a
+   * visible, tested failure rather than a silent leak, which is the right way round for a feature
+   * whose whole promise is that the hostname publishes one catalog. [ServeSites] also refuses a
+   * site whose id would collide with a route, so the two rules cannot disagree.
    */
-  private fun servedSystems(): Set<String> = (listedCatalogs() + unlistedCatalogs()).toSet()
-
-  /**
-   * Whether [first] — a request's first path segment on a **site host** — selects some session
-   * other than this site's own, and so must 404 rather than be served through the wrong domain.
-   *
-   * Deliberately broader than [servedSystems]: a catalog row is not the only thing the generic
-   * `/{system}/…` routes can acquire. An uploaded bundle (`--accept-bundles`, `POST /bundles/<n>`)
-   * registers a session under its own name, and a revision session is addressed as `<system>@<rev>`
-   * — both would otherwise slip past a catalog-only check and serve a neighbour on a site hostname.
-   * [ServeSessionRegistry.peekHost] answers for anything registered without resuming it, and the
-   * `@` split covers a revision of a served catalog that has not been built yet, so neither needs
-   * to be enumerated ahead of time.
-   *
-   * A constant route (`render`, `p`, `api`, `assets`, …) names no session and is not a served
-   * system, so it falls through untouched — and [ServeSites] refuses a site whose id would collide
-   * with one, so the two rules cannot disagree.
-   *
-   * Membership is [ServeSessionRegistry.isKnownSession], NOT `peekHost`. `peekHost` answers
-   * "resident right now" and returns null for a **suspended** session that is still registered and
-   * resumable — so a foreign session that had merely gone idle read as "no such session", fell
-   * through to the `/{system}/…` handler, and got resumed and served through the site hostname. The
-   * gate has to be registration, not residency, or isolation lapses on exactly the timer that makes
-   * a quiet box cheap.
-   */
-  private fun isForeignSession(first: String): Boolean {
-    // …except the visitor's own redeemed playground session, which this host minted seconds ago
-    // under an unguessable token id and is redirecting them to. It is registered, so the
-    // membership check below would call it a neighbour and 404 the last step of their own run.
-    if (playgroundRedeem?.isRedeemedSession(first) == true) return false
-    return first in servedSystems() ||
-      first.substringBefore('@') in servedSystems() ||
-      sessions.isKnownSession(first)
+  private fun isRootedRoute(first: String): Boolean {
+    // The visitor's own redeemed playground session is the one session a site host must let
+    // through: this server minted it seconds ago under an unguessable token id and is redirecting
+    // them to it, so refusing it would 404 the last step of their own run.
+    if (playgroundRedeem?.isRedeemedSession(first) == true) return true
+    return first in ServeSites.RESERVED_SYSTEMS
   }
 
   /** `?a=b` for a non-empty query string, else `""` — for rebuilding a URL we are redirecting. */
@@ -2993,7 +3005,7 @@ class ServeHttpServer(
         // main host) would otherwise be fetchable back through this domain and hand a chat client
         // that catalog's title and thumbnails under this site's name. The front door's own card
         // (system == null) is nobody's catalog and is refused here for the same reason.
-        ?.takeIf { site == null || it.system == site }
+        ?.takeIf { site == null || site in it.systems }
     if (card == null) {
       call.respondText("no such card", status = HttpStatusCode.NotFound)
       return

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -435,10 +435,22 @@ class ServeHttpServer(
             current.respond(HttpStatusCode.PermanentRedirect)
             finish()
           } else if (!isRootedRoute(first)) {
-            // The site's OWN styled 404, not a bare string. This refusal is the most likely 404 on
-            // a site hostname (every mistyped path lands here), so answering it in plain text
-            // would undo the one-skin-per-hostname property for exactly the page a visitor is
-            // most likely to see.
+            // The site's OWN styled 404 — every mistyped path on a site hostname lands here, so a
+            // plain string would undo the one-skin-per-hostname property for the page a visitor is
+            // most likely to meet.
+            //
+            // …but ONLY for a caller who is already allowed to see this server. This interceptor
+            // runs BEFORE the routes' own `rejectBadToken`, and `notFoundPage` threads the access
+            // token through its links — so on a token-gated box the styled page would have handed
+            // the secret to any unauthenticated request for a made-up path, which is every scanner.
+            // An unauthorized caller gets the same bare 404 the token gate itself answers with.
+            val provided =
+              current.request.queryParameters["token"] ?: current.request.headers[TOKEN_HEADER]
+            if (!isAuthorized(token, provided, isPublic)) {
+              current.respondText("not found", status = HttpStatusCode.NotFound)
+              finish()
+              return@intercept
+            }
             val skin = current.siteSkin()
             current.respondText(
               ServeWeb.notFoundPage(
@@ -2679,8 +2691,14 @@ class ServeHttpServer(
    *
    * The cost is that a top-level route missing from that list 404s on a site host. That is a
    * visible, tested failure rather than a silent leak, which is the right way round for a feature
-   * whose whole promise is that the hostname publishes one catalog. [ServeSites] also refuses a
-   * site whose id would collide with a route, so the two rules cannot disagree.
+   * whose whole promise is that the hostname publishes one catalog.
+   *
+   * Letting a reserved segment through is only safe while **no session can be named one**, because
+   * Ktor matches whole paths and this matches a prefix: a bundle uploaded as `api` would make
+   * `/api/` (which no constant route matches) fall to `/{system}/` and serve that bundle. So the
+   * invariant is enforced at the two places a session gets its name —
+   * [ServeBundleStore.sanitizeName] refuses a reserved upload name, and [ServeSites] refuses a site
+   * whose catalog id is one.
    */
   private fun isRootedRoute(first: String): Boolean {
     // The visitor's own redeemed playground session is the one session a site host must let

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -209,6 +209,22 @@ class ServeSessionRegistry(
     host: ServeHost? = null,
     pinned: Boolean = false,
   ) {
+    // A session may never take one of the server's own top-level route names. Such a session is
+    // unreachable at its own landing anyway — Ktor scores a constant segment above `/{system}` —
+    // and it breaks the [ServeSites] interceptor's invariant that a reserved first segment is
+    // always a route: `/api/` matches no constant route, so it would fall to `/{system}/` and
+    // serve that session through a hostname published as one catalog.
+    //
+    // Enforced HERE rather than at each ingestion point because there are five of those (an
+    // upload, a `--bundles` directory, a `--bundle` argument, a catalog id, a revision ref) and
+    // fixing them one at a time is how the last two review rounds went. Every session, however it
+    // is created, is named exactly once — right here.
+    if (sessionId in ServeSites.RESERVED_SYSTEMS) {
+      System.err.println(
+        "serve: refusing session '$sessionId' — that name is one of the server's own routes"
+      )
+      return
+    }
     val replaced = lock.withLock {
       check(!closed) { "ServeSessionRegistry is closed" }
       val prior = sessions[sessionId]

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -217,8 +217,9 @@ class ServeSessionRegistry(
     //
     // Enforced HERE rather than at each ingestion point because there are five of those (an
     // upload, a `--bundles` directory, a `--bundle` argument, a catalog id, a revision ref) and
-    // fixing them one at a time is how the last two review rounds went. Every session, however it
-    // is created, is named exactly once — right here.
+    // fixing them one at a time is how the last two review rounds went. This is one of the two
+    // places a session id is ever bound to an entry — [entryFor] is the other (a ref forked on
+    // demand by [factory], which never passes through here), and it carries the same guard.
     if (sessionId in ServeSites.RESERVED_SYSTEMS) {
       System.err.println(
         "serve: refusing session '$sessionId' — that name is one of the server's own routes"
@@ -462,11 +463,20 @@ class ServeSessionRegistry(
     hosts.forEach { runCatching { it.close() } }
   }
 
-  /** Existing entry, or one forked via [factory]. Caller holds [lock]. */
+  /**
+   * Existing entry, or one forked via [factory]. Caller holds [lock].
+   *
+   * The reserved-name guard from [register] applies here too: a `--revisions` ref named after one
+   * of the server's own routes (`api`, `status`, …) would otherwise be forked on first request,
+   * never having passed through [register], and would then be served by `/{system}/` on a top-level
+   * site host — the exact leak the guard exists to prevent. Refusing the fork keeps the invariant
+   * "no session is ever named after a rooted route" true for every entry in [sessions].
+   */
   private fun entryFor(sessionId: String): Entry? {
     sessions[sessionId]?.let {
       return it
     }
+    if (sessionId in ServeSites.RESERVED_SYSTEMS) return null
     // Hold the lock across the build so racing first-callers for one id can't build twice. A build
     // is
     // slow, but a shared dev/CI server has few tenants and correctness beats build concurrency.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSites.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSites.kt
@@ -181,11 +181,17 @@ data class ServeSites(private val byHost: Map<String, String>) {
      * canonical path on ANY host — a site just makes the collision visible.
      *
      * Enumerated from [ServeHttpServer]'s routing block — every `get("/x…` / `post("/x…` /
-     * `webSocket("/x…` whose first segment is a literal. Re-derive it the same way when a new
-     * top-level route is added; a missing entry lets a site claim that prefix and swallow the route
-     * (`pg` did exactly that, breaking playground redemption on a site host).
+     * `webSocket("/x…` whose first segment is a literal, **including the ones built from a
+     * constant** (`ServeRcFonts.URL_BASE`, `/hero`, `/social`, `/auth/…`), which are the easy ones
+     * to miss.
+     *
+     * The list is load-bearing twice over, so keep it complete when adding a top-level route. A
+     * missing entry lets a site *claim* that prefix and swallow the route — `pg` did exactly that,
+     * breaking playground redemption — and, because the site interceptor uses this as its allowlist
+     * of "not a session", a missing entry also 404s that route on every site host.
+     * `ServeTopLevelSiteTest` walks the whole list against a live server to keep the two honest.
      */
-    private val RESERVED_SYSTEMS =
+    internal val RESERVED_SYSTEMS =
       setOf(
         "healthz",
         "readyz",
@@ -201,6 +207,9 @@ data class ServeSites(private val byHost: Map<String, String>) {
         "wasm",
         "rc-player",
         "rc-player-wasm",
+        // Registered dynamically from `ServeRcFonts.URL_BASE` — the vendored Remote Compose
+        // typefaces. Easy to miss precisely because the path is built from a constant.
+        "rc-fonts",
         "doc-player",
         "hero",
         "social",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSocialCard.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSocialCard.kt
@@ -64,8 +64,17 @@ internal class ServeSocialCard {
     /** Content hash + `.png`; the `/social/{name}` segment and the ETag. */
     val fileName: String,
     val etag: String,
-    /** The catalog this card depicts; null for the front door's. See [Spec.system]. */
-    val system: String? = null,
+    /**
+     * The catalogs allowed to serve this card; empty for the front door's own.
+     *
+     * A **set**, not one owner: the file name is a content hash, so two catalogs that draw an
+     * identical card — same title, same preview count, same hero bytes — collapse onto one entry.
+     * Recording a single owner cached the second catalog's card under the first's name, and the
+     * second site then 404'd the very card its own `og:image` advertised. Every spec that produced
+     * these bytes is remembered instead, so a shared hash serves for all of them and none of their
+     * neighbours. See [Spec.system].
+     */
+    val systems: Set<String> = emptySet(),
   ) {
     /** Always [WIDTH] — declared so callers fill `og:image:width` from the card, not a constant. */
     val width: Int = WIDTH
@@ -163,10 +172,26 @@ internal class ServeSocialCard {
     }
     val bytes = ServeBrand.encodePng(image) ?: return null
     val hash = sha256Hex(bytes).take(HASH_CHARS)
-    val card = Card(bytes = bytes, fileName = "$hash.png", etag = "\"$hash\"", system = spec.system)
-    // putIfAbsent, not put: two specs that draw to identical bytes share the URL, and the first
-    // registration is already the right answer.
-    return byFileName.putIfAbsent(card.fileName, card) ?: card
+    val card =
+      Card(
+        bytes = bytes,
+        fileName = "$hash.png",
+        etag = "\"$hash\"",
+        systems = setOfNotNull(spec.system),
+      )
+    // Two specs that draw to identical bytes share the URL, so the bytes are already right and
+    // only the OWNERS have to accumulate: a card drawn identically for a second catalog must stay
+    // serveable by that catalog's site too, which first-wins (`putIfAbsent`) silently prevented —
+    // the second site 404'd the very card its own og:image advertised.
+    return byFileName.compute(card.fileName) { _, existing ->
+      when {
+        existing == null -> card
+        // Identical spec, identical owner: the registration already there IS the right answer, and
+        // handing back the same instance is what callers (and ServeSocialCardTest) rely on.
+        card.systems.all { it in existing.systems } -> existing
+        else -> existing.copy(systems = existing.systems + card.systems)
+      }
+    } ?: card
   }
 
   /** The product mark and wordmark, top-left — the same pair the site header opens with. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfigTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfigTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -77,6 +78,32 @@ class ServeCatalogsConfigTest {
     assertTrue(problems.any { it.contains("invalid repo") }, problems.toString())
     assertTrue(problems.any { it.contains("unknown group 'nope'") }, problems.toString())
     assertTrue(problems.any { it.contains("duplicate catalog system 'dupe'") }, problems.toString())
+  }
+
+  @Test
+  fun `a catalog named after one of the server's own routes is reported`() {
+    // `api` is a perfectly good slug, so the id regex accepts it — but the registry refuses to name
+    // a session after a rooted route, so such a catalog is scheduled for loading and then fails at
+    // registration. That is a runtime error where the operator should have got the ordinary
+    // malformed-entry warning and a skip, so the rule belongs in validation, which the startup
+    // filter, `problems()` and the admin add all share.
+    val config =
+      ServeCatalogsConfig.parse(
+        """
+        { "catalogs": [ { "system": "api" }, { "system": "status" }, { "system": "wear-m3" } ] }
+        """
+          .trimIndent()
+      )
+
+    val problems = config.problems()
+    assertEquals(2, problems.size, problems.toString())
+    for (reserved in listOf("api", "status")) {
+      assertTrue(
+        problems.any { it.contains("'$reserved' is one of the server's own routes") },
+        problems.toString(),
+      )
+    }
+    assertNull(ServeCatalogsConfig.validateEntry(ServeCatalogsConfig.Entry(system = "wear-m3")))
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -140,6 +140,27 @@ class ServeSessionRegistryTest {
   }
 
   @Test
+  fun `a reserved route name is never bound to a session`() {
+    // No entry in `sessions` may be named after one of the server's own top-level routes — a
+    // session called `api` is unreachable at `/api/` on the main host (Ktor scores the constant
+    // segment above `/{system}`) but WOULD be served by `/{system}/` on a top-level site host,
+    // which is the isolation leak [ServeSites] exists to prevent. There are two places an id is
+    // bound: `register` (checked) and the on-demand fork in `entryFor` — with `--revisions`, a
+    // permitted ref named `api` reaches only the latter, so both have to refuse it.
+    val opener = Opener()
+    val factory = CountingFactory()
+    ServeSessionRegistry(open = opener, factory = factory, reaperIntervalMillis = 0).use { reg ->
+      for (reserved in listOf("api", "status", "render", "p", "rc-fonts")) {
+        assertNull(reg.acquire(reserved), "'$reserved' must not be forked into a session")
+        assertNull(reg.peekHost(reserved))
+        assertTrue(!reg.isKnownSession(reserved), "'$reserved' must not enter the registry")
+      }
+      assertEquals(0, factory.built.get(), "a reserved name never reaches the factory at all")
+      assertNotNull(reg.acquire("main"), "an ordinary ref still forks")
+    }
+  }
+
+  @Test
   fun `acquire builds once, opens once, and caches the live host`() {
     val opener = Opener()
     val factory = CountingFactory()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
@@ -392,6 +392,24 @@ class ServeTopLevelSiteTest {
   }
 
   @Test
+  fun `no ingestion path can name a session after a route`() {
+    // The upload lane was only one of five ways a session gets named (`--bundles` directories,
+    // `--bundle`, catalog ids and revision refs are the others), and fixing them one at a time is
+    // how the previous two rounds went. The registry is where every one of them converges, so the
+    // invariant is enforced there: a session called `api` would make `/api/` — which no constant
+    // route matches — fall to `/{system}/` and serve through a site hostname.
+    server = newServer()
+    registry.register("api", host = bundle("api", listOf("sneaky"), "Sneaky"), pinned = true)
+    assertFalse(registry.isKnownSession("api"), "the registry refuses a route's name")
+    assertEquals(404, get("/api/", host = siteHost).first)
+    // …and the real /api/ routes still answer. (On the main host this fixture has no default
+    // session, so the route needs an explicit one — that is the pre-existing behaviour, not the
+    // interceptor.)
+    assertEquals(200, get("/api/previews", host = siteHost).first)
+    assertEquals(200, get("/api/previews?session=wear-m3").first)
+  }
+
+  @Test
   fun `an uploaded bundle may not take a route's name`() {
     // A session called `api` would be reachable at `/api/` — a path no constant route matches, so
     // it falls to `/{system}/` — which is how a reserved first segment could still resolve to a

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
@@ -332,6 +332,38 @@ class ServeTopLevelSiteTest {
   }
 
   @Test
+  fun `every constant route still works on a site host`() {
+    // The site gate is an ALLOWLIST of the server's own routes, so a route missing from
+    // ServeSites.RESERVED_SYSTEMS would 404 on every site hostname. Walk the whole list against a
+    // live server: no entry may be swallowed by the canonical-path redirect (308) or the
+    // neighbour refusal (404 from the interceptor rather than the handler).
+    server = newServer()
+    for (route in ServeSites.RESERVED_SYSTEMS) {
+      val (code, _, location) = get("/$route", host = siteHost)
+      assertFalse(
+        code == 308,
+        "'/$route' was mistaken for the canonical catalog prefix and redirected to $location",
+      )
+    }
+    // Spot-check the ones with a real body, which must answer identically on both hosts.
+    assertEquals(200, get("/healthz", host = siteHost).first)
+    assertEquals(200, get("/version", host = siteHost).first)
+    assertEquals(200, get("/robots.txt", host = siteHost).first)
+  }
+
+  @Test
+  fun `an unknown first segment is refused rather than resolved`() {
+    // With --revisions a raw ref like `main` is not a registered session until the generic route
+    // leases it and the factory BUILDS it, so no enumeration of existing sessions can catch it in
+    // time. The gate is an allowlist for exactly that reason: anything that is neither this site's
+    // system nor one of the server's routes is refused before it can be created.
+    server = newServer()
+    for (unknown in listOf("main", "some-ref", "not-a-catalog", "wear-m3@abc123")) {
+      assertEquals(404, get("/$unknown/", host = siteHost).first, "'/$unknown/' must be refused")
+    }
+  }
+
+  @Test
   fun `a neighbour's social card is not served through a site host`() {
     server = newServer()
     // Bake the neighbour's card the way the main host does — by rendering its landing — then take

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
@@ -397,7 +397,9 @@ class ServeTopLevelSiteTest {
     // `--bundle`, catalog ids and revision refs are the others), and fixing them one at a time is
     // how the previous two rounds went. The registry is where every one of them converges, so the
     // invariant is enforced there: a session called `api` would make `/api/` — which no constant
-    // route matches — fall to `/{system}/` and serve through a site hostname.
+    // route matches — fall to `/{system}/` and serve through a site hostname. "There" is two
+    // methods, not one: `register` (below) and the on-demand fork in `entryFor`, covered by
+    // `ServeSessionRegistryTest.a reserved route name is never bound to a session`.
     server = newServer()
     registry.register("api", host = bundle("api", listOf("sneaky"), "Sneaky"), pinned = true)
     assertFalse(registry.isKnownSession("api"), "the registry refuses a route's name")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
@@ -332,23 +332,75 @@ class ServeTopLevelSiteTest {
   }
 
   @Test
-  fun `every constant route still works on a site host`() {
-    // The site gate is an ALLOWLIST of the server's own routes, so a route missing from
-    // ServeSites.RESERVED_SYSTEMS would 404 on every site hostname. Walk the whole list against a
-    // live server: no entry may be swallowed by the canonical-path redirect (308) or the
-    // neighbour refusal (404 from the interceptor rather than the handler).
+  fun `real routes reach their handlers on a site host`() {
+    // Written OUT independently of ServeSites.RESERVED_SYSTEMS, and asserting each path reaches its
+    // handler — not merely that it wasn't redirected. Iterating the allowlist could never catch an
+    // omission from the allowlist (a missing route is missing from the loop too), and "not a 308"
+    // passes on the interceptor's own 404, which is precisely the failure a missing entry causes.
     server = newServer()
-    for (route in ServeSites.RESERVED_SYSTEMS) {
-      val (code, _, location) = get("/$route", host = siteHost)
-      assertFalse(
-        code == 308,
-        "'/$route' was mistaken for the canonical catalog prefix and redirected to $location",
+    val routes =
+      mapOf(
+        "/healthz" to "ok",
+        "/version" to "\"public\"",
+        "/robots.txt" to "User-agent",
+        "/sitemap.xml" to "<urlset",
+        "/status.json" to "compose-preview-serve/status",
+        "/api/previews" to "button-filled",
+        "/p/button-filled" to "<!doctype html>",
+        "/render/button-filled.png" to "",
+        "/assets/serve/serve.css" to "",
       )
+    for ((path, marker) in routes) {
+      val (code, body, location) = get(path, host = siteHost)
+      assertEquals(200, code, "'$path' should reach its handler (Location: $location)")
+      if (marker.isNotEmpty()) {
+        assertTrue(body.contains(marker), "'$path' answered something else: ${body.take(200)}")
+      }
     }
-    // Spot-check the ones with a real body, which must answer identically on both hosts.
-    assertEquals(200, get("/healthz", host = siteHost).first)
-    assertEquals(200, get("/version", host = siteHost).first)
-    assertEquals(200, get("/robots.txt", host = siteHost).first)
+  }
+
+  @Test
+  fun `an unauthenticated refusal never carries the access token`() {
+    // The interceptor runs BEFORE the routes' own token gate, and the styled 404 threads the access
+    // token through its links — so on a token-gated box a made-up path would have handed the secret
+    // to any unauthenticated caller, which is every scanner.
+    registry.register(
+      "compose-m3",
+      host = bundle("compose-m3", listOf("button-filled"), "Compose Material 3"),
+      pinned = true,
+    )
+    val secret = "s3cret-token"
+    server =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = secret,
+          sessions = registry,
+          defaultSessionId = "",
+          isPublic = false,
+          catalogSessions = listOf("compose-m3"),
+          sites = ServeSites.of(listOf(siteHost to "compose-m3")),
+        )
+        .also { it.start() }
+    val (code, body, _) = get("/not-a-catalog/", host = siteHost)
+    assertEquals(404, code)
+    assertFalse(body.contains(secret), "the refusal must not disclose the access token: $body")
+    // With the token it is the site's own styled 404 again.
+    val (okCode, okBody, _) = get("/not-a-catalog/?token=$secret", host = siteHost)
+    assertEquals(404, okCode)
+    assertTrue(okBody.contains("<!doctype html>"), okBody.take(200))
+  }
+
+  @Test
+  fun `an uploaded bundle may not take a route's name`() {
+    // A session called `api` would be reachable at `/api/` — a path no constant route matches, so
+    // it falls to `/{system}/` — which is how a reserved first segment could still resolve to a
+    // foreign session on a site host. The invariant the interceptor rests on is that no session
+    // can be named a route.
+    for (reserved in listOf("api", "render", "p", "status", "rc-fonts")) {
+      assertNull(ServeBundleStore.sanitizeName(reserved), "'$reserved' must be refused as a name")
+    }
+    assertEquals("my-bundle", ServeBundleStore.sanitizeName("my-bundle"))
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #3783, which merged while its final review pass was still in flight. These are that pass's findings.

## The shape of the fix

The site gate enumerated what was **foreign** — catalog ids, then registered sessions, then `@` — and every review round found another way for a session to exist that the enumeration hadn't met:

| round | the session kind it missed |
| --- | --- |
| 1 | an uploaded bundle, registered under its own name |
| 2 | a **suspended** entry, which `peekHost` reports as absent |
| 3 | a `--revisions` ref like `main`, not registered *at all* until the generic route leases it and the factory **builds** it |

A list of things to refuse can only ever chase that. The set of constant first segments, on the other hand, is closed and already written down. So a site host now serves its own system, serves the routes, and **refuses everything else** — including whatever the next session kind turns out to be.

```kotlin
if (first == system)            -> 308 to the rooted URL
else if (isRootedRoute(first))  -> fall through   // ServeSites.RESERVED_SYSTEMS
else                            -> 404            // anything else, created or not
```

The trade is that a top-level route missing from `RESERVED_SYSTEMS` 404s on a site host rather than leaking. That's the right way round for a feature whose whole promise is one catalog per hostname, and it's now tested: a case walks a hand-written list of concrete route paths against a live server and asserts each reaches its own handler. `rc-fonts` was exactly such a gap — registered from a constant (`ServeRcFonts.URL_BASE`), absent from the list, and it would have swallowed every font request on a site mapped to a catalog of that name.

## Three more from the same pass

- **`/playground?from=/`** seeded the editor with a neighbour's Kotlin source. The parameter is caller-supplied, so narrowing the catalog *selector* never narrowed it. A foreign seed is now ignored — the playground still opens, on its sample.
- **Social-card ownership.** Two catalogs drawing identical cards (same title, preview count, hero bytes) collapse onto one content hash, and first-wins ownership cached the second catalog's card under the first's name — so the second site 404'd the very card its own `og:image` advertised. Cards now carry the *set* of systems that produced them. Identical specs still return the same instance, which `ServeSocialCardTest` relies on.
- **The refusal was plain text.** Every mistyped path on a site host is the most likely 404 there, and it lost the skin #3783 had just given `/status` and the styled 404. The interceptor serves the site's own 404 now.

## Found in review of this PR

The allowlist rests on one invariant — *a reserved segment is never a session* — because a path the routes don't actually match (`/api/`) falls through to `/{system}/`. Four commits make that true, and fix a bug the styled 404 introduced:

- **The styled refusal leaked the access token.** `notFoundPage` threads the token through its links, and the interceptor runs *before* the routes' own `rejectBadToken` — so on a token-gated box any unauthenticated request for a made-up path came back as HTML containing the server secret. An unauthorized caller now gets the same bare 404 the token gate answers with; the styled page is only for a caller who has already proved they may see this server. (`1000d09`)
- **The invariant moved to the registry.** Sanitizing uploads closed one of five doors — a `--bundles` directory, a `--bundle` argument, a catalog id and a revision ref are the others. `ServeSessionRegistry.register` now refuses a session named after a rooted route outright. (`8aa34e6`)
- **…and to the on-demand fork.** `register` is not the only place an id is bound: `entryFor` inserts a factory-built session too, which is the *only* path a `--revisions` ref named `api` takes. Same guard, before the factory is consulted. (`b94e0c7`)
- **A reserved catalog id is a config problem, not a load failure.** `"system": "api"` in `catalogs.json` is slug-shaped, so it validated, got scheduled for loading, and then failed at registration. `validateEntry` — shared by the startup filter, `problems()` and the admin add — reports it like any other invalid id. (`565c6bf`)

## Test plan

- `ServeTopLevelSiteTest`: every constant route reaches its handler on a site host, an unknown first segment (`main`, `some-ref`, `wear-m3@abc123`) is refused before it can be created, a neighbour's social card 404s while the main host serves it, and an unauthenticated site refusal never contains the token.
- `ServeSessionRegistryTest.a reserved route name is never bound to a session` drives the **factory** path (`acquire`, not `register`) and asserts the factory is never even called.
- `ServeCatalogsConfigTest`: a reserved catalog id is reported by `problems()`; an ordinary one still validates clean.
- `./gradlew :cli:test ktfmtCheckAll` green.

Text-only PR by design — nothing here changes a rendered surface; the 404's skin is unchanged, only who is allowed to see it.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NLHbY43XfjNxnDDGiCycS)_