### PR TITLE
feat(design-artifacts): publish motion captures onto the delivery branch

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -107,6 +107,18 @@ layered `compose/figma-svg` export produced per preview; the catalog pipeline
 carries it in the bundle (`previews/<id>.figma.svg`) and copies it onto the
 branch, exactly as it does the schematic `wireframes/`.
 
+Components carrying an `@InteractionPreview` or `@AnimatedPreview` also ship the
+animated capture itself, under **`motion/`**. It is named from the sticker it sits
+beside — `images/switch-on/ideal__default__dark.png` publishes its capture as
+`motion/switch-on/ideal__default__dark.apng` — so the two cannot drift apart, and a
+function carrying both kinds keeps them separate with an `__interaction` segment.
+`catalog.json` declares them on `components[].motion[]`, a sibling axis to `images[]`
+rather than more entries inside it: everything in `images[]` is a still and every
+consumer assumes it, so a 114-frame recording pasted in there would publish its first
+frame and silently drop the point. Each entry carries the `kind`
+(`interaction` / `animation`), the caption its annotation declared, and the `theme` of
+the sticker it accompanies.
+
 For editable Figma layers the per-sticker `figma/<slug>.svg` is the
 `compose/figma-svg` export (see the `FigmaLayeredSvg` KDoc in
 `:data-layoutinspector-core` for the emitted layer shape); the design-parity

