### PR TITLE
Rework catalog landing layout

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2202,18 +2202,16 @@ object ServeWeb {
 
   /**
    * The search box for the landing grid: a text input that filters cards to those whose label or id
-   * contains the typed text, plus a live result count. Progressive enhancement — the server emits
-   * every card and [catalogFilterScript] does the hiding, so a no-JS client still sees the full
-   * grid. Shown whenever the module has previews (independent of the theme toggle, which only
-   * appears for per-theme catalogs). [count] seeds the total for the "N of M" readout.
+   * contains the typed text. Progressive enhancement — the server emits every card and
+   * [catalogFilterScript] does the hiding, so a no-JS client still sees the full grid. Shown
+   * whenever the module has previews (independent of the theme toggle, which only appears for
+   * per-theme catalogs).
    */
-  private fun searchBoxHtml(count: Int): String =
+  private fun searchBoxHtml(): String =
     """
     <div class="cp-searchbar">
       <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
         autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-      <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="$count"></span>
-      ${bgPickerHtml("Show the transparent checkerboard behind each preview")}
     </div>
     """
       .trimIndent()
@@ -3027,7 +3025,7 @@ object ServeWeb {
       var tree = document.getElementById("cp-tabs");
       if (!tree) return;
       // The toolbar above pins itself at top:0 over everything, so publish its real height for the
-      // sticky tree's offset and for every scroll target's `scroll-margin-top`. Measured rather
+      // sticky menu's offset and for every scroll target's `scroll-margin-top`. Measured rather
       // than assumed: it wraps on a narrow viewport and grows a row with the declared-theme chips,
       // and the static fallback in the stylesheet only covers the unwrapped case.
       // `cp-js` gates every collapse rule in the stylesheet. It used to be set by the section
@@ -5869,13 +5867,16 @@ object ServeWeb {
           append("</div>")
         }
       }
-    // A tree stands BESIDE what it navigates, so a sectioned catalog wraps its nav and its panels
-    // in one two-column container (a single column, tree first, below the sidebar breakpoint). A
-    // flat catalog has no nav to stand beside anything and keeps the bare grid — which is also why
-    // its committed golden is untouched by this.
+    // A tree stands BESIDE what it navigates. Its filter is part of that navigation, so the two
+    // share one sidebar and remain together when the menu becomes sticky. A small catalog with no
+    // tree keeps the filter in the toolbar above its flat grid.
+    val sidebarSearch = if (tabBar.isEmpty() || previews.isEmpty()) "" else searchBoxHtml() + "\n"
     val navAndGrid =
       if (tabBar.isEmpty()) "$tabBar$gridBlock"
-      else "<div class=\"cp-catalog-body\">\n$tabBar$gridBlock\n</div>"
+      else
+        "<div class=\"cp-catalog-body\">\n" +
+          "<aside class=\"cp-catalog-menu\" aria-label=\"Catalog menu\">\n" +
+          "$sidebarSearch$tabBar</aside>\n$gridBlock\n</div>"
     // The "about" intro now sits at the BOTTOM of a catalog page (below the grid) so the catalog's
     // own content leads; it still appears only for the public server.
     val about = if (isPublic) "\n" + aboutSection() else ""
@@ -5886,7 +5887,7 @@ object ServeWeb {
     // catalog page's own heading and grid then start at the top of the content column.
     val back = if (hasHomeIndex) backButton(token, isPublic) else ""
     // The catalog-provenance strip (delivery branch, generation date, tool versions, regenerate
-    // link), shown under the header for a served design-system catalog.
+    // link) closes the catalog instead of interrupting the route from its heading to its content.
     val prov = provenance?.let { provenanceSection(it, refreshUrl) + "\n" } ?: ""
     // The Theme control shows when there is more than one theme to choose between: a baked
     // light/dark pair to swap, and/or the app-declared themes this session can re-render under. A
@@ -5899,7 +5900,7 @@ object ServeWeb {
     // Search + empty-state + the combined filter script are shown whenever there are previews to
     // filter, independent of the theme axis.
     val hasPreviews = previews.isNotEmpty()
-    val searchBox = if (hasPreviews) searchBoxHtml(previews.size) + "\n" else ""
+    val searchBox = if (hasPreviews && tabBar.isEmpty()) searchBoxHtml() + "\n" else ""
     val emptyState =
       if (hasPreviews)
         "\n<p id=\"cp-empty\" class=\"cp-empty\" hidden>No previews match your filter.</p>"
@@ -5977,7 +5978,6 @@ object ServeWeb {
     }
     val actionChips =
       listOfNotNull(
-          actionChip("$basePath/bundle.zip$q", "download all (.zip)"),
           compareChip("svg", "compare SVG").takeIf { hasSvgComparison },
           compareChip("rc", "compare RC players").takeIf { hasRcComparison },
           // Named after the design tool it compares against when the catalog identifies one —
@@ -6003,6 +6003,26 @@ object ServeWeb {
           playgroundHref?.takeIf { it.isNotBlank() }?.let { actionChip(it, "try in playground") },
         )
         .joinToString("\n          ")
+    val transparentAction =
+      if (hasPreviews) bgPickerHtml("Show the transparent checkerboard behind each preview") else ""
+    val catalogActions =
+      listOf(actionChips, transparentAction).filter { it.isNotBlank() }.joinToString("\n          ")
+    val primaryActions =
+      catalogActions
+        .takeIf { it.isNotBlank() }
+        ?.let { "<div class=\"cp-catalog-actions\">\n          $it\n        </div>\n" } ?: ""
+    val downloadAction =
+      "\n<div class=\"cp-catalog-download\">" +
+        actionChip("$basePath/bundle.zip$q", "download all (.zip)") +
+        "</div>\n"
+    val titleRow =
+      "<div class=\"cp-catalog-title\">" +
+        "<h1 class=\"cp-head cp-catalog-head\">${WebEscaping.htmlEscape(heading)}" +
+        "${compactTrustBadge(trust)}</h1>$catalogId</div>"
+    val tools =
+      (themeToggle + searchBox)
+        .takeIf { it.isNotBlank() }
+        ?.let { "<div class=\"cp-catalog-tools\">\n$it</div>\n" } ?: ""
     return document(
       title = "$heading — compose-preview",
       unfurlTitle = heading,
@@ -6018,14 +6038,9 @@ object ServeWeb {
       declaredThemes = declaredThemeChips,
       body =
         """
-        <h1 class="cp-head cp-catalog-head">${WebEscaping.htmlEscape(heading)}${compactTrustBadge(trust)}</h1>
-        $catalogId${degradeBanner(degradations)}$prov<p class="cp-sub">${previews.size} preview(s)${if (systemViews > 0) " · ${formatViews(systemViews)}" else ""}$liveNote</p>
-        <div class="cp-catalog-actions">
-          $actionChips
-        </div>
-        $renderFailureSummary<div class="cp-catalog-tools">
-        $themeToggle$searchBox</div>
-        $navAndGrid$emptyState$filterScript$liveScript$about
+        $titleRow
+        ${degradeBanner(degradations)}<p class="cp-sub">${previews.size} preview(s)${if (systemViews > 0) " · ${formatViews(systemViews)}" else ""}$liveNote</p>
+        $primaryActions$renderFailureSummary$tools$navAndGrid$emptyState$filterScript$liveScript$downloadAction$prov$about
         """
           .trimIndent(),
     )

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -327,7 +327,10 @@ input, select, textarea, progress { accent-color: var(--md-sys-color-primary); }
 .cp-section-count { padding: 4px 10px; border-radius: var(--md-sys-shape-corner-full);
   background: var(--md-sys-color-surface-container-high);
   color: var(--md-sys-color-on-surface-variant); font-weight: 500; }
-.cp-catalog-id { margin: 0 0 14px; font-family: var(--md-sys-typescale-mono-font); }
+.cp-catalog-title { display: flex; align-items: baseline; flex-wrap: wrap; gap: 6px 14px;
+  margin: 0 0 4px; }
+.cp-catalog-title .cp-head, .cp-catalog-title .cp-catalog-id { margin: 0; }
+.cp-catalog-id { font-family: var(--md-sys-typescale-mono-font); }
 .cp-catalog-head { font-size: var(--md-sys-typescale-headline-small-size);
   line-height: var(--md-sys-typescale-headline-small-line); }
 /* Per-preview GitHub links under the viewer title: source file, and "report an issue". One flex
@@ -403,8 +406,8 @@ input, select, textarea, progress { accent-color: var(--md-sys-color-primary); }
   border-color: var(--md-sys-color-outline); color: var(--md-sys-color-primary);
   text-decoration: none; }
 /* Provenance strip: how/when/from-what this catalog was generated (branch, date, versions,
-   a link to re-run the generating workflow). Shown near the catalog header. */
-.cp-prov { margin: 0 0 18px; padding: 14px 18px; border: 0;
+   a link to re-run the generating workflow). It closes the catalog below its content. */
+.cp-prov { margin: 18px 0 0; padding: 14px 18px; border: 0;
   border-radius: var(--md-sys-shape-corner-medium);
   background: var(--md-sys-color-surface-container-low);
   font-size: var(--md-sys-typescale-body-small-size);
@@ -451,6 +454,7 @@ input, select, textarea, progress { accent-color: var(--md-sys-color-primary); }
    in `.cp-catalog-tools` directly beneath. */
 .cp-catalog-actions { margin: 0 0 18px; display: flex; align-items: center; flex-wrap: wrap;
   gap: 8px; }
+.cp-catalog-download { margin: 30px 0 0; }
 .cp-action-chip { display: inline-flex; align-items: center; min-height: 32px; padding: 6px 16px;
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--md-sys-shape-corner-small);
@@ -497,10 +501,14 @@ input, select, textarea, progress { accent-color: var(--md-sys-color-primary); }
 @media (min-width: 960px) {
   .cp-catalog-body { display: grid; grid-template-columns: minmax(168px, 216px) minmax(0, 1fr);
     gap: 32px; align-items: start; }
-  .cp-tree { position: sticky; top: calc(var(--cp-sticky-tools, 64px) + 12px); margin: 0;
-    max-height: calc(100vh - var(--cp-sticky-tools, 64px) - 28px);
+  .cp-catalog-menu { position: sticky; top: calc(var(--cp-sticky-tools, 0px) + 12px);
+    max-height: calc(100vh - var(--cp-sticky-tools, 0px) - 28px);
     overflow-y: auto; overscroll-behavior: contain; }
 }
+.cp-catalog-menu { margin: 0 0 22px; }
+.cp-catalog-menu .cp-searchbar { display: block; margin: 0 0 18px; }
+.cp-catalog-menu .cp-search { width: 100%; min-width: 0; padding-inline: 14px; }
+.cp-catalog-menu .cp-tree { margin: 0; }
 .cp-tree { margin: 0 0 22px; }
 .cp-tree-list, .cp-tree-children { list-style: none; margin: 0; padding: 0; }
 .cp-tree-node[hidden], .cp-tree-children li[hidden] { display: none; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -3572,7 +3572,18 @@ class ServeWebFixtureTest {
     )
     assertTrue(
       landingThemed.contains("id=\"cp-search\""),
-      "the search box shows alongside the theme toggle on a themed catalog",
+      "the search box shows on a themed catalog",
+    )
+    assertTrue(
+      landingThemed
+        .substringAfter("class=\"cp-catalog-menu\"")
+        .substringBefore("</aside>")
+        .contains("id=\"cp-search\""),
+      "a catalog menu leads with its filter",
+    )
+    assertFalse(
+      landingThemed.contains("id=\"cp-count\""),
+      "the menu filter does not repeat the preview count",
     )
     // The combined filter composes search with theme: on a themed catalog the script still persists
     // the theme choice, so search didn't displace the theme half.
@@ -4364,6 +4375,10 @@ class ServeWebFixtureTest {
         refreshUrl = "/compose-m3/refresh",
       )
     assertTrue(landing.contains("class=\"cp-prov cp-disclosure\""), "the provenance details render")
+    assertTrue(
+      landing.indexOf("class=\"cp-prov cp-disclosure\"") > landing.indexOf("id=\"cp-grid\""),
+      "catalog details follow the catalog content",
+    )
     // Links to the delivery branch and the regenerating workflow.
     assertTrue(
       landing.contains(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundLinksTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundLinksTest.kt
@@ -60,14 +60,18 @@ class ServeWebPlaygroundLinksTest {
   }
 
   @Test
-  fun `the catalog landing offers a subtle try-in-playground on its summary line`() {
+  fun `the catalog landing offers a try-in-playground action above the catalog`() {
     val html = landing("/playground?catalog=compose-m3&token=t")
     assertTrue(html.contains("try in playground</a>"))
     assertTrue(html.contains("/playground?catalog=compose-m3&amp;token=t"))
-    // Placed in the run of catalog-level actions next to the zip download, not as a button
-    // competing with the grid.
-    val summary = html.substringAfter("download all (.zip)").substringBefore("</p>")
-    assertTrue(summary.contains("try in playground"), "it joins the summary line: $summary")
+    assertTrue(
+      html.indexOf("try in playground") < html.indexOf("id=\"cp-grid\""),
+      "the playground handoff remains in the primary action row",
+    )
+    assertTrue(
+      html.indexOf("download all (.zip)") > html.indexOf("id=\"cp-grid\""),
+      "the bundle download follows the catalog content",
+    )
   }
 
   @Test

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
@@ -104,13 +104,13 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">wear-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/wear-m3">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">wear-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/wear-m3">✓ trusted</span></h1></div>
         <p class="cp-sub">5 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip?session=wear-m3">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-toolbar">
+<div class="cp-catalog-tools">
+<div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
@@ -119,11 +119,9 @@
 <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="5"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-button-filled__ideal__default__light" data-swap="1" data-bg-theme="dark" data-def="d"
   data-l-src="/render/button-filled__ideal__default__light.png?session=wear-m3" data-l-href="/p/button-filled__ideal__default__light?session=wear-m3"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
@@ -316,6 +314,8 @@ applyThemeChoice();
       }
       apply();
     })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip?session=wear-m3">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -53,13 +53,13 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1></div>
         <p class="cp-sub">5 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip?session=compose-m3">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-toolbar">
+<div class="cp-catalog-tools">
+<div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
@@ -71,11 +71,9 @@
 <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="5"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-button-filled__ideal__default__light" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/button-filled__ideal__default__light.png?session=compose-m3" data-l-href="/p/button-filled__ideal__default__light?session=compose-m3"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
@@ -599,6 +597,8 @@ applyThemeChoice();
         }
       });
     })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip?session=compose-m3">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -53,26 +53,25 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1></div>
         <p class="cp-sub">14 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-toolbar">
+<div class="cp-catalog-tools">
+<div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
   </span>
 </div>
+</div>
+<div class="cp-catalog-body">
+<aside class="cp-catalog-menu" aria-label="Catalog menu">
 <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="14"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
-</div>
-        <div class="cp-catalog-body">
 <nav class="cp-tree" id="cp-tabs" aria-label="Catalog contents">
 <ul class="cp-tree-list" role="tree" aria-label="Catalog contents">
     <li class="cp-tree-node" role="none"><a class="cp-tree-group cp-tree-link" role="treeitem" href="#cp-group-button" data-group="cp-group-button" aria-expanded="true" aria-owns="cp-tree-of-cp-group-button">Button<span class="cp-tree-count">3</span></a>
@@ -114,6 +113,7 @@
 </li>
 </ul>
 </nav>
+</aside>
 <div class="cp-grid-groups" id="cp-grid">
 <div class="cp-subgroup" id="cp-group-button">
 <h2 class="cp-group-head">Button</h2>
@@ -410,7 +410,7 @@ applyThemeChoice();
         var tree = document.getElementById("cp-tabs");
         if (!tree) return;
         // The toolbar above pins itself at top:0 over everything, so publish its real height for the
-        // sticky tree's offset and for every scroll target's `scroll-margin-top`. Measured rather
+        // sticky menu's offset and for every scroll target's `scroll-margin-top`. Measured rather
         // than assumed: it wraps on a narrow viewport and grows a row with the declared-theme chips,
         // and the static fallback in the stylesheet only covers the unwrapped case.
         // `cp-js` gates every collapse rule in the stylesheet. It used to be set by the section
@@ -653,6 +653,8 @@ applyThemeChoice();
       })();
       apply();
     })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-ir-replay-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-ir-replay-themes.html
