### PR TITLE
Add comprehensive remote Material 3 previews

### DIFF
--- a/samples/design-catalog-remote-m3/catalog.spec.json
+++ b/samples/design-catalog-remote-m3/catalog.spec.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/design-artifacts/catalog.spec.schema.json",
-  "$comment": "Catalog spec for Remote Compose (Wear Compose Remote Material 3 + remote-creation-compose primitives). Code-led: each sticker is a real RemoteDocument built by RemotePreview and rasterised by the Remote Compose player, so the render is authoritative. Remote Compose carries explicit colours in the document rather than a light/dark theme split, so there is a single primary mode — and because those colours come from RemoteMaterialTheme (the Wear Compose Material 3 scheme, which is dark-first), that one mode is DARK: the stickers rasterise light content on transparency (a white RemoteIcon/RemoteText, a near-black RemoteCard surface). Hence `modes: [\"dark\"]` and `display.surface: \"dark\"` — without the explicit surface the preview server's fallback id heuristic (`wear|watch` token) doesn't match `remote-m3`, backs the sheet on the default white stage, and the white-on-transparent stickers vanish. The component set mirrors the androidx.wear.compose.remote.material3 surface (the port of Wear Compose Material 3 to Remote Compose), minus the two non-component helpers RemoteContainerPainter (a painter factory) and RemoteTypographyTokens (the raw token table behind RemoteTypography). Each component carries a `parallel` field naming its Wear Compose Material 3 counterpart (a componentId in samples/design-catalog-wear-m3); the design-artifacts cross-system compare page pairs them side by side. The Scaffold templates group is not a component but a whole-screen template — the catalog's declared `display.hero`, so the preview server's front door features a real Remote Compose screen instead of a lone button; it parallels the Wear M3 sibling's `Template/TimeText/largeRound` (that catalog publishes its full-screen templates one component per breakpoint, so the parallel names the large-round card rather than a bare id). The Widget Container group is the other Remote-only extra besides the shader: the squircle frame the Wear widget host draws around widget content, rendered through androidx.glance.wear:wear-tooling-preview's WearWidgetPreview wrapper (no remote-material3 or Wear M3 peer — it is a host frame, not a component). Sibling of samples/design-catalog-{m3,wear-m3}; see docs/design/DESIGN_CATALOGS.md.",
+  "$comment": "Catalog spec for Remote Compose (Wear Compose Remote Material 3 + remote-creation-compose primitives). Every sticker is a real RemoteDocument rasterised by the Remote Compose player. The document carries explicit dark-first Material colours, hence the single dark mode and dark display surface. The inventory covers the renderable androidx.wear.compose.remote.material3 component surface plus focused size, style, content-slot, interaction and motion variants. RemoteContainerPainter and RemoteTypographyTokens are helpers rather than components. RemoteTimeText has source samples but no catalog sticker because the resolved player still rejects its DrawTextOnCircle opcode (57). Each component carries a Wear Material 3 parallel where one exists. The Scaffold template is the catalog hero; Widget Container and the shader are Remote-only extras. Sibling of samples/design-catalog-{m3,wear-m3}; see docs/design/DESIGN_CATALOGS.md.",
   "system": "remote-m3",
   "title": "Remote Compose Material 3",
   "library": [
@@ -21,10 +21,25 @@
       "name": "Buttons",
       "components": [
         { "componentId": "Button/Filled", "preview": "FilledRemoteButton", "parallel": "Button/Filled", "caption": "Remote Material 3 filled button — the primary action." },
+        { "componentId": "Button/Tonal", "preview": "TonalRemoteButton", "parallel": "Button/FilledTonal", "caption": "Tonal button using the theme's secondary-container emphasis." },
         { "componentId": "Button/Outlined", "preview": "OutlinedRemoteButton", "parallel": "Button/Outlined", "caption": "Remote Material 3 outlined-emphasis button (RemoteButton with an explicit border + border colour)." },
+        { "componentId": "Button/Disabled", "preview": "DisabledRemoteButton", "parallel": "Button/Filled", "caption": "Filled button with the library's disabled container and content colours." },
+        { "componentId": "Button/IconLabel", "preview": "IconLabelRemoteButton", "parallel": "Button/Filled", "caption": "Opinionated RemoteButton overload with its recommended icon and label slots." },
+        { "componentId": "Button/IconLabelSecondary", "preview": "IconLabelSecondaryRemoteButton", "parallel": "Button/Filled", "caption": "Two-line RemoteButton with a large icon, primary label and secondary label." },
         { "componentId": "Button/Text", "preview": "TextRemoteButton", "parallel": "Button/Child", "caption": "Low-emphasis round text button (RemoteTextButton)." },
+        { "componentId": "Button/Text-Small", "preview": "SmallRemoteTextButton", "parallel": "Button/Child", "caption": "Small RemoteTextButton at the defined 48dp size." },
+        { "componentId": "Button/Text-Large", "preview": "LargeRemoteTextButton", "parallel": "Button/Child", "caption": "Large RemoteTextButton at the defined 60dp size and labelLarge typography." },
+        { "componentId": "Button/Text-Filled", "preview": "FilledRemoteTextButton", "parallel": "Button/Filled", "caption": "Round text button with a filled primary container." },
+        { "componentId": "Button/Text-Outlined", "preview": "OutlinedRemoteTextButton", "parallel": "Button/Outlined", "caption": "Round text button with an explicit outline treatment." },
         { "componentId": "Button/Icon", "preview": "IconRemoteButton", "parallel": "IconButton", "caption": "Round icon button (RemoteIconButton) carrying a single RemoteIcon." },
+        { "componentId": "Button/Icon-ExtraSmall", "preview": "ExtraSmallRemoteIconButton", "parallel": "IconButton", "caption": "Extra-small RemoteIconButton at the defined 32dp size." },
+        { "componentId": "Button/Icon-Small", "preview": "SmallRemoteIconButton", "parallel": "IconButton", "caption": "Small RemoteIconButton at the defined 48dp size." },
+        { "componentId": "Button/Icon-Large", "preview": "LargeRemoteIconButton", "parallel": "IconButton", "caption": "Large RemoteIconButton at the defined 60dp size." },
+        { "componentId": "Button/Icon-Filled", "preview": "FilledRemoteIconButton", "parallel": "IconButton", "caption": "RemoteIconButton with a filled primary container." },
+        { "componentId": "Button/Icon-Outlined", "preview": "OutlinedRemoteIconButton", "parallel": "IconButton", "caption": "RemoteIconButton with an explicit outline treatment." },
         { "componentId": "Button/Compact", "preview": "CompactRemoteButton", "parallel": "CompactButton", "caption": "Compact single-line button (RemoteCompactButton)." },
+        { "componentId": "Button/Compact-IconLabel", "preview": "CompactIconLabelRemoteButton", "parallel": "CompactButton", "caption": "Compact button with the defined extra-small icon plus a label." },
+        { "componentId": "Button/Compact-IconOnly", "preview": "CompactIconOnlyRemoteButton", "parallel": "CompactButton", "caption": "Icon-only compact button using its dedicated 52dp visible width." },
         { "componentId": "Button/Group", "preview": "ButtonGroupRemote", "parallel": "ButtonGroup", "caption": "Two buttons laid out edge-to-edge by RemoteButtonGroup." },
         { "componentId": "Button/CustomShape", "preview": "CustomShapeRemoteButton", "parallel": "Button/Filled", "caption": "Filled button with a RemoteRoundedCornerShape override." },
         { "componentId": "Button/NamedLabel", "preview": "NamedLabelRemoteButton", "parallel": "Button/Filled", "caption": "Filled button whose label is bound to a Remote Compose named value — the connector flips it live (default render shows \"Tap me\")." }
@@ -36,7 +51,10 @@
         { "componentId": "Card", "preview": "CardRemote", "parallel": "Card", "caption": "Remote Material 3 card." },
         { "componentId": "Card/Outlined", "preview": "OutlinedCardRemote", "parallel": "Card/Outlined", "caption": "Outlined card variant (RemoteOutlinedCard)." },
         { "componentId": "TitleCard", "preview": "TitleCardRemote", "parallel": "TitleCard", "caption": "Card with title, subtitle and supporting text slots." },
-        { "componentId": "AppCard", "preview": "AppCardRemote", "parallel": "AppCard", "caption": "App card with app name, icon, time and content slots." }
+        { "componentId": "TitleCard/TitleOnly", "preview": "TitleOnlyRemoteTitleCard", "parallel": "TitleCard", "caption": "Minimal title-card layout with no optional time, subtitle or body slots." },
+        { "componentId": "TitleCard/TimeContent", "preview": "TimeContentRemoteTitleCard", "parallel": "TitleCard", "caption": "Title card with time and supporting content, exercising the alternate title-row layout." },
+        { "componentId": "AppCard", "preview": "AppCardRemote", "parallel": "AppCard", "caption": "App card with app name, icon and content slots." },
+        { "componentId": "AppCard/Time", "preview": "TimeRemoteAppCard", "parallel": "AppCard", "caption": "App card with the optional time slot and no app image." }
       ]
     },
     {
@@ -48,7 +66,12 @@
     {
       "name": "Communication",
       "components": [
-        { "componentId": "Progress/Circular", "preview": "CircularProgressRemote", "parallel": "Progress/Circular", "caption": "Determinate circular progress indicator at a fixed 66%." }
+        { "componentId": "Progress/Circular", "preview": "CircularProgressRemote", "parallel": "Progress/Circular", "caption": "Determinate circular progress indicator at a fixed 66%." },
+        { "componentId": "Progress/Circular-Disabled", "preview": "DisabledCircularProgressRemote", "parallel": "Progress/Circular", "caption": "Determinate progress using the component's disabled indicator and track brushes." },
+        { "componentId": "Progress/Circular-Indeterminate", "preview": "IndeterminateCircularProgressRemote", "parallel": "Progress/Circular-Indeterminate", "caption": "Indeterminate circular progress; a companion motion preview captures its continuous remote-clock animation." },
+        { "componentId": "PageIndicator/Horizontal", "preview": "HorizontalPageIndicatorRemote", "parallel": "PageIndicator/Horizontal", "caption": "Five-page horizontal indicator curved along the bottom edge." },
+        { "componentId": "PageIndicator/Vertical", "preview": "VerticalPageIndicatorRemote", "parallel": "PageIndicator/Vertical", "caption": "Eight-page vertical indicator exercising the scrolling-dot window." },
+        { "componentId": "PageIndicator/Interactive", "preview": "InteractivePageIndicatorRemote", "parallel": "PageIndicator/Horizontal", "caption": "Interactive page indicator: tapping Next animates the worm between adjacent pages inside the RemoteDocument." }
       ]
     },
     {

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
@@ -24,6 +24,7 @@ import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.RemoteString
+import androidx.compose.remote.creation.compose.state.animateRemoteFloat
 import androidx.compose.remote.creation.compose.state.rb
 import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rememberMutableRemoteFloat
@@ -76,11 +77,12 @@ import ee.schimke.composeai.daemon.rememberOverridableRemoteString
 // (`androidx.wear.compose.remote.material3`) component surface — the port of Wear
 // Compose Material 3 to Remote Compose — so every sticker here has a Wear M3
 // parallel (declared per-component in `catalog.spec.json`'s `parallel` field, and
-// surfaced side-by-side by the branch's cross-system compare page). Only the two
-// non-component helpers are omitted, matching the spec: `RemoteContainerPainter`
-// (a painter factory, not a drawable component) and `RemoteTypographyTokens` (raw
-// token table behind `RemoteTypography`). The `remote-creation-compose` shader
-// sticker is the one Remote-only extra with no Wear M3 peer.
+// surfaced side-by-side by the branch's cross-system compare page). The two
+// non-component helpers are omitted: `RemoteContainerPainter` (a painter factory,
+// not a drawable component) and `RemoteTypographyTokens` (the raw token table).
+// `RemoteTimeText` has source samples in ComponentVariantPreviews.kt but no sticker:
+// the resolved player still rejects its DrawTextOnCircle opcode (57). The
+// `remote-creation-compose` shader sticker is the one Remote-only extra.
 // ---------------------------------------------------------------------------
 
 // `hostAction(...)` — the Remote Compose way to signal the *host*: it posts a payload out of the
@@ -106,7 +108,7 @@ import ee.schimke.composeai.daemon.rememberOverridableRemoteString
  * bare label it always has** — the counter is only reachable once a player dispatches a real touch.
  */
 @Composable
-private fun countedRemote(base: String): Pair<RemoteString, Action> = countedRemote(base.rs)
+internal fun countedRemote(base: String): Pair<RemoteString, Action> = countedRemote(base.rs)
 
 /**
  * [countedRemote] over a label that is itself a remote value — an overridable named string, say —
@@ -115,7 +117,7 @@ private fun countedRemote(base: String): Pair<RemoteString, Action> = countedRem
  * it demonstrates stays fully visible.
  */
 @Composable
-private fun countedRemote(base: RemoteString): Pair<RemoteString, Action> {
+internal fun countedRemote(base: RemoteString): Pair<RemoteString, Action> {
   val clicks = rememberMutableRemoteInt(0)
   val label = selectIfGt(clicks, 0.ri, base + " (" + clicks.toRemoteString() + ")", base)
   return label to valueChange(clicks, (clicks + 1).createReference())
@@ -130,16 +132,16 @@ private fun countedRemote(base: RemoteString): Pair<RemoteString, Action> {
  * colours and only a live tap moves it.
  */
 @Composable
-private fun toggledRemote(): Pair<RemoteFloat, Action> {
+internal fun toggledRemote(): Pair<RemoteFloat, Action> {
   val on = rememberMutableRemoteFloat(0f)
-  return on to valueChange(on, (1f.rf - on).createReference())
+  return animateRemoteFloat(on, duration = 0.45f) to valueChange(on, (1f.rf - on).createReference())
 }
 
 // A simple five-point star used by the icon stickers. Remote Compose has no bundled
 // icon set and `RemoteIcon` takes an `ImageVector`, so the catalog carries one
 // hand-built vector rather than depending on `material-icons`. `RemoteIcon` re-tints
 // it, so the path fill here is a placeholder.
-private val starIcon: ImageVector =
+internal val starIcon: ImageVector =
   ImageVector.Builder(
       name = "Star",
       defaultWidth = 24.dp,
@@ -595,7 +597,8 @@ fun VariableWidthRemote() = RemoteSticker {
   }
 }
 
-// NOTE: `RemoteTimeText` is intentionally NOT catalogued. It draws the time as
+// NOTE: `RemoteTimeText` is intentionally NOT stickered. Source samples live in
+// ComponentVariantPreviews.kt, but it draws the time as
 // *curved* text (a `DrawTextOnCircle` document op) that the Remote Compose player
 // bundled in the renderer can't replay ("Operation 57 is not supported for this
 // version" — an alpha writer/player version skew), so it fails the render outright.

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/ComponentVariantPreviews.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/ComponentVariantPreviews.kt
@@ -1,0 +1,441 @@
+@file:Suppress("RestrictedApiAndroidX")
+
+package com.example.designcatalogremotem3
+
+import androidx.compose.remote.creation.compose.action.valueChange
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.state.RemoteColor
+import androidx.compose.remote.creation.compose.state.RemoteFloat
+import androidx.compose.remote.creation.compose.state.RemoteInt
+import androidx.compose.remote.creation.compose.state.animateRemoteFloat
+import androidx.compose.remote.creation.compose.state.rb
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rememberMutableRemoteInt
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.ri
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.tween
+import androidx.compose.runtime.Composable
+import androidx.wear.compose.remote.material3.RemoteAppCard
+import androidx.wear.compose.remote.material3.RemoteButton
+import androidx.wear.compose.remote.material3.RemoteButtonDefaults
+import androidx.wear.compose.remote.material3.RemoteCircularProgressIndicator
+import androidx.wear.compose.remote.material3.RemoteCompactButton
+import androidx.wear.compose.remote.material3.RemoteHorizontalPageIndicator
+import androidx.wear.compose.remote.material3.RemoteIcon
+import androidx.wear.compose.remote.material3.RemoteIconButton
+import androidx.wear.compose.remote.material3.RemoteIconButtonDefaults
+import androidx.wear.compose.remote.material3.RemoteMaterialTheme
+import androidx.wear.compose.remote.material3.RemotePageIndicatorState
+import androidx.wear.compose.remote.material3.RemoteText
+import androidx.wear.compose.remote.material3.RemoteTextButton
+import androidx.wear.compose.remote.material3.RemoteTextButtonDefaults
+import androidx.wear.compose.remote.material3.RemoteTimeText
+import androidx.wear.compose.remote.material3.RemoteTitleCard
+import androidx.wear.compose.remote.material3.RemoteVerticalPageIndicator
+import androidx.wear.compose.remote.material3.rememberRemotePageIndicatorState
+import ee.schimke.composeai.preview.AnimatedPreview
+
+// This file is the variant matrix for the public component surface in remote-material3 alpha09.
+// CatalogPreviews.kt keeps the concise one-per-family set; these previews cover every public size,
+// the supported emphasis treatments, and the optional icon/label/time/content slots discovered by
+// reviewing the AndroidX source JAR that the module actually resolves.
+
+@CatalogRemoteModes
+@Composable
+fun TonalRemoteButton() = RemoteSticker {
+  val (label, onClick) = countedRemote("Tonal")
+  RemoteButton(
+    onClick = onClick,
+    colors =
+      RemoteButtonDefaults.buttonColors(
+        containerColor = RemoteMaterialTheme.colorScheme.secondaryContainer,
+        contentColor = RemoteMaterialTheme.colorScheme.onSecondaryContainer,
+        secondaryContentColor = RemoteMaterialTheme.colorScheme.onSecondaryContainer,
+        iconColor = RemoteMaterialTheme.colorScheme.onSecondaryContainer,
+      ),
+    content = { RemoteText(label) },
+  )
+}
+
+@CatalogRemoteLarge
+@Composable
+fun IconLabelRemoteButton() = RemoteSticker {
+  val (label, onClick) = countedRemote("Favourite")
+  RemoteButton(
+    onClick = onClick,
+    icon = {
+      RemoteIcon(
+        starIcon,
+        contentDescription = null,
+        modifier = RemoteModifier.size(RemoteButtonDefaults.IconSize),
+      )
+    },
+    label = { RemoteText(label) },
+  )
+}
+
+@CatalogRemoteLarge
+@Composable
+fun IconLabelSecondaryRemoteButton() = RemoteSticker {
+  val (label, onClick) = countedRemote("Morning run")
+  RemoteButton(
+    onClick = onClick,
+    icon = {
+      RemoteIcon(
+        starIcon,
+        contentDescription = null,
+        modifier = RemoteModifier.size(RemoteButtonDefaults.LargeIconSize),
+      )
+    },
+    secondaryLabel = { RemoteText("5.2 km · 28 min".rs) },
+    label = { RemoteText(label) },
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun DisabledRemoteButton() = RemoteSticker {
+  RemoteButton(
+    onClick = valueChange(rememberMutableRemoteInt(0), 1.ri),
+    enabled = false.rb,
+    content = { RemoteText("Disabled".rs) },
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun CompactIconLabelRemoteButton() = RemoteSticker {
+  val (label, onClick) = countedRemote("Add")
+  RemoteCompactButton(
+    onClick = onClick,
+    icon = {
+      RemoteIcon(
+        starIcon,
+        contentDescription = null,
+        modifier = RemoteModifier.size(RemoteButtonDefaults.ExtraSmallIconSize),
+      )
+    },
+    label = { RemoteText(label) },
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun CompactIconOnlyRemoteButton() = RemoteSticker {
+  val (on, onClick) = toggledRemote()
+  val stock = RemoteButtonDefaults.buttonColors()
+  RemoteCompactButton(
+    onClick = onClick,
+    colors =
+      RemoteButtonDefaults.buttonColors(
+        containerColor =
+          tween(stock.containerColor, RemoteMaterialTheme.colorScheme.tertiaryContainer, on)
+      ),
+    icon = {
+      RemoteIcon(
+        starIcon,
+        contentDescription = "Favourite".rs,
+        modifier = RemoteModifier.size(RemoteButtonDefaults.SmallIconSize),
+      )
+    },
+    label = null,
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun ExtraSmallRemoteIconButton() = RemoteSticker {
+  SizedIconButton(RemoteIconButtonDefaults.ExtraSmallButtonSize)
+}
+
+@CatalogRemoteModes
+@Composable
+fun SmallRemoteIconButton() = RemoteSticker {
+  SizedIconButton(RemoteIconButtonDefaults.SmallButtonSize)
+}
+
+@CatalogRemoteModes
+@Composable
+fun LargeRemoteIconButton() = RemoteSticker {
+  SizedIconButton(RemoteIconButtonDefaults.LargeButtonSize)
+}
+
+@Composable
+@RemoteComposable
+private fun SizedIconButton(size: androidx.compose.remote.creation.compose.state.RemoteDp) {
+  val (on, onClick) = toggledRemote()
+  RemoteIconButton(
+    onClick = onClick,
+    modifier = RemoteModifier.size(size),
+    colors =
+      RemoteIconButtonDefaults.iconButtonColors(
+        containerColor =
+          tween(
+            RemoteMaterialTheme.colorScheme.surfaceContainer,
+            RemoteMaterialTheme.colorScheme.primaryContainer,
+            on,
+          ),
+        contentColor = RemoteMaterialTheme.colorScheme.onSurface,
+      ),
+    content = {
+      RemoteIcon(
+        starIcon,
+        contentDescription = "Favourite".rs,
+        modifier = RemoteModifier.size(RemoteIconButtonDefaults.iconSizeFor(size)),
+      )
+    },
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun FilledRemoteIconButton() = RemoteSticker {
+  val (on, onClick) = toggledRemote()
+  RemoteIconButton(
+    onClick = onClick,
+    colors =
+      RemoteIconButtonDefaults.iconButtonColors(
+        containerColor =
+          tween(
+            RemoteMaterialTheme.colorScheme.primary,
+            RemoteMaterialTheme.colorScheme.tertiaryContainer,
+            on,
+          ),
+        contentColor = RemoteMaterialTheme.colorScheme.onPrimary,
+      ),
+    content = { RemoteIcon(starIcon, "Favourite".rs) },
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun OutlinedRemoteIconButton() = RemoteSticker {
+  val (on, onClick) = toggledRemote()
+  RemoteIconButton(
+    onClick = onClick,
+    colors =
+      RemoteIconButtonDefaults.iconButtonColors(
+        containerColor =
+          tween(
+            RemoteColor(androidx.compose.ui.graphics.Color.Transparent),
+            RemoteMaterialTheme.colorScheme.primaryContainer,
+            on,
+          )
+      ),
+    border = 2.rdp,
+    borderColor = RemoteMaterialTheme.colorScheme.outline,
+    content = { RemoteIcon(starIcon, "Favourite".rs) },
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun SmallRemoteTextButton() = RemoteSticker {
+  SizedTextButton(
+    size = RemoteTextButtonDefaults.SmallButtonSize,
+    style = RemoteTextButtonDefaults.smallButtonTextStyle,
+    label = "Aa",
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun LargeRemoteTextButton() = RemoteSticker {
+  SizedTextButton(
+    size = RemoteTextButtonDefaults.LargeButtonSize,
+    style = RemoteTextButtonDefaults.largeButtonTextStyle,
+    label = "Aa",
+  )
+}
+
+@Composable
+@RemoteComposable
+private fun SizedTextButton(
+  size: androidx.compose.remote.creation.compose.state.RemoteDp,
+  style: androidx.compose.remote.creation.compose.text.RemoteTextStyle,
+  label: String,
+) {
+  val (text, onClick) = countedRemote(label)
+  RemoteTextButton(
+    onClick = onClick,
+    modifier = RemoteModifier.size(size),
+    colors =
+      RemoteTextButtonDefaults.textButtonColors(
+        containerColor = RemoteMaterialTheme.colorScheme.surfaceContainer,
+        contentColor = RemoteMaterialTheme.colorScheme.onSurface,
+      ),
+    content = { RemoteText(text, style = style) },
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun FilledRemoteTextButton() = RemoteSticker {
+  val (label, onClick) = countedRemote("OK")
+  RemoteTextButton(
+    onClick = onClick,
+    colors =
+      RemoteTextButtonDefaults.textButtonColors(
+        containerColor = RemoteMaterialTheme.colorScheme.primary,
+        contentColor = RemoteMaterialTheme.colorScheme.onPrimary,
+      ),
+    content = { RemoteText(label) },
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun OutlinedRemoteTextButton() = RemoteSticker {
+  val (label, onClick) = countedRemote("More")
+  RemoteTextButton(
+    onClick = onClick,
+    border = 2.rdp,
+    borderColor = RemoteMaterialTheme.colorScheme.outline,
+    content = { RemoteText(label) },
+  )
+}
+
+@CatalogRemoteLarge
+@Composable
+fun TitleOnlyRemoteTitleCard() = RemoteSticker {
+  val (title, onClick) = countedRemote("Morning run")
+  RemoteTitleCard(onClick = onClick, title = { RemoteText(title) })
+}
+
+@CatalogRemoteLarge
+@Composable
+fun TimeContentRemoteTitleCard() = RemoteSticker {
+  val (title, onClick) = countedRemote("Morning run")
+  RemoteTitleCard(
+    onClick = onClick,
+    title = { RemoteText(title) },
+    time = { RemoteText("10:10".rs) },
+    content = { RemoteText("5.2 km · 28 min".rs) },
+  )
+}
+
+@CatalogRemoteLarge
+@Composable
+fun TimeRemoteAppCard() = RemoteSticker {
+  val (title, onClick) = countedRemote("New message")
+  RemoteAppCard(
+    onClick = onClick,
+    appName = { RemoteText("Messages".rs) },
+    title = { RemoteText(title) },
+    time = { RemoteText("10:10".rs) },
+    content = { RemoteText("See you soon".rs) },
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun DisabledCircularProgressRemote() = RemoteSticker {
+  RemoteCircularProgressIndicator(
+    progress = 0.66f.rf,
+    enabled = false.rb,
+    modifier = RemoteModifier.size(72.rdp),
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun IndeterminateCircularProgressRemote() = RemoteSticker {
+  RemoteCircularProgressIndicator(modifier = RemoteModifier.size(72.rdp))
+}
+
+@CatalogRemoteModes
+@AnimatedPreview(
+  durationMs = 2000,
+  frameIntervalMs = 50,
+  showCurves = false,
+  caption = "The indeterminate arc rotates and changes sweep continuously on the remote clock.",
+)
+@Composable
+fun IndeterminateCircularProgressMotionRemote() = RemoteSticker {
+  RemoteCircularProgressIndicator(modifier = RemoteModifier.size(72.rdp))
+}
+
+@CatalogRemoteModes
+@Composable
+fun HorizontalPageIndicatorRemote() = RemoteSticker {
+  RemoteHorizontalPageIndicator(
+    state = rememberRemotePageIndicatorState(pageCount = 5, selectedPage = 2.ri),
+    modifier = RemoteModifier.size(180.rdp),
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun VerticalPageIndicatorRemote() = RemoteSticker {
+  RemoteVerticalPageIndicator(
+    state = rememberRemotePageIndicatorState(pageCount = 8, selectedPage = 4.ri),
+    modifier = RemoteModifier.size(180.rdp),
+  )
+}
+
+@CatalogRemoteModes
+@Composable
+fun InteractivePageIndicatorRemote() = RemoteSticker {
+  val selected = rememberMutableRemoteInt(0)
+  val animatedPage = animateRemoteFloat(selected.toRemoteFloat(), duration = 0.6f)
+  val state =
+    object : RemotePageIndicatorState {
+      override val pageCount: Int = 4
+      override val selectedPage: RemoteInt = 0.ri
+      override val pageOffset: RemoteFloat = animatedPage
+    }
+  RemoteBox(
+    modifier = RemoteModifier.size(180.rdp),
+    contentAlignment = RemoteAlignment.Center,
+  ) {
+    RemoteHorizontalPageIndicator(state = state)
+    RemoteTextButton(
+      onClick = valueChange(selected, (1.ri - selected).createReference()),
+      content = { RemoteText("Next".rs) },
+    )
+  }
+}
+
+@CatalogRemoteModes
+@AnimatedPreview(
+  durationMs = 1000,
+  frameIntervalMs = 33,
+  showCurves = false,
+  caption = "The selected-page worm expands, travels, and contracts between adjacent pages.",
+)
+@Composable
+fun PageIndicatorMotionRemote() = RemoteSticker {
+  val state =
+    object : RemotePageIndicatorState {
+      override val pageCount: Int = 4
+      override val selectedPage: RemoteInt = 0.ri
+      override val pageOffset: RemoteFloat =
+        animateRemoteFloat(1f.rf, duration = 0.8f, initialValue = 0f)
+    }
+  RemoteHorizontalPageIndicator(
+    state = state,
+    modifier = RemoteModifier.size(180.rdp),
+  )
+}
+
+@Composable
+@RemoteComposable
+fun TimeTextRemoteSample() {
+  RemoteTimeText(modifier = RemoteModifier.size(180.rdp), time = "10:10".rs)
+}
+
+@Composable
+@RemoteComposable
+fun TimeTextWithContextRemoteSample() {
+  RemoteTimeText(
+    modifier = RemoteModifier.size(180.rdp),
+    time = "10:10".rs,
+    leadingText = "Run".rs,
+    trailingText = "72 bpm".rs,
+  )
+}

--- a/samples/design-catalog-remote-m3/src/test/kotlin/com/example/designcatalogremotem3/InteractiveActionCaptureTest.kt
+++ b/samples/design-catalog-remote-m3/src/test/kotlin/com/example/designcatalogremotem3/InteractiveActionCaptureTest.kt
@@ -43,6 +43,17 @@ class InteractiveActionCaptureTest {
       "OutlinedCardRemote" to "Card",
       "TitleCardRemote" to "Morning run",
       "AppCardRemote" to "Morning run",
+      "TonalRemoteButton" to "Tonal",
+      "IconLabelRemoteButton" to "Favourite",
+      "IconLabelSecondaryRemoteButton" to "Morning run",
+      "CompactIconLabelRemoteButton" to "Add",
+      "SmallRemoteTextButton" to "Aa",
+      "LargeRemoteTextButton" to "Aa",
+      "FilledRemoteTextButton" to "OK",
+      "OutlinedRemoteTextButton" to "More",
+      "TitleOnlyRemoteTitleCard" to "Morning run",
+      "TimeContentRemoteTitleCard" to "Morning run",
+      "TimeRemoteAppCard" to "New message",
     )
 
   /**


### PR DESCRIPTION
## Summary

- audit the AndroidX `remote-material3` components and expand the remote-m3 catalog to cover every supported component
- add previews for defined sizes, filled and outlined styles, disabled states, labels, icons, and icon-plus-label combinations
- add click-driven interaction previews and animated GIF previews for moving progress and page-indicator states
- extend interaction capture tests and catalog metadata for the new samples

The catalog now contains 50 component entries and discovers 57 previews, including theme previews and two animation-only GIF previews.

## Impact

The remote Material 3 sample module now provides a substantially more complete component reference and exercises interactive and animated behavior in addition to static rendering.

`RemoteTimeText` is included as source-only samples because the current preview player rejects its `DrawTextOnCircle` operation (opcode 57).

## Validation

- `./gradlew :samples:design-catalog-remote-m3:ktfmtCheck :samples:design-catalog-remote-m3:testDebugUnitTest --console=plain`
- `compose-preview show --module samples:design-catalog-remote-m3 --progress --timeout 900`
- `node scripts/design-artifacts/validate-catalog-spec.mjs --spec samples/design-catalog-remote-m3/catalog.spec.json --module-dir samples/design-catalog-remote-m3`
- verified indeterminate progress animation: 41 frames / 41 unique frames
- verified page indicator animation: 31 frames / 9 unique frames
