### PR TITLE
fix(vscode): refresh discovery after preview additions

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3053,7 +3053,14 @@ async function applyDiscoveryDiff(
         gradleService.resolveModule(editorScope.file)?.modulePath === moduleId
             ? editorScope.file
             : undefined;
-    const fresh = await reconcilePreviewManifest(module, repaintFile);
+    // `added` came from the daemon's scan of freshly-compiled bytecode. Force Gradle discovery in
+    // that case: an overlapping render can have scanned Kotlin's output directory while it was
+    // temporarily empty and left an asset-only manifest that Gradle otherwise calls up-to-date.
+    const fresh = await reconcilePreviewManifest(
+        module,
+        repaintFile,
+        added.length > 0,
+    );
 
     // reconcilePreviewManifest only reshapes the panel (setPreviews) — it does
     // not render. A newly-added @Preview would otherwise show as a card with no
@@ -3710,6 +3717,7 @@ function previewsForFile(
 async function reconcilePreviewManifest(
     module: ModuleInfo,
     repaintFilePath?: string,
+    forceFresh = false,
 ): Promise<PreviewInfo[] | null> {
     if (!gradleService) {
         return null;
@@ -3718,7 +3726,11 @@ async function reconcilePreviewManifest(
     moduleManifestCache.delete(module.modulePath);
     let manifest;
     try {
-        manifest = await gradleService.composePreviewDiscover(module);
+        manifest = await gradleService.composePreviewDiscover(
+            module,
+            undefined,
+            forceFresh,
+        );
     } catch (err) {
         logLine(
             `[daemon] silent discover failed for ${module.modulePath}: ${(err as Error).message} — manifest cache left cleared`,

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -498,6 +498,7 @@ export class GradleService {
     async composePreviewDiscover(
         module: ModuleInfo,
         opts?: TaskOptions,
+        forceFresh = false,
     ): Promise<PreviewManifest | null> {
         if (!isModulePreviewSchedulable(module)) {
             this.logDisabledSkip(module, "composePreviewDiscover");
@@ -506,7 +507,14 @@ export class GradleService {
         const key = module.modulePath;
         const inFlight = this.inFlightDiscover.get(key);
         if (inFlight) {
-            return inFlight;
+            if (!forceFresh) {
+                return inFlight;
+            }
+            try {
+                await inFlight;
+            } catch {
+                /* force-fresh recovery below gets its own attempt */
+            }
         }
         // The cold-start bundle may include `:<module>:composePreviewDiscover` and
         // write the manifest into [manifestCache] on completion. Awaiting an
@@ -520,7 +528,10 @@ export class GradleService {
         // the serialised Gradle queue) and then start a fresh discover.
         const inFlightBundle = this.inFlightColdStart.get(key);
         if (inFlightBundle) {
-            if (this.inFlightColdStartIncludesDiscover.get(key)) {
+            if (
+                !forceFresh &&
+                this.inFlightColdStartIncludesDiscover.get(key)
+            ) {
                 return inFlightBundle;
             }
             try {
@@ -530,11 +541,24 @@ export class GradleService {
             }
         }
         const cached = this.manifestCache.get(key);
-        if (cached && Date.now() - cached.timestamp < MANIFEST_CACHE_TTL_MS) {
+        if (
+            !forceFresh &&
+            cached &&
+            Date.now() - cached.timestamp < MANIFEST_CACHE_TTL_MS
+        ) {
             return cached.manifest;
         }
         const promise = (async (): Promise<PreviewManifest | null> => {
-            await this.runTask(`${key}:composePreviewDiscover`, [], opts);
+            // A daemon `discoveryUpdated.added` is authoritative evidence that compiled bytecode
+            // contains a preview missing from the on-disk manifest. This can happen when a
+            // concurrent render's discovery snapshots Kotlin's output directory during the brief
+            // clean-before-write window and leaves an asset-only `previews.json` behind. Gradle
+            // may subsequently consider that poisoned discovery up-to-date, so the recovery path
+            // must defeat both task history and the build cache (issue #3850).
+            const args = forceFresh
+                ? ["--rerun-tasks", "--no-build-cache"]
+                : [];
+            await this.runTask(`${key}:composePreviewDiscover`, args, opts);
             const manifest = this.readManifest(module);
             if (manifest) {
                 this.manifestCache.set(key, {

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -902,6 +902,43 @@ describe("GradleService", () => {
         );
 
         it(
+            "forces task execution without build cache when daemon discovery found an addition",
+            withTempDir(async (dir, api) => {
+                fs.mkdirSync(path.join(dir, "mod"));
+                const manifestDir = path.join(
+                    dir,
+                    "mod",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.copyFileSync(
+                    path.join(
+                        __dirname,
+                        "..",
+                        "..",
+                        "src",
+                        "test",
+                        "fixtures",
+                        "previews.json",
+                    ),
+                    path.join(manifestDir, "previews.json"),
+                );
+
+                const service = new GradleService(dir, api);
+                const module = { projectDir: "mod", modulePath: ":mod" };
+                await service.composePreviewDiscover(module);
+                await service.composePreviewDiscover(module, undefined, true);
+
+                assert.strictEqual(api.runCalls.length, 2);
+                assert.deepStrictEqual(api.runCalls[1].args, [
+                    "--rerun-tasks",
+                    "--no-build-cache",
+                ]);
+            }),
+        );
+
+        it(
             "translates nested module path to colon-separated Gradle task name",
             withTempDir(async (dir, api) => {
                 fs.mkdirSync(path.join(dir, "samples", "wear"), {


### PR DESCRIPTION
## Summary

- force a fresh Gradle discovery when the daemon announces newly-added previews
- bypass stale task history and the build cache for that recovery discovery
- wait for any in-flight discovery/bootstrap before starting the forced pass
- add regression coverage for the forced discovery arguments and cache bypass

## Root cause

A render and the save-driven Kotlin compile can overlap. Discovery may snapshot the Kotlin class output directory during its clean-before-write window and write an asset-only `previews.json`. The daemon subsequently scans the freshly compiled bytecode and correctly emits `discoveryUpdated.added`, but the extension's reconciliation could accept the poisoned manifest that Gradle considered up to date. The new preview was therefore never included in `setPreviews`.

When an addition is authoritative from the daemon, reconciliation now runs `composePreviewDiscover --rerun-tasks --no-build-cache` before repainting the panel.

## Validation

- `npm run compile`
- focused GradleService suite: 65 passing
- full extension suite: 1,690 passing; two unrelated real-timer tests flaked in the combined run and both passed when rerun together
- repository Prettier commit hook
- `git diff --check`

Closes #3850