### PR TITLE
feat(parity): publish a tag index with the catalog, and read it back

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -544,6 +544,7 @@ class ServeCatalogStore(
     val referenceBranchPaths =
       writeDesignReferences(manifestReferences + catalog.references, base, staging)
     writeAnnotations(base, staging)
+    writeTagIndex(base, staging)
     writeParityActivity(base, staging)
     writeDesignPages(base, staging)
 
@@ -1537,6 +1538,35 @@ class ServeCatalogStore(
     dir.mkdirs()
     File(dir, ServeAnnotationStore.INDEX_FILE)
       .writeText(json.encodeToString(AnnotationManifest.serializer(), manifest))
+  }
+
+  /**
+   * Stage the published tag index, if the catalog has one.
+   *
+   * Exactly [writeAnnotations]' shape and for the same reason: a served catalog is a fresh staging
+   * directory assembled from explicitly fetched parts, so a file nobody copies is invisible to
+   * [ServeBundleHost] however faithfully the producer published it. Without this the index would be
+   * published by every catalog build and read by nobody — and the element gates it exists for would
+   * stay unreachable on published catalogs, which is the gap this whole path closes.
+   *
+   * One self-contained JSON document, no assets to fetch. Validated here before it is written
+   * rather than only on read, so a malformed index never reaches the staging tree at all.
+   */
+  private fun writeTagIndex(base: String, staging: File) {
+    val bytes =
+      runCatching {
+          fetchCatalogAsset("$base${ServeTagIndexStore.DIRECTORY}/${ServeTagIndexStore.INDEX_FILE}")
+        }
+        .getOrNull() ?: return
+    val manifest =
+      runCatching { json.decodeFromString(TagIndexManifest.serializer(), bytes.decodeToString()) }
+        .getOrNull()
+        ?.takeIf { it.schema == TagIndexManifest.SCHEMA } ?: return
+    if (manifest.previews.isEmpty()) return
+    val dir = File(staging, ServeTagIndexStore.DIRECTORY)
+    dir.mkdirs()
+    File(dir, ServeTagIndexStore.INDEX_FILE)
+      .writeText(json.encodeToString(TagIndexManifest.serializer(), manifest))
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndex.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndex.kt
@@ -1,0 +1,110 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/**
+ * A catalog's **published** tag index — `served preview id → testTag → {count, bounds}`.
+ *
+ * The element identity a scoped parity acceptance resolves against
+ * ([docs/design/COMPONENT_PARITY_WORKFLOW.md](../../../../../../../../docs/design/COMPONENT_PARITY_WORKFLOW.md)).
+ *
+ * ## Why this exists alongside [ServeSemanticsTags]
+ *
+ * They are the same projection with different producers, because a published catalog has no daemon.
+ * [ServeSemanticsTags] projects the index live from a render this host just performed; that path
+ * requires a semantics tree, which only a daemon produces. A catalog's renders happened in CI, at
+ * catalog-generation time — so its index is computed *there* (`scripts/design-artifacts/
+ * tag-index.mjs`, the JS twin) and published as `tags/index.json` beside the stickers. This class
+ * is the reader for that file.
+ *
+ * The consequence worth stating: without this, the whole element-gate half of the parity workflow
+ * was unreachable on exactly the surfaces the epic is about, since every published design catalog
+ * is a static bundle.
+ *
+ * ## Fail-soft, like every other carried artifact
+ *
+ * A malformed index, an unknown schema token, or an oversized one drops **wholesale** and the
+ * catalog serves exactly as before — matching [ServeAnnotationStore] and
+ * [ServeDesignReferenceStore]. An acceptance that then finds no tag entry degrades to no element
+ * gate, which is the safe direction: a missing gate costs a check, a wrong one produces a wrong
+ * verdict.
+ */
+@Serializable
+data class TagIndexManifest(
+  val schema: String = SCHEMA,
+  /** Keyed by the **served** preview id (`button-filled__ideal__default__light`). */
+  val previews: Map<String, Map<String, ServeSemanticsTags.TagEntry>> = emptyMap(),
+) {
+  companion object {
+    const val SCHEMA = "compose-preview-tags/v1"
+  }
+}
+
+/** Validated, read-only view of a catalog's `tags/index.json`. */
+class ServeTagIndexStore
+private constructor(private val byPreview: Map<String, Map<String, ServeSemanticsTags.TagEntry>>) {
+
+  /** The tag index for [previewId], empty when the catalog published none for it. */
+  fun forPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
+    byPreview[previewId].orEmpty()
+
+  val isEmpty: Boolean = byPreview.isEmpty()
+
+  /** Previews the catalog published an index for. */
+  val previewIds: Set<String> = byPreview.keys
+
+  companion object {
+    const val DIRECTORY = "tags"
+    const val INDEX_FILE = "index.json"
+
+    /**
+     * Cap on indexed previews. A catalog is third-party data and this file is read at staging time
+     * on a shared host, so it gets the same treatment as the acceptance budget: a bound that a
+     * hostile or broken publisher cannot raise. Generous against real use — the largest published
+     * catalog is in the hundreds of stickers.
+     */
+    const val MAX_PREVIEWS = 4096
+
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Empty store — a catalog that publishes no index at all, which is every catalog until it does.
+     */
+    val EMPTY = ServeTagIndexStore(emptyMap())
+
+    fun load(bundleDir: File, fileSystem: FileSystem = FileSystem.SYSTEM): ServeTagIndexStore =
+      load(bundleDir.toOkioPath(), fileSystem)
+
+    fun load(bundleRoot: Path, fileSystem: FileSystem): ServeTagIndexStore {
+      val index = bundleRoot / DIRECTORY.toPath() / INDEX_FILE.toPath()
+      if (!fileSystem.exists(index)) return EMPTY
+      val manifest =
+        runCatching {
+            JSON.decodeFromString<TagIndexManifest>(fileSystem.read(index) { readUtf8() })
+          }
+          .getOrNull() ?: return EMPTY
+      if (manifest.schema != TagIndexManifest.SCHEMA) return EMPTY
+      if (manifest.previews.size > MAX_PREVIEWS) return EMPTY
+      return ServeTagIndexStore(
+        manifest.previews
+          .mapValues { (_, tags) -> tags.filterValues { it.isUsable() } }
+          .filterValues { it.isNotEmpty() }
+      )
+    }
+
+    /**
+     * A count below 1 is not a tag anything carried, and a zero-area box is not geometry a gate can
+     * measure against — both indicate a producer bug rather than something to resolve badly. The
+     * bounds may legitimately be absent (a tag whose every node had unusable bounds still counts,
+     * which is the point of `count`), so absence is not a rejection.
+     */
+    private fun ServeSemanticsTags.TagEntry.isUsable(): Boolean =
+      count >= 1 && bounds?.let { it.width > 0 && it.height > 0 } != false
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndexStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndexStoreTest.kt
@@ -1,0 +1,99 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import okio.FileSystem
+
+/**
+ * The published tag index is third-party data read at staging time, and an acceptance that cannot
+ * find its tag degrades to no element gate. So every failure mode here must drop to "no index"
+ * rather than take the catalog down — the same posture as [ServeAnnotationStoreTest].
+ */
+class ServeTagIndexStoreTest {
+  private fun store(json: String?): ServeTagIndexStore {
+    val root = Files.createTempDirectory("tags").toFile().also { it.deleteOnExit() }
+    if (json != null) {
+      File(root, ServeTagIndexStore.DIRECTORY).mkdirs()
+      File(root, "${ServeTagIndexStore.DIRECTORY}/${ServeTagIndexStore.INDEX_FILE}").writeText(json)
+    }
+    return ServeTagIndexStore.load(root, FileSystem.SYSTEM)
+  }
+
+  private val valid =
+    """
+    {"schema":"compose-preview-tags/v1","previews":{
+      "button-filled__ideal__default__light":{
+        "glyph":{"count":1,"bounds":{"x":8,"y":8,"width":32,"height":32},"space":"render-pixels"},
+        "row":{"count":3}
+      }}}
+    """
+
+  @Test
+  fun `no index yields an empty store`() {
+    assertTrue(store(null).isEmpty)
+  }
+
+  @Test
+  fun `malformed json is ignored rather than thrown`() {
+    assertTrue(store("{ not json").isEmpty)
+  }
+
+  @Test
+  fun `an index from a future schema is ignored`() {
+    assertTrue(store(valid.replace("compose-preview-tags/v1", "compose-preview-tags/v99")).isEmpty)
+  }
+
+  @Test
+  fun `a valid index is keyed by served preview id`() {
+    val tags = store(valid).forPreview("button-filled__ideal__default__light")
+    assertEquals(setOf("glyph", "row"), tags.keys)
+    assertEquals(1, tags.getValue("glyph").count)
+    assertEquals(
+      AnnotationBounds(x = 8, y = 8, width = 32, height = 32),
+      tags.getValue("glyph").bounds,
+    )
+    assertEquals(ServeSemanticsTags.RENDER_PIXELS, tags.getValue("glyph").space)
+  }
+
+  /**
+   * A tag whose every node had unusable bounds still counts — that is what makes an ambiguity check
+   * work — so an absent box must not be mistaken for a broken entry and dropped.
+   */
+  @Test
+  fun `a counted tag with no bounds survives`() {
+    val tags = store(valid).forPreview("button-filled__ideal__default__light")
+    assertEquals(3, tags.getValue("row").count)
+    assertEquals(null, tags.getValue("row").bounds)
+  }
+
+  @Test
+  fun `an unknown preview has no tags rather than throwing`() {
+    assertTrue(store(valid).forPreview("nothing-published-here").isEmpty())
+  }
+
+  @Test
+  fun `a zero-area box is dropped, and a preview left with nothing drops with it`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","previews":{"p":{
+         "flat":{"count":1,"bounds":{"x":0,"y":0,"width":0,"height":10}}}}}"""
+    assertTrue(store(json).isEmpty, "a preview whose only entry is unusable should not be listed")
+  }
+
+  @Test
+  fun `an oversized index is refused wholesale`() {
+    val previews =
+      (0..ServeTagIndexStore.MAX_PREVIEWS).joinToString(",") { """"p$it":{"t":{"count":1}}""" }
+    assertTrue(store("""{"schema":"compose-preview-tags/v1","previews":{$previews}}""").isEmpty)
+  }
+
+  @Test
+  fun `unknown keys are tolerated so a newer producer does not break an older host`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","generatedAt":"2026-01-01","previews":{"p":{
+         "t":{"count":2,"somethingNew":true}}}}"""
+    assertEquals(2, store(json).forPreview("p").getValue("t").count)
+  }
+}

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -115,6 +115,7 @@ import {
   expandDeferredRecords,
   stampPreviewDensities,
 } from "./bridge-live-preview-ids.mjs";
