### PR TITLE
feat(serve): sign in on a top-level site host via a parent cookie domain

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -135,6 +135,7 @@ internal object CliFlagValidation {
             "--export",
             "--extra-maven-repos",
             "--github-auth-callback-base-url",
+            "--github-auth-cookie-domain",
             "--github-auth-client-id",
             "--github-auth-client-secret",
             "--github-auth-cookie-secret",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -97,6 +97,7 @@ internal object CliFlags {
       "--github-auth-cookie-secret",
       "--github-auth-repo",
       "--github-auth-callback-base-url",
+      "--github-auth-cookie-domain",
       "--github-auth-scope",
       "--github-auth-users",
       "--catalog-repo",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -582,6 +582,14 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val githubAuthCallbackBaseUrl: String? =
     args.flagValue("--github-auth-callback-base-url")?.takeIf { it.isNotBlank() }
   /**
+   * Scopes the auth cookies to a parent domain so one sign-in covers it and every `--sites` host
+   * under it (`preview.coo.ee` ⇒ valid on `m3.preview.coo.ee`). Unset keeps them host-only, which
+   * is right for a single-hostname box; it is deliberately explicit rather than derived, since a
+   * cookie domain is the blast radius of a session.
+   */
+  private val githubAuthCookieDomain: String? =
+    args.flagValue("--github-auth-cookie-domain")?.takeIf { it.isNotBlank() }
+  /**
    * Overrides the OAuth scope. Unset derives it from `--github-auth-repo`'s visibility, which is
    * what a deployment wants unless its GitHub App or org policy demands something specific.
    */
@@ -3062,6 +3070,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         repository = githubAuthRepo!!,
         allowedUsers = githubAuthUsers,
         callbackBaseUrl = githubAuthCallbackBaseUrl,
+        cookieDomain = githubAuthCookieDomain,
         oauthScope = githubAuthScope,
       )
     )
@@ -3207,6 +3216,15 @@ class ServeCommand(args: List<String>) : Command(args) {
         --github-auth-callback-base-url <url>
                           External origin for the OAuth callback, e.g. https://preview.example.com.
                           Omit for local use; reverse-proxied deploys should set it explicitly.
+        --github-auth-cookie-domain <domain>
+                          Scope the auth cookies to a parent domain, so one sign-in covers it and
+                          every --sites hostname under it (preview.example.com also signs in
+                          m3.preview.example.com). Required for sign-in to work on a top-level site
+                          when --github-auth-callback-base-url is pinned: without it the cookies are
+                          host-only, the state cookie never reaches the callback origin, and the
+                          server withholds sign-in on site hosts. Omit on a single-hostname box.
+                          Every host under <domain> is inside the session's reach, so name the
+                          narrowest one that covers your sites.
         --github-auth-scope <scope>
                           Override the OAuth scope instead of deriving it from --github-auth-repo's
                           visibility. Only needed when a GitHub App or org policy demands a specific

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -35,6 +35,25 @@ data class ServeGithubAuthConfig(
   val allowedUsers: Set<String> = emptySet(),
   val callbackBaseUrl: String? = null,
   /**
+   * The domain the auth cookies are written for, so **one sign-in covers a parent host and every
+   * top-level site under it** — set `preview.coo.ee` and a session established anywhere in the
+   * family is valid on `m3.preview.coo.ee` too.
+   *
+   * This is what makes a pinned callback work from a site host at all. Without it the cookies are
+   * host-only: the `cp_gh_state` cookie written on the site host is not sent to the pinned callback
+   * origin, so the CSRF check there sees nothing and answers 401, and a session cookie set at the
+   * callback would be scoped to the wrong host anyway.
+   *
+   * Null (the default) keeps cookies host-only, which is right for a single-hostname box and is the
+   * only safe default: it must be the operator's explicit choice, never derived from the request's
+   * own `Host`, or an attacker-supplied header could widen the scope of a session cookie.
+   *
+   * **Every host under this domain is inside the session's blast radius**, so it must cover only
+   * hosts this deployment controls. A registrable public suffix (`co.uk`, or a bare `com`) is
+   * refused outright; beyond that the operator is trusted to know what lives under their own name.
+   */
+  val cookieDomain: String? = null,
+  /**
    * Overrides the OAuth scope entirely. Null (the default) derives it from the gating repo's
    * visibility — see [ServeGithubAuth.requestedScope], which is what an operator wants unless their
    * GitHub App or org policy needs something specific.
@@ -50,10 +69,60 @@ data class ServeGithubAuthConfig(
     require(repository.matches(Regex("[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+"))) {
       "GitHub auth repository must be owner/repo"
     }
+    val domain = cookieDomain?.trim()?.removePrefix(".")?.takeIf { it.isNotEmpty() }
+    if (domain != null) {
+      val normalized = ServeSites.normalizeHost(domain)
+      require(normalized != null) { "GitHub auth cookie domain '$cookieDomain' is not a hostname" }
+      // A single-label domain (`com`, `localhost`) or a two-label public suffix (`co.uk`) would ask
+      // the browser to scope the session across a whole registry. Browsers reject that, so the
+      // sign-in would fail at the Set-Cookie rather than here — which is a much worse place to find
+      // out. Two labels is the floor, and the known multi-part suffixes are named out.
+      val labels = normalized.split(".")
+      require(labels.size >= 2) {
+        "GitHub auth cookie domain '$cookieDomain' must have at least two labels"
+      }
+      require(normalized !in PUBLIC_SUFFIXES) {
+        "GitHub auth cookie domain '$cookieDomain' is a public suffix — no cookie may span it"
+      }
+      // The pinned callback is where the cookies are actually written, so a domain that doesn't
+      // cover it produces a sign-in the browser drops on the floor.
+      val callbackHost =
+        callbackBaseUrl
+          ?.substringAfter("://", "")
+          ?.substringBefore('/')
+          ?.takeIf { it.isNotEmpty() }
+          ?.let { ServeSites.normalizeHost(it) }
+      require(
+        callbackHost == null || callbackHost == normalized || callbackHost.endsWith(".$normalized")
+      ) {
+        "GitHub auth cookie domain '$cookieDomain' does not cover the callback host '$callbackHost'"
+      }
+    }
   }
 
   companion object {
     const val MIN_COOKIE_SECRET_CHARS = 32
+
+    /**
+     * Two-label names that are registries rather than registrable domains, so a cookie may not span
+     * them. Not a full public-suffix list — that is a large, churning dataset and a `serve` box
+     * carries no copy of it. These are the ones a plausible typo lands on; anything past them is
+     * the operator's own name to reason about.
+     */
+    private val PUBLIC_SUFFIXES =
+      setOf(
+        "co.uk",
+        "org.uk",
+        "ac.uk",
+        "gov.uk",
+        "co.jp",
+        "co.nz",
+        "co.za",
+        "com.au",
+        "com.br",
+        "com.cn",
+        "github.io",
+      )
   }
 }
 
