### PR TITLE
fix(pages): read the container flag the import states, not one inferred from depth

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
@@ -124,14 +124,16 @@ public data class PageNode(
   /** Null when unlinked. Stated by the producer so we don't hardcode which methods are weak. */
   val confidence: PageNodeConfidence? = null,
   /**
-   * The node's type in the design file — `COMPONENT`, `COMPONENT_SET`, `INSTANCE`.
+   * This node is a GROUPING whose contents are listed below it — a Figma `COMPONENT_SET`, whose
+   * children are the variants a definition sheet is a grid of.
    *
-   * A fact, not a judgement: it is what tells a container apart from the components inside it,
-   * which is the difference between "35 shapes, all implemented" and "36 things, one missing". Kept
-   * as free text rather than an enum so a design tool can grow a type without this refusing to
-   * parse; a producer that emits none is handled by [DesignPage.coverageGaps].
+   * Stated by the producer rather than worked out here, because only the import has the real tree.
+   * A manifest lists components and nothing else, so an unlisted frame between two of them lets a
+   * shallower node be followed by a deeper one that is NOT inside it — and depth ordering alone
+   * would call the shallower one a grouping. Nothing implements a component set (a reference names
+   * one of its variants), so it is drawn as structure and left out of the coverage count.
    */
-  val type: String? = null,
+  val container: Boolean = false,
 ) {
   /**
    * A component the design file marks as **private** — Figma's leading-dot convention, used for the
@@ -218,27 +220,20 @@ public data class DesignPage(
    * Two kinds of unlinked node are not gaps, and on a real specimen sheet they are most of them:
    *
    * 1. **Private components** ([PageNode.isPrivate]) — the sheet's own furniture, never published.
-   * 2. **Containers.** A `COMPONENT_SET`'s variants are the components; the set is the box they
-   *    came in. Its variants are listed here in their own right, so counting the set as well
-   *    reports one missing component for a family that is fully implemented.
+   * 2. **Containers** ([PageNode.container]) — a `COMPONENT_SET`'s variants are the components; the
+   *    set is the box they came in. Its variants are listed here in their own right, so counting
+   *    the set as well reports one missing component for a family that is fully implemented.
    *
-   * Container-ness is read from [PageNode.type] when the producer states it, and otherwise inferred
-   * from the walk: nodes are emitted depth-first in document order, so a node immediately followed
-   * by a DEEPER one has component children on this page and is therefore a box rather than a leaf.
-   * The inference exists so that a manifest imported before `type` was recorded still reads
-   * correctly — a published page should not have to wait for a re-import to stop miscounting.
+   * Both are read off the node, never inferred. An earlier cut worked container-ness out from the
+   * walk's depth ordering — a node immediately followed by a deeper one — so a manifest published
+   * before the producer stated it would still read correctly. That inference is unsound in the
+   * direction that matters: a manifest lists components only, so an unlisted frame between two of
+   * them lets a shallower node be followed by a deeper one that is not inside it, and a genuinely
+   * missing component would then be swallowed as "structure". A stale manifest over-counting a
+   * container is visible and harmless; a gap that quietly disappears is neither.
    */
   public val coverageGaps: List<PageNode>
-    get() = nodes.filterIndexed { index, node ->
-      val hasNestedChildren = nodes.getOrNull(index + 1)?.let { it.depth > node.depth } ?: false
-      val isContainer =
-        when (node.type?.uppercase()) {
-          "COMPONENT_SET" -> true
-          null -> hasNestedChildren
-          else -> false
-        }
-      node.isUnlinked && !node.isPrivate && !isContainer
-    }
+    get() = nodes.filter { it.isUnlinked && !it.isPrivate && !it.container }
 
   /**
    * How many components on this page a catalog could implement — the denominator behind "N of M

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
@@ -1,0 +1,88 @@
+package ee.schimke.composeai.designpages
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * What the page means by *what we haven't implemented yet*.
+ *
+ * The distinction is not cosmetic: the kit's Shape page has all 35 of its shapes implemented and
+ * reported `35 of 38` with three dashed-red marks on it, none of which any amount of code could
+ * ever clear.
+ */
+class DesignPagesCoverageTest {
+
+  private fun node(
+    id: String,
+    name: String,
+    depth: Int,
+    link: PageNodeLink,
+    container: Boolean = false,
+  ) =
+    PageNode(
+      nodeId = id,
+      name = name,
+      depth = depth,
+      ref = "figma:file/$id",
+      link = link,
+      container = container,
+    )
+
+  private fun page(vararg nodes: PageNode) =
+    DesignPage(
+      id = "shape",
+      name = "Shape",
+      nodeId = "0:1",
+      frame = PageFrame(1200.0, 800.0),
+      image = PageImage(uri = "shape.svg", format = PageImage.SVG),
+      nodes = nodes.toList(),
+    )
+
+  @Test
+  fun `a variant set and a private component are structure, not missing work`() {
+    val subject =
+      page(
+        node("1:8", "Shape Set", 2, PageNodeLink.UNLINKED, container = true),
+        node("1:1", "Shape=Circle", 3, PageNodeLink.MANIFEST),
+        node("1:2", "Shape=Square", 3, PageNodeLink.MANIFEST),
+        node("1:9", ".Header", 2, PageNodeLink.UNLINKED),
+      )
+
+    // Every one of the three unlinked-or-not nodes above is on the sheet; none of them is work.
+    assertEquals(emptyList(), subject.coverageGaps.map { it.name })
+    assertEquals(2, subject.coverageTotal)
+  }
+
+  @Test
+  fun `a component with no code behind it is the gap the filter exists to show`() {
+    val subject =
+      page(
+        node("1:8", "Shape Set", 2, PageNodeLink.UNLINKED, container = true),
+        node("1:1", "Shape=Circle", 3, PageNodeLink.MANIFEST),
+        node("1:12", "Shape=Gem", 3, PageNodeLink.UNLINKED),
+      )
+
+    assertEquals(listOf("Shape=Gem"), subject.coverageGaps.map { it.name })
+    assertEquals(2, subject.coverageTotal)
+  }
+
+  /**
+   * The reason container-ness is STATED rather than worked out from depth ordering.
+   *
+   * A manifest lists components and nothing else. An unlisted frame between two of them lets a
+   * shallower node be followed by a deeper one that is not inside it — and the inference this
+   * replaced read exactly that shape and called the shallower node a grouping. Here that node is a
+   * genuinely missing component, so the old rule swallowed a real gap as "structure", which is the
+   * one direction this must never fail in.
+   */
+  @Test
+  fun `a shallow component followed by a deeper unrelated one is still a gap`() {
+    val subject =
+      page(
+        node("1:30", "Banner", 2, PageNodeLink.UNLINKED),
+        node("1:31", "Shape=Circle", 3, PageNodeLink.MANIFEST),
+      )
+
+    assertEquals(listOf("Banner"), subject.coverageGaps.map { it.name })
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPageRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPageRoutingTest.kt
@@ -66,7 +66,7 @@ class ServeDesignPageRoutingTest {
        "frame":{"width":1200,"height":800},
        "image":{"uri":"shape.svg","format":"svg"},
        "nodes":[
-         {"nodeId":"1:8","name":"Shape Set","depth":2,
+         {"nodeId":"1:8","name":"Shape Set","depth":2,"container":true,
           "ref":"figma:ocdacdEsnHipMJD3egzxKb/1:8","link":"unlinked"},
          {"nodeId":"1:1","name":"Shape=Circle","depth":3,
           "ref":"figma:ocdacdEsnHipMJD3egzxKb/1:1","link":"manifest",
@@ -118,7 +118,8 @@ class ServeDesignPageRoutingTest {
     assertTrue(type.startsWith("text/html"))
     assertTrue(body.contains("Shape"))
     // FIVE nodes on the sheet, but only THREE are components a catalog could implement, and the
-    // count says so. `Shape Set` is the variant-set container the two linked shapes came out of,
+    // count says so. `Shape Set` says `container` on the wire — the variant set the two linked
+    // shapes came out of,
     // and `.Header` is a private component (Figma's leading-dot convention) — furniture, not work.
     // Counting every node instead reported `2 of 5` and told a reader three components were
     // missing when one was.

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -1311,10 +1311,13 @@ filter on "unlinked" therefore made the kit's Shape page — all 35 shapes imple
 while the count read `35 of 38`. It now reads `35 of 35`, those nodes take a neutral grey, and the
 red is only ever the answer to *what is left to build*.
 
-Container-ness is read from the node's `type` where the producer records it, and otherwise inferred
-from the walk — nodes arrive depth-first in document order, so a node immediately followed by a
-deeper one has component children on this page and is a box rather than a leaf. The inference is
-what lets an already-published page stop miscounting without waiting for a re-import.
+Both are read off the node, never inferred. Container-ness arrives as `container` on the wire,
+stated by the import, because only the import has the real tree. An earlier cut worked it out from
+the walk's depth ordering — a node immediately followed by a deeper one — and that is unsound in the
+direction that matters: a manifest lists components and nothing else, so an unlisted frame between
+two of them lets a shallower node be followed by a deeper one that is not inside it, and a genuinely
+missing component would be swallowed as structure. A stale manifest over-counting a container is
+visible and harmless; a gap that quietly disappears is neither.
 
 Every node, linked or not, is still listed — behind a disclosure that says what it holds
 (`35 of 38 components implemented`). It is an inventory to go and check rather than the first thing

--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -228,6 +228,15 @@ export function planDesignPages({ manifest, spec, catalog }) {
         // one node would hide every page the catalog publishes. Dropping the field costs only a
         // styling hint.
         ...(CONFIDENCE_VALUES.has(node?.confidence) ? { confidence: node.confidence } : {}),
+        // A grouping whose contents are listed below it — a COMPONENT_SET, whose children are the
+        // variants. Nothing implements a set (a reference names one of its variants), so the
+        // consumer draws it as structure and leaves it out of the coverage count. Dropping it here
+        // is not cosmetic: the set comes back as a component nobody implemented, and a page whose
+        // every component is done reports missing work that no code could ever clear.
+        //
+        // Literal `true` only, in the same spirit as `confidence` above — this decodes into a
+        // Kotlin Boolean, and a truthy string is a parse failure for the whole manifest.
+        ...(node?.container === true ? { container: true } : {}),
       });
     }
     if (unresolved > 0) {

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -295,6 +295,26 @@ test("a dot-segment page id is refused — a browser would normalise it away", (
   );
 });
 
+test("a container flag survives publishing", () => {
+  // The projection rebuilds every node from an allowlist, so a field that is not named here is
+  // silently dropped on the way to the delivery branch. When that field is `container`, the
+  // COMPONENT_SET comes back as a component nobody implemented and a fully-implemented page
+  // reports missing work — the exact regression the consumer-side fix was for.
+  const set = { ...appBar, nodeId: "1:8", name: "Shape Set", container: true };
+  const plan = planDesignPages({ manifest: manifest([page([set])]), spec, catalog });
+  const node = plan.manifest.pages[0].nodes.find((n) => n.nodeId === "1:8");
+  assert.equal(node.container, true);
+});
+
+test("a truthy non-boolean container is dropped rather than republished", () => {
+  // It decodes into a Kotlin Boolean; a string there fails the parse for the WHOLE manifest and
+  // hides every page, which is a far worse outcome than counting one set as a gap.
+  const set = { ...appBar, nodeId: "1:8", name: "Shape Set", container: "yes" };
+  const plan = planDesignPages({ manifest: manifest([page([set])]), spec, catalog });
+  const node = plan.manifest.pages[0].nodes.find((n) => n.nodeId === "1:8");
+  assert.equal(node.container, undefined);
+});
+
 test("an unsupported confidence is dropped, not republished", () => {
   // The consumer decodes this into a strict enum, so republishing an unknown value would fail the
   // parse for the WHOLE manifest — one bad string hiding every page the catalog publishes.


### PR DESCRIPTION
## Summary

I went to add node types to `m3-catalog`'s import script and found the import **already answers this** — and better than the plan. `import-figma-pages.mjs` marks a `COMPONENT_SET` that yields variants with `container: true`, computed from the real tree, and the published manifest carries it:

```json
{"nodeId":"58548:7181","name":"Shape Set","depth":2,"container":true,"link":"unlinked"}
```

The contract from #3828 read a `type` field **no producer emits**, so it always fell through to the fallback and the stated fact was never used.

### The fallback is the part that had to go

It worked container-ness out from the walk's depth ordering: a node immediately followed by a deeper one has children on the page, so it must be a box. The import's own comment explains why that doesn't hold — a manifest lists components and nothing else, so an unlisted frame between two of them lets a shallower node be followed by a deeper one that **is not inside it**. The rule then calls that shallower node a grouping and drops it from the count.

When the shallower node is a component nobody has implemented, **a real gap disappears silently**. That's the one direction this must never fail in. A stale manifest that over-counts a container is visible and harmless; a gap that quietly vanishes is neither.

So `container` is read and nothing is guessed. `PageNode.type` is gone — it never carried data.

## Test plan

- New `DesignPagesCoverageTest` covers all three cases, including **the one the inference got wrong**: a shallow unlinked component followed by a deeper unrelated one is still reported as a gap. That test fails on the previous implementation.
- `ServeDesignPageRoutingTest` fixture now states `"container":true` rather than depending on node order to imply it; it still asserts `2 of 3` and that `data-cp-gap` lands only on the real gap.
- `:preview-data-api:test`, `:cli:test`, `ktfmtCheck` green; serve fixture golden regenerated.

Text-only: no rendered surface changes — the Shape page already reads `35 of 35` because the inference happened to get that sheet right. This makes it right for the reason that holds.

---
_Generated by [Claude Code](https://claude.ai/code/session_013DiB3idxwEghMRz2jVFisa)_