### PR TITLE
fix(renderer): settle still-frame captures adaptively

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -714,25 +714,44 @@ class RenderEngine(
             // A preview may install more than one Compose owner (Wear empty-state scaffolds and
             // popup/dialog-like content do this). `onRoot()` asserts that exactly one node matches
             // `isRoot`, so using it independently for capture and every data product drops the
-            // whole render as soon as a second owner appears. Resolve one owner once: prefer the
-            // owner attached to the activity's rendered window, then prefer the richest tree. Use
-            // that same interaction for pixels and its unmerged root for every structured export.
-            val resolvedCaptureRoot = resolveRenderedCaptureRoot(rule)
-            val resolvedSemanticsRoot =
-              resolvedCaptureRoot.semanticsRoot
-                ?: error("No semantics root was produced for '${spec.outputBaseName}'")
+            // whole render as soon as a second owner appears. Prefer the owner attached to the
+            // activity's rendered window, then the richest tree. Re-resolve it for each settling
+            // sample, and resolve its semantics once more after capture so the pixels and every
+            // structured export describe the accepted frame.
             System.err.println(
               "compose-ai-daemon: [render] phase=captureRoboImage.start outputBaseName=${spec.outputBaseName}"
             )
             trace.section("render:captureRoboImage") {
-              resolvedCaptureRoot.interaction.captureRoboImage(
-                file = outputFile,
-                roborazziOptions = roborazziOptions,
-              )
+              val visuallySettled =
+                ee.schimke.composeai.renderer.captureVisuallySettledFrame(
+                  file = outputFile,
+                  role = "daemon preview still",
+                  advanceFrame = {
+                    rule.mainClock.advanceTimeByFrame()
+                    rule.waitForIdle()
+                  },
+                ) { candidate ->
+                  resolveRenderedCaptureRoot(rule)
+                    .interaction
+                    .captureRoboImage(
+                      file = candidate,
+                      roborazziOptions = roborazziOptions,
+                    )
+                }
+              if (!visuallySettled) {
+                System.err.println(
+                  "compose-ai-daemon: [render] frame did not become visually quiescent after " +
+                    "${ee.schimke.composeai.renderer.VISUAL_SETTLE_MAX_SAMPLES} samples; " +
+                    "using the latest frame."
+                )
+              }
             }
             System.err.println(
               "compose-ai-daemon: [render] phase=captureRoboImage.done outputBaseName=${spec.outputBaseName}"
             )
+            val resolvedSemanticsRoot =
+              resolveRenderedCaptureRoot(rule).semanticsRoot
+                ?: error("No semantics root was produced for '${spec.outputBaseName}'")
 
             // AS-parity wrap crop: the sandbox window is generous (400×800 dp) so wrap-content
             // measures naturally, but that leaves the composable in the top-left of a large PNG.

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1821,9 +1821,37 @@ abstract class RobolectricRenderTestBase(
                   )
                 }
               }
-              resolveCaptureRoot()
-                .interaction
-                .captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
+              // Ordinary stills get an adaptive visual-quiescence check. The common case costs
+              // one extra frame/capture and returns as soon as the first two decoded images match;
+              // only a changing preview spends the five-sample budget. Explicit time-sampled
+              // captures stay single-shot: advancing their clock would change the frame the
+              // annotation asked for. Animated/GIF paths were handled above and never reach here.
+              if (job.advanceTimeMillis == null) {
+                val visuallySettled =
+                  captureVisuallySettledFrame(
+                    file = outputFile,
+                    role = "preview still",
+                    advanceFrame = {
+                      rule.mainClock.advanceTimeByFrame()
+                      rule.waitForIdle()
+                      currentTime += VISUAL_SETTLE_FRAME_MS
+                    },
+                  ) { candidate ->
+                    resolveCaptureRoot()
+                      .interaction
+                      .captureRoboImage(file = candidate, roborazziOptions = roborazziOptions)
+                  }
+                if (!visuallySettled) {
+                  System.err.println(
+                    "Preview '${preview.id}': still frame did not become visually quiescent " +
+                      "after $VISUAL_SETTLE_MAX_SAMPLES samples; using the latest frame."
+                  )
+                }
+              } else {
+                resolveCaptureRoot()
+                  .interaction
+                  .captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
+              }
             }
 
             // A `Dialog` / `ModalBottomSheet` preview composes into a window of its own, and the
