### PR TITLE
docs(parity): fix a circular dependency and three contract gaps in the batch plans

### DIFF
--- a/docs/design/parity-batches/00-decisions.md
+++ b/docs/design/parity-batches/00-decisions.md
@@ -84,6 +84,33 @@ substituted from control state can describe a variant the reporter never saw.
 loaded**. Deriving from the successfully displayed frame is the better end state; it is also the one
 that can be got subtly wrong and pass review. Take the crude version first and note the follow-up.
 
+## D5 — the pixel semantics, decided before the fixtures are frozen
+
+**Blocks:** 04 (the fixtures encode these answers), and therefore 05.
+
+§4 deliberately specifies no pixel algorithm — earlier revisions carried a numbered pipeline and
+every version of it had a real defect. What it gives instead is ten invariants plus an explicit list
+of six open questions:
+
+1. the portable pixel path — which resampler, since `drawImage`'s filter is not reproducible
+   off-browser;
+2. whether mask pixels participate in `edgeMask`;
+3. the masked pass's denominator;
+4. what "accepted contribution" means, given it can legitimately go **negative**;
+5. sub-pixel rounding;
+6. the match metric shared by the candidate gate and the resolution test, and whether it is aggregate
+   or per-pixel.
+
+**These cannot be left to batch 05, and an earlier draft of this plan did exactly that.** Batch 04
+must ship a *passing* conformance runner whose fixtures pin intermediate planes and expected verdicts
+— and every one of those expected bytes is a function of the six answers above. A fixture set frozen
+before they are settled either encodes a guess or cannot be produced at all, and batch 05 then
+"conforms" to whichever guess got written down.
+
+**Do:** answer all six here, record each in the design doc as it is made, and only then let 04 freeze
+fixtures. A decision made in code and not written down is how the previous three pipelines went
+wrong.
+
 ---
 
 ## Loose ends (not blocking; file or fix opportunistically)

--- a/docs/design/parity-batches/00-decisions.md
+++ b/docs/design/parity-batches/00-decisions.md
@@ -3,7 +3,10 @@
 **Issues:** none — this batch exists because writing code against an unsettled question is how the
 design doc accumulated three wrong pixel pipelines.
 **Depends on:** nothing.
