### PR TITLE
fix(rc-player): render tinted icons

### DIFF
--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -70,6 +70,16 @@ See the `rc-embedded` column of the catalogs' `rc-compare.html` for the current 
 the baked PNG. Local deltas over the upstream snapshot are listed here as they are made, each with
 the upstream tracking issue it was reported under.
 
+- **Default Compose paint colour aligned with the framework player** (`RcPlayerPaint.kt`).
+  `ComposeLocalPaint.color` initialized to transparent ARGB `0`, while `android.graphics.Paint`
+  initializes to opaque black. A Remote Compose icon paint bundle sets a `SRC_IN` colour filter but
+  no base `COLOR`; the Compose renderer therefore tinted a transparent source and drew no icon,
+  while the View renderer tinted its default-black source successfully. The default is now
+  `Color.Black`, while `isColorSet` remains false so an implicit default is still distinguishable
+  from an explicit `COLOR` operation. `RcPlayerPaintTest` pins the player default and
+  `ComposePathColorFilterRobolectricReproTest` independently demonstrates the SrcIn behaviour using
+  only standard Compose drawing.
+
 ### Resolved: the two action-dispatch deltas (restored at alpha17)
 
 Two deltas used to live here — the `LocalRemoteNamedActionHandler` block and the `CapturedDocument`

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerPaint.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerPaint.kt
@@ -50,7 +50,9 @@ import androidx.compose.ui.unit.Density
  */
 
 internal class ComposeLocalPaint {
-  var color: Int = 0
+  // Match android.graphics.Paint's default. Remote Compose paint bundles may set only a color
+  // filter (Icon tint does this), and SrcIn needs an opaque source color to produce any pixels.
+  var color: Int = Color.Black.toArgb()
   var isColorSet: Boolean = false
   var strokeWidth: Float = 1f
   var isStrokeWidthSet: Boolean = false

--- a/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerPaintTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerPaintTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.remote.player.compose.embedded
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class RcPlayerPaintTest {
+
+  @Test
+  fun defaultColorMatchesFrameworkPaint() {
+    val paint = ComposeLocalPaint()
+
+    assertEquals(Color.Black.toArgb(), paint.color)
+    assertEquals(Color.Black, paint.effectiveColor())
+    assertFalse(
+      "default color must not masquerade as an explicit COLOR operation",
+      paint.isColorSet,
+    )
+  }
+}

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/ComposePathColorFilterRobolectricReproTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/ComposePathColorFilterRobolectricReproTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded
+
+import android.graphics.Bitmap
+import android.graphics.Canvas as AndroidCanvas
+import android.view.View.MeasureSpec
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Minimal standard-Compose reduction of the missing tinted vector in the embedded render lane.
+ *
+ * This deliberately contains no Remote Compose code. It demonstrates that Robolectric renders a
+ * SrcIn-tinted path correctly when its source is opaque, and correctly renders nothing when its
+ * source is transparent. The latter was the input supplied by the embedded player's old default
+ * paint (`ComposeLocalPaint.color == 0`); framework `android.graphics.Paint`, used by the View
+ * player, defaults to opaque black instead.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [34], qualifiers = "xhdpi")
+class ComposePathColorFilterRobolectricReproTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun srcInTintRequiresAnOpaqueSourceColor() {
+    composeRule.setContent {
+      CompositionLocalProvider(LocalDensity provides Density(1f)) {
+        Canvas(Modifier.size(WIDTH.dp, HEIGHT.dp)) {
+          drawRect(BACKGROUND)
+
+          // Control: the same path painted directly with the desired color.
+          translate(left = LEFT_X, top = TOP_Y) { drawPath(star(), color = TINT) }
+
+          // Control: SrcIn tint works under Robolectric when there is opaque source content.
+          translate(left = RIGHT_X, top = TOP_Y) {
+            drawPath(
+              path = star(),
+              color = Color.Black,
+              colorFilter = ColorFilter.tint(TINT, BlendMode.SrcIn),
+            )
+          }
+
+          // Exact reduction of the former embedded-player input. ComposeLocalPaint started at
+          // ARGB 0, making the source fully transparent; SrcIn therefore had no pixels to tint.
+          translate(left = TRANSPARENT_X, top = TOP_Y) {
+            drawPath(
+              path = star(),
+              color = Color.Transparent,
+              colorFilter = ColorFilter.tint(TINT, BlendMode.SrcIn),
+            )
+          }
+        }
+      }
+    }
+    composeRule.waitForIdle()
+
+    val bitmap = drawActivityToBitmap(WIDTH, HEIGHT)
+    val directPixels = bitmap.countPixelsNear(TINT, 0, WIDTH / 3)
+    val tintedPixels = bitmap.countPixelsNear(TINT, WIDTH / 3, 2 * WIDTH / 3)
+    val transparentPixels = bitmap.countPixelsNear(TINT, 2 * WIDTH / 3, WIDTH)
+
+    assertTrue("control path did not render: direct=$directPixels", directPixels > 100)
+    assertTrue(
+      "opaque ColorFilter.tint(..., SrcIn) path did not render: tinted=$tintedPixels",
+      tintedPixels > 100,
+    )
+    assertEquals(
+      "transparent SrcIn source unexpectedly produced tinted pixels",
+      0,
+      transparentPixels,
+    )
+
+    // This is the semantic mismatch between the two RC renderers, independent of Compose drawing.
+    assertEquals(0xff000000.toInt(), android.graphics.Paint().color)
+  }
+
+  private fun drawActivityToBitmap(width: Int, height: Int): Bitmap {
+    val root = composeRule.activity.findViewById<ViewGroup>(android.R.id.content)
+    root.measure(
+      MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
+    )
+    root.layout(0, 0, width, height)
+    return Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888).also {
+      root.draw(AndroidCanvas(it))
+    }
+  }
+
+  private fun Bitmap.countPixelsNear(color: Color, minX: Int, maxX: Int): Int {
+    val expected = color.toArgb()
+    return (0 until height).sumOf { y ->
+      (minX until maxX).count { x ->
+        val actual = getPixel(x, y)
+        channelDistance(actual, expected) <= 12
+      }
+    }
+  }
+
+  private fun channelDistance(a: Int, b: Int): Int =
+    kotlin.math.abs(android.graphics.Color.red(a) - android.graphics.Color.red(b)) +
+      kotlin.math.abs(android.graphics.Color.green(a) - android.graphics.Color.green(b)) +
+      kotlin.math.abs(android.graphics.Color.blue(a) - android.graphics.Color.blue(b))
+
+  private fun star() =
+    Path().apply {
+      moveTo(12f, 2f)
+      lineTo(15.09f, 8.26f)
+      lineTo(22f, 9.27f)
+      lineTo(17f, 14.14f)
+      lineTo(18.18f, 21.02f)
+      lineTo(12f, 17.77f)
+      lineTo(5.82f, 21.02f)
+      lineTo(7f, 14.14f)
+      lineTo(2f, 9.27f)
+      lineTo(8.91f, 8.26f)
+      close()
+    }
+
+  private companion object {
+    const val WIDTH = 192
+    const val HEIGHT = 48
+    const val LEFT_X = 20f
+    const val RIGHT_X = 84f
+    const val TRANSPARENT_X = 148f
+    const val TOP_Y = 12f
+    val BACKGROUND = Color(0xff332e3c)
+    val TINT = Color(0xffcac4d0)
+  }
+}


### PR DESCRIPTION
## What changed

- align the vendored embedded player's default Compose paint color with `android.graphics.Paint` (opaque black)
- add a focused player regression test for the implicit paint default
- add a standard Compose/Robolectric reduction showing `SrcIn` tint behavior for opaque and transparent sources
- document the local vendor delta in `PROVENANCE.md`

## Why

Remote Compose icon paint bundles can set a `SRC_IN` color filter without an explicit base `COLOR`. The embedded player initialized that base color to transparent, so the tint had no source pixels and icons disappeared. The View-backed renderer uses `android.graphics.Paint`, whose default is opaque black, and rendered the same icon correctly.

## Impact

Tinted icons rendered by the embedded Compose player now match the View player instead of disappearing.

## Validation

- `:third-party-rc-embedded-player:testDebugUnitTest --tests 'androidx.compose.remote.player.compose.embedded.RcPlayerPaintTest' --tests 'ee.schimke.composeai.rcembedded.ComposePathColorFilterRobolectricReproTest'`
- `:third-party-rc-embedded-player:ktfmtFormatTest`
- `:third-party-rc-embedded-player:ktfmtFormatMain`