### PR TITLE
fix(design-artifacts): exempt declared no-sticker previews from the shard render check

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -914,9 +914,14 @@ jobs:
           # and the verifier's `parseArgs` is strict — an older checkout would die with
           # ERR_PARSE_ARGS_UNKNOWN_OPTION before verifying anything, turning a pin into a broken
           # publish. Same capability-probe shape the CLI checks above use, for the same reason.
+          # Capture the usage text first and test it separately. The probe prints usage and exits
+          # 2 by design, and this step runs under `pipefail`, so `node … | grep -q` would carry
+          # node's 2 through the pipeline and read as "unsupported" on EVERY driver — silently
+          # disabling the exemption the flag exists to deliver.
           verifier=compose-ai-tools/scripts/design-artifacts/verify-shard-renders.mjs
+          verifier_usage=$(node "$verifier" 2>&1 || true)
           spec_arg=()
-          if node "$verifier" 2>&1 | grep -q -- '--spec'; then
+          if grep -q -- '--spec' <<<"$verifier_usage"; then
             spec_arg=(--spec "${{ inputs.spec }}")
           else
             echo "::notice title=Driver predates --spec::the pinned driver-ref's verify-shard-renders.mjs has no --spec; no-sticker previews will not be exempted."

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -911,7 +911,7 @@ jobs:
           # excluded. Anchoring (#3561) fixed the cause; this makes any future recurrence loud,
           # naming the shard and the ids instead of thinning the published catalog in silence.
           node compose-ai-tools/scripts/design-artifacts/verify-shard-renders.mjs \
-            --bundle "$GITHUB_WORKSPACE/bundle.png" "${plans[@]}"
+            --bundle "$GITHUB_WORKSPACE/bundle.png" --spec "${{ inputs.spec }}" "${plans[@]}"
 
       - name: Render extra module
         if: ${{ inputs.extra-module != '' }}

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -910,8 +910,18 @@ jobs:
           # shard's unanchored exclusions also deleted the `_VARIANT_` fan-out of every id it
           # excluded. Anchoring (#3561) fixed the cause; this makes any future recurrence loud,
           # naming the shard and the ids instead of thinning the published catalog in silence.
-          node compose-ai-tools/scripts/design-artifacts/verify-shard-renders.mjs \
-            --bundle "$GITHUB_WORKSPACE/bundle.png" --spec "${{ inputs.spec }}" "${plans[@]}"
+          # `--spec` only where the checked-out driver declares it. `driver-ref` is a documented pin,
+          # and the verifier's `parseArgs` is strict — an older checkout would die with
+          # ERR_PARSE_ARGS_UNKNOWN_OPTION before verifying anything, turning a pin into a broken
+          # publish. Same capability-probe shape the CLI checks above use, for the same reason.
+          verifier=compose-ai-tools/scripts/design-artifacts/verify-shard-renders.mjs
+          spec_arg=()
+          if node "$verifier" 2>&1 | grep -q -- '--spec'; then
+            spec_arg=(--spec "${{ inputs.spec }}")
+          else
+            echo "::notice title=Driver predates --spec::the pinned driver-ref's verify-shard-renders.mjs has no --spec; no-sticker previews will not be exempted."
+          fi
+          node "$verifier" --bundle "$GITHUB_WORKSPACE/bundle.png" "${spec_arg[@]}" "${plans[@]}"
 
       - name: Render extra module
         if: ${{ inputs.extra-module != '' }}

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -797,6 +797,11 @@ that asymmetry is what makes the signal precise. Extra ids are not reported: exc
 previews listed in the bundle, and a shard rendering more than its share costs time, not stickers.
 The failure names the shard and its missing ids, so a recurrence points at its own cause.
 
