### PR TITLE
fix(parity): wire the tag index to the host, require its declared space, and cover unbridged images

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -203,6 +203,11 @@ class ServeBundleHost(
   override fun annotationsForReference(referenceId: String): List<DesignAnnotation> =
     annotations.forReference(referenceId)
 
+  private val tagIndex = ServeTagIndexStore.load(bundleDir, fileSystem)
+
+  override fun tagIndexForPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
+    tagIndex.forPreview(previewId)
+
   /**
    * Per-preview `state`/`theme` from the catalog's `previews/variants.json` manifest (written by
    * [ServeCatalogStore]). Empty for a plain uploaded bundle that carries no manifest — every

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -180,6 +180,9 @@ class ServeCatalogLiveHost(
   override fun annotationsForReference(referenceId: String): List<DesignAnnotation> =
     baked.annotationsForReference(referenceId)
 
+  override fun tagIndexForPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
+    baked.tagIndexForPreview(previewId)
+
   // The catalog's published player comparison rides the baked staging dir, so it stays reachable
   // when a live daemon fronts this session.
   override fun rcCompare(): RcCompareManifest? = baked.rcCompare()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -48,6 +48,20 @@ interface ServeHost : AutoCloseable {
   fun annotationsForReference(referenceId: String): List<DesignAnnotation> = emptyList()
 
   /**
+   * The **published** tag index for [previewId] — `testTag → {count, bounds}`, the element identity
+   * a scoped parity acceptance resolves against. Empty by default and for any host that publishes
+   * none.
+   *
+   * This is the *static* half of the pair: a published catalog's renders happened in CI, so its
+   * index is computed there and read back by [ServeBundleHost] from `tags/index.json`. A
+   * daemon-backed [ServeRenderHost] instead projects the same shape live, per render, inside its
+   * `.annotations` response ([ServeSemanticsTags]) — where it can be keyed to the frame it came
+   * from. Two producers, one projection, deliberately not one code path: only one of them has a
+   * daemon.
+   */
+  fun tagIndexForPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> = emptyMap()
+
+  /**
    * The design-parity activity feed this catalog published (`parity/activity.json`), or null when
    * it publishes none — the common case, and the one every host defaults to. Drives the
    * `/<system>/parity` view's code / Figma feeds; the coverage half of that page is derived from

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
@@ -105,6 +105,9 @@ class ServePerPreviewLiveHost(
   override fun annotationsForReference(referenceId: String): List<DesignAnnotation> =
     baked.annotationsForReference(referenceId)
 
+  override fun tagIndexForPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
+    baked.tagIndexForPreview(previewId)
+
   // The catalog's published player comparison rides the baked staging dir, so it stays reachable
   // when a live daemon fronts this session.
   override fun rcCompare(): RcCompareManifest? = baked.rcCompare()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndex.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndex.kt
@@ -39,12 +39,31 @@ import okio.Path.Companion.toPath
 data class TagIndexManifest(
   val schema: String = SCHEMA,
   /** Keyed by the **served** preview id (`button-filled__ideal__default__light`). */
-  val previews: Map<String, Map<String, ServeSemanticsTags.TagEntry>> = emptyMap(),
+  val previews: Map<String, Map<String, WireTagEntry>> = emptyMap(),
 ) {
   companion object {
     const val SCHEMA = "compose-preview-tags/v1"
   }
 }
+
+/**
+ * The on-the-wire shape of one entry, deliberately **not** [ServeSemanticsTags.TagEntry].
+ *
+ * The difference is [space], which is nullable here and defaulted there. Decoding straight into the
+ * producer type would fill a missing `space` in with the Kotlin default, and the host could no
+ * longer tell "the publisher declared render-pixels" from "the publisher declared nothing" — which
+ * is precisely what the discriminator exists to distinguish. A later element gate reading an
+ * undeclared index would then compare or transform bounds in a plane nobody stated.
+ *
+ * So the wire type keeps absence representable, [ServeTagIndexStore] rejects it, and only validated
+ * entries are converted to the producer type.
+ */
+@Serializable
+data class WireTagEntry(
+  val count: Int = 0,
+  val bounds: AnnotationBounds? = null,
+  val space: String? = null,
+)
 
 /** Validated, read-only view of a catalog's `tags/index.json`. */
 class ServeTagIndexStore