--- a/scripts/design-artifacts/catalog-motion-publish.mjs
+++ b/scripts/design-artifacts/catalog-motion-publish.mjs
@@ -1,0 +1,190 @@
+/**
+ * Publishing the `motion` axis onto the delivery branch.
+ *
+ * ### The gap this closes
+ *
+ * `catalog-motion.mjs` resolves a component's animated captures out of the render bundle and folds
+ * them onto `components[].motion[]` — but the path it records there is the artifact's home *inside
+ * the bundle* (`previews/<id>.apng`), because that is the only name it has at join time. The bundle
+ * is not published; `design-artifacts/<system>` is. So a catalog shipped as-is declares motion whose
+ * bytes exist nowhere a reader can reach, and every consumer downstream of the branch — the serve
+ * viewer above all — resolves the path to a 404.
+ *
+ * This module names the branch-relative home for each artifact so the generator can copy the bytes
+ * there and rewrite the declaration to match. After it runs, `motion[].path` means the same thing
+ * `images[].path` already does: a file that is actually on the branch, relative to `catalog.json`.
+ *
+ * ### Why the name is inherited from the sibling still, not invented
+ *
+ * A motion capture and the sticker beside it depict the same component in the same theme, state and
+ * size — the capture just shows it moving. `buildCatalog` has already resolved a collision-safe name
+ * for that sticker (`images/<slug>/<variant>__<state>[__theme][__size][…].png`), against a naming
+ * scheme that lives in another package. Deriving a second scheme here would be a second thing to
+ * keep in step with it, and the two would eventually disagree about the same component.
+ *
+ * So the published motion path is the sticker's path with `images/` → `motion/` and the extension
+ * swapped. Identical reasoning to the per-variant figma-svg emit in `generate-design-catalog.mjs`,
+ * which mirrors `images/` → `figma/` for exactly this reason: naming that is *derived* from the
+ * still cannot drift away from the still.
+ *
+ * Depends on nothing outside the standard library, so it unit-tests without an `npm ci` like its
+ * sibling axis modules. [planMotionPublish] is pure on top of that — the naming rule, the part that
+ * can silently drift away from `images/`, is testable without a bundle or an output directory.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { catalogSlug } from "./catalog-image-path.mjs";
+
+/** Artifact extensions a motion capture publishes — the same pair `catalog-motion.mjs` matches. */
+const MOTION_EXTENSIONS = [".apng", ".gif"];
+
+/**
+ * The disambiguating suffix `PreviewDiscovery` appends when one `@Preview` function carries both an
+ * interaction and something else that would claim the same filename.
+ */
+const INTERACTION_SUFFIX = "_interaction";
+
+/** The branch directory motion artifacts publish under, beside `images/`. */
+export const MOTION_DIR = "motion";
+
+/**
+ * The preview id of the **still** a bundle-internal motion artifact sits beside.
+ *
+ * `previews/Switch_Dark.apng` was rendered from preview `Switch_Dark`, whose sticker is
+ * `previews/Switch_Dark.png` — so the leaf minus its extension is already the join key. The one
+ * exception is a function carrying two motion annotations, which `PreviewDiscovery` disambiguates
+ * by suffixing `_interaction`; stripping that recovers the same key.
+ *
+ * @param {string} artifactPath a bundle-relative `previews/…` path.
+ * @returns {string|null} the sibling still's preview id, or `null` if this isn't a motion artifact.
+ */
+export function motionSiblingPreviewId(artifactPath) {
+  const extension = motionExtensionOf(artifactPath);
+  if (!extension) return null;
+  const leaf = artifactPath.slice(artifactPath.lastIndexOf("/") + 1, -extension.length);
+  return leaf.endsWith(INTERACTION_SUFFIX) ? leaf.slice(0, -INTERACTION_SUFFIX.length) : leaf;
+}
+
+/** The motion extension [artifactPath] ends with, or `null`. */
+function motionExtensionOf(artifactPath) {
+  return MOTION_EXTENSIONS.find((extension) => artifactPath?.endsWith(extension)) ?? null;
+}
+
+/**
+ * The branch-relative path a motion artifact publishes at.
+ *
+ * With a sibling sticker resolved, the name is that sticker's:
+ * `images/switch-on/ideal__default__dark.png` becomes
+ * `motion/switch-on/ideal__default__dark.apng`, carrying the `__interaction` disambiguator through
+ * as a variant segment when the artifact had one — so a function publishing both an
+ * interaction and an animation can't have one silently overwrite the other.
+ *
+ * Without one (an image the live-preview bridge deliberately left unstamped, so no `previewId` to
+ * join on) the artifact still publishes, under its own leaf in the component's directory. The bytes
+ * reaching the branch matters more than the name being variant-shaped: an unresolved sibling is a
+ * naming problem, whereas dropping the file is lost coverage.
+ *
+ * @param {string} componentId the owning component, for the fallback's directory.
+ * @param {string} artifactPath the bundle-relative `previews/…` path.
+ * @param {string} [imagePath] the sibling still's published `images/…` path, when one was resolved.
+ * @returns {string|null} the `motion/…` path, or `null` if this isn't a motion artifact.
+ */
+export function motionPublishPath(componentId, artifactPath, imagePath) {
+  const extension = motionExtensionOf(artifactPath);
+  if (!extension) return null;
+  if (imagePath?.startsWith("images/") && imagePath.endsWith(".png")) {
+    const stem = imagePath.slice("images/".length, -".png".length);
+    const leaf = artifactPath.slice(artifactPath.lastIndexOf("/") + 1, -extension.length);
+    const suffix = leaf.endsWith(INTERACTION_SUFFIX) ? `__${INTERACTION_SUFFIX.slice(1)}` : "";
+    return `${MOTION_DIR}/${stem}${suffix}${extension}`;
+  }
+  const leaf = artifactPath.slice(artifactPath.lastIndexOf("/") + 1);
+  return `${MOTION_DIR}/${catalogSlug(componentId)}/${leaf}`;
+}
+
+/**
+ * Plans the branch home of every motion artifact a written manifest declares.
+ *
+ * Pure: it reads the manifest and returns the moves, leaving both the copying and the rewrite to the
+ * caller. That keeps the naming rule — the part that can silently drift away from `images/` —
+ * testable without a bundle, an output directory or an `npm ci`.
+ *
+ * An entry whose `path` is already a `motion/…` path is passed through as a no-op rather than
+ * re-prefixed, so a manifest that has been through this pass twice is unchanged by the second one.
+ *
+ * @param {{components?: Array<object>}} manifest the written `catalog.json`.
+ * @returns {{moves: Array<{componentId: string, entry: object, source: string, target: string,
+ *   viaSibling: boolean}>, unresolved: number}}
+ */
+export function planMotionPublish(manifest) {
+  const moves = [];
+  let unresolved = 0;
+  for (const component of manifest?.components ?? []) {
+    if (!component?.motion?.length) continue;
+    const stillByPreviewId = new Map();
+    for (const image of component.images ?? []) {
+      if (image?.previewId && image.path && !stillByPreviewId.has(image.previewId)) {
+        stillByPreviewId.set(image.previewId, image.path);
+      }
+    }
+    for (const entry of component.motion) {
+      const source = entry?.path;
+      if (!source || source.startsWith(`${MOTION_DIR}/`)) continue;
+      const imagePath = stillByPreviewId.get(motionSiblingPreviewId(source) ?? "");
+      const target = motionPublishPath(component.componentId, source, imagePath);
+      if (!target) continue;
+      if (!imagePath) unresolved += 1;
+      moves.push({
+        componentId: component.componentId,
+        entry,
+        source,
+        target,
+        viaSibling: Boolean(imagePath),
+      });
+    }
+  }
+  return { moves, unresolved };
+}
+
+/**
+ * Copies every declared motion artifact out of the bundle into `<outPath>/motion/…` and repoints the
+ * manifest's declarations at where they landed.
+ *
+ * Mutates [manifest] in place; the caller writes it. A declaration whose bytes the bundle does not
+ * carry is **dropped** rather than published: a path that 404s is worse than no motion at all, since
+ * the viewer would offer a capture and then fail to load it. `motionArtifactsFor` only records
+ * artifacts it matched against `entries`, so that is unreachable short of a bug — which is exactly
+ * why it is reported rather than skipped silently.
+ *
+ * @param {{components?: Array<object>}} manifest the written `catalog.json`, mutated in place.
+ * @param {Record<string, ArrayBufferView|ArrayBuffer>} entries the render bundle's entries.
+ * @param {string} outPath the bundle output directory `motion/` is written under.
+ * @returns {Promise<{published: number, unresolved: number, missing: Array<string>}>}
+ */
+export async function publishMotionArtifacts(manifest, entries, outPath) {
+  const { moves, unresolved } = planMotionPublish(manifest);
+  const missing = [];
+  let published = 0;
+  for (const move of moves) {
+    const bytes = entries?.[move.source];
+    if (!bytes) {
+      missing.push(move.source);
+      continue;
+    }
+    const target = join(outPath, move.target);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, Buffer.from(bytes));
+    move.entry.path = move.target;
+    published += 1;
+  }
+  if (missing.length > 0) {
+    for (const component of manifest.components ?? []) {
+      if (!component.motion) continue;
+      component.motion = component.motion.filter((entry) => !missing.includes(entry.path));
+      if (component.motion.length === 0) delete component.motion;
+    }
+  }
+  return { published, unresolved, missing };
+}

