### PR TITLE
fix: stabilize shared element debug previews

### DIFF
--- a/samples/android/src/main/kotlin/com/example/sampleandroid/SharedElementDebugPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/SharedElementDebugPreviews.kt
@@ -3,6 +3,7 @@ package com.example.sampleandroid
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.CustomizedLookaheadAnimationVisualDebugging
 import androidx.compose.animation.ExperimentalLookaheadAnimationVisualDebugApi
 import androidx.compose.animation.LookaheadAnimationVisualDebugging
 import androidx.compose.animation.SharedTransitionLayout
@@ -60,6 +61,7 @@ import ee.schimke.composeai.preview.AnimatedPreview
  * experimental in 1.11 even though the shared-element APIs themselves are stable).
  */
 private val debugBoundsSpec = BoundsTransform { _, _ -> tween(durationMillis = 600) }
+private val debugElementColor = Color(0xFF4285F4)
 
 private enum class DebugScreen {
   Collapsed,
@@ -86,21 +88,25 @@ fun SharedElementDebugMatchedAnimatedPreview() {
   MaterialTheme {
     Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
       LookaheadAnimationVisualDebugging(isEnabled = true, isShowKeyLabelEnabled = true) {
-        SharedTransitionLayout(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-          AnimatedContent(
-            targetState = screen,
-            label = "debug-matched",
-            modifier = Modifier.fillMaxSize(),
-          ) { target ->
-            when (target) {
-              DebugScreen.Collapsed ->
-                DebugCollapsed(
-                  this@SharedTransitionLayout,
-                  this@AnimatedContent,
-                  includeBadge = false,
-                )
-              DebugScreen.Expanded ->
-                DebugExpanded(this@SharedTransitionLayout, this@AnimatedContent)
+        // AndroidX's default debug-color allocator is process-global. An explicit color keeps this
+        // fixture independent of which other previews rendered earlier in the sandbox.
+        CustomizedLookaheadAnimationVisualDebugging(debugElementColor) {
+          SharedTransitionLayout(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            AnimatedContent(
+              targetState = screen,
+              label = "debug-matched",
+              modifier = Modifier.fillMaxSize(),
+            ) { target ->
+              when (target) {
+                DebugScreen.Collapsed ->
+                  DebugCollapsed(
+                    this@SharedTransitionLayout,
+                    this@AnimatedContent,
+                    includeBadge = false,
+                  )
+                DebugScreen.Expanded ->
+                  DebugExpanded(this@SharedTransitionLayout, this@AnimatedContent)
+              }
             }
           }
         }
@@ -134,21 +140,23 @@ fun SharedElementDebugUnmatchedAnimatedPreview() {
         unmatchedElementColor = Color(0xCCD32F2F),
         isShowKeyLabelEnabled = true,
       ) {
-        SharedTransitionLayout(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-          AnimatedContent(
-            targetState = screen,
-            label = "debug-unmatched",
-            modifier = Modifier.fillMaxSize(),
-          ) { target ->
-            when (target) {
-              DebugScreen.Collapsed ->
-                DebugCollapsed(
-                  this@SharedTransitionLayout,
-                  this@AnimatedContent,
-                  includeBadge = true,
-                )
-              DebugScreen.Expanded ->
-                DebugExpanded(this@SharedTransitionLayout, this@AnimatedContent)
+        CustomizedLookaheadAnimationVisualDebugging(debugElementColor) {
+          SharedTransitionLayout(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            AnimatedContent(
+              targetState = screen,
+              label = "debug-unmatched",
+              modifier = Modifier.fillMaxSize(),
+            ) { target ->
+              when (target) {
+                DebugScreen.Collapsed ->
+                  DebugCollapsed(
+                    this@SharedTransitionLayout,
+                    this@AnimatedContent,
+                    includeBadge = true,
+                  )
+                DebugScreen.Expanded ->
+                  DebugExpanded(this@SharedTransitionLayout, this@AnimatedContent)
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

- give the shared-element visual-debug fixtures an explicit debug color
- bypass AndroidX's process-global default debug-color allocator
- keep the unmatched-element diagnostic color and key labels intact

## Root cause

`LookaheadAnimationVisualDebugHelper` stores its default color index and key-to-color assignments in process-global state. Android preview shards reuse a Robolectric sandbox, so previews rendered earlier in the same process can change the colors assigned to this fixture and therefore change every GIF frame.

Using `CustomizedLookaheadAnimationVisualDebugging` at the fixture boundary makes the output independent of render order without adding renderer-specific cleanup or reflection.

## Impact

The matched and unmatched animated preview GIFs should now be reproducible across shard layouts and repeated renders, removing spurious visual diffs while preserving the debug-overlay coverage.

## Validation

- `./gradlew ktfmtFormatAll --console=plain --no-daemon`
- `git diff --check`
- pre-push attribution scan passed

A filtered GIF render was attempted, but concurrent Gradle worktrees repeatedly contended for the shared Kotlin DSL cache; no source or renderer failure was observed.

Fixes #3852