### PR TITLE
fix(serve): open the query when pinning a token-free link, and make revisions a menu

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -374,15 +374,22 @@ object ServeWeb {
         // would index a dozen near-duplicates of every preview, and the version worth indexing is
         // the live one. The pages stay perfectly shareable — a link someone pastes is followed by
         // a person and unfurled by a fetcher, neither of which is a crawl.
-        "<a class=\"cp-revision\" role=\"menuitem\" rel=\"nofollow\" " +
-          "href=\"${WebEscaping.htmlEscape(href)}\"$mark>" +
+        "<a class=\"cp-revision\" rel=\"nofollow\" href=\"${WebEscaping.htmlEscape(href)}\"$mark>" +
           "<span class=\"cp-revision-date\">${WebEscaping.htmlEscape(date)}</span>" +
           "<code class=\"cp-revision-sha\">${WebEscaping.htmlEscape(label)}</code>$currentTag</a>"
       }
     // The trigger names the revision the page is *on* — the pin when there is one, the tip
     // otherwise — so the closed menu already answers "which version am I looking at?", which was
     // the question the flat wall of chips answered only by making the reader hunt for the
-    // highlighted one.
+    // highlighted one. Its accessible name is that visible text, deliberately: an `aria-label` here
+    // would override the date, sha and current/pinned state and announce the control as bare
+    // "Revision".
+    //
+    // It looks like a menu button and is a plain disclosure, which is what the ARIA says too. No
+    // `role="menu"`/`menuitem`: those promise the menu keyboard model — arrow-key navigation, Esc
+    // to dismiss, managed focus — and nothing here implements it, so the roles would describe
+    // behaviour a keyboard user does not get. `<details>` + a list of links gives real disclosure
+    // and ordinary Tab order for free; the `<nav>` is what names the list for a screen reader.
     val shown = revisions.revisions.firstOrNull { it.commit == (pinned ?: current) }
     val shownDate =
       shown?.date?.takeIf { it.isNotBlank() }?.let { prettyDate(it) }
