### PR TITLE
feat(previews): support addressable interaction variants

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
@@ -47,6 +47,19 @@ package ee.schimke.composeai.preview
  * so a desktop catalog has no reason to keep a hand-written wrapper for a variant that differs only
  * by a knob.
  *
+ * Interaction states are addressable variants too. They use real harness input rather than a
+ * preview-only `MutableInteractionSource`:
+ * ```
+ * @OverrideVariant(name = "hovered", interaction = VariantInteraction.Hovered)
+ * @OverrideVariant(name = "focused", interaction = VariantInteraction.Focused)
+ * @OverrideVariant(name = "pressed", interaction = VariantInteraction.Pressed)
+ * @Composable
+ * fun FilledButton() = Button(onClick = {}) { Text("Button") }
+ * ```
+ *
+ * Each produces its own `_VARIANT_<name>` preview id. [interactionIndex] selects among multiple
+ * interactive nodes; it defaults to the first.
+ *
  * ## Hoisting a whole matrix onto one annotation
  *
  * `@Target` includes `ANNOTATION_CLASS`, so a set of variants that several components share can be
@@ -88,6 +101,18 @@ annotation class OverrideVariant(
    * so keep it slug-friendly (lowercase, no spaces) and unique across the function's variants.
    */
   val name: String,
+  /**
+   * Optional real input state to drive before this variant is captured. Unlike a knob seed, this
+   * goes through Compose's focus / pointer input paths, so the component's own interaction source
+   * and indication produce the pixels. [Focused] and [Pressed] use the same focus walk as
+   * [FocusedPreview]; [Hovered] targets the component without focusing it.
+   */
+  val interaction: VariantInteraction = VariantInteraction.None,
+  /**
+   * Zero-based target: tab order for [VariantInteraction.Focused]/[VariantInteraction.Pressed],
+   * interactive-semantics order for [VariantInteraction.Hovered].
+   */
+  val interactionIndex: Int = 0,
   /** Boolean knob seeds, each `"key=true"` / `"key=false"` (or `"key#index=…"`). */
   val booleans: Array<String> = [],
   /** String knob seeds, each `"key=value"` (or `"key#index=value"`). */
@@ -99,3 +124,11 @@ annotation class OverrideVariant(
   /** Colour knob seeds, each `"key=#AARRGGBB"` (or `#RRGGBB`; or `"key#index=…"`). */
   val colors: Array<String> = [],
 )
+
+/** Harness-driven state for an addressable [OverrideVariant]. */
+enum class VariantInteraction {
+  None,
+  Hovered,
+  Focused,
+  Pressed,
+}

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -102,7 +102,7 @@ data class Capture(
    */
   val optional: Boolean = false,
   /**
-   * Presence markers for the two per-capture **detected-feature** annotations discovery emits: a
+   * Presence markers for per-capture **detected-feature** annotations discovery emits: a
    * `@FocusedPreview` capture carries a `focus` (or `focusGif`) block, and a `@GestureHintPreview`
    * one carries `gestureHint`. Modelled here only as opaque [JsonElement]s — the serve layer needs
    * to know *whether* a preview supports keyboard focus / one-handed gestures (to gate the viewer's
@@ -112,6 +112,7 @@ data class Capture(
    */
   val focus: JsonElement? = null,
   val focusGif: JsonElement? = null,
+  val hover: JsonElement? = null,
   val gestureHint: JsonElement? = null,
 )
 

--- a/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/OverrideVariant.kt
+++ b/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/OverrideVariant.kt
@@ -56,11 +56,16 @@ data class OverrideSeed(
  * A named override variant sourced from an `@OverrideVariant` annotation. Discovery emits one extra
  * synthetic preview per variant carrying this on `PreviewInfo.overrides`; each render backend seeds
  * [toNamedOverrides] onto the `PreviewOverrideController` (batch) or into `RenderSpec.overrides`
- * (daemon) before composing. [name] is the `_VARIANT_<name>` render-output tag and the variant's
- * catalog `state`.
+ * (daemon) before composing. [interaction] records the real harness state discovery materialized
+ * onto the capture. [name] is the `_VARIANT_<name>` render-output tag and catalog `state`.
  */
 @Serializable
-data class OverrideVariantSpec(val name: String, val seeds: List<OverrideSeed> = emptyList()) {
+data class OverrideVariantSpec(
+  val name: String,
+  val seeds: List<OverrideSeed> = emptyList(),
+  val interaction: OverrideVariantInteraction? = null,
+  val interactionIndex: Int = 0,
+) {
   /**
    * The seed map (keyed by [OverrideSeed.seedKey]) this variant applies — the exact shape
    * `PreviewOverrides.namedOverrides` / `PreviewOverrideController.set(...)` take. Unparseable
@@ -75,6 +80,13 @@ data class OverrideVariantSpec(val name: String, val seeds: List<OverrideSeed> =
     }
     return out
   }
+}
+
+@Serializable
+enum class OverrideVariantInteraction {
+  Hovered,
+  Focused,
+  Pressed,
 }
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -269,6 +269,9 @@ data class FocusCapture(
   val pressed: Boolean = false,
 )
 
+/** Hover state driven by a real pointer move without first focusing the target. */
+@Serializable data class HoverCapture(val targetIndex: Int = 0)
+
 /**
  * `@FocusedPreview(gif = true)` capture state. Carries the per-step focus instructions discovery
  * built from `[indices]` / `[traverse]`; the renderer drives each step through the same
@@ -347,8 +350,8 @@ data class GestureHintCapture(
 
 /**
  * Per-preview Android runtime-permission grant state discovered from a `@PermissionPreview`
- * annotation (issue #3676). Non-null when the annotation contributed at least one usable entry;
- * the renderer builds `:data-permissions-connector`'s `PermissionsOverrideExtension` from it, whose
+ * annotation (issue #3676). Non-null when the annotation contributed at least one usable entry; the
+ * renderer builds `:data-permissions-connector`'s `PermissionsOverrideExtension` from it, whose
  * construction seeds Robolectric's `ShadowApplication` grant set **before** the first composition
  * pass — the same controller daemon-driven `renderNow.overrides.permissions` drives through the
  * connector's planner.
@@ -674,6 +677,8 @@ data class Capture(
   val animation: AnimationCapture? = null,
   /** `null` → no focus drive. Set when the preview carries a `@FocusedPreview` annotation. */
   val focus: FocusCapture? = null,
+  /** `null` → no pointer-hover drive. */
+  val hover: HoverCapture? = null,
   /**
    * `null` → no focus-driven GIF. Set when the preview carries `@FocusedPreview(gif = true)`.
    * Mutually exclusive with [focus] on the same capture — the GIF capture owns its steps inline.
@@ -908,15 +913,19 @@ data class OverrideSeed(
 
 /**
  * A named override variant sourced from an `@OverrideVariant` annotation. Discovery emits one extra
- * synthetic [PreviewInfo] per variant (per multipreview member), carrying these [seeds] on
- * [PreviewInfo.overrides]; the renderer seeds them via `PreviewOverrideController.set(...)` before
- * composing, so the same preview function renders once more with the knob(s) flipped. [name] is the
- * `_VARIANT_<name>` render-output tag and the variant's catalog `state`.
+ * synthetic [PreviewInfo] per variant (per multipreview member), carrying these [seeds] and an
+ * optional real [interaction] on [PreviewInfo.overrides]. Discovery materializes the interaction
+ * onto the variant's capture; renderers seed knob values via `PreviewOverrideController.set(...)`
+ * before composing. [name] is the `_VARIANT_<name>` render-output tag and catalog `state`.
  */
 @Serializable
 data class OverrideVariantSpec(
   val name: String,
   val seeds: List<OverrideSeed>,
+  /** Real harness state, when this variant is more than a named knob seed. */
+  val interaction: OverrideVariantInteraction? = null,
+  /** Zero-based target among the preview's interactive nodes. */
+  val interactionIndex: Int = 0,
   /**
    * The **full axis assignment** this variant represents, when it came from a `@PreviewAxis` cross
    * product rather than a hand-written `@OverrideVariant` — `[size=xs, shape=square]`.
@@ -933,6 +942,13 @@ data class OverrideVariantSpec(
    */
   val props: List<CatalogVariantProp> = emptyList(),
 )
+
+@Serializable
+enum class OverrideVariantInteraction {
+  Hovered,
+  Focused,
+  Pressed,
+}
 
 @Serializable
 data class PreviewInfo(

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1527,11 +1527,11 @@ object PreviewDiscovery {
    * filename of the form `<readable>-<digest>`:
    *
    * 1. **`<readable>`** — the last dotted segment of the preview id (function name plus any
-   *    `@Preview(name = …)` variant suffix), with every run of non-alphanumeric characters collapsed
-   *    to a single `_`. So `com.example.PreviewsKt.ActivityListPreview_Devices - Large Round`
-   *    contributes `ActivityListPreview_Devices_Large_Round`. Capped at [MAX_READABLE_STEM] chars so
-   *    a stem plus its structural suffixes stays inside the 255-byte `NAME_MAX` every mainstream
-   *    filesystem enforces.
+   *    `@Preview(name = …)` variant suffix), with every run of non-alphanumeric characters
+   *    collapsed to a single `_`. So `com.example.PreviewsKt.ActivityListPreview_Devices - Large
+   *    Round` contributes `ActivityListPreview_Devices_Large_Round`. Capped at [MAX_READABLE_STEM]
+   *    chars so a stem plus its structural suffixes stays inside the 255-byte `NAME_MAX` every
+   *    mainstream filesystem enforces.
    * 2. **`-<digest>`** — [RENDER_STEM_DIGEST_CHARS] hex chars of `sha256(preview.id)`, taken over
    *    the id verbatim. `-` is an unambiguous delimiter here: [sanitiseSegment] collapses it inside
    *    a segment, so it can never occur in `<readable>`.
@@ -1546,15 +1546,16 @@ object PreviewDiscovery {
    *   shortest-unique-suffix walk read every sibling, so an unrelated addition silently renamed
    *   existing PNGs — which breaks commit-pinned render URLs and makes base-vs-head visual diffing
    *   see a rename as delete + add.
-   * - *Collision-free.* Distinct ids that sanitise identically (`Foo_bar` vs `Foo-bar`) get distinct
-   *   digests. The old positional `_<idx>` tiebreaker minted names without checking them against
-   *   real stems, so a preview genuinely named `Foo_bar_1` could be silently overwritten.
-   * - *Case-safe.* `Foo_Dark` and `Foo_dark` are distinct ids, so they get distinct digests and stay
-   *   distinct files on the case-insensitive filesystems (APFS, NTFS) where the readable parts alone
-   *   would collide.
+   * - *Collision-free.* Distinct ids that sanitise identically (`Foo_bar` vs `Foo-bar`) get
+   *   distinct digests. The old positional `_<idx>` tiebreaker minted names without checking them
+   *   against real stems, so a preview genuinely named `Foo_bar_1` could be silently overwritten.
+   * - *Case-safe.* `Foo_Dark` and `Foo_dark` are distinct ids, so they get distinct digests and
+   *   stay distinct files on the case-insensitive filesystems (APFS, NTFS) where the readable parts
+   *   alone would collide.
    * - *Suffix-safe.* Structural suffixes are appended after the whole stem, so a preview named
    *   `Logo_animated` lands on `Logo_animated-<digestA>.png` while `Logo`'s Lottie sidecar lands on
-   *   `Logo-<digestB>_animated.png`. The digest separates the two namespaces that used to share `_`.
+   *   `Logo-<digestB>_animated.png`. The digest separates the two namespaces that used to share
+   *   `_`.
    * - *Reserved-name-safe.* A preview named `CON` or `NUL` becomes `CON-<digest>`, which is not a
    *   Windows reserved device name.
    *
@@ -1650,18 +1651,17 @@ object PreviewDiscovery {
     previews: List<PreviewInfo>,
     indices: Set<Int>,
     digestChars: Int,
-  ): List<PreviewInfo> =
-    previews.mapIndexed { i, preview ->
-      if (i !in indices) preview
-      else {
-        val suffix = "-${idDigest(preview.id, digestChars)}"
-        preview.copy(
-          captures =
-            preview.captures.map { it.copy(renderOutput = tagLeaf(it.renderOutput, suffix)) },
-          dataProducts = preview.dataProducts.map { it.copy(output = tagLeaf(it.output, suffix)) },
-        )
-      }
+  ): List<PreviewInfo> = previews.mapIndexed { i, preview ->
+    if (i !in indices) preview
+    else {
+      val suffix = "-${idDigest(preview.id, digestChars)}"
+      preview.copy(
+        captures =
+          preview.captures.map { it.copy(renderOutput = tagLeaf(it.renderOutput, suffix)) },
+        dataProducts = preview.dataProducts.map { it.copy(output = tagLeaf(it.output, suffix)) },
+      )
     }
+  }
 
   /**
    * `dir/stem.ext` → `dir/stem<suffix>.ext`, leaving the directory and the full extension alone.
@@ -1726,9 +1726,9 @@ object PreviewDiscovery {
    *
    * Only the tied previews are touched, so one freak pair cannot lengthen an unrelated preview's
    * filename — and because the replacement is still a pure function of the id, the result stays
-   * stable under reordering. That is the property the old positional `_<idx>` tiebreaker lacked:
-   * it indexed into the manifest, so it both churned on reordering and could mint a name that
-   * collided with a real preview's.
+   * stable under reordering. That is the property the old positional `_<idx>` tiebreaker lacked: it
+   * indexed into the manifest, so it both churned on reordering and could mint a name that collided
+   * with a real preview's.
    */
   private fun disambiguateDigestTies(
     stems: List<String>,
@@ -1738,8 +1738,7 @@ object PreviewDiscovery {
     // `Foo_Dark-<d>.png` and `Foo_dark-<d>.png` do. Grouping case-sensitively here would let a
     // case-only pair that also tied on the digest slip through the backstop and overwrite. The
     // stems themselves keep their original casing — only the tie test folds.
-    val tied =
-      stems.groupingBy { it.lowercase() }.eachCount().filterValues { it > 1 }.keys
+    val tied = stems.groupingBy { it.lowercase() }.eachCount().filterValues { it > 1 }.keys
     if (tied.isEmpty()) return stems
     return stems.mapIndexed { i, stem ->
       if (stem.lowercase() !in tied) stem
@@ -2085,9 +2084,10 @@ object PreviewDiscovery {
   /**
    * Derives a synthetic override-variant preview from a rendered [base]: same function, a
    * `_VARIANT_<name>`-suffixed id + render outputs, the [spec]'s seeds carried on
-   * [PreviewInfo.overrides] for the renderer to apply, and no data products (a state variant
-   * doesn't re-emit the heavy scroll/animation products). The unchanged `functionName` is what lets
-   * the design-catalog fold merge the variant image back under its primary sticker.
+   * [PreviewInfo.overrides] for the renderer to apply, any requested harness interaction stamped
+   * onto its capture, and no data products (a state variant doesn't re-emit the heavy
+   * scroll/animation products). The unchanged `functionName` is what lets the design-catalog fold
+   * merge the variant image back under its primary sticker.
    */
   private fun overrideVariantPreview(base: PreviewInfo, spec: OverrideVariantSpec): PreviewInfo {
     val tag = "_VARIANT_${spec.name}"
@@ -2095,7 +2095,30 @@ object PreviewDiscovery {
       id = base.id + tag,
       overrides = spec,
       captures =
-        base.captures.map { it.copy(renderOutput = insertRenderTag(it.renderOutput, tag)) },
+        base.captures.map { capture ->
+          val tagged = capture.copy(renderOutput = insertRenderTag(capture.renderOutput, tag))
+          when (spec.interaction) {
+            OverrideVariantInteraction.Focused ->
+              tagged.copy(
+                focus = FocusCapture(tabIndex = spec.interactionIndex),
+                focusGif = null,
+                hover = null,
+              )
+            OverrideVariantInteraction.Pressed ->
+              tagged.copy(
+                focus = FocusCapture(tabIndex = spec.interactionIndex, pressed = true),
+                focusGif = null,
+                hover = null,
+              )
+            OverrideVariantInteraction.Hovered ->
+              tagged.copy(
+                focus = null,
+                focusGif = null,
+                hover = HoverCapture(targetIndex = spec.interactionIndex),
+              )
+            null -> tagged
+          }
+        },
       dataProducts = emptyList(),
     )
   }
@@ -2113,8 +2136,8 @@ object PreviewDiscovery {
    * Reads `@OverrideVariant` annotations (repeatable — direct instances or the synthetic
    * `.Container` holder Kotlin generates for the repeated case) into one [OverrideVariantSpec]
    * each. Each per-type array entry is `"key=value"` / `"key#index=value"`; the array it lives in
-   * fixes its [OverrideSeedKind]. A variant that names no parseable seed is dropped (it would
-   * render identically to the base).
+   * fixes its [OverrideSeedKind]. A variant that names neither a parseable seed nor a harness
+   * interaction is dropped (it would render identically to the base).
    *
    * Variants may be **hoisted onto a multi-preview-style annotation class** so a matrix several
    * components share is declared once (`@Target` includes `ANNOTATION_CLASS`; see `OverrideVariant`
@@ -2157,8 +2180,20 @@ object PreviewDiscovery {
           readOverrideSeeds(pv.getValue("ints"), OverrideSeedKind.INT) +
           readOverrideSeeds(pv.getValue("floats"), OverrideSeedKind.FLOAT) +
           readOverrideSeeds(pv.getValue("colors"), OverrideSeedKind.COLOR)
-      if (seeds.isEmpty()) continue
-      val spec = OverrideVariantSpec(name = name, seeds = seeds)
+      val interaction =
+        (pv.getValue("interaction") as? AnnotationEnumValue)
+          ?.valueName
+          ?.takeUnless { it == "None" }
+          ?.let { runCatching { OverrideVariantInteraction.valueOf(it) }.getOrNull() }
+      if (seeds.isEmpty() && interaction == null) continue
+      val interactionIndex = ((pv.getValue("interactionIndex") as? Int) ?: 0).coerceAtLeast(0)
+      val spec =
+        OverrideVariantSpec(
+          name = name,
+          seeds = seeds,
+          interaction = interaction,
+          interactionIndex = interactionIndex,
+        )
       val existing = specs.putIfAbsent(name, spec)
       // Only a *conflicting* duplicate is worth a warning. The same annotation reached twice — once
       // flattened by ClassGraph and once by the explicit meta-annotation walk — is the common case

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -187,12 +187,16 @@ class DiscoveryFunctionalTest {
         @Target(AnnotationTarget.FUNCTION)
         annotation class OverrideVariant(
             val name: String,
+            val interaction: VariantInteraction = VariantInteraction.None,
+            val interactionIndex: Int = 0,
             val booleans: Array<String> = [],
             val strings: Array<String> = [],
             val ints: Array<String> = [],
             val floats: Array<String> = [],
             val colors: Array<String> = [],
         )
+
+        enum class VariantInteraction { None, Hovered, Focused, Pressed }
         """
           .trimIndent()
       )
@@ -210,10 +214,18 @@ class DiscoveryFunctionalTest {
         import androidx.compose.ui.tooling.preview.Preview
         import androidx.compose.ui.unit.dp
         import ee.schimke.composeai.preview.OverrideVariant
+        import ee.schimke.composeai.preview.VariantInteraction
 
         @Preview
         @OverrideVariant(name = "off", booleans = ["checked=false"])
         @OverrideVariant(name = "labelled", strings = ["label=Hi", "sub#1=Two"])
+        @OverrideVariant(name = "hovered", interaction = VariantInteraction.Hovered)
+        @OverrideVariant(
+            name = "focused",
+            interaction = VariantInteraction.Focused,
+            interactionIndex = 1,
+        )
+        @OverrideVariant(name = "pressed", interaction = VariantInteraction.Pressed)
         @Composable
         fun TogglePreview() {
             Box(modifier = Modifier.size(50.dp)) { Text("Toggle") }
@@ -236,7 +248,7 @@ class DiscoveryFunctionalTest {
       )
     val toggles = manifest.previews.filter { it.functionName == "TogglePreview" }
     // Base preview + one synthetic seeded preview per `@OverrideVariant`.
-    assertThat(toggles).hasSize(3)
+    assertThat(toggles).hasSize(6)
 
     val base = toggles.single { it.overrides == null }
     assertThat(base.captures.single().renderOutput).doesNotContain("_VARIANT_")
@@ -256,6 +268,20 @@ class DiscoveryFunctionalTest {
         OverrideSeed(key = "label", index = null, kind = OverrideSeedKind.STRING, raw = "Hi"),
         OverrideSeed(key = "sub", index = 1, kind = OverrideSeedKind.STRING, raw = "Two"),
       )
+
+    val hovered = toggles.single { it.overrides?.name == "hovered" }
+    assertThat(hovered.overrides!!.seeds).isEmpty()
+    assertThat(hovered.overrides!!.interaction).isEqualTo(OverrideVariantInteraction.Hovered)
+    assertThat(hovered.captures.single().hover).isEqualTo(HoverCapture(targetIndex = 0))
+    assertThat(hovered.captures.single().focus).isNull()
+
+    val focused = toggles.single { it.overrides?.name == "focused" }
+    assertThat(focused.captures.single().focus).isEqualTo(FocusCapture(tabIndex = 1))
+    assertThat(focused.captures.single().hover).isNull()
+
+    val pressed = toggles.single { it.overrides?.name == "pressed" }
+    assertThat(pressed.captures.single().focus)
+      .isEqualTo(FocusCapture(tabIndex = 0, pressed = true))
   }
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -553,6 +553,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
           scroll = capture.scroll,
           animation = capture.animation,
           focus = capture.focus,
+          hover = capture.hover,
           fanoutSiblingStems = fanoutSiblingStems(manifestOutputFiles, outputFile),
           lane = lane,
         )
@@ -594,6 +595,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
     scroll: ScrollCapture?,
     animation: AnimationCapture? = null,
     focus: FocusCapture? = null,
+    hover: ee.schimke.composeai.discovery.HoverCapture? = null,
     fanoutSiblingStems: List<String> = emptyList(),
     lane: RenderLane,
   ) {
@@ -608,6 +610,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
         scroll = scroll,
         animation = animation,
         focus = focus,
+        hover = hover,
         fanoutSiblingStems = fanoutSiblingStems,
       )
     val overridesSeed =
@@ -841,6 +844,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
     scroll: ScrollCapture?,
     animation: AnimationCapture?,
     focus: FocusCapture?,
+    hover: ee.schimke.composeai.discovery.HoverCapture?,
     fanoutSiblingStems: List<String>,
   ): List<String> =
     listOf(
@@ -948,6 +952,9 @@ abstract class RenderPreviewsTask : DefaultTask() {
       (focus?.enterPlacesFocus ?: false).toString(),
       (focus?.pressed ?: false).toString(),
       (focus?.overlay ?: false).toString(),
+      // 39th — addressable `@OverrideVariant(interaction = Hovered)` target. Kept separate from
+      // focus so hovering never has to focus a node merely to discover where to send the pointer.
+      (hover?.targetIndex ?: -1).toString(),
     )
 }
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -129,6 +129,9 @@ data class FocusCapture(
   val pressed: Boolean = false,
 )
 
+/** Renderer-side mirror of the plugin's `HoverCapture`. */
+@Serializable data class HoverCapture(val targetIndex: Int = 0)
+
 /** Renderer-side mirror of the plugin's `FocusGifCapture`. */
 @Serializable
 data class FocusGifCapture(
@@ -271,10 +274,10 @@ data class RenderPreviewEntry(
   val captures: List<RenderPreviewCapture> = listOf(RenderPreviewCapture()),
   /**
    * Non-null on a synthetic `@OverrideVariant` preview: the `previewOverride*` values the renderer
-   * seeds via `PreviewOverrideController.set(...)` before composing this entry, so the same function
-   * renders once more with the knob(s) flipped. `null` on an ordinary preview (defaults resolve).
-   * Uses the canonical [ee.schimke.composeai.data.overrides.OverrideVariantSpec] so every backend
-   * shares one seed→value mapping.
+   * seeds via `PreviewOverrideController.set(...)` before composing this entry, so the same
+   * function renders once more with the knob(s) flipped. `null` on an ordinary preview (defaults
+   * resolve). Uses the canonical [ee.schimke.composeai.data.overrides.OverrideVariantSpec] so every
+   * backend shares one seed→value mapping.
    */
   val overrides: ee.schimke.composeai.data.overrides.OverrideVariantSpec? = null,
   /**
@@ -304,6 +307,7 @@ data class RenderPreviewCapture(
   val scroll: ScrollCapture? = null,
   val animation: AnimationCapture? = null,
   val focus: FocusCapture? = null,
+  val hover: HoverCapture? = null,
   val focusGif: FocusGifCapture? = null,
   val ambient: AmbientCapture? = null,
   val gestureHint: GestureHintCapture? = null,

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -10,6 +10,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.unit.Constraints
@@ -41,9 +44,9 @@ import ee.schimke.composeai.daemon.LauncherWidgetExtension
 import ee.schimke.composeai.daemon.PermissionsOverrideExtension
 import ee.schimke.composeai.daemon.protocol.AmbientOverride
 import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
-import ee.schimke.composeai.daemon.protocol.GestureOverride
 import ee.schimke.composeai.daemon.protocol.FocusDirection as ProtocolFocusDirection
 import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.daemon.protocol.GestureOverride
 import ee.schimke.composeai.daemon.protocol.LauncherResizeOrder
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetOverride
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetSize
@@ -92,6 +95,55 @@ private fun ScrollAxis.toProductAxis(): ProductScrollAxis =
   when (this) {
     ScrollAxis.VERTICAL -> ProductScrollAxis.VERTICAL
     ScrollAxis.HORIZONTAL -> ProductScrollAxis.HORIZONTAL
+  }
+
+private fun driveHover(rule: AndroidComposeTestRule<*, ComponentActivity>, targetIndex: Int) {
+  val targets = rule.onAllNodes(interactiveNodeMatcher()).fetchSemanticsNodes()
+  val target = targets.getOrNull(targetIndex)
+  if (target == null) {
+    System.err.println(
+      "@OverrideVariant hover: no interactive node at index $targetIndex; " +
+        "capturing the undriven state."
+    )
+    return
+  }
+  val bounds = target.boundsInRoot
+  val x = bounds.center.x
+  val y = bounds.center.y
+  val content = rule.activity.findViewById<android.view.ViewGroup>(android.R.id.content)
+  val view = content?.getChildAt(0) ?: rule.activity.window.decorView
+  val now = android.os.SystemClock.uptimeMillis()
+  fun event(action: Int) =
+    android.view.MotionEvent.obtain(now, now, action, x, y, 0).also {
+      it.source = android.view.InputDevice.SOURCE_MOUSE
+    }
+  rule.runOnUiThread {
+    event(android.view.MotionEvent.ACTION_HOVER_ENTER).let {
+      try {
+        view.dispatchGenericMotionEvent(it)
+      } finally {
+        it.recycle()
+      }
+    }
+    event(android.view.MotionEvent.ACTION_HOVER_MOVE).let {
+      try {
+        view.dispatchGenericMotionEvent(it)
+      } finally {
+        it.recycle()
+      }
+    }
+  }
+  org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
+    .idleFor(java.time.Duration.ofMillis(FocusController.SETTLE_MS))
+}
+
+private fun interactiveNodeMatcher() =
+  SemanticsMatcher("has an interactive action") { node ->
+    val config = node.config
+    config.getOrNull(SemanticsActions.OnClick) != null ||
+      config.getOrNull(SemanticsActions.SetProgress) != null ||
+      config.getOrNull(SemanticsActions.SetText) != null ||
+      config.getOrNull(SemanticsActions.RequestFocus) != null
   }
 
 /**
@@ -168,7 +220,8 @@ object PreviewManifestLoader {
         }
         .map { entry ->
           // `expandParameterProvider` already isolates provider-load failures; this outer guard is
-          // belt-and-suspenders so any *other* unexpected throw while expanding one entry drops just
+          // belt-and-suspenders so any *other* unexpected throw while expanding one entry drops
+          // just
           // that entry rather than failing the whole shard's `@Parameters` load (issue #2493).
           entry to
             runCatching { expandParameterProvider(entry) }
@@ -320,7 +373,8 @@ object PreviewManifestLoader {
     // Row filter (`--exclude-preview-row` → `composeai.preview.rowExclude`). Applied here, after
     // labelling: the id filters above ran over the DISCOVERED entries, where this parameterized
     // preview is a single row with no per-value id, so a label is the only handle on one value. The
-    // stale fan-out cleanup below still keys on the FULL row set, so a skipped row keeps its previous
+    // stale fan-out cleanup below still keys on the FULL row set, so a skipped row keeps its
+    // previous
     // PNG on disk exactly as a filtered-out preview does.
     val keptRows =
       PreviewFilter.keptRowIndices(
@@ -465,17 +519,18 @@ object PreviewManifestLoader {
    *
    * Deliberately built from the **declared** entries rather than the expanded rows, and so from the
    * FULL manifest rather than the filtered selection: a `@Preview(name = "Dark")` sibling that a
-   * `--preview-id` filter dropped is never expanded, so its fan-out rows (`Foo_Dark_<label>.png` and
-   * their companions) appear in no expected-name set, yet they all match the swept preview's `Foo_*`
-   * prefix. Protecting the declared stem covers the sibling's whole fan-out without requiring it to
-   * have been expanded, which is what makes good on the loader's promise that a filtered-out preview
-   * keeps its existing artifacts.
+   * `--preview-id` filter dropped is never expanded, so its fan-out rows (`Foo_Dark_<label>.png`
+   * and their companions) appear in no expected-name set, yet they all match the swept preview's
+   * `Foo_*` prefix. Protecting the declared stem covers the sibling's whole fan-out without
+   * requiring it to have been expanded, which is what makes good on the loader's promise that a
+   * filtered-out preview keeps its existing artifacts.
    *
-   * Mirrors the plugin's `fanoutSiblingStems`, which computes the same list for the desktop renderer
-   * (that subprocess has no manifest, so the plugin passes the stems on the command line). The
-   * same-extension restriction is load-bearing in both: the sweep only ever deletes files belonging
-   * to an [templateFile]-extension output, so shielding a different-extension sibling's stem would
-   * strand a genuinely stale `Foo_Dark.png` from before that sibling's capture became a GIF.
+   * Mirrors the plugin's `fanoutSiblingStems`, which computes the same list for the desktop
+   * renderer (that subprocess has no manifest, so the plugin passes the stems on the command line).
+   * The same-extension restriction is load-bearing in both: the sweep only ever deletes files
+   * belonging to an [templateFile]-extension output, so shielding a different-extension sibling's
+   * stem would strand a genuinely stale `Foo_Dark.png` from before that sibling's capture became a
+   * GIF.
    */
   private fun fanoutSiblingStems(
     declaredOutputFiles: List<File>,
@@ -574,7 +629,6 @@ object PreviewManifestLoader {
     }
     return null
   }
-
 }
 
 /**
@@ -661,8 +715,7 @@ abstract class RobolectricRenderTestBase(
     // Round crop fires for ordinary Compose @Preview captures with a round device, matching
     // Layoutlib / Android Studio. Tile and notification captures have their own surface renderers
     // and are intentionally left out of this Studio @Preview parity mask.
-    val isRound =
-      isRoundDevice(params.device) && params.kind == PreviewKind.COMPOSE
+    val isRound = isRoundDevice(params.device) && params.kind == PreviewKind.COMPOSE
 
     // AS-parity default: previews render with `LocalInspectionMode = true`,
     // matching Android Studio's `@Preview` behaviour, so a preview that
@@ -747,14 +800,17 @@ abstract class RobolectricRenderTestBase(
     // Drop any named-override knobs a prior preview declared so this preview's `previewOverride*`
     // lookups accumulate a clean set (drained into the overrides sidecar below).
     ee.schimke.composeai.overrides.PreviewOverrideController.clearDeclarations()
-    // Same for the Remote Compose knob declarations (reflectively — the alpha-gated connector may be
-    // absent), so preview B doesn't serialize the Remote Compose knobs preview A declared in the same
+    // Same for the Remote Compose knob declarations (reflectively — the alpha-gated connector may
+    // be
+    // absent), so preview B doesn't serialize the Remote Compose knobs preview A declared in the
+    // same
     // JVM into its `renders/<stem>.remotecompose.json` sidecar.
     clearRemoteComposeDeclarations()
     // Seed any `@OverrideVariant` values onto the controller so this synthetic variant preview's
     // `previewOverride*` reads resolve to the flipped knob(s). Replaces the whole seed map, so an
     // ordinary preview (null overrides → empty map) clears the prior variant's seeds — no leakage
-    // between previews. Same `ControllerPreviewOverrideHost` seam the daemon's `renderNow.overrides`
+    // between previews. Same `ControllerPreviewOverrideHost` seam the daemon's
+    // `renderNow.overrides`
     // lane feeds; here the batch render owns the controller lifecycle directly.
     ee.schimke.composeai.overrides.PreviewOverrideController.set(overrideSeedMap(preview))
     // Arm the per-preview downloadable-font tracker so a face that falls back to Roboto during THIS
@@ -792,7 +848,8 @@ abstract class RobolectricRenderTestBase(
         )
       }
       // A downloadable font that couldn't be resolved rendered in the platform fallback (Roboto) —
-      // wrong typeface for a branded preview. By default that's fatal (throw → the catch below drops
+      // wrong typeface for a branded preview. By default that's fatal (throw → the catch below
+      // drops
       // the PNG and writes `.error.json`, same as any render failure). With
       // `-Dcomposeai.fonts.failOnFallback=false` keep the PNG and record the fell-back faces in a
       // non-fatal `<png>.warnings.json` instead.
@@ -803,7 +860,11 @@ abstract class RobolectricRenderTestBase(
       // Coil requests that didn't resolve are never fatal — a blank image is a legitimate thing to
       // capture (an offline/empty state), and the renderer can't conjure bytes the sandbox can't
       // reach. They ride in the same warnings sidecar so the blank is diagnosable.
-      RenderWarningsSidecar.writeOrDelete(pngFile, fontFallbacks, CoilLoadDiagnostics.drainPreview())
+      RenderWarningsSidecar.writeOrDelete(
+        pngFile,
+        fontFallbacks,
+        CoilLoadDiagnostics.drainPreview(),
+      )
       // Render succeeded: if the preview's flavour captured an IR, write it beside the PNG as
       // the `renders/<stem>.<ext>` sidecar `BundlePreviewTask.resolvePreviewIr` packs.
       writeIrSidecar(pngFile, preview.id)
@@ -811,7 +872,8 @@ abstract class RobolectricRenderTestBase(
       // `renders/<stem>.overrides.json` sidecar `BundlePreviewTask.resolvePreviewOverrides` packs.
       writeOverridesSidecar(pngFile)
       // Same, for Remote Compose named-value knobs declared through `LocalRemoteComposeHost`:
-      // `renders/<stem>.remotecompose.json`, packed by `BundlePreviewTask.resolvePreviewRemoteCompose`.
+      // `renders/<stem>.remotecompose.json`, packed by
+      // `BundlePreviewTask.resolvePreviewRemoteCompose`.
       writeRemoteComposeSidecar(pngFile)
     } catch (e: Throwable) {
       System.err.println(
@@ -902,8 +964,8 @@ abstract class RobolectricRenderTestBase(
   }
 
   /**
-   * Write the Remote Compose named-value knobs the preview declared through `LocalRemoteComposeHost`
-   * as the `renders/<stem>.remotecompose.json` sidecar
+   * Write the Remote Compose named-value knobs the preview declared through
+   * `LocalRemoteComposeHost` as the `renders/<stem>.remotecompose.json` sidecar
    * `BundlePreviewTask.resolvePreviewRemoteCompose` packs. An empty / absent set deletes any stale
    * sidecar. Read **reflectively** so this renderer never hard-depends on the alpha-gated
    * `:data-remotecompose-connector` (`RemoteComposeController` is only on the classpath when the
@@ -947,7 +1009,9 @@ abstract class RobolectricRenderTestBase(
     try {
       if (json == null) {
         if (sidecar.isFile && !sidecar.delete()) {
-          System.err.println("Failed to delete stale remotecompose sidecar: ${sidecar.absolutePath}")
+          System.err.println(
+            "Failed to delete stale remotecompose sidecar: ${sidecar.absolutePath}"
+          )
         }
         return
       }
@@ -1193,8 +1257,7 @@ abstract class RobolectricRenderTestBase(
           val reduceMotionLocal =
             if (annotationReduceMotion || scrollCaptureInProgress) WearReduceMotionLocal.get()
             else null
-          val reduceMotionState =
-            androidx.compose.runtime.mutableStateOf(annotationReduceMotion)
+          val reduceMotionState = androidx.compose.runtime.mutableStateOf(annotationReduceMotion)
           // @AnimatedPreview(showCurves = true): capture the slot table
           // by wrapping the composition in `InspectablePreviewContent`,
           // which seeds parameter information collection and snapshots
@@ -1348,102 +1411,102 @@ abstract class RobolectricRenderTestBase(
               }
             }
             withReduceMotion {
-            CompositionLocalProvider(values = providedValues) {
-              if (focusExtension != null) {
-                capturedView = androidx.compose.ui.platform.LocalView.current
-              }
-              val previewBody: @Composable () -> Unit = {
-                val core: @Composable () -> Unit = {
-                  MeasuredWrapBox(
-                    wrapWidth = wrapWidth,
-                    wrapHeight = wrapHeight,
-                    onMeasured = { measured = it },
-                  ) {
-                    strategyFor(params.kind).Render(preview, widthDp, heightDp, previewArgs)
+              CompositionLocalProvider(values = providedValues) {
+                if (focusExtension != null) {
+                  capturedView = androidx.compose.ui.platform.LocalView.current
+                }
+                val previewBody: @Composable () -> Unit = {
+                  val core: @Composable () -> Unit = {
+                    MeasuredWrapBox(
+                      wrapWidth = wrapWidth,
+                      wrapHeight = wrapHeight,
+                      onMeasured = { measured = it },
+                    ) {
+                      strategyFor(params.kind).Render(preview, widthDp, heightDp, previewArgs)
+                    }
+                  }
+                  if (applySystemBars) {
+                    SystemBarsFrame(uiMode = params.uiMode) { core() }
+                  } else {
+                    core()
                   }
                 }
-                if (applySystemBars) {
-                  SystemBarsFrame(uiMode = params.uiMode) { core() }
-                } else {
-                  core()
+                val curveOrPlain: @Composable () -> Unit = {
+                  if (animationCurveCapture != null) {
+                    InspectablePreviewContent(animationCurveCapture, previewBody)
+                  } else {
+                    previewBody()
+                  }
                 }
-              }
-              val curveOrPlain: @Composable () -> Unit = {
-                if (animationCurveCapture != null) {
-                  InspectablePreviewContent(animationCurveCapture, previewBody)
-                } else {
-                  previewBody()
+                val focusOrPlain: @Composable () -> Unit = {
+                  if (focusExtension != null) {
+                    focusExtension.AroundComposable { curveOrPlain() }
+                  } else {
+                    curveOrPlain()
+                  }
                 }
-              }
-              val focusOrPlain: @Composable () -> Unit = {
-                if (focusExtension != null) {
-                  focusExtension.AroundComposable { curveOrPlain() }
-                } else {
-                  curveOrPlain()
+                // `@GestureHintPreview` — installs `LocalGestureRegistry` /
+                // `LocalOneHandedGestureEnabled` and force-shows the hint, same
+                // `DataExtensionPhase.OuterEnvironment` seam as ambient.
+                val gestureHintOrPlain: @Composable () -> Unit = {
+                  if (gestureHintExtension != null) {
+                    gestureHintExtension.AroundComposable { focusOrPlain() }
+                  } else {
+                    focusOrPlain()
+                  }
                 }
-              }
-              // `@GestureHintPreview` — installs `LocalGestureRegistry` /
-              // `LocalOneHandedGestureEnabled` and force-shows the hint, same
-              // `DataExtensionPhase.OuterEnvironment` seam as ambient.
-              val gestureHintOrPlain: @Composable () -> Unit = {
-                if (gestureHintExtension != null) {
-                  gestureHintExtension.AroundComposable { focusOrPlain() }
-                } else {
-                  focusOrPlain()
+                val ambientOrPlain: @Composable () -> Unit = {
+                  if (ambientExtension != null) {
+                    ambientExtension.AroundComposable { gestureHintOrPlain() }
+                  } else {
+                    gestureHintOrPlain()
+                  }
                 }
-              }
-              val ambientOrPlain: @Composable () -> Unit = {
-                if (ambientExtension != null) {
-                  ambientExtension.AroundComposable { gestureHintOrPlain() }
-                } else {
-                  gestureHintOrPlain()
+                // Launcher-widget sizing wraps OUTSIDE ambient/focus/curve so the
+                // `Box.size(...)` constrains the visible viewport before any inner
+                // override applies — the cell footprint is the launcher chrome, not
+                // the preview's own surface chemistry. Matches the connector's
+                // `DataExtensionPhase.OuterEnvironment` ordering.
+                val launcherWidgetOrPlain: @Composable () -> Unit = {
+                  if (launcherWidgetExtension != null) {
+                    launcherWidgetExtension.AroundComposable { ambientOrPlain() }
+                  } else {
+                    ambientOrPlain()
+                  }
                 }
-              }
-              // Launcher-widget sizing wraps OUTSIDE ambient/focus/curve so the
-              // `Box.size(...)` constrains the visible viewport before any inner
-              // override applies — the cell footprint is the launcher chrome, not
-              // the preview's own surface chemistry. Matches the connector's
-              // `DataExtensionPhase.OuterEnvironment` ordering.
-              val launcherWidgetOrPlain: @Composable () -> Unit = {
-                if (launcherWidgetExtension != null) {
-                  launcherWidgetExtension.AroundComposable { ambientOrPlain() }
-                } else {
-                  ambientOrPlain()
-                }
-              }
-              // `@PermissionPreview` — the grants were already seeded into Robolectric when the
-              // extension was constructed above; this wrap is what scopes the connector's
-              // query tracking to this preview (`PermissionsController.beginRender`) and clears
-              // the override on dispose so the next preview in the sandbox starts clean. Same
-              // `DataExtensionPhase.OuterEnvironment` seam as ambient / gestures.
-              val permissionsOrPlain: @Composable () -> Unit = {
-                if (permissionsExtension != null) {
-                  // `Around` (not `AroundComposable`): the permissions extension implements the
-                  // raw `AroundComposableHook`, because it needs the context's `previewId` to
-                  // scope query tracking — the convenience `AroundComposableExtension` base the
-                  // gesture / launcher-widget extensions use drops the context.
-                  permissionsExtension.Around(
-                    ExtensionComposeContext(
-                      extensionId = PermissionsOverrideExtension.ID,
-                      previewId = preview.id,
-                      renderMode = null,
-                    )
-                  ) {
+                // `@PermissionPreview` — the grants were already seeded into Robolectric when the
+                // extension was constructed above; this wrap is what scopes the connector's
+                // query tracking to this preview (`PermissionsController.beginRender`) and clears
+                // the override on dispose so the next preview in the sandbox starts clean. Same
+                // `DataExtensionPhase.OuterEnvironment` seam as ambient / gestures.
+                val permissionsOrPlain: @Composable () -> Unit = {
+                  if (permissionsExtension != null) {
+                    // `Around` (not `AroundComposable`): the permissions extension implements the
+                    // raw `AroundComposableHook`, because it needs the context's `previewId` to
+                    // scope query tracking — the convenience `AroundComposableExtension` base the
+                    // gesture / launcher-widget extensions use drops the context.
+                    permissionsExtension.Around(
+                      ExtensionComposeContext(
+                        extensionId = PermissionsOverrideExtension.ID,
+                        previewId = preview.id,
+                        renderMode = null,
+                      )
+                    ) {
+                      launcherWidgetOrPlain()
+                    }
+                  } else {
                     launcherWidgetOrPlain()
                   }
-                } else {
-                  launcherWidgetOrPlain()
                 }
-              }
-              val pseudoOrPlain: @Composable () -> Unit = {
-                if (pseudolocaleExtension != null) {
-                  pseudolocaleExtension.AroundComposable { permissionsOrPlain() }
-                } else {
-                  permissionsOrPlain()
+                val pseudoOrPlain: @Composable () -> Unit = {
+                  if (pseudolocaleExtension != null) {
+                    pseudolocaleExtension.AroundComposable { permissionsOrPlain() }
+                  } else {
+                    permissionsOrPlain()
+                  }
                 }
+                keyboardExtension.AroundComposable { pseudoOrPlain() }
               }
-              keyboardExtension.AroundComposable { pseudoOrPlain() }
-            }
             }
           }
           // With `mainClock.autoAdvance = false` the clock stays at 0
@@ -1524,6 +1587,16 @@ abstract class RobolectricRenderTestBase(
                 org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
                   .idleFor(java.time.Duration.ofMillis(FocusController.SETTLE_MS))
               }
+            }
+
+            // Addressable hovered `@OverrideVariant`: send a real mouse hover to the requested
+            // interactive semantics node without walking focus first. A mouse press is not used —
+            // it would combine Hovered and Pressed, and focusing merely to find the target would
+            // combine Hovered and Focused.
+            capture?.hover?.let { hover ->
+              driveHover(rule, hover.targetIndex)
+              rule.mainClock.advanceTimeBy(FocusController.SETTLE_MS)
+              currentTime += FocusController.SETTLE_MS
             }
 
             // @ScrollingPreview(END): drive the first scrollable on the
@@ -1950,7 +2023,8 @@ abstract class RobolectricRenderTestBase(
       addAll(ee.schimke.composeai.data.render.previewSizeQualifiers(widthDp, heightDp))
       if (isRound) add("round")
       // The frame decides, not the request — shared with the daemon's two qualifier builders
-      // (`RenderEngine.applyPreviewQualifiers`, `RobolectricHost`) so a preview rendered through the
+      // (`RenderEngine.applyPreviewQualifiers`, `RobolectricHost`) so a preview rendered through
+      // the
       // plugin and the same preview rendered through the daemon land on the same `Configuration`.
       // There is no separate request on this lane: `device = "spec:…,orientation=portrait"` is
       // already resolved into these dimensions by `DeviceDimensions`.
@@ -2199,7 +2273,12 @@ public fun driveScrollingPreviewToEnd(
   rule: AndroidComposeTestRule<*, ComponentActivity>,
   scroll: ScrollCapture,
 ): Boolean {
-  val result = driveScrollToEnd(rule = rule, axis = scroll.axis.toProductAxis(), maxScrollPx = scroll.maxScrollPx)
+  val result =
+    driveScrollToEnd(
+      rule = rule,
+      axis = scroll.axis.toProductAxis(),
+      maxScrollPx = scroll.maxScrollPx,
+    )
   if (result is ScrollDriveResult.NoScrollable) return false
   settlePostScrollAnimations(rule)
   return true
@@ -2416,11 +2495,7 @@ private fun handleGifCaptureInternal(
   fun captureFrame(delayMs: Int) {
     val frameFile = File(framesDir, "frame_${frameFiles.size}.png")
     captureDecodableFrame(frameFile, role = "scroll GIF") { f ->
-      stableDialogCrop.captureFrame(
-        rule = rule,
-        file = f,
-        roborazziOptions = frameRoborazziOptions,
-      )
+      stableDialogCrop.captureFrame(rule = rule, file = f, roborazziOptions = frameRoborazziOptions)
     }
     frameFiles += frameFile
     frameDelays += delayMs
@@ -2760,11 +2835,7 @@ private fun handleAnimatedCapture(
   fun captureFrame(virtualTimeMs: Long) {
     val frameFile = File(framesDir, "frame_${frameFiles.size}.png")
     captureDecodableFrame(frameFile, role = "animation") { f ->
-      stableDialogCrop.captureFrame(
-        rule = rule,
-        file = f,
-        roborazziOptions = frameRoborazziOptions,
-      )
+      stableDialogCrop.captureFrame(rule = rule, file = f, roborazziOptions = frameRoborazziOptions)
     }
     frameFiles += frameFile
     frameTimes += virtualTimeMs
@@ -3069,8 +3140,9 @@ private fun overrideSeedMap(
 
 /**
  * Maps the renderer-side [GestureHintCapture] (read from `previews.json`) onto the connector's
- * `protocol.GestureOverride` wire shape — only the `showHints` immediate-mode flag; `@GestureHintPreview`
- * carries no invoke / enabled dimensions (those are daemon-interactive concerns).
+ * `protocol.GestureOverride` wire shape — only the `showHints` immediate-mode flag;
+ * `@GestureHintPreview` carries no invoke / enabled dimensions (those are daemon-interactive
+ * concerns).
  */
 private fun GestureHintCapture.toGestureOverride(): GestureOverride =
   GestureOverride(showHints = showHints)

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
@@ -10,12 +10,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asSkiaBitmap
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
@@ -144,7 +148,8 @@ fun renderFocusPreview(
   wrapHeight: Boolean,
   previewArgs: List<Any?>,
   localeTag: String?,
-  focus: DesktopFocusIntent,
+  focus: DesktopFocusIntent? = null,
+  hoverIndex: Int? = null,
   /**
    * `@ScrollingPreview(END)` on the same capture: drive the scrollable to its content end *before*
    * walking focus, so a capture carrying both intents documents both. Without this the focus branch
@@ -163,6 +168,7 @@ fun renderFocusPreview(
   maxHeightPx: Int? = null,
   fileSystem: FileSystem = SystemFileSystem,
 ): Boolean {
+  require(focus != null || hoverIndex != null) { "focus or hover intent required" }
   val clazz = Class.forName(className)
   // Reflection + wrapper resolution are [renderPreview]'s, not near-copies: an overload lookup
   // without its `argsMatch` filter can pick a same-arity-but-wrong-types sibling, and a wrapper
@@ -263,13 +269,14 @@ fun renderFocusPreview(
           // `LaunchedEffect`-driven `moveFocus` walk — live in `:data-focus-connector-desktop`, the
           // same seam the daemon's `renderNow.overrides.focus` path uses. Nothing about the walk is
           // reimplemented here; the renderer only decides *when* to flip the controller.
-          FocusOverrideExtension().AroundComposable {
+          val framed: @Composable () -> Unit = {
             if (shouldApplySystemBars(showSystemUi, device, kind = null)) {
               SystemBarsFrame(uiMode = uiMode) { wrapped() }
             } else {
               wrapped()
             }
           }
+          if (focus != null) FocusOverrideExtension().AroundComposable(framed) else framed()
         }
       }
 
@@ -309,41 +316,47 @@ fun renderFocusPreview(
       // Indexed mode is one flip (the index is absolute). Traversal mode flips once per replayed
       // step, each settling before the next, so the walk accumulates exactly as it does on the
       // Android renderer's long-lived composition — see [DesktopFocusIntent.directions].
-      val steps = if (focus.directions.isEmpty()) 1 else focus.directions.size
-      repeat(steps) { index ->
-        FocusController.set(focus.toOverride(index))
-        // `waitForIdle()` before the clock advance, not after: the walk lives in a
-        // `LaunchedEffect`, and whether its coroutine has been *dispatched* by the time we advance
-        // is not something a fixed window can guarantee. Skipping this made the capture a race the
-        // CI render lost while the local one won — the walk landed after the settle, so the node
-        // was focused (the `landed` probe below said so) but its indication had never been given a
-        // frame to fade in, and the published sticker looked exactly like the untouched button.
-        waitForIdle()
-        mainClock.advanceTimeBy(FocusController.SETTLE_MS)
-      }
-
-      // Focus is on a node before the indication is drawn, so probing for it is a precondition,
-      // not the settle. Wait for the walk to land, then give the state layer its own full window —
-      // Material's focus indicator crossfades over ~150 ms and a capture taken mid-fade documents
-      // a weaker state than the component actually has.
-      landed = awaitFocusLanded(this, mainClock)
-      if (landed) {
-        mainClock.advanceTimeBy(FocusController.SETTLE_MS)
-        if (focus.pressed) {
-          // A real pointer down on the focused element. `performTouchInput { down(center) }` goes
-          // through the scene's ordinary hit-testing dispatch, so `Modifier.clickable` raises
-          // `PressInteraction.Press` on its own interaction source — the component's wiring, not
-          // ours. Touch rather than mouse deliberately: a mouse press would also raise
-          // `HoverInteraction.Enter`, and a sticker labelled "pressed" should not be documenting
-          // hover as well.
-          onAllNodes(isFocused()).onFirst().performTouchInput { down(center) }
-          // Press indication is animated (Material's state layer crossfade plus the ripple's own
-          // growth), and `clickable` additionally delays the press emission when the composable
-          // sits in a scrollable ancestor. Two settle windows cover both.
-          mainClock.advanceTimeBy(FocusController.SETTLE_MS)
+      if (focus != null) {
+        val steps = if (focus.directions.isEmpty()) 1 else focus.directions.size
+        repeat(steps) { index ->
+          FocusController.set(focus.toOverride(index))
+          waitForIdle()
           mainClock.advanceTimeBy(FocusController.SETTLE_MS)
         }
-        focusedBounds = focusedNodeBounds(this)
+
+        // Focus is on a node before the indication is drawn, so probing for it is a precondition,
+        // not the settle. Wait for the walk to land, then give the state layer its own full window.
+        landed = awaitFocusLanded(this, mainClock)
+        if (landed) {
+          mainClock.advanceTimeBy(FocusController.SETTLE_MS)
+          if (focus.pressed) {
+            // A real pointer down on the focused element. `performTouchInput { down(center) }` goes
+            // through the scene's ordinary hit-testing dispatch, so `Modifier.clickable` raises
+            // `PressInteraction.Press` on its own interaction source — the component's wiring, not
+            // ours. Touch rather than mouse deliberately: a mouse press would also raise
+            // `HoverInteraction.Enter`, and a sticker labelled "pressed" should not be documenting
+            // hover as well.
+            onAllNodes(isFocused()).onFirst().performTouchInput { down(center) }
+            mainClock.advanceTimeBy(FocusController.SETTLE_MS)
+            mainClock.advanceTimeBy(FocusController.SETTLE_MS)
+          }
+          focusedBounds = focusedNodeBounds(this)
+        }
+      } else {
+        // Hover is positional input, not a focus walk: find the requested interactive semantics
+        // node and move a mouse into its centre. This raises HoverInteraction.Enter without also
+        // producing FocusInteraction.Focus (or the extra hover a mouse press would add).
+        val matcher = interactiveNodeMatcher()
+        val targets = onAllNodes(matcher).fetchSemanticsNodes()
+        val index = hoverIndex ?: 0
+        if (index in targets.indices) {
+          onAllNodes(matcher)[index].performMouseInput { moveTo(center) }
+          waitForIdle()
+          mainClock.advanceTimeBy(FocusController.SETTLE_MS)
+          landed = true
+        }
+      }
+      if (landed) {
         captureFocusFrame(
           provider = this,
           outputFile = outputFile,
@@ -366,8 +379,13 @@ fun renderFocusPreview(
 
   if (!landed) {
     System.err.println(
-      "@FocusedPreview on $className.$functionName: nothing took focus " +
-        "(${focus.describe()}) — falling back to the undriven capture."
+      if (focus != null) {
+        "@FocusedPreview on $className.$functionName: nothing took focus " +
+          "(${focus.describe()}) — falling back to the undriven capture."
+      } else {
+        "@OverrideVariant hover on $className.$functionName: no interactive node at index " +
+          "${hoverIndex ?: 0} — falling back to the undriven capture."
+      }
     )
     return false
   }
@@ -376,7 +394,7 @@ fun renderFocusPreview(
   // capture preserved as `<basename>.raw.png`. Same review aid (and same drawing) as the Android
   // path's `FocusOverlay`; the bounds come from the semantics tree here rather than from
   // `AndroidComposeView.focusOwner`, because desktop has no `View` to reflect into.
-  if (focus.overlay) {
+  if (focus?.overlay == true) {
     focusedBounds?.let {
       FocusOverlayDesktop.apply(it, outputFile, focus.documentedOverride(), fileSystem)
     }
@@ -385,6 +403,15 @@ fun renderFocusPreview(
   writePreviewOverridesSidecar(outputFile, fileSystem)
   return true
 }
+
+private fun interactiveNodeMatcher() =
+  SemanticsMatcher("has an interactive action") { node ->
+    val config = node.config
+    config.getOrNull(SemanticsActions.OnClick) != null ||
+      config.getOrNull(SemanticsActions.SetProgress) != null ||
+      config.getOrNull(SemanticsActions.SetText) != null ||
+      config.getOrNull(SemanticsActions.RequestFocus) != null
+  }
 
 private fun DesktopFocusIntent.describe(): String =
   when {

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -255,6 +255,7 @@ fun main(args: Array<String>) {
   val focusEnterPlacesFocus = args.getOrNull(35)?.toBoolean() ?: false
   val focusPressed = args.getOrNull(36)?.toBoolean() ?: false
   val focusOverlay = args.getOrNull(37)?.toBoolean() ?: false
+  val hoverIndex = args.getOrNull(38)?.toIntOrNull()?.takeIf { it >= 0 }
   val focusIntent: DesktopFocusIntent? =
     when {
       focusDirections.isNotEmpty() ->
@@ -476,7 +477,7 @@ fun main(args: Array<String>) {
           fontScale = fontScale,
         )
       } else if (
-        focusIntent != null &&
+        (focusIntent != null || hoverIndex != null) &&
           scrollDispatchMode != DesktopScrollMode.LONG &&
           scrollDispatchMode != DesktopScrollMode.GIF
       ) {
@@ -508,6 +509,7 @@ fun main(args: Array<String>) {
             previewArgs = previewArgs,
             localeTag = localeTag,
             focus = focusIntent,
+            hoverIndex = hoverIndex,
             scrollToEnd = scrollDispatchMode == DesktopScrollMode.END,
             scrollAxis = scrollAxis,
             scrollMaxScrollPx = scrollMaxScrollPx,

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopFocusRendererTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopFocusRendererTest.kt
@@ -34,10 +34,11 @@ class DesktopFocusRendererTest {
     name: String,
     focus: DesktopFocusIntent?,
     functionName: String = "FocusableButtonRow",
+    hoverIndex: Int? = null,
   ): Pair<File, Boolean> {
     val out = File(tempFolder.newFolder(name), "$name.png")
     val drove =
-      if (focus == null) {
+      if (focus == null && hoverIndex == null) {
         renderPreview(
           className = fixtureClass,
           functionName = functionName,
@@ -70,6 +71,7 @@ class DesktopFocusRendererTest {
           previewArgs = emptyList(),
           localeTag = null,
           focus = focus,
+          hoverIndex = hoverIndex,
         )
       }
     // Keep the captures for the PR's visual evidence (build dir, not committed).
@@ -165,6 +167,15 @@ class DesktopFocusRendererTest {
     val pressed =
       bytes(render("desktop-focus-press", DesktopFocusIntent(tabIndex = 0, pressed = true)).first)
     assertNotEquals("pressed capture must differ from the focused one", focused, pressed)
+  }
+
+  /** Hover uses a real mouse move and must not need a focus walk to change the component state. */
+  @Test
+  fun hoveredCaptureDiffersFromUndrivenCapture() {
+    val plain = bytes(render("desktop-hover-none", null).first)
+    val (hovered, drove) = render("desktop-hover-0", null, hoverIndex = 0)
+    assertTrue("hover must find the first interactive node", drove)
+    assertNotEquals("hovered capture must differ from the undriven one", plain, bytes(hovered))
   }
 
   /**


### PR DESCRIPTION
## Summary

- extend `@OverrideVariant` with Hovered, Focused, and Pressed interaction states plus a target index
- discover interaction-only variants as stable, addressable `_VARIANT_<name>` preview IDs
- drive hover, focus, and press state in the desktop and Android renderers before capture
- add discovery coverage and a desktop rendered-pixel regression test

## Why

Design pages could render interaction-state captures, but those captures had no stable preview identity. That meant Hovered, Focused, and Pressed variants could not be linked or selected from generated design pages.

The root cause was that `@OverrideVariant` only described seeded data overrides, while renderer capture instructions were separate and hover had no capture primitive.

## Impact

Consumers can declare interaction variants directly on a preview and receive stable outputs that design tooling can address. Existing seeded override behavior is unchanged.

Fixes #3832.

## Validation

- `ktfmtCheckAll` via the repository commit hook
- focused production compilation for annotations, data APIs, discovery/plugin, and Android/desktop renderers
- `DiscoveryFunctionalTest.composePreviewDiscover expands @OverrideVariant into synthetic seeded previews`
- `DesktopFocusRendererTest.hoveredCaptureDiffersFromUndrivenCapture`