### PR TITLE
fix(serve): scope unknown-kind tolerance to the kind field

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -376,8 +376,15 @@ object PlaygroundSourceCleaner {
    * invisible in the first place.
    */
   private fun unqualifyScaffoldCalls(text: String, rules: UsageRules): String {
-    if (rules.scaffolds.isEmpty() || rules.scaffoldPackages.isEmpty()) return text
-    val names = rules.scaffolds.keys.joinToString("|") { Regex.escape(it) }
+    // Only helpers a pass will actually rewrite. Unqualifying is a *setup* step — it exists so the
+    // kind passes, which match a bare name, can see a package-qualified call. Doing it for a
+    // [UsageRules.Kind.UNKNOWN] helper strips the qualifier and then no pass rewrites the call and
+    // no pass adds an import, turning `ee.schimke.m3catalog.toggleable(true)` — which resolved —
+    // into a bare `toggleable(true)` that does not. Left qualified, the call keeps working and
+    // still lands in residue via `mentionsQualifiedCall`.
+    val rewritable = rules.scaffolds.filterValues { it.kind != UsageRules.Kind.UNKNOWN }
+    if (rewritable.isEmpty() || rules.scaffoldPackages.isEmpty()) return text
+    val names = rewritable.keys.joinToString("|") { Regex.escape(it) }
     val packages = rules.scaffoldPackages.joinToString("|") { Regex.escape(it) }
     // `[({]` and not just `(`: a trailing-lambda call — `counted { }` — has no parentheses at all,
     // and that is the shape most scaffolding wrappers are written in.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -1,7 +1,13 @@
 package ee.schimke.composeai.cli.serve
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 
 /**
@@ -81,11 +87,10 @@ data class UsageRules(
   @Serializable
   data class Scaffold(
     /**
-     * What to do with the helper. Defaults to [Kind.UNKNOWN] — not because a rule may omit it, but
-     * because `coerceInputValues` needs a default to coerce an unrecognised kind *to*; see
-     * [Kind.UNKNOWN].
+     * What to do with the helper. A kind this build cannot read decodes as [Kind.UNKNOWN] rather
+     * than failing the document — see [Kind.UNKNOWN] and [LenientKind].
      */
-    @SerialName("kind") val kind: Kind = Kind.UNKNOWN,
+    @SerialName("kind") @Serializable(with = LenientKind::class) val kind: Kind = Kind.UNKNOWN,
     /** [Kind.RENAME] only: the plain-Compose name to call instead. */
     @SerialName("renameTo") val renameTo: String? = null,
     /** An import the replacement needs, e.g. `androidx.compose.material3.MaterialTheme`. */
@@ -193,6 +198,32 @@ data class UsageRules(
     UNKNOWN,
   }
 
+  /**
+   * Decodes an unrecognised [Kind] name as [Kind.UNKNOWN] instead of throwing.
+   *
+   * Deliberately a serializer on this one field rather than `coerceInputValues` on the whole
+   * document. That option is global and coerces *any* explicit `null` to its property's default, so
+   * it also quietly repaired malformed rules this code cannot honour — an `INLINE` rule with
+   * `"members": null` would decode to an empty member map, and [PlaygroundSourceCleaner] would then
+   * delete the binding while leaving its member references pointing at nothing. Only the *kind*
+   * vocabulary is expected to drift across refs, so only the kind is forgiving; everything else
+   * still fails the document and takes the safe [GENERIC] fallback.
+   */
+  internal object LenientKind : KSerializer<Kind> {
+    override val descriptor: SerialDescriptor =
+      PrimitiveSerialDescriptor(
+        "ee.schimke.composeai.cli.serve.UsageRules.Kind",
+        PrimitiveKind.STRING,
+      )
+
+    override fun serialize(encoder: Encoder, value: Kind) = encoder.encodeString(value.name)
+
+    override fun deserialize(decoder: Decoder): Kind {
+      val name = decoder.decodeString()
+      return Kind.entries.firstOrNull { it.name == name } ?: Kind.UNKNOWN
+    }
+  }
+
   companion object {
     /** Every override knob takes `(key, default, index)`; the default is `$1`. */
     private val OVERRIDE_KNOB_PARAMS = listOf("key", "default", "index")
@@ -284,10 +315,6 @@ data class UsageRules(
     private val json = Json {
       ignoreUnknownKeys = true
       isLenient = true
-      // An unrecognised `kind` becomes [Kind.UNKNOWN] — that one rule stops firing, the rest of the
-      // file is honoured. Without it a single retired kind rejects the whole document; see
-      // [Kind.UNKNOWN] for the regression that taught us so.
-      coerceInputValues = true
     }
 
     /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -416,6 +416,59 @@ class PlaygroundSourceCleanerTest {
     assertEquals(UsageRules.Kind.UNKNOWN, rules.scaffolds["toggleable"]?.kind)
   }
 
+  /**
+   * Forgiving about the *kind* vocabulary is not the same as forgiving about the rest of the
+   * document. A rules file this code cannot honour must still take the safe GENERIC fallback: an
+   * `INLINE` rule with a null member map would otherwise decode to an empty one, and `applyInline`
+   * would delete the binding while leaving its member references pointing at nothing.
+   */
+  @Test
+  fun `tolerating an unknown kind does not make the rest of the document forgiving`() {
+    assertNull(UsageRules.parse("""{"scaffolds":{"counted":{"kind":"INLINE","members":null}}}"""))
+    assertNull(UsageRules.parse("""{"scaffoldPackages":null}"""))
+  }
+
+  /**
+   * Unqualifying is setup for the kind passes, so a helper no pass will rewrite must not be put
+   * through it: stripping the qualifier off a call nothing then rewrites — and nothing imports —
+   * turns code that resolved into code that does not.
+   */
+  @Test
+  fun `an unknown kind keeps the package qualifier that makes it resolve`() {
+    val rules =
+      assertNotNull(
+        UsageRules.parse(
+          """
+          {
+            "scaffoldPackages": ["ee.schimke.m3catalog"],
+            "scaffolds": { "toggleable": { "kind": "DESTRUCTURE" } }
+          }
+          """
+            .trimIndent()
+        )
+      )
+    val source =
+      """
+      package ee.schimke.m3catalog.sections
+
+      import androidx.compose.material3.Switch
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun SwitchSticker() {
+        var checked by ee.schimke.m3catalog.toggleable(true)
+        Switch(checked = checked, onCheckedChange = { checked = it })
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(source, lineIn(source, "fun SwitchSticker"), rules)
+      )
+    assertTrue(result.text.contains("ee.schimke.m3catalog.toggleable(true)"), result.text)
+    assertTrue(result.residue.contains("toggleable"), "${result.residue}")
+  }
+
   /** An unknown kind fires no pass, so the helper survives the clean and is reported as residue. */
   @Test
   fun `a helper whose kind is unknown is left alone and reported`() {


### PR DESCRIPTION
## Summary

Follow-up to #3890. Codex left two P2s on that PR minutes before it auto-merged; both are correct and both are about code now on `main`.

**1. `coerceInputValues` was too broad.** It is a whole-document option, not a kind-specific one — it coerces an explicit `null` to the default on *any* property that has one. So an `INLINE` rule written `"members": null` decoded to an empty member map, and `applyInline` would delete the helper binding while leaving its member references pointing at nothing. Before #3890 that document was rejected and the caller took the safe `GENERIC` fallback.

Only the *kind* vocabulary is expected to drift across refs, so only the kind is forgiving now, via a `LenientKind` serializer on that single field. Everything else fails the document again, exactly as before.

**2. `unqualifyScaffoldCalls` ran over every scaffold regardless of kind.** Unqualifying is *setup* for the kind passes, which match a bare name. Running it for a helper no pass rewrites strips the qualifier and then nothing adds an import — so `ee.schimke.m3catalog.toggleable(true)`, which resolved, became a bare `toggleable(true)`, which does not. It now skips `UNKNOWN` entries; residue still reports them through `mentionsQualifiedCall`, so the helper is flagged rather than silently mangled.

## Test plan

Two new tests in `PlaygroundSourceCleanerTest`, alongside the two from #3890 (all green):

- `tolerating an unknown kind does not make the rest of the document forgiving` — `"members": null` and `"scaffoldPackages": null` both return null from `parse` again.
- `an unknown kind keeps the package qualifier that makes it resolve` — a `scaffoldPackages`-qualified unknown-kind call survives the clean verbatim and still lands in residue.

`:cli:test` for `*PlaygroundSourceCleanerTest*`, `*UsageSnippetCorpusTest*`, `*UsageSourceParserTest*` — green. `:cli:ktfmtFormat` — clean.

Non-visual: rules-parsing and cleaner-pass scoping, so text-only evidence is right here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSy88QXELBZVmZSJ9AoLg)_