### PR TITLE
fix(renderer): sweep .error.json companions with stale fan-out rows

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -368,6 +368,14 @@ object PreviewManifestLoader {
    *   written. The manifest-wide set makes that impossible (every fork's outputs are expected), and
    *   gating the sweep on [ownedIds] additionally keeps forks whose shard was assigned none of a
    *   preview's fan-out from redundantly re-sweeping its prefix.
+   *
+   * A stale row's companions go with it. A failed row writes `<stem>_<label><ext>.error.json`
+   * ([RenderErrorSidecar]) and no PNG, so an extension-only filter never matched the one file the
+   * row actually left behind, and the orphan outlived every subsequent run — the CLI's
+   * missing-render report then rediscovers it by directory glob and can present an obsolete
+   * exception as a failure of the current run (PR #3815). A companion is classified by the output
+   * it names ([fanoutOutputNameOf]), so it is kept exactly when that output is expected and swept
+   * exactly when that output is stale.
    */
   internal fun deleteStaleFanoutFiles(
     outDir: File?,
@@ -395,7 +403,8 @@ object PreviewManifestLoader {
         dir
           .listFiles()
           ?.filter { f ->
-            f.name.startsWith(prefix) && f.name.endsWith(ext) && f.name !in expectedNames
+            val output = fanoutOutputNameOf(f.name, ext)
+            f.name.startsWith(prefix) && output != null && output !in expectedNames
           }
           ?.forEach { f ->
             if (!f.delete()) {
@@ -404,6 +413,32 @@ object PreviewManifestLoader {
           }
       }
     }
+  }
+
+  /**
+   * Suffixes a renderer appends to a render output's own file name to make a companion that lives
+   * beside it — `renders/Foo.png` → `renders/Foo.png.error.json` ([RenderErrorSidecar.pathFor]) and
+   * `renders/Foo.png.warnings.json` ([RenderWarningsSidecar.pathFor]).
+   *
+   * Kept in sync with the desktop renderer's `RENDER_COMPANION_SUFFIXES`: the two sweeps answer the
+   * same question about the same directory layout, and a suffix known to one but not the other
+   * would leave an orphan on whichever backend rendered the module.
+   */
+  internal val RENDER_COMPANION_SUFFIXES = listOf(".error.json", ".warnings.json")
+
+  /**
+   * The render output [name] belongs to: [name] itself when it is an `[ext]` output, the output it
+   * names when it is one of that output's [RENDER_COMPANION_SUFFIXES] companions, and `null`
+   * otherwise.
+   *
+   * Companions are matched before the plain extension so an output whose own extension is `.json`
+   * resolves `Foo_Alice.json.error.json` to `Foo_Alice.json` rather than to itself.
+   */
+  internal fun fanoutOutputNameOf(name: String, ext: String): String? {
+    RENDER_COMPANION_SUFFIXES.forEach { companion ->
+      if (name.endsWith(ext + companion)) return name.removeSuffix(companion)
+    }
+    return name.takeIf { it.endsWith(ext) }
   }
 
   private fun fanoutLeaf(renderOutput: String): String? {

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
@@ -114,6 +114,66 @@ class PreviewManifestLoaderStaleFanoutTest {
     assertFalse(File(tmp.root, "Foo_Dark_stale.png").exists())
   }
 
+  /**
+   * The orphan PR #3815 hit: a row that FAILED writes only `<row>.png.error.json`, never a PNG, so
+   * the sweep's extension filter matched nothing and the sidecar survived the provider rename that
+   * retired the row. The CLI's missing-render report then rediscovers it by directory glob and can
+   * present a dead exception as a failure of the current run. A companion is classified by the
+   * output it names, so it lives and dies with that output — including under the sibling-stem guard
+   * (`Foo_Dark_*` is the sibling's, never `Foo`'s).
+   */
+  @Test
+  fun `sweeps a stale row's companions and keeps an expected row's`() {
+    val foo = entry("Foo", parameterized = true, "renders/Foo.png")
+    val fooDark = entry("Foo_Dark", parameterized = true, "renders/Foo_Dark.png")
+    val expandedByEntry =
+      listOf(
+        foo to listOf(fanoutRow(foo, "_Alice")),
+        fooDark to listOf(fanoutRow(fooDark, "_Alice")),
+      )
+
+    tmp.newFile("Foo_Alice.png") // expected fan-out of Foo
+    tmp.newFile("Foo_Alice.png.error.json") // its companion: this run's row, keep
+    tmp.newFile("Foo_Alice.png.warnings.json")
+    tmp.newFile("Foo_renamed.png.error.json") // failed row, provider value since renamed
+    tmp.newFile("Foo_renamed.png.warnings.json")
+    tmp.newFile("Foo_Dark_Alice.png.error.json") // sibling's companion, not ours
+
+    PreviewManifestLoader.deleteStaleFanoutFiles(
+      outDir = tmp.root,
+      allEntries = listOf(foo, fooDark),
+      expandedByEntry = expandedByEntry,
+      ownedIds = expandedByEntry.flatMap { it.second }.map { it.entry.id }.toSet(),
+    )
+
+    assertTrue(File(tmp.root, "Foo_Alice.png").exists())
+    assertTrue(File(tmp.root, "Foo_Alice.png.error.json").exists())
+    assertTrue(File(tmp.root, "Foo_Alice.png.warnings.json").exists())
+    assertTrue(File(tmp.root, "Foo_Dark_Alice.png.error.json").exists())
+    assertFalse(File(tmp.root, "Foo_renamed.png.error.json").exists())
+    assertFalse(File(tmp.root, "Foo_renamed.png.warnings.json").exists())
+  }
+
+  /** A companion is scoped by the extension of the output it names, exactly as that output is. */
+  @Test
+  fun `companions of another template's extension are not candidates`() {
+    val foo = entry("Foo", parameterized = true, "renders/Foo.gif")
+    val expandedByEntry = listOf(foo to listOf(fanoutRow(foo, "_Alice")))
+
+    tmp.newFile("Foo_stale.gif.error.json")
+    tmp.newFile("Foo_stale.png.error.json")
+
+    PreviewManifestLoader.deleteStaleFanoutFiles(
+      outDir = tmp.root,
+      allEntries = listOf(foo),
+      expandedByEntry = expandedByEntry,
+      ownedIds = setOf("Foo_Alice"),
+    )
+
+    assertFalse(File(tmp.root, "Foo_stale.gif.error.json").exists())
+    assertTrue(File(tmp.root, "Foo_stale.png.error.json").exists())
+  }
+
   @Test
   fun `non-parameterized previews never trigger a sweep`() {
     val plain = entry("Foo", parameterized = false, "renders/Foo.png")

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -853,6 +853,34 @@ private fun jsonString(s: String): String {
 private val NO_PARAM = Any()
 
 /**
+ * Suffixes a renderer appends to a render output's own file name to make a companion that lives
+ * beside it — `renders/Foo.png` → `renders/Foo.png.error.json`. The stale-fan-out sweeps must treat
+ * a companion as belonging to the output it names, or a removed provider value leaves its sidecar
+ * behind forever (see [deleteStaleFanoutFiles]).
+ *
+ * `.error.json` is written by [writeErrorSidecar] here and by `RenderErrorSidecar` on the Android
+ * side; `.warnings.json` (`RenderWarningsSidecar`) only has an Android writer today, but the sweep
+ * covers it on both backends so the cleanup contract doesn't depend on which renderer produced the
+ * directory. Kept in sync with `PreviewManifestLoader.RENDER_COMPANION_SUFFIXES`.
+ */
+internal val RENDER_COMPANION_SUFFIXES = listOf(".error.json", ".warnings.json")
+
+/**
+ * The render output [name] belongs to: [name] itself when it is an `[ext]` output, the output it
+ * names when it is one of that output's [RENDER_COMPANION_SUFFIXES] companions, and `null`
+ * otherwise.
+ *
+ * Companions are matched before the plain extension so an output whose own extension is `.json` (a
+ * data product) resolves `Foo_Alice.json.error.json` to `Foo_Alice.json` rather than to itself.
+ */
+internal fun fanoutOutputNameOf(name: String, ext: String): String? {
+  RENDER_COMPANION_SUFFIXES.forEach { companion ->
+    if (name.endsWith(ext + companion)) return name.removeSuffix(companion)
+  }
+  return name.takeIf { it.endsWith(ext) }
+}
+
+/**
  * Deletes `<stem>_*<ext>` files from prior runs that this render won't rewrite — stale fan-out left
  * behind by provider renames ("loading" → "busy") and the `_PARAM_<idx>` → `_<label>` migration.
  *
@@ -862,6 +890,13 @@ private val NO_PARAM = Any()
  * `Foo_*` while belonging to a different subprocess. The plugin — which has the manifest this
  * subprocess doesn't — passes those stems in [protectedSiblingStems]; any file that is
  * `<sibling>.<ext>` or `<sibling>_*` is theirs, not stale.
+ *
+ * A stale row's companions go with it. A failed row writes `<stem>_<label><ext>.error.json` and no
+ * output, so an extension-only filter never matched the one file the row actually left behind, and
+ * the orphan outlived every subsequent run — the CLI's missing-render report then rediscovers it by
+ * directory glob and can present an obsolete exception as a failure of the current run (PR #3815).
+ * The companion is classified by the output it names, so it is kept exactly when that output is
+ * expected and swept exactly when that output is stale.
  */
 internal fun deleteStaleFanoutFiles(
   template: File,
@@ -876,9 +911,10 @@ internal fun deleteStaleFanoutFiles(
   dir
     .listFiles()
     ?.filter { f ->
+      val output = fanoutOutputNameOf(f.name, ext)
       f.name.startsWith(prefix) &&
-        f.name.endsWith(ext) &&
-        f.name !in expectedNames &&
+        output != null &&
+        output !in expectedNames &&
         protectedSiblingStems.none { sib ->
           f.name.startsWith("$sib.") || f.name.startsWith("${sib}_")
         }

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DeleteStaleFanoutFilesTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DeleteStaleFanoutFilesTest.kt
@@ -83,4 +83,79 @@ class DeleteStaleFanoutFilesTest {
     assertTrue(File(tmp.root, "Foo_x.gif").exists())
     assertTrue(File(tmp.root, "Bar_x.png").exists())
   }
+
+  /**
+   * The orphan PR #3815 hit: a row that FAILED leaves only `<row>.png.error.json`, never a PNG, so
+   * the sweep's extension filter matched nothing and the sidecar survived the provider rename that
+   * retired the row. The CLI then rediscovers it by glob and can print a dead exception as a
+   * current failure.
+   */
+  @Test
+  fun `deletes the error sidecar of a stale row`() {
+    val template = File(tmp.root, "Foo.png")
+    touch("Foo_renamed.png.error.json")
+
+    deleteStaleFanoutFiles(template, expectedNames = setOf("Foo_Alice.png"))
+
+    assertFalse(File(tmp.root, "Foo_renamed.png.error.json").exists())
+  }
+
+  @Test
+  fun `keeps the companions of an expected row`() {
+    val template = File(tmp.root, "Foo.png")
+    touch("Foo_Alice.png")
+    touch("Foo_Alice.png.error.json")
+    touch("Foo_Alice.png.warnings.json")
+
+    deleteStaleFanoutFiles(template, expectedNames = setOf("Foo_Alice.png"))
+
+    assertTrue(File(tmp.root, "Foo_Alice.png").exists())
+    assertTrue(File(tmp.root, "Foo_Alice.png.error.json").exists())
+    assertTrue(File(tmp.root, "Foo_Alice.png.warnings.json").exists())
+  }
+
+  @Test
+  fun `deletes the warnings sidecar of a stale row`() {
+    val template = File(tmp.root, "Foo.png")
+    touch("Foo_renamed.png")
+    touch("Foo_renamed.png.warnings.json")
+
+    deleteStaleFanoutFiles(template, expectedNames = emptySet())
+
+    assertFalse(File(tmp.root, "Foo_renamed.png").exists())
+    assertFalse(File(tmp.root, "Foo_renamed.png.warnings.json").exists())
+  }
+
+  /**
+   * A companion belongs to the output it names, so it is scoped by that output's extension exactly
+   * as the output itself is — the renderer forks per output and a GIF template's subprocess must
+   * not sweep the PNG template's rows (or their sidecars).
+   */
+  @Test
+  fun `companions are scoped to the template extension`() {
+    val gifTemplate = File(tmp.root, "Foo.gif")
+    touch("Foo_stale.gif.error.json")
+    touch("Foo_stale.png.error.json")
+
+    deleteStaleFanoutFiles(gifTemplate, expectedNames = emptySet())
+
+    assertFalse(File(tmp.root, "Foo_stale.gif.error.json").exists())
+    assertTrue(File(tmp.root, "Foo_stale.png.error.json").exists())
+  }
+
+  @Test
+  fun `sibling protection covers the sibling's companions (issue 2193)`() {
+    val template = File(tmp.root, "Foo.png")
+    touch("Foo_Dark_Alice.png.error.json")
+    touch("Foo_stale.png.error.json")
+
+    deleteStaleFanoutFiles(
+      template,
+      expectedNames = setOf("Foo_Alice.png"),
+      protectedSiblingStems = listOf("Foo_Dark"),
+    )
+
+    assertTrue(File(tmp.root, "Foo_Dark_Alice.png.error.json").exists())
+    assertFalse(File(tmp.root, "Foo_stale.png.error.json").exists())
+  }
 }


### PR DESCRIPTION
Root fix for the orphaned-sidecar bug found in the third review thread of #3815 ([discussion_r3781549524](https://github.com/yschimke/compose-ai-tools/pull/3815#discussion_r3781549524)), which that PR deliberately left alone as out of scope.

## The bug

Both `deleteStaleFanoutFiles` implementations filtered candidates on `f.name.endsWith(ext)`, with `ext` taken from the **template's** extension:

| Implementation | Pre-fix filter |
| --- | --- |
| `DesktopRendererMain.deleteStaleFanoutFiles` | `f.name.startsWith(prefix) && f.name.endsWith(ext) && f.name !in expectedNames && …` |
| `PreviewManifestLoader.deleteStaleFanoutFiles` | `f.name.startsWith(prefix) && f.name.endsWith(ext) && f.name !in expectedNames` |

A `@PreviewParameter` row that **fails** writes `<stem>_<label><ext>.error.json` and no output at all, so the sidecar was the *only* file the row left on disk — and the one file the extension filter could never match. Rename or remove that provider value and the sidecar outlives every subsequent run.

The consequence is the one #3815 documented: the CLI's missing-render report rediscovers the orphan by directory glob, and if another current value leaves the preview missing, the report can present the obsolete exception as a failure from this invocation. #3815 mitigated it CLI-side by dating a scanned output `UNDATED`; the orphan itself lives here.

## The fix

A candidate is now classified by the **render output it names** rather than by its own name:

```kotlin
internal fun fanoutOutputNameOf(name: String, ext: String): String? {
  RENDER_COMPANION_SUFFIXES.forEach { companion ->
    if (name.endsWith(ext + companion)) return name.removeSuffix(companion)
  }
  return name.takeIf { it.endsWith(ext) }
}
```

so a companion is kept exactly when its output is expected and swept exactly when its output is stale. Everything else about the sweep is unchanged — in particular the issue #2193 sibling-stem guard now shields a sibling's companions for free, because `Foo_Dark_Alice.png.error.json` still starts with `Foo_Dark_`.

Companions are matched **before** the plain extension so an output whose own extension is `.json` (a data product) resolves `Foo_Alice.json.error.json` to `Foo_Alice.json` rather than to itself.

## What was verified before writing

- **The extension filter really is the exclusion**, in both implementations — quoted above, confirmed by reading, and confirmed empirically: the new tests fail against the pre-fix code (4 of 9 desktop, 2 of 5 android).
- **Companion naming, from the writer side.** `RenderErrorSidecar.pathFor` (android) and `errorSidecarFor` (desktop) are both `File(output.parentFile, output.name + ".error.json")` — appended to the **full output name**, extension included. So a GIF output's sidecar is `<row>.gif.error.json`, not `<row>.error.json`, and the fix is extension-correct for both. Pinned by `companions are scoped to the template extension`, which asserts a `.gif` template's sweep takes `Foo_stale.gif.error.json` and leaves `Foo_stale.png.error.json` — the renderer forks per output, and that per-extension scoping is load-bearing (the pre-existing `only files matching the template prefix and extension are candidates` test relies on it).
- **No in-process reader loses its footing.** The only reads of `.error.json` anywhere are post-render and out-of-process: the plugin (`ComposePreviewTasks.formatMissingPreviewsMessage`, `BundlePreviewTask.resolvePreviewRenderError`) and the CLI (`MissingRenderReport`, `ServeBundle*`). Inside the renderers the sidecars are only ever written or `deleteStale`d — there is no reader. Both sweeps also run *before* any row renders (android at shard load, desktop before the row loop), so they can only ever remove a **previous** run's files. `BundlePreviewTask.resolvePreviewRenderError` is in fact a beneficiary: its fan-out glob picks `minByOrNull { it.name }`, which could previously land on an orphan.
- **A second companion has the identical bug**, and is fixed here: `<output>.warnings.json` (`RenderWarningsSidecar.pathFor`), same sibling placement, same invisibility to the extension filter. It has an Android writer only, but both sweeps carry the suffix so the cleanup contract doesn't depend on which backend produced the directory.

## Where the two implementations still differ (not fixed here)

Called out rather than quietly patched on one side:

- **Data-product outputs.** The desktop renderer is forked **per output** by `RenderPreviewsTask`, so its sweep runs for data-product paths too. The android sweep enumerates `entry.captures` only — `entry.dataProducts` never gets a template — so **stale fan-out data products (and now their companions) are never swept on the Android backend**. Real, pre-existing, and a wider change than this one: it needs a data-product template loop with its own #2193 reasoning, and the expected-name set would have to grow to match. Worth its own PR.
- **Sibling protection.** Desktop takes `protectedSiblingStems` from the plugin (it has no manifest); android derives an equivalent guard from the manifest-wide expected set plus `ownedIds`. Different mechanisms, same guarantee — not a divergence that matters here, and the new tests cover the companion case on both.
- **Other sidecars are a different shape and out of scope.** `NotificationSidecar` (`data/notifications/<id>.notification.json`) and `CatalogTokenSidecar` (`data/catalog-tokens/<id>.catalog.json`) are keyed by **preview id** and live in a **different directory** from the render output, so no directory-scoped fan-out sweep reaches them and they can strand the same way on a provider rename. Reporting, not fixing: the fan-out cleanup would need a second, id-keyed pass over `data/**`, which is a design question rather than the same one-line contract bug.

## Test plan

Renderer-side unit tests in both modules, all failing against the pre-fix code:

- `renderers/desktop/.../DeleteStaleFanoutFilesTest` — `deletes the error sidecar of a stale row`, `deletes the warnings sidecar of a stale row`, `keeps the companions of an expected row`, `companions are scoped to the template extension`, `sibling protection covers the sibling's companions (issue 2193)`.
- `renderers/android/.../PreviewManifestLoaderStaleFanoutTest` — `sweeps a stale row's companions and keeps an expected row's`, `companions of another template's extension are not candidates`.

Pre-fix run (main sources reverted, tests kept):

```
DeleteStaleFanoutFilesTest > deletes the warnings sidecar of a stale row FAILED
DeleteStaleFanoutFilesTest > sibling protection covers the sibling's companions (issue 2193) FAILED
DeleteStaleFanoutFilesTest > companions are scoped to the template extension FAILED
DeleteStaleFanoutFilesTest > deletes the error sidecar of a stale row FAILED
9 tests completed, 4 failed

PreviewManifestLoaderStaleFanoutTest > companions of another template's extension are not candidates FAILED
PreviewManifestLoaderStaleFanoutTest > sweeps a stale row's companions and keeps an expected row's FAILED
5 tests completed, 2 failed
```

Green after the fix:

- `./gradlew :renderer-desktop:test :renderer-android:testDebugUnitTest` — BUILD SUCCESSFUL
- `./gradlew :cli:test --rerun-tasks` — BUILD SUCCESSFUL (the CLI's `SCANNED`/`UNDATED` dating from #3815 depends on this contract; it is unchanged and still correct, since `docs/RENDERER_COMPATIBILITY.md` skew means a current CLI still meets older renderers that leak orphans)
- `./gradlew :renderer-desktop:ktfmtFormat :renderer-android:ktfmtFormat` — clean

No visual surface is touched: this is filesystem-cleanup logic in the renderers, with no `@Preview` output, webview, or overlay affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_