### PR TITLE
fix(design-artifacts): republish a page node's type, so containers are exact

### DIFF
--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -219,6 +219,20 @@ export function planDesignPages({ manifest, spec, catalog }) {
           Number.isInteger(node?.depth) && node.depth >= 0 && node.depth <= 2147483647
             ? node.depth
             : 0,
+        // The node's type in the design file, republished so the consumer can tell a container from
+        // the components inside it EXACTLY rather than by inference. `DesignPage.coverageGaps`
+        // falls back to "a node followed by a deeper one has children" when no type is stated, and
+        // that fallback is only as good as the walk: an import lists components only, so an unlisted
+        // frame between two of them lets a shallower node be followed by a deeper one that is not
+        // inside it — and the shallower one then drops out of the count as furniture, understating
+        // the gaps. Stripping the field here meant every delivery branch took that fallback, however
+        // carefully the importer had stated the type.
+        //
+        // Free text, like the consumer's own field, so a design tool growing a type does not fail
+        // the parse — but only a non-empty string, since `""` is not a type and would read as one.
+        ...(typeof node?.type === "string" && node.type.trim() !== ""
+          ? { type: node.type.trim() }
+          : {}),
         ...(node?.ref ? { ref: String(node.ref) } : {}),
         link,
         ...(node?.code ? { code: String(node.code) } : {}),

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -307,6 +307,22 @@ test("an unsupported confidence is dropped, not republished", () => {
   assert.equal(node.previewId, "top-app-bar-medium__ideal__default__light");
 });
 
+test("a node's design-file type is republished, so containers are exact not inferred", () => {
+  // `DesignPage.coverageGaps` reads `type` to tell a COMPONENT_SET container from the components
+  // inside it, and infers from nesting depth only when no type is stated. Stripping the field here
+  // meant every delivery branch took the inference, which an unlisted frame between two components
+  // can fool.
+  const set = { ...statusBar, nodeId: "1:3", name: "Switch", type: "COMPONENT_SET" };
+  const plan = planDesignPages({ manifest: manifest([page([set, appBar])]), spec, catalog });
+  const [container, component] = plan.manifest.pages[0].nodes;
+  assert.equal(container.type, "COMPONENT_SET");
+  assert.equal(component.type, undefined);
+  // Not a type: an empty string would read as one on the consumer's side.
+  const blank = { ...statusBar, nodeId: "1:4", type: "  " };
+  const other = planDesignPages({ manifest: manifest([page([blank])]), spec, catalog });
+  assert.equal(other.manifest.pages[0].nodes[0].type, undefined);
+});
+
 test("an out-of-range depth is normalised rather than republished", () => {
   // `Number.isInteger(2147483648)` is true, but the consumer decodes depth as a Kotlin Int — so
   // republishing it fails the parse for the whole manifest and hides every page. Depth is only a


### PR DESCRIPTION
## What

#3828 taught `DesignPage.coverageGaps` to read `PageNode.type`, so a `COMPONENT_SET` container is told apart from the components inside it — with a fallback for manifests that state no type: *a node immediately followed by a deeper one has children on this page.*

The producer states none. `design-pages.mjs` rebuilds each node field by field on the way to the delivery branch, and `type` was not among the fields, so **every published page takes the fallback** however carefully the import recorded the type — including the pages the public server reads.

This republishes it.

## Why the fallback isn't good enough on its own

It is only as sound as the walk. An import lists *components* only, so an unlisted frame between two of them lets a shallower node be followed by a deeper one that is **not** inside it. The shallower node is then read as a container and drops out of the denominator — understating the gaps, which is the one direction a coverage instrument must not err in.

This repo's own design-page fixture has that shape: `.Header` at depth 2 followed by shapes at depth 3 under a different parent. It happens to be caught by `isPrivate` instead, so the inference's mistake is invisible there — but a sheet whose furniture doesn't start with a dot has nothing to catch it.

Republished as free text like the consumer's own field, so a design tool growing a type doesn't fail the parse — but only when non-empty, since `""` is not a type and would read as one.

## Scope note

This branch previously carried a parallel fix for the same miscount (a `container` boolean, grouping presentation, counts over specimens). #3828 landed first and does it better — private components as well as containers, and red reserved for a real gap. That work is dropped; what's left is the one piece #3828 needs and doesn't have.

The other half is in the importer: yschimke/m3-catalog#65 emits `type` (replacing the `container` flag from #64, which nothing reads), so the kit's pages get the exact path rather than the inference.

## Test plan

`node --test scripts/design-artifacts/design-pages.test.mjs` — 18 pass, covering the republish, a node with no type, and a blank one.

Text-only change: no visual surface moves. The design page's own before/after for this behaviour is in #3828.