@@ -53,13 +53,13 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">remote-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/remote-m3">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">remote-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/remote-m3">✓ trusted</span></h1></div>
         <p class="cp-sub">5 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip?session=remote-m3">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-toolbar">
+<div class="cp-catalog-tools">
+<div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
@@ -68,11 +68,9 @@
 <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="5"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-button-filled__ideal__default__light" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/button-filled__ideal__default__light.png?session=remote-m3" data-l-href="/p/button-filled__ideal__default__light?session=remote-m3"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
@@ -265,6 +263,8 @@ applyThemeChoice();
       }
       apply();
     })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip?session=remote-m3">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-live.html
@@ -53,13 +53,13 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1></div>
         <p class="cp-sub">5 preview(s) · <span class="cp-live-note">hold a card for a live session</span></p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip?session=compose-m3">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-toolbar">
+<div class="cp-catalog-tools">
+<div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
@@ -68,11 +68,9 @@
 <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="5"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-button-filled__ideal__default__light" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/button-filled__ideal__default__light.png?session=compose-m3" data-l-href="/p/button-filled__ideal__default__light?session=compose-m3"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
@@ -267,6 +265,8 @@ applyThemeChoice();
     })();</script>
 <script>window.cpCatalogLive = {base:"",query:"session=compose-m3",signInHref:"",holdMs:500,cards:[{l:"button-filled__ideal__default__light",d:"button-filled__ideal__default__dark"},{l:"switch-on__ideal__default__light",d:"switch-on__ideal__default__dark"},{l:"badge",d:"badge"}]};</script>
 <script src="/assets/serve/fixture/catalog-live.js"></script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip?session=compose-m3">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -53,21 +53,19 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></h1></div>
         <p class="cp-sub">6 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/meshcore-mobile/bundle.zip">download all (.zip)</a>
           <a class="cp-action-chip" href="/meshcore-mobile/parity">compare to Figma</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-searchbar">