+import { catalogTagIndex } from "./tag-index.mjs";
 import {
   catalogImagePath,
   derivationMismatches,
@@ -1635,6 +1636,33 @@ for (const component of indexManifest.components ?? []) {
     figmaVariantSvgPaths.add(target);
     figmaVariantSvgCount += 1;
   }
+}
+
+// The published tag index (`tags/index.json`) — `served preview id → {testTag: {count, bounds}}`,
+// the element identity a scoped parity acceptance resolves against (compose-ai-tools#3680).
+//
+// It has to be published rather than projected on demand: the serve host derives this from a live
+// daemon render, and a published catalog has no daemon, so for a catalog the projection can only
+// happen HERE, where the semantics trees the render produced are still in hand. Same join as the
+// per-variant figma-svg emit above and for the same reason — each image already carries the
+// `previewId` that keys the bundle's sidecar and the `path` the served route id derives from, so
+// neither namespace is re-derived.
+{
+  const tags = catalogTagIndex(indexManifest, [bundle, extraBundle]);
+  const tagsDir = join(outPath, "tags");
+  await mkdir(tagsDir, { recursive: true });
+  await writeFile(
+    join(tagsDir, "index.json"),
+    `${JSON.stringify({ schema: tags.schema, previews: tags.previews }, null, 2)}\n`,
+    "utf8",
+  );
+  console.log(
+    `[${spec.system}] tag index: ${tags.indexed} preview(s) indexed` +
+      (tags.gaps > 0
+        ? `, ${tags.gaps} bridged image(s) carried no semantics tree (pack with --with-semantics ` +
+          `to close the gap — an unindexed preview simply gets no element gate)`
+        : ""),
+  );
 }
 
 // Figma Code Connect manifest next to the figma-svg vectors: one mapping per component binding its

