### PR TITLE
Publish and surface parity issue index

### DIFF
--- a/.github/actions/apply/lib/push-branch.sh
+++ b/.github/actions/apply/lib/push-branch.sh
@@ -14,6 +14,11 @@
 #   SHA_OUTPUT_FILE      — path (absolute) to write the pushed commit
 #                          SHA to. Empty = don't write.
 #   MAX_ATTEMPTS         — push race retry budget. Default 5.
+#   CARRY_FORWARD_PATHS  — whitespace-separated paths the fetched tip owns. On every retry their
+#                          tip versions replace the working tree versions (render publisher mode).
+#   DELTA_ON_TIP_PATHS   — whitespace-separated paths this invocation owns. On every retry start
+#                          from the fetched tip and replace only these paths (index publisher mode).
+#   REMOTE_URL           — test seam; defaults to the authenticated GitHub repository URL.
 #
 # Exits 0 on success / skip, non-zero on push failure.
 set -euo pipefail
@@ -25,15 +30,63 @@ set -euo pipefail
 SKIP_IF_UNCHANGED="${SKIP_IF_UNCHANGED:-0}"
 SHA_OUTPUT_FILE="${SHA_OUTPUT_FILE:-}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
+CARRY_FORWARD_PATHS="${CARRY_FORWARD_PATHS:-}"
+DELTA_ON_TIP_PATHS="${DELTA_ON_TIP_PATHS:-}"
+
+if [ -n "$CARRY_FORWARD_PATHS" ] && [ -n "$DELTA_ON_TIP_PATHS" ]; then
+  echo "CARRY_FORWARD_PATHS and DELTA_ON_TIP_PATHS are mutually exclusive." >&2
+  exit 2
+fi
+
+validate_owned_paths() {
+  for path in $1; do
+    case "$path" in
+      /*|../*|*/../*|*/..) echo "Unsafe owned path: $path" >&2; exit 2 ;;
+    esac
+  done
+}
+validate_owned_paths "$CARRY_FORWARD_PATHS"
+validate_owned_paths "$DELTA_ON_TIP_PATHS"
 
 git init -q
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git remote add origin \
-  "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git"
+REMOTE_URL="${REMOTE_URL:-https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git}"
+git remote add origin "$REMOTE_URL"
 
 git add -A
 TREE=$(git write-tree)
+
+# Build the race winner's candidate tree without merging unrelated working-directory content.
+# `git read-tree` resets only the index; the caller's files remain available for diagnostics.
+tree_for_parent() {
+  parent="$1"
+  if [ -n "$DELTA_ON_TIP_PATHS" ] && [ -n "$parent" ]; then
+    git read-tree "$parent"
+    for path in $DELTA_ON_TIP_PATHS; do
+      if git cat-file -e "${TREE}:${path}" 2>/dev/null; then
+        git restore --source="$TREE" --staged -- "$path"
+      else
+        git rm -q --cached --ignore-unmatch -- "$path"
+      fi
+    done
+    git write-tree
+    return
+  fi
+  if [ -n "$CARRY_FORWARD_PATHS" ] && [ -n "$parent" ]; then
+    git read-tree "$TREE"
+    for path in $CARRY_FORWARD_PATHS; do
+      if git cat-file -e "${parent}:${path}" 2>/dev/null; then
+        git restore --source="$parent" --staged -- "$path"
+      else
+        git rm -q --cached --ignore-unmatch -- "$path"
+      fi
+    done
+    git write-tree
+    return
+  fi
+  echo "$TREE"
+}
 
 # Retry loop handles the push race when two PRs finish concurrently
 # against the same shared branch. Per-PR concurrency in the workflow
@@ -46,7 +99,10 @@ while :; do
   if git fetch --depth=1 --quiet origin "$TARGET_BRANCH" 2>/dev/null; then
     PARENT=$(git rev-parse FETCH_HEAD)
     PARENT_TREE=$(git rev-parse "${PARENT}^{tree}")
-    if [ "$SKIP_IF_UNCHANGED" = "1" ] && [ "$TREE" = "$PARENT_TREE" ]; then
+  fi
+  CANDIDATE_TREE=$(tree_for_parent "$PARENT")
+  if [ -n "$PARENT" ]; then
+    if [ "$SKIP_IF_UNCHANGED" = "1" ] && [ "$CANDIDATE_TREE" = "$PARENT_TREE" ]; then
       echo "Tree unchanged vs ${TARGET_BRANCH}; skipping push."
       if [ -n "$SHA_OUTPUT_FILE" ]; then
         : > "$SHA_OUTPUT_FILE"
@@ -56,10 +112,10 @@ while :; do
   fi
 
   if [ -n "$PARENT" ]; then
-    COMMIT=$(git commit-tree "$TREE" -p "$PARENT" -m "$MSG")
+    COMMIT=$(git commit-tree "$CANDIDATE_TREE" -p "$PARENT" -m "$MSG")
   else
     # First push ever for this branch — orphan commit.
-    COMMIT=$(git commit-tree "$TREE" -m "$MSG")
+    COMMIT=$(git commit-tree "$CANDIDATE_TREE" -m "$MSG")
   fi
 
   if git push --quiet origin "${COMMIT}:refs/heads/${TARGET_BRANCH}" 2>&1; then

--- a/.github/actions/apply/lib/test-push-branch.sh
+++ b/.github/actions/apply/lib/test-push-branch.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+HELPER=$(cd "$(dirname "$0")" && pwd)/push-branch.sh
+REMOTE="$ROOT/remote.git"
+git init -q --bare "$REMOTE"
+
+publish() {
+  work="$1"
+  mode="$2"
+  (
+    cd "$work"
+    env TARGET_BRANCH=design-artifacts/m3 REPO=local/test GITHUB_TOKEN_INLINE=test \
+      MSG=test REMOTE_URL="$REMOTE" "$mode"=parity/issues.json "$HELPER"
+  )
+}
+
+seed="$ROOT/seed"
+mkdir -p "$seed/parity"
+printf 'render-v1\n' > "$seed/render.txt"
+printf 'issues-old\n' > "$seed/parity/issues.json"
+publish "$seed" DELTA_ON_TIP_PATHS
+
+assert_tip() {
+  expected_render="$1"
+  expected_issues="$2"
+  check="$ROOT/check-$RANDOM"
+  git clone -q --branch design-artifacts/m3 "$REMOTE" "$check"
+  test "$(cat "$check/render.txt")" = "$expected_render"
+  test "$(cat "$check/parity/issues.json")" = "$expected_issues"
+}
+
+prepare() {
+  name="$1"
+  dir="$ROOT/$name"
+  git clone -q --branch design-artifacts/m3 "$REMOTE" "$dir"
+  git -C "$dir" remote remove origin
+  printf '%s\n' "$dir"
+}
+
+# Index lands first; the stale render publisher retries and carries the newer index forward.
+render=$(prepare render-first-order)
+index=$(prepare index-first-order)
+printf 'render-v2\n' > "$render/render.txt"
+printf 'issues-new\n' > "$index/parity/issues.json"
+publish "$index" DELTA_ON_TIP_PATHS
+publish "$render" CARRY_FORWARD_PATHS
+assert_tip render-v2 issues-new
+
+# Reverse the ordering: the stale index publisher changes only its owned path on the new tip.
+render=$(prepare render-second-order)
+index=$(prepare index-second-order)
+printf 'render-v3\n' > "$render/render.txt"
+printf 'issues-newer\n' > "$index/parity/issues.json"
+publish "$render" CARRY_FORWARD_PATHS
+publish "$index" DELTA_ON_TIP_PATHS
+assert_tip render-v3 issues-newer
+
+echo "push-branch race tests passed"

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1393,6 +1393,7 @@ jobs:
           GITHUB_TOKEN_INLINE="$GH_TOKEN" \
           MSG="chore(design-artifacts): regenerate ${SYSTEM} catalog ($(date -u +%F), ${SOURCE_SHA})" \
           SKIP_IF_UNCHANGED=1 \
