### PR TITLE
fix(cli): scope the exact-id row gate to --id, not the substring selectors

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1141,33 +1141,28 @@ internal fun previewIdMatchesRequest(
 }
 
 /**
- * Does any preview in [manifests] satisfy the request **directly** — i.e. without appealing to the
- * unknowable `@PreviewParameter` rows below?
+ * Is [exactId] a preview that actually exists in [manifests]?
  *
  * The gate on [previewMatchesRequestIncludingRows]'s row lane, and the reason a precise selector
  * stays precise. Two modules can declare a parameterized `Foo` and an ordinary `Foo_Dark`; without
  * this, `--id Foo_Dark` would keep both — the second on its own name, the first because `Foo_Dark`
  * *could* be a row of `Foo` — and `serve` aborts on more than one module before its row-level
- * filtering ever runs. So a real match anywhere wins outright, mirroring the daemon's own
+ * filtering ever runs. So a real hit wins outright, mirroring the daemon's own
  * exact-hit-before-row-split rule (`PreviewRowAddress.split` is only consulted on a miss).
+ *
+ * **`--id` only, deliberately.** Extending this precedence to `--filter` / `--preview` looks
+ * symmetrical and is wrong: those are substring rules, so matching several previews at once is
+ * their normal mode, not a conflict to resolve. A parameterized `Foo` yielding `Foo_Crimson`
+ * alongside an ordinary `CrimsonButton` means `--filter Crimson` legitimately names both, and
+ * letting the concrete one suppress the row owner would drop a preview that satisfies the
+ * documented predicate. Only `--id` is single-target, and only `--id` has a caller who breaks when
+ * a second module tags along.
  */
