### PR TITLE
fix(serve): capture session snapshots as part of the registry's transitions

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3309,16 +3309,20 @@ class ServeHttpServer(
    * catalog — the snapshot [ServeSessionRegistry.peekHost] tells a caller to keep rather than read
    * absence as a verdict.
    *
-   * Its own map beside [catalogMetaSeen] rather than a field inside it, for one reason: it is
-   * written *first*, before the hero thumbnail is baked. That bake decodes and rescales a PNG, and
-   * a session is detached from its host **under** the registry lock while listeners run **after**
-   * it is released — so a Source request arriving in between would find `peekHost` null, the
-   * session still known, and a snapshot not yet installed. Publishing the cheap half up front
-   * closes that window instead of widening it by a decode.
+   * Written and removed **only** by [ServeSessionRegistry.SessionSnapshots], under the registry's
+   * own lock, as part of the detach and retire transitions. That single-writer rule is what makes
+   * it correct rather than merely narrow: a reader sees the session resident (and uses the live
+   * host) or suspended-with-a-snapshot, never the gap between, and a retirement cannot be overtaken
+   * by a slower writer still holding the removed host.
    *
-   * Same lifecycle as [catalogMetaSeen] otherwise, and dropped in the same places: written on
-   * suspension and on resident reads, replaced wholesale by a refresh, and evicted when the catalog
-   * is retired.
+   * Two earlier shapes did not hold, and both failed the same way — the storage was the registry's
+   * business but lived outside it. Refreshing this from resident reads gave it a second writer
+   * outside the lock, which is how a retired catalog's entry came back. Publishing it from a
+   * suspend listener only shortened the window, because listeners run after the lock is released.
+   *
+   * Nothing is written while a session is resident, and nothing needs to be: the live host answers
+   * then, and the snapshot is taken from the host being detached, which is fresher than anything a
+   * resident read could have left behind.
    */
   private val catalogSourceLocationsSeen =
     ConcurrentHashMap<String, Map<String, PlaygroundSeedResolver.Location>>()
@@ -3378,13 +3382,50 @@ class ServeHttpServer(
   init {
     // Snapshot a catalog's facts as its daemon goes idle — the last moment they're readable.
     sessions.addSuspendListener { id, host -> rememberCatalogMeta(id, host) }
-    // A retired catalog's snapshots go with it. Without this every published-then-retired system
-    // on a churning host is retained for the life of the process — a pre-existing leak of
-    // [catalogMetaSeen] that the source locations would have made materially heavier.
-    sessions.addUnregisterListener { id ->
-      catalogMetaSeen.remove(id)
-      catalogSourceLocationsSeen.remove(id)
-    }
+    // A retired catalog's status snapshot goes with it. Without this every published-then-retired
+    // system on a churning host is retained for the life of the process. This one is a listener
+    // rather than a registry transition because [catalogMetaSeen] is also written from resident
+    // status reads, so it has other writers by design and cannot claim the guarantee below; the
+    // eviction is still strictly better than never evicting.
+    sessions.addUnregisterListener { id -> catalogMetaSeen.remove(id) }
+    // The source locations ride the registry's own transitions instead — see
+    // [catalogSourceLocationsSeen]. Both halves are pure map operations: no I/O, no blocking, no
+    // re-entry into the registry, which is what the under-lock contract requires.
+    sessions.setSessionSnapshots(
+      object : ServeSessionRegistry.SessionSnapshots {
+        override fun capture(sessionId: String, host: ServeHost) {
+          catalogSourceLocationsSeen[sessionId] = sourceLocationsOf(host)
+        }
+
+        override fun discard(sessionId: String) {
+          catalogSourceLocationsSeen.remove(sessionId)
+        }
+      }
+    )
+  }
+
+  /**
+   * Every preview's source location on [host], as the suspended-catalog snapshot keeps them.
+   *
+   * Runs under the registry lock (see [ServeSessionRegistry.SessionSnapshots]), so it walks the
+   * preview list, builds a map, and does nothing else — no render, no decode, no I/O.
+   */
+  private fun sourceLocationsOf(host: ServeHost): Map<String, PlaygroundSeedResolver.Location> {
+    val bundle = catalogBundleHost(host) ?: return emptyMap()
+    val source = bundle.catalogSource ?: return emptyMap()
+    return host.previews
+      .mapNotNull { preview ->
+        val file = preview.sourceFile?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        preview.id to
+          PlaygroundSeedResolver.Location(
+            repo = source.repo,
+            ref = source.ref,
+            module = source.module,
+            sourceFile = file,
+            bodyLine = preview.bodyLine,
+          )
+      }
+      .toMap()
   }
 
   /**
@@ -3395,25 +3436,6 @@ class ServeHttpServer(
    */
   private fun rememberCatalogMeta(id: String, host: ServeHost) {
     val bundle = catalogBundleHost(host) ?: return
-    // Published BEFORE the hero bake below — see [catalogSourceLocationsSeen] for why the order
-    // matters.
-    val catalogSource = bundle.catalogSource
-    catalogSourceLocationsSeen[id] =
-      if (catalogSource == null) emptyMap()
-      else
-        host.previews
-          .mapNotNull { preview ->
-            val file = preview.sourceFile?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-            preview.id to
-              PlaygroundSeedResolver.Location(
-                repo = catalogSource.repo,
-                ref = catalogSource.ref,
-                module = catalogSource.module,
-                sourceFile = file,
-                bodyLine = preview.bodyLine,
-              )
-          }
-          .toMap()
     val heroId = bundle.declaredHeroPreviewId ?: ServeWeb.representativePreviewId(host.previews)
     val heroCrop = heroId?.let { bundle.contentCrop(it) }
     catalogMetaSeen[id] =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3394,7 +3394,12 @@ class ServeHttpServer(
     sessions.setSessionSnapshots(
       object : ServeSessionRegistry.SessionSnapshots {
         override fun capture(sessionId: String, host: ServeHost) {
-          catalogSourceLocationsSeen[sessionId] = sourceLocationsOf(host)
+          // Nothing stored for a host with no catalog source — a forked revision session, a plain
+          // module — rather than an empty map per session. The GC discards these anyway, but an
+          // entry that can never answer is not worth holding in the first place.
+          val locations = sourceLocationsOf(host)
+          if (locations.isEmpty()) catalogSourceLocationsSeen.remove(sessionId)
+          else catalogSourceLocationsSeen[sessionId] = locations
         }
 
         override fun discard(sessionId: String) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -165,6 +165,39 @@ class ServeSessionRegistry(
     unregisterListeners += listener
   }
 
+  /**
+   * A projection of a session's host that has to outlive its residency, captured and discarded as
+   * part of the registry's **own** transitions rather than alongside them.
+   *
+   * [addSuspendListener] cannot provide this, and the difference is the whole point. A suspend
+   * listener runs *after* the lock is released, so a reader can observe the moment in between:
+   * `peekHost` already null, [isKnownSession] still true, and no snapshot yet. And because a
+   * listener writes to storage the registry does not own, a retirement can be overtaken by a slower
+   * writer still holding the removed host, which resurrects the entry it just evicted.
+   *
+   * Both disappear when the capture and the transition are the same act. [capture] runs under the
+   * lock immediately before the host is detached, so "resident" and "snapshotted" are the only two
+   * states a reader can see; [discard] runs under the same lock as the removal, so nothing can be
+   * written back afterwards.
+   *
+   * The cost of that guarantee is the contract: both run **with the registry lock held**, so an
+   * implementation must do no I/O, must not block, and must never re-enter the registry.
+   */
+  interface SessionSnapshots {
+    /** Under the lock, immediately before [host] is detached from [sessionId]. */
+    fun capture(sessionId: String, host: ServeHost)
+
+    /** Under the lock, as [sessionId] is retired. */
+    fun discard(sessionId: String)
+  }
+
+  @Volatile private var snapshots: SessionSnapshots? = null
+
+  /** Install the [SessionSnapshots] hook. See its KDoc for the contract it must honour. */
+  fun setSessionSnapshots(snapshots: SessionSnapshots?) {
+    this.snapshots = snapshots
+  }
+
   // Wall-clock of the most recent acquire/lease/release across all sessions — the basis for the
   // server-level idle check ([idleMillis]) that the ephemeral exit-when-idle watchdog reads.
   @Volatile private var lastActivity: Long = clock()
@@ -263,7 +296,15 @@ class ServeSessionRegistry(
    * under that id.
    */
   fun unregister(sessionId: String): Boolean {
-    val removed = lock.withLock { sessions.remove(sessionId) }
+    val removed = lock.withLock {
+      val removed = sessions.remove(sessionId)
+      // Discarded under the SAME lock as the removal, so a concurrent detach either captured
+      // before this and is discarded here, or finds no entry to capture from at all. Outside the
+      // lock the two can interleave, and the slower writer resurrects what the retirement just
+      // evicted.
+      if (removed != null) snapshots?.let { runCatching { it.discard(sessionId) } }
+      removed
+    }
     removed?.host?.let { runCatching { it.close() } }
     // Outside the lock and guarded, exactly like the suspend notification: a listener may re-enter
     // the registry, and one that throws must not leave the session half-retired.
@@ -376,6 +417,9 @@ class ServeSessionRegistry(
             !host.backgroundWorkActive &&
             now - entry.lastAccess >= idleTimeoutMillis
         ) {
+          // Under the lock, BEFORE the detach: this and `entry.host = null` are one transition,
+          // so no reader can catch the session detached with its snapshot not yet published.
+          snapshots?.let { runCatching { it.capture(id, host) } }
           entry.host = null
           entry.startedAt = null
           entry.closing = true

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -487,6 +487,12 @@ class ServeSessionRegistry(
     }
     for ((id, entry) in stale) {
       sessions.remove(id)
+      // The second removal path, and it has to discard too. Every suspended session is captured —
+      // a forked revision host included, which contributes an empty map since it is no catalog —
+      // so a GC that removed the entry without the snapshot would leak one per reclaimed revision
+      // and defeat exactly the bound this function exists to enforce. Under the same lock as the
+      // removal, like [unregister].
+      snapshots?.let { runCatching { it.discard(id) } }
       runCatching { entry.state?.reclaim?.invoke() }
     }
     stale.size

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -527,6 +527,49 @@ class ServeSessionRegistryTest {
       }
   }
 
+  /**
+   * The GC is the *second* removal path, and it has to discard too.
+   *
+   * Every suspended session is captured, a forked revision host included, so a reclaim that removed
+   * the entry without its snapshot would leak one per reclaimed revision — defeating the bound this
+   * GC exists to enforce, on the surface with the most churn.
+   */
+  @Test
+  fun `reclaiming a forked session discards its snapshot`() {
+    val clock = AtomicLong(0)
+    val held = mutableSetOf<String>()
+    val factory = ServeSessionFactory { id -> stateFor(id) }
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        suspendedGcTimeoutMillis = 1_000,
+        clock = clock::get,
+      )
+      .use { reg ->
+        reg.setSessionSnapshots(
+          object : ServeSessionRegistry.SessionSnapshots {
+            override fun capture(sessionId: String, host: ServeHost) {
+              held += sessionId
+            }
+
+            override fun discard(sessionId: String) {
+              held -= sessionId
+            }
+          }
+        )
+        assertNotNull(reg.acquire("rev1"))
+        clock.set(200)
+        assertEquals(1, reg.suspendIdle())
+        assertEquals(setOf("rev1"), held, "suspended, so a snapshot is held for it")
+
+        clock.set(1_500)
+        assertEquals(1, reg.reclaimIdleForked(), "past the GC window → reclaimed")
+        assertEquals(emptySet(), held, "and the GC discarded its snapshot with it")
+      }
+  }
+
   @Test
   fun `a long-idle suspended forked session is reclaimed and its worktree pruned`() {
     val clock = AtomicLong(0)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -259,6 +259,87 @@ class ServeSessionRegistryTest {
     }
   }
 
+  /**
+   * The guarantee a suspend listener cannot give: no reader can observe a session detached from its
+   * host with its snapshot not yet published.
+   *
+   * `capture` runs under the registry lock immediately before the detach, so the two are one
+   * transition. This asserts it from inside the callback — at the moment `capture` runs the host is
+   * still attached, which is exactly what makes "resident" and "snapshotted" the only two states
+   * visible from outside.
+   */
+  @Test
+  fun `a snapshot is captured as part of the detach, not after it`() {
+    val clock = AtomicLong(0)
+    val captured = mutableListOf<String>()
+    var attachedAtCapture: Boolean? = null
+    ServeSessionRegistry(
+        open = Opener(),
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        reg.setSessionSnapshots(
+          object : ServeSessionRegistry.SessionSnapshots {
+            override fun capture(sessionId: String, host: ServeHost) {
+              captured += sessionId
+              // Read through the registry's own accessor: still resident here, because the detach
+              // has not happened yet. If capture ever moves after it, this flips and the window
+              // this test exists to deny is back.
+              attachedAtCapture = reg.peekHost(sessionId) != null
+            }
+
+            override fun discard(sessionId: String) {
+              captured -= sessionId
+            }
+          }
+        )
+        reg.register("compose-m3", stateFor("compose-m3"))
+        assertNotNull(reg.acquire("compose-m3"), "resident before the idle window")
+
+        clock.set(1_000)
+        assertEquals(1, reg.suspendIdle(), "the idle session was suspended")
+        assertEquals(listOf("compose-m3"), captured, "its snapshot was captured")
+        assertEquals(true, attachedAtCapture, "capture ran BEFORE the host was detached")
+        assertNull(reg.peekHost("compose-m3"), "and the session is suspended afterwards")
+      }
+  }
+
+  /** Retirement discards under the same lock, so nothing survives the catalog it belonged to. */
+  @Test
+  fun `retiring a suspended catalog discards its snapshot`() {
+    val clock = AtomicLong(0)
+    val held = mutableSetOf<String>()
+    ServeSessionRegistry(
+        open = Opener(),
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        reg.setSessionSnapshots(
+          object : ServeSessionRegistry.SessionSnapshots {
+            override fun capture(sessionId: String, host: ServeHost) {
+              held += sessionId
+            }
+
+            override fun discard(sessionId: String) {
+              held -= sessionId
+            }
+          }
+        )
+        reg.register("compose-m3", stateFor("compose-m3"))
+        reg.acquire("compose-m3")
+        clock.set(1_000)
+        reg.suspendIdle()
+        assertEquals(setOf("compose-m3"), held, "suspended, so its snapshot is held")
+
+        assertTrue(reg.unregister("compose-m3"), "the catalog was retired")
+        assertEquals(emptySet(), held, "and its snapshot went with it")
+      }
+  }
+
   @Test
   fun `liveSeatWeight surfaces the session state's weight, defaulting to 1`() {
     ServeSessionRegistry(open = Opener()).use { reg ->


### PR DESCRIPTION
The structural fix for the two races review found on #3841. Both had one cause: the storage was the registry's business but lived outside it, coordinated by a listener *beside* the transition instead of being *part* of it.

## What could not be fixed from outside

**The suspend gap.** A suspend listener runs after the lock is released, so a reader could catch the moment in between — `peekHost` already null, `isKnownSession` still true, no snapshot yet — and get a transient 404 on the first Source click. Publishing before the hero bake only shortened it: the listener still ran late, and the projection has to walk every preview.

**Retirement being overtaken.** Because a listener writes storage the registry doesn't own, an admin retirement could lose to a slower writer still holding the removed host — a resident status read, or a concurrent suspend — recreating the entry the retirement had just evicted. The leak survived under churn.

## SessionSnapshots

`capture` runs **under the lock, immediately before the host is detached**, so "resident" and "snapshotted" are the only two states visible from outside. `discard` runs **under the same lock as the removal**, so nothing can be written back afterwards.

The price is the contract, and the interface says so: both run with the registry lock held — no I/O, no blocking, no re-entering the registry. Both implementations here are map operations over a list already in memory.

A side benefit: the source locations now have exactly one writer and need no resident-read refresh, which makes them *fresher* — taken from the host being detached rather than from whenever a status page last looked.

## This closes the test gap I've carried for three PRs

The reason the previous rounds were untested is that the logic lived in private members of `ServeHttpServer` and needed a server driven through suspension. As a registry transition it is a unit, so:

- **`a snapshot is captured as part of the detach, not after it`** — asserts from *inside* `capture` that `reg.peekHost(id)` is still non-null at that moment. If capture ever moves after the detach, this flips and the window is back.
- **`retiring a suspended catalog discards its snapshot`** — suspends, confirms the snapshot is held, retires, confirms it is gone.

Plus the retirement-signal test from #3841.

## What deliberately did not change

`catalogMetaSeen` (the status/home snapshot) keeps its listener-based eviction. It is also written from resident reads, so it has other writers **by design** and cannot claim this guarantee. Its eviction is still strictly better than the never-evicting behaviour that predates this work; giving it the same treatment would mean changing how the status page refreshes, which is out of scope here.

## Test plan

- `./gradlew :cli:test` green against current `main`; `ktfmtCheck` clean.
- Two new registry tests above; `ServeSessionRegistryTest` now covers capture ordering, retirement discard, and the unregister signal.

Non-visual: registry lifecycle and resolver plumbing, no markup or styling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_