### PR TITLE
fix(discovery): make render filenames collision-free and stable

### DIFF
--- a/docs/RENDER_FILENAMES.md
+++ b/docs/RENDER_FILENAMES.md
@@ -29,7 +29,7 @@ It makes a stem a **pure function of one preview's own id**, and that single pro
 
 | Property | What it buys |
 |---|---|
-| Stable | Adding, removing or renaming any *other* preview in the module cannot change this preview's filename. Commit-pinned render URLs keep resolving, and base-vs-head visual diffing sees a diff rather than a delete + add. |
+| Stable | Adding, removing or renaming any *other* preview in the module cannot change this preview's filename — the [tie backstop](#the-tie-backstop) below is the sole exception. Commit-pinned render URLs keep resolving, and base-vs-head visual diffing sees a diff rather than a delete + add. |
 | Collision-free | Distinct ids that sanitise identically (`Foo_bar` vs `Foo-bar`) get distinct digests. |
 | Case-safe | `Foo_Dark` and `Foo_dark` stay distinct files on case-insensitive filesystems (APFS, NTFS), where the readable parts alone are one file. |
 | Suffix-safe | The digest sits between the readable part and the structural suffixes below, so a preview genuinely named `Logo_animated` (`Logo_animated-<digestA>.png`) cannot collide with `Logo`'s Lottie sidecar (`Logo-<digestB>_animated.png`). |
@@ -37,7 +37,13 @@ It makes a stem a **pure function of one preview's own id**, and that single pro
 
 This replaced a shortest-unique-suffix walk that read every sibling preview to decide how much of the package/class path to prepend, with a positional `_<idx>` tiebreaker on top. That scheme renamed existing PNGs whenever an unrelated preview was added, renumbered on manifest reordering, and could mint a `_<idx>` name that silently overwrote a preview genuinely named that way.
 
+### The tie backstop
+
 If two ids ever agree on *both* readable part and truncated digest, only the tied previews are re-stemmed with a full-length sha256 — still a pure function of the id, so the rest of the module is untouched and the result stays stable under reordering.
+
+This is the one case where a preview's filename can change because of a *sibling*, and it is a deliberate trade. Resolving a collision inherently requires knowing about the collision — that fact lives in the pair, not in either id — so no per-id-only rule can both keep names stable and keep them unique. Dropping the backstop in favour of an unconditional wider digest would turn a tie back into a **silent overwrite**, which is the bug this scheme exists to prevent. A rename is loud and recoverable; an overwrite loses a render while the manifest still reports success.
+
+The trigger needs two previews to collide on the readable part *and* on 32 bits of digest. Since the readable part is function-plus-variant, a match already means two identically-named functions in different classes within one module; for 20 such previews the probability is around 5 × 10⁻⁸. The ordering the scheme commits to is **correctness > stability > brevity**.
 
 ## `@PreviewParameter` fan-out labels
 

--- a/docs/RENDER_FILENAMES.md
+++ b/docs/RENDER_FILENAMES.md
@@ -11,9 +11,33 @@ To keep a specific render across runs, copy the file somewhere outside `build/`.
 
 ## Filename normalization
 
-`renderOutput` paths use `[A-Za-z0-9._-]` only. Any other character (spaces, parens, commas, Unicode dashes, emoji) collapses to `_`. A whitelist is deliberate: enumerating a blacklist of shell-hostile characters is a losing game across shells and CI systems.
+A render stem is **`<readable>-<digest>`**:
 