+<div class="cp-catalog-tools">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="6"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-com-example-ButtonPreview" href="/meshcore-mobile/p/com.example.ButtonPreview">
   <div class="cp-imgwrap">
     <img loading="lazy" alt="Button" src="/meshcore-mobile/render/com.example.ButtonPreview.png">
@@ -178,6 +176,8 @@
   }
   apply();
 })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/meshcore-mobile/bundle.zip">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -53,60 +53,20 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
-              <details class="cp-prov cp-disclosure">
-        <summary>
-          <span class="cp-prov-title">Catalog details</span>
-          <span class="cp-disclosure-hint">Source, generation time and tooling</span>
-        </summary>
-        <div class="cp-prov-body" aria-label="Catalog provenance">
-          <span class="cp-prov-item"><span class="cp-prov-key">catalog</span> <a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/compose-m3"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> yschimke/compose-ai-tools@design-artifacts/compose-m3</a></span>
-          <span class="cp-prov-item"><span class="cp-prov-key">generated</span> 2026-07-17 09:30 UTC</span>
-          <span class="cp-prov-item"><span class="cp-prov-key">rendered by</span> compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></span>
-          <span class="cp-prov-item"><a href="https://github.com/yschimke/compose-ai-tools/actions/workflows/design-artifacts.yml">regenerate ↗</a></span>
-          <span class="cp-prov-item"><button type="button" class="cp-prov-refresh" data-refresh-url="/compose-m3/refresh">refresh</button><span class="cp-prov-refresh-status" role="status" aria-live="polite"></span></span>
-        </div>
-      </details>
-      <script>
-(() => {
-  const button = document.querySelector('.cp-prov-refresh');
-  if (!button) return;
-  const status = document.querySelector('.cp-prov-refresh-status');
-  button.addEventListener('click', async () => {
-    button.disabled = true;
-    status.textContent = 'checking…';
-    try {
-      const response = await fetch(button.dataset.refreshUrl, { method: 'POST' });
-      const result = await response.json();
-      if (result.status === 'updated') {
-        status.textContent = 'updated';
-        window.location.reload();
-        return;
-      }
-      status.textContent = result.status === 'current' ? 'up to date' :
-        result.status === 'checking' ? 'check in progress' : 'check failed';
-    } catch (_) {
-      status.textContent = 'check failed';
-    }
-    button.disabled = false;
-  });
-})();
-</script>
-<p class="cp-sub">6 preview(s)</p>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1></div>
+        <p class="cp-sub">6 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a>
           <a class="cp-action-chip" href="/pages">2 pages</a>
           <a class="cp-action-chip" href="/playground?catalog=compose-m3">try in playground</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-searchbar">
