### PR TITLE
fix(samples): restore the Remote Compose doc-capture guard, unstale an xr-glimmer comment

### DIFF
--- a/samples/remotecompose/build.gradle.kts
+++ b/samples/remotecompose/build.gradle.kts
@@ -12,7 +12,7 @@ composePreview {
   // `:samples:android` for the broader JDK 17 toolchain rationale.
   sdkVersion.set(35)
 
-  // `RemoteWidgetDocCaptureTest` reads the `.rcdoc` sidecar + PNG from
+  // `RemoteWidgetDocCaptureTest` reads the `.rc` sidecar + PNG from
   // `build/compose-previews/renders/`; chain the unit-test tasks onto `composePreviewRenderAll`.
   renderBeforeUnitTests.set(true)
 }

--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/WearWidgetPreviews.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/WearWidgetPreviews.kt
@@ -26,7 +26,7 @@ import ee.schimke.composeai.daemon.RemoteOverridablePreviewWrapper
 /**
  * The Remote Compose widget "content" — the payload a real Glance Wear widget draws, and whose
  * **encoded RemoteCompose document is the critical artifact** the render pipeline captures as the
- * `<stem>.rcdoc` sidecar (packed into the bundle by `BundlePreviewTask.resolvePreviewIr`).
+ * `<stem>.rc` sidecar (packed into the bundle by `BundlePreviewTask.resolvePreviewIr`).
  */
 @Composable
 @RemoteComposable
