### PR TITLE
fix(serve): stop the usage cleaner emitting seeds that do not compile

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
@@ -55,6 +55,19 @@ data class PlaygroundSeed(
    * carrying names that will not resolve — and the note says so instead of over-promising.
    */
   val residue: List<String> = emptyList(),
+  /**
+   * True when the catalog actually declared what its own helpers mean (a `compose-usage.json` with
+   * scaffold rules), as opposed to getting [UsageRules.GENERIC].
+   *
+   * The distinction has to reach the editor's note, because the two produce very different buffers
+   * from the same code path. With rules, `Sticker`/`counted`/the knobs are resolved away and "press
+   * Run" is true. Without them only the shared annotations come off — the catalog's own helpers
+   * stay exactly where they were, and they will not resolve against the published bundle. They are
+   * not [residue] either, since residue reports *declared* scaffolding that survived a rule and
+   * under generic rules nothing was declared. So without this flag the note claimed the frame and
+   * knobs were gone while they were still on screen.
+   */
+  val scaffoldsDeclared: Boolean = false,
 )
 
 /**
@@ -207,6 +220,7 @@ class PlaygroundSeedResolver(
         sliced = cleaned != null || sliced != null,
         cleaned = cleaned != null,
         residue = cleaned?.residue.orEmpty(),
+        scaffoldsDeclared = cleaned != null && rulesFor(where).scaffolds.isNotEmpty(),
       )
     // Bounded, and deliberately not an LRU: entries are a few KB, a catalog has a fixed number of
     // previews, and a full cache means the ones people actually open are already served from it. A
@@ -255,7 +269,13 @@ class PlaygroundSeedResolver(
         ?.takeIf { it.size <= maxBytes }
         ?.decodeToString()
         ?.let { UsageRules.parse(it, onLog) } ?: UsageRules.GENERIC
-    rulesCache[key] = rules to now
+    // Bounded and swept, like the seed cache beside it. A TTL alone only stops an expired value
+    // being *returned* — it never removes the key, so a long-running host seeing catalogs
+    // republished under changing refs would keep an entry per historical ref forever, each holding
+    // a
+    // parsed rules object and (below) up to the fetch cap of string data.
+    evictExpired(rulesCache, now)
+    if (rulesCache.size < maxEntries) rulesCache[key] = rules to now
     return rules
   }
 
@@ -294,8 +314,14 @@ class PlaygroundSeedResolver(
         STRING_RESOURCE.findAll(text).associate {
           it.groupValues[1] to unescapeAndroidString(it.groupValues[2])
         }
-    stringsCache[key] = strings to now
+    evictExpired(stringsCache, now)
+    if (stringsCache.size < maxEntries) stringsCache[key] = strings to now
     return strings
+  }
+
+  /** Drops every entry past its TTL. Called before an insert, so the caps stay reachable. */
+  private fun <K, V> evictExpired(cache: ConcurrentHashMap<K, Pair<V, Long>>, now: Long) {
+    cache.entries.removeIf { now - it.value.second >= ttlSeconds * 1000 }
   }
 
   companion object {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -174,9 +174,18 @@ object PlaygroundSourceCleaner {
    * pattern unanchored would match the `val c = counted(…)` inside a body and report the block as
    * declaring `c`.
    */
+  /**
+   * Modifiers are matched as "any run of lowercase words" rather than as a closed list. Kotlin has
+   * many, and a closed list missed exactly the ones that change what a declaration *is* — `data
+   * class`, `enum class`, `sealed class`, `value class`. A preview referencing a same-file `data
+   * class Model` then had that block left out of the closure while the seed still claimed to be
+   * clean, so `Model(...)` came back unresolved with no residue to warn about it. Over-matching is
+   * harmless here: the pattern is still anchored at column 0 and still has to reach a real
+   * declaration keyword.
+   */
   private val DECLARATION =
     Regex(
-      """^(?:(?:private|internal|public|expect|actual)\s+)*(?:fun|val|var|class|object|interface)\s+(?:<[^>]*>\s+)?([A-Za-z_][A-Za-z0-9_]*)"""
+      """^(?:[a-z]+\s+)*(?:fun|val|var|class|object|interface|typealias)\s+(?:<[^>]*>\s+)?([A-Za-z_][A-Za-z0-9_]*)"""
     )
 
   /**
@@ -192,20 +201,31 @@ object PlaygroundSourceCleaner {
   // Header
   // ---------------------------------------------------------------------------------------------
 
-  /** simple name (or alias) → fully-qualified name, for every `import` in the file. */
-  private fun importMap(lines: List<String>): Map<String, String> {
-    val out = LinkedHashMap<String, String>()
-    for (line in lines) {
-      val t = line.trim()
-      if (!t.startsWith("import ")) continue
-      val spec = t.removePrefix("import ").trim()
-      val alias = spec.substringAfter(" as ", "").trim()
-      val fqn = spec.substringBefore(" as ").trim()
-      val simple = alias.ifEmpty { fqn.substringAfterLast('.') }
-      if (simple.isNotEmpty()) out[simple] = fqn
-    }
-    return out
+  /**
+   * One `import` line: what the body refers to it by ([name] — the alias when there is one), where
+   * it points, and how to write it back out.
+   *
+   * Aliases are carried rather than collapsed to the FQN's last segment. Deriving the name from the
+   * FQN would look up `Bar` for `import foo.Bar as Baz` — so a body that says `Baz` would prune the
+   * import it needs, and an import that survived would be re-emitted without its `as Baz`.
+   */
+  private data class Import(val name: String, val fqn: String, val alias: String?) {
+    fun render(): String = if (alias == null) "import $fqn" else "import $fqn as $alias"
   }
+
+  private fun importsOf(lines: List<String>): List<Import> = lines.mapNotNull { line ->
+    val t = line.trim()
+    if (!t.startsWith("import ")) return@mapNotNull null
+    val spec = t.removePrefix("import ").trim()
+    val alias = spec.substringAfter(" as ", "").trim().ifEmpty { null }
+    val fqn = spec.substringBefore(" as ").trim()
+    val name = alias ?: fqn.substringAfterLast('.')
+    if (name.isEmpty()) null else Import(name, fqn, alias)
+  }
+
+  /** Name → FQN, for resolving an annotation's simple name against the file's own imports. */
+  private fun importMap(lines: List<String>): Map<String, String> =
+    importsOf(lines).associate { it.name to it.fqn }
 
   /**
    * The cleaned file header: the imports [body] still uses, plus the ones the rewrites introduced,
@@ -228,31 +248,56 @@ object PlaygroundSourceCleaner {
     rules: UsageRules,
     residue: MutableSet<String>,
   ): String {
+    // Kept whole, by paren balance rather than by line. A ktfmt-wrapped
+    // `@file:OptIn(\n  A::class,\n  B::class,\n)` is one annotation across five lines, and a
+    // line-at-a-time filter would emit its opening line alone — an unterminated annotation, and a
+    // header that then prunes the imports only its discarded arguments referenced.
     val fileAnnotations =
-      lines
-        .takeWhile { !it.trimStart().startsWith("package ") }
-        .filter { it.trimStart().startsWith("@file:") }
-        .filterNot { line ->
-          val name =
-            line.trim().removePrefix("@file:").takeWhile { it.isLetterOrDigit() || it == '_' }
-          isScaffoldAnnotation(name, imports, rules)
-        }
+      annotationBlocks(lines.takeWhile { !it.trimStart().startsWith("package ") })
+        .filterNot { isScaffoldAnnotation(it.name, imports, rules) }
+        .map { it.text }
     val kept =
-      imports.values.filter { fqn ->
-        val simple = fqn.substringAfterLast('.')
-        if (isScaffoldPackage(fqn, rules)) {
+      importsOf(lines).filter { import ->
+        if (isScaffoldPackage(import.fqn, rules)) {
           // A scaffold import that is still referenced means a rule is missing, not that the import
           // should be kept — record it and drop it, so the residue names the gap.
-          if (mentionsWord(body, simple)) residue.add(simple)
+          if (mentionsIdentifier(body, import.name)) residue.add(import.name)
           false
         } else {
-          mentionsWord(body, simple) || fileAnnotations.any { mentionsWord(it, simple) }
+          mentionsIdentifier(body, import.name) ||
+            fileAnnotations.any { mentionsIdentifier(it, import.name) }
         }
       }
-    val all = (kept + addedImports).distinct().sorted().map { "import $it" }
+    val all = (kept.map { it.render() } + addedImports.map { "import $it" }).distinct().sorted()
     return (fileAnnotations + (if (fileAnnotations.isEmpty()) emptyList() else listOf("")) + all)
       .joinToString("\n")
       .trim()
+  }
+
+  private data class AnnotationBlock(val name: String, val text: String)
+
+  /**
+   * The file-level annotations in [lines], each as one block however many lines it spans. Also used
+   * by [stripScaffoldAnnotations], so the two agree about where an annotation ends.
+   */
+  private fun annotationBlocks(lines: List<String>): List<AnnotationBlock> {
+    val out = mutableListOf<AnnotationBlock>()
+    var i = 0
+    while (i < lines.size) {
+      if (!lines[i].trimStart().startsWith("@file:")) {
+        i++
+        continue
+      }
+      val end = annotationEnd(lines, i)
+      out.add(
+        AnnotationBlock(
+          name = annotationName(lines[i]),
+          text = lines.subList(i, end + 1).joinToString("\n"),
+        )
+      )
+      i = end + 1
+    }
+    return out
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -318,24 +363,34 @@ object PlaygroundSourceCleaner {
         i++
         continue
       }
-      val name =
-        trimmed.removePrefix("@").removePrefix("file:").takeWhile {
-          it.isLetterOrDigit() || it == '_'
-        }
-      // Consume the whole annotation, however many lines its argument list spans.
-      var depth = 0
-      var end = i
-      while (end < lines.size) {
-        depth += parenBalance(lines[end])
-        if (depth <= 0) break
-        end++
+      val end = annotationEnd(lines, i)
+      if (!isScaffoldAnnotation(annotationName(line), imports, rules)) {
+        for (j in i..end) out.add(lines[j])
       }
-      if (!isScaffoldAnnotation(name, imports, rules)) {
-        for (j in i..minOf(end, lines.lastIndex)) out.add(lines[j])
-      }
-      i = minOf(end, lines.lastIndex) + 1
+      i = end + 1
     }
     return out.joinToString("\n")
+  }
+
+  /** `@file:OptIn(...)` / `@CatalogComponent(...)` → `OptIn` / `CatalogComponent`. */
+  private fun annotationName(line: String): String =
+    line.trimStart().removePrefix("@").removePrefix("file:").takeWhile {
+      it.isLetterOrDigit() || it == '_'
+    }
+
+  /**
+   * The index of the last line of the annotation starting at [start] — the same line when it takes
+   * no arguments or fits on one, and the line closing its argument list when ktfmt has wrapped it.
+   */
+  private fun annotationEnd(lines: List<String>, start: Int): Int {
+    var depth = 0
+    var end = start
+    while (end < lines.size) {
+      depth += parenBalance(lines[end])
+      if (depth <= 0) break
+      end++
+    }
+    return minOf(end, lines.lastIndex)
   }
 
   private fun parenBalance(line: String): Int {
@@ -359,11 +414,22 @@ object PlaygroundSourceCleaner {
    */
   private fun inlineStringResources(text: String, strings: Map<String, String>): String {
     if (strings.isEmpty()) return text
-    return Regex("""stringResource\(\s*Res\.string\.([A-Za-z0-9_]+)\s*\)""").replace(text) { m ->
-      strings[m.groupValues[1]]?.let {
-        "\"" + it.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
-      } ?: m.value
+    // Masked like every other pass. A doc comment or a literal may quote a lookup verbatim
+    // (`Text("Use stringResource(Res.string.label)")`), and substituting there would splice a
+    // quoted string into the middle of a quoted string.
+    val mask = codeMask(text)
+    val sb = StringBuilder()
+    var last = 0
+    for (m in Regex("""stringResource\(\s*Res\.string\.([A-Za-z0-9_]+)\s*\)""").findAll(text)) {
+      val value = strings[m.groupValues[1]] ?: continue
+      if (!mask[m.range.first]) continue
+      sb.append(text, last, m.range.first)
+      sb.append("\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"")
+      last = m.range.last + 1
     }
+    if (last == 0) return text
+    sb.append(text, last, text.length)
+    return sb.toString()
   }
 
   private fun applyRename(
@@ -394,12 +460,22 @@ object PlaygroundSourceCleaner {
         val lambdaClose = matchBrace(out, lambdaOpen) ?: break
         val inner = out.substring(lambdaOpen + 1, lambdaClose)
         val callIndent = indentOf(out, call.start)
-        // Splice from the start of the call's *line*, not from the call itself: the line's own
-        // indent is already the column the body is being re-indented to, and leaving it in place
-        // would indent the lifted body twice.
         val lineStart = out.lastIndexOf('\n', call.start - 1) + 1
+        val prefix = out.substring(lineStart, call.start)
+        val body = dedent(inner, callIndent)
+        // Where the splice starts depends on what precedes the call on its own line.
+        //
+        // When the line is only indentation, splice from the line start: that indent is already the
+        // column the lifted body is being re-indented to, and keeping it would indent it twice.
+        //
+        // When something else precedes it, that something belongs to the declaration — the wrapper
+        // is the expression body of the preview (`fun Card() = ButtonFrame(size) { … }`). Splicing
+        // from the line start there deleted `fun Card() =` along with the wrapper, left the lifted
+        // body at top level, and still called the result cleaned. So keep the prefix, and drop the
+        // body's own first-line indent, which the prefix now supplies.
         out =
-          out.substring(0, lineStart) + dedent(inner, callIndent) + out.substring(lambdaClose + 1)
+          if (prefix.isBlank()) out.substring(0, lineStart) + body + out.substring(lambdaClose + 1)
+          else out.substring(0, call.start) + body.trimStart() + out.substring(lambdaClose + 1)
       }
     }
     return out
@@ -449,13 +525,21 @@ object PlaygroundSourceCleaner {
       if (scaffold.kind != UsageRules.Kind.INLINE) continue
       var guard = 0
       while (guard++ < MAX_REWRITES) {
-        val binding = findBinding(out, name) ?: break
-        out = removeLines(out, binding.lineRange)
-        for ((member, template) in scaffold.members) {
-          val replacement =
+        val binding = findValBinding(out, name) ?: break
+        val replacements =
+          scaffold.members.mapValues { (_, template) ->
             Regex("""\$(\d+)""").replace(template) { m ->
               binding.arguments.getOrNull(m.groupValues[1].toInt())?.trim() ?: m.value
             }
+          }
+        // The same guard applySubstitute carries, and for the same reason — plus a worse failure
+        // if it is missing. A template citing an argument the call does not supply emits a literal
+        // `$1` into the editor, and this path would already have deleted the binding that made the
+        // code work. Leave the declaration alone; the residue check then reports the unwritten
+        // rule.
+        if (replacements.values.any { it.contains(Regex("""\$\d""")) }) break
+        out = removeLines(out, binding.lineRange)
+        for ((member, replacement) in replacements) {
           out = replaceWord(out, "${binding.name}.$member", replacement)
         }
       }
@@ -491,8 +575,8 @@ object PlaygroundSourceCleaner {
       dropped.add(name)
       var guard = 0
       while (guard++ < MAX_REWRITES) {
-        val binding = findBinding(out, name) ?: break
-        if (binding.name.isNotEmpty()) dropped.add(binding.name)
+        val binding = findValBinding(out, name) ?: break
+        dropped.add(binding.name)
         out = removeLines(out, binding.lineRange)
       }
     }
@@ -607,6 +691,37 @@ object PlaygroundSourceCleaner {
   internal fun mentionsWord(text: String, word: String): Boolean =
     wordOccurrences(text, word).isNotEmpty()
 
+  /**
+   * Whether [text] refers to [name] *at all*, including as the member half of a qualified
+   * expression — which is what deciding an import's fate requires, and what [mentionsWord] must not
+   * do.
+   *
+   * [mentionsWord] rejects an occurrence preceded by `.`, correctly: it drives the rewrites, and
+   * `foo.counted` is not the `counted` a scaffold rule means. But Compose is built on imported
+   * extensions used through receiver syntax — `Modifier.padding(16.dp)`, `16.dp`,
+   * `Modifier.height(…)` — where every reference to the imported name follows a dot. Pruning on the
+   * strict test therefore deleted `import androidx.compose.foundation.layout.padding` and `import
+   * androidx.compose.ui.unit.dp` out from under a body that still used them, producing a seed
+   * advertised as runnable that did not compile, with no residue to say so.
+   *
+   * Erring the other way costs an unused import — a warning, not a failure — which is the direction
+   * this whole pass is supposed to fail in.
+   */
+  private fun mentionsIdentifier(text: String, name: String): Boolean {
+    val mask = codeMask(text)
+    var from = 0
+    while (true) {
+      val at = text.indexOf(name, from).takeIf { it >= 0 } ?: return false
+      from = at + 1
+      if (!mask[at]) continue
+      val before = text.getOrNull(at - 1)
+      val after = text.getOrNull(at + name.length)
+      if (before?.let { isIdentifierChar(it) } == true) continue
+      if (after?.let { isIdentifierChar(it) } == true) continue
+      return true
+    }
+  }
+
   private fun replaceWord(text: String, word: String, replacement: String): String {
     val hits = wordOccurrences(text, word)
     if (hits.isEmpty()) return text
@@ -620,34 +735,46 @@ object PlaygroundSourceCleaner {
     return sb.toString()
   }
 
-  private fun findCall(text: String, name: String): Call? {
-    for (at in wordOccurrences(text, name)) {
+  private fun findCall(text: String, name: String): Call? = findCalls(text, name).firstOrNull()
+
+  private fun findCalls(text: String, name: String): List<Call> =
+    wordOccurrences(text, name).mapNotNull { at ->
       var k = at + name.length
       while (k < text.length && text[k].isWhitespace()) k++
-      if (k < text.length && text[k] == '(') {
-        val close = matchParen(text, k) ?: continue
-        return Call(at, k, close)
-      }
+      if (k < text.length && text[k] == '(') matchParen(text, k)?.let { Call(at, k, it) } else null
+    }
+
+  /**
+   * `val <name> = <scaffold>(<args>)` — the binding, its arguments, and the lines it occupies, or
+   * **null when the call is not bound to a `val` at all**.
+   *
+   * Reporting an unbound call as a nameless binding, as this first did, was a real bug and not a
+   * tidy default. Both callers delete `lineRange`, and for a direct call that range is the whole
+   * physical line the call sits on — so a ktfmt-legal one-liner `Button(onClick = {}, enabled =
+   * catalogEnabled()) { … }` was deleted **whole** rather than merely losing its `enabled`
+   * argument, and the cleaner then returned an empty themed preview with no residue to show for it.
+   * It looked right on the fixture only because ktfmt had wrapped that call and put every knob on a
+   * line of its own, where deleting the line happens to be the correct answer.
+   *
+   * An unbound call is not this function's business: [filterCallArguments] removes it where it sits
+   * in a named argument, and the survivor check reports it where it does not.
+   */
+  private fun findValBinding(text: String, scaffold: String): Binding? {
+    for (call in findCalls(text, scaffold)) {
+      val lineStart = text.lastIndexOf('\n', call.start - 1) + 1
+      val prefix = text.substring(lineStart, call.start)
+      val name =
+        Regex("""^\s*val\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*$""").find(prefix)?.groupValues?.get(1)
+          ?: continue
+      val args =
+        splitTopLevel(text.substring(call.argsStart + 1, call.argsEnd)).map {
+          it.trim(',', ' ', '\n')
+        }
+      val firstLine = text.substring(0, lineStart).count { it == '\n' }
+      val lastLine = text.substring(0, call.argsEnd).count { it == '\n' }
+      return Binding(name, args, firstLine..lastLine)
     }
     return null
-  }
-
-  /** `val <name> = <scaffold>(<args>)` — the binding, its arguments, and the lines it occupies. */
-  private fun findBinding(text: String, scaffold: String): Binding? {
-    val call = findCall(text, scaffold) ?: return null
-    val lineStart = text.lastIndexOf('\n', call.start - 1) + 1
-    val prefix = text.substring(lineStart, call.start)
-    val match = Regex("""^\s*val\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*$""").find(prefix)
-    val name = match?.groupValues?.get(1)
-    val args =
-      splitTopLevel(text.substring(call.argsStart + 1, call.argsEnd)).map {
-        it.trim(',', ' ', '\n')
-      }
-    val firstLine = text.substring(0, lineStart).count { it == '\n' }
-    val lastLine = text.substring(0, call.argsEnd).count { it == '\n' }
-    // A scaffold call that is not bound to a `val` still needs consuming, or the loop that calls
-    // this would spin on it forever. Reported with an empty name, which matches nothing downstream.
-    return Binding(name ?: "", args, firstLine..lastLine)
   }
 
   private fun matchParen(text: String, open: Int): Int? = matchDelimiter(text, open, '(', ')')

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4000,7 +4000,23 @@ object ServeWeb {
         // Which of the three it is matters to a reader, and they promise different things. A
         // cleaned seed is usage code — the catalog's annotations, sticker frame, click tally and
         // knobs resolved away — so it may say "ready to Run"; the other two may not.
-        if (seed.cleaned) {
+        if (seed.cleaned && !seed.scaffoldsDeclared) {
+          // Cleaned, but by the generic rules alone: this catalog has not said what its own helpers
+          // mean, so only the shared annotations came off and its `Sticker`/`counted`/knob calls
+          // are
+          // still in the buffer. Claiming "the sticker frame and knobs are gone, press Run" here
+          // would be describing a different seed than the one on screen.
+          """
+
+          <p id="pg-seed" class="cp-sub">Opened from $where — <code>${
+              WebEscaping.htmlEscape(seed.previewId)
+            }</code> in <code>${WebEscaping.htmlEscape(seed.catalog)}</code>, with the catalog
+            annotations removed. <code>${
+              WebEscaping.htmlEscape(seed.catalog)
+            }</code> has not declared what its own helpers mean in plain Compose, so the ones this
+            preview uses are still here and will not resolve against the published catalog — delete
+            them or replace them with your own values.</p>"""
+        } else if (seed.cleaned) {
           val caveat =
             if (seed.residue.isEmpty()) ""
             else {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -450,6 +450,242 @@ class PlaygroundSourceCleanerTest {
     assertTrue(text.contains("catalogChoice(\"style\", \"outlined\")"), text)
   }
 
+  // -----------------------------------------------------------------------------------------
+  // Regressions found by review of the first cut. Each of these produced a seed that was
+  // advertised as runnable and did not compile — the one failure mode the design says it must
+  // not have. They survived the original fixture because ktfmt had wrapped its calls, putting
+  // every knob on a line of its own where the buggy behaviour happened to be correct.
+  // -----------------------------------------------------------------------------------------
+
+  /**
+   * Compose is built on imported extensions reached through receiver syntax, where every reference
+   * to the imported name follows a dot. Pruning imports on the strict word test deleted `padding`
+   * and `dp` out from under a body that still used them.
+   */
+  @Test
+  fun `imports used through receiver syntax survive the prune`() {
+    val source =
+      """
+      package demo
+
+      import androidx.compose.foundation.layout.padding
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.unit.dp
+      import ee.schimke.m3catalog.Sticker
+
+      @Composable
+      fun Padded() = Sticker {
+        Text("hi", modifier = Modifier.padding(16.dp))
+      }
+      """
+        .trimIndent()
+    val text =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "Text(\"hi\""), rules))
+        .text
+    assertTrue(text.contains("import androidx.compose.foundation.layout.padding"), text)
+    assertTrue(text.contains("import androidx.compose.ui.unit.dp"), text)
+    assertTrue(text.contains("import androidx.compose.ui.Modifier"), text)
+  }
+
+  /** An aliased import must keep both the name the body uses and its `as` clause. */
+  @Test
+  fun `aliased imports keep their alias`() {
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.Text as Label
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.Sticker
+
+      @Composable
+      fun Aliased() = Sticker {
+        Label("hi")
+      }
+      """
+        .trimIndent()
+    val text =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "Label(\"hi\")"), rules))
+        .text
+    assertTrue(text.contains("import androidx.compose.material3.Text as Label"), text)
+  }
+
+  /**
+   * The worst of them. A ktfmt-legal one-line call with a DROP helper in a named argument was
+   * deleted whole, because the unbound call reported a "binding" whose line range was the entire
+   * call's line — leaving an empty themed preview, with no residue to show for it.
+   */
+  @Test
+  fun `a drop helper on a one-line call loses only its argument`() {
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.Button
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.Sticker
+      import ee.schimke.m3catalog.catalogEnabled
+
+      @Composable
+      fun One() = Sticker {
+        Button(onClick = {}, enabled = catalogEnabled()) { Text("Go") }
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "Button("), rules))
+    assertTrue(result.text.contains("""Button(onClick = {}) { Text("Go") }"""), result.text)
+    assertEquals(emptyList(), result.residue)
+  }
+
+  /**
+   * An UNWRAP helper as the preview's expression body must not take `fun Card() =` with it. The
+   * splice started at the line, not at the call.
+   */
+  @Test
+  fun `unwrapping an expression body keeps the declaration`() {
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.ButtonFrame
+
+      @Composable
+      fun Card() = ButtonFrame(2) {
+        Text("inside")
+      }
+      """
+        .trimIndent()
+    val text =
+      assertNotNull(
+          PlaygroundSourceCleaner.clean(source, lineIn(source, "Text(\"inside\")"), rules)
+        )
+        .text
+    assertTrue(text.contains("fun Card() ="), text)
+    assertFalse(text.contains("ButtonFrame"), text)
+  }
+
+  /** A same-file `data class` the body still needs must come along with it. */
+  @Test
+  fun `modified type declarations are recognised by the closure`() {
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.Sticker
+
+      data class Model(val label: String)
+
+      @Composable
+      fun Row() = Sticker {
+        Text(Model("hi").label)
+      }
+      """
+        .trimIndent()
+    val text =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "Text(Model"), rules)).text
+    assertTrue(text.contains("data class Model(val label: String)"), text)
+  }
+
+  /** A wrapped `@file:OptIn(...)` must be emitted whole, not as its opening line. */
+  @Test
+  fun `a multiline file annotation survives intact`() {
+    val source =
+      """
+      @file:OptIn(
+        ExperimentalMaterial3ExpressiveApi::class,
+        ExperimentalMaterial3Api::class,
+      )
+
+      package demo
+
+      import androidx.compose.material3.ExperimentalMaterial3Api
+      import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.Sticker
+
+      @Composable
+      fun Opted() = Sticker {
+        Text("hi")
+      }
+      """
+        .trimIndent()
+    val text =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "Text(\"hi\")"), rules))
+        .text
+    assertTrue(text.contains("ExperimentalMaterial3Api::class,\n)"), text)
+    assertTrue(text.contains("import androidx.compose.material3.ExperimentalMaterial3Api"), text)
+  }
+
+  /** String-resource inlining is masked like every other pass. */
+  @Test
+  fun `a resource lookup quoted inside a literal is not substituted`() {
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.Sticker
+
+      @Composable
+      fun Doc() = Sticker {
+        Text("Use stringResource(Res.string.label_filled) for the label")
+      }
+      """
+        .trimIndent()
+    val text =
+      assertNotNull(
+          PlaygroundSourceCleaner.clean(source, lineIn(source, "Use string"), rules, strings)
+        )
+        .text
+    assertTrue(
+      text.contains("""Text("Use stringResource(Res.string.label_filled) for the label")"""),
+      text,
+    )
+  }
+
+  /** An INLINE template citing an argument the call lacks must not delete the binding either. */
+  @Test
+  fun `an inline template that cannot be filled leaves the code alone`() {
+    val badRules =
+      rules.copy(
+        scaffolds =
+          mapOf(
+            "counted" to
+              UsageRules.Scaffold(kind = UsageRules.Kind.INLINE, members = mapOf("label" to "\$3"))
+          )
+      )
+    val source =
+      """
+      package demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.counted
+
+      @Composable
+      fun Tally() {
+        val c = counted("Filled")
+        Text(c.label)
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "val c ="), badRules))
+    assertFalse(result.text.contains("\$3"), result.text)
+    assertTrue(result.text.contains("""val c = counted("Filled")"""), result.text)
+    assertEquals(listOf("counted"), result.residue)
+  }
+
   private fun lineIn(text: String, needle: String): Int =
     text.lines().indexOfFirst { it.contains(needle) } + 1
 }


### PR DESCRIPTION
Follow-up to #3816, which merged while the Codex review was still landing. That review found **eight ways the cleaner could return a buffer advertised as runnable that does not build** — the one failure mode the design says it must not have. All are real, all are fixed here, and each has a test that **fails against #3816 and passes against this branch**.

They shared a root cause worth recording: the fixture was a verbatim extract of `Buttons.kt`, where ktfmt had wrapped every call and put each knob on a line of its own. That is exactly the shape in which several of these bugs are indistinguishable from correct behaviour. A more realistic fixture was not a stricter one.

## Correctness

| | Was | Now |
|---|---|---|
| **Receiver-style imports** (P1) | `mentionsWord` rejects any occurrence preceded by `.` — right for driving rewrites, wrong for imports. Compose is built on imported extensions reached that way, so `Modifier.padding(16.dp)` had `padding` and `dp` pruned out from under it | Import retention uses a laxer identifier test. Erring the other way costs an unused import — a warning, not a failure, which is the direction this pass is meant to fail in |
| **Direct `DROP` call** (P1) | An unbound helper reported a nameless binding whose line range was the call's whole physical line, so a one-line `Button(onClick = {}, enabled = catalogEnabled()) { … }` was deleted **entire** rather than losing one argument — an empty themed preview, no residue | `findValBinding` returns null for unbound calls. The argument filter and survivor check already handled them |
| **`UNWRAP` as expression body** (P1) | Splice started at the line, not the call, so `fun Card() = ButtonFrame(size) { … }` lost `fun Card() =` and left the body at top level | Keeps the prefix when one is present |
| **Aliased imports** (P2) | Keyed by the FQN's last segment, so `import foo.Bar as Baz` pruned when the body said `Baz`, and re-emitted without `as Baz` | `Import` carries the alias through both |
| **Modified type declarations** (P2) | Closed modifier list omitted exactly the ones that change what a declaration *is* — `data`/`enum`/`sealed`/`value` — so a same-file `data class Model` was left out of the closure | Matches any lowercase modifier run |
| **Multi-line `@file:OptIn`** (P2) | Filtered line by line, emitting the opening line alone: unterminated annotation, plus loss of imports only its discarded arguments referenced | Consumed by paren balance, sharing `annotationEnd` with the strip pass so the two cannot disagree |
| **Unmasked string inlining** (P2) | The one pass not masked, so `Text("Use stringResource(Res.string.label)")` had a quoted string spliced into the middle of a quoted string | Masked like every other pass |
| **`INLINE` placeholder** (P2) | A template citing a missing argument emitted a literal `$1` *and* deleted the binding that made the code work | Declines the declaration, as the substitution pass already did |

## Honesty and hygiene

- **The note over-claimed under generic rules.** With no `compose-usage.json`, only the shared annotations come off and the catalog's own `Sticker`/`counted`/knobs stay. They are not residue — residue reports *declared* scaffolding that survived a rule, and nothing was declared — so the seed said "the sticker frame and knobs are gone, press Run" while they were still on screen. New `scaffoldsDeclared` flag drives a third note that says what actually happened. (My own resolver test had asserted the wrong state here.)
- **Unbounded caches.** The rules and strings caches only *expired* values, never removed keys, so a host seeing catalogs republished under changing refs grew an entry per historical ref forever. Now swept and bounded, like the seed cache beside them.

## Test plan

- `./gradlew :cli:test` — full suite green. `PlaygroundSourceCleanerTest` 13 → 21 cases.
- **Verified the tests bite**: restoring `PlaygroundSourceCleaner.kt` from `origin/main` and re-running gives `21 tests completed, 8 failed` — precisely the eight new regressions. Restored, green again.
- `./gradlew :cli:ktfmtFormat` clean.

Non-visual (text derivation + an editor note), so no render evidence applies.

## Still open from the original plan

Unchanged by this PR: the viewer's Source tab, `usage` on `catalog.json`, upgrading `code-connect.json`'s `codeSnippet`, `@CatalogScaffold` replacing the JSON file, and the pixel gate. The last one is the real answer to this class of bug — rendering each snippet as a generated `@Preview` and diffing it against the sticker's own PNG would have caught the empty-preview case as a picture, without anyone having to think of the fixture shape that exposes it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_