### PR TITLE
feat(design-artifacts): emit design-map.json from the catalog annotations

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -567,6 +567,14 @@ onto `previews.json` as `catalog.reference` / `catalog.referenceSet` and out to 
 exported inventory, and both have a same-named spec field that overrides the annotation.
 `referenceSet` is optional — omit it and everything behaves exactly as before.
 
+These handles are what
+[`emit-design-map.mjs`](../../scripts/design-artifacts/emit-design-map.mjs) projects into a
+`design-map.json` — so the correspondence file design-parity reads is *derived from the
+annotations* rather than hand-maintained beside them. Variant renders come out as unresolved
+declarations in a sidecar, because translating a knob (`size=l`) to a kit node (`Size=Large`)
+needs that kit's published vocabulary, which lives on the design-parity side. See
+[`scripts/design-artifacts/docs/design-map.md`](../../scripts/design-artifacts/docs/design-map.md).
+
 ### Breakpoints and multipreviews: `select`, not a split `@Preview`
 
 A multipreview annotation (`@WearPreviewDevices`, a local `@CatalogWearBreakpoints`)

--- a/scripts/design-artifacts/design-map.mjs
+++ b/scripts/design-artifacts/design-map.mjs
@@ -1,0 +1,247 @@
+/**
+ * Project a discovery manifest into a `design-map.json` — the correspondence file design-parity
+ * reads to know which design node a code component is meant to look like.
+ *
+ * ## Why this is a projection and not a config file
+ *
+ * design-parity joins a code subject to a design reference through a `design-map.json` entry:
+ * `{ code, source, ref, previewId }`. Hand-maintaining that for a catalog's worth of previews is
+ * exactly the mapping-config sprawl a catalog exists to avoid — and it drifts the moment a preview
+ * is renamed, silently, because the join keys on the fully-qualified preview id.
+ *
+ * So the map is DERIVED. Every catalogued component already carries its seed-kit handle on the
+ * annotation this repo defines:
+ *
+ *     @CatalogComponent(id = "Button/Filled", reference = "figma:<fileKey>/<nodeId>")
+ *
+ * `composePreviewDiscover` writes that through to `previews.json` as `catalog.reference`, so this
+ * module is a pure projection of the annotations. Keeping the ref in code is the point: a JSON map
+ * keyed on preview names drifts when a preview is renamed, and fails silently when it does.
+ *
+ * ## Why this lives HERE and not in design-parity
+ *
+ * Every field it reads — `catalog.reference`, `referenceSet`, `noReference`,
+ * `referenceContentsOnly`, `catalog.props`, `overrides.seeds` — is defined in this repository, by
+ * `@CatalogComponent` / `@CatalogVariant` / `@OverrideVariant` and emitted by this repository's
+ * discovery. Rename a field and the projection has to change in the same commit; putting the two
+ * on opposite sides of a repo boundary is how a manifest reader goes quietly stale.
+ *
+ * ## What this deliberately does NOT do
+ *
+ * It does not resolve a variant knob to a design node. `size=l` is a fact about the Compose API;
+ * `Size=Large` is a fact about somebody's design kit, and translating between them needs that kit's
+ * published vocabulary — which this repo has no business holding, and which
+ * [`@design-parity/kit-index`](https://github.com/yschimke/design-parity/tree/main/packages/kit-index)
+ * does hold.
+ *
+ * So the variant renders come out as **declarations**, in a sidecar
+ * ({@link DESIGN_MAP_VARIANTS_SCHEMA}): "this preview is the same component with these knobs
+ * turned". A resolver that owns a kit index turns each into a tagged `ref`/`previewId` pair beside
+ * the base one. A repo with no kit index still gets a valid map of base references, which is the
+ * majority of the value and costs no design-tool credential.
+ *
+ * The sidecar is a separate file rather than another key on the map because the design-map schema
+ * sets `additionalProperties: false` — a map carrying an extra key would fail its own validator.
+ *
+ * Pure and dependency-free (no `@design-parity/*`, no I/O) so it unit-tests without an `npm ci`,
+ * like its siblings `catalog-image-path.mjs` / `catalog-variants.mjs`. The I/O around it is
+ * `emit-design-map.mjs`.
+ */
+
+/** The sidecar `schema` string a resolver must match before reading variant declarations. */
+export const DESIGN_MAP_VARIANTS_SCHEMA = "compose-preview-design-map-variants/v1";
+
+/**
+ * The capture a component's base reference pairs with.
+ *
+ * One entry per component, not per rendered mode — and the LIGHT capture, because that is the mode
+ * design kits draw their frames in. Diffing a dark render against a light reference reports the
+ * whole palette as a finding.
+ */
+const LIGHT_CAPTURE = /_Light$/;
+
+/** A light capture that is also an `@OverrideVariant` render: `…_Light_VARIANT_<name>`. */
+const LIGHT_VARIANT_CAPTURE = /_Light_VARIANT_/;
+
+/** design-parity addresses a code subject as `<path>#<function>`. */
+export function codeHandle(preview, { prefix = "catalog" } = {}) {
+  const path = preview.sourceFile ? `${prefix}/${preview.sourceFile}` : prefix;
+  return `${path}#${preview.functionName}`;
+}
+
+/**
+ * The design source a reference handle names. design-parity dispatches its adapter on this, so a
+ * wrong answer picks a driver that cannot read the ref at all.
+ */
+export function sourceForRef(ref) {
+  const scheme = String(ref).split(":")[0];
+  return scheme === "figma" ? "figma" : "claude-design";
+}
+
+/**
+ * The knobs one variant render turns, normalised to `{ key, raw }`.
+ *
+ * A variant reaches us two ways and both NAME their axis — nothing is inferred from a function
+ * name:
+ *
+ *   `@OverrideVariant(name = "l", strings = ["size=l"])` — a reseeded render of the same
+ *     composable. Arrives as role COMPONENT with `_VARIANT_` in the id and the knobs on
+ *     `overrides`.
+ *
+ *   `@CatalogVariant(of = "Fab/Standard", props = ["size=large"])` — its own composable, because
+ *     the difference is more than a knob. Arrives as role VARIANT with the knobs in `catalog.props`.
+ *
+ * For the first form, `overrides.props` is preferred over `overrides.seeds` when present. They are
+ * not the same list: `seeds` holds only the values that differ from the composable's defaults,
+ * while `props` — emitted for a `@PreviewAxis` cross product — carries the FULL axis assignment,
+ * defaults included. A cell that knows its own axes pairs by construction; one described only by
+ * its non-default seeds is missing the axes it happens to sit at, and a kit that spells its default
+ * size explicitly in a combination cell then has nothing to match against.
+ */
+export function variantSeeds(preview) {
+  const catalog = preview.catalog;
+  if (catalog?.role === "VARIANT") {
+    // `props` names the axis; `state` is the annotation's shorthand for the one axis common enough
+    // to have its own parameter. Either is a declaration, so neither is inferred —
+    // `@CatalogVariant(state = "disabled")` says the state axis as plainly as
+    // `props = ["state=disabled"]` would.
+    const props = [...(catalog.props ?? [])];
+    if (catalog.state && !props.some((p) => p.key === "state")) {
+      props.push({ key: "state", value: catalog.state });
+    }
+    return props.map((p) => ({ key: p.key, raw: p.value }));
+  }
+
+  const overrides = preview.overrides;
+  if (!overrides) return [];
+  if (overrides.props?.length) {
+    return overrides.props.map((p) => ({ key: p.key, raw: p.value }));
+  }
+  return (overrides.seeds ?? []).map((s) => ({ key: s.key, raw: s.raw }));
+}
+
+/** The name a variant render goes by, for a report and for the design-map `state` slot. */
+function variantName(preview, seeds) {
+  const catalog = preview.catalog;
+  if (catalog?.role === "VARIANT") {
+    return catalog.state ?? seeds.map((s) => s.raw).join("-");
+  }
+  return preview.overrides?.name ?? seeds.map((s) => `${s.key}=${s.raw}`).join(", ");
+}
+
+/**
+ * Every variant render, grouped by the component it folds under.
+ *
+ * Both annotation forms are collected. The `@CatalogVariant` form was invisible to the first cut of
+ * this projection, which is why a FAB size axis read as unauthored while `FabSmall`/`FabMedium`/
+ * `FabLarge` sat in the catalog all along.
+ */
+export function variantRendersByComponent(previews) {
+  const byComponent = new Map();
+  for (const preview of previews) {
+    const catalog = preview.catalog;
+    if (!catalog) continue;
+
+    // An `@OverrideVariant` render is a reseed of the SAME composable, so it keeps the parent's
+    // COMPONENT role and is distinguished only by the `_VARIANT_` tag discovery puts in its id.
+    // A `@CatalogVariant` render is its own composable, so it carries the VARIANT role and an
+    // ordinary light-capture id. Either way only the light capture participates.
+    const isOverrideVariant =
+      catalog.role === "COMPONENT" && LIGHT_VARIANT_CAPTURE.test(preview.id);
+    const isCatalogVariant = catalog.role === "VARIANT" && LIGHT_CAPTURE.test(preview.id);
+    if (!isOverrideVariant && !isCatalogVariant) continue;
+
+    // A variant that names no axis says only "this is different", which is not enough to look
+    // anything up in a kit. Dropped rather than guessed at from the function name.
+    const seeds = variantSeeds(preview);
+    if (!seeds.length) continue;
+
+    const list = byComponent.get(catalog.componentId) ?? [];
+    list.push({ previewId: preview.id, name: variantName(preview, seeds), seeds });
+    byComponent.set(catalog.componentId, list);
+  }
+  return byComponent;
+}
+
+/**
+ * Project a discovery manifest into a design map plus its unresolved variant declarations.
+ *
+ * @param {Array<object>} previews `previews.json`'s `previews` array.
+ * @param {{prefix?: string}} [opts] `prefix` is the path segment prepended to each `sourceFile` to
+ *   form the code handle — the module the previews live in, as a reviewer would name it.
+ * @returns {{map: object, variants: object, diagnostics: object}} the map, the sidecar, and what
+ *   was skipped and why. Nothing is thrown for a missing reference: an unmapped component is a
+ *   fact to report, not a failure.
+ */
+export function projectDesignMap(previews, opts = {}) {
+  const variantRenders = variantRendersByComponent(previews);
+
+  const components = [];
+  const declarations = [];
+  /** Components carrying neither a reference nor a stated reason for its absence. */
+  const unmapped = [];
+  /**
+   * Components whose reference is absent for a STATED reason. Reported apart from `unmapped`
+   * because they are the opposite situation: someone looked, and what they found is that the kit
+   * has nothing live to point at. Rolling the two together is what made a retired pattern read as
+   * neglect.
+   */
+  const statedAbsent = [];
+
+  for (const preview of previews) {
+    const catalog = preview.catalog;
+    if (!catalog || catalog.role !== "COMPONENT") continue;
+    if (!LIGHT_CAPTURE.test(preview.id)) continue;
+
+    if (!catalog.reference) {
+      if (catalog.noReference) {
+        statedAbsent.push({ componentId: catalog.componentId, reason: catalog.noReference });
+      } else {
+        unmapped.push(catalog.componentId);
+      }
+      continue;
+    }
+
+    const code = codeHandle(preview, opts);
+    components.push({
+      code,
+      source: sourceForRef(catalog.reference),
+      ref: catalog.reference,
+      // The component SET, when the annotation names one. `ref` stays the one variant parity diffs
+      // against; `refSet` is what a whole-screen import matches an instance through, since a screen
+      // rarely uses the exact variant this sticker pictures. Absent unless the annotation says so.
+      ...(catalog.referenceSet ? { refSet: catalog.referenceSet } : {}),
+      // Figma normally exports only the referenced node. Preserve an explicit per-component opt-out
+      // when the annotation says this reference intentionally relies on overlapping sheet content.
+      ...(catalog.referenceContentsOnly === false ? { referenceContentsOnly: false } : {}),
+      previewId: preview.id,
+    });
+
+    const renders = variantRenders.get(catalog.componentId) ?? [];
+    if (renders.length) {
+      declarations.push({
+        code,
+        componentId: catalog.componentId,
+        reference: catalog.reference,
+        basePreviewId: preview.id,
+        renders,
+      });
+    }
+  }
+
+  components.sort((a, b) => a.code.localeCompare(b.code));
+  declarations.sort((a, b) => a.code.localeCompare(b.code));
+  unmapped.sort();
+  statedAbsent.sort((a, b) => a.componentId.localeCompare(b.componentId));
+
+  return {
+    map: { components },
+    variants: { schema: DESIGN_MAP_VARIANTS_SCHEMA, components: declarations },
+    diagnostics: {
+      unmapped,
+      statedAbsent,
+      variantRenders: declarations.reduce((n, d) => n + d.renders.length, 0),
+      withSet: components.filter((c) => c.refSet).length,
+    },
+  };
+}

