### PR TITLE
Fix remote Material 3 preview review feedback

### DIFF
--- a/samples/design-catalog-remote-m3/catalog.spec.json
+++ b/samples/design-catalog-remote-m3/catalog.spec.json
@@ -21,7 +21,7 @@
       "name": "Buttons",
       "components": [
         { "componentId": "Button/Filled", "preview": "FilledRemoteButton", "parallel": "Button/Filled", "caption": "Remote Material 3 filled button — the primary action." },
-        { "componentId": "Button/Tonal", "preview": "TonalRemoteButton", "parallel": "Button/FilledTonal", "caption": "Tonal button using the theme's secondary-container emphasis." },
+        { "componentId": "Button/Tonal", "preview": "TonalRemoteButton", "parallel": "Button/Tonal", "caption": "Tonal button using the theme's secondary-container emphasis." },
         { "componentId": "Button/Outlined", "preview": "OutlinedRemoteButton", "parallel": "Button/Outlined", "caption": "Remote Material 3 outlined-emphasis button (RemoteButton with an explicit border + border colour)." },
         { "componentId": "Button/Disabled", "preview": "DisabledRemoteButton", "parallel": "Button/Filled", "caption": "Filled button with the library's disabled container and content colours." },
         { "componentId": "Button/IconLabel", "preview": "IconLabelRemoteButton", "parallel": "Button/Filled", "caption": "Opinionated RemoteButton overload with its recommended icon and label slots." },
@@ -68,10 +68,10 @@
       "components": [
         { "componentId": "Progress/Circular", "preview": "CircularProgressRemote", "parallel": "Progress/Circular", "caption": "Determinate circular progress indicator at a fixed 66%." },
         { "componentId": "Progress/Circular-Disabled", "preview": "DisabledCircularProgressRemote", "parallel": "Progress/Circular", "caption": "Determinate progress using the component's disabled indicator and track brushes." },
-        { "componentId": "Progress/Circular-Indeterminate", "preview": "IndeterminateCircularProgressRemote", "parallel": "Progress/Circular-Indeterminate", "caption": "Indeterminate circular progress; a companion motion preview captures its continuous remote-clock animation." },
-        { "componentId": "PageIndicator/Horizontal", "preview": "HorizontalPageIndicatorRemote", "parallel": "PageIndicator/Horizontal", "caption": "Five-page horizontal indicator curved along the bottom edge." },
-        { "componentId": "PageIndicator/Vertical", "preview": "VerticalPageIndicatorRemote", "parallel": "PageIndicator/Vertical", "caption": "Eight-page vertical indicator exercising the scrolling-dot window." },
-        { "componentId": "PageIndicator/Interactive", "preview": "InteractivePageIndicatorRemote", "parallel": "PageIndicator/Horizontal", "caption": "Interactive page indicator: tapping Next animates the worm between adjacent pages inside the RemoteDocument." }
+        { "componentId": "Progress/Circular-Indeterminate", "preview": "IndeterminateCircularProgressRemote", "motionPreview": "IndeterminateCircularProgressMotionRemote", "parallel": "Progress/Circular/Indeterminate", "caption": "Indeterminate circular progress; its motion capture records the continuous remote-clock animation." },
+        { "componentId": "PageIndicator/Horizontal", "preview": "HorizontalPageIndicatorRemote", "parallel": "Template/PageIndicator/largeRound", "caption": "Five-page horizontal indicator curved along the bottom edge." },
+        { "componentId": "PageIndicator/Vertical", "preview": "VerticalPageIndicatorRemote", "caption": "Eight-page vertical indicator exercising the scrolling-dot window." },
+        { "componentId": "PageIndicator/Interactive", "preview": "InteractivePageIndicatorRemote", "parallel": "Template/PageIndicator/largeRound", "caption": "Interactive page indicator: tapping Next animates the worm between adjacent pages inside the RemoteDocument." }
       ]
     },
     {

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/ComponentVariantPreviews.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/ComponentVariantPreviews.kt
@@ -206,7 +206,12 @@ fun FilledRemoteIconButton() = RemoteSticker {
             RemoteMaterialTheme.colorScheme.tertiaryContainer,
             on,
           ),
-        contentColor = RemoteMaterialTheme.colorScheme.onPrimary,
+        contentColor =
+          tween(
+            RemoteMaterialTheme.colorScheme.onPrimary,
+            RemoteMaterialTheme.colorScheme.onTertiaryContainer,
+            on,
+          ),
       ),
     content = { RemoteIcon(starIcon, "Favourite".rs) },
   )