-The common dotted package prefix across all previews in a module is stripped too, so `ee.schimke.ha.previews.CardPreviewsKt.Foo.png` lands as `CardPreviewsKt.Foo.png`. `PreviewInfo.id` keeps the full FQN — consumers keying by id (CLI state, JUnit test names) are unaffected.
+```
+ActivityListPreview_Devices_Large_Round-4f9c2a17.png
+└──────────── readable ──────────────┘ └ digest ┘
+```
+
+- **`<readable>`** — the function name plus any `@Preview(name = …)` variant suffix, sanitised. The charset is `[A-Za-z0-9_]`; any other character (spaces, parens, commas, Unicode dashes, emoji) collapses to a single `_`, and runs collapse together, so `Devices - Large Round` becomes `Devices_Large_Round`. A whitelist is deliberate: enumerating a blacklist of shell-hostile characters is a losing game across shells and CI systems. Capped at 80 chars so a stem plus its structural suffixes stays inside the 255-byte `NAME_MAX` that ext4, APFS and NTFS all enforce.
+- **`-<digest>`** — 8 hex chars of `sha256(preview.id)`, over the id verbatim. `-` is unambiguous here because sanitisation can never emit one inside `<readable>`.
+
+The package and class never appear. `PreviewInfo.id` keeps the full FQN — consumers keying by id (CLI state, JUnit test names) are unaffected.
+
+### Why the digest is unconditional
+
+It makes a stem a **pure function of one preview's own id**, and that single property carries every guarantee the filenames need:
+
+| Property | What it buys |
+|---|---|
+| Stable | Adding, removing or renaming any *other* preview in the module cannot change this preview's filename. Commit-pinned render URLs keep resolving, and base-vs-head visual diffing sees a diff rather than a delete + add. |
+| Collision-free | Distinct ids that sanitise identically (`Foo_bar` vs `Foo-bar`) get distinct digests. |
+| Case-safe | `Foo_Dark` and `Foo_dark` stay distinct files on case-insensitive filesystems (APFS, NTFS), where the readable parts alone are one file. |
+| Suffix-safe | The digest sits between the readable part and the structural suffixes below, so a preview genuinely named `Logo_animated` (`Logo_animated-<digestA>.png`) cannot collide with `Logo`'s Lottie sidecar (`Logo-<digestB>_animated.png`). |
+| Reserved-name-safe | A preview named `CON` or `NUL` becomes `CON-<digest>`, which is not a Windows reserved device name. |
+
+This replaced a shortest-unique-suffix walk that read every sibling preview to decide how much of the package/class path to prepend, with a positional `_<idx>` tiebreaker on top. That scheme renamed existing PNGs whenever an unrelated preview was added, renumbered on manifest reordering, and could mint a `_<idx>` name that silently overwrote a preview genuinely named that way.
+
+If two ids ever agree on *both* readable part and truncated digest, only the tied previews are re-stemmed with a full-length sha256 — still a pure function of the id, so the rest of the module is untouched and the result stays stable under reordering.
 
 ## `@PreviewParameter` fan-out labels
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1542,9 +1542,10 @@ object PreviewDiscovery {
    * **Why the digest is unconditional.** It is what makes a stem a pure function of one preview's
    * own id, and that single property carries every guarantee the filenames need:
    * - *Stable.* Adding, removing or renaming any other preview in the module cannot change this
-   *   preview's filename. The previous shortest-unique-suffix walk read every sibling, so an
-   *   unrelated addition silently renamed existing PNGs — which breaks commit-pinned render URLs and
-   *   makes base-vs-head visual diffing see a rename as delete + add.
+   *   preview's filename — the sole exception being [disambiguateDigestTies] below. The previous
+   *   shortest-unique-suffix walk read every sibling, so an unrelated addition silently renamed
+   *   existing PNGs — which breaks commit-pinned render URLs and makes base-vs-head visual diffing
+   *   see a rename as delete + add.
    * - *Collision-free.* Distinct ids that sanitise identically (`Foo_bar` vs `Foo-bar`) get distinct
    *   digests. The old positional `_<idx>` tiebreaker minted names without checking them against
    *   real stems, so a preview genuinely named `Foo_bar_1` could be silently overwritten.

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -9,6 +9,7 @@ import io.github.classgraph.MethodInfo
 import io.github.classgraph.MethodParameterInfo
 import io.github.classgraph.ScanResult
 import java.io.File
+import java.security.MessageDigest
 import java.util.zip.ZipFile
 import kotlin.math.roundToInt
 import kotlinx.serialization.json.Json
@@ -31,6 +32,26 @@ import kotlinx.serialization.json.floatOrNull
  * `previews.json`.
  */
 object PreviewDiscovery {
+
+  /**
+   * Longest readable prefix a render stem may carry, before its `-<digest>` and before the
+   * structural suffixes renderers append (`_PARAM_<label>`, `_SCROLL_<mode>`, `_animated`, …).
+   * Chosen so a stem plus the longest suffix chain stays well inside the 255-byte `NAME_MAX` that
+   * ext4, APFS and NTFS all enforce. Preview names this long are already unreadable as filenames;
+   * the digest keeps them unique after the cut.
+   */
+  internal const val MAX_READABLE_STEM: Int = 80
+
+  /**
+   * Hex chars of `sha256(preview.id)` appended to every render stem. 8 chars (32 bits) makes a tie
+   * vanishingly unlikely even in a catalog module with thousands of previews — and a tie needs the
+   * readable parts to match too, since the digest only disambiguates within one readable name.
+   * [MAX_READABLE_STEM] leaves room for it regardless.
+   */
+  internal const val RENDER_STEM_DIGEST_CHARS: Int = 8
+
+  /** Digest width used by the tie backstop. Full sha256 hex — cannot collide for distinct ids. */
+  internal const val FULL_DIGEST_CHARS: Int = 64
 
   /** Inputs the scan needs from the calling build system. All paths are absolute. */
   data class Input(
@@ -1503,26 +1524,41 @@ object PreviewDiscovery {
 
   /**
    * Rewrite each capture's `renderOutput` (and each `dataProduct.output`) to a shorter, shell-safe
-   * filename. Two passes shape the result:
+   * filename of the form `<readable>-<digest>`:
    *
-   * 1. **Sanitisation per dotted segment.** Within a segment (the chunks between `.`s of the
-   *    preview id) any run of non-alphanumeric characters collapses to a single `_`. So `Devices -
-   *    Large Round` becomes `Devices_Large_Round`, `tile light (light)` becomes `tile_light_light`,
-   *    etc. Dots stay as segment separators.
-   * 2. **Shortest unique suffix per preview.** Each preview takes the rightmost segments needed to
-   *    disambiguate it from every other preview in the module — the function-name-plus-variant
-   *    segment alone for unique names, prepending the class only when another preview shares the
-   *    same function name, prepending package parts only when classes collide too. So
-   *    `com.example.PreviewsKt.ActivityListPreview_Devices - Large Round` becomes
-   *    `ActivityListPreview_Devices_Large_Round` in most modules.
+   * 1. **`<readable>`** — the last dotted segment of the preview id (function name plus any
+   *    `@Preview(name = …)` variant suffix), with every run of non-alphanumeric characters collapsed
+   *    to a single `_`. So `com.example.PreviewsKt.ActivityListPreview_Devices - Large Round`
+   *    contributes `ActivityListPreview_Devices_Large_Round`. Capped at [MAX_READABLE_STEM] chars so
+   *    a stem plus its structural suffixes stays inside the 255-byte `NAME_MAX` every mainstream
+   *    filesystem enforces.
+   * 2. **`-<digest>`** — [RENDER_STEM_DIGEST_CHARS] hex chars of `sha256(preview.id)`, taken over
+   *    the id verbatim. `-` is an unambiguous delimiter here: [sanitiseSegment] collapses it inside
+   *    a segment, so it can never occur in `<readable>`.
    *
    * `preview.id` itself stays untouched — it's the stable identity consumers key by (history
-   * folders, CLI state, JUnit test names). Only the on-disk filename benefits from the prettier
-   * form.
+   * folders, CLI state, JUnit test names). Only the on-disk filename takes this form.
    *
-   * If sanitisation forces a true collision (two distinct ids whose fully-sanitised forms are
-   * byte-identical — e.g. `Foo_bar` vs `Foo-bar` after collapsing), a `_<idx>` suffix
-   * disambiguates. The renders directory has to stay collision-free even when input names couldn't.
+   * **Why the digest is unconditional.** It is what makes a stem a pure function of one preview's
+   * own id, and that single property carries every guarantee the filenames need:
+   * - *Stable.* Adding, removing or renaming any other preview in the module cannot change this
+   *   preview's filename. The previous shortest-unique-suffix walk read every sibling, so an
+   *   unrelated addition silently renamed existing PNGs — which breaks commit-pinned render URLs and
+   *   makes base-vs-head visual diffing see a rename as delete + add.
+   * - *Collision-free.* Distinct ids that sanitise identically (`Foo_bar` vs `Foo-bar`) get distinct
+   *   digests. The old positional `_<idx>` tiebreaker minted names without checking them against
+   *   real stems, so a preview genuinely named `Foo_bar_1` could be silently overwritten.
+   * - *Case-safe.* `Foo_Dark` and `Foo_dark` are distinct ids, so they get distinct digests and stay
+   *   distinct files on the case-insensitive filesystems (APFS, NTFS) where the readable parts alone
+   *   would collide.
+   * - *Suffix-safe.* Structural suffixes are appended after the whole stem, so a preview named
+   *   `Logo_animated` lands on `Logo_animated-<digestA>.png` while `Logo`'s Lottie sidecar lands on
+   *   `Logo-<digestB>_animated.png`. The digest separates the two namespaces that used to share `_`.
+   * - *Reserved-name-safe.* A preview named `CON` or `NUL` becomes `CON-<digest>`, which is not a
+   *   Windows reserved device name.
+   *
+   * [disambiguateDigestTies] is the backstop for a truncated-digest collision, which needs two ids
+   * that agree on both readable part and digest prefix.
    */
   private fun normalizeRenderOutputs(previews: List<PreviewInfo>): List<PreviewInfo> {
     if (previews.isEmpty()) return previews
@@ -1542,45 +1578,59 @@ object PreviewDiscovery {
   }
 
   /**
-   * Pick one shell-safe stem per preview. Each stem is the shortest sanitised suffix that uniquely
-   * identifies its preview against the others — see [normalizeRenderOutputs] for the algorithm and
-   * rationale. Exposed `internal` so the unit tests can assert "no spaces ever", "no `class.`
-   * prefix when the function name is unique", and the collision-disambiguator paths directly
-   * without a full discovery pipeline.
+   * Pick one shell-safe stem per preview — see [normalizeRenderOutputs] for the format and
+   * rationale. Exposed `internal` so the unit tests can assert the charset, the stability of a stem
+   * under unrelated additions, and the collision paths directly without a full discovery pipeline.
    */
   internal fun resolveRenderStems(previews: List<PreviewInfo>): List<String> {
     if (previews.isEmpty()) return emptyList()
-    val sanitisedSegmentsByPreview = previews.map { sanitiseSegments(it) }
-    val stems = sanitisedSegmentsByPreview.mapIndexed { i, mySegs ->
-      shortestUniqueSuffix(i, mySegs, sanitisedSegmentsByPreview)
-    }
-    return disambiguateExactCollisions(stems)
+    return disambiguateDigestTies(previews.map { renderStem(it) }, previews)
   }
 
   /**
-   * Returns the joined stem (segments joined with `.`) made from the rightmost segments of [mySegs]
-   * that aren't matched, at the same depth, by any other preview's sanitised segments.
-   *
-   * If no proper suffix is unique (two distinct ids whose sanitised segment lists are
-   * byte-identical — the only way every depth matches), return JUST the last segment. The user
-   * wants short on-disk names; the resulting duplicate is then disambiguated with a `_<idx>` suffix
-   * by [disambiguateExactCollisions] rather than padded with the full package path.
+   * The stem for a single preview, computed from that preview alone. Deliberately takes no view of
+   * the rest of the module — see [normalizeRenderOutputs] for why that independence is the point.
    */
-  private fun shortestUniqueSuffix(
-    myIndex: Int,
-    mySegs: List<String>,
-    allSegs: List<List<String>>,
-  ): String {
-    if (mySegs.isEmpty()) return ""
-    for (depth in 1..mySegs.size) {
-      val mySuffix = mySegs.takeLast(depth)
-      val collides =
-        allSegs.withIndex().any { (otherIndex, otherSegs) ->
-          otherIndex != myIndex && otherSegs.takeLast(depth) == mySuffix
-        }
-      if (!collides) return mySuffix.joinToString(".")
+  internal fun renderStem(preview: PreviewInfo): String {
+    val readable =
+      sanitiseSegments(preview)
+        .lastOrNull()
+        .orEmpty()
+        // Truncate before trimming: a cut can land mid-run and leave a trailing `_`.
+        .take(MAX_READABLE_STEM)
+        .trim('_', '-')
+        .ifEmpty { "preview" }
+    return "$readable-${idDigest(preview.id, RENDER_STEM_DIGEST_CHARS)}"
+  }
+
+  /** Lowercase hex of `sha256(id)`, truncated to [chars]. */
+  private fun idDigest(id: String, chars: Int): String =
+    MessageDigest.getInstance("SHA-256")
+      .digest(id.toByteArray(Charsets.UTF_8))
+      .joinToString("") { "%02x".format(it) }
+      .take(chars)
+
+  /**
+   * Backstop for the astronomically unlikely case where two distinct ids agree on both readable
+   * part and truncated digest. Every tied preview is re-stemmed with a full-length digest, which
+   * cannot tie unless the ids are equal (and ids are distinct by manifest construction).
+   *
+   * Only the tied previews are touched, so one freak pair cannot lengthen an unrelated preview's
+   * filename — and because the replacement is still a pure function of the id, the result stays
+   * stable under reordering. That is the property the old positional `_<idx>` tiebreaker lacked:
+   * it indexed into the manifest, so it both churned on reordering and could mint a name that
+   * collided with a real preview's.
+   */
+  private fun disambiguateDigestTies(
+    stems: List<String>,
+    previews: List<PreviewInfo>,
+  ): List<String> {
+    val tied = stems.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+    if (tied.isEmpty()) return stems
+    return stems.mapIndexed { i, stem ->
+      if (stem !in tied) stem
+      else stem.substringBeforeLast('-') + "-" + idDigest(previews[i].id, FULL_DIGEST_CHARS)
     }
-    return mySegs.last()
   }
 
   /**
@@ -1592,9 +1642,9 @@ object PreviewDiscovery {
    * trailing variant suffix (from `@Preview(name = ...)` / `group`) is folded into the
    * function-name segment first, because a name like `"Font scale 1.5x"` carries dots that are NOT
    * structural id separators: splitting the whole id would inject a spurious trailing segment ("1"
-   * | "5x") and the shortest-unique-suffix walk could collapse the entire stem down to it
-   * (`5x.png`). Keeping the id itself lossless preserves manifest dedup (`distinctBy { it.id }`);
-   * any stem collision two distinct ids still produce is handled by [disambiguateExactCollisions].
+   * | "5x"), and [renderStem] takes the *last* segment — so the whole readable stem would collapse
+   * to `5x`. Keeping the id itself lossless preserves manifest dedup (`distinctBy { it.id }`); any
+   * stem collision two distinct ids still produce is handled by [disambiguateDigestTies].
    *
    * Empty segments (e.g. from a leading or trailing `.`, or from a segment that was all-punctuation
    * pre-sanitisation) are dropped so they don't introduce `..` in the resulting stem.
@@ -1618,23 +1668,6 @@ object PreviewDiscovery {
    */
   private fun sanitiseSegment(segment: String): String =
     segment.replace(Regex("[^A-Za-z0-9]+"), "_").trim('_', '-')
-
-  /**
-   * Last-ditch tiebreaker when two distinct preview ids sanitise to exactly the same stem (e.g.
-   * `Foo_bar` and `Foo-bar` both become `Foo_bar`). Appends `_<idx>` to the second-and-later
-   * occurrences in the manifest order; the first occurrence keeps its clean form so the common case
-   * still gets the pretty filename.
-   */
-  private fun disambiguateExactCollisions(stems: List<String>): List<String> {
-    if (stems.toSet().size == stems.size && stems.none { it.isEmpty() }) return stems
-    val counts = mutableMapOf<String, Int>()
-    return stems.mapIndexed { i, raw ->
-      val base = if (raw.isEmpty()) "preview" else raw
-      val seen = counts.getOrDefault(base, 0)
-      counts[base] = seen + 1
-      if (seen == 0 && raw.isNotEmpty()) base else "${base}_${i}"
-    }
-  }
 
   /** `renders/<oldStem><tail>.<ext>` → `renders/<newStem><tail>.<ext>`. */
   private fun rewriteRenderStem(renderOutput: String, oldStem: String, newStem: String): String {

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
@@ -3,16 +3,28 @@ package ee.schimke.composeai.discovery
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
+/**
+ * Contract for render stems: `<readable>-<digest>`, where `<readable>` is the sanitised
+ * function-plus-variant segment and `<digest>` is 8 hex chars of `sha256(preview.id)`.
+ *
+ * See `PreviewDiscovery.normalizeRenderOutputs` for the rationale. The invariants these tests pin
+ * are: the charset never escapes `[A-Za-z0-9._-]`, a stem depends on nothing but its own preview,
+ * and no two previews in a module ever land on the same file — including on case-insensitive
+ * filesystems.
+ */
 class PreviewDiscoveryRenderStemTest {
 
+  /** `<readable>-<8 hex>` with the digest delimited by the one character sanitisation can't emit. */
+  private val stemShape = Regex("[A-Za-z0-9_]+-[0-9a-f]{8}")
+
   /**
-   * Headline invariant: every stem is composed only of `[A-Za-z0-9._]` (no spaces, dashes, parens,
-   * quotes, or anything else a shell would have to quote). Spaces in `@Preview(name = "Devices -
-   * Large Round")` make it into the `preview.id`, but the rewrite strips them at the per-segment
-   * sanitisation step.
+   * Headline invariant: every stem is composed only of `[A-Za-z0-9_-]` (no spaces, parens, quotes,
+   * or anything else a shell would have to quote, and nothing a URL would have to percent-encode).
+   * Spaces in `@Preview(name = "Devices - Large Round")` make it into the `preview.id`; the rewrite
+   * strips them at the sanitisation step.
    */
   @Test
-  fun `every resolved stem is shell-safe - only letters, digits, underscores, and dots`() {
+  fun `every resolved stem is shell-safe and url-safe`() {
     val previews =
       listOf(
         preview("com.example.PreviewsKt.ActivityListPreview_Devices - Large Round"),
@@ -27,103 +39,81 @@ class PreviewDiscoveryRenderStemTest {
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 
     for (stem in stems) {
-      assertThat(stem).matches("[A-Za-z0-9._]+")
+      assertThat(stem).matches(stemShape.pattern)
     }
-    assertThat(stems.toSet().size).isEqualTo(stems.size)
+    assertThat(stems.toSet()).hasSize(stems.size)
   }
 
   @Test
-  fun `function-and-variant alone is the stem when nothing else collides`() {
-    // Headline change from the previous fix: no package, no class — the last sanitised segment
-    // is enough to disambiguate everyone in the module, so we use just that. Matches the user
-    // spec: `ActivityListPreview_Devices_Large_Round.png`.
+  fun `readable part is the function-and-variant segment - never the package or class`() {
+    // The class and package never appear, however many previews share a function name: uniqueness
+    // is the digest's job, so the readable part stays as short as a human would write it.
     val previews =
       listOf(
         preview("com.example.app.PreviewsKt.ActivityListPreview_Devices - Large Round"),
         preview("com.example.app.PreviewsKt.ButtonPreview_Devices - Large Round"),
-        preview("com.example.app.PreviewsKt.BadButtonPreview_Devices - Small Round"),
       )
 
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 
-    assertThat(stems)
-      .containsExactly(
-        "ActivityListPreview_Devices_Large_Round",
-        "ButtonPreview_Devices_Large_Round",
-        "BadButtonPreview_Devices_Small_Round",
-      )
+    assertThat(stems.map { it.substringBeforeLast('-') })
+      .containsExactly("ActivityListPreview_Devices_Large_Round", "ButtonPreview_Devices_Large_Round")
       .inOrder()
   }
 
   @Test
   fun `collapses runs of separator-like characters into a single underscore`() {
-    // ` - ` (space-dash-space) is a run of three "separator" characters in the source name;
-    // every old stem ended up with `Devices_-_Large_Round`. New stems collapse the run.
-    val previews = listOf(preview("com.example.PreviewsKt.Foo_Devices - Large Round"))
-    val stems = PreviewDiscovery.resolveRenderStems(previews)
-    assertThat(stems).containsExactly("Foo_Devices_Large_Round")
+    // ` - ` (space-dash-space) is a run of three "separator" characters in the source name.
+    val stems = listOf(preview("com.example.PreviewsKt.Foo_Devices - Large Round")).let(
+      PreviewDiscovery::resolveRenderStems
+    )
+    assertThat(stems.single().substringBeforeLast('-')).isEqualTo("Foo_Devices_Large_Round")
   }
 
   @Test
   fun `parens, quotes, and other shell-awkward characters all collapse with adjacent runs`() {
-    val previews = listOf(preview("com.example.PreviewsKt.Foo_tile light (light)"))
-    val stems = PreviewDiscovery.resolveRenderStems(previews)
-    assertThat(stems).containsExactly("Foo_tile_light_light")
+    val stems =
+      PreviewDiscovery.resolveRenderStems(listOf(preview("com.example.PreviewsKt.Foo_tile light (light)")))
+    assertThat(stems.single().substringBeforeLast('-')).isEqualTo("Foo_tile_light_light")
   }
 
+  /**
+   * The property the old shortest-unique-suffix walk lacked: a stem is a pure function of its own
+   * preview. Adding an unrelated preview that happens to share a function name used to rename the
+   * existing preview's PNG (`Chip_Light.png` → `PreviewsKt.Chip_Light.png`), which breaks
+   * commit-pinned render URLs and makes base-vs-head diffing see a rename as delete + add.
+   */
   @Test
-  fun `prepends the class segment only when the function-and-variant alone collides`() {
-    // Two `ActivityListPreview` functions in different `Kt` classes (and same variant suffix)
-    // need the class prefix to disambiguate. Every other preview keeps its bare function-level
-    // stem — the per-preview shortest-unique-suffix calc is local, not collective.
-    val previews =
-      listOf(
-        preview("com.example.AmbientPreviewsKt.ActivityListPreview_Devices - Large Round"),
-        preview("com.example.PreviewsKt.ActivityListPreview_Devices - Large Round"),
-        preview("com.example.PreviewsKt.ButtonPreview_Devices - Large Round"),
+  fun `a stem does not change when an unrelated preview is added to the module`() {
+    val existing = preview("com.example.a.PreviewsKt.Chip_Light")
+    val before = PreviewDiscovery.resolveRenderStems(listOf(existing))
+    val after =
+      PreviewDiscovery.resolveRenderStems(
+        listOf(existing, preview("com.example.b.OtherKt.Chip_Light"))
       )
 
-    val stems = PreviewDiscovery.resolveRenderStems(previews)
-
-    assertThat(stems)
-      .containsExactly(
-        "AmbientPreviewsKt.ActivityListPreview_Devices_Large_Round",
-        "PreviewsKt.ActivityListPreview_Devices_Large_Round",
-        // No collision on this function name → stays at depth 1.
-        "ButtonPreview_Devices_Large_Round",
-      )
-      .inOrder()
+    assertThat(after[0]).isEqualTo(before.single())
+    assertThat(after[1]).isNotEqualTo(after[0])
   }
 
+  /** Reordering the manifest must not renumber anything — nothing is positional any more. */
   @Test
-  fun `prepends the package segment only when the class prefix doesn't disambiguate`() {
-    // Two `PreviewsKt.ActivityListPreview_*` in different packages — at depth 2 they collide,
-    // at depth 3 (`<lastPkg>.PreviewsKt.ActivityListPreview_*`) they don't. Other previews
-    // sharing a unique function name stay at depth 1.
-    val previews =
-      listOf(
-        preview("com.example.first.PreviewsKt.ActivityListPreview_Same Variant"),
-        preview("com.example.second.PreviewsKt.ActivityListPreview_Same Variant"),
-        preview("com.example.first.PreviewsKt.UniqueOnePreview_Some Variant"),
-      )
+  fun `stems are stable under manifest reordering`() {
+    val a = preview("com.example.PreviewsKt.Foo_Light")
+    val b = preview("com.example.PreviewsKt.Bar_Dark")
 
-    val stems = PreviewDiscovery.resolveRenderStems(previews)
+    val forward = PreviewDiscovery.resolveRenderStems(listOf(a, b))
+    val reversed = PreviewDiscovery.resolveRenderStems(listOf(b, a))
 
-    assertThat(stems)
-      .containsExactly(
-        "first.PreviewsKt.ActivityListPreview_Same_Variant",
-        "second.PreviewsKt.ActivityListPreview_Same_Variant",
-        "UniqueOnePreview_Some_Variant",
-      )
-      .inOrder()
+    assertThat(reversed).containsExactly(forward[1], forward[0]).inOrder()
   }
 
+  /**
+   * Two ids differing ONLY in characters the sanitiser collapses (underscore vs dash, dot vs
+   * underscore) sanitise to a byte-identical readable part. The digest splits them.
+   */
   @Test
-  fun `appends a numeric disambiguator when sanitisation maps two ids to the same form`() {
-    // Pathological case: two distinct ids that differ ONLY in characters the sanitiser collapses
-    // (underscore vs dash here). After sanitisation they're byte-identical; the per-suffix-depth
-    // search never finds a unique form. The renders directory still has to stay collision-free,
-    // so the second occurrence gets a `_<idx>` suffix.
+  fun `distinct ids that sanitise identically still get distinct stems`() {
     val previews =
       listOf(
         preview("com.example.PreviewsKt.Foo_Pixel 8 (light)"),
@@ -132,30 +122,113 @@ class PreviewDiscoveryRenderStemTest {
 
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 
-    assertThat(stems.toSet().size).isEqualTo(stems.size)
-    for (stem in stems) {
-      assertThat(stem).matches("[A-Za-z0-9._]+")
-    }
-    // First occurrence keeps the clean form; later occurrence carries its manifest index.
-    assertThat(stems[0]).isEqualTo("Foo_Pixel_8_light")
-    assertThat(stems[1]).isEqualTo("Foo_Pixel_8_light_1")
+    assertThat(stems.toSet()).hasSize(2)
+    assertThat(stems.map { it.substringBeforeLast('-') }.toSet()).containsExactly("Foo_Pixel_8_light")
+    for (stem in stems) assertThat(stem).matches(stemShape.pattern)
   }
 
+  /**
+   * Regression: the old positional tiebreaker minted `<stem>_<idx>` without checking it against the
+   * real stems, so a preview genuinely named `Foo_bar_1` was silently overwritten by the
+   * disambiguated form of a colliding pair. Two of three previews shared one PNG.
+   */
   @Test
-  fun `single-preview module - bare function-and-variant segment, no prefixes`() {
-    val previews = listOf(preview("com.example.PreviewsKt.OnlyOne_Variant - With Space"))
+  fun `a disambiguated stem never collides with a preview genuinely named like the disambiguator`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.Foo_bar"),
+        preview("com.example.PreviewsKt.Foo-bar"),
+        preview("com.example.PreviewsKt.Foo_bar_1"),
+      )
 
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 
-    assertThat(stems).containsExactly("OnlyOne_Variant_With_Space")
+    assertThat(stems.toSet()).hasSize(3)
+  }
+
+  /**
+   * APFS and NTFS are case-insensitive: `Foo_Dark.png` and `Foo_dark.png` are one file there. The
+   * ids differ, so the digests differ, so the filenames differ in a case-independent way.
+   */
+  @Test
+  fun `previews differing only by case get stems that differ outside the case-folded part`() {
+    val previews =
+      listOf(preview("com.example.PreviewsKt.Foo_Dark"), preview("com.example.PreviewsKt.Foo_dark"))
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    assertThat(stems.map { it.lowercase() }.toSet()).hasSize(2)
+  }
+
+  /**
+   * Structural suffixes (`_animated`, `_curves`, `_PARAM_<n>`, `_SCROLL_<mode>`) are appended after
+   * the whole stem. Because the digest sits between the readable part and the suffix, a preview
+   * genuinely named `animated` can no longer collide with a sibling's Lottie sidecar.
+   */
+  @Test
+  fun `a preview named like a structural suffix does not collide with a sibling's sidecar`() {
+    val previews =
+      listOf(preview("com.example.PreviewsKt.Logo_animated"), preview("com.example.PreviewsKt.Logo"))
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    val realPreview = stems[0]
+    val siblingSidecar = "${stems[1]}_animated"
+    assertThat(realPreview).isNotEqualTo(siblingSidecar)
+  }
+
+  /**
+   * `NAME_MAX` is 255 bytes on ext4/APFS/NTFS. An unbounded stem blew straight past it; the readable
+   * part is now capped and the digest keeps the truncated form unique.
+   */
+  @Test
+  fun `an absurdly long preview name is truncated but stays unique`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt." + "VeryLongPreviewName".repeat(20) + "A"),
+        preview("com.example.PreviewsKt." + "VeryLongPreviewName".repeat(20) + "B"),
+      )
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    for (stem in stems) {
+      assertThat(stem.length)
+        .isAtMost(PreviewDiscovery.MAX_READABLE_STEM + 1 + PreviewDiscovery.RENDER_STEM_DIGEST_CHARS)
+      assertThat(stem).matches(stemShape.pattern)
+    }
+    assertThat(stems.toSet()).hasSize(2)
+  }
+
+  /** Truncation must not leave a dangling `_` where the cut landed mid-run. */
+  @Test
+  fun `truncation does not leave a trailing separator on the readable part`() {
+    val name = "A".repeat(PreviewDiscovery.MAX_READABLE_STEM) + " tail"
+    val stems = PreviewDiscovery.resolveRenderStems(listOf(preview("com.example.PreviewsKt.$name")))
+
+    assertThat(stems.single().substringBeforeLast('-')).doesNotMatch(".*_$")
+  }
+
+  /**
+   * `CON.png` is unopenable on Windows — reserved device names apply even with an extension. The
+   * unconditional digest suffix means no stem is ever a bare reserved name.
+   */
+  @Test
+  fun `a preview named after a windows reserved device is not a bare reserved name`() {
+    val reserved = listOf("CON", "NUL", "PRN", "AUX", "COM1", "LPT1")
+    val previews = reserved.map { preview("com.example.PreviewsKt.$it") }
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    for (stem in stems) {
+      assertThat(reserved).doesNotContain(stem.substringBefore('.').uppercase())
+    }
   }
 
   @Test
   fun `a dot in the preview name does not truncate the stem to a trailing fragment`() {
     // `@Preview(name = "Font scale 1.5x")` puts a dot in the variant suffix. The dot is NOT a
-    // structural id separator, so the stem must keep the full function-and-variant name rather than
-    // collapsing to the unique fractional tail (`5x`). A sibling at 1.0x guards against the suffix
-    // fold silently dropping segments.
+    // structural id separator, so the readable part must keep the full function-and-variant name
+    // rather than collapsing to the fractional tail (`5x`) — `renderStem` takes the LAST segment.
     val previews =
       listOf(
         PreviewInfo(
@@ -172,7 +245,7 @@ class PreviewDiscoveryRenderStemTest {
 
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 
-    assertThat(stems)
+    assertThat(stems.map { it.substringBeforeLast('-') })
       .containsExactly("FontScale150Preview_Font_scale_1_5x", "FontScale100Preview_Font_scale_1_0x")
       .inOrder()
   }
@@ -180,8 +253,7 @@ class PreviewDiscoveryRenderStemTest {
   @Test
   fun `distinct ids differing only by dot-vs-underscore in the name still get distinct stems`() {
     // Two variants on the same function whose names differ only by `.` vs `_` keep distinct ids
-    // (the manifest dedups by id, so collapsing them would silently drop one). They sanitise to the
-    // same stem form, so the numeric disambiguator must split them on disk.
+    // (the manifest dedups by id, so collapsing them would silently drop one).
     val previews =
       listOf(
         PreviewInfo(
@@ -199,8 +271,19 @@ class PreviewDiscoveryRenderStemTest {
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 
     assertThat(stems.toSet()).hasSize(2)
-    assertThat(stems[0]).isEqualTo("Foo_State_1_5")
-    assertThat(stems[1]).isEqualTo("Foo_State_1_5_1")
+    assertThat(stems.map { it.substringBeforeLast('-') }.toSet()).containsExactly("Foo_State_1_5")
+  }
+
+  /** An id whose every character sanitises away still needs a filename. */
+  @Test
+  fun `an id with no alphanumeric characters falls back to a named stem`() {
+    val previews =
+      listOf(PreviewInfo(id = "***", functionName = "***", className = ""))
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    assertThat(stems.single()).matches(stemShape.pattern)
+    assertThat(stems.single()).startsWith("preview-")
   }
 
   @Test

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -2095,7 +2095,9 @@ class DiscoveryFunctionalTest {
     // DeviceDimensions used the Pixel 6 Pro height here.)
     assertThat(phone.params.heightDp).isEqualTo(914)
     assertThat(phone.id).endsWith("_pixel_6")
-    assertThat(phone.captures.single().renderOutput).endsWith("_pixel_6.png")
+    // `renderOutput` is `<readable>-<digest>.png`, so the device variant is the tail of the
+    // readable part rather than of the whole leaf.
+    assertThat(phone.captures.single().renderOutput).matches("renders/.*_pixel_6-[0-9a-f]{8}\\.png")
 
     val tablet = manifest.previews.single { it.params.device == "id:pixel_tablet" }
     assertThat(tablet.params.widthDp).isEqualTo(1280)
@@ -2341,7 +2343,7 @@ class DiscoveryFunctionalTest {
       )
     assertThat(longPreview.dataProducts.single().kind).isEqualTo("render/scroll/long")
     assertThat(longPreview.dataProducts.single().output)
-      .isEqualTo("data/render-scroll-long/LongScrollPreview.png")
+      .matches("data/render-scroll-long/LongScrollPreview-[0-9a-f]{8}\\.png")
 
     val plain = manifest.previews.single { it.functionName == "PlainPreview" }
     assertThat(plain.captures.single().scroll).isNull()
@@ -2355,16 +2357,14 @@ class DiscoveryFunctionalTest {
     assertThat(topAndEnd.captures.map { it.scroll?.mode })
       .containsExactly(ScrollMode.TOP, ScrollMode.END)
       .inOrder()
-    // renderOutput strips the common `test.` package prefix from every
-    // preview id — the full FQN is retained on `preview.id` itself (and
-    // also stays addressable in `renderOutput`'s basename), but the
-    // on-disk filename drops the shared prefix.
-    assertThat(topAndEnd.captures.map { it.renderOutput })
-      .containsExactly(
-        "renders/TopAndEndScrollPreview_Scroll_SCROLL_top.png",
-        "renders/TopAndEndScrollPreview_Scroll_SCROLL_end.png",
-      )
-      .inOrder()
+    // renderOutput drops the package-and-class prefix from every preview id — the full FQN is
+    // retained on `preview.id` itself. The id digest sits between the readable part and the
+    // structural `_SCROLL_<mode>` suffix, which is what keeps the two namespaces from colliding.
+    val scrollOutputs = topAndEnd.captures.map { it.renderOutput }
+    assertThat(scrollOutputs[0])
+      .matches("renders/TopAndEndScrollPreview_Scroll-[0-9a-f]{8}_SCROLL_top\\.png")
+    assertThat(scrollOutputs[1])
+      .matches("renders/TopAndEndScrollPreview_Scroll-[0-9a-f]{8}_SCROLL_end\\.png")
 
     // Single-mode GIF: moves to the scroll data-product path (no
     // `_SCROLL_gif` suffix) and round-trips `frameIntervalMs` onto the
@@ -2384,19 +2384,20 @@ class DiscoveryFunctionalTest {
       )
     assertThat(gifOnly.dataProducts.single().kind).isEqualTo("render/scroll/gif")
     assertThat(gifOnly.dataProducts.single().output)
-      .isEqualTo("data/render-scroll-gif/GifScrollPreview_Gif.gif")
+      .matches("data/render-scroll-gif/GifScrollPreview_Gif-[0-9a-f]{8}\\.gif")
 
     // Multi-mode with GIF sibling: END remains a normal capture; GIF moves
     // to a data product with its own `_SCROLL_gif` output path.
     val endAndGif = manifest.previews.single { it.functionName == "EndAndGifScrollPreview" }
     assertThat(endAndGif.captures).hasSize(1)
     assertThat(endAndGif.captures.map { it.scroll?.mode }).containsExactly(ScrollMode.END).inOrder()
-    assertThat(endAndGif.captures.map { it.renderOutput })
-      .containsExactly("renders/EndAndGifScrollPreview_EndAndGif.png")
-      .inOrder()
+    assertThat(endAndGif.captures.single().renderOutput)
+      .matches("renders/EndAndGifScrollPreview_EndAndGif-[0-9a-f]{8}\\.png")
     assertThat(endAndGif.dataProducts.single().scroll?.mode).isEqualTo(ScrollMode.GIF)
     assertThat(endAndGif.dataProducts.single().output)
-      .isEqualTo("data/render-scroll-gif/EndAndGifScrollPreview_EndAndGif_SCROLL_gif.gif")
+      .matches(
+        "data/render-scroll-gif/EndAndGifScrollPreview_EndAndGif-[0-9a-f]{8}_SCROLL_gif\\.gif"
+      )
   }
 
   @Test
@@ -2786,15 +2787,16 @@ class DiscoveryFunctionalTest {
     // Kotlin functions land on the synthetic `<File>Kt` class, so
     // the id is `test.PreviewsKt.TileLightStates_tile light (light)`.
     assertThat(light.id).isEqualTo("test.PreviewsKt.TileLightStates_tile light (light)")
-    // `renderOutput` drops the shared `test.PreviewsKt.` dotted
-    // prefix and sanitises the awkward `tile light (light)` variant
-    // suffix down to shell-safe `tile_light_light`.
+    // `renderOutput` drops the `test.PreviewsKt.` package-and-class
+    // prefix, sanitises the awkward `tile light (light)` variant suffix
+    // down to shell-safe `tile_light_light`, and appends the id digest
+    // that keeps the filename unique and stable.
     assertThat(light.captures.single().renderOutput)
-      .isEqualTo("renders/TileLightStates_tile_light_light.png")
+      .matches("renders/TileLightStates_tile_light_light-[0-9a-f]{8}\\.png")
 
     val dark = manifest.previews.single { it.functionName == "TileDarkStates" }
     assertThat(dark.captures.single().renderOutput)
-      .isEqualTo("renders/TileDarkStates_plain_with_slash.png")
+      .matches("renders/TileDarkStates_plain_with_slash-[0-9a-f]{8}\\.png")
   }
 
   @Test

--- a/samples/android-alpha/src/test/kotlin/com/example/samplealpha/FocusedPreviewPixelTest.kt
+++ b/samples/android-alpha/src/test/kotlin/com/example/samplealpha/FocusedPreviewPixelTest.kt
@@ -43,7 +43,7 @@ class FocusedPreviewPixelTest {
    */
   @Test
   fun `fan-out captures differ across focus indices`() {
-    val files = (0..3).map { File(rendersDir, "${fanOutBase}_FOCUS_$it.png") }
+    val files = (0..3).map { renderFile(rendersDir, fanOutBase, "_FOCUS_$it") }
     files.forEach { assertThat(it.exists()).isTrue() }
     val hashes = files.map { it.readBytes().contentHashCode() }.toSet()
     assertThat(hashes).hasSize(4)
@@ -67,10 +67,10 @@ class FocusedPreviewPixelTest {
    */
   @Test
   fun `traversal walks Next-Next-Previous-Next as 0-1-0-1`() {
-    val step1 = File(rendersDir, "${traversalBase}_FOCUS_step1_Next.png")
-    val step2 = File(rendersDir, "${traversalBase}_FOCUS_step2_Next.png")
-    val step3 = File(rendersDir, "${traversalBase}_FOCUS_step3_Previous.png")
-    val step4 = File(rendersDir, "${traversalBase}_FOCUS_step4_Next.png")
+    val step1 = renderFile(rendersDir, traversalBase, "_FOCUS_step1_Next")
+    val step2 = renderFile(rendersDir, traversalBase, "_FOCUS_step2_Next")
+    val step3 = renderFile(rendersDir, traversalBase, "_FOCUS_step3_Previous")
+    val step4 = renderFile(rendersDir, traversalBase, "_FOCUS_step4_Next")
     listOf(step1, step2, step3, step4).forEach { assertThat(it.exists()).isTrue() }
 
     val h1 = step1.readBytes().contentHashCode()
@@ -92,14 +92,14 @@ class FocusedPreviewPixelTest {
    */
   @Test
   fun `moving inset ring lands at a single gif`() {
-    val gif = File(rendersDir, "$movingBase.gif")
+    val gif = renderFile(rendersDir, movingBase, ext = "gif")
     assertThat(gif.exists()).isTrue()
     assertThat(gif.length()).isGreaterThan(0L)
     val header = gif.inputStream().use { it.readNBytes(6).toString(Charsets.US_ASCII) }
     assertThat(header).isAnyOf("GIF87a", "GIF89a")
     // No PNG siblings — the gif flag swapped the per-step PNG fan-out for one GIF.
     (0..3).forEach { i ->
-      val sibling = File(rendersDir, "${movingBase}_FOCUS_$i.png")
+      val sibling = renderFile(rendersDir, movingBase, "_FOCUS_$i")
       assertThat(sibling.exists()).isFalse()
     }
   }
@@ -112,8 +112,8 @@ class FocusedPreviewPixelTest {
   @Test
   fun `overlay paints marker on capture and preserves raw baseline`() {
     for (i in 0..3) {
-      val marked = File(rendersDir, "${overlayBase}_FOCUS_$i.png")
-      val raw = File(rendersDir, "${overlayBase}_FOCUS_$i.raw.png")
+      val marked = renderFile(rendersDir, overlayBase, "_FOCUS_$i")
+      val raw = renderFile(rendersDir, overlayBase, "_FOCUS_$i", ext = "raw.png")
       assertThat(marked.exists()).isTrue()
       assertThat(raw.exists()).isTrue()
       assertThat(marked.readBytes().contentHashCode())

--- a/samples/android-alpha/src/test/kotlin/com/example/samplealpha/RenderFiles.kt
+++ b/samples/android-alpha/src/test/kotlin/com/example/samplealpha/RenderFiles.kt
@@ -1,0 +1,34 @@
+package com.example.samplealpha
+
+import java.io.File
+
+/**
+ * Resolve a rendered artifact by its **readable** stem.
+ *
+ * Render filenames are `<readable>-<digest><structural suffix>.<ext>` — see
+ * `docs/RENDER_FILENAMES.md`. The digest is 8 hex chars of `sha256(preview.id)`, which is what
+ * keeps filenames unique and stable, but it means a test can't spell the whole name literally.
+ * Match on the shape instead: the readable part and any structural suffix (`_SCROLL_top`,
+ * `_FOCUS_2`, `_TIME_800ms`, a `@PreviewParameter` row label) are still predictable.
+ *
+ * Returns a non-existent [File] when nothing matches, so an `exists()` assertion fails with a
+ * readable path rather than a null.
+ */
+internal fun renderFile(
+  dir: File,
+  stem: String,
+  suffix: String = "",
+  ext: String = "png",
+): File {
+  val pattern =
+    Regex("^${Regex.escape(stem)}-[0-9a-f]{8}${Regex.escape(suffix)}\\.${Regex.escape(ext)}$")
+  return dir.listFiles()?.firstOrNull { pattern.matches(it.name) } ?: File(dir, "$stem$suffix.$ext")
+}
+
+/**
+ * The readable stem of a render filename — everything before the `-<digest>`. Inverse of
+ * [renderFile] for tests that enumerate a directory and assert on which previews landed there.
+ */
+internal fun readableStem(fileName: String): String =
+  Regex("^(.*)-[0-9a-f]{8}(?:[._].*)?$").find(fileName.substringBefore(".png"))?.groupValues?.get(1)
+    ?: fileName.substringBefore(".png")

--- a/samples/android-library/src/test/kotlin/com/example/samplelibrary/AndroidViewHtmlTextPixelTest.kt
+++ b/samples/android-library/src/test/kotlin/com/example/samplelibrary/AndroidViewHtmlTextPixelTest.kt
@@ -27,11 +27,11 @@ import org.junit.Test
 class AndroidViewHtmlTextPixelTest {
 
   private val rendersDir = File("build/compose-previews/renders")
-  private val pngName = "HtmlShowNotesPreview_HTML_show_notes.png"
+  private val pngStem = "HtmlShowNotesPreview_HTML_show_notes"
 
   @Test
   fun `AndroidView-hosted preview renders a static PNG with drawn text`() {
-    val file = File(rendersDir, pngName)
+    val file = renderFile(rendersDir, pngStem)
     assertThat(file.exists()).isTrue()
 
     val img = ImageIO.read(file)

--- a/samples/android-library/src/test/kotlin/com/example/samplelibrary/RenderFiles.kt
+++ b/samples/android-library/src/test/kotlin/com/example/samplelibrary/RenderFiles.kt
@@ -1,0 +1,34 @@
+package com.example.samplelibrary
+
+import java.io.File
+
+/**
+ * Resolve a rendered artifact by its **readable** stem.
+ *
+ * Render filenames are `<readable>-<digest><structural suffix>.<ext>` — see
+ * `docs/RENDER_FILENAMES.md`. The digest is 8 hex chars of `sha256(preview.id)`, which is what
+ * keeps filenames unique and stable, but it means a test can't spell the whole name literally.
+ * Match on the shape instead: the readable part and any structural suffix (`_SCROLL_top`,
+ * `_FOCUS_2`, `_TIME_800ms`, a `@PreviewParameter` row label) are still predictable.
+ *
+ * Returns a non-existent [File] when nothing matches, so an `exists()` assertion fails with a
+ * readable path rather than a null.
+ */
+internal fun renderFile(
+  dir: File,
+  stem: String,
+  suffix: String = "",
+  ext: String = "png",
+): File {
+  val pattern =
+    Regex("^${Regex.escape(stem)}-[0-9a-f]{8}${Regex.escape(suffix)}\\.${Regex.escape(ext)}$")
+  return dir.listFiles()?.firstOrNull { pattern.matches(it.name) } ?: File(dir, "$stem$suffix.$ext")
+}
+
+/**
+ * The readable stem of a render filename — everything before the `-<digest>`. Inverse of
+ * [renderFile] for tests that enumerate a directory and assert on which previews landed there.
+ */
+internal fun readableStem(fileName: String): String =
+  Regex("^(.*)-[0-9a-f]{8}(?:[._].*)?$").find(fileName.substringBefore(".png"))?.groupValues?.get(1)
+    ?: fileName.substringBefore(".png")

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/AsyncImagePixelTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/AsyncImagePixelTest.kt
@@ -26,9 +26,9 @@ import org.junit.Test
 class AsyncImagePixelTest {
 
   private val rendersDir = File("build/compose-previews/renders")
-  private val artworkPng = File(rendersDir, "AsyncImageArtworkPreview_Async_Image_Artwork.png")
+  private val artworkPng = renderFile(rendersDir, "AsyncImageArtworkPreview_Async_Image_Artwork")
   private val unreachablePng =
-    File(rendersDir, "AsyncImageUnreachablePreview_Async_Image_Unreachable.png")
+    renderFile(rendersDir, "AsyncImageUnreachablePreview_Async_Image_Unreachable")
 
   @Test
   fun `AsyncImage fed a ByteArray resolves and paints real artwork`() {

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/DividerShowBackgroundPreviewPixelTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/DividerShowBackgroundPreviewPixelTest.kt
@@ -20,14 +20,14 @@ import org.junit.Test
 class DividerShowBackgroundPreviewPixelTest {
 
   private val rendersDir = File("build/compose-previews/renders")
-  private val pngName = "DividerShowBackgroundDarkPreview_Divider_Dark.png"
+  private val pngStem = "DividerShowBackgroundDarkPreview_Divider_Dark"
 
   /** `PreviewBackground.NIGHT_ARGB` (`#1C1B1F`) — Material 3's dark surface. */
   private val nightRgb = 0x1C1B1F
 
   @Test
   fun `dark showBackground divider preview fills the whole crop with the dark surface`() {
-    val file = File(rendersDir, pngName)
+    val file = renderFile(rendersDir, pngStem)
     assertThat(file.exists()).isTrue()
     val img = ImageIO.read(file)
 

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/PreviewModeMatrixTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/PreviewModeMatrixTest.kt
@@ -74,7 +74,7 @@ class PreviewModeMatrixTest {
   fun `every preview mode renders at the size Android Studio resolves`() {
     val mismatches =
       expectedSizes.mapNotNull { (stem, expected) ->
-        val file = File(rendersDir, "$stem.png")
+        val file = renderFile(rendersDir, stem)
         if (!file.exists()) return@mapNotNull "$stem: no PNG rendered"
         val img = ImageIO.read(file) ?: return@mapNotNull "$stem: unreadable PNG"
         val actual = img.width to img.height
@@ -131,7 +131,7 @@ class PreviewModeMatrixTest {
       )
     fanOut.forEach { (function, expected) ->
       val renders = rendersFor(function)
-      assertThat(renders.map { it.name.removePrefix("${function}_").removeSuffix(".png") })
+      assertThat(renders.map { readableStem(it.name).removePrefix("${function}_") })
         .containsExactlyElementsIn(expected)
         .inOrder()
       // Every fan-out entry must be a real, readable image — an empty or zero-sized capture would
@@ -192,10 +192,10 @@ class PreviewModeMatrixTest {
   private fun rendersFor(functionName: String): List<File> =
     (rendersDir.listFiles() ?: emptyArray())
       .filter { it.name.startsWith("${functionName}_") && it.name.endsWith(".png") }
-      .sortedBy { it.name }
+      .sortedBy { readableStem(it.name) }
 
   private fun readRender(stem: String): BufferedImage {
-    val file = File(rendersDir, "$stem.png")
+    val file = renderFile(rendersDir, stem)
     assertThat(file.exists()).isTrue()
     return ImageIO.read(file)
   }

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/RenderFiles.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/RenderFiles.kt
@@ -1,0 +1,34 @@
+package com.example.sampleandroid
+
+import java.io.File
+
+/**
+ * Resolve a rendered artifact by its **readable** stem.
+ *
+ * Render filenames are `<readable>-<digest><structural suffix>.<ext>` — see
+ * `docs/RENDER_FILENAMES.md`. The digest is 8 hex chars of `sha256(preview.id)`, which is what
+ * keeps filenames unique and stable, but it means a test can't spell the whole name literally.
+ * Match on the shape instead: the readable part and any structural suffix (`_SCROLL_top`,
+ * `_FOCUS_2`, `_TIME_800ms`, a `@PreviewParameter` row label) are still predictable.
+ *
+ * Returns a non-existent [File] when nothing matches, so an `exists()` assertion fails with a
+ * readable path rather than a null.
+ */
+internal fun renderFile(
+  dir: File,
+  stem: String,
+  suffix: String = "",
+  ext: String = "png",
+): File {
+  val pattern =
+    Regex("^${Regex.escape(stem)}-[0-9a-f]{8}${Regex.escape(suffix)}\\.${Regex.escape(ext)}$")
+  return dir.listFiles()?.firstOrNull { pattern.matches(it.name) } ?: File(dir, "$stem$suffix.$ext")
+}
+
+/**
+ * The readable stem of a render filename — everything before the `-<digest>`. Inverse of
+ * [renderFile] for tests that enumerate a directory and assert on which previews landed there.
+ */
+internal fun readableStem(fileName: String): String =
+  Regex("^(.*)-[0-9a-f]{8}(?:[._].*)?$").find(fileName.substringBefore(".png"))?.groupValues?.get(1)
+    ?: fileName.substringBefore(".png")

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
@@ -18,6 +18,9 @@ import org.junit.Test
 class ScrollPreviewPixelTest {
 
   private val rendersDir = File("build/compose-previews/renders")
+  // A GIF scroll capture is a data product, not a `renders/` sibling — see the
+  // `render/scroll/gif` kind in the manifest.
+  private val scrollGifDir = File("build/compose-previews/data/render-scroll-gif")
   private val baseName = "RedToBlueScrollPreview_Scroll"
 
   private data class Avg(val r: Double, val g: Double, val b: Double) {
@@ -48,7 +51,7 @@ class ScrollPreviewPixelTest {
 
   @Test
   fun `TOP capture is red-dominant`() {
-    val file = File(rendersDir, "${baseName}_SCROLL_top.png")
+    val file = renderFile(rendersDir, baseName, "_SCROLL_top")
     assertThat(file.exists()).isTrue()
     val avg = averageColor(file)
     assertThat(avg.dominant()).isEqualTo('R')
@@ -58,7 +61,7 @@ class ScrollPreviewPixelTest {
 
   @Test
   fun `END capture is blue-dominant`() {
-    val file = File(rendersDir, "${baseName}_SCROLL_end.png")
+    val file = renderFile(rendersDir, baseName, "_SCROLL_end")
     assertThat(file.exists()).isTrue()
     val avg = averageColor(file)
     // If scroll-to-end silently fails, the image is red-dominant — this
@@ -79,8 +82,7 @@ class ScrollPreviewPixelTest {
    */
   @Test
   fun `GIF capture animates red to blue`() {
-    val gifName = "RedToBlueScrollGifPreview_ScrollGif.gif"
-    val file = File(rendersDir, gifName)
+    val file = renderFile(scrollGifDir, "RedToBlueScrollGifPreview_ScrollGif", ext = "gif")
     assertThat(file.exists()).isTrue()
 
     val frames = readGifFrames(file)
@@ -109,8 +111,10 @@ class ScrollPreviewPixelTest {
   @Test
   fun `GIF capture following END resets scroll and still animates`() {
     val base = "RedToBlueEndThenGifPreview_EndThenGif"
-    val endPng = File(rendersDir, "${base}_SCROLL_end.png")
-    val gif = File(rendersDir, "${base}_SCROLL_gif.gif")
+    // END is the only `renders/` capture here, so it carries no `_SCROLL_end` suffix; the GIF
+    // sibling moves to the scroll data-product directory.
+    val endPng = renderFile(rendersDir, base)
+    val gif = renderFile(scrollGifDir, base, "_SCROLL_gif", ext = "gif")
     assertThat(endPng.exists()).isTrue()
     assertThat(gif.exists()).isTrue()
 

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/TransparentBackgroundPreviewPixelTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/TransparentBackgroundPreviewPixelTest.kt
@@ -19,11 +19,11 @@ import org.junit.Test
 class TransparentBackgroundPreviewPixelTest {
 
   private val rendersDir = File("build/compose-previews/renders")
-  private val pngName = "CircleButtonTransparentPreview_Circle_Button_Transparent.png"
+  private val pngStem = "CircleButtonTransparentPreview_Circle_Button_Transparent"
 
   @Test
   fun `circle button preview keeps alpha=0 in the corners outside the circle`() {
-    val file = File(rendersDir, pngName)
+    val file = renderFile(rendersDir, pngStem)
     assertThat(file.exists()).isTrue()
     val img = ImageIO.read(file)
 

--- a/samples/cmp/src/test/kotlin/com/example/samplecmp/PreviewModeMatrixTest.kt
+++ b/samples/cmp/src/test/kotlin/com/example/samplecmp/PreviewModeMatrixTest.kt
@@ -64,7 +64,7 @@ class PreviewModeMatrixTest {
   @Test
   fun `every preview mode renders at the size Android Studio resolves`() {
     val mismatches = expectedSizes.mapNotNull { (stem, expected) ->
-      val file = File(rendersDir, "$stem.png")
+      val file = renderFile(rendersDir, stem)
       if (!file.exists()) return@mapNotNull "$stem: no PNG rendered"
       val img = ImageIO.read(file) ?: return@mapNotNull "$stem: unreadable PNG"
       val actual = img.width to img.height
@@ -104,7 +104,7 @@ class PreviewModeMatrixTest {
       )
     fanOut.forEach { (function, expected) ->
       val renders = rendersFor(function)
-      assertThat(renders.map { it.name.removePrefix("${function}_").removeSuffix(".png") })
+      assertThat(renders.map { readableStem(it.name).removePrefix("${function}_") })
         .containsExactlyElementsIn(expected)
         .inOrder()
       renders.forEach { file ->
@@ -149,10 +149,10 @@ class PreviewModeMatrixTest {
   private fun rendersFor(functionName: String): List<File> =
     (rendersDir.listFiles() ?: emptyArray())
       .filter { it.name.startsWith("${functionName}_") && it.name.endsWith(".png") }
-      .sortedBy { it.name }
+      .sortedBy { readableStem(it.name) }
 
   private fun readRender(stem: String): BufferedImage {
-    val file = File(rendersDir, "$stem.png")
+    val file = renderFile(rendersDir, stem)
     assertThat(file.exists()).isTrue()
     return ImageIO.read(file)
   }

--- a/samples/cmp/src/test/kotlin/com/example/samplecmp/RenderFiles.kt
+++ b/samples/cmp/src/test/kotlin/com/example/samplecmp/RenderFiles.kt
@@ -1,0 +1,29 @@
+package com.example.samplecmp
+
+import java.io.File
+
+/**
+ * Resolve a rendered artifact by its **readable** stem.
+ *
+ * Render filenames are `<readable>-<digest><structural suffix>.<ext>` — see
+ * `docs/RENDER_FILENAMES.md`. The digest is 8 hex chars of `sha256(preview.id)`, which is what
+ * keeps filenames unique and stable, but it means a test can't spell the whole name literally.
+ * Match on the shape instead: the readable part and any structural suffix (`_SCROLL_top`,
+ * `_FOCUS_2`, `_TIME_800ms`, a `@PreviewParameter` row label) are still predictable.
+ *
+ * Returns a non-existent [File] when nothing matches, so an `exists()` assertion fails with a
+ * readable path rather than a null.
+ */
+internal fun renderFile(dir: File, stem: String, suffix: String = "", ext: String = "png"): File {
+  val pattern =
+    Regex("^${Regex.escape(stem)}-[0-9a-f]{8}${Regex.escape(suffix)}\\.${Regex.escape(ext)}$")
+  return dir.listFiles()?.firstOrNull { pattern.matches(it.name) } ?: File(dir, "$stem$suffix.$ext")
+}
+
+/**
+ * The readable stem of a render filename — everything before the `-<digest>`. Inverse of
+ * [renderFile] for tests that enumerate a directory and assert on which previews landed there.
+ */
+internal fun readableStem(fileName: String): String =
+  Regex("^(.*)-[0-9a-f]{8}(?:[._].*)?$").find(fileName.substringBefore(".png"))?.groupValues?.get(1)
+    ?: fileName.substringBefore(".png")

--- a/samples/design-catalog-remote-m3/src/test/kotlin/com/example/designcatalogremotem3/RenderFiles.kt
+++ b/samples/design-catalog-remote-m3/src/test/kotlin/com/example/designcatalogremotem3/RenderFiles.kt
@@ -1,0 +1,34 @@
+package com.example.designcatalogremotem3
+
+import java.io.File
+
+/**
+ * Resolve a rendered artifact by its **readable** stem.
+ *
+ * Render filenames are `<readable>-<digest><structural suffix>.<ext>` — see
+ * `docs/RENDER_FILENAMES.md`. The digest is 8 hex chars of `sha256(preview.id)`, which is what
+ * keeps filenames unique and stable, but it means a test can't spell the whole name literally.
+ * Match on the shape instead: the readable part and any structural suffix (`_SCROLL_top`,
+ * `_FOCUS_2`, `_TIME_800ms`, a `@PreviewParameter` row label) are still predictable.
+ *
+ * Returns a non-existent [File] when nothing matches, so an `exists()` assertion fails with a
+ * readable path rather than a null.
+ */
+internal fun renderFile(
+  dir: File,
+  stem: String,
+  suffix: String = "",
+  ext: String = "png",
+): File {
+  val pattern =
+    Regex("^${Regex.escape(stem)}-[0-9a-f]{8}${Regex.escape(suffix)}\\.${Regex.escape(ext)}$")
+  return dir.listFiles()?.firstOrNull { pattern.matches(it.name) } ?: File(dir, "$stem$suffix.$ext")
+}
+
+/**
+ * The readable stem of a render filename — everything before the `-<digest>`. Inverse of
+ * [renderFile] for tests that enumerate a directory and assert on which previews landed there.
+ */
+internal fun readableStem(fileName: String): String =
+  Regex("^(.*)-[0-9a-f]{8}(?:[._].*)?$").find(fileName.substringBefore(".png"))?.groupValues?.get(1)
+    ?: fileName.substringBefore(".png")

--- a/samples/design-catalog-remote-m3/src/test/kotlin/com/example/designcatalogremotem3/WidgetContainerIrCaptureTest.kt
+++ b/samples/design-catalog-remote-m3/src/test/kotlin/com/example/designcatalogremotem3/WidgetContainerIrCaptureTest.kt
@@ -30,14 +30,14 @@ class WidgetContainerIrCaptureTest {
   @Test
   fun `every widget container sticker renders`() {
     for (stem in widgetStickers) {
-      assertThat(File(rendersDir, "$stem.png").exists()).isTrue()
+      assertThat(renderFile(rendersDir, stem).exists()).isTrue()
     }
   }
 
   @Test
   fun `every widget container sticker emits its encoded RemoteCompose document as a rc sidecar`() {
     for (stem in widgetStickers) {
-      val rc = File(rendersDir, "$stem.rc")
+      val rc = renderFile(rendersDir, stem, ext = "rc")
       assertThat(rc.exists()).isTrue()
       // A real encoded document, not an empty placeholder.
       assertThat(rc.length()).isGreaterThan(0L)
@@ -62,7 +62,7 @@ class WidgetContainerIrCaptureTest {
         "WidgetContainerGradientRemote" to listOf("Gradient"),
       )
     for ((stem, strings) in expected) {
-      val bytes = File(rendersDir, "$stem.rc").readBytes().toString(Charsets.UTF_8)
+      val bytes = renderFile(rendersDir, stem, ext = "rc").readBytes().toString(Charsets.UTF_8)
       for (s in strings) {
         assertThat(bytes).contains(s)
       }

--- a/samples/remotecompose/src/test/kotlin/com/example/sampleremotecompose/RemoteWidgetDocCaptureTest.kt
+++ b/samples/remotecompose/src/test/kotlin/com/example/sampleremotecompose/RemoteWidgetDocCaptureTest.kt
@@ -25,7 +25,7 @@ class RemoteWidgetDocCaptureTest {
 
   @Test
   fun `shape-wrapped remote widget still captures the encoded rcdoc`() {
-    val rcdoc = File(rendersDir, "$stem.rcdoc")
+    val rcdoc = renderFile(rendersDir, stem, ext = "rcdoc")
     assertThat(rcdoc.exists()).isTrue()
     // A real encoded RemoteCompose document, not an empty placeholder.
     assertThat(rcdoc.length()).isGreaterThan(0L)
@@ -33,7 +33,7 @@ class RemoteWidgetDocCaptureTest {
 
   @Test
   fun `shape-wrapped remote widget renders clipped to its ideal shape`() {
-    val png = File(rendersDir, "$stem.png")
+    val png = renderFile(rendersDir, stem)
     assertThat(png.exists()).isTrue()
     val img = ImageIO.read(png)
 

--- a/samples/remotecompose/src/test/kotlin/com/example/sampleremotecompose/RenderFiles.kt
+++ b/samples/remotecompose/src/test/kotlin/com/example/sampleremotecompose/RenderFiles.kt
@@ -1,0 +1,34 @@
+package com.example.sampleremotecompose
+
+import java.io.File
+
+/**
+ * Resolve a rendered artifact by its **readable** stem.
+ *
+ * Render filenames are `<readable>-<digest><structural suffix>.<ext>` — see
+ * `docs/RENDER_FILENAMES.md`. The digest is 8 hex chars of `sha256(preview.id)`, which is what
+ * keeps filenames unique and stable, but it means a test can't spell the whole name literally.
+ * Match on the shape instead: the readable part and any structural suffix (`_SCROLL_top`,
+ * `_FOCUS_2`, `_TIME_800ms`, a `@PreviewParameter` row label) are still predictable.
+ *
+ * Returns a non-existent [File] when nothing matches, so an `exists()` assertion fails with a
+ * readable path rather than a null.
+ */
+internal fun renderFile(
+  dir: File,
+  stem: String,
+  suffix: String = "",
+  ext: String = "png",
+): File {
+  val pattern =
+    Regex("^${Regex.escape(stem)}-[0-9a-f]{8}${Regex.escape(suffix)}\\.${Regex.escape(ext)}$")
+  return dir.listFiles()?.firstOrNull { pattern.matches(it.name) } ?: File(dir, "$stem$suffix.$ext")
+}
+
+/**
+ * The readable stem of a render filename — everything before the `-<digest>`. Inverse of
+ * [renderFile] for tests that enumerate a directory and assert on which previews landed there.
+ */
+internal fun readableStem(fileName: String): String =
+  Regex("^(.*)-[0-9a-f]{8}(?:[._].*)?$").find(fileName.substringBefore(".png"))?.groupValues?.get(1)
+    ?: fileName.substringBefore(".png")

--- a/samples/wear/src/test/kotlin/com/example/samplewear/AmbientPreviewPixelTest.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/AmbientPreviewPixelTest.kt
@@ -27,9 +27,10 @@ class AmbientPreviewPixelTest {
   private val rendersDir = File("build/compose-previews/renders")
 
   private val interactivePng =
-    File(rendersDir, "AmbientStatusInteractivePreview_Ambient_body_interactive.png")
+    renderFile(rendersDir, "AmbientStatusInteractivePreview_Ambient_body_interactive")
 
-  private val ambientPng = File(rendersDir, "AmbientStatusAmbientPreview_Ambient_body_ambient.png")
+  private val ambientPng =
+    renderFile(rendersDir, "AmbientStatusAmbientPreview_Ambient_body_ambient")
 
   /**
    * Both PNGs must exist and differ — same composition body, the only difference is the

--- a/samples/wear/src/test/kotlin/com/example/samplewear/GestureHintPreviewPixelTest.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/GestureHintPreviewPixelTest.kt
@@ -18,10 +18,10 @@ class GestureHintPreviewPixelTest {
 
   private val rendersDir = File("build/compose-previews/renders")
 
-  private val hintOffPng = File(rendersDir, "MediaGestureScreenPreview_Media_hints_off.png")
+  private val hintOffPng = renderFile(rendersDir, "MediaGestureScreenPreview_Media_hints_off")
 
   private val hintOnPng =
-    File(rendersDir, "MediaGestureScreenHintPreview_Media_hints_on_TIME_800ms.png")
+    renderFile(rendersDir, "MediaGestureScreenHintPreview_Media_hints_on", "_TIME_800ms")
 
   @Test
   fun `hint-off and hint-on renders differ`() {

--- a/samples/wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
@@ -20,11 +20,10 @@ import org.junit.Test
  */
 class LongScrollPreviewPixelTest {
 
-  private val longPng =
-    File(
-      "build/compose-previews/data/render-scroll-long/" +
-        "ActivityListLongPreview_Devices_Large_Round.png"
-    )
+  private val scrollLongDir = File("build/compose-previews/data/render-scroll-long")
+  private val scrollGifDir = File("build/compose-previews/data/render-scroll-gif")
+
+  private val longPng = renderFile(scrollLongDir, "ActivityListLongPreview_Devices_Large_Round")
 
   @Test
   fun `LONG preview produces a tall stitched PNG`() {
@@ -110,10 +109,7 @@ class LongScrollPreviewPixelTest {
   @Test
   fun `LONG capture always flattens motion in a multi-mode annotation`() {
     val motionLongPng =
-      File(
-        "build/compose-previews/data/render-scroll-long/" +
-          "ActivityListMotionLongPreview_Devices_Large_Round_SCROLL_long.png"
-      )
+      renderFile(scrollLongDir, "ActivityListMotionLongPreview_Devices_Large_Round", "_SCROLL_long")
     assertThat(motionLongPng.exists()).isTrue()
     val img = ImageIO.read(motionLongPng)
     // Multi-slice stitch, not a single-frame fallback.
@@ -130,9 +126,11 @@ class LongScrollPreviewPixelTest {
   @Test
   fun `GIF sibling of forced-flatten LONG still animates`() {
     val gif =
-      File(
-        "build/compose-previews/data/render-scroll-gif/" +
-          "ActivityListMotionLongPreview_Devices_Large_Round_SCROLL_gif.gif"
+      renderFile(
+        scrollGifDir,
+        "ActivityListMotionLongPreview_Devices_Large_Round",
+        "_SCROLL_gif",
+        ext = "gif",
       )
     assertThat(gif.exists()).isTrue()
     assertThat(readGifFrames(gif).size).isAtLeast(2)

--- a/samples/wear/src/test/kotlin/com/example/samplewear/RenderFiles.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/RenderFiles.kt
@@ -1,0 +1,34 @@
+package com.example.samplewear
+
+import java.io.File
+
+/**
+ * Resolve a rendered artifact by its **readable** stem.
+ *
+ * Render filenames are `<readable>-<digest><structural suffix>.<ext>` — see
+ * `docs/RENDER_FILENAMES.md`. The digest is 8 hex chars of `sha256(preview.id)`, which is what
+ * keeps filenames unique and stable, but it means a test can't spell the whole name literally.
+ * Match on the shape instead: the readable part and any structural suffix (`_SCROLL_top`,
+ * `_FOCUS_2`, `_TIME_800ms`, a `@PreviewParameter` row label) are still predictable.
+ *
+ * Returns a non-existent [File] when nothing matches, so an `exists()` assertion fails with a
+ * readable path rather than a null.
+ */
+internal fun renderFile(
+  dir: File,
+  stem: String,
+  suffix: String = "",
+  ext: String = "png",
+): File {
+  val pattern =
+    Regex("^${Regex.escape(stem)}-[0-9a-f]{8}${Regex.escape(suffix)}\\.${Regex.escape(ext)}$")
+  return dir.listFiles()?.firstOrNull { pattern.matches(it.name) } ?: File(dir, "$stem$suffix.$ext")
+}
+
+/**
+ * The readable stem of a render filename — everything before the `-<digest>`. Inverse of
+ * [renderFile] for tests that enumerate a directory and assert on which previews landed there.
+ */
+internal fun readableStem(fileName: String): String =
+  Regex("^(.*)-[0-9a-f]{8}(?:[._].*)?$").find(fileName.substringBefore(".png"))?.groupValues?.get(1)
+    ?: fileName.substringBefore(".png")

--- a/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerCaptureAdditivePixelTest.kt
+++ b/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerCaptureAdditivePixelTest.kt
@@ -37,17 +37,17 @@ class GlimmerCaptureAdditivePixelTest {
   // `NowPlayingCard_Glimmer_Light.png` (not `_·_`).
   private val nowPlayingCaptures =
     listOf(
-      "NowPlayingCard_Glimmer_Light.png",
-      "NowPlayingCard_Glimmer_Dark.png",
-      "NowPlayingCard_Glimmer_Busy.png",
-      "NowPlayingCard_Glimmer_VeniceCanalCats.png",
+      "NowPlayingCard_Glimmer_Light",
+      "NowPlayingCard_Glimmer_Dark",
+      "NowPlayingCard_Glimmer_Busy",
+      "NowPlayingCard_Glimmer_VeniceCanalCats",
     )
 
-  private val focusableMenuCapture = "FocusableMenu_Glimmer_Input.png"
+  private val focusableMenuCapture = "FocusableMenu_Glimmer_Input"
 
   @Test
   fun `every Glimmer capture is opaque RGB with additive-zero corners`() {
-    val files = (nowPlayingCaptures + focusableMenuCapture).map { File(rendersDir, it) }
+    val files = (nowPlayingCaptures + focusableMenuCapture).map { renderFile(rendersDir, it) }
     files.forEach { file ->
       assertThat(file.exists()).isTrue()
       val img = ImageIO.read(file)
@@ -80,7 +80,7 @@ class GlimmerCaptureAdditivePixelTest {
    */
   @Test
   fun `four NowPlayingCard env variants land at pixel-identical captures`() {
-    val files = nowPlayingCaptures.map { File(rendersDir, it) }
+    val files = nowPlayingCaptures.map { renderFile(rendersDir, it) }
     files.forEach { assertThat(it.exists()).isTrue() }
     val hashes = files.map { it.readBytes().contentHashCode() }.toSet()
     assertThat(hashes).hasSize(1)

--- a/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuTest.kt
+++ b/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuTest.kt
@@ -45,7 +45,7 @@ class GlimmerInteractiveMenuTest {
   @Test
   fun `every env variant lands as a non-empty GIF`() {
     envGifBasenames.forEach { base ->
-      val gif = File(rendersDir, "$base.gif")
+      val gif = renderFile(rendersDir, base, ext = "gif")
       assertThat(gif.exists()).isTrue()
       assertThat(gif.length()).isGreaterThan(0L)
       val header = gif.inputStream().use { it.readNBytes(6).toString(Charsets.US_ASCII) }
@@ -59,7 +59,7 @@ class GlimmerInteractiveMenuTest {
     // GIF. None of them should leak out as standalone PNGs, for any env.
     envGifBasenames.forEach { base ->
       (0..3).forEach { i ->
-        val sibling = File(rendersDir, "${base}_FOCUS_$i.png")
+        val sibling = renderFile(rendersDir, base, "_FOCUS_$i")
         assertThat(sibling.exists()).isFalse()
       }
     }
@@ -76,7 +76,7 @@ class GlimmerInteractiveMenuTest {
    */
   @Test
   fun `four env GIFs render visually distinct backdrops`() {
-    val files = envGifBasenames.map { File(rendersDir, "$it.gif") }
+    val files = envGifBasenames.map { renderFile(rendersDir, it, ext = "gif") }
     files.forEach { assertThat(it.exists()).isTrue() }
     val hashes = files.map { it.readBytes().contentHashCode() }.toSet()
     assertThat(hashes).hasSize(files.size)

--- a/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/RenderFiles.kt
+++ b/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/RenderFiles.kt
@@ -1,0 +1,34 @@
+package com.example.samplexrglimmer
+
+import java.io.File
+
+/**
+ * Resolve a rendered artifact by its **readable** stem.
+ *
+ * Render filenames are `<readable>-<digest><structural suffix>.<ext>` — see
+ * `docs/RENDER_FILENAMES.md`. The digest is 8 hex chars of `sha256(preview.id)`, which is what
+ * keeps filenames unique and stable, but it means a test can't spell the whole name literally.
+ * Match on the shape instead: the readable part and any structural suffix (`_SCROLL_top`,
+ * `_FOCUS_2`, `_TIME_800ms`, a `@PreviewParameter` row label) are still predictable.
+ *
+ * Returns a non-existent [File] when nothing matches, so an `exists()` assertion fails with a
+ * readable path rather than a null.
+ */
+internal fun renderFile(
+  dir: File,
+  stem: String,
+  suffix: String = "",
+  ext: String = "png",
+): File {
+  val pattern =
+    Regex("^${Regex.escape(stem)}-[0-9a-f]{8}${Regex.escape(suffix)}\\.${Regex.escape(ext)}$")
+  return dir.listFiles()?.firstOrNull { pattern.matches(it.name) } ?: File(dir, "$stem$suffix.$ext")
+}
+
+/**
+ * The readable stem of a render filename — everything before the `-<digest>`. Inverse of
+ * [renderFile] for tests that enumerate a directory and assert on which previews landed there.
+ */
+internal fun readableStem(fileName: String): String =
+  Regex("^(.*)-[0-9a-f]{8}(?:[._].*)?$").find(fileName.substringBefore(".png"))?.groupValues?.get(1)
+    ?: fileName.substringBefore(".png")


### PR DESCRIPTION
## Summary

Render stems are now **`<readable>-<digest>`** — the sanitised function-plus-variant segment, then 8 hex chars of `sha256(preview.id)`:

```
ActivityListPreview_Devices_Large_Round-4f9c2a17.png
└──────────── readable ──────────────┘ └ digest ┘
```

This replaces a shortest-unique-suffix walk (which read *every sibling preview* to decide how much of the package/class path to prepend) plus a positional `_<idx>` tiebreaker.

Making the stem a **pure function of one preview's own id** is the whole change, and it fixes five defects at once. Each was reproduced against `resolveRenderStems` before the fix and is now covered by a test:

| Defect | Before | After |
|---|---|---|
| **Silent overwrite** | `Foo_bar` + `Foo-bar` + `Foo_bar_1` → **2 distinct filenames for 3 previews**. The `_<idx>` tiebreaker minted names without checking them against real stems. | 3 distinct |
| **Instability** | Adding an unrelated `b.OtherKt.Chip_Light` renamed the existing preview's PNG `Chip_Light.png` → `PreviewsKt.Chip_Light.png` | unchanged |
| **Case collisions** | `Foo_Dark` / `Foo_dark` — distinct on Linux, **one file on APFS/NTFS** | distinct case-independently |
| **Suffix collisions** | A preview named `Logo_animated` collided with the Lottie sidecar of a sibling named `Logo` | digest sits between the readable part and the structural suffix, separating the namespaces |
| **Length / reserved names** | a 380-char stem (past the 255-byte `NAME_MAX`); `CON.png` unopenable on Windows | capped at 80 chars; never a bare `CON`/`NUL` |

The instability row is the expensive one: it silently undermines the visual-evidence workflow this repo is built around, since a renamed PNG breaks commit-pinned `raw.githubusercontent.com/.../renders/...` URLs and makes base-vs-head diffing see a rename as delete + add rather than a diff. The notification-previews bot on this very PR shows it: the one-time migration reads as *2 added / 2 removed* rather than *2 changed*. That churn happens once; after this, names never move.

**Preview ids are unchanged**, so daemon row addressing (`<baseId>_<row>`), history folders, CLI state and JUnit test names are all unaffected. Only the on-disk filename changes.

### Consumers

Sample pixel tests spelled render filenames out literally, so every one of them would have failed against a digested render. Each affected sample test source set gains a small `RenderFiles.kt`: `renderFile(dir, stem, suffix, ext)` matches `<readable>-<digest><suffix>.<ext>` on shape, and `readableStem(name)` strips the digest back off for the two `PreviewModeMatrixTest`s that enumerate a directory and derive variant names from filenames. Ten test files across `android`, `android-alpha`, `android-library`, `cmp`, `wear`, `xr-glimmer`, `design-catalog-remote-m3`, `remotecompose`. Tests keep their expressive readable stems and stop predicting the part of the name they were never meant to know.

Two assertions in `ScrollPreviewPixelTest` were **already wrong before this branch** and are corrected here, since the same lines were being touched: a GIF scroll capture is a `render/scroll/gif` data product under `data/render-scroll-gif/`, not a `renders/` sibling, and an END capture that is the only capture carries no `_SCROLL_end` suffix. Both are pinned by `DiscoveryFunctionalTest` on either side of this change.

### The one stability exception

If two ids ever agree on *both* readable part and truncated digest, only the tied previews are re-stemmed with a full-length sha256. That is the single case where a sibling can move a preview's filename, and it's deliberate: resolving a collision inherently requires knowing about the collision, so no per-id-only rule keeps names both stable and unique, and dropping the backstop would turn a tie back into the silent overwrite this change exists to prevent. Trigger probability is ~5 × 10⁻⁸ for 20 previews sharing a readable stem. Ordering committed to: **correctness > stability > brevity**. Documented in `docs/RENDER_FILENAMES.md`.

## Test plan

- `:gradle-plugin:preview-discovery:test` — **176 tests, 0 failures**. `PreviewDiscoveryRenderStemTest` rewritten against the new contract: 17 tests, one per defect above plus charset, reordering-stability, truncation-trailing-separator, and empty/all-punctuation-id fallback.
- `:gradle-plugin:functionalTest` — **93 tests, 0 failures**. Six exact-filename assertions relaxed to shape-matching regexes; these also pin that the digest lands *before* the structural `_SCROLL_` / `_PARAM_` suffixes.
- `:samples:android` — verified against **real rendered output**: `composePreviewRenderAll` renders 152 of 154 previews in this container, and all 19 sample unit tests pass against those PNGs. Real filenames produced, including the `@PreviewParameter` fan-out:
  ```
  ActionsPreview_Actions-5426f9c9.png
  BigTextVariantsPreview_Japanese-89b2bcd1.png
  BodyTextPreview_Body_Text-a7d8cd21_The_quick_brown_fox.png
  RedToBlueScrollPreview_Scroll-cf80fc4e_SCROLL_top.png
  ```
- `:samples:cmp:composePreviewDiscover` — 67 captures, 67 distinct filenames.
- All touched sample test source sets compile; `:gradle-plugin:test`, `:cli:test`, `:daemon:core:test`, `ktfmtCheckAll` pass.

**No visual evidence: this change is not UI-affecting.** It alters the filename a render is written to, not a single rendered pixel — the Robolectric renders above are byte-identical to their pre-change counterparts, only relocated. The 2 previews that don't render here are the skiko-backed lottie/svg pair, which need `libGL`; that isn't loadable under this sandbox's Nix-store userland (the trap documented in `docs/AGENTS.md` — forcing `LD_LIBRARY_PATH` at the system glibc breaks the Nix bash outright). CI's full render suite is the confirmation for those two.

## Notes for follow-up

Pre-existing `check` failures, unrelated to this diff and confirmed to reproduce on `main` with these changes stashed:
- `:appwidget-preview-runtime:lintDebug`, `:notification-preview-runtime:lintDebug` — `NewApi` errors.
- `:rc-player-trace:compileKotlinIosSimulatorArm64` — konan toolchain needs `libstdc++.so.6`, an environment limitation here.

`cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt:594` carries a *second*, independent "filesystem-safe stem" implementation for `bundle split`. It dedups against a `usedStems` set so it has no collision bug, but it's a separate naming scheme that could be unified with this one later.