### PR TITLE
fix(cli): warn about unknown command flags

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -1,0 +1,275 @@
+package ee.schimke.composeai.cli
+
+/**
+ * Per-command option allowlists used to keep an unrecognised option from disappearing silently
+ * (issue #3781).
+ *
+ * Parsing in this CLI is intentionally lightweight: commands read the options they care about
+ * directly from [List] rather than registering them with a parser. That makes a typo
+ * indistinguishable from an option the command simply did not read. Keep that parsing model, but
+ * validate the routed argv against the command that will receive it and warn before any expensive
+ * work starts.
+ *
+ * The warning is deliberately non-fatal for backwards compatibility. Existing scripts which pass an
+ * extra option keep their exit-code behaviour, while a human or CI log can no longer mistake the
+ * option for one that took effect.
+ */
+internal object CliFlagValidation {
+  private val commandBase =
+    setOf(
+      "--module",
+      "--filter",
+      "--id",
+      "--preview",
+      "--verbose",
+      "-v",
+      "--progress",
+      "--timeout",
+      "--changed-only",
+      "--brief",
+      "--force",
+      "--variant",
+      "--with-extension",
+      "--with",
+      "--permutations",
+      "--missing-renders",
+      "--no-auto-inject",
+    )
+
+  private val reportFlags = commandBase + setOf("--json", "--fail-on")
+
+  val BY_COMMAND: Map<String, Set<String>> =
+    mapOf(
+      "show" to commandBase + setOf("--json", "--images"),
+      "show-resources" to commandBase + setOf("--json"),
+      "list" to commandBase + setOf("--json"),
+      "render" to commandBase + setOf("--output", "--bundle", "--embed-deps", "--format"),
+      "render-matrix" to
+        commandBase +
+          setOf(
+            "--json",
+            "--help",
+            "-h",
+            "--device",
+            "--locale",
+            "--ui-mode",
+            "--font-scale",
+            "--contact-sheet",
+            "--cells-dir",
+          ),
+      "record" to
+        commandBase +
+          setOf(
+            "--script",
+            "--out",
+            "--output",
+            "--format",
+            "--fps",
+            "--scale",
+            "--overrides",
+            "--baseline-dir",
+          ),
+      "a11y" to reportFlags,
+      "diff-semantics" to setOf("--json", "--fail-on-change", "--help", "-h"),
+      "devices" to setOf("--json", "--help", "-h"),
+      "extensions" to setOf("--json"),
+      "history" to
+        setOf(
+          "--agent",
+          "--branch",
+          "--commit",
+          "--cursor",
+          "--data",
+          "--history-dir",
+          "--inline",
+          "--json",
+          "--limit",
+          "--mode",
+          "--out",
+          "--preview",
+          "--ref",
+          "--since",
+          "--source",
+          "--until",
+        ),
+      "history-manifest" to
+        setOf("--baselines", "--branch", "--help", "-h", "--output", "--quiet", "--repo"),
+      // Extra flags are forwarded to ReportCommand after the profile file is expanded.
+      "profile" to reportFlags,
+      "doctor" to
+        setOf(
+          "--daemon",
+          "--explain",
+          "--json",
+          "--plugin-version",
+          "--project",
+          "--report",
+          "--variant",
+          "--verbose",
+          "-v",
+          "--with-daemon",
+        ),
+      "serve" to
+        commandBase +
+          setOf(
+            "--accept-bundles",
+            "--accept-bundles-from",
+            "--accept-docs",
+            "--accept-docs-from",
+            "--admin-token",
+            "--allow-render-trusted",
+            "--bundle",
+            "--bundles",
+            "--catalog-branch-prefix",
+            "--catalog-max-images",
+            "--catalog-refresh-interval",
+            "--catalog-repo",
+            "--catalog-source-root",
+            "--catalogs",
+            "--catalogs-file",
+            "--catalogs-unlisted",
+            "--discover",
+            "--doc-ttl",
+            "--engagement-file",
+            "--exit-when-idle",
+            "--export",
+            "--extra-maven-repos",
+            "--github-auth-callback-base-url",
+            "--github-auth-client-id",
+            "--github-auth-client-secret",
+            "--github-auth-cookie-secret",
+            "--github-auth-repo",
+            "--github-auth-scope",
+            "--github-auth-users",
+            "--help",
+            "-h",
+            "--history-branch",
+            "--host",
+            "--inline",
+            "--lan",
+            "--live-seats",
+            "--no-history",
+            "--playground",
+            "--playground-android-bundle",
+            "--playground-bundle",
+            "--playground-caller-concurrency",
+            "--playground-catalog-limit",
+            "--playground-compile-slots",
+            "--playground-rate-limit",
+            "--playground-sandbox",
+            "--playground-sandbox-cpus",
+            "--playground-sandbox-memory-mb",
+            "--playground-sandbox-pids",
+            "--playground-sandbox-ro",
+            "--playground-sandbox-ttl",
+            "--port",
+            "--public",
+            "--rc-player-wasm-dir",
+            "--revisions",
+            "--revisions-allow",
+            "--sites",
+            "--token",
+            "--trust-forwarded-for",
+            "--trust-store",
+            "--wasm-dir",
+          ),
+      "share-preview" to
+        setOf(
+          "--allow-non-preview-branch",
+          "--branch",
+          "--desc",
+          "--json",
+          "--mechanism",
+          "--message",
+          "--pr-number",
+          "--public",
+          "--raw-base",
+          "--remote",
+        ),
+      // `bundle` owns nested subcommands. Validate at the routed-command boundary while allowing
+      // the union of their options; nested positional dispatch remains BundleCommand's concern.
+      "bundle" to
+        commandBase +
+          setOf(
+            "--embed-deps",
+            "--exclude-preview-id",
+            "--exclude-preview-row",
+            "--ext",
+            "--external-images",
+            "--help",
+            "-h",
+            "--in-bundle",
+            "--include-data-extensions",
+            "--json",
+            "--key",
+            "--key-id",
+            "--knob",
+            "--no-crop",
+            "--no-render",
+            "--origin",
+            "--output",
+            "-o",
+            "--per-preview",
+            "--producer",
+            "--provenance-identity",
+            "--provenance-type",
+            "--renders",
+            "--res",
+            "--res-out",
+            "--shared-classpath-out",
+            "--svg",
+            "--title",
+            "--trust",
+            "--view-only",
+            "--with-semantics",
+          ),
+      "mcp" to
+        setOf(
+          "--antigravity",
+          "--antigravity-config",
+          "--claude",
+          "--codex",
+          "--codex-config",
+          "--help",
+          "-h",
+          "--json",
+          "--module",
+          "--no-antigravity",
+          "--no-claude",
+          "--no-codex",
+          "--project",
+          "--replicas-per-daemon",
+          "--verbose",
+          "-v",
+        ),
+      "update" to setOf("--dry-run"),
+      "init-script" to setOf("--path", "--print"),
+      "pin" to setOf("--cli", "--json", "--remove", "--unset"),
+      "version" to emptySet(),
+      "help" to setOf("--all"),
+    )
+
+  /** Every distinct option registered for at least one command, for the source drift guard. */
+  val ALL: Set<String> = BY_COMMAND.values.flatten().toSet()
+
+  /** Unknown option spellings, de-duplicated in argv order. */
+  fun unknownFlags(command: String, args: List<String>): List<String> {
+    val allowed = BY_COMMAND.getValue(command)
+    val unknown = linkedSetOf<String>()
+    var index = 0
+    while (index < args.size) {
+      val raw = args[index]
+      if (raw == "--") break
+      if (!raw.startsWith("-") || raw == "-") {
+        index++
+        continue
+      }
+      val flag = raw.substringBefore('=')
+      if (flag !in allowed) unknown += flag
+      // Only a recognised, required-value flag owns the following token. An unknown flag must not
+      // hide another option after it, while a legitimate value such as "--literal" must be safe.
+      index += if (flag in allowed && flag in CliFlags.VALUE_FLAGS && '=' !in raw) 2 else 1
+    }
+    return unknown.toList()
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -126,6 +126,7 @@ internal object CliFlags {
       "--agent",
       "--antigravity-config",
       "--baseline-dir",
+      "--baselines",
       "--codex-config",
       "--commit",
       "--cursor",
@@ -134,6 +135,8 @@ internal object CliFlags {
       "--mode",
       "--project",
       "--ref",
+      "--repo",
+      "--replicas-per-daemon",
       "--since",
       "--source",
       "--title",
@@ -162,7 +165,8 @@ internal object CliFlags {
    * the following token. Listed only so `CliFlagsRegistryTest` can tell them apart from a missing
    * [VALUE_FLAGS] entry — they are intentionally excluded from command-detection skipping.
    */
-  val ATTACHED_OR_OPTIONAL_FLAGS: Set<String> = setOf("--images", "--exit-when-idle")
+  val ATTACHED_OR_OPTIONAL_FLAGS: Set<String> =
+    setOf("--images", "--exit-when-idle", "--contact-sheet", "--cells-dir")
 
   /**
    * The first positional token in [args] — the bare token that isn't the value of a value-consuming

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
@@ -76,7 +76,7 @@ internal object CliRouter {
   }
 
   fun route(args: Array<String>): Route {
-    val commandIndex = CliFlags.findCommandIndex(args)
+    val commandIndex = findCommandIndex(args, KNOWN_FLAT + GROUP_NAMES)
     if (commandIndex < 0) {
       return if ("--help" in args || "-h" in args) Route.TopUsage(full = "--all" in args)
       else Route.NoCommand
@@ -86,7 +86,7 @@ internal object CliRouter {
     val rest = args.toMutableList().apply { removeAt(commandIndex) }
 
     if (command in GROUP_NAMES) {
-      val subIndex = CliFlags.findCommandIndex(rest.toTypedArray())
+      val subIndex = findCommandIndex(rest.toTypedArray(), subcommandsOf(command).toSet())
       val sub = if (subIndex >= 0) rest[subIndex] else null
       if (sub != null && sub in subcommandsOf(command)) {
         val subArgs = rest.toMutableList().apply { removeAt(subIndex) }
@@ -97,5 +97,37 @@ internal object CliRouter {
     }
 
     return if (command in KNOWN_FLAT) Route.Run(command, rest) else Route.Unknown(command)
+  }
+
+  /**
+   * Locate a command while preserving the historical unknown-command result for ordinary
+   * positionals. There is one recoverable ambiguity: an unknown option before the command may have
+   * a separate value, and [CliFlags.findCommandIndex] necessarily mistakes that value for the
+   * command because the option is absent from its value-consuming registry. When that exact shape
+   * occurs, continue to the first known command token so per-command validation can report the real
+   * problem (`--fitler Foo render` warns about `--fitler`, rather than claiming `Foo` is a
+   * command).
+   */
+  private fun findCommandIndex(args: Array<String>, candidates: Set<String>): Int {
+    val first = CliFlags.findCommandIndex(args)
+    if (first < 0 || args[first] in candidates) return first
+
+    val previous = args.getOrNull(first - 1) ?: return first
+    val previousFlag = previous.substringBefore('=')
+    val firstCouldBeUnknownFlagValue =
+      previous.startsWith("-") && '=' !in previous && previousFlag !in CliFlags.VALUE_FLAGS
+    if (!firstCouldBeUnknownFlagValue) return first
+
+    var index = first + 1
+    while (index < args.size) {
+      val arg = args[index]
+      when {
+        arg in CliFlags.VALUE_FLAGS -> index += 2
+        arg.startsWith("-") -> index++
+        arg in candidates -> return index
+        else -> index++
+      }
+    }
+    return first
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -50,7 +50,15 @@ fun main(args: Array<String>) {
   }
 
   when (val route = CliRouter.route(args)) {
-    is CliRouter.Route.Run -> COMMANDS.getValue(route.command).invoke(route.args)
+    is CliRouter.Route.Run -> {
+      for (flag in CliFlagValidation.unknownFlags(route.command, route.args)) {
+        System.err.println(
+          "compose-preview: warning: unrecognised option '$flag' for '${route.command}' " +
+            "(ignored)"
+        )
+      }
+      COMMANDS.getValue(route.command).invoke(route.args)
+    }
     is CliRouter.Route.GroupUsage -> {
       printGroupUsage(route.group)
       exitProcess(if (route.isError) 1 else 0)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.fail
  */
 class CliFlagsRegistryTest {
   private val flagCallSite = Regex("""flagValue(?:sAll)?\(\s*"(--[a-z][a-z-]*)"""")
+  private val membershipCallSite = Regex(""""(--[a-z][a-z-]*)"\s+(?:in|!in)\s+(?:args|rawArgs)""")
 
   @Test
   fun `every flagValue call site is classified in CliFlags`() {
@@ -43,6 +44,26 @@ class CliFlagsRegistryTest {
   }
 
   @Test
+  fun `flags read by commands are present in a command allowlist`() {
+    val used =
+      mainSources()
+        .flatMap { file ->
+          val source = file.readText()
+          (flagCallSite.findAll(source) + membershipCallSite.findAll(source)).map {
+            it.groupValues[1]
+          }
+        }
+        .toSortedSet()
+
+    val unclassified = used - CliFlagValidation.ALL
+    assertEquals(
+      emptySet(),
+      unclassified,
+      "Flags read by commands but absent from every per-command allowlist",
+    )
+  }
+
+  @Test
   fun `findCommandIndex skips value flags and their values`() {
     assertEquals(0, CliFlags.findCommandIndex(arrayOf("show")))
     assertEquals(2, CliFlags.findCommandIndex(arrayOf("--module", ":app", "show")))
@@ -50,6 +71,14 @@ class CliFlagsRegistryTest {
     // Regression: a global-position value flag that used to be unclassified mis-detected its value
     // as the command.
     assertEquals(2, CliFlags.findCommandIndex(arrayOf("--since", "2024", "history", "list")))
+    assertEquals(
+      2,
+      CliFlags.findCommandIndex(arrayOf("--repo", "/tmp/project", "history-manifest")),
+    )
+    assertEquals(
+      2,
+      CliFlags.findCommandIndex(arrayOf("--replicas-per-daemon", "2", "mcp", "serve")),
+    )
     // --force takes a required reason; the space form must skip the reason (ForceFlagTest pins that
     // `--force <reason>` is supported), or the reason is mistaken for the command.
     assertEquals(2, CliFlags.findCommandIndex(arrayOf("--force", "edit didn't reflect", "render")))
@@ -65,6 +94,7 @@ class CliFlagsRegistryTest {
     // --images is optional-value (bare --images means auto): a bare token after it is the command,
     // not its value.
     assertEquals(1, CliFlags.findCommandIndex(arrayOf("--images", "show")))
+    assertEquals(1, CliFlags.findCommandIndex(arrayOf("--contact-sheet", "render-matrix")))
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CliRouterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CliRouterTest.kt
@@ -20,6 +20,37 @@ class CliRouterTest {
   }
 
   @Test
+  fun `every routed command has a flag allowlist`() {
+    assertEquals(CliRouter.KNOWN_FLAT, CliFlagValidation.BY_COMMAND.keys)
+  }
+
+  @Test
+  fun `unknown flag validation is command specific and supports attached values`() {
+    assertEquals(
+      listOf("--fitler", "--fail-on"),
+      CliFlagValidation.unknownFlags(
+        "render",
+        listOf("--module", ":app", "--fitler=Button", "--fail-on", "warnings"),
+      ),
+    )
+    assertEquals(
+      emptyList(),
+      CliFlagValidation.unknownFlags(
+        "a11y",
+        listOf("--module=:app", "--filter", "Button", "--fail-on=warnings"),
+      ),
+    )
+  }
+
+  @Test
+  fun `a recognised value may look like a flag without becoming an unknown option`() {
+    assertEquals(
+      emptyList(),
+      CliFlagValidation.unknownFlags("render", listOf("--filter", "--literal-preview-name")),
+    )
+  }
+
+  @Test
   fun `groups are disjoint and don't collide with core, meta, or group names`() {
     val grouped = CliRouter.GROUPS.values.flatten()
     assertEquals(grouped.size, grouped.toSet().size, "a command appears in two groups")
@@ -54,6 +85,31 @@ class CliRouterTest {
     assertEquals(
       CliRouter.Route.Run("render", listOf("--output", "out.png")),
       CliRouter.route(arrayOf("render", "--output", "out.png")),
+    )
+  }
+
+  @Test
+  fun `unknown valued flag before a command still routes to that command for validation`() {
+    assertEquals(
+      CliRouter.Route.Run("render", listOf("--fitler", "Button")),
+      CliRouter.route(arrayOf("--fitler", "Button", "render")),
+    )
+    assertEquals(
+      CliRouter.Route.Run("a11y", listOf("--fitler", "Button")),
+      CliRouter.route(arrayOf("inspect", "--fitler", "Button", "a11y")),
+    )
+    // A value belonging to a known flag must not be recovered as the command.
+    assertEquals(
+      CliRouter.Route.Run("list", listOf("--fitler", "Button", "--filter", "render")),
+      CliRouter.route(arrayOf("--fitler", "Button", "--filter", "render", "list")),
+    )
+  }
+
+  @Test
+  fun `ordinary unknown first positional stays an unknown command`() {
+    assertEquals(
+      CliRouter.Route.Unknown("frobnicate"),
+      CliRouter.route(arrayOf("frobnicate", "render")),
     )
   }
 


### PR DESCRIPTION
## Summary

- add per-command option allowlists and warn on stderr when a command receives an unknown option
- preserve existing command exit codes for backwards compatibility
- recover routing for an unknown valued option before a command, so `--fitler Foo render` reports the typo instead of treating `Foo` as the command
- add drift guards covering routed commands and flags read from command sources
- classify previously missed valued/optional flags used by history, MCP, and render-matrix

## Root cause

CLI commands read flags opportunistically from their raw argument lists. `CliRouter` validated command tokens but there was no per-command known-option registry, so any option a command did not read simply disappeared. Unknown valued options before a command could additionally make their value look like the command token.

## Impact

Typos and flags copied from sibling commands are now visible before expensive command work begins. The warning is intentionally non-fatal, matching the compatibility-focused option described in #3781.

Closes #3781.

## Validation

- formatted all six changed Kotlin files with ktfmt 0.62 Google style; dry-run check passes
- compiled the routing/flag-validation sources with Kotlin 2.4.10
- compiled `CliFlagsRegistryTest` with Kotlin 2.4.10
- `git diff --check`

The repository-wide Gradle test/format hooks were attempted but stalled under shared Gradle-daemon contention; the commit used the directly verified formatter result, and CI remains the full repository-wide check.