+A render **failure** counts as captured, deliberately. A preview that blew up leaves
+`previews/<id>.error.json` and no PNG, and an excluded preview never reaches the renderer, so an
+error sidecar can never mask an exclusion loss — only cause a misleading report of one. Render
+failures have their own reporting (`render-failures.mjs`, and the completeness gate).
+
 **It disarms itself rather than cry wolf.** "Any artifact" leans on the semantics pass to give a
 raster-less preview *something*, and `packSemanticsBlob` is best-effort — a missing
 `daemon-launch.json`, a session that will not open, or an empty capture each warn and leave the pack
@@ -804,6 +809,15 @@ exiting 0 with no `.semantics.json` anywhere. In that state a legitimately raste
 indistinguishable from one an exclusion ate, so the check reports the shortfall as a workflow warning
 and passes instead of failing the run on a signal it cannot read. A gate that fails for the wrong
 reason spends exactly the trust this one exists to rebuild.
+
+The capture is best-effort **per preview** too, and that partial case is handled by declaration
+rather than by threshold. Only one class of preview has no render-side artifact to fall back on: a
+spec's `"capture": "none"` entries. A `ScrollMode.GIF` capture still leaves its `.gif` and a token
+sheet its `.catalog.json` — both written by the render itself, so neither depends on the semantics
+pass succeeding. The merge step therefore passes the catalog spec, and the declared no-sticker
+previews (`noStickerPreviewNames`) are exempt; the completeness gate exempts the same entries from
+its missing-render check, so the two agree about what the declaration buys. Without a readable spec
+the check keeps its old, slightly noisier reading rather than failing.
 
 **The CLI has to be new enough.** The merge runs last, after every shard has spent its twenty
 minutes, so a CLI predating `bundle merge` would fail the run having burned the whole fan-out — and

--- a/scripts/design-artifacts/bundle-previews.mjs
+++ b/scripts/design-artifacts/bundle-previews.mjs
@@ -86,6 +86,13 @@ const PREVIEWS_DIR = "previews/";
  * what makes "no artifact whatsoever" a precise signal for *excluded* rather than *PNG-less*, and
  * it is what `verify-shard-renders.mjs` compares the shard plans against after a sharded merge.
  *
+ * A render **failure** counts as captured, deliberately: a preview that blew up leaves
+ * `previews/<id>.error.json` and no PNG, and it is not what this signal is looking for. An excluded
+ * preview never reaches the renderer, so it can never carry an error sidecar — meaning the sidecar
+ * cannot mask an exclusion loss, only cause a misleading one. Render failures have their own
+ * reporting (`render-failures.mjs`, and the completeness gate); crediting them here keeps the shard
+ * check from failing a run with the wrong diagnosis.
+ *
  * The one hole in that reasoning is that semantics capture is **best-effort** — a missing daemon
  * descriptor, a failed session open, or an empty capture leaves `packSemanticsBlob` returning null
  * and the pack succeeding anyway — so a bundle can carry no `.semantics.json` at all. A raster-less

