### PR TITLE
fix(serve): rewrite fully qualified knob calls, and make the corpus fail loudly

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -446,10 +446,12 @@ tasks.withType<Test>().configureEach {
   // Catalog checkouts for the usage-snippet corpus (UsageSnippetCorpusTest). Absent by default, so
   // the corpus is a no-op in a normal build; `scripts/usage-corpus.sh` supplies them. Forwarded
   // rather than read from the environment so the paths show up in the build's own inputs.
+  // `repos` is one property carrying every checkout as `name=path,name=path`, rather than one
+  // forwarded key per catalog: a fixed key list silently ignores any checkout not named in it, so
+  // adding a third catalog would have produced an empty corpus and a passing run.
   for (key in
     listOf(
-      "composeai.usageCorpus.m3-catalog",
-      "composeai.usageCorpus.meshcore-mobile",
+      "composeai.usageCorpus.repos",
       "composeai.usageCorpus.out",
       "composeai.usageCorpus.samples",
     )) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -315,6 +315,8 @@ object PlaygroundSourceCleaner {
   ): String {
     var out = stripScaffoldAnnotations(text, imports, rules)
     out = inlineStringResources(out, strings)
+    // Before anything matches on a helper name: a call written fully qualified is the same call.
+    out = unqualifyScaffoldCalls(out, rules)
     // Order matters. UNWRAP first, so a wrapper takes its own arguments away with it before DROP
     // starts reasoning about which arguments mention a dropped binding. INLINE next, so a member
     // substitution lands before DROP inspects the argument it sits in. DROP, then RENAME last —
@@ -327,6 +329,36 @@ object PlaygroundSourceCleaner {
     if (isEntry) out = stampPreview(out, rules, addedImports)
     for (name in rules.scaffolds.keys) if (mentionsWord(out, name)) residue.add(name)
     return out.trimEnd()
+  }
+
+  /**
+   * A **package-qualified** call to a declared helper —
+   * `ee.schimke.composeai.overrides.previewOverrideString("k", "v")` — reduced to the bare name, so
+   * every pass below sees the call it already knows how to rewrite.
+   *
+   * Without this, such a call is invisible in both directions: [wordOccurrences] rejects an
+   * occurrence preceded by `.` (correctly — `foo.counted` is not the scaffold `counted`), so no
+   * rule fires, *and* the call needs no import, so the residue pass has nothing to report. The seed
+   * comes out marked cleaned with a repository-internal call still in it, which is the one outcome
+   * this whole design is built to avoid.
+   *
+   * The prefix must be **two or more** lowercase-initial segments — a package path, never a
+   * receiver. `overrides.previewOverrideString` (one segment, possibly a local val) is left alone;
+   * guessing there could rewrite a call on somebody's object.
+   */
+  private fun unqualifyScaffoldCalls(text: String, rules: UsageRules): String {
+    if (rules.scaffolds.isEmpty()) return text
+    val names = rules.scaffolds.keys.joinToString("|") { Regex.escape(it) }
+    val qualified = Regex("""(?<![A-Za-z0-9_.])(?:[a-z][A-Za-z0-9_]*\.){2,}($names)(?=\s*\()""")
+    val mask = codeMask(text)
+    val out = StringBuilder(text.length)
+    var at = 0
+    for (m in qualified.findAll(text)) {
+      if (!mask[m.range.first]) continue
+      out.append(text, at, m.range.first).append(m.groupValues[1])
+      at = m.range.last + 1
+    }
+    return if (at == 0) text else out.append(text, at, text.length).toString()
   }
 
   private fun isScaffoldPackage(fqn: String, rules: UsageRules): Boolean =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -450,6 +450,53 @@ class PlaygroundSourceCleanerTest {
     assertTrue(cleaned.text.contains("""Text("Shopping")"""), cleaned.text)
   }
 
+  /**
+   * A package-qualified call is the same call. It was invisible in both directions before: no rule
+   * fired (an occurrence after `.` is rejected, correctly) and no residue was reported (the call
+   * needs no import), so the seed came out marked cleaned with a repo-internal call still in it.
+   */
+  @Test
+  fun `a fully qualified knob call is rewritten like a bare one`() {
+    val source =
+      """
+      package ee.schimke.demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Title() =
+        Text(ee.schimke.composeai.overrides.previewOverrideString("title", "Shopping"))
+      """
+        .trimIndent()
+    val cleaned =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Title"), UsageRules.GENERIC)
+      )
+    assertTrue(cleaned.text.contains("""Text("Shopping")"""), cleaned.text)
+    assertFalse(cleaned.text.contains("previewOverrideString"), cleaned.text)
+  }
+
+  /** A single-segment receiver is not a package, and must not be unqualified on a guess. */
+  @Test
+  fun `a member call that shares a scaffold name is left alone`() {
+    val rules =
+      UsageRules(scaffolds = mapOf("counted" to UsageRules.Scaffold(kind = UsageRules.Kind.UNWRAP)))
+    val source =
+      """
+      package ee.schimke.demo
+
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Tally() = stats.counted { }
+      """
+        .trimIndent()
+    val cleaned =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Tally"), rules))
+    assertTrue(cleaned.text.contains("stats.counted"), cleaned.text)
+  }
+
   /** Named arguments out of declaration order still bind by name, as Kotlin binds them. */
   @Test
   fun `a knob with reordered named arguments still resolves its default`() {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
@@ -17,36 +17,59 @@ import kotlin.test.assertTrue
  *
  * ### Opt-in, and silent without checkouts
  *
- * Driven by `-Dcomposeai.usageCorpus.<system>=<path>`, so it is a no-op in a normal build and on
- * any machine without the catalogs. `scripts/usage-corpus.sh` supplies the paths and then compiles
- * what this writes; see `docs/design/USAGE_SNIPPET_CORPUS.md` for the whole loop.
+ * Driven by `-Dcomposeai.usageCorpus.repos=<name>=<path>,…`, so it is a no-op in a normal build and
+ * on any machine without the catalogs. `scripts/usage-corpus.sh` supplies the paths and then
+ * compiles what this writes; see `docs/design/USAGE_SNIPPET_CORPUS.md` for the whole loop.
  *
- * The catalogs are deliberately unalike, which is the point of testing both:
- * - **m3-catalog** is annotation-first (`@CatalogComponent` / `@CatalogVariant`) and ships a
+ * The catalogs are deliberately unalike, which is the point of testing both, and which sampler runs
+ * is decided by the checkout's *shape* rather than its name:
+ * - **annotation-first** (m3-catalog): `@CatalogComponent` / `@CatalogVariant`, plus a
  *   `compose-usage.json`, so its snippets are expected to come out as usage code.
- * - **meshcore-mobile** is spec-driven (`catalog.spec.json` names plain `@Preview` functions) and
- *   ships no rules at all, so it exercises the generic path — annotation stripping only.
+ * - **spec-driven** (meshcore-mobile): a `catalog.spec.json` naming plain `@Preview` functions, and
+ *   no rules at all, so it exercises the generic path — annotation stripping only.
  */
 class UsageSnippetCorpusTest {
 
   private data class Sample(val system: String, val kind: String, val function: String)
 
-  private fun repo(system: String): File? =
-    System.getProperty("composeai.usageCorpus.$system")?.takeIf { it.isNotBlank() }?.let(::File)
+  /**
+   * The checkouts to sample, as `name=path,name=path` in `composeai.usageCorpus.repos`.
+   *
+   * One property rather than one per catalog on purpose: a fixed set of forwarded keys silently
+   * ignores any checkout whose name is not in it, which would have produced an empty corpus and a
+   * passing run for a catalog nobody sampled.
+   */
+  private fun repos(): List<Pair<String, File>> =
+    System.getProperty("composeai.usageCorpus.repos").orEmpty().split(',').mapNotNull { entry ->
+      val at = entry.indexOf('=').takeIf { it > 0 } ?: return@mapNotNull null
+      val name = entry.substring(0, at).trim()
+      val path = entry.substring(at + 1).trim()
+      if (name.isEmpty() || path.isEmpty()) null else name to File(path)
+    }
 
   private val outDir =
     File(System.getProperty("composeai.usageCorpus.out") ?: "build/usage-corpus").also {
       it.mkdirs()
     }
 
-  /** Every `.kt` under a checkout, excluding build output and tests. */
-  private fun sources(root: File): List<File> =
-    root
+  /**
+   * Every `.kt` under a checkout, excluding build output and test sources.
+   *
+   * The source-set names matter here: `/test/` alone misses every Kotlin Multiplatform layout —
+   * `src/commonTest`, `src/jvmTest`, `src/desktopTest`, `src/androidUnitTest` — and both catalogs
+   * sampled are multiplatform. A test fixture picked up as a production preview would quietly move
+   * the reported ratio, so the filter matches any `src/<name>Test…` segment as well as the
+   * single-platform spellings.
+   */
+  private fun sources(root: File): List<File> {
+    val testSourceSet = Regex("""/src/[A-Za-z0-9]*([Tt]est|TestFixtures)[A-Za-z0-9]*/""")
+    return root
       .walkTopDown()
       .onEnter { it.name !in setOf("build", ".git", ".gradle") }
       .filter { it.isFile && it.extension == "kt" }
-      .filterNot { it.path.contains("/test/") || it.path.contains("/androidTest/") }
+      .filterNot { testSourceSet.containsMatchIn(it.path) || it.path.contains("/testFixtures/") }
       .toList()
+  }
 
   /**
    * A 1-based line inside [function]'s declaration — the anchor the cleaner walks outwards from.
@@ -97,8 +120,8 @@ class UsageSnippetCorpusTest {
       }
   }
 
-  /** m3-catalog: annotation-first, so the samples come from the annotations themselves. */
-  private fun m3Samples(root: File, perKind: Int): List<Sample> {
+  /** Annotation-first (m3-catalog): the samples come from the annotations themselves. */
+  private fun annotationSamples(system: String, root: File, perKind: Int): List<Sample> {
     val out = mutableListOf<Sample>()
     for (file in sources(root).sortedBy { it.path }) {
       val lines = runCatching { file.readText().lines() }.getOrNull() ?: continue
@@ -114,7 +137,7 @@ class UsageSnippetCorpusTest {
           lines.drop(i).firstNotNullOfOrNull {
             Regex("""^fun\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(""").find(it)?.groupValues?.get(1)
           } ?: continue
-        if (out.none { it.function == fn }) out += Sample("m3-catalog", kind, fn)
+        if (out.none { it.function == fn }) out += Sample(system, kind, fn)
       }
     }
     // Spread across the alphabet rather than taking the first N, which would be one section file.
@@ -127,8 +150,8 @@ class UsageSnippetCorpusTest {
     }
   }
 
-  /** meshcore-mobile: spec-driven, so the samples come from `catalog.spec.json`. */
-  private fun meshcoreSamples(root: File, perKind: Int): List<Sample> {
+  /** Spec-driven (meshcore-mobile): the samples come from `catalog.spec.json`. */
+  private fun specSamples(system: String, root: File, perKind: Int): List<Sample> {
     val spec = File(root, "catalog.spec.json").takeIf { it.isFile } ?: return emptyList()
     val text = spec.readText()
     // Deliberately regex rather than a JSON parser: this test has no JSON dependency and the shape
@@ -151,7 +174,7 @@ class UsageSnippetCorpusTest {
         .toList()
     fun spread(all: List<String>, kind: String) =
       (if (all.size <= perKind) all else (0 until perKind).map { all[it * all.size / perKind] })
-        .map { Sample("meshcore-mobile", kind, it) }
+        .map { Sample(system, kind, it) }
     return spread(components, "component") + spread(variants, "variant")
   }
 
@@ -184,22 +207,26 @@ class UsageSnippetCorpusTest {
 
   @Test
   fun `generate usage snippets from the catalog checkouts`() {
-    val m3 = repo("m3-catalog")
-    val meshcore = repo("meshcore-mobile")
-    if (m3 == null && meshcore == null) return // no checkouts wired: nothing to do
+    val repos = repos()
+    if (repos.isEmpty()) return // no checkouts wired: nothing to do
 
     val report = StringBuilder()
     var written = 0
 
-    for (root in listOfNotNull(m3, meshcore)) {
-      val system = if (root == m3) "m3-catalog" else "meshcore-mobile"
+    for ((system, root) in repos) {
       val files = sources(root)
       val (rules, declared) = rulesFor(root)
       val strings = stringsFor(root, rules)
+      // Which sampler by the catalog's *shape*, not its name — keying on the name would silently
+      // mis-sample the next catalog somebody points this at. Annotations first, spec as the
+      // fallback, rather than branching on the spec file's presence: m3-catalog ships **both**, so
+      // "has a spec ⇒ spec-driven" sampled it as the wrong shape and produced nothing.
       val samples =
-        if (system == "m3-catalog") m3Samples(root, perKind) else meshcoreSamples(root, perKind)
+        annotationSamples(system, root, perKind).ifEmpty { specSamples(system, root, perKind) }
       report.appendLine(
-        "## $system — ${samples.size} samples, rules: ${if (declared) "declared (${rules.scaffolds.size} scaffolds)" else "GENERIC (none declared)"}"
+        // The catalog's *own* scaffolds, not the merged map — counting the inherited generic rules
+        // would credit every catalog with rules it never wrote.
+        "## $system — ${samples.size} samples, rules: ${if (declared) "declared (${rules.scaffolds.keys.count { it !in UsageRules.GENERIC.scaffolds }} scaffolds)" else "GENERIC (none declared)"}"
       )
       for (sample in samples) {
         val found = findFunction(files, sample.function)

--- a/scripts/usage-corpus.sh
+++ b/scripts/usage-corpus.sh
@@ -32,9 +32,15 @@ if [ ${#repos[@]} -eq 0 ]; then
   exit 2
 fi
 
-props=()
+# One property carrying every checkout, rather than one key per catalog: a fixed key list on the
+# Gradle side silently ignores any checkout not named in it, so a third catalog would have produced
+# an empty corpus and a passing run.
+spec=""
 for repo in "${repos[@]}"; do
-  props+=("-Dcomposeai.usageCorpus.$(basename "$repo")=$repo")
+  case "$repo" in
+    *,*) echo "usage-corpus: checkout path may not contain a comma: $repo" >&2; exit 2 ;;
+  esac
+  spec="${spec:+$spec,}$(basename "$repo")=$repo"
 done
 
 rm -rf "$out"
@@ -42,7 +48,8 @@ mkdir -p "$out"
 
 echo "==> generating snippets into $out"
 (cd "$here" && ./gradlew --quiet :cli:test --tests '*UsageSnippetCorpusTest*' \
-  "${props[@]}" -Dcomposeai.usageCorpus.out="$out" -Dcomposeai.usageCorpus.samples="$samples" \
+  "-Dcomposeai.usageCorpus.repos=$spec" \
+  -Dcomposeai.usageCorpus.out="$out" -Dcomposeai.usageCorpus.samples="$samples" \
   --rerun-tasks >/dev/null)
 
 cat "$out/REPORT.md"
@@ -54,8 +61,22 @@ summary="$out/COMPILE.md"
 for repo in "${repos[@]}"; do
   system="$(basename "$repo")"
   dir="$out/$system"
-  [ -d "$dir" ] || continue
-  total=$(find "$dir" -name '*.kt' | wc -l | tr -d ' ')
+  total=0
+  [ -d "$dir" ] && total=$(find "$dir" -name '*.kt' | wc -l | tr -d ' ')
+  # A checkout that produced nothing is a failure, not a catalog to skip. The generator only asserts
+  # that *some* snippet was written, so a silent skip here lets one good catalog carry a run in
+  # which the other was never sampled at all — the report then reads as a pass for both.
+  if [ "$total" -eq 0 ]; then
+    {
+      echo "## $system — NO SNIPPETS GENERATED"
+      echo
+      echo "Nothing was written to \`$dir\`. See its section in REPORT.md: every sample was"
+      echo "\`SOURCE NOT FOUND\` / \`DECLINED\`, or the checkout was never sampled."
+      echo
+    } >>"$summary"
+    status=1
+    continue
+  fi
   echo "==> compiling $total snippets from $system"
 
   # A failing compile is an expected outcome here, not a script error: the diagnostics ARE the
@@ -95,7 +116,12 @@ for repo in "${repos[@]}"; do
       while read -r file; do
         [ -z "$file" ] && continue
         # The first distinct reason per file: enough to classify without pasting a wall of Kotlin.
-        reason=$(grep -F "$file:" "$log" | grep -oE "(Unresolved reference '[^']+'|[A-Z][a-z].*)" | head -1)
+        # Both greps may legitimately match nothing (a diagnostic worded some other way), and under
+        # `set -euo pipefail` an unmatched grep in a command substitution would abort the whole run
+        # mid-report — so tolerate it and fall back to the raw diagnostic line.
+        first=$(grep -F "$file:" "$log" | head -1 || true)
+        reason=$(printf '%s' "$first" | grep -oE "(Unresolved reference '[^']+'|[A-Z][a-z].*)" | head -1 || true)
+        [ -n "$reason" ] || reason="${first:-no diagnostic captured}"
         echo "- \`$file\` — $reason"
       done <<<"$failed"
     fi


### PR DESCRIPTION
Follow-ups to #3849, which merged before this second review round could land on it.

### A package-qualified helper call was invisible in both directions

`ee.schimke.composeai.overrides.previewOverrideString(...)` matched no rule — `wordOccurrences` rejects an occurrence preceded by `.`, correctly, since `foo.counted` is not the scaffold `counted` — *and* reported no residue, since such a call needs no import. The seed therefore came out marked **cleaned** with a repository-internal call still in it, which is the single outcome this whole design exists to prevent. The repo's own `RedFixturePreviews.kt` fixtures call the knobs this way.

A pre-pass now unqualifies a call whose prefix is **two or more** lowercase-initial segments — a package path, never a receiver — so `stats.counted { }` is still left alone rather than rewritten on a guess.

### A checkout that produced no snippets was skipped, not failed

The generator only asserts that *some* snippet was written globally, so one good catalog could carry a run in which the other was never sampled, and the report read as a pass for both. A missing or empty directory for a requested checkout is now a corpus failure.

**That check earned itself immediately — it caught a regression in this very commit.** Choosing the sampler by "has a `catalog.spec.json` ⇒ spec-driven" sampled m3-catalog as the wrong shape and produced zero snippets, because m3-catalog ships **both** a spec and the annotations. It's now annotations first, spec as the fallback. Without the new check that would have been a silent 0-sample pass reported as success.

### The forwarded system-property keys were a fixed list of two

Any checkout whose basename wasn't in that list produced an empty corpus and a passing run. Replaced with a single `composeai.usageCorpus.repos=name=path,…` property, and the sampler keys on the catalog's shape rather than its name — so pointing this at a third catalog works instead of silently doing nothing.

### Test sources leaked into the sampling pool

`/test/` alone misses every Kotlin Multiplatform layout — `src/commonTest`, `src/jvmTest`, `src/androidUnitTest` — and both sampled catalogs are multiplatform, so a fixture could be compiled in place of a production preview and move the reported ratio.

### Reason extraction could abort the run

Under `set -euo pipefail` an unmatched `grep` inside a command substitution kills the script mid-report, so one unexpectedly-worded diagnostic would strand every later snippet and catalog unsummarised. It now falls back to the raw diagnostic line.

### Test plan

- `./gradlew :cli:test` — green, including four new cleaner tests: fully-qualified knob call rewritten, single-segment receiver left alone, named-argument binding, and rules-file inheritance.
- `./gradlew ktfmtCheckAll` — green.
- `scripts/usage-corpus.sh /home/user/m3-catalog <meshcore checkout>` — ran end to end after every change. Ratios re-measured and unchanged: **m3-catalog 3/10, meshcore-mobile 0/10**, with m3's sampling verified correct in `REPORT.md` (10 samples, 17 declared scaffolds).

Non-visual: a text-pass cleaner, a test harness, a shell script and build wiring. Nothing rendered changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_