### PR TITLE
fix(design-map): drop the leading ./ from the bin path

### DIFF
--- a/design-map/package.json
+++ b/design-map/package.json
@@ -9,7 +9,7 @@
     ".": "./design-map.mjs"
   },
   "bin": {
-    "compose-design-map": "./emit-design-map.mjs"
+    "compose-design-map": "emit-design-map.mjs"
   },
   "files": [
     "design-map.mjs",


### PR DESCRIPTION
`npm publish` warns:

```
npm warn publish "bin[compose-design-map]" script name emit-design-map.mjs was invalid and removed
```

which reads like the package ships without its executable — i.e. that `npx @yschimke/compose-design-map` would do nothing.

**It doesn't.** npm is normalising `./emit-design-map.mjs` to `emit-design-map.mjs` and calling that a removal. The proof is a package already in production: `@design-parity/kit-index` publishes with the identical warning, and its `bin` is intact on the registry —

```
$ curl -s https://registry.npmjs.org/@design-parity%2fkit-index/0.1.50 | jq .bin
{ "design-parity-kit-index": "dist/cli/kit-index.js" }
```

— which is why m3-catalog's `npx --yes @design-parity/kit-index@0.1.50 resolve` works at all.

So this is cosmetic. But it fires on every release, and "invalid and removed" is exactly the kind of warning someone acts on at the wrong moment. Writing the path in the form npm normalises to stops the noise.

## Test plan

- `npm test` in `design-map/` — 20 passed.
- `npm pack --dry-run` is now **warning-free**, same 5 files (`LICENSE`, `README.md`, both `.mjs`, `package.json`).
- No functional change: the published `bin` value is byte-for-byte what npm was already writing.


---
_Generated by [Claude Code](https://claude.ai/code/session_014wHVcQdoUcFHskjrmob9gT)_