### PR TITLE
fix(cli): resolve exact preview ids before treating a selector as a row

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1141,51 +1141,103 @@ internal fun previewIdMatchesRequest(
 }
 
 /**
- * Like [previewIdMatchesRequest], but a selector naming one of [preview]'s **`@PreviewParameter`
- * rows** also counts as a match (issue #3786).
+ * Does any preview in [manifests] satisfy the request **directly** — i.e. without appealing to the
+ * unknowable `@PreviewParameter` rows below?
+ *
+ * The gate on [previewMatchesRequestIncludingRows]'s row lane, and the reason a precise selector
+ * stays precise. Two modules can declare a parameterized `Foo` and an ordinary `Foo_Dark`; without
+ * this, `--id Foo_Dark` would keep both — the second on its own name, the first because `Foo_Dark`
+ * *could* be a row of `Foo` — and `serve` aborts on more than one module before its row-level
+ * filtering ever runs. So a real match anywhere wins outright, mirroring the daemon's own
+ * exact-hit-before-row-split rule (`PreviewRowAddress.split` is only consulted on a miss).
+ */
+internal fun requestHasDirectMatch(
+  manifests: List<Pair<PreviewModule, PreviewManifest>>,
+  exactId: String?,
+  filter: String?,
+  previewRef: String? = null,
+): Boolean = manifests.any { (_, manifest) ->
+  manifest.previews.any {
+    previewIdMatchesRequest(
+      it.id,
+      exactId = exactId,
+      filter = filter,
+      previewRef = previewRef,
+      className = it.className,
+      functionName = it.functionName,
+    )
+  }
+}
+
+/**
+ * Like [previewIdMatchesRequest], but a **`@PreviewParameter` preview** whose rows might satisfy
+ * the request also counts as a match (issue #3786).
  *
  * Discovery emits one manifest entry per parameterized *function* — it reads bytecode and cannot
  * instantiate a `PreviewParameterProvider` — so the manifest holds `Foo` and has never heard of
- * `Foo_PARAM_1`. `serve` synthesises the row ids later, from the fan-out on disk
+ * `Foo_PARAM_1` or `Foo_Crimson`. `serve` synthesises the row ids later, from the fan-out on disk
  * ([ServeParameterRows][ee.schimke.composeai.cli.serve.ServeParameterRows]), but module selection
  * and render narrowing both run *before* that, against the manifest. Matching on the manifest alone
- * therefore dropped the module and the command exited with "no previews discovered" — precisely
- * when the caller had been most specific.
+ * dropped the module and the command exited with "no previews discovered" — precisely when the
+ * caller had been most specific.
  *
- * **Why a prefix test is safe here**, where a bare `substringBeforeLast('_')` would not be: this
- * doesn't guess at the id grammar. It anchors on a real manifest id that *declares a provider*, so
- * the only previews whose rows we admit are the ones that genuinely have rows. A declared preview
- * whose id ends in `_1` is in the manifest under its own name and matches directly; the worst case
- * for a false positive is a selector that happens to start with a parameterized preview's id — and
- * that costs only the render narrowing, never a wrong answer.
+ * **The rule is "maybe", not a grammar.** A parameterized preview's row ids genuinely cannot be
+ * known here, so any selector that doesn't match its base id is undecidable rather than false — and
+ * `--filter` makes that unavoidable: it is a case-insensitive *substring* of the final row id, so
+ * `--filter Crimson` is a perfectly ordinary way to ask for one row of every provider and matches
+ * no base id anywhere. An earlier `<base>_<row>` prefix test looked precise but quietly answered
+ * "no" to exactly those requests, and changed `--filter`'s documented substring rule into a
+ * case-sensitive prefix one for rows. Undecidable therefore resolves to **keep**: a wrong drop is a
+ * hard error the caller cannot work around, a wrong keep costs only build time.
  *
- * The row lane is deliberately per-selector rather than "any selector looks like a row": the three
- * selectors intersect ([previewIdMatchesRequest]), so `--id Foo_PARAM_1 --filter Foo` has to keep
- * holding. When no selector is a row address this reduces exactly to [previewIdMatchesRequest].
+ * Two things stop that from becoming "keep everything":
+ * 1. [requestHasDirectMatch] — when the request matches a real preview anywhere, the row lane is
+ *    off entirely, so precise selection stays precise.
+ * 2. A preview with **no** provider has no rows, so it is still matched exactly as before. That is
+ *    what preserves the "no previews discovered" diagnostic for a typo.
+ *
+ * The render is still narrowed to the parameterized previews rather than the whole module — see
+ * [PreviewRenderScope.forRequest] — so #3730's optimisation survives the conservatism.
  */
 internal fun previewMatchesRequestIncludingRows(
   preview: PreviewInfo,
   exactId: String?,
   filter: String?,
   previewRef: String? = null,
+  requestMatchedDirectly: Boolean,
 ): Boolean {
-  val id = preview.id
-  val parameterized = !preview.params.previewParameterProviderClassName.isNullOrBlank()
-  fun rowOf(selector: String) = parameterized && isRowAddressOf(id, selector)
-  if (exactId != null && id != exactId && !rowOf(exactId)) return false
-  if (filter != null && !id.contains(filter, ignoreCase = true) && !rowOf(filter)) return false
   if (
-    previewRef != null &&
-      !previewMatchesReference(
-        previewRef,
-        id,
-        className = preview.className,
-        functionName = preview.functionName,
-      ) &&
-      !rowOf(previewRef)
+    previewIdMatchesRequest(
+      preview.id,
+      exactId = exactId,
+      filter = filter,
+      previewRef = previewRef,
+      className = preview.className,
+      functionName = preview.functionName,
+    )
   ) {
-    return false
+    return true
   }
+  if (requestMatchedDirectly) return false
+  if (preview.params.previewParameterProviderClassName.isNullOrBlank()) return false
+  // `--id` is exact by contract, so it pins the candidate row id outright: it must be spelled
+  // `<base>_<row>`, and once it is, the other selectors can be tested against that concrete id
+  // rather than left undecidable. That keeps an unsatisfiable intersection
+  // (`--id Foo_PARAM_1 --filter Unrelated`) failing fast, and keeps a typo'd `--id` from dragging
+  // in every parameterized preview in the repo.
+  if (exactId != null) {
+    if (!isRowAddressOf(preview.id, exactId)) return false
+    return previewIdMatchesRequest(
+      exactId,
+      exactId = null,
+      filter = filter,
+      previewRef = previewRef,
+      className = preview.className,
+      functionName = preview.functionName,
+    )
+  }
+  // `--filter` / `--preview` alone are substring rules over an id that does not exist yet. Nothing
+  // here can decide them, so the preview stays a candidate.
   return true
 }
 