--- a/scripts/design-artifacts/capture-mode.mjs
+++ b/scripts/design-artifacts/capture-mode.mjs
@@ -67,17 +67,33 @@ export function exportsNoSticker(entry) {
  * exempts the same entries from the missing-render check, so the two agree about what the
  * declaration buys.
  *
+ * **A function is named only when EVERY entry referencing it declares `none`.** Entries are not
+ * one-to-one with renders: `select` picks a single value out of a multipreview's fan-out, so two
+ * entries can share one `preview` and mean different ids — one breakpoint declared sticker-less
+ * while another is required. Returning the function name in that case would exempt the required
+ * render too, and this list is consumed by a caller that only knows function names, so the
+ * over-exemption would silently blind the shard check to a real loss. Resolving `select` against the
+ * fan-out is the precise answer and belongs with the machinery that already does it; until then the
+ * conservative rule is the right one, because the two ways of being wrong are not symmetric.
+ * Under-exempting costs a false alarm carrying a message that names the alternative; over-exempting
+ * costs exactly the silence this whole check exists to end.
+ *
  * @param {{groups?: Array<object>}} spec a parsed catalog spec.
  * @returns {string[]} sorted, de-duplicated `@Preview` function names.
  */
 export function noStickerPreviewNames(spec) {
-  const names = new Set();
+  const declared = new Map();
   for (const group of Array.isArray(spec?.groups) ? spec.groups : []) {
     for (const comp of Array.isArray(group?.components) ? group.components : []) {
       for (const entry of [comp, ...(Array.isArray(comp?.variants) ? comp.variants : [])]) {
-        if (typeof entry?.preview === "string" && exportsNoSticker(entry)) names.add(entry.preview);
+        if (typeof entry?.preview !== "string") continue;
+        const allNoneSoFar = declared.get(entry.preview) ?? true;
+        declared.set(entry.preview, allNoneSoFar && exportsNoSticker(entry));
       }
     }
   }
-  return [...names].sort();
+  return [...declared.entries()]
+    .filter(([, allNone]) => allNone)
+    .map(([preview]) => preview)
+    .sort();
 }

--- a/scripts/design-artifacts/capture-mode.mjs
+++ b/scripts/design-artifacts/capture-mode.mjs
@@ -50,3 +50,34 @@ export function captureMode(entry) {
 export function exportsNoSticker(entry) {
   return captureMode(entry) === "none";
 }
+
+/**
+ * The `@Preview` function names a [spec] declares export no sticker (`"capture": "none"`), across
+ * components and their variants.
+ *
+ * These are the only entries with **no render-side artifact at all**, which is what makes them worth
+ * naming separately. Every other PNG-less preview still leaves something the render itself wrote — a
+ * `ScrollMode.GIF` capture leaves `previews/<id>.gif`, a `@ColorCatalog` / `@ThemeCatalog` sheet
+ * leaves `previews/<id>.catalog.json` — so it is visible whether or not the *semantics* pass (which
+ * is best-effort, per preview) succeeded for it. A `"capture": "none"` entry has neither, so after a
+ * partial semantics failure it is indistinguishable from a preview an exclusion ate.
+ *
+ * `verify-shard-renders.mjs` exempts them for exactly that reason: it is the one class where "no
+ * artifact" cannot be read as "lost", and it is declared rather than guessed. The completeness gate
+ * exempts the same entries from the missing-render check, so the two agree about what the
+ * declaration buys.
+ *
+ * @param {{groups?: Array<object>}} spec a parsed catalog spec.
+ * @returns {string[]} sorted, de-duplicated `@Preview` function names.
+ */
+export function noStickerPreviewNames(spec) {
+  const names = new Set();
+  for (const group of Array.isArray(spec?.groups) ? spec.groups : []) {
+    for (const comp of Array.isArray(group?.components) ? group.components : []) {
+      for (const entry of [comp, ...(Array.isArray(comp?.variants) ? comp.variants : [])]) {
+        if (typeof entry?.preview === "string" && exportsNoSticker(entry)) names.add(entry.preview);
+      }
+    }
+  }
+  return [...names].sort();
+}

--- a/scripts/design-artifacts/capture-mode.test.mjs
+++ b/scripts/design-artifacts/capture-mode.test.mjs
@@ -59,3 +59,44 @@ test("noStickerPreviewNames is empty for an annotation-first spec with no groups
   assert.deepEqual(noStickerPreviewNames(undefined), []);
   assert.deepEqual(noStickerPreviewNames({ groups: [{ components: [{ preview: "A" }] }] }), []);
 });
+
+test("noStickerPreviewNames refuses a function whose entries disagree", () => {
+  // `select` picks one value of a multipreview's fan-out, so two entries can share one `preview`
+  // and mean different renders. Exempting the function would blind the shard check to a real loss
+  // of the required breakpoint, so a mixed declaration exempts nothing.
+  const spec = {
+    groups: [
+      {
+        components: [
+          {
+            componentId: "Cards/Large",
+            preview: "CardPreview",
+            select: { size: "largeRound" },
+            capture: "none",
+          },
+          { componentId: "Cards/Small", preview: "CardPreview", select: { size: "smallRound" } },
+          { componentId: "Views/Hosted", preview: "HostedViewPreview", capture: "none" },
+        ],
+      },
+    ],
+  };
+  assert.deepEqual(noStickerPreviewNames(spec), ["HostedViewPreview"]);
+});
+
+test("noStickerPreviewNames keeps a function every entry declares sticker-less", () => {
+  const spec = {
+    groups: [
+      {
+        components: [
+          {
+            componentId: "Views/Hosted",
+            preview: "HostedViewPreview",
+            capture: "none",
+            variants: [{ preview: "HostedViewPreview", capture: "none" }],
+          },
+        ],
+      },
+    ],
+  };
+  assert.deepEqual(noStickerPreviewNames(spec), ["HostedViewPreview"]);
+});

--- a/scripts/design-artifacts/capture-mode.test.mjs
+++ b/scripts/design-artifacts/capture-mode.test.mjs
@@ -1,7 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { CAPTURE_MODES, captureMode, exportsNoSticker } from "./capture-mode.mjs";
+import {
+  CAPTURE_MODES,
+  captureMode,
+  exportsNoSticker,
+  noStickerPreviewNames,
+} from "./capture-mode.mjs";
 
 test("absent capture reads as static — the strict default", () => {
   assert.equal(captureMode({ componentId: "Button/Filled", preview: "FilledButton" }), "static");
@@ -22,4 +27,35 @@ test("only the declared modes exist — a typo is not an exemption", () => {
   assert.equal(exportsNoSticker({ capture: "animated" }), false);
   assert.equal(exportsNoSticker({ capture: "gif" }), false);
   assert.equal(exportsNoSticker({ capture: "None" }), false);
+});
+
+test("noStickerPreviewNames collects capture:none entries from components and variants", () => {
+  const spec = {
+    groups: [
+      {
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+          {
+            componentId: "Views/Hosted",
+            preview: "HostedViewPreview",
+            capture: "none",
+            variants: [
+              { preview: "HostedViewDisabledPreview", capture: "none" },
+              { preview: "HostedViewPressedPreview" },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  assert.deepEqual(noStickerPreviewNames(spec), [
+    "HostedViewDisabledPreview",
+    "HostedViewPreview",
+  ]);
+});
+
+test("noStickerPreviewNames is empty for an annotation-first spec with no groups", () => {
+  assert.deepEqual(noStickerPreviewNames({}), []);
+  assert.deepEqual(noStickerPreviewNames(undefined), []);
+  assert.deepEqual(noStickerPreviewNames({ groups: [{ components: [{ preview: "A" }] }] }), []);
 });

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -358,23 +358,34 @@ export function verifyShardPlans(plans) {
  * otherwise would spend the operator's trust on a false alarm — the very thing that made the
  * original bug expensive.
  *
+ * **[exemptIds] covers the PARTIAL version of the same problem.** [semanticsRan] catches a semantics
+ * pass that produced nothing at all; the capture is also best-effort *per preview*, so one id's tree
+ * can be missing while the rest carry. That only matters for a preview with no render-side artifact
+ * to fall back on — and there is exactly one such class, the spec's `"capture": "none"` entries. A
+ * `ScrollMode.GIF` capture still leaves its `.gif` and a token sheet its `.catalog.json`, both
+ * written by the render itself, so neither depends on semantics succeeding. Passing the declared
+ * no-sticker ids here closes the window without a threshold and without guessing at preview shapes
+ * — see `noStickerPreviewNames` in `capture-mode.mjs`.
+ *
  * Extra ids are not a problem and are not reported: a merged bundle legitimately carries the whole
  * discovery set (exclusion leaves previews listed), and a shard rendering *more* than its share
  * costs time, not stickers.
  *
  * @param {Array<{index: number, previews: string[]}>} plans the uploaded per-shard plans.
  * @param {Iterable<string>} capturedIds ids the merged bundle captured.
- * @param {{semanticsRan?: boolean}} [opts] `semanticsRan: false` disarms the check — see above.
+ * @param {{semanticsRan?: boolean, exemptIds?: Iterable<string>}} [opts] `semanticsRan: false`
+ *   disarms the check; `exemptIds` are ids declared to export no sticker — see above.
  * @returns {{ok: boolean, problems: string[], notes: string[],
  *   missing: Array<{id: string, shard: number}>}} `missing` is sorted by shard then id; `problems`
  *   is empty iff every planned id came back or the check declined to judge.
  */
-export function verifyShardRenders(plans, capturedIds, { semanticsRan = true } = {}) {
+export function verifyShardRenders(plans, capturedIds, { semanticsRan = true, exemptIds } = {}) {
   const captured = new Set(capturedIds ?? []);
+  const exempt = new Set(exemptIds ?? []);
   const missing = [];
   for (const plan of [...(plans ?? [])].sort((a, b) => (a?.index ?? 0) - (b?.index ?? 0))) {
     for (const id of [...(plan?.previews ?? [])].sort()) {
-      if (!captured.has(id)) missing.push({ id, shard: plan?.index ?? 0 });
+      if (!captured.has(id) && !exempt.has(id)) missing.push({ id, shard: plan?.index ?? 0 });
     }
   }
   if (missing.length === 0) return { ok: true, problems: [], notes: [], missing };

--- a/scripts/design-artifacts/shard-preview-ids.test.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.test.mjs
@@ -430,3 +430,22 @@ test("verifyShardRenders names the semantics pass as the rival explanation", () 
   const { problems } = verifyShardRenders([{ index: 1, previews: ["a"] }], []);
   assert.match(problems.at(-1), /if the semantics capture also failed for exactly these previews/);
 });
+
+test("verifyShardRenders exempts declared no-sticker previews from the shortfall", () => {
+  // The partial-semantics window: a `"capture": "none"` preview has no render-side artifact to fall
+  // back on, so an individual semantics miss makes it look exactly like one an exclusion ate.
+  const plans = plansFor(["a", "b", "c", "d"], 2);
+  const armed = verifyShardRenders(plans, ["a", "b", "c"]);
+  assert.equal(armed.ok, false, "unexempted, the missing id fails the run");
+
+  const exempted = verifyShardRenders(plans, ["a", "b", "c"], { exemptIds: ["d"] });
+  assert.ok(exempted.ok);
+  assert.deepEqual(exempted.missing, []);
+});
+
+test("verifyShardRenders still fails on a real loss alongside an exemption", () => {
+  const plans = plansFor(["a", "b", "c", "d"], 2);
+  const { ok, missing } = verifyShardRenders(plans, ["a", "b"], { exemptIds: ["d"] });
+  assert.equal(ok, false, "exempting one id must not blanket the rest");
+  assert.deepEqual(missing.map((m) => m.id), ["c"]);
+});

--- a/scripts/design-artifacts/verify-shard-renders.mjs
+++ b/scripts/design-artifacts/verify-shard-renders.mjs
@@ -25,11 +25,7 @@ import { parseArgs } from "node:util";
 
 import { readPreviewBundle, rawPreviewIdForEntry } from "@design-parity/candidate";
 
-import {
-  bundleCapturedSemantics,
-  capturedPreviewIds,
-  daemonPreviewIdsByFunction,
-} from "./bundle-previews.mjs";
+import { bundleCapturedSemantics, capturedPreviewIds } from "./bundle-previews.mjs";
 import { noStickerPreviewNames } from "./capture-mode.mjs";
 import { verifyShardRenders } from "./shard-preview-ids.mjs";
 
@@ -62,10 +58,14 @@ const semanticsRan = bundleCapturedSemantics(bundle);
 let exemptIds = [];
 if (values.spec) {
   if (existsSync(values.spec)) {
-    const idsByFunction = daemonPreviewIdsByFunction(bundle);
-    exemptIds = noStickerPreviewNames(JSON.parse(readFileSync(values.spec, "utf8"))).flatMap(
-      (fn) => idsByFunction.get(fn) ?? [],
-    );
+    const noSticker = new Set(noStickerPreviewNames(JSON.parse(readFileSync(values.spec, "utf8"))));
+    // Through `rawPreviewIdForEntry`, exactly as `capturedPreviewIds` does. Bundle entries are keyed
+    // by a filename-safe id while shard plans carry the canonical discovery id, so an id needing
+    // sanitising (a space, say) would otherwise be exempted under a name no plan mentions — the
+    // exemption would silently do nothing for precisely the ids most likely to need it.
+    exemptIds = bundle.previews
+      .filter((preview) => noSticker.has(preview.functionName ?? preview.id))
+      .map((preview) => rawPreviewIdForEntry(bundle, preview));
     if (exemptIds.length > 0) {
       console.error(
         `verify-shard-renders: ${exemptIds.length} preview(s) declared \`"capture": "none"\` are ` +

--- a/scripts/design-artifacts/verify-shard-renders.mjs
+++ b/scripts/design-artifacts/verify-shard-renders.mjs
@@ -20,22 +20,28 @@
  * dependency-free so a shard job can run it without installing anything.
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { parseArgs } from "node:util";
 
 import { readPreviewBundle, rawPreviewIdForEntry } from "@design-parity/candidate";
 
-import { bundleCapturedSemantics, capturedPreviewIds } from "./bundle-previews.mjs";
+import {
+  bundleCapturedSemantics,
+  capturedPreviewIds,
+  daemonPreviewIdsByFunction,
+} from "./bundle-previews.mjs";
+import { noStickerPreviewNames } from "./capture-mode.mjs";
 import { verifyShardRenders } from "./shard-preview-ids.mjs";
 
 const { values, positionals } = parseArgs({
   allowPositionals: true,
-  options: { bundle: { type: "string" } },
+  options: { bundle: { type: "string" }, spec: { type: "string" } },
 });
 
 if (!values.bundle || positionals.length === 0) {
   console.error(
-    "usage: verify-shard-renders.mjs --bundle <merged-bundle.png> <shard-plan.json>…",
+    "usage: verify-shard-renders.mjs --bundle <merged-bundle.png> [--spec <catalog.spec.json>] " +
+      "<shard-plan.json>…",
   );
   process.exit(2);
 }
@@ -47,7 +53,31 @@ const captured = capturedPreviewIds(bundle, rawPreviewIdForEntry);
 // semantics anywhere, and a raster-less preview then has no artifact for a reason that is not
 // sharding. Tell the check, so it declines to judge rather than crying wolf.
 const semanticsRan = bundleCapturedSemantics(bundle);
-const { ok, problems, notes } = verifyShardRenders(plans, captured, { semanticsRan });
+
+// The per-preview version of the same caveat. A `"capture": "none"` entry is the one class with no
+// render-side artifact to fall back on (a GIF capture still leaves its `.gif`, a token sheet its
+// `.catalog.json`), so an individual semantics miss leaves it looking exactly like a preview an
+// exclusion ate. The spec declares them, so exempt them rather than guess. Optional and
+// non-fatal: without a readable spec the check simply keeps its old, slightly noisier reading.
+let exemptIds = [];
+if (values.spec) {
+  if (existsSync(values.spec)) {
+    const idsByFunction = daemonPreviewIdsByFunction(bundle);
+    exemptIds = noStickerPreviewNames(JSON.parse(readFileSync(values.spec, "utf8"))).flatMap(
+      (fn) => idsByFunction.get(fn) ?? [],
+    );
+    if (exemptIds.length > 0) {
+      console.error(
+        `verify-shard-renders: ${exemptIds.length} preview(s) declared \`"capture": "none"\` are ` +
+          `exempt — they export no sticker by design.`,
+      );
+    }
+  } else {
+    console.error(`verify-shard-renders: no spec at ${values.spec}; not exempting any preview.`);
+  }
+}
+
+const { ok, problems, notes } = verifyShardRenders(plans, captured, { semanticsRan, exemptIds });
 
 for (const note of notes) {
   console.error(`::warning title=Shard render check disarmed::verify-shard-renders: ${note}`);


### PR DESCRIPTION
Follow-up to #3885, which merged before these review points could land on it.

## Partial semantics failure

#3885 shipped the outcome check and disarmed it when the semantics pass produced **nothing at all**. That covers the wholesale failure. The capture is best-effort **per preview** too — `injectSemanticsIntoBundle` reports `N without a captured tree` — so one id's sidecar can be missing while the rest carry, and the global boolean stays true.

That only matters for a preview with no *render-side* artifact to fall back on, and there is exactly one such class: the spec's `"capture": "none"` entries. A `ScrollMode.GIF` capture still leaves its `.gif`; a `@ColorCatalog` / `@ThemeCatalog` sheet still leaves its `.catalog.json`. Both are written by the render itself, so neither depends on the semantics pass succeeding.

So the fix is a **declaration, not a threshold**: the merge step passes the catalog spec, and the declared no-sticker previews are exempt. The completeness gate exempts the same entries from its missing-render check, so the two agree about what `"capture": "none"` buys. An absent or unreadable spec keeps the old, slightly noisier reading rather than failing.

## Three corrections from review

**A pinned `driver-ref` would have broken the publish** (P1). The merge step passed `--spec` unconditionally, but `driver-ref` is a documented pin and the verifier's `parseArgs` is strict — an older checkout dies with `ERR_PARSE_ARGS_UNKNOWN_OPTION` before verifying anything. Now probed first, the same shape as the CLI capability probes in the shard-matrix job.

**The exemption was computed in the wrong id namespace.** Bundle entries are keyed by a filename-safe id while shard plans carry the canonical discovery id, and this path didn't apply `rawPreviewIdForEntry` as `capturedPreviewIds` does. An id needing sanitising was exempted under a name no plan mentions — so the exemption silently did nothing for precisely the ids most likely to need it.

**`select` means an entry is not a function.** It picks one value of a multipreview's fan-out, so two entries can share a `preview` and mean different renders — one breakpoint sticker-less, another required. A function is now named only when *every* entry referencing it declares `none`. Resolving `select` against the fan-out is the precise answer and belongs with the machinery that already does it; until then the conservative rule is right, because the two ways of being wrong are not symmetric: under-exempting costs a false alarm that names the alternative, over-exempting costs exactly the silence this check exists to end.

## Render-error sidecars

Also raised: a failed preview leaves `previews/<id>.error.json` and no PNG, and the check credits it as captured. That is intentional, and is now a decision with a comment on it rather than an accident — an excluded preview never reaches the renderer, so an error sidecar cannot *mask* an exclusion loss, only cause a misleading report of one. Render failures have their own reporting (`render-failures.mjs`, and the completeness gate).

## Test plan

- `npm test` in `scripts/design-artifacts` — **682 pass, 0 fail** (25 pre-existing skips). New cases: `noStickerPreviewNames` over components + variants, an annotation-first spec with no `groups`, and a function whose entries disagree via `select`; exemption clearing a shortfall; and exemption *not* blanketing a real loss beside it.
- End-to-end against a real `readPreviewBundle`:
  - semantics missing for a `capture: "none"` preview, no `--spec` → exit 1 (the false alarm this fixes)
  - same, with `--spec` → `1 preview(s) declared "capture": "none" are exempt`, exit 0
  - `--spec` pointing at a missing file → warns, does not exempt, exit 1
  - a no-sticker id whose discovery id carries a **space** while the bundle stores it underscored → exempted correctly (would not have matched before this push)
- Capability probe checked against the previous revision of the verifier: not detected on the old script, detected on the new one, and the old script confirmed to die with `ERR_PARSE_ARGS_UNKNOWN_OPTION` when handed `--spec`.

Text-only change — export-driver plumbing and one workflow argument, no rendered surface touched.