### PR TITLE
docs(parity): add implementable batch plans for the component-parity epic

### DIFF
--- a/docs/design/parity-batches/00-decisions.md
+++ b/docs/design/parity-batches/00-decisions.md
@@ -63,9 +63,14 @@ Any resampler that is not `drawImage` produces different pixels, so the publishe
 **once**, deliberately. Invariant I10 is what stops them moving a second time. The decision is not
 *whether* but *how it is announced*:
 
-**Do:** bump the score schema version, regenerate committed baselines **in the same change**, and
-note it in the release notes. Never in a change that also alters acceptance semantics — a moved
-number and a changed verdict in one diff cannot be told apart.
+**There is no version to bump yet — that is part of the decision.** `scoreImages` returns
+`{percent, geometry}` and nothing else, and a repo-wide search finds no versioned parity-score
+carrier and no committed score-baseline format. So a downstream reader currently has no way to tell
+an old-kernel number from a rebaselined one.
+
+**Do:** identify the carrier or introduce one *first*; then bump it, regenerate committed baselines
+**in the same change**, and note it in the release notes. Never in a change that also alters
+acceptance semantics — a moved number and a changed verdict in one diff cannot be told apart.
 
 ## D4 — the frame-vs-controls race in `refreshReportLink()`
 

--- a/docs/design/parity-batches/00-decisions.md
+++ b/docs/design/parity-batches/00-decisions.md
@@ -1,0 +1,96 @@
+# Batch 00 — decisions and corrections
+
+**Issues:** none — this batch exists because writing code against an unsettled question is how the
+design doc accumulated three wrong pixel pipelines.
+**Depends on:** nothing.
+**Blocks:** [02](02-issue-index.md) (D2), [04](04-acceptance-schema.md) (D1), [05](05-acceptance-engines.md) (D1, D3).
+**Ships:** no user-visible change. Output is edits to
+[`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) and to the affected issues.
+
+Each decision below is stated with the options, the recommendation, and what breaks if it is deferred
+past the batch that needs it. None is large. All are cheap now and expensive after two engines have
+been written against opposite readings.
+
+---
+
+## D1 — which plane the element tag index reports bounds in
+
+**Blocks:** 04 (the `plane` discriminant), 05 (the element gate), 03 (what a selection records).
+
+The design doc says the server publishes tag bounds already transformed into an acceptance's
+*canonical plane*. **Neither producer can do that.** The canonical plane is resolved per comparison,
+from a reference raster and an acceptance record; `ServeSemanticsTags` sees one daemon render and
+`scripts/design-artifacts/tag-index.mjs` sees one packed bundle. Both therefore emit `boundsInRoot`
+render pixels and declare `space: "render-pixels"` on the wire, and `ServeTagIndexStore` rejects any
+entry that declares anything else — so nothing can silently consume these as canonical today.
+
+| Option | Consequence |
+| --- | --- |
+| **(a) The transform belongs to the comparison.** Index stays render-pixel; the comparison maps into the canonical plane at gate time. | Doc §4/§5 need correcting. No producer changes. **Recommended.** |
+| (b) The index becomes comparison-scoped. | A third producer keyed by `(previewId, referenceId, acceptance)`, recomputed per comparison, and the published `tags/index.json` stops being a per-preview artifact. |
+
+(a) is recommended because a plane is a property of a *comparison*, and the index is a property of a
+*render*. Under (b) the published artifact would have to be regenerated whenever an acceptance
+changed, which is precisely the "publishing must not require a re-render" property batches 02 and 05
+both rely on.
+
+**Do:** amend the doc to say the index publishes render-pixel bounds and names its space, and that
+the canonical-plane transform is a step of the comparison. Then relax or keep `space` validation
+deliberately rather than by accident.
+
+## D2 — which surface carries the report form
+
+**Blocks:** 02 and 03 (both put things on "the page where you see the problem").
+
+[#3802](https://github.com/yschimke/compose-ai-tools/issues/3802) records that the form currently
+lives only on the viewer, whose always-available live number is `scoreSvgUrls` — PNG against the
+*generated SVG*. That is a render-fidelity measurement, not a design-parity one. Emitting it into an
+issue body labelled as a parity score produces a plausible, mislabelled number feeding an index.
+
+| Option | Consequence |
+| --- | --- |
+| **(a) Move the form to the focused comparison** `/{system}/compare/{previewId}`. | Always has a concrete `(previewId, referenceId)` pair *and* the real score, and is where element selection lands in 03. Viewer keeps a link to it. **Recommended.** |
+| (b) Keep it on the viewer; omit the score field unless the Spec lane computed one. | Cheaper, but leaves the reporter on a page that cannot name a `referenceId`, so the locator is incomplete for exactly the reports that matter. |
+
+**Do:** record the choice on #3802 and #3806 before either is picked up, since both spend their
+budget on page wiring.
+
+## D3 — the score rebaseline is versioned, and when
+
+**Blocks:** 05.
+
+Any resampler that is not `drawImage` produces different pixels, so the published parity numbers move
+**once**, deliberately. Invariant I10 is what stops them moving a second time. The decision is not
+*whether* but *how it is announced*:
+
+**Do:** bump the score schema version, regenerate committed baselines **in the same change**, and
+note it in the release notes. Never in a change that also alters acceptance semantics — a moved
+number and a changed verdict in one diff cannot be told apart.
+
+## D4 — the frame-vs-controls race in `refreshReportLink()`
+
+**Blocks:** 02 (small, but it is the difference between a correct locator and a subtly wrong one).
+
+`refreshLinks()` fires the moment a control moves; provenance is recorded later, in the replacement
+image's `onload`. Between those moments the visible pixels are the *previous* frame, so a locator
+substituted from control state can describe a variant the reporter never saw.
+
+**Do:** for the first landing, **disable the report affordance until the requested frame has
+loaded**. Deriving from the successfully displayed frame is the better end state; it is also the one
+that can be got subtly wrong and pass review. Take the crude version first and note the follow-up.
+
+---
+
+## Loose ends (not blocking; file or fix opportunistically)
+
+- **`stampPreviewDensities` has the same fold bug** `previewsByFunctionReplacing` was written to fix:
+  it dedupes by id and *appends*, so a later bundle does not replace an earlier candidate. It was
+  deliberately left alone because it feeds Figma export scale, not the live lane, and changing it
+  moves exported artwork. Worth a scoped issue with a before/after export check.
+- **`vscode-preview/main` baseline instability.** The visual-diff bot intermittently reports a
+  phantom row: the fixture captures byte-identically at base and head across repeated runs
+  (`9dd897a3…`), and the extra row changes identity between runs. Proven drift in the stored
+  baseline, not in any PR's diff. Worth an issue so reviewers stop discounting real rows.
+- **`ssim` / `globalSsim` in `format-compare.js` have no callers.** Decide in 05 whether they are
+  removed or wired; leaving dead scoring code beside live scoring code invites a future reader to
+  assume the wrong one is authoritative.

--- a/docs/design/parity-batches/01-locator-and-report.md
+++ b/docs/design/parity-batches/01-locator-and-report.md
@@ -70,6 +70,14 @@ href"** rule.
   "a stale bystander"). Overrides are query parameters; *interaction* is not, so a redirect lands the
   reporter on pixels nobody saw. Transferring the displayed frame and its runtime state is a much
   larger piece of work — scope it deliberately, do not smuggle it in here.
+- **Moving the form to the comparison (D2) is not free — the comparison does not carry overrides
+  yet.** `handleReferenceComparison` reads exactly two request values, `name` and `reference`; the
+  Actual render URL `referenceComparisonPage` builds carries authentication and session parameters,
+  not theme, device, font, `knob.*` or `rc.*`. A visitor arriving from an overridden frame would see
+  and report the **default** render while the locator described another state — the same
+  identity-vs-pixels mismatch this batch exists to prevent, arriving from the other direction.
+  Parsing and forwarding the complete normalised override map is a prerequisite of D2, not a
+  follow-up to it.
 - **Pick the surface that knows the score.** The viewer's always-available number is `scoreSvgUrls` —
   PNG against the *generated SVG*, a render-fidelity measurement unrelated to the design reference.
   Emitting it as a parity score produces a plausible, mislabelled number feeding an index. Either

--- a/docs/design/parity-batches/01-locator-and-report.md
+++ b/docs/design/parity-batches/01-locator-and-report.md
@@ -1,0 +1,98 @@
+# Batch 01 — the locator contract and the report body
+
+**Issues:** [#3801](https://github.com/yschimke/compose-ai-tools/issues/3801) (contract),
+[#3802](https://github.com/yschimke/compose-ai-tools/issues/3802) (emit it).
+**Depends on:** nothing. D2/D4 from [batch 00](00-decisions.md) decide *where* the form lives and how
+it stays honest, so settle those first if 00 is being done at all.
+**Blocks:** 02, 03, 04, 05, 06 — every one of them keys off this identity.
+**Ships:** partly. Nothing new appears on a page, but every issue filed after this lands is
+machine-identifiable, and issues filed before it need their bodies hand-edited later. **That is the
+argument for doing this batch first even if nothing else gets done.**
+
+**Read first:** [`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) §2 and §6 step 1;
+`cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt` in full (220 lines — the
+KDoc explains why the link is prefilled rather than filed server-side, which constrains everything
+here); `viewer.js` around `refreshReportLink()` (~line 657).
+
+---
+
+## What to build
+
+### 1. `compose-parity-locator/v1`
+
+Identity is `repository + system + componentId + previewId + referenceId + variant + overrides`.
+Serialised into the issue body as a **fenced code block**, alongside — not instead of — the prose
+table `ServeIssueReport.body` already writes. Both come from one `Context` so they cannot disagree.
+
+Rules that are not negotiable, each because it has a silent failure mode:
+
+- **`previewId` is the *served* id, not the daemon discovery id.** This mistake has been made before
+  (see the `previewIds` note in `docs/public-preview-server.md`); the page still renders and every
+  row quietly loses its link. `ServeCatalogStore.previewIdFor` / `catalogPreviewId()` is the rule.
+- **The preview-server URL is a reproduction link, never the identity.** `ServeIssueReport.withoutToken`
+  already strips the capability out of anything reaching a body, which is a second reason it cannot be.
+- **`variant` is axes only.** Live overrides are *not* folded in. One fact, one field — two
+  representations means two spellings and no rule for which wins.
+- **`overrides` is the whole normalised map the render lane received** — display fields, size fields,
+  overlay toggles, `knob.*`, `rc.*` — not an enumerated list of families. A knob *is* the component's
+  state, so an enumerated scope lets an acceptance authored at `knob.label=Send` match
+  `knob.label=Delete`, and the list drifts silently the first time a family is added.
+- **`overrides` is one-line canonical JSON**, keys sorted by code point, always present, `{}` meaning
+  the default render. `key=value` joined by `;` was tried and cannot round-trip its own inputs: knob
+  values are free text, so a label of `a;knob.color=red` reads back as two overrides.
+- **Fenced block, not an HTML comment.** A comment is invisible in the rendered issue, so a reporter
+  editing the body cannot see they have broken the index.
+
+### 2. Emit it
+
+Extend `ServeIssueReport.Context` with `componentId`, `referenceId`, variant axes, active overrides,
+comparison URL and raw scores; render the block from it.
+
+**This is not pure Kotlin, and that is the whole difficulty.** The server fills the hidden `body`
+input for the settings the page was *served* at; `refreshReportLink()` then rewrites exactly one
+thing — it swaps `{{render}}` for the live `/render` URL. A locator built entirely server-side
+records the **default** variant while the embedded screenshot shows whatever the reporter dialled in.
+The index would key the issue to one identity and the pixels would show another, and the Phase 3
+acceptance lookup would then miss.
+
+So: override-dependent fields get their own placeholders alongside `RENDER_PLACEHOLDER`, substituted
+by `refreshReportLink()` from live viewer state, on the existing **"write an input value, never an
+href"** rule.
+
+## Traps
+
+- **Substitute from the displayed frame, not from the controls** — see [D4](00-decisions.md#d4--the-frame-vs-controls-race-in-refreshreportlink).
+  Landing the crude version (disable the affordance until the requested frame has loaded) is
+  explicitly acceptable and explicitly preferred over a subtly-wrong derivation.
+- **Reporting stays disabled outright in the Live, Wasm and Remote Compose lanes** — not redirected to
+  the focused comparison. Those lanes paint into a canvas or iframe while `#cp-img` / `data-cp-blob`
+  go on describing the static snapshot the visitor arrived from (`viewer.js` already calls that blob
+  "a stale bystander"). Overrides are query parameters; *interaction* is not, so a redirect lands the
+  reporter on pixels nobody saw. Transferring the displayed frame and its runtime state is a much
+  larger piece of work — scope it deliberately, do not smuggle it in here.
+- **Pick the surface that knows the score.** The viewer's always-available number is `scoreSvgUrls` —
+  PNG against the *generated SVG*, a render-fidelity measurement unrelated to the design reference.
+  Emitting it as a parity score produces a plausible, mislabelled number feeding an index. Either
+  move the form to the focused comparison (D2, recommended) or omit the score field entirely when the
+  Spec lane has not computed one.
+- Anything reaching a body goes through `withoutToken`. New URL-bearing fields must too, and a test
+  should prove it for each.
+
+## Done when
+
+- A round-trip test: build a `Context`, render the body, parse the fenced block back, and get the
+  same locator — including an `overrides` value containing `;`, `=`, a newline, and a non-ASCII
+  label.
+- Canonical JSON is byte-stable: same map, different insertion order, identical string.
+- A `ServeWebFixtureTest` fixture pins the rendered body for a catalog preview *with* overrides in
+  force, so a future change to the prose table cannot silently reshape the block.
+- A JS test proves the placeholders are substituted into the input's **value**, and that no `href`
+  is written.
+- Token-bearing URLs are absent from every emitted field.
+
+## Visual evidence
+
+The report affordance is UI. If its enabled/disabled state or placement changes, capture the
+before/after through the preview-harness (`ServeWebFixtureTest` → `pages-snapshot.spec.mjs`) and
+embed the PNGs in the PR body — a description of the change is not evidence. If the batch lands
+without touching visible pixels, say so explicitly in the PR.

--- a/docs/design/parity-batches/01-locator-and-report.md
+++ b/docs/design/parity-batches/01-locator-and-report.md
@@ -2,8 +2,10 @@
 
 **Issues:** [#3801](https://github.com/yschimke/compose-ai-tools/issues/3801) (contract),
 [#3802](https://github.com/yschimke/compose-ai-tools/issues/3802) (emit it).
-**Depends on:** nothing. D2/D4 from [batch 00](00-decisions.md) decide *where* the form lives and how
-it stays honest, so settle those first if 00 is being done at all.
+**Depends on:** **[00](00-decisions.md) D2 and D4** — not optional. D2 decides where the form lives;
+**D4 must be settled before this batch ships**, because an unresolved frame race lets the batch emit
+a locator built from control state while the page still displays the previous frame, which is the one
+defect that makes every issue filed afterwards wrong in a way nobody notices. Nothing else blocks it.
 **Blocks:** 02, 03, 04, 05, 06 — every one of them keys off this identity.
 **Ships:** partly. Nothing new appears on a page, but every issue filed after this lands is
 machine-identifiable, and issues filed before it need their bodies hand-edited later. **That is the
@@ -97,6 +99,10 @@ href"** rule.
 - A JS test proves the placeholders are substituted into the input's **value**, and that no `href`
   is written.
 - Token-bearing URLs are absent from every emitted field.
+- **The pending and failed render cases are covered**, not just the settled one: reporting while a
+  requested frame is still in flight, and reporting after that render has failed, must both either
+  be refused or produce a locator describing the frame actually on screen. This is the D4 defect and
+  it needs its own tests, since the happy path passes with or without the fix.
 
 ## Visual evidence
 

--- a/docs/design/parity-batches/02-issue-index.md
+++ b/docs/design/parity-batches/02-issue-index.md
@@ -43,17 +43,33 @@ Traps:
 - **Name the permission explicitly:** the App needs **Contents: write** on the catalog repo, because
   that is what `POST /repos/{owner}/{repo}/dispatches` requires. Read-only Contents returns 403 and
   the trigger is silently dead — indistinguishable from "no issues changed".
-- **The cron backstop is not optional.** Per-source-repo credential provisioning is real setup work,
-  and an unwired repo has nothing else to fall back on. That will be the normal state for a while.
+- **The dispatch credential is not the read credential.** Contents: write on the catalog repo is what
+  lets the workflow *fire and commit*; it grants nothing on the **source** repo whose issues are being
+  scanned. For a public source the catalog workflow's own `GITHUB_TOKEN` can read issues, but for a
+  private or permission-restricted one it cannot — the dispatch wakes the workflow and the source's
+  issues are simply absent from the generated index, which looks identical to "that repo has no parity
+  issues". Provision a catalog-side credential with **Issues: read** on every scanned repository, and
+  make an unreadable source repo a loud failure rather than an empty section.
+- **The cron backstop is not optional** — but it only backstops the *trigger*, not the credential.
+  Per-source-repo provisioning is real setup work, and an unwired repo has nothing else to fall back
+  on. That will be the normal state for a while. Carrying the changed issue in the dispatch payload
+  improves the event path and does nothing for the reconciliation cron, which still has to read.
 - **Closed rows are published, not dropped.** An issue referenced by any acceptance stays in the index
   with `state: "closed"`. Absence must never be read as closure — a consumer that cannot find a row
   reports *unknown*. Otherwise the first time the file fails to parse, every acceptance in the catalog
   is marked stale at once. Batch 06 depends on this directly.
-- **The publish race needs care.** `.github/actions/apply/lib/push-branch.sh` computes
-  `TREE=$(git write-tree)` once *before* its retry loop and reparents that stale tree on a
-  non-fast-forward, never merging the fetched parent — so a concurrent render can be silently dropped.
-  Any carry-forward fix must be **opt-in** (an env var naming the paths), since other publishers share
-  the helper.
+- **The publish race needs care, and the two publishers need *different* modes.**
+  `.github/actions/apply/lib/push-branch.sh` computes `TREE=$(git write-tree)` once *before* its retry
+  loop and reparents that stale tree on a non-fast-forward, never merging the fetched parent — so a
+  concurrent render can be silently dropped. Making a carry-forward mode opt-in (an env var naming the
+  paths) is necessary but **not sufficient**, because the two publishers race in opposite directions:
+  - the **render** publisher must carry the fetched parent's `parity/issues.json` **forward**;
+  - the **index** publisher must replace **only its own path** on the fetched tip.
+
+  Applying carry-forward symmetrically discards a freshly generated index; using the whole-tree helper
+  as-is for the index rolls back a concurrent render. Two index jobs overlapping need cancellation or
+  a re-query on retry, so an older snapshot cannot overwrite a newer one. Opt-in is required because
+  other publishers share the helper. Test **both** publish orderings and index-vs-index.
 - **Canonicalise issue URLs** to `owner`/`repo`/`number` before aggregating. Trailing slashes, `www.`,
   and mixed-case owners otherwise split one issue into several groups.
 
@@ -103,6 +119,9 @@ problem"** and the epic's presentation section is satisfied.
 - The reader drops a malformed index wholesale and the session serves exactly as before — asserted,
   not assumed.
 - All six fixtures pass, including the closed row surviving to the consumer.
+- The publish race is covered in **three** orderings: render-then-index, index-then-render, and
+  index-then-index. None of them may lose the other's output.
+- A source repo the credential cannot read fails loudly rather than contributing an empty section.
 - Issue rows are visible on all four surfaces, with an open issue and a closed one both represented.
 
 ## Visual evidence

--- a/docs/design/parity-batches/02-issue-index.md
+++ b/docs/design/parity-batches/02-issue-index.md
@@ -1,0 +1,113 @@
+# Batch 02 — the issue index, end to end
+
+**Issues:** [#3804](https://github.com/yschimke/compose-ai-tools/issues/3804) (producer),
+[#3805](https://github.com/yschimke/compose-ai-tools/issues/3805) (reader),
+[#3806](https://github.com/yschimke/compose-ai-tools/issues/3806) (surfaces).
+**Depends on:** [01](01-locator-and-report.md) — the producer parses the locator block back out of
+issue bodies, so there is nothing to parse until 01 has been filing them.
+**Ships:** **yes.** This is the first visible payoff and the point at which the epic's first four
+acceptance criteria are met: open issues appear on the pages where the problem is visible.
+
+**Read first:** [`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) §3 and §6
+steps 2, 4, 7. `ServeParityActivity.kt` is the pattern for the reader — copy its shape, do not design
+a new one. `ServeTagIndexStore.kt` is a second, closer worked example, including the
+`ServeCatalogStore` staging call.
+
+> **Not the tag index.** This batch handles `parity/issues.json` — a snapshot of *GitHub issues*,
+> schema `compose-preview-issues/v1`. The already-merged `ServeTagIndexStore` reads `tags/index.json`,
+> the *element* index, `compose-preview-tags/v1`. Different artifact, different schema; both are "an
+> index the serve host loads fail-soft", which is exactly why they get conflated.
+
+Three issues, one batch, because a producer with no reader and a reader with no surface are both
+untestable end to end — and the whole value is in the last hop.
+
+---
+
+## 2a — producer (#3804)
+
+A workflow reads issues, parses each body's locator block, and commits `parity/issues.json` to
+`design-artifacts/`.
+
+**A file-only commit propagates without a render.** `ServeCatalogRefresher` re-fetches on any branch
+head move and `ServeCatalogStore.load` re-stages the whole tree, so a workflow committing *only*
+`parity/issues.json` reaches every serving host within one refresh interval. The epic's "updating
+this index must not require rerendering the catalog" is satisfiable exactly as written.
+
+Traps:
+
+- **Credentials are the hard part, and the default is the trap.** A GitHub App installation token
+  expires in an hour, so it is minted per run, never stored. `actions/create-github-app-token` **must**
+  be given `owner` and `repositories` naming the **catalog** repo. The default scopes the token to the
+  repo the workflow runs in — the *source* repo, where the App is not installed and which is not the
+  dispatch target. Taking the default either fails while minting or yields a token that cannot dispatch.
+- **Name the permission explicitly:** the App needs **Contents: write** on the catalog repo, because
+  that is what `POST /repos/{owner}/{repo}/dispatches` requires. Read-only Contents returns 403 and
+  the trigger is silently dead — indistinguishable from "no issues changed".
+- **The cron backstop is not optional.** Per-source-repo credential provisioning is real setup work,
+  and an unwired repo has nothing else to fall back on. That will be the normal state for a while.
+- **Closed rows are published, not dropped.** An issue referenced by any acceptance stays in the index
+  with `state: "closed"`. Absence must never be read as closure — a consumer that cannot find a row
+  reports *unknown*. Otherwise the first time the file fails to parse, every acceptance in the catalog
+  is marked stale at once. Batch 06 depends on this directly.
+- **The publish race needs care.** `.github/actions/apply/lib/push-branch.sh` computes
+  `TREE=$(git write-tree)` once *before* its retry loop and reparents that stale tree on a
+  non-fast-forward, never merging the fetched parent — so a concurrent render can be silently dropped.
+  Any carry-forward fix must be **opt-in** (an env var naming the paths), since other publishers share
+  the helper.
+- **Canonicalise issue URLs** to `owner`/`repo`/`number` before aggregating. Trailing slashes, `www.`,
+  and mixed-case owners otherwise split one issue into several groups.
+
+**Cross-repo:** the issue-triggered workflow lands in the catalog repo.
+
+## 2b — reader (#3805)
+
+`ServeParityIssues.kt` plus the `ServeCatalogStore` staging call plus fixture-backed tests. Serves
+nothing yet; it lands before anything renders it.
+
+- **The serve host never calls the GitHub API at page-render time.** Same rule that keeps it away from
+  Figma URLs. Host and the offline design-parity run read the same committed file.
+- **Validate, then reassemble.** A catalog is third-party data and an `html_url` from it is
+  attacker-controlled. Parse to `owner`/`repo`/`number`, check each, and **rebuild** the URL — never
+  forward the string.
+- **Cap the row count**, in the same spirit as the acceptance budget. A hostile or broken index must
+  not be able to exhaust a page.
+- **Closed rows are legitimate content**, not noise to filter at load. Batch 06 needs to tell "closed"
+  from "not in the file".
+- Fixtures cover: valid, wrong schema token, truncated, oversized, a row with an unparseable URL, and
+  a closed row.
+
+Remember the three-part rule: producer, **staging call**, host loader. `ServeTagIndexStore` shipped
+without the middle piece once and without a production caller once. Both were invisible until someone
+went looking.
+
+## 2c — surfaces (#3806)
+
+**There is no component page, and one should not be invented.** The epic's "component page" is not a
+route. The surfaces are the catalog landing grid (component *cards*), the viewer `/{system}/p/{id}`,
+the focused comparison `/{system}/compare/{previewId}`, and the parity dashboard
+(`ServeParityDashboard.kt`). Read "component page" as **"the page you are on when you see the
+problem"** and the epic's presentation section is satisfied.
+
+- Issue rows on all four surfaces.
+- Dashboard splits: new differences needing triage; accepted known differences; components with open
+  issues; and — once statuses exist (batch 06) — recorded differences that no longer reproduce, and
+  closed issues with a surviving acceptance. **The last two columns can land after the rest.**
+- Area classification surfaced from the low-cardinality labels: `area:{spec,component,preview,renderer,comparison}`
+  and `parity:{regression,known-difference,verification-needed}`. **No label per component** (epic
+  non-goal) — component identity lives in the body locator.
+
+## Done when
+
+- The producer round-trips: a locator block written by 01 parses back into the same identity, and a
+  body with a *mangled* block is reported rather than silently skipped.
+- The reader drops a malformed index wholesale and the session serves exactly as before — asserted,
+  not assumed.
+- All six fixtures pass, including the closed row surviving to the consumer.
+- Issue rows are visible on all four surfaces, with an open issue and a closed one both represented.
+
+## Visual evidence
+
+This batch changes four rendered surfaces, so the PR **must** embed before/after PNGs for each. Add
+the fixture(s) to `ServeWebFixtureTest` and register them with `pages-snapshot.spec.mjs` in the same
+change, so every later change to these surfaces is diffed for free — that wiring is part of the batch,
+not a follow-up.

--- a/docs/design/parity-batches/02-issue-index.md
+++ b/docs/design/parity-batches/02-issue-index.md
@@ -21,6 +21,23 @@ a new one. `ServeTagIndexStore.kt` is a second, closer worked example, including
 Three issues, one batch, because a producer with no reader and a reader with no surface are both
 untestable end to end — and the whole value is in the last hop.
 
+## 2.0 — settle the wire shape first
+
+**`compose-preview-issues/v1` does not yet exist as a field-level schema.** §3 says "shape as in the
+epic" and the repo carries no manifest, no row example, and no fixture. A JavaScript producer and a
+Kotlin reader cannot be built independently against a schema token, and the locator block from batch
+01 is not an index schema — it is what gets *parsed into* one. So the first commit of this batch
+defines the rows: issue state, labels, title, the locator scope fields, and in particular **whether
+`overrides` stays canonical text or becomes an object** (it is text in the issue body; it does not
+have to stay text in the index, but the choice has to be made once and written down).
+
+The doc already prescribes the arrangement that keeps the two languages honest, and it is the same
+one `parity-activity.mjs` uses today: a **pure** producer half `scripts/design-artifacts/parity-issues.mjs`
+(no I/O, no network, unit-testable without `npm ci`) driven by an I/O half `emit-parity-issues.mjs`,
+with the output committed as `scripts/design-artifacts/fixtures/parity-issues.json` **and loaded by
+the Kotlin reader's own test**. That shared fixture is the only thing preventing silent drift — build
+it in this batch, not after.
+
 ---
 
 ## 2a — producer (#3804)

--- a/docs/design/parity-batches/03-element-selection.md
+++ b/docs/design/parity-batches/03-element-selection.md
@@ -1,0 +1,100 @@
+# Batch 03 — element selection on the focused comparison
+
+**Issue:** [#3803](https://github.com/yschimke/compose-ai-tools/issues/3803).
+**Depends on:** [01](01-locator-and-report.md) (the selection rides into the locator). The tag index
+half of this issue's original prerequisite is **already done** — see below.
+**Blocks:** the element gates in [batch 05](05-acceptance-engines.md).
+**Ships:** **yes.** Click an element, report *that element* rather than "somewhere in this picture".
+
+**Read first:** [`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) §5 and §6
+steps 5–6; `ServeSemanticsTags.kt` and `scripts/design-artifacts/tag-index.mjs` (the two producers,
+and the KDoc in each explains the rules); `inspect.js` and `viewer.js`'s `data-cp-src` frame
+recording, which is the coupling this batch has to break.
+
+---
+
+## Prerequisite status
+
+The tag index is **complete** — carved out to
+[#3878](https://github.com/yschimke/compose-ai-tools/issues/3878) and delivered by
+[#3830](https://github.com/yschimke/compose-ai-tools/pull/3830) /
+[#3860](https://github.com/yschimke/compose-ai-tools/pull/3860) /
+[#3864](https://github.com/yschimke/compose-ai-tools/pull/3864). Both producers exist (live daemon
+projection; published-catalog `tags/index.json`) and the host API is `ServeHost.tagIndexForPreview`.
+It has **no HTTP surface yet** — deliberately, because this batch is its first consumer and inventing
+a route before a caller existed would have frozen a guess. Adding that route is part of this batch.
+
+What remains from the original prerequisite is the **derived semantics annotations** on the focused
+comparison.
+
+## Work
+
+### 1. Derived semantics annotations on the focused comparison
+
+The comparison page today receives only the *producer-authored* annotation lists from a bundle's
+`annotations/index.json`. The **derived** layers — typography and theme projected from the render's
+own semantics tree by `ServeDesignAnnotations` — are viewer-only, because `inspect.js` is coupled to
+the viewer's DOM ids and to `viewer.js`'s `data-cp-src` frame recording. Mounting them over the
+comparison page's Actual panel means **generalising that machinery to accept a host element**, which
+is its own change with real regression surface on a shipped page.
+
+Do that generalisation as its own commit, with the viewer's behaviour pinned by fixtures *before* the
+refactor, so the diff bot proves the viewer did not move.
+
+(#3830 made the *theme* annotation kind reachable on the comparison page — it previously had a box
+and a legend row built for it and no toggle able to reveal them — but that is the **authored** layer,
+not the derived one.)
+
+### 2. Expose the tag index over HTTP
+
+`ServeHost.tagIndexForPreview(previewId)` needs a route the page can fetch. Keep it in the shape of
+the other per-preview JSON the comparison already pulls, and keep the wire type the one
+`ServeTagIndexStore` validates — including `space`, which the reader requires and
+[D1](00-decisions.md#d1--which-plane-the-element-tag-index-reports-bounds-in) governs.
+
+### 3. Selection
+
+Click an annotated element, **or** drag a region.
+
+**Selection must be drivable from the tag index, not only from annotation boxes.** A uniquely tagged
+node with neither typography nor container tokens produces no annotation at all — so a page that only
+makes annotation boxes clickable offers nothing to select for exactly the nodes best suited to a tag
+selector, and the reporter falls back to a drag rectangle. That silently downgrades the acceptance to
+geometric, with no element gate, so a tagged glyph that later vanishes or moves goes **undetected**.
+The index already carries `{count, bounds}` per tag, which is everything a selectable target needs.
+
+### 4. Selection rides into the prefilled report
+
+Into the locator block from batch 01, as the `element` selector plus its authoring-time `bounds` —
+the same fields the acceptance schema (batch 04) will carry.
+
+## Traps
+
+- **Element identity is tag uniqueness, not `ref` path shape.** `SemanticsRefs` assigns `ref` as a
+  `/`-joined path and *indexes siblings sharing an anchor* (`r/role:Button[0]`), so an inserted
+  sibling silently retargets an existing `ref`. That is the entire reason the tag index exists.
+- **`count` is the uniqueness check.** It counts every node carrying the tag, including nodes whose
+  bounds are unusable. A tag with `count > 1` is not a usable identity — offer it as a *region*
+  selection or refuse it, never as an element selector.
+- **The key is the tag verbatim.** No trimming anywhere in the chain: `"item"` and `" item "` are
+  different identities, and collapsing them produces false ambiguity in one direction and false
+  disappearance in the other.
+- **Selection is a *report* affordance. Reporting a difference must never accept it** — epic non-goal,
+  and the easiest boundary in the whole epic to erode by accident.
+- `bounds` may be absent for a tag whose every carrying node had a zero-area box. Handle it; do not
+  assume presence.
+
+## Done when
+
+- A tagged node with no typography or container tokens is selectable — the case the annotation-box-only
+  design misses. Pin it with a fixture.
+- A duplicated tag (`count: 2`) cannot be chosen as an element selector.
+- A drag region and a tag selection both round-trip into the locator block and back.
+- The viewer's annotation rendering is byte-identical before and after the `inspect.js`
+  generalisation, proved by the snapshot harness.
+
+## Visual evidence
+
+Mandatory. Before/after of the comparison page with the derived layers mounted and a selection
+active, both themes, via `ServeWebFixtureTest` → `pages-snapshot.spec.mjs`. The existing
+`renders/parity-comparison-annotations/` set is the precedent for committing them alongside.

--- a/docs/design/parity-batches/03-element-selection.md
+++ b/docs/design/parity-batches/03-element-selection.md
@@ -1,8 +1,12 @@
 # Batch 03 — element selection on the focused comparison
 
 **Issue:** [#3803](https://github.com/yschimke/compose-ai-tools/issues/3803).
-**Depends on:** [01](01-locator-and-report.md) (the selection rides into the locator). The tag index
-half of this issue's original prerequisite is **already done** — see below.
+**Depends on:** [01](01-locator-and-report.md) (the selection rides into the locator) **and
+[00](00-decisions.md) D1** — a selection persists authoring-time `bounds`, and until the plane
+question is settled those bounds get written in a space nobody has agreed on. Recording them in the
+wrong space makes an unmoved element fail the movement gate later, which is the exact failure the
+element gate exists to detect. The tag index half of this issue's original prerequisite is **already
+done** — see below.
 **Blocks:** the element gates in [batch 05](05-acceptance-engines.md).
 **Ships:** **yes.** Click an element, report *that element* rather than "somewhere in this picture".
 
@@ -51,6 +55,22 @@ not the derived one.)
 the other per-preview JSON the comparison already pulls, and keep the wire type the one
 `ServeTagIndexStore` validates — including `space`, which the reader requires and
 [D1](00-decisions.md#d1--which-plane-the-element-tag-index-reports-bounds-in) governs.
+
+**But that route alone is not enough to enable an element gate, and this is the trap in this batch.**
+`tagIndexForPreview` is the *published static* index, and both live host wrappers delegate it to
+their baked host — so on a daemon-backed or otherwise live comparison it does not describe the frame
+being scored. The live per-render index rides the `.annotations` response instead, and *that* call
+re-renders: it is a separate request from `/render/<id>.png`, so it does not describe the PNG the
+client already fetched either. (This was asserted the other way round while the index was being
+built, and it was wrong. Co-locating `tags` with `annotations` buys agreement between those two
+projections and nothing more.)
+
+With overrides, conditional composition or animation in play, a gate fed from either path can
+validate an element against bounds from a **different frame** and let the wrong mask suppress
+pixels. So: establish a shared render generation, or carry the index with the scored pixels, before
+element gates are switched on in [batch 05](05-acceptance-engines.md). Selection and reporting —
+this batch's actual payload — are fine without it, because a reported selection is a claim about
+what the reporter saw, not a verdict.
 
 ### 3. Selection
 

--- a/docs/design/parity-batches/04-acceptance-schema.md
+++ b/docs/design/parity-batches/04-acceptance-schema.md
@@ -43,9 +43,12 @@ Each exists because two engines would otherwise diverge on identical bytes.
 
 - **Scope matching uses every recorded field.** Served ids are unique only *within* a system, so
   matching on `(previewId, referenceId)` alone lets a `wear-m3` acceptance suppress pixels in `m3`.
-- **Both tolerances are bounded**: `candidateTolerance` ∈ `[0, 8]` (8-bit channel distance),
-  `element.tolerance` ∈ `[0.0, 0.25]`. Both are numbers an author can use to disable the model
-  quietly, so both are range-checked, inclusive at the ceiling.
+- **Both tolerances are bounded**: `candidateTolerance` ∈ `[0, 8]` **and integer** (8-bit channel
+  distance), `element.tolerance` ∈ `[0.0, 0.25]` real. Both are numbers an author can use to disable
+  the model quietly, so both are range-checked, inclusive at the ceiling. The integer requirement on
+  `candidateTolerance` is normative and easy to drop: JSON has one number type, so `0.5` sails through
+  a range-only check in JavaScript and is rejected by a Kotlin `Int` field — a cross-engine divergence
+  produced by the validator itself. Fixtures must cover a **fractional** value, not just the endpoints.
 - **The mask encoding is normative**: 8-bit greyscale, no alpha, `0` unmasked / `255` masked, strictly
   binary — and **checked in the `IHDR`, not inferred from samples**, because the browser normalises
   every decode to RGBA and an indexed or RGBA mask with binary values would otherwise pass.
@@ -64,9 +67,15 @@ Each exists because two engines would otherwise diverge on identical bytes.
   `isSafeRelativePath` rewrites `\` to `/` before splitting, so `a\b.png` is checked as two segments
   and opened as one filename on POSIX; `#` and `?` become URL syntax when the host fetches rather
   than reads.
-- **Hashes compare normalised.** `ServeDesignReferenceStore` lowercases a reference hash to validate
-  it and then serves the original spelling, so raw string inequality reports `reference-changed` for
-  an unchanged reference.
+- **Hashes compare normalised — but only the *served* one may be spelled loosely.**
+  `ServeDesignReferenceStore` lowercases a reference hash to validate it and then serves the original
+  spelling, so raw string inequality reports `reference-changed` for an unchanged reference; both
+  sides are lowercased before comparison (equivalently, compare decoded digest bytes). Separately and
+  **first**, every hash *this schema owns* — `referenceSha256`, `maskSha256`, `acceptedCandidateSha256`
+  — must be exactly 64 lowercase hex characters or the record is `schema-invalid`. Collapsing the two
+  rules lets one engine lowercase an uppercase *recorded* hash and accept it while another rejects it,
+  so they need **separate** fixtures: a rejecting uppercase-**recorded** hash, and an accepting
+  uppercase-**served** / lowercase-recorded pair.
 - **Result shape** is `{raw, accepted, unaccepted, statuses, validationFailures}`. `statuses` is keyed
   by acceptance id and **absent entirely** for a document-level rejection. `validationFailures`
   carries one entry per `(record, reason)` pair; `duplicate-id` gets one entry per duplicated *value*,
@@ -91,7 +100,9 @@ Each exists because two engines would otherwise diverge on identical bytes.
 - Every rule above has at least one **rejecting** fixture and one accepting one.
 - The fixture set includes: a valid document; duplicate ids; both dot names; a `\`-bearing path; a
   `#`-bearing path; an RGBA mask with binary values; an APNG; each budget cap breached individually;
-  each tolerance out of range at both ends; an uppercase reference hash that must **not** report
-  `reference-changed`; and a document-level rejection that yields no `statuses` map at all.
+  each tolerance out of range at both ends **and a fractional `candidateTolerance`**; an
+  uppercase-**recorded** hash that must be `schema-invalid`; an uppercase-**served** hash that must
+  **not** report `reference-changed`; and a document-level rejection that yields no `statuses` map at
+  all.
 - A conformance runner exists in this repo and passes, so batch 05's two engines have something to be
   measured against on day one.

--- a/docs/design/parity-batches/04-acceptance-schema.md
+++ b/docs/design/parity-batches/04-acceptance-schema.md
@@ -1,0 +1,97 @@
+# Batch 04 — the committed known-difference schema
+
+**Issue:** [#3807](https://github.com/yschimke/compose-ai-tools/issues/3807).
+**Depends on:** [00](00-decisions.md) D1 (the `plane` discriminant is meaningless until the plane
+question is settled).
+**Blocks:** [05](05-acceptance-engines.md) entirely — both engines and the publish path.
+**Ships:** no user-visible change. The deliverable is a contract plus **conformance fixtures**, and
+the fixtures are the deliverable, not a follow-up: they are the only thing keeping three runners (the
+JS scorer, `design-parity`'s suite, and the server projector's Kotlin tests) honest about one
+definition.
+
+**Read first:** [`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) §4 **in full**.
+It is the longest section and it is the specification; this file is an index into it, not a
+substitute.
+
+`compose-preview-known-differences/v1` is defined **here**, in this repo, because `serve` is a
+consumer and this is where the other wire contracts already live. `design-parity` and
+`@design-parity/catalog-export` consume it.
+
+```
+.design-parity/
+  known-differences.json
+  known-differences/
+    m3-iconbutton-tonal-glyph/
+      mask.png
+      accepted-candidate.png
+```
+
+---
+
+## A record carries
+
+A stable `id`; a **mandatory** `issue` URL; the full locator scope (`system` / `component` /
+`previewId` / `referenceId` / `variant` / `overrides`); an optional `element` selector with its
+authoring-time `bounds` and `tolerance`; `mask` and `acceptedCandidate` paths; **three** hashes
+(`referenceSha256`, `maskSha256`, `acceptedCandidateSha256`); the canonical plane the mask was
+authored against (`plane` discriminant plus the resolved box); `candidateTolerance`; and free-text
+`note` + `acceptedAt`.
+
+## The validation rules are the substance
+
+Each exists because two engines would otherwise diverge on identical bytes.
+
+- **Scope matching uses every recorded field.** Served ids are unique only *within* a system, so
+  matching on `(previewId, referenceId)` alone lets a `wear-m3` acceptance suppress pixels in `m3`.
+- **Both tolerances are bounded**: `candidateTolerance` ∈ `[0, 8]` (8-bit channel distance),
+  `element.tolerance` ∈ `[0.0, 0.25]`. Both are numbers an author can use to disable the model
+  quietly, so both are range-checked, inclusive at the ceiling.
+- **The mask encoding is normative**: 8-bit greyscale, no alpha, `0` unmasked / `255` masked, strictly
+  binary — and **checked in the `IHDR`, not inferred from samples**, because the browser normalises
+  every decode to RGBA and an indexed or RGBA mask with binary values would otherwise pass.
+- **Neither artifact may be animated.** An APNG passes every other check and then hands the two
+  engines different pixels — a decoder reads `IDAT`, an `<img>` advances the animation. Reject on
+  `acTL`.
+- **Budget before decode**: 256 acceptances, 128 megapixels, 8192 px per axis, 8 MiB encoded per
+  artifact — all versioned. The area cap does **not** imply the axis cap (`1 × 128,000,000` is inside
+  the budget and undecodable in every browser), and neither implies the byte cap (`ServeCatalogStore`
+  refuses any catalog asset over 25 MB). **Compare as you go and short-circuit** — never accumulate a
+  total that can overflow differently in Kotlin and JavaScript.
+- **`id` is constrained three ways**: as a path segment, as a map key (`__proto__` is a fine path
+  segment and a catastrophic object key), and against **both** dot names — `.` passes a `..`-only
+  check and normalises to the `known-differences` root.
+- **Artifact paths are contained *and* portable**: `[A-Za-z0-9._-]` segments joined by `/`.
+  `isSafeRelativePath` rewrites `\` to `/` before splitting, so `a\b.png` is checked as two segments
+  and opened as one filename on POSIX; `#` and `?` become URL syntax when the host fetches rather
+  than reads.
+- **Hashes compare normalised.** `ServeDesignReferenceStore` lowercases a reference hash to validate
+  it and then serves the original spelling, so raw string inequality reports `reference-changed` for
+  an unchanged reference.
+- **Result shape** is `{raw, accepted, unaccepted, statuses, validationFailures}`. `statuses` is keyed
+  by acceptance id and **absent entirely** for a document-level rejection. `validationFailures`
+  carries one entry per `(record, reason)` pair; `duplicate-id` gets one entry per duplicated *value*,
+  ordered by first occurrence; token ordering is fixed so two engines serialise identically.
+- **Cut from v1**: `kind: producer` and the structured `finding` matcher. Neither had an authoring
+  path or defined semantics, and a field consumers must guess at is worse than an absent one. Do not
+  reinstate either without an authoring path in the same change.
+
+## Traps
+
+- The wire type must make **absence representable** wherever absence is meaningful. A Kotlin default
+  filled in a missing field twice in this epic — once on encode (fixed with `@EncodeDefault`), once on
+  decode (fixed with a nullable wire type distinct from the domain type). Decide per field, and write
+  the rejecting test.
+- **Assert on the wire, not the round trip.** A test that decodes into the producer type restores its
+  defaults and passes whether or not the field was ever serialised. Assert against raw JSON.
+- The fixture set is consumed by three runtimes. Keep it language-neutral: JSON plus PNG bytes plus an
+  expected-result JSON, no Kotlin or JS harness assumptions baked into the directory shape.
+
+## Done when
+
+- Every rule above has at least one **rejecting** fixture and one accepting one.
+- The fixture set includes: a valid document; duplicate ids; both dot names; a `\`-bearing path; a
+  `#`-bearing path; an RGBA mask with binary values; an APNG; each budget cap breached individually;
+  each tolerance out of range at both ends; an uppercase reference hash that must **not** report
+  `reference-changed`; and a document-level rejection that yields no `statuses` map at all.
+- A conformance runner exists in this repo and passes, so batch 05's two engines have something to be
+  measured against on day one.

--- a/docs/design/parity-batches/05-acceptance-engines.md
+++ b/docs/design/parity-batches/05-acceptance-engines.md
@@ -102,6 +102,14 @@ Apply acceptances in `format-compare.js`, reporting `raw` / `accepted` / `unacce
 carry a per-acceptance `statuses` map with a required fixed-candidate `resolved` case, so an engine
 that defers resolution cannot satisfy its own contract.
 
+**Per-comparison evaluation is not the whole job — the browser needs a catalog-wide walk too.**
+An acceptance naming a removed or renamed preview, reference, component or variant is never scoped
+into *any* focused comparison, so an engine that only evaluates inside `format-compare.js` leaves it
+permanently absent from the browser result and the dashboard while `design-parity` reports
+`orphaned-target` for the same record. That is the "invisible forever" failure the `orphaned-target`
+rule exists to prevent, reintroduced by the *shape* of the evaluation rather than by the rule. Add
+the host-level walk over the complete acceptance set in this batch.
+
 **The raw number will move once, deliberately.** Any kernel that is not `drawImage` produces different
 pixels. What invariant I10 buys is that the *geometry* stays one resample from source to score plane
 at the candidate box's dimensions, so the number does not move a **second** time. The move is a
@@ -109,6 +117,15 @@ versioned rebaseline — see [D3](00-decisions.md#d3--the-score-rebaseline-is-ve
 
 **Element gates must not be enabled without the tag index**, and the index's bounds are render-pixel
 (D1) — the transform into the canonical plane happens here, in the comparison.
+
+**And "no index" must mean "no suppression", not "geometric suppression".** `ServeTagIndex.kt`'s KDoc
+currently says an acceptance that finds no tag entry "degrades to no element gate, which is the safe
+direction". That is only safe if the acceptance also stops suppressing: an **element-scoped**
+acceptance whose gate cannot run and whose mask still joins the valid union has silently become a
+plain ignore rectangle, and a tagged element that has disappeared or moved goes on being hidden —
+precisely the failure the element gate was added to catch. Define the unavailable-index outcome as
+**every element-scoped acceptance suppresses nothing**, pin it in both engines, and correct that KDoc
+sentence in the same change.
 
 ## 5c — publish (#3809)
 
@@ -123,7 +140,16 @@ acceptances the offline run does.
 - **Path containment is checked at staging**, on a host that fetches third-party catalogs, so a
   traversal here is an escape from the artifact tree rather than a typo. The schema's portable-path
   grammar exists so the fetching host and the offline reader resolve the same file.
-- **Publishing must not require a re-render** — the same property `parity/issues.json` relies on.
+- **Publishing must not require a re-render — and routing acceptances through `catalog-export` does
+  not deliver that.** `design-artifacts.yml` is `bundle pack → catalog-export → publish out/`, so any
+  path that goes through it waits on a full render (8–29 min scoped, 31–38 min full), and adding a
+  path to `scope-systems.sh` only *selects* that render, it does not bypass it. The issue index gets
+  the property because §3 gives it a **separate one-file committer** — the doc says outright that the
+  render workflow is "the wrong granularity for 'someone relabelled an issue'". An acceptance edit is
+  the same granularity as an issue relabel. So this batch needs its own index-style publisher that
+  commits just the acceptance paths onto the delivery branch, sharing the carry-forward behaviour
+  batch 02 works out, or it must drop the no-rerender claim and say acceptances land on the next
+  render. **Pick one explicitly** — the claim as written is currently unsupported.
 - **Check `scripts/design-artifacts/scope-systems.sh` maps the new published path.** A wrong mapping
   silently strands a catalog on stale artifacts. It has a self-test (`test-scope-systems.sh`); change
   it only with that passing. Note also that catalog and export-driver merges regenerate the delivery
@@ -138,6 +164,14 @@ acceptances the offline run does.
   A single aggregate status cannot express a mixed-validity case, so two engines can emit the same
   summary while disagreeing about the details — the per-acceptance `statuses` map is what makes the
   disagreement visible.
+- **…and the fixtures pin the intermediate planes, not only the surviving mask.** Two engines can
+  agree on which mask survived while differing in the tag projection, the resolved selector, the
+  resampled planes or the boundary pixels — and then disagree on the next catalog. §4 requires three
+  runners, not two: the JS suite consumes an already-built index so it never exercises the **Kotlin
+  projector**, which must consume the same payload fixtures and produce the expected index; and the
+  selector stage must be resolved both from the index *and* separately through **design-parity's own
+  production resolver**, since that is where the offline verdict actually comes from. Pinning an
+  artifact without running the code that produces it proves nothing about that code.
 - The mask-edge case is pinned: an accepted difference adjacent to an opposite unaccepted regression
   is reported as both, not cancelled.
 - A `resolved` acceptance's mask demonstrably does **not** suppress its neighbours.

--- a/docs/design/parity-batches/05-acceptance-engines.md
+++ b/docs/design/parity-batches/05-acceptance-engines.md
@@ -1,0 +1,139 @@
+# Batch 05 — both acceptance engines, and the publish path
+
+**Issues:** [#3808](https://github.com/yschimke/compose-ai-tools/issues/3808) (offline engine),
+[#3810](https://github.com/yschimke/compose-ai-tools/issues/3810) (browser engine),
+[#3809](https://github.com/yschimke/compose-ai-tools/issues/3809) (publish).
+**Depends on:** [04](04-acceptance-schema.md) (schema + fixtures — freeze it first, both sides build
+against one definition), [03](03-element-selection.md) (element gates must not be enabled without a
+selection path), [00](00-decisions.md) D1 and D3.
+**Ships:** **yes.** Accepted and unaccepted scores reported separately, on a real catalog.
+
+**Read first:** [`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) §4 — the ten
+invariants **and** the open-problems list; `format-compare.js`'s `scorePlanes` **in full** before
+touching a line of it.
+
+The three issues are one batch because the whole point is that the two engines agree bit for bit, and
+"agree" is not testable one engine at a time. Publish rides along because an engine nobody's catalog
+can feed is not finished.
+
+---
+
+## The document deliberately does not specify a pixel algorithm
+
+Earlier revisions carried a numbered pipeline and **every version of it had a real defect** — a gate
+placed before the data it reads existed, a resample that mixed what a previous step had separated, a
+delta computed in the wrong direction. What §4 gives instead is ten invariants that are not
+negotiable, plus an explicit list of what this batch has to **decide**:
+
+1. the portable pixel path — which resampler, since `drawImage`'s filter is not reproducible
+   off-browser;
+2. whether mask pixels participate in `edgeMask`;
+3. the masked pass's denominator;
+4. what "accepted contribution" means, given it can legitimately go **negative**;
+5. sub-pixel rounding;
+6. the match metric shared by the candidate gate and the resolution test, and whether it is aggregate
+   or per-pixel.
+
+Record each decision in the design doc as it is made. A decision made in code and not written down is
+how the previous three pipelines went wrong.
+
+## Facts about the existing scorer that constrain all of it
+
+`scorePlanes` is more particular than it looks; this was misread three times before the whole function
+was read.
+
+1. A **per-plane edge mask** — a pixel is an edge when its 4-neighbour luma gradient reaches
+   `EDGE_GRADIENT_THRESHOLD = 12`.
+2. Each directed pass starts from the difference at the **same coordinate**.
+3. It widens to the `EDGE_SEARCH_RADIUS = 5` displaced search **only** when the source pixel is an edge
+   **and** the same-coordinate difference already exceeds `LUMA_TOLERANCE = 16`.
+4. A candidate target counts **only if it is itself an edge**.
+5. Each displaced match is penalised by `√(ox² + oy²) × EDGE_POSITION_COST` (= 10).
+6. The per-pixel charge is `max(0, best − LUMA_TOLERANCE) / (255 − LUMA_TOLERANCE)`, averaged over
+   `width × height`, both directions averaged into `mismatch`.
+7. The returned score is `max(0, min(100, (1 − mismatch) × 100))` — **a clamped percentage**, so a
+   port that stops at step 6 publishes every number inverted.
+
+`ssim` / `globalSsim` are still in the file and **have no callers** — see
+[loose ends](00-decisions.md#loose-ends-not-blocking-file-or-fix-opportunistically).
+
+## 5a — offline engine (#3808)
+
+`design-parity` reads `known-differences.json`, applies the same semantics the browser does, and
+reports `raw`, `accepted` and `unaccepted` separately.
+
+**The raw finding is always preserved** — epic requirement, and the reason acceptance is not an ignore
+rectangle. An acceptance never removes a difference from the report; it moves it into `accepted` while
+`unaccepted` keeps everything else visible.
+
+- **Separation precedes resampling.** The masked and unmasked regions of *both* inputs are split in
+  their own pixel space, per acceptance, before any resample — never a pre-averaged composite.
+  `drawImage` averages **signed** luma, so on a footprint straddling a mask edge an accepted
+  difference can cancel an opposite unaccepted regression before scoring ever sees the pixel.
+- **Only `valid` acceptances contribute a mask to the scoring union.** `resolved`, `invalidated` and
+  `refused` suppress nothing. Keeping a `resolved` mask would remove its pixels as neighbourhood
+  candidates for the pixels *around* it, which can hide a regression sitting next to the thing just
+  fixed.
+- **The union cannot be formed before the gates have run**, and the gates need canonical pixels — so
+  the surviving-union split is a distinct, later stage, not the same pass.
+- **Status precedence is strict**: `refused` → any non-`candidate-changed` invalidation → `resolved` →
+  `candidate-changed` → `valid`. `resolved` is guarded on the candidate gate having actually **fired**,
+  otherwise a tolerant metric marks an unchanged candidate resolved the moment it is authored.
+
+**Cross-repo.** Sequence after the schema is frozen.
+
+## 5b — browser engine (#3810)
+
+Apply acceptances in `format-compare.js`, reporting `raw` / `accepted` / `unaccepted` separately,
+**including status evaluation**.
+
+**Status evaluation belongs here, not in batch 06.** The conformance fixtures this work must pass
+carry a per-acceptance `statuses` map with a required fixed-candidate `resolved` case, so an engine
+that defers resolution cannot satisfy its own contract.
+
+**The raw number will move once, deliberately.** Any kernel that is not `drawImage` produces different
+pixels. What invariant I10 buys is that the *geometry* stays one resample from source to score plane
+at the candidate box's dimensions, so the number does not move a **second** time. The move is a
+versioned rebaseline — see [D3](00-decisions.md#d3--the-score-rebaseline-is-versioned-and-when).
+
+**Element gates must not be enabled without the tag index**, and the index's bounds are render-pixel
+(D1) — the transform into the canonical plane happens here, in the comparison.
+
+## 5c — publish (#3809)
+
+Carry `.design-parity/known-differences.json` and its artifact directories from the source repo
+through `@design-parity/catalog-export` into the published catalog, so a serving host reads the same
+acceptances the offline run does.
+
+- **The artifacts are fetched, not just referenced.** Once a mask and an accepted-candidate PNG are
+  published catalog assets they go through `ServeCatalogStore`'s ordinary staging, which applies
+  `MAX_FETCH_BYTES` (25 MB per asset) — one reason the schema caps artifacts at 8 MiB, comfortably
+  below it, so the two engines disagree nowhere near where a fetch would fail.
+- **Path containment is checked at staging**, on a host that fetches third-party catalogs, so a
+  traversal here is an escape from the artifact tree rather than a typo. The schema's portable-path
+  grammar exists so the fetching host and the offline reader resolve the same file.
+- **Publishing must not require a re-render** — the same property `parity/issues.json` relies on.
+- **Check `scripts/design-artifacts/scope-systems.sh` maps the new published path.** A wrong mapping
+  silently strands a catalog on stale artifacts. It has a self-test (`test-scope-systems.sh`); change
+  it only with that passing. Note also that catalog and export-driver merges regenerate the delivery
+  branches automatically while **renderer/plugin/CLI changes do not** and need a manual
+  `design-artifacts.yml` dispatch.
+
+**Cross-repo.**
+
+## Done when
+
+- **Both engines pass the same batch-04 conformance fixtures, byte for byte on which mask survived.**
+  A single aggregate status cannot express a mixed-validity case, so two engines can emit the same
+  summary while disagreeing about the details — the per-acceptance `statuses` map is what makes the
+  disagreement visible.
+- The mask-edge case is pinned: an accepted difference adjacent to an opposite unaccepted regression
+  is reported as both, not cancelled.
+- A `resolved` acceptance's mask demonstrably does **not** suppress its neighbours.
+- The rebaseline lands in its own change with regenerated baselines and a release note, touching no
+  acceptance semantics.
+- A real published catalog carries acceptances and the served comparison shows accepted vs unaccepted.
+
+## Visual evidence
+
+Mandatory — the comparison page gains score splits. Before/after through the harness, both themes.

--- a/docs/design/parity-batches/05-acceptance-engines.md
+++ b/docs/design/parity-batches/05-acceptance-engines.md
@@ -79,6 +79,17 @@ rectangle. An acceptance never removes a difference from the report; it moves it
 - **Status precedence is strict**: `refused` → any non-`candidate-changed` invalidation → `resolved` →
   `candidate-changed` → `valid`. `resolved` is guarded on the candidate gate having actually **fired**,
   otherwise a tolerant metric marks an unchanged candidate resolved the moment it is authored.
+- **Open question: an acceptance that accepts nothing.** If `accepted-candidate.png` already agrees
+  with the reference inside the mask, the record encodes no actual difference. The candidate gate
+  compares candidate against `accepted-candidate.png`, so it does not fire, and precedence falls
+  through to `valid` — the mask joins the suppression union having never represented an accepted
+  difference. Note the harm is **not** "a later regression is hidden": a regression inside the mask
+  changes the candidate, fires the gate, and is reported. The real costs are that a *sub-tolerance*
+  regression is suppressed in a region that never differed, and that the mask removes its pixels from
+  the neighbourhood search of everything around it — the same objection the doc already makes to
+  keeping a `resolved` mask. `mask-empty` is already refused for a comparable reason. Decide whether
+  this earns an `acceptance-is-noop` refusal after the fingerprint gate; if it does, it needs a
+  conformance fixture and a doc amendment, so decide it **before** the fixtures are frozen in batch 04.
 
 **Cross-repo.** Sequence after the schema is frozen.
 

--- a/docs/design/parity-batches/06-resolution-and-docs.md
+++ b/docs/design/parity-batches/06-resolution-and-docs.md
@@ -1,0 +1,107 @@
+# Batch 06 — resolution, closure, and the consumer-facing docs
+
+**Issues:** [#3811](https://github.com/yschimke/compose-ai-tools/issues/3811) (statuses + closure),
+[#3812](https://github.com/yschimke/compose-ai-tools/issues/3812) (documentation).
+**Depends on:** [05](05-acceptance-engines.md) (the statuses) and [02](02-issue-index.md) (the issue
+index — the stale join has nothing to join against without it).
+**Ships:** **yes.** The loop closes: a fixed difference deletes its acceptance and closes its issue.
+
+**Read first:** [`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) §6 Phase 4 and
+step 13.
+
+---
+
+## 6a — surface the statuses, and act on them (#3811)
+
+**This step surfaces statuses; it does not compute them.** `resolved` detection lands with the scorer
+in batch 05, because that engine's own fixtures require it. What lands here is `resolved` /
+`invalidated` / `refused` on the dashboard and the gate, plus **stale**.
+
+### Stale is a second axis, not a status
+
+`status` is what a **comparison** concluded, and is exactly what the two engines must agree on.
+Stale/unknown come from the **issue index**, which one engine may have and the other may not. Folding
+them into `status` would make the conformance fixtures depend on a file outside the contract.
+
+So the join happens *here* — at the dashboard and the gate — over an acceptance's mandatory `issue`
+URL, producing `open` / `closed` / `unknown` per acceptance. **The evaluation result gains no field.**
+
+- **Only one combination is stale**: `closed` **and** status not `resolved`. `resolved` + `closed` is
+  the loop having *completed*. `unknown` is never stale.
+- **Stale requires positive evidence of closure, never inference from absence.** The index is
+  fail-soft, capped, can lag between regenerations, and does not cover source repos whose dispatch
+  credential nobody has wired. Treating absence as closed would mark live acceptances stale across an
+  entire catalog the first time the file failed to parse — which is exactly why batch 02 publishes
+  closed rows.
+
+### The loop needs an owner
+
+Nothing above actually *removes* anything. `resolved` means deleting the acceptance, and an issue
+closes once every linked acceptance has resolved — but surfacing a status does neither.
+
+Both are committed-file operations, so both belong in a PR, and **the ordering matters**: delete first
+and the issue loses the only record of what it was about; close first and the surviving siblings are
+briefly stale against a closed issue. So they happen **in one change** — a PR that deletes the
+resolved records and their directories *and* closes the issue via a closing keyword in its
+description, so the merge does both atomically.
+
+**With one restriction:** "every acceptance linked to this issue" is not evaluable from a run that
+reads one `known-differences.json`. `v1` gives an issue a **single owning document**, and a run that
+cannot establish ownership deletes its resolved records but **omits the closing keyword**, leaving
+closure to whoever can see the other referencing documents. Deletion is always safe locally; closure
+is the half that needs knowledge a single run does not have.
+
+> This repo squash-merges from the **PR title**, not the body — so a closing keyword in the body does
+> its work through GitHub's PR-closes-issue linkage, not through the commit message. Verify that on
+> the first one rather than assuming.
+
+## 6b — documentation (#3812)
+
+Document the reporting → triage → acceptance → verification → closure loop in
+`docs/public-preview-server.md`, beside the existing parity view section.
+
+This is the **consumer-facing** half. `COMPONENT_PARITY_WORKFLOW.md` is the design record — why each
+rule exists and what breaks without it — and it should stay that. What a catalog owner needs is
+shorter and different in kind:
+
+- how to file a parity issue from a comparison, what the locator block is for, and **that editing it
+  breaks the index**;
+- which labels to use — `area:{spec,component,preview,renderer,comparison}`,
+  `parity:{regression,known-difference,verification-needed}` — and that there is deliberately **no
+  per-component label**;
+- how to author an acceptance: the directory layout, the mandatory tracking issue, the mask encoding
+  rules, and the fact that **a tolerance which needs to be large is evidence the acceptance is wrong**;
+- what each status means when it appears on the dashboard, and what to do about it;
+- the closure step, and why deletion and issue-closing happen in one PR.
+
+### Setup documentation for the credential path
+
+This belongs in prose where someone provisioning a new source repo will find it, because the default
+is the thing that looks right and silently is not:
+
+- the App must be installed on the **catalog** repo with **Contents: write**;
+- `actions/create-github-app-token` must be given `owner` **and** `repositories`;
+- a 403 there looks exactly like "no issues changed".
+
+### Worth noting, not building here
+
+Mask authoring has **no UI** in this plan — a human hand-writes `known-differences.json` and produces
+the two PNGs. Probably acceptable for the first acceptances, since they should be rare and deliberate.
+But "export this selection as an acceptance stub" from the focused comparison is the obvious
+follow-up, and is worth **deciding on** rather than discovering. File it as an issue in this batch
+whichever way the decision goes.
+
+## Done when
+
+- The dashboard shows stale acceptances, and an index that fails to parse produces `unknown`
+  everywhere rather than `stale` anywhere — asserted with a fixture, since this is the failure that
+  would discredit the whole dashboard at once.
+- `resolved` + `closed` renders as completion, not as a problem.
+- One real acceptance has gone all the way round: reported, accepted, fixed, deleted, issue closed —
+  and the PR that did it is linked from the docs as the worked example.
+- `docs/public-preview-server.md` covers all six bullets above plus the credential setup.
+
+## Visual evidence
+
+Dashboard changes are visual. Before/after through the harness, both themes, with at least one row in
+each new state.

--- a/docs/design/parity-batches/06-resolution-and-docs.md
+++ b/docs/design/parity-batches/06-resolution-and-docs.md
@@ -26,6 +26,13 @@ them into `status` would make the conformance fixtures depend on a file outside 
 So the join happens *here* — at the dashboard and the gate — over an acceptance's mandatory `issue`
 URL, producing `open` / `closed` / `unknown` per acceptance. **The evaluation result gains no field.**
 
+**Canonicalise both sides before joining.** Batch 02's reader parses each index row to
+`owner`/`repo`/`number` and rebuilds the URL; an acceptance's `issue` is hand-authored and can carry a
+trailing slash, `www.`, a mixed-case owner, or a `#issuecomment-…` fragment. Joining on the raw
+strings means a genuinely closed issue reports `unknown` and stale detection never fires — a silent
+false negative, which is the worse direction here. Parse both sides to the canonical identity, and use
+that same identity when grouping acceptances for closure.
+
 - **Only one combination is stale**: `closed` **and** status not `resolved`. `resolved` + `closed` is
   the loop having *completed*. `unknown` is never stale.
 - **Stale requires positive evidence of closure, never inference from absence.** The index is
@@ -61,8 +68,19 @@ Document the reporting → triage → acceptance → verification → closure lo
 `docs/public-preview-server.md`, beside the existing parity view section.
 
 This is the **consumer-facing** half. `COMPONENT_PARITY_WORKFLOW.md` is the design record — why each
-rule exists and what breaks without it — and it should stay that. What a catalog owner needs is
-shorter and different in kind:
+rule exists and what breaks without it — and it should stay that.
+
+**But note where consumer docs actually live.** [`docs/AGENTS.md`](../../AGENTS.md) draws a hard line:
+this file and `docs/` are **contributor** docs for working on *this* repo, while consumer docs for the
+published plugin and CLI live in [`yschimke/skills`](https://github.com/yschimke/skills). #3812 names
+`docs/public-preview-server.md`, which is right for the contributor-facing half — how the server
+loads and renders the index — but a **catalog owner** provisioning credentials and authoring
+acceptances is a consumer, and would never find it there. So this batch is two deliverables: the
+mechanism in `docs/public-preview-server.md`, and the workflow + credential setup as a
+`compose-preview-review` reference in the skills repo. Doing only the first leaves the audience this
+material is written for without it.
+
+What a catalog owner needs is shorter and different in kind from the design record:
 
 - how to file a parity issue from a comparison, what the locator block is for, and **that editing it
   breaks the index**;
@@ -99,7 +117,8 @@ whichever way the decision goes.
 - `resolved` + `closed` renders as completion, not as a problem.
 - One real acceptance has gone all the way round: reported, accepted, fixed, deleted, issue closed —
   and the PR that did it is linked from the docs as the worked example.
-- `docs/public-preview-server.md` covers all six bullets above plus the credential setup.
+- `docs/public-preview-server.md` covers the mechanism, **and** the catalog-owner workflow plus
+  credential setup has landed in `yschimke/skills` — both halves, per the AGENTS.md doc split.
 
 ## Visual evidence
 

--- a/docs/design/parity-batches/README.md
+++ b/docs/design/parity-batches/README.md
@@ -1,0 +1,64 @@
+# Component-parity delivery batches
+
+Implementable batches for [#3680](https://github.com/yschimke/compose-ai-tools/issues/3680). Each
+file is one branch's worth of work: what to build, what to read first, the traps that are already
+known, and what "done" means.
+
+The contract these implement is
+[`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md). **Read it before starting any
+batch** — these files say what to do, not why, and the why is load-bearing throughout.
+
+## Order
+
+```
+00 decisions ──┬──────────────────────────────► (unblocks 02, 04, 05)
+               │
+01 locator ────┴──► 02 issue index ──────────────────────────────┐
+      │                                                          │
+      └──────────► 03 element selection ──┐                      │
+                                          ├─► 05 engines ──► 06 resolution + docs
+                        04 schema ────────┘
+```
+
+| Batch | Covers | Depends on | Ships something a person can see |
+| --- | --- | --- | --- |
+| [00](00-decisions.md) — decisions and corrections | — | nothing | no (unblocks 02/04/05) |
+| [01](01-locator-and-report.md) — locator + issue body | [#3801](https://github.com/yschimke/compose-ai-tools/issues/3801), [#3802](https://github.com/yschimke/compose-ai-tools/issues/3802) | nothing | partly — issues gain a parseable identity |
+| [02](02-issue-index.md) — issue index end to end | [#3804](https://github.com/yschimke/compose-ai-tools/issues/3804), [#3805](https://github.com/yschimke/compose-ai-tools/issues/3805), [#3806](https://github.com/yschimke/compose-ai-tools/issues/3806) | 01 | **yes** — open issues on the pages |
+| [03](03-element-selection.md) — element selection | [#3803](https://github.com/yschimke/compose-ai-tools/issues/3803) | 01 | **yes** — click an element to report it |
+| [04](04-acceptance-schema.md) — acceptance schema | [#3807](https://github.com/yschimke/compose-ai-tools/issues/3807) | 00 | no (contract + fixtures) |
+| [05](05-acceptance-engines.md) — both engines + publish | [#3808](https://github.com/yschimke/compose-ai-tools/issues/3808), [#3809](https://github.com/yschimke/compose-ai-tools/issues/3809), [#3810](https://github.com/yschimke/compose-ai-tools/issues/3810) | 03, 04 | **yes** — accepted vs unaccepted scores |
+| [06](06-resolution-and-docs.md) — resolution, closure, docs | [#3811](https://github.com/yschimke/compose-ai-tools/issues/3811), [#3812](https://github.com/yschimke/compose-ai-tools/issues/3812) | 02, 05 | **yes** — the loop closes |
+
+**01 and 02 can run ahead of everything else.** They deliver the epic's first four acceptance
+criteria and depend on none of the acceptance machinery. If only one batch gets done, do 01 — every
+issue filed after it lands is machine-identifiable, and issues filed before it need their bodies
+hand-edited later.
+
+## Already delivered
+
+Not a batch; context for what exists.
+
+- The design contract — [#3689](https://github.com/yschimke/compose-ai-tools/pull/3689).
+- The **element tag index**, `testTag → {count, bounds, space}` — [#3878](https://github.com/yschimke/compose-ai-tools/issues/3878),
+  delivered by [#3830](https://github.com/yschimke/compose-ai-tools/pull/3830) /
+  [#3860](https://github.com/yschimke/compose-ai-tools/pull/3860) /
+  [#3864](https://github.com/yschimke/compose-ai-tools/pull/3864). Two producers (live daemon
+  projection; published-catalog `tags/index.json`), one host API `ServeHost.tagIndexForPreview`.
+- The theme annotation layer, reachable on the focused comparison, with visible legend ordinals.
+
+## Conventions every batch inherits
+
+- **Fail-soft on anything read from a catalog.** A catalog is third-party data. Malformed, wrong
+  schema token, or oversized drops *wholesale* and the session serves as before. `ServeAnnotationStore`,
+  `ServeDesignReferenceStore` and `ServeTagIndexStore` are the worked examples.
+- **A published artifact needs three things, not one**: a producer that writes it, a `ServeCatalogStore`
+  staging call that copies it into the served tree, and a host that loads it. Miss the middle one and
+  the file is invisible; miss the last and it is read by nobody. Both mistakes have been made here.
+- **Never let a language default stand in for a wire fact.** A Kotlin default filled in a missing
+  field twice in this epic — once on encode (`@EncodeDefault`), once on decode (a nullable wire type).
+  If absence must be distinguishable, make it representable and reject it explicitly.
+- **Assert on the wire, not the round trip.** A test that decodes into the producer type restores its
+  defaults and passes whether or not the field was ever serialised.
+- **Confirm a new test fails without its fix.** Cheap, and it caught two tests here that would
+  otherwise have proved nothing.


### PR DESCRIPTION
Splits the twelve workstreams of #3680 into seven implementable batches under `docs/design/parity-batches/` — one branch's worth of work each, with what to build, what to read first, the traps already known, and what "done" means.

`COMPONENT_PARITY_WORKFLOW.md` stays the design record (why each rule exists). These files are the delivery plan (what to do, in what order, and what has already been decided).

## The batches

| Batch | Covers | Depends on | Visible payoff |
| --- | --- | --- | --- |
| 00 — decisions and corrections | — | nothing | no (unblocks 02/04/05) |
| 01 — locator + report body | #3801, #3802 | nothing | partly — issues become machine-identifiable |
| 02 — issue index end to end | #3804, #3805, #3806 | 01 | **yes** — open issues on the pages |
| 03 — element selection | #3803 | 01 | **yes** — click an element to report it |
| 04 — acceptance schema | #3807 | 00 | no (contract + conformance fixtures) |
| 05 — both engines + publish | #3808, #3809, #3810 | 03, 04 | **yes** — accepted vs unaccepted scores |
| 06 — resolution, closure, docs | #3811, #3812 | 02, 05 | **yes** — the loop closes |

**01 and 02 can run ahead of everything else** and deliver the epic's first four acceptance criteria. If only one batch gets done, do 01 — every issue filed after it lands is machine-identifiable, and issues filed before it need their bodies hand-edited later.

## Batch 00 exists on purpose

Four questions currently sit unsettled and each one blocks a later batch. Writing code against an unsettled question is how the design doc accumulated three wrong pixel pipelines, so they get recorded with options and a recommendation rather than discovered mid-implementation:

- **D1** — which plane the element tag index reports bounds in. The doc says canonical; neither producer can compute a canonical plane (it is resolved per comparison). Recommendation: the transform belongs to the comparison, and the doc needs correcting.
- **D2** — which surface carries the report form. The viewer's always-available number is `scoreSvgUrls` (PNG vs generated SVG) — a render-fidelity measurement that would feed the index as a mislabelled parity score. Recommendation: the focused comparison, which knows both `referenceId` and the real score.
- **D3** — the score rebaseline is versioned, and must not share a change with any acceptance-semantics edit.
- **D4** — the frame-vs-controls race in `refreshReportLink()`; take the crude fix first, because the better one can be got subtly wrong and pass review.

Plus three non-blocking loose ends: the `stampPreviewDensities` fold bug, the `vscode-preview/main` baseline instability, and the caller-less `ssim` / `globalSsim`.

## Inherited conventions

The README carries the conventions the already-delivered work established the hard way — fail-soft on anything read from a catalog; a published artifact needs a producer **and** a `ServeCatalogStore` staging call **and** a host loader (both of the other two have been missed here); never let a language default stand in for a wire fact; assert on the wire, not the round trip; confirm a new test fails without its fix.

## Test plan

Documentation only — no code, no build wiring, no rendered surface changes, so there is nothing to capture visually. Verified by reading: every issue number, file path, symbol (`scorePlanes`, `ServeParityActivity`, `ServeTagIndexStore`, `ServeIssueReport.withoutToken`, `refreshReportLink`, `scope-systems.sh`, `push-branch.sh`) and named constant (`EDGE_GRADIENT_THRESHOLD = 12`, `EDGE_SEARCH_RADIUS = 5`, `LUMA_TOLERANCE = 16`, `EDGE_POSITION_COST = 10`, `MAX_FETCH_BYTES` 25 MB) cited in the batch files was checked against the tree at `eb2f4db`, and the relative links between the README and the seven batch files resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVGf6MmwV8gHZ8xScG5siq)_