### PR TITLE
feat(serve): add demand-activated catalog RSS feeds

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -35,6 +35,7 @@ import ee.schimke.composeai.cli.serve.ServeBundleDaemon
 import ee.schimke.composeai.cli.serve.ServeBundleHost
 import ee.schimke.composeai.cli.serve.ServeBundleStore
 import ee.schimke.composeai.cli.serve.ServeCatalogAdmin
+import ee.schimke.composeai.cli.serve.ServeCatalogChangeFeed
 import ee.schimke.composeai.cli.serve.ServeCatalogLiveHost
 import ee.schimke.composeai.cli.serve.ServeCatalogRefresher
 import ee.schimke.composeai.cli.serve.ServeCatalogStore
@@ -220,6 +221,16 @@ class ServeCommand(args: List<String>) : Command(args) {
    */
   private val catalogRefreshSeconds: Long =
     args.flagValue("--catalog-refresh-interval")?.toLongOrNull() ?: DEFAULT_CATALOG_REFRESH_SECONDS
+
+  /**
+   * How long an RSS reader keeps a catalog's background change-feed worker interested. Every
+   * `feed.xml` request renews the lease; after this many quiet seconds the worker stops fetching
+   * the delivery branch while retaining its last XML + shallow Git cache. `0` disables the feed
+   * lane.
+   */
+  private val catalogFeedIdleSeconds: Long =
+    args.flagValue("--catalog-feed-idle-timeout")?.toLongOrNull()
+      ?: DEFAULT_CATALOG_FEED_IDLE_SECONDS
 
   /**
    * Shared mode: a directory of pre-rendered portable bundles (or a single bundle) to host
@@ -555,6 +566,32 @@ class ServeCommand(args: List<String>) : Command(args) {
       .flagValue("--catalogs-file")
       ?.takeIf { it.isNotBlank() }
       ?.let { ServeCatalogsConfigFile(it.toPath()) }
+
+  /** Durable feed cache; defaults beside catalogs.json on deployed boxes, temp for local serve. */
+  private val catalogFeedCacheDir: File by lazy {
+    val preferred =
+      args.flagValue("--catalog-feed-cache")?.takeIf { it.isNotBlank() }?.let(::File)
+        ?: catalogsFile
+          ?.displayPath
+          ?.let(::File)
+          ?.absoluteFile
+          ?.parentFile
+          ?.resolve("catalog-feeds")
+    if (
+      preferred != null && (preferred.isDirectory || preferred.mkdirs()) && preferred.canWrite()
+    ) {
+      preferred
+    } else {
+      java.nio.file.Files.createTempDirectory("serve-catalog-feeds").toFile().also {
+        it.deleteOnExit()
+        if (preferred != null) {
+          System.err.println(
+            "serve: catalog feed cache ${preferred.absolutePath} is not writable; using ${it.absolutePath}"
+          )
+        }
+      }
+    }
+  }
 
   /**
    * Shared secret for the runtime admin routes (`--admin-token`; env `SERVE_ADMIN_TOKEN`) — both
@@ -2081,6 +2118,21 @@ class ServeCommand(args: List<String>) : Command(args) {
     val githubAuth = buildGithubAuth()
     val playgroundLane =
       openPlaygroundService(docStore, registry, repoAccessGated = githubAuth != null)
+    val catalogFeed =
+      if (catalogLoads != null && catalogFeedIdleSeconds > 0) {
+        ServeCatalogChangeFeed(
+          entries = { catalogLoads.snapshot().map { it.config } },
+          cacheRoot = catalogFeedCacheDir,
+          idleTimeoutMillis = catalogFeedIdleSeconds * 1000,
+          // Feed polling is demand-gated, but while active it follows the same operational cadence
+          // as catalog refresh. If ordinary refresh is disabled, retain the normal ten-minute feed
+          // cadence: a subscribed feed is itself an explicit request to watch this branch.
+          pollIntervalMillis =
+            (catalogRefreshSeconds.takeIf { it > 0 } ?: DEFAULT_CATALOG_REFRESH_SECONDS) * 1000,
+        )
+      } else {
+        null
+      }
     val server =
       ServeHttpServer(
         host = host,
@@ -2099,6 +2151,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         sites = sites,
         catalogLoads = catalogLoads,
         catalogRefresh = catalogRefresh,
+        catalogFeed = catalogFeed,
         maxLiveSeats = liveSeats,
         liveSeatLimiter = liveSeatLimiter,
         daemonLog = daemonLog,
@@ -2174,6 +2227,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           System.err.println("\nserve: shutting down…")
           runCatching { advertiser?.close() }
           runCatching { server.stop() }
+          runCatching { catalogFeed?.close() }
           runCatching { registry.close() }
           closeables.forEach { c -> runCatching { c?.close() } }
           done.countDown()
@@ -3375,6 +3429,14 @@ class ServeCommand(args: List<String>) : Command(args) {
                           place when it moved — so a regenerated branch is picked up with no restart
                           (default ${DEFAULT_CATALOG_REFRESH_SECONDS}s; 0 disables, serving the boot snapshot only). Uses
                           `git ls-remote` (no API rate limit), and skips a branch it can't resolve.
+        --catalog-feed-idle-timeout <seconds>
+                          Publish /<catalog>/feed.xml. A request renews that feed's background
+                          history-computation lease; after this many seconds without another request
+                          it stops fetching while keeping the last generated feed and shallow Git
+                          cache (default ${DEFAULT_CATALOG_FEED_IDLE_SECONDS}s; 0 disables).
+        --catalog-feed-cache <dir>
+                          Durable shallow-Git + generated-XML cache for catalog feeds. Defaults to a
+                          catalog-feeds directory beside --catalogs-file, or a temp dir in local mode.
         --wasm-dir <system>=<dir>[,<system>=<dir>…]
                           In-browser CMP tier: map a design system to its assembled Kotlin/Wasm
                           catalog app (./gradlew :samples:cmp-wasm-catalog:wasmCatalogDist →
@@ -3402,6 +3464,7 @@ class ServeCommand(args: List<String>) : Command(args) {
      * — cheap enough to poll every watched catalog at this cadence indefinitely.
      */
     const val DEFAULT_CATALOG_REFRESH_SECONDS = 600L
+    const val DEFAULT_CATALOG_FEED_IDLE_SECONDS = 7L * 24 * 60 * 60
 
     /**
      * Compiles per minute per caller. Sized for a person using the editor, not for a script: a

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogChangeFeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogChangeFeed.kt
@@ -1,0 +1,720 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Demand-activated catalog change feeds.
+ *
+ * A request renews a per-feed interest lease and returns the last completed RSS document. While the
+ * lease is live, a daemon worker periodically fetches the catalog's delivery branch and rebuilds
+ * the document when its head moves. An expired lease stops all fetching; it does not delete the
+ * cached Git objects or XML, so a later reader resumes cheaply.
+ *
+ * The worker keeps a shallow **bare Git repository** rather than fetching every published PNG.
+ * `catalog.json` supplies preview identity/order, `references/index.json` supplies Figma metadata
+ * and published match scores, and Git's tree supplies exact image blob ids. That is enough to
+ * distinguish add/delete/metadata/pixel changes without GitHub API quota or hundreds of raw-image
+ * requests.
+ */
+class ServeCatalogChangeFeed
+internal constructor(
+  private val entries: () -> List<CatalogLoadTracker.Config>,
+  private val cacheRoot: File,
+  private val idleTimeoutMillis: Long,
+  private val pollIntervalMillis: Long,
+  private val now: () -> Long = System::currentTimeMillis,
+  private val source: CatalogFeedSource = GitCatalogFeedSource(cacheRoot),
+  private val onLog: (String) -> Unit = { System.err.println(it) },
+  startScheduler: Boolean = true,
+) : AutoCloseable {
+
+  data class Result(val xml: String, val building: Boolean)
+
+  private data class Key(val system: String, val baseUrl: String)
+
+  private class State {
+    @Volatile var activeUntil: Long = 0
+    @Volatile var xml: String? = null
+    @Volatile var head: String? = null
+    val building = AtomicBoolean(false)
+  }
+
+  private val states = ConcurrentHashMap<Key, State>()
+  /** Canonical-path and top-level-site feeds share one bare repo; never fetch it concurrently. */
+  private val sourceLocks = ConcurrentHashMap<String, Any>()
+  private val exec: ScheduledExecutorService =
+    Executors.newScheduledThreadPool(2) { task ->
+      Thread(task, "serve-catalog-feed").apply { isDaemon = true }
+    }
+
+  init {
+    require(idleTimeoutMillis > 0) { "feed idle timeout must be positive" }
+    require(pollIntervalMillis > 0) { "feed poll interval must be positive" }
+    cacheRoot.mkdirs()
+    if (startScheduler) {
+      exec.scheduleWithFixedDelay(
+        {
+          runCatching(::tick).onFailure { onLog("serve: catalog feed tick failed: ${it.message}") }
+        },
+        pollIntervalMillis,
+        pollIntervalMillis,
+        TimeUnit.MILLISECONDS,
+      )
+    }
+  }
+
+  /** Renew interest in [system]'s feed and return the newest completed document immediately. */
+  fun request(system: String, baseUrl: String): Result? {
+    val config = entries().firstOrNull { it.system == system } ?: return null
+    val cleanBase = baseUrl.trimEnd('/')
+    val key = Key(system, cleanBase)
+    val state =
+      states.computeIfAbsent(key) {
+        State().apply {
+          loadCached(key)?.let { (cachedHead, cachedXml) ->
+            head = cachedHead
+            xml = cachedXml
+          }
+        }
+      }
+    state.activeUntil = now() + idleTimeoutMillis
+    enqueue(key, config, state)
+    return Result(
+      xml = state.xml ?: CatalogFeedXml.empty(config.system, cleanBase),
+      building = state.building.get(),
+    )
+  }
+
+  /** One activity pass. Package-visible so lease expiry is deterministic in tests. */
+  internal fun tick() {
+    val configs = entries().associateBy { it.system }
+    val at = now()
+    for ((key, state) in states) {
+      if (state.activeUntil <= at) continue
+      val config = configs[key.system] ?: continue
+      enqueue(key, config, state)
+    }
+  }
+
+  internal fun isActive(system: String, baseUrl: String): Boolean =
+    states[Key(system, baseUrl.trimEnd('/'))]?.activeUntil?.let { it > now() } == true
+
+  private fun enqueue(key: Key, config: CatalogLoadTracker.Config, state: State) {
+    if (!state.building.compareAndSet(false, true)) return
+    exec.execute {
+      try {
+        val history =
+          synchronized(sourceLocks.computeIfAbsent(config.system) { Any() }) { source.read(config) }
+        if (history.revisions.isEmpty()) return@execute
+        val newHead = history.revisions.first().commit
+        if (newHead == state.head && state.xml != null) return@execute
+        val xml = CatalogFeedXml.render(config.system, key.baseUrl, history)
+        persist(key, newHead, xml)
+        state.xml = xml
+        state.head = newHead
+        onLog("serve: catalog feed ${key.system} generated at ${newHead.take(8)}")
+      } catch (t: Exception) {
+        onLog("serve: catalog feed ${key.system} refresh failed: ${t.message}")
+      } finally {
+        state.building.set(false)
+      }
+    }
+  }
+
+  private fun cacheDir(key: Key): File =
+    File(File(cacheRoot, safeName(key.system)), "feeds/${digest(key.baseUrl).take(16)}")
+
+  private fun loadCached(key: Key): Pair<String, String>? {
+    val dir = cacheDir(key)
+    val head = File(dir, "head").takeIf(File::isFile)?.readText()?.trim().orEmpty()
+    val xml = File(dir, "feed.xml").takeIf(File::isFile)?.readText().orEmpty()
+    return if (head.matches(COMMIT) && xml.isNotBlank()) head to xml else null
+  }
+
+  private fun persist(key: Key, head: String, xml: String) {
+    val dir = cacheDir(key)
+    if (!dir.mkdirs() && !dir.isDirectory) return
+    atomicWrite(File(dir, "feed.xml"), xml)
+    atomicWrite(File(dir, "head"), "$head\n")
+  }
+
+  private fun atomicWrite(target: File, text: String) {
+    val tmp = File(target.parentFile, ".${target.name}.${Thread.currentThread().id}.tmp")
+    tmp.writeText(text)
+    runCatching {
+      Files.move(
+        tmp.toPath(),
+        target.toPath(),
+        StandardCopyOption.ATOMIC_MOVE,
+        StandardCopyOption.REPLACE_EXISTING,
+      )
+    }
+      .getOrElse { Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING) }
+  }
+
+  override fun close() {
+    exec.shutdownNow()
+  }
+
+  companion object {
+    private val COMMIT = Regex("[0-9a-f]{40}")
+
+    internal fun safeName(value: String): String =
+      value.replace(Regex("[^A-Za-z0-9._-]+"), "-").trim('-').ifBlank { "catalog" }
+
+    private fun digest(value: String): String =
+      MessageDigest.getInstance("SHA-256").digest(value.toByteArray()).joinToString("") {
+        "%02x".format(it)
+      }
+  }
+}
+
+/** A fully materialised, newest-first slice of one delivery branch. */
+internal data class CatalogFeedHistory(
+  val title: String?,
+  val revisions: List<CatalogFeedRevision>,
+  val batches: List<CatalogFeedBatch>,
+  val repo: String? = null,
+)
+
+internal data class CatalogFeedRevision(
+  val commit: String,
+  val date: String,
+  val subject: String,
+  val sourceSha: String?,
+)
+
+internal enum class CatalogPreviewChangeKind {
+  ADDED,
+  DELETED,
+  CHANGED,
+  METADATA,
+}
+
+internal data class CatalogPreviewChange(
+  val kind: CatalogPreviewChangeKind,
+  val id: String,
+  val label: String,
+  val beforeBlob: String? = null,
+  val afterBlob: String? = null,
+  val order: Int = Int.MAX_VALUE,
+)
+
+internal data class CatalogReferenceChange(
+  val id: String,
+  val label: String,
+  val previewId: String,
+  val specChanged: Boolean,
+  val beforeMatch: Double?,
+  val afterMatch: Double?,
+  val order: Int = Int.MAX_VALUE,
+  val beforePresent: Boolean = true,
+  val afterPresent: Boolean = true,
+)
+
+internal data class CatalogFeedBatch(
+  val before: CatalogFeedRevision,
+  val after: CatalogFeedRevision,
+  val previews: List<CatalogPreviewChange>,
+  val references: List<CatalogReferenceChange>,
+)
+
+/** Source seam: real serving uses Git; tests can provide an already-built history. */
+internal fun interface CatalogFeedSource {
+  fun read(config: CatalogLoadTracker.Config): CatalogFeedHistory
+}
+
+/** Shallow bare-Git implementation of [CatalogFeedSource]. */
+internal class GitCatalogFeedSource(
+  private val root: File,
+  private val git: (File, List<String>) -> CatalogFeedGitResult = ::runCatalogFeedGit,
+) : CatalogFeedSource {
+
+  override fun read(config: CatalogLoadTracker.Config): CatalogFeedHistory {
+    require(REPO.matches(config.repo)) { "invalid catalog repo" }
+    require(BRANCH.matches(config.branch) && ".." !in config.branch.split('/')) {
+      "invalid catalog branch"
+    }
+    val dir = File(root, ServeCatalogChangeFeed.safeName(config.system))
+    if (!File(dir, "HEAD").isFile) {
+      dir.mkdirs()
+      check(git(dir, listOf("init", "--bare", ".")).ok) { "could not initialise feed cache" }
+    }
+    val remote = "https://github.com/${config.repo}.git"
+    val ref = "refs/heads/catalog-feed"
+    val fetch =
+      git(
+        dir,
+        listOf(
+          "fetch",
+          "--quiet",
+          "--force",
+          "--depth=$HISTORY_DEPTH",
+          remote,
+          "+refs/heads/${config.branch}:$ref",
+        ),
+      )
+    check(fetch.ok) { fetch.stderr.ifBlank { "could not fetch catalog history" } }
+    val log =
+      git(
+        dir,
+        listOf(
+          "log",
+          "--first-parent",
+          "--max-count=$HISTORY_DEPTH",
+          "--format=%H%x1f%aI%x1f%s",
+          ref,
+        ),
+      )
+    check(log.ok) { "could not read catalog history" }
+    val revisions = log.stdout.lineSequence().mapNotNull(::parseRevision).toList()
+    if (revisions.isEmpty()) return CatalogFeedHistory(null, emptyList(), emptyList(), config.repo)
+
+    val snapshots = revisions.associate { it.commit to snapshot(dir, it.commit) }
+    val batches =
+      revisions.zipWithNext().map { (after, before) ->
+        CatalogFeedDiff.between(
+          before,
+          snapshots.getValue(before.commit),
+          after,
+          snapshots.getValue(after.commit),
+        )
+      }
+    return CatalogFeedHistory(
+      title = snapshots.getValue(revisions.first().commit).title,
+      revisions = revisions,
+      batches = batches,
+      repo = config.repo,
+    )
+  }
+
+  private fun snapshot(dir: File, commit: String): CatalogSnapshot {
+    val catalog = git(dir, listOf("show", "$commit:catalog.json")).stdout.takeIf { it.isNotBlank() }
+    val references =
+      git(dir, listOf("show", "$commit:references/index.json")).stdout.takeIf { it.isNotBlank() }
+    val tree = git(dir, listOf("ls-tree", "-r", commit, "--", "images", "references"))
+    val blobs = if (tree.ok) parseTree(tree.stdout) else emptyMap()
+    return CatalogSnapshot.parse(catalog, references, blobs)
+  }
+
+  companion object {
+    const val HISTORY_DEPTH = 21
+    private val REPO = Regex("[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*")
+    private val BRANCH = Regex("[A-Za-z0-9][A-Za-z0-9._/-]{0,240}")
+    private val SHA = Regex("[0-9a-f]{40}")
+    private val SOURCE_SHA = Regex("(?:from |catalog \\([^)]*?,\\s*)([0-9a-f]{7,40})(?:\\)|$)")
+
+    internal fun parseRevision(line: String): CatalogFeedRevision? {
+      val fields = line.split('\u001f', limit = 3)
+      if (fields.size != 3 || !SHA.matches(fields[0])) return null
+      return CatalogFeedRevision(
+        commit = fields[0],
+        date = fields[1],
+        subject = fields[2],
+        sourceSha = SOURCE_SHA.find(fields[2])?.groupValues?.get(1),
+      )
+    }
+
+    internal fun parseTree(text: String): Map<String, String> = buildMap {
+      for (line in text.lineSequence()) {
+        val tab = line.indexOf('\t')
+        if (tab < 0) continue
+        val header = line.substring(0, tab).split(' ')
+        val blob = header.getOrNull(2) ?: continue
+        if (SHA.matches(blob)) put(line.substring(tab + 1), blob)
+      }
+    }
+  }
+}
+
+internal data class CatalogFeedGitResult(
+  val exitCode: Int,
+  val stdout: String,
+  val stderr: String,
+) {
+  val ok: Boolean
+    get() = exitCode == 0
+}
+
+private fun runCatalogFeedGit(dir: File, args: List<String>): CatalogFeedGitResult {
+  val process = ProcessBuilder(listOf("git") + args).directory(dir).start()
+  val stdout = StringBuilder()
+  val stderr = StringBuilder()
+  val outThread = Thread {
+    process.inputStream.bufferedReader().use { stdout.append(it.readText()) }
+  }
+  val errThread = Thread {
+    process.errorStream.bufferedReader().use { stderr.append(it.readText()) }
+  }
+  outThread.start()
+  errThread.start()
+  if (!process.waitFor(60, TimeUnit.SECONDS)) {
+    process.destroyForcibly()
+    outThread.join(1_000)
+    errThread.join(1_000)
+    return CatalogFeedGitResult(124, stdout.toString(), "git timed out")
+  }
+  outThread.join()
+  errThread.join()
+  return CatalogFeedGitResult(process.exitValue(), stdout.toString(), stderr.toString())
+}
+
+internal data class CatalogSnapshot(
+  val title: String?,
+  val previews: LinkedHashMap<String, SnapshotPreview>,
+  val references: LinkedHashMap<String, SnapshotReference>,
+) {
+  companion object {
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    fun parse(
+      catalogJson: String?,
+      referencesJson: String?,
+      blobs: Map<String, String>,
+    ): CatalogSnapshot {
+      val catalog = catalogJson?.let {
+        runCatching { JSON.parseToJsonElement(it).jsonObject }.getOrNull()
+      }
+      val title = catalog.string("title")
+      val previews = linkedMapOf<String, SnapshotPreview>()
+      val components = catalog?.get("components") as? JsonArray ?: JsonArray(emptyList())
+      for (componentElement in components) {
+        val component = componentElement as? JsonObject ?: continue
+        val componentId = component.string("componentId")
+        val images = component["images"] as? JsonArray ?: continue
+        for (imageElement in images) {
+          val image = imageElement as? JsonObject ?: continue
+          val path = image.string("path") ?: continue
+          if (!path.startsWith("images/") || !path.endsWith(".png") || ".." in path.split('/'))
+            continue
+          val id = ServeCatalogStore.previewIdFor(path)
+          previews[id] =
+            SnapshotPreview(
+              id = id,
+              label = componentId ?: id,
+              path = path,
+              blob = blobs[path],
+              metadata =
+                listOf(
+                    component.string("section"),
+                    component.string("group"),
+                    image.string("state"),
+                    image.string("theme"),
+                    image["props"]?.toString(),
+                  )
+                  .joinToString("\u001f") { it.orEmpty() },
+              order = previews.size,
+            )
+        }
+      }
+
+      val references = linkedMapOf<String, SnapshotReference>()
+      val referenceRoot = referencesJson?.let {
+        runCatching { JSON.parseToJsonElement(it).jsonObject }.getOrNull()
+      }
+      val rows = referenceRoot?.get("references") as? JsonArray ?: JsonArray(emptyList())
+      for (element in rows) {
+        val obj = element as? JsonObject ?: continue
+        val id = obj.string("id") ?: continue
+        val previewId = obj.string("previewId") ?: continue
+        val raster = obj["raster"] as? JsonObject
+        val source = obj["source"] as? JsonObject
+        val match = obj["match"] as? JsonObject
+        val rasterPath = raster.string("path")
+        references.putIfAbsent(
+          id,
+          SnapshotReference(
+            id = id,
+            label = obj.string("label") ?: id,
+            previewId = previewId,
+            specFingerprint =
+              listOf(
+                  source?.toString().orEmpty(),
+                  rasterPath.orEmpty(),
+                  raster.string("sha256") ?: rasterPath?.let(blobs::get).orEmpty(),
+                )
+                .joinToString("\u001f"),
+            match = match.number("percent"),
+            order = references.size,
+          ),
+        )
+      }
+      return CatalogSnapshot(title, previews, references)
+    }
+
+    private fun JsonObject?.string(name: String): String? =
+      (this?.get(name) as? JsonPrimitive)?.takeIf { it.isString }?.content
+
+    private fun JsonObject?.number(name: String): Double? =
+      (this?.get(name) as? JsonPrimitive)?.doubleOrNull
+  }
+}
+
+internal data class SnapshotPreview(
+  val id: String,
+  val label: String,
+  val path: String,
+  val blob: String?,
+  val metadata: String,
+  val order: Int,
+)
+
+internal data class SnapshotReference(
+  val id: String,
+  val label: String,
+  val previewId: String,
+  val specFingerprint: String,
+  val match: Double?,
+  val order: Int,
+)
+
+internal object CatalogFeedDiff {
+  fun between(
+    beforeRevision: CatalogFeedRevision,
+    before: CatalogSnapshot,
+    afterRevision: CatalogFeedRevision,
+    after: CatalogSnapshot,
+  ): CatalogFeedBatch {
+    val ids = before.previews.keys + after.previews.keys
+    val previews =
+      ids
+        .mapNotNull { id ->
+          val old = before.previews[id]
+          val new = after.previews[id]
+          when {
+            old == null && new != null ->
+              CatalogPreviewChange(
+                CatalogPreviewChangeKind.ADDED,
+                id,
+                new.label,
+                afterBlob = new.blob,
+                order = new.order,
+              )
+            old != null && new == null ->
+              CatalogPreviewChange(
+                CatalogPreviewChangeKind.DELETED,
+                id,
+                old.label,
+                beforeBlob = old.blob,
+                // Keep the live catalog's authored order primary; removals no longer have a live
+                // slot, so
+                // append them in their former authored order instead of interleaving them
+                // unpredictably.
+                order = after.previews.size + old.order,
+              )
+            old != null && new != null && old.blob != new.blob ->
+              CatalogPreviewChange(
+                CatalogPreviewChangeKind.CHANGED,
+                id,
+                new.label,
+                old.blob,
+                new.blob,
+                new.order,
+              )
+            old != null &&
+              new != null &&
+              (old.metadata != new.metadata || old.label != new.label) ->
+              CatalogPreviewChange(
+                CatalogPreviewChangeKind.METADATA,
+                id,
+                new.label,
+                old.blob,
+                new.blob,
+                new.order,
+              )
+            else -> null
+          }
+        }
+        .sortedWith(compareBy<CatalogPreviewChange> { it.order }.thenBy { it.id })
+
+    val referenceIds = before.references.keys + after.references.keys
+    val references =
+      referenceIds
+        .mapNotNull { id ->
+          val old = before.references[id]
+          val new = after.references[id]
+          if (
+            old != null &&
+              new != null &&
+              old.label == new.label &&
+              old.previewId == new.previewId &&
+              old.specFingerprint == new.specFingerprint &&
+              old.match == new.match
+          )
+            return@mapNotNull null
+          CatalogReferenceChange(
+            id = id,
+            label = new?.label ?: old!!.label,
+            previewId = new?.previewId ?: old!!.previewId,
+            specChanged =
+              old?.specFingerprint != new?.specFingerprint || old == null || new == null,
+            beforeMatch = old?.match,
+            afterMatch = new?.match,
+            order = new?.order ?: old!!.order,
+            beforePresent = old != null,
+            afterPresent = new != null,
+          )
+        }
+        .sortedWith(compareBy<CatalogReferenceChange> { it.order }.thenBy { it.id })
+
+    return CatalogFeedBatch(beforeRevision, afterRevision, previews, references)
+  }
+}
+
+/** Pure RSS 2.0 projection of [CatalogFeedHistory]. */
+internal object CatalogFeedXml {
+  fun empty(system: String, baseUrl: String): String =
+    document(
+      title = "$system catalog changes",
+      baseUrl = baseUrl,
+      batches = emptyList(),
+      generated = Instant.now(),
+      repo = null,
+    )
+
+  fun render(system: String, baseUrl: String, history: CatalogFeedHistory): String =
+    document(
+      title = "${history.title?.takeIf { it.isNotBlank() } ?: system} catalog changes",
+      baseUrl = baseUrl,
+      batches = history.batches,
+      generated = history.revisions.firstOrNull()?.date?.let(::instantOrNull) ?: Instant.now(),
+      repo = history.repo,
+    )
+
+  private fun document(
+    title: String,
+    baseUrl: String,
+    batches: List<CatalogFeedBatch>,
+    generated: Instant,
+    repo: String?,
+  ): String = buildString {
+    append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+    append("<rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel>\n")
+    append("<title>${xml(title)}</title>\n")
+    append("<link>${xml(baseUrl)}</link>\n")
+    append("<description>${xml("Published preview and design-spec changes")}</description>\n")
+    append("<atom:link href=\"")
+      .append(xml("$baseUrl/feed.xml"))
+      .append("\" rel=\"self\" type=\"application/rss+xml\"/>\n")
+    append("<lastBuildDate>${rfc822(generated)}</lastBuildDate>\n")
+    for (batch in batches) append(item(baseUrl, repo, batch))
+    append("</channel></rss>\n")
+  }
+
+  private fun item(baseUrl: String, repo: String?, batch: CatalogFeedBatch): String {
+    val p = batch.previews.groupingBy { it.kind }.eachCount()
+    val summary = buildList {
+      p[CatalogPreviewChangeKind.ADDED]?.let { add("$it added") }
+      p[CatalogPreviewChangeKind.DELETED]?.let { add("$it deleted") }
+      p[CatalogPreviewChangeKind.CHANGED]?.let { add("$it visually changed") }
+      p[CatalogPreviewChangeKind.METADATA]?.let { add("$it metadata changed") }
+      if (batch.references.isNotEmpty()) add("${batch.references.size} design reference changes")
+      if (isEmpty()) add("catalog metadata changed")
+    }
+      .joinToString(", ")
+    val commitUrl = ServeCatalogRevision.treeUrl(repo, batch.after.commit)
+    val fallbackLink = "$baseUrl?at=${batch.after.commit}"
+    val link = commitUrl ?: fallbackLink
+    val html = description(baseUrl, batch)
+    return buildString {
+      append("<item>\n")
+      append("<title>${xml(summary)}</title>\n")
+      append("<link>${xml(link)}</link>\n")
+      append("<guid isPermaLink=\"false\">${batch.after.commit}</guid>\n")
+      instantOrNull(batch.after.date)?.let { append("<pubDate>${rfc822(it)}</pubDate>\n") }
+      append("<description>${xml(html)}</description>\n")
+      append("</item>\n")
+    }
+  }
+
+  private fun description(baseUrl: String, batch: CatalogFeedBatch): String = buildString {
+    append("<p>Catalog publication <code>${batch.after.commit.take(8)}</code>")
+    batch.after.sourceSha?.let { append(" from source <code>${html(it)}</code>") }
+    append(".</p>")
+    if (batch.previews.isNotEmpty()) {
+      append("<h3>Previews</h3><ul>")
+      for (change in batch.previews) {
+        val oldUrl =
+          "$baseUrl/render/${WebEscaping.urlEncodeSegment(change.id)}.png?at=${batch.before.commit}"
+        val newUrl =
+          "$baseUrl/render/${WebEscaping.urlEncodeSegment(change.id)}.png?at=${batch.after.commit}"
+        append("<li><strong>${html(change.label)}</strong>: ${change.kind.name.lowercase()}")
+        when (change.kind) {
+          CatalogPreviewChangeKind.ADDED ->
+            append("<br><img alt=\"After\" src=\"${html(newUrl)}\">")
+          CatalogPreviewChangeKind.DELETED ->
+            append("<br><img alt=\"Before\" src=\"${html(oldUrl)}\">")
+          CatalogPreviewChangeKind.CHANGED ->
+            append(
+              "<br><img alt=\"Before\" src=\"${html(oldUrl)}\"> <img alt=\"After\" src=\"${html(newUrl)}\">"
+            )
+          CatalogPreviewChangeKind.METADATA -> Unit
+        }
+        append("</li>")
+      }
+      append("</ul>")
+    }
+    if (batch.references.isNotEmpty()) {
+      append("<h3>Design references</h3><ul>")
+      for (change in batch.references) {
+        append("<li><strong>${html(change.label)}</strong>")
+        if (change.specChanged) append(": spec changed") else append(": diff score changed")
+        if (change.beforeMatch != null || change.afterMatch != null) {
+          append("; match ${score(change.beforeMatch)} → ${score(change.afterMatch)}")
+          if (change.beforeMatch != null && change.afterMatch != null) {
+            val delta = change.afterMatch - change.beforeMatch
+            append(
+              " (${if (delta >= 0) "+" else ""}${"%.2f".format(java.util.Locale.ROOT, delta)} pp)"
+            )
+          }
+        }
+        if (change.specChanged) {
+          val encodedId = WebEscaping.urlEncodeSegment(change.id)
+          if (change.beforePresent) {
+            val oldUrl = "$baseUrl/reference/$encodedId.png?at=${batch.before.commit}"
+            append("<br><img alt=\"Before design reference\" src=\"${html(oldUrl)}\">")
+          }
+          if (change.afterPresent) {
+            val newUrl = "$baseUrl/reference/$encodedId.png?at=${batch.after.commit}"
+            append(" <img alt=\"After design reference\" src=\"${html(newUrl)}\">")
+          }
+        }
+        append("</li>")
+      }
+      append("</ul>")
+    }
+  }
+
+  private fun score(value: Double?): String =
+    value?.let { "%.2f%%".format(java.util.Locale.ROOT, it) } ?: "n/a"
+
+  private fun instantOrNull(value: String): Instant? = runCatching {
+    Instant.parse(value)
+  }
+    .getOrNull()
+
+  private fun rfc822(value: Instant): String =
+    DateTimeFormatter.RFC_1123_DATE_TIME.format(value.atZone(ZoneOffset.UTC))
+
+  private fun xml(value: String): String =
+    value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+
+  private fun html(value: String): String = xml(value).replace("'", "&#39;")
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -72,6 +72,7 @@ import kotlinx.serialization.json.Json
  * Endpoints (all token-gated except `/healthz`, `/readyz`, `/version`, and the `/wasm/` static
  * assets):
  * - `GET /` landing page, `GET /p/{id}` viewer page,
+ * - `GET /{system}/feed.xml` demand-activated catalog change feed,
  * - `GET /render/{id}.png` PNG bytes, `GET /api/previews` JSON, `GET /healthz` liveness,
  * - `GET /hero/{system}/{hash}.png` a prebaked, immutable front-door thumbnail ([ServeHeroImages]),
  * - `GET /social/{hash}.png` the drawn link-unfurl card a page advertises ([ServeSocialCard]), and
@@ -152,6 +153,8 @@ class ServeHttpServer(
   private val catalogLoads: CatalogLoadTracker? = null,
   /** Immediate catalog branch check exposed by `POST /{system}/refresh`. */
   private val catalogRefresh: ((String) -> CatalogRefreshResult)? = null,
+  /** Demand-activated, expiring background RSS generator for published catalog history. */
+  private val catalogFeed: ServeCatalogChangeFeed? = null,
   portRange: Int = DEFAULT_PORT_RANGE,
   /**
    * Max renders in flight across the HTTP `/render` lane. Defaults to the host's CPU count so a
@@ -974,6 +977,11 @@ class ServeHttpServer(
         post("/refresh") { handleCatalogRefresh(sessionInPath = false) }
         post("/{system}/refresh") { handleCatalogRefresh(sessionInPath = true) }
 
+        if (catalogFeed != null) {
+          get("/feed.xml") { handleCatalogFeed(sessionInPath = false) }
+          get("/{system}/feed.xml") { handleCatalogFeed(sessionInPath = true) }
+        }
+
         get("/api/previews") { handleApiPreviews(sessionInPath = false) }
         get("/{system}/api/previews") { handleApiPreviews(sessionInPath = true) }
         get("/api/daemons") { handleDaemonStatus(sessionInPath = false) }
@@ -1051,6 +1059,35 @@ class ServeHttpServer(
     // previews out through `/api/previews?session=wear-m3` while `/wear-m3/` 404s — the isolation
     // undone by the older spelling of the same request.
     else siteSystem() ?: call.request.queryParameters["session"] ?: defaultSessionId
+
+  /**
+   * A catalog's RSS document. The request itself is the subscription signal: [catalogFeed] renews
+   * its interest lease and queues background catch-up, while this handler immediately returns the
+   * last completed document (or a valid empty document on the first cold request).
+   */
+  private suspend fun RoutingContext.handleCatalogFeed(sessionInPath: Boolean) {
+    if (rejectBadToken()) return
+    val feed =
+      catalogFeed
+        ?: run {
+          call.respondText("not found", status = HttpStatusCode.NotFound)
+          return
+        }
+    val system = selectedSessionId(sessionInPath)
+    val basePath = webSessionAndBase(sessionInPath).second
+    val result =
+      withContext(Dispatchers.IO) { feed.request(system, externalOrigin() + basePath) }
+        ?: run {
+          call.respondText("not found", status = HttpStatusCode.NotFound)
+          return
+        }
+    if (result.building) call.response.headers.append(HttpHeaders.RetryAfter, "30")
+    markGeneration("catalog-feed", "no-cache")
+    call.respondText(
+      result.xml,
+      ContentType.parse("application/rss+xml; charset=utf-8"),
+    )
+  }
 
   /**
    * The catalog this request's **host** publishes as a top-level site, or null on the main host

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogChangeFeedTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogChangeFeedTest.kt
@@ -1,0 +1,291 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+class ServeCatalogChangeFeedTest {
+  private val temporary = mutableListOf<File>()
+
+  private fun tempDir(): File =
+    Files.createTempDirectory("catalog-feed-test").toFile().also(temporary::add)
+
+  @AfterTest
+  fun cleanUp() {
+    temporary.forEach { it.deleteRecursively() }
+  }
+
+  private val oldRevision =
+    CatalogFeedRevision(
+      commit = "a".repeat(40),
+      date = "2026-08-14T10:00:00Z",
+      subject = "chore(design-artifacts): regenerate demo catalog (2026-08-14, 1111111)",
+      sourceSha = "1111111",
+    )
+  private val newRevision =
+    CatalogFeedRevision(
+      commit = "b".repeat(40),
+      date = "2026-08-15T10:00:00Z",
+      subject = "chore(design-artifacts): regenerate demo catalog (2026-08-15, 2222222)",
+      sourceSha = "2222222",
+    )
+
+  @Test
+  fun `snapshot diff reports additions deletions pixel changes metadata and figma effect`() {
+    val before =
+      CatalogSnapshot.parse(
+        catalogJson =
+          """{"title":"Demo","components":[
+            {"componentId":"Old","images":[{"path":"images/old/default.png"}]},
+            {"componentId":"Button","section":"Controls","images":[{"path":"images/button/default.png","theme":"light"}]},
+            {"componentId":"Label","images":[{"path":"images/label/default.png"}]}
+          ]}""",
+        referencesJson =
+          """{"references":[{"id":"button-spec","previewId":"button__default","label":"Button spec",
+            "raster":{"path":"references/button.png","sha256":"old-spec"},
+            "source":{"provider":"figma","revision":"4"},"match":{"percent":80.0}}]}""",
+        blobs =
+          mapOf(
+            "images/old/default.png" to "1".repeat(40),
+            "images/button/default.png" to "2".repeat(40),
+            "images/label/default.png" to "3".repeat(40),
+          ),
+      )
+    val after =
+      CatalogSnapshot.parse(
+        catalogJson =
+          """{"title":"Demo","components":[
+            {"componentId":"Button","section":"Controls","images":[{"path":"images/button/default.png","theme":"light"}]},
+            {"componentId":"Label","section":"Typography","images":[{"path":"images/label/default.png"}]},
+            {"componentId":"New","images":[{"path":"images/new/default.png"}]}
+          ]}""",
+        referencesJson =
+          """{"references":[{"id":"button-spec","previewId":"button__default","label":"Button spec",
+            "raster":{"path":"references/button.png","sha256":"new-spec"},
+            "source":{"provider":"figma","revision":"5"},"match":{"percent":92.5}}]}""",
+        blobs =
+          mapOf(
+            "images/button/default.png" to "4".repeat(40),
+            "images/label/default.png" to "3".repeat(40),
+            "images/new/default.png" to "5".repeat(40),
+          ),
+      )
+
+    val batch = CatalogFeedDiff.between(oldRevision, before, newRevision, after)
+    assertEquals(
+      listOf(
+        CatalogPreviewChangeKind.CHANGED,
+        CatalogPreviewChangeKind.METADATA,
+        CatalogPreviewChangeKind.ADDED,
+        CatalogPreviewChangeKind.DELETED,
+      ),
+      batch.previews.map { it.kind },
+      "changes retain current authored catalog order, then former order for removals",
+    )
+    val figma = batch.references.single()
+    assertTrue(figma.specChanged)
+    assertEquals(80.0, figma.beforeMatch)
+    assertEquals(92.5, figma.afterMatch)
+  }
+
+  @Test
+  fun `rss includes immutable before after images and figma score delta`() {
+    val batch =
+      CatalogFeedBatch(
+        before = oldRevision,
+        after = newRevision,
+        previews =
+          listOf(
+            CatalogPreviewChange(
+              CatalogPreviewChangeKind.CHANGED,
+              "button__default",
+              "Button",
+              "1".repeat(40),
+              "2".repeat(40),
+            )
+          ),
+        references =
+          listOf(
+            CatalogReferenceChange("spec", "Button spec", "button__default", true, 80.0, 92.5)
+          ),
+      )
+    val xml =
+      CatalogFeedXml.render(
+        "demo",
+        "https://preview.example/demo",
+        CatalogFeedHistory("Demo app", listOf(newRevision, oldRevision), listOf(batch)),
+      )
+    assertTrue(xml.contains("Demo app catalog changes"))
+    assertTrue(xml.contains("at=${oldRevision.commit}"))
+    assertTrue(xml.contains("at=${newRevision.commit}"))
+    assertTrue(xml.contains("80.00% → 92.50%"))
+    assertTrue(xml.contains("+12.50 pp"))
+    assertTrue(xml.contains("Before design reference"))
+    assertTrue(xml.contains("After design reference"))
+    assertTrue(xml.indexOf("Before") < xml.indexOf("After"))
+  }
+
+  @Test
+  fun `feed interest expires and a later request reactivates it`() {
+    var clock = 1_000L
+    val reads = AtomicInteger()
+    val history = CatalogFeedHistory("Demo", listOf(newRevision, oldRevision), emptyList())
+    val service =
+      ServeCatalogChangeFeed(
+        entries = { listOf(config()) },
+        cacheRoot = tempDir(),
+        idleTimeoutMillis = 100,
+        pollIntervalMillis = 10_000,
+        now = { clock },
+        source =
+          CatalogFeedSource {
+            reads.incrementAndGet()
+            history
+          },
+        onLog = {},
+        startScheduler = false,
+      )
+    try {
+      service.request("demo", "https://preview.example/demo")
+      await { reads.get() == 1 }
+      assertTrue(service.isActive("demo", "https://preview.example/demo"))
+
+      clock += 101
+      service.tick()
+      Thread.sleep(30)
+      assertEquals(1, reads.get(), "an expired feed does not poll")
+      assertFalse(service.isActive("demo", "https://preview.example/demo"))
+
+      service.request("demo", "https://preview.example/demo")
+      // The cached head is current, but reactivation still performs the cheap fetch that
+      // establishes
+      // whether it needs to catch up.
+      await { reads.get() == 2 }
+      assertTrue(service.isActive("demo", "https://preview.example/demo"))
+    } finally {
+      service.close()
+    }
+  }
+
+  @Test
+  fun `git log and tree parsers preserve commit metadata and blobs`() {
+    val revision =
+      GitCatalogFeedSource.parseRevision(
+        "${"c".repeat(40)}\u001f2026-08-15T12:30:00Z\u001f" +
+          "chore(design-artifacts): regenerate demo catalog (2026-08-15, deadbee)"
+      )
+    assertNotNull(revision)
+    assertEquals("deadbee", revision.sourceSha)
+    assertEquals(
+      mapOf("images/button/default.png" to "d".repeat(40)),
+      GitCatalogFeedSource.parseTree("100644 blob ${"d".repeat(40)}\timages/button/default.png\n"),
+    )
+  }
+
+  private fun config() =
+    CatalogLoadTracker.Config(
+      system = "demo",
+      listed = false,
+      repo = "example/catalog",
+      branch = "design-artifacts/demo",
+    )
+
+  private fun await(condition: () -> Boolean) {
+    repeat(100) {
+      if (condition()) return
+      Thread.sleep(10)
+    }
+    error("condition did not become true")
+  }
+}
+
+class ServeCatalogChangeFeedRoutingTest {
+  private val registry = ServeSessionRegistry(open = { null })
+  private val cache = Files.createTempDirectory("catalog-feed-routing").toFile()
+  private val feed =
+    ServeCatalogChangeFeed(
+      entries = {
+        listOf(
+          CatalogLoadTracker.Config(
+            "demo",
+            false,
+            "example/catalog",
+            "design-artifacts/demo",
+          )
+        )
+      },
+      cacheRoot = cache,
+      idleTimeoutMillis = 60_000,
+      pollIntervalMillis = 60_000,
+      source =
+        CatalogFeedSource {
+          val old = CatalogFeedRevision("a".repeat(40), "2026-08-14T10:00:00Z", "old", null)
+          val new = CatalogFeedRevision("b".repeat(40), "2026-08-15T10:00:00Z", "new", null)
+          CatalogFeedHistory(
+            "Demo",
+            listOf(new, old),
+            listOf(
+              CatalogFeedBatch(
+                old,
+                new,
+                listOf(CatalogPreviewChange(CatalogPreviewChangeKind.ADDED, "new", "New")),
+                emptyList(),
+              )
+            ),
+          )
+        },
+      onLog = {},
+      startScheduler = false,
+    )
+  private val server =
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "unused",
+        sessions = registry,
+        defaultSessionId = "demo",
+        isPublic = true,
+        catalogFeed = feed,
+      )
+      .also { it.start() }
+  private val client = OkHttpClient()
+
+  @AfterTest
+  fun close() {
+    server.stop()
+    feed.close()
+    registry.close()
+    cache.deleteRecursively()
+  }
+
+  @Test
+  fun `catalog feed route returns rss and unknown catalog is absent`() {
+    var body = ""
+    for (attempt in 0 until 100) {
+      val response = get("/demo/feed.xml")
+      assertEquals(200, response.first)
+      assertTrue(response.second.startsWith("application/rss+xml"))
+      body = response.third
+      if (body.contains("<item>")) break
+      Thread.sleep(10)
+    }
+    assertTrue(body.contains("<item>"), body)
+    assertTrue(body.contains("https://127.0.0.1:").not(), "forwarded scheme is not invented")
+    assertEquals(404, get("/unknown/feed.xml").first)
+  }
+
+  private fun get(path: String): Triple<Int, String, String> {
+    val request = Request.Builder().url("http://127.0.0.1:${server.port}$path").build()
+    client.newCall(request).execute().use {
+      return Triple(it.code, it.header("Content-Type").orEmpty(), it.body.string())
+    }
+  }
+}

--- a/deploy/cloudrun/entrypoint.sh
+++ b/deploy/cloudrun/entrypoint.sh
@@ -73,6 +73,8 @@ fi
 # (and ?session=<system>). Each entry may carry a per-repo source as <system>@<owner>/<repo>
 # (e.g. meshcore-mobile@yschimke/meshcore-mobile).
 [[ -n "${SERVE_CATALOGS_UNLISTED:-}" ]] && args+=(--catalogs-unlisted "${SERVE_CATALOGS_UNLISTED}")
+[[ -n "${SERVE_CATALOG_FEED_IDLE:-}" ]] &&
+  args+=(--catalog-feed-idle-timeout "${SERVE_CATALOG_FEED_IDLE}")
 # Top-level sites (<host>=<system>[,…]): one of the catalogs above, additionally served on a
 # hostname of its own where it looks like the only thing here. A routing view over the same
 # sessions — no extra catalog, no extra render.

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -174,6 +174,8 @@ services:
       # regenerated branch reaches this running server without a restart (Watchtower only rolls the
       # image). Empty ⇒ the CLI default (600s); set 0 to disable and serve the boot snapshot only.
       SERVE_CATALOG_REFRESH: "${SERVE_CATALOG_REFRESH:-}"
+      # RSS feed history work sleeps after this many seconds without a feed request. Empty ⇒ 7 days.
+      SERVE_CATALOG_FEED_IDLE: "${SERVE_CATALOG_FEED_IDLE:-}"
       # Bundle-upload lane (POST a locally-built bundle and browse it here). Off unless asked for.
       SERVE_ACCEPT_BUNDLES: "${SERVE_ACCEPT_BUNDLES:-}"
       SERVE_ACCEPT_BUNDLES_FROM: "${SERVE_ACCEPT_BUNDLES_FROM:-}"

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -366,6 +366,10 @@ fi
 # boot snapshot until the container recycles). This is what lets a `design-artifacts.yml` regen
 # reach preview.coo.ee on its own — Watchtower only rolls the *image*, never the branch content.
 [[ -n "${SERVE_CATALOG_REFRESH:-}" ]] && args+=(--catalog-refresh-interval "${SERVE_CATALOG_REFRESH}")
+# RSS history is demand-activated: each feed request renews this inactivity lease. Once it expires,
+# its branch worker sleeps while retaining the generated XML + shallow Git cache under /config.
+[[ -n "${SERVE_CATALOG_FEED_IDLE:-}" ]] &&
+  args+=(--catalog-feed-idle-timeout "${SERVE_CATALOG_FEED_IDLE}")
 
 echo "entrypoint: compose-preview serve on 0.0.0.0:${PORT}" >&2
 exec compose-preview "${args[@]}"

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       # Optional additions to that file (<system>@<owner>/<repo>, comma-separated).
       SERVE_CATALOGS: "${SERVE_CATALOGS:-}"
       SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-}"
+      SERVE_CATALOG_FEED_IDLE: "${SERVE_CATALOG_FEED_IDLE:-}"
       # Top-level sites (<host>=<system>[,…]): serve one of the catalogs above on a hostname
       # of its own, where it presents as the whole server. Caddy in front must route the name
       # here; catalogs.json's "sites" is the durable form of the same setting.

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -212,6 +212,32 @@ occupy ~84 MB of packed objects in total. If a branch ever does need resetting,
 a manual force-push still works — nothing in the pipeline depends on the history
 being contiguous.
 
+### Catalog change feed
+
+`serve` exposes that publication history as RSS at `/<system>/feed.xml` (and `/feed.xml` on a
+top-level catalog site). The outer order is delivery-branch commit ancestry, newest first. One feed
+item is one publication batch; changes inside it retain the current catalog's authored component
+order, with deleted previews appended in their former order. The item records:
+
+- added and deleted preview images;
+- changed preview blobs with immutable before/after images pinned to the two delivery commits;
+- catalog placement/axis metadata changes; and
+- added, removed, or changed design references with immutable before/after reference images and
+  their old/new published match score.
+
+Feed work is demand-activated. The first request returns the last cached document (or an empty,
+valid RSS document on a cold cache) and queues a background shallow-Git history pass. Each later
+request renews an interest lease. After `--catalog-feed-idle-timeout` seconds with no request, the
+worker stops polling that feed but retains its XML and Git objects; a later request reactivates it
+and catches up. The default is seven days, `0` disables the lane, and
+`--catalog-feed-cache <dir>` overrides the durable cache location (otherwise it lives beside
+`--catalogs-file` on a deployed box).
+
+The score delta is deliberately described as the **published match before/after**, not as causal
+attribution: when the Compose render and Figma raster changed in the same publication, two scores
+cannot say which change caused which part of the movement. A future four-way scorer can add that
+attribution without changing the feed's commit ordering or preview identities.
+
 ## Publishing from another repo (reusable workflow)
 
 A consumer repo that owns a `catalog.spec.json` + a renderable `@Preview` module


### PR DESCRIPTION
## Summary

- add an ordered RSS change feed for each app catalog at `/<system>/feed.xml`
- report added, deleted, changed, and metadata-only previews with immutable before/after links
- include Figma reference changes and published match-score deltas without claiming causal attribution
- compute history asynchronously from shallow Git data and retain the last generated feed
- renew an activity lease on feed requests and stop polling after the configurable idle timeout
- expose CLI and deployment configuration, plus design documentation

## Why

Catalog consumers need a chronological view of published UI changes and their visible effects, but generating that history continuously would waste resources for catalogs with no feed readers. Feed requests now act as a subscription signal, allowing generation to happen in the background only while a catalog is actively read.

## Operational impact

The default inactivity timeout is seven days. Set `--catalog-feed-idle-timeout 0` to disable the route, or configure `SERVE_CATALOG_FEED_IDLE` in deployed environments. Generated XML and shallow Git state are cached across idle periods.

A cold request immediately receives a valid empty feed with `Retry-After: 30` while background generation runs; subsequent requests receive the latest completed document.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests ServeCatalogChangeFeedTest --tests ServeCatalogChangeFeedRoutingTest`
- focused pinned-revision and catalog-refresher tests
- shell syntax checks for modified entrypoints
- `git diff --check`