+<div class="cp-catalog-tools">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="6"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-com-example-ButtonPreview" href="/p/com.example.ButtonPreview">
   <div class="cp-imgwrap">
     <img loading="lazy" alt="Button" src="/render/com.example.ButtonPreview.png">
@@ -217,6 +177,46 @@
   }
   apply();
 })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a></div>
+      <details class="cp-prov cp-disclosure">
+        <summary>
+          <span class="cp-prov-title">Catalog details</span>
+          <span class="cp-disclosure-hint">Source, generation time and tooling</span>
+        </summary>
+        <div class="cp-prov-body" aria-label="Catalog provenance">
+          <span class="cp-prov-item"><span class="cp-prov-key">catalog</span> <a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/compose-m3"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> yschimke/compose-ai-tools@design-artifacts/compose-m3</a></span>
+          <span class="cp-prov-item"><span class="cp-prov-key">generated</span> 2026-07-17 09:30 UTC</span>
+          <span class="cp-prov-item"><span class="cp-prov-key">rendered by</span> compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></span>
+          <span class="cp-prov-item"><a href="https://github.com/yschimke/compose-ai-tools/actions/workflows/design-artifacts.yml">regenerate ↗</a></span>
+          <span class="cp-prov-item"><button type="button" class="cp-prov-refresh" data-refresh-url="/compose-m3/refresh">refresh</button><span class="cp-prov-refresh-status" role="status" aria-live="polite"></span></span>
+        </div>
+      </details>
+      <script>
+(() => {
+  const button = document.querySelector('.cp-prov-refresh');
+  if (!button) return;
+  const status = document.querySelector('.cp-prov-refresh-status');
+  button.addEventListener('click', async () => {
+    button.disabled = true;
+    status.textContent = 'checking…';
+    try {
+      const response = await fetch(button.dataset.refreshUrl, { method: 'POST' });
+      const result = await response.json();
+      if (result.status === 'updated') {
+        status.textContent = 'updated';
+        window.location.reload();
+        return;
+      }
+      status.textContent = result.status === 'current' ? 'up to date' :
+        result.status === 'checking' ? 'check in progress' : 'check failed';
+    } catch (_) {
+      status.textContent = 'check failed';
+    }
+    button.disabled = false;
+  });
+})();
+</script>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -53,20 +53,17 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></h1></div>
         <p class="cp-sub">9 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/meshcore-mobile/bundle.zip">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-searchbar">
