### PR TITLE
fix(serve): honour addImports on every usage rule kind, not just DESTRUCTURE

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -341,7 +341,7 @@ object PlaygroundSourceCleaner {
     // plain by the time the state declaration quotes it. Parsed-only by design — see
     // [UsageRules.Kind.DESTRUCTURE].
     if (parser != null) out = applyDestructureParsed(out, rules, addedImports, parser)
-    out = applyInline(out, rules)
+    out = applyInline(out, rules, addedImports)
     out = applyDrop(out, rules, residue)
     out = applyRename(out, rules, addedImports)
     if (isEntry) out = stampPreview(out, rules, addedImports)
@@ -790,7 +790,11 @@ object PlaygroundSourceCleaner {
    * `val c = counted("Filled")` + `c.onClick` + `c.label` → `{}` + `"Filled"`, with the binding
    * line deleted.
    */
-  private fun applyInline(text: String, rules: UsageRules): String {
+  private fun applyInline(
+    text: String,
+    rules: UsageRules,
+    addedImports: MutableSet<String>,
+  ): String {
     var out = text
     for ((name, scaffold) in rules.scaffolds) {
       if (scaffold.kind != UsageRules.Kind.INLINE) continue
@@ -813,6 +817,7 @@ object PlaygroundSourceCleaner {
         for ((member, replacement) in replacements) {
           out = replaceWord(out, "${binding.name}.$member", replacement)
         }
+        addedImports.addAll(scaffold.imports)
       }
     }
     return out

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -511,7 +511,7 @@ object PlaygroundSourceCleaner {
       val to = scaffold.renameTo ?: continue
       if (!mentionsWord(out, name)) continue
       out = replaceWord(out, name, to)
-      scaffold.addImport?.let { addedImports.add(it) }
+      addedImports.addAll(scaffold.imports)
     }
     return out
   }
@@ -685,8 +685,7 @@ object PlaygroundSourceCleaner {
         if (start < 0 || end > out.length || start >= end) return out
         out = out.substring(0, start) + replacement + out.substring(end)
       }
-      scaffold.addImport?.let { addedImports.add(it) }
-      addedImports.addAll(scaffold.addImports)
+      addedImports.addAll(scaffold.imports)
     }
     return out
   }
@@ -744,7 +743,7 @@ object PlaygroundSourceCleaner {
       val (start, end, replacement) = edit
       if (start < 0 || end > out.length || start >= end) return out
       out = out.substring(0, start) + replacement.first + out.substring(end)
-      replacement.second.addImport?.let { addedImports.add(it) }
+      addedImports.addAll(replacement.second.imports)
     }
     return out
   }
