### PR TITLE
feat(serve): add parity locator reporting

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2468,6 +2468,50 @@ class ServeHttpServer(
         respondNotFoundHtml("That preview has no matching design reference.")
         return@withLeasedSession
       }
+      val overrideParams =
+        call.request.queryParameters
+          .entries()
+          .mapNotNull { (key, values) ->
+            val value = values.firstOrNull() ?: return@mapNotNull null
+            if (ServeOverrides.isOverrideParam(key)) key to value else null
+          }
+          .toMap()
+          .let { ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, it) }
+      val bundleHost = catalogBundleHost(renderHost)
+      val sourceHref =
+        bundleHost?.catalogSource?.let { source ->
+          ServeUrls.githubBlobUrl(source.repo, source.ref, source.module, preview.sourceFile)
+        }
+      val reportContext =
+        ServeIssueReport.Context(
+          repo = ServeIssueReport.repoFor(bundleHost?.catalogSource, bundleHost?.provenance),
+          previewId = preview.id,
+          previewLabel = preview.label,
+          system = basePath.trim('/').takeIf { it.isNotEmpty() } ?: sessionId,
+          componentId = ServeIssueReport.componentIdFor(preview),
+          referenceId = reference.id,
+          variant = ServeIssueReport.variantFor(preview),
+          overrides = overrideParams,
+          sourceUrl = sourceHref,
+          catalog = bundleHost?.provenance?.let { "${it.repo}@${it.branch}" },
+          toolVersion = bundleHost?.provenance?.toolVersion,
+          comparisonUrl = ServeIssueReport.withoutToken(externalPageUrl()),
+          renderUrl =
+            ServeIssueReport.withoutToken(
+              "${externalOrigin()}$basePath/render/${WebEscaping.urlEncodeSegment(preview.id)}.png" +
+                requestQuerySuffix()
+            ),
+          publicRender = isPublic,
+        )
+      val reportIssue =
+        ServeWeb.ReportIssue(
+          action = ServeIssueReport.action(reportContext.repo),
+          title = ServeIssueReport.title(reportContext),
+          body = ServeIssueReport.body(reportContext),
+          bodyTemplate = ServeIssueReport.body(reportContext, renderPlaceholder = true),
+          repo = reportContext.repo,
+          login = githubAuth?.currentLogin(call),
+        )
       val revisions = catalogRevisions(renderHost)
       val pinned = revisions.pinned != null
       markGeneration("static-page", pageCacheControl())