+          CARRY_FORWARD_PATHS='parity/issues.json' \
           GIT_AUTHOR_NAME='${{ inputs.commit-user-name }}' \
           GIT_AUTHOR_EMAIL='${{ inputs.commit-user-email }}' \
           GIT_COMMITTER_NAME='${{ inputs.commit-user-name }}' \

--- a/.github/workflows/parity-issues-reusable.yml
+++ b/.github/workflows/parity-issues-reusable.yml
@@ -1,0 +1,78 @@
+name: Publish parity issue index
+
+on:
+  workflow_call:
+    inputs:
+      system:
+        description: Catalog slug; publishes to design-artifacts/<system>.
+        required: true
+        type: string
+      repositories:
+        description: JSON array of owner/name repositories whose issues carry locator blocks.
+        required: true
+        type: string
+      driver-ref:
+        description: compose-ai-tools ref providing the producer and push helper.
+        default: main
+        type: string
+    secrets:
+      ISSUES_TOKEN:
+        description: Optional token with Issues read access to every configured repository.
+        required: false
+  workflow_dispatch:
+    inputs:
+      system:
+        required: true
+        type: string
+      repositories:
+        description: JSON array of owner/name repositories.
+        required: true
+        type: string
+      driver-ref:
+        default: main
+        type: string
+
+permissions:
+  contents: write
+  issues: read
+
+concurrency:
+  group: ${{ github.repository }}-${{ inputs.system }}-parity-issues
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out issue-index driver
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: yschimke/compose-ai-tools
+          ref: ${{ inputs.driver-ref }}
+          path: compose-ai-tools
+
+      - name: Generate parity/issues.json
+        env:
+          GH_TOKEN: ${{ secrets.ISSUES_TOKEN || github.token }}
+          REPOSITORIES: ${{ inputs.repositories }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          args=()
+          while IFS= read -r repo; do
+            args+=(--repo "$repo")
+          done < <(jq -er '.[]' <<<"$REPOSITORIES")
+          node compose-ai-tools/scripts/design-artifacts/emit-parity-issues.mjs \
+            --out out "${args[@]}"
+
+      - name: Publish the one-path delta
+        env:
+          TARGET_BRANCH: design-artifacts/${{ inputs.system }}
+          REPO: ${{ github.repository }}
+          GITHUB_TOKEN_INLINE: ${{ github.token }}
+          MSG: "chore(parity): refresh ${{ inputs.system }} issue index"
+          DELTA_ON_TIP_PATHS: parity/issues.json
+        run: |
+          set -euo pipefail
+          cd out
+          bash "$GITHUB_WORKSPACE/compose-ai-tools/.github/actions/apply/lib/push-branch.sh"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -195,6 +195,10 @@ class ServeBundleHost(
 
   override fun parityActivity(): ParityActivity? = parityActivity
 
+  private val parityIssues = ServeParityIssuesStore.load(bundleDir, fileSystem)
+
+  override fun parityIssues(): ParityIssues? = parityIssues
+
   private val annotations = ServeAnnotationStore.load(bundleDir, fileSystem)
 
   override fun annotationsForPreview(previewId: String): List<DesignAnnotation> =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -183,6 +183,10 @@ class ServeCatalogLiveHost(
   override fun tagIndexForPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
     baked.tagIndexForPreview(previewId)
 
+  override fun parityActivity(): ParityActivity? = baked.parityActivity()
+
+  override fun parityIssues(): ParityIssues? = baked.parityIssues()
+
   // The catalog's published player comparison rides the baked staging dir, so it stays reachable
   // when a live daemon fronts this session.
   override fun rcCompare(): RcCompareManifest? = baked.rcCompare()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -546,6 +546,7 @@ class ServeCatalogStore(
     writeAnnotations(base, staging)
     writeTagIndex(base, staging)
     writeParityActivity(base, staging)
+    writeParityIssues(base, staging)
     writeDesignPages(base, staging)
 
     // The staged catalog is usable — atomically replace the live dir with it. The delete + rename
@@ -1594,6 +1595,20 @@ class ServeCatalogStore(
     dir.mkdirs()
     File(dir, ParityActivity.FILE)
       .writeText(json.encodeToString(ParityActivity.serializer(), activity))
+  }
+
+  /** Stage the validated GitHub issue snapshot published beside the parity activity feed. */
+  private fun writeParityIssues(base: String, staging: File) {
+    val bytes =
+      runCatching { fetchCatalogAsset("$base${ParityIssues.DIRECTORY}/${ParityIssues.FILE}") }
+        .getOrNull() ?: return
+    val issues =
+      runCatching { json.decodeFromString(ParityIssues.serializer(), bytes.decodeToString()) }
+        .getOrNull()
+        ?.let { ServeParityIssuesStore.sanitize(it) } ?: return
+    val dir = File(staging, ParityIssues.DIRECTORY)
+    dir.mkdirs()
+    File(dir, ParityIssues.FILE).writeText(json.encodeToString(ParityIssues.serializer(), issues))
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -69,6 +69,9 @@ interface ServeHost : AutoCloseable {
    */
   fun parityActivity(): ParityActivity? = null
 
+  /** The validated GitHub issue snapshot this catalog published. */
+  fun parityIssues(): ParityIssues? = null
+
   /**
    * The app's declared `@ThemeCatalog` themes — module-global, so the viewer's Theme selector can
    * offer "render this preview under Brand Dark". Non-empty only for a daemon-backed host

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1906,7 +1906,9 @@ class ServeHttpServer(
           // Same condition `handleParity` serves on, so the link never leads to that route's 404.
           hasParityView =
             renderHost.parityActivity() != null ||
+              renderHost.parityIssues() != null ||
               renderHost.previews.any { renderHost.designReferencesFor(it.id).isNotEmpty() },
+          parityIssues = renderHost.parityIssues()?.issues.orEmpty(),
           // Same condition `handleDesignPageIndex` serves on, for the same reason. Listed by name
           // in the navigation tree, so the landing has to know what they are called, not just how
           // many there are.
@@ -2163,7 +2165,8 @@ class ServeHttpServer(
       val activity = renderHost.parityActivity()
       val hasReference = { id: String -> renderHost.designReferencesFor(id).isNotEmpty() }
       val mapped = renderHost.previews.any { hasReference(it.id) }
-      if (activity == null && !mapped) {
+      val issues = renderHost.parityIssues()?.issues.orEmpty()
+      if (activity == null && !mapped && issues.isEmpty()) {
         if (json) call.respond(HttpStatusCode.NotFound)
         else
           respondNotFoundHtml(
@@ -2181,7 +2184,7 @@ class ServeHttpServer(
       if (json) {
         markGeneration("parity", pageCacheControl())
         call.respondText(
-          JSON.encodeToString(ParityResponse.serializer(), ParityResponse.of(dashboard)),
+          JSON.encodeToString(ParityResponse.serializer(), ParityResponse.of(dashboard, issues)),
           ContentType.Application.Json,
         )
         return@withLeasedSession
@@ -2201,6 +2204,7 @@ class ServeHttpServer(
           version = BUNDLE_VERSION,
           displayTitle = catalogBundleHost(renderHost)?.title,
           hasReferenceFor = hasReference,
+          parityIssues = issues,
           // Same derivation the landing uses to label its "compare to Figma" action, so the page a
           // visitor arrives on names the tool the same way the link that brought them here did.
           designToolLabel =
@@ -2541,6 +2545,12 @@ class ServeHttpServer(
             if (pinned) emptyList() else renderHost.annotationsForReference(reference.id),
           actualAnnotations =
             if (pinned) emptyList() else renderHost.annotationsForPreview(previewId),
+          parityIssues =
+            renderHost.parityIssues()?.issues.orEmpty().filter { issue ->
+              preview.id in issue.previewIds ||
+                reference.id in issue.referenceIds ||
+                (preview.componentId != null && issue.component == preview.componentId)
+            },
           revisions = revisions,
           overrides = overrideParams,
           reportIssue = reportIssue,
@@ -4595,6 +4605,11 @@ class ServeHttpServer(
           historyInlineJson = localHistoryJson,
           historyLocalRenders = localHistoryJson != null,
           revisions = revisions,
+          parityIssues =
+            renderHost.parityIssues()?.issues.orEmpty().filter { issue ->
+              preview.id in issue.previewIds ||
+                (preview.componentId != null && issue.component == preview.componentId)
+            },
           // A top-level site's pages carry their session in the ORIGIN, so same-session links
           // drop the `?session=` the rooted legacy form would add. See [ServeSites].
           sessionInOrigin = siteSystem() != null,
@@ -6411,9 +6426,14 @@ private data class ParityResponse(
   val drift: List<ParityDriftDto> = emptyList(),
   val activity: List<ParityEventDto> = emptyList(),
   val gaps: List<ParityGapDto> = emptyList(),
+  /** Validated GitHub issue rows published by the catalog, including closed rows. */
+  val issues: List<ParityIssue> = emptyList(),
 ) {
   companion object {
-    fun of(dashboard: ServeParityDashboard.Dashboard): ParityResponse =
+    fun of(
+      dashboard: ServeParityDashboard.Dashboard,
+      issues: List<ParityIssue> = emptyList(),
+    ): ParityResponse =
       ParityResponse(
         generatedAt = dashboard.generatedAt,
         windowDays = dashboard.windowDays,
@@ -6466,6 +6486,7 @@ private data class ParityResponse(
               component = it.component,
             )
           },
+        issues = issues,
       )
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssues.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssues.kt
@@ -1,0 +1,123 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import java.time.Instant
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+
+/** A catalog-published snapshot of the GitHub issues joined to its previews. */
+@Serializable
+data class ParityIssues(
+  val schema: String = SCHEMA,
+  val generatedAt: String? = null,
+  val issues: List<ParityIssue> = emptyList(),
+) {
+  companion object {
+    const val SCHEMA = "compose-preview-issues/v1"
+    const val DIRECTORY = "parity"
+    const val FILE = "issues.json"
+  }
+}
+
+@Serializable
+data class ParityIssue(
+  val repository: String,
+  val number: Int,
+  val title: String,
+  /** Read from the wire only to validate the claimed identity; rebuilt before use. */
+  val url: String,
+  val state: String,
+  val area: String? = null,
+  val parity: String? = null,
+  val system: String? = null,
+  val component: String? = null,
+  val previewIds: List<String> = emptyList(),
+  val referenceIds: List<String> = emptyList(),
+  val acceptanceId: String? = null,
+)
+
+/** Fail-soft trust boundary for `parity/issues.json`. */
+object ServeParityIssuesStore {
+  const val MAX_ISSUES = 2000
+  private const val MAX_TEXT = 300
+  private val REPOSITORY = Regex("[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}")
+  private val ID = Regex("[^\\p{Cc}]{1,300}")
+  private val AREAS = setOf("spec", "component", "preview", "renderer", "comparison")
+  private val PARITY = setOf("regression", "known-difference", "verification-needed")
+  private val JSON = Json { ignoreUnknownKeys = true }
+
+  fun load(bundleDir: File, fileSystem: FileSystem = SystemFileSystem): ParityIssues? {
+    val path = bundleDir.toOkioPath() / ParityIssues.DIRECTORY.toPath() / ParityIssues.FILE
+    val raw =
+      runCatching {
+          if (!fileSystem.exists(path)) return@runCatching null
+          JSON.decodeFromString<ParityIssues>(fileSystem.read(path) { readUtf8() })
+        }
+        .getOrNull() ?: return null
+    return sanitize(raw)
+  }
+
+  fun sanitize(raw: ParityIssues): ParityIssues? {
+    if (raw.schema != ParityIssues.SCHEMA || raw.issues.size > MAX_ISSUES) return null
+    val generatedAt = raw.generatedAt?.trim()?.takeIf(::isTimestamp)
+    val issues = raw.issues.mapNotNull(::sanitizeIssue).distinctBy { it.repository to it.number }
+    if (issues.isEmpty()) return null
+    return ParityIssues(generatedAt = generatedAt, issues = issues)
+  }
+
+  private fun sanitizeIssue(raw: ParityIssue): ParityIssue? {
+    val repository = raw.repository.trim().lowercase().takeIf(REPOSITORY::matches) ?: return null
+    if (raw.number < 1) return null
+    val expected = "https://github.com/$repository/issues/${raw.number}"
+    val claimed = canonicalIssueUrl(raw.url) ?: return null
+    if (claimed != expected) return null
+    val state =
+      raw.state.trim().lowercase().takeIf { it == "open" || it == "closed" } ?: return null
+    val title =
+      raw.title.trim().takeIf { it.isNotEmpty() }?.let { clamp(it, MAX_TEXT) } ?: return null
+    return ParityIssue(
+      repository = repository,
+      number = raw.number,
+      title = title,
+      url = expected,
+      state = state,
+      area = raw.area?.removePrefix("area:")?.lowercase()?.takeIf(AREAS::contains),
+      parity = raw.parity?.removePrefix("parity:")?.lowercase()?.takeIf(PARITY::contains),
+      system = raw.system.cleanId(),
+      component = raw.component.cleanId(),
+      previewIds = raw.previewIds.mapNotNull { it.cleanId() }.distinct().take(100),
+      referenceIds = raw.referenceIds.mapNotNull { it.cleanId() }.distinct().take(100),
+      acceptanceId = raw.acceptanceId.cleanId(),
+    )
+  }
+
+  private fun String?.cleanId(): String? =
+    this?.trim()?.takeIf { ID.matches(it) }?.let { clamp(it, MAX_TEXT) }
+
+  private fun canonicalIssueUrl(value: String): String? {
+    val match =
+      Regex(
+          "https://(?:www\\.)?github\\.com/([^/]+)/([^/]+)/issues/([0-9]+)/?",
+          RegexOption.IGNORE_CASE,
+        )
+        .matchEntire(value.trim()) ?: return null
+    val repository = "${match.groupValues[1]}/${match.groupValues[2]}".lowercase()
+    if (!REPOSITORY.matches(repository)) return null
+    val number = match.groupValues[3].toIntOrNull()?.takeIf { it > 0 } ?: return null
+    return "https://github.com/$repository/issues/$number"
+  }
+
+  private fun isTimestamp(value: String): Boolean =
+    runCatching {
+        Instant.parse(value)
+        true
+      }
+      .getOrDefault(false)
+
+  private fun clamp(value: String, max: Int): String =
+    if (value.length <= max) value else value.take(max - 1) + "…"
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
@@ -108,6 +108,10 @@ class ServePerPreviewLiveHost(
   override fun tagIndexForPreview(previewId: String): Map<String, ServeSemanticsTags.TagEntry> =
     baked.tagIndexForPreview(previewId)
 
+  override fun parityActivity(): ParityActivity? = baked.parityActivity()
+
+  override fun parityIssues(): ParityIssues? = baked.parityIssues()
+
   // The catalog's published player comparison rides the baked staging dir, so it stays reachable
   // when a live daemon fronts this session.
   override fun rcCompare(): RcCompareManifest? = baked.rcCompare()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -841,6 +841,46 @@ object ServeWeb {
       "$GITHUB_ICON report an issue</button></form>"
   }
 
+  /** Render catalog-published GitHub issues. Every href has already been rebuilt by the store. */
+  private fun parityIssueRowsHtml(issues: List<ParityIssue>): String {
+    if (issues.isEmpty()) return ""
+    val rows =
+      issues.joinToString("\n") { issue ->
+        val state = if (issue.state == "closed") " closed" else ""
+        val classification =
+          listOfNotNull(issue.area?.let { "area:$it" }, issue.parity?.let { "parity:$it" })
+            .joinToString(" · ")
+        val meta = if (classification.isEmpty()) issue.state else "${issue.state} · $classification"
+        "<li class=\"cp-parity-issue$state\"><a href=\"${WebEscaping.htmlEscape(issue.url)}\" " +
+          "rel=\"noopener\">#${issue.number} ${WebEscaping.htmlEscape(issue.title)}</a>" +
+          "<span>${WebEscaping.htmlEscape(meta)}</span></li>"
+      }
+    return "<aside class=\"cp-parity-issues\"><strong>Issues</strong><ul>$rows</ul></aside>"
+  }
+
+  /** Compact, non-link form safe to place inside a card whose whole body is already an anchor. */
+  private fun parityIssueBadgeHtml(issues: List<ParityIssue>): String {
+    if (issues.isEmpty()) return ""
+    val open = issues.count { it.state == "open" }
+    val closed = issues.size - open
+    val label =
+      buildList {
+          if (open > 0) add("$open open")
+          if (closed > 0) add("$closed closed")
+        }
+        .joinToString(" · ")
+    val title = issues.joinToString("; ") { "#${it.number} ${it.title}" }
+    return "<span class=\"cp-issue-badge\" title=\"${WebEscaping.htmlEscape(title)}\">${WebEscaping.htmlEscape(label)} issue${if (issues.size == 1) "" else "s"}</span>"
+  }
+
+  private fun issuesForPreview(
+    issues: List<ParityIssue>,
+    preview: ServePreview,
+  ): List<ParityIssue> = issues.filter { issue ->
+    preview.id in issue.previewIds ||
+      (preview.componentId != null && issue.component == preview.componentId)
+  }
+
   /**
    * Provenance of a served design-system catalog: the trusted GitHub [repo]/[branch] it was fetched
    * from, when it was [generatedAt] (ISO-8601), and the [toolVersion]
@@ -5557,6 +5597,8 @@ object ServeWeb {
      * (the default) leaves every existing caller's URLs byte-identical.
      */
     sessionInOrigin: Boolean = false,
+    /** Validated catalog-published issues, matched onto each component card. */
+    parityIssues: List<ParityIssue> = emptyList(),
   ): String {
     // The session id links may carry. Null on a rooted site (and for the default session): the
     // URL already says which catalog this is. `sessionId` itself stays intact below — it keys the
@@ -5675,6 +5717,12 @@ object ServeWeb {
       val lightLabel = gridDisplayName(l)
       val darkLabel = gridDisplayName(d)
       val defaultLabel = gridDisplayName(def)
+      val issueBadge =
+        parityIssueBadgeHtml(
+          listOfNotNull(card.light, card.dark, card.neutral)
+            .flatMap { issuesForPreview(parityIssues, it) }
+            .distinctBy { it.repository to it.number }
+        )
       // `data-def` is the variant a DECLARED theme re-renders (the server-side default), so picking
       // one doesn't also flip the card's light/dark base.
       return """
@@ -5689,7 +5737,7 @@ object ServeWeb {
           </div>
           <div class="cp-meta">
             <div class="cp-label" title="${WebEscaping.htmlEscape(def.id)}">${WebEscaping.htmlEscape(defaultLabel)}</div>
-            <div class="cp-id">${WebEscaping.htmlEscape(def.id)}</div>
+            <div class="cp-id">${WebEscaping.htmlEscape(def.id)}</div>$issueBadge
             ${viewCountHtml(cardViews(card))}
           </div>
         </a>
@@ -5701,6 +5749,7 @@ object ServeWeb {
       val label = WebEscaping.htmlEscape(gridDisplayName(p))
       val src = renderSrc(p)
       val idText = WebEscaping.htmlEscape(p.id)
+      val issueBadge = parityIssueBadgeHtml(issuesForPreview(parityIssues, p))
       p.renderFailure?.let { failure ->
         val errorName = failure.errorClass.substringAfterLast('.').ifBlank { "RenderError" }
         val message = failure.message.takeIf { it.isNotBlank() } ?: "The preview did not render."
@@ -5749,7 +5798,7 @@ object ServeWeb {
             </div>
             <div class="cp-meta">
               <div class="cp-label" title="$idText">$label</div>
-              <div class="cp-id">$idText</div>
+              <div class="cp-id">$idText</div>$issueBadge
               ${viewCountHtml(engagement[p.id]?.views ?: 0L)}
             </div>
           </a>
@@ -6514,6 +6563,7 @@ $rows
     overrides: Map<String, String> = emptyMap(),
     /** Prefilled parity report for this exact preview/reference comparison. */
     reportIssue: ReportIssue? = null,
+    parityIssues: List<ParityIssue> = emptyList(),
   ): String {
     // The session id links may carry. Null on a rooted site (and for the default session): the
     // URL already says which catalog this is. `sessionId` itself stays intact below — it keys the
@@ -6593,6 +6643,7 @@ $rows
       withPin("$basePath/compare/${WebEscaping.urlEncodeSegment(preview.id)}?$query", pin)
     }
     val revisionsBlock = revisionsHtml(revisions) { pin -> pageHref(pin, reference.id) }
+    val issueRows = parityIssueRowsHtml(parityIssues)
     val referencePicker =
       if (referenceChoices.size <= 1) ""
       else {
@@ -6628,7 +6679,7 @@ $rows
           <h1 class="cp-head cp-catalog-head">${WebEscaping.htmlEscape(reference.label)}${compactTrustBadge(trust)}</h1>
           <p class="cp-sub">${WebEscaping.htmlEscape(previewDisplayName(preview))} · ${WebEscaping.htmlEscape(preview.id)}</p>
           $revisionsBlock
-          $referencePicker
+          $referencePicker$issueRows
           <div class="cp-reference-meta"><strong>Source:</strong> $source$revision</div>
           <div class="cp-reference-grid">
             <section><h2>Reference</h2><div class="cp-compare-shot" data-cp-annotated="reference"><img src="$raster" alt="Design reference"></div></section>
@@ -7015,6 +7066,7 @@ $rows
     displayTitle: String? = null,
     /** Whether a preview carries a design reference — decides "compare" vs "open" on a link. */
     hasReferenceFor: (String) -> Boolean = { false },
+    parityIssues: List<ParityIssue> = emptyList(),
     /**
      * The design tool this catalog is specified by ("Figma", …) — names the whole-catalog compare
      * link. Null keeps the neutral "design references" wording. See [designToolLabel].
@@ -7276,8 +7328,32 @@ $rows
           .trimIndent()
       }
 
+    val githubIssueBand =
+      if (parityIssues.isEmpty()) ""
+      else {
+        val open = parityIssues.filter { it.state == "open" }
+        val closed = parityIssues.filter { it.state == "closed" }
+        val groups = open.groupBy { it.component ?: "Unscoped" }
+        val summary =
+          groups.entries.joinToString("\n") { (component, rows) ->
+            "<section class=\"cp-parity-issue-group\"><h3>${esc(component)} (${rows.size})</h3>${parityIssueRowsHtml(rows)}</section>"
+          }
+        val openBand =
+          "<h2 class=\"cp-status-sec\">Components with open issues (${open.size})</h2>" +
+            if (open.isEmpty()) "<p class=\"cp-muted\">No open issues.</p>" else summary
+        val closedBand =
+          if (closed.isEmpty()) ""
+          else
+            "<h2 class=\"cp-status-sec\">Closed issues (${closed.size})</h2>${parityIssueRowsHtml(closed)}"
+        openBand + closedBand
+      }
     val issueBand =
-      if (driftBand.isEmpty() && coverage.unmapped.isEmpty() && dashboard.gaps.isEmpty()) {
+      if (
+        parityIssues.isEmpty() &&
+          driftBand.isEmpty() &&
+          coverage.unmapped.isEmpty() &&
+          dashboard.gaps.isEmpty()
+      ) {
         """
         <h2 class="cp-status-sec">Issues</h2>
         <p class="cp-muted">No mapping gaps or one-sided changes were detected.</p>
@@ -7286,6 +7362,7 @@ $rows
       } else {
         """
         <h2 class="cp-status-sec">Issues</h2>
+        $githubIssueBand
         $driftBand
         $unmappedBand
         """
@@ -7775,6 +7852,7 @@ $rows
      * (the default) leaves every existing caller's URLs byte-identical.
      */
     sessionInOrigin: Boolean = false,
+    parityIssues: List<ParityIssue> = emptyList(),
   ): String {
     // The session id links may carry. Null on a rooted site (and for the default session): the
     // URL already says which catalog this is. `sessionId` itself stays intact below — it keys the
@@ -7813,6 +7891,7 @@ $rows
     val navSuffix =
       querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
     val displayName = previewDisplayName(preview)
+    val issueRows = parityIssueRowsHtml(parityIssues)
     val label = WebEscaping.htmlEscape(displayName)
     val idText = WebEscaping.htmlEscape(preview.id)
     val modes = preview.modes.joinToString(",") { it.wire }
@@ -8837,7 +8916,7 @@ $rows
         <code class="cp-preview-id" title="$idText">$idText</code>
         ${viewerViewCountHtml(engagement.views)}$headTogglesHtml
       </div>
-      $revisionsBlock${degradeBanner(degradations)}
+      $revisionsBlock${degradeBanner(degradations)}$issueRows
       $axesBlock
       <div class="cp-preview-primary" aria-label="Preview renderer">
       $primaryControls

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -1655,6 +1655,16 @@ html.cp-bg-transparent .cp-viewer[data-mode="source"] .cp-stage { background: tr
   border-radius: 6px; }
 .cp-rc-px { color: var(--cp-fg-muted); font-size: 0.72rem; font-variant-numeric: tabular-nums; }
 .cp-reference-meta { margin: 12px 0 20px; color: var(--cp-fg-muted); font-size: 0.82rem; }
+.cp-parity-issues { margin: 12px 0; padding: 12px 14px; border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 12px; background: var(--md-sys-color-surface-container); }
+.cp-parity-issues ul { list-style: none; margin: 7px 0 0; padding: 0; display: grid; gap: 6px; }
+.cp-parity-issue { display: flex; gap: 10px; align-items: baseline; justify-content: space-between; }
+.cp-parity-issue > span { color: var(--cp-fg-muted); font-size: .75rem; white-space: nowrap; }
+.cp-parity-issue.closed { opacity: .58; }
+.cp-issue-badge { display: inline-flex; width: fit-content; margin-top: 5px; padding: 2px 7px;
+  border-radius: 999px; background: var(--md-sys-color-secondary-container); color: var(--md-sys-color-on-secondary-container);
+  font-size: .68rem; font-weight: 650; }
+.cp-parity-issue-group h3 { margin-bottom: 0; }
 .cp-reference-picker { display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
   margin: 14px 0 10px; color: var(--cp-fg-muted); font-size: 0.8rem; }
 .cp-reference-picker > span { margin-right: 2px; font-weight: 650; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -467,6 +467,50 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `catalog stages the published parity issue index`() {
+    val root = tempRoot()
+    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val issues =
+      """
+      {"schema":"compose-preview-issues/v1","generatedAt":"2026-08-15T09:12:00Z",
+       "issues":[{"repository":"yschimke/m3-catalog","number":40,"title":"Padding differs",
+         "url":"https://github.com/yschimke/m3-catalog/issues/40","state":"open",
+         "area":"component","parity":"known-difference","system":"compose-m3",
+         "component":"Button/Filled","previewIds":["button"],"referenceIds":["button-figma"]}]}
+      """
+        .trimIndent()
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = { url ->
+          requested += url
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.encodeToByteArray()
+            url.endsWith("/parity/issues.json") -> issues.encodeToByteArray()
+            url.endsWith("/images/button.png") -> png()
+            else -> null
+          }
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    assertTrue(requested.any { it.endsWith("/parity/issues.json") }, "the index is fetched")
+    val loaded = registered.getValue("compose-m3").parityIssues()
+    assertNotNull(loaded, "the index reached the host through the staging tree")
+    assertEquals(40, loaded.issues.single().number)
+    assertEquals("button-figma", loaded.issues.single().referenceIds.single())
+  }
+
+  @Test
   fun `a catalog publishing no parity feed serves without one`() {
     val root = tempRoot()
     val catalog =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssuesStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssuesStoreTest.kt
@@ -1,0 +1,112 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.Test
+
+class ServeParityIssuesStoreTest {
+  private val fs = FakeFileSystem()
+  private val root = "/bundle".toPath()
+  private val json = Json { prettyPrint = true }
+
+  private fun issue(
+    number: Int = 40,
+    state: String = "open",
+    url: String = "https://github.com/yschimke/m3-catalog/issues/$number",
+  ) =
+    ParityIssue(
+      repository = "yschimke/m3-catalog",
+      number = number,
+      title = "IconButton glyph colour",
+      url = url,
+      state = state,
+      area = "component",
+      parity = "known-difference",
+      system = "m3",
+      component = "IconButton/Tonal",
+      previewIds = listOf("iconbutton-tonal__ideal__default__light"),
+      referenceIds = listOf("iconbutton-tonal-figma"),
+    )
+
+  private fun write(raw: String) {
+    fs.createDirectories(root / ParityIssues.DIRECTORY)
+    fs.write(root / ParityIssues.DIRECTORY / ParityIssues.FILE) { writeUtf8(raw) }
+  }
+
+  private fun write(value: ParityIssues) = write(json.encodeToString(value))
+
+  private fun load() = ServeParityIssuesStore.load(File("/bundle"), fs)
+
+  @Test
+  fun `loads valid open and closed rows`() {
+    write(
+      ParityIssues(
+        generatedAt = "2026-08-15T10:00:00Z",
+        issues = listOf(issue(), issue(41, "closed")),
+      )
+    )
+    val rows = assertNotNull(load()).issues
+    assertEquals(listOf("open", "closed"), rows.map { it.state })
+    assertEquals("https://github.com/yschimke/m3-catalog/issues/40", rows.first().url)
+  }
+
+  @Test
+  fun `loads the JavaScript producer fixture without schema drift`() {
+    write(File("../scripts/design-artifacts/fixtures/parity-issues.json").readText())
+    assertEquals(listOf("open", "closed"), assertNotNull(load()).issues.map { it.state })
+  }
+
+  @Test
+  fun `missing wrong-schema and truncated indexes fail soft`() {
+    assertNull(load())
+    write(ParityIssues(schema = "future/v2", issues = listOf(issue())))
+    assertNull(load())
+    write("{\"schema\":\"compose-preview-issues/v1\",\"issues\":[")
+    assertNull(load())
+  }
+
+  @Test
+  fun `oversized index drops wholesale`() {
+    write(ParityIssues(issues = List(ServeParityIssuesStore.MAX_ISSUES + 1) { issue(it + 1) }))
+    assertNull(load())
+  }
+
+  @Test
+  fun `unparseable or mismatched urls are dropped and never forwarded`() {
+    val sanitized =
+      assertNotNull(
+        ServeParityIssuesStore.sanitize(
+          ParityIssues(
+            issues =
+              listOf(
+                issue(url = "javascript:alert(1)"),
+                issue(41, url = "https://github.com/other/repo/issues/41"),
+                issue(42, url = "https://WWW.GITHUB.COM/YSCHIMKE/M3-CATALOG/issues/42/"),
+              )
+          )
+        )
+      )
+    assertEquals(listOf(42), sanitized.issues.map { it.number })
+    assertEquals("https://github.com/yschimke/m3-catalog/issues/42", sanitized.issues.single().url)
+  }
+
+  @Test
+  fun `unknown labels are discarded without discarding the issue`() {
+    val row =
+      assertNotNull(
+          ServeParityIssuesStore.sanitize(
+            ParityIssues(issues = listOf(issue().copy(area = "admin", parity = "magic")))
+          )
+        )
+        .issues
+        .single()
+    assertNull(row.area)
+    assertNull(row.parity)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -634,6 +634,33 @@ class ServeWebFixtureTest {
     val update =
       System.getenv("UPDATE_SERVE_WEB_FIXTURES") == "true" ||
         System.getProperty("updateServeWebFixtures") == "true"
+    val parityIssues =
+      listOf(
+        ParityIssue(
+          repository = "yschimke/m3-catalog",
+          number = 40,
+          title = "Glyph colour is darker than the design token",
+          url = "https://github.com/yschimke/m3-catalog/issues/40",
+          state = "open",
+          area = "component",
+          parity = "known-difference",
+          component = "IconButton/Tonal",
+          previewIds =
+            listOf("com.example.ProfileScreenPreview", "button-filled__ideal__default__light"),
+        ),
+        ParityIssue(
+          repository = "yschimke/m3-catalog",
+          number = 41,
+          title = "Verify the disabled state after the token update",
+          url = "https://github.com/yschimke/m3-catalog/issues/41",
+          state = "closed",
+          area = "preview",
+          parity = "verification-needed",
+          component = "IconButton/Tonal",
+          previewIds =
+            listOf("com.example.ProfileScreenPreview", "button-filled__ideal__default__light"),
+        ),
+      )
 
     // Render the fixtures with a producer-trust badge so the visual-diff harness captures it: a
     // trusted (signature) landing and an unverified viewer exercise both badge styles.
@@ -661,6 +688,7 @@ class ServeWebFixtureTest {
         // lists these by name instead.
         designPages =
           listOf(ServeWeb.PageLink("shape", "Shape"), ServeWeb.PageLink("type", "Typography")),
+        parityIssues = parityIssues,
       )
     // The public preview server's FRONT DOOR: an index of the published design systems, each a card
     // with a meaningful hero preview, its title + library, trust badge, and a link to /<system>/.
@@ -853,6 +881,7 @@ class ServeWebFixtureTest {
         // host with the compile lane renders — the row is where every one of these affordances
         // lands, so a change to its rhythm shows up here.
         playgroundHref = "/playground?from=compose-m3/com.example.ProfileScreenPreview",
+        parityIssues = parityIssues,
       )
     // A second viewer carrying the in-browser Wasm tier, so the harness captures the "Run in
     // browser (Wasm)" toggle + iframe seam a CMP catalog session shows.
@@ -1447,6 +1476,7 @@ class ServeWebFixtureTest {
         // The catalog names its design tool, so the page's way back out to the whole-catalog
         // comparison table is captured with the same wording as the link that leads here.
         designToolLabel = "Figma",
+        parityIssues = parityIssues,
       )
     val referenceComparison =
       ServeWeb.referenceComparisonPage(
@@ -1584,6 +1614,7 @@ class ServeWebFixtureTest {
                 ),
             ),
           ),
+        parityIssues = parityIssues,
       )
     // The same comparison, PINNED to an older publish (issue #3723) — the state a shared permalink
     // opens in. Captured because it is where the feature is visible: the banner naming the

--- a/scripts/design-artifacts/emit-parity-issues.mjs
+++ b/scripts/design-artifacts/emit-parity-issues.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/** Query configured repositories with `gh`, parse locator fences, and write parity/issues.json. */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { buildIssueIndex } from "./parity-issues.mjs";
+
+const args = process.argv.slice(2);
+const value = (name) => { const i = args.indexOf(name); return i < 0 ? null : args[i + 1]; };
+const out = value("--out");
+const repos = args.flatMap((arg, i) => arg === "--repo" && args[i + 1] ? [args[i + 1]] : []);
+if (!out || repos.length === 0) {
+  console.error("usage: emit-parity-issues.mjs --out <bundle-dir> --repo <owner/name> [--repo ...]");
+  process.exit(2);
+}
+
+const issues = [];
+for (const repo of repos) {
+  const raw = execFileSync("gh", ["api", "--paginate", "--slurp", `repos/${repo}/issues?state=all&per_page=100`], { encoding: "utf8", maxBuffer: 25 * 1024 * 1024 });
+  const pages = JSON.parse(raw);
+  issues.push(...pages.flat().filter((issue) => !issue.pull_request));
+}
+let failures = 0;
+const index = buildIssueIndex(issues, { onError: (issue, error) => { failures++; console.error(`::warning::parity-issues: #${issue?.number ?? "?"}: ${error}`); } });
+const target = join(out, "parity", "issues.json");
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(target, JSON.stringify(index, null, 2) + "\n");
+console.log(`parity-issues: wrote ${index.issues.length} row(s) to ${target}; ${failures} issue(s) rejected`);
+if (failures) process.exitCode = 1;

--- a/scripts/design-artifacts/fixtures/README.md
+++ b/scripts/design-artifacts/fixtures/README.md
@@ -1,4 +1,9 @@
-# `fixtures/` — captured Remote Compose documents for the player tests
+# `fixtures/` — cross-runtime design-artifact fixtures
+
+`parity-issues.json` is emitted in the JavaScript producer's wire format and loaded directly by
+`ServeParityIssuesStoreTest`, pinning the producer and Kotlin consumer to the same schema.
+
+The `.rc` files below are captured Remote Compose documents for the player tests.
 
 Small, committed `.rc` documents the browser-player tests in this directory replay. They are real
 captures from the `design-catalog-remote-m3` render, not hand-written bytes, so a test built on one

--- a/scripts/design-artifacts/fixtures/parity-issues.json
+++ b/scripts/design-artifacts/fixtures/parity-issues.json
@@ -1,0 +1,32 @@
+{
+  "schema": "compose-preview-issues/v1",
+  "generatedAt": "2026-08-15T10:00:00Z",
+  "issues": [
+    {
+      "repository": "yschimke/m3-catalog",
+      "number": 40,
+      "title": "IconButton/Tonal uses a darker glyph colour",
+      "url": "https://github.com/yschimke/m3-catalog/issues/40",
+      "state": "open",
+      "area": "component",
+      "parity": "known-difference",
+      "system": "m3",
+      "component": "IconButton/Tonal",
+      "previewIds": ["iconbutton-tonal__ideal__default__light"],
+      "referenceIds": ["iconbutton-tonal-figma"]
+    },
+    {
+      "repository": "yschimke/m3-catalog",
+      "number": 41,
+      "title": "Verify the disabled state after the token update",
+      "url": "https://github.com/yschimke/m3-catalog/issues/41",
+      "state": "closed",
+      "area": "preview",
+      "parity": "verification-needed",
+      "system": "m3",
+      "component": "IconButton/Tonal",
+      "previewIds": ["iconbutton-tonal__ideal__default__light"],
+      "referenceIds": ["iconbutton-tonal-figma"]
+    }
+  ]
+}

--- a/scripts/design-artifacts/parity-issues.mjs
+++ b/scripts/design-artifacts/parity-issues.mjs
@@ -1,0 +1,75 @@
+/** Pure producer for the catalog's `parity/issues.json`. */
+
+export const ISSUES_SCHEMA = "compose-preview-issues/v1";
+export const LOCATOR_FENCE = "compose-parity-locator/v1";
+
+const REPO = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/;
+const FENCE = /```compose-parity-locator\/v1\s*\n([\s\S]*?)\n```/g;
+const AREA = new Set(["spec", "component", "preview", "renderer", "comparison"]);
+const PARITY = new Set(["regression", "known-difference", "verification-needed"]);
+
+export function canonicalIssueUrl(value) {
+  const match = /^https:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/issues\/([1-9][0-9]*)\/?$/i.exec(String(value ?? "").trim());
+  if (!match) return null;
+  const repository = `${match[1]}/${match[2]}`.toLowerCase();
+  if (!REPO.test(repository)) return null;
+  return { repository, number: Number(match[3]), url: `https://github.com/${repository}/issues/${Number(match[3])}` };
+}
+
+/** Parse exactly one visible locator fence. A malformed or duplicate block is an explicit error. */
+export function parseLocator(body) {
+  const matches = [...String(body ?? "").matchAll(FENCE)];
+  if (matches.length !== 1) return { ok: false, error: matches.length ? "multiple locator blocks" : "missing locator block" };
+  const fields = Object.create(null);
+  for (const line of matches[0][1].split(/\r?\n/)) {
+    const colon = line.indexOf(":");
+    if (colon < 1) return { ok: false, error: `malformed locator line: ${line}` };
+    const key = line.slice(0, colon).trim();
+    const value = line.slice(colon + 1).trim();
+    if (Object.hasOwn(fields, key)) return { ok: false, error: `duplicate locator field: ${key}` };
+    fields[key] = value;
+  }
+  const required = ["repository", "system", "component", "preview", "reference", "variant", "overrides", "revision"];
+  const missing = required.filter((key) => !Object.hasOwn(fields, key) || fields[key] === "");
+  if (missing.length) return { ok: false, error: `missing locator field(s): ${missing.join(", ")}` };
+  if (!REPO.test(fields.repository)) return { ok: false, error: "invalid repository" };
+  let overrides;
+  try { overrides = JSON.parse(fields.overrides); } catch { return { ok: false, error: "invalid overrides JSON" }; }
+  if (!overrides || Array.isArray(overrides) || typeof overrides !== "object") return { ok: false, error: "overrides must be an object" };
+  const canonicalOverrides = Object.fromEntries(Object.keys(overrides).sort().map((key) => [key, overrides[key]]));
+  if (JSON.stringify(canonicalOverrides) !== fields.overrides) return { ok: false, error: "overrides are not canonical JSON" };
+  return { ok: true, locator: { repository: fields.repository.toLowerCase(), system: fields.system, component: fields.component, previewId: fields.preview, referenceId: fields.reference, variant: fields.variant, overrides: canonicalOverrides, revision: fields.revision } };
+}
+
+function labelValue(labels, prefix, allowed) {
+  const values = (labels ?? []).map((label) => typeof label === "string" ? label : label?.name).filter(Boolean);
+  return values.map((label) => label.toLowerCase()).find((label) => label.startsWith(prefix) && allowed.has(label.slice(prefix.length)))?.slice(prefix.length) ?? null;
+}
+
+/** Build an index and report mangled locator blocks instead of silently losing them. */
+export function buildIssueIndex(issues, { generatedAt = new Date().toISOString(), onError = () => {} } = {}) {
+  const byIdentity = new Map();
+  for (const issue of issues ?? []) {
+    const identity = canonicalIssueUrl(issue?.html_url ?? issue?.url);
+    if (!identity) { onError(issue, "invalid issue URL"); continue; }
+    const parsed = parseLocator(issue?.body);
+    if (!parsed.ok) { onError(issue, parsed.error); continue; }
+    if (parsed.locator.repository !== identity.repository) { onError(issue, "locator repository does not match issue URL"); continue; }
+    const row = {
+      repository: identity.repository,
+      number: identity.number,
+      title: String(issue?.title ?? "").trim(),
+      url: identity.url,
+      state: issue?.state === "closed" ? "closed" : "open",
+      area: labelValue(issue?.labels, "area:", AREA),
+      parity: labelValue(issue?.labels, "parity:", PARITY),
+      system: parsed.locator.system,
+      component: parsed.locator.component,
+      previewIds: [parsed.locator.previewId],
+      referenceIds: [parsed.locator.referenceId],
+    };
+    if (!row.title) { onError(issue, "missing title"); continue; }
+    byIdentity.set(`${row.repository}/${row.number}`, row);
+  }
+  return { schema: ISSUES_SCHEMA, generatedAt, issues: [...byIdentity.values()].sort((a, b) => a.repository.localeCompare(b.repository) || a.number - b.number) };
+}

--- a/scripts/design-artifacts/parity-issues.test.mjs
+++ b/scripts/design-artifacts/parity-issues.test.mjs
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildIssueIndex, canonicalIssueUrl, parseLocator } from "./parity-issues.mjs";
+
+const body = `Difference details.\n\n\`\`\`compose-parity-locator/v1
+repository: yschimke/m3-catalog
+system: m3
+component: IconButton/Tonal
+preview: iconbutton-tonal__ideal__default__light
+reference: iconbutton-tonal-figma
+variant: ideal/default/light
+overrides: {"fontScale":"1.5","knob.label":"Send;now=x"}
+revision: yschimke/m3-catalog@main
+\`\`\``;
+
+test("a locator round-trips the exact identity and canonical overrides", () => {
+  assert.deepEqual(parseLocator(body), { ok: true, locator: { repository: "yschimke/m3-catalog", system: "m3", component: "IconButton/Tonal", previewId: "iconbutton-tonal__ideal__default__light", referenceId: "iconbutton-tonal-figma", variant: "ideal/default/light", overrides: { fontScale: "1.5", "knob.label": "Send;now=x" }, revision: "yschimke/m3-catalog@main" } });
+});
+
+test("mangled blocks are reported instead of silently skipped", () => {
+  const errors = [];
+  const index = buildIssueIndex([{ html_url: "https://github.com/yschimke/m3-catalog/issues/40", title: "x", body: body.replace("overrides:", "overrides"), state: "open" }], { generatedAt: "2026-08-15T10:00:00Z", onError: (_, error) => errors.push(error) });
+  assert.deepEqual(index.issues, []);
+  assert.match(errors[0], /malformed|missing locator/);
+});
+
+test("buildIssueIndex canonicalises URLs, labels, and preserves closed rows", () => {
+  const index = buildIssueIndex([{ html_url: "https://WWW.GITHUB.COM/YSCHIMKE/M3-CATALOG/issues/40/", title: "Glyph colour", body, state: "closed", labels: [{ name: "area:component" }, { name: "parity:known-difference" }] }], { generatedAt: "2026-08-15T10:00:00Z" });
+  assert.equal(index.issues[0].url, "https://github.com/yschimke/m3-catalog/issues/40");
+  assert.equal(index.issues[0].state, "closed");
+  assert.equal(index.issues[0].area, "component");
+});
+
+test("canonicalIssueUrl rejects non-GitHub and mismatched shapes", () => {
+  assert.equal(canonicalIssueUrl("javascript:alert(1)"), null);
+  assert.equal(canonicalIssueUrl("https://github.com/o/r/pull/2"), null);
+});

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -113,7 +113,7 @@
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="com.example.ProfileScreenPreview">Profile screen</div>
-    <div class="cp-id">com.example.ProfileScreenPreview</div>
+    <div class="cp-id">com.example.ProfileScreenPreview</div><span class="cp-issue-badge" title="#40 Glyph colour is darker than the design token; #41 Verify the disabled state after the token update">1 open · 1 closed issues</span>
     
   </div>
 </a>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-parity.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-parity.html
@@ -148,6 +148,7 @@
         </ul>
         <p class="cp-muted" id="cp-parity-feed-empty" hidden>No activity in this lane.</p>
                 <h2 class="cp-status-sec">Issues</h2>
+        <h2 class="cp-status-sec">Components with open issues (1)</h2><section class="cp-parity-issue-group"><h3>IconButton/Tonal (1)</h3><aside class="cp-parity-issues"><strong>Issues</strong><ul><li class="cp-parity-issue"><a href="https://github.com/yschimke/m3-catalog/issues/40" rel="noopener">#40 Glyph colour is darker than the design token</a><span>open · area:component · parity:known-difference</span></li></ul></aside></section><h2 class="cp-status-sec">Closed issues (1)</h2><aside class="cp-parity-issues"><strong>Issues</strong><ul><li class="cp-parity-issue closed"><a href="https://github.com/yschimke/m3-catalog/issues/41" rel="noopener">#41 Verify the disabled state after the token update</a><span>closed · area:preview · parity:verification-needed</span></li></ul></aside>
                 <h3 class="cp-parity-sub">Out-of-sync activity</h3>
         <p class="cp-muted">Components that moved on one side only inside this window — where the
           render and its reference are most likely to have drifted apart.</p>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
@@ -61,7 +61,8 @@
           <span>Design references</span>
           <a class="cp-reference-choice" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;fontScale=1.5&amp;knob.label=Send%3Bnow%3Dx&amp;reference=design-button-filled-light" aria-current="page">Figma filled button</a>
 <a class="cp-reference-choice" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;fontScale=1.5&amp;knob.label=Send%3Bnow%3Dx&amp;reference=design-button-filled-review">Review revision</a>
-        </nav>
+        </nav><aside class="cp-parity-issues"><strong>Issues</strong><ul><li class="cp-parity-issue"><a href="https://github.com/yschimke/m3-catalog/issues/40" rel="noopener">#40 Glyph colour is darker than the design token</a><span>open · area:component · parity:known-difference</span></li>
+<li class="cp-parity-issue closed"><a href="https://github.com/yschimke/m3-catalog/issues/41" rel="noopener">#41 Verify the disabled state after the token update</a><span>closed · area:preview · parity:verification-needed</span></li></ul></aside>
           <div class="cp-reference-meta"><strong>Source:</strong> figma · revision fixture-42</div>
           <div class="cp-reference-grid">
             <section><h2>Reference</h2><div class="cp-compare-shot" data-cp-annotated="reference"><img src="/reference/design-button-filled-light.png?session=compose-m3&fontScale=1.5&knob.label=Send%3Bnow%3Dx" alt="Design reference"></div></section>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -58,7 +58,8 @@
 
         <span class="cp-head-toggles"><button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button><button type="button" class="cp-drawer-toggle cp-axis-toggle" id="cp-theme-toggle" aria-expanded="true" aria-controls="cp-theme-bar"><span class="cp-toggle-label">Theme</span><span class="cp-toggle-value" id="cp-theme-toggle-value">Day</span></button><button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button></span>
       </div>
-
+      <aside class="cp-parity-issues"><strong>Issues</strong><ul><li class="cp-parity-issue"><a href="https://github.com/yschimke/m3-catalog/issues/40" rel="noopener">#40 Glyph colour is darker than the design token</a><span>open · area:component · parity:known-difference</span></li>
+<li class="cp-parity-issue closed"><a href="https://github.com/yschimke/m3-catalog/issues/41" rel="noopener">#41 Verify the disabled state after the token update</a><span>closed · area:preview · parity:verification-needed</span></li></ul></aside>
 
       <div class="cp-preview-primary" aria-label="Preview renderer">
       <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" data-default-lane-label="Live preview" title="Static snapshot — this session has no live lane to switch to" disabled>

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -176,6 +176,8 @@ const STYLED_FIXTURES = new Set([
     // switches the format pane, so it needs both the stylesheet and the scripts routed in.
     "serve-rc-lanes",
     "serve-reference-compare",
+    "serve-viewer",
+    "serve-parity",
     "serve-viewer-catalog-knobs",
     "serve-landing-catalog-palette",
     "serve-viewer-catalog-palette",


### PR DESCRIPTION
Implements batch 2 from #3879.

## What changed

- adds a reusable producer workflow for the `compose-preview-issues/v1` issue index
- validates and stages `parity/issues.json` through a fail-soft Kotlin reader
- surfaces open and closed issues on catalog cards, preview pages, focused comparisons, and the parity dashboard
- makes render and issue-index publishers preserve each other's branch-owned paths during push races
- adds cross-runtime fixtures, parser/reader tests, staging coverage, race-order tests, and dark/light page snapshots

## Why

Published catalogs need a stable, local issue index that joins GitHub issues to preview/reference identities without making live GitHub requests. The two independent publishers also need to update the same artifact branch without dropping each other's output.

## Validation

- focused Kotlin suite: 87 tests passed
- issue producer: 4 Node tests passed
- Playwright: 8 dark/light page snapshots passed
- publisher race test: both ordering cases passed
- workflow YAML, shell syntax, Node syntax, and diff checks passed