### PR TITLE
fix(serve): compare corpus paths with invariant separators

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
@@ -94,7 +94,10 @@ class UsageSnippetCorpusTest {
       .walkTopDown()
       .onEnter { it.name !in setOf("build", ".git", ".gradle") }
       .filter { it.isFile && it.extension == "kt" }
-      .filterNot { testSourceSet.containsMatchIn(it.path) }
+      // `invariantSeparatorsPath`, not `path`: on Windows the latter is backslash-separated, the
+      // regex below only knows `/src/…/`, and every fixture would then read as production — which
+      // would fail this class's own source-set test on a Windows checkout.
+      .filterNot { testSourceSet.containsMatchIn(it.invariantSeparatorsPath) }
       .toList()
   }
 
@@ -135,8 +138,9 @@ class UsageSnippetCorpusTest {
   private fun stringsFor(root: File, rules: UsageRules): Map<String, String> {
     val path = rules.stringsPath ?: return emptyMap()
     val file =
-      root.walkTopDown().firstOrNull { it.isFile && it.path.endsWith(path.replace('\\', '/')) }
-        ?: return emptyMap()
+      root.walkTopDown().firstOrNull {
+        it.isFile && it.invariantSeparatorsPath.endsWith(path.replace('\\', '/'))
+      } ?: return emptyMap()
     return Regex(
         """<string\s+name="([A-Za-z0-9_]+)"\s*>(.*?)</string>""",
         RegexOption.DOT_MATCHES_ALL,


### PR DESCRIPTION
Follow-up to #3854, which merged before this could land on it.

`File.path` is backslash-separated on Windows, and the source-set filter only knows `/src/…/`. On a Windows checkout every fixture would read as production, so the source-set test added in #3854 would fail — on a machine where the corpus properties are absent and the whole test class is supposed to be inert. The strings-resource lookup had the same seam.

Both now compare `invariantSeparatorsPath`.

### Test plan

- `./gradlew :cli:test` — green.
- `./gradlew ktfmtCheckAll` — green.
- Not reproducible on this Linux runner by construction; the change is the standard `File` idiom for exactly this.

Non-visual: one test-harness path comparison.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_