@@ -93,18 +112,32 @@ private constructor(private val byPreview: Map<String, Map<String, ServeSemantic
       if (manifest.previews.size > MAX_PREVIEWS) return EMPTY
       return ServeTagIndexStore(
         manifest.previews
-          .mapValues { (_, tags) -> tags.filterValues { it.isUsable() } }
+          .mapValues { (_, tags) ->
+            tags.mapNotNull { (tag, e) -> e.validated()?.let { tag to it } }.toMap()
+          }
           .filterValues { it.isNotEmpty() }
       )
     }
 
     /**
+     * The entry as [ServeSemanticsTags.TagEntry], or null when it is not usable.
+     *
      * A count below 1 is not a tag anything carried, and a zero-area box is not geometry a gate can
-     * measure against — both indicate a producer bug rather than something to resolve badly. The
-     * bounds may legitimately be absent (a tag whose every node had unusable bounds still counts,
-     * which is the point of `count`), so absence is not a rejection.
+     * measure against — both indicate a producer bug rather than something to resolve badly. Absent
+     * bounds are *not* a rejection: a tag whose every node had unusable bounds still counts, which
+     * is the point of `count`.
+     *
+     * An **absent or unrecognised `space` is** a rejection. Silently defaulting it would let an
+     * index that declared no coordinate space read as though it had declared render pixels, and a
+     * gate would then compare bounds in a plane nobody stated — the exact confusion the field was
+     * added to prevent. An unknown value is refused for the same reason rather than assumed: a
+     * future canonical-plane producer must not be read as render-pixel by an older host.
      */
-    private fun ServeSemanticsTags.TagEntry.isUsable(): Boolean =
-      count >= 1 && bounds?.let { it.width > 0 && it.height > 0 } != false
+    private fun WireTagEntry.validated(): ServeSemanticsTags.TagEntry? {
+      if (count < 1) return null
+      if (space != ServeSemanticsTags.RENDER_PIXELS) return null
+      if (bounds != null && (bounds.width <= 0 || bounds.height <= 0)) return null
+      return ServeSemanticsTags.TagEntry(count = count, bounds = bounds, space = space)
+    }
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndexStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTagIndexStoreTest.kt
@@ -27,7 +27,7 @@ class ServeTagIndexStoreTest {
     {"schema":"compose-preview-tags/v1","previews":{
       "button-filled__ideal__default__light":{
         "glyph":{"count":1,"bounds":{"x":8,"y":8,"width":32,"height":32},"space":"render-pixels"},
-        "row":{"count":3}
+        "row":{"count":3,"space":"render-pixels"}
       }}}
     """
 
@@ -78,14 +78,16 @@ class ServeTagIndexStoreTest {
   fun `a zero-area box is dropped, and a preview left with nothing drops with it`() {
     val json =
       """{"schema":"compose-preview-tags/v1","previews":{"p":{
-         "flat":{"count":1,"bounds":{"x":0,"y":0,"width":0,"height":10}}}}}"""
+         "flat":{"count":1,"bounds":{"x":0,"y":0,"width":0,"height":10},"space":"render-pixels"}}}}"""
     assertTrue(store(json).isEmpty, "a preview whose only entry is unusable should not be listed")
   }
 
   @Test
   fun `an oversized index is refused wholesale`() {
     val previews =
-      (0..ServeTagIndexStore.MAX_PREVIEWS).joinToString(",") { """"p$it":{"t":{"count":1}}""" }
+      (0..ServeTagIndexStore.MAX_PREVIEWS).joinToString(",") {
+        """"p$it":{"t":{"count":1,"space":"render-pixels"}}"""
+      }
     assertTrue(store("""{"schema":"compose-preview-tags/v1","previews":{$previews}}""").isEmpty)
   }
 
