### PR TITLE
fix(discovery): guarantee render output paths are unique manifest-wide

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -743,7 +743,7 @@ object PreviewDiscovery {
           )
       }
 
-    val allPreviews = normalized + appPreviews
+    val allPreviews = enforceOutputUniqueness(normalized + appPreviews)
 
     // The generic per-extension reports map is empty on the standalone Gradle path — a11y
     // (today's only canned-report producer) writes its artefacts exclusively through the
@@ -1576,6 +1576,106 @@ object PreviewDiscovery {
         }
       preview.copy(captures = rewritten, dataProducts = rewrittenProducts)
     }
+  }
+
+  /**
+   * Final guarantee that no two previews in the manifest write to the same path.
+   *
+   * [normalizeRenderOutputs] only resolves stems among the *annotation-derived* previews. Several
+   * other sources are appended afterwards with literal, already-shell-safe stems — Lottie and SVG
+   * assets, the colour/typography/shape/theme catalogs, activities and app tours — and by default
+   * several of them land in the same `renders/` directory. No per-source resolver can see the
+   * others, so nothing previously checked the combined result: an annotation preview whose stem
+   * happened to equal an asset's (e.g. a composable literally named `lottie__Foo` beside a Lottie
+   * asset resolving to the same leaf) produced two manifest entries claiming one file, and one
+   * render silently overwrote the other.
+   *
+   * Rather than teach each source about the others — which fails again the next time a source is
+   * added — this validates the invariant on the assembled list. Comparison is **case-folded**,
+   * because the question is "do these address the same file" and on APFS/NTFS they do.
+   *
+   * On a collision *every* entry in the colliding group is re-stemmed with a digest of its own
+   * preview id, so the outcome stays a pure function of the ids rather than of manifest order.
+   * Entries that collide with nothing are untouched, so this cannot churn filenames in the
+   * overwhelmingly normal case where the invariant already holds.
+   *
+   * Scope note: this makes the *declared* output paths unique. It does not reason about
+   * `@PreviewParameter` fan-out siblings, which the renderer names `<stem>_<label>` at render time
+   * — a stem that is a strict prefix of another could in principle still overlap there. That needs
+   * the provider's values, which discovery cannot enumerate.
+   */
+  internal fun enforceOutputUniqueness(previews: List<PreviewInfo>): List<PreviewInfo> {
+    if (previews.size < 2) return previews
+    val contested = contestedIndices(previews)
+    if (contested.isEmpty()) return previews
+
+    // Retagging can itself land on a path some *untouched* preview already owns — the same trap
+    // the old positional `_<idx>` tiebreaker fell into. So re-check the result, and if anything is
+    // still contested, redo it from the original list at full digest width, widening the tagged set
+    // to include whatever the first attempt disturbed. Re-tagging from the original (rather than
+    // from the first attempt) is what keeps a digest from being appended twice.
+    val short = retagOutputs(previews, contested, RENDER_STEM_DIGEST_CHARS)
+    val stillContested = contestedIndices(short)
+    if (stillContested.isEmpty()) return short
+    return retagOutputs(previews, contested + stillContested, FULL_DIGEST_CHARS)
+  }
+
+  /**
+   * Indices of previews holding at least one output path that another preview also claims.
+   * Case-folded, since that is how APFS and NTFS decide whether two names are one file. Previews
+   * declaring no outputs at all are ignored rather than all colliding on the empty path.
+   */
+  private fun contestedIndices(previews: List<PreviewInfo>): Set<Int> {
+    val pathsPerPreview = previews.map { outputPaths(it).map(String::lowercase).distinct() }
+    val counts = mutableMapOf<String, Int>()
+    for (paths in pathsPerPreview) {
+      for (path in paths) counts[path] = counts.getOrDefault(path, 0) + 1
+    }
+    val duplicated = counts.filterValues { it > 1 }.keys
+    if (duplicated.isEmpty()) return emptySet()
+    return pathsPerPreview
+      .withIndex()
+      .filter { (_, paths) -> paths.any { it in duplicated } }
+      .map { it.index }
+      .toSet()
+  }
+
+  private fun outputPaths(preview: PreviewInfo): List<String> =
+    (preview.captures.map { it.renderOutput } + preview.dataProducts.map { it.output }).filter {
+      it.isNotEmpty()
+    }
+
+  /** Re-stem every output of the previews at [indices] with a digest of that preview's own id. */
+  private fun retagOutputs(
+    previews: List<PreviewInfo>,
+    indices: Set<Int>,
+    digestChars: Int,
+  ): List<PreviewInfo> =
+    previews.mapIndexed { i, preview ->
+      if (i !in indices) preview
+      else {
+        val suffix = "-${idDigest(preview.id, digestChars)}"
+        preview.copy(
+          captures =
+            preview.captures.map { it.copy(renderOutput = tagLeaf(it.renderOutput, suffix)) },
+          dataProducts = preview.dataProducts.map { it.copy(output = tagLeaf(it.output, suffix)) },
+        )
+      }
+    }
+
+  /**
+   * `dir/stem.ext` → `dir/stem<suffix>.ext`, leaving the directory and the full extension alone.
+   * Splits on the *first* dot so multi-dot sidecars (`.raw.png`, `.warnings.json`) keep their whole
+   * suffix rather than having the tag wedged into the middle of it.
+   */
+  private fun tagLeaf(path: String, suffix: String): String {
+    if (path.isEmpty()) return path
+    val dir = path.substringBeforeLast('/', missingDelimiterValue = "")
+    val leaf = path.substringAfterLast('/')
+    val dot = leaf.indexOf('.')
+    val tagged =
+      if (dot < 0) leaf + suffix else leaf.substring(0, dot) + suffix + leaf.substring(dot)
+    return if (dir.isEmpty()) tagged else "$dir/$tagged"
   }
 
   /**

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryOutputUniquenessTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryOutputUniquenessTest.kt
@@ -1,0 +1,196 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * `enforceOutputUniqueness` is the manifest-wide backstop for render output paths.
+ *
+ * Stem resolution only covers the annotation-derived previews; Lottie/SVG assets, the token
+ * catalogs, activities and app tours are all appended afterwards with literal stems, and several
+ * land in the same `renders/` directory. These tests pin that the assembled manifest never contains
+ * two entries claiming one file — including case-insensitively, which is what APFS and NTFS compare.
+ */
+class PreviewDiscoveryOutputUniquenessTest {
+
+  private fun preview(
+    id: String,
+    vararg renderOutputs: String,
+    dataProducts: List<String> = emptyList(),
+  ): PreviewInfo =
+    PreviewInfo(
+      id = id,
+      functionName = id.substringAfterLast('.'),
+      className = id.substringBeforeLast('.', missingDelimiterValue = ""),
+      captures = renderOutputs.map { Capture(renderOutput = it) },
+      dataProducts = dataProducts.map { PreviewDataProduct(kind = "render/test", output = it) },
+    )
+
+  private fun outputs(previews: List<PreviewInfo>): List<String> =
+    previews.flatMap { p -> p.captures.map { it.renderOutput } + p.dataProducts.map { it.output } }
+
+  /** The reported defect: an annotation stem colliding with an appended Lottie asset's stem. */
+  @Test
+  fun `an annotation preview colliding with a lottie asset is split apart`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.lottie__Foo", "renders/lottie__Foo-abcd1234.png"),
+        preview("lottie__Foo-abcd1234", "renders/lottie__Foo-abcd1234.png"),
+      )
+
+    val result = PreviewDiscovery.enforceOutputUniqueness(previews)
+
+    assertThat(outputs(result).toSet()).hasSize(2)
+    // Ids are identity and must survive untouched — only the on-disk path moves.
+    assertThat(result.map { it.id }).isEqualTo(previews.map { it.id })
+  }
+
+  /** APFS/NTFS fold case, so paths differing only by case are one file and must be split. */
+  @Test
+  fun `paths differing only by case are treated as colliding`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.Foo", "renders/Widget_Dark.png"),
+        preview("svg__widget_dark", "renders/widget_dark.png"),
+      )
+
+    val result = PreviewDiscovery.enforceOutputUniqueness(previews)
+
+    assertThat(outputs(result).map { it.lowercase() }.toSet()).hasSize(2)
+  }
+
+  /** A collision must not drag unrelated entries onto new filenames. */
+  @Test
+  fun `previews that collide with nothing keep their exact paths`() {
+    val bystander = preview("com.example.PreviewsKt.Untouched", "renders/Untouched-11112222.png")
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.Dup", "renders/Clash.png"),
+        preview("lottie__Clash", "renders/Clash.png"),
+        bystander,
+      )
+
+    val result = PreviewDiscovery.enforceOutputUniqueness(previews)
+
+    assertThat(result[2].captures.single().renderOutput)
+      .isEqualTo("renders/Untouched-11112222.png")
+  }
+
+  /** Order must not decide who gets renamed — the outcome is a function of the ids. */
+  @Test
+  fun `the result is stable under manifest reordering`() {
+    val a = preview("com.example.PreviewsKt.Alpha", "renders/Clash.png")
+    val b = preview("lottie__Clash", "renders/Clash.png")
+
+    val forward = PreviewDiscovery.enforceOutputUniqueness(listOf(a, b))
+    val reversed = PreviewDiscovery.enforceOutputUniqueness(listOf(b, a))
+
+    assertThat(reversed.map { it.id to outputs(listOf(it)) }.reversed())
+      .isEqualTo(forward.map { it.id to outputs(listOf(it)) })
+  }
+
+  /** The digest goes before the extension, and multi-dot sidecars keep their full suffix. */
+  @Test
+  fun `the disambiguator lands before the extension including multi-dot sidecars`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.A", "renders/Clash.raw.png"),
+        preview("lottie__Clash", "renders/Clash.raw.png"),
+      )
+
+    val result = PreviewDiscovery.enforceOutputUniqueness(previews)
+
+    for (path in outputs(result)) {
+      assertThat(path).endsWith(".raw.png")
+      assertThat(path).matches("renders/Clash-[0-9a-f]{8}\\.raw\\.png")
+    }
+    assertThat(outputs(result).toSet()).hasSize(2)
+  }
+
+  /** Data-product outputs share the namespace with captures and must be checked too. */
+  @Test
+  fun `a data product colliding with a capture is split apart`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.A", "data/render-scroll-gif/Clash.gif"),
+        preview("com.example.PreviewsKt.B", dataProducts = listOf("data/render-scroll-gif/Clash.gif")),
+      )
+
+    val result = PreviewDiscovery.enforceOutputUniqueness(previews)
+
+    assertThat(outputs(result).toSet()).hasSize(2)
+  }
+
+  /** Every capture of a re-stemmed preview moves together, so its fan-out stays internally consistent. */
+  @Test
+  fun `all captures of a colliding preview are retagged consistently`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.A", "renders/Clash.png", "renders/Clash_SCROLL_end.png"),
+        preview("lottie__Clash", "renders/Clash.png"),
+      )
+
+    val result = PreviewDiscovery.enforceOutputUniqueness(previews)
+
+    // Each leaf is tagged before its own extension, so a structural `_SCROLL_end` suffix stays
+    // attached to the stem it belongs to and both captures carry the same digest.
+    val stems = result[0].captures.map { it.renderOutput.substringAfterLast('/') }
+    val digest = stems[0].removePrefix("Clash-").removeSuffix(".png")
+    assertThat(digest).matches("[0-9a-f]{8}")
+    assertThat(stems[1]).isEqualTo("Clash_SCROLL_end-$digest.png")
+  }
+
+  /**
+   * The trap the old positional `_<idx>` tiebreaker fell into: the disambiguated name must not
+   * itself land on a path some untouched preview already owns. Here the retag of `Clash` is
+   * pre-empted by a third preview genuinely occupying that exact path, so the pass must escalate
+   * rather than hand two previews the same file.
+   */
+  @Test
+  fun `a retag that would collide with an untouched preview escalates instead`() {
+    val clash = preview("com.example.PreviewsKt.A", "renders/Clash.png")
+    val digest = PreviewDiscovery.renderStem(clash).substringAfterLast('-')
+    val previews =
+      listOf(
+        clash,
+        preview("lottie__Clash", "renders/Clash.png"),
+        // Sits exactly where `clash`'s short-digest retag would land.
+        preview("com.example.PreviewsKt.Squatter", "renders/Clash-$digest.png"),
+      )
+
+    val result = PreviewDiscovery.enforceOutputUniqueness(previews)
+
+    assertThat(outputs(result).map { it.lowercase() }.toSet()).hasSize(3)
+  }
+
+  @Test
+  fun `a manifest with no collisions is returned untouched`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.A", "renders/A-11112222.png"),
+        preview("lottie__B", "renders/lottie__B.png"),
+      )
+
+    assertThat(PreviewDiscovery.enforceOutputUniqueness(previews)).isEqualTo(previews)
+  }
+
+  @Test
+  fun `a single preview and an empty manifest are no-ops`() {
+    assertThat(PreviewDiscovery.enforceOutputUniqueness(emptyList())).isEmpty()
+    val one = listOf(preview("com.example.PreviewsKt.A", "renders/A.png"))
+    assertThat(PreviewDiscovery.enforceOutputUniqueness(one)).isEqualTo(one)
+  }
+
+  /** Previews carrying no output paths at all must not be mistaken for colliding on "". */
+  @Test
+  fun `previews with no outputs are ignored rather than colliding on the empty path`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.A"),
+        preview("com.example.PreviewsKt.B"),
+        preview("com.example.PreviewsKt.C", "renders/C.png"),
+      )
+
+    assertThat(PreviewDiscovery.enforceOutputUniqueness(previews)).isEqualTo(previews)
+  }
+}


