### PR TITLE
fix(design-artifacts): fail a sharded render that lost previews

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -231,7 +231,9 @@ on:
           them back into the bundle one serial render would have produced. Every shard derives its
           own partition from its own `compose-preview list --json` (deterministic: the id list is
           sorted, then round-robined), so there is no serial discover-then-fan-out prefix — and the
-          merge cross-checks the shards' plans before trusting them.
+          merge cross-checks the shards' plans before trusting them, then checks the merged bundle
+          back against those plans so a shard that lost work fails the run instead of publishing a
+          thinner catalog on a green tick (m3-catalog#15).
 
           What this buys, and what it does not: only the MARGINAL cost divides. Re-measured on
           m3-catalog after #3548 (issue #3559), a single-job render is
@@ -901,6 +903,15 @@ jobs:
           else
             compose-preview bundle merge "${bundles[@]}" -o "$GITHUB_WORKSPACE/bundle.png"
           fi
+          # And now the OUTCOME, which the plan check above cannot see. `--verify` confirms the
+          # shards agreed on a disjoint cover; it passes whether or not a single preview came back.
+          # m3-catalog#15 was exactly that gap: a correct partition of 1095 previews, `6 shard(s)
+          # cover 1095 preview(s) exactly once` printed, 267 merged, and a green run — because each
+          # shard's unanchored exclusions also deleted the `_VARIANT_` fan-out of every id it
+          # excluded. Anchoring (#3561) fixed the cause; this makes any future recurrence loud,
+          # naming the shard and the ids instead of thinning the published catalog in silence.
+          node compose-ai-tools/scripts/design-artifacts/verify-shard-renders.mjs \
+            --bundle "$GITHUB_WORKSPACE/bundle.png" "${plans[@]}"
 
       - name: Render extra module
         if: ${{ inputs.extra-module != '' }}

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -777,6 +777,26 @@ by count — two runners that saw `["a"]` and `["b"]` are disjoint with a union 
 pairwise disjoint, and a complete cover. A disagreement would otherwise surface as a
 completeness-gate failure naming a component, with nothing pointing at the shards.
 
+**Then the merged bundle is checked back against those plans**
+([`verify-shard-renders.mjs`](../../scripts/design-artifacts/verify-shard-renders.mjs)), because the
+plan and the outcome are different questions and only the first one used to be asked. A plan check
+confirms the shards *intended* a disjoint cover; it passes whether or not a single preview came
+back. m3-catalog run 31217598543 lived precisely in that gap — it partitioned 1095 previews
+correctly, printed `6 shard(s) cover 1095 preview(s) exactly once`, and merged 267 of them, because
+each shard's exclusion list was unanchored and so also deleted the `_VARIANT_` fan-out of every id it
+excluded. **The run was green**, and the loss reached the operator as a downstream warning about
+previews with no static PNG — which reads like a list of token sheets, not three quarters of a
+render. Anchoring the exclusions fixed the cause; this closes the silence, which is what made it
+expensive.
+
+The comparison is "did this preview come back with **any** `previews/<id>.*` artifact", not "did it
+come back with a PNG": a PNG check would flag every animated `ScrollMode.GIF` capture, every
+`@ColorCatalog` / `@ThemeCatalog` sheet and every `"capture": "none"` entry as a loss. An excluded
+preview is skipped in the render *and* the semantics pass, so it comes back with nothing at all —
+that asymmetry is what makes the signal precise. Extra ids are not reported: exclusion leaves
+previews listed in the bundle, and a shard rendering more than its share costs time, not stickers.
+The failure names the shard and its missing ids, so a recurrence points at its own cause.
+
 **The CLI has to be new enough.** The merge runs last, after every shard has spent its twenty
 minutes, so a CLI predating `bundle merge` would fail the run having burned the whole fan-out — and
 that is the *default* configuration's failure mode, since `cli-source: released` +

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -797,6 +797,14 @@ that asymmetry is what makes the signal precise. Extra ids are not reported: exc
 previews listed in the bundle, and a shard rendering more than its share costs time, not stickers.
 The failure names the shard and its missing ids, so a recurrence points at its own cause.
 
+**It disarms itself rather than cry wolf.** "Any artifact" leans on the semantics pass to give a
+raster-less preview *something*, and `packSemanticsBlob` is best-effort — a missing
+`daemon-launch.json`, a session that will not open, or an empty capture each warn and leave the pack
+exiting 0 with no `.semantics.json` anywhere. In that state a legitimately raster-less preview is
+indistinguishable from one an exclusion ate, so the check reports the shortfall as a workflow warning
+and passes instead of failing the run on a signal it cannot read. A gate that fails for the wrong
+reason spends exactly the trust this one exists to rebuild.
+
 **The CLI has to be new enough.** The merge runs last, after every shard has spent its twenty
 minutes, so a CLI predating `bundle merge` would fail the run having burned the whole fan-out — and
 that is the *default* configuration's failure mode, since `cli-source: released` +

--- a/scripts/design-artifacts/bundle-previews.mjs
+++ b/scripts/design-artifacts/bundle-previews.mjs
@@ -65,3 +65,52 @@ export function candidatePreviewBundle(bundle) {
   });
   return { bundle: { ...bundle, previews }, dropped };
 }
