### PR TITLE
refactor(serve): drop the DESTRUCTURE usage rule kind

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -337,10 +337,6 @@ object PlaygroundSourceCleaner {
     out =
       if (parser != null) applySubstituteParsed(out, rules, addedImports, parser)
       else applySubstitute(out, rules, addedImports)
-    // After SUBSTITUTE, so a knob in the initializer (`toggleable(catalogEnabled())`) is already
-    // plain by the time the state declaration quotes it. Parsed-only by design — see
-    // [UsageRules.Kind.DESTRUCTURE].
-    if (parser != null) out = applyDestructureParsed(out, rules, addedImports, parser)
     out = applyInline(out, rules, addedImports)
     out = applyDrop(out, rules, residue)
     out = applyRename(out, rules, addedImports)
@@ -588,106 +584,6 @@ object PlaygroundSourceCleaner {
       }
     }
     return bound.toList()
-  }
-
-  /**
-   * `val (checked, onCheckedChange) = toggleable(true)` → `var checked by remember {
-   * mutableStateOf(true) }`, with every use of `onCheckedChange` becoming `{ checked = it }`.
-   *
-   * ### Why this one could not be a text pass
-   *
-   * The other kinds rewrite an expression or delete a binding. This replaces a **declaration** and
-   * rebinds a *second* name that the declaration introduced — so it has to know the destructuring
-   * exists, which names it binds, in what order, and where its initializer starts and ends. A regex
-   * that thought it knew those things is how this file earned most of its review findings, which is
-   * why the kind is gated on the parser being staged rather than degrading to a guess.
-   *
-   * ### All or nothing, per declaration
-   *
-   * The same discipline [applyDrop] uses. If the template cites an argument the call does not have,
-   * or the declaration binds a shape the rule does not describe (one name, or three), the whole
-   * rewrite is abandoned for that declaration and the helper is left exactly as the catalog wrote
-   * it — reported as residue. A half-applied state rewrite compiles to something subtly wrong,
-   * which is worse than a snippet that visibly still calls a helper.
-   */
-  private fun applyDestructureParsed(
-    text: String,
-    rules: UsageRules,
-    addedImports: MutableSet<String>,
-    parser: UsageSourceParser,
-  ): String {
-    if (rules.scaffolds.none { it.value.kind == UsageRules.Kind.DESTRUCTURE }) return text
-    var out = text
-    var guard = 0
-    while (guard++ < MAX_REWRITES) {
-      val facts = parser.facts(out) ?: return out
-      val rewrite =
-        facts.destructurings
-          .asSequence()
-          .mapNotNull { declaration ->
-            // The initializer, as a call: the facts report the two separately, and the call is what
-            // carries the callee, its arguments and its receiver.
-            val call =
-              facts.calls.firstOrNull {
-                it.replaceStart == declaration.initializerStart ||
-                  it.start == declaration.initializerStart
-              } ?: return@mapNotNull null
-            val scaffold = rules.scaffolds[call.callee] ?: return@mapNotNull null
-            if (scaffold.kind != UsageRules.Kind.DESTRUCTURE) return@mapNotNull null
-            // Same guard the substitution pass carries: a matching name on somebody else's receiver
-            // is not this scaffold.
-            if (call.receiver != null && call.receiver !in rules.scaffoldPackages) {
-              return@mapNotNull null
-            }
-            val plain = scaffold.plain ?: return@mapNotNull null
-            // Exactly the value/setter pair the kind describes. Anything else is a shape the rule
-            // does not speak for.
-            if (declaration.names.size != 2) return@mapNotNull null
-            val (value, setterName) = declaration.names
-            if (value.isEmpty() || setterName.isEmpty()) return@mapNotNull null
-            val args = facts.bind(call, scaffold.params) ?: return@mapNotNull null
-            val render = { template: String ->
-              Regex("""\$(\d+)|\${'$'}value|\${'$'}setter""").replace(template) { m ->
-                when (m.value) {
-                  "\$value" -> value
-                  "\$setter" -> setterName
-                  else -> args.getOrNull(m.groupValues[1].toInt()) ?: m.value
-                }
-              }
-            }
-            val declarationText = render(plain)
-            val setterText = scaffold.setter?.let(render)
-            if (declarationText.contains(Regex("""\${'$'}\d"""))) return@mapNotNull null
-            if (setterText?.contains(Regex("""\${'$'}\d""")) == true) return@mapNotNull null
-            Triple(declaration, declarationText to setterText, scaffold)
-          }
-          .firstOrNull() ?: return out
-
-      val (declaration, replacements, scaffold) = rewrite
-      val (declarationText, setterText) = replacements
-      if (declaration.start < 0 || declaration.end > out.length) return out
-
-      // The declaration and every reference to the setter name, from **one** parse, applied
-      // right-to-left so earlier offsets stay valid. Not `replaceWord`: that also rewrites the
-      // argument *label* in `Switch(onCheckedChange = onCheckedChange)`, which produced
-      // `{ checked = it } = { checked = it }` — the parse separates a label from a reference and a
-      // word scan cannot.
-      val edits = buildList {
-        add(declaration.start to declaration.end to declarationText)
-        if (setterText != null) {
-          facts.references
-            .filter { it.name == declaration.names[1] && it.start >= declaration.end }
-            .forEach { add(it.start to it.end to setterText) }
-        }
-      }
-      for ((range, replacement) in edits.sortedByDescending { it.first.first }) {
-        val (start, end) = range
-        if (start < 0 || end > out.length || start >= end) return out
-        out = out.substring(0, start) + replacement + out.substring(end)
-      }
-      addedImports.addAll(scaffold.imports)
-    }
-    return out
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -91,8 +91,8 @@ data class UsageRules(
      * delegation reads and which nothing in the snippet mentions by name.
      *
      * Applies alongside [addImport] to every kind that emits a replacement — RENAME, SUBSTITUTE,
-     * DESTRUCTURE, INLINE; see [imports]. DROP and UNWRAP write no new code, so an import declared
-     * on one of those has nothing to serve.
+     * INLINE; see [imports]. DROP and UNWRAP write no new code, so an import declared on one of
+     * those has nothing to serve.
      */
     @SerialName("addImports") val addImports: List<String> = emptyList(),
     /** [Kind.SUBSTITUTE] only: what the call reads as, with `$0`, `$1`… for its arguments. */
@@ -107,15 +107,6 @@ data class UsageRules(
      * call that uses named arguments at all (reporting it as residue) rather than guessing.
      */
     @SerialName("params") val params: List<String> = emptyList(),
-    /**
-     * [Kind.DESTRUCTURE] only: what the **second** destructured name reads as at its use sites.
-     *
-     * `val (checked, onCheckedChange) = toggleable(true)` binds a value and its setter.
-     * [Scaffold.plain] replaces the declaration; this replaces every mention of `onCheckedChange`,
-     * which would otherwise refer to a binding that no longer exists. Cites `$value` for the first
-     * name, so `toggleable` declares `{ $value = it }`.
-     */
-    @SerialName("setter") val setter: String? = null,
     /**
      * [Kind.INLINE] only: member → replacement, where `$0`, `$1`… are the call's arguments.
      * `counted` declares `{"label": "$0", "onClick": "{}"}`, which is the whole of what that helper
@@ -177,32 +168,6 @@ data class UsageRules(
      * on a named argument.
      */
     SUBSTITUTE,
-
-    /**
-     * A helper whose result is **destructured into state**, replaced by the state a developer would
-     * write themselves.
-     *
-     * m3-catalog's `toggleable` / `selectable` / `multiSelectable` / `draggable` / `editable` each
-     * return `Pair<T, (T) -> Unit>` so one sticker can be frozen on the baked lane and live on the
-     * interactive one:
-     * ```
-     * val (checked, onCheckedChange) = toggleable(true)
-     * ```
-     *
-     * The plain reading is not a *value* — it is real state, `var checked by remember {
-     * mutableStateOf(true) }`, plus a setter at every use site. That is why none of the other four
-     * kinds could express it, and why `compose-usage.json` carried it as a declared gap: RENAME and
-     * SUBSTITUTE rewrite one expression, DROP deletes, INLINE substitutes members of a binding —
-     * none replaces a declaration *and* rebinds a second name.
-     *
-     * Declares [Scaffold.plain] for the declaration, [Scaffold.setter] for the second name's use
-     * sites, and [Scaffold.addImports] for what the replacement needs.
-     *
-     * **Needs the parser.** A destructuring declaration, its entry names and its initializer are
-     * exactly the structure a regex cannot be trusted with, so this kind applies only when
-     * `:usage-source-psi` is staged; without it the helper is reported as residue, as before.
-     */
-    DESTRUCTURE,
   }
 
   companion object {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 /**
- * The structure [PlaygroundSourceCleaner] used to guess at, read off a real parse.
+ * The call structure [PlaygroundSourceCleaner] used to guess at, read off a real parse.
  *
  * Produced by `:usage-source-psi` inside an isolated classloader (see [UsageSourceParser]) and
  * carried across as JSON, so no Kotlin frontend type ever reaches the CLI's own classpath.
@@ -20,15 +20,6 @@ import kotlinx.serialization.json.Json
 @Serializable
 data class UsageSourceFacts(
   @SerialName("calls") val calls: List<Call> = emptyList(),
-  @SerialName("destructurings") val destructurings: List<Destructuring> = emptyList(),
-  /**
-   * Every name **reference**, excluding argument labels.
-   *
-   * The exclusion is the point. `Switch(onCheckedChange = onCheckedChange)` writes that name twice
-   * and only the second is a reference; rebinding the first turns a label into an expression. PSI
-   * knows which is which, and a word scan does not.
-   */
-  @SerialName("references") val references: List<Reference> = emptyList(),
   /**
    * Set when the analyzer could not parse at all; the caller then behaves as if it had no facts.
    */
@@ -76,23 +67,6 @@ data class UsageSourceFacts(
     @SerialName("text") val text: String = "",
     @SerialName("start") val start: Int = -1,
     @SerialName("end") val end: Int = -1,
-  )
-
-  @Serializable
-  data class Reference(
-    @SerialName("name") val name: String = "",
-    @SerialName("start") val start: Int = -1,
-    @SerialName("end") val end: Int = -1,
-  )
-
-  @Serializable
-  data class Destructuring(
-    @SerialName("start") val start: Int,
-    @SerialName("end") val end: Int,
-    @SerialName("names") val names: List<String> = emptyList(),
-    @SerialName("initializer") val initializer: String = "",
-    @SerialName("initializerStart") val initializerStart: Int = -1,
-    @SerialName("initializerEnd") val initializerEnd: Int = -1,
   )
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -572,11 +572,11 @@ class PlaygroundSourceCleanerTest {
   }
 
   /**
-   * `addImports` is not a DESTRUCTURE field.
+   * `addImports` belongs to every kind that emits a replacement.
    *
-   * m3-catalog's state helpers return a `MutableState` now, so their rules are ordinary SUBSTITUTE
-   * — and the substitution emitted `var checked by remember { mutableStateOf(true) }` against a
-   * snippet with no `remember` import, because only DESTRUCTURE read the plural field.
+   * m3-catalog's state helpers return a `MutableState`, so their rules are ordinary SUBSTITUTE —
+   * and the substitution emitted `var checked by remember { mutableStateOf(true) }` against a
+   * snippet with no `remember` import, because only one rewrite read the plural field.
    * Perfect-looking Kotlin that does not compile, which the corpus gate caught and no unit test
    * would have.
    */
@@ -679,105 +679,6 @@ class PlaygroundSourceCleanerTest {
     )
     assertTrue(result.text.contains("import android.util.Log"), result.text)
     assertEquals(emptyList(), result.residue)
-  }
-
-  /**
-   * The `$known-gaps` entry m3-catalog's `compose-usage.json` carried: `toggleable` and friends
-   * return `Pair<T, (T) -> Unit>` destructured into a value and a setter, and the plain reading is
-   * real state rather than a value. Roughly 18 stickers were affected.
-   */
-  @Test
-  fun `a destructured state helper becomes remembered state`() {
-    val destructuring =
-      UsageRules(
-        scaffolds =
-          mapOf(
-            "toggleable" to
-              UsageRules.Scaffold(
-                kind = UsageRules.Kind.DESTRUCTURE,
-                plain = "var \$value by remember { mutableStateOf(\$0) }",
-                setter = "{ \$value = it }",
-                addImports =
-                  listOf(
-                    "androidx.compose.runtime.getValue",
-                    "androidx.compose.runtime.mutableStateOf",
-                    "androidx.compose.runtime.remember",
-                    "androidx.compose.runtime.setValue",
-                  ),
-              )
-          )
-      )
-    val source =
-      """
-      package ee.schimke.m3catalog.sections
-
-      import androidx.compose.material3.Switch
-      import androidx.compose.runtime.Composable
-      import ee.schimke.m3catalog.toggleable
-
-      @Composable
-      fun SwitchSticker() {
-        val (checked, onCheckedChange) = toggleable(true)
-        Switch(checked = checked, onCheckedChange = onCheckedChange)
-      }
-      """
-        .trimIndent()
-    val result =
-      assertNotNull(
-        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun SwitchSticker"), destructuring)
-      )
-    assertTrue(
-      result.text.contains("var checked by remember { mutableStateOf(true) }"),
-      result.text,
-    )
-    // The setter name no longer exists, so every use of it has to be rebound — a declaration
-    // rewritten without this leaves code that reads fine and does not compile.
-    assertTrue(result.text.contains("onCheckedChange = { checked = it }"), result.text)
-    assertFalse(result.text.contains("toggleable"), result.text)
-    // `by` needs `getValue`/`setValue`, which nothing in the snippet mentions by name.
-    for (import in listOf("getValue", "setValue", "remember", "mutableStateOf")) {
-      assertTrue(result.text.contains("import androidx.compose.runtime.$import"), result.text)
-    }
-    assertEquals(emptyList(), result.residue)
-  }
-
-  /**
-   * A declaration binding a shape the rule does not describe is left alone, and reported — the same
-   * all-or-nothing discipline DROP uses. Half-rewritten state compiles to something subtly wrong,
-   * which is worse than a snippet that visibly still calls a helper.
-   */
-  @Test
-  fun `a destructuring the rule does not describe is left as residue`() {
-    val destructuring =
-      UsageRules(
-        scaffolds =
-          mapOf(
-            "triple" to
-              UsageRules.Scaffold(
-                kind = UsageRules.Kind.DESTRUCTURE,
-                plain = "var \$value by remember { mutableStateOf(\$0) }",
-                setter = "{ \$value = it }",
-              )
-          )
-      )
-    val source =
-      """
-      package ee.schimke.m3catalog.sections
-
-      import androidx.compose.runtime.Composable
-      import ee.schimke.m3catalog.triple
-
-      @Composable
-      fun Odd() {
-        val (a, b, c) = triple(1)
-        Text("${'$'}a ${'$'}b ${'$'}c")
-      }
-      """
-        .trimIndent()
-    val result =
-      assertNotNull(PlaygroundSourceCleaner.clean(source, lineIn(source, "fun Odd"), destructuring))
-    assertTrue(result.text.contains("val (a, b, c) = triple(1)"), result.text)
-    assertTrue(result.residue.contains("triple"), "${result.residue}")
   }
 
   /** Named arguments out of declaration order still bind by name, as Kotlin binds them. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSourceParserTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSourceParserTest.kt
@@ -86,18 +86,6 @@ class UsageSourceParserTest {
     assertEquals("state.metrics", byName["counted"]?.receiver)
   }
 
-  /** Destructuring, which the `$known-gaps` entry in `compose-usage.json` is waiting on. */
-  @Test
-  fun `destructuring declarations are reported with their entries`() {
-    val facts =
-      assertNotNull(
-        parser?.facts("""fun x() { val (checked, onChange) = toggleable("on", true) }""")
-      )
-    val destructuring = assertNotNull(facts.destructurings.singleOrNull())
-    assertEquals(listOf("checked", "onChange"), destructuring.names)
-    assertEquals("""toggleable("on", true)""", destructuring.initializer)
-  }
-
   /**
    * Binding is Kotlin's rule, and it needs the callee's parameter names — the parse supplies
    * labels, not signatures. See `docs/design/PSI_PARSE_SPIKE.md`.

--- a/docs/design/PSI_PARSE_SPIKE.md
+++ b/docs/design/PSI_PARSE_SPIKE.md
@@ -134,8 +134,9 @@ The spike said yes, so the parse is now in the cleaner. The shape is the one the
 - **`:usage-source-psi`** — the parser, compiling `compileOnly` against `kotlin-compiler-embeddable`
   so the frontend is never a runtime dependency of anything in the main build. It exposes one method,
   `analyze(String): String`, returning JSON: calls (callee, offsets, arguments with their labels,
-  trailing-lambda ranges, receiver) and destructuring declarations. It reports **facts, never
-  decisions** — `ee.schimke.composeai.overrides` and `state.metrics` are the same tree shape, so it
+  trailing-lambda ranges, receiver). It also reported destructuring declarations and name
+  references, for the `DESTRUCTURE` kind below; both went when that kind did. It reports **facts,
+  never decisions** — `ee.schimke.composeai.overrides` and `state.metrics` are the same tree shape, so it
   hands over each receiver verbatim and lets the rules' allow-list do the classifying.
 - **Staged as `lib-usage-psi/`**, loaded together with the already-staged `lib-bta/` jars in a
   `URLClassLoader` parented to the platform loader — the same isolation the playground compiler uses.
@@ -165,8 +166,11 @@ positional slot — putting `{ … }` where `default` belongs. Filtered out, and
 A parse fixes the **machinery**. It does not move the ratio much on its own:
 
 - m3-catalog's 2 destructuring failures: **done**, and the ratio moved 3/10 → 4/10. The
-  `DESTRUCTURE` rule kind reads the facts' entries and initialiser; `compose-usage.json`'s
-  `$known-gaps` entry is retired.
+  `DESTRUCTURE` rule kind read the facts' entries and initialiser; `compose-usage.json`'s
+  `$known-gaps` entry is retired. **Since removed** — m3-catalog's helpers now return a
+  `MutableState` used through `by`, so the same snippets come out of an ordinary `SUBSTITUTE` rule
+  and the kind had no consumer left. The facts it needed (`destructurings`, `references`) went with
+  it.
 - The 2 conditional-`stringResource` failures become tractable for the same reason: the inliner can
   see the `if` rather than declining on a regex.
 - `CatalogFilledStars` (×4) still needs a substitution rule — no parse invents an icon.

--- a/docs/design/USAGE_SNIPPET_CORPUS.md
+++ b/docs/design/USAGE_SNIPPET_CORPUS.md
@@ -81,7 +81,7 @@ Two things had to follow from putting those knobs in `GENERIC`:
 
 | Cause | Files | Status |
 |---|---|---|
-| ~~`toggleable` / `editable` destructure a `Pair`~~ | ~~2~~ → 0 | **Fixed.** The `DESTRUCTURE` rule kind, which the parse made writable — `val (checked, onCheckedChange) = toggleable(true)` now comes out as `var checked by remember { mutableStateOf(true) }` with the setter rebound at its use sites. One of the two compiled immediately; the other is now blocked only on the `stringResource` row below |
+| ~~`toggleable` / `editable` destructure a `Pair`~~ | ~~2~~ → 0 | **Fixed**, twice. First by the `DESTRUCTURE` rule kind; then properly, by m3-catalog changing the helpers to return a `MutableState` used through `by`, so `var checked by toggleable(true)` is an ordinary `SUBSTITUTE` to `var checked by remember { mutableStateOf(true) }`. `DESTRUCTURE` was removed once that landed. One of the two compiled immediately; the other is now blocked only on the `stringResource` row below |
 | Conditional `stringResource(if (…) Res.string.a else Res.string.b)` | 2 | The inliner only handles the exact single-key form and declines the rest, correctly — but the snippet then keeps an unresolvable `Res` |
 | `CatalogFilledStars`, a catalog-owned `ImageVector` | 4 | No rule; wants substituting with a stock `Icons.Filled.Star` or similar |
 

--- a/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/JsonWriter.kt
+++ b/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/JsonWriter.kt
@@ -35,27 +35,15 @@ internal class JsonWriter {
       first = false
       val nested = JsonWriter()
       nested.write(item)
-      val body = nested.finishRaw()
-      // A writer whose `write` block emitted a bare value (`raw`) rather than fields is spliced as
-      // that value; otherwise it is an object.
-      if (nested.wroteRaw) out.append(body) else out.append('{').append(body).append('}')
+      out.append('{').append(nested.out).append('}')
     }
     out.append(']')
   }
-
-  fun raw(value: String) {
-    wroteRaw = true
-    out.append(value)
-  }
-
-  private var wroteRaw = false
 
   private fun separator() {
     if (needsComma) out.append(',')
     needsComma = true
   }
-
-  private fun finishRaw(): String = out.toString()
 
   fun finish(): String = "{" + out + "}"
 }

--- a/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
+++ b/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
@@ -10,13 +10,10 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLambdaArgument
-import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
-import org.jetbrains.kotlin.psi.KtValueArgumentName
 
 /**
  * Parses Kotlin source and reports the **structure** the usage cleaner needs, as JSON.
@@ -61,8 +58,7 @@ class UsageSourceAnalyzer : AutoCloseable {
   }
 
   /**
-   * [source] → a JSON object of `calls` and `destructurings`, or `{"error":"…"}` if it could not be
-   * parsed at all.
+   * [source] → a JSON object of `calls`, or `{"error":"…"}` if it could not be parsed at all.
    *
    * Never throws across the reflective boundary: an exception here would surface in the caller as
    * an `InvocationTargetException` carrying a frontend-loaded class the caller cannot name. A JSON
@@ -79,26 +75,6 @@ class UsageSourceAnalyzer : AutoCloseable {
       json {
         arrayField("calls", PsiTreeUtil.findChildrenOfType(file, KtCallExpression::class.java)) {
           call(it)
-        }
-        arrayField(
-          "destructurings",
-          PsiTreeUtil.findChildrenOfType(file, KtDestructuringDeclaration::class.java),
-        ) {
-          destructuring(it)
-        }
-        // Name references, minus argument *labels*. `Switch(onCheckedChange = onCheckedChange)`
-        // mentions that name twice and only the second is a reference — rebinding the first turns
-        // the label into an expression and the call into nonsense. PSI separates them; a word scan
-        // cannot, which is how the first version of the DESTRUCTURE rule broke this exact call.
-        arrayField(
-          "references",
-          PsiTreeUtil.findChildrenOfType(file, KtNameReferenceExpression::class.java).filter {
-            it.parent !is KtValueArgumentName
-          },
-        ) { reference ->
-          field("name", reference.getReferencedName())
-          number("start", reference.textRange.startOffset)
-          number("end", reference.textRange.endOffset)
         }
       }
     } catch (e: Throwable) {
@@ -146,15 +122,5 @@ class UsageSourceAnalyzer : AutoCloseable {
       number("start", expr?.textRange?.startOffset ?: -1)
       number("end", expr?.textRange?.endOffset ?: -1)
     }
-  }
-
-  private fun JsonWriter.destructuring(node: KtDestructuringDeclaration) {
-    number("start", node.textRange.startOffset)
-    number("end", node.textRange.endOffset)
-    arrayField("names", node.entries.map { it.name ?: "" }) { raw("\"" + escape(it) + "\"") }
-    val init = node.initializer
-    field("initializer", init?.text ?: "")
-    number("initializerStart", init?.textRange?.startOffset ?: -1)
-    number("initializerEnd", init?.textRange?.endOffset ?: -1)
   }
 }


### PR DESCRIPTION
## Summary

`DESTRUCTURE` existed for one shape: m3-catalog's interaction helpers returning `Pair<T, (T) -> Unit>`, destructured into a value and a setter, whose plain reading is real state rather than a value. No other kind could replace a *declaration* and rebind a *second* name, so it got its own kind, a parser gate, and its own parse facts.

m3-catalog#77 removed the shape. The five helpers now return a `MutableState<T>` used through `by`, so `var checked by toggleable(true)` cleans to `var checked by remember { mutableStateOf(true) }` through an ordinary `SUBSTITUTE` rule — and `compose-usage.json` no longer declares a single `DESTRUCTURE` rule. The kind has no consumer left in any catalog, and an unexercised rewrite path is a liability rather than a capability: it can only rot.

So it goes, along with everything that existed only to serve it:

- `UsageRules.Kind.DESTRUCTURE` and `Scaffold.setter`
- `PlaygroundSourceCleaner.applyDestructureParsed` and its call site
- the analyzer's `destructurings` and `references` arrays, and the matching `UsageSourceFacts.Destructuring` / `Reference` models — nothing else read either
- `JsonWriter.raw` / `wroteRaw`, whose only caller was the destructuring `names` array; `arrayField` now writes objects unconditionally

Net −336/+18.

The corpus outcome is unchanged, which is the point: the two snippets this kind was built to fix are the same two `SUBSTITUTE` now handles, via the helper signatures rather than via a bespoke rewrite.

`docs/design/PSI_PARSE_SPIKE.md` and `docs/design/USAGE_SNIPPET_CORPUS.md` keep their history — the kind did ship and did move m3-catalog 3/10 → 4/10 — with a note recording that it was later removed and why.

## Test plan

- `:cli:test --tests '*PlaygroundSourceCleanerTest*' --tests '*UsageSourceParserTest*' --tests '*UsageRules*'` — green. Two cleaner tests (`a destructured state helper becomes remembered state`, `a destructuring the rule does not describe is left as residue`) and one parser test (`destructuring declarations are reported with their entries`) are deleted with the code they covered; everything else in those classes is untouched and passing, including `a substituted call contributes every import its rule declares`, which is the test that now covers the state-helper snippet end to end.
- `:cli:compileKotlin`, `:cli:compileTestKotlin`, `:usage-source-psi:compileKotlin` — clean.
- `:cli:ktfmtFormat`, `:usage-source-psi:ktfmtFormat` — clean.

No visual surface is touched: this is rule-vocabulary and parse-facts plumbing, so text-only evidence is the right kind here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_