--- a/scripts/design-artifacts/design-map.test.mjs
+++ b/scripts/design-artifacts/design-map.test.mjs
@@ -1,0 +1,242 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DESIGN_MAP_VARIANTS_SCHEMA,
+  codeHandle,
+  projectDesignMap,
+  sourceForRef,
+  variantRendersByComponent,
+  variantSeeds,
+} from "./design-map.mjs";
+
+const FILE = "AbCdEf";
+const ref = (nodeId) => `figma:${FILE}/${nodeId}`;
+
+/** A COMPONENT-role light capture — the shape every mapped component arrives in. */
+const component = (name, catalog, extra = {}) => ({
+  id: `com.example.CatalogKt.${name}_Light`,
+  functionName: name,
+  sourceFile: "Catalog.kt",
+  catalog: { role: "COMPONENT", componentId: name, ...catalog },
+  ...extra,
+});
+
+/** An `@OverrideVariant` reseed of `name` — same composable, so still COMPONENT role. */
+const overrideVariant = (name, variant, overrides) => ({
+  id: `com.example.CatalogKt.${name}_Light_VARIANT_${variant}`,
+  functionName: name,
+  sourceFile: "Catalog.kt",
+  catalog: { role: "COMPONENT", componentId: name },
+  overrides: { name: variant, ...overrides },
+});
+
+/** A `@CatalogVariant` — its own composable, so VARIANT role and an ordinary light id. */
+const catalogVariant = (name, of, catalog) => ({
+  id: `com.example.CatalogKt.${name}_Light`,
+  functionName: name,
+  sourceFile: "Catalog.kt",
+  catalog: { role: "VARIANT", componentId: of, ...catalog },
+});
+
+test("codeHandle addresses a subject as <path>#<function>", () => {
+  assert.equal(
+    codeHandle({ sourceFile: "Catalog.kt", functionName: "FilledButton" }),
+    "catalog/Catalog.kt#FilledButton",
+  );
+  assert.equal(
+    codeHandle({ sourceFile: "ui/Buttons.kt", functionName: "Fab" }, { prefix: "app/src" }),
+    "app/src/ui/Buttons.kt#Fab",
+  );
+});
+
+test("sourceForRef dispatches on the ref's scheme", () => {
+  assert.equal(sourceForRef(ref("1:2")), "figma");
+  assert.equal(sourceForRef("claude-design:export/button.html"), "claude-design");
+});
+
+test("projects one entry per component, from the light capture only", () => {
+  const { map } = projectDesignMap([
+    component("FilledButton", { reference: ref("1:2") }),
+    { ...component("FilledButton", { reference: ref("1:2") }), id: "com.example.CatalogKt.FilledButton_Dark" },
+  ]);
+  assert.equal(map.components.length, 1);
+  assert.deepEqual(map.components[0], {
+    code: "catalog/Catalog.kt#FilledButton",
+    source: "figma",
+    ref: ref("1:2"),
+    previewId: "com.example.CatalogKt.FilledButton_Light",
+  });
+});
+
+test("carries refSet and a referenceContentsOnly opt-out only when declared", () => {
+  const { map } = projectDesignMap([
+    component("A", { reference: ref("1:2"), referenceSet: ref("1:1") }),
+    component("B", { reference: ref("2:2"), referenceContentsOnly: false }),
+    component("C", { reference: ref("3:2"), referenceContentsOnly: true }),
+  ]);
+  const [a, b, c] = map.components;
+  assert.equal(a.refSet, ref("1:1"));
+  assert.equal(b.referenceContentsOnly, false);
+  // The default is true; restating it would put a field on every entry that says nothing.
+  assert.ok(!("referenceContentsOnly" in c));
+  assert.ok(!("refSet" in c));
+});
+
+test("separates a stated absence from nobody having looked", () => {
+  const { map, diagnostics } = projectDesignMap([
+    component("Mapped", { reference: ref("1:2") }),
+    component("Retired", { noReference: "the kit retired this pattern in M3" }),
+    component("Forgotten", {}),
+  ]);
+  assert.deepEqual(map.components.map((c) => c.code), ["catalog/Catalog.kt#Mapped"]);
+  assert.deepEqual(diagnostics.statedAbsent, [
+    { componentId: "Retired", reason: "the kit retired this pattern in M3" },
+  ]);
+  assert.deepEqual(diagnostics.unmapped, ["Forgotten"]);
+});
+
+test("entries are sorted by code handle, so the file is diffable", () => {
+  const { map } = projectDesignMap([
+    component("Zebra", { reference: ref("1:2") }),
+    component("Alpha", { reference: ref("2:2") }),
+  ]);
+  assert.deepEqual(map.components.map((c) => c.code), [
+    "catalog/Catalog.kt#Alpha",
+    "catalog/Catalog.kt#Zebra",
+  ]);
+});
+
+test("variantSeeds prefers the full axis assignment over the non-default seeds", () => {
+  // `seeds` holds only what differs from the composable's defaults; `props` carries every axis the
+  // cell sits at. A kit that spells its default size explicitly in a combination cell has nothing
+  // to match against if only the non-default half arrives.
+  const preview = overrideVariant("Button", "s-square", {
+    seeds: [{ key: "shape", kind: "STRING", raw: "square" }],
+    props: [
+      { key: "size", value: "s" },
+      { key: "shape", value: "square" },
+    ],
+  });
+  assert.deepEqual(variantSeeds(preview), [
+    { key: "size", raw: "s" },
+    { key: "shape", raw: "square" },
+  ]);
+});
+
+test("variantSeeds falls back to seeds for a hand-written override variant", () => {
+  const preview = overrideVariant("Button", "l", {
+    seeds: [{ key: "size", kind: "STRING", raw: "l" }],
+  });
+  assert.deepEqual(variantSeeds(preview), [{ key: "size", raw: "l" }]);
+});
+
+test("variantSeeds reads a CatalogVariant's props, and its state shorthand", () => {
+  assert.deepEqual(
+    variantSeeds(catalogVariant("FabLarge", "Fab", { props: [{ key: "size", value: "large" }] })),
+    [{ key: "size", raw: "large" }],
+  );
+  // `state` is the annotation's shorthand for the one axis common enough to have its own parameter.
+  assert.deepEqual(variantSeeds(catalogVariant("ButtonDisabled", "Button", { state: "disabled" })), [
+    { key: "state", raw: "disabled" },
+  ]);
+  // An explicit state prop wins; the shorthand does not get appended twice.
+  assert.deepEqual(
+    variantSeeds(
+      catalogVariant("X", "Button", { state: "disabled", props: [{ key: "state", value: "off" }] }),
+    ),
+    [{ key: "state", raw: "off" }],
+  );
+});
+
+test("collects both annotation forms under the component they fold onto", () => {
+  const byComponent = variantRendersByComponent([
+    component("Fab", { reference: ref("1:2") }),
+    overrideVariant("Fab", "l", { seeds: [{ key: "size", kind: "STRING", raw: "l" }] }),
+    catalogVariant("FabLarge", "Fab", { props: [{ key: "size", value: "large" }] }),
+  ]);
+  assert.deepEqual(
+    byComponent.get("Fab").map((r) => r.name),
+    ["l", "large"],
+  );
+});
+
+test("ignores a variant that names no axis, and non-light captures", () => {
+  const byComponent = variantRendersByComponent([
+    // Named, but says only "this is different" — nothing to look up in a kit.
+    overrideVariant("Button", "special", { seeds: [] }),
+    // A dark capture of a real variant: the light one already stands for it.
+    {
+      ...overrideVariant("Button", "l", { seeds: [{ key: "size", kind: "STRING", raw: "l" }] }),
+      id: "com.example.CatalogKt.Button_Dark_VARIANT_l",
+    },
+    // A VARIANT-role dark capture, likewise.
+    { ...catalogVariant("B", "Button", { state: "disabled" }), id: "com.example.CatalogKt.B_Dark" },
+  ]);
+  assert.equal(byComponent.size, 0);
+});
+
+test("emits variant declarations in a sidecar, unresolved", () => {
+  const { map, variants, diagnostics } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    overrideVariant("Button", "l", { seeds: [{ key: "size", kind: "STRING", raw: "l" }] }),
+    overrideVariant("Button", "square", { seeds: [{ key: "shape", kind: "STRING", raw: "square" }] }),
+  ]);
+
+  // The map keeps the base ref as a plain string — resolving the variants is somebody else's job,
+  // and a map that guessed at them would be worse than one that says nothing.
+  assert.equal(map.components[0].ref, ref("1:2"));
+  assert.equal(variants.schema, DESIGN_MAP_VARIANTS_SCHEMA);
+  assert.deepEqual(variants.components, [
+    {
+      code: "catalog/Catalog.kt#Button",
+      componentId: "Button",
+      reference: ref("1:2"),
+      basePreviewId: "com.example.CatalogKt.Button_Light",
+      renders: [
+        {
+          previewId: "com.example.CatalogKt.Button_Light_VARIANT_l",
+          name: "l",
+          seeds: [{ key: "size", raw: "l" }],
+        },
+        {
+          previewId: "com.example.CatalogKt.Button_Light_VARIANT_square",
+          name: "square",
+          seeds: [{ key: "shape", raw: "square" }],
+        },
+      ],
+    },
+  ]);
+  assert.equal(diagnostics.variantRenders, 2);
+});
+
+test("declares no variants for a component with none, rather than an empty entry", () => {
+  const { variants } = projectDesignMap([component("Button", { reference: ref("1:2") })]);
+  assert.deepEqual(variants.components, []);
+});
+
+test("drops variants of a component that has no reference to hang them on", () => {
+  // Without a base ref there is nothing for a resolver to walk from, so declaring the renders
+  // would hand it a question it cannot answer.
+  const { variants, diagnostics } = projectDesignMap([
+    component("Button", {}),
+    overrideVariant("Button", "l", { seeds: [{ key: "size", kind: "STRING", raw: "l" }] }),
+  ]);
+  assert.deepEqual(variants.components, []);
+  assert.deepEqual(diagnostics.unmapped, ["Button"]);
+});
+
+test("counts the components naming a component set", () => {
+  const { diagnostics } = projectDesignMap([
+    component("A", { reference: ref("1:2"), referenceSet: ref("1:1") }),
+    component("B", { reference: ref("2:2") }),
+  ]);
+  assert.equal(diagnostics.withSet, 1);
+});
+
+test("projects an empty manifest without complaint", () => {
+  const { map, variants, diagnostics } = projectDesignMap([]);
+  assert.deepEqual(map, { components: [] });
+  assert.deepEqual(variants.components, []);
+  assert.deepEqual(diagnostics.unmapped, []);
+});

