### PR TITLE
test(serve): stop asserting the trust badge #3893 deliberately removed

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -12,6 +12,7 @@ import javax.imageio.ImageIO
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -462,13 +463,23 @@ class ServeStatusTest {
       assertTrue(whileIdle.contains("\"metaStale\":true"), whileIdle)
       assertTrue(whileIdle.contains("\"trusted\":1"), "the summary counts it: $whileIdle")
 
-      // The HTML page says "last known" instead of leaving the trust cell reading as untrusted.
+      // …and the HTML page marks the row "last known" rather than dropping the qualifier.
+      //
+      // Positive trust is deliberately SILENT since #3893 — a green tick beside every catalog is
+      // chrome nobody reads, and only the warning verdict carries information — so this used to
+      // assert `✓ trusted` and can't. What still has to hold, and is what the regression was
+      // actually about, is that suspending a catalog must not downgrade its verdict: the one
+      // catalog on this page is trusted, so the untrusted warning must be absent from the whole
+      // document even though its facts are now a snapshot rather than a live read.
       val htmlUrl = "http://127.0.0.1:${srv.port}/status"
       val html =
         client.newCall(Request.Builder().url(htmlUrl).build()).execute().use {
           it.body?.string() ?: ""
         }
-      assertTrue(html.contains("✓ trusted"), html)
+      assertFalse(
+        html.contains("untrusted"),
+        "a suspended trusted catalog is not downgraded: $html",
+      )
       assertTrue(html.contains("last known"), html)
     } finally {
       srv.stop()


### PR DESCRIPTION
`main` has been red since #3893. `:cli:test` reports `2253 tests completed, 1 failed`, and the one failure is `ServeStatusTest > a suspended catalog still reports its last-known trust()` at `ServeStatusTest.kt:471`.

#3893 made positive producer trust silent — a green tick beside every catalog is chrome nobody reads, and only the warning verdict carries information — so `compactTrustBadge` now returns empty for anything that isn't `unverified`. The test still asserted the removed string:

```kotlin
assertTrue(html.contains("✓ trusted"), html)
```

The page is right; the assertion is stale. It was not caught in #3893 because that PR didn't touch `ServeStatusTest.kt`.

## What replaces it

The test is named for a regression about *not losing* a verdict when a catalog's daemon idles, and it has already proved the substance of that through `status.json` a few lines above — `"trust":"branch:joreilly/Confetti@design-artifacts/confetti-wear"`, `"metaStale":true`, `"trusted":1` all survive the suspension. What the HTML assertion adds is that the rendered row doesn't *downgrade*. Under the new design that reads as:

```kotlin
assertFalse(html.contains("untrusted"), "a suspended trusted catalog is not downgraded: $html")
assertTrue(html.contains("last known"), html)
```

The single catalog registered in this test is trusted, so the warning must be absent from the whole document. That is not a vacuous assertion — an unverified catalog does render `⚠ untrusted`, as the `serve-status` page fixture shows for `cadence`:

```html
<td> <span class="cp-badge cp-badge--unverified" title="producer trust: unverified">⚠ untrusted</span></td>
```

## Visual evidence

None: this is a test-only change. No production Kotlin, CSS, or JS is touched, and `ServeWebFixtureTest` reports the page fixtures still in sync, so nothing rendered can have moved.

I did first try the other reading — giving `/status` its own badge that keeps saying `✓ trusted`, on the grounds that the public-surface helpers' own KDoc defers to it ("the full verdict and its basis remain available on `/status`"). That was wrong: the silence is intended on every page, not just the public ones. If the `/status` trust column reading `—` for trusted catalogs is ever felt to be too quiet for an operator table, that's a design change worth its own PR, not a test fix.

## Test plan

- `./gradlew :cli:test` — 2253 passed, 0 failed (was 1 failed on `main`) ✅
- `./gradlew :cli:ktfmtCheck` ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vf7zeKSafCBxgGm3KsXHGe)_