@@ -2498,6 +2542,8 @@ class ServeHttpServer(
           actualAnnotations =
             if (pinned) emptyList() else renderHost.annotationsForPreview(previewId),
           revisions = revisions,
+          overrides = overrideParams,
+          reportIssue = reportIssue,
           // A top-level site's pages carry their session in the ORIGIN, so same-session links
           // drop the `?session=` the rooted legacy form would add. See [ServeSites].
           sessionInOrigin = siteSystem() != null,
@@ -4395,35 +4441,6 @@ class ServeHttpServer(
         bundleHost?.catalogSource?.let { src ->
           ServeUrls.githubBlobUrl(src.repo, src.ref, src.module, preview.sourceFile)
         }
-      // The prefilled "report an issue" link. Both URLs it carries are stripped of the session
-      // token: on a token-gated box every link on the page bakes the token in, and that token is
-      // the capability to drive this server — it must not ride along into a public issue body.
-      val reportContext =
-        ServeIssueReport.Context(
-          repo = ServeIssueReport.repoFor(bundleHost?.catalogSource, bundleHost?.provenance),
-          previewId = preview.id,
-          previewLabel = preview.label,
-          system = basePath.trim('/').takeIf { it.isNotEmpty() },
-          sourceUrl = sourceHref,
-          catalog = bundleHost?.provenance?.let { "${it.repo}@${it.branch}" },
-          toolVersion = bundleHost?.provenance?.toolVersion,
-          viewerUrl = ServeIssueReport.withoutToken(externalPageUrl()),
-          renderUrl = ServeIssueReport.withoutToken(imageUrl),
-          // A token-gated box 404s the tokenless render URL this body carries, so its report keeps
-          // the link form rather than embedding an image that could never load.
-          publicRender = isPublic,
-        )
-      val reportIssue =
-        ServeWeb.ReportIssue(
-          action = ServeIssueReport.action(reportContext.repo),
-          title = ServeIssueReport.title(reportContext),
-          body = ServeIssueReport.body(reportContext),
-          bodyTemplate = ServeIssueReport.body(reportContext, renderPlaceholder = true),
-          repo = reportContext.repo,
-          // Named in the tooltip when this box has a GitHub session for the visitor, so they know
-          // whose account the issue will be authored by before they leave the page.
-          login = githubAuth?.currentLogin(call),
-        )
       val liveAuthPrompt =
         githubAuth
           ?.takeIf { renderHost.hasLiveStream }
@@ -4539,7 +4556,9 @@ class ServeHttpServer(
             ),
           version = BUNDLE_VERSION,
           sourceHref = sourceHref,
-          reportIssue = reportIssue,
+          // A viewer cannot reliably name the selected design reference or the parity score.
+          // Reporting lives on the focused comparison, where both are concrete.
+          reportIssue = null,
           // The Figma node this preview is specified by, when the catalog publishes a Figma-backed
           // design reference for it. Resolved from data the catalog already carries — nothing is
           // fetched from Figma, here or anywhere else in serve.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
@@ -1,5 +1,13 @@
 package ee.schimke.composeai.cli.serve
 
+import java.util.Locale
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
 /**
  * Builds the prefilled GitHub **new-issue** link the viewer offers beside its "source" link, so
  * someone looking at a preview that renders wrongly can file it against the repo that owns the code
@@ -30,6 +38,11 @@ internal object ServeIssueReport {
    */
   const val RENDER_PLACEHOLDER: String = "{{render}}"
 
+  /** Filled by the focused comparison once its browser-side scorer has completed. */
+  const val RAW_SCORES_PLACEHOLDER: String = "{{rawScores}}"
+
+  const val LOCATOR_FENCE: String = "compose-parity-locator/v1"
+
   /** Repo bugs fall back to when a session names no source of its own — the renderer is ours. */
   const val FALLBACK_REPO: String = "yschimke/compose-ai-tools"
 
@@ -47,6 +60,14 @@ internal object ServeIssueReport {
     val previewLabel: String? = null,
     /** The served design system (`wear-m3`), when this session is a catalog. */
     val system: String? = null,
+    /** Stable catalog component identity. */
+    val componentId: String? = null,
+    /** Design reference compared with this exact preview. */
+    val referenceId: String? = null,
+    /** Preview-id axes only; live controls belong exclusively to [overrides]. */
+    val variant: String = "",
+    /** The complete, normalised query map consumed by the render lane. */
+    val overrides: Map<String, String> = emptyMap(),
     /** GitHub blob URL of the preview's source file (from [ServeUrls.githubBlobUrl]). */
     val sourceUrl: String? = null,
     /**
@@ -57,6 +78,8 @@ internal object ServeIssueReport {
     val toolVersion: String? = null,
     /** Absolute viewer URL for this preview. Token-bearing URLs are stripped by [withoutToken]. */
     val viewerUrl: String? = null,
+    /** Absolute focused comparison URL for this preview/reference pair. */
+    val comparisonUrl: String? = null,
     /** Absolute `/render/<id>.png` URL at the overrides in force when the page was served. */
     val renderUrl: String? = null,
     /**
@@ -69,6 +92,25 @@ internal object ServeIssueReport {
      * Defaults to false so a caller that doesn't know keeps the link form.
      */
     val publicRender: Boolean = false,
+    /** Browser-computed parity measurements; absent until the focused comparison finishes. */
+    val rawScores: RawScores? = null,
+  )
+
+  data class RawScores(
+    val structuralMatch: Double,
+    val pixelsChanged: Double,
+    val proportionDifference: Double? = null,
+  )
+
+  data class Locator(
+    val repository: String,
+    val system: String,
+    val componentId: String,
+    val previewId: String,
+    val referenceId: String,
+    val variant: String,
+    val overrides: Map<String, String>,
+    val revision: String? = null,
   )
 
   /**
@@ -101,14 +143,19 @@ internal object ServeIssueReport {
     val rows = buildList {
       ctx.system?.trim()?.takeIf { it.isNotEmpty() }?.let { add("| Design system | `$it` |") }
       add("| Preview | `${ctx.previewId}` |")
-      ctx.sourceUrl?.takeIf { it.isNotBlank() }?.let { add("| Source | $it |") }
+      withoutToken(ctx.sourceUrl)?.takeIf { it.isNotBlank() }?.let { add("| Source | $it |") }
       ctx.catalog?.takeIf { it.isNotBlank() }?.let { add("| Catalog | `$it` |") }
       ctx.toolVersion
         ?.takeIf { it.isNotBlank() }
         ?.let { add("| Rendered by | compose-ai-tools $it |") }
+      val scores =
+        if (renderPlaceholder && !ctx.referenceId.isNullOrBlank()) RAW_SCORES_PLACEHOLDER
+        else ctx.rawScores?.let(::formatRawScores)
+      scores?.let { add("| Raw comparison | `$it` |") }
     }
     val render =
-      if (renderPlaceholder) RENDER_PLACEHOLDER else ctx.renderUrl?.takeIf { it.isNotBlank() }
+      if (renderPlaceholder) RENDER_PLACEHOLDER
+      else withoutToken(ctx.renderUrl)?.takeIf { it.isNotBlank() }
     // Whether the render can be *embedded* is decided by the real URL even when the body is the
     // JS template, so both forms of the body have the same shape and the placeholder swap can't
     // turn a working image into a broken one. Two independent conditions have to hold: GitHub's
@@ -116,7 +163,12 @@ internal object ServeIssueReport {
     // body strips.
     val embed = render != null && ctx.publicRender && isEmbeddable(ctx.renderUrl)
     val links = buildList {
-      ctx.viewerUrl?.takeIf { it.isNotBlank() }?.let { add("[Open this preview]($it)") }
+      withoutToken(ctx.viewerUrl)
+        ?.takeIf { it.isNotBlank() }
+        ?.let { add("[Open this preview]($it)") }
+      withoutToken(ctx.comparisonUrl)
+        ?.takeIf { it.isNotBlank() }
+        ?.let { add("[Open comparison]($it)") }
       // Only worth its own line when the image isn't already showing it.
       if (!embed) render?.let { add("[PNG at these settings]($it)") }
     }
@@ -144,7 +196,120 @@ internal object ServeIssueReport {
       append(rows.joinToString("\n"))
       if (links.isNotEmpty()) append("\n\n").append(links.joinToString(" · "))
       append("\n")
+      locator(ctx)?.let { append("\n").append(locatorBlock(it)) }
     }
+  }
+
+  private fun formatRawScores(scores: RawScores): String = buildString {
+    append(
+      "%.1f%% structural match; %.2f%% pixels changed"
+        .format(Locale.ROOT, scores.structuralMatch, scores.pixelsChanged)
+    )
+    scores.proportionDifference?.let {
+      append("; %.1f%% proportion difference".format(Locale.ROOT, it))
+    }
+  }
+
+  fun locator(ctx: Context): Locator? {
+    val system = ctx.system?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val component = ctx.componentId?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val reference = ctx.referenceId?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    return Locator(
+      repository = ctx.repo,
+      system = system,
+      componentId = component,
+      previewId = ctx.previewId,
+      referenceId = reference,
+      variant = ctx.variant,
+      overrides = ctx.overrides,
+      revision = ctx.catalog?.trim()?.takeIf { it.isNotEmpty() },
+    )
+  }
+
+  /** Catalog-authored component id, with the parity dashboard's stable route-id fallback. */
+  fun componentIdFor(preview: ServePreview): String =
+    preview.componentId?.takeIf { it.isNotBlank() }
+      ?: run {
+        val ideal = preview.id.indexOf("__ideal")
+        if (ideal > 0) preview.id.substring(0, ideal)
+        else {
+          val parts = preview.id.split("__")
+          val theme = parts.indices.lastOrNull { it >= 1 && parts[it] in setOf("light", "dark") }
+          if (theme == null) preview.id
+          else parts.filterIndexed { index, _ -> index != theme }.joinToString("__")
+        }
+      }
+
+  /** Axis segments already encoded by the served preview id, never live overrides. */
+  fun variantFor(preview: ServePreview): String =
+    preview.id.substringAfter("__", missingDelimiterValue = "").replace("__", "/")
+
+  fun locatorBlock(locator: Locator): String = buildString {
+    append("```$LOCATOR_FENCE\n")
+    append("repository: ${locator.repository}\n")
+    append("system: ${locator.system}\n")
+    append("component: ${locator.componentId}\n")
+    append("preview: ${locator.previewId}\n")
+    append("reference: ${locator.referenceId}\n")
+    append("variant: ${locator.variant}\n")
+    append("overrides: ${canonicalOverrides(locator.overrides)}\n")
+    locator.revision?.let { append("revision: $it\n") }
+    append("```\n")
+  }
+
+  fun locatorFromBody(body: String): Locator? {
+    val fenced = body.substringAfter("```$LOCATOR_FENCE\n", missingDelimiterValue = "")
+    if (fenced.isEmpty()) return null
+    val content = fenced.substringBefore("\n```", missingDelimiterValue = "")
+    if (content.isEmpty()) return null
+    val fields =
+      content
+        .lineSequence()
+        .mapNotNull { line ->
+          val separator = line.indexOf(':')
+          if (separator <= 0) null
+          else line.substring(0, separator) to line.substring(separator + 1).trimStart()
+        }
+        .toMap()
+    val overrides =
+      runCatching { parseOverrides(fields["overrides"] ?: return null) }.getOrNull() ?: return null
+    return Locator(
+      repository = fields["repository"]?.takeIf { it.isNotBlank() } ?: return null,
+      system = fields["system"]?.takeIf { it.isNotBlank() } ?: return null,
+      componentId = fields["component"]?.takeIf { it.isNotBlank() } ?: return null,
+      previewId = fields["preview"]?.takeIf { it.isNotBlank() } ?: return null,
+      referenceId = fields["reference"]?.takeIf { it.isNotBlank() } ?: return null,
+      variant = fields["variant"] ?: return null,
+      overrides = overrides,
+      revision = fields["revision"]?.takeIf { it.isNotBlank() },
+    )
+  }
+
+  fun canonicalOverrides(overrides: Map<String, String>): String {
+    val sorted = overrides.entries.sortedWith { a, b -> compareCodePoints(a.key, b.key) }
+    return Json.encodeToString(
+      JsonObject.serializer(),
+      JsonObject(sorted.associate { it.key to JsonPrimitive(it.value) }),
+    )
+  }
+
+  private fun parseOverrides(value: String): Map<String, String> =
+    Json.parseToJsonElement(value).jsonObject.mapValues { (_, element) ->
+      element.jsonPrimitive.takeIf { it.isString }?.contentOrNull
+        ?: error("override values must be strings")
+    }
+
+  private fun compareCodePoints(a: String, b: String): Int {
+    var ai = 0
+    var bi = 0
+    while (ai < a.length && bi < b.length) {
+      val ac = a.codePointAt(ai)
+      val bc = b.codePointAt(bi)
+      if (ac != bc) return ac.compareTo(bc)
+      ai += Character.charCount(ac)
+      bi += Character.charCount(bc)
+    }
+    return (a.length - ai).compareTo(b.length - bi)
   }
 
   /** Markdown-safe alt text: the preview's label or id, with `]` and `[` stripped. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -6510,12 +6510,26 @@ $rows
      * (the default) leaves every existing caller's URLs byte-identical.
      */
     sessionInOrigin: Boolean = false,
+    /** Normalised render-lane query values that reproduce the compared candidate. */
+    overrides: Map<String, String> = emptyMap(),
+    /** Prefilled parity report for this exact preview/reference comparison. */
+    reportIssue: ReportIssue? = null,
   ): String {
     // The session id links may carry. Null on a rooted site (and for the default session): the
     // URL already says which catalog this is. `sessionId` itself stays intact below — it keys the
     // per-catalog localStorage entries and the dark-first lookup, which a site still needs.
     val linkSessionId = if (sessionInOrigin) null else sessionId
-    val q = querySuffix(linkQuery(token, linkSessionId, basePath, isPublic))
+    val overrideQuery =
+      overrides.entries
+        .sortedBy { it.key }
+        .joinToString("&") { (key, value) ->
+          "${WebEscaping.urlEncodeSegment(key)}=${WebEscaping.urlEncodeSegment(value)}"
+        }
+    val linkQuery =
+      listOf(linkQuery(token, linkSessionId, basePath, isPublic), overrideQuery)
+        .filter { it.isNotEmpty() }
+        .joinToString("&")
+    val q = querySuffix(linkQuery)
     val navSuffix =
       querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
     val heading = catalogHeading(displayTitle, moduleLabel)
@@ -6572,7 +6586,7 @@ $rows
     val pageHref: (String?, String) -> String = { pin, referenceId ->
       val query =
         listOfNotNull(
-            linkQuery(token, linkSessionId, basePath, isPublic).takeIf { it.isNotEmpty() },
+            linkQuery.takeIf { it.isNotEmpty() },
             "reference=${WebEscaping.urlEncodeSegment(referenceId)}",
           )
           .joinToString("&")
@@ -6596,6 +6610,7 @@ $rows
         """
           .trimIndent()
       }
+    val report = reportIssueHtml(reportIssue)
     return document(
       title = "${reference.label} — design comparison",
       unfurlTitle = "$heading design comparison",
@@ -6621,7 +6636,7 @@ $rows
             <section><h2>Actual</h2><div class="cp-compare-shot" data-cp-annotated="actual"><img src="$actual" alt="Actual Compose preview"></div></section>
           </div>
           $annotationControls
-          <p class="cp-reference-result" role="status">comparing…</p>
+          <p class="cp-reference-result" role="status">comparing…</p>$report
           <label class="cp-overlay-control">Overlay <input class="cp-overlay-range" type="range" min="0" max="100" value="50"><span>50%</span></label>
           <div class="cp-reference-overlay"><img src="$raster" alt=""><img src="$actual" alt=""></div>
         </div>

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js
@@ -617,6 +617,25 @@
     var actualUrl = referenceRoot.getAttribute("data-actual");
     var diffCanvas = referenceRoot.querySelector(".cp-reference-diff");
     var resultText = referenceRoot.querySelector(".cp-reference-result");
+    function refreshComparisonReport(result) {
+      var body = document.getElementById("cp-report-body");
+      if (!body) return;
+      var template = body.getAttribute("data-report-template");
+      if (!template) return;
+      var render = new URL(actualUrl, location.href);
+      render.searchParams.delete("token");
+      var changedPercent = result.pixels ? result.changed * 100 / result.pixels : 0;
+      var rawScores = result.score.toFixed(1) + "% structural match; " +
+        changedPercent.toFixed(2) + "% pixels changed";
+      if (result.geometry >= GEOMETRY_REPORT_THRESHOLD) {
+        rawScores += "; " + result.geometry.toFixed(1) + "% proportion difference";
+      }
+      // The report remains a GET form. Page-derived values are written only to its hidden input,
+      // never to an href/navigation sink.
+      body.value = template
+        .replace("{{render}}", render.toString())
+        .replace("{{rawScores}}", rawScores);
+    }
     compareImageUrls(referenceUrl, actualUrl, diffCanvas).then(function (result) {
       var changedPercent = result.pixels ? result.changed * 100 / result.pixels : 0;
       // The geometry figure is only worth the visitor's attention once the two content boxes are
@@ -626,6 +645,7 @@
         : "";
       resultText.textContent = result.score.toFixed(1) + "% structural match · " +
         changedPercent.toFixed(2) + "% pixels changed" + geometry;
+      refreshComparisonReport(result);
     }, function () {
       resultText.textContent = "Comparison unavailable";
     });

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -14,10 +14,16 @@ class ServeIssueReportTest {
       previewId = "Article__dark",
       previewLabel = "Article",
       system = "jetnews",
+      componentId = "Article/Card",
+      referenceId = "article-card-figma",
+      variant = "dark",
+      overrides = linkedMapOf("uiMode" to "dark"),
       sourceUrl = "https://github.com/yschimke/compose-samples/blob/previews/app/Article.kt",
       catalog = "yschimke/compose-samples@design-artifacts/jetnews",
       toolVersion = "0.19.37",
       viewerUrl = "https://preview.coo.ee/jetnews/p/Article__dark",
+      comparisonUrl =
+        "https://preview.coo.ee/jetnews/compare/Article__dark?reference=article-card-figma",
       renderUrl = "https://preview.coo.ee/jetnews/render/Article__dark.png?uiMode=dark",
       publicRender = true,
     )
@@ -83,6 +89,34 @@ class ServeIssueReportTest {
     // The screenshot is asked for as a paste, because that lands the pixels on GitHub's own CDN
     // rather than leaving the evidence pointed at a URL that re-renders later.
     assertTrue(body.contains("Copy PNG"), "the body tells the reporter how to attach the render")
+    assertTrue(body.contains("```compose-parity-locator/v1"), body)
+  }
+
+  @Test
+  fun `locator block round trips arbitrary override text`() {
+    val overrides =
+      linkedMapOf("knob.label" to "Send;knob.color=red\n日本語", "knob.quote" to "a=\"b\"")
+    val context = full.copy(overrides = overrides)
+    assertEquals(
+      ServeIssueReport.locator(context),
+      ServeIssueReport.locatorFromBody(ServeIssueReport.body(context)),
+    )
+  }
+
+  @Test
+  fun `canonical override JSON is stable across insertion order and uses code point order`() {
+    val first = linkedMapOf("z" to "last", "😀" to "astral", "a" to "first")
+    val second = linkedMapOf("a" to "first", "z" to "last", "😀" to "astral")
+    val expected = "{\"a\":\"first\",\"z\":\"last\",\"😀\":\"astral\"}"
+    assertEquals(expected, ServeIssueReport.canonicalOverrides(first))
+    assertEquals(expected, ServeIssueReport.canonicalOverrides(second))
+  }
+
+  @Test
+  fun `comparison template exposes placeholders for browser-computed values`() {
+    val template = ServeIssueReport.body(full, renderPlaceholder = true)
+    assertTrue(template.contains("{{render}}"), template)
+    assertTrue(template.contains("{{rawScores}}"), template)
   }
 
   @Test
@@ -203,5 +237,14 @@ class ServeIssueReportTest {
     assertEquals("https://host/p/x", ServeIssueReport.withoutToken("https://host/p/x"))
     assertNull(ServeIssueReport.withoutToken(null))
     assertNull(ServeIssueReport.withoutToken("  "))
+    val tokenBearing =
+      full.copy(
+        sourceUrl = "https://github.com/o/r/blob/main/A.kt?token=source",
+        viewerUrl = "https://host/p/x?token=viewer",
+        comparisonUrl = "https://host/compare/x?token=comparison",
+        renderUrl = "https://host/render/x.png?token=render",
+      )
+    val body = ServeIssueReport.body(tokenBearing)
+    assertFalse(body.contains("token="), body)
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -124,12 +124,24 @@ class ServeWebFixtureTest {
 
   private val fixtureFigmaSpec = ServeFigmaSpec.of(fixtureDesignReference)
 
-  private fun fixtureReportIssue(previewId: String, label: String, sourceFile: String) =
+  private fun fixtureReportIssue(
+    previewId: String,
+    label: String,
+    sourceFile: String,
+    componentId: String? = null,
+    referenceId: String? = null,
+    variant: String = "",
+    overrides: Map<String, String> = emptyMap(),
+  ) =
     ServeIssueReport.Context(
         repo = "yschimke/compose-ai-tools",
         previewId = previewId,
         previewLabel = label,
         system = "compose-m3",
+        componentId = componentId,
+        referenceId = referenceId,
+        variant = variant,
+        overrides = overrides,
         sourceUrl =
           ServeUrls.githubBlobUrl(
             "yschimke/compose-ai-tools",
@@ -139,8 +151,17 @@ class ServeWebFixtureTest {
           ),
         catalog = "yschimke/compose-ai-tools@design-artifacts/compose-m3",
         toolVersion = provenance.toolVersion,
-        viewerUrl = "https://preview.coo.ee/compose-m3/p/$previewId",
-        renderUrl = "https://preview.coo.ee/compose-m3/render/$previewId.png",
+        viewerUrl =
+          if (referenceId == null) "https://preview.coo.ee/compose-m3/p/$previewId" else null,
+        comparisonUrl =
+          referenceId?.let { "https://preview.coo.ee/compose-m3/compare/$previewId?reference=$it" },
+        renderUrl =
+          "https://preview.coo.ee/compose-m3/render/$previewId.png" +
+            overrides.entries
+              .sortedBy { it.key }
+              .joinToString("&", prefix = if (overrides.isEmpty()) "" else "?") { (key, value) ->
+                "${WebEscaping.urlEncodeSegment(key)}=${WebEscaping.urlEncodeSegment(value)}"
+              },
         // The goldens stand in for preview.coo.ee, whose render lane is token-free — so they
         // capture the embedded-image form of the body.
         publicRender = true,
@@ -1433,6 +1454,17 @@ class ServeWebFixtureTest {
         trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
         isPublic = true,
         version = version,
+        overrides = mapOf("fontScale" to "1.5", "knob.label" to "Send;now=x"),
+        reportIssue =
+          fixtureReportIssue(
+            previewId = themedPreviews.first().id,
+            label = themedPreviews.first().label,
+            sourceFile = themedPreviews.first().sourceFile.orEmpty(),
+            componentId = ServeIssueReport.componentIdFor(themedPreviews.first()),
+            referenceId = comparisonReferences.first().id,
+            variant = ServeIssueReport.variantFor(themedPreviews.first()),
+            overrides = mapOf("fontScale" to "1.5", "knob.label" to "Send;now=x"),
+          ),
         // Both panels annotated, so the fixture covers the case the layers exist for: reading the
         // reference's spec against the actual's. The layout boxes agree here and the type styles
         // don't, which is what the page is meant to make obvious.
@@ -2585,6 +2617,19 @@ class ServeWebFixtureTest {
         referenceComparison.contains("aria-label=\"Design references\"") &&
         referenceComparison.contains(">Review revision</a>"),
       "the focused comparison presents the handoff triptych and provenance",
+    )
+    assertTrue(
+      referenceComparison.contains("compose-parity-locator/v1") &&
+        referenceComparison.contains(
+          "overrides: {&quot;fontScale&quot;:&quot;1.5&quot;,&quot;knob.label&quot;:&quot;Send;now=x&quot;}"
+        ) &&
+        referenceComparison.contains("{{rawScores}}"),
+      "the focused comparison pins the locator, canonical overrides and score placeholder",
+    )
+    assertTrue(
+      assetText("format-compare.js").contains("body.value = template") &&
+        assetText("format-compare.js").contains(".replace(\"{{rawScores}}\", rawScores)"),
+      "the browser scorer substitutes the report input value after comparison",
     )
     val referencedState =
       ServePreview(

--- a/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
@@ -21,7 +21,7 @@
       <span>compose-preview</span>
     </a>
     <span class="cp-site-catalog">compose-m3</span>
-    <nav class="cp-breadcrumb" aria-label="Breadcrumb"><a href="/compare?session=compose-m3">compose-m3</a><span class="cp-crumb-sep" aria-hidden="true">/</span><span class="cp-crumb-current">Design comparison</span></nav>
+    <nav class="cp-breadcrumb" aria-label="Breadcrumb"><a href="/compare?session=compose-m3&amp;fontScale=1.5&amp;knob.label=Send%3Bnow%3Dx">compose-m3</a><span class="cp-crumb-sep" aria-hidden="true">/</span><span class="cp-crumb-current">Design comparison</span></nav>
   </div>
   <div class="cp-site-status">
     <span class="cp-daemon-status" id="cp-daemon-status" role="status" hidden></span>
@@ -53,20 +53,20 @@
   </nav>
 </header>
         <main class="cp-main">
-                <div id="cp-reference-compare" data-reference="/reference/design-button-filled-light.png?session=compose-m3" data-actual="/render/button-filled__ideal__default__light.png?session=compose-m3">
+                <div id="cp-reference-compare" data-reference="/reference/design-button-filled-light.png?session=compose-m3&fontScale=1.5&knob.label=Send%3Bnow%3Dx" data-actual="/render/button-filled__ideal__default__light.png?session=compose-m3&fontScale=1.5&knob.label=Send%3Bnow%3Dx">
           <h1 class="cp-head cp-catalog-head">Figma filled button <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></h1>
           <p class="cp-sub">Button · Filled (light) · button-filled__ideal__default__light</p>
           
                   <nav class="cp-reference-picker" aria-label="Design references">
           <span>Design references</span>
-          <a class="cp-reference-choice" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-light" aria-current="page">Figma filled button</a>
-<a class="cp-reference-choice" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;reference=design-button-filled-review">Review revision</a>
+          <a class="cp-reference-choice" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;fontScale=1.5&amp;knob.label=Send%3Bnow%3Dx&amp;reference=design-button-filled-light" aria-current="page">Figma filled button</a>
+<a class="cp-reference-choice" href="/compare/button-filled__ideal__default__light?session=compose-m3&amp;fontScale=1.5&amp;knob.label=Send%3Bnow%3Dx&amp;reference=design-button-filled-review">Review revision</a>
         </nav>
           <div class="cp-reference-meta"><strong>Source:</strong> figma · revision fixture-42</div>
           <div class="cp-reference-grid">
-            <section><h2>Reference</h2><div class="cp-compare-shot" data-cp-annotated="reference"><img src="/reference/design-button-filled-light.png?session=compose-m3" alt="Design reference"></div></section>
+            <section><h2>Reference</h2><div class="cp-compare-shot" data-cp-annotated="reference"><img src="/reference/design-button-filled-light.png?session=compose-m3&fontScale=1.5&knob.label=Send%3Bnow%3Dx" alt="Design reference"></div></section>
             <section><h2>Diff</h2><div class="cp-compare-shot"><canvas class="cp-reference-diff" aria-label="Highlighted pixel difference"></canvas></div></section>
-            <section><h2>Actual</h2><div class="cp-compare-shot" data-cp-annotated="actual"><img src="/render/button-filled__ideal__default__light.png?session=compose-m3" alt="Actual Compose preview"></div></section>
+            <section><h2>Actual</h2><div class="cp-compare-shot" data-cp-annotated="actual"><img src="/render/button-filled__ideal__default__light.png?session=compose-m3&fontScale=1.5&knob.label=Send%3Bnow%3Dx" alt="Actual Compose preview"></div></section>
           </div>
                   <div class="cp-annotation-controls" role="group" aria-label="Annotation layers">
           <span class="cp-compare-control-label">Annotations</span>
@@ -76,8 +76,76 @@
         </div>
         <script type="application/json" id="cp-annotations">{"reference":[{"kind":"layout","bounds":{"x":12,"y":12,"width":196,"height":48},"label":"pad 16dp · gap 8dp","role":"Button","detail":{"padding":"16","gap":"8","cornerRadius":"20"}},{"kind":"typography","bounds":{"x":46,"y":26,"width":128,"height":20},"label":"labelLarge 14sp/20","role":"Label","detail":{"token":"labelLarge","fontFamily":"Roboto","fontSize":"14","fontWeight":"500","lineHeight":"20","unit":"sp"}},{"kind":"typography","bounds":{"x":46,"y":58,"width":128,"height":20},"label":"labelLarge 14sp/20","role":"Secondary label","detail":{"token":"labelLarge","fontFamily":"Roboto","fontSize":"14","fontWeight":"500","lineHeight":"20","unit":"sp"}}],"actual":[{"kind":"layout","bounds":{"x":12,"y":12,"width":196,"height":48},"label":"pad 16dp · gap 8dp","role":"Button","detail":{"padding":"16","gap":"8","cornerRadius":"20"}},{"kind":"typography","bounds":{"x":46,"y":26,"width":128,"height":20},"label":"bodyMedium 14sp/20","role":"Label","detail":{"token":"bodyMedium","fontFamily":"Roboto-Medium","fontSize":"14","fontWeight":"500","lineHeight":"20","unit":"sp"}},{"kind":"typography","bounds":{"x":46,"y":58,"width":128,"height":20},"label":"bodyMedium 14sp/20","role":"Secondary label","detail":{"token":"bodyMedium","fontFamily":"Roboto-Medium","fontSize":"14","fontWeight":"500","lineHeight":"20","unit":"sp"}},{"kind":"typography","bounds":{"x":46,"y":90,"width":128,"height":20},"label":"bodyMedium 14sp/20 wght 700","role":"Emphasized label","detail":{"token":"bodyMedium","fontFamily":"Roboto-Medium","fontSize":"14","fontWeight":"700","lineHeight":"20","unit":"sp"}},{"kind":"theme","bounds":{"x":12,"y":12,"width":196,"height":48},"label":"fill #FF6750A4 · radius 20.0dp · border 1.0dp #FF79747E","role":"Button","detail":{"background":"#FF6750A4","cornerRadius":"20.0dp","borderColor":"#FF79747E","borderWidth":"1.0dp"}}]}</script>
           <p class="cp-reference-result" role="status">comparing…</p>
+      <form class="cp-report" id="cp-report" method="get" target="_blank" rel="noopener" action="https://github.com/yschimke/compose-ai-tools/issues/new"><input type="hidden" name="title" value="Preview issue: Button · Filled (light) (compose-m3)"><input type="hidden" name="body" id="cp-report-body" value="### What&#39;s wrong
+
+&lt;!-- What did you expect to see, and what did you get? --&gt;
+
+
+### Screenshot
+
+![Button · Filled (light)](https://preview.coo.ee/compose-m3/render/button-filled__ideal__default__light.png?fontScale=1.5&amp;knob.label=Send%3Bnow%3Dx)
+
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
+
+
+### Which preview
+
+| | |
+| --- | --- |
+| Design system | `compose-m3` |
+| Preview | `button-filled__ideal__default__light` |
+| Catalog | `yschimke/compose-ai-tools@design-artifacts/compose-m3` |
+| Rendered by | compose-ai-tools 0.16.54 |
+
+[Open comparison](https://preview.coo.ee/compose-m3/compare/button-filled__ideal__default__light?reference=design-button-filled-light)
+
+```compose-parity-locator/v1
+repository: yschimke/compose-ai-tools
+system: compose-m3
+component: button-filled
+preview: button-filled__ideal__default__light
+reference: design-button-filled-light
+variant: ideal/default/light
+overrides: {&quot;fontScale&quot;:&quot;1.5&quot;,&quot;knob.label&quot;:&quot;Send;now=x&quot;}
+revision: yschimke/compose-ai-tools@design-artifacts/compose-m3
+```
+" data-report-template="### What&#39;s wrong
+
+&lt;!-- What did you expect to see, and what did you get? --&gt;
+
+
+### Screenshot
+
+![Button · Filled (light)]({{render}})
+
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
+
+
+### Which preview
+
+| | |
+| --- | --- |
+| Design system | `compose-m3` |
+| Preview | `button-filled__ideal__default__light` |
+| Catalog | `yschimke/compose-ai-tools@design-artifacts/compose-m3` |
+| Rendered by | compose-ai-tools 0.16.54 |
+| Raw comparison | `{{rawScores}}` |
+
+[Open comparison](https://preview.coo.ee/compose-m3/compare/button-filled__ideal__default__light?reference=design-button-filled-light)
+
+```compose-parity-locator/v1
+repository: yschimke/compose-ai-tools
+system: compose-m3
+component: button-filled
+preview: button-filled__ideal__default__light
+reference: design-button-filled-light
+variant: ideal/default/light
+overrides: {&quot;fontScale&quot;:&quot;1.5&quot;,&quot;knob.label&quot;:&quot;Send;now=x&quot;}
+revision: yschimke/compose-ai-tools@design-artifacts/compose-m3
+```
+"><button type="submit" class="cp-report-link" title="File an issue on yschimke/compose-ai-tools as @yschimke"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> report an issue</button></form>
           <label class="cp-overlay-control">Overlay <input class="cp-overlay-range" type="range" min="0" max="100" value="50"><span>50%</span></label>
-          <div class="cp-reference-overlay"><img src="/reference/design-button-filled-light.png?session=compose-m3" alt=""><img src="/render/button-filled__ideal__default__light.png?session=compose-m3" alt=""></div>
+          <div class="cp-reference-overlay"><img src="/reference/design-button-filled-light.png?session=compose-m3&fontScale=1.5&knob.label=Send%3Bnow%3Dx" alt=""><img src="/render/button-filled__ideal__default__light.png?session=compose-m3&fontScale=1.5&knob.label=Send%3Bnow%3Dx" alt=""></div>
         </div>
         <script src="/assets/serve/fixture/url-state.js"></script>
         <script src="/assets/serve/fixture/format-compare.js"></script>


### PR DESCRIPTION
## Summary

- add the versioned `compose-parity-locator/v1` contract with deterministic canonical JSON
- include component, reference, variant, overrides, comparison URL, and raw scorer context in issue reports
- expose reporting only from focused reference comparisons and preserve normalized override queries
- add unit coverage and a browser fixture for the comparison/reporting flow

## Why

This implements batch 1 of the parity workflow planned in #3879. It gives reports a stable machine-readable locator while keeping tokens out of generated issue bodies and comparison links.

## Impact

Parity reports now carry enough normalized identity and render context for downstream triage and automation. The generic interactive viewer remains unchanged; the report affordance appears only when comparing against a reference.

## Validation

- `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.ServeIssueReportTest' --tests 'ee.schimke.composeai.cli.serve.ServeWebFixtureTest' --no-daemon`
- `npx playwright test -c preview-harness/playwright.config.mjs pages-snapshot -g 'serve-reference-compare'`
- `node --check cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/format-compare.js`
- `git diff --check`
- repository pre-commit formatting checks