@@ -781,7 +780,7 @@ object PlaygroundSourceCleaner {
         // call alone instead; the residue check below then reports it as an unwritten rule.
         if (rendered.contains(Regex("""\$\d"""))) break
         out = out.substring(0, call.start) + rendered + out.substring(call.argsEnd + 1)
-        scaffold.addImport?.let { addedImports.add(it) }
+        addedImports.addAll(scaffold.imports)
       }
     }
     return out

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -90,7 +90,9 @@ data class UsageRules(
      * by remember { mutableStateOf(…) }` needs four, including the `getValue`/`setValue` the `by`
      * delegation reads and which nothing in the snippet mentions by name.
      *
-     * Applies to every kind, alongside [addImport]; see [imports].
+     * Applies alongside [addImport] to every kind that emits a replacement — RENAME, SUBSTITUTE,
+     * DESTRUCTURE, INLINE; see [imports]. DROP and UNWRAP write no new code, so an import declared
+     * on one of those has nothing to serve.
      */
     @SerialName("addImports") val addImports: List<String> = emptyList(),
     /** [Kind.SUBSTITUTE] only: what the call reads as, with `$0`, `$1`… for its arguments. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -86,9 +86,11 @@ data class UsageRules(
     /** An import the replacement needs, e.g. `androidx.compose.material3.MaterialTheme`. */
     @SerialName("addImport") val addImport: String? = null,
     /**
-     * Imports the replacement needs, when one is not enough — [Kind.DESTRUCTURE]'s `var x by
-     * remember { mutableStateOf(…) }` needs four, including the `getValue`/`setValue` the `by`
+     * Imports the replacement needs, when one is not enough — a state helper substituted to `var x
+     * by remember { mutableStateOf(…) }` needs four, including the `getValue`/`setValue` the `by`
      * delegation reads and which nothing in the snippet mentions by name.
+     *
+     * Applies to every kind, alongside [addImport]; see [imports].
      */
     @SerialName("addImports") val addImports: List<String> = emptyList(),
     /** [Kind.SUBSTITUTE] only: what the call reads as, with `$0`, `$1`… for its arguments. */
@@ -118,7 +120,20 @@ data class UsageRules(
      * means to a reader: the label you passed, and a click handler.
      */
     @SerialName("members") val members: Map<String, String> = emptyMap(),
-  )
+  ) {
+    /**
+     * Every import this rule's replacement needs — [addImport] and [addImports] together.
+     *
+     * Two fields rather than one is a convenience for the rules author: most replacements need
+     * exactly one import and `"addImport": "…"` reads better than a one-element list. Every rewrite
+     * reads *this*, so a rule that spells its imports either way is honoured the same. Reading only
+     * `addImport` is how the state helpers first emitted `remember { mutableStateOf(true) }` with
+     * no `remember` import: a snippet that looks right and does not compile, which is exactly the
+     * failure the compile gate exists to catch.
+     */
+    val imports: List<String>
+      get() = if (addImport == null) addImports else addImports + addImport
+  }
 
   enum class Kind {
     /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -634,6 +634,54 @@ class PlaygroundSourceCleanerTest {
   }
 
   /**
+   * The other kind that emits a replacement, and the one nobody had exercised: INLINE's member
+   * templates are arbitrary Kotlin, so a rule can perfectly well inline a symbol that needs an
+   * import. `applyInline` was not even handed the import set — the same omission as the plural
+   * field, one layer up.
+   */
+  @Test
+  fun `an inlined member contributes the imports its rule declares`() {
+    val rules =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "counted" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.INLINE,
+                members = mapOf("label" to "\$0", "onClick" to "{ Log.d(\"tap\") }"),
+                addImport = "android.util.Log",
+              )
+          )
+      )
+    val source =
+      """
+      package ee.schimke.m3catalog.sections
+
+      import androidx.compose.material3.Button
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.counted
+
+      @Composable
+      fun ButtonSticker() {
+        val c = counted("Filled")
+        Button(onClick = c.onClick) { Text(c.label) }
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun ButtonSticker"), rules)
+      )
+    assertTrue(
+      result.text.contains("""Button(onClick = { Log.d("tap") }) { Text("Filled") }"""),
+      result.text,
+    )
+    assertTrue(result.text.contains("import android.util.Log"), result.text)
+    assertEquals(emptyList(), result.residue)
+  }
+
+  /**
    * The `$known-gaps` entry m3-catalog's `compose-usage.json` carried: `toggleable` and friends
    * return `Pair<T, (T) -> Unit>` destructured into a value and a setter, and the plain reading is
    * real state rather than a value. Roughly 18 stickers were affected.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -572,6 +572,68 @@ class PlaygroundSourceCleanerTest {
   }
 
   /**
+   * `addImports` is not a DESTRUCTURE field.
+   *
+   * m3-catalog's state helpers return a `MutableState` now, so their rules are ordinary SUBSTITUTE
+   * — and the substitution emitted `var checked by remember { mutableStateOf(true) }` against a
+   * snippet with no `remember` import, because only DESTRUCTURE read the plural field.
+   * Perfect-looking Kotlin that does not compile, which the corpus gate caught and no unit test
+   * would have.
+   */
+  @Test
+  fun `a substituted call contributes every import its rule declares`() {
+    val rules =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "toggleable" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.SUBSTITUTE,
+                params = listOf("initial"),
+                plain = "remember { mutableStateOf(\$0) }",
+                addImports =
+                  listOf(
+                    "androidx.compose.runtime.getValue",
+                    "androidx.compose.runtime.mutableStateOf",
+                    "androidx.compose.runtime.remember",
+                    "androidx.compose.runtime.setValue",
+                  ),
+              )
+          )
+      )
+    val source =
+      """
+      package ee.schimke.m3catalog.sections
+
+      import androidx.compose.material3.Switch
+      import androidx.compose.runtime.Composable
+      import androidx.compose.runtime.getValue
+      import androidx.compose.runtime.setValue
+      import ee.schimke.m3catalog.toggleable
+
+      @Composable
+      fun SwitchSticker() {
+        var checked by toggleable(true)
+        Switch(checked = checked, onCheckedChange = { checked = it })
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun SwitchSticker"), rules)
+      )
+    assertTrue(
+      result.text.contains("var checked by remember { mutableStateOf(true) }"),
+      result.text,
+    )
+    for (import in listOf("getValue", "setValue", "remember", "mutableStateOf")) {
+      assertTrue(result.text.contains("import androidx.compose.runtime.$import"), result.text)
+    }
+    assertFalse(result.text.contains("toggleable"), result.text)
+    assertEquals(emptyList(), result.residue)
+  }
+
+  /**
    * The `$known-gaps` entry m3-catalog's `compose-usage.json` carried: `toggleable` and friends
    * return `Pair<T, (T) -> Unit>` destructured into a value and a setter, and the plain reading is
    * real state rather than a value. Roughly 18 stickers were affected.


### PR DESCRIPTION
`UsageRules.Scaffold` carries two import fields — `addImport` for the common single-import case, `addImports` for a replacement that needs several. Only the DESTRUCTURE rewrite ever read the plural one, so a SUBSTITUTE (or RENAME, or INLINE) rule declaring `addImports` had them silently dropped.

That was invisible until m3-catalog moved its state helpers from a destructured `Pair<T, (T) -> Unit>` to a `MutableState<T>` used with `by` (yschimke/m3-catalog#76), which turns those five rules into ordinary SUBSTITUTE. The snippet corpus caught it on the first run:

```
- `component_ListDialog.kt` — ListDialog.kt:52:24 Unresolved reference 'remember'.
```

The rewrite itself was already perfect — `var checked by remember { mutableStateOf(true) }`, `onCheckedChange = { checked = it }` — and the file carried none of the four imports that needs. Kotlin that reads exactly right and does not compile, which is the whole class of failure the corpus gate exists to catch and which no residue check can see.

## Change

Both fields now feed one `Scaffold.imports`, and every rewrite reads that instead of `addImport` directly, so a rule is honoured the same whichever way it spells its imports. Two fields stay, because `"addImport": "…"` genuinely reads better than a one-element list for the majority of rules.

## Test plan

- New `a substituted call contributes every import its rule declares` in `PlaygroundSourceCleanerTest` — a SUBSTITUTE rule with four `addImports`, asserting all four land.
- `./gradlew ktfmtFormat :cli:test` green.
- `scripts/usage-corpus.sh ~/m3-catalog` against the m3-catalog branch: 2/10 → 3/10 on the default sample, and in a 33-snippet run no state-helper snippet fails to compile. The remaining failures are unrelated and pre-existing (string resources, `CatalogFilledStars`, shape recipes).

Non-visual: this changes generated snippet text, not any rendered surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_