### PR TITLE
test: check generated usage snippets against a real compiler

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -441,7 +441,21 @@ tasks.register<Zip>("packageAndroidDaemon") {
   into("lib-daemon-android") { from(stageDaemonAndroidLibs) }
 }
 
-tasks.withType<Test>().configureEach { useJUnitPlatform() }
+tasks.withType<Test>().configureEach {
+  useJUnitPlatform()
+  // Catalog checkouts for the usage-snippet corpus (UsageSnippetCorpusTest). Absent by default, so
+  // the corpus is a no-op in a normal build; `scripts/usage-corpus.sh` supplies them. Forwarded
+  // rather than read from the environment so the paths show up in the build's own inputs.
+  for (key in
+    listOf(
+      "composeai.usageCorpus.m3-catalog",
+      "composeai.usageCorpus.meshcore-mobile",
+      "composeai.usageCorpus.out",
+      "composeai.usageCorpus.samples",
+    )) {
+    providers.systemProperty(key).orNull?.let { systemProperty(key, it) }
+  }
+}
 
 abstract class CheckCliDaemonLibraryBoundary : DefaultTask() {
   @get:Classpath abstract val runtimeClasspath: ConfigurableFileCollection

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.serve.UsageRules.Companion.declaresCatalogScaffolds
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -279,7 +280,7 @@ class PlaygroundSeedResolver(
         sliced = cleaned != null || sliced != null,
         cleaned = cleaned != null,
         residue = cleaned?.residue.orEmpty(),
-        scaffoldsDeclared = cleaned != null && rulesFor(where).scaffolds.isNotEmpty(),
+        scaffoldsDeclared = cleaned != null && rulesFor(where).declaresCatalogScaffolds(),
       )
     // Bounded, and deliberately not an LRU: entries are a few KB, a catalog has a fixed number of
     // previews, and a full cache means the ones people actually open are already served from it. A

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -481,6 +481,47 @@ object PlaygroundSourceCleaner {
     return out
   }
 
+  /** A `name = value` argument, as distinct from a positional one. */
+  private val NAMED_ARG =
+    Regex("""^([A-Za-z_][A-Za-z0-9_]*)\s*=(?!=)\s*(.+)$""", RegexOption.DOT_MATCHES_ALL)
+
+  /**
+   * Resolve a call's arguments to the positions a `$0`/`$1` template cites, so a **named** argument
+   * substitutes as its value rather than as `default = "Shopping"`.
+   *
+   * [params] names the callee's parameters in declaration order. With it, positional arguments fill
+   * parameters left to right and named ones fill by name, which is exactly Kotlin's own rule, so
+   * `previewOverrideString(key = "title", default = "Shopping")` and
+   * `previewOverrideString("title", "Shopping")` both put `"Shopping"` at `$1`.
+   *
+   * Without it — a rule declared before this existed — the old positional reading stands, except
+   * that a call using named arguments returns null so the caller leaves the call alone and reports
+   * it as residue. Guessing would be the one outcome worse than not rewriting: it emits Kotlin that
+   * looks right and does not compile.
+   *
+   * An argument naming a parameter [params] does not list (a second overload's, say) is ignored
+   * rather than fatal, and does not consume a positional slot — matching how Kotlin resolves it.
+   */
+  private fun bindArguments(args: List<String>, params: List<String>): List<String?>? {
+    val named = args.map { NAMED_ARG.find(it) }
+    if (params.isEmpty()) return if (named.any { it != null }) null else args
+    val bound = arrayOfNulls<String>(params.size)
+    var next = 0
+    for ((i, arg) in args.withIndex()) {
+      val match = named[i]
+      if (match == null) {
+        // Positional: the next parameter no named argument has already claimed.
+        while (next < params.size && bound[next] != null) next++
+        if (next >= params.size) continue // beyond the declared list; nothing cites it
+        bound[next++] = arg
+      } else {
+        val at = params.indexOf(match.groupValues[1])
+        if (at >= 0) bound[at] = match.groupValues[2].trim()
+      }
+    }
+    return bound.toList()
+  }
+
   /**
    * `catalogChoice("style", "outlined", "outlined", "elevated")` → `"outlined"` — the whole call
    * expression replaced by what it evaluates to on the lane the render was baked on.
@@ -500,7 +541,11 @@ object PlaygroundSourceCleaner {
       var guard = 0
       while (guard++ < MAX_REWRITES) {
         val call = findCall(out, name) ?: break
-        val args = splitTopLevel(out.substring(call.argsStart + 1, call.argsEnd)).map { it.trim() }
+        val args =
+          bindArguments(
+            splitTopLevel(out.substring(call.argsStart + 1, call.argsEnd)).map { it.trim() },
+            scaffold.params,
+          ) ?: break
         val rendered =
           Regex("""\$(\d+)""").replace(plain) { m ->
             args.getOrNull(m.groupValues[1].toInt()) ?: m.value

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -77,6 +77,16 @@ data class UsageRules(
     /** [Kind.SUBSTITUTE] only: what the call reads as, with `$0`, `$1`… for its arguments. */
     @SerialName("plain") val plain: String? = null,
     /**
+     * [Kind.SUBSTITUTE] only: the helper's parameter names, in declaration order, so `$0`/`$1`
+     * resolve the way Kotlin does when the call uses **named** arguments —
+     * `previewOverrideString(key = "title", default = "Shopping")` must put `"Shopping"` at `$1`,
+     * not `default = "Shopping"`.
+     *
+     * Optional: a rule that omits it keeps the plain positional reading, and declines to rewrite a
+     * call that uses named arguments at all (reporting it as residue) rather than guessing.
+     */
+    @SerialName("params") val params: List<String> = emptyList(),
+    /**
      * [Kind.INLINE] only: member → replacement, where `$0`, `$1`… are the call's arguments.
      * `counted` declares `{"label": "$0", "onClick": "{}"}`, which is the whole of what that helper
      * means to a reader: the label you passed, and a click handler.
@@ -127,6 +137,9 @@ data class UsageRules(
   }
 
   companion object {
+    /** Every override knob takes `(key, default, index)`; the default is `$1`. */
+    private val OVERRIDE_KNOB_PARAMS = listOf("key", "default", "index")
+
     /**
      * The rules that need no catalog knowledge at all: strip this repo's own preview/catalog
      * annotations, prune the imports that leaves unused. Every catalog gets at least this, so a
@@ -145,16 +158,29 @@ data class UsageRules(
         // Found by the snippet corpus (`scripts/usage-corpus.sh`): two of m3-catalog's ten sampled
         // snippets failed to compile on this alone, and neither was reported as residue — the
         // helpers are not in a scaffold package, so nothing flagged them.
+        //
+        // `params` carries each helper's own parameter names so a named-argument call
+        // (`previewOverrideString(key = "title", default = "Shopping")`) substitutes as the value
+        // and not as `default = "Shopping"`. Every knob takes `(key, default, …)`, so `$1` is the
+        // default in all of them; only the middle parameters differ.
         scaffolds =
-          listOf(
-              "previewOverrideString",
-              "previewOverrideInt",
-              "previewOverrideFloat",
-              "previewOverrideBoolean",
-              "previewOverrideColor",
-              "previewOverrideDp",
+          mapOf(
+              "previewOverrideString" to OVERRIDE_KNOB_PARAMS,
+              "previewOverrideInt" to OVERRIDE_KNOB_PARAMS,
+              "previewOverrideFloat" to OVERRIDE_KNOB_PARAMS,
+              "previewOverrideBoolean" to OVERRIDE_KNOB_PARAMS,
+              "previewOverrideColor" to OVERRIDE_KNOB_PARAMS,
+              "previewOverrideDp" to OVERRIDE_KNOB_PARAMS,
+              "previewOverrideFont" to
+                listOf("key", "default", "suggestions", "googleFonts", "index"),
+              // Two overloads, differing only in the third parameter (`options` / `values`). An
+              // argument naming a parameter this list omits is ignored rather than fatal, so one
+              // entry covers both.
+              "previewOverrideChoice" to listOf("key", "default", "options", "index"),
             )
-            .associateWith { Scaffold(kind = Kind.SUBSTITUTE, plain = "\$1") },
+            .mapValues { (_, params) ->
+              Scaffold(kind = Kind.SUBSTITUTE, plain = "\$1", params = params)
+            },
       )
 
     /**
@@ -166,6 +192,18 @@ data class UsageRules(
      * the shared rules. A catalog can still override any of them by naming the same helper: its own
      * entry wins.
      */
+    /**
+     * Did the **catalog** declare scaffolding, as opposed to inheriting this repo's own rules?
+     *
+     * The Source panel's note turns on this: "the catalog declared its scaffolding, so what is left
+     * is usage code" is a much stronger claim than "this repo stripped its own annotations", and
+     * only the catalog can earn it. Asking `scaffolds.isNotEmpty()` used to answer it, and stopped
+     * being able to the moment [GENERIC] carried entries of its own — every catalog would then
+     * claim a declaration it never made.
+     */
+    fun UsageRules.declaresCatalogScaffolds(): Boolean =
+      scaffolds.keys.any { it !in GENERIC.scaffolds }
+
     private fun UsageRules.withGenericDefaults(): UsageRules =
       copy(
         scaffoldAnnotationPackages =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -133,7 +133,45 @@ data class UsageRules(
      * catalog that has declared nothing still opens in the playground without a stack of
      * annotations naming a machinery the visitor has no way to run.
      */
-    val GENERIC = UsageRules(scaffoldAnnotationPackages = listOf("ee.schimke.composeai.preview"))
+    val GENERIC =
+      UsageRules(
+        scaffoldAnnotationPackages = listOf("ee.schimke.composeai.preview"),
+        // The preview-override knobs are **this repo's** API, not a catalog's, so no catalog should
+        // have to declare them — and until they were here, every catalog's "plain Compose" leaked
+        // `previewOverrideString(...)` into code a developer was invited to copy. Each takes
+        // `(key, default, …)`, so the default is what the render on screen was made with and `$1`
+        // is its plain reading.
+        //
+        // Found by the snippet corpus (`scripts/usage-corpus.sh`): two of m3-catalog's ten sampled
+        // snippets failed to compile on this alone, and neither was reported as residue — the
+        // helpers are not in a scaffold package, so nothing flagged them.
+        scaffolds =
+          listOf(
+              "previewOverrideString",
+              "previewOverrideInt",
+              "previewOverrideFloat",
+              "previewOverrideBoolean",
+              "previewOverrideColor",
+              "previewOverrideDp",
+            )
+            .associateWith { Scaffold(kind = Kind.SUBSTITUTE, plain = "\$1") },
+      )
+
+    /**
+     * A catalog's declared rules **plus** the ones that are this repo's business rather than any
+     * catalog's — the preview-override knobs and this repo's annotation packages.
+     *
+     * Without this a declared `compose-usage.json` replaced [GENERIC] wholesale, so the catalogs
+     * that had gone to the trouble of declaring their scaffolding were the only ones NOT getting
+     * the shared rules. A catalog can still override any of them by naming the same helper: its own
+     * entry wins.
+     */
+    private fun UsageRules.withGenericDefaults(): UsageRules =
+      copy(
+        scaffoldAnnotationPackages =
+          (scaffoldAnnotationPackages + GENERIC.scaffoldAnnotationPackages).distinct(),
+        scaffolds = GENERIC.scaffolds + scaffolds,
+      )
 
     private val json = Json {
       ignoreUnknownKeys = true
@@ -146,7 +184,7 @@ data class UsageRules(
      */
     fun parse(text: String, onLog: (String) -> Unit = {}): UsageRules? =
       try {
-        json.decodeFromString<UsageRules>(text)
+        json.decodeFromString<UsageRules>(text).withGenericDefaults()
       } catch (e: Exception) {
         onLog("compose-usage.json is not valid usage rules (${e.message}); using generic rules")
         null

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -360,7 +360,9 @@ class PlaygroundSourceCleanerTest {
     val text = assertNotNull(cleanAt("""caption = "Highest emphasis""")).let { it }
     val generic = assertNotNull(cleanAt("""caption = "Highest emphasis"""))
     assertFalse(generic.text.contains("@CatalogComponent"))
-    assertTrue(UsageRules.GENERIC.scaffolds.isEmpty())
+    // GENERIC knows only about THIS repo's own API — the preview-override knobs — and nothing about
+    // any catalog's scaffolding.
+    assertTrue(UsageRules.GENERIC.scaffolds.keys.all { it.startsWith("previewOverride") })
     val withGeneric =
       assertNotNull(
         PlaygroundSourceCleaner.clean(
@@ -378,6 +380,48 @@ class PlaygroundSourceCleanerTest {
   fun `malformed rules degrade to generic rather than failing the handoff`() {
     assertNull(UsageRules.parse("{ not json"))
     assertNotNull(UsageRules.parse("""{"scaffoldAnnotationPackages":["a.b"]}"""))
+  }
+
+  /**
+   * The preview-override knobs are this repo's API, not a catalog's, so a catalog that declares its
+   * own scaffolding must still get them — before this, declaring `compose-usage.json` *replaced*
+   * the generic rules, so the catalogs that had done the work were the only ones leaking
+   * `previewOverrideString(...)` into code a developer was invited to copy.
+   */
+  @Test
+  fun `declared rules inherit the generic ones`() {
+    val rules = assertNotNull(UsageRules.parse("""{"scaffolds":{"Sticker":{"kind":"UNWRAP"}}}"""))
+    assertTrue(rules.scaffolds.containsKey("Sticker"))
+    assertTrue(rules.scaffolds.containsKey("previewOverrideString"))
+    assertTrue(rules.scaffoldAnnotationPackages.contains("ee.schimke.composeai.preview"))
+  }
+
+  /**
+   * A knob nothing declared is exactly what residue cannot see: `previewOverrideString` is not in a
+   * scaffold package, so the snippet was reported clean and did not compile. Found by the corpus
+   * (`scripts/usage-corpus.sh`); see `docs/design/USAGE_SNIPPET_CORPUS.md`.
+   */
+  @Test
+  fun `a preview override knob becomes the default the render was baked with`() {
+    val source =
+      """
+      package ee.schimke.demo
+
+      import androidx.compose.material3.Badge
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.composeai.preview.previewOverrideString
+
+      @Composable
+      fun NumberBadge() = Badge { Text(previewOverrideString("label", "3")) }
+      """
+        .trimIndent()
+    val cleaned =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun NumberBadge"), UsageRules.GENERIC)
+      )
+    assertTrue(cleaned.text.contains("""Text("3")"""), cleaned.text)
+    assertFalse(cleaned.text.contains("previewOverrideString"), cleaned.text)
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -425,6 +425,101 @@ class PlaygroundSourceCleanerTest {
   }
 
   /**
+   * The same knob written with named arguments. A positional reading emits `Text(default =
+   * "Shopping")`, which is Kotlin that looks right and does not compile — the worst outcome
+   * available, since it reaches the visitor as "plain Compose you can run".
+   */
+  @Test
+  fun `a named-argument knob substitutes as its value, not as the argument label`() {
+    val source =
+      """
+      package ee.schimke.demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.composeai.preview.previewOverrideString
+
+      @Composable
+      fun Title() = Text(previewOverrideString(key = "title", default = "Shopping"))
+      """
+        .trimIndent()
+    val cleaned =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Title"), UsageRules.GENERIC)
+      )
+    assertTrue(cleaned.text.contains("""Text("Shopping")"""), cleaned.text)
+  }
+
+  /** Named arguments out of declaration order still bind by name, as Kotlin binds them. */
+  @Test
+  fun `a knob with reordered named arguments still resolves its default`() {
+    val source =
+      """
+      package ee.schimke.demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.composeai.preview.previewOverrideString
+
+      @Composable
+      fun Title() = Text(previewOverrideString(default = "Shopping", key = "title"))
+      """
+        .trimIndent()
+    val cleaned =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Title"), UsageRules.GENERIC)
+      )
+    assertTrue(cleaned.text.contains("""Text("Shopping")"""), cleaned.text)
+  }
+
+  /**
+   * A rule that declares no `params` cannot know which parameter a named argument names, so it
+   * declines rather than guessing — and says so, as residue.
+   */
+  @Test
+  fun `a substitute rule without params declines a named-argument call`() {
+    val rules =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "catalogChoice" to UsageRules.Scaffold(kind = UsageRules.Kind.SUBSTITUTE, plain = "\$1")
+          )
+      )
+    val source =
+      """
+      package ee.schimke.demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Style() = Text(catalogChoice(key = "style", default = "outlined"))
+      """
+        .trimIndent()
+    val cleaned =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Style"), rules))
+    assertTrue(cleaned.text.contains("catalogChoice("), cleaned.text)
+    assertTrue(cleaned.residue.contains("catalogChoice"), "${cleaned.residue}")
+  }
+
+  /**
+   * `scaffoldsDeclared` drives a much stronger claim in the Source panel than annotation-stripping
+   * earns, so only a catalog can turn it on. It used to be `scaffolds.isNotEmpty()`, which stopped
+   * meaning that the moment GENERIC carried entries of its own.
+   */
+  @Test
+  fun `inheriting the generic rules is not declaring scaffolding`() {
+    with(UsageRules.Companion) {
+      assertFalse(UsageRules.GENERIC.declaresCatalogScaffolds())
+      assertFalse(assertNotNull(UsageRules.parse("{}")).declaresCatalogScaffolds())
+      assertTrue(
+        assertNotNull(UsageRules.parse("""{"scaffolds":{"Sticker":{"kind":"UNWRAP"}}}"""))
+          .declaresCatalogScaffolds()
+      )
+    }
+  }
+
+  /**
    * A knob that has a plain reading is substituted rather than deleted. `catalogChoice` returns its
    * default on the baked lane by construction, so the default is what the render on screen was made
    * with — and it is the biggest single helper in m3-catalog after the frame and the tally.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
@@ -1,0 +1,210 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Generates usage snippets from **real catalog checkouts** and writes them where a compiler can be
+ * pointed at them.
+ *
+ * ### Why a corpus and not more fixtures
+ *
+ * Every other test of the cleaner feeds it source this repository controls. That is the wrong shape
+ * for the question "does the Source panel work across the catalogs": a fixture proves the rules I
+ * wrote match the source I wrote. This walks a checkout, samples previews the way a visitor
+ * browsing would land on them, and emits whatever comes out — including the failures.
+ *
+ * ### Opt-in, and silent without checkouts
+ *
+ * Driven by `-Dcomposeai.usageCorpus.<system>=<path>`, so it is a no-op in a normal build and on
+ * any machine without the catalogs. `scripts/usage-corpus.sh` supplies the paths and then compiles
+ * what this writes; see `docs/design/USAGE_SNIPPET_CORPUS.md` for the whole loop.
+ *
+ * The catalogs are deliberately unalike, which is the point of testing both:
+ * - **m3-catalog** is annotation-first (`@CatalogComponent` / `@CatalogVariant`) and ships a
+ *   `compose-usage.json`, so its snippets are expected to come out as usage code.
+ * - **meshcore-mobile** is spec-driven (`catalog.spec.json` names plain `@Preview` functions) and
+ *   ships no rules at all, so it exercises the generic path — annotation stripping only.
+ */
+class UsageSnippetCorpusTest {
+
+  private data class Sample(val system: String, val kind: String, val function: String)
+
+  private fun repo(system: String): File? =
+    System.getProperty("composeai.usageCorpus.$system")?.takeIf { it.isNotBlank() }?.let(::File)
+
+  private val outDir =
+    File(System.getProperty("composeai.usageCorpus.out") ?: "build/usage-corpus").also {
+      it.mkdirs()
+    }
+
+  /** Every `.kt` under a checkout, excluding build output and tests. */
+  private fun sources(root: File): List<File> =
+    root
+      .walkTopDown()
+      .onEnter { it.name !in setOf("build", ".git", ".gradle") }
+      .filter { it.isFile && it.extension == "kt" }
+      .filterNot { it.path.contains("/test/") || it.path.contains("/androidTest/") }
+      .toList()
+
+  /**
+   * A 1-based line inside [function]'s declaration — the anchor the cleaner walks outwards from.
+   *
+   * Discovery normally supplies this from the classfile line table. Reading it off the source is
+   * what lets the corpus run without building the catalog, and it lands in the same place: the
+   * cleaner only needs *a* line inside the declaration.
+   */
+  private fun anchorOf(text: String, function: String): Int? {
+    val lines = text.lines()
+    val at = lines.indexOfFirst { line ->
+      Regex("""^\s*(?:@\w+\s+)*(?:private\s+|internal\s+)?fun\s+$function\s*\(""")
+        .containsMatchIn(line)
+    }
+    if (at < 0) return null
+    // The line after the signature is inside the body for both block and expression forms; fall
+    // back to the signature line itself, which the slice also accepts.
+    return if (at + 1 <= lines.lastIndex && lines[at + 1].isNotBlank()) at + 2 else at + 1
+  }
+
+  private fun findFunction(files: List<File>, function: String): Pair<File, Int>? =
+    files.firstNotNullOfOrNull { file ->
+      val text = runCatching { file.readText() }.getOrNull() ?: return@firstNotNullOfOrNull null
+      if (!text.contains("fun $function")) return@firstNotNullOfOrNull null
+      anchorOf(text, function)?.let { file to it }
+    }
+
+  /** The catalog's declared rules, or [UsageRules.GENERIC] when it ships none. */
+  private fun rulesFor(root: File): Pair<UsageRules, Boolean> {
+    val file = File(root, PlaygroundSeedResolver.USAGE_RULES_FILE)
+    if (!file.isFile) return UsageRules.GENERIC to false
+    return (UsageRules.parse(file.readText()) ?: UsageRules.GENERIC) to true
+  }
+
+  /** English string resources, so `stringResource(Res.string.x)` inlines as the rendered label. */
+  private fun stringsFor(root: File, rules: UsageRules): Map<String, String> {
+    val path = rules.stringsPath ?: return emptyMap()
+    val file =
+      root.walkTopDown().firstOrNull { it.isFile && it.path.endsWith(path.replace('\\', '/')) }
+        ?: return emptyMap()
+    return Regex(
+        """<string\s+name="([A-Za-z0-9_]+)"\s*>(.*?)</string>""",
+        RegexOption.DOT_MATCHES_ALL,
+      )
+      .findAll(file.readText())
+      .associate {
+        it.groupValues[1] to PlaygroundSeedResolver.unescapeAndroidString(it.groupValues[2])
+      }
+  }
+
+  /** m3-catalog: annotation-first, so the samples come from the annotations themselves. */
+  private fun m3Samples(root: File, perKind: Int): List<Sample> {
+    val out = mutableListOf<Sample>()
+    for (file in sources(root).sortedBy { it.path }) {
+      val lines = runCatching { file.readText().lines() }.getOrNull() ?: continue
+      for ((i, line) in lines.withIndex()) {
+        val kind =
+          when {
+            line.trimStart().startsWith("@CatalogComponent") -> "component"
+            line.trimStart().startsWith("@CatalogVariant") -> "variant"
+            else -> continue
+          }
+        // The declaration's own `fun` line is below the annotation stack.
+        val fn =
+          lines.drop(i).firstNotNullOfOrNull {
+            Regex("""^fun\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(""").find(it)?.groupValues?.get(1)
+          } ?: continue
+        if (out.none { it.function == fn }) out += Sample("m3-catalog", kind, fn)
+      }
+    }
+    // Spread across the alphabet rather than taking the first N, which would be one section file.
+    return listOf("component", "variant").flatMap { kind ->
+      out
+        .filter { it.kind == kind }
+        .let { all ->
+          if (all.size <= perKind) all else (0 until perKind).map { all[it * all.size / perKind] }
+        }
+    }
+  }
+
+  /** meshcore-mobile: spec-driven, so the samples come from `catalog.spec.json`. */
+  private fun meshcoreSamples(root: File, perKind: Int): List<Sample> {
+    val spec = File(root, "catalog.spec.json").takeIf { it.isFile } ?: return emptyList()
+    val text = spec.readText()
+    // Deliberately regex rather than a JSON parser: this test has no JSON dependency and the shape
+    // it needs (preview names, and the nested ones under "variants") is unambiguous in this file.
+    val variantBlocks = Regex(""""variants"\s*:\s*\[(.*?)]""", RegexOption.DOT_MATCHES_ALL)
+    val previewName = Regex(""""preview"\s*:\s*"([A-Za-z_][A-Za-z0-9_]*)"""")
+    val variants =
+      variantBlocks
+        .findAll(text)
+        .flatMap { previewName.findAll(it.groupValues[1]) }
+        .map { it.groupValues[1] }
+        .distinct()
+        .toList()
+    val components =
+      previewName
+        .findAll(text)
+        .map { it.groupValues[1] }
+        .distinct()
+        .filterNot { it in variants }
+        .toList()
+    fun spread(all: List<String>, kind: String) =
+      (if (all.size <= perKind) all else (0 until perKind).map { all[it * all.size / perKind] })
+        .map { Sample("meshcore-mobile", kind, it) }
+    return spread(components, "component") + spread(variants, "variant")
+  }
+
+  private val perKind =
+    System.getProperty("composeai.usageCorpus.samples")?.toIntOrNull()?.coerceAtLeast(1) ?: 5
+
+  @Test
+  fun `generate usage snippets from the catalog checkouts`() {
+    val m3 = repo("m3-catalog")
+    val meshcore = repo("meshcore-mobile")
+    if (m3 == null && meshcore == null) return // no checkouts wired: nothing to do
+
+    val report = StringBuilder()
+    var written = 0
+
+    for (root in listOfNotNull(m3, meshcore)) {
+      val system = if (root == m3) "m3-catalog" else "meshcore-mobile"
+      val files = sources(root)
+      val (rules, declared) = rulesFor(root)
+      val strings = stringsFor(root, rules)
+      val samples =
+        if (system == "m3-catalog") m3Samples(root, perKind) else meshcoreSamples(root, perKind)
+      report.appendLine(
+        "## $system — ${samples.size} samples, rules: ${if (declared) "declared (${rules.scaffolds.size} scaffolds)" else "GENERIC (none declared)"}"
+      )
+      for (sample in samples) {
+        val found = findFunction(files, sample.function)
+        if (found == null) {
+          report.appendLine("- ${sample.kind}/${sample.function}: SOURCE NOT FOUND")
+          continue
+        }
+        val (file, anchor) = found
+        val cleaned =
+          runCatching { PlaygroundSourceCleaner.clean(file.readText(), anchor, rules, strings) }
+            .getOrElse { e ->
+              report.appendLine("- ${sample.kind}/${sample.function}: THREW ${e::class.simpleName}")
+              null
+            }
+        if (cleaned == null) {
+          report.appendLine("- ${sample.kind}/${sample.function}: DECLINED (would seed verbatim)")
+          continue
+        }
+        val dir = File(outDir, system).also { it.mkdirs() }
+        File(dir, "${sample.kind}_${sample.function}.kt").writeText(cleaned.text)
+        written++
+        val residue = if (cleaned.residue.isEmpty()) "clean" else "residue=${cleaned.residue}"
+        report.appendLine("- ${sample.kind}/${sample.function}: $residue (${file.name})")
+      }
+      report.appendLine()
+    }
+
+    File(outDir, "REPORT.md").writeText(report.toString())
+    println(report)
+    assertTrue(written > 0, "no snippets were generated from the supplied checkouts")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
@@ -155,6 +155,30 @@ class UsageSnippetCorpusTest {
     return spread(components, "component") + spread(variants, "variant")
   }
 
+  /**
+   * Give each snippet its own package, so the corpus compiles as N independent pastes rather than
+   * as one source set.
+   *
+   * Without this the snippets share the default package, and the compile answers a different
+   * question than the one asked in both directions: two previews from the same file that each close
+   * over the same same-file helper collide as redeclarations (a failure the developer pasting *one*
+   * of them would never see), and a catalog symbol one snippet leaks can resolve against a
+   * declaration another snippet happened to copy (a pass the developer would never get). Distinct
+   * packages remove both — nothing here imports anything else here.
+   *
+   * The package goes after any file annotations and before the imports, which is where Kotlin wants
+   * it.
+   */
+  private fun inOwnPackage(text: String, system: String, name: String): String {
+    fun part(raw: String) = raw.replace(Regex("[^A-Za-z0-9]"), "_").lowercase()
+    val decl = "package usagecorpus.${part(system)}.${part(name)}"
+    val lines = text.lines()
+    val at = lines.indexOfFirst { it.trimStart().startsWith("import ") }
+    val insertAt =
+      if (at >= 0) at else lines.indexOfLast { it.trimStart().startsWith("@file:") } + 1
+    return (lines.take(insertAt) + listOf(decl, "") + lines.drop(insertAt)).joinToString("\n")
+  }
+
   private val perKind =
     System.getProperty("composeai.usageCorpus.samples")?.toIntOrNull()?.coerceAtLeast(1) ?: 5
 
@@ -195,7 +219,8 @@ class UsageSnippetCorpusTest {
           continue
         }
         val dir = File(outDir, system).also { it.mkdirs() }
-        File(dir, "${sample.kind}_${sample.function}.kt").writeText(cleaned.text)
+        val name = "${sample.kind}_${sample.function}"
+        File(dir, "$name.kt").writeText(inOwnPackage(cleaned.text, system, name))
         written++
         val residue = if (cleaned.residue.isEmpty()) "clean" else "residue=${cleaned.residue}"
         report.appendLine("- ${sample.kind}/${sample.function}: $residue (${file.name})")

--- a/docs/design/USAGE_SNIPPET_CORPUS.md
+++ b/docs/design/USAGE_SNIPPET_CORPUS.md
@@ -15,6 +15,11 @@ It samples previews from each checkout (5 default + 5 variant by default,
 `USAGE_CORPUS_SAMPLES=n` to change), runs the real `PlaygroundSourceCleaner` over them with that
 catalog's own rules, and compiles the results. Exit status is 0 when every snippet compiles.
 
+A build that fails *before* type-checking — dependency resolution, a missing toolchain, a daemon
+crash — produces no per-file diagnostic, so the script treats a nonzero exit with nothing to
+attribute as a corpus failure and prints the log tail. Reading it as "no diagnostics, therefore
+everything compiled" is the one bug that would quietly turn the whole loop into a no-op.
+
 ## The compile bar is a consumer's classpath, not the catalog's
 
 `:tools:usage-compile-check` compiles the corpus against **Compose and material3 only**. That is
@@ -24,6 +29,14 @@ and nowhere else. The bar is "a developer pasted this into their own Compose app
 
 The module is empty unless `-PusageCorpus=<dir>` points it at a generated corpus, so it costs a
 normal build nothing.
+
+Each snippet is emitted into **its own package**, so the corpus compiles as N independent pastes
+rather than as one source set. Sharing a package would answer a different question in both
+directions: two previews from the same file that each close over the same helper would collide as
+redeclarations (a failure nobody pasting *one* of them would see), and a catalog symbol one snippet
+leaked could resolve against a declaration another snippet happened to copy (a pass nobody would
+get). It changed neither ratio below, which is worth knowing — the numbers were not an artefact of
+the snippets propping each other up.
 
 ## What it found
 
@@ -52,6 +65,18 @@ rules inherit the generic ones rather than replacing them.
 Residue only ever reported *declared* scaffolding that survived a rule. It cannot see a helper nobody
 declared, which is precisely the case worth catching. **The compiler is the honest signal.**
 
+Two things had to follow from putting those knobs in `GENERIC`:
+
+- **Named arguments.** `previewOverrideString(key = "title", default = "Shopping")` substituted
+  positionally as `default = "Shopping"` — Kotlin that looks right and does not compile, which is
+  the worst outcome available for something presented as runnable. A `SUBSTITUTE` rule now declares
+  the helper's `params`, so `$1` binds the way Kotlin binds it; a rule that declares none declines a
+  named-argument call and reports it as residue rather than guessing.
+- **`scaffoldsDeclared` had to stop meaning `scaffolds.isNotEmpty()`.** That flag drives the Source
+  panel's stronger claim — *the catalog declared its scaffolding, so what is left is usage code* —
+  and only a catalog can earn it. A non-empty `GENERIC` would have had every catalog claiming a
+  declaration it never made, so it now asks whether any scaffold is the catalog's own.
+
 ### m3-catalog's remaining seven failures, by cause
 
 | Cause | Files | Status |
@@ -79,6 +104,20 @@ different premises:
 So for a catalog like meshcore the Source panel shows *the preview, sliced and import-pruned* — not
 usage code, and the panel already says so when a catalog has declared no rules. That is the correct
 outcome, and worth knowing before anyone tries to fix it with rules.
+
+### Known gap: an override *variant* still shows the author's default
+
+Substituting `previewOverride*(key, default, …)` with `default` is right for the default render and
+wrong for a seeded `@OverrideVariant` card: opening the `off` variant of a toggle emits `true`
+because that is what the source says, not the `false` the render was seeded with. The values exist —
+`PreviewInfo.overrides` carries them — but the seed path resolves a *source location*
+(`PlaygroundSeedResolver.Location`), which has no override values in it, so fixing this means
+plumbing them from the preview through the location into a key-aware substitution.
+
+This is not a regression: before the knobs were rewritten at all, the variant's snippet said
+`previewOverrideBoolean("checked", true)`, which did not reproduce the seeded render *and* did not
+compile. It is now honest about the default render and still wrong about the variant, which is
+strictly better and still worth fixing.
 
 ## Running it in CI
 

--- a/docs/design/USAGE_SNIPPET_CORPUS.md
+++ b/docs/design/USAGE_SNIPPET_CORPUS.md
@@ -1,0 +1,88 @@
+# Does the generated usage source actually compile?
+
+The Source panel tells a visitor a snippet is "the plain Compose that produces this render", and the
+playground invites them to press Run on it. Nothing was holding that claim to anything: the cleaner's
+tests feed it source *this* repository wrote, so they prove the rules match the fixtures and nothing
+more.
+
+This is the loop that checks the claim against real catalogs:
+
+```sh
+scripts/usage-corpus.sh ~/m3-catalog ~/meshcore-mobile
+```
+
+It samples previews from each checkout (5 default + 5 variant by default,
+`USAGE_CORPUS_SAMPLES=n` to change), runs the real `PlaygroundSourceCleaner` over them with that
+catalog's own rules, and compiles the results. Exit status is 0 when every snippet compiles.
+
+## The compile bar is a consumer's classpath, not the catalog's
+
+`:tools:usage-compile-check` compiles the corpus against **Compose and material3 only**. That is
+deliberate and it is the whole point: compiling against the catalog's own classpath would let its
+internal helpers resolve, and the leakage worth finding is exactly the leakage that resolves there
+and nowhere else. The bar is "a developer pasted this into their own Compose app".
+
+The module is empty unless `-PusageCorpus=<dir>` points it at a generated corpus, so it costs a
+normal build nothing.
+
+## What it found
+
+First run, ten samples per catalog:
+
+| Catalog | Compiles | Rules |
+|---|---|---|
+| m3-catalog | **3 / 10** | 17 declared scaffolds |
+| meshcore-mobile | **0 / 10** | none — generic path |
+
+### Residue is not a proxy for "compiles"
+
+The most useful thing the corpus said immediately. `NumberBadge` was reported **clean** — no residue
+at all — and did not compile:
+
+```kotlin
+Badge { Text(previewOverrideString("label", "3")) }
+```
+
+`previewOverrideString` is *this repository's* knob API, not a catalog's. It is not in a scaffold
+package and no catalog had declared it, so nothing flagged it, and every catalog's "plain Compose"
+was quietly leaking it into code a developer was invited to copy. It is now a `GENERIC` rule
+substituting the default argument (`previewOverride*(key, default, …)` → `default`), and declared
+rules inherit the generic ones rather than replacing them.
+
+Residue only ever reported *declared* scaffolding that survived a rule. It cannot see a helper nobody
+declared, which is precisely the case worth catching. **The compiler is the honest signal.**
+
+### m3-catalog's remaining seven failures, by cause
+
+| Cause | Files | Status |
+|---|---|---|
+| `toggleable` / `editable` destructure a `Pair` | 2 | The known gap in `compose-usage.json`'s `$known-gaps` — needs a `DESTRUCTURE` rule kind whose plain form is `var x by remember { mutableStateOf(…) }` |
+| Conditional `stringResource(if (…) Res.string.a else Res.string.b)` | 2 | The inliner only handles the exact single-key form and declines the rest, correctly — but the snippet then keeps an unresolvable `Res` |
+| `CatalogFilledStars`, a catalog-owned `ImageVector` | 4 | No rule; wants substituting with a stock `Icons.Filled.Star` or similar |
+
+None is a defect in the cleaner's machinery. Three are missing vocabulary, which is what the corpus
+exists to surface.
+
+### meshcore-mobile is a structural mismatch, not a missing rules file
+
+All ten failed, and adding a `compose-usage.json` would not fix them. The two catalogs are built on
+different premises:
+
+- **m3-catalog** is annotation-first. Each `@CatalogComponent` is a sticker wrapping *one library
+  component*, so there is a call site to reduce to — `Button(onClick = {}) { Text("Filled") }`.
+- **meshcore-mobile** is spec-driven: `catalog.spec.json` names plain `@Preview` functions, and those
+  previews compose the **app's own screens** with fixture data — `ContactRow` over a hand-built
+  `Contact`, `DeviceBody` with a fake `SelfInfo`. There is no library call site underneath. The
+  honest reduction of "the chat screen with twelve fake contacts" is that screen with twelve fake
+  contacts.
+
+So for a catalog like meshcore the Source panel shows *the preview, sliced and import-pruned* — not
+usage code, and the panel already says so when a catalog has declared no rules. That is the correct
+outcome, and worth knowing before anyone tries to fix it with rules.
+
+## Running it in CI
+
+Not wired to CI yet, deliberately: it needs checkouts of the catalog repositories, and the failure
+count is currently a **baseline to drive down** rather than a gate to hold. The shape it wants is a
+scheduled job that checks out both catalogs, runs the script, and reports the ratio — turning it into
+a gate once m3-catalog reaches 10/10.

--- a/scripts/usage-corpus.sh
+++ b/scripts/usage-corpus.sh
@@ -61,12 +61,31 @@ for repo in "${repos[@]}"; do
   # A failing compile is an expected outcome here, not a script error: the diagnostics ARE the
   # result. Kotlin reports every file it can resolve-check, so one run attributes per snippet.
   log="$out/$system-compile.log"
+  rc=0
   (cd "$here" && ./gradlew --quiet ":tools:usage-compile-check:compileKotlin" \
-    "-PusageCorpus=$dir" --rerun-tasks) >"$log" 2>&1 || true
+    "-PusageCorpus=$dir" --rerun-tasks) >"$log" 2>&1 || rc=$?
 
   failed=$(grep -oE "^e: file://[^:]+\.kt" "$log" | sed 's|.*/||' | sort -u || true)
   nfailed=$(printf '%s\n' "$failed" | grep -c . || true)
   npassed=$((total - nfailed))
+
+  # A nonzero exit with no per-file diagnostic is not "everything compiled" — it is the build
+  # failing before it got as far as type-checking (dependency resolution, a missing toolchain, a
+  # daemon crash). Reporting that as a clean run is the one failure mode that would quietly turn
+  # this whole loop into a no-op, so it is a corpus failure and it says why.
+  if [ "$rc" -ne 0 ] && [ -z "$failed" ]; then
+    {
+      echo "## $system — BUILD FAILED before type-checking (exit $rc)"
+      echo
+      echo "No per-file diagnostics, so nothing can be attributed to a snippet. Tail of the log:"
+      echo '```'
+      tail -20 "$log"
+      echo '```'
+      echo
+    } >>"$summary"
+    status=1
+    continue
+  fi
 
   {
     echo "## $system — $npassed/$total compile"

--- a/scripts/usage-corpus.sh
+++ b/scripts/usage-corpus.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Generate usage snippets from real catalog checkouts and check that they COMPILE.
+#
+# The Source panel tells a visitor a snippet is "the plain Compose that produces this render". Every
+# other test of the cleaner feeds it source this repository controls, which can only prove that the
+# rules match the fixtures. This walks actual catalogs, samples previews the way somebody browsing
+# would land on them, and puts the output in front of a Kotlin compiler.
+#
+#   scripts/usage-corpus.sh ~/m3-catalog ~/meshcore-mobile
+#
+# Each argument is a catalog checkout; the system name is the directory name. With no arguments it
+# looks for sibling checkouts of this repo. Exit status is 0 when every sampled snippet compiles.
+#
+# The compile classpath is deliberately **Compose and material3 only** (:tools:usage-compile-check),
+# not the catalog's own: compiling against the catalog would let its internal helpers resolve and
+# hide precisely the leakage this is looking for. The bar is "a developer pasted this into their own
+# Compose app".
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+out="${USAGE_CORPUS_OUT:-$here/build/usage-corpus}"
+samples="${USAGE_CORPUS_SAMPLES:-5}"
+
+repos=("$@")
+if [ ${#repos[@]} -eq 0 ]; then
+  for guess in "$here/../m3-catalog" "$here/../meshcore-mobile"; do
+    [ -d "$guess" ] && repos+=("$(cd "$guess" && pwd)")
+  done
+fi
+if [ ${#repos[@]} -eq 0 ]; then
+  echo "usage-corpus: no catalog checkouts given and none found beside $here" >&2
+  exit 2
+fi
+
+props=()
+for repo in "${repos[@]}"; do
+  props+=("-Dcomposeai.usageCorpus.$(basename "$repo")=$repo")
+done
+
+rm -rf "$out"
+mkdir -p "$out"
+
+echo "==> generating snippets into $out"
+(cd "$here" && ./gradlew --quiet :cli:test --tests '*UsageSnippetCorpusTest*' \
+  "${props[@]}" -Dcomposeai.usageCorpus.out="$out" -Dcomposeai.usageCorpus.samples="$samples" \
+  --rerun-tasks >/dev/null)
+
+cat "$out/REPORT.md"
+
+status=0
+summary="$out/COMPILE.md"
+: >"$summary"
+
+for repo in "${repos[@]}"; do
+  system="$(basename "$repo")"
+  dir="$out/$system"
+  [ -d "$dir" ] || continue
+  total=$(find "$dir" -name '*.kt' | wc -l | tr -d ' ')
+  echo "==> compiling $total snippets from $system"
+
+  # A failing compile is an expected outcome here, not a script error: the diagnostics ARE the
+  # result. Kotlin reports every file it can resolve-check, so one run attributes per snippet.
+  log="$out/$system-compile.log"
+  (cd "$here" && ./gradlew --quiet ":tools:usage-compile-check:compileKotlin" \
+    "-PusageCorpus=$dir" --rerun-tasks) >"$log" 2>&1 || true
+
+  failed=$(grep -oE "^e: file://[^:]+\.kt" "$log" | sed 's|.*/||' | sort -u || true)
+  nfailed=$(printf '%s\n' "$failed" | grep -c . || true)
+  npassed=$((total - nfailed))
+
+  {
+    echo "## $system — $npassed/$total compile"
+    if [ -n "$failed" ]; then
+      echo
+      echo "Did not compile:"
+      while read -r file; do
+        [ -z "$file" ] && continue
+        # The first distinct reason per file: enough to classify without pasting a wall of Kotlin.
+        reason=$(grep -F "$file:" "$log" | grep -oE "(Unresolved reference '[^']+'|[A-Z][a-z].*)" | head -1)
+        echo "- \`$file\` — $reason"
+      done <<<"$failed"
+    fi
+    echo
+  } >>"$summary"
+
+  [ "$nfailed" -gt 0 ] && status=1
+done
+
+cat "$summary"
+echo "==> corpus: $out"
+exit "$status"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -240,6 +240,9 @@ include(":wear-preview-runtime")
 
 project(":wear-preview-runtime").projectDir = file("runtimes/wear-preview")
 
+// The usage-snippet compile gate (see its build file). Empty unless `-PusageCorpus=` points it at
+// a generated corpus, so it costs a normal build nothing.
+include(":tools:usage-compile-check")
 include(":samples:android")
 
 // Compose Material 3 **design catalog** — one `@Preview` per component in its

--- a/tools/usage-compile-check/build.gradle.kts
+++ b/tools/usage-compile-check/build.gradle.kts
@@ -1,0 +1,44 @@
+// `:tools:usage-compile-check` — does a generated usage snippet actually compile?
+//
+// The Source panel says a snippet is "the plain Compose that produces this render". This module is
+// what holds that claim to something: it compiles the corpus `UsageSnippetCorpusTest` generates
+// against **Compose and material3 only** — the classpath a developer pasting the snippet into their
+// own app has, and deliberately NOT the catalog's own classpath, which would let catalog-internal
+// helpers resolve and hide exactly the leakage worth finding.
+//
+// Sources come from `-PusageCorpus=<dir>`; with none the module is empty and compiles trivially, so
+// a normal build is unaffected. Driven by `scripts/usage-corpus.sh`, which generates the corpus,
+// runs this, and attributes each `e:` diagnostic back to the snippet it came from.
+plugins {
+  // Every project with a build file applies this — `settings.gradle.kts` derives the
+  // `ktfmtCheckAll` / `ktfmtFormatAll` aggregate from exactly that invariant, so a module without
+  // it breaks the aggregate task rather than merely skipping formatting.
+  id("composeai.base-conventions")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+}
+
+kotlin { jvmToolchain(21) }
+
+val usageCorpus: String? = providers.gradleProperty("usageCorpus").orNull
+
+kotlin {
+  sourceSets["main"].kotlin.setSrcDirs(usageCorpus?.let { listOf(file(it)) } ?: emptyList<Any>())
+}
+
+dependencies {
+  implementation(compose.desktop.currentOs)
+  implementation(libs.jetbrains.compose.material3)
+  implementation(libs.jetbrains.compose.foundation)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.components.ui.tooling.preview)
+  // Material icons: `Icons.Filled.*` shows up in real catalog previews.
+  implementation(compose.materialIconsExtended)
+}
+
+// Diagnostics are the product here: a snippet that does not compile is the finding, so the compile
+// must report every error it can rather than stopping at the first file.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  compilerOptions { allWarningsAsErrors.set(false) }
+}


### PR DESCRIPTION
The Source panel tells a visitor a snippet is "the plain Compose that produces this render", and the playground invites them to press Run on it. Nothing held that claim to anything: every existing cleaner test feeds it source *this repository wrote*, which can only prove the rules match the fixtures.

This adds the loop that checks it against real catalogs.

```sh
scripts/usage-corpus.sh ~/m3-catalog ~/meshcore-mobile
```

It samples previews from each checkout (5 default + 5 variant per catalog, `USAGE_CORPUS_SAMPLES=n` to change), runs the real `PlaygroundSourceCleaner` over them with that catalog's own rules, and compiles the output. Exit status is 0 when every snippet compiles.

### The compile bar is a consumer's classpath, not the catalog's

`:tools:usage-compile-check` compiles the corpus against **Compose and material3 only**. Compiling against the catalog's own classpath would let its internal helpers resolve, and the leakage worth finding is exactly the leakage that resolves there and nowhere else. The bar is "a developer pasted this into their own Compose app".

The module has no sources unless `-PusageCorpus=<dir>` points it at a corpus, and the generator test is a no-op without `-Dcomposeai.usageCorpus.<system>=<path>`, so a normal build pays nothing.

### What it found

| Catalog | Compiles | Rules |
|---|---|---|
| m3-catalog | **3 / 10** | 17 declared scaffolds |
| meshcore-mobile | **0 / 10** | none — generic path |

**Residue is not a proxy for "compiles."** `NumberBadge` was reported *clean* — no residue at all — and did not compile:

```kotlin
Badge { Text(previewOverrideString("label", "3")) }
```

`previewOverride*` is *this repository's* knob API, not a catalog's. It sits in no scaffold package and no catalog had declared it, so nothing flagged it, and every catalog's "plain Compose" was quietly leaking it into code a developer was invited to copy. Residue only ever reported *declared* scaffolding that survived a rule; it cannot see a helper nobody declared, which is precisely the case worth catching.

So this PR also fixes that: the override knobs are now `GENERIC` rules substituting the default argument (`previewOverride*(key, default, …)` → `default`), and **declared rules inherit the generic ones rather than replacing them** — before this, the catalogs that had gone to the trouble of declaring their scaffolding were the only ones *not* getting the shared rules. A catalog can still override any of them by naming the same helper.

m3-catalog's remaining seven failures are missing vocabulary, not machinery defects: `toggleable`/`editable` destructuring a `Pair` (2 — the known `$known-gaps` entry, wants a `DESTRUCTURE` kind), conditional `stringResource(if …)` (2 — the inliner correctly declines, but the snippet then keeps an unresolvable `Res`), and `CatalogFilledStars`, a catalog-owned `ImageVector` (4).

meshcore-mobile's 0/10 is a **structural mismatch, not a missing rules file**. m3-catalog is annotation-first — each `@CatalogComponent` wraps one library component, so there is a call site to reduce to. meshcore's `catalog.spec.json` names plain `@Preview` functions that compose the *app's own screens* over fixture data; there is no library call site underneath, and the honest reduction of "the chat screen with twelve fake contacts" is that screen with twelve fake contacts. For such a catalog the Source panel shows the preview sliced and import-pruned, and the panel already says so. Worth knowing before anyone tries to fix it with rules.

### Not wired to CI, deliberately

It needs checkouts of the catalog repositories, and the failure count is currently a baseline to drive down rather than a gate to hold. The shape it wants is a scheduled job that checks out both catalogs and reports the ratio — turning it into a gate once m3-catalog reaches 10/10.

### Test plan

- `./gradlew :cli:test` — green, including the new `declared rules inherit the generic ones` and `a preview override knob becomes the default the render was baked with`.
- `./gradlew ktfmtCheckAll` — green (the new module applies `composeai.base-conventions`, which the settings-derived aggregate task requires of every project with a build file).
- `./gradlew :tools:usage-compile-check:compileKotlin` with no `-PusageCorpus` — no-op, as intended.
- `scripts/usage-corpus.sh /home/user/m3-catalog <meshcore checkout>` — ran end to end, producing the numbers above.

No visual surfaces change: this is a test harness, a build module, and one rules-inheritance fix behind the Source panel. The panel's own rendering is unchanged.

Docs: `docs/design/USAGE_SNIPPET_CORPUS.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_