### PR DESCRIPTION
## Summary

Closes the last open finding from the #3839 review.

`normalizeRenderOutputs` only resolves stems among the **annotation-derived** previews. Several other sources are appended afterwards with literal stems, and several default to the same `renders/` directory:

- Lottie assets (`discoverLottieAssets`) and SVG assets (`discoverSvgAssets`) — both `lottieRenderSubdir` / `svgRenderSubdir` default to `"renders"`
- the colour / typography / shape / theme token catalogs
- activities and app tours

No per-source resolver can see the others, and nothing validated the combined result. So two manifest entries could claim one path and one render would silently overwrite the other — the reported shape being a composable literally named `lottie__Foo` beside a Lottie asset resolving to the same leaf. `SANITIZE_RENDER_STEM` is `[^A-Za-z0-9._-]`, which keeps `-`, so an asset filename can carry a digest-shaped tail and reach the same name.

Rather than teach each source about the others — which fails again the next time a source is added — this validates the invariant on the **assembled** list. `enforceOutputUniqueness` runs once over `normalized + appPreviews` and re-stems any preview whose declared output path is claimed by another.

Design points, each pinned by a test:

- **Case-folded comparison.** The question is "do these address the same file", and on APFS/NTFS they do.
- **Both sides re-stemmed, by id.** Every entry in a colliding group gets a digest of its own preview id, so the outcome is a function of the ids rather than of manifest order.
- **Bystanders untouched.** A collision cannot churn the filename of a preview that collides with nothing, so the normal case (invariant already holds) is a no-op.
- **Escalation on a second-order collision.** A retag can itself land on a path an untouched preview already owns — precisely the trap the old positional `_<idx>` tiebreaker fell into. The result is re-checked, and if anything is still contested the pass redoes it from the original list at full digest width, widening the tagged set to include whatever the first attempt disturbed.
- **Ids never move.** Only `renderOutput` / `dataProduct.output` change; identity is untouched.
- **Tag lands before the extension**, splitting on the first dot so multi-dot sidecars (`.raw.png`, `.warnings.json`) keep their whole suffix.

