### PR TITLE
feat(serve): give the usage cleaner a real parse, behind the isolated loader

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -140,6 +140,21 @@ val composePreviewBta =
     isCanBeConsumed = false
   }
 
+// Sidecar configuration carrying `:usage-source-psi` — the Kotlin *parser* behind the usage
+// cleaner.
+// Same isolation story as `lib-bta/` above, and loaded together with it: the analyzer needs a
+// frontend, and the frontend must never be on the CLI's own classpath. Resolved into
+// `cli/build/install/compose-preview/lib-usage-psi/`, located at runtime via
+// `APP_HOME/lib-usage-psi/` (or `-Dcomposeai.cli.libUsagePsiDir`).
+//
+// Just this module's jar: `:usage-source-psi` declares the frontend `compileOnly`, so its runtime
+// closure is the Kotlin stdlib the CLI already ships, and the compiler jars ride in `lib-bta/`.
+val composePreviewUsagePsi =
+  configurations.create("composePreviewUsagePsi") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+  }
+
 dependencies {
   // The BTA implementation + Compose compiler plugin jars, staged into `lib-bta/` (see the
   // `composePreviewBta` configuration above). `kotlin-build-tools-impl` pulls
@@ -152,6 +167,7 @@ dependencies {
     "composePreviewBta",
     "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable:${libs.versions.kotlin.get()}",
   )
+  add("composePreviewUsagePsi", project(":usage-source-psi"))
   // BTA *interfaces only* — the CLI references `BtaCompileSession`'s build-tools-api parameter
   // types
   // (`CompilerPlugin`, `KotlinLogger`, `SourcesChanges`) to drive an in-process playground compile.
@@ -433,6 +449,7 @@ distributions {
       into("lib-daemon-desktop") { from(stageDaemonDesktopLibs) }
       into("lib-rcjvm") { from(stageRcJvmLibs) }
       into("lib-bta") { from(stageBtaLibs) }
+      into("lib-usage-psi") { from(composePreviewUsagePsi) }
       // Static browser sidecar: release-matched CMP/Skiko Remote Compose player assets.
       into("rc-player-wasm") { from(rcPlayerWasmDist) }
     }
@@ -482,10 +499,20 @@ tasks.withType<Test>().configureEach {
   // time.
   val btaJars = composePreviewBta.incoming.files
   inputs.files(btaJars).withPropertyName("libBtaJars").withNormalizer(ClasspathNormalizer::class)
+  // And `:usage-source-psi` beside them, so `PlaygroundSourceCleaner` takes its **parsed** path
+  // under test instead of silently falling back to the text passes — which would leave the
+  // parser-backed rewrite, the whole point of the change, with no coverage at all.
+  val usagePsiJars = composePreviewUsagePsi.incoming.files
+  inputs
+    .files(usagePsiJars)
+    .withPropertyName("libUsagePsiJars")
+    .withNormalizer(ClasspathNormalizer::class)
   jvmArgumentProviders.add(
     CommandLineArgumentProvider {
       listOf(
-        "-Dcomposeai.libBtaJars=" + btaJars.joinToString(File.pathSeparator) { it.absolutePath }
+        "-Dcomposeai.libBtaJars=" + btaJars.joinToString(File.pathSeparator) { it.absolutePath },
+        "-Dcomposeai.usagePsi.jars=" +
+          (usagePsiJars + btaJars).joinToString(File.pathSeparator) { it.absolutePath },
       )
     }
   )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -34,18 +34,25 @@ package ee.schimke.composeai.cli.serve
  *    This is the step that turns "expect unresolved references" into a buffer that compiles.
  * 6. **Prune imports** to what survived, add what the rewrites need, stamp a real `@Preview`.
  *
- * ### Why this is a text pass and not a parse
+ * ### Part parse, part text scan
  *
- * A PSI pass would be more general, and it is not available here: the Kotlin frontend is
- * deliberately kept off the CLI's classpath (`cli/build.gradle.kts` — it is staged into `lib-bta/`
- * and loaded in an isolated classloader only for an actual compile). Pulling a compiler frontend
- * into the serve process to prettify a seed would be a bad trade.
+ * This began as pure text, because the Kotlin frontend is deliberately kept off the CLI's classpath
+ * (`cli/build.gradle.kts`). The snippet corpus then showed what that cost: named-argument binding,
+ * a receiver chain mistaken for a package qualifier, a trailing-lambda call with no parentheses, a
+ * qualified call no pass could see — five defects, all of them structure being guessed at.
  *
- * So this scans text, and it is built to **fail in the safe direction**: every pass is masked
- * against string and comment content so it cannot rewrite inside a literal, and anything it does
- * not understand it leaves alone. [Result.residue] reports declared scaffolding that survived, so a
- * seed that came out half-cleaned can say so rather than pretending. The caller falls back to the
- * verbatim slice when [clean] returns null.
+ * So the structural questions now go to a real parse. [UsageSourceParser] loads `:usage-source-psi`
+ * into the *same kind* of isolated classloader the playground compiler already uses, so the
+ * frontend still never reaches the CLI's own classpath; [applySubstituteParsed] and the residue
+ * scan read [UsageSourceFacts] rather than regex. The remaining passes are still text, and the
+ * whole parse is optional: a host with no staged sidecar keeps the text path, which is what shipped
+ * before.
+ *
+ * Either way it is built to **fail in the safe direction**: every text pass is masked against
+ * string and comment content so it cannot rewrite inside a literal, anything it does not understand
+ * it leaves alone, and [Result.residue] reports declared scaffolding that survived — so a seed that
+ * came out half-cleaned says so rather than pretending. The caller falls back to the verbatim slice
+ * when [clean] returns null.
  *
  * The formatting assumptions are ktfmt's (Google style), which every catalog in these repos is
  * formatted with: one argument per line in a wrapped call, a blank line between top-level
@@ -77,6 +84,7 @@ object PlaygroundSourceCleaner {
     bodyLine: Int?,
     rules: UsageRules,
     strings: Map<String, String> = emptyMap(),
+    parser: UsageSourceParser? = UsageSourceParser.of(),
   ): Result? {
     if (bodyLine == null) return null
     val lines = source.lines()
@@ -111,6 +119,7 @@ object PlaygroundSourceCleaner {
           isEntry = index == entryIndex,
           residue = residue,
           addedImports = addedImports,
+          parser = parser,
         )
       cleanedByIndex[index] = cleaned
       for ((name, at) in declaredAt) {
@@ -312,6 +321,7 @@ object PlaygroundSourceCleaner {
     isEntry: Boolean,
     residue: MutableSet<String>,
     addedImports: MutableSet<String>,
+    parser: UsageSourceParser?,
   ): String {
     var out = stripScaffoldAnnotations(text, imports, rules)
     out = inlineStringResources(out, strings)
@@ -322,13 +332,24 @@ object PlaygroundSourceCleaner {
     // substitution lands before DROP inspects the argument it sits in. DROP, then RENAME last —
     // renaming early would hide a name the other passes match on.
     out = applyUnwrap(out, rules)
-    out = applySubstitute(out, rules, addedImports)
+    // The parse settles argument binding, trailing-lambda calls and qualifiers; the text pass is
+    // the fallback for a host with no staged sidecar (see [UsageSourceParser]).
+    out =
+      if (parser != null) applySubstituteParsed(out, rules, addedImports, parser)
+      else applySubstitute(out, rules, addedImports)
     out = applyInline(out, rules)
     out = applyDrop(out, rules, residue)
     out = applyRename(out, rules, addedImports)
     if (isEntry) out = stampPreview(out, rules, addedImports)
+    // Residue: declared scaffolding that survived. With a parse, every *call* is visible however it
+    // is qualified — which is what the text scan structurally could not do, since it rejects a name
+    // after a `.` by design. The word scan stays alongside it for non-call references (a binding, a
+    // resource key) that no call node would report.
+    val calledNames =
+      parser?.facts(out)?.calls?.map { it.callee }?.toSet()
+        ?: rules.scaffolds.keys.filter { mentionsQualifiedCall(out, it) }.toSet()
     for (name in rules.scaffolds.keys) {
-      if (mentionsWord(out, name) || mentionsQualifiedCall(out, name)) residue.add(name)
+      if (name in calledNames || mentionsWord(out, name)) residue.add(name)
     }
     return out.trimEnd()
   }
@@ -563,6 +584,58 @@ object PlaygroundSourceCleaner {
       }
     }
     return bound.toList()
+  }
+
+  /**
+   * [applySubstitute] over a real parse: the same rules, with the guesswork removed.
+   *
+   * What changes against the text pass, all of it something the snippet corpus caught:
+   * - arguments bind the way Kotlin binds them, named or positional, in any order;
+   * - a trailing-lambda call (`counted { }`) is a call, though it has no parentheses;
+   * - a qualified call replaces as a whole — no separate unqualifying step, and no regex deciding
+   *   from shape whether `state.metrics` was a package.
+   *
+   * Re-parses after each rewrite rather than batching edits, so a knob nested inside another call
+   * (`counted(catalogChoice(…))`) is plain by the time the outer call's argument text is read.
+   * Innermost-first — descending start offset — for the same reason. Blocks are a declaration each
+   * and parsing one costs well under a millisecond, so the loop is cheaper than the bookkeeping
+   * that would replace it.
+   */
+  private fun applySubstituteParsed(
+    text: String,
+    rules: UsageRules,
+    addedImports: MutableSet<String>,
+    parser: UsageSourceParser,
+  ): String {
+    var out = text
+    var guard = 0
+    while (guard++ < MAX_REWRITES) {
+      val facts = parser.facts(out) ?: return out
+      val edit =
+        facts.calls
+          .asSequence()
+          .filter { rules.scaffolds[it.callee]?.kind == UsageRules.Kind.SUBSTITUTE }
+          .sortedByDescending { it.start }
+          .mapNotNull { call ->
+            val scaffold = rules.scaffolds.getValue(call.callee)
+            val plain = scaffold.plain ?: return@mapNotNull null
+            val args = facts.bind(call, scaffold.params) ?: return@mapNotNull null
+            val rendered =
+              Regex("""\$(\d+)""").replace(plain) { m ->
+                args.getOrNull(m.groupValues[1].toInt()) ?: m.value
+              }
+            // A template citing an argument the call does not have would emit a literal `$1`. Leave
+            // the call alone; the residue scan then reports it as an unwritten rule.
+            if (rendered.contains(Regex("""\$\d"""))) null
+            else Triple(call.replaceStart, call.replaceEnd, rendered to scaffold)
+          }
+          .firstOrNull() ?: return out
+      val (start, end, replacement) = edit
+      if (start < 0 || end > out.length || start >= end) return out
+      out = out.substring(0, start) + replacement.first + out.substring(end)
+      replacement.second.addImport?.let { addedImports.add(it) }
+    }
+    return out
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
@@ -1,0 +1,222 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.locateBundleSidecarJars
+import java.io.File
+import java.net.URLClassLoader
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * The structure [PlaygroundSourceCleaner] used to guess at, read off a real parse.
+ *
+ * Produced by `:usage-source-psi` inside an isolated classloader (see [UsageSourceParser]) and
+ * carried across as JSON, so no Kotlin frontend type ever reaches the CLI's own classpath.
+ *
+ * Offsets are 0-based character indices into the source that was analysed, end-exclusive. `-1`
+ * means the element is absent — a call with no parentheses, an argument with no name, a call that
+ * is not qualified.
+ */
+@Serializable
+data class UsageSourceFacts(
+  @SerialName("calls") val calls: List<Call> = emptyList(),
+  @SerialName("destructurings") val destructurings: List<Destructuring> = emptyList(),
+  /**
+   * Set when the analyzer could not parse at all; the caller then behaves as if it had no facts.
+   */
+  @SerialName("error") val error: String? = null,
+) {
+
+  @Serializable
+  data class Call(
+    @SerialName("callee") val callee: String,
+    @SerialName("start") val start: Int,
+    @SerialName("end") val end: Int,
+    /** The `(…)` list, `-1` when the call has only a trailing lambda (`counted { }`). */
+    @SerialName("argsStart") val argsStart: Int = -1,
+    @SerialName("argsEnd") val argsEnd: Int = -1,
+    @SerialName("lambdaStart") val lambdaStart: Int = -1,
+    @SerialName("lambdaEnd") val lambdaEnd: Int = -1,
+    @SerialName("lambdaBodyStart") val lambdaBodyStart: Int = -1,
+    @SerialName("lambdaBodyEnd") val lambdaBodyEnd: Int = -1,
+    /**
+     * The receiver of `receiver.callee(…)`, exactly as written, or null when the call is not
+     * qualified.
+     *
+     * This is the field the whole exercise turned on. `ee.schimke.composeai.overrides` and
+     * `state.metrics` are the same tree shape, so the parse cannot say which is a package — but it
+     * can hand over each one as an exact string, which makes the rules' allow-list a lookup instead
+     * of the regex-over-surrounding-text that got it wrong.
+     */
+    @SerialName("receiver") val receiver: String? = null,
+    @SerialName("qualifiedStart") val qualifiedStart: Int = -1,
+    @SerialName("qualifiedEnd") val qualifiedEnd: Int = -1,
+    @SerialName("args") val args: List<Arg> = emptyList(),
+  ) {
+    /** The range to replace when substituting the call: the qualified form if there is one. */
+    val replaceStart: Int
+      get() = if (qualifiedStart >= 0) qualifiedStart else start
+
+    val replaceEnd: Int
+      get() = if (qualifiedEnd >= 0) maxOf(qualifiedEnd, end) else end
+  }
+
+  @Serializable
+  data class Arg(
+    /** The `name` of `name = value`, or null for a positional argument. */
+    @SerialName("name") val name: String? = null,
+    @SerialName("text") val text: String = "",
+    @SerialName("start") val start: Int = -1,
+    @SerialName("end") val end: Int = -1,
+  )
+
+  @Serializable
+  data class Destructuring(
+    @SerialName("start") val start: Int,
+    @SerialName("end") val end: Int,
+    @SerialName("names") val names: List<String> = emptyList(),
+    @SerialName("initializer") val initializer: String = "",
+    @SerialName("initializerStart") val initializerStart: Int = -1,
+    @SerialName("initializerEnd") val initializerEnd: Int = -1,
+  )
+
+  /**
+   * Resolve this call's arguments to the positions a `$0`/`$1` template cites, the way Kotlin binds
+   * them: positional arguments fill [params] left to right, named ones fill by name.
+   *
+   * A parse supplies the *labels*; it does not supply the callee's signature, so [params] is still
+   * required — for a positional call there is nothing in the syntax saying which slot is `default`,
+   * and for a labelled one the label does not say which *index* the template means. See
+   * `docs/design/PSI_PARSE_SPIKE.md`.
+   *
+   * Returns null when [params] is empty and any argument is named: without the parameter list there
+   * is no way to place it, and guessing emits Kotlin that looks right and does not compile.
+   */
+  fun bind(call: Call, params: List<String>): List<String?>? {
+    if (params.isEmpty()) {
+      return if (call.args.any { it.name != null }) null else call.args.map { it.text }
+    }
+    val bound = arrayOfNulls<String>(params.size)
+    var next = 0
+    for (arg in call.args) {
+      val name = arg.name
+      if (name == null) {
+        while (next < params.size && bound[next] != null) next++
+        if (next >= params.size) continue
+        bound[next++] = arg.text
+      } else {
+        val at = params.indexOf(name)
+        if (at >= 0) bound[at] = arg.text
+      }
+    }
+    return bound.toList()
+  }
+}
+
+/**
+ * Loads `:usage-source-psi` into an isolated classloader and runs it.
+ *
+ * ### The isolation, and why it is the same one the compiler already uses
+ *
+ * The analyzer needs a Kotlin frontend; the CLI must not have one. So the jars — the staged
+ * `lib-bta/` (which carries `kotlin-compiler-embeddable`) plus this module's own `lib-usage-psi/` —
+ * are loaded into a [URLClassLoader] parented to the **platform** loader, exactly as
+ * [PlaygroundBtaCompiler] loads the compiler. Nothing is shared with the CLI's classpath: the whole
+ * contract across the boundary is one method taking a String and returning JSON.
+ *
+ * ### Absent is a normal state
+ *
+ * A non-installed run (`./gradlew run`, a test, a developer's IDE) has no staged sidecars. [of]
+ * returns null there and the cleaner keeps its text passes, which is what it always did. The parse
+ * is an upgrade where it is available, not a new hard requirement — a serve host must not stop
+ * cleaning seeds because a directory is missing.
+ */
+class UsageSourceParser
+private constructor(private val analyzer: Any, private val analyze: java.lang.reflect.Method) {
+
+  fun facts(source: String): UsageSourceFacts? =
+    try {
+      val raw = analyze.invoke(analyzer, source) as? String ?: return null
+      json.decodeFromString<UsageSourceFacts>(raw).takeIf { it.error == null }
+    } catch (e: Exception) {
+      null
+    }
+
+  companion object {
+    private val json = Json {
+      ignoreUnknownKeys = true
+      isLenient = true
+    }
+
+    private const val ANALYZER = "ee.schimke.composeai.usagepsi.UsageSourceAnalyzer"
+
+    /** Path-separated jar list, for tests and for a host that stages the sidecars elsewhere. */
+    const val JARS_PROPERTY = "composeai.usagePsi.jars"
+
+    @Volatile private var cached: UsageSourceParser? = null
+    @Volatile private var attempted = false
+
+    /**
+     * The process-wide parser, or null when the sidecars are not present.
+     *
+     * Built once and reused: the frontend's environment setup is ~0.5 s and per-file parsing is ~3
+     * ms, so paying setup per seed would invert those numbers. Also attempted only once — a host
+     * missing the sidecar should not retry a classloader build on every seed it serves.
+     */
+    fun of(onLog: (String) -> Unit = {}): UsageSourceParser? {
+      cached?.let {
+        return it
+      }
+      synchronized(this) {
+        cached?.let {
+          return it
+        }
+        if (attempted) return null
+        attempted = true
+        val jars = jars()
+        if (jars.isEmpty()) {
+          onLog("usage-source-psi not staged; cleaning with the text passes")
+          return null
+        }
+        return try {
+          val loader =
+            URLClassLoader(
+              jars.map { it.toURI().toURL() }.toTypedArray(),
+              ClassLoader.getPlatformClassLoader(),
+            )
+          val type = loader.loadClass(ANALYZER)
+          val instance = type.getDeclaredConstructor().newInstance()
+          val method = type.getMethod("analyze", String::class.java)
+          UsageSourceParser(instance, method).also { cached = it }
+        } catch (e: Exception) {
+          onLog("usage-source-psi failed to load (${e.message}); cleaning with the text passes")
+          null
+        }
+      }
+    }
+
+    private fun jars(): List<File> {
+      System.getProperty(JARS_PROPERTY)
+        ?.takeIf { it.isNotBlank() }
+        ?.let { property ->
+          return property
+            .split(File.pathSeparator)
+            .filter { it.endsWith(".jar") }
+            .map(::File)
+            .filter { it.isFile }
+        }
+      val psi = locateBundleSidecarJars("lib-usage-psi")
+      // The analyzer is nothing without the frontend, so both sidecars or neither.
+      val bta = locateBundleSidecarJars("lib-bta")
+      return if (psi.isEmpty() || bta.isEmpty()) emptyList() else psi + bta
+    }
+
+    /** Test seam: forget the cached parser so a test can install different jars. */
+    internal fun resetForTest() {
+      synchronized(this) {
+        cached = null
+        attempted = false
+      }
+    }
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSourceParserTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSourceParserTest.kt
@@ -1,0 +1,129 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the parser boundary itself — that it **loads**, and that the facts crossing it are the ones
+ * the cleaner reasons from.
+ *
+ * Worth its own test because the failure mode is silence: [UsageSourceParser.of] returns null when
+ * the sidecar is missing and [PlaygroundSourceCleaner] quietly keeps its text passes. Every cleaner
+ * test would still pass, having exercised none of this. The build forwards the staged jars via
+ * `composeai.usagePsi.jars` (see `cli/build.gradle.kts`) precisely so that cannot happen unnoticed,
+ * and the first assertion here is that the forwarding worked.
+ */
+class UsageSourceParserTest {
+
+  private val parser = UsageSourceParser.of { println("usage-source-psi: $it") }
+
+  @Test
+  fun `the analyzer loads from the staged sidecar`() {
+    assertNotNull(
+      parser,
+      "usage-source-psi did not load; the parsed path would silently not be under test",
+    )
+  }
+
+  /** Named arguments arrive with their labels; positional ones arrive bare. */
+  @Test
+  fun `arguments carry their labels`() {
+    val facts =
+      assertNotNull(
+        parser?.facts("""fun x() = Text(previewOverrideString(key = "k", default = "v"))""")
+      )
+    val call = assertNotNull(facts.calls.firstOrNull { it.callee == "previewOverrideString" })
+    assertEquals(
+      listOf("key" to "\"k\"", "default" to "\"v\""),
+      call.args.map { it.name to it.text },
+    )
+  }
+
+  /**
+   * A trailing lambda is *not* a value argument as far as binding is concerned.
+   *
+   * PSI disagrees — `KtLambdaArgument` extends `KtValueArgument`, so an unfiltered list hands the
+   * lambda a positional slot and `{ … }` lands where `default` belongs. Found by reading the facts
+   * for a real call rather than by a failing rewrite, which is the cheaper order.
+   */
+  @Test
+  fun `a trailing lambda is not one of the bound arguments`() {
+    val facts = assertNotNull(parser?.facts("""fun x() = counted("label") { Text("hi") }"""))
+    val call = assertNotNull(facts.calls.firstOrNull { it.callee == "counted" })
+    assertEquals(listOf("\"label\""), call.args.map { it.text })
+    assertTrue(call.lambdaStart >= 0, "the lambda should still be reported, as its own range")
+  }
+
+  /** A call with no parentheses at all is still a call. */
+  @Test
+  fun `a bare trailing-lambda call is reported`() {
+    val facts = assertNotNull(parser?.facts("""fun x() = counted { Text("hi") }"""))
+    val call = assertNotNull(facts.calls.firstOrNull { it.callee == "counted" })
+    assertEquals(-1, call.argsStart, "there is no argument list to report")
+    assertTrue(call.args.isEmpty())
+  }
+
+  /** The receiver comes across whole, which is what makes the package allow-list a lookup. */
+  @Test
+  fun `a qualified call reports its receiver`() {
+    val facts =
+      assertNotNull(
+        parser?.facts(
+          """
+          fun x() {
+            ee.schimke.composeai.overrides.previewOverrideString("k", "v")
+            state.metrics.counted { }
+          }
+          """
+            .trimIndent()
+        )
+      )
+    val byName = facts.calls.associateBy { it.callee }
+    assertEquals("ee.schimke.composeai.overrides", byName["previewOverrideString"]?.receiver)
+    assertEquals("state.metrics", byName["counted"]?.receiver)
+  }
+
+  /** Destructuring, which the `$known-gaps` entry in `compose-usage.json` is waiting on. */
+  @Test
+  fun `destructuring declarations are reported with their entries`() {
+    val facts =
+      assertNotNull(
+        parser?.facts("""fun x() { val (checked, onChange) = toggleable("on", true) }""")
+      )
+    val destructuring = assertNotNull(facts.destructurings.singleOrNull())
+    assertEquals(listOf("checked", "onChange"), destructuring.names)
+    assertEquals("""toggleable("on", true)""", destructuring.initializer)
+  }
+
+  /**
+   * Binding is Kotlin's rule, and it needs the callee's parameter names — the parse supplies
+   * labels, not signatures. See `docs/design/PSI_PARSE_SPIKE.md`.
+   */
+  @Test
+  fun `binding follows Kotlin, and declines what it cannot place`() {
+    val params = listOf("key", "default", "index")
+    val facts =
+      assertNotNull(
+        parser?.facts(
+          """
+          fun x() {
+            previewOverrideString(default = "b", key = "a")
+            previewOverrideString("a", "b")
+          }
+          """
+            .trimIndent()
+        )
+      )
+    val calls = facts.calls.filter { it.callee == "previewOverrideString" }
+    assertEquals(2, calls.size)
+    // Reordered labels and plain positions both land `"b"` at index 1.
+    for (call in calls) assertEquals("\"b\"", facts.bind(call, params)?.get(1))
+    // With no declared parameters a labelled call cannot be placed, so it is declined rather than
+    // guessed — the alternative emits `default = "b"` where a value belongs.
+    assertNull(facts.bind(calls.first(), emptyList()))
+    assertEquals(listOf("\"a\"", "\"b\""), facts.bind(calls.last(), emptyList()))
+  }
+}

--- a/docs/design/PSI_PARSE_SPIKE.md
+++ b/docs/design/PSI_PARSE_SPIKE.md
@@ -127,11 +127,47 @@ stopping at `getText()`, which returns the view-provider buffer without a tree e
 the pattern outlived its first fix. Both now walk the tree and assert what they find. The rule this
 file should have started with: an assertion over `text` proves nothing about a *parse*.
 
+## What shipped
+
+The spike said yes, so the parse is now in the cleaner. The shape is the one the spike argued for:
+
+- **`:usage-source-psi`** — the parser, compiling `compileOnly` against `kotlin-compiler-embeddable`
+  so the frontend is never a runtime dependency of anything in the main build. It exposes one method,
+  `analyze(String): String`, returning JSON: calls (callee, offsets, arguments with their labels,
+  trailing-lambda ranges, receiver) and destructuring declarations. It reports **facts, never
+  decisions** — `ee.schimke.composeai.overrides` and `state.metrics` are the same tree shape, so it
+  hands over each receiver verbatim and lets the rules' allow-list do the classifying.
+- **Staged as `lib-usage-psi/`**, loaded together with the already-staged `lib-bta/` jars in a
+  `URLClassLoader` parented to the platform loader — the same isolation the playground compiler uses.
+  Nothing crosses the boundary but a `String` in and JSON out, so the two sides share no classes.
+- **`UsageSourceParser`** builds that loader once per process (setup is ~0.5 s, parsing ~3 ms) and
+  `PlaygroundSourceCleaner` uses it for the substitution pass and the residue scan. A host with no
+  staged sidecar keeps the text passes, unchanged — the parse is an upgrade where available, not a
+  new hard requirement.
+
+`:cli:test` forwards the staged jars (`composeai.usagePsi.jars`) so the parsed path is what the tests
+actually exercise. Without that the cleaner would fall back silently and every test would still pass,
+having covered none of it.
+
+**The corpus ratios are unchanged: m3-catalog 3/10, meshcore-mobile 0/10, same seven failures.** That
+is the result to expect and the bar the spike set — parity, per snippet, before anything else. The
+parse fixes shapes the text pass got wrong (an argument binding, a receiver chain, a call with no
+parentheses); none of the seven remaining failures is one of those. Moving the ratio needs the new
+rule vocabulary below, which the facts now make possible.
+
+One bug found while wiring it, worth recording because it would have been silent: `KtLambdaArgument`
+*is* a `KtValueArgument`, so a trailing lambda arrives in the value-argument list and takes a
+positional slot — putting `{ … }` where `default` belongs. Filtered out, and pinned by a test.
+
 ## What this does and does not buy
 
 A parse fixes the **machinery**. It does not move the ratio much on its own:
 
-- m3-catalog's 2 destructuring failures and 2 conditional-`stringResource` failures become tractable.
+- m3-catalog's 2 destructuring failures become tractable — the facts now carry
+  `KtDestructuringDeclaration` entries and initialisers, so a `DESTRUCTURE` rule kind whose plain
+  form is `var x by remember { mutableStateOf(…) }` has everything it needs. Not written yet.
+- The 2 conditional-`stringResource` failures become tractable for the same reason: the inliner can
+  see the `if` rather than declining on a regex.
 - `CatalogFilledStars` (×4) still needs a substitution rule — no parse invents an icon.
 - meshcore-mobile's 0/10 stays structural: its previews compose app screens over fixture data, so
   there is no library call site to reduce to.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -242,6 +242,7 @@ project(":wear-preview-runtime").projectDir = file("runtimes/wear-preview")
 
 // The usage-snippet compile gate (see its build file). Empty unless `-PusageCorpus=` points it at
 // a generated corpus, so it costs a normal build nothing.
+include(":usage-source-psi")
 include(":tools:usage-compile-check")
 include(":samples:android")
 

--- a/usage-source-psi/build.gradle.kts
+++ b/usage-source-psi/build.gradle.kts
@@ -1,0 +1,33 @@
+// `:usage-source-psi` — the Kotlin **parser** behind the usage cleaner, kept off the CLI's
+// classpath.
+//
+// `PlaygroundSourceCleaner` used to answer every structural question with regex, because the Kotlin
+// frontend is deliberately not a CLI dependency (see `cli/build.gradle.kts`'s `lib-bta/` note). The
+// snippet corpus showed what that cost: named-argument binding, receiver chains mistaken for
+// package
+// qualifiers, trailing-lambda calls with no parentheses, qualified calls no pass could see. All
+// structure, all guessed at.
+//
+// So the parse lives here instead, in a module that:
+//  - compiles `compileOnly` against `kotlin-compiler-embeddable` — the frontend is never a
+// *runtime*
+//    dependency of anything in the main build;
+//  - is staged into the CLI install as `lib-usage-psi/`, loaded alongside the already-staged
+//    `lib-bta/` jars in one isolated classloader;
+//  - exposes exactly one entry point returning JSON, so the loader needs no shared types with the
+//    CLI and the reflective surface is a single method.
+//
+// See `docs/design/PSI_PARSE_SPIKE.md` for the measurements this design came from.
+plugins {
+  id("composeai.base-conventions")
+  alias(libs.plugins.kotlin.jvm)
+}
+
+kotlin { jvmToolchain(17) }
+
+dependencies {
+  // compileOnly, and it must stay that way: the frontend reaches the runtime only via the staged
+  // `lib-bta/` jars in the isolated loader. A plain `implementation` here would put a compiler
+  // frontend on the classpath of everything that depends on this module.
+  compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:${libs.versions.kotlin.get()}")
+}

--- a/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/JsonWriter.kt
+++ b/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/JsonWriter.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.usagepsi
+
+/**
+ * A minimal JSON writer, so this module's only runtime need is the Kotlin stdlib.
+ *
+ * The module is loaded into an isolated classloader holding the Kotlin frontend and nothing else;
+ * adding a serialization library would mean staging it beside the frontend and keeping the two
+ * classpaths in step. The schema written here is a handful of fields, and it is consumed by exactly
+ * one reader (`UsageSourceFacts` in `:cli`), so hand-writing it is the smaller commitment.
+ *
+ * Escaping is the part worth getting right, since the values are arbitrary Kotlin source: quotes,
+ * backslashes, newlines and control characters all reach this from a catalog's own code.
+ */
+internal class JsonWriter {
+  private val out = StringBuilder()
+  private var needsComma = false
+
+  fun field(name: String, value: String?) {
+    separator()
+    out.append('"').append(escape(name)).append("\":")
+    if (value == null) out.append("null") else out.append('"').append(escape(value)).append('"')
+  }
+
+  fun number(name: String, value: Int) {
+    separator()
+    out.append('"').append(escape(name)).append("\":").append(value)
+  }
+
+  fun <T> arrayField(name: String, items: Collection<T>, write: JsonWriter.(T) -> Unit) {
+    separator()
+    out.append('"').append(escape(name)).append("\":[")
+    var first = true
+    for (item in items) {
+      if (!first) out.append(',')
+      first = false
+      val nested = JsonWriter()
+      nested.write(item)
+      val body = nested.finishRaw()
+      // A writer whose `write` block emitted a bare value (`raw`) rather than fields is spliced as
+      // that value; otherwise it is an object.
+      if (nested.wroteRaw) out.append(body) else out.append('{').append(body).append('}')
+    }
+    out.append(']')
+  }
+
+  fun raw(value: String) {
+    wroteRaw = true
+    out.append(value)
+  }
+
+  private var wroteRaw = false
+
+  private fun separator() {
+    if (needsComma) out.append(',')
+    needsComma = true
+  }
+
+  private fun finishRaw(): String = out.toString()
+
+  fun finish(): String = "{" + out + "}"
+}
+
+internal fun json(build: JsonWriter.() -> Unit): String = JsonWriter().apply(build).finish()
+
+internal fun escape(value: String): String {
+  val out = StringBuilder(value.length + 16)
+  for (ch in value) {
+    when (ch) {
+      '"' -> out.append("\\\"")
+      '\\' -> out.append("\\\\")
+      '\n' -> out.append("\\n")
+      '\r' -> out.append("\\r")
+      '\t' -> out.append("\\t")
+      '\b' -> out.append("\\b")
+      '' -> out.append("\\f")
+      else -> if (ch < ' ') out.append("\\u%04x".format(ch.code)) else out.append(ch)
+    }
+  }
+  return out.toString()
+}

--- a/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
+++ b/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
@@ -1,0 +1,144 @@
+package ee.schimke.composeai.usagepsi
+
+import org.jetbrains.kotlin.K1Deprecation
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
+import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtValueArgument
+
+/**
+ * Parses Kotlin source and reports the **structure** the usage cleaner needs, as JSON.
+ *
+ * ### Why JSON, and why one method
+ *
+ * This class runs inside an isolated classloader holding a whole Kotlin frontend; the CLI that
+ * calls it holds none of those types. Returning JSON means the two sides share no classes at all,
+ * so the loader can be parented to the platform loader with nothing bridged, and the reflective
+ * surface stays a single `analyze(String): String`. A typed interface would need a shared package
+ * visible to both loaders — more moving parts for a boundary this narrow.
+ *
+ * ### Parse only
+ *
+ * No classpath, no source roots, no resolution: [KotlinCoreEnvironment] with an empty
+ * [CompilerConfiguration] is enough to build a tree, and the tree is all the rewrites need. The
+ * expensive half of a frontend is resolution, which nothing here asks for. Setup costs ~0.5 s once
+ * per process and parsing ~3 ms per file (`docs/design/PSI_PARSE_SPIKE.md`), against a seed path
+ * that already makes a network round trip.
+ *
+ * ### What it deliberately does not do
+ *
+ * It reports facts, never decisions. Whether `ee.schimke.composeai.overrides.previewOverrideString`
+ * is scaffolding to unqualify, and whether `state.metrics.counted` is somebody's receiver chain, is
+ * a question about a catalog's declared rules — the same `KtDotQualifiedExpression` either way.
+ * This hands over the receiver as an exact string so the caller can look it up, which is precisely
+ * what the regex it replaces could not do.
+ */
+@OptIn(CompilerConfiguration.Internals::class, K1Deprecation::class)
+class UsageSourceAnalyzer : AutoCloseable {
+
+  private val disposable: Disposable = Disposer.newDisposable("usage-source-psi")
+
+  private val factory: PsiFileFactory by lazy {
+    val env =
+      KotlinCoreEnvironment.createForProduction(
+        disposable,
+        CompilerConfiguration(),
+        EnvironmentConfigFiles.JVM_CONFIG_FILES,
+      )
+    PsiFileFactory.getInstance(env.project)
+  }
+
+  /**
+   * [source] → a JSON object of `calls` and `destructurings`, or `{"error":"…"}` if it could not be
+   * parsed at all.
+   *
+   * Never throws across the reflective boundary: an exception here would surface in the caller as
+   * an `InvocationTargetException` carrying a frontend-loaded class the caller cannot name. A JSON
+   * error field degrades to "no facts", and the cleaner's caller already knows how to fall back.
+   *
+   * Offsets are 0-based character indices into [source], end-exclusive, so the caller can splice
+   * without re-finding anything.
+   */
+  fun analyze(source: String): String =
+    try {
+      val file =
+        factory.createFileFromText("Usage.kt", KotlinFileType.INSTANCE, source) as? KtFile
+          ?: return json { field("error", "not a Kotlin file") }
+      json {
+        arrayField("calls", PsiTreeUtil.findChildrenOfType(file, KtCallExpression::class.java)) {
+          call(it)
+        }
+        arrayField(
+          "destructurings",
+          PsiTreeUtil.findChildrenOfType(file, KtDestructuringDeclaration::class.java),
+        ) {
+          destructuring(it)
+        }
+      }
+    } catch (e: Throwable) {
+      json { field("error", e::class.java.simpleName + ": " + (e.message ?: "")) }
+    }
+
+  override fun close() = Disposer.dispose(disposable)
+
+  private fun JsonWriter.call(call: KtCallExpression) {
+    field("callee", call.calleeExpression?.text ?: "")
+    number("start", call.textRange.startOffset)
+    number("end", call.textRange.endOffset)
+
+    // The parenthesised argument list, absent entirely for `counted { }` — the shape a regex
+    // requiring `(` missed, and the one most scaffolding wrappers are written in.
+    val argList = call.valueArgumentList
+    number("argsStart", argList?.textRange?.startOffset ?: -1)
+    number("argsEnd", argList?.textRange?.endOffset ?: -1)
+
+    val lambda = call.lambdaArguments.firstOrNull()
+    number("lambdaStart", lambda?.textRange?.startOffset ?: -1)
+    number("lambdaEnd", lambda?.textRange?.endOffset ?: -1)
+    val body = lambda?.getLambdaExpression()?.bodyExpression
+    number("lambdaBodyStart", body?.textRange?.startOffset ?: -1)
+    number("lambdaBodyEnd", body?.textRange?.endOffset ?: -1)
+
+    // The whole `receiver.callee(...)` expression when qualified, so the caller can replace or keep
+    // it as one unit rather than guessing where the receiver began.
+    val qualified = call.parent as? KtDotQualifiedExpression
+    val isSelector = qualified?.selectorExpression === call
+    field("receiver", if (isSelector) qualified.receiverExpression.text else null)
+    number("qualifiedStart", if (isSelector) qualified.textRange.startOffset else -1)
+    number("qualifiedEnd", if (isSelector) qualified.textRange.endOffset else -1)
+
+    // `KtLambdaArgument` *is* a `KtValueArgument`, so a trailing lambda arrives in this list — and
+    // would then take a positional slot during binding, putting `{ … }` where `default` belongs.
+    // It is reported above as its own range instead.
+    arrayField(
+      "args",
+      call.valueArguments.filterIsInstance<KtValueArgument>().filter { it !is KtLambdaArgument },
+    ) { arg ->
+      field("name", arg.getArgumentName()?.asName?.asString())
+      val expr = arg.getArgumentExpression()
+      field("text", expr?.text ?: "")
+      number("start", expr?.textRange?.startOffset ?: -1)
+      number("end", expr?.textRange?.endOffset ?: -1)
+    }
+  }
+
+  private fun JsonWriter.destructuring(node: KtDestructuringDeclaration) {
+    number("start", node.textRange.startOffset)
+    number("end", node.textRange.endOffset)
+    arrayField("names", node.entries.map { it.name ?: "" }) { raw("\"" + escape(it) + "\"") }
+    val init = node.initializer
+    field("initializer", init?.text ?: "")
+    number("initializerStart", init?.textRange?.startOffset ?: -1)
+    number("initializerEnd", init?.textRange?.endOffset ?: -1)
+  }
+}


### PR DESCRIPTION
Implements what #3857 measured.

The cleaner answered every structural question with regex, because the Kotlin frontend is deliberately kept off the CLI's classpath. The snippet corpus made that cost concrete: across five review rounds, nearly every defect it found was the same thing — structure being guessed at. Named-argument binding. A receiver chain read as a package qualifier. A trailing-lambda call missed for want of a `(`. A qualified call no pass could see and no residue reported.

### The shape

- **`:usage-source-psi`** — compiles `compileOnly` against `kotlin-compiler-embeddable`, so the frontend is never a runtime dependency of anything in the main build. One method, `analyze(String): String`, returning JSON: calls (callee, offsets, arguments with labels, trailing-lambda ranges, receiver) and destructuring declarations.
- It reports **facts, never decisions**. `ee.schimke.composeai.overrides` and `state.metrics` are the same tree shape, so it hands over each receiver verbatim and the rules' allow-list classifies. That's precisely the call the regex couldn't make.
- Staged as **`lib-usage-psi/`**, loaded with the already-staged `lib-bta/` jars in a `URLClassLoader` parented to the platform loader — the same isolation `PlaygroundBtaCompiler` uses. Nothing crosses but a String and JSON, so the two sides share no classes.
- **`UsageSourceParser`** builds it once per process (~0.5 s setup, ~3 ms per parse); the cleaner uses it for the substitution pass and the residue scan. A host with no staged sidecar keeps the text passes unchanged — the parse is an upgrade where available, not a new hard requirement.

`:cli:test` forwards the staged jars (`composeai.usagePsi.jars`) so the parsed path is what the tests actually run. Without that the cleaner falls back silently and every test still passes having covered none of it — the failure mode this corpus keeps finding, and one it would be embarrassing to build in deliberately.

### Result

**Corpus ratios unchanged: m3-catalog 3/10, meshcore-mobile 0/10, same seven failures.**

That's the bar the spike set — parity per snippet before anything else — and it is the honest outcome: none of the seven remaining failures is one of the shapes a parse fixes. What the parse fixes is the *machinery* that produced wrong output on snippets the corpus happened not to sample. Moving the ratio needs the rule vocabulary the facts now make possible:

- a `DESTRUCTURE` kind — the entries and initialiser are in the facts, so `toggleable`/`editable` become writable (2 failures);
- a conditional-aware string inliner, which can now see the `if` rather than declining on a regex (2 failures);
- `CatalogFilledStars` (4) still needs a substitution rule; no parse invents an icon.

### One bug found while wiring it

`KtLambdaArgument` **is** a `KtValueArgument`, so a trailing lambda arrives in the value-argument list and takes a positional slot — putting `{ … }` where `default` belongs. Silent, and wrong. Filtered out, and pinned by a test.

### Test plan

- `./gradlew :cli:test` — green, including the new `UsageSourceParserTest`, whose first assertion is that the analyzer actually loaded.
- `./gradlew ktfmtCheckAll` — green.
- `./gradlew :cli:checkCliDaemonLibraryBoundary` — green; the new module is a sidecar configuration, never on the CLI's runtime classpath.
- `scripts/usage-corpus.sh /home/user/m3-catalog <meshcore checkout>` — ran end to end on the parsed path; ratios and failure list identical to baseline.

Non-visual: a parser module, a serve-side rewrite pass, build wiring, tests and docs. Nothing rendered changes.

Docs: `docs/design/PSI_PARSE_SPIKE.md` (new "What shipped" section).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_