+
+/** Zip directory every per-preview artifact lands under. */
+const PREVIEWS_DIR = "previews/";
+
+/**
+ * The ids of previews the bundle actually **captured** — those carrying at least one
+ * `previews/<id>.*` artifact of any kind.
+ *
+ * Deliberately "any artifact", not "a PNG": [candidatePreviewBundle] already answers the PNG
+ * question, and the two are asking different things. Plenty of previews are PNG-less *by design*
+ * — an animated `ScrollMode.GIF` capture emits only a `.gif`, a `@ColorCatalog` / `@ThemeCatalog`
+ * sheet only a `.catalog.json`, a `"capture": "none"` entry nothing raster at all — so a PNG check
+ * would call all of those a loss. What no captured preview ever lacks is *every* artifact: a pack
+ * runs `--with-semantics`, so even a raster-less preview comes back with its `.semantics.json`.
+ *
+ * A preview an `--exclude-preview-id` pattern matched, by contrast, is skipped in **both** passes
+ * (that is the whole point of the CLI applying the same exclusion list to the render and the
+ * semantics capture), so it comes back with nothing at all under `previews/`. That asymmetry is
+ * what makes "no artifact whatsoever" a precise signal for *excluded* rather than *PNG-less*, and
+ * it is what `verify-shard-renders.mjs` compares the shard plans against after a sharded merge.
+ *
+ * Ids are returned in the caller's namespace: bundle entries are stored under filename-safe ids
+ * while shard plans and `design-map.json` are authored against the canonical discovery id, so
+ * [rawIdFor] maps one to the other (`rawPreviewIdForEntry` from `@design-parity/candidate`). It
+ * defaults to the entry id, which is correct whenever no sanitising happened.
+ *
+ * @param {{previews?: Array<{id: string}>, entries?: Record<string, unknown>}} bundle
+ * @param {(bundle: object, entry: object) => string} [rawIdFor]
+ * @returns {Set<string>} the captured ids.
+ */
+export function capturedPreviewIds(bundle, rawIdFor = (_bundle, entry) => entry.id) {
+  const byEntryId = new Map((bundle?.previews ?? []).map((p) => [p.id, p]));
+  const captured = new Set();
+  for (const path of Object.keys(bundle?.entries ?? {})) {
+    if (!path.startsWith(PREVIEWS_DIR)) continue;
+    const rest = path.slice(PREVIEWS_DIR.length);
+    // An artifact is `<id>.<ext>`, and neither the id nor the extension is dot-free in general
+    // (`Foo.semantics.json`, and an id may carry a dot of its own), so walk the dots left to right
+    // and take the first split whose left half is a preview this bundle declares.
+    for (let dot = rest.indexOf("."); dot > 0; dot = rest.indexOf(".", dot + 1)) {
+      const entry = byEntryId.get(rest.slice(0, dot));
+      if (entry) {
+        captured.add(rawIdFor(bundle, entry));
+        break;
+      }
+    }
+  }
+  return captured;
+}

--- a/scripts/design-artifacts/bundle-previews.mjs
+++ b/scripts/design-artifacts/bundle-previews.mjs
@@ -86,6 +86,13 @@ const PREVIEWS_DIR = "previews/";
  * what makes "no artifact whatsoever" a precise signal for *excluded* rather than *PNG-less*, and
  * it is what `verify-shard-renders.mjs` compares the shard plans against after a sharded merge.
  *
+ * The one hole in that reasoning is that semantics capture is **best-effort** — a missing daemon
+ * descriptor, a failed session open, or an empty capture leaves `packSemanticsBlob` returning null
+ * and the pack succeeding anyway — so a bundle can carry no `.semantics.json` at all. A raster-less
+ * preview then really does have zero artifacts for a reason that has nothing to do with sharding.
+ * [bundleCapturedSemantics] is how the caller detects that and declines to judge; see
+ * `verifyShardRenders`.
+ *
  * Ids are returned in the caller's namespace: bundle entries are stored under filename-safe ids
  * while shard plans and `design-map.json` are authored against the canonical discovery id, so
  * [rawIdFor] maps one to the other (`rawPreviewIdForEntry` from `@design-parity/candidate`). It
