### PR TITLE
fix(design-artifacts): stamp @OverrideVariant stickers with their renderer density

### DIFF
--- a/scripts/design-artifacts/bridge-live-preview-ids.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.mjs
@@ -498,6 +498,13 @@ export function bridgeLivePreviewIds(
  * Stamp each baked image with the density of the preview annotation that rendered it. This is
  * independent of live alias publication: static catalogs and intentionally unbridged supplement
  * images still need the density to export Figma references at the correct physical scale.
+ *
+ * "At the correct physical scale" is the whole job, and an unstamped image does not degrade —
+ * `FigmaRestRasterizer.scaleFor` has no scale to request without a density, so it throws and the
+ * reference is DROPPED. That is why the `@OverrideVariant` fallback below matters far more here
+ * than the phrase "still need the density" suggests: on m3-catalog it was the difference between 4
+ * and 436 published variant references, and every `@OverrideVariant` state — every tab content
+ * axis, every button state cell — served its page with no design-spec lane at all.
  */
 export function stampPreviewDensities(manifest, spec, bundles) {
   const previewForState = previewForStateOf(spec);
@@ -514,8 +521,20 @@ export function stampPreviewDensities(manifest, spec, bundles) {
       const candidates = previewsByFn.get(fn) ?? [];
       const candidateId = pickVariantId(candidates, image, breakpointForSize);
       const candidate = candidates.find((it) => it.id === candidateId);
-      if (candidate?.density !== undefined) {
-        image.density = candidate.density;
+      const density =
+        candidate?.density !== undefined
+          ? candidate.density
+          : overrideVariantDensity({
+              previewForState,
+              previewsByFn,
+              breakpointForSize,
+              componentId: component.componentId,
+              image,
+              state,
+              fn,
+            });
+      if (density !== undefined) {
+        image.density = density;
         stamped++;
       }
     }
@@ -523,6 +542,52 @@ export function stampPreviewDensities(manifest, spec, bundles) {
   return stamped;
 }
 
+/**
+ * The density of a synthetic `@OverrideVariant` sticker, or undefined — the gap that made
+ * [stampPreviewDensities] the one place the fallback [bridgeLivePreviewIds] and
+ * [resolveSemanticsIds] both carry was missing, and the one whose absence went unnoticed longest
+ * because it fails as a missing *reference* rather than a missing live lane.
+ *
+ * A non-default state with no spec `variants` entry is a synthetic `<baseId>_VARIANT_<state>`
+ * preview. `PreviewDiscovery.overrideVariantPreview` derives it as `base.copy(id = base.id + tag)`,
+ * which decides both halves of this lookup: the variant keeps the base's `functionName` — so it is
+ * already in the base function's candidate list, and `resolveFunction` still finds nothing for the
+ * state — and it keeps the base's `params`, so it carries the base's density verbatim.
+ *
+ * So this narrows that list to the tagged ids and picks among them, rather than reconstructing an
+ * id from the base's. Reconstruction is what the sibling fallbacks do, and it is a trap here: the
+ * variants share the base's function, so `pickVariantId` can return one AS the base and build a
+ * doubled `…_VARIANT_icon_VARIANT_icon` that matches nothing.
+ *
+ * Which theme the pick lands on cannot change the answer — density is a `@Preview` param, identical
+ * across a `@CatalogModes` pair — but it is separated properly anyway so the value always comes from
+ * a record describing these exact pixels.
+ */
+function overrideVariantDensity({
+  previewForState,
+  previewsByFn,
+  breakpointForSize,
+  componentId,
+  image,
+  state,
+  fn,
+}) {
+  if (state === "default" || fn) return undefined;
+  // Props-bearing images are a spec-declared axis, not an `@OverrideVariant` — the same guard the
+  // sibling fallbacks apply, so a props variant with a missing spec entry stays unstamped rather
+  // than borrowing a density from a sticker it isn't.
+  if (image.props != null && Object.keys(image.props).length > 0) return undefined;
+  const baseFn = previewForState.get(variantKey(componentId, "default"));
+  const tag = `_VARIANT_${state}`;
+  const candidates = (previewsByFn.get(baseFn) ?? []).filter((candidate) =>
+    candidate.id.endsWith(tag),
+  );
+  // Empty ⇒ this state rendered no variant preview, and a density is a statement about the
+  // annotation that drew the pixels. Inventing one from the base would hand the rasteriser an
+  // export scale for a render that never happened.
+  const picked = pickVariantId(candidates, image, breakpointForSize);
+  return candidates.find((candidate) => candidate.id === picked)?.density;
+}
 
 /**
  * `functionName → candidates`, where a **later bundle REPLACES an earlier one** for any function it

--- a/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
@@ -995,6 +995,122 @@ test("static and unbridged images retain the density of the preview that rendere
   assert.equal(manifest.components[0].images[0].previewId, undefined);
 });
 
+test("an @OverrideVariant state is stamped with the density of the annotation that rendered it", () => {
+  // The regression this closes: an `@OverrideVariant` state has NO spec `variants` entry, so
+  // `resolveFunction` finds no function for it and the image went out with no density at all.
+  // `FigmaRestRasterizer.scaleFor` cannot request an export scale without one, so it throws and the
+  // reference is dropped — which is how m3-catalog published 4 of 436 variant references and served
+  // every `@OverrideVariant` page with no design-spec lane.
+  const spec = {
+    groups: [{ components: [{ componentId: "Tabs/Primary", preview: "PrimaryTabs" }] }],
+  };
+  const manifest = {
+    components: [
+      {
+        componentId: "Tabs/Primary",
+        images: [
+          { state: "default", theme: "light", path: "default.png" },
+          { state: "icon-label", path: "icon-label.png" },
+          { state: "icon-label", theme: "dark", path: "icon-label-dark.png" },
+        ],
+      },
+    ],
+  };
+  const bundle = {
+    previews: [
+      { id: "TabsKt.PrimaryTabs_Light", functionName: "PrimaryTabs", params: { density: 2.625 } },
+      {
+        id: "TabsKt.PrimaryTabs_Dark",
+        functionName: "PrimaryTabs",
+        params: { density: 2.625, uiMode: 0x20 },
+      },
+      // The synthetic variants discovery mints, as `overrideVariantPreview` builds them: the
+      // base's `functionName` and the base's `params`, under a `_VARIANT_`-suffixed id.
+      {
+        id: "TabsKt.PrimaryTabs_Light_VARIANT_icon-label",
+        functionName: "PrimaryTabs",
+        params: { density: 2.625 },
+      },
+      {
+        id: "TabsKt.PrimaryTabs_Dark_VARIANT_icon-label",
+        functionName: "PrimaryTabs",
+        params: { density: 2.625, uiMode: 0x20 },
+      },
+    ],
+  };
+
+  assert.equal(stampPreviewDensities(manifest, spec, [bundle]), 3);
+  assert.deepEqual(
+    manifest.components[0].images.map((i) => i.density),
+    [2.625, 2.625, 2.625],
+  );
+});
+
+test("a variant density comes from the variant's own record, not the base's", () => {
+  const spec = {
+    groups: [{ components: [{ componentId: "Tabs/Primary", preview: "PrimaryTabs" }] }],
+  };
+  const manifest = {
+    components: [
+      { componentId: "Tabs/Primary", images: [{ state: "icon", path: "icon.png" }] },
+    ],
+  };
+  const bundle = {
+    previews: [
+      { id: "PrimaryTabs", functionName: "PrimaryTabs", params: { density: 2.625 } },
+      // Deliberately not the base's 2.625: the value must be read off the variant's own record.
+      { id: "PrimaryTabs_VARIANT_icon", functionName: "PrimaryTabs", params: { density: 3 } },
+    ],
+  };
+
+  assert.equal(stampPreviewDensities(manifest, spec, [bundle]), 1);
+  assert.equal(manifest.components[0].images[0].density, 3);
+});
+
+test("a state that rendered no _VARIANT_ preview is left unstamped rather than given the base's", () => {
+  // A density is a statement about the annotation that drew these pixels. Inventing one for a
+  // sticker no bundle carries would hand the rasteriser a scale for a render that never happened.
+  const spec = {
+    groups: [{ components: [{ componentId: "Tabs/Primary", preview: "PrimaryTabs" }] }],
+  };
+  const manifest = {
+    components: [
+      { componentId: "Tabs/Primary", images: [{ state: "ghost", path: "ghost.png" }] },
+    ],
+  };
+  const bundle = {
+    previews: [{ id: "PrimaryTabs", functionName: "PrimaryTabs", params: { density: 2.625 } }],
+  };
+
+  assert.equal(stampPreviewDensities(manifest, spec, [bundle]), 0);
+  assert.equal(manifest.components[0].images[0].density, undefined);
+});
+
+test("a props-bearing image is not stamped through the @OverrideVariant fallback", () => {
+  // Props variants are a spec-declared axis. Reaching the fallback for one would mean the spec is
+  // incomplete, and borrowing a density from the base sticker would paper over that silently.
+  const spec = {
+    groups: [{ components: [{ componentId: "Tabs/Primary", preview: "PrimaryTabs" }] }],
+  };
+  const manifest = {
+    components: [
+      {
+        componentId: "Tabs/Primary",
+        images: [{ state: "large", props: { fontScale: "2.0" }, path: "large.png" }],
+      },
+    ],
+  };
+  const bundle = {
+    previews: [
+      { id: "PrimaryTabs", functionName: "PrimaryTabs", params: { density: 2.625 } },
+      { id: "PrimaryTabs_VARIANT_large", functionName: "PrimaryTabs", params: { density: 2.625 } },
+    ],
+  };
+
+  assert.equal(stampPreviewDensities(manifest, spec, [bundle]), 0);
+  assert.equal(manifest.components[0].images[0].density, undefined);
+});
+
 // --- deferred (live-only) records -------------------------------------------------------------
 
 test("a mode-deferred record resolves the annotation its theme names, not the first id", () => {


### PR DESCRIPTION
## The symptom

On m3-catalog, the design-spec lane is on the default sticker and absent from every variant of the same component:

| | |
|---|---|
| [`tabs-primary__ideal__default__light`](https://preview.coo.ee/m3-catalog/p/tabs-primary__ideal__default__light) | Figma chip, Spec/Diff/Triptych/Slider, score readout, `spec diff →` |
| [`tabs-primary__ideal__icon-label`](https://preview.coo.ee/m3-catalog/p/tabs-primary__ideal__icon-label?uiMode=light) | nothing — no chip at all |

Not UI gating. `ServeWeb.kt` only emits the lane when `designReferencesFor(previewId)` returns something, and the published `references/index.json` has no record for the variant.

## Why

`design-map.json` binds it (`PrimaryTabs`, `state: "icon-label"` → `…PrimaryTabs_Light_VARIANT_icon-label`), and `planDesignReferences` emits it — re-run against the published `catalog.json` it produces **552 records, 116 primary + 436 secondary**. The delivery branch carries **120**.

The other 432 died on one log line, from the last run's `Publish design references` step:

```
design-references: note: tabs-primary__ideal__icon-label: catalog image is missing its renderer density
```

`stampPreviewDensities` resolves an image's `@Preview` through `previewForStateOf`, which only knows states declared as spec `variants`. An `@OverrideVariant` state has no such entry, so `resolveFunction` returns `undefined` and the image goes out with no density. That does not degrade gracefully: `FigmaRestRasterizer.scaleFor` has no export scale to request without one, so it throws and the planned reference is dropped. Only `state: "default"` images resolve — the default key always exists — which is exactly why the four FAB *size* cells survived and every *state* cell did not.

In the published `catalog.json`: 1358 images, **247 carry a density**. Every `_VARIANT_` image is `"density": null`.

## The fix

`bridgeLivePreviewIds` and `resolveSemanticsIds` already carry a fallback for this shape. This is the third site, and the one whose absence went unnoticed longest because it fails as a missing *reference* rather than a missing live lane.

It resolves the density differently from those two, deliberately. Both reconstruct a `<baseId>_VARIANT_<state>` id from the base's, which is a trap here — `PreviewDiscovery.overrideVariantPreview` derives the variant as `base.copy(id = base.id + tag)`, so it keeps the base's `functionName` and is already *in* the base function's candidate list; `pickVariantId` can return one AS the base and build a doubled `…_VARIANT_icon_VARIANT_icon` that matches nothing. Narrowing that list to the tagged ids and picking among them needs no reconstruction at all. `base.copy` also means the variant carries the base's `params`, so its density is read straight off its own record.

Guards kept: a state that rendered no `_VARIANT_` preview stays unstamped rather than borrowing the base's — a density is a statement about the annotation that drew the pixels — and props-bearing images are excluded, since those are a spec-declared axis and silently borrowing there would paper over an incomplete spec.

## Test plan

- `node --test scripts/design-artifacts/bridge-live-preview-ids.test.mjs` — 36 pass, 4 new:
  - an `@OverrideVariant` state is stamped with the density of the annotation that rendered it
  - a variant density comes from the variant's own record, not the base's
  - a state that rendered no `_VARIANT_` preview is left unstamped
  - a props-bearing image is not stamped through the fallback
- Full `scripts/design-artifacts` suite: 719 tests, 690 pass, 5 fail — all 5 fail identically on `main` in this container (missing npm deps), none touch this path.
- End-to-end against the **published** `catalog.json` + `design-map.json`, replaying the bundle as discovery emits it: images carrying a density go **247/1358 → 1357/1358**, and planned references that are rasterisable go **120 → 552**. The three `tabs-primary` records all resolve at `density=2.625`.

## Visual evidence

This is export-pipeline plumbing — it writes no pixels itself. What it restores is the *pairing*, so the honest evidence is the pair that today has no spec to compare against.

Published today, on the delivery branch — the default sticker and the Figma reference that gets published for it, which is why that page has the lane:

| Render | Figma spec |
|---|---|
| ![default render](https://raw.githubusercontent.com/yschimke/m3-catalog/dc04a20efa533e8220903c18770b6c3b01a42367/images/tabs-primary/ideal__default__light.png) | ![default spec](https://raw.githubusercontent.com/yschimke/m3-catalog/dc04a20efa533e8220903c18770b6c3b01a42367/references/tabs-primary__ideal__default__light.png) |

The two variants of the same component, published as renders with **no reference beside them** — `design-map.json` binds both to kit nodes (`54563:40070`, `54563:40093`), and both were dropped for want of a density:

| `icon` | `icon-label` |
|---|---|
| ![icon render](https://raw.githubusercontent.com/yschimke/m3-catalog/dc04a20efa533e8220903c18770b6c3b01a42367/images/tabs-primary/ideal__icon.png) | ![icon-label render](https://raw.githubusercontent.com/yschimke/m3-catalog/dc04a20efa533e8220903c18770b6c3b01a42367/images/tabs-primary/ideal__icon-label.png) |

After this lands, those two get the same right-hand column the default already has. The published pixels can't be shown from here: minting them needs a `FIGMA_TOKEN`, and this container's egress proxy refuses Chromium's `CONNECT` to `preview.coo.ee` (`ERR_CONNECTION_RESET`), so the served toolbars can't be screenshotted either. It is verified on the next `design-artifacts` run on `main`: the reference count on `design-artifacts/m3-catalog` should go 120 → ~552, and both URLs above should gain the Figma chip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVsi3TZN9GXEUhoBVCxw1Y)_