--- a/scripts/design-artifacts/docs/design-map.md
+++ b/scripts/design-artifacts/docs/design-map.md
@@ -1,0 +1,104 @@
+# Emitting `design-map.json`
+
+`design-map.json` is [design-parity](https://github.com/yschimke/design-parity)'s correspondence
+file: it says which design node a code component is meant to look like. This repo now **writes**
+one, from the catalog annotations it already defines.
+
+```
+./gradlew :<module>:composePreviewDiscover
+node scripts/design-artifacts/emit-design-map.mjs \
+  --previews <module>/build/compose-previews/previews.json
+```
+
+Both outputs are generated — regenerate rather than edit. `--check` regenerates in memory and exits
+non-zero if a committed copy has drifted, which is the CI posture.
+
+## Why the producer lives here
+
+Every field the projection reads is defined in this repository:
+
+| Field on `previews.json` | Declared by |
+| --- | --- |
+| `catalog.reference`, `referenceSet`, `noReference`, `referenceContentsOnly` | [`@CatalogComponent`](../../../api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt) |
+| `catalog.props`, `catalog.state` | `@CatalogVariant` |
+| `overrides.seeds`, `overrides.props` | `@OverrideVariant` / `@PreviewAxis` |
+
+Rename one of those and the projection has to change in the same commit. Keeping the two on
+opposite sides of a repo boundary is how a manifest reader goes quietly stale — and the reference
+belongs on the annotation rather than in a JSON map for the same reason: a map keyed on preview
+names drifts the moment a preview is renamed, and fails silently when it does.
+
+The consuming half already lived here too — [`design-references.mjs`](../design-references.mjs)
+reads a `design-map.json` to build a published catalog's `references/index.json`. Until now nothing
+in the ecosystem wrote one except a hand-maintained script in a downstream catalog repo.
+
+## Where the split falls
+
+A catalog picturing `Button` at three sizes and two shapes has six renders and **one** reference.
+Pairing the other five means answering "which kit node is `size=l`?" — and that is not a question
+this repo can answer:
+
+```
+  previews.json
+      │
+      │  emit-design-map.mjs           ← THIS REPO. Knows what the annotations mean.
+      │
+      ├──▶ design-map.json             base references, one per component. Valid on its own.
+      │
+      └──▶ design-map-variants.json    "these previews are the same component with these knobs
+                                        turned" — unresolved, because `size=l` is a fact about
+                                        the Compose API and `Size=Large` is a fact about somebody's
+                                        design kit
+                │
+                │  @design-parity/kit-index      ← THE OTHER REPO. Knows what the KIT means.
+                ▼
+           design-map.json with a tagged ref/previewId pair per variant
+```
+
+`size=l` → `Size=Large` is a translation against a kit's published vocabulary. That vocabulary is a
+Figma concern, it needs a Figma credential to derive, and it differs per kit — none of which this
+repo has any business holding. So the variant renders come out as **declarations** and a resolver
+that owns a kit index turns them into node ids.
+
+The two halves are separable because the first is useful alone: a repo with no kit index still gets
+a valid map of base references, which is most of the value at none of the cost.
+
+## The sidecar
+
+`design-map-variants.json` carries `schema: "compose-preview-design-map-variants/v1"`; a resolver
+must match that string before reading it. One entry per component that has variant renders:
+
+```jsonc
+{
+  "schema": "compose-preview-design-map-variants/v1",
+  "components": [
+    {
+      "code": "catalog/Catalog.kt#FilledButton",   // the design-map entry these belong to
+      "componentId": "Button/Filled",
+      "reference": "figma:AbCdEf/1:2",              // the node a resolver walks from
+      "basePreviewId": "…FilledButton_Light",
+      "renders": [
+        { "previewId": "…FilledButton_Light_VARIANT_l", "name": "l",
+          "seeds": [{ "key": "size", "raw": "l" }, { "key": "shape", "raw": "round" }] }
+      ]
+    }
+  ]
+}
+```
+
+It is a separate file rather than another key on the map because the design-map schema sets
+`additionalProperties: false` — a map carrying an extra key would fail its own validator. No file is
+written when nothing declares an axis.
+
+## Two things worth knowing
+
+**Only the light capture is mapped.** One entry per component, not per rendered mode, and the light
+one — because that is the mode design kits draw their frames in. Diffing a dark render against a
+light reference reports the whole palette as a finding.
+
+**`overrides.props` beats `overrides.seeds` where both exist.** They are not the same list. `seeds`
+holds only the values that differ from the composable's defaults; `props` — emitted for a
+`@PreviewAxis` cross product — carries the full axis assignment, defaults included. A cell that
+knows its own axes pairs by construction, which is exactly what `OverrideVariantSpec.props` was
+added for. A cell described only by its non-default seeds is missing the axes it happens to sit at,
+and a kit that spells its default size explicitly in a combination cell then has nothing to match.

--- a/scripts/design-artifacts/emit-design-map.mjs
+++ b/scripts/design-artifacts/emit-design-map.mjs
@@ -1,0 +1,129 @@
+/**
+ * Write a repo's `design-map.json` from its discovery manifest — the I/O around `design-map.mjs`.
+ *
+ *     node emit-design-map.mjs [--previews <path>] [--out design-map.json]
+ *                              [--variants design-map-variants.json] [--prefix catalog]
+ *                              [--check] [--strict]
+ *
+ * Run `./gradlew :<module>:composePreviewDiscover` first so the manifest exists.
+ *
+ * ## Two files out
+ *
+ * `--out` is the design map design-parity reads. `--variants` is the sidecar of **unresolved**
+ * variant declarations: which other previews are the same component with knobs turned, and which
+ * knobs. Turning those into design nodes needs a design kit's published vocabulary, which this repo
+ * does not hold — see the module KDoc in `design-map.mjs` for why the split falls here. A repo with
+ * no resolver still gets a valid map of base references from this alone.
+ *
+ * Both are **outputs**: regenerate rather than edit. `--check` is the CI posture — it regenerates
+ * in memory and exits non-zero if either committed file has drifted, without writing.
+ *
+ * ## Failure posture
+ *
+ * An unmapped component is reported, never fatal: a catalog is allowed to contain components nobody
+ * has mapped yet, and failing the build over one would make adding a component a breaking change.
+ * `--strict` turns that report into a non-zero exit for a repo that wants its coverage gated.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import { projectDesignMap } from "./design-map.mjs";
+
+function arg(name, def = undefined) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < process.argv.length && !process.argv[i + 1].startsWith("--")
+    ? process.argv[i + 1]
+    : def;
+}
+
+const PREVIEWS = arg("previews", "build/compose-previews/previews.json");
+const OUT = arg("out", "design-map.json");
+const VARIANTS_OUT = arg("variants", "design-map-variants.json");
+const PREFIX = arg("prefix", "catalog");
+const CHECK = process.argv.includes("--check");
+const STRICT = process.argv.includes("--strict");
+
+if (!fs.existsSync(PREVIEWS)) {
+  console.error(
+    `No discovery manifest at ${PREVIEWS}.\n` +
+      `Run \`./gradlew :<module>:composePreviewDiscover\` first, or pass --previews <path>.`,
+  );
+  process.exit(2);
+}
+
+const manifest = JSON.parse(fs.readFileSync(PREVIEWS, "utf8"));
+const { map, variants, diagnostics } = projectDesignMap(manifest.previews ?? [], {
+  prefix: PREFIX,
+});
+
+const serialize = (value) => `${JSON.stringify(value, null, 2)}\n`;
+const mapText = serialize(map);
+// A component with no variant renders needs no sidecar at all. Writing an empty one would put a
+// file in the repo whose only content is the assertion that it has nothing to say.
+const wantsVariants = variants.components.length > 0;
+const variantsText = serialize(variants);
+
+let drifted = false;
+function reconcile(file, text, wanted) {
+  const exists = fs.existsSync(file);
+  if (CHECK) {
+    const current = exists ? fs.readFileSync(file, "utf8") : null;
+    const expected = wanted ? text : null;
+    if (current !== expected) {
+      drifted = true;
+      const what = !wanted && exists ? "is stale and should be removed" : "is out of date";
+      console.error(`::error::${file} ${what} — regenerate with \`node emit-design-map.mjs\`.`);
+    }
+    return;
+  }
+  if (!wanted) {
+    if (exists) {
+      fs.rmSync(file);
+      console.log(`Removed ${file} (no variant renders declare an axis).`);
+    }
+    return;
+  }
+  fs.mkdirSync(path.dirname(path.resolve(file)), { recursive: true });
+  fs.writeFileSync(file, text);
+}
+
+reconcile(OUT, mapText, true);
+reconcile(VARIANTS_OUT, variantsText, wantsVariants);
+
+if (!CHECK) {
+  console.log(
+    `Wrote ${OUT}: ${map.components.length} mapped component(s), ` +
+      `${diagnostics.withSet} naming their component set.`,
+  );
+  if (wantsVariants) {
+    console.log(
+      `Wrote ${VARIANTS_OUT}: ${diagnostics.variantRenders} variant render(s) across ` +
+        `${variants.components.length} component(s), awaiting a kit resolver.`,
+    );
+  }
+}
+
+if (diagnostics.statedAbsent.length) {
+  console.log(
+    `\n${diagnostics.statedAbsent.length} component(s) have no reference for a stated reason — ` +
+      `the kit has nothing live to point at, which is a fact about the kit rather than a gap in ` +
+      `this catalog:`,
+  );
+  for (const s of diagnostics.statedAbsent) {
+    console.log(`  - ${s.componentId} — ${s.reason}`);
+  }
+}
+
+if (diagnostics.unmapped.length) {
+  console.log(
+    `\n${diagnostics.unmapped.length} component(s) carry neither ` +
+      `@CatalogComponent(reference = …) nor a noReference explaining why, and were skipped:`,
+  );
+  for (const id of diagnostics.unmapped) console.log(`  - ${id}`);
+}
+
+if (drifted) process.exit(1);
+if (STRICT && diagnostics.unmapped.length) {
+  console.error(`::error::--strict: ${diagnostics.unmapped.length} component(s) are unmapped.`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What changed

This repo now **writes** a `design-map.json` — design-parity's correspondence file — from the catalog annotations it already defines.

| File | What it is |
| --- | --- |
| [`design-map.mjs`](https://github.com/yschimke/compose-ai-tools/blob/agent/emit-design-map/scripts/design-artifacts/design-map.mjs) | The pure projection. No `@design-parity/*` deps, no I/O, so it unit-tests without an `npm ci` — same posture as `catalog-image-path.mjs` / `catalog-variants.mjs`. |
| [`emit-design-map.mjs`](https://github.com/yschimke/compose-ai-tools/blob/agent/emit-design-map/scripts/design-artifacts/emit-design-map.mjs) | The I/O around it, with `--check` for CI drift and `--strict` for coverage gating. |
| [`docs/design-map.md`](https://github.com/yschimke/compose-ai-tools/blob/agent/emit-design-map/scripts/design-artifacts/docs/design-map.md) | The contract, and where the split falls. |

```
./gradlew :<module>:composePreviewDiscover
node scripts/design-artifacts/emit-design-map.mjs --previews <module>/build/compose-previews/previews.json
```

## Why the producer belongs here

The *consuming* half already lived here — [`design-references.mjs`](https://github.com/yschimke/compose-ai-tools/blob/main/scripts/design-artifacts/design-references.mjs) reads a `design-map.json` to build a published catalog's `references/index.json`. Nothing in the ecosystem ever **wrote** one except a hand-maintained script in a downstream catalog repo, where it drifted out of sync with the annotations it projects.

Every field the projection reads is defined in this repository:

| Field on `previews.json` | Declared by |
| --- | --- |
| `catalog.reference`, `referenceSet`, `noReference`, `referenceContentsOnly` | `@CatalogComponent` |
| `catalog.props`, `catalog.state` | `@CatalogVariant` |
| `overrides.seeds`, `overrides.props` | `@OverrideVariant` / `@PreviewAxis` |

Rename one and the projection has to change in the same commit. And deriving the map is the point: a JSON map keyed on preview names drifts the moment a preview is renamed, and fails silently when it does — which is why the reference lives on the annotation in the first place.

## Where the split falls, and why

A catalog picturing `Button` at three sizes and two shapes has six renders and **one** reference. Pairing the other five means answering *"which kit node is `size=l`?"* — and this repo cannot answer that.

```
  previews.json
      │
      │  emit-design-map.mjs           ← THIS REPO. Knows what the annotations mean.
      │
      ├──▶ design-map.json             base references, one per component. Valid on its own.
      │
      └──▶ design-map-variants.json    "these previews are the same component with these knobs
                                        turned" — unresolved
                │
                │  @design-parity/kit-index      ← THE OTHER REPO. Knows what the KIT means.
                ▼
           design-map.json with a tagged ref/previewId pair per variant
```

`size=l` is a fact about the Compose API; `Size=Large` is a fact about somebody's design kit. Translating between them needs that kit's published vocabulary, a Figma credential to derive it, and differs per kit — none of which this repo has any business holding.

The two halves separate cleanly because **the first is useful alone**: a repo with no kit resolver still gets a valid map of base references, which is most of the value at no credential cost.

The sidecar is a separate file rather than another key on the map because the design-map schema sets `additionalProperties: false` — a map carrying an extra key would fail its own validator. No file is written when nothing declares an axis.

## One improvement over the script this came from

`overrides.props` is now preferred over `overrides.seeds` where both exist. They are not the same list: `seeds` holds only the values that differ from the composable's defaults, while `props` — emitted for a `@PreviewAxis` cross product — carries the **full axis assignment**, defaults included.

A cell described only by its non-default seeds is missing the axes it happens to sit at, and a kit that spells its default size explicitly in a combination cell (`size=s, width=narrow, shape=square`) then has nothing to match against. This is exactly what `OverrideVariantSpec.props` was added for — *"a cell that knows its own properties publishes them as `props`, and pairs by construction."*

## Test plan

- **16 tests** in `design-map.test.mjs`, `node --test`, dependency-free. They cover both annotation forms folding onto one component, the `props`-over-`seeds` preference, the light-capture-only rule, `refSet` / `referenceContentsOnly` appearing only when declared, a stated absence (`noReference`) reported apart from nobody-having-looked, and variants dropped when their component has no base ref to hang them on.
- The emitted map **validates against design-parity's own schema** — checked by running its `validate-design-map.js` CLI over the output, not by asserting a shape I invented: `ok design-map.json (1 components)`.
- `--check` exercised in both directions: exit 0 on a clean tree, exit 1 with `::error::… is out of date` after tampering.
- Full driver suite: 645 passed, 24 skipped, **5 failed — all pre-existing**, confirmed identical on a stashed clean tree (they need `npm ci` deps this sandbox lacks: playwright, pngjs, `@design-parity/catalog-export`). My tests need none of those by design.
- New files are under `scripts/design-artifacts/**`, so `ci-paths.json` already routes them to the Design Artifacts Driver Tests job.

Non-visual change — resolver and manifest plumbing, nothing rendered — so there is no before/after to embed.

## Follow-up, not in this PR

The resolver side (`@design-parity/kit-index`, [design-parity#327](https://github.com/yschimke/design-parity/pull/327), merged) needs a small entry point that reads this sidecar and rewrites the map. Once that exists, m3-catalog can delete its `scripts/` copies rather than keep them running in parallel.