+<div class="cp-catalog-body">
+<aside class="cp-catalog-menu" aria-label="Catalog menu">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="9"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
-</div>
-        <div class="cp-catalog-body">
 <nav class="cp-tree" id="cp-tabs" aria-label="Catalog sections">
 <ul class="cp-tree-list" role="tree" aria-label="Catalog sections">
 <li class="cp-tree-node" role="none">
@@ -124,6 +121,7 @@
 </li>
 </ul>
 </nav>
+</aside>
 <div class="cp-sections" id="cp-grid">
 <section class="cp-section" id="cp-panel-themes" role="region" aria-labelledby="cp-tab-themes" data-section="themes">
 <h2 class="cp-section-head">Themes</h2>
@@ -376,7 +374,7 @@
     var tree = document.getElementById("cp-tabs");
     if (!tree) return;
     // The toolbar above pins itself at top:0 over everything, so publish its real height for the
-    // sticky tree's offset and for every scroll target's `scroll-margin-top`. Measured rather
+    // sticky menu's offset and for every scroll target's `scroll-margin-top`. Measured rather
     // than assumed: it wraps on a narrow viewport and grows a row with the declared-theme chips,
     // and the static fallback in the stylesheet only covers the unwrapped case.
     // `cp-js` gates every collapse rule in the stylesheet. It used to be set by the section
