### PR TITLE
Fix Android data-product fan-out cleanup

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -208,8 +208,8 @@ object PreviewManifestLoader {
     // from prior runs that today's manifest doesn't account for. Guards
     // against provider renames ("loading" → "busy") and the
     // `_PARAM_<idx>` → `_<label>` migration leaving a mix of old-shape
-    // and new-shape PNGs on disk. Runs at shard-load time, before any
-    // test body writes to the directory.
+    // and new-shape captures or rendered data products on disk. Runs at shard-load time, before
+    // any test body writes to the directory.
     deleteStaleFanoutFiles(
       outDir = System.getProperty("composeai.render.outputDir")?.let(::File),
       allEntries = allEntries,
@@ -354,8 +354,9 @@ object PreviewManifestLoader {
   }
 
   /**
-   * Deletes stale `<stem>_*<ext>` fan-out files for the parameterized previews in
-   * [expandedByEntry].
+   * Deletes stale `<stem>_*<ext>` capture and rendered-data-product fan-out files for the
+   * parameterized previews in [expandedByEntry]. Both output classes use the same path-aware sweep
+   * rule so their cleanup cannot drift independently.
    *
    * Three guards keep the prefix match from destroying correct sibling output (issue #2193):
    * - **Manifest-wide expected set.** `@Preview(name = …)` / `@Preview(group = …)` variant suffixes
@@ -393,45 +394,35 @@ object PreviewManifestLoader {
     ownedIds: Set<String>,
   ) {
     if (outDir == null || !outDir.isDirectory) return
-    val expectedNames = buildSet {
-      allEntries.flatMap { it.captures }.mapNotNullTo(this) { fanoutLeaf(it.renderOutput) }
-      expandedByEntry
-        .flatMap { it.second }
-        .flatMap { it.entry.captures }
-        .mapNotNullTo(this) { fanoutLeaf(it.renderOutput) }
+    val productRoot = outDir.parentFile ?: outDir
+    val expectedFiles = buildSet {
+      allEntries.forEach { entry ->
+        entry.captures.mapNotNullTo(this) { captureOutputFile(outDir, it.renderOutput) }
+        entry.dataProducts.mapNotNullTo(this) { productOutputFile(productRoot, it.output) }
+      }
+      expandedByEntry.flatMap { it.second }.forEach { row ->
+        row.entry.captures.mapNotNullTo(this) { captureOutputFile(outDir, it.renderOutput) }
+        row.entry.dataProducts.mapNotNullTo(this) { productOutputFile(productRoot, it.output) }
+      }
     }
-    val declaredOutputFiles =
-      allEntries
-        .flatMap { it.captures }
-        .map { it.renderOutput }
-        .filter { it.isNotEmpty() }
-        .map { File(outDir, it.substringAfter("renders/")) }
+    val declaredOutputFiles = buildList {
+      allEntries.forEach { entry ->
+        entry.captures.mapNotNullTo(this) { captureOutputFile(outDir, it.renderOutput) }
+        entry.dataProducts.mapNotNullTo(this) { productOutputFile(productRoot, it.output) }
+      }
+    }
     for ((entry, rows) in expandedByEntry) {
       if (entry.params.previewParameterProviderClassName == null) continue
       if (rows.none { it.entry.id in ownedIds }) continue
       for (template in entry.captures) {
-        val templateFile = File(outDir, template.renderOutput.substringAfter("renders/"))
-        val dir = templateFile.parentFile ?: continue
-        val stem = templateFile.nameWithoutExtension
-        val ext = ".${templateFile.extension}"
-        val prefix = stem + "_"
-        val siblingStems = fanoutSiblingStems(declaredOutputFiles, templateFile)
-        dir
-          .listFiles()
-          ?.filter { f ->
-            val output = fanoutOutputNameOf(f.name, ext)
-            f.name.startsWith(prefix) &&
-              output != null &&
-              output !in expectedNames &&
-              siblingStems.none { sib ->
-                f.name.startsWith("$sib.") || f.name.startsWith("${sib}_")
-              }
-          }
-          ?.forEach { f ->
-            if (!f.delete()) {
-              System.err.println("Failed to delete stale fan-out file: ${f.absolutePath}")
-            }
-          }
+        captureOutputFile(outDir, template.renderOutput)?.let { templateFile ->
+          deleteStaleFanoutFiles(templateFile, expectedFiles, declaredOutputFiles)
+        }
+      }
+      for (template in entry.dataProducts) {
+        productOutputFile(productRoot, template.output)?.let { templateFile ->
+          deleteStaleFanoutFiles(templateFile, expectedFiles, declaredOutputFiles)
+        }
       }
     }
   }
@@ -502,9 +493,42 @@ object PreviewManifestLoader {
       .distinct()
   }
 
-  private fun fanoutLeaf(renderOutput: String): String? {
+  private fun captureOutputFile(outDir: File, renderOutput: String): File? {
     if (renderOutput.isEmpty()) return null
-    return renderOutput.substringAfterLast('/').ifEmpty { renderOutput }
+    return File(outDir, renderOutput.substringAfterLast('/'))
+  }
+
+  private fun productOutputFile(productRoot: File, output: String): File? {
+    if (output.isEmpty()) return null
+    return File(productRoot, output)
+  }
+
+  private fun deleteStaleFanoutFiles(
+    templateFile: File,
+    expectedFiles: Set<File>,
+    declaredOutputFiles: List<File>,
+  ) {
+    val dir = templateFile.parentFile ?: return
+    val stem = templateFile.nameWithoutExtension
+    val ext = ".${templateFile.extension}"
+    val prefix = stem + "_"
+    val siblingStems = fanoutSiblingStems(declaredOutputFiles, templateFile)
+    dir
+      .listFiles()
+      ?.filter { file ->
+        val output = fanoutOutputNameOf(file.name, ext)
+        file.name.startsWith(prefix) &&
+          output != null &&
+          File(dir, output) !in expectedFiles &&
+          siblingStems.none { sibling ->
+            file.name.startsWith("$sibling.") || file.name.startsWith("${sibling}_")
+          }
+      }
+      ?.forEach { file ->
+        if (!file.delete()) {
+          System.err.println("Failed to delete stale fan-out file: ${file.absolutePath}")
+        }
+      }
   }
 
   /**

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
@@ -9,8 +9,8 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 /**
- * Pins the stale fan-out cleanup in [PreviewManifestLoader.deleteStaleFanoutFiles], in particular
- * the two issue #2193 guards:
+ * Pins the stale fan-out cleanup in [PreviewManifestLoader.deleteStaleFanoutFiles], including
+ * rendered data products (issue #3823) and the two issue #2193 guards:
  * - the expected set spans the whole manifest, so a sibling preview whose stem underscore-extends
  *   the swept one's (`Foo` vs the `@Preview(name = "Dark")` variant `Foo_Dark`) never has its base
  *   render or fan-out classified as stale;
@@ -49,8 +49,23 @@ class PreviewManifestLoaderStaleFanoutTest {
               renderOutput = PreviewManifestLoader.insertBeforeExtension(it.renderOutput, suffix)
             )
           },
+        dataProducts =
+          base.dataProducts.map {
+            it.copy(output = PreviewManifestLoader.insertBeforeExtension(it.output, suffix))
+          },
       ),
       listOf(Any()),
+    )
+
+  private fun productEntry(id: String, output: String): RenderPreviewEntry =
+    RenderPreviewEntry(
+      id = id,
+      functionName = id,
+      className = "com.example.PreviewsKt",
+      params =
+        RenderPreviewParams(previewParameterProviderClassName = "com.example.UserProvider"),
+      captures = emptyList(),
+      dataProducts = listOf(RenderPreviewArtifact(kind = "render/scroll/long", output = output)),
     )
 
   @Test
@@ -260,6 +275,39 @@ class PreviewManifestLoaderStaleFanoutTest {
 
     assertFalse(File(tmp.root, "Foo_Dark.png").exists())
     assertTrue(File(tmp.root, "Foo_Dark.gif").exists())
+  }
+
+  @Test
+  fun `deletes stale data-product fan-out without cross-directory name collisions`() {
+    val previewRoot = tmp.newFolder("previews")
+    val rendersDir = File(previewRoot, "renders").also { it.mkdirs() }
+    val foo = productEntry("Foo", "data/scroll-long/Foo.png")
+    val other = productEntry("Other", "data/other/Foo_stale.png")
+    val expandedByEntry =
+      listOf(
+        foo to listOf(fanoutRow(foo, "_Alice")),
+        other to listOf(fanoutRow(other, "_stale")),
+      )
+    val fooDir = File(previewRoot, "data/scroll-long").also { it.mkdirs() }
+    val otherDir = File(previewRoot, "data/other").also { it.mkdirs() }
+    File(fooDir, "Foo_Alice.png").createNewFile()
+    File(fooDir, "Foo_Alice.png.error.json").createNewFile()
+    File(fooDir, "Foo_stale.png").createNewFile()
+    File(fooDir, "Foo_stale.png.error.json").createNewFile()
+    File(otherDir, "Foo_stale.png").createNewFile()
+
+    PreviewManifestLoader.deleteStaleFanoutFiles(
+      outDir = rendersDir,
+      allEntries = listOf(foo, other),
+      expandedByEntry = expandedByEntry,
+      ownedIds = setOf("Foo_Alice"),
+    )
+
+    assertTrue(File(fooDir, "Foo_Alice.png").exists())
+    assertTrue(File(fooDir, "Foo_Alice.png.error.json").exists())
+    assertFalse(File(fooDir, "Foo_stale.png").exists())
+    assertFalse(File(fooDir, "Foo_stale.png.error.json").exists())
+    assertTrue(File(otherDir, "Foo_stale.png").exists())
   }
 
   @Test


### PR DESCRIPTION
## Summary

- sweep stale Android `@PreviewParameter` fan-out files for rendered data-product outputs as well as captures
- use one path-aware cleanup rule for both output classes
- add regression coverage for stale product removal and same-name outputs in different product directories

## Root cause

Android built its expected-output set exclusively from `entry.captures` and only iterated capture templates during cleanup. Consequently, renamed or removed provider rows left stale files under `entry.dataProducts` indefinitely.

## Impact

Stale rendered data products can no longer survive provider-value changes and later be consumed as current output by the CLI or preview server.

Fixes #3823.

## Validation

- `git diff --check`
- pre-push attribution scan
- attempted `:renderer-android:testDebugUnitTest --tests ee.schimke.composeai.renderer.PreviewManifestLoaderStaleFanoutTest`; Gradle remained blocked in repository-wide configuration
- attempted aggregate and module-scoped ktfmt checks; both remained blocked in repository-wide Gradle configuration, and the aggregate attempt was also interrupted by an external Gradle daemon stop

CI remains the authoritative test and formatting validation.