--- a/scripts/design-artifacts/tag-index.mjs
+++ b/scripts/design-artifacts/tag-index.mjs
@@ -1,0 +1,168 @@
+/**
+ * Project a `compose/semantics` tree into a **tag index** — `testTag → {count, bounds, space}`.
+ *
+ * The JavaScript twin of the serve host's `ServeSemanticsTags` (Kotlin). Both exist because the
+ * index has two producers and the same consumer contract: the serve host projects it live from a
+ * daemon render, and a *published catalog* has no daemon at render time, so its index has to be
+ * computed here, at catalog-generation time, and committed beside the stickers.
+ *
+ * The two implementations must not drift, so every rule below is stated in both and pinned by the
+ * shared fixture in `fixtures/tag-index/`. Where they disagree, an element gate resolves a tag
+ * differently on the server than in an offline parity run — the precise cross-engine divergence the
+ * component-parity contract exists to prevent.
+ *
+ * ## The rules, and why each is not negotiable
+ *
+ * - **`count` counts every node carrying the tag**, including nodes whose bounds are unusable. A tag
+ *   is only a usable identity while exactly one node carries it, and Compose does not enforce that;
+ *   dropping a zero-area duplicate would report `count: 1` for a genuinely ambiguous tag and let a
+ *   consumer resolve it as unique. `count` is the whole reason the index exists rather than a plain
+ *   `tag → bounds` map.
+ * - **`bounds` is the FIRST usable box in depth-first order**, absent when no node carrying the tag
+ *   has one. First rather than last because depth-first is the order both engines walk, so "first"
+ *   is reproducible where "last" depends on where the duplicate happened to land.
+ * - **The key is the tag verbatim.** Blank-or-absent decides omission and nothing else. Compose
+ *   matches a `testTag` as the exact string, so trimming would be a second identity rule: `"item"`
+ *   and `" item "` would collapse into one entry reporting `count: 2` (false ambiguity) while an
+ *   acceptance recording `" item "` found no key at all (false disappearance).
+ * - **`space` is on the wire.** Bounds are `boundsInRoot` — absolute-to-root render pixels, the same
+ *   space the published sticker is in. The design doc currently says the index publishes bounds
+ *   already transformed into an acceptance's canonical plane; neither producer can do that (the
+ *   plane is resolved per comparison, from a reference raster and an acceptance record, and neither
+ *   producer has one). Until that is settled, each entry names its own space so no consumer can
+ *   silently treat these as canonical.
+ *
+ * Pure and I/O-free — no `@design-parity/*`, no filesystem — so it unit-tests without an `npm ci`,
+ * like its siblings `catalog-image-path.mjs` / `catalog-priority.mjs`. The driver does the writing.
+ */
+
+import { catalogPreviewId } from "./live-preview.mjs";
+
+/** The coordinate space {@link tagIndex} reports bounds in. Mirrors `ServeSemanticsTags`. */
+export const RENDER_PIXELS = "render-pixels";
+
+/** Schema token of the published `tags/index.json`. */
+export const TAG_INDEX_SCHEMA = "compose-preview-tags/v1";
+
+/**
+ * Parse a `"left,top,right,bottom"` wire box into `{x, y, width, height}`, or null when it is
+ * malformed or has no area. Mirrors `SlotBounds.parse` + the `hasArea` guard on the Kotlin side —
+ * a zero-area box is *not* usable geometry, but the node carrying it still counts.
+ */
+function parseBounds(wire) {
+  const parts = String(wire ?? "").split(",");
+  if (parts.length !== 4) return null;
+  const n = parts.map((p) => {
+    const trimmed = p.trim();
+    return /^-?\d+$/.test(trimmed) ? Number.parseInt(trimmed, 10) : Number.NaN;
+  });
+  if (n.some(Number.isNaN)) return null;
+  const [left, top, right, bottom] = n;
+  if (right <= left || bottom <= top) return null;
+  return { x: left, y: top, width: right - left, height: bottom - top };
+}
+
+/**
+ * The tag index for one `ComposeSemanticsPayload` (`{ root }`), in depth-first encounter order.
+ *
+ * Returns a plain object built with a null prototype: `__proto__` is a perfectly good `testTag` and
+ * a catastrophic object key, and a catalog is third-party data. The Kotlin side keys a `Map` for
+ * the same reason.
+ */
+export function tagIndex(payload) {
+  const out = Object.create(null);
+  const walk = (node) => {
+    if (!node || typeof node !== "object") return;
+    const raw = node.testTag;
+    if (typeof raw === "string" && raw.trim() !== "") {
+      const box = parseBounds(node.boundsInRoot);
+      const existing = out[raw];
+      if (existing === undefined) {
+        out[raw] = { count: 1, ...(box ? { bounds: box } : {}), space: RENDER_PIXELS };
+      } else {
+        existing.count += 1;
+        if (!existing.bounds && box) existing.bounds = box;
+      }
+    }
+    const children = Array.isArray(node.children) ? node.children : [];
+    for (const child of children) walk(child);
+  };
+  walk(payload?.root);
+  return out;
+}
+
+/**
+ * `daemon preview id → ComposeSemanticsPayload` from one bundle's carried sidecars.
+ *
+ * The sidecar is `previews/<id>.semantics.json`, written by `bundle pack --with-semantics`. The
+ * by-id counterpart of `figmaSvgById`, and read the same way: off `bundle.entries`, keyed by the
+ * daemon preview id, so it joins to a catalog image through the `previewId` `bridgeLivePreviewIds`
+ * stamps on it. A preview with no carried tree is simply absent.
+ */
+export function semanticsById(bundle) {
+  const out = new Map();
+  for (const preview of bundle?.previews ?? []) {
+    const bytes = bundle.entries?.[`previews/${preview.id}.semantics.json`];
+    if (!bytes) continue;
+    try {
+      const payload = JSON.parse(new TextDecoder().decode(bytes));
+      if (payload?.root) out.set(preview.id, payload);
+    } catch {
+      // A malformed sidecar costs that preview its index, not the whole catalog — the same
+      // fail-soft posture every other carried artifact gets.
+    }
+  }
+  return out;
+}
+
+/** Fold {@link semanticsById} across several bundles, later bundles winning. Mirrors `figmaSvgByIds`. */
+export function semanticsByIds(bundles) {
+  const out = new Map();
+  for (const bundle of bundles ?? []) {
+    if (!bundle) continue;
+    for (const [id, payload] of semanticsById(bundle)) out.set(id, payload);
+  }
+  return out;
+}
+
+/**
+ * The published tag index for a built catalog: `served preview id → { tag → {count, bounds, space} }`.
+ *
+ * Driven from `manifest.components[].images[]` rather than from a naming scheme of its own, exactly
+ * like the per-variant figma-svg emit, because each image already carries both halves of the join:
+ * `previewId` (stamped by `bridgeLivePreviewIds`) keys the bundle's semantics sidecar, and `path`
+ * yields the served route id through {@link catalogPreviewId}'s rule. Re-deriving either would be a
+ * second naming scheme to keep in step, and a mis-keyed index fails *silently* — every gate simply
+ * never resolves.
+ *
+ * **Only exact pairs are published.** An image `bridgeLivePreviewIds` deliberately left unbridged
+ * (a state with no desktop source, or a function the Android-only supplement overrode) gets no
+ * entry, and neither does one whose bundle carried no tree. That matters more here than for a
+ * vector: bounds are per-variant, so falling back to a sibling variant's tree would publish boxes
+ * that describe different pixels, and an element gate would report movement that never happened. An
+ * absent entry degrades to "no element gate"; a wrong one produces a wrong verdict.
+ *
+ * Returns the index plus the counts the driver reports, so a whole bundle silently missing its
+ * semantics shows up as a number rather than as an empty file nobody looks at.
+ */
+export function catalogTagIndex(manifest, bundles) {
+  const treesById = semanticsByIds(bundles);
+  const previews = Object.create(null);
+  let indexed = 0;
+  let gaps = 0;
+  for (const component of manifest?.components ?? []) {
+    for (const image of component?.images ?? []) {
+      if (!image?.previewId || typeof image.path !== "string") continue;
+      const tree = treesById.get(image.previewId);
+      if (!tree) {
+        gaps += 1;
+        continue;
+      }
+      const tags = tagIndex(tree);
+      if (Object.keys(tags).length === 0) continue;
+      previews[catalogPreviewId(image.path)] = tags;
+      indexed += 1;
+    }
+  }
+  return { schema: TAG_INDEX_SCHEMA, previews, indexed, gaps };
+}

