### PR TITLE
feat(serve): seed the playground with usage code, not sticker source

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
@@ -42,6 +42,19 @@ data class PlaygroundSeed(
    * hunting for the rest.
    */
   val sliced: Boolean = false,
+  /**
+   * True when [text] has been rewritten into plain Compose by [PlaygroundSourceCleaner] — the
+   * catalog's annotations, sticker frame, click tally and knobs resolved away — rather than carried
+   * verbatim. This changes what the editor may claim: a verbatim seed is "the preview's source, and
+   * some of it will not resolve"; a cleaned one is "usage code, ready to Run".
+   */
+  val cleaned: Boolean = false,
+  /**
+   * Declared scaffolding that survived cleaning ([PlaygroundSourceCleaner.Result.residue]). Empty
+   * is the good case. Non-empty means the seed is *partly* cleaned — better than verbatim, but
+   * carrying names that will not resolve — and the note says so instead of over-promising.
+   */
+  val residue: List<String> = emptyList(),
 )
 
 /**
@@ -162,15 +175,38 @@ class PlaygroundSeedResolver(
       onLog("$rawUrl is not valid UTF-8; playground seed unavailable")
       return null
     }
+    // Cleaning first, slicing as the fallback. The cleaner does its own slicing (it has to — it
+    // closes over the same-file helpers the cleaned body still calls, which a single-declaration
+    // slice would have cut away), so this is one choice between two whole strategies rather than
+    // two passes. Null means it found nothing it could safely do, and the verbatim slice stands.
+    //
+    // Gated on the anchor, which is also why the rules file is not fetched for a catalog whose
+    // manifest predates `bodyLine`: without an anchor the cleaner cannot say which declaration was
+    // clicked, so there is nothing to clean and no reason to ask GitHub for rules describing it.
+    val cleaned =
+      try {
+        if (where.bodyLine == null) null
+        else {
+          val rules = rulesFor(where)
+          PlaygroundSourceCleaner.clean(text, where.bodyLine, rules, stringsFor(where, rules))
+        }
+      } catch (e: Exception) {
+        // A seed is a convenience. A cleaner bug must degrade to the verbatim slice that worked
+        // before it existed, never take the playground handoff down with it.
+        onLog("cleaning $system/$previewId failed (${e.message}); seeding the verbatim slice")
+        null
+      }
     val sliced = sliceDeclaration(text, where.bodyLine)
     val seed =
       PlaygroundSeed(
         catalog = system,
         previewId = previewId,
         fileName = fileNameFor(where.sourceFile),
-        text = sliced ?: text,
+        text = cleaned?.text ?: sliced ?: text,
         blobUrl = ServeUrls.githubBlobUrl(where.repo, where.ref, where.module, where.sourceFile),
-        sliced = sliced != null,
+        sliced = cleaned != null || sliced != null,
+        cleaned = cleaned != null,
+        residue = cleaned?.residue.orEmpty(),
       )
     // Bounded, and deliberately not an LRU: entries are a few KB, a catalog has a fixed number of
     // previews, and a full cache means the ones people actually open are already served from it. A
@@ -183,7 +219,110 @@ class PlaygroundSeedResolver(
     return seed
   }
 
+  /**
+   * The catalog's own [UsageRules], read from `compose-usage.json` at the repo root, at the same
+   * `ref` the catalog was published from — so the rules and the source they describe can never be
+   * from different revisions.
+   *
+   * Cached per `(repo, ref)` rather than per preview: one catalog has one rules file, and every
+   * preview in it wants the same one. A catalog that ships no rules file caches the *absence* too
+   * (as [UsageRules.GENERIC]), so browsing a catalog without one does not re-ask GitHub for a file
+   * that isn't there on every card.
+   */
+  private val rulesCache = ConcurrentHashMap<Pair<String, String>, Pair<UsageRules, Long>>()
+
+  private val stringsCache =
+    ConcurrentHashMap<Pair<String, String>, Pair<Map<String, String>, Long>>()
+
+  private fun rulesFor(where: Location): UsageRules {
+    val key = where.repo to where.ref
+    val now = clock()
+    rulesCache[key]
+      ?.takeIf { now - it.second < ttlSeconds * 1000 }
+      ?.let {
+        return it.first
+      }
+    val url = ServeUrls.githubRawUrl(where.repo, where.ref, null, USAGE_RULES_FILE)
+    val rules =
+      url
+        ?.let { u ->
+          try {
+            fetch(u)
+          } catch (_: Exception) {
+            null
+          }
+        }
+        ?.takeIf { it.size <= maxBytes }
+        ?.decodeToString()
+        ?.let { UsageRules.parse(it, onLog) } ?: UsageRules.GENERIC
+    rulesCache[key] = rules to now
+    return rules
+  }
+
+  /**
+   * The catalog's English string resources, so `stringResource(Res.string.label_filled)` can be
+   * inlined as the label the sticker actually renders.
+   *
+   * Parsed with a deliberately narrow regex rather than an XML parser: this reads one known
+   * generated file shape, and a `<string name="x">y</string>` it does not recognise simply is not
+   * inlined, which leaves the lookup in place — the safe direction.
+   */
+  private fun stringsFor(where: Location, rules: UsageRules): Map<String, String> {
+    val path = rules.stringsPath?.takeIf { it.isNotBlank() } ?: return emptyMap()
+    val key = where.repo to "${where.ref}:${where.module}:$path"
+    val now = clock()
+    stringsCache[key]
+      ?.takeIf { now - it.second < ttlSeconds * 1000 }
+      ?.let {
+        return it.first
+      }
+    val url = ServeUrls.githubRawUrl(where.repo, where.ref, where.module, path)
+    val text =
+      url
+        ?.let { u ->
+          try {
+            fetch(u)
+          } catch (_: Exception) {
+            null
+          }
+        }
+        ?.takeIf { it.size <= maxBytes }
+        ?.decodeToString()
+    val strings =
+      if (text == null) emptyMap()
+      else
+        STRING_RESOURCE.findAll(text).associate {
+          it.groupValues[1] to unescapeAndroidString(it.groupValues[2])
+        }
+    stringsCache[key] = strings to now
+    return strings
+  }
+
   companion object {
+    /**
+     * Where a catalog declares what its own scaffolding is. Repo root, beside `catalog.spec.json`.
+     */
+    const val USAGE_RULES_FILE = "compose-usage.json"
+
+    private val STRING_RESOURCE =
+      Regex("""<string\s+name="([A-Za-z0-9_]+)"\s*>(.*?)</string>""", RegexOption.DOT_MATCHES_ALL)
+
+    /**
+     * The Android/CMP resource escapes a label can carry. Not a general XML unescape — an entity
+     * this does not know is left as written, which shows up in the snippet as itself rather than as
+     * a wrong character.
+     */
+    internal fun unescapeAndroidString(raw: String): String =
+      raw
+        .replace("\\'", "'")
+        .replace("\\\"", "\"")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
+        .trim()
+
     /** A preview source file. Well above any real one, well below "somebody linked a blob". */
     const val DEFAULT_MAX_BYTES = 256 * 1024
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -1,0 +1,756 @@
+package ee.schimke.composeai.cli.serve
+
+/**
+ * Turns a catalog sticker's source into the **usage code** a developer would write — the thing the
+ * playground handoff (and, next, the viewer's Source tab) should open on.
+ *
+ * ### The problem
+ *
+ * `PlaygroundSeedResolver` already narrows a preview file to the one declaration behind the card
+ * that was clicked, verbatim. Verbatim is honest but it is not usable: a sticker carries the
+ * machinery that lets a single declaration serve a baked PNG, a live clickable session, six themes
+ * and a variant matrix at once. Opening `Button/Filled` in the playground today hands over three
+ * catalog annotations, a `Sticker { }` frame, a click tally, a size knob, a shape knob, an enabled
+ * knob, a private layout wrapper and a string-resource lookup — around thirty lines, of which two
+ * are about `Button`. Worse, half of those names live in the catalog's *own* module, and the
+ * playground compiles against the published bundle, so a fair number of them do not even resolve:
+ * the seed note has to warn that unresolved references are expected and should be deleted.
+ *
+ * So the noise is not only cosmetic. Cleaning is what makes the seed **runnable**.
+ *
+ * ### The approach: subtract declared scaffolding, then close over what is left
+ *
+ * Everything here is either catalog-agnostic or driven by [UsageRules], which the catalog declares
+ * once for its handful of helpers rather than per component. In order:
+ *
+ * 1. **Slice** to the declaration containing the anchor line (as the seed already did).
+ * 2. **Strip catalog annotations**, resolved through the file's own imports so a rule can only ever
+ *    strike an annotation it actually names.
+ * 3. **Inline string resources**, so the snippet renders the label the sticker renders.
+ * 4. **Apply the scaffold rules** — unwrap, substitute, inline, drop, rename (see
+ *    [UsageRules.Kind]).
+ * 5. **Close over same-file references.** Whatever the cleaned body still calls that is declared in
+ *    the same file (`FigmaButtonContent`, `SizedLabel`) is pulled in and cleaned too, recursively.
+ *    This is the step that turns "expect unresolved references" into a buffer that compiles.
+ * 6. **Prune imports** to what survived, add what the rewrites need, stamp a real `@Preview`.
+ *
+ * ### Why this is a text pass and not a parse
+ *
+ * A PSI pass would be more general, and it is not available here: the Kotlin frontend is
+ * deliberately kept off the CLI's classpath (`cli/build.gradle.kts` — it is staged into `lib-bta/`
+ * and loaded in an isolated classloader only for an actual compile). Pulling a compiler frontend
+ * into the serve process to prettify a seed would be a bad trade.
+ *
+ * So this scans text, and it is built to **fail in the safe direction**: every pass is masked
+ * against string and comment content so it cannot rewrite inside a literal, and anything it does
+ * not understand it leaves alone. [Result.residue] reports declared scaffolding that survived, so a
+ * seed that came out half-cleaned can say so rather than pretending. The caller falls back to the
+ * verbatim slice when [clean] returns null.
+ *
+ * The formatting assumptions are ktfmt's (Google style), which every catalog in these repos is
+ * formatted with: one argument per line in a wrapped call, a blank line between top-level
+ * declarations, no blank line inside an annotation stack.
+ */
+object PlaygroundSourceCleaner {
+
+  /**
+   * @property text the cleaned Kotlin: imports, the entry declaration, and any same-file helpers it
+   *   still needs.
+   * @property entryFunction the name of the declaration the anchor fell in, for the editor's note.
+   * @property residue declared scaffolding that survived every pass — empty is the good case. A
+   *   non-empty residue is a *reportable* outcome, not a failure: the seed is still better than
+   *   verbatim, and the names here are the ones whose rules need writing.
+   */
+  data class Result(val text: String, val entryFunction: String?, val residue: List<String>)
+
+  /**
+   * Clean [source] around [bodyLine]. Returns null when there is nothing safe to do — no anchor, an
+   * anchor that does not land in a declaration (the file moved under a branch `ref` since discovery
+   * ran), or a file with no import header to reason about — in which case the caller seeds the
+   * verbatim slice as before.
+   *
+   * [strings] maps string-resource keys to the English literal, empty when the catalog declares no
+   * [UsageRules.stringsPath].
+   */
+  fun clean(
+    source: String,
+    bodyLine: Int?,
+    rules: UsageRules,
+    strings: Map<String, String> = emptyMap(),
+  ): Result? {
+    if (bodyLine == null) return null
+    val lines = source.lines()
+    if (bodyLine < 1 || bodyLine > lines.size) return null
+    if (lines[bodyLine - 1].isBlank()) return null
+
+    val imports = importMap(lines)
+    val blocks = topLevelBlocks(lines)
+    val entryIndex =
+      blocks.indexOfFirst { bodyLine - 1 in it.range }.takeIf { it >= 0 } ?: return null
+    val declaredAt = blocks.withIndex().mapNotNull { (i, b) -> b.name?.let { it to i } }.toMap()
+
+    val residue = LinkedHashSet<String>()
+    val addedImports = LinkedHashSet<String>()
+    val cleanedByIndex = LinkedHashMap<Int, String>()
+
+    // Close over same-file references breadth-first: clean a block, see what it still calls that
+    // this file declares, queue those. `seen` bounds it — mutual recursion between two helpers
+    // would otherwise loop.
+    val queue = ArrayDeque(listOf(entryIndex))
+    val seen = mutableSetOf<Int>()
+    while (queue.isNotEmpty()) {
+      val index = queue.removeFirst()
+      if (!seen.add(index)) continue
+      val block = blocks[index]
+      val cleaned =
+        cleanBlock(
+          text = block.text,
+          rules = rules,
+          imports = imports,
+          strings = strings,
+          isEntry = index == entryIndex,
+          residue = residue,
+          addedImports = addedImports,
+        )
+      cleanedByIndex[index] = cleaned
+      for ((name, at) in declaredAt) {
+        if (at != index && at !in seen && mentionsWord(cleaned, name)) queue.addLast(at)
+      }
+    }
+
+    // Entry first, then its helpers in file order — a reader wants the composable they clicked at
+    // the top, not after two private helpers they did not ask about.
+    val bodies = buildList {
+      add(cleanedByIndex.getValue(entryIndex))
+      cleanedByIndex.keys
+        .sorted()
+        .filter { it != entryIndex }
+        .forEach { add(cleanedByIndex.getValue(it)) }
+    }
+    val body = bodies.joinToString("\n\n").trimEnd()
+    if (body.isBlank()) return null
+
+    val header = headerFor(lines, imports, body, addedImports, rules, residue)
+    val text = if (header.isEmpty()) body else "$header\n\n$body"
+    return Result(text, blocks[entryIndex].name, residue.toList())
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Block splitting — the same "column 0 after a blank line" rule PlaygroundSeed.sliceDeclaration
+  // uses, applied to every declaration in the file rather than just the anchored one. See that
+  // function's KDoc for why this rule and not brace counting.
+  // ---------------------------------------------------------------------------------------------
+
+  private data class Block(val range: IntRange, val text: String, val name: String?)
+
+  private fun topLevelBlocks(lines: List<String>): List<Block> {
+    val headerEnd = headerEndExclusive(lines)
+    val starts = (headerEnd..lines.lastIndex).filter { startsTopLevelDeclaration(lines, it) }
+    return starts.mapIndexed { i, start ->
+      val nextStart = starts.getOrNull(i + 1) ?: (lines.size)
+      var end = nextStart - 1
+      while (end > start && lines[end].isBlank()) end--
+      val text = lines.subList(start, end + 1).joinToString("\n")
+      Block(start..end, text, declaredName(text))
+    }
+  }
+
+  private fun startsTopLevelDeclaration(lines: List<String>, i: Int): Boolean {
+    val line = lines[i]
+    if (line.isBlank()) return false
+    if (line.first().isWhitespace()) return false
+    return i == 0 || lines[i - 1].isBlank()
+  }
+
+  private fun headerEndExclusive(lines: List<String>): Int {
+    val lastImport = lines.indexOfLast { it.trimStart().startsWith("import ") }
+    if (lastImport >= 0) return lastImport + 1
+    val packageLine = lines.indexOfLast { it.trimStart().startsWith("package ") }
+    return if (packageLine >= 0) packageLine + 1 else 0
+  }
+
+  /**
+   * Anchored at **column 0**, which is what makes it a *top-level* declaration matcher: the same
+   * pattern unanchored would match the `val c = counted(…)` inside a body and report the block as
+   * declaring `c`.
+   */
+  private val DECLARATION =
+    Regex(
+      """^(?:(?:private|internal|public|expect|actual)\s+)*(?:fun|val|var|class|object|interface)\s+(?:<[^>]*>\s+)?([A-Za-z_][A-Za-z0-9_]*)"""
+    )
+
+  /**
+   * The name a declaration block introduces. Scans for the first column-0 declaration line rather
+   * than examining one candidate: a block opens with KDoc and an annotation stack, and a multi-line
+   * annotation's continuation lines (` id = "Button/Filled",`) look like neither an annotation nor
+   * a declaration.
+   */
+  private fun declaredName(text: String): String? =
+    text.lines().firstNotNullOfOrNull { DECLARATION.find(it)?.groupValues?.get(1) }
+
+  // ---------------------------------------------------------------------------------------------
+  // Header
+  // ---------------------------------------------------------------------------------------------
+
+  /** simple name (or alias) → fully-qualified name, for every `import` in the file. */
+  private fun importMap(lines: List<String>): Map<String, String> {
+    val out = LinkedHashMap<String, String>()
+    for (line in lines) {
+      val t = line.trim()
+      if (!t.startsWith("import ")) continue
+      val spec = t.removePrefix("import ").trim()
+      val alias = spec.substringAfter(" as ", "").trim()
+      val fqn = spec.substringBefore(" as ").trim()
+      val simple = alias.ifEmpty { fqn.substringAfterLast('.') }
+      if (simple.isNotEmpty()) out[simple] = fqn
+    }
+    return out
+  }
+
+  /**
+   * The cleaned file header: the imports [body] still uses, plus the ones the rewrites introduced,
+   * sorted.
+   *
+   * The `package` line is dropped deliberately. The snippet is no longer the catalog's code — it is
+   * plain Compose that happens to have been derived from it — and compiling it into the catalog's
+   * package would let it reach `internal` members that a real consumer could not, which would make
+   * a snippet that builds here and not for the person who copies it.
+   *
+   * A file-level annotation is kept only when it is not catalog machinery (`@file:OptIn` stays,
+   * `@file:CatalogGroup` goes) — but only if something in [body] still needs it, which is why the
+   * import prune runs over the annotations too.
+   */
+  private fun headerFor(
+    lines: List<String>,
+    imports: Map<String, String>,
+    body: String,
+    addedImports: Set<String>,
+    rules: UsageRules,
+    residue: MutableSet<String>,
+  ): String {
+    val fileAnnotations =
+      lines
+        .takeWhile { !it.trimStart().startsWith("package ") }
+        .filter { it.trimStart().startsWith("@file:") }
+        .filterNot { line ->
+          val name =
+            line.trim().removePrefix("@file:").takeWhile { it.isLetterOrDigit() || it == '_' }
+          isScaffoldAnnotation(name, imports, rules)
+        }
+    val kept =
+      imports.values.filter { fqn ->
+        val simple = fqn.substringAfterLast('.')
+        if (isScaffoldPackage(fqn, rules)) {
+          // A scaffold import that is still referenced means a rule is missing, not that the import
+          // should be kept — record it and drop it, so the residue names the gap.
+          if (mentionsWord(body, simple)) residue.add(simple)
+          false
+        } else {
+          mentionsWord(body, simple) || fileAnnotations.any { mentionsWord(it, simple) }
+        }
+      }
+    val all = (kept + addedImports).distinct().sorted().map { "import $it" }
+    return (fileAnnotations + (if (fileAnnotations.isEmpty()) emptyList() else listOf("")) + all)
+      .joinToString("\n")
+      .trim()
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Block cleaning
+  // ---------------------------------------------------------------------------------------------
+
+  private fun cleanBlock(
+    text: String,
+    rules: UsageRules,
+    imports: Map<String, String>,
+    strings: Map<String, String>,
+    isEntry: Boolean,
+    residue: MutableSet<String>,
+    addedImports: MutableSet<String>,
+  ): String {
+    var out = stripScaffoldAnnotations(text, imports, rules)
+    out = inlineStringResources(out, strings)
+    // Order matters. UNWRAP first, so a wrapper takes its own arguments away with it before DROP
+    // starts reasoning about which arguments mention a dropped binding. INLINE next, so a member
+    // substitution lands before DROP inspects the argument it sits in. DROP, then RENAME last —
+    // renaming early would hide a name the other passes match on.
+    out = applyUnwrap(out, rules)
+    out = applySubstitute(out, rules, addedImports)
+    out = applyInline(out, rules)
+    out = applyDrop(out, rules, residue)
+    out = applyRename(out, rules, addedImports)
+    if (isEntry) out = stampPreview(out, rules, addedImports)
+    for (name in rules.scaffolds.keys) if (mentionsWord(out, name)) residue.add(name)
+    return out.trimEnd()
+  }
+
+  private fun isScaffoldPackage(fqn: String, rules: UsageRules): Boolean =
+    rules.scaffoldAnnotationPackages.any { fqn == it || fqn.startsWith("$it.") }
+
+  private fun isScaffoldAnnotation(
+    simpleName: String,
+    imports: Map<String, String>,
+    rules: UsageRules,
+  ): Boolean {
+    val fqn = imports[simpleName] ?: return false
+    return isScaffoldPackage(fqn, rules)
+  }
+
+  /**
+   * Remove annotation lines whose simple name resolves, through the file's imports, into one of the
+   * catalog's annotation packages — including the multi-line form (`@CatalogComponent(\n id =
+   * …,\n)`), consumed by parenthesis balance rather than by line count.
+   */
+  private fun stripScaffoldAnnotations(
+    text: String,
+    imports: Map<String, String>,
+    rules: UsageRules,
+  ): String {
+    val lines = text.lines()
+    val out = mutableListOf<String>()
+    var i = 0
+    while (i < lines.size) {
+      val line = lines[i]
+      val trimmed = line.trimStart()
+      val isAnnotation = trimmed.startsWith("@")
+      if (!isAnnotation) {
+        out.add(line)
+        i++
+        continue
+      }
+      val name =
+        trimmed.removePrefix("@").removePrefix("file:").takeWhile {
+          it.isLetterOrDigit() || it == '_'
+        }
+      // Consume the whole annotation, however many lines its argument list spans.
+      var depth = 0
+      var end = i
+      while (end < lines.size) {
+        depth += parenBalance(lines[end])
+        if (depth <= 0) break
+        end++
+      }
+      if (!isScaffoldAnnotation(name, imports, rules)) {
+        for (j in i..minOf(end, lines.lastIndex)) out.add(lines[j])
+      }
+      i = minOf(end, lines.lastIndex) + 1
+    }
+    return out.joinToString("\n")
+  }
+
+  private fun parenBalance(line: String): Int {
+    val mask = codeMask(line)
+    var n = 0
+    for (k in line.indices) {
+      if (!mask[k]) continue
+      if (line[k] == '(') n++
+      if (line[k] == ')') n--
+    }
+    return n
+  }
+
+  /**
+   * `stringResource(Res.string.label_filled)` → `"Filled"`. The sticker renders a translated string
+   * because a catalog must; a usage snippet that showed the lookup instead of the label would be
+   * teaching the reader about the catalog's resource module rather than about the component.
+   *
+   * Only exact, single-argument `Res.string.<key>` lookups are inlined — anything with a formatting
+   * argument or a computed key is left alone.
+   */
+  private fun inlineStringResources(text: String, strings: Map<String, String>): String {
+    if (strings.isEmpty()) return text
+    return Regex("""stringResource\(\s*Res\.string\.([A-Za-z0-9_]+)\s*\)""").replace(text) { m ->
+      strings[m.groupValues[1]]?.let {
+        "\"" + it.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+      } ?: m.value
+    }
+  }
+
+  private fun applyRename(
+    text: String,
+    rules: UsageRules,
+    addedImports: MutableSet<String>,
+  ): String {
+    var out = text
+    for ((name, scaffold) in rules.scaffolds) {
+      if (scaffold.kind != UsageRules.Kind.RENAME) continue
+      val to = scaffold.renameTo ?: continue
+      if (!mentionsWord(out, name)) continue
+      out = replaceWord(out, name, to)
+      scaffold.addImport?.let { addedImports.add(it) }
+    }
+    return out
+  }
+
+  /** `ButtonFrame(size) { <body> }` → `<body>`, de-indented to the call's own column. */
+  private fun applyUnwrap(text: String, rules: UsageRules): String {
+    var out = text
+    for ((name, scaffold) in rules.scaffolds) {
+      if (scaffold.kind != UsageRules.Kind.UNWRAP) continue
+      var guard = 0
+      while (guard++ < MAX_REWRITES) {
+        val call = findCall(out, name) ?: break
+        val lambdaOpen = out.indexOf('{', call.argsEnd).takeIf { it >= 0 } ?: break
+        val lambdaClose = matchBrace(out, lambdaOpen) ?: break
+        val inner = out.substring(lambdaOpen + 1, lambdaClose)
+        val callIndent = indentOf(out, call.start)
+        // Splice from the start of the call's *line*, not from the call itself: the line's own
+        // indent is already the column the body is being re-indented to, and leaving it in place
+        // would indent the lifted body twice.
+        val lineStart = out.lastIndexOf('\n', call.start - 1) + 1
+        out =
+          out.substring(0, lineStart) + dedent(inner, callIndent) + out.substring(lambdaClose + 1)
+      }
+    }
+    return out
+  }
+
+  /**
+   * `catalogChoice("style", "outlined", "outlined", "elevated")` → `"outlined"` — the whole call
+   * expression replaced by what it evaluates to on the lane the render was baked on.
+   *
+   * Runs before [applyInline] so a knob nested inside a tally (`counted(catalogChoice(…))`) is
+   * already plain by the time the tally's argument is captured as text.
+   */
+  private fun applySubstitute(
+    text: String,
+    rules: UsageRules,
+    addedImports: MutableSet<String>,
+  ): String {
+    var out = text
+    for ((name, scaffold) in rules.scaffolds) {
+      if (scaffold.kind != UsageRules.Kind.SUBSTITUTE) continue
+      val plain = scaffold.plain ?: continue
+      var guard = 0
+      while (guard++ < MAX_REWRITES) {
+        val call = findCall(out, name) ?: break
+        val args = splitTopLevel(out.substring(call.argsStart + 1, call.argsEnd)).map { it.trim() }
+        val rendered =
+          Regex("""\$(\d+)""").replace(plain) { m ->
+            args.getOrNull(m.groupValues[1].toInt()) ?: m.value
+          }
+        // A template citing an argument the call does not have would silently emit `$1`. Leave the
+        // call alone instead; the residue check below then reports it as an unwritten rule.
+        if (rendered.contains(Regex("""\$\d"""))) break
+        out = out.substring(0, call.start) + rendered + out.substring(call.argsEnd + 1)
+        scaffold.addImport?.let { addedImports.add(it) }
+      }
+    }
+    return out
+  }
+
+  /**
+   * `val c = counted("Filled")` + `c.onClick` + `c.label` → `{}` + `"Filled"`, with the binding
+   * line deleted.
+   */
+  private fun applyInline(text: String, rules: UsageRules): String {
+    var out = text
+    for ((name, scaffold) in rules.scaffolds) {
+      if (scaffold.kind != UsageRules.Kind.INLINE) continue
+      var guard = 0
+      while (guard++ < MAX_REWRITES) {
+        val binding = findBinding(out, name) ?: break
+        out = removeLines(out, binding.lineRange)
+        for ((member, template) in scaffold.members) {
+          val replacement =
+            Regex("""\$(\d+)""").replace(template) { m ->
+              binding.arguments.getOrNull(m.groupValues[1].toInt())?.trim() ?: m.value
+            }
+          out = replaceWord(out, "${binding.name}.$member", replacement)
+        }
+      }
+    }
+    return out
+  }
+
+  /**
+   * Delete a knob and everything downstream of it: the `val` that binds it, and — the part that
+   * does the real work — every **named** argument whose value mentions either.
+   *
+   * ### All or nothing, per declaration
+   *
+   * Only named arguments are eligible. A positional one carries no label to reason about, and
+   * `Spacer(Modifier.width(size.iconSpacing))` would become `Spacer()`, which does not compile — a
+   * text pass that guesses here produces code that looks clean and is broken, which is strictly
+   * worse than code that looks noisy and runs.
+   *
+   * So the pass verifies itself: if any reference to a dropped binding survives the argument
+   * filter, the whole DROP is **abandoned** for this declaration and the original text returned,
+   * with the helper recorded in [residue]. The knob either disappears completely or is left exactly
+   * as the catalog wrote it. There is no half-rewritten state, and the residue names precisely
+   * which helper needs a better rule.
+   */
+  private fun applyDrop(text: String, rules: UsageRules, residue: MutableSet<String>): String {
+    val dropped = mutableSetOf<String>()
+    val helpers = mutableSetOf<String>()
+    var out = text
+    for ((name, scaffold) in rules.scaffolds) {
+      if (scaffold.kind != UsageRules.Kind.DROP) continue
+      if (!mentionsWord(out, name)) continue
+      helpers.add(name)
+      dropped.add(name)
+      var guard = 0
+      while (guard++ < MAX_REWRITES) {
+        val binding = findBinding(out, name) ?: break
+        if (binding.name.isNotEmpty()) dropped.add(binding.name)
+        out = removeLines(out, binding.lineRange)
+      }
+    }
+    if (dropped.isEmpty()) return out
+    out =
+      filterCallArguments(out) { arg ->
+        isNamedArgument(arg) && dropped.any { mentionsWord(arg, it) }
+      }
+    val survivor = dropped.firstOrNull { mentionsWord(out, it) }
+    if (survivor != null) {
+      residue.addAll(helpers)
+      return text
+    }
+    return out
+  }
+
+  private fun isNamedArgument(arg: String): Boolean =
+    Regex("""^\s*[A-Za-z_][A-Za-z0-9_]*\s*=[^=]""").containsMatchIn(arg)
+
+  /** Puts a real `@Preview` back on the entry point, since the catalog's own was just stripped. */
+  private fun stampPreview(
+    text: String,
+    rules: UsageRules,
+    addedImports: MutableSet<String>,
+  ): String {
+    val simple = rules.previewAnnotation.substringAfterLast('.')
+    if (mentionsWord(text, "@$simple")) return text
+    val lines = text.lines().toMutableList()
+    val at = lines.indexOfFirst { it.trimStart().startsWith("@Composable") }
+    val insertAt = if (at >= 0) at else lines.indexOfFirst { DECLARATION.containsMatchIn(it) }
+    if (insertAt < 0) return text
+    lines.add(insertAt, "@$simple")
+    addedImports.add(rules.previewAnnotation)
+    return lines.joinToString("\n")
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Text mechanics. Every one of these is masked against string/comment content, so no pass can
+  // rewrite inside a literal — the failure that makes naive source rewriting untrustworthy.
+  // ---------------------------------------------------------------------------------------------
+
+  private const val MAX_REWRITES = 64
+
+  private data class Call(val start: Int, val argsStart: Int, val argsEnd: Int)
+
+  private data class Binding(val name: String, val arguments: List<String>, val lineRange: IntRange)
+
+  /**
+   * Marks each character as *code* (true) or as string/char/comment content (false). Handles line
+   * comments, block comments, `'c'`, `"…"` with escapes, and raw `"""…"""` strings.
+   */
+  internal fun codeMask(text: String): BooleanArray {
+    val mask = BooleanArray(text.length) { true }
+    var i = 0
+    while (i < text.length) {
+      when {
+        text.startsWith("//", i) -> {
+          val end = text.indexOf('\n', i).takeIf { it >= 0 } ?: text.length
+          for (k in i until end) mask[k] = false
+          i = end
+        }
+        text.startsWith("/*", i) -> {
+          val end = (text.indexOf("*/", i + 2).takeIf { it >= 0 }?.plus(2)) ?: text.length
+          for (k in i until end) mask[k] = false
+          i = end
+        }
+        text.startsWith("\"\"\"", i) -> {
+          val end = (text.indexOf("\"\"\"", i + 3).takeIf { it >= 0 }?.plus(3)) ?: text.length
+          for (k in i until end) mask[k] = false
+          i = end
+        }
+        text[i] == '"' || text[i] == '\'' -> {
+          val quote = text[i]
+          var k = i + 1
+          while (k < text.length && text[k] != quote) {
+            if (text[k] == '\\') k++
+            k++
+          }
+          val end = minOf(k + 1, text.length)
+          for (j in i until end) mask[j] = false
+          i = end
+        }
+        else -> i++
+      }
+    }
+    return mask
+  }
+
+  private fun isIdentifierChar(c: Char) = c.isLetterOrDigit() || c == '_'
+
+  /** Occurrences of [word] at code positions, bounded by non-identifier characters. */
+  private fun wordOccurrences(text: String, word: String): List<Int> {
+    if (word.isEmpty()) return emptyList()
+    val mask = codeMask(text)
+    val out = mutableListOf<Int>()
+    var from = 0
+    while (true) {
+      val at = text.indexOf(word, from).takeIf { it >= 0 } ?: return out
+      from = at + 1
+      if (!mask[at]) continue
+      val head = word.first()
+      val before = text.getOrNull(at - 1)
+      val after = text.getOrNull(at + word.length)
+      val leftOk =
+        if (isIdentifierChar(head)) before?.let { !isIdentifierChar(it) && it != '.' } ?: true
+        else true
+      val rightOk = after?.let { !isIdentifierChar(it) } ?: true
+      if (leftOk && rightOk) out.add(at)
+    }
+  }
+
+  internal fun mentionsWord(text: String, word: String): Boolean =
+    wordOccurrences(text, word).isNotEmpty()
+
+  private fun replaceWord(text: String, word: String, replacement: String): String {
+    val hits = wordOccurrences(text, word)
+    if (hits.isEmpty()) return text
+    val sb = StringBuilder()
+    var last = 0
+    for (at in hits) {
+      sb.append(text, last, at).append(replacement)
+      last = at + word.length
+    }
+    sb.append(text, last, text.length)
+    return sb.toString()
+  }
+
+  private fun findCall(text: String, name: String): Call? {
+    for (at in wordOccurrences(text, name)) {
+      var k = at + name.length
+      while (k < text.length && text[k].isWhitespace()) k++
+      if (k < text.length && text[k] == '(') {
+        val close = matchParen(text, k) ?: continue
+        return Call(at, k, close)
+      }
+    }
+    return null
+  }
+
+  /** `val <name> = <scaffold>(<args>)` — the binding, its arguments, and the lines it occupies. */
+  private fun findBinding(text: String, scaffold: String): Binding? {
+    val call = findCall(text, scaffold) ?: return null
+    val lineStart = text.lastIndexOf('\n', call.start - 1) + 1
+    val prefix = text.substring(lineStart, call.start)
+    val match = Regex("""^\s*val\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*$""").find(prefix)
+    val name = match?.groupValues?.get(1)
+    val args =
+      splitTopLevel(text.substring(call.argsStart + 1, call.argsEnd)).map {
+        it.trim(',', ' ', '\n')
+      }
+    val firstLine = text.substring(0, lineStart).count { it == '\n' }
+    val lastLine = text.substring(0, call.argsEnd).count { it == '\n' }
+    // A scaffold call that is not bound to a `val` still needs consuming, or the loop that calls
+    // this would spin on it forever. Reported with an empty name, which matches nothing downstream.
+    return Binding(name ?: "", args, firstLine..lastLine)
+  }
+
+  private fun matchParen(text: String, open: Int): Int? = matchDelimiter(text, open, '(', ')')
+
+  private fun matchBrace(text: String, open: Int): Int? = matchDelimiter(text, open, '{', '}')
+
+  private fun matchDelimiter(text: String, open: Int, o: Char, c: Char): Int? {
+    val mask = codeMask(text)
+    var depth = 0
+    for (i in open until text.length) {
+      if (!mask[i]) continue
+      if (text[i] == o) depth++
+      if (text[i] == c) {
+        depth--
+        if (depth == 0) return i
+      }
+    }
+    return null
+  }
+
+  /** Splits an argument list on top-level commas, keeping each argument's own text intact. */
+  private fun splitTopLevel(args: String): List<String> {
+    val mask = codeMask(args)
+    val out = mutableListOf<String>()
+    var depth = 0
+    var start = 0
+    for (i in args.indices) {
+      if (!mask[i]) continue
+      when (args[i]) {
+        '(',
+        '[',
+        '{' -> depth++
+        ')',
+        ']',
+        '}' -> depth--
+        ',' ->
+          if (depth == 0) {
+            out.add(args.substring(start, i))
+            start = i + 1
+          }
+      }
+    }
+    if (start <= args.lastIndex) out.add(args.substring(start))
+    return out.filter { it.isNotBlank() }
+  }
+
+  /**
+   * Drops arguments matching [shouldDrop] from every call in [text], and collapses a call left with
+   * a single short argument back onto one line — so a wrapped four-argument `Button(…)` whose knobs
+   * were all catalog machinery comes out as `Button(onClick = {})` rather than as a two-line husk.
+   */
+  private fun filterCallArguments(text: String, shouldDrop: (String) -> Boolean): String {
+    var out = text
+    var searchFrom = 0
+    var guard = 0
+    while (guard++ < MAX_REWRITES * 4) {
+      val mask = codeMask(out)
+      val open = (searchFrom until out.length).firstOrNull { out[it] == '(' && mask[it] } ?: break
+      val close = matchParen(out, open)
+      if (close == null) {
+        searchFrom = open + 1
+        continue
+      }
+      val inner = out.substring(open + 1, close)
+      val args = splitTopLevel(inner)
+      val keep = args.filterNot { shouldDrop(it) }
+      if (keep.size == args.size) {
+        searchFrom = open + 1
+        continue
+      }
+      val rendered =
+        when {
+          keep.isEmpty() -> ""
+          // `.trim()` first: a surviving argument lifted out of a wrapped call still carries the
+          // newline and indent that put it on its own line, and testing before trimming would keep
+          // every collapsible call in its multi-line husk.
+          keep.size == 1 && !keep[0].trim().contains('\n') -> keep[0].trim()
+          else -> keep.joinToString(",") + ","
+        }
+      out = out.substring(0, open + 1) + rendered + out.substring(close)
+      searchFrom = open + 1
+    }
+    return out
+  }
+
+  private fun indentOf(text: String, at: Int): Int {
+    val lineStart = text.lastIndexOf('\n', at - 1) + 1
+    return text.substring(lineStart, at).takeWhile { it == ' ' }.length
+  }
+
+  /** Re-indents a lambda body lifted out of its wrapper, to the column the wrapper sat at. */
+  private fun dedent(inner: String, toColumn: Int): String {
+    val lines = inner.lines().filter { it.isNotBlank() }
+    if (lines.isEmpty()) return ""
+    val common = lines.minOf { line -> line.takeWhile { it == ' ' }.length }
+    val shift = common - toColumn
+    return lines.joinToString("\n") { line ->
+      if (shift > 0) line.drop(minOf(shift, line.takeWhile { it == ' ' }.length)) else line
+    }
+  }
+
+  private fun removeLines(text: String, range: IntRange): String {
+    val lines = text.lines()
+    return lines.filterIndexed { i, _ -> i !in range }.joinToString("\n")
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3997,9 +3997,28 @@ object ServeWeb {
                 WebEscaping.htmlEscape(seed.fileName)
               }</a>"""
           } ?: WebEscaping.htmlEscape(seed.fileName)
-        // Which of the two it is matters to a reader: told "the whole file" while looking at one
-        // function, they would go hunting for the rest of it.
-        if (seed.sliced)
+        // Which of the three it is matters to a reader, and they promise different things. A
+        // cleaned seed is usage code — the catalog's annotations, sticker frame, click tally and
+        // knobs resolved away — so it may say "ready to Run"; the other two may not.
+        if (seed.cleaned) {
+          val caveat =
+            if (seed.residue.isEmpty()) ""
+            else {
+              val names =
+                seed.residue.joinToString(", ") { "<code>${WebEscaping.htmlEscape(it)}</code>" }
+              " Some of this catalog's own helpers ($names) had no plain-Compose form to rewrite " +
+                "to, so they are still here and will not resolve — delete them or replace them " +
+                "with your own values."
+            }
+          """
+
+          <p id="pg-seed" class="cp-sub">Opened from $where — <code>${
+              WebEscaping.htmlEscape(seed.previewId)
+            }</code> in <code>${WebEscaping.htmlEscape(seed.catalog)}</code>, rewritten as the
+            plain Compose that produces this render. The catalog's annotations, sticker frame and
+            variant knobs are not code you need in order to use the component, so they are gone.
+            Press Run.$caveat</p>"""
+        } else if (seed.sliced)
           """
 
           <p id="pg-seed" class="cp-sub">Opened from $where — the declaration of

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -1,0 +1,155 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * What a catalog declares about **its own scaffolding** — the vocabulary [PlaygroundSourceCleaner]
+ * needs to turn a sticker's source into the usage code a developer would actually write.
+ *
+ * ### Why this is data the catalog owns, and not rules this repo hard-codes
+ *
+ * A sticker is not a usage example. It carries the machinery that lets one declaration serve a
+ * baked PNG, a live clickable session, six themes and a variant matrix at once — `Sticker { }` for
+ * the frame, `counted(…)` so no sticker ships a dead handler, `catalogButtonSize()` so a matrix
+ * cell can drive a knob. All of that is *true* and all of it is noise to somebody who just wants to
+ * know how to call `Button`.
+ *
+ * Which names those are is a fact about the catalog, not about this server, so the catalog declares
+ * them. And the ratio is the whole argument for doing it this way: m3-catalog has ~400 catalogued
+ * components and **17** scaffolding helpers, nearly all of them in three files. Declaring the
+ * seventeen costs a file that fits on a screen; annotating the four hundred would be a
+ * hand-maintained mapping that drifts the moment a sticker is edited — which is exactly the failure
+ * mode that repo's README already rejects for name-keyed mapping files.
+ *
+ * ### Where it comes from
+ *
+ * `compose-usage.json` at the root of the catalog's own repo, read at the same `ref` the catalog
+ * was published from (see [PlaygroundSeedResolver]). A catalog that ships no such file gets
+ * [GENERIC] — annotation stripping and import pruning, which need no catalog knowledge and already
+ * remove most of the noise.
+ *
+ * This is deliberately a *file* for the prototype. The intended end state is
+ * `@CatalogScaffold(...)` on the helpers themselves, projected into the manifest by discovery, so
+ * the declaration sits next to the thing it describes and a helper cannot be added without one.
+ * That change swaps how this object is *populated*; every consumer below stays as it is.
+ */
+@Serializable
+data class UsageRules(
+  /**
+   * Packages whose annotations are catalog machinery: `@CatalogComponent`, `@CatalogModes`,
+   * `@SizeShapeMatrix`, `@file:CatalogGroup`. An annotation is matched by resolving its simple name
+   * through the file's own imports, so a rule here can never strike an unrelated annotation that
+   * happens to share a name.
+   */
+  @SerialName("scaffoldAnnotationPackages")
+  val scaffoldAnnotationPackages: List<String> = emptyList(),
+
+  /** Helper name → what the cleaner should do with it. */
+  @SerialName("scaffolds") val scaffolds: Map<String, Scaffold> = emptyMap(),
+
+  /**
+   * Module-relative path to the English string resources, so `stringResource(Res.string.label_x)`
+   * can be inlined as the literal the sticker actually renders. Null ⇒ string resources are left
+   * alone (and their imports kept), which compiles but reads worse.
+   */
+  @SerialName("stringsPath") val stringsPath: String? = null,
+
+  /**
+   * The `@Preview` annotation to stamp on the cleaned entry point, since the catalog's own
+   * (`@CatalogModes`) was just stripped. Must be one of the FQNs
+   * [PlaygroundPreviewDiscoverer.DEFAULT_PREVIEW_ANNOTATION_FQNS] recognises, or the playground
+   * will compile the snippet and then find nothing to render.
+   */
+  @SerialName("previewAnnotation")
+  val previewAnnotation: String = "androidx.compose.ui.tooling.preview.Preview",
+) {
+
+  /** What to do with one scaffolding helper. */
+  @Serializable
+  data class Scaffold(
+    @SerialName("kind") val kind: Kind,
+    /** [Kind.RENAME] only: the plain-Compose name to call instead. */
+    @SerialName("renameTo") val renameTo: String? = null,
+    /** An import the replacement needs, e.g. `androidx.compose.material3.MaterialTheme`. */
+    @SerialName("addImport") val addImport: String? = null,
+    /** [Kind.SUBSTITUTE] only: what the call reads as, with `$0`, `$1`… for its arguments. */
+    @SerialName("plain") val plain: String? = null,
+    /**
+     * [Kind.INLINE] only: member → replacement, where `$0`, `$1`… are the call's arguments.
+     * `counted` declares `{"label": "$0", "onClick": "{}"}`, which is the whole of what that helper
+     * means to a reader: the label you passed, and a click handler.
+     */
+    @SerialName("members") val members: Map<String, String> = emptyMap(),
+  )
+
+  enum class Kind {
+    /**
+     * Call the plain-Compose equivalent instead. `Sticker { }` → `MaterialTheme { }`: the sticker
+     * frame *is* a `MaterialTheme` over the baseline scheme, so the rename is the honest reading —
+     * and unwrapping it instead would leave the snippet unthemed, which is worse than noisy.
+     */
+    RENAME,
+
+    /**
+     * Drop the call and keep its trailing lambda's body. For layout scaffolding that exists to make
+     * the *render* consistent (`ButtonFrame`) rather than to say anything about the component.
+     */
+    UNWRAP,
+
+    /**
+     * The helper, and everything downstream of it, is knob plumbing: delete it.
+     *
+     * This is the rule that earns its keep. Declaring `catalogButtonSize` as DROP removes its `val`
+     * binding *and* every named argument whose value mentions that binding — so one line of
+     * declaration deletes `contentPadding = size.contentPadding`, `modifier =
+     * Modifier.height(size.containerHeight)` and the rest of the matrix wiring at once. What is
+     * left is the call with its defaults, which is what the default render shows and what a
+     * developer would write.
+     */
+    DROP,
+
+    /** Substitute the call's [Scaffold.members] at their use sites; delete the binding. */
+    INLINE,
+
+    /**
+     * Replace the whole call expression with [Scaffold.plain], which may cite the call's own
+     * arguments as `$0`, `$1`…
+     *
+     * This is for a knob that already *has* a plain reading: `catalogChoice(key, default, …)`
+     * returns `default` on the baked lane by construction, so `catalogChoice("style", "outlined",
+     * "outlined", "elevated")` declares `"$1"` and the snippet says `"outlined"` — the value the
+     * render on screen was made with. Unlike [DROP], it works on an expression anywhere, not only
+     * on a named argument.
+     */
+    SUBSTITUTE,
+  }
+
+  companion object {
+    /**
+     * The rules that need no catalog knowledge at all: strip this repo's own preview/catalog
+     * annotations, prune the imports that leaves unused. Every catalog gets at least this, so a
+     * catalog that has declared nothing still opens in the playground without a stack of
+     * annotations naming a machinery the visitor has no way to run.
+     */
+    val GENERIC = UsageRules(scaffoldAnnotationPackages = listOf("ee.schimke.composeai.preview"))
+
+    private val json = Json {
+      ignoreUnknownKeys = true
+      isLenient = true
+    }
+
+    /**
+     * Parse `compose-usage.json`, or null when it isn't valid — a catalog's malformed rules file
+     * must degrade to [GENERIC], never take the playground handoff down with it.
+     */
+    fun parse(text: String, onLog: (String) -> Unit = {}): UsageRules? =
+      try {
+        json.decodeFromString<UsageRules>(text)
+      } catch (e: Exception) {
+        onLog("compose-usage.json is not valid usage rules (${e.message}); using generic rules")
+        null
+      }
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeedResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeedResolverTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -212,5 +213,139 @@ class PlaygroundSeedResolverTest {
     // survives into the name and nothing traversal-shaped reaches the staging dir.
     assertEquals("passwd.kt", PlaygroundSeedResolver.fileNameFor("../../etc/passwd"))
     assertEquals("Snippet.kt", PlaygroundSeedResolver.fileNameFor("a/b/../"))
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // Cleaning: the handoff a visitor actually gets when they click "playground" from a catalog
+  // card. Everything above pins how the source is *found*; this pins what lands in the editor.
+  // -----------------------------------------------------------------------------------------
+
+  private val stickerFile =
+    """
+    @file:CatalogGroup(name = "Buttons", section = "Actions")
+
+    package ee.schimke.m3catalog.sections
+
+    import androidx.compose.material3.Button
+    import androidx.compose.material3.Text
+    import androidx.compose.runtime.Composable
+    import ee.schimke.composeai.preview.CatalogComponent
+    import ee.schimke.composeai.preview.CatalogGroup
+    import ee.schimke.m3catalog.CatalogModes
+    import ee.schimke.m3catalog.Sticker
+    import ee.schimke.m3catalog.counted
+    import ee.schimke.m3catalog.generated.resources.Res
+    import ee.schimke.m3catalog.generated.resources.label_filled
+    import org.jetbrains.compose.resources.stringResource
+
+    @CatalogComponent(id = "Button/Filled", caption = "Highest emphasis.")
+    @CatalogModes
+    @Composable
+    fun FilledButton() = Sticker {
+      val c = counted(stringResource(Res.string.label_filled))
+      Button(onClick = c.onClick) { Text(c.label) }
+    }
+    """
+      .trimIndent()
+
+  private val usageRules =
+    """
+    {
+      "scaffoldAnnotationPackages": ["ee.schimke.composeai.preview", "ee.schimke.m3catalog"],
+      "stringsPath": "src/main/composeResources/values/strings.xml",
+      "scaffolds": {
+        "Sticker": {
+          "kind": "RENAME",
+          "renameTo": "MaterialTheme",
+          "addImport": "androidx.compose.material3.MaterialTheme"
+        },
+        "counted": { "kind": "INLINE", "members": { "label": "${'$'}0", "onClick": "{}" } }
+      }
+    }
+    """
+      .trimIndent()
+
+  private val stringsXml = """<resources><string name="label_filled">Filled</string></resources>"""
+
+  /** The catalog's source ref, with the anchor discovery records inside the sticker's body. */
+  private val anchored =
+    m3.copy(bodyLine = stickerFile.lines().indexOfFirst { it.contains("val c =") } + 1)
+
+  private fun cleaningResolver() =
+    resolver(
+      locate = { _, _ -> anchored },
+      body = { url ->
+        when {
+          url.endsWith(PlaygroundSeedResolver.USAGE_RULES_FILE) -> usageRules.toByteArray()
+          url.endsWith("strings.xml") -> stringsXml.toByteArray()
+          else -> stickerFile.toByteArray()
+        }
+      },
+    )
+
+  @Test
+  fun `the handoff seeds usage code, not the sticker`() {
+    val seed = assertNotNull(cleaningResolver().seed("m3-catalog", "sections.FilledButton"))
+    assertTrue(seed.cleaned)
+    assertEquals(emptyList(), seed.residue)
+    assertEquals(
+      """
+      import androidx.compose.material3.Button
+      import androidx.compose.material3.MaterialTheme
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.tooling.preview.Preview
+
+      @Preview
+      @Composable
+      fun FilledButton() = MaterialTheme {
+        Button(onClick = {}) { Text("Filled") }
+      }
+      """
+        .trimIndent(),
+      seed.text,
+    )
+  }
+
+  /** One rules file per catalog, not per card: browsing a group must not re-ask GitHub for it. */
+  @Test
+  fun `the rules file is fetched once per catalog ref`() {
+    val resolver = cleaningResolver()
+    resolver.seed("m3-catalog", "sections.FilledButton")
+    resolver.seed("m3-catalog", "sections.TonalButton")
+    assertEquals(1, fetched.count { it.endsWith(PlaygroundSeedResolver.USAGE_RULES_FILE) })
+    assertEquals(1, fetched.count { it.endsWith("strings.xml") })
+  }
+
+  /** A catalog that declares nothing still loses this repo's annotations. */
+  @Test
+  fun `a catalog with no rules file falls back to generic cleaning`() {
+    val resolver =
+      resolver(
+        locate = { _, _ -> anchored },
+        body = { url ->
+          if (url.endsWith(PlaygroundSeedResolver.USAGE_RULES_FILE)) null
+          else stickerFile.toByteArray()
+        },
+      )
+    val seed = assertNotNull(resolver.seed("m3-catalog", "sections.FilledButton"))
+    assertTrue(seed.cleaned)
+    assertFalse(seed.text.contains("@CatalogComponent"), seed.text)
+    assertTrue(seed.text.contains("Sticker {"), "generic rules must not invent a rename")
+    // Empty, and correctly so: residue reports *declared* scaffolding that survived a rule. Under
+    // generic rules the catalog's own package was never declared as scaffolding, so `Sticker` is an
+    // ordinary reference that keeps its import — noisy, but not a gap in anyone's rules.
+    assertEquals(emptyList(), seed.residue)
+    assertTrue(seed.text.contains("import ee.schimke.m3catalog.Sticker"), seed.text)
+  }
+
+  /** No anchor ⇒ no cleaning, and no request for rules describing a declaration we cannot name. */
+  @Test
+  fun `a manifest with no anchor seeds verbatim and asks for no rules`() {
+    val seed = assertNotNull(resolver(body = { stickerFile.toByteArray() }).seed("m3", "p"))
+    assertFalse(seed.cleaned)
+    assertFalse(seed.sliced)
+    assertEquals(stickerFile, seed.text)
+    assertTrue(fetched.none { it.endsWith(PlaygroundSeedResolver.USAGE_RULES_FILE) })
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -1,0 +1,455 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the sticker → usage-code rewrite.
+ *
+ * The fixture is **not** shaped like a section file; it is a verbatim extract of one, taken from
+ * m3-catalog's `catalog/src/main/kotlin/ee/schimke/m3catalog/sections/Buttons.kt`. That matters:
+ * the whole question this prototype answers is whether real catalog source — a matrix-driven
+ * sticker with a click tally, three knobs, a private frame and a translated label — comes out as
+ * something a visitor can press Run on. A hand-tidied fixture would answer a question nobody asked.
+ *
+ * The rules below are the subset of m3-catalog's own `compose-usage.json` these fixtures exercise.
+ * That file declares seventeen scaffolding helpers in total, for a catalog of ~400 components.
+ */
+class PlaygroundSourceCleanerTest {
+
+  private val rules =
+    UsageRules(
+      scaffoldAnnotationPackages = listOf("ee.schimke.composeai.preview", "ee.schimke.m3catalog"),
+      scaffolds =
+        mapOf(
+          "Sticker" to
+            UsageRules.Scaffold(
+              kind = UsageRules.Kind.RENAME,
+              renameTo = "MaterialTheme",
+              addImport = "androidx.compose.material3.MaterialTheme",
+            ),
+          "counted" to
+            UsageRules.Scaffold(
+              kind = UsageRules.Kind.INLINE,
+              members = mapOf("label" to "\$0", "onClick" to "{}"),
+            ),
+          "catalogEnabled" to UsageRules.Scaffold(kind = UsageRules.Kind.DROP),
+          "catalogButtonShape" to UsageRules.Scaffold(kind = UsageRules.Kind.DROP),
+          "catalogButtonSize" to UsageRules.Scaffold(kind = UsageRules.Kind.DROP),
+          "ButtonFrame" to UsageRules.Scaffold(kind = UsageRules.Kind.UNWRAP),
+        ),
+      stringsPath = "src/main/composeResources/values/strings.xml",
+    )
+
+  private val strings = mapOf("label_filled" to "Filled", "label_tonal" to "Tonal")
+
+  /** Verbatim from `Buttons.kt`, trimmed to the declarations the anchors below land in. */
+  private val buttonsKt =
+    """
+    @file:CatalogGroup(name = "Buttons", section = "Actions")
+    @file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+    package ee.schimke.m3catalog.sections
+
+    import androidx.compose.foundation.layout.Box
+    import androidx.compose.foundation.layout.Spacer
+    import androidx.compose.foundation.layout.height
+    import androidx.compose.foundation.layout.width
+    import androidx.compose.material3.Button
+    import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+    import androidx.compose.material3.Icon
+    import androidx.compose.material3.Text
+    import androidx.compose.runtime.Composable
+    import androidx.compose.ui.Alignment
+    import androidx.compose.ui.Modifier
+    import androidx.compose.ui.unit.dp
+    import ee.schimke.composeai.preview.CatalogComponent
+    import ee.schimke.composeai.preview.CatalogGroup
+    import ee.schimke.composeai.preview.CatalogVariant
+    import ee.schimke.m3catalog.CatalogModes
+    import ee.schimke.m3catalog.CatalogSize
+    import ee.schimke.m3catalog.SizeShapeMatrix
+    import ee.schimke.m3catalog.Sticker
+    import ee.schimke.m3catalog.catalogButtonShape
+    import ee.schimke.m3catalog.catalogButtonSize
+    import ee.schimke.m3catalog.catalogEnabled
+    import ee.schimke.m3catalog.counted
+    import ee.schimke.m3catalog.generated.resources.Res
+    import ee.schimke.m3catalog.generated.resources.label_filled
+    import org.jetbrains.compose.resources.stringResource
+
+    @Composable
+    private fun ButtonFrame(size: CatalogSize, content: @Composable () -> Unit) {
+      Box(
+        modifier = Modifier.height(if (size == CatalogSize.Small) 48.dp else size.containerHeight),
+        contentAlignment = Alignment.Center,
+      ) {
+        content()
+      }
+    }
+
+    @CatalogComponent(
+      id = "Button/Filled",
+      reference = "figma:ocdacdEsnHipMJD3egzxKb/57994:2324",
+      caption = "Highest emphasis; the primary action. Five sizes x two shapes fold in as variants.",
+    )
+    @CatalogModes
+    @SizeShapeMatrix
+    @Composable
+    fun FilledButton() = Sticker {
+      val c = counted(stringResource(Res.string.label_filled))
+      val size = catalogButtonSize()
+      ButtonFrame(size) {
+        Button(
+          onClick = c.onClick,
+          enabled = catalogEnabled(),
+          shape = catalogButtonShape(),
+          contentPadding = size.contentPadding,
+          modifier = Modifier.height(size.containerHeight),
+        ) {
+          Text(c.label)
+        }
+      }
+    }
+
+    @CatalogVariant(
+      of = "Button/Filled",
+      props = ["content=label"],
+      caption = "Label only, vs the kit's icon + label default.",
+    )
+    @CatalogModes
+    @Composable
+    fun FilledButtonLabelOnly() = Sticker {
+      val c = counted(stringResource(Res.string.label_filled))
+      Button(onClick = c.onClick) { Text(c.label) }
+    }
+    """
+      .trimIndent()
+
+  private fun lineOf(needle: String): Int =
+    buttonsKt
+      .lines()
+      .indexOfFirst { it.contains(needle) }
+      .let {
+        require(it >= 0) { "fixture has no line containing $needle" }
+        it + 1
+      }
+
+  private fun cleanAt(needle: String) =
+    PlaygroundSourceCleaner.clean(buttonsKt, lineOf(needle), rules, strings)
+
+  /**
+   * The headline case: the simple variant comes out as the four lines somebody would actually
+   * write, with nothing left of the catalog but the component call.
+   */
+  @Test
+  fun `a variant sticker becomes plain compose`() {
+    val result = assertNotNull(cleanAt("Button(onClick = c.onClick) { Text(c.label) }"))
+    assertEquals(
+      """
+      @file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+      import androidx.compose.material3.Button
+      import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+      import androidx.compose.material3.MaterialTheme
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.tooling.preview.Preview
+
+      @Preview
+      @Composable
+      fun FilledButtonLabelOnly() = MaterialTheme {
+        Button(onClick = {}) { Text("Filled") }
+      }
+      """
+        .trimIndent(),
+      result.text,
+    )
+    assertEquals(emptyList(), result.residue)
+    assertEquals("FilledButtonLabelOnly", result.entryFunction)
+  }
+
+  /**
+   * The matrix-driven case — the one the whole design has to survive. Three knobs, a private frame,
+   * a click tally and a resource lookup all resolve away, leaving the default render's call.
+   */
+  @Test
+  fun `a matrix sticker loses its knobs, its frame and its tally`() {
+    val result = assertNotNull(cleanAt("""caption = "Highest emphasis"""))
+    assertEquals(
+      """
+      @file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+      import androidx.compose.material3.Button
+      import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+      import androidx.compose.material3.MaterialTheme
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.tooling.preview.Preview
+
+      @Preview
+      @Composable
+      fun FilledButton() = MaterialTheme {
+        Button(onClick = {}) {
+          Text("Filled")
+        }
+      }
+      """
+        .trimIndent(),
+      result.text,
+    )
+    assertEquals(emptyList(), result.residue)
+  }
+
+  /** Not one annotation from either annotation package may reach the editor. */
+  @Test
+  fun `catalog annotations and their imports are gone`() {
+    val text = assertNotNull(cleanAt("""caption = "Highest emphasis""")).text
+    for (noise in
+      listOf(
+        "@CatalogComponent",
+        "@CatalogModes",
+        "@SizeShapeMatrix",
+        "@CatalogVariant",
+        "@file:CatalogGroup",
+        "ee.schimke.m3catalog",
+        "ee.schimke.composeai.preview",
+        "figma:",
+      )) {
+      assertFalse(text.contains(noise), "cleaned source still carries $noise:\n$text")
+    }
+  }
+
+  /**
+   * The playground compiles a snippet and then looks for a `@Preview` in it. Stripping the
+   * catalog's own `@CatalogModes` (which is where the preview came from) without putting a real one
+   * back would produce a snippet that compiles and renders nothing.
+   */
+  @Test
+  fun `a real Preview replaces the catalog's meta-annotation`() {
+    val text = assertNotNull(cleanAt("""caption = "Highest emphasis""")).text
+    assertTrue(text.contains("@Preview"))
+    assertTrue(text.contains("import androidx.compose.ui.tooling.preview.Preview"))
+    assertTrue(
+      PlaygroundPreviewDiscoverer.DEFAULT_PREVIEW_ANNOTATION_FQNS.contains(rules.previewAnnotation),
+      "the stamped annotation must be one the playground's discoverer recognises",
+    )
+  }
+
+  /**
+   * The package line is dropped: the snippet is plain Compose derived from the catalog, not the
+   * catalog's own code, and compiling it into that package would let it reach `internal` members a
+   * real consumer could not.
+   */
+  @Test
+  fun `the catalog package is not carried over`() {
+    val text = assertNotNull(cleanAt("""caption = "Highest emphasis""")).text
+    assertFalse(text.contains("package ee.schimke.m3catalog"))
+  }
+
+  /**
+   * A helper the entry point still calls after cleaning is pulled in with it. This is what turns
+   * the old seed note's "expect unresolved references to delete" into a buffer that builds.
+   */
+  @Test
+  fun `same-file helpers the cleaned body still needs are carried along`() {
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.Sticker
+
+      @Composable
+      private fun Caption(text: String) {
+        Text(text)
+      }
+
+      @Composable
+      fun Card() = Sticker {
+        Caption("hello")
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "Caption(\"hello\")"), rules)
+      )
+    assertTrue(result.text.contains("private fun Caption"), result.text)
+    assertTrue(result.text.indexOf("fun Card") < result.text.indexOf("private fun Caption"))
+  }
+
+  /**
+   * The fail-safe. `Spacer(Modifier.width(size.iconSpacing))` has no argument name to reason about,
+   * so dropping the `size` knob here would leave `Spacer()`, which does not compile. The pass must
+   * abandon the rewrite and say so rather than emit clean-looking broken code.
+   */
+  @Test
+  fun `a drop that cannot complete is abandoned, not half-applied`() {
+    val source =
+      """
+      package demo
+
+      import androidx.compose.foundation.layout.Spacer
+      import androidx.compose.foundation.layout.width
+      import androidx.compose.ui.Modifier
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.catalogButtonSize
+
+      @Composable
+      fun Row() {
+        val size = catalogButtonSize()
+        Spacer(Modifier.width(size.iconSpacing))
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "Spacer("), rules))
+    assertTrue(result.text.contains("val size = catalogButtonSize()"), result.text)
+    assertFalse(
+      result.text.contains("Spacer()"),
+      "emitted an uncompilable Spacer():\n${result.text}",
+    )
+    assertEquals(listOf("catalogButtonSize"), result.residue)
+  }
+
+  /** No anchor, or an anchor the file has moved out from under, means "seed it verbatim". */
+  @Test
+  fun `an unusable anchor declines rather than guesses`() {
+    assertNull(PlaygroundSourceCleaner.clean(buttonsKt, null, rules))
+    assertNull(PlaygroundSourceCleaner.clean(buttonsKt, 9_999, rules))
+    assertNull(PlaygroundSourceCleaner.clean(buttonsKt, lineOf("package ee.schimke"), rules))
+  }
+
+  /** Nothing may be rewritten inside a string or a comment. */
+  @Test
+  fun `literals and comments are never rewritten`() {
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.Sticker
+
+      // Sticker is the frame every preview gets.
+      @Composable
+      fun Note() = Sticker {
+        Text("wrapped in a Sticker, counted by counted()")
+      }
+      """
+        .trimIndent()
+    val text =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "Text(\"wrapped"), rules))
+        .text
+    assertTrue(text.contains("\"wrapped in a Sticker, counted by counted()\""), text)
+    assertTrue(text.contains("// Sticker is the frame every preview gets."), text)
+    assertTrue(text.contains("= MaterialTheme {"), text)
+  }
+
+  /**
+   * Generic rules alone — a catalog that has declared nothing still loses this repo's annotations.
+   */
+  @Test
+  fun `generic rules still strip the preview annotations`() {
+    val text = assertNotNull(cleanAt("""caption = "Highest emphasis""")).let { it }
+    val generic = assertNotNull(cleanAt("""caption = "Highest emphasis"""))
+    assertFalse(generic.text.contains("@CatalogComponent"))
+    assertTrue(UsageRules.GENERIC.scaffolds.isEmpty())
+    val withGeneric =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          buttonsKt,
+          lineOf("""caption = "Highest emphasis"""),
+          UsageRules.GENERIC,
+        )
+      )
+    assertFalse(withGeneric.text.contains("@CatalogComponent"), withGeneric.text)
+    assertTrue(withGeneric.text.contains("Sticker {"), "generic rules must not invent a rename")
+    assertTrue(text.text.isNotEmpty())
+  }
+
+  @Test
+  fun `malformed rules degrade to generic rather than failing the handoff`() {
+    assertNull(UsageRules.parse("{ not json"))
+    assertNotNull(UsageRules.parse("""{"scaffoldAnnotationPackages":["a.b"]}"""))
+  }
+
+  /**
+   * A knob that has a plain reading is substituted rather than deleted. `catalogChoice` returns its
+   * default on the baked lane by construction, so the default is what the render on screen was made
+   * with — and it is the biggest single helper in m3-catalog after the frame and the tally.
+   */
+  @Test
+  fun `a choice knob becomes the value the render was baked with`() {
+    val choiceRules =
+      rules.copy(
+        scaffolds =
+          rules.scaffolds +
+            ("catalogChoice" to
+              UsageRules.Scaffold(kind = UsageRules.Kind.SUBSTITUTE, plain = "\$1"))
+      )
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.AssistChip
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.Sticker
+      import ee.schimke.m3catalog.catalogChoice
+
+      @Composable
+      fun Chip() = Sticker {
+        val style = catalogChoice("style", "outlined", "outlined", "elevated")
+        Text(style)
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "val style"), choiceRules))
+    assertTrue(result.text.contains("""val style = "outlined""""), result.text)
+    assertEquals(emptyList(), result.residue)
+  }
+
+  /**
+   * A template citing an argument the call does not carry must leave the call alone rather than
+   * emit a literal `$1` into somebody's editor.
+   */
+  @Test
+  fun `a substitution template that cannot be filled is declined`() {
+    val badRules =
+      rules.copy(
+        scaffolds =
+          mapOf(
+            "catalogChoice" to UsageRules.Scaffold(kind = UsageRules.Kind.SUBSTITUTE, plain = "\$7")
+          )
+      )
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.catalogChoice
+
+      @Composable
+      fun Chip() {
+        Text(catalogChoice("style", "outlined"))
+      }
+      """
+        .trimIndent()
+    val text =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "Text("), badRules)).text
+    assertFalse(text.contains("\$7"), text)
+    assertTrue(text.contains("catalogChoice(\"style\", \"outlined\")"), text)
+  }
+
+  private fun lineIn(text: String, needle: String): Int =
+    text.lines().indexOfFirst { it.contains(needle) } + 1
+}


### PR DESCRIPTION
Prototype for the "source tab" idea: the code a developer needs to *use* a component as displayed, rather than the preview's own source. This PR does the hard half — the derivation and the playground handoff. The viewer tab is the follow-up, and reads the same string.

## The problem

Clicking **playground** from a catalog card hands the editor the preview verbatim. For `Button/Filled` that is ~30 lines, of which two are about `Button`:

```kotlin
@file:CatalogGroup(name = "Buttons", section = "Actions")
package ee.schimke.m3catalog.sections
// …17 imports, 12 of them catalog machinery…

@CatalogComponent(
  id = "Button/Filled",
  reference = "figma:ocdacdEsnHipMJD3egzxKb/57994:2324",
  caption = "Highest emphasis; the primary action. Five sizes x two shapes fold in as variants.",
)
@CatalogModes
@SizeShapeMatrix
@Composable
fun FilledButton() = Sticker {
  val c = counted(stringResource(Res.string.label_filled))
  val size = catalogButtonSize()
  ButtonFrame(size) {
    Button(
      onClick = c.onClick,
      enabled = catalogEnabled(),
      shape = catalogButtonShape(),
      contentPadding = size.contentPadding,
      modifier = Modifier.height(size.containerHeight),
    ) {
      Text(c.label)
    }
  }
}
```

And it is not only noise. Half those names live in the catalog's *own* module while the playground compiles against the published bundle, so the seed note has to warn that unresolved references are expected and should be deleted. Cleaning is what makes the seed **runnable**.

## What lands instead

Same preview, same anchor, after this change — pinned by an exact-match test:

```kotlin
import androidx.compose.material3.Button
import androidx.compose.material3.MaterialTheme
import androidx.compose.material3.Text
import androidx.compose.runtime.Composable
import androidx.compose.ui.tooling.preview.Preview

@Preview
@Composable
fun FilledButton() = MaterialTheme {
  Button(onClick = {}) {
    Text("Filled")
  }
}
```

## How

`PlaygroundSourceCleaner` slices to the clicked declaration, strips the catalog's annotations (resolved through the file's *own* imports, so a rule can only strike an annotation it names), inlines `stringResource(Res.string.label_filled)` as the label actually rendered, applies the catalog's scaffold rules, closes over the same-file helpers the cleaned body still calls, prunes the imports that leaves unused, and stamps a real `@Preview` in place of the meta-annotation it removed.

Five rule kinds, driven by data the catalog declares — `RENAME` (`Sticker` → `MaterialTheme`; the frame *is* a `MaterialTheme`, and unwrapping would leave the snippet unthemed), `UNWRAP`, `DROP`, `INLINE`, `SUBSTITUTE`.

`DROP` is the one that earns its keep: declaring `catalogButtonSize` deletes its binding *and* every named argument mentioning it, so one line removes `contentPadding`, `modifier`, and the rest of the matrix wiring at once.

## Why the rules are the catalog's, not this repo's

`compose-usage.json` at the catalog's repo root, read at the same `ref` the catalog was published from, so rules and source can never be from different revisions. **17 entries for m3-catalog's ~400 components** ([companion PR](https://github.com/yschimke/m3-catalog/pull/63)) — scaffolding changes a few times a year, whereas a per-component snippet mapping would drift on the next sticker edit and fail silently when it did, which is what m3-catalog's README already rejects for name-keyed mapping files.

Cached per `(repo, ref)`, not per card. A catalog that ships no file gets `GENERIC` — annotation stripping and import pruning, which need no catalog knowledge.

## Failing in the safe direction

Text pass, not PSI: the Kotlin frontend is deliberately kept off the CLI classpath (`cli/build.gradle.kts:127-135` — staged into `lib-bta/` for real compiles only), and dragging a compiler frontend into the serve process to prettify a seed would be a bad trade. So the passes are built to decline rather than guess:

- Every pass is masked against string and comment content — nothing is rewritten inside a literal.
- A `DROP` that cannot complete is **abandoned whole**. `Spacer(Modifier.width(size.iconSpacing))` has no argument name to reason about, and dropping the knob would leave `Spacer()`, which does not compile. Clean-looking broken code is strictly worse than noisy code that runs, so the knob is restored and the helper reported as *residue*.
- Anything the cleaner declines falls back to the verbatim slice that worked before; a cleaner exception is caught and does the same.
- The seed note now says which of the three a visitor is looking at, and names any residue, instead of over-promising.

## Known gap, deliberately not papered over

m3-catalog's destructuring state helpers (`toggleable`, `selectable`, `multiSelectable`, `editable` — ~18 stickers) have no rule kind yet; their plain form is real remembered state. They surface as residue and are recorded in the companion PR rather than silently mis-cleaned.

## Test plan

- `:cli:test` — full suite green (`./gradlew :cli:test`), including 13 new cases.
- `PlaygroundSourceCleanerTest` — fixture is a **verbatim extract of m3-catalog's `Buttons.kt`**, not a tidied stand-in. Exact-match assertions on both the simple variant and the matrix-driven sticker; plus annotation removal, `@Preview` stamping against `PlaygroundPreviewDiscoverer`'s own recognised FQNs, package dropping, same-file closure, the abandoned-`DROP` fail-safe, literal/comment safety, and generic-rules fallback.
- `PlaygroundSeedResolverTest` — end-to-end through the real handoff with an injected fetcher: cleaned seed, rules fetched once per catalog ref, missing rules file, and no-anchor verbatim fallback.
- `:cli:ktfmtFormat` clean.

No visual surface changes in this PR — the derivation is text, and the editor buffer is what changes. The viewer's Source tab, which is the visual half, is the follow-up.

## Follow-ups

1. **Source tab on `/p/<id>`** in the lane switcher, reading this same string.
2. **`usage` on `catalog.json`** — arguably the highest-value consumer, since that is what agents and MCP read.
3. **Upgrade `code-connect.json`'s `codeSnippet`** from the `TODO("() -> Unit")` skeleton `renderCallSite` emits today to this real usage.
4. **`@CatalogScaffold` on the helpers**, projected into the manifest by discovery, replacing the JSON file — puts the declaration next to the thing it describes and covers per-section private helpers like `ButtonFrame` properly.
5. **The pixel gate.** Emit each snippet as a generated `@Preview` so the existing render pipeline diffs `Usage_FilledButton.png` against `FilledButton.png` — a cleaning rule that lies then shows up as a picture, on the PR that broke it.