@@ -664,6 +662,8 @@
   })();
   apply();
 })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/meshcore-mobile/bundle.zip">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-site.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-site.html
@@ -52,21 +52,19 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></h1></div>
         <p class="cp-sub">6 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a>
           <a class="cp-action-chip" href="/parity">compare to Figma</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-searchbar">
+<div class="cp-catalog-tools">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="6"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-com-example-ButtonPreview" href="/p/com.example.ButtonPreview">
   <div class="cp-imgwrap">
     <img loading="lazy" alt="Button" src="/render/com.example.ButtonPreview.png">
@@ -177,6 +175,8 @@
   }
   apply();
 })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -53,13 +53,13 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1></div>
         <p class="cp-sub">8 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-toolbar">
+<div class="cp-catalog-tools">
+<div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
@@ -68,11 +68,9 @@
 <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="8"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-checkbox__ideal__default__light" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/checkbox__ideal__default__light.png" data-l-href="/p/checkbox__ideal__default__light"
   data-l-id="checkbox__ideal__default__light" data-l-label="Checkbox · Checked (light)"
@@ -255,6 +253,8 @@ applyThemeChoice();
       }
       apply();
     })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -53,15 +53,15 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1></div>
         <p class="cp-sub">5 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip?session=compose-m3">download all (.zip)</a>
           <a class="cp-action-chip" href="/compare?format=svg&amp;session=compose-m3">compare SVG</a>
           <a class="cp-action-chip" href="/compare?format=rc&amp;session=compose-m3">compare RC players</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-toolbar">