--- a/scripts/design-artifacts/tag-index.test.mjs
+++ b/scripts/design-artifacts/tag-index.test.mjs
@@ -1,0 +1,215 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { RENDER_PIXELS, catalogTagIndex, tagIndex } from "./tag-index.mjs";
+
+const node = (bounds, testTag, children = []) => ({
+  nodeId: "n",
+  boundsInRoot: bounds,
+  ...(testTag === undefined ? {} : { testTag }),
+  children,
+});
+
+const index = (root) => tagIndex({ root });
+
+test("a unique tag reports count one and its render-pixel box", () => {
+  const tags = index(node("0,0,100,100", undefined, [node("24,24,48,48", "glyph")]));
+  assert.deepEqual(Object.keys(tags), ["glyph"]);
+  assert.equal(tags.glyph.count, 1);
+  assert.deepEqual(tags.glyph.bounds, { x: 24, y: 24, width: 24, height: 24 });
+  assert.equal(tags.glyph.space, RENDER_PIXELS);
+});
+
+test("a repeated tag reports every occurrence", () => {
+  const tags = index(
+    node("0,0,100,100", undefined, [
+      node("0,0,20,20", "row"),
+      node("0,20,20,40", "row"),
+      node("0,40,20,60", "row"),
+    ]),
+  );
+  assert.equal(tags.row.count, 3);
+});
+
+// The case the count field exists for: dropping a zero-area duplicate would report `count: 1` for a
+// tag two nodes carry, and an acceptance would resolve it as unique.
+test("a duplicate with no usable bounds still raises the count", () => {
+  const tags = index(
+    node("0,0,100,100", undefined, [
+      node("10,10,30,30", "chip"),
+      node("40,40,40,40", "chip"), // zero area
+      node("not,a,box", "chip"), // unparseable
+    ]),
+  );
+  assert.equal(tags.chip.count, 3);
+  // The first usable box wins, so the geometry is still the drawable node's.
+  assert.deepEqual(tags.chip.bounds, { x: 10, y: 10, width: 20, height: 20 });
+});
+
+test("a tag whose only node has no usable bounds reports a count and no box", () => {
+  const tags = index(node("0,0,100,100", undefined, [node("5,5,5,5", "ghost")]));
+  assert.equal(tags.ghost.count, 1);
+  assert.equal(tags.ghost.bounds, undefined);
+});
+
+test("the first usable box in depth-first order is the one reported", () => {
+  const tags = index(
+    node("0,0,100,100", undefined, [
+      node("0,0,50,50", undefined, [node("1,1,11,11", "dup")]),
+      node("50,50,90,90", "dup"),
+    ]),
+  );
+  assert.equal(tags.dup.count, 2);
+  assert.deepEqual(tags.dup.bounds, { x: 1, y: 1, width: 10, height: 10 });
+});
+
+// Compose matches a testTag as the exact string. Trimming would merge these into one `count: 2`
+// entry — false ambiguity for "pad", and no key at all for an acceptance recording " pad ".
+test("a tag is keyed verbatim, not trimmed", () => {
+  const tags = index(
+    node("0,0,100,100", undefined, [node("0,0,10,10", "pad"), node("20,20,30,30", " pad ")]),
+  );
+  assert.deepEqual(Object.keys(tags).sort(), [" pad ", "pad"]);
+  assert.equal(tags["pad"].count, 1);
+  assert.equal(tags[" pad "].count, 1);
+});
+
+test("blank and absent tags are not keys", () => {
+  const tags = index(
+    node("0,0,100,100", undefined, [
+      node("0,0,10,10"),
+      node("0,0,10,10", ""),
+      node("0,0,10,10", "   "),
+    ]),
+  );
+  assert.deepEqual(Object.keys(tags), []);
+});
+
+test("a tagged root is indexed like any other node", () => {
+  const tags = index(node("0,0,64,64", "root-tag"));
+  assert.equal(tags["root-tag"].count, 1);
+  assert.deepEqual(tags["root-tag"].bounds, { x: 0, y: 0, width: 64, height: 64 });
+});
+
+// A catalog is third-party data and `__proto__` is a perfectly good testTag. Keying a plain object
+// literal with it mutates the prototype instead of creating an own property, so the entry vanishes
+// and duplicate detection breaks — the same hazard the Kotlin side answers by keying a Map.
+test("a __proto__ tag becomes an own property rather than mutating the prototype", () => {
+  const tags = index(node("0,0,100,100", undefined, [node("0,0,10,10", "__proto__")]));
+  assert.equal(Object.prototype.hasOwnProperty.call(tags, "__proto__"), true);
+  assert.equal(tags["__proto__"].count, 1);
+  assert.equal({}.hasOwnProperty("__proto__"), false, "the global prototype must be untouched");
+});
+
+test("a malformed or absent payload yields an empty index rather than throwing", () => {
+  assert.deepEqual(Object.keys(tagIndex(undefined)), []);
+  assert.deepEqual(Object.keys(tagIndex({})), []);
+  assert.deepEqual(Object.keys(tagIndex({ root: null })), []);
+});
+
+// --- the catalog-level join -------------------------------------------------
+
+const bundleWith = (trees) => ({
+  previews: Object.keys(trees).map((id) => ({ id })),
+  entries: Object.fromEntries(
+    Object.entries(trees).map(([id, tree]) => [
+      `previews/${id}.semantics.json`,
+      new TextEncoder().encode(JSON.stringify(tree)),
+    ]),
+  ),
+});
+
+const manifestWith = (images) => ({
+  components: [{ componentId: "Button/Filled", images }],
+});
+
+test("the index is keyed by the SERVED preview id, not the daemon one", () => {
+  const out = catalogTagIndex(
+    manifestWith([
+      { path: "images/button-filled/ideal__default__light.png", previewId: "Filled_Light" },
+    ]),
+    [bundleWith({ Filled_Light: { root: node("0,0,100,40", undefined, [node("8,8,32,32", "glyph")]) } })],
+  );
+  // `Filled_Light` is the daemon id; the route the viewer serves is derived from the image path.
+  assert.deepEqual(Object.keys(out.previews), ["button-filled__ideal__default__light"]);
+  assert.equal(out.previews["button-filled__ideal__default__light"].glyph.count, 1);
+  assert.equal(out.indexed, 1);
+  assert.equal(out.gaps, 0);
+  assert.equal(out.schema, "compose-preview-tags/v1");
+});
+
+// Bounds are per-variant, so a sibling variant's tree describes different pixels. An absent entry
+// costs an element gate; a wrong one produces a wrong `element-moved` verdict.
+test("an unbridged image is skipped rather than borrowing a sibling's tree", () => {
+  const out = catalogTagIndex(
+    manifestWith([
+      { path: "images/button-filled/ideal__default__light.png", previewId: "Filled_Light" },
+      { path: "images/button-filled/ideal__default__dark.png" }, // no previewId — never bridged
+    ]),
+    [bundleWith({ Filled_Light: { root: node("0,0,100,40", undefined, [node("8,8,32,32", "glyph")]) } })],
+  );
+  assert.deepEqual(Object.keys(out.previews), ["button-filled__ideal__default__light"]);
+  assert.equal(out.gaps, 0, "an image that never bridged is not a gap — there is nothing to carry");
+});
+
+test("a bridged image whose bundle carried no tree is counted as a gap", () => {
+  const out = catalogTagIndex(
+    manifestWith([
+      { path: "images/button-filled/ideal__default__dark.png", previewId: "Filled_Dark" },
+    ]),
+    [bundleWith({ Filled_Light: { root: node("0,0,10,10", "x") } })],
+  );
+  assert.deepEqual(Object.keys(out.previews), []);
+  assert.equal(out.gaps, 1, "a bridged image with no carried tree is the case worth reporting");
+});
+
+test("trees are folded across bundles, the supplement winning", () => {
+  const primary = bundleWith({ Filled_Light: { root: node("0,0,10,10", "from-primary") } });
+  const extra = bundleWith({ Filled_Light: { root: node("0,0,10,10", "from-extra") } });
+  const out = catalogTagIndex(
+    manifestWith([
+      { path: "images/button-filled/ideal__default__light.png", previewId: "Filled_Light" },
+    ]),
+    [primary, extra],
+  );
+  assert.deepEqual(
+    Object.keys(out.previews["button-filled__ideal__default__light"]),
+    ["from-extra"],
+  );
+});
+
+test("a malformed sidecar costs that preview its entry, not the catalog", () => {
+  const bundle = {
+    previews: [{ id: "Filled_Light" }, { id: "Filled_Dark" }],
+    entries: {
+      "previews/Filled_Light.semantics.json": new TextEncoder().encode("{ not json"),
+      "previews/Filled_Dark.semantics.json": new TextEncoder().encode(
+        JSON.stringify({ root: node("0,0,10,10", "ok") }),
+      ),
+    },
+  };
+  const out = catalogTagIndex(
+    manifestWith([
+      { path: "images/button-filled/ideal__default__light.png", previewId: "Filled_Light" },
+      { path: "images/button-filled/ideal__default__dark.png", previewId: "Filled_Dark" },
+    ]),
+    [bundle],
+  );
+  assert.deepEqual(Object.keys(out.previews), ["button-filled__ideal__default__dark"]);
+  assert.equal(out.gaps, 1);
+});
+
+test("a preview whose tree carries no tags contributes no entry", () => {
+  const out = catalogTagIndex(
+    manifestWith([
+      { path: "images/button-filled/ideal__default__light.png", previewId: "Filled_Light" },
+    ]),
+    [bundleWith({ Filled_Light: { root: node("0,0,100,40") } })],
+  );
+  assert.deepEqual(Object.keys(out.previews), []);
+});
+
+test("an empty or absent manifest yields an empty index rather than throwing", () => {
+  assert.deepEqual(Object.keys(catalogTagIndex(undefined, []).previews), []);
+  assert.deepEqual(Object.keys(catalogTagIndex({}, undefined).previews), []);
+});


