### PR TITLE
fix(renderer): scope fan-out companions to their own output's extension

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -356,12 +356,20 @@ object PreviewManifestLoader {
    * Deletes stale `<stem>_*<ext>` fan-out files for the parameterized previews in
    * [expandedByEntry].
    *
-   * Two guards keep the prefix match from destroying correct sibling output (issue #2193):
+   * Three guards keep the prefix match from destroying correct sibling output (issue #2193):
    * - **Manifest-wide expected set.** `@Preview(name = …)` / `@Preview(group = …)` variant suffixes
    *   make a sibling preview's stem an underscore-extension of the base stem (`Foo` vs `Foo_Dark`),
    *   so the sibling's base render and its own fan-out (`Foo_Dark_<label>.png`) match `Foo_*`. The
    *   exclusion set therefore spans every manifest entry's outputs — declared ([allEntries]) and
    *   expanded ([expandedByEntry]) — not just the preview whose prefix is being swept.
+   * - **Declared sibling stems.** The expected set only covers a sibling's *expanded* rows when the
+   *   sibling was itself expanded, which a `--preview` / `--preview-id` filter prevents: the filter
+   *   applies to the selection [expandedByEntry] is built from, while [allEntries] stays the full
+   *   manifest. A filtered-out parameterized sibling therefore contributes its declared
+   *   `Foo_Dark.png` and nothing else, leaving `Foo_Dark_<label>.png` and its companions
+   *   unaccounted for under `Foo`'s prefix. [fanoutSiblingStems] shields the whole stem, so the
+   *   loader's promise that a filtered-out preview keeps its existing artifacts holds for a
+   *   parameterized one too — matching what the plugin already computes for the desktop renderer.
    * - **Shard-owned pass.** Every parallel fork (`maxParallelForks = shardCount`) expands the whole
    *   manifest at shard load, at a time when sibling forks may already be rendering — under the old
    *   per-entry expected set a late-loading fork would delete fan-out PNGs another fork had just
@@ -391,6 +399,12 @@ object PreviewManifestLoader {
         .flatMap { it.entry.captures }
         .mapNotNullTo(this) { fanoutLeaf(it.renderOutput) }
     }
+    val declaredOutputFiles =
+      allEntries
+        .flatMap { it.captures }
+        .map { it.renderOutput }
+        .filter { it.isNotEmpty() }
+        .map { File(outDir, it.substringAfter("renders/")) }
     for ((entry, rows) in expandedByEntry) {
       if (entry.params.previewParameterProviderClassName == null) continue
       if (rows.none { it.entry.id in ownedIds }) continue
@@ -400,11 +414,17 @@ object PreviewManifestLoader {
         val stem = templateFile.nameWithoutExtension
         val ext = ".${templateFile.extension}"
         val prefix = stem + "_"
+        val siblingStems = fanoutSiblingStems(declaredOutputFiles, templateFile)
         dir
           .listFiles()
           ?.filter { f ->
             val output = fanoutOutputNameOf(f.name, ext)
-            f.name.startsWith(prefix) && output != null && output !in expectedNames
+            f.name.startsWith(prefix) &&
+              output != null &&
+              output !in expectedNames &&
+              siblingStems.none { sib ->
+                f.name.startsWith("$sib.") || f.name.startsWith("${sib}_")
+              }
           }
           ?.forEach { f ->
             if (!f.delete()) {
@@ -429,16 +449,56 @@ object PreviewManifestLoader {
   /**
    * The render output [name] belongs to: [name] itself when it is an `[ext]` output, the output it
    * names when it is one of that output's [RENDER_COMPANION_SUFFIXES] companions, and `null`
-   * otherwise.
+   * otherwise — `null` meaning "not this template's business", which on a delete path is the answer
+   * that keeps a file.
    *
-   * Companions are matched before the plain extension so an output whose own extension is `.json`
-   * resolves `Foo_Alice.json.error.json` to `Foo_Alice.json` rather than to itself.
+   * A companion is recognised by its suffix **before** the plain-extension fallback is reached, and
+   * is then held to the same per-extension scoping as any other candidate: it belongs to this sweep
+   * only if the output it names carries [ext]. Deciding in the other order breaks down as soon as
+   * [ext] is itself `.json`, because then every `.error.json` in the directory ends with [ext] and
+   * the fallback claims image companions like `Foo_Alice.png.error.json` as JSON outputs of its
+   * own, deleting another output's *current* diagnostics.
    */
   internal fun fanoutOutputNameOf(name: String, ext: String): String? {
     RENDER_COMPANION_SUFFIXES.forEach { companion ->
-      if (name.endsWith(ext + companion)) return name.removeSuffix(companion)
+      if (name.endsWith(companion)) return name.removeSuffix(companion).takeIf { it.endsWith(ext) }
     }
     return name.takeIf { it.endsWith(ext) }
+  }
+
+  /**
+   * Stems of declared manifest outputs in the same directory as [templateFile], with the same
+   * extension, whose name extends [templateFile]'s stem with an underscore — the issue #2193
+   * siblings whose files a prefix-greedy sweep would otherwise mistake for its own fan-out.
+   *
+   * Deliberately built from the **declared** entries rather than the expanded rows, and so from the
+   * FULL manifest rather than the filtered selection: a `@Preview(name = "Dark")` sibling that a
+   * `--preview-id` filter dropped is never expanded, so its fan-out rows (`Foo_Dark_<label>.png` and
+   * their companions) appear in no expected-name set, yet they all match the swept preview's `Foo_*`
+   * prefix. Protecting the declared stem covers the sibling's whole fan-out without requiring it to
+   * have been expanded, which is what makes good on the loader's promise that a filtered-out preview
+   * keeps its existing artifacts.
+   *
+   * Mirrors the plugin's `fanoutSiblingStems`, which computes the same list for the desktop renderer
+   * (that subprocess has no manifest, so the plugin passes the stems on the command line). The
+   * same-extension restriction is load-bearing in both: the sweep only ever deletes files belonging
+   * to an [templateFile]-extension output, so shielding a different-extension sibling's stem would
+   * strand a genuinely stale `Foo_Dark.png` from before that sibling's capture became a GIF.
+   */
+  private fun fanoutSiblingStems(
+    declaredOutputFiles: List<File>,
+    templateFile: File,
+  ): List<String> {
+    val prefix = templateFile.nameWithoutExtension + "_"
+    return declaredOutputFiles
+      .filter {
+        it.parentFile == templateFile.parentFile &&
+          it != templateFile &&
+          it.extension == templateFile.extension
+      }
+      .map { it.nameWithoutExtension }
+      .filter { it.startsWith(prefix) }
+      .distinct()
   }
 
   private fun fanoutLeaf(renderOutput: String): String? {

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
@@ -174,6 +174,94 @@ class PreviewManifestLoaderStaleFanoutTest {
     assertTrue(File(tmp.root, "Foo_stale.png.error.json").exists())
   }
 
+  /**
+   * A `.json` template makes every companion in the directory end with the template's own
+   * extension, so a classifier that tries the plain extension before the companion suffixes reads
+   * `Foo_Alice.png.error.json` as a JSON output of its own and deletes the PNG's *current*
+   * diagnostics. Predates the companion sweep: the pre-#3822 filter was a bare `endsWith(".json")`,
+   * which matched it just the same.
+   */
+  @Test
+  fun `a json template does not claim another extension's companions`() {
+    val foo = entry("Foo", parameterized = true, "renders/Foo.json")
+    val expandedByEntry = listOf(foo to listOf(fanoutRow(foo, "_Alice")))
+
+    tmp.newFile("Foo_Alice.png.error.json")
+    tmp.newFile("Foo_Alice.gif.warnings.json")
+    tmp.newFile("Foo_stale.json.error.json")
+
+    PreviewManifestLoader.deleteStaleFanoutFiles(
+      outDir = tmp.root,
+      allEntries = listOf(foo),
+      expandedByEntry = expandedByEntry,
+      ownedIds = setOf("Foo_Alice"),
+    )
+
+    assertTrue(File(tmp.root, "Foo_Alice.png.error.json").exists())
+    assertTrue(File(tmp.root, "Foo_Alice.gif.warnings.json").exists())
+    assertFalse(File(tmp.root, "Foo_stale.json.error.json").exists())
+  }
+
+  /**
+   * A `--preview-id` filter selects `Foo` and drops parameterized sibling `Foo_Dark`. The filter
+   * applies to the selection `expandedByEntry` is built from, while `allEntries` stays the full
+   * manifest — so `Foo_Dark` contributes its declared `Foo_Dark.png` and nothing else, and its
+   * fan-out rows are in no expected-name set while still matching `Foo`'s `Foo_*` prefix. The
+   * loader's documented promise is that a filtered-out preview keeps its existing artifacts, so the
+   * declared sibling stem has to shield the whole fan-out — companions included.
+   */
+  @Test
+  fun `a filtered-out parameterized sibling keeps its fan-out and companions`() {
+    val foo = entry("Foo", parameterized = true, "renders/Foo.png")
+    val fooDark = entry("Foo_Dark", parameterized = true, "renders/Foo_Dark.png")
+    // `Foo_Dark` was filtered out, so it is never expanded: only `Foo` reaches expansion.
+    val expandedByEntry = listOf(foo to listOf(fanoutRow(foo, "_Alice")))
+
+    tmp.newFile("Foo_Dark.png") // declared sibling base render
+    tmp.newFile("Foo_Dark_Alice.png") // its fan-out row, never expanded this run
+    tmp.newFile("Foo_Dark_Alice.png.error.json") // that row failed last run
+    tmp.newFile("Foo_stale.png") // genuinely stale fan-out of Foo
+    tmp.newFile("Foo_stale.png.error.json")
+
+    PreviewManifestLoader.deleteStaleFanoutFiles(
+      outDir = tmp.root,
+      allEntries = listOf(foo, fooDark),
+      expandedByEntry = expandedByEntry,
+      ownedIds = setOf("Foo_Alice"),
+    )
+
+    assertTrue(File(tmp.root, "Foo_Dark.png").exists())
+    assertTrue(File(tmp.root, "Foo_Dark_Alice.png").exists())
+    assertTrue(File(tmp.root, "Foo_Dark_Alice.png.error.json").exists())
+    assertFalse(File(tmp.root, "Foo_stale.png").exists())
+    assertFalse(File(tmp.root, "Foo_stale.png.error.json").exists())
+  }
+
+  /**
+   * The sibling-stem guard is same-extension only, mirroring the plugin's `fanoutSiblingStems`:
+   * shielding a different-extension sibling would strand a genuinely stale `Foo_Dark.png` left from
+   * before that sibling's capture became a GIF.
+   */
+  @Test
+  fun `a different-extension sibling stem does not shield same-extension staleness`() {
+    val foo = entry("Foo", parameterized = true, "renders/Foo.png")
+    val fooDarkGif = entry("Foo_Dark", parameterized = false, "renders/Foo_Dark.gif")
+    val expandedByEntry = listOf(foo to listOf(fanoutRow(foo, "_Alice")))
+
+    tmp.newFile("Foo_Dark.png") // stale: this sibling renders a GIF now
+    tmp.newFile("Foo_Dark.gif") // the sibling's current output
+
+    PreviewManifestLoader.deleteStaleFanoutFiles(
+      outDir = tmp.root,
+      allEntries = listOf(foo, fooDarkGif),
+      expandedByEntry = expandedByEntry,
+      ownedIds = setOf("Foo_Alice"),
+    )
+
+    assertFalse(File(tmp.root, "Foo_Dark.png").exists())
+    assertTrue(File(tmp.root, "Foo_Dark.gif").exists())
+  }
+
   @Test
   fun `non-parameterized previews never trigger a sweep`() {
     val plain = entry("Foo", parameterized = false, "renders/Foo.png")

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -868,14 +868,19 @@ internal val RENDER_COMPANION_SUFFIXES = listOf(".error.json", ".warnings.json")
 /**
  * The render output [name] belongs to: [name] itself when it is an `[ext]` output, the output it
  * names when it is one of that output's [RENDER_COMPANION_SUFFIXES] companions, and `null`
- * otherwise.
+ * otherwise — `null` meaning "not this template's business", which on a delete path is the answer
+ * that keeps a file.
  *
- * Companions are matched before the plain extension so an output whose own extension is `.json` (a
- * data product) resolves `Foo_Alice.json.error.json` to `Foo_Alice.json` rather than to itself.
+ * A companion is recognised by its suffix **before** the plain-extension fallback is reached, and
+ * is then held to the same per-extension scoping as any other candidate: it belongs to this sweep
+ * only if the output it names carries [ext]. Deciding in the other order breaks down as soon as
+ * [ext] is itself `.json` — a data product — because then every `.error.json` in the directory ends
+ * with [ext], and the fallback claims image companions like `Foo_Alice.png.error.json` as JSON
+ * outputs of its own, deleting another output's *current* diagnostics.
  */
 internal fun fanoutOutputNameOf(name: String, ext: String): String? {
   RENDER_COMPANION_SUFFIXES.forEach { companion ->
-    if (name.endsWith(ext + companion)) return name.removeSuffix(companion)
+    if (name.endsWith(companion)) return name.removeSuffix(companion).takeIf { it.endsWith(ext) }
   }
   return name.takeIf { it.endsWith(ext) }
 }

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DeleteStaleFanoutFilesTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DeleteStaleFanoutFilesTest.kt
@@ -143,6 +143,27 @@ class DeleteStaleFanoutFilesTest {
     assertTrue(File(tmp.root, "Foo_stale.png.error.json").exists())
   }
 
+  /**
+   * A `.json` data-product template makes every companion in the directory end with the template's
+   * own extension, so a classifier that tries the plain extension before the companion suffixes
+   * reads `Foo_Alice.png.error.json` as a JSON output of its own and deletes the PNG's *current*
+   * diagnostics. Note this one predates the companion sweep: the pre-#3822 filter was a bare
+   * `endsWith(".json")`, which matched it just the same.
+   */
+  @Test
+  fun `a json template does not claim another extension's companions`() {
+    val jsonTemplate = File(tmp.root, "Foo.json")
+    touch("Foo_Alice.png.error.json")
+    touch("Foo_Alice.gif.warnings.json")
+    touch("Foo_stale.json.error.json")
+
+    deleteStaleFanoutFiles(jsonTemplate, expectedNames = setOf("Foo_Alice.json"))
+
+    assertTrue(File(tmp.root, "Foo_Alice.png.error.json").exists())
+    assertTrue(File(tmp.root, "Foo_Alice.gif.warnings.json").exists())
+    assertFalse(File(tmp.root, "Foo_stale.json.error.json").exists())
+  }
+
   @Test
   fun `sibling protection covers the sibling's companions (issue 2193)`() {
     val template = File(tmp.root, "Foo.png")


### PR DESCRIPTION
Follow-up to #3822, which merged while these were being investigated. Both findings come from its review threads ([r3781921919](https://github.com/yschimke/compose-ai-tools/pull/3822#discussion_r3781921919), [r3781921926](https://github.com/yschimke/compose-ai-tools/pull/3822#discussion_r3781921926)) and both describe the sweep **deleting a file it should keep** — the failure mode that matters most on a delete path.

Both hold. Neither is purely a #3822 regression, and neither is purely pre-existing, so the history is set out per file below rather than summarised.

## 1. A `.json` template claimed other extensions' companions

`fanoutOutputNameOf` tried `ext + companion` first and fell back to a plain `endsWith(ext)`. When the template's own extension is `.json` — a data product — **every** `.error.json` in the directory satisfies that fallback. `Foo_Alice.png.error.json` doesn't match `.json.error.json`, falls through, and is returned as a JSON output of its own; absent from the JSON template's expected names, it gets deleted. That is a PNG's *current* diagnostics removed by a JSON output's sweep.

The fix inverts the order: recognise a companion by its suffix first, then hold it to the same per-extension scoping as any other candidate — it belongs to this sweep only if the output it names carries `ext`.

```kotlin
internal fun fanoutOutputNameOf(name: String, ext: String): String? {
  RENDER_COMPANION_SUFFIXES.forEach { companion ->
    if (name.endsWith(companion)) return name.removeSuffix(companion).takeIf { it.endsWith(ext) }
  }
  return name.takeIf { it.endsWith(ext) }
}
```

`null` now means "not this template's business", which on a delete path is the answer that keeps a file.

**History: pre-existing, not a #3822 regression.** The pre-#3822 filter was a bare `f.name.endsWith(ext)`, so with `ext = ".json"` it matched `Foo_Alice.png.error.json` just as readily. Verified by running the new test against `origin/main` as it stood before #3822 — it fails there too. #3822 neither introduced nor widened this; it simply didn't fix it while it was in the area.

## 2. A filtered-out parameterized sibling lost its fan-out

`PreviewFilter.select` runs on the manifest, and `expandedByEntry` is built from the **selection** while `allEntries` stays the **full** manifest. So when a `--preview-id` filter keeps `Foo` and drops parameterized sibling `Foo_Dark`, `Foo_Dark` contributes its declared `Foo_Dark.png` to the expected set and nothing else — its fan-out rows `Foo_Dark_<label>.png` are never expanded, appear in no expected-name set, and still match `Foo`'s `Foo_*` prefix.

That contradicts the contract the loader states at `RobolectricRenderTest.kt:132`:

> The FULL `manifest.previews` is still what `deleteStaleFanoutFiles` protects below, so a filtered-out preview keeps its existing PNG on disk exactly as it does on desktop.

Checked at the source as asked, and the promise is real — so it is the specification, and the fix follows from it. The Android sweep now computes `fanoutSiblingStems` from the declared entries, mirroring the plugin's [`fanoutSiblingStems`](https://github.com/yschimke/compose-ai-tools/blob/main/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt#L1138) that already feeds the desktop renderer the same list — same directory, same extension, strict underscore-extension of the swept stem. Protecting the declared *stem* covers the sibling's whole fan-out without requiring it to have been expanded.

The same-extension restriction is carried over deliberately and has its own test: shielding a different-extension sibling would strand a genuinely stale `Foo_Dark.png` left from before that sibling's capture became a GIF.

**History: mixed — and the split is the interesting part.** Against pre-#3822 code the scenario's assertions fall out like this:

| File | pre-#3822 | #3822 (`84e0aed6bd`) | this PR |
| --- | --- | --- | --- |
| `Foo_Dark_Alice.png` (sibling fan-out) | **deleted** — pre-existing hole | deleted | kept |
| `Foo_Dark_Alice.png.error.json` (its companion) | **kept** — didn't match `.png` | **deleted** — regression | kept |

So the reviewer's "the sidecar was excluded by the old `.png` suffix test" is exactly right: #3822 regressed the companion. But it regressed it *into consistency with* a pre-existing hole that was already eating the sibling's PNGs. Fixing only the companion would have left the louder half of the bug in place, so this fixes the stem.

Evidence, from running the new test against the pre-#3822 sources: it fails at line 234 (`Foo_Dark_Alice.png`), and with that one assertion commented out it fails at line 237 (`Foo_stale.png.error.json`, the orphan #3822 fixed) — never at line 235, the sibling's companion. That is the companion surviving pre-#3822 and the PNG not.

## Test plan

Three new tests, each failing against the state it indicts:

| Test | Module | Fails against |
| --- | --- | --- |
| `a json template does not claim another extension's companions` | desktop + android | #3822 head **and** pre-#3822 |
| `a filtered-out parameterized sibling keeps its fan-out and companions` | android | #3822 head **and** pre-#3822 (different assertion each time, per the table above) |
| `a different-extension sibling stem does not shield same-extension staleness` | android | guards the new guard against over-reach; passes before and after by construction |

Against #3822's merged head:

```
DeleteStaleFanoutFilesTest > a json template does not claim another extension's companions FAILED
10 tests completed, 1 failed

PreviewManifestLoaderStaleFanoutTest > a filtered-out parameterized sibling keeps its fan-out and companions FAILED
PreviewManifestLoaderStaleFanoutTest > a json template does not claim another extension's companions FAILED
8 tests completed, 2 failed
```

Green on this branch:

- `./gradlew :renderer-desktop:test :renderer-android:testDebugUnitTest` — BUILD SUCCESSFUL
- `./gradlew :cli:test --rerun-tasks` — BUILD SUCCESSFUL
- `./gradlew :renderer-desktop:ktfmtFormat :renderer-android:ktfmtFormat` — clean

The two pre-existing #2193 tests still pass unchanged, which is the load-bearing check on the new sibling guard: `deletes stale fan-out but keeps expected, sibling base and sibling fan-out files` still deletes `Foo_Dark_stale.png` (protected during `Foo`'s sweep, deleted during `Foo_Dark`'s own), and `sweeps only previews with a row assigned to this shard` still deletes `Foo_Dark_stale.png` under `Foo_Dark`'s prefix — the strict-underscore-extension rule is what keeps the guard from neutering the sweep in that direction.

No visual surface is touched: filesystem-cleanup logic in the renderers, no `@Preview` output, webview, or overlay affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu4KHhS1pHeLoRY3D1US16)_