### PR TITLE
fix(remote-m3): address post-merge preview failures

### DIFF
--- a/.github/ci/remote-m3-cmp-wasm-allowlist.json
+++ b/.github/ci/remote-m3-cmp-wasm-allowlist.json
@@ -1,0 +1,34 @@
+{
+  "entries": [
+    {
+      "id": "com.example.designcatalogremotem3.ComponentVariantPreviewsKt.CompactIconLabelRemoteButton_width_200dp_height_200dp_dpi_320",
+      "reason": "CMP/Wasm does not yet implement the intrinsic WidthModifier/HeightModifier dimension used by this component; observed in actions/runs/31898714419.",
+      "expires": "2026-09-15"
+    },
+    {
+      "id": "com.example.designcatalogremotem3.ComponentVariantPreviewsKt.CompactIconOnlyRemoteButton_width_200dp_height_200dp_dpi_320",
+      "reason": "CMP/Wasm does not yet implement the intrinsic WidthModifier/HeightModifier dimension used by this component; observed in actions/runs/31898714419.",
+      "expires": "2026-09-15"
+    },
+    {
+      "id": "com.example.designcatalogremotem3.ComponentVariantPreviewsKt.DisabledRemoteButton_width_200dp_height_200dp_dpi_320",
+      "reason": "CMP/Wasm cannot resolve the disabled content dynamic color emitted by Remote Material 3; observed in actions/runs/31898714419.",
+      "expires": "2026-09-15"
+    },
+    {
+      "id": "com.example.designcatalogremotem3.ComponentVariantPreviewsKt.IconLabelRemoteButton_width_320dp_height_240dp_dpi_320",
+      "reason": "CMP/Wasm does not yet implement the intrinsic WidthModifier/HeightModifier dimension used by this component; observed in actions/runs/31898714419.",
+      "expires": "2026-09-15"
+    },
+    {
+      "id": "com.example.designcatalogremotem3.ComponentVariantPreviewsKt.IconLabelSecondaryRemoteButton_width_320dp_height_240dp_dpi_320",
+      "reason": "CMP/Wasm lacks the intrinsic dimension and dynamic color support required by this component; observed in actions/runs/31898714419.",
+      "expires": "2026-09-15"
+    },
+    {
+      "id": "com.example.designcatalogremotem3.ComponentVariantPreviewsKt.IndeterminateCircularProgressRemote_width_200dp_height_200dp_dpi_320",
+      "reason": "CMP/Wasm currently draws no pixels for the Remote Material 3 indeterminate clock animation; observed in actions/runs/31898714419.",
+      "expires": "2026-09-15"
+    }
+  ]
+}

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -618,5 +618,6 @@ jobs:
       # it is a gate, not enrichment — a document it cannot draw fails the render rather than
       # dropping a column — so it stays where someone is watching the result.
       rc-cmp-wasm-lane: true
+      rc-cmp-wasm-allowlist: .github/ci/remote-m3-cmp-wasm-allowlist.json
     secrets:
       buildfetch_ro_token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}

