### PR TITLE
samples(android): type into the soft-keyboard preview through public input APIs

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -240,17 +240,6 @@ internal constructor(
     // without a keycode is ordinary (`€` and every other non-US-layout key has no `KEYCODE_*`), so
     // it must not be dropped here — issue #3491.
     if (isKey && input.keyCode.isNullOrBlank() && input.text.isNullOrEmpty()) return
-    if (isKey) {
-      // Mirror the keycode into the soft-keyboard band before the held-rule loop runs the actual
-      // `performKeyInput` so an agent driving keyboard input through `interactive/input` sees the
-      // matching cap light up. The band's "press implies visible" rule also raises the band even
-      // when the consumer hasn't called `keyboardController.show()`.
-      val label = KeyboardBandLabels.fromAndroidKeycode(input.keyCode)
-      if (label != null) {
-        if (input.kind == InteractiveInputKind.KEY_DOWN) KeyboardController.notifyKeyDown(label)
-        else KeyboardController.notifyKeyUp(label)
-      }
-    }
     lastUsedAtMs.set(System.currentTimeMillis())
     val replyLatch = CountDownLatch(1)
     val replyError = AtomicReference<Throwable?>(null)

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -3982,11 +3982,21 @@ open class RobolectricHost(
             dispatchRotaryScroll(rule, position, delta)
           }
         }
-        "keyDown" -> dispatchHeldKeyEvent(rule, cmd.keyCode, cmd.text, down = true)
+        "keyDown" -> {
+          // This must run inside the held Robolectric sandbox. KeyboardController contains Compose
+          // snapshot state and is acquired separately by the sandbox classloader; updating the
+          // daemon-host copy in AndroidInteractiveSession changes no state observed by the
+          // sandbox-rendered keyboard band.
+          KeyboardBandLabels.fromAndroidKeycode(cmd.keyCode)?.let(KeyboardController::notifyKeyDown)
+          dispatchHeldKeyEvent(rule, cmd.keyCode, cmd.text, down = true)
+        }
         // The release carries its character too, so a focused field suppresses both halves of the
         // keystroke. Dropping it here would dispatch a physical key-up whose key-down was
         // suppressed — the unpaired release this pairing exists to avoid.