@@ -101,16 +108,40 @@ export function capturedPreviewIds(bundle, rawIdFor = (_bundle, entry) => entry.
   for (const path of Object.keys(bundle?.entries ?? {})) {
     if (!path.startsWith(PREVIEWS_DIR)) continue;
     const rest = path.slice(PREVIEWS_DIR.length);
-    // An artifact is `<id>.<ext>`, and neither the id nor the extension is dot-free in general
-    // (`Foo.semantics.json`, and an id may carry a dot of its own), so walk the dots left to right
-    // and take the first split whose left half is a preview this bundle declares.
+    // An artifact is `<id>.<ext>`, and neither half is dot-free in general (`Foo.semantics.json`,
+    // and an id may carry a dot of its own), so walk every dot and keep the LONGEST declared id
+    // that fits. Taking the first match instead would be wrong exactly where ids nest: with both
+    // `pkg.Screen` and `pkg.Screen.Dark` declared, `previews/pkg.Screen.Dark.png` would be credited
+    // to `pkg.Screen` and the longer preview — fully rendered — would be reported as lost. That is
+    // the same substring confusion that caused the bug this check exists to catch, so it would be a
+    // poor place to repeat it.
+    let longest;
     for (let dot = rest.indexOf("."); dot > 0; dot = rest.indexOf(".", dot + 1)) {
       const entry = byEntryId.get(rest.slice(0, dot));
-      if (entry) {
-        captured.add(rawIdFor(bundle, entry));
-        break;
-      }
+      if (entry) longest = entry;
     }
+    if (longest) captured.add(rawIdFor(bundle, longest));
   }
   return captured;
+}
+
+/**
+ * True when [bundle] carries at least one `previews/<id>.semantics.json` — i.e. the semantics pass
+ * actually ran and produced something.
+ *
+ * Load-bearing for [capturedPreviewIds]'s "any artifact" reading. `packSemanticsBlob` is documented
+ * best-effort: a missing `daemon-launch.json`, a session that would not open, or a capture that
+ * returned nothing all warn to stderr and leave the *already-written* bundle alone, so `bundle pack`
+ * exits 0 having carried no semantics for any preview. In that state a preview with no raster of its
+ * own — an animated `ScrollMode.GIF` capture, a token sheet, a `"capture": "none"` entry — has
+ * genuinely zero artifacts, and "no artifact" no longer means "excluded". A caller that would
+ * otherwise fail a run on that signal should check here first and decline to judge instead.
+ *
+ * @param {{entries?: Record<string, unknown>}} bundle
+ * @returns {boolean}
+ */
+export function bundleCapturedSemantics(bundle) {
+  return Object.keys(bundle?.entries ?? {}).some(
+    (path) => path.startsWith(PREVIEWS_DIR) && path.endsWith(".semantics.json"),
+  );
 }

--- a/scripts/design-artifacts/bundle-previews.test.mjs
+++ b/scripts/design-artifacts/bundle-previews.test.mjs
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  bundleCapturedSemantics,
   candidatePreviewBundle,
   capturedPreviewIds,
   daemonPreviewIdsByFunction,