-internal fun requestHasDirectMatch(
+internal fun manifestsDeclareExactId(
   manifests: List<Pair<PreviewModule, PreviewManifest>>,
   exactId: String?,
-  filter: String?,
-  previewRef: String? = null,
-): Boolean = manifests.any { (_, manifest) ->
-  manifest.previews.any {
-    previewIdMatchesRequest(
-      it.id,
-      exactId = exactId,
-      filter = filter,
-      previewRef = previewRef,
-      className = it.className,
-      functionName = it.functionName,
-    )
-  }
-}
+): Boolean =
+  exactId != null && manifests.any { (_, manifest) -> manifest.previews.any { it.id == exactId } }
 
 /**
  * Like [previewIdMatchesRequest], but a **`@PreviewParameter` preview** whose rows might satisfy
@@ -1191,8 +1186,9 @@ internal fun requestHasDirectMatch(
  * hard error the caller cannot work around, a wrong keep costs only build time.
  *
  * Two things stop that from becoming "keep everything":
- * 1. [requestHasDirectMatch] — when the request matches a real preview anywhere, the row lane is
- *    off entirely, so precise selection stays precise.
+ * 1. [manifestsDeclareExactId] — when `--id` names a preview that really exists, the row lane is
+ *    off entirely, so precise selection stays precise. Scoped to `--id`, because only it is
+ *    single-target; see that function for why the substring selectors must not inherit it.
  * 2. A preview with **no** provider has no rows, so it is still matched exactly as before. That is
  *    what preserves the "no previews discovered" diagnostic for a typo.
  *
@@ -1204,7 +1200,7 @@ internal fun previewMatchesRequestIncludingRows(
   exactId: String?,
   filter: String?,
   previewRef: String? = null,
-  requestMatchedDirectly: Boolean,
+  exactIdExists: Boolean,
 ): Boolean {
   if (
     previewIdMatchesRequest(
@@ -1218,7 +1214,7 @@ internal fun previewMatchesRequestIncludingRows(
   ) {
     return true
   }
-  if (requestMatchedDirectly) return false
+  if (exactIdExists) return false
   if (preview.params.previewParameterProviderClassName.isNullOrBlank()) return false
   // `--id` is exact by contract, so it pins the candidate row id outright: it must be spelled
   // `<base>_<row>`, and once it is, the other selectors can be tested against that concrete id
@@ -1298,9 +1294,9 @@ internal fun modulesMatchingPreviewRequest(
   if (exactId == null && filter == null && previewRef == null) return modules
   // Row-aware (issue #3786): a module whose only match is `Foo_PARAM_1` must survive, because the
   // row ids don't exist until `serve` reads the rendered fan-out back off disk — long after this
-  // narrowing ran. Resolved across ALL manifests first so a request that matches a real preview
-  // somewhere never also drags in the parameterized previews it could hypothetically be a row of.
-  val matchedDirectly = requestHasDirectMatch(manifests, exactId, filter, previewRef)
+  // narrowing ran. Resolved across ALL manifests first so an `--id` that names a real preview never
+  // also drags in the parameterized previews it could hypothetically be a row of.
+  val exactIdExists = manifestsDeclareExactId(manifests, exactId)
   val matchingPaths =
     manifests
       .filter { (_, manifest) ->
@@ -1310,7 +1306,7 @@ internal fun modulesMatchingPreviewRequest(
             exactId = exactId,
             filter = filter,
             previewRef = previewRef,
-            requestMatchedDirectly = matchedDirectly,
+            exactIdExists = exactIdExists,
           )
         }
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
@@ -89,9 +89,9 @@ internal object PreviewRenderScope {
     // like `Crimson`) picks out an id that only exists once the fan-out is on disk, so it can never
     // match a manifest entry here. Selecting the parameterized previews it *might* name keeps the
     // #3730 narrowing working for row requests instead of falling through to
-    // `selected.isEmpty() -> FULL` and rendering the whole module. Gated on there being no direct
-    // match anywhere, so a request that names a real preview still narrows to exactly that one.
-    val matchedDirectly = requestHasDirectMatch(manifests, exactId, filter, previewRef)
+    // `selected.isEmpty() -> FULL` and rendering the whole module. Gated on `--id` not naming a
+    // preview that really exists, so an exact request still narrows to exactly that one.
+    val exactIdExists = manifestsDeclareExactId(manifests, exactId)
     for ((_, manifest) in manifests) {
       for (preview in manifest.previews) {
         discovered++
@@ -102,7 +102,7 @@ internal object PreviewRenderScope {
             exactId = exactId,
             filter = filter,
             previewRef = previewRef,
-            requestMatchedDirectly = matchedDirectly,
+            exactIdExists = exactIdExists,
           )
         if (
           !mayOwnRequestedRow &&

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
@@ -197,6 +197,57 @@ class PreviewRowSelectorTest {
     }
   }
 
+  /**
+   * Review follow-up (#3798). The exact-hit precedence must NOT extend to the substring selectors.
+   * A parameterized `Foo` yielding `Foo_Crimson` and an ordinary `CrimsonButton` are *both*
+   * legitimately named by `--filter Crimson` — matching several previews at once is what a
+   * substring rule is for, not a conflict to resolve — so letting the concrete one suppress the row
+   * owner would drop a preview that satisfies the documented predicate. Only `--id` is
+   * single-target, and only `--id` has a caller (`serve`) that breaks when a second module tags
+   * along.
+   */
+  @Test
+  fun `a direct filter hit does not suppress other modules' row owners`() {
+    val app = module(":app")
+    val ui = module(":ui")
+
+    val selected =
+      modulesMatchingPreviewRequest(
+        modules = listOf(app, ui),
+        manifests =
+          listOf(
+            manifest(app, preview("Foo", parameterized = true)),
+            manifest(ui, preview("CrimsonButton")),
+          ),
+        exactId = null,
+        filter = "Crimson",
+      )
+
+    assertEquals(listOf(":app", ":ui"), selected.map { it.gradlePath })
+  }
+
+  /** Same for the loose `--preview` form, which is a substring rule too. */
+  @Test
+  fun `a direct preview-ref hit does not suppress other modules' row owners`() {
+    val app = module(":app")
+    val ui = module(":ui")
+
+    val selected =
+      modulesMatchingPreviewRequest(
+        modules = listOf(app, ui),
+        manifests =
+          listOf(
+            manifest(app, preview("Foo", parameterized = true)),
+            manifest(ui, preview("CrimsonButton")),
+          ),
+        exactId = null,
+        filter = null,
+        previewRef = "Crimson",
+      )
+
+    assertEquals(listOf(":app", ":ui"), selected.map { it.gradlePath })
+  }
+
   /** The same undecidability applies to `--preview`, whose loose form is also a substring rule. */
   @Test
   fun `preview ref keeps a parameterized preview for a row label`() {


### PR DESCRIPTION
Review follow-up to #3798 (issue #3786), which auto-merged before the comment could be addressed. The finding was valid — and it's one I'd consciously accepted while writing #3798, so it's worth correcting rather than defending.

## What was wrong

#3798 added a direct-match gate so an exact `--id` naming a real preview would stop *also* dragging in the parameterized previews it could hypothetically be a row of. That part was right. But the gate was computed over all three selectors at once, and extending it to `--filter` / `--preview` inverts their meaning.

Those are substring rules: matching several previews at once is their normal mode, not a conflict to resolve.

| Manifest | Selector | Should match | #3798 |
| --- | --- | --- | --- |
| parameterized `Foo` → `Foo_Crimson`<br>ordinary `CrimsonButton` | `--filter Crimson` | both | ❌ `Foo`'s module dropped |

The concrete hit on `CrimsonButton` set `requestMatchedDirectly`, which switched off `Foo`'s row lane — so its module fell out of selection and narrowing even though `Foo_Crimson` satisfies the documented substring predicate and `ServeCommand.matches(row.id)` would have matched it.

## The rule now

`requestHasDirectMatch` narrows to `manifestsDeclareExactId`: exact-hit precedence applies to **`--id` only**.

That's the selector the precedence was actually for. `--id` is single-target, and it's the one with a caller that breaks when a second module tags along — `serve` aborts on more than one manifest before its row-level filtering runs, which is the regression #3798 set out to fix. Neither is true of the substring selectors, so they keep possible row owners alongside their direct matches.

## Test plan

`PreviewRowSelectorTest` — 12 tests, all ran, 0 failures. New here:

| Test | Pins |
| --- | --- |
| `a direct filter hit does not suppress other modules' row owners` | the `Crimson` / `CrimsonButton` case |
| `a direct preview-ref hit does not suppress other modules' row owners` | same for `--preview`'s loose form |

Still green and still meaningful: `an exact hit anywhere wins over a hypothetical row of a parameterized preview` (#3798's fix, now correctly scoped to `--id`), the reproduce case, the no-provider drop, the `Foo_1` grammar hazard, and the intersecting `--id`/`--filter` case.

Full `:cli:test` suite green — shared matcher, so the surface is `render`, `show`, `a11y` and `record` as well as `serve`.

**Visual evidence: N/A** — selector plumbing; nothing rendered changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SamkbmKYKnb7XhJUU5TYbM)_