### PR DESCRIPTION
Closes the gap found while tracing the data path in #3830: **the element-gate half of the component-parity workflow was unreachable on every published design catalog** — which is the only kind of surface the epic is actually about.

Refs #3680, #3803.

## The problem

The serve host projects a tag index (`testTag → {count, bounds}`) from a live daemon render — that's what #3830 added. But a published catalog has no daemon. `ServeCatalogStore` stages PNGs, SVGs, RC docs and design references; nothing carries a semantics tree, and nothing in `serve` reads the `previews/<id>.semantics.json` the bundle format already defines.

So on `m3-catalog` — the epic's own named pilot — no acceptance could ever resolve an element, and no amount of consumer-side work would have changed that.

The projection has to run where the trees still exist: at catalog-generation time, in CI, published beside the stickers.

## Producer — `scripts/design-artifacts/tag-index.mjs`

The JS twin of `ServeSemanticsTags`, rule for rule, because two producers feeding one consumer contract is exactly where engines drift:

- **`count` counts every node carrying the tag**, including ones whose bounds are unusable — dropping a zero-area duplicate would report `count: 1` for a genuinely ambiguous tag and let a consumer resolve it as unique. That's the whole reason the index isn't a plain `tag → bounds` map.
- **First usable box in depth-first order** — reproducible, where "last" depends on where the duplicate landed.
- **Keys verbatim** — Compose matches the exact string, so trimming would merge `"item"` and `" item "` into false ambiguity while leaving an acceptance recording the latter with no key at all.
- **The coordinate space is named on the wire**, same as the Kotlin side, for the unresolved canonical-plane question carried over from #3830.
- **Null-prototype keying**, because `__proto__` is a perfectly good `testTag` and a catalog is third-party data. Tested, including that the global prototype stays untouched.