-        "keyUp" -> dispatchHeldKeyEvent(rule, cmd.keyCode, cmd.text, down = false)
+        "keyUp" -> {
+          KeyboardBandLabels.fromAndroidKeycode(cmd.keyCode)?.let(KeyboardController::notifyKeyUp)
+          dispatchHeldKeyEvent(rule, cmd.keyCode, cmd.text, down = false)
+        }
       }
     }
 

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -109,10 +109,9 @@ dependencies {
   // be on Media3 / no media stack at all; we don't want to drag this artifact onto every
   // notification-preview consumer.
   implementation("androidx.media:media:1.8.0")
-  // Soft-keyboard data extension — `SoftKeyboardAnimatedPreview` uses
-  // `LocalSoftwareKeyboardController.show()` (the natural app-side IME path the connector's
-  // around-composable shadows) to raise the band, and writes `KeyboardController.notifyKeyDown`
-  // directly to drive per-cap press highlights in the absence of an interactive daemon session.
+  // Soft-keyboard data extension — `SoftKeyboardAnimatedPreview` uses only ordinary Compose text
+  // input, focus, and `LocalSoftwareKeyboardController.show()`. Its committed recording script
+  // drives text and per-cap press highlights through the daemon's public `input.keyboard` path.
   implementation(project(":data-keyboard-connector"))
   // `TypographySpecimen` / `FontFamilySpecimen` / `FallbackCoverageSpecimen` helpers — Material 3
   // type-role audit sheet, font-family weight ladder, and a fixed script-coverage check set,

--- a/samples/android/compose-previews/recordings/README.md
+++ b/samples/android/compose-previews/recordings/README.md
@@ -1,0 +1,18 @@
+# Soft-keyboard recording
+
+`soft-keyboard-typing.json` turns the ordinary `Soft Keyboard — typing` preview into a deterministic
+input recording. It deliberately uses the same `input.keyDown` / `input.keyUp` events as a held
+interactive session; the sample composable does not call the keyboard connector directly.
+
+From the repository root:
+
+```shell
+compose-preview record \
+  --module :samples:android \
+  --preview "Soft Keyboard — typing" \
+  --script samples/android/compose-previews/recordings/soft-keyboard-typing.json \
+  --out samples/android/build/compose-previews/soft-keyboard-typing.apng
+```
+
+The final `assert.textEquals` event also makes the command fail if real text dispatch did not produce
+`hello world` in the focused field.

--- a/samples/android/compose-previews/recordings/soft-keyboard-typing.json
+++ b/samples/android/compose-previews/recordings/soft-keyboard-typing.json
@@ -1,0 +1,33 @@
+[
+  { "tMs": 0, "kind": "recording.probe", "label": "empty" },
+  { "tMs": 160, "kind": "input.keyDown", "keyCode": "36", "text": "h" },
+  { "tMs": 260, "kind": "input.keyUp", "keyCode": "36", "text": "h" },
+  { "tMs": 340, "kind": "input.keyDown", "keyCode": "33", "text": "e" },
+  { "tMs": 440, "kind": "input.keyUp", "keyCode": "33", "text": "e" },
+  { "tMs": 520, "kind": "input.keyDown", "keyCode": "40", "text": "l" },
+  { "tMs": 620, "kind": "input.keyUp", "keyCode": "40", "text": "l" },
+  { "tMs": 700, "kind": "input.keyDown", "keyCode": "40", "text": "l" },
+  { "tMs": 800, "kind": "input.keyUp", "keyCode": "40", "text": "l" },
+  { "tMs": 880, "kind": "input.keyDown", "keyCode": "43", "text": "o" },
+  { "tMs": 980, "kind": "input.keyUp", "keyCode": "43", "text": "o" },
+  { "tMs": 1060, "kind": "input.keyDown", "keyCode": "62", "text": " " },
+  { "tMs": 1160, "kind": "input.keyUp", "keyCode": "62", "text": " " },
+  { "tMs": 1240, "kind": "input.keyDown", "keyCode": "51", "text": "w" },
+  { "tMs": 1340, "kind": "input.keyUp", "keyCode": "51", "text": "w" },
+  { "tMs": 1420, "kind": "input.keyDown", "keyCode": "43", "text": "o" },
+  { "tMs": 1520, "kind": "input.keyUp", "keyCode": "43", "text": "o" },
+  { "tMs": 1600, "kind": "input.keyDown", "keyCode": "46", "text": "r" },
+  { "tMs": 1700, "kind": "input.keyUp", "keyCode": "46", "text": "r" },
+  { "tMs": 1780, "kind": "input.keyDown", "keyCode": "40", "text": "l" },
+  { "tMs": 1880, "kind": "input.keyUp", "keyCode": "40", "text": "l" },
+  { "tMs": 1960, "kind": "input.keyDown", "keyCode": "32", "text": "d" },
+  { "tMs": 2060, "kind": "input.keyUp", "keyCode": "32", "text": "d" },
+  { "tMs": 2140, "kind": "input.keyDown", "keyCode": "66" },
+  { "tMs": 2240, "kind": "input.keyUp", "keyCode": "66" },
+  {
+    "tMs": 2240,
+    "kind": "assert.textEquals",
+    "target": { "testTag": "message-editor" },
+    "inputText": "hello world"
+  }
+]

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/SoftKeyboardAnimatedPreview.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/SoftKeyboardAnimatedPreview.kt
@@ -1,18 +1,12 @@
-@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
-
 package com.example.sampleandroid
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -20,144 +14,83 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import ee.schimke.composeai.daemon.KeyboardController
-import ee.schimke.composeai.preview.AnimatedPreview
 
 /**
- * Animated demo of the soft-keyboard data extension (`:data-keyboard-connector`). Demonstrates the
- * two control surfaces the extension exposes:
+ * Real application-side text editor used by both previews below.
  *
- * 1. **App-side, passive** — `LocalSoftwareKeyboardController.current?.show()` raises the band
- *    through the connector's shadow controller. This is the same call Compose's `BasicTextField`
- *    makes internally on focus, so any normal app code that focuses a text field gets the band for
- *    free; the explicit `show()` here just keeps the preview's intent obvious in source.
- * 2. **Direct controller writes** — `KeyboardController.notifyKeyDown(label)` /
- *    `notifyKeyUp(label)` mirror what `AndroidInteractiveSession.dispatch` does for live daemon
- *    sessions. The preview drives it from a `LaunchedEffect` so a paused-clock `@AnimatedPreview`
- *    capture can step through a typing sequence without needing an interactive session attached.
- *
- * The on-screen band is rendered by the around-composable in `:data-keyboard-connector`; this file
- * doesn't reach into any rendering API. That's the architectural shape — the extension owns the
- * band, the app owns the state.
+ * The sample owns only ordinary Compose state, focus, and the public software-keyboard controller.
+ * A scripted capture sends `input.keyDown` / `input.keyUp` events through the daemon's public input
+ * path; those events update this field and independently drive the keyboard connector's pressed-key
+ * overlay. Keeping those two effects on the same input path means a capture cannot appear to type
+ * when focus or text dispatch is broken.
+ */
+@Composable
+private fun SoftKeyboardMessageEditor() {
+  var value by remember { mutableStateOf("") }
+  val focusRequester = remember { FocusRequester() }
+  val keyboardController = LocalSoftwareKeyboardController.current
+
+  LaunchedEffect(Unit) {
+    focusRequester.requestFocus()
+    keyboardController?.show()
+  }
+  DisposableEffect(keyboardController) { onDispose { keyboardController?.hide() } }
+
+  Surface(modifier = Modifier.fillMaxSize(), color = Color(0xFFF1F3F4)) {
+    Column(
+      modifier = Modifier.fillMaxSize().padding(24.dp),
+      verticalArrangement = androidx.compose.foundation.layout.Arrangement.Top,
+    ) {
+      Text(text = "Compose", style = MaterialTheme.typography.titleMedium)
+      Box(
+        modifier =
+          Modifier.padding(top = 16.dp)
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(horizontal = 12.dp, vertical = 16.dp),
+        contentAlignment = Alignment.CenterStart,
+      ) {
+        BasicTextField(
+          value = value,
+          onValueChange = { value = it },
+          modifier =
+            Modifier.fillMaxWidth().focusRequester(focusRequester).testTag("message-editor"),
+          textStyle =
+            TextStyle(color = Color(0xFF1F1F1F), fontSize = 20.sp, fontWeight = FontWeight.Medium),
+          cursorBrush = SolidColor(Color(0xFF1F1F1F)),
+          singleLine = true,
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Recording target for `compose-previews/recordings/soft-keyboard-typing.json`. The plain preview
+ * is the deterministic empty-field frame; replaying the committed script produces the animated
+ * capture through real text input.
  */
 @Preview(name = "Soft Keyboard — typing", widthDp = 360, heightDp = 640)
-@AnimatedPreview(durationMs = 2400, frameIntervalMs = 80, showCurves = false)
 @Composable
-fun SoftKeyboardAnimatedPreview() {
-  val keyboardController = LocalSoftwareKeyboardController.current
-  DisposableEffect(Unit) {
-    keyboardController?.show()
-    onDispose { keyboardController?.hide() }
-  }
-  val transition = rememberInfiniteTransition(label = "typing")
-  val phase by
-    transition.animateFloat(
-      initialValue = 0f,
-      targetValue = TYPING_SEQUENCE.size.toFloat(),
-      animationSpec =
-        infiniteRepeatable(animation = tween(durationMillis = 2400, easing = LinearEasing)),
-      label = "phase",
-    )
-  val index = phase.toInt().coerceIn(0, TYPING_SEQUENCE.size - 1)
-  val slot = TYPING_SEQUENCE[index]
-  // Mirror the daemon's interactive `KEY_DOWN` / `KEY_UP` shape so the band's `pressedKey` state
-  // reaches it through the supported `KeyboardController` API rather than a private back-channel.
-  LaunchedEffect(index) { KeyboardController.notifyKeyDown(slot.pressed) }
-  DisposableEffect(Unit) { onDispose { KeyboardController.notifyKeyUp() } }
+fun SoftKeyboardAnimatedPreview() = SoftKeyboardMessageEditor()
 
-  val running = buildString { for (i in 0..index) append(TYPING_SEQUENCE[i].typed) }
-
-  Surface(modifier = Modifier.fillMaxSize(), color = Color(0xFFF1F3F4)) {
-    Column(
-      modifier = Modifier.fillMaxSize().padding(24.dp),
-      verticalArrangement = androidx.compose.foundation.layout.Arrangement.Top,
-    ) {
-      Text(text = "Compose", style = MaterialTheme.typography.titleMedium)
-      Box(
-        modifier =
-          Modifier.padding(top = 16.dp)
-            .fillMaxWidth()
-            .background(Color.White)
-            .padding(horizontal = 12.dp, vertical = 16.dp),
-        contentAlignment = Alignment.CenterStart,
-      ) {
-        Text(
-          text = running.ifEmpty { "" } + "│",
-          style =
-            TextStyle(color = Color(0xFF1F1F1F), fontSize = 20.sp, fontWeight = FontWeight.Medium),
-        )
-      }
-    }
-  }
-}
-
-/**
- * Static counterpart that exercises only the app-side path: focusing nothing, calling
- * `keyboardController.show()` directly. The band appears because the around-composable's shadow
- * `LocalSoftwareKeyboardController` catches the call and flips
- * `KeyboardController.notifyImeVisibility(true)`. Useful as a baseline diff target against the
- * animated preview.
- */
+/** Static baseline for the same public focus and IME-visibility path. */
 @Preview(name = "Soft Keyboard — idle", widthDp = 360, heightDp = 640)
 @Composable
-fun SoftKeyboardIdlePreview() {
-  val keyboardController = LocalSoftwareKeyboardController.current
-  DisposableEffect(Unit) {
-    keyboardController?.show()
-    onDispose { keyboardController?.hide() }
-  }
-  Surface(modifier = Modifier.fillMaxSize(), color = Color(0xFFF1F3F4)) {
-    Column(
-      modifier = Modifier.fillMaxSize().padding(24.dp),
-      verticalArrangement = androidx.compose.foundation.layout.Arrangement.Top,
-    ) {
-      Text(text = "Compose", style = MaterialTheme.typography.titleMedium)
-      Box(
-        modifier =
-          Modifier.padding(top = 16.dp)
-            .fillMaxWidth()
-            .background(Color.White)
-            .padding(horizontal = 12.dp, vertical = 16.dp),
-        contentAlignment = Alignment.CenterStart,
-      ) {
-        Text(
-          text = "│",
-          style =
-            TextStyle(color = Color(0xFF1F1F1F), fontSize = 20.sp, fontWeight = FontWeight.Medium),
-        )
-      }
-    }
-  }
-}
-
-/**
- * One step in the typing demo: which key cap is depicted as pressed for this slot, and which
- * character (if any) gets appended to the running text. The two can differ — e.g. the "space" key
- * types ' '.
- */
-private data class TypingSlot(val pressed: String, val typed: String)
-
-private val TYPING_SEQUENCE: List<TypingSlot> =
-  listOf(
-    TypingSlot("h", "h"),
-    TypingSlot("e", "e"),
-    TypingSlot("l", "l"),
-    TypingSlot("l", "l"),
-    TypingSlot("o", "o"),
-    TypingSlot("space", " "),
-    TypingSlot("w", "w"),
-    TypingSlot("o", "o"),
-    TypingSlot("r", "r"),
-    TypingSlot("l", "l"),
-    TypingSlot("d", "d"),
-    TypingSlot("enter", ""),
-  )
+fun SoftKeyboardIdlePreview() = SoftKeyboardMessageEditor()


### PR DESCRIPTION
Closes #3673.

## What changed

- replace the sample's manually animated text and direct `KeyboardController` writes with a focused `BasicTextField`
- add a committed deterministic `input.keyDown` / `input.keyUp` recording script that types `hello world`
- mirror Android key presses inside the held Robolectric sandbox before dispatching the real Compose key event
- document how to replay the sample recording

## Why

The previous sample simulated both typed text and keyboard highlights from composable-owned animation state, so it did not exercise the public input path. Moving the sample to real input exposed a classloader bug: `AndroidInteractiveSession` updated the daemon-host copy of `KeyboardController`, while the keyboard overlay observed the sandbox copy. The field received input, but pressed keys did not light up.

The mirror now runs in the sandbox dispatch loop alongside `performKeyInput`, keeping text input and the visible pressed-key effect on the same public event path.

## Validation

- `:daemon:android:ktfmtCheck`
- `:daemon:android:compileDebugKotlin`
- `:samples:android:composePreviewDiscover`
- deterministic 28-frame replay at 12 fps
- verified the held `H` frame changes the keyboard crop by 10,931 pixels relative to the released frame (previously zero)