@@ -397,17 +404,17 @@ object ServeWeb {
     return banner +
       """
       <details class="cp-revisions">
-        <summary class="cp-revisions-btn" aria-haspopup="menu" aria-label="Revision">
+        <summary class="cp-revisions-btn">
           <span class="cp-revisions-key">Revision</span>
           <span class="cp-revision-date">${WebEscaping.htmlEscape(shownDate)}</span>
           ${shownSha?.let { "<code class=\"cp-revision-sha\">${WebEscaping.htmlEscape(it)}</code>" }.orEmpty()}
           $shownTag
           <span class="cp-revisions-caret" aria-hidden="true">▾</span>
         </summary>
-        <div class="cp-revisions-menu" role="menu" aria-label="Published revisions">
-          <div class="cp-revision-list">
+        <div class="cp-revisions-menu">
+          <nav class="cp-revision-list" aria-label="Published revisions">
             $rows
-          </div>
+          </nav>
           <p class="cp-revision-note">Every publish of this design system is a commit on its
           delivery branch. Opening one pins this page — and the pixels on it — to that publish for
           good.</p>

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -359,7 +359,7 @@ object ServeWeb {
       }
     if (revisions.revisions.isEmpty()) return "$banner\n"
     val rows =
-      revisions.revisions.joinToString("\n          ") { revision ->
+      revisions.revisions.joinToString("\n            ") { revision ->
         val isCurrent = revision.commit == current
         // A pin is what the page URL says; with no pin the page is showing the branch tip, so that
         // is the row marked. One row is marked either way, and never two.
@@ -374,22 +374,44 @@ object ServeWeb {
         // would index a dozen near-duplicates of every preview, and the version worth indexing is
         // the live one. The pages stay perfectly shareable — a link someone pastes is followed by
         // a person and unfurled by a fetcher, neither of which is a crawl.
-        "<a class=\"cp-revision\" rel=\"nofollow\" href=\"${WebEscaping.htmlEscape(href)}\"$mark>" +
+        "<a class=\"cp-revision\" role=\"menuitem\" rel=\"nofollow\" " +
+          "href=\"${WebEscaping.htmlEscape(href)}\"$mark>" +
           "<span class=\"cp-revision-date\">${WebEscaping.htmlEscape(date)}</span>" +
           "<code class=\"cp-revision-sha\">${WebEscaping.htmlEscape(label)}</code>$currentTag</a>"
       }
-    val summary =
-      if (pinned == null) "Revisions"
-      else "Revisions · pinned ${ServeCatalogRevision.short(pinned)}"
+    // The trigger names the revision the page is *on* — the pin when there is one, the tip
+    // otherwise — so the closed menu already answers "which version am I looking at?", which was
+    // the question the flat wall of chips answered only by making the reader hunt for the
+    // highlighted one.
+    val shown = revisions.revisions.firstOrNull { it.commit == (pinned ?: current) }
+    val shownDate =
+      shown?.date?.takeIf { it.isNotBlank() }?.let { prettyDate(it) }
+        ?: pinned?.let { ServeCatalogRevision.short(it) }
+        ?: shown?.short
+        ?: ""
+    val shownSha =
+      shown?.sourceSha ?: shown?.short ?: pinned?.let { ServeCatalogRevision.short(it) }
+    val shownTag =
+      if (pinned == null) "<span class=\"cp-revision-tag\">current</span>"
+      else "<span class=\"cp-revision-tag cp-revision-tag--pinned\">pinned</span>"
     return banner +
       """
-      <details class="cp-revisions"${if (pinned == null) "" else " open"}>
-        <summary>${WebEscaping.htmlEscape(summary)}</summary>
-        <div class="cp-revision-list">
-          $rows
+      <details class="cp-revisions">
+        <summary class="cp-revisions-btn" aria-haspopup="menu" aria-label="Revision">
+          <span class="cp-revisions-key">Revision</span>
+          <span class="cp-revision-date">${WebEscaping.htmlEscape(shownDate)}</span>
+          ${shownSha?.let { "<code class=\"cp-revision-sha\">${WebEscaping.htmlEscape(it)}</code>" }.orEmpty()}
+          $shownTag
+          <span class="cp-revisions-caret" aria-hidden="true">▾</span>
+        </summary>
+        <div class="cp-revisions-menu" role="menu" aria-label="Published revisions">
+          <div class="cp-revision-list">
+            $rows
+          </div>
+          <p class="cp-revision-note">Every publish of this design system is a commit on its
+          delivery branch. Opening one pins this page — and the pixels on it — to that publish for
+          good.</p>
         </div>
-        <p class="cp-revision-note">Every publish of this design system is a commit on its delivery
-        branch. Opening one pins this page — and the pixels on it — to that publish for good.</p>
       </details>
       """
         .trimIndent() +
@@ -397,15 +419,24 @@ object ServeWeb {
   }
 
   /**
-   * Add `at=<sha>` to a link's query suffix (either empty or already `?…`), or return it unchanged
-   * when the page carries no pin. One helper because a pinned page has to pin *everything* it links
-   * — the render, the reference, its sibling variants — and a single missed suffix is a panel
-   * quietly showing the present next to the past.
+   * Add `at=<sha>` to a link, or return it unchanged when the page carries no pin. One helper
+   * because a pinned page has to pin *everything* it links — the render, the reference, its sibling
+   * variants — and a single missed suffix is a panel quietly showing the present next to the past.
+   *
+   * Callers pass either a bare query suffix (empty, or already `?…`) or a whole URL that may or may
+   * not carry a query, so the separator is chosen from what the string actually contains rather
+   * than from whether it is empty. Getting that wrong is not a cosmetic slip: a public server
+   * builds token-free links, so `/<system>/p/<id>` has no `?` at all, and appending `&at=<sha>`
+   * folds the pin into the *path* — the URL 404s and every revision in the menu is a dead link.
    */
-  private fun withPin(querySuffix: String, pinned: String?): String {
-    val pin = pinned?.takeIf { it.isNotBlank() } ?: return querySuffix
+  private fun withPin(link: String, pinned: String?): String {
+    val pin = pinned?.takeIf { it.isNotBlank() } ?: return link
     val param = "${ServeCatalogRevision.PARAM}=${WebEscaping.urlEncodeSegment(pin)}"
-    return if (querySuffix.isEmpty()) "?$param" else "$querySuffix&$param"
+    return when {
+      !link.contains('?') -> "$link?$param"
+      link.endsWith('?') || link.endsWith('&') -> "$link$param"
+      else -> "$link&$param"
+    }
   }
 
   /** Canonical source repo, used for the "source" / branch / workflow links. */

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -762,24 +762,50 @@ cp-bg-toggle { display: contents; }
   color: var(--md-sys-color-on-secondary-container); }
 .cp-pinned code { font-size: 0.86em; }
 .cp-pinned-current { font-weight: 650; }
-/* The revision list is a disclosure, closed by default: on an ordinary page view it is one line of
-   chrome, and it opens on a pinned page because that is where moving between publishes is the
-   thing you came to do. */
-.cp-revisions { margin: 0 0 12px; font-size: 0.82rem; color: var(--cp-fg-muted); }
-.cp-revisions > summary { cursor: pointer; font-weight: 650; padding: 4px 0; }
-.cp-revision-list { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 0; }
-.cp-revision { display: inline-flex; align-items: baseline; gap: 8px; padding: 6px 12px;
+/* The revision control is a menu, not a wall: an outlined trigger that names the revision the page
+   is on, and a floating list of the others — the same `<details>`-as-menu shape as the settings
+   button above. A dozen publishes as chips took four lines of page before the preview and made the
+   reader hunt for the highlighted one; closed, this is a single control that already says which
+   version you are looking at. */
+.cp-revisions { position: relative; display: inline-block; margin: 0 0 12px;
+  font-size: 0.82rem; color: var(--cp-fg-muted); }
+.cp-revisions-btn { display: inline-flex; align-items: baseline; gap: 8px; padding: 7px 14px;
   border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: var(--md-sys-shape-corner-small);
-  color: var(--md-sys-color-on-surface-variant); text-decoration: none; }
-.cp-revision:hover { color: var(--md-sys-color-on-surface);
+  border-radius: var(--md-sys-shape-corner-full);
+  color: var(--md-sys-color-on-surface-variant); cursor: pointer; list-style: none;
+  user-select: none;
+  transition: background var(--md-sys-motion-duration-short2) var(--md-sys-motion-easing-standard); }
+.cp-revisions-btn::-webkit-details-marker { display: none; }
+.cp-revisions-btn:hover, .cp-revisions[open] > .cp-revisions-btn {
+  color: var(--md-sys-color-on-surface);
+  background: color-mix(in srgb, var(--md-sys-color-on-surface) 8%, transparent); }
+.cp-revisions-key { font-weight: 650; }
+.cp-revisions-caret { font-size: 0.9em; opacity: 0.7; }
+.cp-revisions[open] .cp-revisions-caret { transform: rotate(180deg); }
+/* Menu surface: M3 elevated container, capped so a long branch history scrolls inside the popup
+   instead of pushing the page around. */
+.cp-revisions-menu { position: absolute; left: 0; top: calc(100% + 6px); z-index: 50;
+  width: max-content; max-width: min(420px, calc(100vw - 32px));
+  max-height: min(60vh, 420px); overflow-y: auto; padding: 8px 4px;
+  border: 0; border-radius: var(--md-sys-shape-corner-medium);
+  background: var(--md-sys-color-surface-container-high);
+  box-shadow: var(--md-sys-elevation-level2); }
+.cp-revision-list { display: flex; flex-direction: column; gap: 2px; margin: 0; }
+.cp-revision { display: flex; align-items: baseline; gap: 10px; padding: 9px 12px;
+  border: 0; border-radius: var(--md-sys-shape-corner-small);
+  color: var(--cp-fg); text-decoration: none; white-space: nowrap; }
+.cp-revision:hover {
   background: color-mix(in srgb, var(--md-sys-color-on-surface) 8%, transparent); }
 .cp-revision[aria-current="true"] { background: var(--md-sys-color-secondary-container);
-  border-color: transparent; color: var(--md-sys-color-on-secondary-container); }
+  color: var(--md-sys-color-on-secondary-container); }
 .cp-revision-date { font-variant-numeric: tabular-nums; }
-.cp-revision-sha { font-size: 0.92em; opacity: 0.85; }
-.cp-revision-tag { font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.06em; }
-.cp-revision-note { margin: 10px 0 0; max-width: 62ch; }
+.cp-revision-sha { font-size: 0.92em; opacity: 0.85; margin-left: auto; }
+.cp-revision-tag { font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.06em;
+  opacity: 0.8; }
+.cp-revision-tag--pinned { color: var(--md-sys-color-primary); opacity: 1; }
+.cp-revision-note { margin: 8px 12px 4px; max-width: 44ch; color: var(--cp-fg-muted);
+  font-size: var(--md-sys-typescale-body-small-size);
+  line-height: var(--md-sys-typescale-body-small-line); }
 /* Status page (GET /status): stat tiles, config grid, and the catalog/daemon/failure tables. */
 .cp-status-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
   gap: 10px; margin: 0 0 22px; max-width: 860px; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
@@ -218,6 +218,20 @@ class ServePinnedRevisionTest {
   }
 
   @Test
+  fun `a revision link on a token-free page starts its query, and resolves`() {
+    val port = start().port
+
+    val page = text("http://127.0.0.1:$port/$system/p/$previewId")
+
+    // A public server builds token-free links, so the page URL carries no query at all and the pin
+    // has to *open* one. `&at=` there would fold the sha into the path — the shape that made every
+    // revision in the menu a 404 rather than a permalink.
+    assertTrue(page.contains("/p/$previewId?at=$oldCommit"), page)
+    assertFalse(page.contains("/p/$previewId&at="), page)
+    assertEquals(200, get("http://127.0.0.1:$port/$system/p/$previewId?at=$oldCommit").first)
+  }
+
+  @Test
   fun `a daemon-produced lane is refused under a pin rather than answered from today`() {
     val port = start().port
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1582,6 +1582,20 @@ class ServeWebFixtureTest {
             repo = "yschimke/compose-ai-tools",
           ),
       )
+    // The same page with the revision menu popped open. The control is a `<details>` menu that
+    // ships closed, so a screenshot of the page above only ever captures its trigger — and the list
+    // of publishes, the part a change to this feature is most likely to break visually, would never
+    // be diffed. Forcing the disclosure open is the whole difference between the two fixtures; the
+    // markup inside it is the server's own.
+    val viewerRevisionsOpen =
+      viewerRevisions.replace(
+        "<details class=\"cp-revisions\">",
+        "<details class=\"cp-revisions\" open>",
+      )
+    assertFalse(
+      viewerRevisionsOpen == viewerRevisions,
+      "the revision menu's <details> tag changed shape — update this fixture's open-state rewrite",
+    )
     // The design page's inlined export. Run through the real [SvgSanitizer] rather than pasted in
     // whole, so the golden HTML is what the server would actually emit — including anything the
     // sanitizer strips.
@@ -2253,6 +2267,7 @@ class ServeWebFixtureTest {
         "serve-reference-compare.html" to referenceComparison,
         "serve-reference-compare-pinned.html" to referenceComparisonPinned,
         "serve-viewer-revisions.html" to viewerRevisions,
+        "serve-viewer-revisions-open.html" to viewerRevisionsOpen,
         "serve-viewer-pinned-lanes.html" to viewerPinnedLanes,
         "serve-design-page.html" to designPageHtml,
         "serve-design-page-index.html" to designPageIndex,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare-pinned.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare-pinned.html
@@ -60,16 +60,25 @@
   <span class="cp-pinned-icon" aria-hidden="true">⚓</span>
   <span>Pinned to catalog revision <a href="https://github.com/yschimke/compose-ai-tools/tree/421350e5cae04212a193cc8137be1c337a9d5396" target="_blank" rel="noopener noreferrer"><code>421350e5</code></a>, published 2026-08-12 15:42 UTC — these pixels cannot change.</span>
   <a class="cp-pinned-current" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light">view current</a>
-</section><details class="cp-revisions" open>
-  <summary>Revisions · pinned 421350e5</summary>
-  <div class="cp-revision-list">
-    <a class="cp-revision" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
-    <a class="cp-revision" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
-    <a class="cp-revision" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=421350e5cae04212a193cc8137be1c337a9d5396" aria-current="true"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
-    <a class="cp-revision" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
+</section><details class="cp-revisions">
+  <summary class="cp-revisions-btn" aria-haspopup="menu" aria-label="Revision">
+    <span class="cp-revisions-key">Revision</span>
+    <span class="cp-revision-date">2026-08-12 15:42 UTC</span>
+    <code class="cp-revision-sha">7b573ecc</code>
+    <span class="cp-revision-tag cp-revision-tag--pinned">pinned</span>
+    <span class="cp-revisions-caret" aria-hidden="true">▾</span>
+  </summary>
+  <div class="cp-revisions-menu" role="menu" aria-label="Published revisions">
+    <div class="cp-revision-list">
+      <a class="cp-revision" role="menuitem" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
+      <a class="cp-revision" role="menuitem" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
+      <a class="cp-revision" role="menuitem" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=421350e5cae04212a193cc8137be1c337a9d5396" aria-current="true"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
+      <a class="cp-revision" role="menuitem" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
+    </div>
+    <p class="cp-revision-note">Every publish of this design system is a commit on its
+    delivery branch. Opening one pins this page — and the pixels on it — to that publish for
+    good.</p>
   </div>
-  <p class="cp-revision-note">Every publish of this design system is a commit on its delivery
-  branch. Opening one pins this page — and the pixels on it — to that publish for good.</p>
 </details>
 
                   <nav class="cp-reference-picker" aria-label="Design references">

--- a/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare-pinned.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare-pinned.html
@@ -61,20 +61,20 @@
   <span>Pinned to catalog revision <a href="https://github.com/yschimke/compose-ai-tools/tree/421350e5cae04212a193cc8137be1c337a9d5396" target="_blank" rel="noopener noreferrer"><code>421350e5</code></a>, published 2026-08-12 15:42 UTC — these pixels cannot change.</span>
   <a class="cp-pinned-current" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light">view current</a>
 </section><details class="cp-revisions">
-  <summary class="cp-revisions-btn" aria-haspopup="menu" aria-label="Revision">
+  <summary class="cp-revisions-btn">
     <span class="cp-revisions-key">Revision</span>
     <span class="cp-revision-date">2026-08-12 15:42 UTC</span>
     <code class="cp-revision-sha">7b573ecc</code>
     <span class="cp-revision-tag cp-revision-tag--pinned">pinned</span>
     <span class="cp-revisions-caret" aria-hidden="true">▾</span>
   </summary>
-  <div class="cp-revisions-menu" role="menu" aria-label="Published revisions">
-    <div class="cp-revision-list">
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=421350e5cae04212a193cc8137be1c337a9d5396" aria-current="true"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
-    </div>
+  <div class="cp-revisions-menu">
+    <nav class="cp-revision-list" aria-label="Published revisions">
+      <a class="cp-revision" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
+      <a class="cp-revision" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
+      <a class="cp-revision" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=421350e5cae04212a193cc8137be1c337a9d5396" aria-current="true"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
+      <a class="cp-revision" rel="nofollow" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
+    </nav>
     <p class="cp-revision-note">Every publish of this design system is a commit on its
     delivery branch. Opening one pins this page — and the pixels on it — to that publish for
     good.</p>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-pinned-lanes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-pinned-lanes.html
@@ -63,20 +63,20 @@
   <span>Pinned to catalog revision <a href="https://github.com/yschimke/compose-ai-tools/tree/41c7a15fd21f52e7c6a959a0c441eb600ca46d4f" target="_blank" rel="noopener noreferrer"><code>41c7a15f</code></a>, published 2026-08-13 07:10 UTC — these pixels cannot change.</span>
   <a class="cp-pinned-current" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture">view current</a>
 </section><details class="cp-revisions">
-  <summary class="cp-revisions-btn" aria-haspopup="menu" aria-label="Revision">
+  <summary class="cp-revisions-btn">
     <span class="cp-revisions-key">Revision</span>
     <span class="cp-revision-date">2026-08-13 07:10 UTC</span>
     <code class="cp-revision-sha">b34eff53</code>
     <span class="cp-revision-tag cp-revision-tag--pinned">pinned</span>
     <span class="cp-revisions-caret" aria-hidden="true">▾</span>
   </summary>
-  <div class="cp-revisions-menu" role="menu" aria-label="Published revisions">
-    <div class="cp-revision-list">
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f" aria-current="true"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=421350e5cae04212a193cc8137be1c337a9d5396"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
-    </div>
+  <div class="cp-revisions-menu">
+    <nav class="cp-revision-list" aria-label="Published revisions">
+      <a class="cp-revision" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
+      <a class="cp-revision" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f" aria-current="true"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
+      <a class="cp-revision" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=421350e5cae04212a193cc8137be1c337a9d5396"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
+      <a class="cp-revision" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
+    </nav>
     <p class="cp-revision-note">Every publish of this design system is a commit on its
     delivery branch. Opening one pins this page — and the pixels on it — to that publish for
     good.</p>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-pinned-lanes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-pinned-lanes.html
@@ -62,16 +62,25 @@
   <span class="cp-pinned-icon" aria-hidden="true">⚓</span>
   <span>Pinned to catalog revision <a href="https://github.com/yschimke/compose-ai-tools/tree/41c7a15fd21f52e7c6a959a0c441eb600ca46d4f" target="_blank" rel="noopener noreferrer"><code>41c7a15f</code></a>, published 2026-08-13 07:10 UTC — these pixels cannot change.</span>
   <a class="cp-pinned-current" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture">view current</a>
-</section><details class="cp-revisions" open>
-  <summary>Revisions · pinned 41c7a15f</summary>
-  <div class="cp-revision-list">
-    <a class="cp-revision" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
-    <a class="cp-revision" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f" aria-current="true"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
-    <a class="cp-revision" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=421350e5cae04212a193cc8137be1c337a9d5396"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
-    <a class="cp-revision" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
+</section><details class="cp-revisions">
+  <summary class="cp-revisions-btn" aria-haspopup="menu" aria-label="Revision">
+    <span class="cp-revisions-key">Revision</span>
+    <span class="cp-revision-date">2026-08-13 07:10 UTC</span>
+    <code class="cp-revision-sha">b34eff53</code>
+    <span class="cp-revision-tag cp-revision-tag--pinned">pinned</span>
+    <span class="cp-revisions-caret" aria-hidden="true">▾</span>
+  </summary>
+  <div class="cp-revisions-menu" role="menu" aria-label="Published revisions">
+    <div class="cp-revision-list">
+      <a class="cp-revision" role="menuitem" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
+      <a class="cp-revision" role="menuitem" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f" aria-current="true"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
+      <a class="cp-revision" role="menuitem" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=421350e5cae04212a193cc8137be1c337a9d5396"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
+      <a class="cp-revision" role="menuitem" rel="nofollow" href="/remote-m3/p/appcard__ideal__default__compact?token=demo-token-fixture&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
+    </div>
+    <p class="cp-revision-note">Every publish of this design system is a commit on its
+    delivery branch. Opening one pins this page — and the pixels on it — to that publish for
+    good.</p>
   </div>
-  <p class="cp-revision-note">Every publish of this design system is a commit on its delivery
-  branch. Opening one pins this page — and the pixels on it — to that publish for good.</p>
 </details>
 
 

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions-open.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions-open.html
@@ -58,7 +58,7 @@
 
         <span class="cp-head-toggles"><button type="button" class="cp-drawer-toggle cp-axis-toggle" id="cp-theme-toggle" aria-expanded="true" aria-controls="cp-theme-bar"><span class="cp-toggle-label">Theme</span><span class="cp-toggle-value" id="cp-theme-toggle-value">Day</span></button><button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button></span>
       </div>
-      <details class="cp-revisions">
+      <details class="cp-revisions" open>
   <summary class="cp-revisions-btn" aria-haspopup="menu" aria-label="Revision">
     <span class="cp-revisions-key">Revision</span>
     <span class="cp-revision-date">2026-08-13 09:42 UTC</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions-open.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions-open.html
@@ -59,20 +59,20 @@
         <span class="cp-head-toggles"><button type="button" class="cp-drawer-toggle cp-axis-toggle" id="cp-theme-toggle" aria-expanded="true" aria-controls="cp-theme-bar"><span class="cp-toggle-label">Theme</span><span class="cp-toggle-value" id="cp-theme-toggle-value">Day</span></button><button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button></span>
       </div>
       <details class="cp-revisions" open>
-  <summary class="cp-revisions-btn" aria-haspopup="menu" aria-label="Revision">
+  <summary class="cp-revisions-btn">
     <span class="cp-revisions-key">Revision</span>
     <span class="cp-revision-date">2026-08-13 09:42 UTC</span>
     <code class="cp-revision-sha">0b0c2063</code>
     <span class="cp-revision-tag">current</span>
     <span class="cp-revisions-caret" aria-hidden="true">▾</span>
   </summary>
-  <div class="cp-revisions-menu" role="menu" aria-label="Published revisions">
-    <div class="cp-revision-list">
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture" aria-current="true"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=421350e5cae04212a193cc8137be1c337a9d5396"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
-    </div>
+  <div class="cp-revisions-menu">
+    <nav class="cp-revision-list" aria-label="Published revisions">
+      <a class="cp-revision" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture" aria-current="true"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
+      <a class="cp-revision" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
+      <a class="cp-revision" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=421350e5cae04212a193cc8137be1c337a9d5396"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
+      <a class="cp-revision" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
+    </nav>
     <p class="cp-revision-note">Every publish of this design system is a commit on its
     delivery branch. Opening one pins this page — and the pixels on it — to that publish for
     good.</p>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions.html
@@ -59,20 +59,20 @@
         <span class="cp-head-toggles"><button type="button" class="cp-drawer-toggle cp-axis-toggle" id="cp-theme-toggle" aria-expanded="true" aria-controls="cp-theme-bar"><span class="cp-toggle-label">Theme</span><span class="cp-toggle-value" id="cp-theme-toggle-value">Day</span></button><button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button></span>
       </div>
       <details class="cp-revisions">
-  <summary class="cp-revisions-btn" aria-haspopup="menu" aria-label="Revision">
+  <summary class="cp-revisions-btn">
     <span class="cp-revisions-key">Revision</span>
     <span class="cp-revision-date">2026-08-13 09:42 UTC</span>
     <code class="cp-revision-sha">0b0c2063</code>
     <span class="cp-revision-tag">current</span>
     <span class="cp-revisions-caret" aria-hidden="true">▾</span>
   </summary>
-  <div class="cp-revisions-menu" role="menu" aria-label="Published revisions">
-    <div class="cp-revision-list">
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture" aria-current="true"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=421350e5cae04212a193cc8137be1c337a9d5396"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
-      <a class="cp-revision" role="menuitem" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
-    </div>
+  <div class="cp-revisions-menu">
+    <nav class="cp-revision-list" aria-label="Published revisions">
+      <a class="cp-revision" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture" aria-current="true"><span class="cp-revision-date">2026-08-13 09:42 UTC</span><code class="cp-revision-sha">0b0c2063</code><span class="cp-revision-tag">current</span></a>
+      <a class="cp-revision" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=41c7a15fd21f52e7c6a959a0c441eb600ca46d4f"><span class="cp-revision-date">2026-08-13 07:10 UTC</span><code class="cp-revision-sha">b34eff53</code></a>
+      <a class="cp-revision" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=421350e5cae04212a193cc8137be1c337a9d5396"><span class="cp-revision-date">2026-08-12 15:42 UTC</span><code class="cp-revision-sha">7b573ecc</code></a>
+      <a class="cp-revision" rel="nofollow" href="/p/com.example.ProfileScreenPreview?token=demo-token-fixture&amp;at=4f7c1ae06b177603984734dc4fa3c0ea365e71e0"><span class="cp-revision-date">2026-08-12 09:05 UTC</span><code class="cp-revision-sha">4f7c1ae0</code></a>
+    </nav>
     <p class="cp-revision-note">Every publish of this design system is a commit on its
     delivery branch. Opening one pins this page — and the pixels on it — to that publish for
     good.</p>


### PR DESCRIPTION
## Summary

Every revision link on the public catalog 404s. `withPin` chose its query separator by whether the string it was handed was *empty*, but its callers pass a whole URL — so on a public server, which builds token-free links, `/wear-m3/p/<id>` came back as `/wear-m3/p/<id>&at=<sha>` and the pin landed in the **path**:

```
https://preview.coo.ee/wear-m3/p/progress-circular-indeterminate__ideal__default&at=37f3b67…  → 404
https://preview.coo.ee/wear-m3/p/progress-circular-indeterminate__ideal__default?at=37f3b67…  → 200
```

It worked locally because a `?token=…` had already opened the query. The separator is now picked from what the link actually contains.

The list itself was also several lines of wrapped chips above the preview, and answered "which revision am I looking at?" only by making the reader find the highlighted one. It's now a dropdown: the trigger names the revision the page is on (`current` / `pinned`), the rest live in a popup on the same `<details>`-as-menu shape as the Settings button.

## Visual evidence

Pinned viewer, before — the chip wall:

![Pinned viewer with the old chip list](https://raw.githubusercontent.com/yschimke/compose-ai-tools/edcfde739c70a801577bbd5c639a82594057d16c/renders/revision-menu-before.png)

Same page, after — one control that already says which publish is on screen:

![Pinned viewer with the revision menu closed](https://raw.githubusercontent.com/yschimke/compose-ai-tools/edcfde739c70a801577bbd5c639a82594057d16c/renders/revision-menu-after.png)

Menu open:

![The revision menu open over the viewer](https://raw.githubusercontent.com/yschimke/compose-ai-tools/edcfde739c70a801577bbd5c639a82594057d16c/renders/revision-menu-open.png)

Captures are from the preview-harness (`serve-viewer-pinned-lanes`, `serve-viewer-revisions-open`), light theme.

## Coverage

A `<details>` menu ships closed, so a page screenshot would only ever capture the trigger and the list — the part most likely to break visually — would never be diffed. `serve-viewer-revisions-open.html` is the same rendered page with the disclosure forced open, so the harness renders and diffs the menu itself on every PR from here on. The rewrite that opens it asserts it matched, so a change to the `<details>` markup fails the fixture test rather than silently capturing a closed menu.

## Test plan

- `./gradlew :cli:test --tests '*Serve*'` — green.
- New regression test in `ServePinnedRevisionTest`: on a token-free page the revision link is `/<system>/p/<id>?at=<sha>`, never `…&at=`, and that URL answers 200. It fails on `main`.
- Fixtures regenerated with `UPDATE_SERVE_WEB_FIXTURES=true`; the drift guard passes against them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrXVPoCqqViBQF7khJKrhL)_