@@ -184,4 +185,36 @@ test("capturedPreviewIds ignores entries outside previews/ and unknown ids", () 
 test("capturedPreviewIds is empty for a bundle with nothing in it", () => {
   assert.equal(capturedPreviewIds({}).size, 0);
   assert.equal(capturedPreviewIds(undefined).size, 0);
+});
+
+test("capturedPreviewIds credits an artifact to the LONGEST declared id that fits", () => {
+  // Ids can carry dots of their own, so `pkg.Screen` and `pkg.Screen.Dark` can both be declared.
+  // Stopping at the first dot boundary would credit `previews/pkg.Screen.Dark.png` to `pkg.Screen`
+  // and report the longer preview — fully rendered — as lost.
+  const bundle = {
+    previews: [{ id: "pkg.Screen" }, { id: "pkg.Screen.Dark" }],
+    entries: {
+      "previews/pkg.Screen.png": enc("png"),
+      "previews/pkg.Screen.Dark.png": enc("png"),
+    },
+  };
+  assert.deepEqual([...capturedPreviewIds(bundle)].sort(), ["pkg.Screen", "pkg.Screen.Dark"]);
+});
+
+test("capturedPreviewIds still resolves a dotted id's multi-extension sidecar", () => {
+  const bundle = {
+    previews: [{ id: "pkg.Screen" }],
+    entries: { "previews/pkg.Screen.semantics.json": enc("{}") },
+  };
+  assert.deepEqual([...capturedPreviewIds(bundle)], ["pkg.Screen"]);
+});
+
+test("bundleCapturedSemantics reports whether the best-effort semantics pass produced anything", () => {
+  const withSemantics = {
+    entries: { "previews/A.png": enc("png"), "previews/A.semantics.json": enc("{}") },
+  };
+  assert.equal(bundleCapturedSemantics(withSemantics), true);
+  // A failed daemon open leaves the pack exiting 0 with the PNGs but no semantics at all.
+  assert.equal(bundleCapturedSemantics({ entries: { "previews/A.png": enc("png") } }), false);
+  assert.equal(bundleCapturedSemantics({}), false);
 });

--- a/scripts/design-artifacts/bundle-previews.test.mjs
+++ b/scripts/design-artifacts/bundle-previews.test.mjs
@@ -1,7 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { candidatePreviewBundle, daemonPreviewIdsByFunction } from "./bundle-previews.mjs";
+import {
+  candidatePreviewBundle,
+  capturedPreviewIds,
+  daemonPreviewIdsByFunction,
+} from "./bundle-previews.mjs";
 
 const enc = (s) => new TextEncoder().encode(s);
 
@@ -98,4 +102,86 @@ test("daemonPreviewIdsByFunction folds a supplement, primary winning on a repeat
 test("daemonPreviewIdsByFunction falls back to the id when a preview names no function", () => {
   const ids = daemonPreviewIdsByFunction([{ previews: [{ id: "Bare" }] }]);
   assert.deepEqual(ids.get("Bare"), ["Bare"]);
+});
+
+// --- capturedPreviewIds: what came back at all, not what came back as a PNG ------------------
+
+test("capturedPreviewIds counts any per-preview artifact, not just a PNG", () => {
+  // The three PNG-less shapes are all legitimately captured: an animated GIF preview, a
+  // catalog-token sheet, and a `"capture": "none"` entry that still gets its semantics blob.
+  const bundle = {
+    previews: [
+      { id: "Card_Light" },
+      { id: "CardScrollGif" },
+      { id: "BrandDark_theme" },
+      { id: "HostedView_Light" },
+    ],
+    entries: {
+      "previews/Card_Light.png": enc("png"),
+      "previews/Card_Light.semantics.json": enc("{}"),
+      "previews/CardScrollGif.gif": enc("gif"),
+      "previews/BrandDark_theme.catalog.json": enc("{}"),
+      "previews/HostedView_Light.semantics.json": enc("{}"),
+    },
+  };
+  assert.deepEqual(
+    [...capturedPreviewIds(bundle)].sort(),
+    ["BrandDark_theme", "CardScrollGif", "Card_Light", "HostedView_Light"],
+  );
+});
+
+test("capturedPreviewIds omits a preview an exclusion skipped in both passes", () => {
+  // This is the m3-catalog#15 signature: `--exclude-preview-id` skips the render AND the semantics
+  // capture, so the preview is listed in the bundle with nothing at all under `previews/`.
+  const bundle = {
+    previews: [{ id: "Switch_On_Light" }, { id: "Switch_On_Light_VARIANT_off" }],
+    entries: {
+      "previews/Switch_On_Light.png": enc("png"),
+      "previews/Switch_On_Light.semantics.json": enc("{}"),
+    },
+  };
+  assert.deepEqual([...capturedPreviewIds(bundle)], ["Switch_On_Light"]);
+});
+
+test("capturedPreviewIds does not let a longer id claim a shorter one's artifact", () => {
+  // `previews/Switch_On_Light_VARIANT_off.png` starts with the base id, so a prefix match without
+  // the dot boundary would report the base as captured — exactly the substring confusion that
+  // caused the bug this check exists to catch.
+  const bundle = {
+    previews: [{ id: "Switch_On_Light" }, { id: "Switch_On_Light_VARIANT_off" }],
+    entries: { "previews/Switch_On_Light_VARIANT_off.png": enc("png") },
+  };
+  assert.deepEqual([...capturedPreviewIds(bundle)], ["Switch_On_Light_VARIANT_off"]);
+});
+
+test("capturedPreviewIds reports canonical discovery ids, not sanitized entry ids", () => {
+  // Bundles store filename-safe ids; shard plans are authored against the discovery id.
+  const bundle = {
+    previews: [{ id: "Chip_Large_Round" }],
+    entries: { "previews/Chip_Large_Round.png": enc("png") },
+    manifest: { previewIds: ["Chip_Large_Round"], rawPreviewIds: ["Chip_Large Round"] },
+  };
+  const rawIdFor = (b, entry) => {
+    const i = b.manifest.previewIds.indexOf(entry.id);
+    return i >= 0 ? b.manifest.rawPreviewIds[i] : entry.id;
+  };
+  assert.deepEqual([...capturedPreviewIds(bundle, rawIdFor)], ["Chip_Large Round"]);
+});
+
+test("capturedPreviewIds ignores entries outside previews/ and unknown ids", () => {
+  const bundle = {
+    previews: [{ id: "Card_Light" }],
+    entries: {
+      "previews/Card_Light.png": enc("png"),
+      "previews/Ghost_Light.png": enc("png"), // no matching previews.json entry
+      "classes/app.jar": enc("jar"),
+      "bundle.json": enc("{}"),
+    },
+  };
+  assert.deepEqual([...capturedPreviewIds(bundle)], ["Card_Light"]);
+});
+
+test("capturedPreviewIds is empty for a bundle with nothing in it", () => {
+  assert.equal(capturedPreviewIds({}).size, 0);
+  assert.equal(capturedPreviewIds(undefined).size, 0);
 });

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -70,6 +70,11 @@
  *    fewer previews than the others for no reason. Removing them first means the shards balance
  *    over the set that is actually going to render, and the deferral still applies within each.
  *
+ * Planning is only half of it. [verifyShardPlans] checks that the shards agreed on a disjoint
+ * cover — their *intent* — and [verifyShardRenders] checks what the merged bundle actually came back
+ * with, because a correct partition that renders nothing passes the first check and used to pass the
+ * whole run. See [verifyShardRenders] for the run that did exactly that.
+ *
  * One axis this cannot balance: a `@PreviewParameter` provider's rows. Discovery emits one id for
  * the parameterized function and the renderer expands the rows later, so such a preview travels
  * whole — it lands in one shard carrying however many rows it expands to. That is correct (the rows
@@ -317,6 +322,66 @@ export function verifyShardPlans(plans) {
     );
   }
   return { ok: problems.length === 0, problems };
+}
+
+/**
+ * Cross-check what the shards actually **captured** against what they planned to render, after the
+ * merge and before anything downstream trusts the bundle.
+ *
+ * [verifyShardPlans] checks the shards' *intent*: it reads the plans they uploaded and confirms they
+ * form a disjoint cover of one agreed discovery set. That is a check of the partition, and it passes
+ * whether or not a single preview came back. The failure this repo actually shipped lived entirely
+ * on the other side of it — m3-catalog run 31217598543 partitioned 1095 previews correctly across
+ * six shards, printed `6 shard(s) cover 1095 preview(s) exactly once`, and merged 267 of them,
+ * because each shard's unanchored exclusion list also deleted the `_VARIANT_` fan-out of every id it
+ * excluded. **The run was green.** The loss surfaced only as a downstream warning about previews
+ * with no static PNG, which reads like a catalogue of PNG-less sheets rather than three quarters of
+ * a render going missing.
+ *
+ * Anchoring the exclusions (#3561) fixed that cause. This closes the *silence*, which is the part
+ * that made it expensive: any future path that drops a shard's work — a matcher regression, a
+ * mis-emitted pattern, a render that half-failed without failing the step — now fails the run
+ * naming the shard and the ids, instead of publishing a thinner catalog on a green tick.
+ *
+ * The comparison is only meaningful because [capturedIds] means "came back with *some* artifact",
+ * not "came back with a PNG" — see `capturedPreviewIds` in `bundle-previews.mjs` for why a
+ * PNG-based check would flag every animated capture and token sheet as a loss.
+ *
+ * Extra ids are not a problem and are not reported: a merged bundle legitimately carries the whole
+ * discovery set (exclusion leaves previews listed), and a shard rendering *more* than its share
+ * costs time, not stickers.
+ *
+ * @param {Array<{index: number, previews: string[]}>} plans the uploaded per-shard plans.
+ * @param {Iterable<string>} capturedIds ids the merged bundle captured.
+ * @returns {{ok: boolean, problems: string[], missing: Array<{id: string, shard: number}>}}
+ *   `missing` is sorted by shard then id; `problems` is empty iff every planned id came back.
+ */
+export function verifyShardRenders(plans, capturedIds) {
+  const captured = new Set(capturedIds ?? []);
+  const missing = [];
+  for (const plan of [...(plans ?? [])].sort((a, b) => (a?.index ?? 0) - (b?.index ?? 0))) {
+    for (const id of [...(plan?.previews ?? [])].sort()) {
+      if (!captured.has(id)) missing.push({ id, shard: plan?.index ?? 0 });
+    }
+  }
+  if (missing.length === 0) return { ok: true, problems: [], missing };
+
+  const planned = (plans ?? []).reduce((n, p) => n + (p?.previews?.length ?? 0), 0);
+  const byShard = new Map();
+  for (const { id, shard } of missing) byShard.set(shard, [...(byShard.get(shard) ?? []), id]);
+  const problems = [
+    `${missing.length} of ${planned} planned preview(s) came back with no artifact at all`,
+    ...[...byShard.entries()]
+      .sort((a, b) => a[0] - b[0])
+      // Naming a few ids per shard is what turns this from "something went wrong" into a lead; the
+      // full list is the plan file, which the run already uploaded.
+      .map(([shard, ids]) => {
+        const shown = ids.slice(0, 5).join(", ");
+        return `shard ${shard} planned ${ids.length} preview(s) that were never captured: ${shown}` +
+          (ids.length > 5 ? `, … (+${ids.length - 5} more)` : "");
+      }),
+  ];
+  return { ok: false, problems, missing };
 }
 
 // --- CLI ----------------------------------------------------------------------

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -347,16 +347,29 @@ export function verifyShardPlans(plans) {
  * not "came back with a PNG" — see `capturedPreviewIds` in `bundle-previews.mjs` for why a
  * PNG-based check would flag every animated capture and token sheet as a loss.
  *
+ * **[semanticsRan] is what keeps that reading honest.** The "any artifact" signal leans on the
+ * semantics pass to give a raster-less preview *something*, and that pass is best-effort: a missing
+ * daemon descriptor, a session that would not open, or an empty capture all leave `bundle pack`
+ * exiting 0 with no `.semantics.json` anywhere. A catalog holding a legitimately raster-less preview
+ * would then look exactly like one whose shards ate their own work, and this gate would fail a run
+ * for a reason that has nothing to do with sharding. So when the caller reports the semantics pass
+ * produced nothing (`bundleCapturedSemantics`), the answer is "cannot tell", not "lost": the check
+ * passes with the reason recorded in [notes]. It has no teeth in that state, and pretending
+ * otherwise would spend the operator's trust on a false alarm — the very thing that made the
+ * original bug expensive.
+ *
  * Extra ids are not a problem and are not reported: a merged bundle legitimately carries the whole
  * discovery set (exclusion leaves previews listed), and a shard rendering *more* than its share
  * costs time, not stickers.
  *
  * @param {Array<{index: number, previews: string[]}>} plans the uploaded per-shard plans.
  * @param {Iterable<string>} capturedIds ids the merged bundle captured.
- * @returns {{ok: boolean, problems: string[], missing: Array<{id: string, shard: number}>}}
- *   `missing` is sorted by shard then id; `problems` is empty iff every planned id came back.
+ * @param {{semanticsRan?: boolean}} [opts] `semanticsRan: false` disarms the check — see above.
+ * @returns {{ok: boolean, problems: string[], notes: string[],
+ *   missing: Array<{id: string, shard: number}>}} `missing` is sorted by shard then id; `problems`
+ *   is empty iff every planned id came back or the check declined to judge.
  */
-export function verifyShardRenders(plans, capturedIds) {
+export function verifyShardRenders(plans, capturedIds, { semanticsRan = true } = {}) {
   const captured = new Set(capturedIds ?? []);
   const missing = [];
   for (const plan of [...(plans ?? [])].sort((a, b) => (a?.index ?? 0) - (b?.index ?? 0))) {
@@ -364,7 +377,20 @@ export function verifyShardRenders(plans, capturedIds) {
       if (!captured.has(id)) missing.push({ id, shard: plan?.index ?? 0 });
     }
   }
-  if (missing.length === 0) return { ok: true, problems: [], missing };
+  if (missing.length === 0) return { ok: true, problems: [], notes: [], missing };
+  if (!semanticsRan) {
+    return {
+      ok: true,
+      problems: [],
+      notes: [
+        `${missing.length} planned preview(s) came back with no artifact, but the bundle carries no ` +
+          `semantics at all — the capture pass produced nothing, so a preview that is raster-less by ` +
+          `design is indistinguishable from one an exclusion ate. Not judging. Fix the semantics ` +
+          `capture (see the pack's own warning) to restore this check.`,
+      ],
+      missing,
+    };
+  }
 
   const planned = (plans ?? []).reduce((n, p) => n + (p?.previews?.length ?? 0), 0);
   const byShard = new Map();
@@ -381,7 +407,11 @@ export function verifyShardRenders(plans, capturedIds) {
           (ids.length > 5 ? `, … (+${ids.length - 5} more)` : "");
       }),
   ];
-  return { ok: false, problems, missing };
+  problems.push(
+    "if the semantics capture also failed for exactly these previews, that — not sharding — is the " +
+      "cause; the pack step's own warnings say which.",
+  );
+  return { ok: false, problems, notes: [], missing };
 }
 
 // --- CLI ----------------------------------------------------------------------

--- a/scripts/design-artifacts/shard-preview-ids.test.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.test.mjs
@@ -405,3 +405,28 @@ test("verifyShardRenders is vacuously satisfied by a no-op shard", () => {
   // More shards than previews: the extra shard uploads a plan with an empty partition.
   assert.ok(verifyShardRenders([{ index: 1, previews: ["a"] }, { index: 2, previews: [] }], ["a"]).ok);
 });
+
+test("verifyShardRenders declines to judge when the semantics pass produced nothing", () => {
+  // `--with-semantics` is best-effort: a failed daemon open leaves the pack exiting 0 with no
+  // semantics anywhere, so a raster-less preview has no artifact for a reason that is not sharding.
+  // Failing there would spend the operator's trust on a false alarm.
+  const plans = plansFor(["a", "b", "c", "d"], 2);
+  const { ok, problems, notes, missing } = verifyShardRenders(plans, ["a", "b"], {
+    semanticsRan: false,
+  });
+  assert.ok(ok, "the run is not failed");
+  assert.deepEqual(problems, []);
+  assert.equal(missing.length, 2, "the shortfall is still reported for the caller to log");
+  assert.match(notes.join("\n"), /carries no semantics at all/);
+});
+
+test("verifyShardRenders keeps its teeth once semantics did run", () => {
+  const plans = plansFor(["a", "b", "c", "d"], 2);
+  assert.equal(verifyShardRenders(plans, ["a", "b"], { semanticsRan: true }).ok, false);
+  assert.equal(verifyShardRenders(plans, ["a", "b"]).ok, false, "defaults to armed");
+});
+
+test("verifyShardRenders names the semantics pass as the rival explanation", () => {
+  const { problems } = verifyShardRenders([{ index: 1, previews: ["a"] }], []);
+  assert.match(problems.at(-1), /if the semantics capture also failed for exactly these previews/);
+});

--- a/scripts/design-artifacts/shard-preview-ids.test.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.test.mjs
@@ -10,6 +10,7 @@ import {
   renderableDigest,
   shardRenderPlan,
   verifyShardPlans,
+  verifyShardRenders,
 } from "./shard-preview-ids.mjs";
 
 const preview = (id) => ({ id, functionName: id.replace(/_(Light|Dark)$/, "") });
@@ -341,4 +342,66 @@ test("the plan's previews stay PLAIN ids while its exclusions are patterns", () 
     verifyShardPlans(plan.shards.map((s) => ({ ...s, total: plan.total, renderable: plan.renderable, digest: plan.digest }))),
     { ok: true, problems: [] },
   );
+});
+
+// --- the OUTCOME check: what the shards actually captured --------------------------------------
+
+test("verifyShardRenders accepts a merge in which every planned preview came back", () => {
+  const plans = plansFor(["a", "b", "c", "d"], 2);
+  const { ok, problems, missing } = verifyShardRenders(plans, ["a", "b", "c", "d"]);
+  assert.deepEqual(problems, []);
+  assert.deepEqual(missing, []);
+  assert.ok(ok);
+});
+
+test("verifyShardRenders catches the loss the plan check passes", () => {
+  // The m3-catalog#15 shape: the partition is a perfect disjoint cover — `verifyShardPlans` is
+  // happy — and the shards' unanchored exclusions ate the variants anyway.
+  const ids = ["Switch_Light", "Switch_Light_VARIANT_off", "Card_Light", "Card_Light_VARIANT_alt"];
+  const plans = plansFor(ids, 2);
+  assert.ok(verifyShardPlans(plans).ok, "the plans themselves are fine");
+
+  const { ok, problems, missing } = verifyShardRenders(plans, ["Card_Light", "Switch_Light"]);
+  assert.equal(ok, false);
+  assert.deepEqual(missing.map((m) => m.id).sort(), [
+    "Card_Light_VARIANT_alt",
+    "Switch_Light_VARIANT_off",
+  ]);
+  assert.match(problems[0], /2 of 4 planned preview\(s\) came back with no artifact at all/);
+  assert.match(
+    problems.join("\n"),
+    /shard 2 planned 2 preview\(s\) that were never captured: Card_Light_VARIANT_alt, Switch_Light_VARIANT_off/,
+  );
+});
+
+test("verifyShardRenders attributes each missing id to the shard that planned it", () => {
+  const plans = [
+    { index: 1, previews: ["a", "c"] },
+    { index: 2, previews: ["b", "d"] },
+  ];
+  const { missing } = verifyShardRenders(plans, ["a"]);
+  assert.deepEqual(missing, [
+    { id: "c", shard: 1 },
+    { id: "b", shard: 2 },
+    { id: "d", shard: 2 },
+  ]);
+});
+
+test("verifyShardRenders truncates a long id list but reports the true count", () => {
+  const ids = Array.from({ length: 9 }, (_, i) => `P${i}`);
+  const { problems } = verifyShardRenders([{ index: 1, previews: ids }], []);
+  assert.match(problems[1], /P0, P1, P2, P3, P4, … \(\+4 more\)/);
+  assert.match(problems[1], /planned 9 preview\(s\)/);
+});
+
+test("verifyShardRenders ignores extra captures — a merged bundle carries the whole set", () => {
+  // Exclusion leaves excluded previews listed, and a shard rendering more than its share costs
+  // time, not stickers. Only a shortfall is a failure.
+  const plans = plansFor(["a", "b"], 2);
+  assert.ok(verifyShardRenders(plans, ["a", "b", "deferred_Dark", "z"]).ok);
+});
+
+test("verifyShardRenders is vacuously satisfied by a no-op shard", () => {
+  // More shards than previews: the extra shard uploads a plan with an empty partition.
+  assert.ok(verifyShardRenders([{ index: 1, previews: ["a"] }, { index: 2, previews: [] }], ["a"]).ok);
 });