### Scope

This makes the *declared* output paths unique. It deliberately does not reason about `@PreviewParameter` fan-out siblings, which the renderer names `<stem>_<label>` at render time — a stem that is a strict prefix of another could in principle still overlap there, but resolving that needs the provider's values, which discovery cannot enumerate. Noted in the KDoc.

## Test plan

New `PreviewDiscoveryOutputUniquenessTest` — **11 tests, 0 failures**:

- the reported annotation-vs-Lottie collision is split apart, with ids intact
- paths differing only by case are treated as colliding
- a retag that would collide with an untouched preview escalates instead
- bystanders keep their exact paths; result is stable under manifest reordering
- data-product outputs share the namespace with captures and are checked too
- all captures of a re-stemmed preview move together
- the tag lands before multi-dot extensions
- no-collision manifests, single-preview, empty, and output-less previews are all no-ops

Also green: `:gradle-plugin:preview-discovery:test`, `:gradle-plugin:test`, `:gradle-plugin:functionalTest` (93 tests), `ktfmtCheckAll`.

Not UI-affecting — no rendered pixel changes, and no filename changes at all unless a manifest actually contains a collision, which no current module does.

## Companion

The other open finding — consumer-facing docs — is [yschimke/skills#…](https://github.com/yschimke/skills/tree/agent/render-filename-contract), which documents the `<readable>-<digest>` contract in the `compose-preview` SKILL.md and corrects three stale example paths in the audit reference.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PnKrBBiErbjivax9E9QLU)_