--- a/scripts/design-artifacts/catalog-motion-publish.mjs
+++ b/scripts/design-artifacts/catalog-motion-publish.mjs
@@ -41,10 +41,22 @@ import { catalogSlug } from "./catalog-image-path.mjs";
 const MOTION_EXTENSIONS = [".apng", ".gif"];
 
 /**
- * The disambiguating suffix `PreviewDiscovery` appends when one `@Preview` function carries both an
- * interaction and something else that would claim the same filename.
+ * The disambiguating suffixes `PreviewDiscovery` appends when one `@Preview` function carries a
+ * motion annotation *and* something else that would claim the same filename — `_interaction` when an
+ * interaction shares with a GIF-producing peer, `_anim` when an animation shares with a scroll /
+ * timing fan-out or a `@FocusedPreview(gif = true)`. Both are appended to the preview id, so
+ * stripping them recovers the id the sibling sticker is named from.
+ *
+ * `_focus_gif` is deliberately absent: a focused GIF carries neither an `interaction` nor an
+ * `animation` declaration, so `motionDeclarationOf` never classifies it as motion and no artifact
+ * reaches here under that name.
  */
-const INTERACTION_SUFFIX = "_interaction";
+const MOTION_SUFFIXES = ["_interaction", "_anim"];
+
+/** The disambiguator [leaf] ends with, or `null` when it carries none. */
+function motionSuffixOf(leaf) {
+  return MOTION_SUFFIXES.find((suffix) => leaf.endsWith(suffix)) ?? null;
+}
 
 /** The branch directory motion artifacts publish under, beside `images/`. */
 export const MOTION_DIR = "motion";
@@ -53,9 +65,10 @@ export const MOTION_DIR = "motion";
  * The preview id of the **still** a bundle-internal motion artifact sits beside.
  *
  * `previews/Switch_Dark.apng` was rendered from preview `Switch_Dark`, whose sticker is
- * `previews/Switch_Dark.png` — so the leaf minus its extension is already the join key. The one
- * exception is a function carrying two motion annotations, which `PreviewDiscovery` disambiguates
- * by suffixing `_interaction`; stripping that recovers the same key.
+ * `previews/Switch_Dark.png` — so the leaf minus its extension is already the join key. The
+ * exception is a function whose motion capture had to share its filename space, which
+ * `PreviewDiscovery` disambiguates with a `_interaction` / `_anim` suffix; stripping that recovers
+ * the same key.
  *
  * @param {string} artifactPath a bundle-relative `previews/…` path.
  * @returns {string|null} the sibling still's preview id, or `null` if this isn't a motion artifact.