--- a/scripts/design-artifacts/catalog-motion.mjs
+++ b/scripts/design-artifacts/catalog-motion.mjs
@@ -33,6 +33,11 @@ const MOTION_EXTENSIONS = [".apng", ".gif"];
 /** The two ways a capture came to move. */
 export const MOTION_KINDS = ["interaction", "animation"];
 
+/** The preview function whose motion artifacts belong to a catalog component. */
+export function motionPreviewFor(component) {
+  return component?.motionPreview ?? component?.preview;
+}
+
 /**
  * The motion artifacts a bundle carries for one `@Preview` function.
  *

--- a/scripts/design-artifacts/catalog-motion.test.mjs
+++ b/scripts/design-artifacts/catalog-motion.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { foldMotion, motionArtifactsFor, motionDeclarationOf } from "./catalog-motion.mjs";
+import {
+  foldMotion,
+  motionArtifactsFor,
+  motionDeclarationOf,
+  motionPreviewFor,
+} from "./catalog-motion.mjs";
 
 const interactionCapture = (renderOutput, caption) => ({
   renderOutput,
@@ -11,6 +16,14 @@ const interactionCapture = (renderOutput, caption) => ({
 const animationCapture = (renderOutput, caption) => ({
   renderOutput,
   animation: { durationMs: 0, frameIntervalMs: 16, caption },
+});
+
+test("motionPreviewFor uses an explicit motion function and otherwise falls back to the still", () => {
+  assert.equal(motionPreviewFor({ preview: "Spinner" }), "Spinner");
+  assert.equal(
+    motionPreviewFor({ preview: "Spinner", motionPreview: "SpinnerMotion" }),
+    "SpinnerMotion",
+  );
 });
 
 test("motionDeclarationOf names the kind and keeps the caption", () => {

--- a/scripts/design-artifacts/catalog-priority.mjs
+++ b/scripts/design-artifacts/catalog-priority.mjs
@@ -198,7 +198,9 @@ export function previewNamesByPriority(spec) {
   // the driver is still going to bake — the failure that would leave a "required" entry with no PNG
   // and trip the completeness gate.
   for (const { component } of components(spec)) {
-    note(component?.preview, entryPriority(component));
+    const priority = entryPriority(component);
+    note(component?.preview, priority);
+    note(component?.motionPreview, priority);
     for (const variant of component?.variants ?? []) {
       note(variant?.preview, variantPriority(component, variant));
     }

--- a/scripts/design-artifacts/catalog-priority.test.mjs
+++ b/scripts/design-artifacts/catalog-priority.test.mjs
@@ -115,7 +115,7 @@ test("a deferred component's variants stay out of the render filter", () => {
 test("previewNamesByPriority only defers a function nothing required points at", () => {
   const { required, deferred } = previewNamesByPriority(
     spec([
-      { componentId: "A", preview: "Alpha" },
+      { componentId: "A", preview: "Alpha", motionPreview: "AlphaMotion" },
       { componentId: "B", preview: "Beta", priority: "deferred" },
       // Shared function: one entry defers it, another needs it — so it must still render.
       { componentId: "C", preview: "Alpha", priority: "deferred" },
@@ -129,7 +129,7 @@ test("previewNamesByPriority only defers a function nothing required points at",
       },
     ]),
   );
-  assert.deepEqual(required, ["Alpha", "Delta", "DeltaPressed"]);
+  assert.deepEqual(required, ["Alpha", "AlphaMotion", "Delta", "DeltaPressed"]);
   // "Alpha" is required by componentId A even though C defers it, so it must still render.
   assert.deepEqual(deferred, ["Beta", "DeltaDisabled"]);
 });

--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -393,8 +393,8 @@ export function discoverComponentIds(sources) {
   return [...ids].sort();
 }
 
-/** Every `preview` a spec references, top-level and inside `variants`, each with
- *  a human-readable JSON-ish path for diagnostics. */
+/** Every static, motion, and variant preview a spec references, each with a human-readable
+ *  JSON-ish path for diagnostics. */
 export function specPreviewRefs(spec) {
   const refs = [];
   const groups = Array.isArray(spec?.groups) ? spec.groups : [];
@@ -404,6 +404,9 @@ export function specPreviewRefs(spec) {
       const base = `groups[${gi}].components[${ci}]`;
       if (typeof comp?.preview === "string") {
         refs.push({ preview: comp.preview, path: `${base} (${comp.componentId ?? "?"})` });
+      }
+      if (typeof comp?.motionPreview === "string") {
+        refs.push({ preview: comp.motionPreview, path: `${base}.motionPreview` });
       }
       const variants = Array.isArray(comp?.variants) ? comp.variants : [];
       variants.forEach((v, vi) => {
@@ -572,6 +575,7 @@ export function validateSpec(spec, opts = {}) {
   // The subset of the above whose referring entry did NOT declare `"capture": "none"`. A PNG-less
   // preview is only an error for those: a `"none"` entry is *declaring* the absence.
   const staticRefPaths = new Map(); // preview name -> [paths]
+  const motionRefPaths = new Map(); // motion preview name -> [paths]
 
   spec.groups.forEach((group, gi) => {
     const gp = `groups[${gi}]`;
@@ -604,6 +608,13 @@ export function validateSpec(spec, opts = {}) {
         pushMulti(previewToPaths, comp.preview, cp);
         recordSelect(previewToSelects, comp.preview, comp);
         if (!exportsNoSticker(comp)) pushMulti(staticRefPaths, comp.preview, cp);
+      }
+      if (comp?.motionPreview !== undefined) {
+        if (typeof comp.motionPreview !== "string" || comp.motionPreview.length === 0) {
+          errors.push(`${cp}.motionPreview must be a non-empty @Preview function name`);
+        } else {
+          pushMulti(motionRefPaths, comp.motionPreview, cp);
+        }
       }
       errors.push(...priorityErrors(comp, cp));
       const variants = comp?.variants;
@@ -704,7 +715,16 @@ export function validateSpec(spec, opts = {}) {
         );
       }
     }
-    const referenced = new Set(previewToPaths.keys());
+    for (const [preview, paths] of motionRefPaths) {
+      if (!known.has(preview)) {
+        const hint = closest(preview, [...known]);
+        const suffix = hint ? ` — did you mean "${hint}"?` : "";
+        errors.push(
+          `motion preview "${preview}" (${paths[0]}) matches no @Preview function in the scanned module${suffix}`,
+        );
+      }
+    }
+    const referenced = new Set([...previewToPaths.keys(), ...motionRefPaths.keys()]);
     // PNG-less previews can't be catalogued at all, so their absence isn't a
     // coverage gap worth reporting.
     const orphans = [...known].filter((p) => !referenced.has(p) && !pngLess.has(p));

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -103,19 +103,24 @@ test("discoverPreviews handles keyword modifiers and multi-line annotation args"
   assert.deepEqual(discoverPreviews([src]).previews, ["WideOne"]);
 });
 
-test("specPreviewRefs collects component and variant previews", () => {
+test("specPreviewRefs collects component, motion, and variant previews", () => {
   const spec = {
     groups: [
       {
         name: "Buttons",
         components: [
-          { componentId: "Button/Filled", preview: "Filled", variants: [{ state: "pressed", preview: "FilledPressed" }] },
+          {
+            componentId: "Button/Filled",
+            preview: "Filled",
+            motionPreview: "FilledMotion",
+            variants: [{ state: "pressed", preview: "FilledPressed" }],
+          },
         ],
       },
     ],
   };
   const refs = specPreviewRefs(spec).map((r) => r.preview);
-  assert.deepEqual(refs, ["Filled", "FilledPressed"]);
+  assert.deepEqual(refs, ["Filled", "FilledMotion", "FilledPressed"]);
 });
 
 test("editDistance and closest suggest near typos only", () => {
@@ -452,6 +457,53 @@ test("validateSpec rejects a component pointing at a PNG-less preview", () => {
   assert.equal(errors.length, 1);
   assert.ok(errors[0].includes('preview "ToggleAnimatedPreview"'));
   assert.ok(errors[0].includes("renders no static PNG"));
+});
+
+test("validateSpec accepts a separate PNG-less motion preview", () => {
+  const spec = {
+    system: "s",
+    title: "T",
+    groups: [
+      {
+        name: "Motion",
+        components: [
+          {
+            componentId: "Motion/Spinner",
+            preview: "Spinner",
+            motionPreview: "SpinnerMotion",
+          },
+        ],
+      },
+    ],
+  };
+  const { errors, warnings } = validateSpec(spec, {
+    knownPreviews: ["Spinner", "SpinnerMotion"],
+    pngLessPreviews: ["SpinnerMotion"],
+  });
+  assert.deepEqual(errors, []);
+  assert.deepEqual(warnings, []);
+});
+
+test("validateSpec rejects an unknown separate motion preview", () => {
+  const spec = {
+    system: "s",
+    title: "T",
+    groups: [
+      {
+        name: "Motion",
+        components: [
+          {
+            componentId: "Motion/Spinner",
+            preview: "Spinner",
+            motionPreview: "MissingMotion",
+          },
+        ],
+      },
+    ],
+  };
+  const { errors } = validateSpec(spec, { knownPreviews: ["Spinner", "SpinnerMotion"] });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes('motion preview "MissingMotion"'));
 });
 
 test("validateSpec rejects a PNG-less preview referenced from a variant", () => {

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -131,6 +131,11 @@
           "minLength": 1,
           "description": "EXACT @Preview function name that renders this component. Must match a discovered @Preview (or multipreview) function in `module`."
         },
+        "motionPreview": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional exact @Preview function name that supplies this component's animated or interaction capture when motion must live on a separate function from the static `preview`."
+        },
         "select": { "$ref": "#/definitions/select" },
         "caption": {
           "type": "string",

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -45,7 +45,7 @@ import {
 import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 
 import { foldVariants, variantLabel } from "./catalog-variants.mjs";
-import { foldMotion, motionArtifactsFor } from "./catalog-motion.mjs";
+import { foldMotion, motionArtifactsFor, motionPreviewFor } from "./catalog-motion.mjs";
 import { publishMotionArtifacts } from "./catalog-motion-publish.mjs";
 import {
   DEFERRED,
@@ -643,10 +643,14 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       };
       // The component's animated captures, alongside (never inside) its stills — see
       // catalog-motion.mjs for why `images[]` is the wrong home for a 114-frame recording. Read off
-      // the component's own `@Preview` function only: a state variant's motion capture is
+      // the component's own `@Preview` function by default, or its explicit `motionPreview` when
+      // the static sticker and GIF need separate functions. A state variant's motion capture is
       // suppressed at discovery, so there is none to collect, and folding the variants' would
       // publish duplicates of one script anyway.
-      const motion = foldMotion(baked, motionArtifactsFor(opts.motionBundle, component.preview));
+      const motion = foldMotion(
+        baked,
+        motionArtifactsFor(opts.motionBundle, motionPreviewFor(component)),
+      );
       if (motion.length > 0) source.motion = motion;
       // A group may declare a top-level `section` (the tab the preview server
       // buckets it under: Themes / Components / Screens / Animations / …). It sits


### PR DESCRIPTION
## Summary

Follow-up to #3934 addressing all four unresolved review threads:

- point tonal and indeterminate progress at valid Wear M3 component IDs
- map horizontal/interactive page indicators to the existing Wear template and leave vertical unpaired
- add an explicit `motionPreview` catalog association so the static progress sticker publishes its separate GIF capture
- animate the filled icon button content color to `onTertiaryContainer` with its container

## Validation

- 93 focused design-artifacts tests covering catalog spec, priority filtering, motion, and sample validation
- `:samples:design-catalog-remote-m3:ktfmtCheck`
- `:samples:design-catalog-remote-m3:testDebugUnitTest` (15 tests)
- catalog spec validator: 0 warnings, 0 errors
- focused Compose render produced the static PNG and a 41-frame animation GIF
- `git diff --check`
