### PR TITLE
feat(design-artifacts): declare interaction variants, and gate --strict before writing

### DIFF
--- a/scripts/design-artifacts/design-map.mjs
+++ b/scripts/design-artifacts/design-map.mjs
@@ -114,10 +114,22 @@ export function variantSeeds(preview) {
 
   const overrides = preview.overrides;
   if (!overrides) return [];
-  if (overrides.props?.length) {
-    return overrides.props.map((p) => ({ key: p.key, raw: p.value }));
+
+  const seeds = overrides.props?.length
+    ? overrides.props.map((p) => ({ key: p.key, raw: p.value }))
+    : (overrides.seeds ?? []).map((s) => ({ key: s.key, raw: s.raw }));
+
+  // An interaction variant seeds no knob — the renderer drives real hover, focus or press against
+  // the composed node instead, so the difference lives in the harness rather than in the data.
+  // A design kit models it as a value of the same `State` axis that carries Enabled and Disabled,
+  // so it enters resolution as a seed of the `state` knob and reaches the kit through the alias
+  // that knob already has. Without this the variant declares nothing: `seeds` is empty, an empty
+  // vector matches every sibling, and the render is dropped as "names no axis".
+  const interaction = overrides.interaction;
+  if (interaction && interaction !== "None" && !seeds.some((s) => s.key === "state")) {
+    seeds.push({ key: "state", raw: String(interaction).toLowerCase() });
   }
-  return (overrides.seeds ?? []).map((s) => ({ key: s.key, raw: s.raw }));
+  return seeds;
 }
 
 /** The name a variant render goes by, for a report and for the design-map `state` slot. */

--- a/scripts/design-artifacts/design-map.test.mjs
+++ b/scripts/design-artifacts/design-map.test.mjs
@@ -131,6 +131,50 @@ test("variantSeeds falls back to seeds for a hand-written override variant", () 
   assert.deepEqual(variantSeeds(preview), [{ key: "size", raw: "l" }]);
 });
 