--- a/scripts/design-artifacts/verify-shard-renders.mjs
+++ b/scripts/design-artifacts/verify-shard-renders.mjs
@@ -25,7 +25,7 @@ import { parseArgs } from "node:util";
 
 import { readPreviewBundle, rawPreviewIdForEntry } from "@design-parity/candidate";
 
-import { capturedPreviewIds } from "./bundle-previews.mjs";
+import { bundleCapturedSemantics, capturedPreviewIds } from "./bundle-previews.mjs";
 import { verifyShardRenders } from "./shard-preview-ids.mjs";
 
 const { values, positionals } = parseArgs({
@@ -43,7 +43,15 @@ if (!values.bundle || positionals.length === 0) {
 const plans = positionals.map((file) => JSON.parse(readFileSync(file, "utf8")));
 const bundle = await readPreviewBundle(values.bundle);
 const captured = capturedPreviewIds(bundle, rawPreviewIdForEntry);
-const { ok, problems } = verifyShardRenders(plans, captured);
+// `--with-semantics` is best-effort: a failed daemon open leaves the pack exiting 0 with no
+// semantics anywhere, and a raster-less preview then has no artifact for a reason that is not
+// sharding. Tell the check, so it declines to judge rather than crying wolf.
+const semanticsRan = bundleCapturedSemantics(bundle);
+const { ok, problems, notes } = verifyShardRenders(plans, captured, { semanticsRan });
+
+for (const note of notes) {
+  console.error(`::warning title=Shard render check disarmed::verify-shard-renders: ${note}`);
+}
 
 if (!ok) {
   for (const problem of problems) {
@@ -60,7 +68,9 @@ if (!ok) {
 }
 
 const planned = plans.reduce((n, p) => n + (p?.previews?.length ?? 0), 0);
-console.error(
-  `verify-shard-renders: all ${planned} preview(s) the ${plans.length} shard(s) planned came back ` +
-    `in the merged bundle`,
-);
+if (notes.length === 0) {
+  console.error(
+    `verify-shard-renders: all ${planned} preview(s) the ${plans.length} shard(s) planned came ` +
+      `back in the merged bundle`,
+  );
+}

--- a/scripts/design-artifacts/verify-shard-renders.mjs
+++ b/scripts/design-artifacts/verify-shard-renders.mjs
@@ -1,0 +1,66 @@
+/**
+ * Fail a sharded render that lost work, at the point the loss is still attributable.
+ *
+ * Run after `compose-preview bundle merge`, before the catalog is generated:
+ *
+ *   node verify-shard-renders.mjs --bundle bundle.png shard-plan-1.json shard-plan-2.json …
+ *
+ * `shard-preview-ids.mjs --verify` already cross-checks the shards' *plans* — same discovered set,
+ * pairwise disjoint, complete cover. This checks the *outcome*, which is a different question and
+ * the one that went unasked: m3-catalog run 31217598543 passed the plan check (`6 shard(s) cover
+ * 1095 preview(s) exactly once`) and merged 267 of those 1095, because each shard's unanchored
+ * exclusion list also deleted the `_VARIANT_` fan-out of every id it excluded (m3-catalog#15). The
+ * anchored `=<id>` form (#3561) fixed that cause; nothing yet noticed the effect, and the run was
+ * green.
+ *
+ * The glue is thin on purpose — both halves it composes are pure and unit-tested without an
+ * `npm ci` (`capturedPreviewIds` in `bundle-previews.mjs`, `verifyShardRenders` in
+ * `shard-preview-ids.mjs`). Only the bundle read needs the export engine, which is why this lives in
+ * its own file rather than as another mode on `shard-preview-ids.mjs`: that module is deliberately
+ * dependency-free so a shard job can run it without installing anything.
+ */
+
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+import { readPreviewBundle, rawPreviewIdForEntry } from "@design-parity/candidate";
+
+import { capturedPreviewIds } from "./bundle-previews.mjs";
+import { verifyShardRenders } from "./shard-preview-ids.mjs";
+
+const { values, positionals } = parseArgs({
+  allowPositionals: true,
+  options: { bundle: { type: "string" } },
+});
+
+if (!values.bundle || positionals.length === 0) {
+  console.error(
+    "usage: verify-shard-renders.mjs --bundle <merged-bundle.png> <shard-plan.json>…",
+  );
+  process.exit(2);
+}
+
+const plans = positionals.map((file) => JSON.parse(readFileSync(file, "utf8")));
+const bundle = await readPreviewBundle(values.bundle);
+const captured = capturedPreviewIds(bundle, rawPreviewIdForEntry);
+const { ok, problems } = verifyShardRenders(plans, captured);
+
+if (!ok) {
+  for (const problem of problems) {
+    console.error(`verify-shard-renders: ${problem}`);
+  }
+  console.error(
+    "verify-shard-renders: refusing to publish — the merged bundle is missing previews the shards " +
+      "were assigned. A preview skipped by `--exclude-preview-id` comes back with no artifact at " +
+      "all, so this is what an over-matching exclusion looks like: check that every emitted " +
+      "exclusion is `=`-anchored and that the CLI is new enough to honour the anchor. Re-run with " +
+      "`render-shards: 1` to publish while that is diagnosed.",
+  );
+  process.exit(1);
+}
+
+const planned = plans.reduce((n, p) => n + (p?.previews?.length ?? 0), 0);
+console.error(
+  `verify-shard-renders: all ${planned} preview(s) the ${plans.length} shard(s) planned came back ` +
+    `in the merged bundle`,
+);


### PR DESCRIPTION
Closes the second half of [yschimke/m3-catalog#15](https://github.com/yschimke/m3-catalog/issues/15).

## The gap

The shards' **plans** were cross-checked; their **output** never was. `shard-preview-ids.mjs --verify` confirms the partitions form a disjoint cover of one agreed discovery set — that is a check of *intent*, and it passes whether or not a single preview came back.

m3-catalog run [31217598543](https://github.com/yschimke/m3-catalog/actions/runs/31217598543) lived exactly in that gap: 1095 previews partitioned correctly across six shards, `6 shard(s) cover 1095 preview(s) exactly once` printed, **267 merged**, and a green run — because each shard's exclusion list was unanchored, and a base id is a substring of its own `_VARIANT_` ids, so every shard also deleted the variants it was itself assigned. The loss reached the operator as a downstream warning about previews with no static PNG, which reads like a list of token sheets rather than three quarters of a render.

Anchored `=<id>` exclusions (#3561, emitted since #3570) fixed the **cause**. This closes the **silence** — the part that made it expensive.

## What changed

- **`verify-shard-renders.mjs`** (new) — runs in the merge step, after `bundle merge`. Compares the merged bundle back against the uploaded shard plans and fails the run naming the shard and its missing ids.
- **`verifyShardRenders(plans, capturedIds)`** in `shard-preview-ids.mjs` — the pure comparison. Reports a shortfall only; extra ids are fine (exclusion leaves previews *listed*, and a shard rendering more than its share costs time, not stickers).
- **`capturedPreviewIds(bundle, rawIdFor)`** in `bundle-previews.mjs` — the pure "what came back" side.
- Workflow + `DESIGN_CATALOGS.md` updated to describe the plan check and the outcome check as the two separate questions they are.

**Why "any artifact" and not "a PNG".** A PNG check would flag every animated `ScrollMode.GIF` capture, every `@ColorCatalog` / `@ThemeCatalog` sheet and every `"capture": "none"` entry as a loss — all of those are PNG-less by design. An *excluded* preview, by contrast, is skipped in the render **and** the semantics pass, so it comes back with nothing at all under `previews/`. That asymmetry is what makes the signal precise.

**Why a separate CLI.** `shard-preview-ids.mjs` is deliberately dependency-free so a shard job can run it without an `npm ci`. Only the bundle read needs the export engine, so the npm-dependent glue is its own thin file; both halves it composes are pure and unit-tested.

## Test plan

- `npm test` in `scripts/design-artifacts` — 695 tests pass (0 fail), including 12 new cases covering the m3-catalog#15 shape (a plan check that passes while the variants are gone), per-shard attribution, id truncation, sanitized→canonical id mapping, and the boundary case where a longer id must not claim a shorter one's artifact.
- End-to-end against a real bundle read (`readPreviewBundle` over a synthesized polyglot):
  - variants missing → exit 1, `2 of 4 planned preview(s) came back with no artifact at all` / `shard 2 planned 2 preview(s) that were never captured: Card_Light_VARIANT_alt, Switch_Light_VARIANT_off`
  - all present → exit 0, `all 4 preview(s) the 2 shard(s) planned came back in the merged bundle`
- No CI shard run exercises this today (every catalog ships `render-shards: 1`); the check is inert at N=1, where the merge job does not run at all.

Text-only change — build wiring and export-driver plumbing, no rendered surface touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_013SXmsUZoyNYEyhMFa4FS9e)_