### PR TITLE
feat(serve): add the DESTRUCTURE rule kind

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -337,6 +337,10 @@ object PlaygroundSourceCleaner {
     out =
       if (parser != null) applySubstituteParsed(out, rules, addedImports, parser)
       else applySubstitute(out, rules, addedImports)
+    // After SUBSTITUTE, so a knob in the initializer (`toggleable(catalogEnabled())`) is already
+    // plain by the time the state declaration quotes it. Parsed-only by design — see
+    // [UsageRules.Kind.DESTRUCTURE].
+    if (parser != null) out = applyDestructureParsed(out, rules, addedImports, parser)
     out = applyInline(out, rules)
     out = applyDrop(out, rules, residue)
     out = applyRename(out, rules, addedImports)
@@ -584,6 +588,107 @@ object PlaygroundSourceCleaner {
       }
     }
     return bound.toList()
+  }
+
+  /**
+   * `val (checked, onCheckedChange) = toggleable(true)` → `var checked by remember {
+   * mutableStateOf(true) }`, with every use of `onCheckedChange` becoming `{ checked = it }`.
+   *
+   * ### Why this one could not be a text pass
+   *
+   * The other kinds rewrite an expression or delete a binding. This replaces a **declaration** and
+   * rebinds a *second* name that the declaration introduced — so it has to know the destructuring
+   * exists, which names it binds, in what order, and where its initializer starts and ends. A regex
+   * that thought it knew those things is how this file earned most of its review findings, which is
+   * why the kind is gated on the parser being staged rather than degrading to a guess.
+   *
+   * ### All or nothing, per declaration
+   *
+   * The same discipline [applyDrop] uses. If the template cites an argument the call does not have,
+   * or the declaration binds a shape the rule does not describe (one name, or three), the whole
+   * rewrite is abandoned for that declaration and the helper is left exactly as the catalog wrote
+   * it — reported as residue. A half-applied state rewrite compiles to something subtly wrong,
+   * which is worse than a snippet that visibly still calls a helper.
+   */
+  private fun applyDestructureParsed(
+    text: String,
+    rules: UsageRules,
+    addedImports: MutableSet<String>,
+    parser: UsageSourceParser,
+  ): String {
+    if (rules.scaffolds.none { it.value.kind == UsageRules.Kind.DESTRUCTURE }) return text
+    var out = text
+    var guard = 0
+    while (guard++ < MAX_REWRITES) {
+      val facts = parser.facts(out) ?: return out
+      val rewrite =
+        facts.destructurings
+          .asSequence()
+          .mapNotNull { declaration ->
+            // The initializer, as a call: the facts report the two separately, and the call is what
+            // carries the callee, its arguments and its receiver.
+            val call =
+              facts.calls.firstOrNull {
+                it.replaceStart == declaration.initializerStart ||
+                  it.start == declaration.initializerStart
+              } ?: return@mapNotNull null
+            val scaffold = rules.scaffolds[call.callee] ?: return@mapNotNull null
+            if (scaffold.kind != UsageRules.Kind.DESTRUCTURE) return@mapNotNull null
+            // Same guard the substitution pass carries: a matching name on somebody else's receiver
+            // is not this scaffold.
+            if (call.receiver != null && call.receiver !in rules.scaffoldPackages) {
+              return@mapNotNull null
+            }
+            val plain = scaffold.plain ?: return@mapNotNull null
+            // Exactly the value/setter pair the kind describes. Anything else is a shape the rule
+            // does not speak for.
+            if (declaration.names.size != 2) return@mapNotNull null
+            val (value, setterName) = declaration.names
+            if (value.isEmpty() || setterName.isEmpty()) return@mapNotNull null
+            val args = facts.bind(call, scaffold.params) ?: return@mapNotNull null
+            val render = { template: String ->
+              Regex("""\$(\d+)|\${'$'}value|\${'$'}setter""").replace(template) { m ->
+                when (m.value) {
+                  "\$value" -> value
+                  "\$setter" -> setterName
+                  else -> args.getOrNull(m.groupValues[1].toInt()) ?: m.value
+                }
+              }
+            }
+            val declarationText = render(plain)
+            val setterText = scaffold.setter?.let(render)
+            if (declarationText.contains(Regex("""\${'$'}\d"""))) return@mapNotNull null
+            if (setterText?.contains(Regex("""\${'$'}\d""")) == true) return@mapNotNull null
+            Triple(declaration, declarationText to setterText, scaffold)
+          }
+          .firstOrNull() ?: return out
+
+      val (declaration, replacements, scaffold) = rewrite
+      val (declarationText, setterText) = replacements
+      if (declaration.start < 0 || declaration.end > out.length) return out
+
+      // The declaration and every reference to the setter name, from **one** parse, applied
+      // right-to-left so earlier offsets stay valid. Not `replaceWord`: that also rewrites the
+      // argument *label* in `Switch(onCheckedChange = onCheckedChange)`, which produced
+      // `{ checked = it } = { checked = it }` — the parse separates a label from a reference and a
+      // word scan cannot.
+      val edits = buildList {
+        add(declaration.start to declaration.end to declarationText)
+        if (setterText != null) {
+          facts.references
+            .filter { it.name == declaration.names[1] && it.start >= declaration.end }
+            .forEach { add(it.start to it.end to setterText) }
+        }
+      }
+      for ((range, replacement) in edits.sortedByDescending { it.first.first }) {
+        val (start, end) = range
+        if (start < 0 || end > out.length || start >= end) return out
+        out = out.substring(0, start) + replacement + out.substring(end)
+      }
+      scaffold.addImport?.let { addedImports.add(it) }
+      addedImports.addAll(scaffold.addImports)
+    }
+    return out
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -85,6 +85,12 @@ data class UsageRules(
     @SerialName("renameTo") val renameTo: String? = null,
     /** An import the replacement needs, e.g. `androidx.compose.material3.MaterialTheme`. */
     @SerialName("addImport") val addImport: String? = null,
+    /**
+     * Imports the replacement needs, when one is not enough — [Kind.DESTRUCTURE]'s `var x by
+     * remember { mutableStateOf(…) }` needs four, including the `getValue`/`setValue` the `by`
+     * delegation reads and which nothing in the snippet mentions by name.
+     */
+    @SerialName("addImports") val addImports: List<String> = emptyList(),
     /** [Kind.SUBSTITUTE] only: what the call reads as, with `$0`, `$1`… for its arguments. */
     @SerialName("plain") val plain: String? = null,
     /**
@@ -97,6 +103,15 @@ data class UsageRules(
      * call that uses named arguments at all (reporting it as residue) rather than guessing.
      */
     @SerialName("params") val params: List<String> = emptyList(),
+    /**
+     * [Kind.DESTRUCTURE] only: what the **second** destructured name reads as at its use sites.
+     *
+     * `val (checked, onCheckedChange) = toggleable(true)` binds a value and its setter.
+     * [Scaffold.plain] replaces the declaration; this replaces every mention of `onCheckedChange`,
+     * which would otherwise refer to a binding that no longer exists. Cites `$value` for the first
+     * name, so `toggleable` declares `{ $value = it }`.
+     */
+    @SerialName("setter") val setter: String? = null,
     /**
      * [Kind.INLINE] only: member → replacement, where `$0`, `$1`… are the call's arguments.
      * `counted` declares `{"label": "$0", "onClick": "{}"}`, which is the whole of what that helper
@@ -145,6 +160,32 @@ data class UsageRules(
      * on a named argument.
      */
     SUBSTITUTE,
+
+    /**
+     * A helper whose result is **destructured into state**, replaced by the state a developer would
+     * write themselves.
+     *
+     * m3-catalog's `toggleable` / `selectable` / `multiSelectable` / `draggable` / `editable` each
+     * return `Pair<T, (T) -> Unit>` so one sticker can be frozen on the baked lane and live on the
+     * interactive one:
+     * ```
+     * val (checked, onCheckedChange) = toggleable(true)
+     * ```
+     *
+     * The plain reading is not a *value* — it is real state, `var checked by remember {
+     * mutableStateOf(true) }`, plus a setter at every use site. That is why none of the other four
+     * kinds could express it, and why `compose-usage.json` carried it as a declared gap: RENAME and
+     * SUBSTITUTE rewrite one expression, DROP deletes, INLINE substitutes members of a binding —
+     * none replaces a declaration *and* rebinds a second name.
+     *
+     * Declares [Scaffold.plain] for the declaration, [Scaffold.setter] for the second name's use
+     * sites, and [Scaffold.addImports] for what the replacement needs.
+     *
+     * **Needs the parser.** A destructuring declaration, its entry names and its initializer are
+     * exactly the structure a regex cannot be trusted with, so this kind applies only when
+     * `:usage-source-psi` is staged; without it the helper is reported as residue, as before.
+     */
+    DESTRUCTURE,
   }
 
   companion object {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
@@ -22,6 +22,14 @@ data class UsageSourceFacts(
   @SerialName("calls") val calls: List<Call> = emptyList(),
   @SerialName("destructurings") val destructurings: List<Destructuring> = emptyList(),
   /**
+   * Every name **reference**, excluding argument labels.
+   *
+   * The exclusion is the point. `Switch(onCheckedChange = onCheckedChange)` writes that name twice
+   * and only the second is a reference; rebinding the first turns a label into an expression. PSI
+   * knows which is which, and a word scan does not.
+   */
+  @SerialName("references") val references: List<Reference> = emptyList(),
+  /**
    * Set when the analyzer could not parse at all; the caller then behaves as if it had no facts.
    */
   @SerialName("error") val error: String? = null,
@@ -66,6 +74,13 @@ data class UsageSourceFacts(
     /** The `name` of `name = value`, or null for a positional argument. */
     @SerialName("name") val name: String? = null,
     @SerialName("text") val text: String = "",
+    @SerialName("start") val start: Int = -1,
+    @SerialName("end") val end: Int = -1,
+  )
+
+  @Serializable
+  data class Reference(
+    @SerialName("name") val name: String = "",
     @SerialName("start") val start: Int = -1,
     @SerialName("end") val end: Int = -1,
   )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -571,6 +571,105 @@ class PlaygroundSourceCleanerTest {
     assertTrue(cleaned.text.contains("Text(\"Basket\")"), cleaned.text)
   }
 
+  /**
+   * The `$known-gaps` entry m3-catalog's `compose-usage.json` carried: `toggleable` and friends
+   * return `Pair<T, (T) -> Unit>` destructured into a value and a setter, and the plain reading is
+   * real state rather than a value. Roughly 18 stickers were affected.
+   */
+  @Test
+  fun `a destructured state helper becomes remembered state`() {
+    val destructuring =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "toggleable" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.DESTRUCTURE,
+                plain = "var \$value by remember { mutableStateOf(\$0) }",
+                setter = "{ \$value = it }",
+                addImports =
+                  listOf(
+                    "androidx.compose.runtime.getValue",
+                    "androidx.compose.runtime.mutableStateOf",
+                    "androidx.compose.runtime.remember",
+                    "androidx.compose.runtime.setValue",
+                  ),
+              )
+          )
+      )
+    val source =
+      """
+      package ee.schimke.m3catalog.sections
+
+      import androidx.compose.material3.Switch
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.toggleable
+
+      @Composable
+      fun SwitchSticker() {
+        val (checked, onCheckedChange) = toggleable(true)
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun SwitchSticker"), destructuring)
+      )
+    assertTrue(
+      result.text.contains("var checked by remember { mutableStateOf(true) }"),
+      result.text,
+    )
+    // The setter name no longer exists, so every use of it has to be rebound — a declaration
+    // rewritten without this leaves code that reads fine and does not compile.
+    assertTrue(result.text.contains("onCheckedChange = { checked = it }"), result.text)
+    assertFalse(result.text.contains("toggleable"), result.text)
+    // `by` needs `getValue`/`setValue`, which nothing in the snippet mentions by name.
+    for (import in listOf("getValue", "setValue", "remember", "mutableStateOf")) {
+      assertTrue(result.text.contains("import androidx.compose.runtime.$import"), result.text)
+    }
+    assertEquals(emptyList(), result.residue)
+  }
+
+  /**
+   * A declaration binding a shape the rule does not describe is left alone, and reported — the same
+   * all-or-nothing discipline DROP uses. Half-rewritten state compiles to something subtly wrong,
+   * which is worse than a snippet that visibly still calls a helper.
+   */
+  @Test
+  fun `a destructuring the rule does not describe is left as residue`() {
+    val destructuring =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "triple" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.DESTRUCTURE,
+                plain = "var \$value by remember { mutableStateOf(\$0) }",
+                setter = "{ \$value = it }",
+              )
+          )
+      )
+    val source =
+      """
+      package ee.schimke.m3catalog.sections
+
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.triple
+
+      @Composable
+      fun Odd() {
+        val (a, b, c) = triple(1)
+        Text("${'$'}a ${'$'}b ${'$'}c")
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Odd"), destructuring))
+    assertTrue(result.text.contains("val (a, b, c) = triple(1)"), result.text)
+    assertTrue(result.residue.contains("triple"), "${result.residue}")
+  }
+
   /** Named arguments out of declaration order still bind by name, as Kotlin binds them. */
   @Test
   fun `a knob with reordered named arguments still resolves its default`() {

--- a/docs/design/PSI_PARSE_SPIKE.md
+++ b/docs/design/PSI_PARSE_SPIKE.md
@@ -13,7 +13,7 @@ defect it surfaced was **parser-shaped**:
 | `state.metrics.counted` taken for a package qualifier | qualified expression structure |
 | `counted { }` missed — the regex required `(` | a call is a call |
 | a qualified call neither rewritten nor reported | the callee, regardless of qualifier |
-| `toggleable` destructuring a `Pair` (still open) | destructuring declarations |
+| `toggleable` destructuring a `Pair` | destructuring declarations |
 
 Five symptoms, one missing thing: structure. So: measure before rewriting.
 
@@ -149,7 +149,8 @@ The spike said yes, so the parse is now in the cleaner. The shape is the one the
 actually exercise. Without that the cleaner would fall back silently and every test would still pass,
 having covered none of it.
 
-**The corpus ratios are unchanged: m3-catalog 3/10, meshcore-mobile 0/10, same seven failures.** That
+**On landing, the corpus ratios were unchanged: m3-catalog 3/10, meshcore-mobile 0/10, same seven
+failures** (the `DESTRUCTURE` kind that followed took m3-catalog to 4/10). That
 is the result to expect and the bar the spike set — parity, per snippet, before anything else. The
 parse fixes shapes the text pass got wrong (an argument binding, a receiver chain, a call with no
 parentheses); none of the seven remaining failures is one of those. Moving the ratio needs the new
@@ -163,9 +164,9 @@ positional slot — putting `{ … }` where `default` belongs. Filtered out, and
 
 A parse fixes the **machinery**. It does not move the ratio much on its own:
 
-- m3-catalog's 2 destructuring failures become tractable — the facts now carry
-  `KtDestructuringDeclaration` entries and initialisers, so a `DESTRUCTURE` rule kind whose plain
-  form is `var x by remember { mutableStateOf(…) }` has everything it needs. Not written yet.
+- m3-catalog's 2 destructuring failures: **done**, and the ratio moved 3/10 → 4/10. The
+  `DESTRUCTURE` rule kind reads the facts' entries and initialiser; `compose-usage.json`'s
+  `$known-gaps` entry is retired.
 - The 2 conditional-`stringResource` failures become tractable for the same reason: the inliner can
   see the `if` rather than declining on a regex.
 - `CatalogFilledStars` (×4) still needs a substitution rule — no parse invents an icon.

--- a/docs/design/USAGE_SNIPPET_CORPUS.md
+++ b/docs/design/USAGE_SNIPPET_CORPUS.md
@@ -44,7 +44,7 @@ First run, ten samples per catalog:
 
 | Catalog | Compiles | Rules |
 |---|---|---|
-| m3-catalog | **3 / 10** | 17 declared scaffolds |
+| m3-catalog | **4 / 10** | 22 declared scaffolds |
 | meshcore-mobile | **0 / 10** | none — generic path |
 
 ### Residue is not a proxy for "compiles"
@@ -77,11 +77,11 @@ Two things had to follow from putting those knobs in `GENERIC`:
   and only a catalog can earn it. A non-empty `GENERIC` would have had every catalog claiming a
   declaration it never made, so it now asks whether any scaffold is the catalog's own.
 
-### m3-catalog's remaining seven failures, by cause
+### m3-catalog's remaining six failures, by cause
 
 | Cause | Files | Status |
 |---|---|---|
-| `toggleable` / `editable` destructure a `Pair` | 2 | The known gap in `compose-usage.json`'s `$known-gaps` — needs a `DESTRUCTURE` rule kind whose plain form is `var x by remember { mutableStateOf(…) }` |
+| ~~`toggleable` / `editable` destructure a `Pair`~~ | ~~2~~ → 0 | **Fixed.** The `DESTRUCTURE` rule kind, which the parse made writable — `val (checked, onCheckedChange) = toggleable(true)` now comes out as `var checked by remember { mutableStateOf(true) }` with the setter rebound at its use sites. One of the two compiled immediately; the other is now blocked only on the `stringResource` row below |
 | Conditional `stringResource(if (…) Res.string.a else Res.string.b)` | 2 | The inliner only handles the exact single-key form and declines the rest, correctly — but the snippet then keeps an unresolvable `Res` |
 | `CatalogFilledStars`, a catalog-owned `ImageVector` | 4 | No rule; wants substituting with a stock `Icons.Filled.Star` or similar |
 

--- a/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
+++ b/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
@@ -14,7 +14,9 @@ import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtValueArgumentName
 
 /**
  * Parses Kotlin source and reports the **structure** the usage cleaner needs, as JSON.
@@ -83,6 +85,20 @@ class UsageSourceAnalyzer : AutoCloseable {
           PsiTreeUtil.findChildrenOfType(file, KtDestructuringDeclaration::class.java),
         ) {
           destructuring(it)
+        }
+        // Name references, minus argument *labels*. `Switch(onCheckedChange = onCheckedChange)`
+        // mentions that name twice and only the second is a reference — rebinding the first turns
+        // the label into an expression and the call into nonsense. PSI separates them; a word scan
+        // cannot, which is how the first version of the DESTRUCTURE rule broke this exact call.
+        arrayField(
+          "references",
+          PsiTreeUtil.findChildrenOfType(file, KtNameReferenceExpression::class.java).filter {
+            it.parent !is KtValueArgumentName
+          },
+        ) { reference ->
+          field("name", reference.getReferencedName())
+          number("start", reference.textRange.startOffset)
+          number("end", reference.textRange.endOffset)
         }
       }
     } catch (e: Throwable) {


### PR DESCRIPTION
The gap m3-catalog's `compose-usage.json` carried in `$known-gaps`, now writable because of the parse.

`toggleable` / `selectable` / `multiSelectable` / `draggable` / `editable` each return `Pair<T, (T) -> Unit>`, so one sticker serves both the frozen baked lane and the live interactive one:

```kotlin
val (checked, onCheckedChange) = toggleable(true)
```

The plain reading isn't a *value* — it's state, plus a setter at every use site:

```kotlin
var checked by remember { mutableStateOf(true) }
Checkbox(checked = checked, onCheckedChange = { checked = it })
```

RENAME and SUBSTITUTE rewrite one expression, DROP deletes, INLINE substitutes members of a binding. None replaces a **declaration** and rebinds a second name that declaration introduced — which is why the gap stayed open, and why it needed the parse first: finding a destructuring, its entry names, their order and its initializer is precisely what a regex can't be trusted with. So the kind is **gated on the parser being staged** rather than degrading to a guess.

All-or-nothing per declaration, like DROP: a shape the rule doesn't describe (one name, or three) is left exactly as the catalog wrote it and reported as residue. Half-rewritten state compiles to something subtly wrong, which is worse than a snippet that visibly still calls a helper.

### The bug that shaped the design

Rebinding the setter with a word scan also rewrote the argument **label**:

```kotlin
Switch(onCheckedChange = onCheckedChange)   →   Switch({ checked = it } = { checked = it })
```

PSI distinguishes a `KtValueArgumentName` from a reference; a word scan can't. The analyzer now reports name references with labels excluded, and both edits come from one parse applied right-to-left.

### Result

Measured on the corpus, with the matching rules in [m3-catalog#…](https://github.com/yschimke/m3-catalog/pull/new/agent/destructure-state-rules):

**m3-catalog 3/10 → 4/10**, and `toggleable`/`editable` residue is gone entirely. `ListDialog` compiles outright; `DockedSearchBarSticker` is now blocked only on the conditional-`stringResource` gap, not on two things.

The generated `ListDialog` body:

```kotlin
var checked by remember { mutableStateOf(true) }
…
Checkbox(checked = checked, onCheckedChange = { checked = it })
```

### Test plan

- `./gradlew :cli:test` — green, including `a destructured state helper becomes remembered state` and `a destructuring the rule does not describe is left as residue`.
- `./gradlew ktfmtCheckAll` — green.
- `scripts/usage-corpus.sh /home/user/m3-catalog <meshcore checkout>` — 4/10 and 0/10, re-verified against the final rules file.

Non-visual: a rewrite pass, a rule kind, analyzer facts, tests and docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_