### PR TITLE
feat(serve): carry published motion captures through the store, host and route

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -123,6 +123,22 @@ class ServeBundleHost(
    */
   private val fetchBakedPng: ((String) -> ByteArray?)? = null,
   /**
+   * Ids this catalog publishes an animated capture for.
+   *
+   * Separate from [declaredBaked] because a capture is not a preview: it never appears in the grid,
+   * owns no card, and is only ever reachable from the still it accompanies. Empty for a plain
+   * uploaded bundle and for any catalog exported before the branch carried these bytes.
+   */
+  declaredMotion: List<String> = emptyList(),
+  /**
+   * Fetch one declared capture's bytes from the delivery branch, or null when they can't be had.
+   * Same seam as [fetchBakedPng], for the same reason: the store owns URL assembly, the SSRF gate,
+   * the size cap and the test seam, and this host only names an id it was told about.
+   */
+  private val fetchMotion: ((String) -> ByteArray?)? = null,
+  /** Each declared capture's branch path, so a pinned (`?at=<sha>`) request can resolve one. */
+  private val motionBranchPaths: Map<String, String> = emptyMap(),
+  /**
    * Each declared preview's path on the delivery branch (`images/<slug>/<variant>.png`), which is
    * what a **pinned** request resolves against: the same tree, read at an older commit. Empty for a
    * plain uploaded bundle (nothing to pin to) and for any host with no delivery branch behind it.
@@ -297,6 +313,15 @@ class ServeBundleHost(
    * The declared baked set. An id here is **not** live-only even while its file is missing — that
    * is the whole point of declaring it — so it takes precedence over [liveOnly] below.
    */
+  /**
+   * Ids this catalog publishes a capture for, as a set for the containment check on request.
+   *
+   * Declared here rather than beside the motion fill below because the preview list is built during
+   * construction and reads it — a property initialised later would be empty at that point, and
+   * every capture would be filtered out of the manifest it is supposed to appear in.
+   */
+  private val declaredMotionIds: Set<String> = declaredMotion.toSet()
+
   private val declaredBakedIds: Set<String> =
     declaredBaked.filterTo(LinkedHashSet()) { previewFile(it, PNG_SUFFIX) != null }
 
@@ -335,6 +360,24 @@ class ServeBundleHost(
           id = id,
           label = id,
           componentId = meta?.componentId,
+          // Only captures this host can actually land. A manifest entry with no fetch seam behind
+          // it (a plain bundle, or a catalog whose store didn't register the lane) would offer the
+          // reader a control that 404s, which is worse than not offering it.
+          motion =
+            if (fetchMotion == null) emptyList()
+            else
+              meta
+                ?.motion
+                .orEmpty()
+                .filter { it.id in declaredMotionIds && it.extension in MOTION_EXTENSIONS }
+                .map {
+                  ServeMotion(
+                    id = it.id,
+                    kind = it.kind,
+                    caption = it.caption,
+                    extension = it.extension,
+                  )
+                },
           renderFailure = meta?.renderFailure ?: readRenderFailure(id),
           // A packed sidecar remains authoritative for ordinary uploaded bundles. Published
           // catalogs additionally carry these declarations inline so a supplement-only preview's
@@ -784,6 +827,57 @@ class ServeBundleHost(
   private val fillLocks = java.util.concurrent.ConcurrentHashMap<String, Any>()
 
   /**
+   * The staged file for one animated capture, fetching it on first request.
+   *
+   * Deliberately a near-copy of [bakedPngFile] rather than a shared generic: the two lanes differ
+   * in the one place that matters (the extension, which a browser is not free to guess) and share
+   * the part that is merely mechanical. Folding them together would mean threading a suffix through
+   * the fill path, which is how a capture ends up written under a still's name.
+   */
+  private fun motionFile(motionId: String, extension: String): okio.Path? {
+    if (motionId !in declaredMotionIds) return null
+    if (extension !in MOTION_EXTENSIONS) return null
+    // The requested suffix must be the one THIS capture was published as, not merely a format the
+    // lane supports. Checking only the allowlist would let `<id>.gif` serve an APNG's bytes typed
+    // as
+    // a GIF: the same bytes, a content type the requester chose, and a browser that renders one
+    // frame and stops. The declared branch path is the authority on which it is.
+    if (motionBranchPaths[motionId]?.endsWith(extension) != true) return null
+    val path = previewFile(motionId, extension)?.toOkioPath() ?: return null
+    if (fileSystem.exists(path)) return path
+    val fetch = fetchMotion ?: return null
+    // Keyed distinctly from the baked lane: a capture and its sibling still share an id, so one
+    // lock namespace would have a cold capture fetch block a warm sticker read on the same card.
+    synchronized(fillLocks.computeIfAbsent("$MOTION_LOCK_PREFIX$motionId") { Any() }) {
+      if (fileSystem.exists(path)) return path
+      val bytes = runCatching { fetch(motionId) }.getOrNull() ?: return null
+      return runCatching {
+        path.parent?.let(fileSystem::createDirectories)
+        val partial = path.parent!!.resolve(path.name + PARTIAL_SUFFIX)
+        fileSystem.write(partial) { write(bytes) }
+        fileSystem.atomicMove(partial, path)
+        path
+      }
+        .getOrNull()
+    }
+  }
+
+  /**
+   * The bytes of one published capture, or null when this host can't serve it.
+   *
+   * The only motion entry point: a caller names an id and an extension it read off the served
+   * manifest, and gets bytes or nothing. Both are checked against what the catalog declared, so a
+   * request can neither invent an id nor choose the suffix its response is typed with.
+   */
+  override fun motionBytes(motionId: String, extension: String): ByteArray? =
+    motionFile(motionId, extension)?.takeIf(fileSystem::exists)?.let {
+      runCatching { fileSystem.read(it) { readByteArray() } }.getOrNull()
+    }
+
+  /** The branch path of a declared capture, for a pinned request. */
+  fun motionBranchPath(motionId: String): String? = motionBranchPaths[motionId]
+
+  /**
    * The local-pixels fast path. Deliberately [localBakedPng], not [bakedPngFile]: a declared
    * preview whose PNG hasn't arrived yet needs a fetch, and fetching is work that belongs behind
    * admission like any other. Answering null sends it down the ordinary [render] path, which fills
@@ -1015,6 +1109,14 @@ class ServeBundleHost(
   companion object {
     private const val PREVIEWS_SUBDIR = "previews"
     private const val PNG_SUFFIX = ".png"
+
+    /**
+     * Extensions a published capture may be served under — closed, and checked on every request.
+     */
+    val MOTION_EXTENSIONS = listOf(".apng", ".gif")
+
+    /** Namespaces the motion fill locks apart from the baked ones, which share an id space. */
+    private const val MOTION_LOCK_PREFIX = "motion:"
     private const val RENDER_ERROR_SUFFIX = ".error.json"
     private const val RENDER_ERROR_SCHEMA = "compose-preview-error/v1"
     /** Suffix of the sibling a lazy fill writes before moving it into place atomically. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -186,6 +186,36 @@ class ServeCatalogStore(
   }
 
   /**
+   * The route-safe id a published capture is served under, or null when it can't be served.
+   *
+   * Same containment reasoning as the baked images and the deferred records: the branch is trusted,
+   * but a garbled or compromised catalog must not mint odd ids or escape the staged dir. The
+   * extension is checked against a closed list rather than merely being *some* suffix — these bytes
+   * are handed to a browser, and an open-ended suffix taken from fetched JSON is how a catalog
+   * would get to choose the content type it is served under.
+   *
+   * The id is derived exactly as a still's is, so a capture the export named from its sibling
+   * sticker lands on that sticker's id plus whatever disambiguating segment it carried
+   * (`__interaction` / `__anim`). Nothing here re-derives the export's naming rule — the pairing to
+   * a card is done by `theme` in the load loop, not by taking the name apart.
+   */
+  private fun motionPreviewIdOf(path: String): String? {
+    if (path.isBlank() || !path.startsWith("$MOTION_DIR/")) return null
+    val extension = MOTION_EXTENSIONS.firstOrNull { path.endsWith(it) } ?: return null
+    if (".." in path.split("/")) return null
+    // Flattened exactly as a still's path is, so a capture named from its sibling sticker shares
+    // that sticker's id — the two never collide because they are served from separate routes, and a
+    // second capture on the same card keeps its own id via the `__interaction` / `__anim` segment
+    // the export carried through.
+    return path.removePrefix("$MOTION_DIR/").removeSuffix(extension).replace("/", "__")
+  }
+
+  /** The extension [path] carries, or null when it is not a servable capture. */
+  private fun motionExtensionOf(path: String): String? = MOTION_EXTENSIONS.firstOrNull {
+    path.endsWith(it)
+  }
+
+  /**
    * One declared baked image, resolved to everything the load loop needs *before* any fetch: its
    * route-safe [id], the staged [target] it writes to (null when that path escaped the previews dir
    * — planned anyway so it still counts as declared, then skipped), and the component context that
@@ -202,6 +232,10 @@ class ServeCatalogStore(
     val group: String?,
     val componentSourceFile: String?,
     val componentBodyLine: Int?,
+    /**
+     * The owning component's published captures, paired to this image by theme in the load loop.
+     */
+    val componentMotion: List<Motion>,
   )
 
   /**
@@ -346,6 +380,7 @@ class ServeCatalogStore(
             group,
             componentSourceFile,
             componentBodyLine,
+            component.motion,
           )
         }
       }
@@ -358,6 +393,13 @@ class ServeCatalogStore(
     // paint therefore fills the default previews concurrently through the ordinary request path —
     // no separate background pass to schedule, cancel on refresh, or reason about.
     val bakedPathById = LinkedHashMap<String, String>()
+    // Branch path per capture route id, for the host to fetch on demand. Captures are NOT staged
+    // here, on the same reasoning that made the baked images lazy — and more so: a capture is one
+    // to
+    // two orders of magnitude heavier than the sticker beside it, and it is opt-in surface most
+    // visitors never open. Fetching them at registration would make every catalog refresh pay for
+    // pixels nobody asked to see.
+    val motionPathById = LinkedHashMap<String, String>()
     for (planned in plannedImages) {
       if (count >= maxImages) break
       // Counted as the catalog CLAIMS to publish it, which is how the completeness check below
@@ -383,8 +425,29 @@ class ServeCatalogStore(
         // A catalog with neither state/theme nor a section records nothing and stays a flat grid.
         val hasSectionInfo = planned.section != null || planned.group != null
         val props = image.props?.takeIf { it.isNotEmpty() }
+        // Pair the component's captures to THIS card by theme, rather than by taking the published
+        // filename apart. The export already resolved which themed sticker each capture accompanies
+        // and recorded it; re-deriving that here from the name would be a second implementation of
+        // the export's naming rule, and the two would eventually disagree. A capture with no theme
+        // (an unthemed catalog) belongs to every card of its component.
+        val motion =
+          planned.componentMotion.mapNotNull { capture ->
+            val theme = capture.theme?.takeIf { it.isNotBlank() }
+            if (theme != null && !theme.equals(image.theme, ignoreCase = true))
+              return@mapNotNull null
+            val motionId = motionPreviewIdOf(capture.path) ?: return@mapNotNull null
+            val extension = motionExtensionOf(capture.path) ?: return@mapNotNull null
+            motionPathById[motionId] = capture.path
+            MotionMeta(
+              id = motionId,
+              kind = capture.kind.takeIf { it.isNotBlank() },
+              caption = capture.caption?.takeIf { it.isNotBlank() },
+              extension = extension,
+            )
+          }
         if (
-          image.state != null ||
+          motion.isNotEmpty() ||
+            image.state != null ||
             image.theme != null ||
             props != null ||
             planned.componentId != null ||
@@ -407,6 +470,7 @@ class ServeCatalogStore(
               supportsFocus = image.supportsFocus,
               supportsGestures = image.supportsGestures,
               fixedTheme = image.fixedTheme,
+              motion = motion,
               section = planned.section,
               group = planned.group,
               order = if (hasSectionInfo) count else null,
@@ -663,6 +727,15 @@ class ServeCatalogStore(
           fetchBakedPng = { id ->
             bakedPathById[id]?.let { path -> fetchCatalogAsset(base + path) }
           },
+          // The same seam for the motion axis: ids the catalog publishes a capture for, and the
+          // fetch that lands one. Captures are never staged at registration (see [motionPathById]),
+          // so this lane is lazy all the way down — a catalog with motion costs nothing extra until
+          // a reader actually asks to watch something.
+          declaredMotion = motionPathById.keys.toList(),
+          fetchMotion = { id ->
+            motionPathById[id]?.let { path -> fetchCatalogAsset(base + path) }
+          },
+          motionBranchPaths = motionPathById.toMap(),
           // The branch path of every baked render, so a pinned (`?at=<sha>`) request can be
           // answered out of the same tree at an older commit — see [ServeCatalogRevision].
           bakedBranchPaths = bakedPathById.toMap(),
@@ -1919,6 +1992,39 @@ class ServeCatalogStore(
      * for an older catalog, or a preview whose classfile carried no line numbers.
      */
     val bodyLine: Int? = null,
+    /**
+     * The component's animated captures (`@InteractionPreview` / `@AnimatedPreview`), published
+     * beside its stills under `motion/` on the delivery branch.
+     *
+     * A sibling axis to [images] rather than more entries inside it, because every consumer of
+     * [images] assumes a still: the grid lays them out as a sheet, a parity run diffs them against
+     * a kit node. A 114-frame recording folded in there would publish its first frame and silently
+     * drop the point. Empty for a catalog with no motion, and for one exported before the branch
+     * carried these bytes at all.
+     */
+    val motion: List<Motion> = emptyList(),
+  )
+
+  /**
+   * One published animated capture: what moved, why a reader should care, and which themed card it
+   * belongs beside.
+   *
+   * [path] is a branch path (`motion/<slug>/<variant>.apng`) named from the sibling sticker by the
+   * export, so it flattens to the same route id the still does — see [motionPreviewIdOf].
+   */
+  @Serializable
+  private data class Motion(
+    val path: String = "",
+    /** `"interaction"` (a scripted gesture) or `"animation"` (a self-running animation). */
+    val kind: String = "",
+    /**
+     * The caption the annotation declared. A motion capture without one is close to useless — the
+     * reader can see *that* something moved, and this is what tells them which property they are
+     * being shown — so the viewer surfaces it beside the capture rather than dropping it.
+     */
+    val caption: String? = null,
+    /** The theme of the sticker this capture accompanies, used to pair it with the right card. */
+    val theme: String? = null,
   )
 
   @Serializable
@@ -1980,6 +2086,22 @@ class ServeCatalogStore(
    * authored component list — because [ServeBundleHost] otherwise lists previews sorted by id. All
    * three are null for a plain (untabbed) catalog / uploaded bundle, preserving the flat layout.
    */
+  /**
+   * One animated capture offered beside a preview, as the served manifest carries it.
+   *
+   * [id] is the route the bytes are fetched under, not a branch path: the store owns URL assembly
+   * and the size cap, exactly as it does for baked PNGs, so the host and the viewer only ever name
+   * an id. [extension] rides along because the two formats are not interchangeable to a browser —
+   * an APNG served as a GIF renders its first frame and stops.
+   */
+  @Serializable
+  data class MotionMeta(
+    val id: String,
+    val kind: String? = null,
+    val caption: String? = null,
+    val extension: String = ".apng",
+  )
+
   @Serializable
   data class VariantMeta(
     val state: String? = null,
@@ -2000,6 +2122,12 @@ class ServeCatalogStore(
     val supportsGestures: Boolean = false,
     /** Discovery-time `@FixedTheme` — see [Image.fixedTheme]. */
     val fixedTheme: Boolean = false,
+    /**
+     * Animated captures this preview can offer instead of its still. Empty for the overwhelming
+     * majority of previews; a viewer shows the still exactly as before and surfaces these only as
+     * an opt-in control, because motion is the answer to a question most readers aren't asking.
+     */
+    val motion: List<MotionMeta> = emptyList(),
     val section: String? = null,
     val group: String? = null,
     val order: Int? = null,
@@ -2036,6 +2164,16 @@ class ServeCatalogStore(
     const val DEFAULT_BRANCH_PREFIX = "design-artifacts/"
     const val CATALOG_FILE = "catalog.json"
     const val IMAGES_DIR = "images"
+
+    /** The delivery branch's directory of published animated captures, beside `images/`. */
+    const val MOTION_DIR = "motion"
+
+    /**
+     * Extensions a published capture can carry. Closed deliberately: these bytes are served to a
+     * browser, and an open-ended suffix on a path from fetched JSON is how a catalog would get to
+     * name the content type it is served under.
+     */
+    val MOTION_EXTENSIONS = listOf(".apng", ".gif")
     const val FIGMA_DIR = "figma"
     /** A preview id folds the component slug + variant as `<slug>__<variant>`. */
     const val SLUG_SEPARATOR = "__"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -227,6 +227,16 @@ interface ServeHost : AutoCloseable {
   fun bakedRenderSize(previewId: String): Pair<Int, Int>? = null
 
   /**
+   * The bytes of one published animated capture, or null when this host has none to serve.
+   *
+   * Defaults to null so every host that isn't a published catalog — a daemon, a plain bundle —
+   * simply has no motion lane rather than needing to say so. [extension] is part of the request
+   * because the two formats aren't interchangeable to a browser, and it is validated against what
+   * the catalog declared rather than trusted, so a request can't choose its own content type.
+   */
+  fun motionBytes(motionId: String, extension: String): ByteArray? = null
+
+  /**
    * A visitor is present on this session's pages right now (see `POST /api/presence`) — get its
    * live render lane ready, if it has one and isn't ready already.
    *

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1008,6 +1008,12 @@ class ServeHttpServer(
         get("/render/{name}") { handleRender(sessionInPath = false) }
         get("/{system}/render/{name}") { handleRender(sessionInPath = true) }
 
+        // The motion lane, beside `/render` rather than inside it: a capture is not a render of a
+        // preview, it is a second artifact about the same component, and folding it into the render
+        // route would mean that route's suffix decided the content type from a fetched path.
+        get("/motion/{name}") { handleMotion(sessionInPath = false) }
+        get("/{system}/motion/{name}") { handleMotion(sessionInPath = true) }
+
         // Project mode only (see [projectHistory]): one version of a render, addressed by its
         // content sha, read straight out of the local repository. Registered conditionally like
         // every other optional lane, so a server without a repo has no such route at all.
@@ -5385,6 +5391,37 @@ class ServeHttpServer(
     return host.bakedRenderSize(name) != null
   }
 
+  /**
+   * Serve one published animated capture.
+   *
+   * The extension is read off the request and matched against the closed set the host accepts, then
+   * passed to it so the lookup and the `Content-Type` are decided by the same string. Anything else
+   * — an unknown suffix, an id the catalog never declared — is a flat 404: this route reaches bytes
+   * fetched from a delivery branch, so it must never be able to serve them under a type the
+   * requester chose.
+   */
+  private suspend fun RoutingContext.handleMotion(sessionInPath: Boolean) {
+    if (rejectHeadProbe()) return
+    val name = call.parameters["name"].orEmpty()
+    val extension = MOTION_CONTENT_TYPES.keys.firstOrNull { name.endsWith(it) }
+    if (extension == null) {
+      call.respondText("", status = HttpStatusCode.NotFound)
+      return
+    }
+    val motionId = name.removeSuffix(extension)
+    val host = sessions.peekHost(selectedSessionId(sessionInPath))
+    val bytes = host?.motionBytes(motionId, extension)
+    if (bytes == null) {
+      call.respondText("", status = HttpStatusCode.NotFound)
+      return
+    }
+    // Same caching posture as a baked render: the bytes under an id are immutable for a publish,
+    // and a capture is heavy enough that re-fetching it per scrub would be the whole cost of the
+    // feature.
+    call.response.headers.append(HttpHeaders.CacheControl, prebakedImageCacheControl())
+    call.respondBytes(bytes, ContentType.parse(MOTION_CONTENT_TYPES.getValue(extension)))
+  }
+
   private suspend fun RoutingContext.rejectHeadProbe(): Boolean {
     if (call.request.local.method != HttpMethod.Head) return false
     call.response.headers.append(HttpHeaders.Allow, HttpMethod.Get.value)
@@ -5794,6 +5831,17 @@ class ServeHttpServer(
   }
 
   companion object {
+    /**
+     * Extensions the motion route serves, and the type each is served as. A closed map rather than
+     * a suffix-to-mime derivation: the key set IS the allowlist, so one place decides both "may
+     * this be served" and "as what", and the two cannot drift apart.
+     *
+     * APNG is deliberately `image/apng`, not `image/png`. Both decode, but the distinction is what
+     * tells a browser — and a reader saving the file — that there is more here than one frame.
+     */
+    val MOTION_CONTENT_TYPES: Map<String, String> =
+      linkedMapOf(".apng" to "image/apng", ".gif" to "image/gif")
+
     const val TOKEN_HEADER: String = "X-Compose-Preview-Token"
 
     /** Header carrying the `--admin-token` for the `/admin/catalogs` routes. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -61,6 +61,28 @@ interface StreamHandle : AutoCloseable {
 }
 
 /** One servable preview: its id, a human label, and which delivery modes it supports. */
+/**
+ * One animated capture a preview can offer instead of its still.
+ *
+ * Motion answers a question a screenshot cannot: whether a component's own interaction plumbing
+ * actually drives its transition, and how that transition is shaped. It is also not what most
+ * readers came for — so the viewer surfaces this as a control beside the still rather than playing
+ * it by default, and a preview carrying none is presented exactly as it was before.
+ */
+data class ServeMotion(
+  /** The route the bytes are served under (`/motion/<id><extension>`). */
+  val id: String,
+  /** `"interaction"` (a scripted gesture) or `"animation"` (a self-running animation). */
+  val kind: String? = null,
+  /**
+   * The caption the annotation declared — which property the reader is being shown. Without it a
+   * capture tells someone only that *something* moved, so the viewer shows it alongside.
+   */
+  val caption: String? = null,
+  /** `.apng` or `.gif`. Not interchangeable: an APNG typed as a GIF renders one frame and stops. */
+  val extension: String = ".apng",
+)
+
 data class ServePreview(
   val id: String,
   val label: String,
@@ -184,6 +206,15 @@ data class ServePreview(
   val componentId: String? = null,
   /** Published render failure for a catalog card that has no PNG. */
   val renderFailure: CatalogRenderFailure? = null,
+  /**
+   * Animated captures published for this preview. Empty for the overwhelming majority — a still is
+   * the whole artifact for most components — so a viewer treats this as opt-in extra surface and
+   * never as a replacement for the baked pixels.
+   *
+   * Last in the parameter list deliberately: several callers construct a [ServePreview]
+   * positionally, so a new field anywhere earlier silently rebinds their arguments.
+   */
+  val motion: List<ServeMotion> = emptyList(),
 )
 
 /** Structured, catalog-published render failure. Additive to `design-parity-catalog/v1`. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -223,6 +223,88 @@ class ServeCatalogStoreTest {
     assertEquals(imagesAtPublish + 1, requested.count { it.endsWith(".png") })
   }
 
+  /**
+   * A catalog whose one component publishes a still, a capture beside it, and a second capture
+   * whose path tries to climb out of the motion directory.
+   */
+  private val motionCatalogJson =
+    """
+    {
+      "meta": {"system": "compose-m3"},
+      "components": [
+        {
+          "componentId": "Switch/On",
+          "images": [
+            {"path": "images/switch-on/ideal__default__dark.png", "theme": "dark",
+             "previewId": "SwitchOn_Dark"}
+          ],
+          "motion": [
+            {"path": "motion/switch-on/ideal__default__dark.apng", "kind": "interaction",
+             "caption": "Toggle off and back on.", "theme": "dark"},
+            {"path": "motion/../../etc/passwd.apng", "kind": "interaction", "theme": "dark"}
+          ]
+        }
+      ]
+    }
+    """
+      .trimIndent()
+
+  @Test
+  fun `a published capture is offered on its card and fetched only when watched`() {
+    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val fetcher: (String) -> ByteArray? = { url ->
+      requested += url
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> motionCatalogJson.toByteArray()
+        url.endsWith(".png") -> png()
+        url.endsWith(".apng") -> byteArrayOf(1, 2, 3)
+        else -> null
+      }
+    }
+    store(TrustStore.EMPTY, fetch = fetcher).load("compose-m3")
+    val host = registered.getValue("compose-m3")
+
+    val preview = host.previews.single { it.id == "switch-on__ideal__default__dark" }
+    // The traversal attempt is gone; the legitimate capture is offered with its caption intact.
+    val motion = preview.motion.single()
+    assertEquals("switch-on__ideal__default__dark", motion.id)
+    assertEquals("interaction", motion.kind)
+    assertEquals("Toggle off and back on.", motion.caption)
+    assertEquals(".apng", motion.extension)
+
+    // Nothing was fetched to publish it. A capture is one to two orders of magnitude heavier than
+    // the sticker beside it and most readers never open one, so paying for it at registration would
+    // be the whole cost of the feature spent on nobody.
+    assertEquals(0, requested.count { it.endsWith(".apng") })
+
+    // It lands on first watch, and only once — the second read comes off disk.
+    assertContentEquals(byteArrayOf(1, 2, 3), host.motionBytes(motion.id, ".apng"))
+    assertEquals(1, requested.count { it.endsWith(".apng") })
+    assertContentEquals(byteArrayOf(1, 2, 3), host.motionBytes(motion.id, ".apng"))
+    assertEquals(1, requested.count { it.endsWith(".apng") })
+  }
+
+  @Test
+  fun `a capture request cannot choose an id or a type the catalog never published`() {
+    val fetcher: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> motionCatalogJson.toByteArray()
+        url.endsWith(".png") -> png()
+        else -> byteArrayOf(1, 2, 3)
+      }
+    }
+    store(TrustStore.EMPTY, fetch = fetcher).load("compose-m3")
+    val host = registered.getValue("compose-m3")
+    val id = "switch-on__ideal__default__dark"
+
+    // These bytes come off a delivery branch, so the suffix a request asks for must never be what
+    // decides how they are typed — the declared extension is, and this id declared `.apng`.
+    assertNull(host.motionBytes(id, ".gif"))
+    // Nor may a request name a capture the catalog never declared, however plausible the id.
+    assertNull(host.motionBytes("switch-on__ideal__default__light", ".apng"))
+    assertNull(host.motionBytes("../../etc/passwd", ".apng"))
+  }
+
   @Test
   fun `a catalog publishes before its baked vectors are fetched`() {
     // The vectors are the last bulk fetch on the publish path — one per image plus one per slug.


### PR DESCRIPTION
## Summary

Layers two and three of the viewer's motion section, following #3917 which put the bytes on the branch. This is the data path from `motion/` to something a browser can fetch. **The viewer control that offers them is not in this PR** — see below.

- **`ServeCatalogStore`** models `components[].motion[]`, containment-checks each published path the way it already does stills and deferred records, and records the capture on the variant manifest of the card it accompanies.
- **`ServeBundleHost`** fills a capture on first request through the same seam the baked stills use.
- **`ServeHttpServer`** serves them at `/motion/<id><ext>` (and the `/{system}/` variant).

**Pairing is done on `theme`, not on the filename.** The export already resolved which themed sticker each capture belongs beside and recorded it. Taking the published name apart here would be a second implementation of the export's naming rule, and the two would eventually disagree about the same component.

**Captures are never staged at registration.** The baked stills went lazy because fetching them all kept a catalog invisible for minutes after its metadata arrived. A capture is one to two orders of magnitude heavier than the sticker beside it *and* is opt-in surface most readers never open — eager fetching would spend the entire cost of the feature on people who never asked to watch anything. It fills on first request, with its own lock namespace so a cold capture can't queue behind (or block) a warm sticker read on the same card.

**One bug worth calling out, because a test caught it rather than review.** The route initially validated the requested suffix only against the formats the lane supports, not against what *that id* declared. So `/motion/<id>.gif` would have served an APNG's bytes typed as `image/gif` — same bytes, a content type the requester chose, and a browser that renders one frame and stops. These bytes come off a delivery branch, so the declared extension is now the authority and a mismatch is a flat 404.

## Test plan

- `:cli:test --tests "*ServeCatalogStoreTest*" --tests "*ServeBundleHostTest*"` — passing. Two new tests:
  - a published capture is offered on its card with kind/caption/extension intact, a sibling entry whose path climbs out of `motion/` is dropped, **nothing** is fetched to publish it, and it lands exactly once on first watch;
  - a request can choose neither an id nor a content type the catalog never published — the `.gif`-for-an-APNG case above, an undeclared id, and a traversal id.
- `:cli:compileKotlin` / `:cli:compileTestKotlin` clean; `ktfmtFormat` applied.

## Not verified end to end, and why

The `motion/` directory does not exist on any delivery branch yet, so this code has never run against real published bytes. The re-render triggered by #3917 ([run 31890209677](https://github.com/yschimke/compose-ai-tools/actions/runs/31890209677)) succeeded and published **zero** motion entries. The export pass is correct — it had nothing to publish, because the bundle it read carries no motion captures. Root cause is not yet confirmed; the leading candidate is that published catalogs render with `composeaiUseReleasedRuntimes=true`, and `@InteractionPreview` has not shipped in a release. That is tracked separately from this PR.

Text-only: this is serving plumbing and adds no rendered surface. The visual evidence belongs with the viewer control, which is where a reader first sees a capture.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qLcyPRqEYwRVxMf6f9Fus)_