### PR TITLE
fix(serve): focus page gaps on components

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
@@ -134,6 +134,13 @@ public data class PageNode(
    * one of its variants), so it is drawn as structure and left out of the coverage count.
    */
   val container: Boolean = false,
+  /**
+   * The node type reported by the design tool, for example `COMPONENT` or `COMPONENT_SET`.
+   *
+   * Kept as free text so a new design-tool type remains an additive manifest change. Consumers only
+   * attach meaning to the grouping type they understand; see [isContainer].
+   */
+  val type: String? = null,
 ) {
   /**
    * A component the design file marks as **private** — Figma's leading-dot convention, used for the
@@ -145,6 +152,20 @@ public data class PageNode(
    */
   public val isPrivate: Boolean
     get() = name.startsWith(".")
+
+  /**
+   * Whether this is a family/grouping rather than one concrete component.
+   *
+   * Current imports preserve Figma's exact `COMPONENT_SET` type. [container] remains as the
+   * backwards-compatible producer hint, but reading [type] is essential: otherwise a whole grid of
+   * variants becomes one enormous "missing component" hotspot over the actual components inside it.
+   */
+  public val isContainer: Boolean
+    get() = container || type.equals("COMPONENT_SET", ignoreCase = true)
+
+  /** A concrete, public component that the page should count and highlight. */
+  public val isComponent: Boolean
+    get() = !isPrivate && !isContainer
 
   /** Whether this node can be drawn by us, i.e. it names a preview we could ask for. */
   public val isRenderable: Boolean
@@ -207,7 +228,7 @@ public data class DesignPage(
 ) {
   /** Nodes with code behind them. */
   public val linked: List<PageNode>
-    get() = nodes.filter { !it.isUnlinked }
+    get() = nodes.filter { it.isComponent && !it.isUnlinked }
 
   /** Nodes with no code behind them. Not the same as [coverageGaps] — see there. */
   public val unlinked: List<PageNode>
@@ -233,7 +254,7 @@ public data class DesignPage(
    * container is visible and harmless; a gap that quietly disappears is neither.
    */
   public val coverageGaps: List<PageNode>
-    get() = nodes.filter { it.isUnlinked && !it.isPrivate && !it.container }
+    get() = nodes.filter { it.isComponent && it.isUnlinked }
 
   /**
    * How many components on this page a catalog could implement — the denominator behind "N of M

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
@@ -18,6 +18,7 @@ class DesignPagesCoverageTest {
     depth: Int,
     link: PageNodeLink,
     container: Boolean = false,
+    type: String? = null,
   ) =
     PageNode(
       nodeId = id,
@@ -26,6 +27,7 @@ class DesignPagesCoverageTest {
       ref = "figma:file/$id",
       link = link,
       container = container,
+      type = type,
     )
 
   private fun page(vararg nodes: PageNode) =
@@ -63,6 +65,20 @@ class DesignPagesCoverageTest {
       )
 
     assertEquals(listOf("Shape=Gem"), subject.coverageGaps.map { it.name })
+    assertEquals(2, subject.coverageTotal)
+  }
+
+  @Test
+  fun `a component set type is a grouping not a giant component hotspot`() {
+    val subject =
+      page(
+        node("1:8", "Input chip", 2, PageNodeLink.UNLINKED, type = "COMPONENT_SET"),
+        node("1:9", "State=Enabled", 3, PageNodeLink.MANIFEST),
+        node("1:10", "State=Dragged", 3, PageNodeLink.UNLINKED),
+      )
+
+    assertEquals(listOf("State=Dragged"), subject.coverageGaps.map { it.name })
+    assertEquals(listOf("State=Enabled"), subject.linked.map { it.name })
     assertEquals(2, subject.coverageTotal)
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -6784,8 +6784,9 @@ $rows
     // click, the modifier click and the status-bar preview all start working, the destination is
     // announced instead of a pressed state that was never true, and the sheet still navigates with
     // no script at all.
+    val components = page.nodes.filter(PageNode::isComponent)
     val outlines =
-      page.nodes.joinToString("\n") { node ->
+      components.joinToString("\n") { node ->
         val label =
           if (node.isUnlinked) "${node.name} — no code behind this"
           else "${node.name} — ${node.code.orEmpty()}"
@@ -6813,7 +6814,7 @@ $rows
     // to the spec and never flips back pays for nothing, and every URL in it stays server-built and
     // server-escaped (reading one out of the DOM into `img.src` is CodeQL's `js/xss-through-dom`).
     val renders =
-      page.nodes
+      components
         .mapNotNull { node ->
           val previewId = renderable(node) ?: return@mapNotNull null
           "<img class=\"cp-page-render\" alt=\"\" loading=\"lazy\" " +
@@ -6832,7 +6833,7 @@ $rows
     // already avoid, and the destination here is built from a preview id that came off a design
     // file. Cloning a server-built, server-escaped element has no sink in it at all.
     val diffLinks =
-      page.nodes
+      components
         .mapNotNull { node ->
           val previewId = renderable(node) ?: return@mapNotNull null
           val sep = if (q.isEmpty()) "?" else "&"
@@ -6848,7 +6849,7 @@ $rows
     // (the two are the same thing by definition, but `ref` is optional and this deep link is the
     // only link an unlinked node has).
     val rows =
-      page.nodes.joinToString("\n") { node ->
+      components.joinToString("\n") { node ->
         val previewId = renderable(node)
         val href =
           previewId?.let { "$basePath/p/${WebEscaping.urlEncodeSegment(it)}$q" }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -75,6 +75,7 @@ class ServeWebFixtureTest {
     link: PageNodeLink = PageNodeLink.MANIFEST,
     confidence: PageNodeConfidence? = if (code == null) null else PageNodeConfidence.HIGH,
     depth: Int = 3,
+    type: String? = null,
   ) =
     PageNode(
       nodeId = nodeId,
@@ -85,6 +86,7 @@ class ServeWebFixtureTest {
       previewId = previewId,
       link = link,
       confidence = confidence,
+      type = type,
     )
 
   private val token = "demo-token-fixture"
@@ -1605,6 +1607,7 @@ class ServeWebFixtureTest {
           """
           <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800" fill="none">
             <rect width="1200" height="800" fill="#F7F2FA"/>
+            <g data-node-id="1:0"><rect x="120" y="170" width="1020" height="560" fill="none"/></g>
             <g data-node-id="1:9"><rect x="40" y="32" width="1120" height="64" rx="16" fill="#EADDFF"/></g>
             <g data-node-id="1:1"><circle cx="180" cy="300" r="90" fill="#6750A4"/></g>
             <g data-node-id="1:2"><rect x="330" y="210" width="180" height="180" rx="36" fill="#6750A4"/></g>
@@ -1622,8 +1625,8 @@ class ServeWebFixtureTest {
     // component on it. The mix is the point: two `manifest` links whose previews this catalog
     // publishes, one `convention` (low-confidence name match), one `manifest` link to a preview
     // that ISN'T published (outline, no render), one node the manifest names that the export does
-    // not carry, and two `unlinked` — the sheet's own header and a shape no code implements, which
-    // is the finding the surface exists to surface.
+    // not carry, and three `unlinked`: the component-set grid and sheet header (both structure),
+    // plus a specific shape no code implements, which is the finding the surface exists to surface.
     val designPageFixture =
       DesignPage(
         id = "shape",
@@ -1633,6 +1636,13 @@ class ServeWebFixtureTest {
         image = PageImage(uri = "shape.svg"),
         nodes =
           listOf(
+            pageNode(
+              "1:0",
+              "Shape set",
+              link = PageNodeLink.UNLINKED,
+              depth = 1,
+              type = "COMPONENT_SET",
+            ),
             pageNode("1:9", ".Header", link = PageNodeLink.UNLINKED, depth = 2),
             pageNode(
               "1:1",
@@ -2312,6 +2322,23 @@ class ServeWebFixtureTest {
 
     assertGoldensInSync(pagesDir, goldens)
     assertUnfurlCardsInSync(pagesDir, unfurlCards)
+    assertFalse(
+      designPageHtml.contains(
+        "class=\"cp-page-node\" data-link=\"unlinked\" data-cp-node=\"1:0\""
+      ) ||
+        designPageHtml.contains(
+          "class=\"cp-page-row\" data-link=\"unlinked\" data-cp-node=\"1:0\""
+        ),
+      "a component-set grid is page structure, never a giant interactive hotspot or audit row",
+    )
+    assertFalse(
+      designPageHtml.contains("data-cp-node=\"1:9\""),
+      "private sheet furniture is not presented as missing component work",
+    )
+    assertTrue(
+      designPageHtml.contains("data-cp-gap data-cp-node=\"1:6\""),
+      "a concrete unimplemented component remains a focused gap hotspot",
+    )
     // The parity page's load-bearing claims, asserted rather than left to the pixel diff. A
     // comment on Switch (whose code never moved in this window) is one-sided design movement, so
     // it must reach the "needs a look" band; Button moved on both sides and must NOT, because that

--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -220,13 +220,9 @@ export function planDesignPages({ manifest, spec, catalog }) {
             ? node.depth
             : 0,
         // The node's type in the design file, republished so the consumer can tell a container from
-        // the components inside it EXACTLY rather than by inference. `DesignPage.coverageGaps`
-        // falls back to "a node followed by a deeper one has children" when no type is stated, and
-        // that fallback is only as good as the walk: an import lists components only, so an unlisted
-        // frame between two of them lets a shallower node be followed by a deeper one that is not
-        // inside it — and the shallower one then drops out of the count as furniture, understating
-        // the gaps. Stripping the field here meant every delivery branch took that fallback, however
-        // carefully the importer had stated the type.
+        // the components inside it exactly. In particular, a COMPONENT_SET is the grid/column that
+        // arranges its concrete variants; treating it as another component produces one enormous
+        // missing-work outline over all of the useful, specific component hotspots.
         //
         // Free text, like the consumer's own field, so a design tool growing a type does not fail
         // the parse — but only a non-empty string, since `""` is not a type and would read as one.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-design-page.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-design-page.html
@@ -78,6 +78,7 @@
             <div class="cp-page-stage" style="--cp-page-aspect:1.5000">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" height="800" viewBox="0 0 1200 800" width="1200">
   <rect fill="#F7F2FA" height="800" width="1200"/>
+  <g data-node-id="1:0"><rect fill="none" height="560" width="1020" x="120" y="170"/></g>
   <g data-node-id="1:9"><rect fill="#EADDFF" height="64" rx="16" width="1120" x="40" y="32"/></g>
   <g data-node-id="1:1"><circle cx="180" cy="300" fill="#6750A4" r="90"/></g>
   <g data-node-id="1:2"><rect fill="#6750A4" height="180" rx="36" width="180" x="330" y="210"/></g>
@@ -94,8 +95,7 @@
 <a class="cp-page-diff-link" tabindex="-1" aria-hidden="true" data-cp-node="1:2" href="/p/com.example.ProfileCardPreview?session=compose-m3&mode=spec&amp;specView=diff"></a>
 <a class="cp-page-diff-link" tabindex="-1" aria-hidden="true" data-cp-node="1:3" href="/p/com.example.ProfileCardPreview?session=compose-m3&mode=spec&amp;specView=diff"></a>
 <a class="cp-page-diff-link" tabindex="-1" aria-hidden="true" data-cp-node="1:404" href="/p/com.example.ProfileCardPreview?session=compose-m3&mode=spec&amp;specView=diff"></a></template>
-              <a class="cp-page-node" data-link="unlinked" href="https://www.figma.com/design/ocdacdEsnHipMJD3egzxKb?node-id=1-9" data-cp-node="1:9" title=".Header — no code behind this"><span class="cp-visually-hidden">.Header — no code behind this</span></a>
-<a class="cp-page-node" data-link="manifest" href="/p/com.example.ProfileCardPreview?session=compose-m3" data-cp-node="1:1" title="Shape=Circle — ui/Shapes.kt#CircleShape"><span class="cp-visually-hidden">Shape=Circle — ui/Shapes.kt#CircleShape</span></a>
+              <a class="cp-page-node" data-link="manifest" href="/p/com.example.ProfileCardPreview?session=compose-m3" data-cp-node="1:1" title="Shape=Circle — ui/Shapes.kt#CircleShape"><span class="cp-visually-hidden">Shape=Circle — ui/Shapes.kt#CircleShape</span></a>
 <a class="cp-page-node" data-link="manifest" href="/p/com.example.ProfileCardPreview?session=compose-m3" data-cp-node="1:2" title="Shape=Square — ui/Shapes.kt#SquareShape"><span class="cp-visually-hidden">Shape=Square — ui/Shapes.kt#SquareShape</span></a>
 <a class="cp-page-node" data-link="convention" href="/p/com.example.ProfileCardPreview?session=compose-m3" data-cp-node="1:3" title="Shape=Triangle — ui/Shapes.kt#TriangleShape"><span class="cp-visually-hidden">Shape=Triangle — ui/Shapes.kt#TriangleShape</span></a>
 <a class="cp-page-node" data-link="manifest" href="https://www.figma.com/design/ocdacdEsnHipMJD3egzxKb?node-id=1-4" data-cp-node="1:4" title="Shape=Pill — ui/Shapes.kt#PillShape"><span class="cp-visually-hidden">Shape=Pill — ui/Shapes.kt#PillShape</span></a>
@@ -106,8 +106,7 @@
             <details class="cp-page-nodes">
               <summary>5 of 6 components implemented</summary>
               <div class="cp-page-list">
-              <a class="cp-page-row" data-link="unlinked" data-cp-node="1:9" href="https://www.figma.com/design/ocdacdEsnHipMJD3egzxKb?node-id=1-9"><span class="cp-page-dot" aria-hidden="true"></span><span class="cp-page-row-name">.Header</span><span class="cp-page-row-code">no code behind this</span></a>
-<a class="cp-page-row" data-link="manifest" data-cp-node="1:1" href="/p/com.example.ProfileCardPreview?session=compose-m3"><span class="cp-page-dot" aria-hidden="true"></span><span class="cp-page-row-name">Shape=Circle</span><span class="cp-page-row-code">ui/Shapes.kt#CircleShape</span></a>
+              <a class="cp-page-row" data-link="manifest" data-cp-node="1:1" href="/p/com.example.ProfileCardPreview?session=compose-m3"><span class="cp-page-dot" aria-hidden="true"></span><span class="cp-page-row-name">Shape=Circle</span><span class="cp-page-row-code">ui/Shapes.kt#CircleShape</span></a>
 <a class="cp-page-row" data-link="manifest" data-cp-node="1:2" href="/p/com.example.ProfileCardPreview?session=compose-m3"><span class="cp-page-dot" aria-hidden="true"></span><span class="cp-page-row-name">Shape=Square</span><span class="cp-page-row-code">ui/Shapes.kt#SquareShape</span></a>
 <a class="cp-page-row" data-link="convention" data-cp-node="1:3" href="/p/com.example.ProfileCardPreview?session=compose-m3"><span class="cp-page-dot" aria-hidden="true"></span><span class="cp-page-row-name">Shape=Triangle</span><span class="cp-page-row-code">ui/Shapes.kt#TriangleShape</span></a>
 <a class="cp-page-row" data-link="manifest" data-cp-node="1:4" href="https://www.figma.com/design/ocdacdEsnHipMJD3egzxKb?node-id=1-4"><span class="cp-page-dot" aria-hidden="true"></span><span class="cp-page-row-name">Shape=Pill</span><span class="cp-page-row-code">ui/Shapes.kt#PillShape</span></a>


### PR DESCRIPTION
## What changed

- Treat design-tool `COMPONENT_SET` nodes as structural containers, including manifests that provide the node type rather than the legacy container flag.
- Emit page hotspots, audit rows, render slots, and diff targets only for concrete public components.
- Keep missing-component highlighting focused on the specific unimplemented variant and exclude grids, columns, and private sheet furniture from coverage counts.
- Add model, producer, HTML fixture, and visual regression coverage for the broad-container case.

## Why

A contract mismatch meant the page producer preserved Figma node types while the Kotlin consumer ignored them. Whole component-set grids could therefore be classified as unimplemented components, producing large distracting red overlays over the actual variants.

## User impact

Design pages now highlight the component that needs implementation instead of drawing red boxes around large grids or columns of variants.

## Validation

- `node --test scripts/design-artifacts/design-pages.test.mjs` (20 passed)
- `./gradlew :preview-data-api:test --tests '*DesignPagesCoverageTest*'`
- `UPDATE_SERVE_WEB_FIXTURES=true ./gradlew :cli:test --tests '*ServeWebFixtureTest*'`
- `npx playwright test -c preview-harness/playwright.config.mjs pages-snapshot -g 'snapshot · serve-design-page'` (4 passed, light and dark)
- `./gradlew :preview-data-api:ktfmtFormat :cli:ktfmtFormat`
