### PR TITLE
fix(format): reformat for ktfmt 0.27

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -454,10 +454,12 @@ object PreviewManifestLoader {
         entry.captures.mapNotNullTo(this) { captureOutputFile(outDir, it.renderOutput) }
         entry.dataProducts.mapNotNullTo(this) { productOutputFile(productRoot, it.output) }
       }
-      expandedByEntry.flatMap { it.second }.forEach { row ->
-        row.entry.captures.mapNotNullTo(this) { captureOutputFile(outDir, it.renderOutput) }
-        row.entry.dataProducts.mapNotNullTo(this) { productOutputFile(productRoot, it.output) }
-      }
+      expandedByEntry
+        .flatMap { it.second }
+        .forEach { row ->
+          row.entry.captures.mapNotNullTo(this) { captureOutputFile(outDir, it.renderOutput) }
+          row.entry.dataProducts.mapNotNullTo(this) { productOutputFile(productRoot, it.output) }
+        }
     }
     val declaredOutputFiles = buildList {
       allEntries.forEach { entry ->

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
@@ -62,8 +62,7 @@ class PreviewManifestLoaderStaleFanoutTest {
       id = id,
       functionName = id,
       className = "com.example.PreviewsKt",
-      params =
-        RenderPreviewParams(previewParameterProviderClassName = "com.example.UserProvider"),
+      params = RenderPreviewParams(previewParameterProviderClassName = "com.example.UserProvider"),
       captures = emptyList(),
       dataProducts = listOf(RenderPreviewArtifact(kind = "render/scroll/long", output = output)),
     )


### PR DESCRIPTION
`format.yml` is currently **red on `main`**, which fails the check on every open PR.

## Cause

#3859 bumped `ktfmt` 0.26.0 → 0.27.0 in `gradle/libs.versions.toml`. 0.27 wraps trailing-lambda chains and short named arguments differently, so two existing files stopped being conformant without anyone editing them.

That went unnoticed because **#3859's own `format.yml` run never completed** — it was superseded and cancelled, as were #3871's and #3876's. `ef5d1baa` (#3877) was the first run after the bump to actually finish, so it is where the failure first *appears*, but it is not where it was introduced: `PreviewManifestLoaderStaleFanoutTest.kt` is byte-identical (`5039b84b`) before and after #3877 and fails anyway.

## Change

Formatter output only — `./gradlew :renderer-android:ktfmtFormat`, no hand edits, no semantic change:

- `RobolectricRenderTest.kt` — a `.flatMap { … }.forEach { … }` chain broken one call per line.
- `PreviewManifestLoaderStaleFanoutTest.kt` — a named argument that now fits on one line.

## Test plan

`:renderer-android:ktfmtFormat` produces an empty diff on this branch (it is the formatter's own output). CI's `ktfmt (Google style)` job is the real check — it should go green here, and unblock every other open PR against `main`.

Worth a look at why three consecutive `format.yml` runs were cancelled rather than queued; a bump that changes formatting rules can land unverified whenever that happens.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVGf6MmwV8gHZ8xScG5siq)_