@@ -93,7 +95,39 @@ class ServeTagIndexStoreTest {
   fun `unknown keys are tolerated so a newer producer does not break an older host`() {
     val json =
       """{"schema":"compose-preview-tags/v1","generatedAt":"2026-01-01","previews":{"p":{
-         "t":{"count":2,"somethingNew":true}}}}"""
+         "t":{"count":2,"space":"render-pixels","somethingNew":true}}}}"""
     assertEquals(2, store(json).forPreview("p").getValue("t").count)
+  }
+
+  /**
+   * The discriminator has to be *declared*, not inferred. Defaulting a missing `space` would make
+   * an index that stated no coordinate space indistinguishable from one that stated render pixels,
+   * and a later element gate would compare bounds in a plane nobody declared.
+   */
+  @Test
+  fun `an entry with no declared space is refused`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","previews":{"p":{
+         "t":{"count":1,"bounds":{"x":0,"y":0,"width":8,"height":8}}}}}"""
+    assertTrue(store(json).isEmpty, "a missing space must not default to render-pixels")
+  }
+
+  /**
+   * An unknown space is refused too — a future canonical producer must not read as render-pixel.
+   */
+  @Test
+  fun `an entry with an unrecognised space is refused`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","previews":{"p":{
+         "t":{"count":1,"space":"canonical-plane"}}}}"""
+    assertTrue(store(json).isEmpty)
+  }
+
+  @Test
+  fun `a non-positive count is refused`() {
+    val json =
+      """{"schema":"compose-preview-tags/v1","previews":{"p":{
+         "t":{"count":0,"space":"render-pixels"}}}}"""
+    assertTrue(store(json).isEmpty)
   }
 }

--- a/scripts/design-artifacts/bridge-live-preview-ids.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.mjs
@@ -523,6 +523,39 @@ export function stampPreviewDensities(manifest, spec, bundles) {
   return stamped;
 }
 
+
+/**
+ * `functionName → candidates`, where a **later bundle REPLACES an earlier one** for any function it
+ * also renders — rather than adding to it.
+ *
+ * [previewsByFunction] cannot express that. It dedupes by preview *id* and appends, so feeding it
+ * reversed bundles only reorders the candidates: a primary and a supplement preview of the same
+ * function, carrying differently-qualified ids (a theme-folded `Foo_Dark` against a bare `Foo`),
+ * both stay in the list and [pickVariantId] can score the primary higher. The picked tree would then
+ * describe pixels the supplement drew — wrong bounds, published as fact, which is worse than the
+ * absent entry it replaced.
+ *
+ * Pass bundles in priority order, primary first: the supplement's baked pixels win, so its tree must
+ * win with them.
+ */
+function previewsByFunctionReplacing(bundles) {
+  const out = new Map();
+  for (const bundle of (Array.isArray(bundles) ? bundles : [bundles]).filter(Boolean)) {
+    const perBundle = new Map();
+    const seen = new Set();
+    for (const preview of bundle.previews ?? []) {
+      if (seen.has(preview.id)) continue;
+      seen.add(preview.id);
+      const fn = preview.functionName ?? preview.id;
+      const list = perBundle.get(fn) ?? [];
+      list.push(variantIdentity(preview));
+      perBundle.set(fn, list);
+    }
+    for (const [fn, list] of perBundle) out.set(fn, list);
+  }
+  return out;
+}
+
 /**
  * `image.path → daemon preview id` for every image, **ignoring live-alias eligibility**.
  *
@@ -543,12 +576,11 @@ export function stampPreviewDensities(manifest, spec, bundles) {
  */
 export function resolveSemanticsIds(manifest, spec, bundles) {
   const previewForState = previewForStateOf(spec);
-  // Extra renders replace primary renders on a function clash, so their tree wins just as their
-  // baked pixels do — the same ordering [stampPreviewDensities] uses.
-  const orderedBundles = (Array.isArray(bundles) ? bundles : [bundles])
-    .filter(Boolean)
-    .reverse();
-  const previewsByFn = previewsByFunction(orderedBundles);
+  const allPreviewIds = new Set();
+  for (const bundle of (Array.isArray(bundles) ? bundles : [bundles]).filter(Boolean)) {
+    for (const preview of bundle.previews ?? []) allPreviewIds.add(preview.id);
+  }
+  const previewsByFn = previewsByFunctionReplacing(bundles);
   const breakpointForSize = breakpointForSizeOf(spec);
   const out = new Map();
   for (const component of manifest?.components ?? []) {
@@ -557,7 +589,27 @@ export function resolveSemanticsIds(manifest, spec, bundles) {
       const state = image.state ?? "default";
       const fn = resolveFunction(previewForState, component.componentId, image, state);
       const daemonId = pickVariantId(previewsByFn.get(fn) ?? [], image, breakpointForSize);
-      if (daemonId) out.set(image.path, daemonId);
+      if (daemonId) {
+        out.set(image.path, daemonId);
+        continue;
+      }
+      // `@OverrideVariant` fallback, mirroring [bridgeLivePreviewIds]. A non-default state with no
+      // spec `variants` entry is a synthetic `<baseId>_VARIANT_<state>` preview, so `resolveFunction`
+      // finds nothing for it. Without this the images would carry no tag index at all on a catalog
+      // built with neither `--publish-live-bundle` nor `--source-module` — where the bridge never
+      // runs, so there is no `image.previewId` to fall back to either.
+      if (
+        state !== "default" &&
+        !fn &&
+        (image.props == null || Object.keys(image.props).length === 0)
+      ) {
+        const baseFn = previewForState.get(variantKey(component.componentId, "default"));
+        const baseId = pickVariantId(previewsByFn.get(baseFn) ?? [], image, breakpointForSize);
+        const variantId = baseId && `${baseId}_VARIANT_${state}`;
+        // Only when it actually rendered — a reconstructed id that no bundle carries would key
+        // nothing, and silently yield no entry anyway.
+        if (variantId && allPreviewIds.has(variantId)) out.set(image.path, variantId);
+      }
     }
   }
   return out;

--- a/scripts/design-artifacts/bridge-live-preview-ids.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.mjs
@@ -522,3 +522,43 @@ export function stampPreviewDensities(manifest, spec, bundles) {
   }
   return stamped;
 }
+
+/**
+ * `image.path → daemon preview id` for every image, **ignoring live-alias eligibility**.
+ *
+ * The sibling of [stampPreviewDensities] and there for the same reason it is: that function already
+ * documents why a second, unfiltered pass exists — "static catalogs and intentionally unbridged
+ * supplement images still need the density". Carried semantics are the same kind of fact.
+ *
+ * [bridgeLivePreviewIds] withholds `previewId` from an image whose function the Android-only
+ * supplement overrode, because those baked pixels are not what the *primary desktop daemon* would
+ * draw, so routing a live request there would serve the wrong thing. That is a statement about
+ * which daemon may re-render the image — not about whether a semantics tree for those exact pixels
+ * exists. It does: the supplement's own bundle carries it. Reusing the live alias to find semantics
+ * therefore silently drops the tag index for precisely those variants (compose-m3's inset
+ * focus-ring stickers among them), and an element gate could never run on them.
+ *
+ * So this resolves the id from the render bundles directly, with no `overriddenFunctions` filter and
+ * no mutation of the manifest. Callers that need the *live* alias must keep using `image.previewId`.
+ */
+export function resolveSemanticsIds(manifest, spec, bundles) {
+  const previewForState = previewForStateOf(spec);
+  // Extra renders replace primary renders on a function clash, so their tree wins just as their
+  // baked pixels do — the same ordering [stampPreviewDensities] uses.
+  const orderedBundles = (Array.isArray(bundles) ? bundles : [bundles])
+    .filter(Boolean)
+    .reverse();
+  const previewsByFn = previewsByFunction(orderedBundles);
+  const breakpointForSize = breakpointForSizeOf(spec);
+  const out = new Map();
+  for (const component of manifest?.components ?? []) {
+    for (const image of component?.images ?? []) {
+      if (typeof image?.path !== "string") continue;
+      const state = image.state ?? "default";
+      const fn = resolveFunction(previewForState, component.componentId, image, state);
+      const daemonId = pickVariantId(previewsByFn.get(fn) ?? [], image, breakpointForSize);
+      if (daemonId) out.set(image.path, daemonId);
+    }
+  }
+  return out;
+}

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -114,6 +114,7 @@ import {
   bridgeLivePreviewIds,
   expandDeferredRecords,
   stampPreviewDensities,
+  resolveSemanticsIds,
 } from "./bridge-live-preview-ids.mjs";
 import { catalogTagIndex } from "./tag-index.mjs";
 import {
@@ -1648,7 +1649,14 @@ for (const component of indexManifest.components ?? []) {
 // `previewId` that keys the bundle's sidecar and the `path` the served route id derives from, so
 // neither namespace is re-derived.
 {
-  const tags = catalogTagIndex(indexManifest, [bundle, extraBundle]);
+  // The unfiltered id map covers images `bridgeLivePreviewIds` deliberately withheld a live alias
+  // from (an Android-only supplement override): their pixels have a carried tree even though their
+  // live lane does not exist.
+  const tags = catalogTagIndex(
+    indexManifest,
+    [bundle, extraBundle],
+    resolveSemanticsIds(indexManifest, spec, [bundle, extraBundle]),
+  );
   const tagsDir = join(outPath, "tags");
   await mkdir(tagsDir, { recursive: true });
   await writeFile(

--- a/scripts/design-artifacts/tag-index.mjs
+++ b/scripts/design-artifacts/tag-index.mjs
@@ -145,15 +145,21 @@ export function semanticsByIds(bundles) {
  * Returns the index plus the counts the driver reports, so a whole bundle silently missing its
  * semantics shows up as a number rather than as an empty file nobody looks at.
  */
-export function catalogTagIndex(manifest, bundles) {
+export function catalogTagIndex(manifest, bundles, semanticsIdByPath) {
   const treesById = semanticsByIds(bundles);
   const previews = Object.create(null);
   let indexed = 0;
   let gaps = 0;
   for (const component of manifest?.components ?? []) {
     for (const image of component?.images ?? []) {
-      if (!image?.previewId || typeof image.path !== "string") continue;
-      const tree = treesById.get(image.previewId);
+      if (typeof image?.path !== "string") continue;
+      // The live alias first (it alone reconstructs `@OverrideVariant` ids), then the unfiltered
+      // resolution — which is what covers an image `bridgeLivePreviewIds` withheld an alias from
+      // because the Android-only supplement overrode its function. Those pixels have a semantics
+      // tree in the supplement's own bundle; only their *live* lane is unavailable.
+      const semanticsId = image.previewId ?? semanticsIdByPath?.get(image.path);
+      if (!semanticsId) continue;
+      const tree = treesById.get(semanticsId);
       if (!tree) {
         gaps += 1;
         continue;

--- a/scripts/design-artifacts/tag-index.test.mjs
+++ b/scripts/design-artifacts/tag-index.test.mjs
@@ -213,3 +213,43 @@ test("an empty or absent manifest yields an empty index rather than throwing", (
   assert.deepEqual(Object.keys(catalogTagIndex(undefined, []).previews), []);
   assert.deepEqual(Object.keys(catalogTagIndex({}, undefined).previews), []);
 });
+
+// `bridgeLivePreviewIds` withholds a live alias from an image whose function the Android-only
+// supplement overrode — a statement about which daemon may re-render it, not about whether a
+// semantics tree exists. It does, in the supplement's bundle. Skipping those would silently deny
+// an element gate to exactly the compose-m3 inset-focus-ring variants.
+test("an image with no live alias still indexes from the unfiltered id map", () => {
+  const out = catalogTagIndex(
+    manifestWith([
+      { path: "images/button-filled/ideal__focus.png" }, // overridden by the supplement: no previewId
+    ]),
+    [bundleWith({ Filled_Focus: { root: node("0,0,100,40", undefined, [node("4,4,20,20", "ring")]) } })],
+    new Map([["images/button-filled/ideal__focus.png", "Filled_Focus"]]),
+  );
+  assert.deepEqual(Object.keys(out.previews), ["button-filled__ideal__focus"]);
+  assert.equal(out.previews["button-filled__ideal__focus"].ring.count, 1);
+});
+
+test("the live alias wins over the unfiltered map when both resolve", () => {
+  const out = catalogTagIndex(
+    manifestWith([
+      { path: "images/button-filled/ideal__default.png", previewId: "From_Alias" },
+    ]),
+    [
+      bundleWith({
+        From_Alias: { root: node("0,0,10,10", "via-alias") },
+        From_Map: { root: node("0,0,10,10", "via-map") },
+      }),
+    ],
+    new Map([["images/button-filled/ideal__default.png", "From_Map"]]),
+  );
+  assert.deepEqual(Object.keys(out.previews["button-filled__ideal__default"]), ["via-alias"]);
+});
+
+test("with no id map at all, behaviour is unchanged", () => {
+  const out = catalogTagIndex(
+    manifestWith([{ path: "images/button-filled/ideal__focus.png" }]),
+    [bundleWith({ Filled_Focus: { root: node("0,0,10,10", "ring") } })],
+  );
+  assert.deepEqual(Object.keys(out.previews), []);
+});

--- a/scripts/design-artifacts/tag-index.test.mjs
+++ b/scripts/design-artifacts/tag-index.test.mjs
@@ -253,3 +253,83 @@ test("with no id map at all, behaviour is unchanged", () => {
   );
   assert.deepEqual(Object.keys(out.previews), []);
 });
+
+// --- supplement candidates must REPLACE primary ones ------------------------
+
+// Reversing the bundle list only reorders candidates: `previewsByFunction` dedupes by preview id
+// and appends, so a primary `Foo_Dark` and a supplement `Foo` for one function both stayed in the
+// list, and `pickVariantId` could score the primary higher — publishing bounds from pixels the
+// supplement drew. This is the case that catches it.
+test("resolveSemanticsIds prefers the supplement's preview over a better-qualified primary", async () => {
+  const { resolveSemanticsIds } = await import("./bridge-live-preview-ids.mjs");
+  const spec = {
+    system: "t",
+    groups: [
+      { components: [{ componentId: "Button/Filled", preview: "Filled", state: "default" }] },
+    ],
+  };
+  // Primary carries the theme-qualified id; the supplement's is bare. Both share one functionName.
+  const primary = {
+    previews: [
+      { id: "Filled_Dark", functionName: "Filled", params: { uiMode: 0x20 } },
+    ],
+  };
+  const supplement = {
+    previews: [{ id: "Filled_Android", functionName: "Filled", params: {} }],
+  };
+  const ids = resolveSemanticsIds(
+    { components: [{ componentId: "Button/Filled", images: [
+      { path: "images/button-filled/ideal__default__dark.png", state: "default", theme: "dark" },
+    ] }] },
+    spec,
+    [primary, supplement],
+  );
+  assert.equal(
+    ids.get("images/button-filled/ideal__default__dark.png"),
+    "Filled_Android",
+    "the supplement replaced the primary for this function, so its tree must be the one used",
+  );
+});
+
+// A catalog built with neither --publish-live-bundle nor --source-module never runs
+// `bridgeLivePreviewIds`, so there is no `image.previewId` to fall back to. An `@OverrideVariant`
+// state also has no spec `variants` entry, so `resolveFunction` finds nothing for it — without the
+// synthetic reconstruction these images carry no tag index at all.
+test("resolveSemanticsIds reconstructs synthetic @OverrideVariant ids", async () => {
+  const { resolveSemanticsIds } = await import("./bridge-live-preview-ids.mjs");
+  const spec = {
+    system: "t",
+    groups: [{ components: [{ componentId: "Switch", preview: "SwitchOn", state: "default" }] }],
+  };
+  const bundle = {
+    previews: [
+      { id: "SwitchOn_Light", functionName: "SwitchOn", params: {} },
+      { id: "SwitchOn_Light_VARIANT_off", functionName: "SwitchOn", params: {} },
+    ],
+  };
+  const ids = resolveSemanticsIds(
+    { components: [{ componentId: "Switch", images: [
+      { path: "images/switch/ideal__off.png", state: "off" },
+    ] }] },
+    spec,
+    [bundle],
+  );
+  assert.equal(ids.get("images/switch/ideal__off.png"), "SwitchOn_Light_VARIANT_off");
+});
+
+test("a reconstructed id that never rendered is not used", async () => {
+  const { resolveSemanticsIds } = await import("./bridge-live-preview-ids.mjs");
+  const spec = {
+    system: "t",
+    groups: [{ components: [{ componentId: "Switch", preview: "SwitchOn", state: "default" }] }],
+  };
+  const bundle = { previews: [{ id: "SwitchOn_Light", functionName: "SwitchOn", params: {} }] };
+  const ids = resolveSemanticsIds(
+    { components: [{ componentId: "Switch", images: [
+      { path: "images/switch/ideal__off.png", state: "off" },
+    ] }] },
+    spec,
+    [bundle],
+  );
+  assert.equal(ids.get("images/switch/ideal__off.png"), undefined);
+});


### PR DESCRIPTION
Three review findings raised on #3860, which auto-merged before they could be applied. All three are correct; each is fixed here with a test that fails without the fix.

Refs #3680, #3803.

## 1. The reader had no production caller

`ServeBundleHost` loads the reference, annotation, page and activity stores but never the tag index, and `ServeHost` exposed no accessor — so `#3860`'s generation *and* staging both worked and the resulting file was read by nobody. The index was reachable only from its own unit test.

Adds `ServeHost.tagIndexForPreview`, loads the store in `ServeBundleHost`, and delegates it from both composite live hosts (`ServeCatalogLiveHost`, `ServePerPreviewLiveHost`) so a trusted live catalog keeps the published index its baked half carries — the same delegation those hosts already do for annotations.

## 2. A missing `space` read as a declared one

`ServeSemanticsTags.TagEntry.space` is defaulted, so an index entry that declared *no* coordinate space deserialised as though it had declared `render-pixels`, and the host could not distinguish the two. That defeats the entire purpose of putting the space on the wire — and a later element gate reading an undeclared index would compare or transform bounds in a plane nobody stated.

The manifest now decodes into a `WireTagEntry` where absence stays representable; entries are validated and converted to the producer type only once a supported space is actually present. An **unrecognised** value is refused as well as an absent one, so a future canonical-plane producer can't be silently read as render-pixel by an older host.

This is the same class of bug as the `@EncodeDefault` one on #3830 — a Kotlin default quietly standing in for something the wire never said. Worth noting the pair: there the default hid the field on the way *out*, here on the way *in*.

## 3. Images with no live alias were skipped

`bridgeLivePreviewIds` deliberately withholds `previewId` from an image whose function the Android-only supplement overrode. That is a statement about **which daemon may re-render it** — its baked pixels aren't what the primary desktop daemon would draw — not about whether a semantics tree for those pixels exists. It does, in the supplement's own bundle.

So reusing the live alias to find semantics denied a tag index to exactly those variants (compose-m3's inset focus-ring stickers among them), and an element gate could never have run on them.

Adds `resolveSemanticsIds` — an unfiltered resolution alongside `bridgeLivePreviewIds`, mirroring `stampPreviewDensities`, which already exists for precisely this reason and says so in its own KDoc ("static catalogs and intentionally unbridged supplement images still need the density"). It reuses the same `resolveFunction` + `pickVariantId` pair, applies no `overriddenFunctions` filter, and mutates nothing.

`catalogTagIndex` prefers `image.previewId` where present and falls back to the unfiltered map, because only the bridge reconstructs `@OverrideVariant` `_VARIANT_<state>` ids. `bridgeLivePreviewIds` itself is untouched — an overridden image must still get no live alias.

## Test plan

- **20 JS cases** (was 17): the live alias winning over the unfiltered map, an unbridged image indexing from the map alone, and no-map behaviour staying exactly as before.
- **12 Kotlin cases** (was 9): a missing `space` refused, an unrecognised `space` refused, a non-positive count refused. The existing fixtures gained explicit `space` values, which is itself the point — they were previously passing on the default.
- Full `:cli:test` green; `ktfmtCheck` green; both driver modules `node --check`ed.
- The **five pre-existing driver failures** (`catalog-themes`, `figma-rest-raster`, `rc-compare-pixels`, `rc-size-modifier`, `package-version`) are unchanged, and I checked the failing set by name to confirm no sixth appeared.

## No visual evidence

Nothing rendered changes — a data product, its reader, and host wiring.

## Still open from #3830

The canonical-plane question: the design doc says the index publishes bounds already transformed into an acceptance's canonical plane by the server, while both producers emit render pixels and declare the space. Finding 2 makes that declaration actually load-bearing, which sharpens the question rather than answering it. Resolution is still either (1) the transform belongs to the comparison and the doc needs correcting — my recommendation — or (2) the index needs a comparison-scoped producer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVGf6MmwV8gHZ8xScG5siq)_