+<div class="cp-catalog-tools">
+<div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
@@ -70,11 +70,9 @@
 <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="5"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-button-filled__ideal__default__light" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/button-filled__ideal__default__light.png?session=compose-m3" data-l-href="/p/button-filled__ideal__default__light?session=compose-m3"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
@@ -267,6 +265,8 @@ applyThemeChoice();
       }
       apply();
     })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip?session=compose-m3">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-tree-depth.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-tree-depth.html
@@ -53,26 +53,25 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1></div>
         <p class="cp-sub">18 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip?session=compose-m3">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-toolbar">
+<div class="cp-catalog-tools">
+<div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
   </span>
 </div>
+</div>
+<div class="cp-catalog-body">
+<aside class="cp-catalog-menu" aria-label="Catalog menu">
 <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="18"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
-</div>
-        <div class="cp-catalog-body">
 <nav class="cp-tree" id="cp-tabs" aria-label="Catalog contents">
 <ul class="cp-tree-list" role="tree" aria-label="Catalog contents">
     <li class="cp-tree-node" role="none"><a class="cp-tree-group cp-tree-link" role="treeitem" href="#cp-group-button" data-group="cp-group-button" aria-expanded="true" aria-owns="cp-tree-of-cp-group-button">Button<span class="cp-tree-count">2</span></a>
@@ -111,6 +110,7 @@
     </li>
 </ul>
 </nav>
+</aside>
 <div class="cp-grid-groups" id="cp-grid">
 <div class="cp-subgroup" id="cp-group-button">
 <h2 class="cp-group-head">Button</h2>
