### PR TITLE
fix(serve): keep receivers the substitution rules do not own

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
@@ -175,6 +175,7 @@ private fun bundleSidecarSysprop(sidecarName: String): String =
     "lib-renderer" -> "composeai.cli.libRendererDir"
     "lib-rcjvm" -> "composeai.cli.libRcjvmDir"
     "lib-bta" -> "composeai.cli.libBtaDir"
+    "lib-usage-psi" -> "composeai.cli.libUsagePsiDir"
     else -> "composeai.cli.${sidecarName.replace('-', '.')}Dir"
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -615,6 +615,12 @@ object PlaygroundSourceCleaner {
         facts.calls
           .asSequence()
           .filter { rules.scaffolds[it.callee]?.kind == UsageRules.Kind.SUBSTITUTE }
+          // A matching *name* is not a matching call. `state.previewOverrideString(…)` is
+          // somebody's
+          // member function, and the replacement range covers the whole qualified expression — so
+          // substituting on the name alone would delete their receiver and their call. Only a bare
+          // call, or one qualified by a package the rules name, is this scaffold.
+          .filter { it.receiver == null || it.receiver in rules.scaffoldPackages }
           .sortedByDescending { it.start }
           .mapNotNull { call ->
             val scaffold = rules.scaffolds.getValue(call.callee)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
@@ -138,7 +138,10 @@ private constructor(private val analyzer: Any, private val analyze: java.lang.re
     try {
       val raw = analyze.invoke(analyzer, source) as? String ?: return null
       json.decodeFromString<UsageSourceFacts>(raw).takeIf { it.error == null }
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
+      // Throwable, not Exception: a staged closure that is incomplete or built for a newer JVM
+      // raises `NoClassDefFoundError` / `UnsupportedClassVersionError`, which are `Error`s. Letting
+      // one through would take down a playground request over an optional sidecar.
       null
     }
 
@@ -188,8 +191,11 @@ private constructor(private val analyzer: Any, private val analyze: java.lang.re
           val instance = type.getDeclaredConstructor().newInstance()
           val method = type.getMethod("analyze", String::class.java)
           UsageSourceParser(instance, method).also { cached = it }
-        } catch (e: Exception) {
-          onLog("usage-source-psi failed to load (${e.message}); cleaning with the text passes")
+        } catch (e: Throwable) {
+          // Same reason as [facts]: a broken or mismatched staged closure fails with a
+          // `LinkageError`, not an `Exception`, and the documented behaviour for an unusable
+          // sidecar is to fall back rather than to fail the request.
+          onLog("usage-source-psi failed to load ($e); cleaning with the text passes")
           null
         }
       }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -535,6 +535,42 @@ class PlaygroundSourceCleanerTest {
     assertTrue(cleaned.residue.contains("counted"), "${cleaned.residue}")
   }
 
+  /**
+   * A matching callee *name* is not a matching call.
+   *
+   * The parsed substitution pass replaces the whole qualified expression, so selecting on the name
+   * alone would delete somebody's receiver along with their call — `state.previewOverrideString(…)`
+   * is an application's own member function that happens to share a name with a scaffold. Only a
+   * bare call, or one qualified by a package the rules name, is the scaffold.
+   */
+  @Test
+  fun `a member call sharing a substitute rule's name keeps its receiver`() {
+    val source =
+      """
+      package ee.schimke.demo
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Title() {
+        Text(state.previewOverrideString("title", "Shopping"))
+        Text(ee.schimke.composeai.overrides.previewOverrideString("subtitle", "Basket"))
+      }
+      """
+        .trimIndent()
+    val cleaned =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Title"), UsageRules.GENERIC)
+      )
+    assertTrue(
+      cleaned.text.contains("state.previewOverrideString(\"title\", \"Shopping\")"),
+      "an unrelated member call was rewritten: ${cleaned.text}",
+    )
+    // The package-qualified one is the scaffold, and is substituted.
+    assertTrue(cleaned.text.contains("Text(\"Basket\")"), cleaned.text)
+  }
+
   /** Named arguments out of declaration order still bind by name, as Kotlin binds them. */
   @Test
   fun `a knob with reordered named arguments still resolves its default`() {


### PR DESCRIPTION
Three review findings on #3861, which auto-merged before they could land on it.

### A matching callee name is not a matching call

The parsed substitution pass selected calls on the callee name alone, and its replacement range covers the **whole qualified expression**. So `state.previewOverrideString("title", "Shopping")` — an application's own member function that happens to share a name with a scaffold — would have had its receiver *and* its call replaced wholesale.

That is worse than the leak the parse was fixing, and it is squarely my regression: the text pass it replaced couldn't reach a qualified call at all, so widening the reach without re-checking the receiver introduced a way to corrupt working code. Substitution is now limited to a bare call, or one qualified by a package the rules name — the same allow-list the unqualify pass uses — with a test asserting an unrelated member call survives while the package-qualified one is substituted.

### `-Dcomposeai.cli.libUsagePsiDir` did not exist

Its KDoc advertised the override, but `bundleSidecarSysprop` derives `composeai.cli.lib.usage.psiDir` without an explicit mapping. A host staging the sidecar somewhere else would have been ignored and dropped silently to the text path — documentation describing a knob that isn't wired. Mapped like every other sidecar.

### A `LinkageError` is not an `Exception`

An incomplete or version-mismatched staged closure raises `NoClassDefFoundError` / `UnsupportedClassVersionError`, neither of which is an `Exception`. Those escaped both the loader's fallback and the seed resolver's own catch, taking a playground request down over a sidecar documented as optional. Both catch `Throwable` now, which is what "degrades to the text passes" has to mean if it is going to be true.

### Test plan

- `./gradlew :cli:test` — green, including the new `a member call sharing a substitute rule's name keeps its receiver`.
- `./gradlew ktfmtCheckAll` — green.

Non-visual: a serve-side rewrite pass, a sysprop mapping, and error handling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_