## The join, which is where this could have failed silently

Driven from `manifest.components[].images[]`, reusing what the per-variant figma-svg emit already established: each image carries the `previewId` that keys the bundle's semantics sidecar (stamped by `bridgeLivePreviewIds`) *and* the `path` the served route id derives from (`catalogPreviewId`, the JS twin of `ServeCatalogStore.previewIdFor`). Neither namespace is re-derived — a second naming scheme here would be one more thing to keep in step, and a mis-keyed index doesn't fail loudly, it just never resolves.

**Only exact pairs are published.** An image `bridgeLivePreviewIds` deliberately left unbridged, or one whose bundle carried no tree, gets no entry. This matters more than it does for a vector: bounds are per-variant, so borrowing a sibling variant's tree would publish boxes describing different pixels and make a gate report movement that never happened. An absent entry costs an element gate; a wrong one produces a wrong verdict. Bridged-but-uncarried images are counted and reported, so a whole bundle missing its semantics shows up as a number rather than an empty file nobody looks at.

## Consumer — `ServeTagIndexStore` + staging

Reads `tags/index.json` fail-soft, matching `ServeAnnotationStore` and `ServeDesignReferenceStore`: malformed, wrong schema token, or oversized drops wholesale and the catalog serves exactly as before. A counted tag with *no* bounds survives, since that's precisely what makes an ambiguity check work.

