### PR TITLE
fix(discovery): case-fold the render stem tie test

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1583,16 +1583,24 @@ object PreviewDiscovery {
    * rationale. Exposed `internal` so the unit tests can assert the charset, the stability of a stem
    * under unrelated additions, and the collision paths directly without a full discovery pipeline.
    */
-  internal fun resolveRenderStems(previews: List<PreviewInfo>): List<String> {
+  internal fun resolveRenderStems(
+    previews: List<PreviewInfo>,
+    // Narrowed only by tests: a real 8-hex tie needs ~2^32 work to construct, so the backstop and
+    // its case-folding are exercised at a width where a collision is reachable.
+    digestChars: Int = RENDER_STEM_DIGEST_CHARS,
+  ): List<String> {
     if (previews.isEmpty()) return emptyList()
-    return disambiguateDigestTies(previews.map { renderStem(it) }, previews)
+    return disambiguateDigestTies(previews.map { renderStem(it, digestChars) }, previews)
   }
 
   /**
    * The stem for a single preview, computed from that preview alone. Deliberately takes no view of
    * the rest of the module — see [normalizeRenderOutputs] for why that independence is the point.
    */
-  internal fun renderStem(preview: PreviewInfo): String {
+  internal fun renderStem(
+    preview: PreviewInfo,
+    digestChars: Int = RENDER_STEM_DIGEST_CHARS,
+  ): String {
     val readable =
       sanitiseSegments(preview)
         .lastOrNull()
@@ -1601,7 +1609,7 @@ object PreviewDiscovery {
         .take(MAX_READABLE_STEM)
         .trim('_', '-')
         .ifEmpty { "preview" }
-    return "$readable-${idDigest(preview.id, RENDER_STEM_DIGEST_CHARS)}"
+    return "$readable-${idDigest(preview.id, digestChars)}"
   }
 
   /** Lowercase hex of `sha256(id)`, truncated to [chars]. */
@@ -1626,10 +1634,15 @@ object PreviewDiscovery {
     stems: List<String>,
     previews: List<PreviewInfo>,
   ): List<String> {
-    val tied = stems.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+    // Case-folded, because the question is "do these address the same file", and on APFS/NTFS
+    // `Foo_Dark-<d>.png` and `Foo_dark-<d>.png` do. Grouping case-sensitively here would let a
+    // case-only pair that also tied on the digest slip through the backstop and overwrite. The
+    // stems themselves keep their original casing — only the tie test folds.
+    val tied =
+      stems.groupingBy { it.lowercase() }.eachCount().filterValues { it > 1 }.keys
     if (tied.isEmpty()) return stems
     return stems.mapIndexed { i, stem ->
-      if (stem !in tied) stem
+      if (stem.lowercase() !in tied) stem
       else stem.substringBeforeLast('-') + "-" + idDigest(previews[i].id, FULL_DIGEST_CHARS)
     }
   }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
@@ -286,6 +286,66 @@ class PreviewDiscoveryRenderStemTest {
     assertThat(stems.single()).startsWith("preview-")
   }
 
+  /**
+   * The backstop expands both sides of a genuine digest tie. Exercised at a 2-char digest because
+   * constructing an 8-char tie needs ~2^32 work; the logic under test is width-independent.
+   */
+  @Test
+  fun `a genuine digest tie expands both tied stems`() {
+    // These two ids collide on the first 2 hex chars of sha256 (verified pair).
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.Foo_Dark50"),
+        preview("com.example.PreviewsKt.Foo_dark50"),
+      )
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews, digestChars = 2)
+
+    assertThat(stems.toSet()).hasSize(2)
+    // Both sides carry the full-length digest, not just the second one.
+    for (stem in stems) {
+      assertThat(stem.substringAfterLast('-')).hasLength(PreviewDiscovery.FULL_DIGEST_CHARS)
+    }
+  }
+
+  /**
+   * Regression: the tie test groups case-folded. Two stems differing only by case address the same
+   * file on APFS/NTFS, so a case-only pair that *also* ties on the digest must still be expanded —
+   * a case-sensitive grouping would call them distinct and let one overwrite the other.
+   */
+  @Test
+  fun `a case-only pair that also ties on the digest is still expanded`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.Foo_Dark50"),
+        preview("com.example.PreviewsKt.Foo_dark50"),
+      )
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews, digestChars = 2)
+
+    // The point: distinct *case-insensitively*, which is what the filesystem compares.
+    assertThat(stems.map { it.lowercase() }.toSet()).hasSize(2)
+  }
+
+  /** A tie must not drag unrelated previews into the long form. */
+  @Test
+  fun `a digest tie leaves untied stems untouched`() {
+    val bystander = preview("com.example.PreviewsKt.Unrelated_Preview")
+    val alone = PreviewDiscovery.resolveRenderStems(listOf(bystander), digestChars = 2).single()
+
+    val withTie =
+      PreviewDiscovery.resolveRenderStems(
+        listOf(
+          preview("com.example.PreviewsKt.Foo_Dark50"),
+          preview("com.example.PreviewsKt.Foo_dark50"),
+          bystander,
+        ),
+        digestChars = 2,
+      )
+
+    assertThat(withTie[2]).isEqualTo(alone)
+  }
+
   @Test
   fun `empty input returns empty stems list`() {
     assertThat(PreviewDiscovery.resolveRenderStems(emptyList())).isEmpty()


### PR DESCRIPTION
## Summary

Follow-up to #3839, from review feedback that landed after it merged.

`disambiguateDigestTies` grouped stems **case-sensitively**. Two previews whose readable parts differ only by case *and* whose truncated digests coincide were therefore never classified as tied, so their digests were never expanded:

```
Foo_Dark-51….png
Foo_dark-51….png     ← same file on APFS / NTFS
```

That is the exact failure mode the digest was introduced to close, surviving inside the backstop meant to guarantee it. #3839's case-safety argument was "distinct ids ⇒ distinct digests", which holds right up until the digests happen to tie — and the tie path then failed to notice, because it compared the way Linux does rather than the way the filesystem does.

Fix: group by the case-folded stem. Stems keep their original casing; only the tie test folds.

## Testability

An 8-hex tie needs ~2³² work to construct, so the backstop was previously only reachable in theory. `resolveRenderStems` and `renderStem` gain an `internal digestChars` parameter (defaulted, so no production call site changes) — at 2 hex a real colliding pair is findable, and the logic under test is width-independent.

`com.example.PreviewsKt.Foo_Dark50` and `…Foo_dark50` collide on the first 2 hex chars of sha256; that verified pair drives all three new tests.

## Test plan

`:gradle-plugin:preview-discovery:test` — **20 tests in `PreviewDiscoveryRenderStemTest`, 0 failures** (17 before). Three added:

- `a genuine digest tie expands both tied stems` — both sides get the full-length digest, not just the later one.
- `a case-only pair that also ties on the digest is still expanded` — the regression this PR fixes; fails without the case-fold, since the two stems are equal case-insensitively.
- `a digest tie leaves untied stems untouched` — a freak pair must not drag an unrelated preview onto the long form.

`:gradle-plugin:test` and `ktfmtCheckAll` pass.

Not UI-affecting — no rendered pixel changes, and no filename changes outside the tie path, which is unreachable in any real module today.

## Still open from the same review

Two findings from that review are **not** addressed here, deliberately:

- **Asset-preview collisions.** Lottie/SVG previews are appended *after* `normalizeRenderOutputs` with literal stems and default to the same `renders/` directory, so they never participate in stem resolution. A collision needs a composable literally named `lottie__Foo` alongside an asset file named `Foo-` plus that same 8-hex digest, with a `.json` extension. Real, but pre-existing and *less* likely after #3839 — previously only the names had to match, now the digest must too. Worth a separate fix: a duplicate-output check across the combined manifest (which would also catch any future appender), or reserving the `lottie__` / `svg__` namespace so normalised stems cannot enter it.
- **Consumer skill docs.** `yschimke/skills` carries concrete filename examples — `skills/compose-preview-review/references/agent-audits.md` uses the `renders/com.example.ProfileHeaderPreview.png` and `…SaveToolbarPreview.a11y.png` forms. Those need the new format, but note they were **already stale before #3839** (main stripped the package prefix, so the `com.example.` form hasn't been produced for some time). That's a separate PR in a different repo, which this session can only read.