### PR TITLE
docs(deploy): document top-level site setup and add a version-controlled config overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1205,6 +1205,13 @@ jobs:
       # kept the public host's playground pinned to one catalog with the Android modes off.
       - name: Run deploy compose env-passthrough tests
         run: ./deploy/image/test-compose-env-passthrough.sh
+      # The version-control config overlay is opt-in, so nothing exercises it on the way to a
+      # release — a wrong source path or mount target is found on a box, after a restart, serving a
+      # stale catalog set. Every failure mode is silent: a missing source makes Docker create an
+      # empty directory at the mount point, and a dropped `:ro` lets the admin API write back into
+      # the git working tree.
+      - name: Run deploy config-mount tests
+        run: ./deploy/image/test-deploy-config-mount.sh
       # A sandbox profile the docs recommend but the image cannot launch is silent in the posture
       # this image ships in: a repo-access-gated host admits the playground before it looks at the
       # jail, so a missing binary logs a preflight warning and serves UNCONTAINED rather than

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -66,6 +66,96 @@ DOMAIN=preview.example.com ./setup.sh
 Pin a version with `IMAGE_TAG=0.16.33` in `.env` (a bare tag; defaults to the
 `latest` tag when unset).
 
+### Serving a catalog on its own hostname
+
+A published catalog can additionally be served on a hostname of its own, where it presents as the
+whole server — `m3.preview.coo.ee` shows what `preview.coo.ee/m3-catalog/` shows, with the catalog's
+landing at `/` and no front door. What that changes about the pages is
+[docs/public-preview-server.md](../../docs/public-preview-server.md#top-level-sites-one-catalog-on-a-hostname-of-its-own);
+what it takes to stand one up is three things, in two places.
+
+**1. DNS.** A `CNAME` to the box's existing hostname is the simplest form and is what
+`m3.preview.coo.ee` uses — it is a subdomain, so there is no apex-CNAME problem, the IP stays in one
+place, and an `AAAA` added later is inherited for free:
+
+```
+m3.preview.coo.ee.  CNAME  preview.coo.ee.
+```
+
+An `A` record straight to the host IP works identically; it is just a second copy of the IP to keep
+in step. Let it resolve before the restart below — Caddy needs it to answer the HTTP-01 challenge,
+which follows the alias without caring that it is one.
+
+**2. `.env` on the box** — **both** variables, because they configure different processes:
+
+```bash
+SERVE_SITES=m3.preview.coo.ee=m3-catalog   # the app: which catalog this Host means
+SITE_DOMAINS=m3.preview.coo.ee             # Caddy: match the name AND get a cert for it
+```
+
+Multiple sites are comma-separated in `SERVE_SITES`, space- or comma-separated in `SITE_DOMAINS`.
+**Certificates need no configuration beyond that second line** — `SITE_DOMAINS` lands on the
+Caddyfile's site-address line beside `{$DOMAIN}`, and Caddy provisions and renews a Let's Encrypt
+cert per name from there. Omit it and the site is configured in the app and unreachable at the edge:
+Caddy never matches the hostname, so it never requests a cert for it. Keep the two in step — a name
+in one and not the other is either a site nothing routes to or a hostname the app doesn't recognise.
+
+**3. Recreate both services.** `./rollout.sh` won't do it: it rolls `preview` only when the *image*
+changes, and `caddy` isn't rollable at all (fixed 80/443 ports). An env change needs a recreate:
+
+```bash
+docker compose up -d          # preview picks up SERVE_SITES, caddy picks up SITE_DOMAINS
+curl -sI https://m3.preview.coo.ee/ | head -1                            # 200 — catalog landing at /
+curl -sI https://m3.preview.coo.ee/m3-catalog/p/button-filled | head -1  # 308 → /p/button-filled
+curl -sI https://m3.preview.coo.ee/wear-m3/ | head -1                    # 404 — neighbours unreachable
+```
+
+Sites are read **at startup**, so this is a restart either way; the additive `/admin/catalogs`
+reconcile does not carry them. GitHub sign-in is deliberately not offered on a site host (the
+`cp_gh_state` cookie is host-only and this box pins a callback origin), so its live and playground
+surfaces stay snapshot-only.
+
+> `catalogs.json`'s `"sites"` key says the same thing as durable config — but on this image that
+> file is a volume the box seeds once and never overwrites, so committing a site to
+> `deploy/preview.coo.ee/catalogs.json` does **not** deliver it: `publish-config-to-box.sh`
+> reconciles catalogs, groups and producers, not `sites`. Either set `SERVE_SITES` as above and
+> accept that `.env` is untracked, or adopt the overlay below and let the committed file be the
+> source of truth.
+
+### Config from version control (`docker-compose.deploy-config.yml`)
+
+`/config/catalogs.json` and `/config/producers.json` live on the `preview_config` **named volume**,
+seeded on first boot and never overwritten (#2879 / #2897) so an image roll can't stomp a runtime
+edit. The cost is that config the box has never seen cannot arrive by `git pull` — only by a
+hand-edit or by the additive admin reconcile, which is blind to `sites`.
+
+The opt-in overlay in this directory makes the committed deployment config authoritative instead:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.deploy-config.yml up -d
+```
+
+or set `COMPOSE_FILE=docker-compose.yml:docker-compose.deploy-config.yml` in `.env` so every later
+`docker compose` here picks it up. It bind-mounts the two files read-only from `DEPLOY_CONFIG_DIR`
+(default `../preview.coo.ee`, the same variable `publish-config-to-box.sh` uses), so deploying
+config becomes `git pull && docker compose up -d` and `sites` rides along with everything else.
+
+Read-only does **not** break the admin API: `ServeCatalogAdmin.persist()` fails soft, so
+`POST /admin/catalogs` still registers and serves the catalog and only reports back
+`"warning": "not persisted: …"`. In steady state the reconcile never reaches that path — every entry
+it POSTs is already in the file the box booted from, so the admin API answers `409`, which the
+script counts as success. What you give up is a runtime edit outliving a restart, which is the
+point: that edit is drift from `main`.
+
+> **Diff before adopting this on a box that has been running.** The volume file is a superset
+> whenever anyone added a catalog or a trusted producer directly on the host, and the overlay swaps
+> it wholesale — anything on the box and not in git stops being served at the next restart, with
+> nothing logged. Compare first, and commit whatever is missing:
+> ```bash
+> curl -sH "X-Compose-Preview-Admin-Token: $SERVE_ADMIN_TOKEN" https://<host>/admin/catalogs
+> docker compose exec preview cat /config/catalogs.json
+> ```
+
 ### GitHub auth on `preview.coo.ee`
 
 To keep catalog browsing public while requiring GitHub sign-in for live sessions and playground,
@@ -432,6 +522,7 @@ docker run -d --restart always -p 8080:8080 \
 | `Dockerfile` | Downloads the released CLI and carries the published Maven modules + live-render daemons. |
 | `entrypoint.sh` | Maps `$PORT`/`$SERVE_TOKEN` onto serve flags; generous `--timeout`. |
 | `docker-compose.yml` + `Caddyfile` | Pull the image + Caddy auto-HTTPS + zero-downtime (`rollout`) / Watchtower auto-updates + the `hook` instant-roll webhook. |
+| `docker-compose.deploy-config.yml` + `test-deploy-config-mount.sh` | Opt-in overlay serving a deployment's `catalogs.json` / `producers.json` read-only from version control instead of the volume (see *Config from version control*), and its offline self-test (run by `ci.yml`). |
 | `rollout.sh` | Poll loop / one-shot that pulls `preview` and rolls it via docker-rollout. |
 | `deploy-hook.sh` | Token-gated `POST /__hooks/rollout` webhook (the `hook` service) that runs `rollout.sh` on demand — instant roll on publish. |
 | `docker-rollout` | Vendored [docker-rollout](https://github.com/wowu/docker-rollout) CLI plugin (adds `docker rollout`). |

--- a/deploy/image/docker-compose.deploy-config.yml
+++ b/deploy/image/docker-compose.deploy-config.yml
@@ -1,0 +1,49 @@
+# OPT-IN overlay: serve a DEPLOYMENT's config from version control instead of the volume.
+#
+# The base docker-compose.yml keeps catalogs.json + producers.json on the `preview_config` named
+# volume, seeded on first boot and never overwritten after (#2879 / #2897) so an image roll can't
+# stomp a runtime edit. The cost of that is real and it bit m3.preview.coo.ee: config the box has
+# never seen cannot arrive by `git pull`, and the one automated delivery path —
+# .github/scripts/publish-config-to-box.sh, additive over POST /admin/catalogs — carries catalogs,
+# groups and producers but NOT `sites`. So a top-level site committed to the deployment's
+# catalogs.json reaches the box only if someone hand-edits the volume or sets SERVE_SITES in .env,
+# and a rebuilt box loses it again with nothing to say so.
+#
+# This overlay makes the committed file the source of truth: the box's config is whatever `main`
+# says it is, and deploying config is `git pull && docker compose up -d`.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.deploy-config.yml up -d
+#
+# or, so every later `docker compose` in this directory picks it up without the flags, put this in
+# .env (it is read by compose itself, not passed to a container):
+#
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.deploy-config.yml
+#
+# Read-only is deliberate, and it does NOT break the admin API. ServeCatalogAdmin.persist() fails
+# soft: POST /admin/catalogs still registers and serves the catalog, and only the persistence step
+# reports back `"warning": "not persisted: …"`. In steady state the reconcile doesn't even reach
+# that path — every entry it POSTs is already in the committed file the box booted from, so the
+# admin API answers 409, which the script counts as success. What you give up is a runtime edit
+# outliving a restart, which is the whole point: it would be config drift from `main`.
+#
+# BEFORE ADOPTING THIS ON A BOX THAT HAS BEEN RUNNING, diff the two. The volume file is a superset
+# whenever anyone added a catalog or a trusted producer directly on the host, and this overlay
+# swaps it out wholesale — anything on the box and not in git silently stops being served at the
+# next restart:
+#
+#   curl -sH "X-Compose-Preview-Admin-Token: $SERVE_ADMIN_TOKEN" https://<host>/admin/catalogs
+#   docker compose exec preview cat /config/catalogs.json
+#
+# DEPLOY_CONFIG_DIR names the deployment directory, matching the variable publish-config-to-box.sh
+# already uses for the same choice — so the box and the publish workflow read one answer, not two.
+# It defaults to this repo's own deployment (deploy/preview.coo.ee, relative to this file);
+# an adopter points it at their own directory with the same two filenames.
+services:
+  preview:
+    volumes:
+      # Mounted as individual FILES over the `preview_config` volume, not as a directory over
+      # /config: the volume also carries runtime state the app writes there, and a directory mount
+      # would hide it. Docker orders mounts by path depth, so /config lands first and these nest
+      # inside it.
+      - ${DEPLOY_CONFIG_DIR:-../preview.coo.ee}/catalogs.json:/config/catalogs.json:ro
+      - ${DEPLOY_CONFIG_DIR:-../preview.coo.ee}/producers.json:/config/producers.json:ro

--- a/deploy/image/test-deploy-config-mount.sh
+++ b/deploy/image/test-deploy-config-mount.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Guard: the version-control-backed config overlay actually mounts the files it claims to.
+#
+# Why this needs a test. docker-compose.deploy-config.yml is opt-in, so nothing exercises it on the
+# way to a release — the first time anyone finds out it is wrong is on a box, after a restart, when
+# the app boots from whatever /config it already had and serves a stale catalog set. Every failure
+# mode here is silent that way: a source path that doesn't exist makes Docker create an empty
+# DIRECTORY at the mount point (and the app then reads no catalogs), a target that isn't nested
+# under the base file's /config volume mounts somewhere the app never looks, and a dropped `:ro`
+# lets the admin API write back into the git working tree so the next `git pull` conflicts.
+#
+# It is all static: no Docker, no network, no compose binary.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+overlay="${OVERLAY_FILE:-${here}/docker-compose.deploy-config.yml}"
+base="${COMPOSE_FILE_UNDER_TEST:-${here}/docker-compose.yml}"
+
+for f in "${overlay}" "${base}"; do
+  [[ -f "${f}" ]] || {
+    echo "FAIL: missing ${f}" >&2
+    exit 1
+  }
+done
+
+fail=0
+note() {
+  echo "FAIL: $*" >&2
+  fail=1
+}
+
+# The base file must keep /config on a named volume for the overlay's per-file mounts to nest
+# inside it. If that ever becomes a directory bind, these mounts are redundant at best and
+# shadowed at worst — either way this overlay needs rewriting rather than silently under-mounting.
+grep -qE '^\s*-\s*preview_config:/config\s*$' "${base}" ||
+  note "${base##*/} no longer mounts 'preview_config:/config' — the overlay's /config/<file> mounts assume it."
+
+# Every bind line in the overlay, as `<source>:<target>:<mode>`.
+mapfile -t mounts < <(
+  grep -oE '^\s*-\s*\$\{DEPLOY_CONFIG_DIR:-[^}]+\}/[^:]+:[^:]+:[a-z]+\s*$' "${overlay}" |
+    sed -E 's/^\s*-\s*//; s/\s*$//'
+)
+((${#mounts[@]})) || {
+  echo "FAIL: found no DEPLOY_CONFIG_DIR bind mounts in ${overlay} — the detector is broken." >&2
+  exit 1
+}
+
+for mount in "${mounts[@]}"; do
+  mode="${mount##*:}"
+  target="${mount%:*}"
+  target="${target##*:}"
+  source_spec="${mount%%:/*}"
+  # The default the overlay ships, i.e. what an operator gets with DEPLOY_CONFIG_DIR unset.
+  default_dir="$(sed -E 's/^\$\{DEPLOY_CONFIG_DIR:-([^}]+)\}.*/\1/' <<<"${source_spec}")"
+  rel_file="${source_spec##*\}/}"
+
+  [[ "${mode}" == "ro" ]] ||
+    note "${rel_file} is mounted '${mode}', not 'ro' — the admin API would write into the git working tree."
+
+  # A file mounted anywhere but /config/<same-name> is a file the app never reads: SERVE_*_FILE
+  # points at /config, and the entrypoint seeds by that exact path.
+  [[ "${target}" == "/config/${rel_file}" ]] ||
+    note "${rel_file} mounts at '${target}', expected '/config/${rel_file}'."
+
+  # A missing source is the loudest-looking, quietest-behaving failure: Docker creates an empty
+  # directory there rather than erroring, and the app boots with no catalogs.
+  resolved="${here}/${default_dir}/${rel_file}"
+  [[ -f "${resolved}" ]] ||
+    note "default DEPLOY_CONFIG_DIR source '${default_dir}/${rel_file}' does not exist (looked at ${resolved})."
+done
+
+# The overlay exists to carry `sites`, which publish-config-to-box.sh cannot. If the committed
+# catalogs.json it defaults to ever loses that key, the overlay still works but the gap it was
+# written for is back, unannounced.
+default_catalogs="${here}/../preview.coo.ee/catalogs.json"
+if [[ -f "${default_catalogs}" ]]; then
+  grep -q '"sites"' "${default_catalogs}" ||
+    note "${default_catalogs##*/} declares no \"sites\" — the overlay's reason for existing (delivering sites, which the admin reconcile cannot) is gone."
+fi
+
+if ((fail)); then
+  exit 1
+fi
+echo "OK: ${#mounts[@]} deploy-config mount(s) check out."

--- a/deploy/vps/README.md
+++ b/deploy/vps/README.md
@@ -47,6 +47,35 @@ JDK, and Skiko all ship arm64 builds.
    `preview.example.com`) → the public IP. Let it resolve before setup — Caddy
    needs it to issue a certificate. Check with `dig +short preview.example.com`.
 
+## Serving a catalog on its own hostname
+
+A published catalog can additionally be served on a hostname of its own, where it
+presents as the whole server (`m3.preview.coo.ee` shows what
+`preview.coo.ee/m3-catalog/` shows). It needs a DNS record and **two** settings —
+one for the app, one for the proxy:
+
+```bash
+# DNS: a CNAME to the box's existing hostname is enough (subdomain, so no apex
+# problem, and the IP stays in one place). An A record to the host IP also works.
+#   m3.preview.example.com.  CNAME  preview.example.com.
+
+# .env on the box:
+SERVE_SITES=m3.preview.example.com=m3-catalog   # the app: which catalog this Host means
+SITE_DOMAINS=m3.preview.example.com             # Caddy: match the name AND get a cert for it
+```
+
+`SITE_DOMAINS` lands on the Caddyfile's site-address line beside `{$DOMAIN}`, which
+is what makes Caddy match the hostname **and** provision its Let's Encrypt
+certificate — there is nothing else to configure for TLS. Omit it and the site is
+configured in the app but unreachable at the edge. Keep the two in step, then
+`sudo docker compose up -d` to recreate both services; sites are read at startup.
+
+On this profile `catalogs.json` is bind-mounted from the repo, so the durable form
+is its `"sites"` key and a `git pull` + restart delivers it. See
+[docs/public-preview-server.md](../../docs/public-preview-server.md#top-level-sites-one-catalog-on-a-hostname-of-its-own)
+for what a site changes about the pages, and [`deploy/image/`](../image/README.md)
+for the prebuilt-image profile, where the config lives on a volume instead.
+
 ## Deploy
 
 SSH in, get the repo, and run setup from this directory:


### PR DESCRIPTION
Standing up `m3.preview.coo.ee` surfaced two gaps in the deploy docs and one in the prebuilt-image profile's config delivery.

## Summary

**Neither README said how to add a site hostname.** The two settings it needs configure different processes — `SERVE_SITES` tells the app which catalog a `Host` means, `SITE_DOMAINS` puts the name on Caddy's site-address line, which is what both matches it *and* provisions its certificate. Omitting the second leaves a site configured in the app and unreachable at the edge, with nothing logged; that detail only lived in a Caddyfile comment. Both `deploy/image/README.md` and `deploy/vps/README.md` now carry the DNS record (a CNAME to the box's existing hostname is enough — subdomain, so no apex problem, and the IP stays in one place), both variables, the recreate step (`rollout.sh` won't do it — it rolls `preview` only on an *image* change, and `caddy` isn't rollable at all), and verification curls.

**The deeper gap: on the prebuilt image a site cannot be delivered by config at all.** `/config/catalogs.json` is a named volume seeded on first boot and never overwritten (#2879 / #2897), and `publish-config-to-box.sh` reconciles catalogs, groups and producers but **not** `sites`. So the `sites` entry already committed to `deploy/preview.coo.ee/catalogs.json` reaches no box, and an untracked `.env` is the only route — a rebuilt box loses the site with nothing to say so.

`docker-compose.deploy-config.yml` is an **opt-in** overlay that bind-mounts a deployment's `catalogs.json` + `producers.json` read-only from `DEPLOY_CONFIG_DIR` (the same variable `publish-config-to-box.sh` already uses, so the box and the publish workflow read one answer), making the committed file authoritative — `git pull && docker compose up -d` becomes the config deploy, and `sites` rides along.

Read-only does **not** break the admin API: `ServeCatalogAdmin.persist()` fails soft, so `POST /admin/catalogs` still registers and serves the catalog and only reports `"warning": "not persisted: …"`. In steady state the reconcile never reaches that path — every entry it POSTs is already in the file the box booted from, so the API answers `409`, which the script counts as success. What you give up is a runtime edit outliving a restart, which is the point: that edit is drift from `main`.

Defaults are unchanged — nothing adopts the overlay implicitly. The docs flag that adopting it on a running box needs a diff of the volume against git first, since anything added on the host and never committed stops being served at the next restart.

`test-deploy-config-mount.sh` gates the overlay offline (no Docker, no network), because every way it can be wrong is silent: a missing source makes Docker create an empty *directory* at the mount point, a target outside `/config` is never read, and a dropped `:ro` lets the admin API write into the git working tree.

## Test plan

- `./deploy/image/test-deploy-config-mount.sh` — new guard, passes; wired into `ci.yml` beside the existing deploy tests.
- Mutation-checked the guard against four seeded faults, each caught: `:ro`→`:rw`, target moved off `/config`, `DEPLOY_CONFIG_DIR` default pointed at a non-existent dir, and the base file's `preview_config:/config` volume replaced by a bind.
- `docker compose -f docker-compose.yml -f docker-compose.deploy-config.yml config` merges cleanly and resolves the default to the real committed files:
  ```
  {'type': 'volume', 'source': 'preview_config',  'target': '/config'}
  {'type': 'bind', 'source': '…/deploy/preview.coo.ee/catalogs.json',  'target': '/config/catalogs.json',  'read_only': True}
  {'type': 'bind', 'source': '…/deploy/preview.coo.ee/producers.json', 'target': '/config/producers.json', 'read_only': True}
  ```
  — confirming the per-file binds nest inside the `/config` volume rather than shadowing it.
- Existing deploy suites still pass: `test-compose-env-passthrough.sh`, `test-env-migrations.sh`, `test-publish-config-to-box.sh`.
- YAML parse check on the overlay, `docker-compose.yml`, and `ci.yml`.

Docs-and-deploy-config only — no renderer, catalog, or UI surface changes, so there is no visual output to diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXZKcbv4CXTCZy6oU5muWe)_