+test("variantSeeds turns an interaction variant into a state seed", () => {
+  // `@OverrideVariant(interaction = Pressed)` seeds no knob — the renderer drives a real press
+  // against the composed node. A kit models that as a value of the same `State` axis that carries
+  // Enabled and Disabled, so it has to enter resolution as a `state` seed or the render declares
+  // nothing and is dropped.
+  for (const interaction of ["Hovered", "Focused", "Pressed"]) {
+    assert.deepEqual(
+      variantSeeds(overrideVariant("Button", interaction.toLowerCase(), { interaction })),
+      [{ key: "state", raw: interaction.toLowerCase() }],
+    );
+  }
+});
+
+test("variantSeeds ignores the None interaction, which is the absence of one", () => {
+  assert.deepEqual(variantSeeds(overrideVariant("Button", "x", { interaction: "None" })), []);
+});
+
+test("variantSeeds keeps an interaction beside the knobs a variant also seeds", () => {
+  assert.deepEqual(
+    variantSeeds(
+      overrideVariant("Button", "l-pressed", {
+        interaction: "Pressed",
+        seeds: [{ key: "size", kind: "STRING", raw: "l" }],
+      }),
+    ),
+    [
+      { key: "size", raw: "l" },
+      { key: "state", raw: "pressed" },
+    ],
+  );
+});
+
+test("variantSeeds does not double up when the variant already names a state", () => {
+  assert.deepEqual(
+    variantSeeds(
+      overrideVariant("Button", "disabled", {
+        interaction: "Pressed",
+        seeds: [{ key: "state", kind: "STRING", raw: "disabled" }],
+      }),
+    ),
+    [{ key: "state", raw: "disabled" }],
+  );
+});
+
 test("variantSeeds reads a CatalogVariant's props, and its state shorthand", () => {
   assert.deepEqual(
     variantSeeds(catalogVariant("FabLarge", "Fab", { props: [{ key: "size", value: "large" }] })),

--- a/scripts/design-artifacts/emit-design-map.mjs
+++ b/scripts/design-artifacts/emit-design-map.mjs
@@ -20,9 +20,16 @@
  *
  * ## Failure posture
  *
- * An unmapped component is reported, never fatal: a catalog is allowed to contain components nobody
- * has mapped yet, and failing the build over one would make adding a component a breaking change.
- * `--strict` turns that report into a non-zero exit for a repo that wants its coverage gated.
+ * An unmapped component is reported, never fatal by default: a catalog is allowed to contain
+ * components nobody has mapped yet, and failing the build over one would make adding a component a
+ * breaking change.
+ *
+ * `--strict` is the opposite posture, for a catalog whose whole purpose is to reproduce a kit —
+ * there, a component with no kit node to compare against does not belong in the published
+ * inventory at all, and publishing it means shipping a sticker that can never be checked. It gates
+ * on BOTH kinds of absence: a missing `reference`, and one explained by `noReference`. The
+ * annotation still earns its keep in the default mode, where the two are reported apart so a
+ * retired pattern does not read as neglect; `--strict` simply says there are no exceptions.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -55,6 +62,28 @@ const manifest = JSON.parse(fs.readFileSync(PREVIEWS, "utf8"));
 const { map, variants, diagnostics } = projectDesignMap(manifest.previews ?? [], {
   prefix: PREFIX,
 });
+
+// Gate BEFORE writing, not after. A run that fails should leave the committed map intact rather
+// than replacing it with one CI would then report as merely stale — and an author who dropped a
+// whole group's references wants the list, not one name at a time.
+if (STRICT) {
+  const missing = [
+    ...diagnostics.unmapped.map((id) => `${id} — no reference, and no reason given`),
+    ...diagnostics.statedAbsent.map((s) => `${s.componentId} — ${s.reason}`),
+  ];
+  if (missing.length) {
+    console.error(
+      `::error::--strict: ${missing.length} component(s) carry no ` +
+        `@CatalogComponent(reference = …):`,
+    );
+    for (const line of missing) console.error(`  - ${line}`);
+    console.error(
+      `A catalog that reproduces a kit has nothing to compare these against — remove them, ` +
+        `or drop --strict to publish them unmapped.`,
+    );
+    process.exit(1);
+  }
+}
 
 const serialize = (value) => `${JSON.stringify(value, null, 2)}\n`;
 const mapText = serialize(map);
@@ -123,7 +152,3 @@ if (diagnostics.unmapped.length) {
 }
 
 if (drifted) process.exit(1);
-if (STRICT && diagnostics.unmapped.length) {
-  console.error(`::error::--strict: ${diagnostics.unmapped.length} component(s) are unmapped.`);
-  process.exit(1);
-}


### PR DESCRIPTION
## Why

`emit-design-map.mjs` was extracted from [`yschimke/m3-catalog`](https://github.com/yschimke/m3-catalog), whose copy moved on afterwards. Two gaps, both of which would silently regress that repo when it migrates.

Sibling to [design-parity#335](https://github.com/yschimke/design-parity/pull/335) (merged), which closed the resolver-side half of the same divergence.

## Interaction variants were being dropped

An `@OverrideVariant(interaction = Hovered | Focused | Pressed)` render **seeds no knob** — the renderer drives a real hover, focus or press against the composed node, so the difference lives in the harness rather than in the data.

The projection saw an empty seed list, read it as "names no axis", and dropped the render entirely. A design kit models the same thing as a value of the `State` axis that already carries `Enabled` and `Disabled`, so the interaction now enters as a `state` seed and reaches the kit through the alias that knob already has:

```
@OverrideVariant(interaction = Pressed)  →  seeds: [{ key: "state", raw: "pressed" }]
```

Skipped when the variant names a state itself, so an explicit seed still wins. `None` is the absence of an interaction, not one.

## `--strict` gated after writing

It used to write both files and *then* exit non-zero — leaving a map CI reports as merely stale rather than the intact one the author still has. The gate now runs before anything is written, and collects the whole list rather than failing on the first name.

It also now covers a `noReference` absence, not just a missing one: for a catalog whose purpose is to reproduce a kit, a component with nothing to compare against doesn't belong in the published inventory whether or not someone wrote down why.

## One deliberate divergence, worth a second opinion

m3-catalog made unreferenced components a **hard error** ([#81](https://github.com/yschimke/m3-catalog/pull/81)). I've implemented that as `--strict` instead.

`noReference` is a field *this* repo defines, on `@CatalogComponent`, precisely so a consumer can tell "the kit retired this" from "nobody looked yet". A shared producer shouldn't hard-code one consumer's product decision about its own annotation — so the annotation keeps earning its keep in the default mode, where the two absences are reported apart and a retired pattern doesn't read as neglect.

A catalog that wants no exceptions passes `--strict` and gets exactly m3-catalog's behaviour. Happy to make it unconditional if you'd rather the policy be global.

## Test plan

- **20 tests** in `design-map.test.mjs` (4 new, `node --test`, dependency-free): each interaction value, `None` ignored, an interaction alongside other seeds, and an explicit state winning over one.
- Verified end to end against a hand-built manifest:
  - interaction variant reaches the sidecar as `{"key": "state", "raw": "pressed"}` — previously absent entirely;
  - `--strict` exits 1 naming the component, and `design-map.json` is **not written**;
  - default posture still reports both absence kinds and writes.
- Full driver suite: **686 pass / 5 fail** — the same five that fail on a clean tree in this sandbox for want of `npm ci` deps (playwright, pngjs, `@design-parity/catalog-export`). Confirmed by stashing earlier in the session.

Non-visual — manifest projection, nothing rendered.

## After this

m3-catalog can retire `kit-variants.mjs` and `generate-design-map.mjs` and run the two CLIs, completing what [m3-catalog#110](https://github.com/yschimke/m3-catalog/pull/110) started. It needs a design-parity release carrying #335 first.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wHVcQdoUcFHskjrmob9gT)_