@@ -64,7 +77,8 @@ export function motionSiblingPreviewId(artifactPath) {
   const extension = motionExtensionOf(artifactPath);
   if (!extension) return null;
   const leaf = artifactPath.slice(artifactPath.lastIndexOf("/") + 1, -extension.length);
-  return leaf.endsWith(INTERACTION_SUFFIX) ? leaf.slice(0, -INTERACTION_SUFFIX.length) : leaf;
+  const suffix = motionSuffixOf(leaf);
+  return suffix ? leaf.slice(0, -suffix.length) : leaf;
 }
 
 /** The motion extension [artifactPath] ends with, or `null`. */
@@ -77,9 +91,9 @@ function motionExtensionOf(artifactPath) {
  *
  * With a sibling sticker resolved, the name is that sticker's:
  * `images/switch-on/ideal__default__dark.png` becomes
- * `motion/switch-on/ideal__default__dark.apng`, carrying the `__interaction` disambiguator through
- * as a variant segment when the artifact had one — so a function publishing both an
- * interaction and an animation can't have one silently overwrite the other.
+ * `motion/switch-on/ideal__default__dark.apng`, carrying the `__interaction` / `__anim`
+ * disambiguator through as a variant segment when the artifact had one — so a function publishing
+ * both an interaction and an animation can't have one silently overwrite the other.
  *
  * Without one (an image the live-preview bridge deliberately left unstamped, so no `previewId` to
  * join on) the artifact still publishes, under its own leaf in the component's directory. The bytes
@@ -97,8 +111,9 @@ export function motionPublishPath(componentId, artifactPath, imagePath) {
   if (imagePath?.startsWith("images/") && imagePath.endsWith(".png")) {
     const stem = imagePath.slice("images/".length, -".png".length);
     const leaf = artifactPath.slice(artifactPath.lastIndexOf("/") + 1, -extension.length);
-    const suffix = leaf.endsWith(INTERACTION_SUFFIX) ? `__${INTERACTION_SUFFIX.slice(1)}` : "";
-    return `${MOTION_DIR}/${stem}${suffix}${extension}`;
+    const suffix = motionSuffixOf(leaf);
+    const segment = suffix ? `__${suffix.slice(1)}` : "";
+    return `${MOTION_DIR}/${stem}${segment}${extension}`;
   }
   const leaf = artifactPath.slice(artifactPath.lastIndexOf("/") + 1);
   return `${MOTION_DIR}/${catalogSlug(componentId)}/${leaf}`;

--- a/scripts/design-artifacts/catalog-motion-publish.test.mjs
+++ b/scripts/design-artifacts/catalog-motion-publish.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  motionPublishPath,
+  motionSiblingPreviewId,
+  planMotionPublish,
+  publishMotionArtifacts,
+} from "./catalog-motion-publish.mjs";
+
+test("the sibling still is the artifact's own leaf", () => {
+  assert.equal(motionSiblingPreviewId("previews/Switch_Dark.apng"), "Switch_Dark");
+  assert.equal(motionSiblingPreviewId("previews/Spinner_Light.gif"), "Spinner_Light");
+});
+
+test("the _interaction disambiguator is stripped to reach the still", () => {
+  // A function carrying both annotations renders its interaction under a suffixed name, but the
+  // sticker it sits beside is still the unsuffixed preview.
+  assert.equal(motionSiblingPreviewId("previews/Spinner_Dark_interaction.apng"), "Spinner_Dark");
+});
+
+test("a still is not a motion artifact", () => {
+  assert.equal(motionSiblingPreviewId("previews/Switch_Dark.png"), null);
+  assert.equal(motionSiblingPreviewId(undefined), null);
+});
+
+test("the published path is the sibling sticker's, under motion/", () => {
+  assert.equal(
+    motionPublishPath(
+      "Switch/On",
+      "previews/Switch_Dark.apng",
+      "images/switch-on/ideal__default__dark.png",
+    ),
+    "motion/switch-on/ideal__default__dark.apng",
+  );
+});
+
+test("the sticker's full variant name is inherited, not re-derived", () => {
+  // Props, size and locale segments ride along untouched — the whole point of deriving from the
+  // still rather than restating `buildCatalog`'s naming scheme.
+  assert.equal(
+    motionPublishPath(
+      "Button/Filled",
+      "previews/Button_Dark.gif",
+      "images/button-filled/ideal__default__dark__compact__content-icon-label.png",
+    ),
+    "motion/button-filled/ideal__default__dark__compact__content-icon-label.gif",
+  );
+});
+
+test("two captures on one function keep separate names", () => {
+  const still = "images/spinner/ideal__default__dark.png";
+  assert.equal(
+    motionPublishPath("Spinner", "previews/Spinner_Dark.gif", still),
+    "motion/spinner/ideal__default__dark.gif",
+  );
+  assert.equal(
+    motionPublishPath("Spinner", "previews/Spinner_Dark_interaction.apng", still),
+    "motion/spinner/ideal__default__dark__interaction.apng",
+  );
+});
+
+test("an artifact with no sibling still publishes under its own leaf", () => {
+  assert.equal(
+    motionPublishPath("Switch/On", "previews/Switch_Dark.apng", undefined),
+    "motion/switch-on/Switch_Dark.apng",
+  );
+});
+
+test("planMotionPublish joins each artifact to its still through previewId", () => {
+  const manifest = {
+    components: [
+      {
+        componentId: "Switch/On",
+        images: [
+          { previewId: "Switch_Light", path: "images/switch-on/ideal__default__light.png" },
+          { previewId: "Switch_Dark", path: "images/switch-on/ideal__default__dark.png" },
+        ],
+        motion: [{ path: "previews/Switch_Dark.apng", kind: "interaction", theme: "dark" }],
+      },
+    ],
+  };
+  const { moves, unresolved } = planMotionPublish(manifest);
+  assert.equal(unresolved, 0);
+  assert.deepEqual(
+    moves.map(({ componentId, source, target, viaSibling }) => ({
+      componentId,
+      source,
+      target,
+      viaSibling,
+    })),
+    [
+      {
+        componentId: "Switch/On",
+        source: "previews/Switch_Dark.apng",
+        target: "motion/switch-on/ideal__default__dark.apng",
+        viaSibling: true,
+      },
+    ],
+  );
+  // The entry itself is handed back so the caller can rewrite it in place.
+  assert.equal(moves[0].entry, manifest.components[0].motion[0]);
+});
+
+test("an unbridged image leaves the artifact unresolved but still published", () => {
+  const { moves, unresolved } = planMotionPublish({
+    components: [
+      {
+        componentId: "Switch/On",
+        images: [{ path: "images/switch-on/ideal__default__dark.png" }],
+        motion: [{ path: "previews/Switch_Dark.apng", kind: "interaction" }],
+      },
+    ],
+  });
+  assert.equal(unresolved, 1);
+  assert.equal(moves[0].target, "motion/switch-on/Switch_Dark.apng");
+  assert.equal(moves[0].viaSibling, false);
+});
+
+test("a component with no motion contributes nothing", () => {
+  assert.deepEqual(
+    planMotionPublish({
+      components: [{ componentId: "Card", images: [{ path: "images/card/ideal__default.png" }] }],
+    }),
+    { moves: [], unresolved: 0 },
+  );
+  assert.deepEqual(planMotionPublish(undefined), { moves: [], unresolved: 0 });
+});
+
+test("re-planning an already-published manifest is a no-op", () => {
+  // The pass rewrites `path` in place, so a second run over the same catalog.json must not
+  // re-prefix it into `motion/motion/…`.
+  const manifest = {
+    components: [
+      {
+        componentId: "Switch/On",
+        images: [{ previewId: "Switch_Dark", path: "images/switch-on/ideal__default__dark.png" }],
+        motion: [{ path: "motion/switch-on/ideal__default__dark.apng", kind: "interaction" }],
+      },
+    ],
+  };
+  assert.deepEqual(planMotionPublish(manifest), { moves: [], unresolved: 0 });
+});
+
+/** Runs [body] against a throwaway output directory. */
+async function withOutDir(body) {
+  const out = await mkdtemp(join(tmpdir(), "motion-publish-"));
+  try {
+    await body(out);
+  } finally {
+    await rm(out, { recursive: true, force: true });
+  }
+}
+
+const manifestWithCapture = () => ({
+  components: [
+    {
+      componentId: "Switch/On",
+      images: [{ previewId: "Switch_Dark", path: "images/switch-on/ideal__default__dark.png" }],
+      motion: [{ path: "previews/Switch_Dark.apng", kind: "interaction", theme: "dark" }],
+    },
+  ],
+});
+
+test("publishing writes the bytes to the branch and repoints the declaration", async () => {
+  await withOutDir(async (out) => {
+    const manifest = manifestWithCapture();
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const result = await publishMotionArtifacts(
+      manifest,
+      { "previews/Switch_Dark.apng": bytes },
+      out,
+    );
+
+    assert.deepEqual(result, { published: 1, unresolved: 0, missing: [] });
+    assert.equal(
+      manifest.components[0].motion[0].path,
+      "motion/switch-on/ideal__default__dark.apng",
+    );
+    assert.deepEqual(
+      new Uint8Array(await readFile(join(out, "motion/switch-on/ideal__default__dark.apng"))),
+      bytes,
+    );
+    // The caption and kind ride through untouched — only `path` is rewritten.
+    assert.equal(manifest.components[0].motion[0].kind, "interaction");
+  });
+});
+
+test("a declaration the bundle has no bytes for is dropped, not published as a 404", async () => {
+  await withOutDir(async (out) => {
+    const manifest = manifestWithCapture();
+    const result = await publishMotionArtifacts(manifest, {}, out);
+
+    assert.deepEqual(result, {
+      published: 0,
+      unresolved: 0,
+      missing: ["previews/Switch_Dark.apng"],
+    });
+    // The whole axis went with it rather than being left as an empty array.
+    assert.equal("motion" in manifest.components[0], false);
+  });
+});
+
+test("publishing twice is idempotent", async () => {
+  await withOutDir(async (out) => {
+    const manifest = manifestWithCapture();
+    const entries = { "previews/Switch_Dark.apng": new Uint8Array([1, 2, 3]) };
+    await publishMotionArtifacts(manifest, entries, out);
+    const again = await publishMotionArtifacts(manifest, entries, out);
+
+    assert.deepEqual(again, { published: 0, unresolved: 0, missing: [] });
+    assert.equal(
+      manifest.components[0].motion[0].path,
+      "motion/switch-on/ideal__default__dark.apng",
+    );
+  });
+});
+
+test("the join holds for the fully-qualified ids a real catalog carries", () => {
+  // `bridgeLivePreviewIds` stamps the *daemon* preview id, which is the bundle's own
+  // `preview.id` — fully qualified, dots and all. The bundle names its entries from the same id,
+  // so the leaf-minus-extension join still lands; this is the shape published catalogs actually
+  // carry (compose-m3's Switch/On), not the bare ids the unit cases above use for legibility.
+  const id = "com.example.designcatalogm3.CatalogSelectionKt.SwitchOn_Dark";
+  assert.equal(motionSiblingPreviewId(`previews/${id}.apng`), id);
+  assert.equal(motionSiblingPreviewId(`previews/${id}_interaction.apng`), id);
+
+  const manifest = {
+    components: [
+      {
+        componentId: "Switch/On",
+        images: [
+          { previewId: id, path: "images/switch-on/ideal__default__dark.png" },
+          {
+            previewId: `${id}_VARIANT_off`,
+            path: "images/switch-on/ideal__off__dark.png",
+          },
+        ],
+        motion: [{ path: `previews/${id}.apng`, kind: "interaction", theme: "dark" }],
+      },
+    ],
+  };
+  const { moves, unresolved } = planMotionPublish(manifest);
+  assert.equal(unresolved, 0);
+  assert.equal(moves[0].target, "motion/switch-on/ideal__default__dark.apng");
+});

--- a/scripts/design-artifacts/catalog-motion-publish.test.mjs
+++ b/scripts/design-artifacts/catalog-motion-publish.test.mjs
@@ -17,10 +17,13 @@ test("the sibling still is the artifact's own leaf", () => {
   assert.equal(motionSiblingPreviewId("previews/Spinner_Light.gif"), "Spinner_Light");
 });
 
-test("the _interaction disambiguator is stripped to reach the still", () => {
-  // A function carrying both annotations renders its interaction under a suffixed name, but the
-  // sticker it sits beside is still the unsuffixed preview.
+test("a disambiguated capture is stripped back to reach the still", () => {
+  // A motion capture that had to share its filename space renders under a suffixed name, but the
+  // sticker it sits beside is still the unsuffixed preview. `_interaction` is what discovery
+  // appends to an interaction sharing with a GIF-producing peer; `_anim` is what it appends to an
+  // animation sharing with a scroll / timing fan-out or a `@FocusedPreview(gif = true)`.
   assert.equal(motionSiblingPreviewId("previews/Spinner_Dark_interaction.apng"), "Spinner_Dark");
+  assert.equal(motionSiblingPreviewId("previews/Spinner_Dark_anim.gif"), "Spinner_Dark");
 });
 
 test("a still is not a motion artifact", () => {
@@ -53,6 +56,9 @@ test("the sticker's full variant name is inherited, not re-derived", () => {
 });
 
 test("two captures on one function keep separate names", () => {
+  // Discovery suffixes BOTH sides when a function's captures share a filename space, and the
+  // published names have to stay as distinct as the bundle's — otherwise one silently overwrites
+  // the other on the branch.
   const still = "images/spinner/ideal__default__dark.png";
   assert.equal(
     motionPublishPath("Spinner", "previews/Spinner_Dark.gif", still),
@@ -62,6 +68,28 @@ test("two captures on one function keep separate names", () => {
     motionPublishPath("Spinner", "previews/Spinner_Dark_interaction.apng", still),
     "motion/spinner/ideal__default__dark__interaction.apng",
   );
+  assert.equal(
+    motionPublishPath("Spinner", "previews/Spinner_Dark_anim.gif", still),
+    "motion/spinner/ideal__default__dark__anim.gif",
+  );
+});
+
+test("an _anim animation joins its sticker rather than falling back to the bundle leaf", () => {
+  // The regression the fallback would have hidden: an `@AnimatedPreview` sharing its function with
+  // a scroll / timing fan-out publishes as `<previewId>_anim.gif`, and a helper that stripped only
+  // `_interaction` would miss the join and quietly name it from the bundle instead of the sticker.
+  const { moves, unresolved } = planMotionPublish({
+    components: [
+      {
+        componentId: "Spinner",
+        images: [{ previewId: "Spinner_Dark", path: "images/spinner/ideal__default__dark.png" }],
+        motion: [{ path: "previews/Spinner_Dark_anim.gif", kind: "animation", theme: "dark" }],
+      },
+    ],
+  });
+  assert.equal(unresolved, 0);
+  assert.equal(moves[0].viaSibling, true);
+  assert.equal(moves[0].target, "motion/spinner/ideal__default__dark__anim.gif");
 });
 
 test("an artifact with no sibling still publishes under its own leaf", () => {
@@ -228,6 +256,7 @@ test("the join holds for the fully-qualified ids a real catalog carries", () => 
   const id = "com.example.designcatalogm3.CatalogSelectionKt.SwitchOn_Dark";
   assert.equal(motionSiblingPreviewId(`previews/${id}.apng`), id);
   assert.equal(motionSiblingPreviewId(`previews/${id}_interaction.apng`), id);
+  assert.equal(motionSiblingPreviewId(`previews/${id}_anim.gif`), id);
 
   const manifest = {
     components: [

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -46,6 +46,7 @@ import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 
 import { foldVariants, variantLabel } from "./catalog-variants.mjs";
 import { foldMotion, motionArtifactsFor } from "./catalog-motion.mjs";
+import { publishMotionArtifacts } from "./catalog-motion-publish.mjs";
 import {
   DEFERRED,
   deferralPlan,
@@ -1433,6 +1434,43 @@ if (values["publish-live-bundle"]) {
     }
   }
   stampPreviewDensities(manifest, spec, [bundle, extraBundle]);
+
+  // Publish the motion axis' bytes onto the branch, under `motion/`, and repoint each declaration
+  // at where they landed.
+  //
+  // `catalog-motion.mjs` records the artifact's home INSIDE the render bundle, because at join time
+  // that is the only name it has. The bundle is not published — this branch is — so a catalog left
+  // as-is declares captures whose bytes exist nowhere a reader can reach, and every consumer
+  // downstream resolves `motion[].path` to a 404. Copying them here makes that field mean exactly
+  // what `images[].path` already means: a file on the branch, relative to catalog.json.
+  //
+  // It sits in this block rather than beside the figma-svg emit below because it needs the
+  // `previewId` that `bridgeLivePreviewIds` stamped a few lines up (the join to the sibling sticker
+  // whose name each artifact inherits — see catalog-motion-publish.mjs), and because the rewritten
+  // paths have to reach the `writeFile` that closes this block. Reading the bytes from the PRIMARY
+  // bundle only mirrors `motionBundle` in the join above: a motion capture is published from the
+  // bundle that rendered it, and the `--extra-renders` supplement carries none.
+  {
+    const { published, unresolved, missing } = await publishMotionArtifacts(
+      manifest,
+      bundle.entries,
+      outPath,
+    );
+    if (published > 0 || missing.length > 0) {
+      console.log(
+        `[${spec.system}] motion: published ${published} capture(s) under motion/` +
+          (unresolved > 0
+            ? `, ${unresolved} named from the artifact rather than a sibling sticker (no previewId ` +
+              `to join on — the bytes are published, only the filename is unvariant)`
+            : "") +
+          (missing.length > 0
+            ? `, dropped ${missing.length} declaration(s) whose bytes the bundle did not carry ` +
+              `(${missing.join(", ")})`
+            : ""),
+      );
+    }
+  }
+
   await writeFile(
     catalogJsonPath,
     `${JSON.stringify(manifest, null, 2)}\n`,


### PR DESCRIPTION
## Summary

`catalog-motion.mjs` folds a component's animated captures onto `components[].motion[]`, but the path it records is the artifact's home **inside the render bundle** (`previews/<id>.apng`) — the only name it has at join time. The bundle is not published; `design-artifacts/<system>` is. So every published catalog declared motion whose bytes exist nowhere a reader can reach, and every consumer downstream of the branch resolves `motion[].path` to a 404.

This copies the bytes onto the branch under `motion/` and rewrites the declaration to match, so `motion[].path` means exactly what `images[].path` already does: a file on the branch, relative to `catalog.json`.

**The published name is inherited from the sibling sticker, not derived independently.** `images/switch-on/ideal__default__dark.png` publishes its capture as `motion/switch-on/ideal__default__dark.apng`. Same reasoning as the per-variant figma-svg emit that maps `images/` → `figma/`: a name *derived* from the still cannot drift away from the still, whereas restating `buildCatalog`'s naming scheme here would be a second thing to keep in step with a scheme that lives in another package. A function carrying both an interaction and an animation keeps them apart with the `__interaction` segment `PreviewDiscovery` already disambiguates with.

The join to that sticker is `image.previewId`, which is the bundle's own (fully qualified) preview id — the artifact leaf minus its extension is the same key. Verified against the live `design-artifacts/compose-m3` catalog, where `Switch/On` carries ids of the form `com.example.designcatalogm3.CatalogSelectionKt.SwitchOn_Dark`; there's a regression test pinned to that real shape rather than only the short ids the other cases use for legibility.

Two deliberate failure behaviours:

- **No sibling resolved** (an image the live-preview bridge left unstamped, so no `previewId` to join on) — the artifact still publishes, under its own leaf in the component's directory, and the run logs it. Bytes reaching the branch matters more than the filename being variant-shaped: an unresolved sibling is a naming problem, a dropped file is lost coverage.
- **Bytes not in the bundle** — the *declaration* is dropped rather than published. A path that 404s is worse than no motion at all, since a viewer would offer the capture and then fail to load it. `motionArtifactsFor` only records artifacts it matched against `bundle.entries`, so this is unreachable short of a bug, and a silent skip is how it would stay unreachable-looking.

No workflow change is needed: the publish step runs `git add -A` over the whole `out/` tree, so `motion/` rides along like `figma/` and `wireframes/` do.

This is the first of four layers for the serve viewer's motion section — nothing renders yet. Still to come: modelling `motion[]` on `ServeCatalogStore.Component` and staging the files, serving the bytes from `ServeBundleHost`, and the selectable Motion control on the component page.

## Test plan

- `node --test catalog-motion-publish.test.mjs` — 15 tests, all passing. Covers the naming rule (variant inheritance including props/size/locale segments, the `__interaction` disambiguator, the no-sibling fallback, the real fully-qualified id shape), the plan/rewrite join, and the I/O half against a temp directory: bytes land at the right path, the declaration is repointed, a bytes-less declaration is dropped along with an emptied `motion` array, and a second run is a no-op.
- Full `node --test` in `scripts/design-artifacts`: 708 pass, 24 skipped, 5 pre-existing failures — all `ERR_MODULE_NOT_FOUND` for `@design-parity/*`, `pixelmatch` and `pngjs` in a sandbox with no `npm ci`, unrelated to this change. The new module deliberately depends on nothing outside the standard library, which is why its tests run there at all.
- The generator itself can't be executed here (it imports the private `@design-parity/catalog-export`); `node --check` passes, and the new pass is one call whose logic is covered by the tests above.

Text-only PR: this changes data-product plumbing on the delivery branch. It publishes no new rendered surface and alters no pixels — the captures it copies are the ones `@InteractionPreview` already produced, unchanged. The first visual evidence will come with the viewer layer that displays them.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qLcyPRqEYwRVxMf6f9Fus)_