### PR TITLE
fix(serve): revalidate published captures instead of promising them immutable

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -49,6 +49,7 @@ import java.io.File
 import java.io.InputStream
 import java.net.InetAddress
 import java.net.ServerSocket
+import java.security.MessageDigest
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Semaphore
@@ -5425,10 +5426,27 @@ class ServeHttpServer(
       call.respondText("", status = HttpStatusCode.NotFound)
       return
     }
-    // Same caching posture as a baked render: the bytes under an id are immutable for a publish,
-    // and a capture is heavy enough that re-fetching it per scrub would be the whole cost of the
-    // feature.
-    call.response.headers.append(HttpHeaders.CacheControl, prebakedImageCacheControl())
+    // Revalidated, NOT `immutable` — and the distinction is the whole point of this block.
+    //
+    // Every other user of [prebakedImageCacheControl] is content-addressed: its URL carries the
+    // bytes' own hash, which is what earns the year-long `immutable` promise that what the URL
+    // names can never change. A capture's URL is derived from the STICKER it accompanies
+    // (`motion/switch-on/ideal__default__dark.apng`), so a re-publish replaces the recording behind
+    // the same path — and a client that watched the old one would have been told to keep it for a
+    // year with nothing to revalidate against.
+    //
+    // The ETag is what makes revalidating cheap enough to be the right answer here rather than a
+    // compromise: a capture is many frames, so a 304 saves far more on this route than on a still.
+    val etag = "\"" + motionEtag(bytes) + "\""
+    call.response.headers.append(
+      HttpHeaders.CacheControl,
+      if (isPublic) MOTION_CACHE_CONTROL else DYNAMIC_RESOURCE_CACHE_CONTROL,
+    )
+    call.response.headers.append(HttpHeaders.ETag, etag)
+    if (call.request.headers[HttpHeaders.IfNoneMatch] == etag) {
+      call.respond(HttpStatusCode.NotModified)
+      return
+    }
     call.respondBytes(bytes, ContentType.parse(MOTION_CONTENT_TYPES.getValue(extension)))
   }
 
@@ -6089,6 +6107,21 @@ class ServeHttpServer(
      * catalog changes the hash, hence the URL, so there is nothing to invalidate.
      */
     private const val HERO_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+    /**
+     * A published capture. Public and cacheable by a shared proxy for a few minutes, but always
+     * revalidated by the client, because this route's URL is derived from the sticker the capture
+     * accompanies rather than from its bytes — see [handleMotion]. On a token-gated catalog the
+     * bytes follow the same `no-store` policy as every other private response.
+     */
+    internal const val MOTION_CACHE_CONTROL = "public, max-age=0, s-maxage=300, must-revalidate"
+
+    /** The bytes' own hash, so a re-published capture under the same id revalidates to a miss. */
+    internal fun motionEtag(bytes: ByteArray): String =
+      MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString("") { "%02x".format(it) }
+        .take(16)
 
     /**
      * Caching for the site icons ([ServeSiteIcon]). Public on every server, token-gated or not:

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAuthTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAuthTest.kt
@@ -37,6 +37,25 @@ class ServeAuthTest {
   }
 
   @Test
+  fun `a published capture is revalidated rather than promised immutable`() {
+    // `immutable` is a promise that what a URL names can never change, and every other route that
+    // claims it earns the claim by carrying the bytes' own hash in the path. A capture's URL is
+    // derived from the STICKER it accompanies, so re-publishing a changed recording reuses it —
+    // and a client told to keep the old bytes for a year would have nothing to revalidate against.
+    assertFalse(
+      ServeHttpServer.MOTION_CACHE_CONTROL.contains("immutable"),
+      "a sticker-derived URL must not borrow the content-addressed lanes' immutable promise",
+    )
+    assertTrue(ServeHttpServer.MOTION_CACHE_CONTROL.contains("must-revalidate"))
+
+    // …and the ETag is what keeps revalidating cheap: it is over the BYTES, so a re-publish under
+    // the same id misses and an unchanged one answers 304 without resending many frames.
+    val one = ServeHttpServer.motionEtag(byteArrayOf(1, 2, 3))
+    assertEquals(one, ServeHttpServer.motionEtag(byteArrayOf(1, 2, 3)))
+    assertFalse(one == ServeHttpServer.motionEtag(byteArrayOf(1, 2, 4)))
+  }
+
+  @Test
   fun `public mode authorizes every request regardless of token`() {
     assertTrue(ServeHttpServer.isAuthorized(token, null, isPublic = true))
     assertTrue(ServeHttpServer.isAuthorized(token, "wrong", isPublic = true))


### PR DESCRIPTION
Follow-up to #3928, which landed before this was fixed.

## The bug

`/motion/<id><ext>` borrowed `prebakedImageCacheControl` — `public, max-age=31536000, immutable` — from the hero, social-card and grid-thumbnail lanes. Those three earn that promise by being **content-addressed**: their URLs carry the bytes' own hash, so what a URL names genuinely cannot change. `respondGridThumb`'s own KDoc says exactly that.

A capture's URL does not carry a hash. It is derived from the sticker it accompanies — `images/switch-on/ideal__default__dark.png` → `motion/switch-on/ideal__default__dark.apng` — and that is deliberate, so the still and the recording cannot drift apart. The consequence is that a re-publish replaces the recording behind the same path.

So on the public server: anyone who opened a capture was told to keep those bytes for a year, with no `ETag` to revalidate against. A corrected recording would never reach them. My original comment on that line read *"the bytes under an id are immutable for a publish"* — true, and beside the point, because the URL does not name a publish.

## The fix

Revalidated, with an `ETag` over the bytes, and a `304` path:

```
public, max-age=0, s-maxage=300, must-revalidate
```

A shared proxy may still hold it briefly; the client always asks. Private catalogs keep the existing `no-store` policy unchanged.

The ordering of the reasoning matters and is in the code comment: a capture is many frames, so a `304` is worth far more on this route than on a still. Revalidation is the *right* answer here, not a concession made to fix a bug.

## Test plan

- New `ServeAuthTest` case, alongside the existing prebaked-imagery policy test: the motion policy does not contain `immutable`, does contain `must-revalidate`, and the ETag is stable for identical bytes and differs for changed ones — which is what makes a re-publish under the same id miss.
- `./gradlew :cli:test --tests '*ServeAuthTest*' --tests '*ServeCatalogStoreTest*' --tests '*ServeWebFixtureTest*'` — green.

Text-only: no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qLcyPRqEYwRVxMf6f9Fus)_