`ServeCatalogStore.writeTagIndex` stages it. Without that the index would be published by every catalog build and read by nobody — a served catalog is assembled from explicitly fetched parts, so a file nobody copies is invisible no matter what the producer wrote.

## This populates on the next catalog build

Checked rather than assumed: **every catalog-build path already packs semantics.** `design-artifacts.yml` and `design-artifacts-reusable.yml` both invoke `bundle pack … --with-semantics`, for the primary module and for the `--extra-renders` supplement. So the sidecars this reads are already being produced today, and the index populates on the next run of either workflow — no packing change is needed first.

Where a build *doesn't* carry a tree for some bridged image, the emit reports the count in the build log rather than failing, so a regression in semantics coverage surfaces as a number instead of a silently thin index.

## Test plan

- **17 JS cases** (`node --test tag-index.test.mjs`): the projection rules above, plus the join — keyed by served id not daemon id, unbridged images skipped rather than borrowing a sibling's tree, bridged-but-uncarried counted as a gap, cross-bundle fold with the supplement winning, a malformed sidecar costing one preview rather than the catalog.
- **9 Kotlin cases** (`ServeTagIndexStoreTest`): absent / malformed / future-schema / oversized all drop to empty; a valid index keys by served preview id; a counted tag with no bounds survives; a zero-area box is dropped and a preview left with nothing drops with it; unknown keys tolerated so a newer producer doesn't break an older host.
- Full `:cli:test` green; `ktfmtCheck` green; driver syntax-checked with `node --check`.
- **Five pre-existing failures** in the driver suite (`catalog-themes`, `figma-rest-raster`, `rc-compare-pixels`, `rc-size-modifier`, `package-version`) — verified rather than assumed: they reproduce identically with this change stashed.

## No visual evidence

Nothing rendered changes. This is a published data product and its reader; no `@Preview`, page, or overlay is touched.

## What this does and does not unblock

It makes the element identity *reachable* on a published catalog, which was the blocker. It does **not** yet make gates run — that needs the acceptance schema (#3807) and the scorer work (#3810), and both still want the canonical-plane question from #3830 settled, since the space this index publishes is the space those gates will compare against.