### PR TITLE
fix(serve): unqualify only declared scaffold packages, not package-shaped receivers

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -342,14 +342,17 @@ object PlaygroundSourceCleaner {
    * comes out marked cleaned with a repository-internal call still in it, which is the one outcome
    * this whole design is built to avoid.
    *
-   * The prefix must be **two or more** lowercase-initial segments — a package path, never a
-   * receiver. `overrides.previewOverrideString` (one segment, possibly a local val) is left alone;
-   * guessing there could rewrite a call on somebody's object.
+   * The prefix must be a package the rules **name** ([UsageRules.scaffoldPackages]), not merely
+   * something package-*shaped*. `state.metrics.counted { }` is two lowercase segments followed by a
+   * declared scaffold name, and it is somebody's ordinary receiver chain; stripping it on that
+   * resemblance would hand the call to the scaffold passes and rewrite it. An allow-list can only
+   * ever *miss* a qualified call, which leaves it as residue — the direction this pass fails in.
    */
   private fun unqualifyScaffoldCalls(text: String, rules: UsageRules): String {
-    if (rules.scaffolds.isEmpty()) return text
+    if (rules.scaffolds.isEmpty() || rules.scaffoldPackages.isEmpty()) return text
     val names = rules.scaffolds.keys.joinToString("|") { Regex.escape(it) }
-    val qualified = Regex("""(?<![A-Za-z0-9_.])(?:[a-z][A-Za-z0-9_]*\.){2,}($names)(?=\s*\()""")
+    val packages = rules.scaffoldPackages.joinToString("|") { Regex.escape(it) }
+    val qualified = Regex("""(?<![A-Za-z0-9_.])(?:$packages)\.($names)(?=\s*\()""")
     val mask = codeMask(text)
     val out = StringBuilder(text.length)
     var at = 0

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -327,7 +327,9 @@ object PlaygroundSourceCleaner {
     out = applyDrop(out, rules, residue)
     out = applyRename(out, rules, addedImports)
     if (isEntry) out = stampPreview(out, rules, addedImports)
-    for (name in rules.scaffolds.keys) if (mentionsWord(out, name)) residue.add(name)
+    for (name in rules.scaffolds.keys) {
+      if (mentionsWord(out, name) || mentionsQualifiedCall(out, name)) residue.add(name)
+    }
     return out.trimEnd()
   }
 
@@ -345,14 +347,20 @@ object PlaygroundSourceCleaner {
    * The prefix must be a package the rules **name** ([UsageRules.scaffoldPackages]), not merely
    * something package-*shaped*. `state.metrics.counted { }` is two lowercase segments followed by a
    * declared scaffold name, and it is somebody's ordinary receiver chain; stripping it on that
-   * resemblance would hand the call to the scaffold passes and rewrite it. An allow-list can only
-   * ever *miss* a qualified call, which leaves it as residue — the direction this pass fails in.
+   * resemblance would hand the call to the scaffold passes and rewrite it.
+   *
+   * An allow-list therefore *misses* a qualified call whose package nobody declared — and a miss is
+   * only safe because [mentionsQualifiedCall] reports it as residue. [mentionsWord] alone cannot:
+   * it rejects a name preceded by `.` by design, which is what made a package-qualified call
+   * invisible in the first place.
    */
   private fun unqualifyScaffoldCalls(text: String, rules: UsageRules): String {
     if (rules.scaffolds.isEmpty() || rules.scaffoldPackages.isEmpty()) return text
     val names = rules.scaffolds.keys.joinToString("|") { Regex.escape(it) }
     val packages = rules.scaffoldPackages.joinToString("|") { Regex.escape(it) }
-    val qualified = Regex("""(?<![A-Za-z0-9_.])(?:$packages)\.($names)(?=\s*\()""")
+    // `[({]` and not just `(`: a trailing-lambda call — `counted { }` — has no parentheses at all,
+    // and that is the shape most scaffolding wrappers are written in.
+    val qualified = Regex("""(?<![A-Za-z0-9_.])(?:$packages)\.($names)(?=\s*[({])""")
     val mask = codeMask(text)
     val out = StringBuilder(text.length)
     var at = 0
@@ -770,6 +778,28 @@ object PlaygroundSourceCleaner {
 
   internal fun mentionsWord(text: String, word: String): Boolean =
     wordOccurrences(text, word).isNotEmpty()
+
+  /**
+   * Whether [text] still calls [name] through **any** qualifier — `com.acme.counted(…)`.
+   *
+   * This is the residue half of [unqualifyScaffoldCalls]. That pass only rewrites a call whose
+   * package the rules named, which is right (a receiver chain must not be stripped on a
+   * resemblance) but leaves everything else unrewritten — and [mentionsWord] rejects a name
+   * preceded by `.`, so nothing reported it either. A declared scaffold could therefore survive
+   * into a seed marked *cleaned*, which is the failure this class exists to make impossible.
+   *
+   * Deliberately not trying to tell a package from a receiver: it cannot, without the resolution
+   * this pass does not have. So it over-reports — `state.metrics.counted(…)` lands in residue too.
+   * A false residue costs a note saying a helper may not have been rewritten; a false silence costs
+   * a snippet advertised as runnable that does not compile. Only one of those is worth avoiding.
+   */
+  private fun mentionsQualifiedCall(text: String, name: String): Boolean {
+    if (name.isEmpty()) return false
+    val mask = codeMask(text)
+    val qualified =
+      Regex("""(?<![A-Za-z0-9_])(?:[A-Za-z_][A-Za-z0-9_]*\.)+${Regex.escape(name)}(?=\s*[({])""")
+    return qualified.findAll(text).any { mask[it.range.first] }
+  }
 
   /**
    * Whether [text] refers to [name] *at all*, including as the member half of a qualified

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -46,6 +46,17 @@ data class UsageRules(
   @SerialName("scaffoldAnnotationPackages")
   val scaffoldAnnotationPackages: List<String> = emptyList(),
 
+  /**
+   * Packages the [scaffolds] themselves live in, so a **package-qualified** call
+   * (`ee.schimke.composeai.overrides.previewOverrideString(…)`) is recognised as the same call.
+   *
+   * An allow-list rather than a shape test, because the shape is ambiguous: `state.metrics.counted
+   * { }` looks exactly like a two-segment package prefix, and unqualifying it would let the
+   * scaffold passes rewrite somebody's ordinary receiver chain. Only a prefix named here is
+   * stripped, so a chain this does not know about keeps its meaning.
+   */
+  @SerialName("scaffoldPackages") val scaffoldPackages: List<String> = emptyList(),
+
   /** Helper name → what the cleaner should do with it. */
   @SerialName("scaffolds") val scaffolds: Map<String, Scaffold> = emptyMap(),
 
@@ -149,6 +160,7 @@ data class UsageRules(
     val GENERIC =
       UsageRules(
         scaffoldAnnotationPackages = listOf("ee.schimke.composeai.preview"),
+        scaffoldPackages = listOf("ee.schimke.composeai.overrides"),
         // The preview-override knobs are **this repo's** API, not a catalog's, so no catalog should
         // have to declare them — and until they were here, every catalog's "plain Compose" leaked
         // `previewOverrideString(...)` into code a developer was invited to copy. Each takes
@@ -184,15 +196,6 @@ data class UsageRules(
       )
 
     /**
-     * A catalog's declared rules **plus** the ones that are this repo's business rather than any
-     * catalog's — the preview-override knobs and this repo's annotation packages.
-     *
-     * Without this a declared `compose-usage.json` replaced [GENERIC] wholesale, so the catalogs
-     * that had gone to the trouble of declaring their scaffolding were the only ones NOT getting
-     * the shared rules. A catalog can still override any of them by naming the same helper: its own
-     * entry wins.
-     */
-    /**
      * Did the **catalog** declare scaffolding, as opposed to inheriting this repo's own rules?
      *
      * The Source panel's note turns on this: "the catalog declared its scaffolding, so what is left
@@ -201,13 +204,34 @@ data class UsageRules(
      * being able to the moment [GENERIC] carried entries of its own — every catalog would then
      * claim a declaration it never made.
      */
-    fun UsageRules.declaresCatalogScaffolds(): Boolean =
-      scaffolds.keys.any { it !in GENERIC.scaffolds }
+    fun UsageRules.declaresCatalogScaffolds(): Boolean = catalogScaffolds().isNotEmpty()
 
+    /**
+     * The scaffolds a catalog declared itself — the merged map minus the generic ones it inherited.
+     *
+     * Compared by **entry**, not by key: a catalog that declares only its own reading of
+     * `previewOverrideString` has declared something, and a key-difference test would call that
+     * catalog undeclared while its rule was busy driving the cleaning.
+     */
+    fun UsageRules.catalogScaffolds(): Map<String, Scaffold> =
+      scaffolds.filter { (name, scaffold) ->
+        GENERIC.scaffolds[name] != scaffold
+      }
+
+    /**
+     * A catalog's declared rules **plus** the ones that are this repo's business rather than any
+     * catalog's — the preview-override knobs and this repo's annotation packages.
+     *
+     * Without this a declared `compose-usage.json` replaced [GENERIC] wholesale, so the catalogs
+     * that had gone to the trouble of declaring their scaffolding were the only ones NOT getting
+     * the shared rules. A catalog can still override any of them by naming the same helper: its own
+     * entry wins.
+     */
     private fun UsageRules.withGenericDefaults(): UsageRules =
       copy(
         scaffoldAnnotationPackages =
           (scaffoldAnnotationPackages + GENERIC.scaffoldAnnotationPackages).distinct(),
+        scaffoldPackages = (scaffoldPackages + GENERIC.scaffoldPackages).distinct(),
         scaffolds = GENERIC.scaffolds + scaffolds,
       )
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -509,6 +509,32 @@ class PlaygroundSourceCleanerTest {
     assertTrue(cleaned.text.contains("state.metrics.counted"), cleaned.text)
   }
 
+  /**
+   * A qualified call the rules cannot unqualify must still be *reported*. The allow-list only
+   * rewrites packages the rules name, so an undeclared one is left in place — and `mentionsWord`
+   * rejects a name preceded by `.`, so nothing else would have said so. That combination is how a
+   * seed gets marked cleaned with a catalog-internal call still in it.
+   */
+  @Test
+  fun `an unlisted qualified scaffold call is reported as residue`() {
+    val rules =
+      UsageRules(scaffolds = mapOf("counted" to UsageRules.Scaffold(kind = UsageRules.Kind.UNWRAP)))
+    val source =
+      """
+      package ee.schimke.demo
+
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Tally() = com.acme.counted { }
+      """
+        .trimIndent()
+    val cleaned =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Tally"), rules))
+    assertTrue(cleaned.text.contains("com.acme.counted"), cleaned.text)
+    assertTrue(cleaned.residue.contains("counted"), "${cleaned.residue}")
+  }
+
   /** Named arguments out of declaration order still bind by name, as Kotlin binds them. */
   @Test
   fun `a knob with reordered named arguments still resolves its default`() {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -477,11 +477,19 @@ class PlaygroundSourceCleanerTest {
     assertFalse(cleaned.text.contains("previewOverrideString"), cleaned.text)
   }
 
-  /** A single-segment receiver is not a package, and must not be unqualified on a guess. */
+  /**
+   * A receiver chain is not a package, however much it looks like one. `state.metrics.counted { }`
+   * is two lowercase segments followed by a declared scaffold name — matching on that shape would
+   * strip the receiver and let the scaffold passes rewrite somebody's ordinary call. Only a package
+   * the rules actually name is stripped.
+   */
   @Test
   fun `a member call that shares a scaffold name is left alone`() {
     val rules =
-      UsageRules(scaffolds = mapOf("counted" to UsageRules.Scaffold(kind = UsageRules.Kind.UNWRAP)))
+      UsageRules(
+        scaffoldPackages = listOf("ee.schimke.m3catalog"),
+        scaffolds = mapOf("counted" to UsageRules.Scaffold(kind = UsageRules.Kind.UNWRAP)),
+      )
     val source =
       """
       package ee.schimke.demo
@@ -489,12 +497,16 @@ class PlaygroundSourceCleanerTest {
       import androidx.compose.runtime.Composable
 
       @Composable
-      fun Tally() = stats.counted { }
+      fun Tally() {
+        stats.counted { }
+        state.metrics.counted { }
+      }
       """
         .trimIndent()
     val cleaned =
-      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Tally"), rules))
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "stats.counted"), rules))
     assertTrue(cleaned.text.contains("stats.counted"), cleaned.text)
+    assertTrue(cleaned.text.contains("state.metrics.counted"), cleaned.text)
   }
 
   /** Named arguments out of declaration order still bind by name, as Kotlin binds them. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
@@ -39,13 +39,25 @@ class UsageSnippetCorpusTest {
    * ignores any checkout whose name is not in it, which would have produced an empty corpus and a
    * passing run for a catalog nobody sampled.
    */
-  private fun repos(): List<Pair<String, File>> =
-    System.getProperty("composeai.usageCorpus.repos").orEmpty().split(',').mapNotNull { entry ->
-      val at = entry.indexOf('=').takeIf { it > 0 } ?: return@mapNotNull null
-      val name = entry.substring(0, at).trim()
-      val path = entry.substring(at + 1).trim()
-      if (name.isEmpty() || path.isEmpty()) null else name to File(path)
-    }
+  private fun repos(): List<Pair<String, File>> {
+    // Absent means "no checkouts wired", and is the normal build. *Present but malformed* is a typo
+    // in the documented property, and must not read as the same thing: silently dropping the entry
+    // turns a wrong invocation into a successful no-op, which is the failure this whole loop is
+    // built to stop reporting as a pass.
+    val spec = System.getProperty("composeai.usageCorpus.repos") ?: return emptyList()
+    return spec
+      .split(',')
+      .filter { it.isNotBlank() }
+      .map { entry ->
+        val at = entry.indexOf('=')
+        val name = if (at > 0) entry.substring(0, at).trim() else ""
+        val path = if (at > 0) entry.substring(at + 1).trim() else ""
+        require(name.isNotEmpty() && path.isNotEmpty()) {
+          "composeai.usageCorpus.repos entry is not <name>=<path>: '$entry'"
+        }
+        name to File(path)
+      }
+  }
 
   private val outDir =
     File(System.getProperty("composeai.usageCorpus.out") ?: "build/usage-corpus").also {
@@ -58,11 +70,15 @@ class UsageSnippetCorpusTest {
    * The source-set names matter here: `/test/` alone misses every Kotlin Multiplatform layout —
    * `src/commonTest`, `src/jvmTest`, `src/desktopTest`, `src/androidUnitTest` — and both catalogs
    * sampled are multiplatform. A test fixture picked up as a production preview would quietly move
-   * the reported ratio, so the filter matches any `src/<name>Test…` segment as well as the
-   * single-platform spellings.
+   * the reported ratio.
+   *
+   * Matched at the source-set name's **boundary**, not as a substring: `src/latestMain` and
+   * `src/contestMain` contain `test` and are production, and excluding them would drop real
+   * previews just as quietly in the other direction. A test source set's name ends in `Test`
+   * (`commonTest`, `jvmTest`, `androidUnitTest`) or is `test` / `testFixtures` outright.
    */
   private fun sources(root: File): List<File> {
-    val testSourceSet = Regex("""/src/[A-Za-z0-9]*([Tt]est|TestFixtures)[A-Za-z0-9]*/""")
+    val testSourceSet = Regex("""/src/(test|testFixtures|[A-Za-z0-9]*Test)/""")
     return root
       .walkTopDown()
       .onEnter { it.name !in setOf("build", ".git", ".gradle") }
@@ -225,8 +241,9 @@ class UsageSnippetCorpusTest {
         annotationSamples(system, root, perKind).ifEmpty { specSamples(system, root, perKind) }
       report.appendLine(
         // The catalog's *own* scaffolds, not the merged map — counting the inherited generic rules
-        // would credit every catalog with rules it never wrote.
-        "## $system — ${samples.size} samples, rules: ${if (declared) "declared (${rules.scaffolds.keys.count { it !in UsageRules.GENERIC.scaffolds }} scaffolds)" else "GENERIC (none declared)"}"
+        // would credit every catalog with rules it never wrote. Compared by entry, so a catalog
+        // that declared only its own reading of a generic knob still counts.
+        "## $system — ${samples.size} samples, rules: ${if (declared) "declared (${with(UsageRules.Companion) { rules.catalogScaffolds() }.size} scaffolds)" else "GENERIC (none declared)"}"
       )
       for (sample in samples) {
         val found = findFunction(files, sample.function)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
@@ -45,6 +45,11 @@ class UsageSnippetCorpusTest {
     // turns a wrong invocation into a successful no-op, which is the failure this whole loop is
     // built to stop reporting as a pass.
     val spec = System.getProperty("composeai.usageCorpus.repos") ?: return emptyList()
+    // `-Dcomposeai.usageCorpus.repos=` — present and empty — is a wrong invocation too, and
+    // dropping through to the empty list would make it the same silent no-op as not setting it.
+    require(spec.isNotBlank() && spec.any { it != ',' && !it.isWhitespace() }) {
+      "composeai.usageCorpus.repos is set but empty; omit it, or pass <name>=<path>,…"
+    }
     return spec
       .split(',')
       .filter { it.isNotBlank() }
@@ -75,15 +80,17 @@ class UsageSnippetCorpusTest {
    * Matched at the source-set name's **boundary**, not as a substring: `src/latestMain` and
    * `src/contestMain` contain `test` and are production, and excluding them would drop real
    * previews just as quietly in the other direction. A test source set's name ends in `Test`
-   * (`commonTest`, `jvmTest`, `androidUnitTest`) or is `test` / `testFixtures` outright.
+   * (`commonTest`, `jvmTest`, `androidUnitTest`) or `TestFixtures` (`commonTestFixtures`,
+   * `androidTestFixtures`), or is `test` / `testFixtures` outright.
    */
   private fun sources(root: File): List<File> {
-    val testSourceSet = Regex("""/src/(test|testFixtures|[A-Za-z0-9]*Test)/""")
+    val testSourceSet =
+      Regex("""/src/(test|testFixtures|[A-Za-z0-9]*Test|[A-Za-z0-9]*TestFixtures)/""")
     return root
       .walkTopDown()
       .onEnter { it.name !in setOf("build", ".git", ".gradle") }
       .filter { it.isFile && it.extension == "kt" }
-      .filterNot { testSourceSet.containsMatchIn(it.path) || it.path.contains("/testFixtures/") }
+      .filterNot { testSourceSet.containsMatchIn(it.path) }
       .toList()
   }
 

--- a/scripts/usage-corpus.sh
+++ b/scripts/usage-corpus.sh
@@ -36,11 +36,20 @@ fi
 # Gradle side silently ignores any checkout not named in it, so a third catalog would have produced
 # an empty corpus and a passing run.
 spec=""
+seen=""
 for repo in "${repos[@]}"; do
   case "$repo" in
     *,*) echo "usage-corpus: checkout path may not contain a comma: $repo" >&2; exit 2 ;;
   esac
-  spec="${spec:+$spec,}$(basename "$repo")=$repo"
+  name="$(basename "$repo")"
+  # Two checkouts with the same basename share an output directory, and then the empty-corpus check
+  # below sees the other one's snippets and passes a catalog that was never sampled — the exact
+  # silent success this script exists to stop.
+  case ",$seen," in
+    *",$name,"*) echo "usage-corpus: two checkouts are both named '$name'; rename one" >&2; exit 2 ;;
+  esac
+  seen="${seen:+$seen,}$name"
+  spec="${spec:+$spec,}$name=$repo"
 done
 
 rm -rf "$out"


### PR DESCRIPTION
Third review round on the snippet corpus (#3849, #3851). Both merged before this round could land on them, hence the separate PR.

### A receiver chain is not a package

The fix in #3851 unqualified any call whose prefix was two or more lowercase-initial segments. That is exactly the shape of `state.metrics.counted { }` — an ordinary receiver chain ending in a name some catalog also declares as a scaffold. Stripping the receiver there hands the call to the scaffold passes and rewrites somebody's code, which is worse than the leak it was fixing.

Rules now declare `scaffoldPackages`, and only a prefix named there is stripped; `GENERIC` declares `ee.schimke.composeai.overrides`. An allow-list can only ever *miss* a qualified call, and a miss leaves it as residue — the direction this whole pass is built to fail in.

### A catalog overriding only a generic knob was reported as declaring nothing

`declaresCatalogScaffolds` compared keys against `GENERIC`, so a catalog whose `compose-usage.json` declares its own reading of `previewOverrideString` — a rule actively driving the cleaning — came out as undeclared, and the Source panel would have withheld a claim that catalog had earned. It now compares entries.

### A malformed `repos` property was indistinguishable from an absent one

Absent means "no checkouts wired", which is the normal build. Present-but-mistyped is a wrong invocation, and silently dropping the entry turned it into a successful no-op — the same class of bug as the `|| true` hole this loop keeps finding in itself. It now fails.

### Two checkouts with the same basename shared an output directory

The per-repository empty-corpus check then saw the other one's snippets and passed a catalog that was never sampled — precisely the silent success the check was added to prevent. Duplicate basenames are now rejected up front.

### The test-source filter matched `test` as a substring

`src/latestMain` and `src/contestMain` are production source sets containing `test`, and were excluded wholesale — dropping real previews just as quietly as leaking test ones. Now matched at the source-set name's boundary: ends in `Test` (`commonTest`, `jvmTest`, `androidUnitTest`), or is `test` / `testFixtures` outright.

### Test plan

- `./gradlew :cli:test` — green, including the widened receiver-chain test (`stats.counted` and `state.metrics.counted` both survive) and the fully-qualified-call test.
- `./gradlew ktfmtCheckAll` — green.
- `scripts/usage-corpus.sh /home/user/m3-catalog <meshcore checkout>` — ran end to end. Ratios unchanged: **m3-catalog 3/10, meshcore-mobile 0/10**, m3 still sampling 10 previews and reporting its 17 declared scaffolds.

Non-visual: a text-pass cleaner, a test harness, a shell script. Nothing rendered changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_