@@ -357,7 +357,7 @@ applyThemeChoice();
         var tree = document.getElementById("cp-tabs");
         if (!tree) return;
         // The toolbar above pins itself at top:0 over everything, so publish its real height for the
-        // sticky tree's offset and for every scroll target's `scroll-margin-top`. Measured rather
+        // sticky menu's offset and for every scroll target's `scroll-margin-top`. Measured rather
         // than assumed: it wraps on a narrow viewport and grows a row with the declared-theme chips,
         // and the static fallback in the stylesheet only covers the unwrapped case.
         // `cp-js` gates every collapse rule in the stylesheet. It used to be set by the section
@@ -600,6 +600,8 @@ applyThemeChoice();
       })();
       apply();
     })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip?session=compose-m3">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -53,13 +53,13 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1></div>
         <p class="cp-sub">8 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-toolbar">
+<div class="cp-catalog-tools">
+<div class="cp-toolbar">
   <span class="cp-theme" role="group" aria-label="Preview theme">
     <button type="button" class="cp-theme-btn" data-theme-choice="light">Light</button>
     <button type="button" class="cp-theme-btn" data-theme-choice="dark">Dark</button>
@@ -68,11 +68,9 @@
 <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="8"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-button-filled__ideal__default__light" data-swap="1" data-bg-theme="light" data-def="l"
   data-l-src="/render/button-filled__ideal__default__light.png" data-l-href="/p/button-filled__ideal__default__light"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
@@ -240,6 +238,8 @@ applyThemeChoice();
       }
       apply();
     })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip">download all (.zip)</a></div>
+
 <details class="cp-about cp-disclosure">
   <summary>
     <span class="cp-about-title">About this preview server</span>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -52,20 +52,18 @@
   </nav>
 </header>
         <main class="cp-main">
-                <h1 class="cp-head cp-catalog-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: signature:compose-ai-tools-ci">✓ trusted</span></h1>
+                <div class="cp-catalog-title"><h1 class="cp-head cp-catalog-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: signature:compose-ai-tools-ci">✓ trusted</span></h1></div>
         <p class="cp-sub">6 preview(s)</p>
         <div class="cp-catalog-actions">
-          <a class="cp-action-chip" href="/bundle.zip?token=demo-token-fixture">download all (.zip)</a>
+          <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
         </div>
-        <div class="cp-catalog-tools">
-        <div class="cp-searchbar">
+<div class="cp-catalog-tools">
+<div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="6"></span>
-  <cp-bg-toggle label="Show the transparent checkerboard behind each preview"></cp-bg-toggle>
 </div>
 </div>
-        <div class="cp-grid" id="cp-grid">
+<div class="cp-grid" id="cp-grid">
         <a class="cp-card" id="cp-card-com-example-ButtonPreview" href="/p/com.example.ButtonPreview?token=demo-token-fixture">
   <div class="cp-imgwrap">
     <img loading="lazy" alt="Button" src="/render/com.example.ButtonPreview.png?token=demo-token-fixture">
@@ -176,6 +174,8 @@
   }
   apply();
 })();</script>
+<div class="cp-catalog-download"><a class="cp-action-chip" href="/bundle.zip?token=demo-token-fixture">download all (.zip)</a></div>
+
         </main>
         <footer class="cp-site-footer">
           <a href="https://github.com/yschimke/compose-ai-tools"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> source</a> ·


### PR DESCRIPTION
## Summary

- move the catalog id beside the catalog title
- move Transparent into the primary comparison/playground action row
- place the preview filter at the top of the catalog menu without a duplicate count
- move the bundle download and catalog details below the catalog content
- update responsive styles, layout assertions, and generated landing fixtures

## Why

The catalog landing header had grown into several disconnected rows, while filtering was separated from the navigation it controls. This reorganizes the page around a clearer primary action row, a cohesive navigation sidebar, and lower-priority metadata at the bottom.

## Validation

- `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.ServeWebPlaygroundLinksTest' --tests 'ee.schimke.composeai.cli.serve.ServeWebFixtureTest'`
- repository pre-commit `ktfmtCheckAll`
- `git diff --check`