@@ -1194,8 +1246,8 @@ internal fun previewMatchesRequestIncludingRows(
  * same `<stem>_<suffix>` shape the fan-out renderer writes to disk (docs/RENDER_FILENAMES.md) and
  * the daemon accepts on `renderNow`.
  *
- * Only ever called for a preview that declares a provider, so "looks like a row of a preview that
- * has rows" is the whole claim being made.
+ * Case-sensitive, and only applied to `--id`, whose contract is an exact match. The substring
+ * selectors deliberately don't use it — see [previewMatchesRequestIncludingRows].
  */
 private fun isRowAddressOf(baseId: String, selector: String): Boolean =
   selector.length > baseId.length + 1 &&
@@ -1244,18 +1296,21 @@ internal fun modulesMatchingPreviewRequest(
   // stale discovery manifests suppress that retry after the separate optimization pass fails.
   if (!discoverySucceeded) return modules
   if (exactId == null && filter == null && previewRef == null) return modules
+  // Row-aware (issue #3786): a module whose only match is `Foo_PARAM_1` must survive, because the
+  // row ids don't exist until `serve` reads the rendered fan-out back off disk — long after this
+  // narrowing ran. Resolved across ALL manifests first so a request that matches a real preview
+  // somewhere never also drags in the parameterized previews it could hypothetically be a row of.
+  val matchedDirectly = requestHasDirectMatch(manifests, exactId, filter, previewRef)
   val matchingPaths =
     manifests
       .filter { (_, manifest) ->
-        // Row-aware (issue #3786): a module whose only match is `Foo_PARAM_1` must survive, because
-        // the row ids don't exist until `serve` reads the rendered fan-out back off disk — long
-        // after this narrowing ran.
         manifest.previews.any {
           previewMatchesRequestIncludingRows(
             it,
             exactId = exactId,
             filter = filter,
             previewRef = previewRef,
+            requestMatchedDirectly = matchedDirectly,
           )
         }
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
@@ -85,23 +85,27 @@ internal object PreviewRenderScope {
     val selected = linkedSetOf<String>()
     val renderedIds = linkedSetOf<String>()
     var discovered = 0
+    // Issue #3786 — a selector naming a `@PreviewParameter` row (`Foo_PARAM_1`, or a bare label
+    // like `Crimson`) picks out an id that only exists once the fan-out is on disk, so it can never
+    // match a manifest entry here. Selecting the parameterized previews it *might* name keeps the
+    // #3730 narrowing working for row requests instead of falling through to
+    // `selected.isEmpty() -> FULL` and rendering the whole module. Gated on there being no direct
+    // match anywhere, so a request that names a real preview still narrows to exactly that one.
+    val matchedDirectly = requestHasDirectMatch(manifests, exactId, filter, previewRef)
     for ((_, manifest) in manifests) {
       for (preview in manifest.previews) {
         discovered++
         val expanded = PreviewPermutationsCli.expand(listOf(preview), permutations).map { it.id }
-        // Issue #3786 — a `@PreviewParameter` row selector (`Foo_PARAM_1`) names an id that only
-        // comes into existence once the fan-out is on disk, so it can never match a manifest entry
-        // here. Selecting its *base* keeps the #3730 narrowing working for row requests instead of
-        // falling through to `selected.isEmpty() -> FULL` and rendering the whole module.
-        val rowAddressed =
+        val mayOwnRequestedRow =
           previewMatchesRequestIncludingRows(
             preview,
             exactId = exactId,
             filter = filter,
             previewRef = previewRef,
+            requestMatchedDirectly = matchedDirectly,
           )
         if (
-          !rowAddressed &&
+          !mayOwnRequestedRow &&
             expanded.none {
               previewIdMatchesRequest(
                 it,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
@@ -128,9 +128,8 @@ class PreviewRowSelectorTest {
   }
 
   /**
-   * The prefix test is anchored on a real manifest id *plus* its provider, so it doesn't mis-handle
-   * the case the issue flagged against a naive `substringBeforeLast('_')`: a declared preview whose
-   * id genuinely ends in `_1` is matched under its own name.
+   * A declared preview whose id genuinely ends in `_1` is matched under its own name — the
+   * mis-handling the issue flagged against a naive `substringBeforeLast('_')`.
    */
   @Test
   fun `a declared preview whose id ends in an underscore digit matches as itself`() {
@@ -145,6 +144,75 @@ class PreviewRowSelectorTest {
       )
 
     assertEquals(listOf(":app"), selected.map { it.gradlePath })
+  }
+
+  /**
+   * Review follow-up (#3795). A real preview named `Foo_Dark` in one module and a parameterized
+   * `Foo` in another: `--id Foo_Dark` must resolve to the module that actually declares it. Keeping
+   * both — the second because `Foo_Dark` *could* be a row of `Foo` — makes `serve` abort with "2
+   * modules discovered" before its row-level filtering ever runs, turning a previously working
+   * exact selection into an error. A direct hit anywhere therefore switches the row lane off, the
+   * same way the daemon consults `PreviewRowAddress.split` only on an exact miss.
+   */
+  @Test
+  fun `an exact hit anywhere wins over a hypothetical row of a parameterized preview`() {
+    val app = module(":app")
+    val wear = module(":wear")
+
+    val selected =
+      modulesMatchingPreviewRequest(
+        modules = listOf(app, wear),
+        manifests =
+          listOf(
+            manifest(app, preview("Foo", parameterized = true)),
+            manifest(wear, preview("Foo_Dark")),
+          ),
+        exactId = "Foo_Dark",
+        filter = null,
+      )
+
+    assertEquals(listOf(":wear"), selected.map { it.gradlePath })
+  }
+
+  /**
+   * Review follow-up (#3795). `--filter` is a case-insensitive **substring** of the final id, so
+   * these are ordinary ways to ask for a row — and `ServeCommand.matches(row.id)` would match all
+   * of them. Module selection has to agree, or it drops the module before that check runs. A
+   * `<base>_<row>` prefix rule answered "no" to the last two: a row's label is not a prefix of
+   * anything, and the rule was case-sensitive besides.
+   */
+  @Test
+  fun `filter keeps a parameterized preview for any row-shaped spelling`() {
+    val app = module(":app")
+    val manifests = listOf(manifest(app, preview("Foo", parameterized = true)))
+
+    for (f in listOf("Foo_PARAM_1", "foo_param_1", "PARAM_1", "Crimson")) {
+      assertEquals(
+        listOf(":app"),
+        modulesMatchingPreviewRequest(listOf(app), manifests, exactId = null, filter = f).map {
+          it.gradlePath
+        },
+        "--filter $f must keep the module that owns the rows it could name",
+      )
+    }
+  }
+
+  /** The same undecidability applies to `--preview`, whose loose form is also a substring rule. */
+  @Test
+  fun `preview ref keeps a parameterized preview for a row label`() {
+    val app = module(":app")
+
+    assertEquals(
+      listOf(":app"),
+      modulesMatchingPreviewRequest(
+          listOf(app),
+          listOf(manifest(app, preview("Foo", parameterized = true))),
+          exactId = null,
+          filter = null,
+          previewRef = "Crimson",
+        )
+        .map { it.gradlePath },
+    )
   }
 
   /** The selectors intersect, so a row id on one must not cancel a normal match on another. */


### PR DESCRIPTION
Review follow-up to #3795 (issue #3786), which auto-merged before the review comments could be addressed. Both findings were valid.

## An exact id stopped resolving to the module that declares it

With a parameterized `Foo` in one module and an ordinary `Foo_Dark` in another, `--id Foo_Dark` kept **both** — the second on its own name, the first because `Foo_Dark` could be a row of `Foo`. `serve` aborts on more than one manifest before its row-level filtering runs, so a previously working exact selection turned into `serve: 2 modules discovered`.

`requestHasDirectMatch` now resolves across all manifests **first** and switches the row lane off entirely when the request names a real preview. That mirrors the daemon, which consults `PreviewRowAddress.split` only on an exact miss — #3795 diverged from that precedent without meaning to.

## `--filter` lost its substring semantics for rows

The `<base>_<row>` prefix test looked precise, but it quietly narrowed a documented **case-insensitive substring** rule into a case-sensitive prefix one. Both of these were rejected during module selection even though `ServeCommand.matches(row.id)` would have matched them:

| Selector | Rendered row | `matches(row.id)` | #3795 module selection |
| --- | --- | --- | --- |
| `--filter foo_param_1` | `Foo_PARAM_1` | ✅ | ❌ dropped (case) |
| `--filter Crimson` | `Foo_Crimson` | ✅ | ❌ dropped (not a prefix) |

Filtering by a row's *label* is an ordinary way to ask for one state of every provider, so the second row is a real use case, not a corner.

A row id genuinely cannot be known at manifest time, so for the substring selectors the answer is **undecidable rather than false** — and undecidable now resolves to *keep*: a wrong drop is a hard error the caller cannot work around, a wrong keep costs only build time.

Two things stop that becoming "keep everything":
1. the direct-match gate above;
2. a preview with **no** provider has no rows and is still matched exactly as before — which is what preserves the "no previews discovered" diagnostic for a typo.

## `--id` stays precise

`--id` is exact by contract, so it pins the candidate row id outright, and the other selectors are then tested against that concrete id. So an unsatisfiable intersection (`--id Foo_PARAM_1 --filter Unrelated`) still fails fast, and a typo'd `--id` still can't drag in every parameterized preview in the repo. The conservatism is scoped to the selectors whose semantics actually make it necessary.

The render narrowing follows the same gate, so #3730's optimisation survives: a row request renders the parameterized previews, not the whole module.

## Test plan

`PreviewRowSelectorTest` — 10 tests, all ran, 0 failures. New since #3795:

| Test | Pins |
| --- | --- |
| `an exact hit anywhere wins over a hypothetical row of a parameterized preview` | the `Foo` / `Foo_Dark` regression |
| `filter keeps a parameterized preview for any row-shaped spelling` | `Foo_PARAM_1`, `foo_param_1`, `PARAM_1`, `Crimson` |
| `preview ref keeps a parameterized preview for a row label` | `--preview`'s loose form is a substring rule too |

Retained from #3795, and still meaningful under the new rule: the reproduce case, the no-provider drop, the unrelated-module drop, the `Foo_1` grammar hazard, and the intersecting `--id`/`--filter` case.

Full `:cli:test` suite green — this is a matcher shared by `render`, `show`, `a11y` and `record`.

**Visual evidence: N/A** — selector plumbing; nothing rendered changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SamkbmKYKnb7XhJUU5TYbM)_