--- a/scripts/design-artifacts/catalog-motion.mjs
+++ b/scripts/design-artifacts/catalog-motion.mjs
@@ -48,7 +48,7 @@ export function motionPreviewFor(component) {
  *
  * @param {{entries?: Record<string, unknown>, previews?: Array<object>}} bundle
  * @param {string} functionName the `@Preview` function to collect for.
- * @returns {Array<{path: string, kind: string, caption?: string, theme?: string}>}
+ * @returns {Array<{path: string, previewId: string, kind: string, caption?: string, theme?: string}>}
  */
 export function motionArtifactsFor(bundle, functionName) {
   const out = [];
@@ -61,6 +61,10 @@ export function motionArtifactsFor(bundle, functionName) {
       if (!path) continue;
       out.push({
         path,
+        // Kept until `foldMotion`: a separately named motion function has a different filename
+        // stem from the still, so its position in the function's preview fan-out is the only
+        // reliable bridge back to the already-resolved static axes.
+        previewId: preview.id,
         kind: declaration.kind,
         ...(declaration.caption ? { caption: declaration.caption } : {}),
       });
@@ -111,21 +115,43 @@ function bundleEntryFor(bundle, previewId, renderOutput) {
  * capture's own id carries the same `_Dark` / `_Light` suffix, but re-deriving it here would be a
  * second implementation of the mode-naming rule that `catalog-themes.mjs` already owns, and the two
  * would eventually disagree about a catalog with unusual mode names. Matching positionally against
- * the images the join already resolved keeps one rule.
+ * the images the join already resolved keeps one rule. When `motionPreview` names a separate
+ * function, its filenames necessarily have different stems. In that case [previewIds] and
+ * [motionPreviewIds] describe the two functions' equivalent fan-outs in discovery order; the join
+ * maps the motion id to the corresponding still id before reading the still's resolved theme.
  *
  * @param {Array<{path: string, theme?: string}>} images the component's baked stills.
- * @param {Array<{path: string, kind: string, caption?: string}>} artifacts from [motionArtifactsFor].
+ * @param {Array<{path: string, previewId?: string, kind: string, caption?: string}>} artifacts from [motionArtifactsFor].
+ * @param {string[]} previewIds ids emitted by the component's static preview function.
+ * @param {string[]} motionPreviewIds ids emitted by its motion preview function.
  * @returns {Array<object>} one motion entry per artifact, theme-tagged where it could be resolved.
  */
-export function foldMotion(images, artifacts) {
+export function foldMotion(images, artifacts, previewIds = [], motionPreviewIds = []) {
   if (!artifacts?.length) return [];
+  const correspondingStillIds = equivalentFanOut(previewIds, motionPreviewIds);
   return artifacts.map((artifact) => {
-    const theme = themeForArtifact(images, artifact.path);
+    const { previewId, ...published } = artifact;
+    const theme = themeForArtifact(
+      images,
+      artifact.path,
+      correspondingStillIds.get(previewId),
+    );
     return {
-      ...artifact,
+      ...published,
       ...(theme !== undefined ? { theme } : {}),
     };
   });
+}
+
+/**
+ * Map equivalent cells of two separately named functions' preview fan-outs. Only an equal-length
+ * fan-out is safe to join positionally; otherwise leave the artifacts untagged rather than attach
+ * a confidently wrong theme.
+ */
+function equivalentFanOut(previewIds, motionPreviewIds) {
+  if (previewIds.length === 0 || previewIds.length !== motionPreviewIds.length)
+    return new Map();
+  return new Map(motionPreviewIds.map((id, index) => [id, previewIds[index]]));
 }
 
 /**
@@ -135,10 +161,16 @@ export function foldMotion(images, artifacts) {
  * share every character but the extension — which is exactly the join, and needs no knowledge of
  * how modes are spelled.
  */
-function themeForArtifact(images, artifactPath) {
+function themeForArtifact(images, artifactPath, correspondingStillId) {
   const stem = artifactPath.replace(/\.[^.]+$/, "");
   for (const image of images ?? []) {
     if (image?.path?.replace(/\.[^.]+$/, "") === stem) return image.theme;
+  }
+  if (correspondingStillId !== undefined) {
+    const stillStem = `previews/${correspondingStillId}`;
+    for (const image of images ?? []) {
+      if (image?.path?.replace(/\.[^.]+$/, "") === stillStem) return image.theme;
+    }
   }
   return undefined;
 }

--- a/scripts/design-artifacts/catalog-motion.test.mjs
+++ b/scripts/design-artifacts/catalog-motion.test.mjs
@@ -72,8 +72,18 @@ test("artifacts are collected per function, across every preview it fanned out t
   };
 
   assert.deepEqual(motionArtifactsFor(bundle, "SwitchOn"), [
-    { path: "previews/Sw_Light.apng", kind: "interaction", caption: "Toggle" },
-    { path: "previews/Sw_Dark.apng", kind: "interaction", caption: "Toggle" },
+    {
+      path: "previews/Sw_Light.apng",
+      previewId: "Sw_Light",
+      kind: "interaction",
+      caption: "Toggle",
+    },
+    {
+      path: "previews/Sw_Dark.apng",
+      previewId: "Sw_Dark",
+      kind: "interaction",
+      caption: "Toggle",
+    },
   ]);
 });
 
@@ -106,8 +116,18 @@ test("a function carrying both annotations keeps its two captures apart by rende
   };
 
   assert.deepEqual(motionArtifactsFor(bundle, "Spinner"), [
-    { path: "previews/Spinner.apng", kind: "animation", caption: "Spins on its own" },
-    { path: "previews/Spinner_interaction.apng", kind: "interaction", caption: "Tap to restart" },
+    {
+      path: "previews/Spinner.apng",
+      previewId: "Spinner",
+      kind: "animation",
+      caption: "Spins on its own",
+    },
+    {
+      path: "previews/Spinner_interaction.apng",
+      previewId: "Spinner",
+      kind: "interaction",
+      caption: "Tap to restart",
+    },
   ]);
 });
 
@@ -134,6 +154,56 @@ test("an untagged catalog folds motion with no theme rather than inventing one",
   assert.deepEqual(foldMotion(images, artifacts), [
     { path: "previews/Sw.apng", kind: "interaction" },
   ]);
+});
+
+test("foldMotion joins a separately named motion function's fan-out to the still axes", () => {
+  const images = [
+    { path: "previews/Progress_Light.png", theme: "light" },
+    { path: "previews/Progress_Dark.png", theme: "dark" },
+  ];
+  const artifacts = [
+    {
+      path: "previews/ProgressMotion_Light.apng",
+      previewId: "ProgressMotion_Light",
+      kind: "animation",
+    },
+    {
+      path: "previews/ProgressMotion_Dark.apng",
+      previewId: "ProgressMotion_Dark",
+      kind: "animation",
+    },
+  ];
+
+  assert.deepEqual(
+    foldMotion(
+      images,
+      artifacts,
+      ["Progress_Light", "Progress_Dark"],
+      ["ProgressMotion_Light", "ProgressMotion_Dark"],
+    ),
+    [
+      { path: "previews/ProgressMotion_Light.apng", kind: "animation", theme: "light" },
+      { path: "previews/ProgressMotion_Dark.apng", kind: "animation", theme: "dark" },
+    ],
+  );
+});
+
+test("foldMotion does not guess when separate function fan-outs differ", () => {
+  assert.deepEqual(
+    foldMotion(
+      [{ path: "previews/Progress_Dark.png", theme: "dark" }],
+      [
+        {
+          path: "previews/ProgressMotion_Dark.apng",
+          previewId: "ProgressMotion_Dark",
+          kind: "animation",
+        },
+      ],
+      ["Progress_Light", "Progress_Dark"],
+      ["ProgressMotion_Dark"],
+    ),
+    [{ path: "previews/ProgressMotion_Dark.apng", kind: "animation" }],
+  );
 });
 
 test("no artifacts folds to nothing, so a component without motion gains no field", () => {

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -650,6 +650,8 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       const motion = foldMotion(
         baked,
         motionArtifactsFor(opts.motionBundle, motionPreviewFor(component)),
+        opts.previewIdsByFunction?.get(component.preview),
+        opts.previewIdsByFunction?.get(motionPreviewFor(component)),
       );
       if (motion.length > 0) source.motion = motion;
       // A group may declare a top-level `section` (the tab the preview server


### PR DESCRIPTION
## What changed

- Join an explicit `motionPreview` function's preview fan-out back to the static preview fan-out before copying resolved theme axes.
- Keep the internal motion preview ID out of the published catalog shape.
- Add regression coverage for separately named light/dark motion functions and mismatched fan-outs.
- Keep the required Remote Compose CMP/Wasm lane enabled while temporarily allowlisting the six exact documents blocked by known player gaps. Each exception is reasoned and expires on 2026-09-15.

## Why

PR #3939 received a late review comment after merge: filename-stem matching cannot associate a separately named motion function with its static function's theme axes. Its post-merge Design Artifacts run also failed because six newly catalogued Remote Material 3 documents exercise CMP/Wasm features the player does not yet support.

The fan-out join fixes the catalog metadata loss. The narrow, expiring allowlist lets the catalog publish without hiding failures for the other 44 documents, while preserving the full Android-rendered component inventory.

## Validation

- `node --test catalog-motion.test.mjs rc-compare-gate.test.mjs validate-samples.test.mjs` — 21 passed
- Parsed `.github/ci/remote-m3-cmp-wasm-allowlist.json` through `readCmpWasmAllowlist` — 6 valid entries
- `git diff --check`

The broad `npm test` run completed all observed tests without a failure but did not terminate after local Chromium/CMP-player tests skipped, so it was stopped. The repository has no `spotlessCheck` task; this change contains no Kotlin sources.