@@ -2372,11 +2400,27 @@ private fun handleLongCaptureInternal(
         maxScrollPx = scroll.maxScrollPx,
       ) { scrolledPx ->
         val sliceFile = File(slicesDir, "slice_${slices.size}.png")
-        stableDialogCrop.captureFrame(
-          rule = rule,
-          file = sliceFile,
-          roborazziOptions = sliceRoborazziOptions,
-        )
+        val visuallySettled =
+          captureVisuallySettledFrame(
+            file = sliceFile,
+            role = "scroll LONG slice",
+            advanceFrame = {
+              rule.mainClock.advanceTimeByFrame()
+              rule.waitForIdle()
+            },
+          ) { candidate ->
+            stableDialogCrop.captureFrame(
+              rule = rule,
+              file = candidate,
+              roborazziOptions = sliceRoborazziOptions,
+            )
+          }
+        if (!visuallySettled) {
+          System.err.println(
+            "@ScrollingPreview(LONG) on '$previewId': slice ${slices.size} did not become " +
+              "visually quiescent after $VISUAL_SETTLE_MAX_SAMPLES samples; using the latest frame."
+          )
+        }
         slices += SliceCapture(scrolledPx, sliceFile)
       }
     if (result is ScrollDriveResult.NoScrollable) {
@@ -2408,11 +2452,27 @@ private fun handleLongCaptureInternal(
     // bar, FAB — whatever animates in at scroll-end) is always
     // present. Generic over layout: not Wear-specific.
     val finalFrameFile = File(slicesDir, "final_frame.png")
-    stableDialogCrop.captureFrame(
-      rule = rule,
-      file = finalFrameFile,
-      roborazziOptions = sliceRoborazziOptions,
-    )
+    val visuallySettled =
+      captureVisuallySettledFrame(
+        file = finalFrameFile,
+        role = "scroll LONG final",
+        advanceFrame = {
+          rule.mainClock.advanceTimeByFrame()
+          rule.waitForIdle()
+        },
+      ) { candidate ->
+        stableDialogCrop.captureFrame(
+          rule = rule,
+          file = candidate,
+          roborazziOptions = sliceRoborazziOptions,
+        )
+      }
+    if (!visuallySettled) {
+      System.err.println(
+        "@ScrollingPreview(LONG) on '$previewId': final frame did not become visually " +
+          "quiescent after $VISUAL_SETTLE_MAX_SAMPLES samples; using the latest frame."
+      )
+    }
 
     stitchSlicesWithFinalFrame(
       slices = slices,
@@ -2452,6 +2512,60 @@ private fun settlePostScrollAnimations(rule: AndroidComposeTestRule<*, *>) {
  * / chained animations.
  */
 private const val POST_SCROLL_SETTLE_MS = 1000L
+
+/**
+ * Adaptive sample budget used to prove that a still capture is visually quiescent.
+ *
+ * The first two matching frames are enough for the stable fast path. After any mismatch, three
+ * consecutive identical decoded frames are required. Five total samples let a one- or two-frame
+ * race settle while keeping intentional infinite animations bounded.
+ */
+public const val VISUAL_SETTLE_MAX_SAMPLES = 5
+internal const val VISUAL_SETTLE_SLOW_PATH_IDENTICAL_SAMPLES = 3
+internal const val VISUAL_SETTLE_FRAME_MS = 16L
+
+/**
+ * Captures [file] twice and returns immediately if both decoded frames have identical pixels. After
+ * a mismatch, continues until [VISUAL_SETTLE_SLOW_PATH_IDENTICAL_SAMPLES] consecutive frames match
+ * or the bounded [VISUAL_SETTLE_MAX_SAMPLES] budget is exhausted.
+ *
+ * Consecutive equality is deliberate: a majority vote could select one phase of a looping animation
+ * (A/B/A/B/A) and call it stable. If the budget expires, the latest valid frame remains at [file]
+ * and the caller can continue with a diagnostic rather than failing an otherwise useful render.
+ */
+public fun captureVisuallySettledFrame(
+  file: File,
+  role: String,
+  advanceFrame: () -> Unit,
+  capture: (File) -> Unit,
+): Boolean {
+  var previousWidth = -1
+  var previousHeight = -1
+  var previousPixels: IntArray? = null
+  var identicalSamples = 0
+  var sawMismatch = false
+
+  repeat(VISUAL_SETTLE_MAX_SAMPLES) { sample ->
+    if (sample > 0) advanceFrame()
+    val image = captureDecodableFrame(file, role = role, capture = capture)
+    val pixels = IntArray(image.width * image.height)
+    image.getRGB(0, 0, image.width, image.height, pixels, 0, image.width)
+
+    val sameAsPrevious =
+      image.width == previousWidth &&
+        image.height == previousHeight &&
+        previousPixels?.contentEquals(pixels) == true
+    if (sample > 0 && !sameAsPrevious) sawMismatch = true
+    identicalSamples = if (sameAsPrevious) identicalSamples + 1 else 1
+    val required = if (sawMismatch) VISUAL_SETTLE_SLOW_PATH_IDENTICAL_SAMPLES else 2
+    if (identicalSamples >= required) return true
+
+    previousWidth = image.width
+    previousHeight = image.height
+    previousPixels = pixels
+  }
+  return false
+}
 
 /**
  * Handles `@ScrollingPreview(modes = [GIF])` captures with a "realistic user" scroll shape: 1 s
@@ -2704,13 +2818,16 @@ internal const val FRAME_CAPTURE_ATTEMPTS = 3
  * a genuinely undecodable frame keeps the render red with the same diagnostic as before — the retry
  * only absorbs a glitch that clears on a fresh encode.
  */
-internal fun captureDecodableFrame(file: File, role: String, capture: (File) -> Unit) {
+internal fun captureDecodableFrame(
+  file: File,
+  role: String,
+  capture: (File) -> Unit,
+): BufferedImage {
   var lastFailure: IllegalStateException? = null
   repeat(FRAME_CAPTURE_ATTEMPTS) { attempt ->
     capture(file)
     try {
-      FramePngReader.decode(file, role = role)
-      return
+      return FramePngReader.decode(file, role = role)
     } catch (e: IllegalStateException) {
       lastFailure = e
       System.err.println(

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CaptureVisuallySettledFrameTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CaptureVisuallySettledFrameTest.kt
@@ -1,0 +1,74 @@
+package ee.schimke.composeai.renderer
+
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CaptureVisuallySettledFrameTest {
+
+  @Test
+  fun `fast path accepts the first two identical frames`() {
+    val file = File.createTempFile("settled_final_", ".png").apply { deleteOnExit() }
+    var captures = 0
+    var advances = 0
+
+    val settled =
+      captureVisuallySettledFrame(
+        file = file,
+        role = "test final",
+        advanceFrame = { advances++ },
+      ) { candidate ->
+        captures++
+        writeFrame(candidate, argb = 0xff336699.toInt())
+      }
+
+    assertTrue(settled)
+    assertEquals(2, captures)
+    assertEquals(captures - 1, advances)
+  }
+
+  @Test
+  fun `waits through a changing frame then accepts the stable tail`() {
+    val file = File.createTempFile("settling_final_", ".png").apply { deleteOnExit() }
+    val colours =
+      listOf(0xff000001.toInt(), 0xff000002.toInt(), 0xff000002.toInt(), 0xff000002.toInt())
+    var captures = 0
+
+    val settled =
+      captureVisuallySettledFrame(file, role = "test final", advanceFrame = {}) { candidate ->
+        writeFrame(candidate, colours[captures++])
+      }
+
+    assertTrue(settled)
+    assertEquals(4, captures)
+    assertEquals(colours.last(), ImageIO.read(file).getRGB(0, 0))
+  }
+
+  @Test
+  fun `does not majority-vote an alternating animation`() {
+    val file = File.createTempFile("animated_final_", ".png").apply { deleteOnExit() }
+    val colours = listOf(0xff101010.toInt(), 0xff202020.toInt())
+    var captures = 0
+
+    val settled =
+      captureVisuallySettledFrame(file, role = "test final", advanceFrame = {}) { candidate ->
+        writeFrame(candidate, colours[captures++ % colours.size])
+      }
+
+    assertFalse(settled)
+    assertEquals(VISUAL_SETTLE_MAX_SAMPLES, captures)
+    // On timeout the most recent valid frame is retained; the render remains useful and the caller
+    // emits a diagnostic instead of choosing the majority phase as a false "stable" result.
+    assertEquals(colours.first(), ImageIO.read(file).getRGB(0, 0))
+  }
+
+  private fun writeFrame(file: File, argb: Int) {
+    val image = BufferedImage(5, 4, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until image.height) for (x in 0 until image.width) image.setRGB(x, y, argb)
+    ImageIO.write(image, "png", file)
+  }
+}


### PR DESCRIPTION
## What changed

- apply adaptive visual settling to ordinary still captures, daemon captures, and every LONG-scroll slice/final frame
- accept the stable fast path after two pixel-identical frames
- after a mismatch, require three consecutive identical frames within a five-sample cap
- retain the latest valid frame with a diagnostic when continuously changing content reaches the cap
- keep GIF/animation and explicitly timed captures single-purpose rather than treating intentional motion as instability

## Why

Compose previews can still be racing an animation or final layout update when a screenshot is encoded, producing flaky scroll captures. A fixed delay penalizes every preview and does not prove that the resulting pixels are stable. Consecutive decoded-frame comparison waits only when the visual output is actually changing and avoids incorrectly majority-voting an A/B animation loop.

## Impact

Stable previews pay for one additional frame/capture, while unstable previews are bounded at five samples. In the 57-preview Wear integration render, the updated renderer completed in 25 seconds versus 22 seconds unchanged.

## Validation

- `:renderer-android:testDebugUnitTest` for `CaptureVisuallySettledFrameTest` and `CaptureDecodableFrameTest`
- `:daemon:android:compileDebugKotlin`
- renderer and daemon ktfmt checks
- `:samples:wear:testDebugUnitTest --tests com.example.samplewear.LongScrollPreviewPixelTest`
- visually inspected the resulting LONG-scroll image