@@ -64,9 +133,17 @@ class ServeGithubAuth(
   /** Unauthenticated client for the one-shot visibility probe behind [requestedScope]. */
   private val anonymousClient: OkHttpClient = OkHttpClient(),
 ) {
-  suspend fun RoutingContext.handleStart() {
+  /**
+   * `GET /auth/github/start`. [siteHosts] are the top-level site hostnames this server answers for
+   * ([ServeSites.hosts]) — the **only** hosts a sign-in may be returned to, and the list is checked
+   * again before [handleCallback] issues that redirect. Empty (the default) means the sign-in ends
+   * where it started, which is exactly what this did before sites existed.
+   */
+  suspend fun RoutingContext.handleStart(siteHosts: Set<String> = emptySet()) {
     val returnTo = safeReturnTo(call.request.queryParameters["return"] ?: "/")
-    val state = signedState(nonce(), returnTo)
+    // Null on the ordinary same-host sign-in, which is then byte-for-byte what it always was.
+    val originHost = originHostFor(call, siteHosts)
+    val state = signedState(nonce(), returnTo, originHost)
     call.response.cookies.append(
       stateCookie(
         state,
@@ -77,7 +154,26 @@ class ServeGithubAuth(
     call.respondRedirect(authorizeUrl(call, state))
   }
 
-  suspend fun RoutingContext.handleCallback() {
+  /**
+   * `GET /auth/github/callback` — GitHub's return leg, which on a pinned box always lands on the
+   * pinned origin whatever host the visitor started from.
+   *
+   * Two shapes end up here, and they differ only in where the visitor is sent afterwards. A
+   * **same-host** sign-in (no origin host in the state) returns to a relative path, as it always
+   * did. A **cross-host** sign-in — started on a top-level site — returns to an absolute URL on
+   * that site, so the visitor lands back where they were reading rather than being quietly moved to
+   * the pinned origin.
+   *
+   * **The CSRF check is unchanged**, and that is the point of doing this with a cookie domain
+   * rather than a token handoff: with [ServeGithubAuthConfig.cookieDomain] set, `cp_gh_state` is
+   * written for the parent domain, so it is sent to the pinned callback host too and can be
+   * compared here exactly as it always was. All the cross-host leg adds is *where to go back to* —
+   * a redirect target, not a credential.
+   *
+   * The session cookie is likewise written for the parent domain, so one sign-in is already valid
+   * on every site host under it. There is nothing to hand over.
+   */
+  suspend fun RoutingContext.handleCallback(siteHosts: Set<String> = emptySet()) {
     val state = call.request.queryParameters["state"].orEmpty()
     val expected = call.request.cookieValue(STATE_COOKIE).orEmpty()
     val code = call.request.queryParameters["code"].orEmpty()
@@ -88,6 +184,12 @@ class ServeGithubAuth(
       call.respondText("GitHub sign-in failed.", status = HttpStatusCode.Unauthorized)
       return
     }
+    // Where the visitor started, when that was a different host to this one. Re-validated against
+    // the live site list rather than trusted from [handleStart]: the signature proves this server
+    // minted the state, not that the host is still one of ours, and an unchecked value here is an
+    // open redirect off the back of a real sign-in. Anything unrecognised falls back to a
+    // same-origin relative return, which is where this route always sent people.
+    val returnHost = statePayload.originHost?.takeIf { it in siteHosts && withinCookieDomain(it) }
     val user =
       withContext(Dispatchers.IO) { verifier.verify(code, callbackUrl(call), config) }
         .getOrElse {
@@ -101,7 +203,27 @@ class ServeGithubAuth(
     val secure = isSecure(call, config.callbackBaseUrl)
     call.response.cookies.append(authCookie(session, maxAge = SESSION_TTL_SECONDS, secure = secure))
     call.response.cookies.append(stateCookie("", maxAge = 0, secure = secure))
-    call.respondRedirect(statePayload.returnTo)
+    call.respondRedirect(
+      if (returnHost == null) statePayload.returnTo
+      else "https://$returnHost${statePayload.returnTo}"
+    )
+  }
+
+  /**
+   * Whether a sign-in started on [rawHost] can actually come back to it.
+   *
+   * True when the callback isn't pinned (it is derived from the request, so it never leaves the
+   * host), when this *is* the pinned host, or when [rawHost] is a configured site host that the
+   * session cookie's domain covers — the case this exists for. False for a site outside the cookie
+   * domain: the cookies written at the callback would not be sent to it, so a sign-in started there
+   * would appear to succeed and land the visitor back signed-out. [ServeHttpServer] reads this to
+   * decide whether to offer the sign-in affordance at all.
+   */
+  fun canRoundTrip(rawHost: String?, siteHosts: Set<String>): Boolean {
+    if (!hasPinnedCallback) return true
+    val host = rawHost?.let { ServeSites.normalizeHost(it) } ?: return false
+    if (host == pinnedCallbackHost()) return true
+    return host in siteHosts && withinCookieDomain(host)
   }
 
   fun isAuthenticated(call: ApplicationCall): Boolean {
@@ -231,10 +353,10 @@ class ServeGithubAuth(
 
   /**
    * Whether the OAuth callback is pinned to one origin (`--github-auth-callback-base-url`) rather
-   * than derived from the request. A pinned callback means a sign-in started anywhere else cannot
-   * complete: the host-only state cookie is written on the origin the visitor was on, and GitHub
-   * returns to the pinned one. [ServeHttpServer] reads this to withhold the sign-in affordance on a
-   * top-level site instead of offering a link that 401s.
+   * than derived from the request. A pinned callback means the return leg always lands on that one
+   * origin, whatever host the visitor started from — which is why a sign-in begun on a top-level
+   * site has to be handed back to it ([handleComplete]) instead of finishing at the callback. Use
+   * [canRoundTrip] to ask whether a given host's sign-in can complete; this is the raw setting.
    */
   val hasPinnedCallback: Boolean
     get() = !config.callbackBaseUrl.isNullOrBlank()
@@ -244,14 +366,79 @@ class ServeGithubAuth(
       ?: call?.let { externalOrigin(it) + CALLBACK_PATH }
       ?: CALLBACK_PATH
 
-  private fun signedState(nonce: String, returnTo: String): String = sign("$nonce|$returnTo")
+  /**
+   * The host to send the visitor back to once the callback has run, or null when the sign-in ends
+   * where it started (the ordinary case: no pinned callback, or already on the pinned origin).
+   *
+   * Only a configured site host the cookie domain covers is ever returned. That is the allowlist
+   * which keeps the state's origin field from becoming an open redirect, and it is applied again in
+   * [handleCallback], because between the two legs the value has been round-tripped through the
+   * client.
+   */
+  private fun originHostFor(call: ApplicationCall, siteHosts: Set<String>): String? {
+    if (!hasPinnedCallback || siteHosts.isEmpty()) return null
+    val host = requestHost(call) ?: return null
+    if (host == pinnedCallbackHost()) return null
+    return host.takeIf { it in siteHosts && withinCookieDomain(it) }
+  }
+
+  /**
+   * Whether a cookie written for [ServeGithubAuthConfig.cookieDomain] would actually be sent to
+   * [host] — it is the domain itself, or a subdomain of it. No cookie domain configured ⇒ cookies
+   * are host-only, so nothing but the host that set them qualifies.
+   *
+   * The dot matters: a naive `endsWith` would read `notpreview.coo.ee` as being under
+   * `preview.coo.ee` and offer a sign-in that silently can't work.
+   */
+  private fun withinCookieDomain(host: String): Boolean {
+    val domain = cookieDomain ?: return false
+    return host == domain || host.endsWith(".$domain")
+  }
+
+  /** The configured cookie domain, normalised; null when cookies stay host-only. */
+  private val cookieDomain: String? by lazy {
+    config.cookieDomain
+      ?.trim()
+      ?.removePrefix(".")
+      ?.takeIf { it.isNotEmpty() }
+      ?.let { ServeSites.normalizeHost(it) }
+  }
+
+  /** The host of the pinned callback, so a sign-in already on it is never handed off to itself. */
+  private fun pinnedCallbackHost(): String? =
+    config.callbackBaseUrl
+      ?.substringAfter("://", "")
+      ?.substringBefore('/')
+      ?.takeIf { it.isNotEmpty() }
+      ?.let { ServeSites.normalizeHost(it) }
+
+  /**
+   * `nonce|originHost|returnTo`, with an empty origin host on the same-host flow. The nonce is
+   * base64url and the origin host is a validated hostname, so neither can contain the separator and
+   * `returnTo` keeps its rest-of-string reading — which matters, since a return path may carry a
+   * query string containing anything at all.
+   */
+  private fun signedState(nonce: String, returnTo: String, originHost: String?): String =
+    sign("$nonce|${originHost.orEmpty()}|$returnTo")
 
   private fun verifyState(value: String): StatePayload? {
     val payload = verifySigned(value) ?: return null
-    val idx = payload.indexOf('|')
-    if (idx <= 0) return null
-    val returnTo = safeReturnTo(payload.substring(idx + 1))
-    return StatePayload(returnTo)
+    val firstPipe = payload.indexOf('|')
+    if (firstPipe <= 0) return null
+    val nonce = payload.substring(0, firstPipe)
+    val rest = payload.substring(firstPipe + 1)
+    val secondPipe = rest.indexOf('|')
+    // No second separator ⇒ a state minted before handoff existed: the remainder is the return path
+    // and there is no origin host. Kept so sign-ins already in flight across a restart still land.
+    if (secondPipe < 0) return StatePayload(nonce, safeReturnTo(rest), null)
+    val originField = rest.substring(0, secondPipe)
+    val originHost = originField.takeIf { it.isNotEmpty() }?.let { ServeSites.normalizeHost(it) }
+    // A non-empty middle field that isn't a hostname means this is the legacy shape after all and
+    // the return path simply contained a separator — read it whole rather than truncating it.
+    if (originField.isNotEmpty() && originHost == null) {
+      return StatePayload(nonce, safeReturnTo(rest), null)
+    }
+    return StatePayload(nonce, safeReturnTo(rest.substring(secondPipe + 1)), originHost)
   }
 
   private fun signedSession(
@@ -326,13 +513,23 @@ class ServeGithubAuth(
       value = value,
       path = "/",
       maxAge = maxAge.toInt(),
+      // Null ⇒ no Domain attribute ⇒ host-only, the default and the single-hostname behaviour.
+      // Set, it scopes the cookie to the parent domain and every site host under it, which is what
+      // lets one sign-in cover preview.coo.ee and m3.preview.coo.ee alike. Always the operator's
+      // configured value, never anything derived from the request.
+      domain = cookieDomain,
       secure = secure,
       httpOnly = true,
       encoding = CookieEncoding.URI_ENCODING,
       extensions = mapOf("SameSite" to "Lax"),
     )
 
-  private data class StatePayload(val returnTo: String)
+  private data class StatePayload(
+    val nonce: String,
+    val returnTo: String,
+    /** The site host to hand the finished sign-in back to; null on the same-host flow. */
+    val originHost: String?,
+  )
 
   private data class SessionPayload(
     val login: String,
@@ -345,6 +542,7 @@ class ServeGithubAuth(
   companion object {
     const val START_PATH = "/auth/github/start"
     const val CALLBACK_PATH = "/auth/github/callback"
+
     private const val AUTH_COOKIE = "cp_gh_auth"
     private const val STATE_COOKIE = "cp_gh_state"
     /**
@@ -623,6 +821,18 @@ private fun io.ktor.server.request.ApplicationRequest.cookieValue(name: String):
 internal fun isSecure(call: ApplicationCall, callbackBaseUrl: String? = null): Boolean =
   callbackBaseUrl?.trim()?.takeIf { it.isNotEmpty() }?.startsWith("https://", ignoreCase = true)
     ?: externalOrigin(call).startsWith("https://", ignoreCase = true)
+
+/**
+ * The externally visible hostname of this request, normalised for comparison against the configured
+ * site hosts — `X-Forwarded-Host` first (Caddy sets it, and behind a proxy it is the only view of
+ * the name the visitor typed), else `Host`. Null when what arrives isn't a hostname at all, so a
+ * junk header matches no site and simply gets the pre-handoff behaviour.
+ */
+internal fun requestHost(call: ApplicationCall): String? {
+  val forwarded = call.request.headers["X-Forwarded-Host"]?.substringBefore(',')?.trim()
+  val raw = forwarded?.takeIf { it.isNotEmpty() } ?: call.request.headers[HttpHeaders.Host]
+  return raw?.let { ServeSites.normalizeHost(it) }
+}
 
 private fun externalOrigin(call: ApplicationCall): String {
   val forwardedProto = call.request.headers["X-Forwarded-Proto"]?.substringBefore(",")?.trim()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -579,8 +579,11 @@ class ServeHttpServer(
         }
 
         githubAuth?.let { auth ->
-          get(ServeGithubAuth.START_PATH) { with(auth) { handleStart() } }
-          get(ServeGithubAuth.CALLBACK_PATH) { with(auth) { handleCallback() } }
+          // The site hosts are the allowlist for the post-callback return redirect: the only
+          // hostnames a sign-in started elsewhere may be sent back to. Passed in rather than known
+          // to the auth object, so the site config keeps one home.
+          get(ServeGithubAuth.START_PATH) { with(auth) { handleStart(sites.hosts) } }
+          get(ServeGithubAuth.CALLBACK_PATH) { with(auth) { handleCallback(sites.hosts) } }
         }
 
         // `/status` — the operator/observer view of this running host: published catalogs + their
@@ -1097,20 +1100,23 @@ class ServeHttpServer(
   /**
    * Whether a GitHub sign-in started from *this* request's origin can actually come back to it.
    *
-   * False on a top-level site whose box pins a callback base URL
+   * This used to be false on every top-level site whose box pins a callback base URL
    * (`--github-auth-callback-base-url`, which the deployment sets): the `cp_gh_state` cookie is
-   * host-only, so it is written on the site host while GitHub returns to the pinned one — the
-   * callback then sees no state and answers 401, and its relative return URL could not have come
-   * back to the site anyway. Offering the link would advertise a dead end, so the affordance is
-   * withheld and the surface stays snapshot-only there. Sites on a box with no pinned callback are
-   * unaffected (the callback is derived from the request, so it stays on the site host and the
-   * round trip closes).
+   * host-only, so it was written on the site host while GitHub returned to the pinned one, and the
+   * callback saw no state and answered 401. The affordance was withheld rather than walk a visitor
+   * into that, which left live and playground snapshot-only on every site.
    *
-   * The real fix is an OAuth handoff that carries the originating host through the dance; until
-   * then this keeps the failure honest rather than hidden behind a button.
+   * [ServeGithubAuthConfig.cookieDomain] fixes it at the root: written for the parent domain, both
+   * cookies are sent to the pinned callback host and to every site host under it, so the CSRF check
+   * works where it always did and one session covers the family. The state carries the originating
+   * host purely so the callback knows where to send the visitor back to.
+   *
+   * What stays false is a host outside that domain — an unlisted vhost, or a site on a different
+   * domain entirely. The cookies would not reach it, so a sign-in started there would land the
+   * visitor back signed-out, and offering the link would still be advertising a dead end.
    */
   private fun RoutingContext.oauthCanRoundTrip(): Boolean =
-    siteSystem() == null || githubAuth?.hasPinnedCallback != true
+    githubAuth?.canRoundTrip(requestHost(call), sites.hosts) ?: true
 
   /**
    * The session id to hand [ServeWeb] for nav-marking + link building, and the URL [basePath] its

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubSiteAuthTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubSiteAuthTest.kt
@@ -1,0 +1,272 @@
+package ee.schimke.composeai.cli.serve
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+/**
+ * Signing in **from a top-level site host** on a box whose OAuth callback is pinned to one origin.
+ *
+ * This never worked. The auth cookies were host-only, so a sign-in begun on `m3.preview.coo.ee`
+ * wrote its `cp_gh_state` cookie there while GitHub returned to `preview.coo.ee` — the callback saw
+ * no state, answered 401, and even a session minted there would have been scoped to the wrong host.
+ * The server's answer was to withhold the sign-in affordance on every site, which left live preview
+ * and playground snapshot-only on all of them.
+ *
+ * The fix is a cookie **domain**: written for the parent, both cookies reach the pinned callback
+ * host and every site host under it. So the CSRF check happens exactly where it always did, one
+ * session covers the whole family, and the only thing the cross-host case adds is a redirect
+ * target. These tests pin that, and pin the guards on the redirect target — the one new place a
+ * client-supplied value steers the response.
+ */
+class ServeGithubSiteAuthTest {
+
+  private var now: Instant = Instant.parse("2026-01-01T00:00:00Z")
+  private val clock =
+    object : Clock() {
+      override fun getZone() = ZoneOffset.UTC
+
+      override fun withZone(zone: java.time.ZoneId?) = this
+
+      override fun instant(): Instant = now
+    }
+
+  private val fakeGitHub =
+    OkHttpClient.Builder()
+      .addInterceptor { chain ->
+        val request = chain.request()
+        val body =
+          when (request.url.encodedPath) {
+            "/login/oauth/access_token" -> """{"access_token":"token"}"""
+            "/user" -> """{"login":"octo"}"""
+            else -> """{"private":false,"permissions":{"push":true}}"""
+          }
+        Response.Builder()
+          .request(request)
+          .protocol(Protocol.HTTP_1_1)
+          .code(200)
+          .message("OK")
+          .body(body.toResponseBody("application/json".toMediaType()))
+          .build()
+      }
+      .build()
+
+  private fun auth(cookieDomain: String? = "preview.coo.ee") =
+    ServeGithubAuth(
+      ServeGithubAuthConfig(
+        clientId = "client",
+        clientSecret = "secret",
+        cookieSecret = "x".repeat(32),
+        repository = "yschimke/compose-ai-tools",
+        callbackBaseUrl = "https://preview.coo.ee",
+        cookieDomain = cookieDomain,
+      ),
+      verifier = GitHubOAuthVerifier(fakeGitHub),
+      clock = clock,
+      anonymousClient = fakeGitHub,
+    )
+
+  private val sites =
+    ServeSites.of(listOf("m3.preview.coo.ee" to "m3-catalog", "wear.preview.coo.ee" to "wear-m3"))
+
+  private val registry = ServeSessionRegistry(open = { null })
+
+  private var server: ServeHttpServer? = null
+
+  private fun serverWith(cookieDomain: String? = "preview.coo.ee"): ServeHttpServer =
+    server
+      ?: ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused-in-public",
+          sessions = registry,
+          defaultSessionId = "none",
+          isPublic = true,
+          githubAuth = auth(cookieDomain),
+          sites = sites,
+        )
+        .also {
+          it.start()
+          server = it
+        }
+
+  @AfterTest
+  fun stop() {
+    runCatching { server?.stop() }
+    runCatching { registry.close() }
+  }
+
+  private val noRedirect = OkHttpClient.Builder().followRedirects(false).build()
+
+  private fun get(path: String, host: String?, cookie: String? = null): Response {
+    val builder = Request.Builder().url("http://127.0.0.1:${serverWith().port}$path")
+    if (host != null) builder.header("X-Forwarded-Host", host)
+    if (cookie != null) builder.header("Cookie", cookie)
+    return noRedirect.newCall(builder.build()).execute()
+  }
+
+  /** Start a sign-in on [host]; returns the OAuth `state` and the `cp_gh_state` cookie pair. */
+  private fun start(host: String?): Pair<String, String> =
+    get("/auth/github/start?return=%2Fp%2Fbadge", host).use { resp ->
+      assertEquals(302, resp.code)
+      val state =
+        resp.header("Location").orEmpty().substringAfter("state=").substringBefore("&").let {
+          java.net.URLDecoder.decode(it, "UTF-8")
+        }
+      state to resp.header("Set-Cookie").orEmpty().substringBefore(";")
+    }
+
+  @Test
+  fun `a sign-in started on a site host comes back to that site host`() {
+    val (state, stateCookie) = start("m3.preview.coo.ee")
+    get("/auth/github/callback?code=ok&state=${enc(state)}", "preview.coo.ee", stateCookie).use {
+      assertEquals(302, it.code)
+      // The whole point: the visitor lands back on the site they started from, on the page they
+      // were reading — not on a relative path resolved against the pinned callback origin, which
+      // would silently move them to preview.coo.ee.
+      assertEquals("https://m3.preview.coo.ee/p/badge", it.header("Location"))
+      val session = it.headers("Set-Cookie").first { c -> c.startsWith("cp_gh_auth=") }
+      // …carrying a cookie the site host will actually send back.
+      assertTrue(
+        session.contains("domain=preview.coo.ee", ignoreCase = true),
+        "the session cookie must be scoped to the parent domain, was: $session",
+      )
+    }
+  }
+
+  @Test
+  fun `the state cookie is domain-scoped, which is what lets the CSRF check still run`() {
+    val (_, stateCookie) = start("m3.preview.coo.ee")
+    // The cookie is set on the site host but must be readable at the pinned callback origin.
+    // Without
+    // the Domain attribute this is exactly where the old flow died.
+    assertTrue(stateCookie.startsWith("cp_gh_state="))
+    get("/auth/github/start", "m3.preview.coo.ee").use {
+      assertTrue(
+        it.header("Set-Cookie").orEmpty().contains("domain=preview.coo.ee", ignoreCase = true),
+        "the state cookie must span the parent domain",
+      )
+    }
+  }
+
+  @Test
+  fun `a callback with no matching state cookie is still refused`() {
+    // The login-CSRF guard is unchanged by any of this: an attacker-forged callback carrying their
+    // own code has no state cookie in the victim's browser and dies here, as it always did.
+    val (state, _) = start("m3.preview.coo.ee")
+    get("/auth/github/callback?code=ok&state=${enc(state)}", "preview.coo.ee").use {
+      assertEquals(401, it.code)
+    }
+  }
+
+  @Test
+  fun `a state naming a host this server does not serve cannot steer the redirect`() {
+    // The origin host is signed, but signing proves only that we minted it — a site removed from
+    // config between the two legs, or a state replayed against a differently-configured box, must
+    // not become an open redirect off the back of a real sign-in.
+    val evil =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused",
+          sessions = ServeSessionRegistry(open = { null }),
+          defaultSessionId = "none",
+          isPublic = true,
+          githubAuth = auth(),
+          // Same auth config and secret, but m3 is NOT a site here.
+          sites = ServeSites.of(listOf("wear.preview.coo.ee" to "wear-m3")),
+        )
+        .also { it.start() }
+    try {
+      val (state, stateCookie) = start("m3.preview.coo.ee")
+      noRedirect
+        .newCall(
+          Request.Builder()
+            .url("http://127.0.0.1:${evil.port}/auth/github/callback?code=ok&state=${enc(state)}")
+            .header("X-Forwarded-Host", "preview.coo.ee")
+            .header("Cookie", stateCookie)
+            .build()
+        )
+        .execute()
+        .use {
+          assertEquals(302, it.code)
+          // Falls back to the relative return rather than redirecting off-host.
+          assertEquals("/p/badge", it.header("Location"))
+        }
+    } finally {
+      runCatching { evil.stop() }
+    }
+  }
+
+  @Test
+  fun `a sign-in on the main host is unchanged`() {
+    val (state, stateCookie) = start("preview.coo.ee")
+    get("/auth/github/callback?code=ok&state=${enc(state)}", "preview.coo.ee", stateCookie).use {
+      assertEquals(302, it.code)
+      // Relative, exactly as before the origin host was ever carried.
+      assertEquals("/p/badge", it.header("Location"))
+    }
+  }
+
+  @Test
+  fun `without a cookie domain a site host is told sign-in cannot round-trip`() {
+    val hostOnly = auth(cookieDomain = null)
+    assertFalse(
+      hostOnly.canRoundTrip("m3.preview.coo.ee", sites.hosts),
+      "host-only cookies cannot reach a pinned callback, so the affordance must stay withheld",
+    )
+    assertTrue(hostOnly.canRoundTrip("preview.coo.ee", sites.hosts))
+  }
+
+  @Test
+  fun `with a cookie domain a configured site round-trips, an outsider does not`() {
+    val withDomain = auth()
+    assertTrue(withDomain.canRoundTrip("m3.preview.coo.ee", sites.hosts))
+    assertTrue(withDomain.canRoundTrip("preview.coo.ee", sites.hosts))
+    // Not a configured site, so nothing may be redirected to it…
+    assertFalse(withDomain.canRoundTrip("other.preview.coo.ee", sites.hosts))
+    // …and a lookalike that merely ends with the domain string is not under it. `endsWith` without
+    // the dot would have said yes here and offered a sign-in that cannot work.
+    assertFalse(withDomain.canRoundTrip("notpreview.coo.ee", sites.hosts))
+    assertFalse(withDomain.canRoundTrip(null, sites.hosts))
+  }
+
+  @Test
+  fun `a cookie domain that cannot work is refused at startup, not at the Set-Cookie`() {
+    fun config(domain: String) =
+      ServeGithubAuthConfig(
+        clientId = "client",
+        clientSecret = "secret",
+        cookieSecret = "x".repeat(32),
+        repository = "yschimke/compose-ai-tools",
+        callbackBaseUrl = "https://preview.coo.ee",
+        cookieDomain = domain,
+      )
+    // A public suffix: the browser would drop the cookie and the visitor would just never be signed
+    // in, with nothing logged. Far better to refuse to boot.
+    assertFailsWith<IllegalArgumentException> { config("co.uk") }
+    // A single label is the same failure in a different shape.
+    assertFailsWith<IllegalArgumentException> { config("localhost") }
+    // A domain that doesn't cover the callback host writes cookies nobody ever sends back.
+    assertFailsWith<IllegalArgumentException> { config("example.com") }
+    assertFailsWith<IllegalArgumentException> { config("not a host") }
+    // The working shapes: the callback host itself, and a parent of it.
+    config("preview.coo.ee")
+    config("coo.ee")
+    config(".preview.coo.ee")
+  }
+
+  private fun enc(v: String): String = java.net.URLEncoder.encode(v, "UTF-8")
+}

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -111,9 +111,9 @@ curl -sI https://m3.preview.coo.ee/wear-m3/ | head -1                    # 404 �
 ```
 
 Sites are read **at startup**, so this is a restart either way; the additive `/admin/catalogs`
-reconcile does not carry them. GitHub sign-in is deliberately not offered on a site host (the
-`cp_gh_state` cookie is host-only and this box pins a callback origin), so its live and playground
-surfaces stay snapshot-only.
+reconcile does not carry them. If this box uses GitHub sign-in, set `SERVE_GITHUB_AUTH_COOKIE_DOMAIN`
+as well — see *GitHub auth* below; without it sign-in is withheld on a site host and its live and
+playground surfaces stay snapshot-only.
 
 > `catalogs.json`'s `"sites"` key says the same thing as durable config — but on this image that
 > file is a volume the box seeds once and never overwrites, so committing a site to
@@ -174,7 +174,25 @@ SERVE_GITHUB_AUTH_COOKIE_SECRET=... # openssl rand -hex 32
 ```
 
 The compose profile derives the callback base URL from `DOMAIN`; set
-`SERVE_GITHUB_AUTH_CALLBACK_BASE_URL` to override. Empty `SERVE_GITHUB_AUTH_USERS` allows any
+`SERVE_GITHUB_AUTH_CALLBACK_BASE_URL` to override.
+
+**With top-level sites configured, the cookies need a domain.** `SERVE_GITHUB_AUTH_COOKIE_DOMAIN`
+scopes both auth cookies to a parent domain, so one sign-in covers this host and every `SERVE_SITES`
+hostname under it — sign in on `preview.coo.ee` and `m3.preview.coo.ee` is signed in too. Without it
+the cookies are host-only: a sign-in started on a site host writes its state cookie there while
+GitHub returns to the pinned callback origin, the callback sees no state, and the server withholds
+the sign-in affordance on every site (live and playground stay snapshot-only there). The entrypoint
+derives it from `DOMAIN` when `SERVE_SITES` is set; set it explicitly to narrow it, or to `none` to
+keep cookies host-only:
+
+```bash
+SERVE_GITHUB_AUTH_COOKIE_DOMAIN=preview.coo.ee
+```
+
+Every host under that domain is inside the session's reach, so name the narrowest one covering your
+sites — on a box whose `DOMAIN` is an apex, set this explicitly rather than letting one session span
+the whole zone. A public suffix, or a domain that doesn't cover the callback host, is refused at
+startup rather than producing cookies the browser drops silently. Empty `SERVE_GITHUB_AUTH_USERS` allows any
 signed-in GitHub user to use live previews; playground additionally requires **write** access to
 `SERVE_GITHUB_AUTH_REPO` (default `yschimke/compose-ai-tools`). Set `SERVE_GITHUB_AUTH_USERS` to a
 comma-separated login list only if you want to narrow sign-in for both surfaces. The OAuth app

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -65,6 +65,10 @@ services:
       SERVE_GITHUB_AUTH_COOKIE_SECRET: "${SERVE_GITHUB_AUTH_COOKIE_SECRET:-}"
       SERVE_GITHUB_AUTH_REPO: "${SERVE_GITHUB_AUTH_REPO:-yschimke/compose-ai-tools}"
       SERVE_GITHUB_AUTH_CALLBACK_BASE_URL: "${SERVE_GITHUB_AUTH_CALLBACK_BASE_URL:-}"
+      # Scopes the auth cookies to a parent domain so ONE sign-in covers this host and every
+      # SERVE_SITES hostname under it. Empty derives it from DOMAIN when sites are configured (see
+      # entrypoint.sh); `none` keeps cookies host-only, which withholds sign-in on every site host.
+      SERVE_GITHUB_AUTH_COOKIE_DOMAIN: "${SERVE_GITHUB_AUTH_COOKIE_DOMAIN:-}"
       SERVE_GITHUB_AUTH_USERS: "${SERVE_GITHUB_AUTH_USERS:-}"
       # Empty derives the OAuth scope from the gating repo's visibility (public ⇒ read:user,
       # private ⇒ read:user repo). Only set this when a GitHub App or org policy demands one.

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -139,6 +139,22 @@ if [[ -n "${SERVE_GITHUB_AUTH_CLIENT_ID:-}" ||
   fi
   [[ -n "${github_auth_callback_base_url}" ]] &&
     args+=(--github-auth-callback-base-url "${github_auth_callback_base_url}")
+  # Scope the auth cookies to the parent domain so ONE sign-in covers this host and every
+  # SERVE_SITES hostname under it. Without it the cookies are host-only, the state cookie written on
+  # a site host never reaches the pinned callback origin, and the server withholds the sign-in
+  # affordance on every site (live + playground stay snapshot-only there).
+  #
+  # Derived from DOMAIN, but only when sites are actually configured — a single-hostname box has
+  # nothing to widen for, and a cookie domain is the blast radius of a session. Set it explicitly to
+  # override, or to `none` to keep cookies host-only. Note the derivation is only as narrow as
+  # DOMAIN itself: on a box whose DOMAIN is an apex, set this to the subdomain the sites live under
+  # rather than letting one session span the whole zone.
+  github_auth_cookie_domain="${SERVE_GITHUB_AUTH_COOKIE_DOMAIN:-}"
+  if [[ -z "${github_auth_cookie_domain}" && -n "${SERVE_SITES:-}" && -n "${DOMAIN:-}" ]]; then
+    github_auth_cookie_domain="${DOMAIN}"
+  fi
+  [[ -n "${github_auth_cookie_domain}" && "${github_auth_cookie_domain}" != "none" ]] &&
+    args+=(--github-auth-cookie-domain "${github_auth_cookie_domain}")
   [[ -n "${SERVE_GITHUB_AUTH_USERS:-}" ]] && args+=(--github-auth-users "${SERVE_GITHUB_AUTH_USERS}")
   # Unset derives the scope from the gating repo's visibility (public -> read:user, private ->
   # read:user repo). Only set this when a GitHub App or org policy demands a specific scope.

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -110,13 +110,25 @@ On that hostname:
   another catalog through the wrong domain — and the host **outranks `?session=`**, so the older
   query spelling can't reach past it either.
 
-One surface is **withheld** on a site rather than broken: when the box pins an OAuth callback origin
-(`--github-auth-callback-base-url`, which this deployment sets), a GitHub sign-in started on a site
-host cannot come back to it — the `cp_gh_state` cookie is host-only and GitHub returns to the pinned
-origin. The sign-in affordance is therefore not offered on a site host, and its live/playground
-surfaces stay snapshot-only, instead of advertising a button that 401s. A box with no pinned
-callback derives it from the request and is unaffected. Carrying the originating host through the
-OAuth dance is the real fix and isn't done yet.
+**Sign-in works on a site host, given a cookie domain.** `--github-auth-cookie-domain preview.coo.ee`
+writes both auth cookies for the parent domain, so **one sign-in covers the parent host and every
+site under it** — sign in on `preview.coo.ee` and you are already signed in on `m3.preview.coo.ee`,
+and vice versa. It is what makes the round trip close at all when the box pins an OAuth callback
+origin (`--github-auth-callback-base-url`, which this deployment sets): the `cp_gh_state` cookie
+written on the site host is sent to the pinned origin too, so the CSRF check runs exactly where it
+always did, and the session cookie minted there is already valid back on the site. The state carries
+the originating host purely so the callback knows where to send the visitor back to — a redirect
+target, never a credential, and one checked against the configured site list before it is used.
+
+Without a cookie domain the cookies stay host-only, the sign-in started on a site host cannot come
+back to it, and the affordance is **withheld** there rather than advertising a button that 401s —
+live and playground stay snapshot-only, which is what every site host used to do. The same applies
+to a site on a domain the cookie domain doesn't cover. A box with no pinned callback derives it from
+the request and never needed any of this.
+
+Choose the domain deliberately: every host under it is inside the session's reach, so name the
+narrowest one that covers your sites. A public suffix (`co.uk`) or a domain that doesn't cover the
+callback host is refused at startup rather than producing cookies the browser silently drops.
 
 The same catalog, served both ways. The visible difference is the header: the canonical path keeps
 the "← All design systems" button back to the front door, and the site has no front door to return


### PR DESCRIPTION
GitHub sign-in never worked on a site hostname when the box pins an OAuth callback origin, which `preview.coo.ee` does. The auth cookies were host-only, so a sign-in begun on `m3.preview.coo.ee` wrote its `cp_gh_state` cookie there while GitHub returned to `preview.coo.ee` — the callback saw no state and answered `401`, and a session minted there would have been scoped to the wrong host anyway. The server's answer was to withhold the sign-in affordance on every site, which left live preview and playground snapshot-only on all of them.

## The fix

`--github-auth-cookie-domain` scopes both auth cookies to the parent domain, so they reach the pinned callback host **and** every site host under it. One sign-in covers `preview.coo.ee` and `m3.preview.coo.ee` alike.

The important consequence is that **the CSRF check is unchanged** — the state cookie is readable at the callback again, so it is compared exactly where it always was. Nothing is deferred, and no credential is put in a URL.

All the cross-host case adds is *where to send the visitor back to*: the state carries the originating host so the callback returns them to the page they were reading instead of quietly moving them to the pinned origin. That's a redirect target, and it is re-validated against the live site list at the callback — signing proves this server minted the value, not that the host is still one of ours, so an unchecked one would be an open redirect off the back of a real sign-in. Anything unrecognised falls back to the relative return this route always used.

## Safety properties

- **The cookie domain is explicit, never derived from the request `Host`** — a header-derived value would let a caller widen the scope of a session cookie.
- **Misconfigurations fail at startup, not at the `Set-Cookie`.** A public suffix (`co.uk`), a single label (`localhost`), or a domain that doesn't cover the callback host each produce cookies the browser silently drops and a visitor who simply never signs in — so they're refused at construction instead.
- **Lookalike hosts are not "under" the domain.** The subdomain test requires the dot, so `notpreview.coo.ee` is not treated as being under `preview.coo.ee`.
- **Default unchanged.** Cookies stay host-only unless configured, so a single-hostname box behaves identically, and a site outside the cookie domain keeps the honest withheld affordance rather than offering a button that can't work.

Every host under the configured domain is inside the session's reach, which is why the docs say to name the narrowest one that covers your sites.

## Deployment

The image entrypoint derives the domain from `DOMAIN` when `SERVE_SITES` is set, so `preview.coo.ee` needs no new `.env` entry — a restart picks it up. `SERVE_GITHUB_AUTH_COOKIE_DOMAIN` overrides it; `none` opts out. Note the derivation is only as narrow as `DOMAIN`, so a box whose `DOMAIN` is an apex should set it explicitly rather than letting one session span the whole zone — called out in both the README and the entrypoint comment.

## Test plan

New `ServeGithubSiteAuthTest` (8 tests) drives a live server with a pinned callback and two configured sites:

- a sign-in started on a site host returns to `https://m3.preview.coo.ee/p/badge`, with a session cookie carrying `Domain=preview.coo.ee`
- the state cookie is domain-scoped — the specific thing whose absence broke the old flow
- a callback with **no matching state cookie is still 401**, i.e. the login-CSRF guard is intact
- a state naming a host the server doesn't serve as a site **cannot steer the redirect** (falls back to the relative return) — driven against a second server with the same secret but a different site list
- a sign-in on the main host still returns a relative path, unchanged
- `canRoundTrip` withholds without a cookie domain, allows a configured site with one, and refuses both an unlisted subdomain and the `notpreview.coo.ee` lookalike
- the four rejected cookie-domain shapes fail at construction, and the three working ones don't

Full suite: **2266 CLI tests pass**, `ktfmtCheckAll` clean, `test-compose-env-passthrough.sh` passes with the new `SERVE_GITHUB_AUTH_COOKIE_DOMAIN` forwarded.

Server-side auth plumbing with no rendered surface, so there's no visual output to diff. The user-visible effect is that the sign-in control now appears on a site host instead of being withheld; that's driven by `canRoundTrip`, which the tests above pin directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXZKcbv4CXTCZy6oU5muWe)_