-**Blocks:** [02](02-issue-index.md) (D2), [04](04-acceptance-schema.md) (D1), [05](05-acceptance-engines.md) (D1, D3).
+**Blocks:** [01](01-locator-and-report.md) (D2, D4), [03](03-element-selection.md) (D1),
+[04](04-acceptance-schema.md) (D1, D5), [05](05-acceptance-engines.md) (D1, D3, D5) — and 02 and 06
+transitively, through 01. **Every one is a hard prerequisite**; see the graph in
+[README](README.md#order), which this header must agree with.
 **Ships:** no user-visible change. Output is edits to
 [`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) and to the affected issues.
 
@@ -15,7 +18,8 @@ been written against opposite readings.
 
 ## D1 — which plane the element tag index reports bounds in
 
-**Blocks:** 04 (the `plane` discriminant), 05 (the element gate), 03 (what a selection records).
+**Blocks:** 03 (what a selection records, and in which space), 04 (the `plane` discriminant),
+05 (the element gate).
 
 The design doc says the server publishes tag bounds already transformed into an acceptance's
 *canonical plane*. **Neither producer can do that.** The canonical plane is resolved per comparison,
@@ -40,7 +44,8 @@ deliberately rather than by accident.
 
 ## D2 — which surface carries the report form
 
-**Blocks:** 02 and 03 (both put things on "the page where you see the problem").
+**Blocks:** 01 directly — it decides which page the form is built on, and 01 builds it. 02 and 03
+inherit it, since both put things on "the page where you see the problem".
 
 [#3802](https://github.com/yschimke/compose-ai-tools/issues/3802) records that the form currently
 lives only on the viewer, whose always-available live number is `scoreSvgUrls` — PNG against the
@@ -74,7 +79,8 @@ acceptance semantics — a moved number and a changed verdict in one diff cannot
 
 ## D4 — the frame-vs-controls race in `refreshReportLink()`
 
-**Blocks:** 02 (small, but it is the difference between a correct locator and a subtly wrong one).
+**Blocks:** 01 directly — it is the difference between a correct locator and a subtly wrong one, and
+01 is where locators start being written. 02 inherits it, since the index only ever sees what 01 wrote.
 
 `refreshLinks()` fires the moment a control moves; provenance is recorded later, in the replacement
 image's `onload`. Between those moments the visible pixels are the *previous* frame, so a locator

--- a/docs/design/parity-batches/01-locator-and-report.md
+++ b/docs/design/parity-batches/01-locator-and-report.md
@@ -44,6 +44,12 @@ Rules that are not negotiable, each because it has a silent failure mode:
   values are free text, so a label of `a;knob.color=red` reads back as two overrides.
 - **Fenced block, not an HTML comment.** A comment is invisible in the rendered issue, so a reporter
   editing the body cannot see they have broken the index.
+- **Reserve `element` and `bounds` as optional `v1` fields now**, even though nothing writes them
+  until [batch 03](03-element-selection.md). This batch freezes the writer, the parser and the shared
+  fixture, and batch 02's index schema is built on top; adding two keys to the same `v1` afterwards
+  means a strict parser rejects the report while a permissive one silently discards the selection.
+  Reserving them costs a line each here and a fixture; retrofitting them costs a version bump across
+  three consumers.
 
 ### 2. Emit it
 

--- a/docs/design/parity-batches/01-locator-and-report.md
+++ b/docs/design/parity-batches/01-locator-and-report.md
@@ -50,6 +50,15 @@ Rules that are not negotiable, each because it has a silent failure mode:
   means a strict parser rejects the report while a permissive one silently discards the selection.
   Reserving them costs a line each here and a fixture; retrofitting them costs a version bump across
   three consumers.
+- **`bounds` cannot be a bare rectangle — it needs its space settled at the same time.** Three
+  coordinate spaces are in play and they do not agree: a tag selection's bounds come from the index in
+  **render pixels** ([D1](00-decisions.md#d1--which-plane-the-element-tag-index-reports-bounds-in)), a
+  drag selection is in **display pixels**, and the acceptance contract wants the element baseline in
+  the **canonical plane**. Freeze a parser that accepts a naked rectangle and batch 03 will persist
+  whichever one it happened to have, so an element that never moved reports as *moved* the moment
+  those planes differ. Either require the comparison to convert into the resolved canonical plane
+  before serialising, or carry and validate a `space` discriminant — the same fix
+  `compose-preview-tags/v1` already needed for exactly this reason, which is the precedent to copy.
 
 ### 2. Emit it
 

--- a/docs/design/parity-batches/02-issue-index.md
+++ b/docs/design/parity-batches/02-issue-index.md
@@ -71,10 +71,13 @@ Traps:
   issue title, labels, state and URL, and the producer commits them to the delivery branch — so
   scanning a **private** source repo into a **public** catalog publishes private issue metadata, and
   it does so on the path where everything is working. Decide the policy before enabling private-source
-  reads: either require the delivery repository to be at least as restricted as every repo it scans,
-  or publish a reduced row (identity and state, no title or labels) for sources more private than the
-  destination. Make the check part of the producer, not a convention — the failure is silent, and by
-  the time anyone notices, the titles are in a git history.
+  reads: either **reader-set containment** — every account that can read the delivery repo can already
+  read every source it scans — or publish a reduced row (identity and state, no title or labels) for
+  any source that fails containment. **Comparing visibility levels is not sufficient**, and is the
+  tempting shortcut: two *private* repos with different collaborator sets pass a public-vs-private
+  check while destination-only readers gain the source's issue titles, labels and URLs. Make the check
+  part of the producer, not a convention — the failure is silent, and by the time anyone notices, the
+  titles are in a git history.
 - **The cron backstop is not optional** — but it only backstops the *trigger*, not the credential.
   Per-source-repo provisioning is real setup work, and an unwired repo has nothing else to fall back
   on. That will be the normal state for a while. Carrying the changed issue in the dispatch payload

--- a/docs/design/parity-batches/02-issue-index.md
+++ b/docs/design/parity-batches/02-issue-index.md
@@ -67,6 +67,14 @@ Traps:
   issues are simply absent from the generated index, which looks identical to "that repo has no parity
   issues". Provision a catalog-side credential with **Issues: read** on every scanned repository, and
   make an unreadable source repo a loud failure rather than an empty section.
+- **…and that credential turns successful reconciliation into a disclosure risk.** The rows carry
+  issue title, labels, state and URL, and the producer commits them to the delivery branch — so
+  scanning a **private** source repo into a **public** catalog publishes private issue metadata, and
+  it does so on the path where everything is working. Decide the policy before enabling private-source
+  reads: either require the delivery repository to be at least as restricted as every repo it scans,
+  or publish a reduced row (identity and state, no title or labels) for sources more private than the
+  destination. Make the check part of the producer, not a convention — the failure is silent, and by
+  the time anyone notices, the titles are in a git history.
 - **The cron backstop is not optional** — but it only backstops the *trigger*, not the credential.
   Per-source-repo provisioning is real setup work, and an unwired repo has nothing else to fall back
   on. That will be the normal state for a while. Carrying the changed issue in the dispatch payload

--- a/docs/design/parity-batches/03-element-selection.md
+++ b/docs/design/parity-batches/03-element-selection.md
@@ -68,9 +68,16 @@ projections and nothing more.)
 With overrides, conditional composition or animation in play, a gate fed from either path can
 validate an element against bounds from a **different frame** and let the wrong mask suppress
 pixels. So: establish a shared render generation, or carry the index with the scored pixels, before
-element gates are switched on in [batch 05](05-acceptance-engines.md). Selection and reporting —
-this batch's actual payload — are fine without it, because a reported selection is a claim about
-what the reporter saw, not a verdict.
+element gates are switched on in [batch 05](05-acceptance-engines.md).
+
+**And the exemption for selection is narrower than it first looks.** A *drag* selection is fine
+without coupling — it is derived from the displayed pixels, so it describes what the reporter saw by
+construction. A **tag** selection is not: its bounds come from the index, they are persisted into the
+locator as authoring-time `bounds`, and those bounds become the acceptance's baseline. Bounds read
+from a different frame therefore survive into a record that later reports an unchanged element as
+*moved* — a false invalidation with a plausible explanation attached, which is worse than a missing
+check. So require same-generation coupling for **tag-derived** selection too; leave drag selection
+available meanwhile.
 
 ### 3. Selection
 
@@ -87,6 +94,14 @@ The index already carries `{count, bounds}` per tag, which is everything a selec
 
 Into the locator block from batch 01, as the `element` selector plus its authoring-time `bounds` —
 the same fields the acceptance schema (batch 04) will carry.
+
+**These must be declared as optional `v1` fields in batch 01, not added to `v1` here.** Batch 01
+freezes `compose-parity-locator/v1` — writer, parser and shared fixture — and batch 02's index schema
+is built against it. If this batch then introduces two new keys into the same `v1` block, a strict
+parser rejects the report as mangled and a permissive one silently drops the selection, so the new
+affordance is absent from every downstream consumer while appearing to work in the browser. Either
+reserve `element` and `bounds` as optional in 01, or version the contract here and update the
+producer and reader fixtures together. Reserving them in 01 is much the cheaper of the two.
 
 ## Traps
 

--- a/docs/design/parity-batches/04-acceptance-schema.md
+++ b/docs/design/parity-batches/04-acceptance-schema.md
@@ -1,8 +1,10 @@
 # Batch 04 — the committed known-difference schema
 
 **Issue:** [#3807](https://github.com/yschimke/compose-ai-tools/issues/3807).
-**Depends on:** [00](00-decisions.md) D1 (the `plane` discriminant is meaningless until the plane
-question is settled).
+**Depends on:** [00](00-decisions.md) **D1 and D5**. D1 because the `plane` discriminant is
+meaningless until the plane question is settled; **D5 because the fixtures encode its six answers** —
+resampler, mask-edge participation, denominator, contribution sign, rounding, match metric — and a
+fixture set frozen ahead of them either encodes a guess or cannot be produced at all.
 **Blocks:** [05](05-acceptance-engines.md) entirely — both engines and the publish path.
 **Ships:** no user-visible change. The deliverable is a contract plus **conformance fixtures**, and
 the fixtures are the deliverable, not a follow-up: they are the only thing keeping three runners (the

--- a/docs/design/parity-batches/05-acceptance-engines.md
+++ b/docs/design/parity-batches/05-acceptance-engines.md
@@ -5,7 +5,7 @@
 [#3809](https://github.com/yschimke/compose-ai-tools/issues/3809) (publish).
 **Depends on:** [04](04-acceptance-schema.md) (schema + fixtures — freeze it first, both sides build
 against one definition), [03](03-element-selection.md) (element gates must not be enabled without a
-selection path), [00](00-decisions.md) D1 and D3.
+selection path), [00](00-decisions.md) **D1, D3 and D5**.
 **Ships:** **yes.** Accepted and unaccepted scores reported separately, on a real catalog.
 
 **Read first:** [`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) §4 — the ten
@@ -23,19 +23,14 @@ can feed is not finished.
 Earlier revisions carried a numbered pipeline and **every version of it had a real defect** — a gate
 placed before the data it reads existed, a resample that mixed what a previous step had separated, a
 delta computed in the wrong direction. What §4 gives instead is ten invariants that are not
-negotiable, plus an explicit list of what this batch has to **decide**:
+negotiable, plus six open questions.
 
-1. the portable pixel path — which resampler, since `drawImage`'s filter is not reproducible
-   off-browser;
-2. whether mask pixels participate in `edgeMask`;
-3. the masked pass's denominator;
-4. what "accepted contribution" means, given it can legitimately go **negative**;
-5. sub-pixel rounding;
-6. the match metric shared by the candidate gate and the resolution test, and whether it is aggregate
-   or per-pixel.
-
-Record each decision in the design doc as it is made. A decision made in code and not written down is
-how the previous three pipelines went wrong.
+**Those six are [batch 00's D5](00-decisions.md#d5--the-pixel-semantics-decided-before-the-fixtures-are-frozen), not this batch's.**
+They were briefly assigned here, which made the plan circular: batch 04 owes a *passing* conformance
+runner with expected intermediate planes, and every one of those expected bytes is a function of the
+six answers. Deciding them here would mean 04 freezing fixtures against a guess and 05 then
+conforming to the guess. Implement against the recorded answers; if one turns out to be wrong, amend
+D5 and the fixtures together, in a change that does nothing else.
 
 ## Facts about the existing scorer that constrain all of it
 

--- a/docs/design/parity-batches/README.md
+++ b/docs/design/parity-batches/README.md
@@ -11,27 +11,33 @@ batch** — these files say what to do, not why, and the why is load-bearing thr
 ## Order
 
 ```
-00 decisions ──┬──────────────────────────────► (unblocks 02, 04, 05)
-               │
-01 locator ────┴──► 02 issue index ──────────────────────────────┐
-      │                                                          │
-      └──────────► 03 element selection ──┐                      │
-                                          ├─► 05 engines ──► 06 resolution + docs
-                        04 schema ────────┘
+00 decisions ─┬─ D2,D4 ─► 01 locator ──► 02 issue index ─────────────────┐
+              │              │                                          │
+              ├─ D1 ─────────┴────────► 03 element selection ──┐         │
+              │                                                ├─► 05 ──► 06
+              ├─ D1,D5 ──────────────► 04 schema ──────────────┘  engines  resolution
+              │                                                            + docs
+              └─ D3 ────────────────────────────────────────► 05 engines
 ```
+
+**Every arrow out of 00 is a hard prerequisite, not a suggestion.** Each of D1–D5 blocks a batch
+because deciding it late means rewriting work rather than adding to it — a locator built before D2/D4
+records the wrong frame, and a fixture set frozen before D5 encodes a guess both engines then conform
+to.
 
 | Batch | Covers | Depends on | Ships something a person can see |
 | --- | --- | --- | --- |
-| [00](00-decisions.md) — decisions and corrections | — | nothing | no (unblocks 02/04/05) |
-| [01](01-locator-and-report.md) — locator + issue body | [#3801](https://github.com/yschimke/compose-ai-tools/issues/3801), [#3802](https://github.com/yschimke/compose-ai-tools/issues/3802) | nothing | partly — issues gain a parseable identity |
+| [00](00-decisions.md) — decisions and corrections | — | nothing | no (unblocks 01/02/03/04/05) |
+| [01](01-locator-and-report.md) — locator + issue body | [#3801](https://github.com/yschimke/compose-ai-tools/issues/3801), [#3802](https://github.com/yschimke/compose-ai-tools/issues/3802) | **00 D2, D4** | partly — issues gain a parseable identity |
 | [02](02-issue-index.md) — issue index end to end | [#3804](https://github.com/yschimke/compose-ai-tools/issues/3804), [#3805](https://github.com/yschimke/compose-ai-tools/issues/3805), [#3806](https://github.com/yschimke/compose-ai-tools/issues/3806) | 01 | **yes** — open issues on the pages |
-| [03](03-element-selection.md) — element selection | [#3803](https://github.com/yschimke/compose-ai-tools/issues/3803) | 01 | **yes** — click an element to report it |
-| [04](04-acceptance-schema.md) — acceptance schema | [#3807](https://github.com/yschimke/compose-ai-tools/issues/3807) | 00 | no (contract + fixtures) |
-| [05](05-acceptance-engines.md) — both engines + publish | [#3808](https://github.com/yschimke/compose-ai-tools/issues/3808), [#3809](https://github.com/yschimke/compose-ai-tools/issues/3809), [#3810](https://github.com/yschimke/compose-ai-tools/issues/3810) | 03, 04 | **yes** — accepted vs unaccepted scores |
+| [03](03-element-selection.md) — element selection | [#3803](https://github.com/yschimke/compose-ai-tools/issues/3803) | 01, **00 D1** | **yes** — click an element to report it |
+| [04](04-acceptance-schema.md) — acceptance schema | [#3807](https://github.com/yschimke/compose-ai-tools/issues/3807) | **00 D1, D5** | no (contract + fixtures) |
+| [05](05-acceptance-engines.md) — both engines + publish | [#3808](https://github.com/yschimke/compose-ai-tools/issues/3808), [#3809](https://github.com/yschimke/compose-ai-tools/issues/3809), [#3810](https://github.com/yschimke/compose-ai-tools/issues/3810) | 03, 04, **00 D3** | **yes** — accepted vs unaccepted scores |
 | [06](06-resolution-and-docs.md) — resolution, closure, docs | [#3811](https://github.com/yschimke/compose-ai-tools/issues/3811), [#3812](https://github.com/yschimke/compose-ai-tools/issues/3812) | 02, 05 | **yes** — the loop closes |
 
-**01 and 02 can run ahead of everything else.** They deliver the epic's first four acceptance
-criteria and depend on none of the acceptance machinery. If only one batch gets done, do 01 — every
+**01 and 02 can run ahead of everything else** once 00's D2 and D4 are answered — two decisions, not
+a batch of work. They deliver the epic's first four acceptance criteria and depend on none of the
+acceptance machinery. If only one batch gets done, do 01 — every
 issue filed after it lands is machine-identifiable, and issues filed before it need their bodies
 hand-edited later.
 


### PR DESCRIPTION
Follow-up to #3879, which merged while this round of review feedback was being applied. Same files, no new ones.

## The circular dependency

Batch 04 owes a **passing** conformance runner whose fixtures pin intermediate planes and expected verdicts. But the six pixel-semantics questions those expected bytes depend on — resampler, mask-edge participation in `edgeMask`, the masked pass's denominator, what a (legitimately negative) accepted contribution means, sub-pixel rounding, and the shared match metric — were assigned to batch **05**, which depends on 04.

So as written, 04 could only ever freeze a guess, and 05 would then "conform" to whichever guess got written down. Given the design doc's history of three successive pixel pipelines that each had a real defect, that is the specific failure mode this plan exists to avoid.

They move to batch 00 as **D5**, and 04 and 05 both declare it.

## Three contract gaps

- **The README order table contradicted the batch headers.** 01 was listed as depending on nothing while its own header had just made D2 and D4 hard prerequisites, and 05's row omitted D3. An implementer following the table would start 01 before its surface and frame semantics were settled. Table and diagram now carry every 00 gate.
- **`element` and `bounds` must be reserved as optional locator `v1` fields in batch 01.** Batch 03 was adding them to a `v1` that 01 had already frozen — writer, parser, shared fixture — and that 02's index schema is built on. A strict parser would reject the report as mangled; a permissive one would silently discard the selection, so it would look fine in the browser and be absent from every consumer.
- **Tag-derived selection needs the same render-generation coupling as the gates.** Its bounds come from the index and are persisted as the acceptance's authoring-time baseline, so bounds read from a different frame later report an unchanged element as *moved* — a false invalidation with a plausible explanation attached. Drag selection is derived from displayed pixels and stays exempt.

## One security consequence

The previous round added "provision a credential with **Issues: read** on every scanned repository" to make the cron backstop work for private sources. That fix has a consequence worth stating: the rows carry issue title, labels, state and URL, and the producer commits them to the delivery branch — so scanning a **private** source into a **public** catalog publishes private issue metadata, on the path where everything is working correctly. The batch now requires deciding this before private reads are enabled: either the delivery repo must be at least as restricted as every source it scans, or private-relative sources get a reduced row. As a producer check, not a convention.

## Test plan

Documentation only. Verified by reading: the dependency claims are consistent between the README table, the diagram, and each batch header; `00-decisions.md` now defines D5 and the anchor `05-acceptance-engines.md` links to resolves; and the six questions moved out of 05 are the same six §4 lists.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVGf6MmwV8gHZ8xScG5siq)_