### PR TITLE
fix(cli): resolve @PreviewParameter rows before serve counts modules

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -144,6 +144,22 @@ abstract class Command(
    * intersects them, as `--id` + `--filter` already did.
    */
   protected val previewRef: String? = args.flagValue("--preview")?.takeIf { it.isNotBlank() }
+
+  /**
+   * Whether this command can turn a `@PreviewParameter` fan-out into addressable **row ids**, and
+   * so wants module selection to keep previews whose (unknowable) rows might satisfy the request —
+   * issue #3786's conservative lane, see [previewMatchesRequestIncludingRows].
+   *
+   * Only `serve` can: it expands the fan-out off disk via `ServeParameterRows` after the render,
+   * and then re-filters, so a module kept on a "maybe" is proven or discarded before anything is
+   * shown. Every other command filters its output by base id (`PreviewResultBuilder` carries a row
+   * as a capture's `parameterLabel`, not as an id), so for them a speculative keep could only ever
+   * render a module and then print nothing from it. Opt-in rather than global, so the conservatism
+   * costs build time exactly where it buys a correct answer.
+   */
+  protected open val rowAwareSelection: Boolean
+    get() = false
+
   protected val verbose: Boolean = "--verbose" in args || "-v" in args
   protected val progress: Boolean = verbose || "--progress" in args
   protected val timeoutSeconds: Long =
@@ -601,6 +617,7 @@ abstract class Command(
         filter = filter,
         previewRef = previewRef,
         permutations = permutations,
+        rowAware = rowAwareSelection,
       )
     scope.note?.let { System.err.println("compose-preview: $flag $it; rendering the full module.") }
     if (verbose && scope.narrowed) {
@@ -964,6 +981,7 @@ abstract class Command(
       filter = filter,
       previewRef = previewRef,
       discoverySucceeded = discoverySucceeded,
+      rowAware = rowAwareSelection,
     )
 
   private fun stateFile(module: PreviewModule): File =
@@ -1201,6 +1219,7 @@ internal fun previewMatchesRequestIncludingRows(
   filter: String?,
   previewRef: String? = null,
   exactIdExists: Boolean,
+  rowAware: Boolean = true,
 ): Boolean {
   if (
     previewIdMatchesRequest(
@@ -1214,6 +1233,7 @@ internal fun previewMatchesRequestIncludingRows(
   ) {
     return true
   }
+  if (!rowAware) return false
   if (exactIdExists) return false
   if (preview.params.previewParameterProviderClassName.isNullOrBlank()) return false
   // `--id` is exact by contract, so it pins the candidate row id outright: it must be spelled
@@ -1287,6 +1307,7 @@ internal fun modulesMatchingPreviewRequest(
   filter: String?,
   previewRef: String? = null,
   discoverySucceeded: Boolean = true,
+  rowAware: Boolean = true,
 ): List<PreviewModule> {
   // The render task depends on discovery and is the authoritative retry. Do not let missing or
   // stale discovery manifests suppress that retry after the separate optimization pass fails.
@@ -1307,6 +1328,7 @@ internal fun modulesMatchingPreviewRequest(
             filter = filter,
             previewRef = previewRef,
             exactIdExists = exactIdExists,
+            rowAware = rowAware,
           )
         }
       }
@@ -1645,6 +1667,7 @@ class RenderCommand(args: List<String>) : Command(args) {
             filter = filter,
             previewRef = previewRef,
             discoverySucceeded = discoverySucceeded,
+            rowAware = rowAwareSelection,
           )
       if (modules.isEmpty()) {
         System.err.println("No previews matched.")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
@@ -78,6 +78,7 @@ internal object PreviewRenderScope {
     filter: String?,
     previewRef: String? = null,
     permutations: List<String> = emptyList(),
+    rowAware: Boolean = true,
   ): Scope {
     if (exactId == null && filter == null && previewRef == null) return FULL
     if (manifests.isEmpty()) return FULL
@@ -103,6 +104,7 @@ internal object PreviewRenderScope {
             filter = filter,
             previewRef = previewRef,
             exactIdExists = exactIdExists,
+            rowAware = rowAware,
           )
         if (
           !mayOwnRequestedRow &&

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -95,6 +95,16 @@ import okio.Path.Companion.toPath
  */
 class ServeCommand(args: List<String>) : Command(args) {
 
+  /**
+   * `serve` is the one command that turns a `@PreviewParameter` fan-out into addressable row ids
+   * (issue #3786), so it is the one that wants module selection to keep previews whose rows *might*
+   * match. It can afford to: the render below produces the fan-out, `ServeParameterRows` expands
+   * it, and [modulesWithMatchingPreviews] then discards any module whose "maybe" didn't pan out —
+   * before the one-module check that would otherwise choke on it.
+   */
+  override val rowAwareSelection: Boolean
+    get() = true
+
   private val lan: Boolean = "--lan" in args
   private val host: String =
     when {
@@ -835,57 +845,32 @@ class ServeCommand(args: List<String>) : Command(args) {
       System.err.println("serve: no previews discovered.")
       exitProcess(3)
     }
-    if (outcome.manifests.size > 1) {
-      System.err.println(
-        "serve: ${outcome.manifests.size} modules discovered; a server hosts one module. " +
-          "Narrow with --module <path>:"
-      )
-      outcome.manifests.forEach { (m, _) -> System.err.println("  ${m.gradlePath}") }
-      exitProcess(1)
-    }
-
-    val (module, manifest) = outcome.manifests.single()
-    // `@PreviewParameter` fan-out (issue #3749). Discovery emits ONE entry per parameterized
-    // function, so the manifest alone would list a screen whose states come from a provider as a
-    // single card showing value 0 — the symptom the issue was filed about. The render pass above
-    // already wrote one file per value, and the daemon now accepts those `<baseId>_<row>` ids, so
-    // each on-disk row becomes its own servable preview. A preview with no provider, or whose
-    // fan-out isn't on disk, keeps exactly its old single entry.
-    val claimedOutputs = ServeParameterRows.claimedOutputs(manifest.previews)
-    val previews =
-      manifest.previews.flatMap { info ->
-        val (focus, gestures) = detectedFeaturesOf(info)
-        fun serve(id: String, label: String) =
-          ServePreview(
-            id = id,
-            label = label,
-            uiMode = info.params.uiMode,
-            supportsFocus = focus,
-            supportsGestures = gestures,
-            fixedTheme = info.fixedTheme,
-          )
-        val baseLabel = info.functionName.ifBlank { info.id }
-        val rows = ServeParameterRows.rowsFor(info, module.projectDir, claimedOutputs)
-        // `--id` / `--filter` / `--preview` match the declared preview (so `--id Foo` serves all of
-        // Foo's rows, which is what asking for a parameterized preview means) OR a row id directly,
-        // so a caller can narrow to one state. The declared preview is matched as a *row of the
-        // manifest*, not as a bare id, because `--preview` also accepts `<Class>.<function>` and
-        // the
-        // bare function name — forms only the manifest row can answer. A synthetic row id has no
-        // manifest row of its own, so it is matched by id.
-        when {
-          rows.isEmpty() -> if (matches(info)) listOf(serve(info.id, baseLabel)) else emptyList()
-          matches(info) -> rows.map { serve(it.id, "$baseLabel · ${it.label}") }
-          else -> rows.filter { matches(it.id) }.map { serve(it.id, "$baseLabel · ${it.label}") }
-        }
-      }
-    // The module's declared @ThemeCatalog themes — the Theme selector renders them so a preview can
-    // be re-rendered under Brand Dark etc. Module-global, so unaffected by the --id/--filter above.
-    val declaredThemes = declaredThemesFromPreviews(manifest.previews)
-    if (previews.isEmpty()) {
+    // Expand each module's `@PreviewParameter` fan-out BEFORE deciding how many modules are in play
+    // (issue #3786 review follow-up). Module selection has to keep a parameterized preview whose
+    // rows *might* match — the row ids don't exist until the render above wrote the fan-out — so
+    // `--filter Crimson` can retain a module whose provider turns out to yield only Light/Dark.
+    // That
+    // module contributes nothing servable, and counting it here would abort a request that has
+    // exactly one real answer. Resolving first turns the speculative keep back into a fact.
+    val servable = modulesWithMatchingPreviews(outcome.manifests)
+    if (servable.isEmpty()) {
       System.err.println("serve: no previews matched (--id/--filter excluded them all).")
       exitProcess(3)
     }
+    if (servable.size > 1) {
+      System.err.println(
+        "serve: ${servable.size} modules discovered; a server hosts one module. " +
+          "Narrow with --module <path>:"
+      )
+      servable.forEach { (m, _) -> System.err.println("  ${m.gradlePath}") }
+      exitProcess(1)
+    }
+
+    val (module, previews) = servable.single()
+    val manifest = outcome.manifests.first { (m, _) -> m.gradlePath == module.gradlePath }.second
+    // The module's declared @ThemeCatalog themes — the Theme selector renders them so a preview can
+    // be re-rendered under Brand Dark etc. Module-global, so unaffected by the --id/--filter above.
+    val declaredThemes = declaredThemesFromPreviews(manifest.previews)
 
     if (!runDaemonStart(module)) {
       System.err.println("serve: composePreviewDaemonStart failed for ${module.gradlePath}.")
@@ -2963,6 +2948,64 @@ class ServeCommand(args: List<String>) : Command(args) {
    * dropped every module by the time this runs. The ladder's only reachable outcome was to disagree
    * with the pass that had already decided.
    */
+  /**
+   * Each discovered module paired with the previews it can actually serve for this request, with
+   * the modules that can serve none dropped (issue #3786 review follow-up).
+   *
+   * This is where a `@PreviewParameter` "maybe" from module selection becomes a fact. Module
+   * selection cannot know a provider's rows — they don't exist until the render writes the fan-out
+   * — so it keeps any parameterized preview that *might* match. By the time this runs the fan-out
+   * is on disk and [ServeParameterRows] can enumerate it, so a module retained for a row that
+   * turned out not to exist contributes an empty list and drops out before the one-module check.
+   */
+  private fun modulesWithMatchingPreviews(
+    manifests: List<Pair<PreviewModule, PreviewManifest>>
+  ): List<Pair<PreviewModule, List<ServePreview>>> =
+    manifests
+      .map { (module, manifest) -> module to servablePreviewsOf(module, manifest) }
+      .filter { (_, previews) -> previews.isNotEmpty() }
+
+  /**
+   * The `@PreviewParameter` fan-out expansion (issue #3749). Discovery emits ONE entry per
+   * parameterized function, so the manifest alone would list a screen whose states come from a
+   * provider as a single card showing value 0 — the symptom that issue was filed about. The render
+   * pass already wrote one file per value, and the daemon accepts those `<baseId>_<row>` ids, so
+   * each on-disk row becomes its own servable preview. A preview with no provider, or whose fan-out
+   * isn't on disk, keeps exactly its old single entry.
+   */
+  private fun servablePreviewsOf(
+    module: PreviewModule,
+    manifest: PreviewManifest,
+  ): List<ServePreview> {
+    val claimedOutputs = ServeParameterRows.claimedOutputs(manifest.previews)
+    return manifest.previews.flatMap { info ->
+      val (focus, gestures) = detectedFeaturesOf(info)
+      fun serve(id: String, label: String) =
+        ServePreview(
+          id = id,
+          label = label,
+          uiMode = info.params.uiMode,
+          supportsFocus = focus,
+          supportsGestures = gestures,
+          fixedTheme = info.fixedTheme,
+        )
+      val baseLabel = info.functionName.ifBlank { info.id }
+      val rows = ServeParameterRows.rowsFor(info, module.projectDir, claimedOutputs)
+      // `--id` / `--filter` / `--preview` match the declared preview (so `--id Foo` serves all of
+      // Foo's rows, which is what asking for a parameterized preview means) OR a row id directly,
+      // so
+      // a caller can narrow to one state. The declared preview is matched as a *row of the
+      // manifest*, not as a bare id, because `--preview` also accepts `<Class>.<function>` and the
+      // bare function name — forms only the manifest row can answer. A synthetic row id has no
+      // manifest row of its own, so it is matched by id.
+      when {
+        rows.isEmpty() -> if (matches(info)) listOf(serve(info.id, baseLabel)) else emptyList()
+        matches(info) -> rows.map { serve(it.id, "$baseLabel · ${it.label}") }
+        else -> rows.filter { matches(it.id) }.map { serve(it.id, "$baseLabel · ${it.label}") }
+      }
+    }
+  }
+
   private fun matches(preview: PreviewInfo): Boolean =
     previewIdMatchesRequest(
       preview.id,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
@@ -248,6 +248,42 @@ class PreviewRowSelectorTest {
     assertEquals(listOf(":app", ":ui"), selected.map { it.gradlePath })
   }
 
+  /**
+   * Review follow-up (#3799). The conservative row lane is opt-in, because only `serve` can cash it
+   * in: it expands the fan-out off disk after the render and re-filters, so a speculative keep is
+   * proven or discarded before anything is shown. `render` / `show` / `a11y` filter their output by
+   * base id — `PreviewResultBuilder` carries a row as a capture's `parameterLabel`, not as an id —
+   * so for them a speculative keep could only ever render a module and then print nothing from it.
+   */
+  @Test
+  fun `the row lane is off for commands that cannot expand rows`() {
+    val app = module(":app")
+    val manifests = listOf(manifest(app, preview("Foo", parameterized = true)))
+
+    assertTrue(
+      modulesMatchingPreviewRequest(
+          listOf(app),
+          manifests,
+          exactId = null,
+          filter = "Crimson",
+          rowAware = false,
+        )
+        .isEmpty(),
+      "a non-row-aware command must not render a module on a maybe",
+    )
+    assertEquals(
+      listOf(":app"),
+      modulesMatchingPreviewRequest(
+          listOf(app),
+          manifests,
+          exactId = null,
+          filter = "Crimson",
+          rowAware = true,
+        )
+        .map { it.gradlePath },
+    )
+  }
+
   /** The same undecidability applies to `--preview`, whose loose form is also a substring rule. */
   @Test
   fun `preview ref keeps a parameterized preview for a row label`() {


### PR DESCRIPTION
Review follow-up to #3799 (issue #3786), which auto-merged before the comments could be addressed. Both were valid, and the first is a regression the row lane introduced.

## `serve` aborted on a module that had nothing to serve

Module selection *has* to keep a parameterized preview whose rows might match — the row ids don't exist until the render writes the fan-out. So `--filter Crimson` can retain a module whose provider turns out to yield only `Light`/`Dark`. `serve` then counted manifests and exited:

```
serve: 2 modules discovered; a server hosts one module. Narrow with --module <path>:
```

…before `ServeParameterRows` could prove the second module contributes nothing. A selector with exactly one real answer failed in any multi-module build containing an unrelated provider — which is most of them.

The expansion now runs **first**. `modulesWithMatchingPreviews` pairs each module with the previews it can actually serve and drops the empty ones, so the speculative keep is turned back into a fact before the one-module check sees it:

```kotlin
val servable = modulesWithMatchingPreviews(outcome.manifests)   // rows expanded, empties dropped
if (servable.size > 1) { … }                                    // now counts real answers
val (module, previews) = servable.single()
```

That's the ordering issue #3786's option (1) asked for — "expand row ids during module selection … that ordering is the hard part" — applied to the *check* rather than to selection, where the inputs it needs (the module dir, the rendered fan-out) are all available.

## The row lane is now opt-in

Only `serve` can cash a "maybe" in: it expands the fan-out off disk and re-filters. `render` / `show` / `a11y` filter their output by base id — `PreviewResultBuilder` represents a row as a capture's `parameterLabel`, not as an id — so for them a speculative keep could only ever render a module and then print nothing from it. Wasted build time for an unchanged answer.

`rowAwareSelection` is a `protected open val` on `Command`, `false` by default and overridden in `ServeCommand`. The conservatism now costs exactly where it buys a correct answer.

Fixing this properly would mean row-aware *result* filtering (synthesised row ids in `PreviewResult`, or matching against capture labels) so `show --filter Crimson` could list `Foo`'s Crimson capture. That's a feature rather than a fix, and out of scope for #3786 — this change makes the current behaviour coherent instead of half-applied.

## Also

Folds the fan-out expansion out of `execute` into `servablePreviewsOf`, so the row rules read in one place and are reachable without standing a server up.

## Test plan

- `PreviewRowSelectorTest` — 13 tests, 0 failures. New: `the row lane is off for commands that cannot expand rows`, asserting both directions of the opt-in.
- Full `:cli:test` — **2127 tests, 0 failures**, including the entire `Serve*` suite (~900 tests across 90 classes), which is the surface the `ServeCommand` restructure puts at risk.

**Visual evidence: N/A** — selector plumbing and control flow; nothing rendered changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SamkbmKYKnb7XhJUU5TYbM)_