### PR TITLE
fix(serve): evict catalog snapshots on retirement, and close the suspend race

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -319,8 +319,7 @@ class ServeHttpServer(
           // it was suspended. Taken from the host being suspended, so a catalog refreshed and then
           // idled out snapshots the REPLACEMENT — the case a lazily-primed map got wrong, since a
           // stale entry could answer a tab that loaded before the refresh.
-          sessions.isKnownSession(system) ->
-            catalogMetaSeen[system]?.sourceLocations?.get(previewId)
+          sessions.isKnownSession(system) -> catalogSourceLocationsSeen[system]?.get(previewId)
           // Retired: the catalog is gone and every other session-backed route for it 404s. A
           // remembered location would keep answering — and keep re-fetching the old repository
           // once the seed's TTL lapsed — long after the catalog was withdrawn.
@@ -3305,19 +3304,27 @@ class ServeHttpServer(
    */
   private val catalogMetaSeen = ConcurrentHashMap<String, CatalogMeta>()
 
+  /**
+   * Where each preview's source lives, per system, so `/usage/<id>` can answer for a **suspended**
+   * catalog — the snapshot [ServeSessionRegistry.peekHost] tells a caller to keep rather than read
+   * absence as a verdict.
+   *
+   * Its own map beside [catalogMetaSeen] rather than a field inside it, for one reason: it is
+   * written *first*, before the hero thumbnail is baked. That bake decodes and rescales a PNG, and
+   * a session is detached from its host **under** the registry lock while listeners run **after**
+   * it is released — so a Source request arriving in between would find `peekHost` null, the
+   * session still known, and a snapshot not yet installed. Publishing the cheap half up front
+   * closes that window instead of widening it by a decode.
+   *
+   * Same lifecycle as [catalogMetaSeen] otherwise, and dropped in the same places: written on
+   * suspension and on resident reads, replaced wholesale by a refresh, and evicted when the catalog
+   * is retired.
+   */
+  private val catalogSourceLocationsSeen =
+    ConcurrentHashMap<String, Map<String, PlaygroundSeedResolver.Location>>()
+
   /** A resident-time snapshot of one catalog's status facts. See [catalogMetaSeen]. */
   private data class CatalogMeta(
-    /**
-     * Where each preview's source lives, so `/usage/<id>` can answer for a **suspended** catalog.
-     *
-     * Carried in this snapshot rather than in a map of its own precisely because that map turned
-     * out to need every property this one already has: written on suspension, refreshed on every
-     * resident read, replaced wholesale when a refresh re-registers the system, and dropped with
-     * the session. `peekHost` says as much in its own KDoc — a caller that needs a session's facts
-     * keeps a last-known snapshot via the suspend listener rather than reading absence as a
-     * verdict.
-     */
-    val sourceLocations: Map<String, PlaygroundSeedResolver.Location>,
     val title: String?,
     val subtitle: String?,
     val trust: String?,
@@ -3371,6 +3378,13 @@ class ServeHttpServer(
   init {
     // Snapshot a catalog's facts as its daemon goes idle — the last moment they're readable.
     sessions.addSuspendListener { id, host -> rememberCatalogMeta(id, host) }
+    // A retired catalog's snapshots go with it. Without this every published-then-retired system
+    // on a churning host is retained for the life of the process — a pre-existing leak of
+    // [catalogMetaSeen] that the source locations would have made materially heavier.
+    sessions.addUnregisterListener { id ->
+      catalogMetaSeen.remove(id)
+      catalogSourceLocationsSeen.remove(id)
+    }
   }
 
   /**
@@ -3381,27 +3395,29 @@ class ServeHttpServer(
    */
   private fun rememberCatalogMeta(id: String, host: ServeHost) {
     val bundle = catalogBundleHost(host) ?: return
+    // Published BEFORE the hero bake below — see [catalogSourceLocationsSeen] for why the order
+    // matters.
+    val catalogSource = bundle.catalogSource
+    catalogSourceLocationsSeen[id] =
+      if (catalogSource == null) emptyMap()
+      else
+        host.previews
+          .mapNotNull { preview ->
+            val file = preview.sourceFile?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            preview.id to
+              PlaygroundSeedResolver.Location(
+                repo = catalogSource.repo,
+                ref = catalogSource.ref,
+                module = catalogSource.module,
+                sourceFile = file,
+                bodyLine = preview.bodyLine,
+              )
+          }
+          .toMap()
     val heroId = bundle.declaredHeroPreviewId ?: ServeWeb.representativePreviewId(host.previews)
     val heroCrop = heroId?.let { bundle.contentCrop(it) }
-    val catalogSource = bundle.catalogSource
     catalogMetaSeen[id] =
       CatalogMeta(
-        sourceLocations =
-          if (catalogSource == null) emptyMap()
-          else
-            host.previews
-              .mapNotNull { preview ->
-                val file = preview.sourceFile?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-                preview.id to
-                  PlaygroundSeedResolver.Location(
-                    repo = catalogSource.repo,
-                    ref = catalogSource.ref,
-                    module = catalogSource.module,
-                    sourceFile = file,
-                    bodyLine = preview.bodyLine,
-                  )
-              }
-              .toMap(),
         title = bundle.title?.takeIf { it.isNotBlank() } ?: host.label,
         subtitle = bundle.subtitle,
         trust = BundleVerifier.summary(bundle.trust),

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -149,6 +149,22 @@ class ServeSessionRegistry(
     suspendListeners += listener
   }
 
+  /**
+   * Observers notified when a session is **retired** ([unregister]), so a caller holding a
+   * last-known snapshot of it (see [peekHost]) can drop it.
+   *
+   * The snapshot advice in [peekHost] has no counterpart without this: a holder is told to keep
+   * facts across suspension, and then has no way to learn that the session it kept them for is
+   * gone. On a host with catalog churn — publish, serve, retire, repeat through the admin API —
+   * every retired catalog's snapshot is retained for the life of the process.
+   */
+  private val unregisterListeners = CopyOnWriteArrayList<(String) -> Unit>()
+
+  /** Register a retirement observer. See [unregisterListeners]. */
+  fun addUnregisterListener(listener: (sessionId: String) -> Unit) {
+    unregisterListeners += listener
+  }
+
   // Wall-clock of the most recent acquire/lease/release across all sessions — the basis for the
   // server-level idle check ([idleMillis]) that the ephemeral exit-when-idle watchdog reads.
   @Volatile private var lastActivity: Long = clock()
@@ -249,6 +265,11 @@ class ServeSessionRegistry(
   fun unregister(sessionId: String): Boolean {
     val removed = lock.withLock { sessions.remove(sessionId) }
     removed?.host?.let { runCatching { it.close() } }
+    // Outside the lock and guarded, exactly like the suspend notification: a listener may re-enter
+    // the registry, and one that throws must not leave the session half-retired.
+    if (removed != null) {
+      unregisterListeners.forEach { listener -> runCatching { listener(sessionId) } }
+    }
     return removed != null
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
@@ -230,6 +231,32 @@ class ServeSessionRegistryTest {
         assertEquals(0, factory.built.get(), "a registered session is never built by the factory")
         assertEquals(1, opener.opened.get(), "resumed via the opener")
       }
+  }
+
+  /**
+   * The counterpart to [ServeSessionRegistry.addSuspendListener].
+   *
+   * `peekHost` tells a caller that needs a session's facts to keep a last-known snapshot across
+   * suspension. Without a retirement signal that advice has no ending: the holder is told to keep
+   * facts and never told the session they belong to is gone, so a host that publishes, serves and
+   * retires catalogs through the admin API retains every one of them for the life of the process.
+   */
+  @Test
+  fun `unregister notifies snapshot holders so a retired catalog can be dropped`() {
+    val retired = mutableListOf<String>()
+    ServeSessionRegistry(open = Opener()).use { reg ->
+      reg.addUnregisterListener { retired += it }
+      reg.register("compose-m3", stateFor("compose-m3"))
+      reg.register("wear-m3", stateFor("wear-m3"))
+
+      assertTrue(reg.unregister("compose-m3"), "the registered catalog was retired")
+      assertEquals(listOf("compose-m3"), retired, "only the retired catalog is announced")
+
+      // Nothing was removed, so nothing is announced — a holder must not drop a live session's
+      // snapshot because somebody asked to retire a name that was never registered.
+      assertFalse(reg.unregister("never-published"), "an unknown id retires nothing")
+      assertEquals(listOf("compose-m3"), retired, "a no-op retirement announces nothing")
+    }
   }
 
   @Test


### PR DESCRIPTION
Two findings against the snapshot #3835 moved `/usage` source locations into. Both merged before I could push, so they land here.

## Retired catalogs were never evicted

`catalogMetaSeen` is written on suspension and on resident reads, and removed **nowhere**. A host that publishes, serves and retires catalogs through the admin API keeps every one of them for the life of the process.

That leak pre-dates this work, but attaching a source location per preview to each stale entry made it materially heavier — and #3835 also dropped the 4096-entry cap the earlier map had. So this is mine to close.

The registry now has an **unregister listener** — the counterpart the snapshot advice in `peekHost` never had. Its KDoc tells callers to keep a last-known snapshot across suspension, then gives them no way to learn the session it belongs to is gone. Both snapshots are dropped when a catalog retires.

## A Source request could land in the gap between detachment and the snapshot

`suspendIdle` nulls the entry's host **under** the registry lock and runs listeners **after** releasing it. So `isKnownSession` could be true while no snapshot was installed yet — and `rememberCatalogMeta` widened that window by baking the hero thumbnail (a PNG decode and rescale) *before* assigning the map. A first Source click landing in there got a transient 404.

The source locations are now published **first**, in their own map beside the catalog meta rather than as a field inside it. Same lifecycle — written and evicted in exactly the same places, so they cannot drift — but cheap enough to land before the expensive half instead of behind it.

Keeping them as a field would have meant either publishing a half-built `CatalogMeta` (which the status and home pages also read) or leaving the window open. A sibling map with an identical lifecycle is the smaller compromise.

## Test plan

- `./gradlew :cli:test` green against current `main`; `ktfmtCheck` clean.
- **New test, and it closes part of the gap I flagged on #3835:** `ServeSessionRegistryTest` now covers the retirement signal — that `unregister` announces the retired id to snapshot holders, and that a no-op retirement of an unknown id announces nothing (so a holder can't be tricked into dropping a live session's snapshot). That path is public registry API, so unlike the rest it is directly testable.
- Still untested by me: the suspended-read and refresh paths inside `ServeHttpServer`, which need a harness that drives a session through suspension and re-registration. Smaller than it was — the `locate` branch is now three lines over a map this PR gives a tested lifecycle — but I would rather name it than imply coverage.

Non-visual: registry lifecycle and resolver plumbing, no markup or styling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_