@@ -48,10 +48,10 @@ fun RemoteImageWidget() {
  * A Wear widget **shape** wrapper that preserves the encoded RemoteCompose document.
  *
  * This is the crux of framing a Remote Compose widget in its ideal shape without losing the doc.
- * The `.rcdoc` capture is done *by the RemoteCompose wrapper itself* — [RemoteOverridablePreviewWrapper]
+ * The `.rc` capture is done *by the RemoteCompose wrapper itself* — [RemoteOverridablePreviewWrapper]
  * `.Wrap` runs `captureSingleRemoteDocument` and offers the bytes to `IrSidecarChannel` — and a
  * `@Preview` may carry only **one** `@PreviewWrapper`. A shape wrapper that *replaced* the Remote
- * Compose wrapper would silently drop the `.rcdoc` (verified: the in-body `RemoteContentPreview`
+ * Compose wrapper would silently drop the `.rc` (verified: the in-body `RemoteContentPreview`
  * previews here produce no sidecar, only the `@PreviewWrapper(RemotePreviewWrapper::class)` ones do).
  *
  * So this wrapper **extends** [RemoteOverridablePreviewWrapper] and clips its rendered output to the
@@ -63,7 +63,7 @@ class SquircleRemoteWidgetWrapper : RemoteOverridablePreviewWrapper() {
   @Composable
   override fun Wrap(content: @Composable () -> Unit) {
     // RoundedCornerShape(45%) reads as a squircle on a square widget; the point here is that the
-    // clip frames the shape while super.Wrap still captures the .rcdoc.
+    // clip frames the shape while super.Wrap still captures the .rc.
     Box(modifier = Modifier.clip(RoundedCornerShape(percent = 45))) { super.Wrap(content) }
   }
 }
@@ -71,7 +71,7 @@ class SquircleRemoteWidgetWrapper : RemoteOverridablePreviewWrapper() {
 /**
  * Wear widget preview framed in its ideal (squircle) shape **and** capturing the encoded RemoteCompose
  * document. Mirrors the wear-os-samples `WearWidgetPreview(ImageWidget(), params)` intent, but routes
- * the framing through [SquircleRemoteWidgetWrapper] so the `<stem>.rcdoc` sidecar is still produced —
+ * the framing through [SquircleRemoteWidgetWrapper] so the `<stem>.rc` sidecar is still produced —
  * `RemoteWidgetDocCaptureTest` asserts exactly that. Contrast the plain-Compose shape wrappers in
  * `:samples:wear-widget`, which are correct for non-RemoteCompose widgets but would drop the doc here.
  */

--- a/samples/remotecompose/src/test/kotlin/com/example/sampleremotecompose/RemoteWidgetDocCaptureTest.kt
+++ b/samples/remotecompose/src/test/kotlin/com/example/sampleremotecompose/RemoteWidgetDocCaptureTest.kt
@@ -1,6 +1,7 @@
 package com.example.sampleremotecompose
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import java.io.File
 import javax.imageio.ImageIO
 import org.junit.Test
@@ -9,12 +10,17 @@ import org.junit.Test
  * Regression guard for the critical invariant: **framing a Remote Compose widget in an ideal shape
  * via a `@PreviewWrapper` must not lose the encoded RemoteCompose document.**
  *
- * The `<stem>.rcdoc` sidecar (the encoded doc that `BundlePreviewTask.resolvePreviewIr` packs) is
+ * The `<stem>.rc` sidecar (the encoded doc that `BundlePreviewTask.resolvePreviewIr` packs) is
  * captured only through the RemoteCompose wrapper — `RemoteOverridablePreviewWrapper.Wrap` runs
  * `captureSingleRemoteDocument`. `RemoteWidgetSquirclePreview` frames the widget in a squircle via
  * [SquircleRemoteWidgetWrapper], which **extends** that wrapper rather than replacing it, so both the
  * shape and the doc survive. A shape wrapper that swapped out the RemoteCompose wrapper would render
- * the same PNG but produce no `.rcdoc` — this test fails in that case.
+ * the same PNG but produce no `.rc` — this test fails in that case.
+ *
+ * The extension is `.rc`; it was `.rcdoc` until the serve canvas lane renamed it (#2720). This test
+ * kept asking for the old name and so had been failing — i.e. NOT guarding the invariant — until
+ * that was corrected, which is the failure mode a guard whose subject is "a file exists" always
+ * has: it cannot tell "the producer broke" from "I am looking in the wrong place".
  *
  * `renderBeforeUnitTests = true` chains `composePreviewRenderAll` before this test.
  */
@@ -24,11 +30,20 @@ class RemoteWidgetDocCaptureTest {
   private val stem = "RemoteWidgetSquirclePreview_Remote_Widget_Squircle"
 
   @Test
-  fun `shape-wrapped remote widget still captures the encoded rcdoc`() {
-    val rcdoc = renderFile(rendersDir, stem, ext = "rcdoc")
-    assertThat(rcdoc.exists()).isTrue()
+  fun `shape-wrapped remote widget still captures the encoded rc document`() {
+    val encodedDoc = renderFile(rendersDir, stem, ext = "rc")
+    // Name what is actually on disk when this fails. A bare `exists()` cannot distinguish "the
+    // wrapper stopped capturing the doc" (the regression this guards) from "the sidecar was
+    // renamed and the assertion is now looking for a file nobody writes" — which is exactly how
+    // this test sat red instead of guarding anything after `.rcdoc` became `.rc`.
+    assertWithMessage(
+        "no $stem*.rc sidecar in $rendersDir; found " +
+          (rendersDir.listFiles()?.map { it.name }?.sorted() ?: emptyList<String>())
+      )
+      .that(encodedDoc.exists())
+      .isTrue()
     // A real encoded RemoteCompose document, not an empty placeholder.
-    assertThat(rcdoc.length()).isGreaterThan(0L)
+    assertThat(encodedDoc.length()).isGreaterThan(0L)
   }
 
   @Test

--- a/samples/xr-glimmer/build.gradle.kts
+++ b/samples/xr-glimmer/build.gradle.kts
@@ -49,10 +49,20 @@ android {
 }
 
 dependencies {
-  // `compose-bom-stable` (2026.05.x — Compose 1.10.x) aligns with what
-  // Glimmer alpha13's POM resolves to (`androidx.compose.foundation:1.10.0`),
-  // so no manual `compose-ui` pin needed. The BOM also brings tooling /
-  // preview alongside Compose itself.
+  // `compose-bom-stable` aligns with what Glimmer's own POM resolves to, so no manual `compose-ui`
+  // pin is needed here; the BOM also brings tooling / preview alongside Compose itself.
+  //
+  // Deliberately NOT naming the resolved Compose version in this comment. It used to read
+  // "2026.05.x — Compose 1.10.x", which was true of Glimmer alpha13 and went stale the moment
+  // either ref moved: the module resolves `androidx.compose.runtime:1.12.0-beta02` today, because
+  // Glimmer's alpha line drags Compose forward and conflict resolution takes the higher version.
+  // A stale version in a comment is worse than none — it was read as evidence that this module
+  // sits below the Compose 1.11.0 floor where `ComposeRuntimeFlags.isLinkBufferComposerEnabled`
+  // does not exist, and therefore that the repo-wide `composePreview.linkBufferComposer=true`
+  // (gradle.properties, see docs/LINK_BUFFER_COMPOSER.md) would abort this module's renders.
+  // It does not: `./gradlew :samples:xr-glimmer:composePreviewRenderAll` renders clean.
+  // Check the resolved graph, not this comment:
+  //   ./gradlew :samples:xr-glimmer:dependencies --configuration debugRuntimeClasspath
   implementation(platform(libs.compose.bom.stable))
   implementation(libs.compose.ui)
   implementation(libs.compose.foundation)
@@ -60,8 +70,8 @@ dependencies {
   implementation(libs.activity.compose)
   debugImplementation("androidx.compose.ui:ui-tooling")
 
-  // Glimmer itself. Pulls `androidx.compose.foundation:1.10.0` and
-  // `androidx.compose.ui:1.10.0` transitively per the alpha13 POM.
+  // Glimmer itself. Pulls Compose foundation / ui transitively per its own POM — again, see the
+  // resolved graph rather than a version pinned in prose here.
   implementation(libs.xr.glimmer)
 
   // `@FocusedPreview` — read by FQN at discovery time; the annotation is binary-retained


### PR DESCRIPTION
The two follow-ups surfaced while working on #3840 / #3845. They're unrelated to each other in mechanism but identical in kind: prose that outlived the code it described.

## 1. `RemoteWidgetDocCaptureTest` was failing, not guarding

It asserted on a `<stem>.rcdoc` sidecar. That extension was renamed by the serve canvas lane — `CHANGELOG.md`: *"in-browser Remote Compose canvas render lane (+ rename .rcdoc → .rc)" (#2720)* — and [`RobolectricRenderTest.kt:837`](https://github.com/yschimke/compose-ai-tools/blob/main/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt#L837) has written `File(dir, "$stem.rc")` ever since.

So the test has been **red on `main`**, which means the invariant it exists for has been unprotected since the rename:

> framing a Remote Compose widget in an ideal shape via a `@PreviewWrapper` must not lose the encoded RemoteCompose document

A shape wrapper that swapped out `RemoteOverridablePreviewWrapper` would render an identical PNG and silently produce no document — exactly what this guard is for, and it would not have caught it.

Beyond pointing it at `.rc`, the assertion now names what *is* on disk when it fails. A bare `exists()` cannot distinguish "the wrapper stopped capturing the doc" from "this is looking for a file nobody writes" — and that ambiguity is precisely why a red guard read as a broken producer and sat there:

```
no RemoteWidgetSquirclePreview_Remote_Widget_Squircle*.rc sidecar in build/compose-previews/renders;
found [… RemoteShaderGradientPreview-6739688f.rc,
       RemoteWidgetSquirclePreview_Remote_Widget_Squircle-2f39ed33.png, …]
```

The `.png` for that stem present with no `.rc` beside it tells you which failure you have, immediately.

**Verified in both directions**, since a guard that only passes is worth little:

- against a real render → `BUILD SUCCESSFUL`, both tests green;
- delete the sidecar, re-run without re-rendering → fails with the listing above. It genuinely guards again.

## 2. The `:samples:xr-glimmer` comment that caused a false-positive review

```kotlin
// `compose-bom-stable` (2026.05.x — Compose 1.10.x) aligns with what
// Glimmer alpha13's POM resolves to (`androidx.compose.foundation:1.10.0`)
```

Both refs have moved since. The module actually resolves:

```
$ ./gradlew :samples:xr-glimmer:dependencies --configuration debugRuntimeClasspath
androidx.compose.runtime:runtime:1.7.0 -> 1.12.0-beta02
```

That stale version had a concrete cost: on #3845 it was read as evidence that this module sits below the Compose **1.11.0** floor where `ComposeRuntimeFlags.isLinkBufferComposerEnabled` doesn't exist, and therefore that the repo-wide `composePreview.linkBufferComposer=true` would abort its renders. It doesn't — the module renders clean, and a `=bogus` probe confirms the property does reach its render JVM, so that's a real pass rather than the flag never arriving.

Fixed by **deleting the version claim rather than refreshing it** — a hardcoded transitive version in a comment goes stale on the next alpha bump and misleads again — and pointing at the resolved graph instead.

## Test plan

- [x] `:samples:remotecompose:testDebugUnitTest --rerun-tasks` — `BUILD SUCCESSFUL` (was failing on `main`)
- [x] Negative control: sidecar removed → guard fails with the diagnostic listing
- [x] `:samples:xr-glimmer:composePreviewRenderAll` — 14 artifacts, unchanged (comment-only edit)
- [x] `ktfmtCheckAll`

No visual evidence: neither change touches rendered output. The xr-glimmer edit is comments only, and the remotecompose change is a test assertion plus KDoc — the 14 and 19 artifacts those modules produce are unchanged.

Note `main` also has pre-existing `NewApi` lint failures in 7 modules (reproduced with these changes stashed); not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLUFNBzvyrA9SwYJCMsHnq)_