### PR TITLE
fix(serve): tolerate a usage rule kind this build does not know

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -80,7 +80,12 @@ data class UsageRules(
   /** What to do with one scaffolding helper. */
   @Serializable
   data class Scaffold(
-    @SerialName("kind") val kind: Kind,
+    /**
+     * What to do with the helper. Defaults to [Kind.UNKNOWN] — not because a rule may omit it, but
+     * because `coerceInputValues` needs a default to coerce an unrecognised kind *to*; see
+     * [Kind.UNKNOWN].
+     */
+    @SerialName("kind") val kind: Kind = Kind.UNKNOWN,
     /** [Kind.RENAME] only: the plain-Compose name to call instead. */
     @SerialName("renameTo") val renameTo: String? = null,
     /** An import the replacement needs, e.g. `androidx.compose.material3.MaterialTheme`. */
@@ -168,6 +173,24 @@ data class UsageRules(
      * on a named argument.
      */
     SUBSTITUTE,
+
+    /**
+     * A kind this build does not know — a rule kind that has since been retired, or one a newer
+     * catalog declares against a newer server. No pass matches it, so the helper is left exactly as
+     * the catalog wrote it and reported as residue.
+     *
+     * Never written in a rules file: it is what [parse] coerces an unrecognised `kind` to, and the
+     * reason a catalog's whole `compose-usage.json` no longer dies on one such entry.
+     *
+     * The failure this exists to prevent is not hypothetical. `ignoreUnknownKeys` covers an unknown
+     * *key*; an unknown enum *value* throws, and [parse] catches that and returns null for the
+     * entire document — so retiring the `DESTRUCTURE` kind (#3884) meant a catalog pinned to a ref
+     * that still declared one lost every other rule in the file too, `Sticker` and
+     * `catalogButtonSize` included, and silently fell back to [GENERIC]. A rules file is read at
+     * whatever ref the catalog was published from, so its vocabulary is always potentially older
+     * than this build's.
+     */
+    UNKNOWN,
   }
 
   companion object {
@@ -261,6 +284,10 @@ data class UsageRules(
     private val json = Json {
       ignoreUnknownKeys = true
       isLenient = true
+      // An unrecognised `kind` becomes [Kind.UNKNOWN] — that one rule stops firing, the rest of the
+      // file is honoured. Without it a single retired kind rejects the whole document; see
+      // [Kind.UNKNOWN] for the regression that taught us so.
+      coerceInputValues = true
     }
 
     /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -383,6 +383,68 @@ class PlaygroundSourceCleanerTest {
   }
 
   /**
+   * One rule this build cannot read must not cost a catalog every *other* rule in its file.
+   *
+   * A rules file is read at whatever ref the catalog was published from, so its vocabulary can be
+   * older than the server's. `ignoreUnknownKeys` covers an unknown key; an unknown enum *value*
+   * throws, and [UsageRules.parse] turns any throw into "no rules at all". Retiring the
+   * `DESTRUCTURE` kind (#3884) therefore meant a catalog pinned to a ref that still declared one
+   * silently lost `Sticker` and `catalogButtonSize` too and fell back to GENERIC — the scaffolding
+   * leak this whole file exists to prevent, arriving through the compatibility door.
+   */
+  @Test
+  fun `a rule kind this build does not know costs only that rule`() {
+    val rules =
+      assertNotNull(
+        UsageRules.parse(
+          """
+          {
+            "scaffolds": {
+              "Sticker": { "kind": "RENAME", "renameTo": "MaterialTheme" },
+              "catalogButtonSize": { "kind": "DROP" },
+              "toggleable": { "kind": "DESTRUCTURE", "plain": "x", "setter": "y" }
+            }
+          }
+          """
+            .trimIndent()
+        )
+      )
+    // The rules either side of the retired one survived, which is the whole point.
+    assertEquals(UsageRules.Kind.RENAME, rules.scaffolds["Sticker"]?.kind)
+    assertEquals("MaterialTheme", rules.scaffolds["Sticker"]?.renameTo)
+    assertEquals(UsageRules.Kind.DROP, rules.scaffolds["catalogButtonSize"]?.kind)
+    assertEquals(UsageRules.Kind.UNKNOWN, rules.scaffolds["toggleable"]?.kind)
+  }
+
+  /** An unknown kind fires no pass, so the helper survives the clean and is reported as residue. */
+  @Test
+  fun `a helper whose kind is unknown is left alone and reported`() {
+    val rules =
+      assertNotNull(UsageRules.parse("""{"scaffolds":{"toggleable":{"kind":"DESTRUCTURE"}}}"""))
+    val source =
+      """
+      package ee.schimke.m3catalog.sections
+
+      import androidx.compose.material3.Switch
+      import androidx.compose.runtime.Composable
+      import ee.schimke.m3catalog.toggleable
+
+      @Composable
+      fun SwitchSticker() {
+        var checked by toggleable(true)
+        Switch(checked = checked, onCheckedChange = { checked = it })
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun SwitchSticker"), rules)
+      )
+    assertTrue(result.text.contains("toggleable(true)"), result.text)
+    assertTrue(result.residue.contains("toggleable"), "${result.residue}")
+  }
+
+  /**
    * The preview-override knobs are this repo's API, not a catalog's, so a catalog that declares its
    * own scaffolding must still get them — before this, declaring `compose-usage.json` *replaced*
    * the generic rules, so the catalogs that had done the work were the only ones leaking


### PR DESCRIPTION
## Summary

Follow-up to #3884, which retired the `DESTRUCTURE` rule kind. Codex flagged the compatibility hole on that PR (P1, on `UsageRules.kt`) just before it auto-merged, and it was right.

`compose-usage.json` is read at whatever ref the catalog was published from, so its vocabulary can be **older than the server's**. `ignoreUnknownKeys` covers an unknown *key*; an unknown enum *value* throws, and `parse` turns any throw into "no rules at all". Verified against merged `main` with a rules file declaring a `RENAME`, a `DROP` and one retired `DESTRUCTURE`:

```
PARSED=null
LOGS=[compose-usage.json is not valid usage rules (…Kind does not contain
      element with name 'DESTRUCTURE' at path $.scaffolds['toggleable'].kind);
      using generic rules]
```

All three rules lost, seed falls back to `GENERIC` — the scaffolding leak this machinery exists to prevent, arriving through the compatibility door. The exposure is real rather than theoretical: m3-catalog declared `DESTRUCTURE` rules from #75 (`24b3aea6`) until #77 (`a039ad8f`) removed them, so any catalog pinned or published in that window is affected. Its current ref is fine, so nothing on the live lane is broken today.

An unrecognised kind now coerces to `Kind.UNKNOWN` (`coerceInputValues = true`, with `kind` defaulting to it). Every pass filters on a specific kind, so `UNKNOWN` matches none — the helper is left exactly as the catalog wrote it and reported as residue, while every other rule in the file is honoured.

Chosen over simply re-accepting `DESTRUCTURE` as a documented no-op: this fixes the same class of breakage for the *next* retired kind, and for a newer catalog declaring a kind an older server has never heard of, without putting a dead name back in the enum.

## Test plan

Two new tests in `PlaygroundSourceCleanerTest`, both green:

- `a rule kind this build does not know costs only that rule` — the exact historical shape above; asserts `Sticker` keeps `RENAME`/`MaterialTheme`, `catalogButtonSize` keeps `DROP`, and only `toggleable` degrades to `UNKNOWN`.
- `a helper whose kind is unknown is left alone and reported` — end to end through `clean`: the call survives verbatim and comes back in `residue`.

`:cli:test` for `*PlaygroundSourceCleanerTest*`, `*UsageSnippetCorpusTest*`, `*UsageSourceParserTest*` — green. `:cli:ktfmtFormat` — clean.

Non-visual: rules-parsing compatibility, so text-only evidence is right here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_